### PR TITLE
test(sim/mujoco): pin get_state live-recording progress annotation

### DIFF
--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -1083,3 +1083,50 @@ def test_run_multi_policy_single_robot_records_unnamespaced_columns(tmp_path):
     finally:
         sim.destroy()
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_get_state_reports_live_recording_progress(sim_with_two_robots, tmp_path):
+    """``get_state`` annotates the recorded step count while a recording is live.
+
+    ``Simulation.get_state`` is the human-readable introspection surface an
+    agent polls to monitor a data-collection episode. When a LeRobotDataset
+    recording is active it appends a ``[recording] N steps`` line so the caller
+    can watch the buffer fill mid-rollout; on an idle world that line is absent.
+    The count reflects the trajectory buffer the run_policy hook fills, so it is
+    strictly positive once frames have been rolled out under an active recorder.
+    """
+    import re
+
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_two_robots
+
+    # Idle world: no recording annotation on the state summary.
+    idle = sim.get_state()
+    assert idle["status"] == "success"
+    assert "[recording]" not in idle["content"][0]["text"]
+
+    r = sim.start_recording(repo_id="local/state_progress", fps=20, root=str(tmp_path), overwrite=True)
+    assert r["status"] == "success", r
+
+    from strands_robots.policies.mock import MockPolicy
+
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("alpha"))
+    r = sim.run_policy("alpha", policy_object=policy, duration=0.5, control_frequency=20.0)
+    assert r["status"] == "success", r
+
+    # Recording still active: the summary reports a positive buffered count.
+    active_text = sim.get_state()["content"][0]["text"]
+    match = re.search(r"\[recording\] (\d+) steps", active_text)
+    assert match is not None, active_text
+    assert int(match.group(1)) > 0, active_text
+
+    sim.stop_recording()
+
+    # Back to idle: the annotation is gone once the recording is finalized.
+    done_text = sim.get_state()["content"][0]["text"]
+    assert "[recording]" not in done_text


### PR DESCRIPTION
## Problem

`Simulation.get_state()` is the human-readable introspection surface an agent polls to monitor a data-collection episode. When a LeRobotDataset recording is active it appends a `[recording] N steps` line so the caller can watch the trajectory buffer fill mid-rollout; on an idle world that line is absent.

That recording-progress branch had no test. Every existing `get_state` assertion runs against an idle world, and the recording tests check the finalized dataset (`info.json`, parquet columns) but never poll `get_state` while a recording is live, so the line that renders the progress annotation was uncovered.

## Change

Adds one focused behavioral test to `tests/simulation/mujoco/test_recording_paths.py` that drives the real recorder path (skips without the `lerobot` extra) and asserts the observable contract:

- idle world -> state summary carries no `[recording]` annotation;
- after `start_recording` + a `run_policy` rollout, while recording is still active, the summary reports `[recording] N steps` with a strictly positive `N` (parsed from the rendered text, not read from internal state);
- after `stop_recording`, the annotation is gone.

The assertion parses the rendered text only, so it pins the surface contract rather than implementation details. This closes the parity gap with the Newton backend's discovery/state tests.

## Testing

- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_recording_paths.py` -> 29 passed.
- Confirmed the new test covers the previously-uncovered `get_state` recording-annotation line (absent from term-missing after the addition).
- `ruff check` / `ruff format --check` clean.

Test-only change; no runtime behavior is modified.