### PR TITLE
feat(api): export module-level stream_dataset() / StreamingDatasetReader (closes #1503)

### DIFF
--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
         list_backends,
         register_backend,
     )
-    from strands_robots.streaming_dataset import StreamingDatasetReader
+    from strands_robots.streaming_dataset import StreamingDatasetReader, stream_dataset
     from strands_robots.teleoperator import Teleoperator
     from strands_robots.tools.download_assets import download_assets
     from strands_robots.tools.gr00t_inference import gr00t_inference
@@ -139,6 +139,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SimulationDeviceDriver": ("strands_robots.device_connect", "SimulationDeviceDriver"),
     "ReachyMiniDriver": ("strands_robots.device_connect", "ReachyMiniDriver"),
     "StreamingDatasetReader": ("strands_robots.streaming_dataset", "StreamingDatasetReader"),
+    # Simulator-free dataset read-back: thin alias for StreamingDatasetReader.open.
+    # Lazy so training/eval scripts pay the torch/lerobot import only on first call.
+    "stream_dataset": ("strands_robots.streaming_dataset", "stream_dataset"),
 }
 
 __all__ = [
@@ -187,6 +190,7 @@ __all__ = [
     "SimulationDeviceDriver",
     "ReachyMiniDriver",
     "StreamingDatasetReader",
+    "stream_dataset",
 ]
 
 

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -446,6 +446,10 @@ class DatasetRecordingMixin:
         can instead use ``lerobot-train --dataset.streaming=true`` which uses
         the same underlying StreamingLeRobotDataset.
 
+        Sugar for the module-level :func:`strands_robots.stream_dataset` -
+        reading a dataset does not require a simulator, so scripts without a
+        GL stack should call that function directly.
+
         Args:
             repo_id: HF dataset id (e.g. ``"lerobot/svla_so100_pickplace"``) or
                 a local repo_id paired with ``root=``.
@@ -468,9 +472,9 @@ class DatasetRecordingMixin:
             for frame in reader:
                 ...
         """
-        from strands_robots.streaming_dataset import StreamingDatasetReader
+        from strands_robots.streaming_dataset import stream_dataset
 
-        return StreamingDatasetReader.open(repo_id, **kwargs)
+        return stream_dataset(repo_id, **kwargs)
 
     def get_recording_status(self) -> dict[str, Any]:
         """Returns success in every lifecycle state (no world / not

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -212,3 +212,36 @@ class StreamingDatasetReader:
 
     def __iter__(self) -> Any:
         return iter(self.dataset)
+
+
+def stream_dataset(repo_id: str, **kwargs: Any) -> StreamingDatasetReader:
+    """Open a streaming reader for a LeRobotDataset without a simulator.
+
+    Thin module-level alias for :meth:`StreamingDatasetReader.open`, exported
+    at the package root (``strands_robots.stream_dataset``). Use this from
+    training/eval scripts that only need to READ a dataset - it never touches
+    MuJoCo, a GL context, or a thread pool, unlike constructing a ``Robot()``
+    simulation. ``Simulation.stream_dataset`` is sugar delegating here so the
+    "the same Robot() that records reads it back" flow still works.
+
+    Args:
+        repo_id: HF dataset id (e.g. ``"lerobot/svla_so100_pickplace"``) or a
+            local repo_id paired with ``root=``.
+        **kwargs: Forwarded to :meth:`StreamingDatasetReader.open` - e.g.
+            ``root``, ``delta_timestamps``, ``episodes``, ``shuffle``,
+            ``buffer_size``, ``max_num_shards``, ``drop_videos``
+            (proprio-only, torchcodec-free), ``repo_type``.
+
+    Returns:
+        A :class:`StreamingDatasetReader`.
+
+    Example:
+        import strands_robots
+
+        reader = strands_robots.stream_dataset(
+            "lerobot/svla_so100_pickplace", shuffle=False
+        )
+        for frame in reader:
+            ...
+    """
+    return StreamingDatasetReader.open(repo_id, **kwargs)

--- a/tests/test_package_lazy_imports.py
+++ b/tests/test_package_lazy_imports.py
@@ -269,6 +269,62 @@ class TestPolicyTypeDiscoveryReexported:
         assert proc.returncode == 0, proc.stderr
 
 
+class TestStreamingDatasetReexported:
+    """``stream_dataset`` / ``StreamingDatasetReader`` are package-root exports.
+
+    Reading a dataset back must not require constructing a ``Robot()``
+    simulation (MuJoCo world, GL context, thread pool) - training/eval scripts
+    on GL-less boxes call ``strands_robots.stream_dataset(...)`` directly.
+    Both symbols are lazy (torch/lerobot load on first *call*, not first
+    import), and ``Simulation.stream_dataset`` remains sugar over the same
+    function.
+    """
+
+    def test_in_top_level_all_and_is_lazy(self):
+        for name in ("stream_dataset", "StreamingDatasetReader"):
+            assert name in strands_robots.__all__
+            assert name in strands_robots._LAZY_IMPORTS
+
+    def test_resolves_to_canonical_objects(self):
+        import strands_robots.streaming_dataset as sd_mod
+
+        assert strands_robots.stream_dataset is sd_mod.stream_dataset
+        assert strands_robots.StreamingDatasetReader is sd_mod.StreamingDatasetReader
+
+    def test_stream_dataset_delegates_without_simulator(self, monkeypatch):
+        # Calling the top-level function must reach StreamingDatasetReader.open
+        # with kwargs intact - and require no Simulation/mujoco import.
+        import strands_robots.streaming_dataset as sd_mod
+
+        captured = {}
+
+        def fake_open(repo_id, **kw):
+            captured["repo_id"] = repo_id
+            captured["kw"] = kw
+            return "READER"
+
+        monkeypatch.setattr(sd_mod.StreamingDatasetReader, "open", staticmethod(fake_open), raising=True)
+        out = strands_robots.stream_dataset("org/ds", shuffle=False)
+        assert out == "READER"
+        assert captured == {"repo_id": "org/ds", "kw": {"shuffle": False}}
+
+    def test_streaming_module_import_stays_torch_free(self):
+        # The export must not regress the lazy-import contract: importing the
+        # backing module (as the package-root __getattr__ does on first access)
+        # must not pull torch or lerobot.
+        import subprocess
+        import sys
+
+        code = (
+            "import sys, strands_robots.streaming_dataset as m; "
+            "assert 'torch' not in sys.modules, 'torch eagerly imported'; "
+            "assert 'lerobot' not in sys.modules, 'lerobot eagerly imported'; "
+            "assert callable(m.stream_dataset)"
+        )
+        proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+        assert proc.returncode == 0, proc.stderr
+
+
 class TestImportResilience:
     """``import strands_robots`` must never fail because an optional import-time
     autoconfig step raised.

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -376,6 +376,24 @@ def test_sync_to_bucket_delete_flag_forwarded(tmp_path, monkeypatch):
 # ── stream_dataset facade ──────────────────────────────────────────────────
 
 
+def test_module_level_stream_dataset_delegates(monkeypatch):
+    """stream_dataset(...) is a thin alias for StreamingDatasetReader.open -
+    dataset read-back must not require constructing a simulator."""
+    captured = {}
+
+    def fake_open(repo_id, **kw):
+        captured["repo_id"] = repo_id
+        captured["kw"] = kw
+        return "READER"
+
+    monkeypatch.setattr(sd.StreamingDatasetReader, "open", staticmethod(fake_open), raising=True)
+
+    out = sd.stream_dataset("org/ds", root="/tmp/x", shuffle=False, drop_videos=True)
+    assert out == "READER"
+    assert captured["repo_id"] == "org/ds"
+    assert captured["kw"] == {"root": "/tmp/x", "shuffle": False, "drop_videos": True}
+
+
 def test_recording_mixin_stream_dataset_delegates(monkeypatch):
     """sim.stream_dataset(...) must delegate to StreamingDatasetReader.open,
     keeping streaming a native facade method (not user-side plumbing)."""


### PR DESCRIPTION
## Summary

Closes #1503.

Reading a dataset with `stream_dataset()` previously required constructing a full `Robot()` simulation (MuJoCo world, GL context, thread pool) even though the method is a pure forwarder to `StreamingDatasetReader.open`. Training/eval scripts on GL-less boxes (GPU training nodes, laptops inspecting a dataset) can now read parquet/MP4 shards without a simulator.

Found while verifying the "streaming data loop" blog draft (`BLOG_REVIEW_streaming_data_loop.md`, suggestion 3).

## What changed

- **`strands_robots/streaming_dataset.py`** - new module-level `stream_dataset(repo_id, **kwargs) -> StreamingDatasetReader`, a thin alias for `StreamingDatasetReader.open` with a docstring covering the simulator-free use case.
- **`strands_robots/__init__.py`** - `stream_dataset` added to `_LAZY_IMPORTS`, `__all__`, and the `TYPE_CHECKING` block (the same PEP 562 lazy-export pattern used for `Robot`). `StreamingDatasetReader` was already lazy-exported at the package root; it is now pinned by tests alongside the new symbol.
- **`strands_robots/simulation/recording.py`** - `DatasetRecordingMixin.stream_dataset` stays as sugar, now delegating to the module-level function (docstring updated to point GL-less scripts at the top-level function).

Zero behavior change: torch/lerobot still load on first *call*, not on `import strands_robots` (pinned by a subprocess torch-free-import test).

## Acceptance criteria (from #1503)

- [x] Module-level `stream_dataset(repo_id, **kwargs) -> StreamingDatasetReader` exported lazily from the package root
- [x] `StreamingDatasetReader` exported at the package root (already present; contract now pinned by tests)
- [x] `Simulation.stream_dataset` kept as sugar delegating to the same function
- [x] Zero behavior change; import cost stays lazy

## Test surface

New tests:

- `tests/test_streaming_dataset.py::test_module_level_stream_dataset_delegates` - the alias forwards repo_id + kwargs to `StreamingDatasetReader.open`.
- `tests/test_package_lazy_imports.py::TestStreamingDatasetReexported` (4 tests) - both symbols in `__all__` + `_LAZY_IMPORTS`, resolve to the canonical `strands_robots.streaming_dataset` objects, top-level call delegates without a simulator, and a subprocess check that importing the backing module stays torch/lerobot-free.

Existing contract tests (`test_every_lazy_name_is_exported`, `test_every_lazy_name_has_a_type_checking_import`) automatically cover the new entry.

Validation on the dev box:

- `hatch run lint` - clean (ruff + mypy).
- `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl hatch run test` - **11053 passed, 197 skipped** (+ the one rollout test verified separately: 1 passed). Note: without `MUJOCO_GL=egl` the full suite aborts in `tests/inference/test_remote_policy_sim_rollout.py` on clean `upstream/main` too - pre-existing environmental GL crash on this headless box, unrelated to this PR.

## Out of scope / follow-ups

- None identified. The blog draft update itself (`BLOG_REVIEW_streaming_data_loop.md` suggestion 3) lives outside this repo.

## Project board

If #1503 is on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2), please move it to "In review" (API write to the board is limited from this environment).
