### PR TITLE
test(training/lerobot): cover lerobot-drift ValueError and DDP worker rank-0 logging

### DIFF
--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -961,6 +961,26 @@ class TestSampleWeightingRABC:
         with pytest.raises(ValueError, match="requires lerobot >= 0.5.2"):
             LerobotTrainer(device="cpu").build_config(self._rabc_spec(dataset_root, tmp_path))
 
+    def test_build_config_missing_sample_weighting_field_raises_actionable(self, dataset_root, tmp_path, monkeypatch):
+        # A lerobot whose TrainPipelineConfig predates the nested sample-weighting
+        # field (no ``cfg.sample_weighting`` attribute at all) must raise the
+        # actionable "does not expose sample weighting" ValueError -- distinct from
+        # the ImportError path above, where the field exists but the helper module
+        # is gone. Shadow TrainPipelineConfig with a subclass that hides the
+        # attribute to stand in for that older lerobot.
+        pytest.importorskip("lerobot.utils.sample_weighting")
+        import lerobot.configs.train as lerobot_train_cfg
+
+        class _NoSampleWeightingConfig(lerobot_train_cfg.TrainPipelineConfig):
+            def __getattribute__(self, name):
+                if name == "sample_weighting":
+                    raise AttributeError(name)
+                return super().__getattribute__(name)
+
+        monkeypatch.setattr(lerobot_train_cfg, "TrainPipelineConfig", _NoSampleWeightingConfig)
+        with pytest.raises(ValueError, match="does not expose sample weighting"):
+            LerobotTrainer(device="cpu").build_config(self._rabc_spec(dataset_root, tmp_path))
+
     def test_build_command_emits_nested_flags(self, dataset_root, tmp_path):
         cmd = LerobotTrainer(device="cpu").build_command(self._rabc_spec(dataset_root, tmp_path))
         assert "--sample_weighting.type=rabc" in cmd
@@ -1388,3 +1408,69 @@ class TestHardwareFloor:
     def test_advisory_single_consumer_gpu(self):
         floor = LerobotTrainer(device="cpu").hardware_floor
         assert floor == {"min_gpus": 1, "min_vram_gb": 8, "multinode": False}
+
+
+class TestLerobotDdpWorker:
+    """``_lerobot_worker`` is the per-GPU entry torch's elastic launcher spawns.
+
+    It rebuilds the typed config in-worker and calls lerobot's ``train`` inline
+    (no argv, no nested interpreter). Only local rank 0 tees output to the shared
+    log so parallel workers do not interleave writes into one file.
+    """
+
+    def _install_fake_train(self, monkeypatch, recorder):
+        import sys
+        import types
+
+        module = types.ModuleType("lerobot.scripts.lerobot_train")
+
+        def _train(cfg, **kwargs):
+            recorder["cfg"] = cfg
+            print("TRAINING_RAN")
+
+        module.train = _train
+        monkeypatch.setitem(sys.modules, "lerobot.scripts.lerobot_train", module)
+
+    def _spec(self, tmp_path):
+        return TrainSpec(
+            dataset_root=str(tmp_path),
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=1,
+            extra={"policy_type": "act"},
+        )
+
+    def test_rank0_worker_trains_and_writes_shared_log(self, tmp_path, monkeypatch):
+        from strands_robots.training import lerobot as lerobot_module
+
+        recorder: dict = {}
+        self._install_fake_train(monkeypatch, recorder)
+        sentinel = object()
+        monkeypatch.setattr(LerobotTrainer, "build_config", lambda self, spec: sentinel)
+        monkeypatch.setenv("LOCAL_RANK", "0")
+
+        log_path = tmp_path / "train.log"
+        lerobot_module._lerobot_worker("act", "cpu", self._spec(tmp_path), str(log_path))
+
+        # The config built in-worker is exactly what lerobot's train() receives.
+        assert recorder["cfg"] is sentinel
+        # Rank 0 owns the shared log, so train output lands in it.
+        assert log_path.is_file()
+        assert "TRAINING_RAN" in log_path.read_text()
+
+    def test_nonzero_rank_worker_trains_without_writing_shared_log(self, tmp_path, monkeypatch):
+        from strands_robots.training import lerobot as lerobot_module
+
+        recorder: dict = {}
+        self._install_fake_train(monkeypatch, recorder)
+        sentinel = object()
+        monkeypatch.setattr(LerobotTrainer, "build_config", lambda self, spec: sentinel)
+        monkeypatch.setenv("LOCAL_RANK", "1")
+
+        log_path = tmp_path / "train.log"
+        lerobot_module._lerobot_worker("act", "cpu", self._spec(tmp_path), str(log_path))
+
+        # Training still runs on every rank...
+        assert recorder["cfg"] is sentinel
+        # ...but only rank 0 writes the shared log, so a non-zero rank leaves it absent.
+        assert not log_path.exists()


### PR DESCRIPTION
## What

Two previously-untested paths on `LerobotTrainer` are now pinned by regression tests, taking `strands_robots/training/lerobot.py` from 99% to 100% line coverage.

### 1. lerobot API-drift ValueError (`build_config`, line 905)
`build_config` distinguishes two ways a lerobot install can lack RA-BC sample weighting:
- the `lerobot.utils.sample_weighting` helper module is gone (ImportError branch) — already covered; and
- `TrainPipelineConfig` itself predates the nested `sample_weighting` field, so `cfg` has no such attribute at all.

Only the first was tested. The second must raise the actionable `"does not expose sample weighting (no 'sample_weighting' on TrainPipelineConfig)"` `ValueError` rather than leak a raw error later. The new test shadows `lerobot.configs.train.TrainPipelineConfig` with a subclass that hides the attribute to stand in for that older lerobot, and asserts the actionable message.

### 2. DDP worker rank-0-only logging (`_lerobot_worker`, lines 1090-1097)
`_lerobot_worker` is the per-GPU entry torch's elastic launcher spawns: it rebuilds the typed config in-worker and calls lerobot's `train()` inline (no argv, no nested interpreter), teeing output to the shared log **only on local rank 0** so parallel workers do not interleave writes. Two tests assert the observable contract:
- rank 0 (`LOCAL_RANK=0`): `train()` receives the in-worker config and the shared log file is written; and
- non-zero rank (`LOCAL_RANK=1`): `train()` still runs, but the shared log is left absent.

## Testing
- `mypy strands_robots tests tests_integ` — clean (no issues in 816 files); `ruff check` / `ruff format --check` clean.
- Full suite (headless MuJoCo sim, `MUJOCO_GL=egl`): 11023 passed, 200 skipped.
- `strands_robots/training/lerobot.py`: 99% -> 100% (closes lines 905, 1090-1097).

Test-only change; no runtime behavior is modified.