### PR TITLE
test(hardware): pin _create_minimal_config lerobot-drift guards

### DIFF
--- a/tests/test_hardware_robot_config.py
+++ b/tests/test_hardware_robot_config.py
@@ -26,6 +26,8 @@ stubbed for the driver-construction branches.
 
 from __future__ import annotations
 
+import dataclasses
+import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -183,3 +185,62 @@ class TestInitializeRobotDispatch:
         hw = _make_robot()
         with pytest.raises(ValueError, match="Unsupported robot type"):
             hw._initialize_robot(12345, None)
+
+
+class TestCreateMinimalConfigDefensiveBranches:
+    """Config-build guards for the ``valid_fields`` / construction seams.
+
+    These pin the actionable-error and observability contracts that protect
+    against lerobot registry drift: a config class that is not a dataclass, a
+    dataclass that drops the ``id`` field while the caller passes an explicit
+    ``id=``, and a config whose construction rejects the assembled kwargs. All
+    three resolve the config class through lerobot's draccus registry, so the
+    resolution is stubbed to inject the drifted class rather than depend on a
+    hypothetical future lerobot build.
+    """
+
+    def test_non_dataclass_config_class_raises_actionable_typeerror(self, monkeypatch):
+        from lerobot.robots.config import RobotConfig
+
+        hw = _make_robot()
+
+        class NotADataclass:
+            """A plain class so ``dataclasses.fields()`` raises ``TypeError``."""
+
+        monkeypatch.setattr(RobotConfig, "get_choice_class", lambda robot_type: NotADataclass)
+        with pytest.raises(TypeError, match="non-dataclass config class"):
+            hw._create_minimal_config("so101_follower", None)
+
+    def test_config_without_id_field_warns_on_explicit_id(self, monkeypatch, caplog):
+        from lerobot.robots.config import RobotConfig
+
+        hw = _make_robot()
+
+        @dataclasses.dataclass
+        class NoIdConfig:
+            cameras: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+        monkeypatch.setattr(RobotConfig, "get_choice_class", lambda robot_type: NoIdConfig)
+        with caplog.at_level(logging.WARNING, logger="strands_robots.hardware_robot"):
+            cfg = hw._create_minimal_config("future_robot", None, id="left_arm")
+
+        # An explicit id= that cannot namespace calibration is surfaced, not dropped.
+        assert isinstance(cfg, NoIdConfig)
+        assert any("does not declare an 'id' field" in rec.getMessage() for rec in caplog.records)
+
+    def test_config_construction_failure_wraps_valueerror(self, monkeypatch):
+        from lerobot.robots.config import RobotConfig
+
+        hw = _make_robot()
+
+        @dataclasses.dataclass
+        class ExplodingConfig:
+            id: str = ""
+            cameras: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+            def __post_init__(self) -> None:
+                raise ValueError("post-init rejected the assembled config")
+
+        monkeypatch.setattr(RobotConfig, "get_choice_class", lambda robot_type: ExplodingConfig)
+        with pytest.raises(ValueError, match="Failed to construct ExplodingConfig"):
+            hw._create_minimal_config("so101_follower", None)


### PR DESCRIPTION
## What

Adds three behavior tests pinning the previously-unexercised defensive branches in `Robot._create_minimal_config` (`strands_robots/hardware_robot.py`) that protect against lerobot draccus-registry drift.

## Why

`_create_minimal_config` resolves a robot's config dataclass through lerobot's draccus `ChoiceRegistry` and filters kwargs against `dataclasses.fields(...)`. Three guards on that seam had no test coverage, so a regression in any of them (e.g. a future lerobot returning a non-dataclass, or dropping the `id` field) would have gone unnoticed until it surfaced as a confusing runtime failure:

- a resolved config class that is **not a dataclass** must raise an actionable `TypeError` naming the `robot_type` (the `dataclasses.fields` guard), not blindly forward every kwarg;
- a config dataclass that **drops the `id` field** while the caller passes an explicit `id=` must **warn** (the explicit id cannot namespace calibration files) rather than silently discard it;
- a config whose **construction rejects the assembled kwargs** must be wrapped in a `ValueError` naming the class, robot type, and config.

## How

The tests reuse the existing `_make_robot()` double (built via `__new__`, no hardware) and stub `RobotConfig.get_choice_class` to inject the drifted config class, so the guards are exercised deterministically without depending on a hypothetical future lerobot build. No serial/USB hardware is touched.

## Coverage

`strands_robots/hardware_robot.py`: **95% -> 96%** (28 -> 22 missing lines) across the hardware test suite.

## Test plan

```
ruff check strands_robots tests tests_integ      # clean
ruff format --check strands_robots tests tests_integ  # clean
mypy strands_robots tests tests_integ            # Success: no issues found
pytest tests/test_hardware_robot_config.py       # 15 passed
```

Test-only change; no runtime code modified.