### PR TITLE
fix(streaming): raise on repo_type='bucket' with lerobot<0.6.1; forbid drop_videos no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,12 @@ sim.stop_recording(bucket="your-org/robot-fave")   # → hf://buckets/your-org/r
 Requires the `hf` CLI (`pip install -U huggingface_hub` + `hf auth login`).
 
 **Proprio-only / no video** (e.g. edge devices without a torchcodec wheel):
-`sim.stream_dataset(repo_id, drop_videos=True)` streams state/action only and
-never touches the video decoder.
+`sim.stream_dataset(repo_id, drop_videos=True, delta_timestamps={...})` streams
+state/action only and never touches the video decoder. `drop_videos=True`
+requires a `delta_timestamps` with at least one non-video key (e.g.
+`{"observation.state": [0.0], "action": [0.0]}`) - without one, every feature
+including video would stream, so the call raises `ValueError` instead of
+silently no-opping.
 
 > **macOS note (zero-touch).** torchcodec links ffmpeg via `@rpath`, and
 > Homebrew's ffmpeg (`/opt/homebrew/lib`) is not on the default dyld search

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -391,7 +391,14 @@ Useful kwargs (forwarded to `StreamingLeRobotDataset`, version-tolerant):
 `episodes=[...]` (subset without download), `buffer_size`, `max_num_shards`,
 `return_uint8=True` (default; halves frame bandwidth), and
 `drop_videos=True` (proprio-only — skips video decode entirely, so it works on
-edge devices without a torchcodec wheel).
+edge devices without a torchcodec wheel; requires `delta_timestamps` with at
+least one non-video key, otherwise `open()` raises `ValueError` rather than
+silently streaming video anyway).
+
+One kwarg is **not** tolerant-forwarded because its absence changes semantics:
+`repo_type="bucket"` requires `lerobot>=0.6.1` — on older versions `open()`
+raises `RuntimeError` instead of silently streaming from the versioned dataset
+namespace (a different storage system).
 
 For **training**, the upstream trainer uses the same engine:
 

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -452,8 +452,11 @@ class DatasetRecordingMixin:
             **kwargs: Forwarded to
                 :meth:`StreamingDatasetReader.open` - e.g. ``root``,
                 ``delta_timestamps``, ``episodes``, ``shuffle``, ``buffer_size``,
-                ``max_num_shards``, ``drop_videos`` (proprio-only, torchcodec-free),
-                ``repo_type`` (``"dataset"`` or ``"bucket"``).
+                ``max_num_shards``, ``drop_videos`` (proprio-only,
+                torchcodec-free; requires ``delta_timestamps`` with at least one
+                non-video key, else ValueError), ``repo_type`` (``"dataset"`` or
+                ``"bucket"``; ``"bucket"`` requires lerobot>=0.6.1, else
+                RuntimeError).
 
         Returns:
             A :class:`~strands_robots.streaming_dataset.StreamingDatasetReader`.

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -72,8 +72,19 @@ def _get_streaming_cls() -> Any:
             "Install with: pip install 'strands-robots[lerobot]' "
             "(needs torchcodec for video keys; on aarch64/Jetson that means "
             "torch>=2.11 + torchcodec>=0.11). "
-            "For proprio-only streaming without torchcodec, use drop_videos=True."
+            "For proprio-only streaming without torchcodec, use drop_videos=True "
+            "with a delta_timestamps covering the non-video keys you need."
         ) from exc
