### PR TITLE
test: reject compact review-round provenance tags in package sources

### DIFF
--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -1019,7 +1019,7 @@ def log_safety_event(event_type: str, peer_id: str, payload: dict[str, Any]) -> 
     try:
         seq = _next_seq(peer_id)
     except SeqLockSymlinkError as exc:
-        # PR#221 R3 (issue #238): the seq lockfile is a symlink. Raise
+        # The seq lockfile is a symlink (issue #238). Raise
         # the visible signal: write a poison record with
         # ``sig="SEQ_LOCK_DEGRADED"`` so verify_audit_integrity walkers
         # see a gap on this peer's stream. seq is unknown -- use 0 as

--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -198,7 +198,7 @@ _ROBOT_POLICY_DOC: dict[str, Any] = {
             # the robot never needs to Receive its own copy. Do NOT widen
             # ``AllowReceiveScoped`` back to ``${ThingName}/*`` to "fix" this
             # asymmetry -- that re-opens the fleet-eavesdrop surface the narrow
-            # Receive list closes. See issue #253 / PR #228 R5.
+            # Receive list closes. See issue #253.
             "Sid": "AllowOwnSubscriptions",
             "Effect": "Allow",
             "Action": "iot:Subscribe",

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -589,7 +589,7 @@ def get_session() -> Any | None:
             # (the prior try/except was dead -- _build_config() below
             # invokes resolve_auth_mode() again unconditionally).
             # Aligns with the loud-on-misconfig posture of _float_env
-            # and _load_acl_file. Addressed in PR-224 R1.
+            # and _load_acl_file.
             #
             # Prefer the thread-local
             # ``auth_mode`` stash from ``Mesh.start``. This is the same
@@ -723,7 +723,7 @@ def _get_zenoh_session_directly() -> Any | None:
             # (the prior try/except was dead -- _build_config() below
             # invokes resolve_auth_mode() again unconditionally).
             # Aligns with the loud-on-misconfig posture of _float_env
-            # and _load_acl_file. Addressed in PR-224 R1.
+            # and _load_acl_file.
             #
             # Prefer the thread-local
             # ``auth_mode`` stash. Mirrors the same fix at the

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -104,7 +104,7 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
                     # Cosmos 3 service-mode URL: cosmos3://[host[:port]] -> kwargs.
                     # Without this branch the pattern matches but no parser
                     # populates host/port, so create_policy("cosmos3://prod:9000")
-                    # silently falls back to the default localhost:8000 (#317 R3).
+                    # silently falls back to the default localhost:8000 (#317).
                     match = re.match(r"cosmos3://([^:/]+):?(\d+)?", policy)
                     if match:
                         kwargs["host"] = match.group(1)

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -407,7 +407,7 @@ def _rate_limit_check_and_record(action: str) -> str | None:
 def _audit_tool_action(action: str, target: str, success: bool, detail: str) -> None:
     """Best-effort audit log of every safety-significant tool call.
 
-    R7-5: a swallowed exception with no log line means a broken audit
+    A swallowed exception with no log line means a broken audit
     path silently disappears. Match the ``core.py:_on_cmd`` pattern -
     log at DEBUG so operators investigating "why don't I see my LLM
     tool actions in the audit log?" get a breadcrumb without flooding
@@ -847,7 +847,7 @@ def robot_mesh(
         _audit_tool_action(action, target, False, f"rate_limit: {rl_err}")
         return _err(rl_err)
 
-    # R8-7: parse + validate any command body BEFORE the HITL interrupt so
+    # Parse + validate any command body BEFORE the HITL interrupt so
     # the operator never approves an action the validator then rejects
     # (which would burn an audit "operator approved" record and a
     # rate-limit slot for an action that never ran). This applies to
@@ -929,7 +929,7 @@ def robot_mesh(
             if _fleet_wide
             else f"Physical effect on peer '{target}'. Reply 'y' to approve, anything else to deny."
         )
-        # R8-7: surface the validated command (post-validation form) so the
+        # Surface the validated command (post-validation form) so the
         # operator approves what will actually dispatch, not the raw LLM
         # string. tell/stop/emergency_stop have no JSON command body.
         _approval_command = (
@@ -1093,7 +1093,9 @@ def robot_mesh(
         # above (so the operator approves the validated form). Reuse that
         # result rather than re-parsing the LLM string a second time.
         if validated_send_cmd is None:
-            raise RuntimeError("send reached its handler without pre-validation -- R8-7 contract broken")
+            raise RuntimeError(
+                "send reached its handler without pre-validation -- validate-before-HITL contract broken"
+            )
         cmd = validated_send_cmd
         try:
             result = mesh.send(target, cmd, timeout=timeout)
@@ -1105,13 +1107,15 @@ def robot_mesh(
 
     # ── action: broadcast ─────────────────────────────────────────────────
     if action == "broadcast":
-        # R8-7: pre-validated above before the HITL interrupt fired, so
+        # Pre-validated above before the HITL interrupt fired, so
         # the cmd here is already a clean validated dict.
         # Use explicit raise (not assert) -- assert is stripped under
         # ``python -O`` / ``PYTHONOPTIMIZE=1`` which would silently send
         # an unvalidated cmd to mesh.broadcast.
         if validated_broadcast_cmd is None:
-            raise RuntimeError("broadcast reached its handler without pre-validation -- R8-7 contract broken")
+            raise RuntimeError(
+                "broadcast reached its handler without pre-validation -- validate-before-HITL contract broken"
+            )
         cmd = validated_broadcast_cmd
         try:
             results = mesh.broadcast(cmd, timeout=timeout)

--- a/tests/test_source_strings_no_review_archaeology.py
+++ b/tests/test_source_strings_no_review_archaeology.py
@@ -19,9 +19,12 @@ rejects these review-archaeology shapes:
   * ``review <module>.py:<line>`` (a review citation carrying a rot-prone
     internal source-location back-pointer),
   * review-*round* provenance -- ``review [feedback] round N`` and a PR/issue
-    number narrating a ``round N`` (e.g. ``#168 round 38``, ``#175 round 46d``).
-    Which review pass produced a change is exactly the provenance that belongs
-    in git history, not the source; the number rots and misdirects the reader.
+    number narrating a ``round N`` (e.g. ``#168 round 38``, ``#175 round 46d``),
+    plus the *compact* tags for the same thing: ``R<round>-<item>`` (``R7-5``,
+    ``R8-7``) and a PR/issue number followed by ``R<round>`` (``PR-224 R1``,
+    ``PR#221 R3``, ``#317 R3``). Which review pass produced a change is exactly
+    the provenance that belongs in git history, not the source; the number rots
+    and misdirects the reader.
 
 References to *upstream* files (e.g. ``run_mujoco_gear_wbc.py:47-50``) and to
 stable, named anchors (``AGENTS.md > Review Learnings``, a bare issue number
@@ -51,6 +54,12 @@ import strands_robots
 #     PR review pass that produced a change. The flattener strips the ``#`` of a
 #     ``#NNN`` PR reference, so ``#168 round 38`` arrives here as ``168 round
 #     38`` and is caught by the digits-prefixed alternative.
+#   * ``R<round>-<item>`` (``R7-5``) and ``<digits> R<round>`` -- the compact
+#     spelling of the same review-round provenance. The ``R`` is matched
+#     case-sensitively via ``(?-i:R)`` so lowercase prose (``3 revisions``) is
+#     never mistaken for a round tag; after the flattener strips ``#``/``PR``,
+#     ``PR#221 R3`` and ``#317 R3`` arrive as ``221 R3`` / ``317 R3`` and are
+#     caught by the ``<digits> R<round>`` alternative.
 # Upstream ``<file>.py:<line>`` references (not preceded by ``review``), named
 # anchors like ``Review Learnings``, and bare issue numbers are not matched.
 _REVIEW_ARCHAEOLOGY = re.compile(
@@ -60,6 +69,8 @@ _REVIEW_ARCHAEOLOGY = re.compile(
     r"|\breview\s+[A-Za-z_][A-Za-z0-9_]*\.py:\d+"
     r"|review\s+(?:feedback\s+)?round\s+\d+"
     r"|\b\d+\s+round\s+\d+[a-z]?\b"
+    r"|\b(?-i:R)\d+-\d+\b"
+    r"|\b\d+\s+(?-i:R)\d+\b"
     r")"
 )
 
@@ -110,6 +121,11 @@ def test_review_round_provenance_is_matched() -> None:
         "175 round 46d body-name",  # was "#175 round 46d ..."
         "See review feedback round 4 (symlink-swap defence).",
         "review round 2",
+        "R7-5: a swallowed exception means a broken audit path",  # compact round-item
+        "reached its handler without pre-validation -- R8-7 contract broken",
+        "and _load_acl_file. Addressed in PR-224 R1.",
+        "PR 221 R3 (issue 238): the seq lockfile is a symlink",  # was "PR#221 R3"
+        "default localhost:8000 ( 317 R3)",  # was "(#317 R3)"
     ]
     for text in offenders:
         assert _REVIEW_ARCHAEOLOGY.search(text), f"should be flagged: {text!r}"
@@ -124,6 +140,11 @@ def test_legitimate_references_are_not_matched() -> None:
         "round-trip the dataset and assert it is non-empty",
         "round the value to the nearest integer",
         "the first round of IK refinement converges quickly",  # 'round' without digits
+        "R2-D2",  # 'R<n>-<n>' needs a digit after the dash; D2 is not one
+        "range R1-R5 of the sweep",  # dash followed by 'R', not a digit
+        "resolve to localhost:8000 by default",  # bare port, no round tag
+        "step 3 runs 5 revisions",  # lowercase 'r', not the uppercase round tag
+        "the SO-101 arm has 6 joints",  # digit-dash-digit but no leading 'R'
     ]
     for text in allowed:
         assert not _REVIEW_ARCHAEOLOGY.search(text), f"false positive: {text!r}"


### PR DESCRIPTION
## Problem
The review-archaeology guard (`tests/test_source_strings_no_review_archaeology.py`) rejects narration of *which review pass* produced a change - `review round N`, `#168 round 38` - because that provenance rots (the round number is meaningless the moment it lands) and belongs in git history, not the source. But the same provenance also gets written in a **compact** notation the scan never caught, and eleven such tags had accumulated across the package:

| shape | examples | files |
|---|---|---|
| `R<round>-<item>` | `R7-5`, `R8-7` | `tools/robot_mesh.py` |
| `PR/#<num> R<round>` | `PR-224 R1`, `PR#221 R3`, `#317 R3`, `PR #228 R5` | `mesh/session.py`, `mesh/audit.py`, `mesh/iot/provision.py`, `registry/policies.py` |

These read like an internal contract name (`R8-7 contract broken`) but are just round-pass bookmarks - a reader can't resolve `R8-7` to anything, and the rationale each comment carries stands on its own without it.

## Change
- Extend `_REVIEW_ARCHAEOLOGY` with two alternatives: `\b(?-i:R)\d+-\d+\b` (compact round-item) and `\b\d+\s+(?-i:R)\d+\b` (PR/issue number + `R<round>`, matched after the existing `#`/`PR` flattener). The `R` is matched **case-sensitively** via `(?-i:R)` so lowercase prose (`3 revisions`, `the first round`) is never mistaken for a round tag.
- Strip the eleven escaped tags from the package sources, preserving each comment's WHY and any stable issue-number anchor (`#238`, `#253`, `#317` - bare issue numbers remain allowed per the existing convention). The two `RuntimeError` messages in `robot_mesh.py` now name the contract they describe (`validate-before-HITL contract broken`) instead of the round tag.

## Tests
- `test_review_round_provenance_is_matched` gains the five real pre-fix strings (`R7-5 ...`, `R8-7 contract broken`, `PR-224 R1`, `PR 221 R3`, `317 R3`).
- `test_legitimate_references_are_not_matched` pins the false-positive boundary: `R2-D2`, `range R1-R5`, `localhost:8000`, `step 3 runs 5 revisions`, `SO-101` all stay clean.
- Verified fail-pre-fix: the extended guard flags all eleven offenders when run against the pre-cleanup sources, and passes after.
- Full local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` -> no issues in 807 files, and the suite passes (10897 passed, 196 skipped) headless under `MUJOCO_GL=egl`.

No behavior change - comments, docstrings, and two error-message strings only.