### PR TITLE
fix(sim/isaac): correct USD loader install hint to strands-robots[sim-isaac]

### DIFF
--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -16,8 +16,8 @@ Supported formats:
       definition extraction.
     * **USD** - ``load_usd(path)``. Walks the USD prim hierarchy via
       ``pxr.Usd`` / ``pxr.UsdPhysics`` to extract ``PhysicsRevoluteJoint`` /
-      ``PhysicsPrismaticJoint`` + body inertia. Gated behind the ``[isaac]``
-      extra (``usd-core>=24.5``); raises :class:`ImportError` with an
+      ``PhysicsPrismaticJoint`` + body inertia. Gated behind the ``sim-isaac``
+      extra (``usd-core>=25.5``); raises :class:`ImportError` with an
       install hint when ``pxr`` is unavailable.
 
 Failure semantics (closes the #33 class of bugs - silent ``joint_count=0``
@@ -543,7 +543,7 @@ def _lazy_import_usd() -> tuple[Any, Any, Any]:
 
     Returns (Usd, Sdf, UsdPhysics) tuple. Raises ImportError with an install
     hint when the modules are unavailable (Pixar USD ships only via the
-    ``[isaac]`` extra).
+    ``sim-isaac`` extra).
     """
     try:
         from pxr import Sdf, Usd, UsdPhysics  # type: ignore[import-not-found]
@@ -552,8 +552,8 @@ def _lazy_import_usd() -> tuple[Any, Any, Any]:
     except ImportError as e:
         raise ImportError(
             "USD loader requires Pixar USD (pxr.Usd / pxr.UsdPhysics). "
-            "Install via: pip install 'strands-robots-sim[isaac]' "
-            "or directly: pip install 'usd-core>=24.5'"
+            "Install via: pip install 'strands-robots[sim-isaac]' "
+            "or directly: pip install 'usd-core>=25.5,<27.0.0'"
         ) from e
 
 
@@ -583,7 +583,7 @@ def load_usd(path: str) -> ProceduralRobot:
     ``PhysicsPrismaticJoint`` / ``PhysicsFixedJoint``) plus rigid-body
     prims with ``UsdPhysicsRigidBodyAPI``.
 
-    Gated behind the ``[isaac]`` extra (``usd-core``); raises
+    Gated behind the ``sim-isaac`` extra (``usd-core``); raises
     :class:`ImportError` with an install hint when ``pxr`` is unavailable.
 
     Parameters
@@ -601,7 +601,7 @@ def load_usd(path: str) -> ProceduralRobot:
     FileNotFoundError
         If ``path`` doesn't exist.
     ImportError
-        If ``pxr`` is not importable (install via ``[isaac]`` extra).
+        If ``pxr`` is not importable (install via ``sim-isaac`` extra).
     ValueError
         If the stage fails to open, declares zero rigid bodies, or has a
         joint with an unresolved body0 / body1 reference.

--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -307,8 +307,17 @@ class TestUsdLoaderGate:
             pass
         else:
             pytest.skip("pxr is installed; the import gate does not apply")
-        with pytest.raises(ImportError, match=r"usd-core"):
+        with pytest.raises(ImportError, match=r"usd-core") as excinfo:
             load_usd(_write(tmp_path, "stage.usda", "#usda 1.0\n"))
+        # The hint must point at the real extra that ships usd-core --
+        # ``strands-robots[sim-isaac]`` (see pyproject + isaac/_install.py),
+        # never a nonexistent ``strands-robots-sim[isaac]`` combination that
+        # would leave a following user still without the dependency.
+        msg = str(excinfo.value)
+        assert "strands-robots[sim-isaac]" in msg
+        assert "strands-robots-sim[isaac]" not in msg
+        # The pinned floor in the sim-isaac extra is usd-core>=25.5, not 24.5.
+        assert "usd-core>=25.5" in msg
 
 
 class TestParseFallbacks:


### PR DESCRIPTION
## Problem

When `pxr` (Pixar USD) is not installed, `load_usd()` raises a helpful `ImportError` -- but the install hint points at the wrong target:

```
USD loader requires Pixar USD (pxr.Usd / pxr.UsdPhysics). Install via: pip install 'strands-robots-sim[isaac]' or directly: pip install 'usd-core>=24.5'
```

Both suggestions are wrong:

- **`strands-robots-sim[isaac]`** is a nonexistent package+extra combination. `usd-core` is shipped by *this* package's own extra, and `strands-robots-sim` is the separate out-of-tree backend plugin.
- **`usd-core>=24.5`** is a stale floor; the extra pins `usd-core>=25.5,<27.0.0`.

A user who follows the hint is left still missing the dependency -- a dead-end error.

## Change

Point the hint at the real extra that ships `usd-core`: **`strands-robots[sim-isaac]`** (`usd-core>=25.5,<27.0.0`). This matches the rest of the codebase:

- `simulation/isaac/_install.py`: `PIP_EXTRA = "pip install 'strands-robots[sim-isaac]'"`
- `simulation/factory.py`: `_BACKEND_EXTRAS = {..., "isaac": "sim-isaac"}`

The mirrored docstrings in `loaders.py` (module summary, `_lazy_import_usd`, `load_usd` body + `Raises`) referenced the same wrong `[isaac]` extra / `24.5` version and are corrected in lockstep.

## Tests

Extends the existing `TestUsdLoaderGate::test_pxr_import_gate_has_install_hint` (runs on any host without `pxr`) to assert the hint names the real extra `strands-robots[sim-isaac]`, does **not** contain the bogus `strands-robots-sim[isaac]`, and quotes `usd-core>=25.5`. The strengthened assertions fail on the pre-fix string and pass after.

Local gate: `ruff check` + `ruff format --check` + `mypy` clean; `tests/simulation/isaac/` 79 passed.