### PR TITLE
docs(registry): cross-reference sibling modules by :mod: not filename

### DIFF
--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -3,7 +3,7 @@
 Loads robot definitions and policy provider configs from JSON files.
 
 Features:
-    - **One file to edit**: Add a robot → edit robots.json, done.
+    - **One file to edit**: Add a robot -> edit robots.json, done.
     - **Hot-reload**: JSON is re-read when the file changes (mtime check).
     - **Self-contained entries**: Each robot/policy owns its aliases,
       shorthands, and URL patterns - no separate lookup tables.
@@ -16,17 +16,21 @@ Usage::
     from strands_robots.registry import get_policy_provider, resolve_policy
 
     info = get_robot("so100")
-    name = resolve_name("franka") # → "panda"
+    name = resolve_name("franka")  # -> "panda"
     providers = list_policy_providers()
 
-Architecture:
-    registry/
-        __init__.py      ← this file (re-exports only)
-        loader.py        ← JSON loading + mtime hot-reload + validation
-        robots.py        ← robot query/resolve/list functions
-        policies.py      ← policy resolve/import/kwargs functions
-        robots.json      ← robot definitions (aliases inside each entry)
-        policies.json    ← policy providers (shorthands/urls inside each entry)
+Architecture (this package re-exports the public API of its sibling modules):
+    - :mod:`~strands_robots.registry.loader` - JSON loading + mtime hot-reload
+      + validation.
+    - :mod:`~strands_robots.registry.robots` - robot query/resolve/list functions.
+    - :mod:`~strands_robots.registry.policies` - policy resolve/import/kwargs
+      functions.
+    - :mod:`~strands_robots.registry.discovery` - robot_descriptions
+      auto-discovery of installed robot models.
+    - :mod:`~strands_robots.registry.user_registry` - user-defined robot
+      register/unregister persisted to disk.
+    - ``robots.json`` - robot definitions (aliases inside each entry).
+    - ``policies.json`` - policy providers (shorthands/urls inside each entry).
 """
 
 from .discovery import (

--- a/tests/registry/test_docstring_module_xrefs.py
+++ b/tests/registry/test_docstring_module_xrefs.py
@@ -1,0 +1,66 @@
+"""Registry modules must cross-reference sibling code by module, never by
+source filename.
+
+Referencing a source file (``loader.py``, ``robots.py``, ...) in a docstring is
+documentation archaeology: the name breaks silently the moment a file is
+renamed or split, and it points a reader at a path instead of an importable
+symbol. The project convention (shared with
+:mod:`strands_robots.policies` and the MuJoCo backend, guarded by
+``tests/policies/test_docstring_module_xrefs.py`` and
+``tests/simulation/mujoco/test_docstring_module_xrefs.py``) is to use Sphinx
+cross-reference roles - ``:mod:``, ``:class:``, ``:func:`` - that name the
+actual API object, so the reference is checkable and survives refactors.
+
+This guard walks every module/class/function docstring in the top-level
+``strands_robots.registry`` modules (``__init__.py``, ``loader.py``,
+``robots.py``, ``policies.py``, ``discovery.py``, ``user_registry.py``) and
+fails if any embeds a ``<something>.py`` filename token. Data files
+(``robots.json``, ``policies.json``) are exempt: they are payload, not
+importable modules, and cannot be named with a ``:mod:`` role.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.registry as registry_pkg
+
+# A bare source-filename token such as ``loader.py`` or ``robots.py``.
+_FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(registry_pkg.__file__).parent
+
+
+def _docstrings_with_offenders() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> filename tokens found in that docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = _FILENAME_RE.findall(doc)
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_registry_modules_scanned() -> None:
+    """Guard: the scan actually walked the top-level registry modules."""
+    scanned = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+    assert {"__init__.py", "loader.py", "robots.py", "policies.py"} <= scanned
+
+
+def test_registry_docstrings_reference_modules_not_filenames() -> None:
+    offenders = _docstrings_with_offenders()
+    assert not offenders, (
+        "Registry docstrings must cross-reference siblings by module "
+        "(:mod:`~strands_robots.registry.loader`) not source filename "
+        f"(``loader.py``). Offending docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Problem
The `strands_robots.registry` package docstring documented its architecture with a source-file tree:

```
Architecture:
    registry/
        __init__.py      <- this file (re-exports only)
        loader.py        <- JSON loading + mtime hot-reload + validation
        robots.py        <- robot query/resolve/list functions
        policies.py      <- policy resolve/import/kwargs functions
```

Naming a source file in a docstring is documentation archaeology: the reference breaks silently the moment a file is renamed or split, and it points a reader at a path instead of an importable symbol. The project already guards against this in `strands_robots.policies` and the MuJoCo backend (`tests/policies/test_docstring_module_xrefs.py`, `tests/simulation/mujoco/test_docstring_module_xrefs.py`) but the `registry` package had no such guard and carried four filename citations.

## Change
- Replace the filename tree in `registry/__init__.py` with Sphinx `:mod:` cross-reference roles that name the actual package modules (`loader`, `robots`, `policies`), and add the `discovery` and `user_registry` modules the package also re-exports. Data files (`robots.json`, `policies.json`) stay as literals since they are payload, not importable modules.
- Normalize two non-ASCII arrows in the docstring to ASCII.
- Add `tests/registry/test_docstring_module_xrefs.py`, mirroring the existing policy/MuJoCo guards: it walks every module/class/function docstring in the top-level registry modules and fails if any embeds a `<name>.py` filename token.

## Tests
The new guard fails on the pre-change docstring:
```
Offending docstrings: {'__init__.py::<module>': ['__init__.py', 'loader.py', 'robots.py', 'policies.py']}
```
and passes after the fix. Full local gate is green: `ruff check`/`ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues (808 files), and `tests/registry/` + the sibling docstring guards pass (538 passed).

No behavior change - docstring + test only.