### PR TITLE
refactor(policies/lerobot_local): drop unreachable rtc_config-is-None branch in _init_rtc

### DIFF
--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1400,17 +1400,16 @@ class LerobotLocalPolicy(Policy):
             logger.debug("RTC disabled for policy '%s'", type(self._policy).__name__)
             return
 
-        # Read RTC parameters from config, with user overrides
-        if rtc_config is not None:
-            if self._rtc_execution_horizon is None:
-                self._rtc_execution_horizon = getattr(rtc_config, "execution_horizon", 10)
-            if self._rtc_max_guidance_weight is None:
-                self._rtc_max_guidance_weight = getattr(rtc_config, "max_guidance_weight", 10.0)
-        else:
-            if self._rtc_execution_horizon is None:
-                self._rtc_execution_horizon = 10
-            if self._rtc_max_guidance_weight is None:
-                self._rtc_max_guidance_weight = 10.0
+        # Read RTC parameters from config, honoring user-provided overrides.
+        # Reaching this point guarantees rtc_config is not None: RTC is only
+        # enabled when a non-None rtc_config was found (see the auto-detect and
+        # explicit-enable branches above), so no rtc_config-is-None fallback is
+        # needed here. getattr still supplies the 10 / 10.0 defaults when the
+        # config object omits the attributes.
+        if self._rtc_execution_horizon is None:
+            self._rtc_execution_horizon = getattr(rtc_config, "execution_horizon", 10)
+        if self._rtc_max_guidance_weight is None:
+            self._rtc_max_guidance_weight = getattr(rtc_config, "max_guidance_weight", 10.0)
 
         logger.info(
             "RTC enabled for '%s': execution_horizon=%d, max_guidance_weight=%.1f",

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1403,6 +1403,52 @@ class TestRTCInit:
             mock_logger.warning.assert_called_once()
         assert policy._rtc_enabled is False
 
+    @pytest.mark.parametrize("rtc_requested", [None, True, False])
+    def test_rtc_never_enabled_without_rtc_config(self, rtc_requested):
+        """RTC must never enable when the policy config has no rtc_config.
+
+        This is the invariant that lets ``_init_rtc`` read RTC parameters off
+        ``rtc_config`` unconditionally once enabled: reaching the parameter
+        block guarantees ``rtc_config is not None``. A ``predict_action_chunk``
+        method alone (present on every lerobot policy base class) must not be
+        enough to turn RTC on for any ``rtc_enabled`` request value.
+        """
+        policy = _make_policy()
+        mock_policy = MagicMock()
+        mock_policy.predict_action_chunk = MagicMock()
+        # config exists but exposes no rtc_config attribute.
+        mock_policy.config = MagicMock(spec=[])
+        policy._policy = mock_policy
+        policy._loaded = True
+        policy._rtc_requested = rtc_requested
+        policy._init_rtc()
+        assert policy._rtc_enabled is False
+        # Parameters stay unresolved (the config-None fallback is gone).
+        assert policy._rtc_execution_horizon is None
+        assert policy._rtc_max_guidance_weight is None
+
+    def test_rtc_params_default_when_config_omits_them(self):
+        """Enabled RTC with an rtc_config lacking the tuning attrs uses 10 / 10.0.
+
+        The rtc_config-is-None fallback was removed because ``getattr`` already
+        supplies these defaults when the config object omits the fields.
+        """
+        policy = _make_policy()
+        mock_policy = MagicMock()
+        mock_policy.predict_action_chunk = MagicMock()
+        # rtc_config present and enabled, but WITHOUT execution_horizon /
+        # max_guidance_weight attributes.
+        rtc_cfg = MagicMock(spec=["enabled"])
+        rtc_cfg.enabled = True
+        mock_policy.config.rtc_config = rtc_cfg
+        policy._policy = mock_policy
+        policy._loaded = True
+        policy._rtc_requested = None  # auto-detect
+        policy._init_rtc()
+        assert policy._rtc_enabled is True
+        assert policy._rtc_execution_horizon == 10
+        assert policy._rtc_max_guidance_weight == 10.0
+
 
 class TestRTCConfigSchemaContract:
     """Pin RTC config-reading against lerobot's REAL ``RTCConfig`` schema.


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._init_rtc` reads the RTC tuning parameters through a `if rtc_config is not None: ... else: ...` guard:

```python
if rtc_config is not None:
    if self._rtc_execution_horizon is None:
        self._rtc_execution_horizon = getattr(rtc_config, "execution_horizon", 10)
    if self._rtc_max_guidance_weight is None:
        self._rtc_max_guidance_weight = getattr(rtc_config, "max_guidance_weight", 10.0)
else:
    if self._rtc_execution_horizon is None:
        self._rtc_execution_horizon = 10
    if self._rtc_max_guidance_weight is None:
        self._rtc_max_guidance_weight = 10.0
```

The `else` branch is unreachable. `_init_rtc` only sets `_rtc_enabled = True` when a non-None `rtc_config` was found:

- auto-detect (`rtc_enabled=None`): `self._rtc_enabled = rtc_config is not None and getattr(rtc_config, "enabled", False)`
- explicit enable (`rtc_enabled=True`): disables and returns when `rtc_config is None`, only enables in the `else` where `rtc_config` is not None.

So once execution passes the `if not self._rtc_enabled: return` guard, `rtc_config` is always not None, and the `else` never runs. It is also redundant: `getattr(rtc_config, "execution_horizon", 10)` already yields the exact `10` / `10.0` defaults the dead branch hard-coded.

## Change

Read the RTC parameters unconditionally off `rtc_config` and drop the dead `else`. Behavior is identical; this only removes unreachable code and the two silent hard-coded defaults that duplicated the `getattr` fallbacks.

## Tests

Added to `TestRTCInit`:

- `test_rtc_never_enabled_without_rtc_config` (parametrized over `rtc_enabled` in `None`/`True`/`False`) pins the enabling invariant that makes the removed branch unreachable: a `predict_action_chunk` method alone never turns RTC on when the config has no `rtc_config`, and the parameters stay unresolved.
- `test_rtc_params_default_when_config_omits_them` pins that an enabled `rtc_config` lacking `execution_horizon` / `max_guidance_weight` resolves to `10` / `10.0` via the `getattr` fallbacks (the behavior the deleted branch duplicated).

Full `lerobot_local` suite: 567 passed. Lint + `mypy strands_robots tests tests_integ` clean.

No runtime behavior change (pure resolution logic; dead-branch removal), so no rollout/render artifact applies.