### PR TITLE
test(mesh/iot): pin provisioning survives os.chmod OSError

### DIFF
--- a/tests/mesh/test_iot_provision.py
+++ b/tests/mesh/test_iot_provision.py
@@ -519,3 +519,52 @@ class TestValidateThingNameFullmatch:
 
         with pytest.raises(ValueError, match="invalid characters"):
             provision._validate_thing_name("robot\x0c")
+
+
+class TestChmodFailureResilience:
+    """Provisioning must not crash on a filesystem that rejects ``os.chmod``.
+
+    ``provision_robot`` / ``provision_operator`` best-effort chmod the cert
+    directory (0o700) and the written cert/key (0o600) to lock down private
+    material. On non-POSIX or restricted mounts (some container overlay/bind
+    mounts, network filesystems) ``os.chmod`` raises ``OSError``; provisioning
+    is designed to degrade gracefully rather than abort, since the AWS-side
+    resources are already created by the time the local files are written.
+    """
+
+    pytestmark = pytest.mark.usefixtures("bypass_ca")
+
+    @staticmethod
+    def _install(monkeypatch, fake_iot_client):
+        monkeypatch.setattr(
+            "strands_robots.mesh.iot.provision._require_boto3",
+            lambda: MagicMock(client=lambda *a, **kw: fake_iot_client),
+        )
+
+        def _deny_chmod(*_a, **_kw):
+            raise OSError("chmod not supported on this filesystem")
+
+        monkeypatch.setattr("strands_robots.mesh.iot.provision.os.chmod", _deny_chmod)
+
+    def test_provision_robot_survives_chmod_oserror(self, fake_iot_client, tmp_cert_dir, monkeypatch):
+        self._install(monkeypatch, fake_iot_client)
+
+        result = provision_robot("chmod-denied-robot", cert_dir=tmp_cert_dir)
+
+        # Provisioning completes and the material is still written, even though
+        # the best-effort mode-hardening chmod calls all failed.
+        assert isinstance(result, ProvisionedThing)
+        assert result.thing_name == "chmod-denied-robot"
+        assert result.cert_path.exists()
+        assert result.key_path.exists()
+        assert result.cert_path.read_text().startswith("-----BEGIN CERTIFICATE-----")
+
+    def test_provision_operator_survives_chmod_oserror(self, fake_iot_client, tmp_cert_dir, monkeypatch):
+        self._install(monkeypatch, fake_iot_client)
+
+        result = provision_operator("chmod-denied-ops", cert_dir=tmp_cert_dir)
+
+        assert isinstance(result, ProvisionedThing)
+        assert result.policy_name == OPERATOR_POLICY_NAME
+        assert result.cert_path.exists()
+        assert result.key_path.exists()


### PR DESCRIPTION
## Problem

`provision_robot` / `provision_operator` best-effort `os.chmod` the cert directory (`0o700`) and the written cert/key (`0o600`) to lock down private key material. On non-POSIX or restricted mounts (some container overlay/bind mounts, network filesystems) `os.chmod` raises `OSError`. The code intentionally swallows that so provisioning degrades gracefully - the AWS-side Thing/policy/certificate are already created by the time the local files are written, so aborting would leak cloud resources while surfacing no local key.

Those `except OSError` resilience branches (`provision.py` cert-dir chmod in both entry points, plus the cert/key `_write_certs` chmod) had no test coverage, so a refactor that let the `OSError` propagate would pass CI while breaking provisioning on those filesystems.

## Change

Add `TestChmodFailureResilience` to `tests/mesh/test_iot_provision.py`: monkeypatch `os.chmod` to raise `OSError` and assert both `provision_robot` and `provision_operator` still complete - returning a `ProvisionedThing` with the cert + key written to disk. Uses the existing mocked-boto3 fixtures; no real AWS calls.

Without the `try/except OSError` guards these tests fail (the `OSError` propagates out of provisioning); with them they pass, pinning the graceful-degradation contract.

## Test

```
python -m pytest tests/mesh/test_iot_provision.py -q
# 36 passed
```

Covers the previously-uncovered chmod-failure branches in `strands_robots/mesh/iot/provision.py`. Lint clean (ruff check, ruff format --check, mypy on strands_robots tests tests_integ).