### PR TITLE
docs(sim/isaac): cross-reference procedural builders by :mod: not filename

### DIFF
--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -2,7 +2,8 @@
 
 Follow-up to the R7 Phase 1 procedural-builder slice (PR #46): instead of
 hardcoding ``_build_so100`` / ``_build_panda`` / ``_build_unitree_g1`` in
-``procedural.py``, drive the same ``ProceduralRobot`` dataclass from existing
+:mod:`strands_robots.simulation.isaac.procedural`, drive the same
+``ProceduralRobot`` dataclass from existing
 robot description files (URDF, MJCF, USD) so the code path becomes a generic
 loader rather than a per-robot Python builder.
 

--- a/tests/simulation/isaac/test_docstring_module_xrefs.py
+++ b/tests/simulation/isaac/test_docstring_module_xrefs.py
@@ -1,0 +1,69 @@
+"""Isaac backend modules must cross-reference sibling code by module, never by
+source filename.
+
+Referencing an internal sibling by its source file (``procedural.py``,
+``loaders.py``, ...) in a docstring is documentation archaeology: the name
+breaks silently the moment a file is renamed or split, and it points a reader
+at a path instead of an importable symbol. The project convention (see the
+top-level simulation guard, ``tests/simulation/test_docstring_module_xrefs.py``,
+and the MuJoCo backend guard) is to use Sphinx cross-reference roles -
+``:mod:``, ``:class:``, ``:func:`` - that name the actual API object, so the
+reference is checkable and survives refactors.
+
+This guard walks every module/class/function docstring in the
+``strands_robots.simulation.isaac`` package modules and fails if any embeds a
+``<name>.py`` token that names a real sibling module in the package directory.
+The scan is intentionally restricted to sibling filenames: Isaac modules
+legitimately cite *upstream* reference scripts by filename (Isaac Lab / Isaac
+Sim standalone scripts), which name real files in other repositories and are
+not internal siblings.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.simulation.isaac as isaac_pkg
+
+# A bare source-filename token such as ``procedural.py`` or ``loaders.py``.
+_FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(isaac_pkg.__file__).parent
+
+# The set of real sibling modules. Only filename tokens naming one of these are
+# internal archaeology; anything else is an external upstream file.
+_SIBLING_MODULES = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+
+
+def _docstrings_with_offenders() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> sibling filename tokens found in that docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = [h for h in _FILENAME_RE.findall(doc) if h in _SIBLING_MODULES]
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_isaac_modules_scanned() -> None:
+    """Guard: the scan actually walked the Isaac package modules."""
+    assert {"loaders.py", "procedural.py", "simulation.py"} <= _SIBLING_MODULES
+
+
+def test_isaac_docstrings_reference_modules_not_filenames() -> None:
+    offenders = _docstrings_with_offenders()
+    assert not offenders, (
+        "Isaac backend docstrings must cross-reference siblings by module "
+        "(:mod:`strands_robots.simulation.isaac.procedural`) not source filename "
+        f"(``procedural.py``). Offending docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Problem

The `strands_robots.simulation.isaac.loaders` module docstring cited its sibling procedural builders as ``procedural.py`` -- a source-filename reference. That is documentation archaeology: the name breaks silently the moment the file is renamed or split, and it points a reader at a path instead of an importable symbol. The same docstring already names the module correctly as `:mod:`strands_robots.simulation.isaac.procedural`` a few lines further down, so the two references were inconsistent.

The existing docstring-xref guards cover the top-level `simulation`, `mujoco` backend, `policies`, `registry`, `tools`, `training`, `mesh`, and `assets` packages, but the `simulation.isaac` package had no equivalent guard, so this slipped through.

## Change

- Replace the ``procedural.py`` token in the `loaders` module docstring with the `:mod:` cross-reference already used elsewhere in the same docstring.
- Add `tests/simulation/isaac/test_docstring_module_xrefs.py`, the Isaac-package counterpart to `tests/simulation/test_docstring_module_xrefs.py`. It walks every module/class/function docstring in the isaac package and fails on any ``<name>.py`` token that names a **real sibling module** in the package directory, while intentionally leaving legitimate upstream script filenames (Isaac Lab / Isaac Sim standalone scripts) alone.

## Verification

- Regression guard confirmed: on the pre-fix docstring the guard fails with `{'loaders.py::<module>': ['procedural.py']}`; after the fix it passes.
- `tests/simulation/isaac/`: 79 passed.
- All docstring-xref guards across the repo: 19 passed.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean.

Docs + test-only change; no library behavior is modified.