### PR TITLE
refactor(sim/mujoco): remove dead _recompile_world helper

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -778,22 +778,6 @@ class MuJoCoSimEngine(
             logger.debug("spec.to_xml() failed: %s", xml_err)
         self._world.status = SimStatus.IDLE
 
-    def _recompile_world(self) -> dict[str, Any]:
-        """Rebuild MjModel from scratch via :meth:`_compile_world`.
-
-        This is the "nuke and pave" path used when the world config changes
-        in a way that can't be expressed as a spec mutation (e.g. clearing
-        every body). For incremental changes (add/remove body, camera),
-        prefer ``_recompile_preserving_state`` in :mod:`scene_ops` which
-        goes through ``spec.recompile(model, data)`` and preserves joint
-        state.
-        """
-        try:
-            self._compile_world()
-            return {"status": "success"}
-        except Exception as e:
-            return {"status": "error", "content": [{"text": f"Recompile failed: {e}"}]}
-
     # Robot Management
 
     @staticmethod

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -247,6 +247,19 @@ class TestToolSpecMethodParity:
             # Router must reject; must NOT silently succeed with default values.
             assert result["status"] == "error", f"{action} silently accepted {bad_kwargs}"
 
+    def test_recompile_world_dead_helper_is_gone(self, sim):
+        """`_recompile_world` was an orphaned "nuke and pave" rebuild helper: no
+        caller invoked it (the scene-load path rebuilds through
+        ``scene_ops._recompile_preserving_state``), and it was never reachable
+        through the action dispatcher either -- ``_dispatch_action`` rejects any
+        leading-underscore action and no ``_ACTION_ALIASES`` entry maps to it.
+        Pin its removal so an unreachable, uncoverable branch cannot creep back."""
+        assert not hasattr(type(sim), "_recompile_world")
+        for action in ("recompile_world", "_recompile_world"):
+            result = sim._dispatch_action(action, {})
+            assert result["status"] == "error"
+            assert "Unknown action" in result["content"][0]["text"]
+
 
 class TestUnifiedNoWorldMessage:
     """T14: Every action must use the same 'No world.' message when no world exists."""


### PR DESCRIPTION
## Problem
`MuJoCoSimEngine._recompile_world` is dead code. It has no caller anywhere in the package, tests, or examples, and it is unreachable through the agent action dispatcher: `_dispatch_action` rejects any leading-underscore action, and no `_ACTION_ALIASES` entry maps a public action name to it.

It is a leftover from the original MuJoCo backend: the world-rebuild / scene-clear path now goes through `scene_ops._recompile_preserving_state` (which rebuilds via `spec.recompile(model, data)` and preserves joint state). The three remaining references to `_recompile_world` live in `tests/simulation/mujoco/test_load_scene_interaction.py` docstrings, and they describe it explicitly as the *previous* behavior that was replaced.

The method also wraps `_compile_world()` in a `try/except` whose branches can never execute, so it carries a permanently-uncoverable error path.

## Change
- Delete `_recompile_world` (16 lines). No behavior change: nothing invoked it.
- Add a regression test in `TestToolSpecMethodParity` asserting the helper is gone and that `_dispatch_action` rejects both `recompile_world` and `_recompile_world` as unknown actions, so an unreachable helper cannot creep back onto the class.

## Verification
- New test fails on pre-change code (`hasattr(..., "_recompile_world")` is `True`) and passes after removal.
- `tests/simulation/mujoco/` full suite: 1452 passed (`MUJOCO_GL=egl`).
- Lint clean: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all pass.

No visual artifact: pure dead-code removal with no simulation, rendering, or policy behavior change.