### PR TITLE
test(tools/use_lerobot): pin registry drift-resilience and private-submodule skip

### DIFF
--- a/examples/notebooks/05_streaming_data_loop.ipynb
+++ b/examples/notebooks/05_streaming_data_loop.ipynb
@@ -28,8 +28,8 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
     "import shutil\n",
+    "import sys\n",
     "\n",
     "# macOS uses \"cgl\" for offscreen GL; Linux headless uses \"egl\".\n",
     "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\" if sys.platform == \"darwin\" else \"egl\")\n",

--- a/strands_robots/tools/use_lerobot.py
+++ b/strands_robots/tools/use_lerobot.py
@@ -92,8 +92,6 @@ def _import_from_lerobot(module_path: str):
     full_path = f"lerobot.{module_path}" if not module_path.startswith("lerobot.") else module_path
 
     segments = full_path.split(".")
-    if not segments or segments == [""]:
-        raise LeRobotResolveError(f"Cannot resolve '{module_path}' in lerobot")
 
     # Walk from the longest importable module prefix down to the shortest. The
     # first prefix that imports cleanly is the module; remaining segments are

--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -356,6 +356,56 @@ def test_deep_import_is_cached() -> None:
     assert "lerobot.policies" in M._DEEP_IMPORTED
 
 
+def test_deep_import_skips_private_and_test_submodules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deep import walks public submodules only: ``_private`` names and a
+    ``tests`` package are skipped before any import is attempted, so discovery
+    never drags a package's own test suite into the process."""
+    import types
+
+    root = types.ModuleType("lerobot.fakepkg")
+    root.__path__ = []  # non-empty attribute marks this module as a package
+    real_import = importlib.import_module
+    imported: list[str] = []
+
+    def fake_import(name: str, *a: Any, **k: Any) -> Any:
+        imported.append(name)
+        if name == "lerobot.fakepkg":
+            return root
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    monkeypatch.setattr(
+        M.pkgutil,
+        "iter_modules",
+        lambda path: [(None, "_private", False), (None, "tests", True), (None, "core", True)],
+    )
+    M._DEEP_IMPORTED.discard("lerobot.fakepkg")
+    try:
+        M._deep_import("lerobot.fakepkg")
+    finally:
+        M._DEEP_IMPORTED.discard("lerobot.fakepkg")
+        M._DEEP_IMPORTED.discard("lerobot.fakepkg.core")
+
+    # Only the public ``core`` submodule is recursed into; the private and test
+    # submodules are filtered out and never handed to importlib.
+    assert "lerobot.fakepkg.core" in imported
+    assert "lerobot.fakepkg._private" not in imported
+    assert "lerobot.fakepkg.tests" not in imported
+
+
+def test_registry_choices_empty_when_class_lacks_known_choices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Registry discovery reads lerobot's own ``ChoiceRegistry.get_known_choices``.
+    If a config class ever loses that method (lerobot API drift), discovery must
+    degrade to an empty mapping rather than raising AttributeError."""
+
+    class _NoChoices:
+        pass
+
+    monkeypatch.setattr(M, "_deep_import", lambda pkg, _seen=None: None)
+    monkeypatch.setattr(M, "_import_from_lerobot", lambda path: _NoChoices)
+    assert M._get_registry_choices("robots") == {}
+
+
 # ----------------------------------------------------------------------------
 # import resolution -- resolver-internal error classification
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `use_lerobot` resolver is the dynamic discovery surface for lerobot (any dotted path -> module/class/function, with config choices read from lerobot's own draccus `ChoiceRegistry`). Two behaviors that keep it robust against lerobot API drift were unpinned, and `_import_from_lerobot` carried a guard that can never execute.

## Change

- Remove the empty-path guard in `_import_from_lerobot`. It tested the post-prefix `segments` value, but `full_path` is always either the caller's `lerobot.`-prefixed path or gets the `lerobot.` prefix added, so `full_path.split(".")` can never be empty or `[""]` — the branch was unreachable. The empty/blank-path case is already handled correctly by the final `Cannot resolve '<path>' in lerobot` raise and stays pinned by `test_empty_module_path_cannot_resolve`.
- Add a regression test pinning `_deep_import` skipping `_private` names and `tests` packages, so discovery never imports a package's own test suite.
- Add a regression test pinning registry discovery degrading to an empty mapping when a config class lacks `get_known_choices` (a plausible lerobot API drift), instead of raising `AttributeError`.

## Tests

Both new tests exercise previously-uncovered branches (`_deep_import` submodule filtering; `_get_registry_choices` missing-method fallback). Full suite: 11173 passed, 65 skipped; `use_lerobot.py` resolver has no reachable uncovered lines. Lint/format/mypy clean.

No behavior change for callers — the removed guard was dead code and the new tests are additive.