### PR TITLE
fix(examples/nb05): sync the recorded dataset in the bucket cell and check the result (closes #1499)

### DIFF
--- a/examples/notebooks/05_streaming_data_loop.ipynb
+++ b/examples/notebooks/05_streaming_data_loop.ipynb
@@ -136,12 +136,16 @@
    "outputs": [],
    "source": [
     "if BUCKET:\n",
-    "    from strands_robots import Robot as R2\n",
+    "    from strands_robots.dataset_recorder import DatasetRecorder\n",
     "\n",
-    "    tmp = R2(\"so100\", mesh=False)\n",
-    "    tmp.stop_recording(bucket=BUCKET)\n",
-    "    tmp.destroy()\n",
-    "    print(f\"synced to bucket: hf://buckets/{BUCKET}\")\n",
+    "    # Reopen the dataset recorded in Step 1 and sync it. sync_to_bucket()\n",
+    "    # returns a status dict - check it instead of assuming success.\n",
+    "    rec = DatasetRecorder.resume(\"local/nb5_demo\", root=ROOT)\n",
+    "    result = rec.sync_to_bucket(BUCKET)\n",
+    "    if result.get(\"status\") == \"success\":\n",
+    "        print(f\"synced to bucket: {result['bucket_uri']}\")\n",
+    "    else:\n",
+    "        raise RuntimeError(f\"bucket sync failed: {result.get('message')}\")\n",
     "else:\n",
     "    print(\"BUCKET not set - skipping sync. Local path works for training below.\")"
    ]


### PR DESCRIPTION
## Summary

Fixes #1499.

Cell 7 (the bucket-sync cell) of `examples/notebooks/05_streaming_data_loop.ipynb` was a silent no-op that reported success unconditionally when `BUCKET` was set:

- It booted a **fresh** MuJoCo sim (`R2("so100")`) that had never recorded anything and called `stop_recording(bucket=BUCKET)`, which hit the idempotent "Was not recording." early-return (`strands_robots/simulation/recording.py:178`) and synced nothing.
- It then unconditionally printed `synced to bucket: hf://buckets/{BUCKET}` - a false success for anyone following the notebook's own "set `BUCKET = ...`" instruction.
- It also booted an entire MuJoCo world just to (not) run a CLI sync.

## What changed

Cell 7 now syncs the dataset that cell 3 actually recorded, and checks the returned status dict (issue's suggested fix, verbatim):

```python
if BUCKET:
    from strands_robots.dataset_recorder import DatasetRecorder

    rec = DatasetRecorder.resume("local/nb5_demo", root=ROOT)
    result = rec.sync_to_bucket(BUCKET)
    if result.get("status") == "success":
        print(f"synced to bucket: {result['bucket_uri']}")
    else:
        raise RuntimeError(f"bucket sync failed: {result.get('message')}")
else:
    print("BUCKET not set - skipping sync. Local path works for training below.")
```

- Success now prints the **real** destination (`result['bucket_uri']`, including the `run_id` subpath) instead of a hand-built string.
- Failure raises `RuntimeError` with `sync_to_bucket`'s error message instead of printing success. Follows the AGENTS.md rule "Don't discard return values - if a step returns `{"status": ...}`, check it" and the PR #86 learning about unconditional success reporting.
- No sim is created just to run a CLI sync.
- `DatasetRecorder.resume()` hard-requires lerobot>=0.5.2, which is already covered by the notebook's stated "Bucket steps need ... LeRobot >= 0.6.1" floor in cell 0, so no new requirement is introduced on the bucket path. The local (BUCKET unset) path is unchanged.

Diff: 1 file, +9/-5 lines (notebook JSON).

## Validation

- End-to-end check of the new cell-7 path on this box (4x L4, `MUJOCO_GL=egl`): ran the cell-3 recording code (60 frames), then `DatasetRecorder.resume("local/nb5_demo", root=ROOT)` -> reports 1 episode / 60 frames, `meta/` present, and `sync_to_bucket` correctly returns an error dict on a rejected bucket name (validation path, no credentials needed).
- `hatch run lint` - clean (`Success: no issues found in 816 source files`).
- `MUJOCO_GL=egl hatch run test` - **11049 passed, 197 skipped, 0 failed** (93.35% coverage). Note: without `MUJOCO_GL=egl` the suite aborts inside `tests/inference/test_remote_policy_sim_rollout.py` on this headless box (GL backend interaction; the test passes in isolation) - environmental, pre-existing, and unrelated to this notebook-only diff.

## Acceptance criteria (from #1499)

- [x] Cell 7 syncs the dataset cell 3 recorded (via `DatasetRecorder.resume` + `sync_to_bucket`), not a fresh no-op sim
- [x] The returned status dict is checked; success prints the real `bucket_uri`, failure raises with the message
- [x] No MuJoCo world is booted just to run the sync

## Out of scope / follow-ups

- A lifecycle-independent `sync_dataset_to_bucket(root, bucket)` helper (mentioned in the issue as a future alternative that would avoid the `resume()` lerobot>=0.5.2 hard requirement) does not exist yet; this PR uses the `resume()`-based suggested fix. Happy to file a follow-up issue if wanted.

## Project board

If #1499 is on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2), please move it to "In review" (fork PAT lacks project-write scope).
