### PR TITLE
fix(datasets): version-check huggingface_hub>=1.0 before hf bucket sync

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1050,7 +1050,10 @@ class DatasetRecorder:
         Mutable, Xet-deduplicated dump target for COLLECTION - avoids git-LFS
         history bloat of push_to_hub during recording. Daily re-sync uploads
         only changed chunks (content-defined chunking). Requires the ``hf`` CLI
-        (huggingface_hub>=1.x) and ``hf auth login``.
+        with ``buckets``/``sync`` subcommands, which ship in
+        ``huggingface_hub>=1.0`` - an older install returns a
+        ``{"status": "error"}`` naming the required version rather than piping
+        argparse "invalid choice" noise. Also requires ``hf auth login``.
 
         ``bucket`` and ``run_id`` are validated against an allowlist before any
         subprocess or URI interpolation: ``bucket`` must be ``"name"`` or
@@ -1069,6 +1072,23 @@ class DatasetRecorder:
             return {
                 "status": "error",
                 "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
+            }
+
+        # The `hf buckets` / `hf sync` subcommands ship in huggingface_hub>=1.0.
+        # An older `hf` on PATH exists but rejects these subcommands with
+        # argparse "invalid choice" noise; version-check first so the user gets
+        # an actionable message instead of piped CLI usage errors.
+        import huggingface_hub
+        from packaging.version import Version
+
+        if Version(huggingface_hub.__version__) < Version("1.0"):
+            return {
+                "status": "error",
+                "message": (
+                    f"bucket sync requires huggingface_hub>=1.0 (for `hf buckets`/`hf sync`); "
+                    f"installed: {huggingface_hub.__version__}. "
+                    "pip install -U 'huggingface_hub>=1.0'."
+                ),
             }
 
         if not _BUCKET_RE.match(bucket):

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1565,6 +1565,36 @@ def test_sync_to_bucket_missing_hf_cli_errors(tmp_path, monkeypatch):
     assert "hf" in result["message"]
 
 
+def test_sync_to_bucket_rejects_old_huggingface_hub(tmp_path, monkeypatch):
+    """huggingface_hub<1.0 lacks `hf buckets`/`hf sync` -> actionable error.
+
+    An `hf` binary from an older huggingface_hub exists on PATH but rejects the
+    bucket subcommands with argparse noise. sync_to_bucket must version-check
+    and return a clear "upgrade huggingface_hub>=1.0" error without ever
+    launching the CLI (which would only emit unusable usage text).
+    """
+    import subprocess
+
+    import huggingface_hub
+
+    from strands_robots import dataset_recorder as dr
+
+    _write_meta(tmp_path)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+    monkeypatch.setattr(huggingface_hub, "__version__", "0.36.2")
+
+    def _boom(*_a, **_k):
+        raise AssertionError("subprocess must not run on an unsupported huggingface_hub")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    result = _sync_recorder(tmp_path).sync_to_bucket("my-org/robot-fave")
+
+    assert result["status"] == "error"
+    assert "huggingface_hub>=1.0" in result["message"]
+    assert "0.36.2" in result["message"]
+
+
 @pytest.mark.parametrize(
     "bad_bucket",
     [


### PR DESCRIPTION
## Problem

`DatasetRecorder.sync_to_bucket` requires the `hf` CLI with the `buckets` / `sync` subcommands, which ship in `huggingface_hub>=1.0`. The presence check (`_hf_executable`) only verifies that an `hf` binary exists on PATH, not that it is new enough.

On an older `huggingface_hub` (e.g. the 0.36.x line), an `hf` binary is still present but rejects those subcommands with argparse usage noise:

```
hf: error: argument {auth,cache,download,...}: invalid choice: 'buckets' (choose from 'auth', 'cache', ...)
```

`sync_to_bucket` pipes that text verbatim into its status dict, so the caller gets no hint that the fix is `pip install -U 'huggingface_hub>=1.0'`. The docstring already promised `huggingface_hub>=1.x`; the code did not enforce it.

## Change

After resolving the `hf` executable, add a version guard: if the installed `huggingface_hub` is `<1.0`, return `{"status": "error", ...}` naming the required version and the exact `pip install` command, without launching any subprocess. Version comparison uses `packaging.version.Version` (already a transitive dependency) so pre-release / multi-segment version strings parse robustly. The docstring is updated to state the enforced contract.

## Tests

Adds `test_sync_to_bucket_rejects_old_huggingface_hub`, which monkeypatches `huggingface_hub.__version__` to `0.36.2`, stubs `subprocess.run` to fail the test if called, and asserts the actionable error message (names `huggingface_hub>=1.0` and the installed version). The test fails on pre-fix code (the `hf` subprocess is invoked) and passes after.

Gate: `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`; `tests/test_dataset_recorder.py` + `tests/simulation/mujoco/test_stop_recording_finalize.py` pass (112 tests).

Closes #1505.