### PR TITLE
test(mesh): extend sibling-filename xref guard to comments

### DIFF
--- a/strands_robots/mesh/_acl_config.py
+++ b/strands_robots/mesh/_acl_config.py
@@ -83,7 +83,7 @@ ACL_FILE_MAX_BYTES: int = 256 * 1024
 
 # json5 is imported lazily inside
 # ``_parse_json5`` rather than at module top-level. Importing it eagerly every
-# import of ``strands_robots.mesh`` (including ``session.py`` for
+# import of ``strands_robots.mesh`` (including ``strands_robots.mesh.session`` for
 # ``auth_mode=none`` dev paths) triggered the json5 import even when
 # no ACL file is loaded. Operators running with no ACL file (the
 # permissive default) and no ``mesh`` extra installed got an
@@ -141,7 +141,7 @@ def _load_acl_file(path: Path) -> dict[str, Any]:
     # ACL_FILE_MAX_BYTES + 1 so an attacker who races content between
     # stat() and read() cannot bypass the size cap. Mirrors the
     # O_NOFOLLOW + bounded-read discipline used for the audit log
-    # (audit.py:_ensure_paths). The ACL file gates wire authorisation,
+    # (``strands_robots.mesh.audit._ensure_paths``). The ACL file gates wire authorisation,
     # so the same TOCTOU + symlink-swap defences apply.
     if path.is_symlink():
         raise ValueError(

--- a/strands_robots/mesh/_zenoh_config.py
+++ b/strands_robots/mesh/_zenoh_config.py
@@ -155,7 +155,7 @@ from pathlib import Path
 # the rotation-loop attacker case.
 # #307: use an insertion-ordered dict (acting as an ordered set) so eviction
 # is deterministic FIFO -- matching the _ACL_CACHE eviction order in
-# _acl_config.py (``pop(next(iter(...)))``). Both bounded mesh caches now
+# ``strands_robots.mesh._acl_config`` (``pop(next(iter(...)))``). Both bounded mesh caches now
 # share one eviction discipline; see AGENTS.md cache-eviction note.
 _NON_POSIX_TLS_WARNED_KEYS: OrderedDict[tuple[str, int], None] = OrderedDict()
 _NON_POSIX_TLS_WARNED_LOCK = threading.Lock()
@@ -180,7 +180,7 @@ logger = logging.getLogger(__name__)
 #: Fleet namespace fallback when ``STRANDS_MESH_NAMESPACE`` is unset.
 #:
 #: This must match the literal topic prefix every mesh component emits
-#: (`mesh/core.py`, `mesh/sensors.py`, `mesh/input.py`, the IoT path).
+#: (`strands_robots.mesh.core`, `strands_robots.mesh.sensors`, `strands_robots.mesh.input`, the IoT path).
 #: The `namespace` Zenoh config field provides routing isolation --
 #: two fleets with different namespaces cannot exchange messages even
 #: when their key-expressions collide. The default below tracks the
@@ -612,8 +612,8 @@ def _resolve_tls_paths() -> tuple[Path, Path, Path]:
     # attacker has chmod'd 0o600) would pass while the actual TLS load
     # later opens the symlink target. Symmetric with the
     # ``O_NOFOLLOW`` + lstat-reject discipline applied across
-    # ``audit.py:_ensure_paths``, ``_load_seq_counters``, and
-    # ``_acl_config.py:_load_acl_file``.
+    # ``strands_robots.mesh.audit._ensure_paths``, ``_load_seq_counters``, and
+    # ``strands_robots.mesh._acl_config._load_acl_file``.
     #
     if not _is_posix():
         # Atomic check-and-set under lock so concurrent _build_config
@@ -658,8 +658,8 @@ def _resolve_tls_paths() -> tuple[Path, Path, Path]:
         # returns the link's own metadata -- since the loop already
         # rejected symlinks, ``lstat`` is equivalent to ``stat`` for
         # the path we are looking at, but we keep ``lstat`` explicit to
-        # match the discipline of audit.py:_ensure_paths,
-        # _load_seq_counters, and _acl_config.py:_load_acl_file.
+        # match the discipline of ``strands_robots.mesh.audit._ensure_paths``,
+        # _load_seq_counters, and ``strands_robots.mesh._acl_config._load_acl_file``.
         #
         # Residual TOCTOU window: between this lstat() and Zenoh's
         # eventual open() of the same path, an attacker who controls

--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -693,7 +693,7 @@ class BridgeTransport:
                 except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
                     # narrow per AGENTS.md > Review
                     # Learnings (#86) > "Exception Clauses Must Be Narrow".
-                    # Same tuple as the four wire handlers in core.py
+                    # Same tuple as the four wire handlers in ``strands_robots.mesh.core``
                     # (_on_cmd, _on_response, _on_safety_estop,
                     # _on_safety_resume).
                     payload = None

--- a/tests/mesh/test_docstring_module_xrefs.py
+++ b/tests/mesh/test_docstring_module_xrefs.py
@@ -26,12 +26,22 @@ flagging every ``.py`` token: mesh docstrings legitimately cite *test* modules b
 filename (the guarding ``test_*.py`` files that pin a behavior), which live under
 ``tests/`` and are not importable modules of the package. ``__init__.py`` is
 excluded because it names a package, not a cross-referenceable module symbol.
+
+A sibling filename rots identically whether it sits in a docstring or a plain
+``#`` comment, so the guard covers both: an earlier version scanned only
+docstrings, letting comment references such as ``audit.py:_ensure_paths`` slip
+through. Comment scanning uses :mod:`tokenize` so only real ``#`` comments are
+inspected - a filename used as data in a code string literal
+(``zf.writestr("lambda_function.py", ...)``) names a file in another process,
+not an internal sibling, and is correct as written.
 """
 
 from __future__ import annotations
 
 import ast
+import io
 import re
+import tokenize
 from pathlib import Path
 
 import strands_robots.mesh as mesh_pkg
@@ -77,4 +87,32 @@ def test_mesh_docstrings_reference_modules_not_sibling_filenames() -> None:
         "mesh docstrings must cross-reference sibling modules by module "
         "(:mod:`~strands_robots.mesh.session`) not source filename (``session.py``). "
         f"Offending docstrings: {offenders}"
+    )
+
+
+def _comments_with_sibling_filename_refs() -> dict[str, list[str]]:
+    """Map ``relpath`` -> module-filename tokens found in its ``#`` comments.
+
+    The docstring guard above misses references buried in comments; this closes
+    that gap using :mod:`tokenize` so only genuine comment text is inspected and
+    code string literals that name a file as data are never flagged.
+    """
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.rglob("*.py")):
+        source = source_file.read_text(encoding="utf-8")
+        hits: list[str] = []
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT:
+                hits.extend(t for t in _FILENAME_RE.findall(tok.string) if t in _PACKAGE_MODULES)
+        if hits:
+            offenders[str(source_file.relative_to(_PACKAGE_DIR))] = sorted(set(hits))
+    return offenders
+
+
+def test_mesh_comments_reference_modules_not_sibling_filenames() -> None:
+    offenders = _comments_with_sibling_filename_refs()
+    assert not offenders, (
+        "mesh comments must cross-reference sibling modules by module path "
+        "(``strands_robots.mesh.audit._ensure_paths``) not source filename "
+        f"(``audit.py``). Offending files: {offenders}"
     )


### PR DESCRIPTION
## Problem

The mesh cross-reference guard (`tests/mesh/test_docstring_module_xrefs.py`) walks module/class/function **docstrings** and fails if any cites a sibling by bare source filename (`session.py`) instead of an importable symbol. But it never looked at **comments**, so the same class of documentation archaeology slipped through there unguarded.

Eight such references had accumulated in mesh comments:

- `strands_robots/mesh/_acl_config.py` - `session.py`, `audit.py:_ensure_paths`
- `strands_robots/mesh/_zenoh_config.py` - `_acl_config.py`, `audit.py:_ensure_paths`, and `mesh/core.py` / `mesh/sensors.py` / `mesh/input.py`
- `strands_robots/mesh/transport/bridge_transport.py` - `core.py`

A bare filename rots the moment a file is renamed or split and points a reader at a path on disk rather than a cross-referenceable module symbol - identical breakage whether it sits in a docstring or a comment.

## Change

- Extend the existing guard to also walk `#` comments, using `tokenize` so only genuine comment text is inspected. A filename used as data in a code string literal (e.g. `zf.writestr("lambda_function.py", ...)` in the IoT bootstrap) names a file in another process, not an internal sibling, and is deliberately left out of scope.
- Fix the eight existing comment references to dotted module paths (`strands_robots.mesh.audit._ensure_paths`, `strands_robots.mesh.core`, ...).

This mirrors the guard's own history of tightening scope (it previously grew from top-level modules to the full package tree to close a `transport/` gap).

## Tests

`test_mesh_comments_reference_modules_not_sibling_filenames` is added alongside the existing docstring test. It fails on the pre-fix tree (reporting all three offending files) and passes after the comment fixes. The existing docstring guard and its scan-coverage assertion are unchanged.

Comments/docstrings only - no behavior change.

Gate (scope `strands_robots tests tests_integ`): `ruff check` clean, `ruff format --check` clean, `mypy` clean (`no issues found in 815 source files`). `pytest tests/mesh/` - 2099 passed, 3 skipped.