### PR TITLE
test(sim/mujoco): pin teardown robustness to a renderer close() failure

### DIFF
--- a/tests/simulation/mujoco/test_renderer_hygiene.py
+++ b/tests/simulation/mujoco/test_renderer_hygiene.py
@@ -107,3 +107,48 @@ class TestRendererCacheBounding:
 
         assert (first_w, first_h) not in sim._renderer_tls.renderers
         assert close_calls == [1], "evicted renderer must have close() called exactly once"
+
+
+@requires_gl
+class TestRendererTeardownRobustness:
+    """Teardown must always complete even if a cached renderer's ``close()``
+    raises. ``destroy()``/``cleanup()`` close every main-thread renderer before
+    nulling ``self._world`` and shutting the executor down; if one renderer's
+    ``close()`` propagated, teardown would abort with the world still live and
+    worker threads holding stale ``model``/``data`` pointers - the exact
+    cross-thread free that SIGSEGVs. So a failing ``close()`` is swallowed and
+    the rest of teardown proceeds, emptying the cache regardless."""
+
+    def test_destroy_swallows_renderer_close_failure_and_empties_cache(self, sim):
+        sim.create_world()
+        sim.render(width=160, height=120)
+        renderer = sim._renderer_tls.renderers[(160, 120)]
+
+        close_calls: list[int] = []
+        original_close = renderer.close
+
+        def _boom(*_a, **_k):
+            close_calls.append(1)
+            raise RuntimeError("simulated GL context free failure")
+
+        renderer.close = _boom
+        try:
+            # Teardown must not propagate the close() failure...
+            result = sim.destroy()
+            assert result["status"] == "success"
+            # ...it must still have attempted the close...
+            assert close_calls == [1]
+            # ...and the main-thread renderer cache must be emptied regardless.
+            assert not getattr(sim._renderer_tls, "renderers", {})
+        finally:
+            # Restore the real close() so the renderer's __del__ frees its GL
+            # context cleanly (the simulated failure left it allocated).
+            renderer.close = original_close
+
+    def test_teardown_is_a_noop_before_any_render(self, sim):
+        # No render() has been called, so the TLS cache holds no ``renderers``
+        # attribute yet; closing it must be a clean no-op (no AttributeError).
+        sim.create_world()
+        assert getattr(sim._renderer_tls, "renderers", None) is None
+        result = sim.destroy()
+        assert result["status"] == "success"


### PR DESCRIPTION
## Problem

`Simulation._close_main_thread_renderers()` deliberately swallows a per-renderer `close()` failure:

```python
for r in list(renderers.values()):
    try:
        r.close()
    except Exception:
        pass
renderers.clear()
```

This is a real robustness contract, not incidental defensiveness. `destroy()`/`cleanup()` close every main-thread renderer *before* nulling `self._world` and shutting the executor down. If a single renderer's `close()` propagated, teardown would abort with the world still live and worker threads holding stale `model`/`data` pointers - the exact cross-thread free that SIGSEGVs in `cgl.free()`. The swallow guarantees teardown always runs to completion.

That contract was unverified: the `except Exception: pass` line was uncovered, so nothing would catch a regression that let a `close()` failure escape.

## Change

Test-only. Adds `TestRendererTeardownRobustness` to `tests/simulation/mujoco/test_renderer_hygiene.py`:

- `test_destroy_swallows_renderer_close_failure_and_empties_cache` - patches a cached renderer's `close()` to raise, then asserts `destroy()` still returns `status == success`, that the close was attempted exactly once, and that the main-thread renderer cache is emptied regardless. The real `close()` is restored in a `finally` so the renderer's `__del__` frees its GL context cleanly (no `PytestUnraisableExceptionWarning`), mirroring the existing eviction test's wrap-and-restore pattern.
- `test_teardown_is_a_noop_before_any_render` - pins the no-render path (TLS cache has no `renderers` attribute yet) as a clean no-op.

## Verification

- Removing the protective `try/except` makes `test_destroy_swallows_renderer_close_failure_and_empties_cache` fail (the `RuntimeError` propagates out of `destroy()`), so the test is a genuine guard.
- Full file green: `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_renderer_hygiene.py` -> 8 passed.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues.
- Both new tests are gated behind the existing `requires_gl` marker, so they skip on a headless box without EGL/OSMesa.