### PR TITLE
feat(datasets): lifecycle-independent sync_dataset_to_bucket(root, bucket) helper (closes #1502)

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -345,6 +345,32 @@ episodes to the existing dataset instead of replacing it.
 | `push_to_hub(tags=None, private=False)` | Upload to a versioned HF dataset repo |
 | `sync_to_bucket(bucket, run_id=None, private=True)` | Sync to a mutable HF Storage Bucket (`hf://buckets/...`) — Xet-deduped collection target; needs the `hf` CLI. `bucket` (`name` or `org/name`) and `run_id` (single segment) are allowlist-validated (`[A-Za-z0-9._-]`, no traversal) before the sync |
 
+## Sync an on-disk dataset without a recorder
+
+`DatasetRecorder.sync_to_bucket` needs a live recorder. When the dataset
+already exists on disk — recorded earlier in the process, produced by
+`lerobot-record` on hardware, or a directory you want to re-sync ("daily
+sync") — use the lifecycle-independent module-level helper. It needs neither a
+recorder, a simulation world, nor lerobot to be importable: just the `hf` CLI
+and a finalized dataset directory (one containing `meta/`).
+
+```python
+from strands_robots import sync_dataset_to_bucket
+
+sync_dataset_to_bucket(
+    "/root/.cache/huggingface/lerobot/user/my_dataset",  # on-disk dataset dir
+    "my-org/robot-fave",                                 # bucket "name" or "org/name"
+    # run_id defaults to the directory name when omitted
+)
+# -> {"status": "success", "bucket_uri": "hf://buckets/my-org/robot-fave/my_dataset"}
+```
+
+`bucket` and `run_id` are allowlist-validated (`[A-Za-z0-9._-]`, no traversal
+or shell metacharacters) before any subprocess, and the directory must contain
+`meta/` (normalization stats) or the sync is refused. `DatasetRecorder.sync_to_bucket`
+is a thin delegate to this helper that additionally reports the recorder's
+episode/frame counts.
+
 ## Read back
 
 Fully materialized (downloads everything):

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 # the lazy attributes below (the runtime __getattr__ resolves them to Any
 # from the static analyzer's perspective). PEP 562.
 if TYPE_CHECKING:
+    from strands_robots.dataset_recorder import sync_dataset_to_bucket
     from strands_robots.device_connect import (
         ReachyMiniDriver,
         RobotDeviceDriver,
@@ -139,6 +140,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SimulationDeviceDriver": ("strands_robots.device_connect", "SimulationDeviceDriver"),
     "ReachyMiniDriver": ("strands_robots.device_connect", "ReachyMiniDriver"),
     "StreamingDatasetReader": ("strands_robots.streaming_dataset", "StreamingDatasetReader"),
+    "sync_dataset_to_bucket": ("strands_robots.dataset_recorder", "sync_dataset_to_bucket"),
 }
 
 __all__ = [
@@ -187,6 +189,7 @@ __all__ = [
     "SimulationDeviceDriver",
     "ReachyMiniDriver",
     "StreamingDatasetReader",
+    "sync_dataset_to_bucket",
 ]
 
 

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -137,6 +137,114 @@ def _hf_executable() -> str | None:
     return shutil.which("hf")
 
 
+def sync_dataset_to_bucket(
+    root: str | Path,
+    bucket: str,  # "my-org/robot-fave"
+    run_id: str | None = None,  # subpath; defaults to the directory name
+    *,
+    create: bool = True,
+    private: bool = True,
+    delete: bool = False,
+) -> dict[str, Any]:
+    """Sync an on-disk LeRobotDataset directory into an HF Storage Bucket.
+
+    Lifecycle-independent counterpart to :meth:`DatasetRecorder.sync_to_bucket`:
+    it needs neither a live recorder, a simulation world, nor lerobot to be
+    importable - only the ``hf`` CLI and a finalized dataset directory (one
+    containing ``meta/``). Use it to sync a dataset recorded earlier in the
+    process, one produced by ``lerobot-record`` on hardware, or to re-sync a
+    directory that grew ("daily sync").
+
+    Args:
+        root: Path to the on-disk LeRobotDataset directory (must contain
+            ``meta/`` - call ``finalize()``/``save_episode()`` first, or the
+            downstream loses normalization stats).
+        bucket: Target bucket, ``"name"`` or ``"org/name"``.
+        run_id: Destination subpath under the bucket. Defaults to
+            ``Path(root).name`` when omitted (a bare directory has no
+            ``repo_id`` to derive from).
+        create: Create the bucket first (idempotent - "already exists" is not
+            an error).
+        private: Create the bucket private (only used when ``create`` is True).
+        delete: Pass ``--delete`` to ``hf sync`` (mirror deletions).
+
+    Returns:
+        ``{"status": "success", "bucket_uri": "hf://buckets/<bucket>/<run_id>"}``
+        on success, or ``{"status": "error", "message": ...}`` on any failure.
+
+    ``bucket`` and ``run_id`` are validated against an allowlist before any
+    subprocess or URI interpolation: ``bucket`` must be ``"name"`` or
+    ``"org/name"`` and ``run_id`` a single path segment, both restricted to
+    ``[A-Za-z0-9._-]`` (no path traversal or shell metacharacters). This path is
+    agent-reachable via ``stop_recording(bucket=, run_id=)``. A rejected value
+    returns ``{"status": "error", ...}`` without running ``hf``.
+    """
+    import subprocess
+
+    hf = _hf_executable()
+    if hf is None:
+        return {
+            "status": "error",
+            "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
+        }
+
+    if not _BUCKET_RE.match(bucket):
+        return {
+            "status": "error",
+            "message": f"invalid bucket {bucket!r}: must match "
+            "'name' or 'org/name' using [A-Za-z0-9._-] (no path traversal "
+            "or shell metacharacters).",
+        }
+
+    local_root = str(root)
+    # meta/ must ship or downstream loses normalization stats.
+    if not (Path(local_root) / "meta").exists():
+        return {
+            "status": "error",
+            "message": f"No meta/ under {local_root}; call finalize() before "
+            "syncing (stats/info required for streaming/training).",
+        }
+
+    run_id = run_id or Path(local_root).name
+    if not _RUN_ID_RE.match(run_id):
+        return {
+            "status": "error",
+            "message": f"invalid run_id {run_id!r}: must be a single path "
+            "segment using [A-Za-z0-9._-] (no '/', path traversal, or shell "
+            "metacharacters).",
+        }
+    dest = f"hf://buckets/{bucket}/{run_id}"
+
+    if create:
+        cp = subprocess.run(
+            [hf, "buckets", "create", bucket] + (["--private"] if private else []),
+            capture_output=True,
+            text=True,
+        )
+        blob = (cp.stderr + cp.stdout).lower()
+        if cp.returncode != 0 and "exist" not in blob:
+            return {
+                "status": "error",
+                "message": f"bucket create failed: {cp.stderr.strip()}",
+            }
+
+    cmd = [hf, "sync", local_root, dest]
+    if delete:
+        cmd.append("--delete")
+    logger.info("Syncing %s -> %s", local_root, dest)
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        return {
+            "status": "error",
+            "message": proc.stderr.strip() or proc.stdout.strip(),
+        }
+
+    return {
+        "status": "success",
+        "bucket_uri": dest,
+    }
+
+
 # Lazy check for LeRobot availability.
 # We must NOT import lerobot at module level because it pulls in
 # `datasets` -> `pandas`, which can crash with a numpy ABI mismatch on
@@ -1061,73 +1169,23 @@ class DatasetRecorder:
 
         The shard layout is already Xet/bucket-friendly at the 100 MB default,
         and ``meta/`` MUST ship or downstream loses normalization stats.
+
+        Thin delegate to the lifecycle-independent
+        :func:`sync_dataset_to_bucket`; on success this adds the recorder's
+        ``episodes``/``frames`` counts to the returned dict.
         """
-        import subprocess
-
-        hf = _hf_executable()
-        if hf is None:
-            return {
-                "status": "error",
-                "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
-            }
-
-        if not _BUCKET_RE.match(bucket):
-            return {
-                "status": "error",
-                "message": f"invalid bucket {bucket!r}: must match "
-                "'name' or 'org/name' using [A-Za-z0-9._-] (no path traversal "
-                "or shell metacharacters).",
-            }
-
-        local_root = str(self.dataset.root)
-        # meta/ must ship or downstream loses normalization stats.
-        if not (Path(local_root) / "meta").exists():
-            return {
-                "status": "error",
-                "message": f"No meta/ under {local_root}; call finalize() before "
-                "sync_to_bucket (stats/info required for streaming/training).",
-            }
-
-        run_id = run_id or self.dataset.repo_id.split("/")[-1]
-        if not _RUN_ID_RE.match(run_id):
-            return {
-                "status": "error",
-                "message": f"invalid run_id {run_id!r}: must be a single path "
-                "segment using [A-Za-z0-9._-] (no '/', path traversal, or shell "
-                "metacharacters).",
-            }
-        dest = f"hf://buckets/{bucket}/{run_id}"
-
-        if create:
-            cp = subprocess.run(
-                [hf, "buckets", "create", bucket] + (["--private"] if private else []),
-                capture_output=True,
-                text=True,
-            )
-            blob = (cp.stderr + cp.stdout).lower()
-            if cp.returncode != 0 and "exist" not in blob:
-                return {
-                    "status": "error",
-                    "message": f"bucket create failed: {cp.stderr.strip()}",
-                }
-
-        cmd = [hf, "sync", local_root, dest]
-        if delete:
-            cmd.append("--delete")
-        logger.info("Syncing %s -> %s", local_root, dest)
-        proc = subprocess.run(cmd, capture_output=True, text=True)
-        if proc.returncode != 0:
-            return {
-                "status": "error",
-                "message": proc.stderr.strip() or proc.stdout.strip(),
-            }
-
-        return {
-            "status": "success",
-            "bucket_uri": dest,
-            "episodes": self.episode_count,
-            "frames": self.frame_count,
-        }
+        result = sync_dataset_to_bucket(
+            self.dataset.root,
+            bucket,
+            run_id or self.dataset.repo_id.split("/")[-1],
+            create=create,
+            private=private,
+            delete=delete,
+        )
+        if result.get("status") == "success":
+            result["episodes"] = self.episode_count
+            result["frames"] = self.frame_count
+        return result
 
     @property
     def repo_id(self) -> str:

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1951,3 +1951,101 @@ def test_resolve_dataset_dir_falls_back_to_default_home_when_lerobot_absent(monk
     resolved = resolve_dataset_dir("user/data")
 
     assert resolved == Path.home() / ".cache" / "huggingface" / "lerobot" / "user" / "data"
+
+
+class TestSyncDatasetToBucketFreeFunction:
+    """The lifecycle-independent ``sync_dataset_to_bucket(root, bucket)`` helper.
+
+    Syncing an existing on-disk dataset must not require a live recorder, a
+    simulation world, or lerobot: it operates on a bare directory. These pin
+    that the free function is exported at the package top level and enforces the
+    same allowlist/finalized-meta contract as the recorder method, deriving
+    ``run_id`` from the directory name when omitted.
+    """
+
+    def test_exported_at_package_top_level(self):
+        """``from strands_robots import sync_dataset_to_bucket`` resolves."""
+        import strands_robots
+        from strands_robots.dataset_recorder import sync_dataset_to_bucket as impl
+
+        assert strands_robots.sync_dataset_to_bucket is impl
+        assert "sync_dataset_to_bucket" in strands_robots.__all__
+
+    def test_syncs_bare_directory_deriving_run_id_from_dirname(self, tmp_path, monkeypatch):
+        """No recorder needed: a finalized directory syncs, run_id = dir name."""
+        import subprocess
+
+        from strands_robots.dataset_recorder import sync_dataset_to_bucket
+
+        ds_dir = tmp_path / "robot-fave-20260721"
+        (ds_dir / "meta").mkdir(parents=True)
+        monkeypatch.setattr("strands_robots.dataset_recorder._hf_executable", lambda: "hf")
+
+        seen: list[list[str]] = []
+
+        def _fake_run(cmd, **_kw):
+            seen.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+
+        result = sync_dataset_to_bucket(ds_dir, "my-org/robot-fave")
+
+        assert result["status"] == "success"
+        assert result["bucket_uri"] == "hf://buckets/my-org/robot-fave/robot-fave-20260721"
+        # No recorder -> no episode/frame counts leak into the free-function result.
+        assert "episodes" not in result
+        assert "frames" not in result
+        # hf sync targets the bare directory as-is.
+        sync_cmd = seen[-1]
+        assert sync_cmd[:2] == ["hf", "sync"]
+        assert sync_cmd[2] == str(ds_dir)
+
+    def test_rejects_unsafe_bucket_before_subprocess(self, tmp_path, monkeypatch):
+        """Agent-reachable: injection-unsafe bucket rejected without running hf."""
+        import subprocess
+
+        from strands_robots.dataset_recorder import sync_dataset_to_bucket
+
+        (tmp_path / "meta").mkdir()
+        monkeypatch.setattr("strands_robots.dataset_recorder._hf_executable", lambda: "hf")
+
+        def _boom(*_a, **_k):
+            raise AssertionError("subprocess must not run for an unsafe bucket")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        result = sync_dataset_to_bucket(tmp_path, "../evil")
+        assert result["status"] == "error"
+        assert "invalid bucket" in result["message"]
+
+    def test_requires_finalized_meta_dir(self, tmp_path, monkeypatch):
+        """A directory without meta/ (norm stats) is rejected."""
+        from strands_robots.dataset_recorder import sync_dataset_to_bucket
+
+        monkeypatch.setattr("strands_robots.dataset_recorder._hf_executable", lambda: "hf")
+        result = sync_dataset_to_bucket(tmp_path, "my-org/robot-fave")
+        assert result["status"] == "error"
+        assert "meta/" in result["message"]
+
+    def test_recorder_method_delegates_and_adds_counts(self, tmp_path, monkeypatch):
+        """``DatasetRecorder.sync_to_bucket`` delegates then adds episode/frame counts."""
+        import subprocess
+
+        from strands_robots import dataset_recorder as dr
+
+        _write_meta(tmp_path)
+        monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **_kw: subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr=""),
+        )
+
+        result = _sync_recorder(tmp_path, repo_id="my-org/robot-fave").sync_to_bucket("my-org/robot-fave")
+
+        assert result["status"] == "success"
+        assert result["bucket_uri"] == "hf://buckets/my-org/robot-fave/robot-fave"
+        # The method layer contributes the recorder's counts on top of the delegate.
+        assert result["episodes"] == 2
+        assert result["frames"] == 40

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1965,11 +1965,12 @@ class TestSyncDatasetToBucketFreeFunction:
 
     def test_exported_at_package_top_level(self):
         """``from strands_robots import sync_dataset_to_bucket`` resolves."""
-        import strands_robots
-        import strands_robots.dataset_recorder
+        from strands_robots import __all__ as top_level_all
+        from strands_robots import dataset_recorder as dr
+        from strands_robots import sync_dataset_to_bucket
 
-        assert strands_robots.sync_dataset_to_bucket is strands_robots.dataset_recorder.sync_dataset_to_bucket
-        assert "sync_dataset_to_bucket" in strands_robots.__all__
+        assert sync_dataset_to_bucket is dr.sync_dataset_to_bucket
+        assert "sync_dataset_to_bucket" in top_level_all
 
     def test_syncs_bare_directory_deriving_run_id_from_dirname(self, tmp_path, monkeypatch):
         """No recorder needed: a finalized directory syncs, run_id = dir name."""

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1966,9 +1966,9 @@ class TestSyncDatasetToBucketFreeFunction:
     def test_exported_at_package_top_level(self):
         """``from strands_robots import sync_dataset_to_bucket`` resolves."""
         import strands_robots
-        from strands_robots.dataset_recorder import sync_dataset_to_bucket as impl
+        import strands_robots.dataset_recorder
 
-        assert strands_robots.sync_dataset_to_bucket is impl
+        assert strands_robots.sync_dataset_to_bucket is strands_robots.dataset_recorder.sync_dataset_to_bucket
         assert "sync_dataset_to_bucket" in strands_robots.__all__
 
     def test_syncs_bare_directory_deriving_run_id_from_dirname(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Syncing an on-disk `LeRobotDataset` to an HF Storage Bucket previously required a *live recording session*: `sync_to_bucket` was only a method on `DatasetRecorder`, reachable in practice via `stop_recording(bucket=...)` during an open session or via `DatasetRecorder.resume(...)` (which hard-requires lerobot and constructs a full recorder just to shell out to `hf sync`). There was no public one-liner for the common cases:

- sync a dataset recorded earlier in the process,
- sync a dataset produced by `lerobot-record` on hardware,
- re-sync ("daily sync") a dataset directory that grew.

## Change

Add a module-level, lifecycle-independent helper exported from the package top level:

```python
from strands_robots import sync_dataset_to_bucket

sync_dataset_to_bucket(
    "/root/.cache/huggingface/lerobot/user/my_dataset",  # on-disk dataset dir
    "my-org/robot-fave",                                 # bucket "name" or "org/name"
    # run_id defaults to the directory name when omitted
)
# -> {"status": "success", "bucket_uri": "hf://buckets/my-org/robot-fave/my_dataset"}
```

It needs neither a recorder, a simulation world, nor lerobot to be importable - just the `hf` CLI and a finalized dataset directory (one containing `meta/`).

This is a refactor, not new logic: the bucket/`run_id` allowlist validation, the `meta/` presence check, and the `hf buckets create` + `hf sync` subprocess are lifted out of `DatasetRecorder.sync_to_bucket` into the free function. The method becomes a thin delegate that passes `self.dataset.root` and, on success, adds the recorder's `episodes`/`frames` counts - so the existing method return shape is unchanged. `run_id` defaults to `Path(root).name` for a bare directory (no `repo_id` to derive from).

The agent-reachable input-safety allowlist (`_BUCKET_RE` / `_RUN_ID_RE`) is preserved and still enforced before any subprocess or URI interpolation.

## Tests

New `TestSyncDatasetToBucketFreeFunction` (fails pre-fix - the symbol did not exist):

- exported at the package top level and in `__all__`
- syncs a bare directory with no recorder, deriving `run_id` from the directory name; asserts `hf sync` targets the directory and that no recorder-only `episodes`/`frames` keys leak
- rejects an injection-unsafe bucket before any subprocess
- refuses a directory without `meta/`
- `DatasetRecorder.sync_to_bucket` delegates then adds episode/frame counts (method contract unchanged)

Full local gate green: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` -> no issues in 816 source files, `tests/test_dataset_recorder.py` 99 passed (plus streaming + lazy-import contract tests).

No behavior change to the recording/dataset format itself (this is an upload utility refactor), so no visual/round-trip artifact applies; the regression tests are the proof.

## Docs

`docs/recording.md` gains a "Sync an on-disk dataset without a recorder" subsection.

Unblocks #1498 (idle-sim `stop_recording(bucket=)` can sync `last_dataset_root` via this helper) and #1499 (notebook cell 7 can sync a real dataset with no sim and no `resume`).

---

## §13 Review Changelog

### Round 1
- **CodeQL (mixed import style):** the top-level export test imported `strands_robots` via both `import strands_robots` and `from strands_robots.dataset_recorder import ... as impl`. Reworked the identity assertion to reference the implementation through the already-imported module attribute (`strands_robots.dataset_recorder.sync_dataset_to_bucket`), so the test keeps a single import style for the package. Test intent unchanged: still asserts the top-level export **is** the implementation object and is listed in `__all__`. `TestSyncDatasetToBucketFreeFunction` 5 passed; ruff check + format clean.

### Round 2
- **CodeQL (mixed import style) - proper root-cause fix.** Round 1 only *moved* the violation: it introduced `import strands_robots` + `import strands_robots.dataset_recorder` (bare-import style) into `test_exported_at_package_top_level`, while the rest of `tests/test_dataset_recorder.py` uses `from strands_robots.dataset_recorder import ...` / `from strands_robots import dataset_recorder as dr` throughout. That left both `strands_robots` and `strands_robots.dataset_recorder` imported in mixed styles across the file, so the alert re-fired on both modules (alerts 762/763/764). This round removes the two bare `import` statements entirely and switches the test to the file's dominant from-import idiom:
  ```python
  from strands_robots import __all__ as top_level_all
  from strands_robots import dataset_recorder as dr
  from strands_robots import sync_dataset_to_bucket

  assert sync_dataset_to_bucket is dr.sync_dataset_to_bucket
  assert "sync_dataset_to_bucket" in top_level_all
  ```
  No bare `import strands_robots` remains anywhere in the file. Test intent unchanged: still asserts the top-level export **is** the implementation object and is listed in `__all__`. `TestSyncDatasetToBucketFreeFunction` 5 passed; `ruff check` + `ruff format --check` clean.