### PR TITLE
fix(streaming): fail loud on unforwardable repo_type and no-op drop_videos

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -390,8 +390,16 @@ Equivalently, the standalone reader: `from strands_robots import StreamingDatase
 Useful kwargs (forwarded to `StreamingLeRobotDataset`, version-tolerant):
 `episodes=[...]` (subset without download), `buffer_size`, `max_num_shards`,
 `return_uint8=True` (default; halves frame bandwidth), and
-`drop_videos=True` (proprio-only — skips video decode entirely, so it works on
-edge devices without a torchcodec wheel).
+`drop_videos=True` (proprio-only — keeps camera keys out of the temporal window
+so no video is decoded, letting edge devices without a torchcodec wheel stream
+state/action). `drop_videos=True` requires `delta_timestamps` (it prunes video
+keys from it); without `delta_timestamps` every frame still decodes its MP4, so
+that combination raises rather than silently needing torchcodec anyway.
+
+To stream from a Hugging Face Storage Bucket pass `repo_type="bucket"`. This is
+forwarded to `StreamingLeRobotDataset` and requires a lerobot whose streaming
+reader accepts `repo_type`; on an older lerobot the call raises instead of
+silently reading the versioned dataset namespace.
 
 For **training**, the upstream trainer uses the same engine:
 

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -111,13 +111,50 @@ class StreamingDatasetReader:
         shuffle: bool = True,
         return_uint8: bool = True,  # halves frame bandwidth; policies normalize
         validate_deltas: bool = True,  # parity with the materialized dataset path
-        drop_videos: bool = False,  # proprio-only streaming (no torchcodec)
-        repo_type: str = "dataset",  # "dataset" or "bucket"; forwarded only to a lerobot that accepts it
+        drop_videos: bool = False,  # proprio-only; requires delta_timestamps (else raises)
+        repo_type: str = "dataset",  # "dataset" or "bucket"; a non-default value raises if lerobot cannot forward it
     ) -> StreamingDatasetReader:
         StreamingCls = _get_streaming_cls()
         init_sig = inspect.signature(StreamingCls).parameters
         # If the constructor accepts **kwargs, every candidate is forwardable.
         accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in init_sig.values())
+
+        # repo_type selects WHICH storage system is read ("bucket" vs the
+        # versioned "dataset" namespace). Unlike the cosmetic kwargs below, it
+        # must never be silently dropped: forwarding a bucket request to a
+        # lerobot whose StreamingLeRobotDataset does not declare repo_type would
+        # read a different repo (or 404) with no signal. Fail loud so the caller
+        # upgrades lerobot instead of silently streaming the wrong data. The
+        # default "dataset" is always safe to drop (no semantic change).
+        if repo_type != "dataset" and not (accepts_var_kw or "repo_type" in init_sig):
+            try:
+                from importlib.metadata import version as _pkg_version
+
+                _lr_ver = _pkg_version("lerobot")
+            except Exception:  # noqa: BLE001 - version lookup is best-effort diagnostics
+                _lr_ver = "unknown"
+            raise RuntimeError(
+                f"repo_type={repo_type!r} is not supported by the installed "
+                f"lerobot (version {_lr_ver}): its StreamingLeRobotDataset does "
+                "not accept a repo_type parameter, so the request would silently "
+                "read the versioned dataset namespace instead. Upgrade lerobot to "
+                "a version whose StreamingLeRobotDataset accepts repo_type, or "
+                "pass repo_type='dataset'."
+            )
+
+        # drop_videos avoids torchcodec by keeping camera keys out of the
+        # temporal window (delta_timestamps). With no delta_timestamps there is
+        # nothing to prune and every streamed frame still decodes its camera
+        # MP4 - so the advertised proprio-only, torchcodec-free path is a no-op.
+        # Fail loud rather than quietly requiring torchcodec anyway.
+        if drop_videos and not delta_timestamps:
+            raise ValueError(
+                "drop_videos=True has no effect without delta_timestamps: every "
+                "streamed frame still decodes its camera MP4 (which needs "
+                "torchcodec). Pass delta_timestamps selecting only the proprio "
+                "keys to stream, e.g. delta_timestamps={'observation.state': "
+                "[0.0], 'action': [0.0]}, to stream state/action without video."
+            )
 
         # Proprio-only: strip video keys from delta_timestamps so video decode
         # (torchcodec) is never invoked - lets constrained edge devices stream

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -80,19 +80,31 @@ def test_repo_type_forwarded_when_supported(monkeypatch):
     assert r.dataset.repo_type == "bucket"
 
 
-def test_repo_type_dropped_when_unsupported(monkeypatch):
-    """A constructor without repo_type must not raise when repo_type is passed."""
+class _Narrow:
+    """Constructor that accepts only repo_id (no repo_type, no **kwargs)."""
 
-    class _Narrow:
-        def __init__(self, repo_id):
-            self.repo_id = repo_id
-            self.num_frames = self.num_episodes = self.fps = 0
+    def __init__(self, repo_id):
+        self.repo_id = repo_id
+        self.num_frames = self.num_episodes = self.fps = 0
 
-        def __iter__(self):
-            yield {}
+    def __iter__(self):
+        yield {}
 
+
+def test_repo_type_bucket_raises_when_unsupported(monkeypatch):
+    """repo_type selects WHICH storage is read, so a lerobot that cannot
+    forward it must fail loud rather than silently reading the dataset
+    namespace (a bucket request that quietly reads a different repo)."""
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
-    r = sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+    with pytest.raises(RuntimeError, match="repo_type='bucket' is not supported"):
+        sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+
+
+def test_repo_type_default_dataset_never_raises_when_unsupported(monkeypatch):
+    """The default repo_type='dataset' is a no-op semantic and is always safe
+    to drop on a lerobot without the parameter - it must not raise."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+    r = sd.StreamingDatasetReader.open("org/ds", validate_deltas=False)
     assert r.dataset.repo_id == "org/ds"
 
 
@@ -123,6 +135,15 @@ def test_drop_videos_all_camera_keys_yields_none(monkeypatch):
     )
     # All keys were camera keys → delta_timestamps drops out entirely.
     assert "delta_timestamps" not in r.dataset.kw
+
+
+def test_drop_videos_without_deltas_raises(monkeypatch):
+    """drop_videos=True with no delta_timestamps is a no-op on the wire (every
+    frame still decodes its MP4), so the advertised torchcodec-free path must
+    fail loud instead of silently requiring torchcodec."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    with pytest.raises(ValueError, match="drop_videos=True has no effect without delta_timestamps"):
+        sd.StreamingDatasetReader.open("org/ds", drop_videos=True, validate_deltas=False)
 
 
 def test_dataloader_ignores_shuffle(monkeypatch):


### PR DESCRIPTION
## Problem

`StreamingDatasetReader.open` forwards `repo_type` to lerobot's `StreamingLeRobotDataset` only when that constructor declares the parameter (`strands_robots/streaming_dataset.py`), and otherwise drops it silently. But `repo_type` selects **which storage system is read** - a Hugging Face Storage Bucket vs the versioned dataset namespace. A dropped `repo_type="bucket"` therefore does not fail: it quietly streams a *different* repo (or 404s if none exists by that name), with no warning.

This is a live defect, not a hypothetical: on lerobot 0.6.1 `StreamingLeRobotDataset` has **no** `repo_type` parameter, so every `stream_dataset(..., repo_type="bucket")` today reads the wrong storage with no signal.

```python
>>> import inspect
>>> from lerobot.datasets import StreamingLeRobotDataset
>>> "repo_type" in inspect.signature(StreamingLeRobotDataset).parameters
False
```

`drop_videos` has the same advertised-but-no-op class. It only prunes video keys out of `delta_timestamps`, so when the caller passes no `delta_timestamps`, `drop_videos=True` does nothing at all - while the documented contract is proprio-only, torchcodec-free streaming. Every frame still decodes its camera MP4.

## Change

- Raise `RuntimeError` (reporting the installed lerobot version) when a **non-default** `repo_type` cannot be forwarded to the installed `StreamingLeRobotDataset`. The default `repo_type="dataset"` stays silently droppable since it changes no semantics.
- Raise `ValueError` when `drop_videos=True` is passed with no `delta_timestamps`, directing the caller to pass `delta_timestamps` selecting the proprio keys - instead of silently requiring torchcodec anyway.
- Cosmetic, version-tolerant kwargs continue to drop through unchanged; only kwargs that change *what is read* now fail loud.

No behavior change on the happy path (a supported `repo_type`, or `drop_videos` with `delta_timestamps`, behaves exactly as before).

## Tests

Regression tests that fail on pre-fix code and pass after:
- `test_repo_type_bucket_raises_when_unsupported` - `repo_type="bucket"` against a constructor without the parameter -> `RuntimeError` (was: silent success reading the wrong storage).
- `test_repo_type_default_dataset_never_raises_when_unsupported` - the default `"dataset"` is always safe to drop.
- `test_drop_videos_without_deltas_raises` - `drop_videos=True` with no `delta_timestamps` -> `ValueError` (was: silent no-op).

Verified pre-fix both raise tests report `DID NOT RAISE`; post-fix the full `tests/test_streaming_dataset.py` passes (45 tests). `ruff check`, `ruff format --check`, and `mypy` clean over `strands_robots tests tests_integ`.

## Docs

`docs/recording.md` updated to document that `drop_videos=True` requires `delta_timestamps` and that `repo_type="bucket"` requires a lerobot whose streaming reader accepts `repo_type` (raises on older lerobot instead of silently reading the dataset namespace).

No visual artifact: this is input-validation only on the streaming read path - no policy, sim, rendering, recording-output, or asset behavior changes.

Closes #1501