### PR TITLE
docs(sim): document the six remaining undocumented dispatchable actions + pin the invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Docs: document the six remaining undocumented dispatchable sim actions
+
+`get_state`, `list_objects`, `remove_object`, `reset`, `set_timestep`, and
+`step` were dispatchable through the MuJoCo simulation agent tool (they are in
+the `tool_spec` action enum and `describe()` advertises them) yet their handler
+methods on `MuJoCoSimEngine` had NO docstring -- so an agent enumerating the
+tool spec had no summary of what the action does or when it errors, the exact
+discovery-surface dead-end the docstring convention exists to prevent. Each now
+carries a summary + Args/Returns naming the `{status, content}` result and its
+`status="error"` conditions (e.g. `reset` documents that it flushes buffered
+recording frames as a separate episode and errors while a policy is running;
+`step` documents that `0` is an accepted no-op). A new contract test
+(`test_dispatchable_actions_have_documented_handlers`) pins the invariant on the
+live engine so no future dispatchable action can ship without a docstring.
+
 ### Fixed: training `expert_only` supported-policy set sourced live from lerobot
 
 `LerobotTrainer` gated `method="expert_only"` (freeze the VLM, train only the

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2446,6 +2446,19 @@ class MuJoCoSimEngine(
         }
 
     def remove_object(self, name: str) -> dict[str, Any]:
+        """Remove a named object from the live scene.
+
+        Deletes the object from the world registry and ejects its body from the
+        MjSpec, recompiling the model while preserving the state of the
+        remaining bodies.
+
+        Args:
+            name: The object name (as passed to ``add_object``).
+
+        Returns:
+            A ``{status, content}`` tool result. ``status`` is ``"error"`` when
+            no world exists, ``name`` is unknown, or a policy is running.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if name not in self._world.objects:
@@ -2560,6 +2573,13 @@ class MuJoCoSimEngine(
         return {"status": "success", "content": [{"text": f"'{name}' moved to {position or 'same'}"}]}
 
     def list_objects(self) -> dict[str, Any]:
+        """List every object in the scene with its shape, position, and mass.
+
+        Returns:
+            A ``{status, content}`` tool result whose text enumerates the
+            objects (or reports that there are none). ``status`` is
+            ``"error"`` when no world exists.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if not self._world.objects:
@@ -2787,6 +2807,16 @@ class MuJoCoSimEngine(
     _STEPS_PER_BATCH = 1000  # Release lock every N steps for cancellation.
 
     def step(self, n_steps: int = 1) -> dict[str, Any]:
+        """Advance the simulation by ``n_steps`` physics steps.
+
+        Args:
+            n_steps: Non-negative step count (``0`` is an accepted no-op).
+
+        Returns:
+            A ``{status, content}`` tool result reporting the elapsed sim time
+            and total step count. ``status`` is ``"error"`` when no world
+            exists or ``n_steps`` is negative / not an integer.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # reject negative, accept zero as no-op
@@ -2835,6 +2865,19 @@ class MuJoCoSimEngine(
         }
 
     def reset(self) -> dict[str, Any]:
+        """Reset the world to its initial state, beginning a new rollout.
+
+        Restores the initial pose and re-forwards derived state so the world is
+        render- and observation-ready on return. If a recording is active with
+        buffered frames, flushes them as their own episode first, so a
+        ``run_policy`` + ``reset`` collection loop records one episode per
+        rollout instead of merging every rollout into episode 0.
+
+        Returns:
+            A ``{status, content}`` tool result. ``status`` is ``"error"`` when
+            no world exists or a policy is running (a reset during a live
+            ``mj_step`` can segfault).
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # reset during a running policy races mj_step -> SEGFAULT risk
@@ -2900,6 +2943,16 @@ class MuJoCoSimEngine(
         return {"status": "success", "content": [{"text": f"{flush_note}Reset to initial state."}]}
 
     def get_state(self) -> dict[str, Any]:
+        """Summarize the current simulation state.
+
+        Reports sim time, step count, timestep, gravity, and counts of robots,
+        objects, cameras, bodies, joints, and actuators (plus recording status
+        when a recording is active).
+
+        Returns:
+            A ``{status, content}`` tool result. ``status`` is ``"error"`` when
+            no world exists.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         lines = [
@@ -3013,6 +3066,16 @@ class MuJoCoSimEngine(
         return {"status": "success", "content": [{"text": f"Gravity: {components}"}]}
 
     def set_timestep(self, timestep: float) -> dict[str, Any]:
+        """Set the physics integration timestep in seconds.
+
+        Args:
+            timestep: A finite positive float.
+
+        Returns:
+            A ``{status, content}`` tool result. ``status`` is ``"error"`` when
+            no world exists, a policy is running, or ``timestep`` is
+            non-positive or non-finite.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("set_timestep"):

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -786,6 +786,49 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_dispatchable_actions_have_documented_handlers(self):
+        """Every agent-dispatchable action's handler must carry a docstring.
+
+        The handler docstring is the discovery surface an agent reads to learn
+        what an action does; an undocumented handler dead-ends a caller who
+        enumerated the tool spec. Pins the invariant on the live engine so a
+        newly-wired action cannot ship without documentation. (This closed six
+        stragglers: get_state, list_objects, remove_object, reset,
+        set_timestep, step.)
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        def _find_action_enum(node):
+            if isinstance(node, dict):
+                enum = node.get("enum")
+                if isinstance(enum, list) and all(isinstance(x, str) for x in enum):
+                    yield enum
+                for value in node.values():
+                    yield from _find_action_enum(value)
+
+        sim = Simulation()
+        try:
+            enums = [e for e in _find_action_enum(sim.tool_spec) if "add_robot" in e and "reset" in e]
+            assert len(enums) == 1, "tool_spec must expose exactly one action enum"
+            actions = enums[0]
+            aliases = sim._ACTION_ALIASES
+            undocumented = []
+            for action in actions:
+                handler = getattr(sim, aliases.get(action, action), None)
+                assert callable(handler), f"dispatchable action {action!r} has no callable handler"
+                if not (getattr(handler, "__doc__", None) or "").strip():
+                    undocumented.append(action)
+            assert not undocumented, (
+                "dispatchable actions with undocumented handlers: "
+                f"{sorted(undocumented)} - each action's handler docstring is "
+                "the agent discovery surface for that action"
+            )
+        finally:
+            sim.destroy()
+
 
 class TestNoAlias:
     """Code is the single source of truth: no duplicate-name aliases.


### PR DESCRIPTION
## Problem

Six actions are dispatchable through the MuJoCo simulation agent tool — they are in the `tool_spec` action enum **and** advertised by `describe()['methods']` — yet their handler methods on `MuJoCoSimEngine` carried **no docstring**:

- `get_state`
- `list_objects`
- `remove_object`
- `reset`
- `set_timestep`
- `step`

An agent that enumerates the tool spec to plan a call has the handler docstring as its only summary of *what the action does* and *when it errors*. An undocumented handler is exactly the discovery-surface dead-end the docstring convention exists to prevent — every other dispatchable action (add_robot, run_policy, get_body_state, …) is documented; these six were the stragglers.

## Change

- Added a summary + `Args`/`Returns` docstring to each of the six `MuJoCoSimEngine` handlers, describing the `{status, content}` result and its `status="error"` conditions. Notably:
  - `reset` documents that it flushes buffered recording frames as a separate episode and errors while a policy thread is running.
  - `step` documents that `n=0` is an accepted no-op and negative counts error.
  - `list_objects` / `remove_object` / `get_state` / `set_timestep` document their empty-scene / unknown-name / no-world / non-positive-timestep error paths.
- Docstring-only for the six handlers — **no behavior, signature, or return-shape change**.

## Regression guard

New live-engine contract test `test_dispatchable_actions_have_documented_handlers` (co-located with `test_describe_methods_resolve_to_real_attributes`, same *discovery-surface-is-a-contract* theme): it walks the `tool_spec` action enum, resolves each action to its handler (honoring `_ACTION_ALIASES`), and asserts every handler is callable **and** carries a non-empty docstring. Fails pre-change with the exact six names; passes after. No future dispatchable action can ship without a docstring.

## Verification

- Fails-before proven: reverting only the handler docstrings → the new test fails listing exactly `['get_state','list_objects','remove_object','reset','set_timestep','step']`.
- `tests/simulation/test_sim_engine_describe_discovery.py` + `tests/simulation/mujoco/test_tool_spec.py` → **44 passed**.
- `ruff check` / `ruff format` clean; `mypy` clean on the two changed files (the pre-existing `examples/` mypy errors are out of scope — CI scopes mypy to the package).
- Clean 0-conflict merge into `main`.

No visual artifact: this is a metadata/docstring change to the agent discovery surface (no policy/sim/render/recording/asset behavior change). The fails-before contract test is the proof.