### PR TITLE
test(benchmarks/libero): cover the mujoco import guard in _LiberoOSCController.from_sim

### DIFF
--- a/tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py
+++ b/tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py
@@ -32,6 +32,7 @@ the true binding API.
 
 from __future__ import annotations
 
+import builtins
 import sys
 import types
 
@@ -214,6 +215,68 @@ class TestFromSimDependencyClassification:
         # Must be the base class, not the degrade-gracefully subclass.
         assert not isinstance(exc.value, _ControllerDependencyMissing)
         assert "coverage" in str(exc.value).lower()
+
+
+def _force_mujoco_import_error(monkeypatch, exc: BaseException):
+    """Make ``import mujoco`` (and only that import) raise ``exc``.
+
+    ``from_sim`` imports mujoco lazily as its very first step, before it ever
+    touches robosuite or the sim, so overriding ``builtins.__import__`` for the
+    single ``"mujoco"`` name exercises the mujoco dependency-classification
+    guard while leaving every other import untouched. This is the mujoco-side
+    analogue of ``_install_fake_robosuite`` above: mujoco is installed on this
+    image, so the guard's failure branches are otherwise unreachable.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mujoco":
+            raise exc
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+class TestFromSimMujocoImportClassification:
+    """The lazy ``import mujoco`` in from_sim runs before robosuite and must
+    classify its own failures the same way (#522): a genuinely-absent mujoco
+    degrades gracefully, but the numba/coverage>=7 clash is a fixable setup bug
+    the caller surfaces strictly rather than silently dropping every action."""
+
+    def test_missing_mujoco_degrades_as_dependency_missing(self, monkeypatch):
+        """mujoco truly absent (``ModuleNotFoundError``) -> the degrade-
+        gracefully subclass, since mujoco is an optional sim dependency."""
+        _force_mujoco_import_error(monkeypatch, ModuleNotFoundError("No module named 'mujoco'"))
+
+        with pytest.raises(_ControllerDependencyMissing, match="mujoco not available"):
+            _from_sim(_StubSim(None))
+
+    def test_mujoco_numba_coverage_clash_surfaces_as_install_error(self, monkeypatch):
+        """A mujoco ``ImportError`` carrying the coverage.types/Tracer signature
+        is the #522 clash: raise the base _ControllerInstallError, NOT the
+        degrade-gracefully subclass, so strict mode surfaces it."""
+        _force_mujoco_import_error(
+            monkeypatch,
+            ImportError("module 'coverage.types' has no attribute 'Tracer'"),
+        )
+
+        with pytest.raises(_ControllerInstallError) as exc:
+            _from_sim(_StubSim(None))
+        # Must be the base class, not the degrade-gracefully subclass.
+        assert not isinstance(exc.value, _ControllerDependencyMissing)
+        assert "clash" in str(exc.value).lower()
+
+    def test_other_mujoco_import_error_degrades_as_dependency_missing(self, monkeypatch):
+        """A mujoco ``ImportError`` that is NOT the clash (e.g. a broken native
+        extension / missing GL backend) is treated as an unavailable optional
+        dep and degrades, not surfaced as a fixable setup bug."""
+        _force_mujoco_import_error(
+            monkeypatch,
+            ImportError("libGL.so.1: cannot open shared object file"),
+        )
+
+        with pytest.raises(_ControllerDependencyMissing, match="mujoco import failed"):
+            _from_sim(_StubSim(None))
 
 
 class TestFromSimSceneValidationGuards:


### PR DESCRIPTION
## Problem

`_LiberoOSCController.from_sim` imports mujoco lazily as its very first step, before it touches robosuite or the sim, and classifies an import failure into one of two contracts (#522):

- a genuinely-absent mujoco (`ModuleNotFoundError`) or a mujoco whose native extension is broken (`ImportError`, e.g. missing GL backend) -> `_ControllerDependencyMissing`, so the caller degrades gracefully (mujoco is an optional sim dependency, not a hard one);
- the known numba / coverage>=7 import clash (`AttributeError: module 'coverage.types' has no attribute 'Tracer'`, re-wrapped as an `ImportError`) -> the base `_ControllerInstallError`, a *fixable* setup bug the caller surfaces strictly instead of silently dropping every GR00T action and scoring `success_rate=0`.

The existing `from_sim` tests only exercise the **robosuite** import guard. Because mujoco is installed on the standard test image, `import mujoco as _mj` always succeeds, so the mujoco guard's three branches were never reached and its dependency-classification contract was unpinned.

## Change

Add `TestFromSimMujocoImportClassification` to `tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py`. A small `_force_mujoco_import_error` helper overrides `builtins.__import__` to raise a chosen exception for the single name `"mujoco"` and delegate every other import to the real one -- the mujoco-side analogue of the existing `_install_fake_robosuite` helper. Because the mujoco import is `from_sim`'s first statement (before the sim is ever read), the guard fires against a bare stub sim. Three tests pin the contract:

- `ModuleNotFoundError` -> `_ControllerDependencyMissing` (degrade);
- `ImportError` carrying the coverage.types/Tracer signature -> `_ControllerInstallError`, asserted **not** to be the degrade-gracefully subclass (surface strictly);
- any other `ImportError` -> `_ControllerDependencyMissing` (degrade).

## Verification

- Regression guard confirmed: changing the clash branch to raise the degrade-gracefully subclass makes `test_mujoco_numba_coverage_clash_surfaces_as_install_error` fail (`assert not isinstance(...)`); the correct classification passes.
- The three previously-uncovered branches of the mujoco import guard in `from_sim` are now covered.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports `Success: no issues found`.
- `tests/benchmarks/libero/`: 429 passed, 28 skipped (MUJOCO_GL=egl, headless).

Test-only change; no library behavior is modified.