+
+
+def _lerobot_version() -> str:
+    """Best-effort installed lerobot version string for error messages."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("lerobot")
+    except (ImportError, PackageNotFoundError):
+        return "unknown"
 
 
 class StreamingDatasetReader:
@@ -112,20 +123,63 @@ class StreamingDatasetReader:
         return_uint8: bool = True,  # halves frame bandwidth; policies normalize
         validate_deltas: bool = True,  # parity with the materialized dataset path
         drop_videos: bool = False,  # proprio-only streaming (no torchcodec)
-        repo_type: str = "dataset",  # "dataset" or "bucket"; forwarded only to a lerobot that accepts it
+        repo_type: str = "dataset",  # "dataset" or "bucket"; non-default REQUIRES a lerobot that accepts it
     ) -> StreamingDatasetReader:
+        """Open a version-tolerant streaming reader.
+
+        Raises:
+            RuntimeError: ``repo_type`` is not ``"dataset"`` but the installed
+                ``StreamingLeRobotDataset`` does not accept a ``repo_type``
+                parameter (lerobot < 0.6.1). Silently dropping the kwarg would
+                stream from the versioned *dataset* namespace instead of the
+                requested bucket - a different storage system, not a cosmetic
+                difference - so this is never tolerant-dropped.
+            ValueError: ``drop_videos=True`` but no non-video keys remain in
+                ``delta_timestamps`` (or none were passed). Without a proprio
+                ``delta_timestamps``, StreamingLeRobotDataset streams every
+                feature - including camera keys via torchcodec decode - so the
+                call would silently do the opposite of what was asked.
+            ImportError: ``StreamingLeRobotDataset`` is not importable.
+        """
         StreamingCls = _get_streaming_cls()
         init_sig = inspect.signature(StreamingCls).parameters
         # If the constructor accepts **kwargs, every candidate is forwardable.
         accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in init_sig.values())
 
+        # repo_type selects WHICH storage system is read (versioned dataset
+        # namespace vs bucket). Unlike the cosmetic kwargs below, silently
+        # dropping it on an older lerobot would open the wrong storage system
+        # without error - fail fast instead.
+        if repo_type != "dataset" and not (accepts_var_kw or "repo_type" in init_sig):
+            raise RuntimeError(
+                f"repo_type={repo_type!r} requires lerobot>=0.6.1 "
+                f"(installed: {_lerobot_version()}): the installed "
+                "StreamingLeRobotDataset does not accept a repo_type parameter, "
+                "and silently falling back to the 'dataset' namespace would "
+                "stream from a different storage system. "
+                "Upgrade with: pip install 'lerobot>=0.6.1'"
+            )
+
         # Proprio-only: strip video keys from delta_timestamps so video decode
         # (torchcodec) is never invoked - lets constrained edge devices stream
         # state/action without a torchcodec wheel.
-        if drop_videos and delta_timestamps:
-            delta_timestamps = {
-                k: v for k, v in delta_timestamps.items() if not k.startswith("observation.images.")
-            } or None
+        if drop_videos:
+            if delta_timestamps:
+                delta_timestamps = {
+                    k: v for k, v in delta_timestamps.items() if not k.startswith("observation.images.")
+                } or None
+            if delta_timestamps is None:
+                # Without delta_timestamps, StreamingLeRobotDataset streams
+                # EVERY feature - camera keys included, invoking torchcodec -
+                # so drop_videos=True would be a silent no-op doing the
+                # opposite of what was asked. Refuse rather than no-op.
+                raise ValueError(
+                    "drop_videos=True requires delta_timestamps with at least "
+                    "one non-video key: without it, every feature (including "
+                    "camera keys, via torchcodec decode) is streamed and "
+                    "drop_videos has no effect. Pass e.g. "
+                    "delta_timestamps={'observation.state': [0.0], 'action': [0.0]}."
+                )
 
         kwargs: dict[str, Any] = {"repo_id": repo_id}
         candidate = dict(
@@ -144,9 +198,11 @@ class StreamingDatasetReader:
             repo_type=repo_type,
         )
         for k, v in candidate.items():
-            # repo_type (and any other candidate) is only forwarded to a
-            # StreamingLeRobotDataset that declares it; a version without the
-            # parameter drops it here rather than raising a TypeError.
+            # Tolerant forwarding covers only kwargs whose absence does not
+            # change semantics (a lerobot without the parameter behaves the
+            # same for its default). repo_type is guarded above: a non-default
+            # value on a lerobot that lacks the parameter raises instead of
+            # being dropped here; the "dataset" default is safe to skip.
             if not (accepts_var_kw or k in init_sig):
                 continue
             if k in ("streaming", "shuffle", "return_uint8") or v is not None:

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -80,8 +80,30 @@ def test_repo_type_forwarded_when_supported(monkeypatch):
     assert r.dataset.repo_type == "bucket"
 
 
-def test_repo_type_dropped_when_unsupported(monkeypatch):
-    """A constructor without repo_type must not raise when repo_type is passed."""
+def test_repo_type_bucket_raises_when_unsupported(monkeypatch):
+    """repo_type='bucket' on a constructor without the parameter must raise,
+    never silently open the versioned dataset namespace instead (a different
+    storage system - the forbidden silent-kwarg-drop class)."""
+
+    class _Narrow:
+        def __init__(self, repo_id):
+            raise AssertionError("constructor must never be reached")
+
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+    with pytest.raises(RuntimeError, match=r"repo_type='bucket' requires lerobot>=0\.6\.1"):
+        sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+
+
+def test_repo_type_bucket_forwarded_via_var_kwargs(monkeypatch):
+    """A constructor with **kwargs accepts repo_type; the guard must not fire."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    r = sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+    assert r.dataset.kw["repo_type"] == "bucket"
+
+
+def test_repo_type_dataset_default_ok_when_unsupported(monkeypatch):
+    """The 'dataset' default is semantics-preserving on an old lerobot: it is
+    skipped by tolerant forwarding and open() succeeds without error."""
 
     class _Narrow:
         def __init__(self, repo_id):
