### PR TITLE
test(policies/vera): guard docstrings against bare sibling-filename xrefs

### DIFF
--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -7,7 +7,8 @@ rotation) plus an optional gripper column. MuJoCo arm actuators are commanded in
 Cartesian *delta* onto an absolute target pose and solves it to joint angles.
 
 This module is **copied** from (and intentionally independent of) the cosmos3
-``sim_ik.py``: the cosmos3 version decodes an *absolute* EE pose trajectory
+IK bridge, :mod:`~strands_robots.policies.cosmos3.sim_ik`: that module decodes
+an *absolute* EE pose trajectory
 (translation + rot6d) for its in-process diffusers backend, whereas VERA emits
 *relative* deltas. Copying (rather than sharing) keeps the two providers'
 kinematics decoupled - a change to one model's action semantics can never

--- a/tests/policies/vera/test_docstring_module_xrefs.py
+++ b/tests/policies/vera/test_docstring_module_xrefs.py
@@ -1,0 +1,94 @@
+"""VERA provider modules must cross-reference sibling code by module, never by a
+bare source filename.
+
+Referencing an internal sibling by its source file (``sim_ik.py``,
+``client.py``, ...) in a docstring is documentation archaeology: the name breaks
+silently the moment a file is renamed or split, and it points a reader at a path
+instead of an importable symbol. It is also ambiguous here - the VERA provider
+mirrors several ``cosmos3`` siblings that share a basename (both packages ship a
+``sim_ik.py`` and a ``_msgpack_numpy.py``), so a bare ``sim_ik.py`` cannot tell
+the reader whether the VERA or the cosmos3 module is meant. The project
+convention (see :mod:`tests.simulation.mujoco.test_docstring_module_xrefs` and
+the Isaac backend guard) is to use Sphinx cross-reference roles - ``:mod:``,
+``:class:``, ``:func:`` - that name the actual API object, so the reference is
+checkable and survives refactors.
+
+This guard walks every module/class/function docstring in the
+``strands_robots.policies.vera`` package and fails if any embeds a *bare*
+``<name>.py`` token that names a real sibling module in the package directory.
+
+The scan is deliberately restricted twice over:
+
+* **Sibling filenames only.** VERA modules legitimately cite *upstream*
+  reference scripts by filename (openpi / DreamZero server scripts) that name
+  real files in other repositories and are not internal siblings.
+* **Bare tokens only.** A path-qualified reference such as
+  ``vera/server/protocol/_msgpack_numpy.py`` names the external VERA server file
+  and is unambiguous even though its basename collides with a local sibling, so
+  it is not flagged.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.policies.vera as vera_pkg
+
+# A bare source-filename token (``sim_ik.py``) - but NOT one that is part of a
+# longer path (``.../protocol/_msgpack_numpy.py``) or a dotted attribute, which
+# the negative lookbehind for ``/``, ``.`` and word chars excludes.
+_FILENAME_RE = re.compile(r"(?<![\w/.])[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(vera_pkg.__file__).parent
+
+# Real sibling modules. Only bare filename tokens naming one of these are
+# internal archaeology; anything else is an external upstream file.
+_SIBLING_MODULES = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+
+
+def _docstrings_with_offenders() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> bare sibling filename tokens in that docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = [h for h in _FILENAME_RE.findall(doc) if h in _SIBLING_MODULES]
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_vera_modules_scanned() -> None:
+    """Guard: the scan actually walked the VERA package modules."""
+    assert {"sim_ik.py", "client.py", "provider.py"} <= _SIBLING_MODULES
+
+
+def test_path_qualified_upstream_reference_is_not_flagged() -> None:
+    """A path-qualified external ref keeps its basename off the offender list."""
+    doc = "Mirrors ``vera/server/protocol/_msgpack_numpy.py`` (openpi port)."
+    hits = [h for h in _FILENAME_RE.findall(doc) if h in _SIBLING_MODULES]
+    assert hits == []
+
+
+def test_bare_sibling_reference_would_be_flagged() -> None:
+    """A bare sibling token is exactly what the guard is meant to catch."""
+    doc = "Copied from the cosmos3 ``sim_ik.py``."
+    hits = [h for h in _FILENAME_RE.findall(doc) if h in _SIBLING_MODULES]
+    assert hits == ["sim_ik.py"]
+
+
+def test_vera_docstrings_reference_modules_not_filenames() -> None:
+    offenders = _docstrings_with_offenders()
+    assert not offenders, (
+        "VERA docstrings must cross-reference siblings by module "
+        "(:mod:`~strands_robots.policies.cosmos3.sim_ik`) not a bare source "
+        f"filename (``sim_ik.py``). Offending docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Problem

The `strands_robots.policies.vera.sim_ik` module docstring cited the cosmos3 IK bridge as a bare ``sim_ik.py`` filename:

> This module is **copied** from (and intentionally independent of) the cosmos3 ``sim_ik.py``: ...

Both the `vera` and `cosmos3` provider packages ship a `sim_ik.py` (and a `_msgpack_numpy.py`). A bare filename token is therefore ambiguous - a reader cannot tell whether the local VERA module or the cosmos3 one is meant - and it breaks silently the moment a file is renamed or split. That is exactly the documentation archaeology the `:mod:`/`:class:`/`:func:` cross-reference convention (already guarded for the Isaac and MuJoCo backends) exists to prevent.

## Change

- Cite the cosmos3 module explicitly: ``:mod:`~strands_robots.policies.cosmos3.sim_ik` `` instead of the bare ``sim_ik.py``.
- Add a package-scoped docstring guard `tests/policies/vera/test_docstring_module_xrefs.py`, mirroring the existing Isaac backend guard, that walks every module/class/function docstring in `strands_robots.policies.vera` and fails if any embeds a bare `<name>.py` token naming a real sibling module.

The vera guard is deliberately restricted twice over so it does not produce false positives:

- **Sibling filenames only** - VERA modules legitimately cite upstream reference scripts (openpi / DreamZero) by filename; those are not internal siblings.
- **Bare tokens only** - a path-qualified reference such as ``vera/server/protocol/_msgpack_numpy.py`` names the external VERA server file and is unambiguous even though its basename collides with a local sibling, so it is left untouched. This is enforced with a negative lookbehind (`(?<![\w/.])`) that the two dedicated regex tests pin.

## Tests

Regression: `test_vera_docstrings_reference_modules_not_filenames` fails on the pre-fix docstring with `{'sim_ik.py::<module>': ['sim_ik.py']}` and passes after the fix. Two focused regex tests pin the path-qualified-is-allowed / bare-is-flagged behavior.

```
MUJOCO_GL=egl pytest tests/policies/vera/ tests/policies/test_docstring_module_xrefs.py
166 passed, 1 skipped
```

`hatch run lint` (ruff check + ruff format --check + mypy over `strands_robots tests tests_integ`): `Success: no issues found in 814 source files`.

Docs-and-test only; no runtime behavior change.