### PR TITLE
docs(examples): pass cameras=['front'] so demos record only the declared sensor

### DIFF
--- a/examples/06_agent_collect_and_stream.py
+++ b/examples/06_agent_collect_and_stream.py
@@ -35,7 +35,8 @@ agent(
     f"Create a world with the so100 robot. Add a red cube at [0.2, 0.0, 0.05] "
     f"and a blue cube at [0.25, 0.05, 0.05]. Add a front camera looking at them. "
     f"Start recording a LeRobot dataset (repo_id='{REPO_ID}', root='{DATASET_ROOT}', "
-    f"fps=30, overwrite=True, task='pick up the red cube'). Run the mock policy "
+    f"fps=30, overwrite=True, task='pick up the red cube', cameras=['front']). "
+    f"Run the mock policy "
     f"for 60 steps with instruction 'pick up the red cube'. Stop recording."
 )
 

--- a/examples/notebooks/05_streaming_data_loop.ipynb
+++ b/examples/notebooks/05_streaming_data_loop.ipynb
@@ -72,6 +72,7 @@
     "    root=ROOT,\n",
     "    fps=30,\n",
     "    task=\"pick up the red cube\",\n",
+    "    cameras=[\"front\"],  # record only the declared sensor, not the implicit 'default' view\n",
     "    overwrite=True,\n",
     ")\n",
     "sim.run_policy(\n",


### PR DESCRIPTION
Closes #1504.

## What changed

The recording demos called `start_recording` without `cameras=`, so the recorder
swept in the implicit `default` overview camera alongside the declared `front`
sensor: the dataset gained a dead `observation.images.default` video stream
(roughly doubling the demo's video payload) and the notebook's cell 3 output
showed the loud recorder warning. Verified on `main` @ `6a1decf`.

- **`examples/notebooks/05_streaming_data_loop.ipynb`** (cell 3):
  `sim.start_recording(..., cameras=["front"])` with a short inline comment.
- **`examples/06_agent_collect_and_stream.py`**: the agent prompt's recording
  instruction now includes `cameras=['front']`.

## Why

Step 2 of the demo (bucket sync) is entirely about not uploading redundant
bytes; the companion dataset shipping a dead camera stream - plus a visible
warning in the notebook output - undercut the story.

## Acceptance criteria from the issue

- [x] Notebook 05 cell 3: `sim.start_recording(..., cameras=["front"])`
- [x] `examples/06_agent_collect_and_stream.py`: `cameras=['front']` added to the recording instruction in the agent prompt
- [x] Streamed-frame assertions: audited - no cell or assertion references `observation.images.default` (cell 9 already reads `observation.images.front` only), so no further changes needed
- [ ] Blog draft Step 1 prompt: the blog draft is **not part of this repository** (the review notes `BLOG_REVIEW_streaming_data_loop.md` live outside the repo); it should be updated where the draft is maintained - out of scope for this PR

## Test surface

- `hatch run lint`: clean (ruff + mypy, 816 files).
- `hatch run test` with `MUJOCO_GL=egl`: **11049 passed, 197 skipped** - full suite green.
- Without `MUJOCO_GL=egl` the suite aborts in `tests/inference/test_remote_policy_sim_rollout.py` (MuJoCo GL init); this reproduces identically on clean `upstream/main`, i.e. pre-existing environmental, not introduced here.
- Doc/example-only change; no test reads either changed file.

## Follow-ups

- Update the blog draft's Step 1 prompt (`cameras=['front']`) where the draft is maintained.
- Project board: please move #1504 to "In review" (board write access unavailable from this token).
