### PR TITLE
test(policies/lerobot_local): pin RTC action_names backfill from policy config

### DIFF
--- a/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
+++ b/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
@@ -278,3 +278,48 @@ def test_relative_action_falls_back_when_reanchor_helper_unavailable(make_stub, 
     prev = captured[1]
     assert prev is not None
     assert torch.allclose(prev, leftover_model)
+
+
+@_requires_reanchor
+def test_resolve_rtc_rebase_backfills_action_names_from_policy_config():
+    # A RelativeActionsProcessorStep that was serialized without action_names
+    # (action_names is None) cannot build the per-joint relative mask, so the
+    # re-anchor would convert the wrong action dimensions. _resolve_rtc_rebase_steps
+    # must backfill the layout from the policy config's action_feature_names -
+    # the same fallback LeRobot's RTCInferenceEngine applies - before wiring the
+    # step in as the re-anchor source.
+    names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
+    relative_step = RelativeActionsProcessorStep(enabled=True, action_names=None)
+    policy, _ = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[relative_step]),
+        postprocessor=DataProcessorPipeline(steps=[IdentityProcessorStep()]),
+    )
+    # The fixture's inner policy exposes config.action_feature_names == names.
+    assert relative_step.action_names is None
+
+    policy._resolve_rtc_rebase_steps()
+
+    assert policy._rtc_relative_step is relative_step
+    assert policy._rtc_reanchor_fn is not None
+    # Backfilled from config so the joint mask can be built for re-anchoring.
+    assert relative_step.action_names == names
+
+
+@_requires_reanchor
+def test_resolve_rtc_rebase_leaves_action_names_unset_without_config_layout():
+    # When the policy config carries no action_feature_names either, there is
+    # nothing to backfill from: the relative step keeps action_names is None
+    # (LeRobot builds an all-joints mask in that case) yet the step is still
+    # resolved as the re-anchor source rather than being silently dropped.
+    relative_step = RelativeActionsProcessorStep(enabled=True, action_names=None)
+    policy, _ = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[relative_step]),
+        postprocessor=DataProcessorPipeline(steps=[IdentityProcessorStep()]),
+    )
+    policy._policy.config.action_feature_names = None
+
+    policy._resolve_rtc_rebase_steps()
+
+    assert policy._rtc_relative_step is relative_step
+    assert policy._rtc_reanchor_fn is not None
+    assert relative_step.action_names is None


### PR DESCRIPTION
## Problem

A `RelativeActionsProcessorStep` can be deserialized without `action_names` (i.e. `action_names is None`). In that state it cannot build the per-joint relative mask, so if it were used verbatim the RTC re-anchor would convert the wrong action dimensions at the chunk seam.

`LerobotLocalPolicy._resolve_rtc_rebase_steps` already handles this by backfilling the layout from the policy config's `action_feature_names` - the same fallback LeRobot's `RTCInferenceEngine` applies - before wiring the relative step in as the re-anchor source. That backfill branch was previously unexercised: every existing test constructed the step with explicit `action_names`, so the `action_names is None` path (and its no-config-layout negative) had no regression guard.

## Change

Adds two focused regression tests to `test_rtc_relative_reanchor.py`, reusing the existing `_make_rtc_policy` fixture:

- `test_resolve_rtc_rebase_backfills_action_names_from_policy_config` - a relative step with `action_names=None` gets its layout backfilled from `config.action_feature_names`, and the step is resolved as the re-anchor source.
- `test_resolve_rtc_rebase_leaves_action_names_unset_without_config_layout` - when the config carries no `action_feature_names` either, `action_names` stays `None` (LeRobot then builds an all-joints mask) yet the step is still resolved rather than silently dropped.

Both are gated behind the existing `@_requires_reanchor` skip so they are meaningful only when the installed lerobot ships `reanchor_relative_rtc_prefix`.

## Verification

Test-only change; no production code touched. `LerobotLocalPolicy.policy` module coverage improves from 96.9% to 97.4% (the `1516-1519` backfill cluster is now covered). Full local gate green: `ruff check`, `ruff format --check`, `mypy` clean; `MUJOCO_GL=egl` full suite passes (10901 passed, 203 skipped) at 93.15% total coverage.