@@ -92,7 +114,7 @@ def test_repo_type_dropped_when_unsupported(monkeypatch):
             yield {}
 
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
-    r = sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+    r = sd.StreamingDatasetReader.open("org/ds", repo_type="dataset", validate_deltas=False)
     assert r.dataset.repo_id == "org/ds"
 
 
@@ -113,16 +135,25 @@ def test_drop_videos_strips_camera_deltas(monkeypatch):
     assert "observation.state" in dt and "action" in dt
 
 
-def test_drop_videos_all_camera_keys_yields_none(monkeypatch):
+def test_drop_videos_all_camera_keys_raises(monkeypatch):
+    """If stripping camera keys leaves NO deltas, drop_videos would be a silent
+    no-op (every feature, videos included, would stream) - it must raise."""
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
-    r = sd.StreamingDatasetReader.open(
-        "org/ds",
-        delta_timestamps={"observation.images.front": [-0.1, 0.0]},
-        drop_videos=True,
-        validate_deltas=False,
-    )
-    # All keys were camera keys → delta_timestamps drops out entirely.
-    assert "delta_timestamps" not in r.dataset.kw
+    with pytest.raises(ValueError, match="drop_videos=True requires delta_timestamps"):
+        sd.StreamingDatasetReader.open(
+            "org/ds",
+            delta_timestamps={"observation.images.front": [-0.1, 0.0]},
+            drop_videos=True,
+            validate_deltas=False,
+        )
+
+
+def test_drop_videos_without_deltas_raises(monkeypatch):
+    """drop_videos=True with no delta_timestamps at all previously did nothing
+    (video decode still ran); the documented behavior is now to raise."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    with pytest.raises(ValueError, match="drop_videos=True requires delta_timestamps"):
+        sd.StreamingDatasetReader.open("org/ds", drop_videos=True, validate_deltas=False)
 
 
 def test_dataloader_ignores_shuffle(monkeypatch):


### PR DESCRIPTION
Closes #1501.

## What changed

`StreamingDatasetReader.open()` (`strands_robots/streaming_dataset.py`) tolerant-forwards constructor kwargs via `inspect.signature` so lerobot version bumps can't break it. Two kwargs escaped that shim's intended scope because their absence **changes semantics**, not cosmetics:

1. **`repo_type="bucket"` on lerobot < 0.6.1 now raises `RuntimeError`** instead of being silently dropped. Previously the call succeeded and streamed from the versioned *dataset* namespace - a different storage system than the bucket the user asked for (or 404'd on a nonexistent dataset repo). The error names the required floor and the installed version:
   `repo_type='bucket' requires lerobot>=0.6.1 (installed: 0.5.1): ...`
   The `"dataset"` default remains tolerant-skipped on old lerobot (no behavior change), and a constructor with `**kwargs` still gets `repo_type` forwarded.

2. **`drop_videos=True` with no effective `delta_timestamps` now raises `ValueError`** instead of silently no-opping. Without `delta_timestamps` (or when stripping camera keys empties it), `StreamingLeRobotDataset` streams *every* feature - camera keys included, invoking torchcodec decode - i.e. the opposite of what `drop_videos` promises. The error tells the caller to pass a `delta_timestamps` with at least one non-video key.

Docs updated to match the new contracts: README "Proprio-only / no video" paragraph, `docs/recording.md` streaming kwargs section, and the `stream_dataset()` facade docstring in `strands_robots/simulation/recording.py`.

## Why

This is the "silent kwarg drop" class AGENTS.md forbids ("Reject silently-dropped kwargs", "No silent defaults on error"). Tolerant forwarding is kept only for kwargs whose absence is semantics-preserving (buffer sizes, seeds, etc.); anything that selects *which storage system is read* or *whether video decode runs* must fail fast.

## Test surface

`tests/test_streaming_dataset.py` (+5 net tests; suite: 11052 passed, 197 skipped, 0 failed with `MUJOCO_GL=egl`):

- `test_repo_type_bucket_raises_when_unsupported` - narrow constructor + `repo_type="bucket"` raises `RuntimeError` matching `lerobot>=0.6.1`, and the constructor is provably never reached.
- `test_repo_type_bucket_forwarded_via_var_kwargs` - `**kwargs` constructor still receives `repo_type="bucket"` (guard must not fire).
- `test_repo_type_dataset_default_ok_when_unsupported` - the `"dataset"` default stays tolerant-skipped on a narrow constructor (replaces the old `test_repo_type_dropped_when_unsupported`, which pinned the buggy silent drop).
- `test_drop_videos_without_deltas_raises` - the previously-silent no-op now raises `ValueError`.
- `test_drop_videos_all_camera_keys_raises` - stripping leaves no deltas -> same `ValueError` (replaces `test_drop_videos_all_camera_keys_yields_none`, which pinned a variant of the no-op: all-camera deltas collapsed to `None`, streaming everything including video).
- Existing forwarding/validation/facade tests unchanged and green.

`hatch run lint` clean (ruff check, ruff format, mypy).

## Acceptance criteria from #1501

- [x] `repo_type != "dataset"` + lerobot without the param -> `RuntimeError("repo_type='bucket' requires lerobot>=0.6.1 (installed: X.Y.Z)...")`; tolerant drop kept only for semantics-preserving kwargs.
- [x] `drop_videos=True` with no `delta_timestamps` -> documented behavior is to raise `ValueError` (chosen over warn per the AGENTS.md fail-fast rule: never warn-and-continue when the system will behave unexpectedly), and docs no longer advertise a no-op.
- [x] Regression tests for both (mocked `StreamingLeRobotDataset` without the parameter; `drop_videos` with no / all-camera deltas).
- [ ] Raising the `lerobot` floor to `>=0.6.1` in `pyproject.toml` - **out of scope per the issue's "tracked separately if preferred"**; follow-up issue: #1516.

## Notes

- Board: please move #1501 to "In review" on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2) (item-edit auth unavailable from this box).
- The full-suite abort seen without `MUJOCO_GL=egl` (`test_remote_policy_sim_rollout`) is the known environmental GL issue on this dev box; the test passes in isolation and the full suite is green under EGL.
