### PR TITLE
fix(datasets): version-check huggingface_hub before hf bucket sync (closes #1505)

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -137,6 +137,42 @@ def _hf_executable() -> str | None:
     return shutil.which("hf")
 
 
+def _huggingface_hub_version_error() -> str | None:
+    """Return an actionable error message if ``huggingface_hub`` is too old for bucket sync.
+
+    The ``hf buckets`` / ``hf sync`` subcommands ship in huggingface_hub>=1.0.
+    On older releases (e.g. the 0.36.x stable line) the ``hf`` binary exists,
+    so :func:`_hf_executable` succeeds, but the subcommands fail with argparse
+    usage noise ("invalid choice: 'buckets'") that gives no hint the fix is an
+    upgrade. Version-checking the installed package up front turns that noise
+    into a clear upgrade instruction without spawning a subprocess.
+
+    Returns ``None`` (no error) when:
+
+    - the installed version is >= 1.0, or
+    - ``huggingface_hub`` is not importable in this interpreter (the ``hf``
+      binary may come from a different environment on PATH whose version we
+      cannot see; the normal subprocess error path still applies), or
+    - the version string is unparseable (fail open rather than block a
+      possibly-capable CLI on a cosmetic version format).
+    """
+    try:
+        import huggingface_hub
+    except ImportError:
+        return None
+
+    version = getattr(huggingface_hub, "__version__", "")
+    match = re.match(r"(\d+)\.(\d+)", version)
+    if match is None:
+        return None
+    if (int(match.group(1)), int(match.group(2))) >= (1, 0):
+        return None
+    return (
+        f"bucket sync requires huggingface_hub>=1.0 (`hf buckets`/`hf sync`); "
+        f"installed: {version}. pip install -U 'huggingface_hub>=1.0'."
+    )
+
+
 # Lazy check for LeRobot availability.
 # We must NOT import lerobot at module level because it pulls in
 # `datasets` -> `pandas`, which can crash with a numpy ABI mismatch on
@@ -1070,6 +1106,13 @@ class DatasetRecorder:
                 "status": "error",
                 "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
             }
