### PR TITLE
test(mesh): extend docstring xref guard to transport/ and iot/ subpackages

### DIFF
--- a/strands_robots/mesh/transport/zenoh_transport.py
+++ b/strands_robots/mesh/transport/zenoh_transport.py
@@ -14,7 +14,8 @@ reimplementing them. That keeps:
    ``zenoh.Session`` singleton.
 3. **A clean migration story.** When the Zenoh implementation needs to
    evolve (e.g. to add per-key QoS or per-endpoint TLS), changes go into
-   ``session.py`` and this wrapper benefits automatically.
+   the :mod:`~strands_robots.mesh.session` module and this wrapper
+   benefits automatically.
 
 The Zenoh dependency stays **lazy**: importing this module does not import
 ``zenoh``. The first :meth:`connect` call delegates to ``session.get_session``

--- a/tests/mesh/test_docstring_module_xrefs.py
+++ b/tests/mesh/test_docstring_module_xrefs.py
@@ -1,26 +1,31 @@
-"""Top-level mesh modules must cross-reference *sibling* code by module, never by
-source filename.
+"""Every mesh module - top-level *and* subpackage - must cross-reference sibling
+code by module, never by source filename.
 
-Citing a sibling source file (``core.py``, ``security.py``, ...) in a docstring
-is documentation archaeology: the name breaks silently the moment a file is
-renamed or split, and it points a reader at a path instead of an importable
-symbol. This package already carried a *dead* example - an ``_ProcessAuditState``
-docstring pointed at ``mesh/security.py::_ProcessSecurityState``, a class that no
-longer exists - which is exactly the silent-breakage this rule prevents. The
-project convention (already guarded for the policy package by
+Citing a sibling source file (``core.py``, ``security.py``, ``session.py``, ...)
+in a docstring is documentation archaeology: the name breaks silently the moment
+a file is renamed or split, and it points a reader at a path instead of an
+importable symbol. This package already carried a *dead* example - an
+``_ProcessAuditState`` docstring pointed at ``mesh/security.py::_ProcessSecurityState``,
+a class that no longer exists - which is exactly the silent-breakage this rule
+prevents. The project convention (already guarded for the policy package by
 ``tests/policies/test_docstring_module_xrefs.py``, the trainer package by
 ``tests/training/test_docstring_module_xrefs.py``, and the MuJoCo backend by
 ``tests/simulation/mujoco/test_docstring_module_xrefs.py``) is to use Sphinx
 cross-reference roles - ``:mod:``, ``:class:``, ``:func:`` - that name the actual
 API object, so the reference is checkable and survives refactors.
 
-This guard walks every module/class/function docstring in the *top-level*
-``strands_robots.mesh`` modules (``core.py``, ``security.py``, ``audit.py``, ...)
-and fails if any embeds a ``<name>.py`` token that names an actual sibling
-module. It is intentionally sibling-aware rather than flagging every ``.py``
-token: mesh docstrings legitimately cite *test* modules by filename (the guarding
-``test_*.py`` files that pin a behavior), which live under ``tests/`` and are not
-importable siblings of the package.
+This guard walks every module/class/function docstring across the whole
+``strands_robots.mesh`` package tree - the top-level modules (``core.py``,
+``security.py``, ``audit.py``, ...) *and* the ``transport`` and ``iot``
+subpackages - and fails if any embeds a ``<name>.py`` token that names an actual
+module anywhere in that tree. An earlier version scanned only the top-level
+modules, so a ``session.py`` filename reference in
+``mesh/transport/zenoh_transport.py`` slipped through unguarded; walking the full
+tree closes that gap. The check is intentionally sibling-aware rather than
+flagging every ``.py`` token: mesh docstrings legitimately cite *test* modules by
+filename (the guarding ``test_*.py`` files that pin a behavior), which live under
+``tests/`` and are not importable modules of the package. ``__init__.py`` is
+excluded because it names a package, not a cross-referenceable module symbol.
 """
 
 from __future__ import annotations
@@ -31,17 +36,19 @@ from pathlib import Path
 
 import strands_robots.mesh as mesh_pkg
 
-# A bare source-filename token such as ``core.py`` or ``security.py``.
+# A bare source-filename token such as ``core.py`` or ``session.py``.
 _FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
 
 _PACKAGE_DIR = Path(mesh_pkg.__file__).parent
-_SIBLING_MODULES = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+# Every module across the mesh tree (top-level + transport/ + iot/ subpackages),
+# minus ``__init__.py`` which names a package rather than a referenceable module.
+_PACKAGE_MODULES = {p.name for p in _PACKAGE_DIR.rglob("*.py") if p.name != "__init__.py"}
 
 
 def _docstrings_with_sibling_filename_refs() -> dict[str, list[str]]:
-    """Map ``module.py::qualname`` -> sibling-filename tokens found in its docstring."""
+    """Map ``relpath::qualname`` -> module-filename tokens found in its docstring."""
     offenders: dict[str, list[str]] = {}
-    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+    for source_file in sorted(_PACKAGE_DIR.rglob("*.py")):
         tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
@@ -49,22 +56,25 @@ def _docstrings_with_sibling_filename_refs() -> dict[str, list[str]]:
             doc = ast.get_docstring(node, clean=False)
             if not doc:
                 continue
-            hits = [tok for tok in _FILENAME_RE.findall(doc) if tok in _SIBLING_MODULES]
+            hits = [tok for tok in _FILENAME_RE.findall(doc) if tok in _PACKAGE_MODULES]
             if hits:
                 qualname = getattr(node, "name", "<module>")
-                offenders[f"{source_file.name}::{qualname}"] = hits
+                rel = source_file.relative_to(_PACKAGE_DIR)
+                offenders[f"{rel}::{qualname}"] = hits
     return offenders
 
 
-def test_top_level_mesh_modules_scanned() -> None:
-    """Guard: the scan actually walked the top-level mesh modules."""
-    assert {"core.py", "security.py", "audit.py"} <= _SIBLING_MODULES
+def test_mesh_package_tree_scanned() -> None:
+    """Guard: the scan walked the top-level modules and both subpackages."""
+    assert {"core.py", "security.py", "audit.py"} <= _PACKAGE_MODULES
+    assert {"zenoh_transport.py", "bridge_transport.py"} <= _PACKAGE_MODULES  # transport/
+    assert {"provision.py", "bootstrap.py"} <= _PACKAGE_MODULES  # iot/
 
 
 def test_mesh_docstrings_reference_modules_not_sibling_filenames() -> None:
     offenders = _docstrings_with_sibling_filename_refs()
     assert not offenders, (
-        "Top-level mesh docstrings must cross-reference siblings by module "
-        "(:func:`~strands_robots.mesh.core._parse_positive_float_env`) not source "
-        f"filename (``core.py``). Offending docstrings: {offenders}"
+        "mesh docstrings must cross-reference sibling modules by module "
+        "(:mod:`~strands_robots.mesh.session`) not source filename (``session.py``). "
+        f"Offending docstrings: {offenders}"
     )


### PR DESCRIPTION
## Problem

The mesh docstring cross-reference guard (`tests/mesh/test_docstring_module_xrefs.py`) only walked the *top-level* `strands_robots.mesh` modules via `glob("*.py")`. The `transport/` and `iot/` subpackages were never scanned, so a filename reference living there escaped the guard.

And one did: the module docstring in `strands_robots/mesh/transport/zenoh_transport.py` cited its sibling module by source filename:

```
... changes go into ``session.py`` and this wrapper benefits automatically.
```

That is exactly the documentation-archaeology the guard exists to prevent - a bare `session.py` breaks silently the moment the file is renamed or split, and points a reader at a path instead of an importable symbol. (The same docstring's opening line already does it correctly: `:mod:`strands_robots.mesh.session`.)

## Change

- Broaden the guard to walk the **full** `strands_robots.mesh` tree (`rglob`) so the top-level modules and both the `transport/` and `iot/` subpackages are covered by one guard. `__init__.py` is excluded from the flagged set since it names a package, not a cross-referenceable module symbol; test-module filenames under `tests/` are still not flagged (only names of real package modules match).
- Replace the `` ``session.py`` `` reference in `zenoh_transport.py` with `:mod:`~strands_robots.mesh.session``, matching the same docstring's own top line.

No production behavior changes - docstring text and a test-only guard.

## Test

The broadened guard fails on the pre-fix docstring and passes after:

```
# pre-fix (offender present):
FAILED test_mesh_docstrings_reference_modules_not_sibling_filenames
  Offending docstrings: {'transport/zenoh_transport.py::<module>': ['session.py']}

# post-fix:
2 passed
```

Full mesh suite green: `2096 passed, 3 skipped`. Lint clean: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` ("no issues found in 807 source files").