+
+        # `hf buckets` / `hf sync` need huggingface_hub>=1.0; on 0.x the CLI
+        # exists but rejects those subcommands with argparse noise. Gate on the
+        # installed package version so users get an upgrade instruction instead.
+        version_error = _huggingface_hub_version_error()
+        if version_error is not None:
+            return {"status": "error", "message": version_error}
 
         if not _BUCKET_RE.match(bucket):
             return {

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1565,6 +1565,108 @@ def test_sync_to_bucket_missing_hf_cli_errors(tmp_path, monkeypatch):
     assert "hf" in result["message"]
 
 
+def test_sync_to_bucket_old_huggingface_hub_errors(tmp_path, monkeypatch):
+    """huggingface_hub<1.0 -> clear upgrade instruction, never a subprocess call.
+
+    Regression test for the version gate: on 0.x the ``hf`` binary exists but
+    lacks the ``buckets``/``sync`` subcommands, so without the gate the user
+    gets argparse usage noise piped verbatim into the status dict.
+    """
+    import subprocess
+
+    import huggingface_hub
+
+    from strands_robots import dataset_recorder as dr
+
+    _write_meta(tmp_path)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+    monkeypatch.setattr(huggingface_hub, "__version__", "0.36.2")
+
+    def _boom(*_a, **_k):
+        raise AssertionError("subprocess must not run when huggingface_hub is too old")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    result = _sync_recorder(tmp_path).sync_to_bucket("my-org/robot-fave")
+
+    assert result["status"] == "error"
+    assert "huggingface_hub>=1.0" in result["message"]
+    assert "0.36.2" in result["message"]
+    assert "pip install -U 'huggingface_hub>=1.0'" in result["message"]
+
+
+def test_sync_to_bucket_new_huggingface_hub_passes_version_gate(tmp_path, monkeypatch):
+    """huggingface_hub>=1.0 passes the version gate and proceeds to sync."""
+    import subprocess
+
+    import huggingface_hub
+
+    from strands_robots import dataset_recorder as dr
+
+    _write_meta(tmp_path)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+    monkeypatch.setattr(huggingface_hub, "__version__", "1.0.0")
+
+    def _fake_run(cmd, *_a, **_k):
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = _sync_recorder(tmp_path).sync_to_bucket("my-org/robot-fave")
+
+    assert result["status"] == "success"
+
+
+def test_sync_to_bucket_unimportable_huggingface_hub_skips_version_gate(tmp_path, monkeypatch):
+    """No importable huggingface_hub package -> the gate fails open.
+
+    The ``hf`` binary can come from a different environment on PATH (e.g. a
+    pipx install) whose version this interpreter cannot see; blocking on a
+    missing *package* would break a working CLI. The normal subprocess error
+    path still surfaces genuine failures.
+    """
+    import subprocess
+    import sys
+
+    from strands_robots import dataset_recorder as dr
+
+    _write_meta(tmp_path)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+    # A None entry in sys.modules makes `import huggingface_hub` raise ImportError.
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    def _fake_run(cmd, *_a, **_k):
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = _sync_recorder(tmp_path).sync_to_bucket("my-org/robot-fave")
+
+    assert result["status"] == "success"
+
+
+def test_sync_to_bucket_unparseable_huggingface_hub_version_skips_gate(tmp_path, monkeypatch):
+    """An unparseable version string fails open rather than blocking the CLI."""
+    import subprocess
+
+    import huggingface_hub
+
+    from strands_robots import dataset_recorder as dr
+
+    _write_meta(tmp_path)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+    monkeypatch.setattr(huggingface_hub, "__version__", "unknown")
+
+    def _fake_run(cmd, *_a, **_k):
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = _sync_recorder(tmp_path).sync_to_bucket("my-org/robot-fave")
+
+    assert result["status"] == "success"
+
+
 @pytest.mark.parametrize(
     "bad_bucket",
     [


### PR DESCRIPTION
## Summary

Closes #1505.

`DatasetRecorder.sync_to_bucket` requires the `hf` CLI's `buckets` / `sync` subcommands, which ship in **huggingface_hub >= 1.0**. The presence check (`_hf_executable`) only verified that an `hf` binary exists, so on the current 0.x stable line (verified with 0.36.2) the subcommands fail with argparse usage noise:

```
hf: error: argument {auth,cache,download,...}: invalid choice: 'buckets' (choose from 'auth', 'cache', ...)
```

which `sync_to_bucket` piped verbatim into the status dict, giving the user no hint that the fix is `pip install -U 'huggingface_hub>=1.0'`. The docstring already promised `huggingface_hub>=1.x`; the code now enforces it.

## What changed

- **`strands_robots/dataset_recorder.py`** - new `_huggingface_hub_version_error()` helper: a subprocess-free version gate called in `sync_to_bucket` right after CLI resolution, before any `subprocess.run`. Installed package `< 1.0` returns a clear, actionable error:
  ```
  bucket sync requires huggingface_hub>=1.0 (`hf buckets`/`hf sync`); installed: 0.36.2. pip install -U 'huggingface_hub>=1.0'.
  ```
- **Fail-open edges** (documented in the helper docstring): the gate is skipped when `huggingface_hub` is not importable in the running interpreter (the `hf` binary may come from a different environment on PATH, e.g. pipx, whose version we cannot see) or when the version string is unparseable. The normal subprocess error path still surfaces genuine failures there.

## Test surface

4 new regression tests in `tests/test_dataset_recorder.py`:

- `test_sync_to_bucket_old_huggingface_hub_errors` - monkeypatches `__version__` to `0.36.2`, asserts the upgrade-instruction error and that **no subprocess runs** (matches the issue's regression-test criterion exactly).
- `test_sync_to_bucket_new_huggingface_hub_passes_version_gate` - `1.0.0` proceeds to sync.
- `test_sync_to_bucket_unimportable_huggingface_hub_skips_version_gate` - missing package fails open.
- `test_sync_to_bucket_unparseable_huggingface_hub_version_skips_gate` - garbage version fails open.

## Validation

- `hatch run format` - clean
- `hatch run lint` - clean (ruff + mypy)
- `hatch run test` (full suite, `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl`): **11053 passed, 197 skipped, 0 failed**
- Environmental note: without EGL the suite aborts in MuJoCo GL init on this headless dev box - reproduced identically on clean `upstream/main`, unrelated to this change.

## Acceptance criteria (from #1505)

- [x] Version-check before running any subprocess (version check chosen over `hf buckets --help` capability probe, per the issue's stated preference)
- [x] Error message names the installed version and the exact upgrade command
- [x] Regression test: `__version__` monkeypatched to `0.36.2` -> clear error, no subprocess invoked

## Out of scope / follow-ups

- The blog draft (`BLOG_REVIEW_streaming_data_loop.md`) Prerequisites pinning `huggingface_hub>=1.0` lives outside this repo - tracked by the blog review, not this PR.
- Project board: please move #1505 to "In review" (board write access unavailable from this runner).
