### PR TITLE
fix(sim/recording): stop_recording(bucket=) on an idle sim syncs the last dataset or errors, never a silent drop (closes #1498)

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -117,6 +117,122 @@ _BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
+def sync_dataset_to_bucket(
+    local_root: str,
+    bucket: str,
+    run_id: str | None = None,
+    *,
+    create: bool = True,
+    private: bool = True,
+    delete: bool = False,
+) -> dict[str, Any]:
+    """Sync an on-disk LeRobotDataset into an HF Storage Bucket (Phase 1/2).
+
+    Lifecycle-independent: needs only a finalized dataset directory on disk
+    (``meta/`` present) and the ``hf`` CLI - no live
+    :class:`DatasetRecorder`, no sim world. Both
+    :meth:`DatasetRecorder.sync_to_bucket` and the idle-path bucket sync in
+    ``stop_recording`` delegate here so input validation and CLI
+    orchestration exist exactly once.
+
+    Mutable, Xet-deduplicated dump target for COLLECTION - avoids git-LFS
+    history bloat of push_to_hub during recording. Daily re-sync uploads
+    only changed chunks (content-defined chunking). Requires the ``hf`` CLI
+    (huggingface_hub>=1.x) and ``hf auth login``.
+
+    ``bucket`` and ``run_id`` are validated against an allowlist before any
+    subprocess or URI interpolation: ``bucket`` must be ``"name"`` or
+    ``"org/name"`` and ``run_id`` a single path segment, both restricted to
+    ``[A-Za-z0-9._-]`` (no path traversal or shell metacharacters). This
+    path is agent-reachable via ``stop_recording(bucket=, run_id=)``. A
+    rejected value returns ``{"status": "error", ...}`` without running ``hf``.
+
+    The shard layout is already Xet/bucket-friendly at the 100 MB default,
+    and ``meta/`` MUST ship or downstream loses normalization stats.
+
+    Args:
+        local_root: On-disk dataset root (must contain ``meta/``).
+        bucket: Bucket target, ``"name"`` or ``"org/name"``.
+        run_id: Subpath inside the bucket; defaults to the dataset directory
+            name (``Path(local_root).name``).
+        create: Create the bucket first (pre-existing bucket is not an error).
+        private: Create the bucket as private.
+        delete: Forward ``--delete`` to ``hf sync`` (mirror-remove).
+
+    Returns:
+        ``{"status": "success", "bucket_uri": ...}`` or
+        ``{"status": "error", "message": ...}``.
+    """
+    import subprocess
+
+    hf = _hf_executable()
+    if hf is None:
+        return {
+            "status": "error",
+            "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
+        }
+
+    # `hf buckets` / `hf sync` need huggingface_hub>=1.0; on 0.x the CLI
+    # exists but rejects those subcommands with argparse noise. Gate on the
+    # installed package version so users get an upgrade instruction instead.
+    version_error = _huggingface_hub_version_error()
+    if version_error is not None:
+        return {"status": "error", "message": version_error}
+
+    if not _BUCKET_RE.match(bucket):
+        return {
+            "status": "error",
+            "message": f"invalid bucket {bucket!r}: must match "
+            "'name' or 'org/name' using [A-Za-z0-9._-] (no path traversal "
+            "or shell metacharacters).",
+        }
+
+    # meta/ must ship or downstream loses normalization stats.
+    if not (Path(local_root) / "meta").exists():
+        return {
+            "status": "error",
+            "message": f"No meta/ under {local_root}; the dataset was never finalized. "
+            "Call finalize() (stop_recording does this) before syncing to a bucket "
+            "(stats/info required for streaming/training).",
+        }
+
+    run_id = run_id or Path(local_root).name
+    if not _RUN_ID_RE.match(run_id):
+        return {
+            "status": "error",
+            "message": f"invalid run_id {run_id!r}: must be a single path "
+            "segment using [A-Za-z0-9._-] (no '/', path traversal, or shell "
+            "metacharacters).",
+        }
+    dest = f"hf://buckets/{bucket}/{run_id}"
+
+    if create:
+        cp = subprocess.run(
+            [hf, "buckets", "create", bucket] + (["--private"] if private else []),
+            capture_output=True,
+            text=True,
+        )
+        blob = (cp.stderr + cp.stdout).lower()
+        if cp.returncode != 0 and "exist" not in blob:
+            return {
+                "status": "error",
+                "message": f"bucket create failed: {cp.stderr.strip()}",
+            }
+
+    cmd = [hf, "sync", str(local_root), dest]
+    if delete:
+        cmd.append("--delete")
+    logger.info("Syncing %s -> %s", local_root, dest)
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        return {
+            "status": "error",
+            "message": proc.stderr.strip() or proc.stdout.strip(),
+        }
+
+    return {"status": "success", "bucket_uri": dest}
+
+
 def _hf_executable() -> str | None:
     """Resolve the ``hf`` CLI, preferring the one in the running interpreter's
     environment before falling back to PATH.
@@ -1085,94 +1201,24 @@ class DatasetRecorder:
     ) -> dict[str, Any]:
         """Sync the on-disk LeRobotDataset into an HF Storage Bucket (Phase 1/2).
 
-        Mutable, Xet-deduplicated dump target for COLLECTION - avoids git-LFS
-        history bloat of push_to_hub during recording. Daily re-sync uploads
-        only changed chunks (content-defined chunking). Requires the ``hf`` CLI
-        (huggingface_hub>=1.x) and ``hf auth login``.
-
-        ``bucket`` and ``run_id`` are validated against an allowlist before any
-        subprocess or URI interpolation: ``bucket`` must be ``"name"`` or
-        ``"org/name"`` and ``run_id`` a single path segment, both restricted to
-        ``[A-Za-z0-9._-]`` (no path traversal or shell metacharacters). This
-        path is agent-reachable via ``stop_recording(bucket=, run_id=)``. A
-        rejected value returns ``{"status": "error", ...}`` without running ``hf``.
-
-        The shard layout is already Xet/bucket-friendly at the 100 MB default,
-        and ``meta/`` MUST ship or downstream loses normalization stats.
+        Thin wrapper over the lifecycle-independent
+        :func:`sync_dataset_to_bucket` (which holds the input validation and
+        ``hf`` CLI orchestration), bound to this recorder's dataset root and
+        repo id. On success the recorder's episode/frame counters are added to
+        the payload.
         """
-        import subprocess
-
-        hf = _hf_executable()
-        if hf is None:
-            return {
-                "status": "error",
-                "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
-            }
-
-        # `hf buckets` / `hf sync` need huggingface_hub>=1.0; on 0.x the CLI
-        # exists but rejects those subcommands with argparse noise. Gate on the
-        # installed package version so users get an upgrade instruction instead.
-        version_error = _huggingface_hub_version_error()
-        if version_error is not None:
-            return {"status": "error", "message": version_error}
-
-        if not _BUCKET_RE.match(bucket):
-            return {
-                "status": "error",
-                "message": f"invalid bucket {bucket!r}: must match "
-                "'name' or 'org/name' using [A-Za-z0-9._-] (no path traversal "
-                "or shell metacharacters).",
-            }
-
-        local_root = str(self.dataset.root)
-        # meta/ must ship or downstream loses normalization stats.
-        if not (Path(local_root) / "meta").exists():
-            return {
-                "status": "error",
-                "message": f"No meta/ under {local_root}; call finalize() before "
-                "sync_to_bucket (stats/info required for streaming/training).",
-            }
-
-        run_id = run_id or self.dataset.repo_id.split("/")[-1]
-        if not _RUN_ID_RE.match(run_id):
-            return {
-                "status": "error",
-                "message": f"invalid run_id {run_id!r}: must be a single path "
-                "segment using [A-Za-z0-9._-] (no '/', path traversal, or shell "
-                "metacharacters).",
-            }
-        dest = f"hf://buckets/{bucket}/{run_id}"
-
-        if create:
-            cp = subprocess.run(
-                [hf, "buckets", "create", bucket] + (["--private"] if private else []),
-                capture_output=True,
-                text=True,
-            )
-            blob = (cp.stderr + cp.stdout).lower()
-            if cp.returncode != 0 and "exist" not in blob:
-                return {
-                    "status": "error",
-                    "message": f"bucket create failed: {cp.stderr.strip()}",
-                }
-
-        cmd = [hf, "sync", local_root, dest]
-        if delete:
-            cmd.append("--delete")
-        logger.info("Syncing %s -> %s", local_root, dest)
-        proc = subprocess.run(cmd, capture_output=True, text=True)
-        if proc.returncode != 0:
-            return {
-                "status": "error",
-                "message": proc.stderr.strip() or proc.stdout.strip(),
-            }
-
-        return {
-            "status": "success",
-            "bucket_uri": dest,
-            "episodes": self.episode_count,
-            "frames": self.frame_count,
-        }
+        result = sync_dataset_to_bucket(
+            str(self.dataset.root),
+            bucket,
+            run_id=run_id or self.dataset.repo_id.split("/")[-1],
+            create=create,
+            private=private,
+            delete=delete,
+        )
+        if result.get("status") == "success":
+            result["episodes"] = self.episode_count
+            result["frames"] = self.frame_count
+        return result
 
     @property
     def repo_id(self) -> str:

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -154,8 +154,15 @@ class DatasetRecordingMixin:
     ) -> dict[str, Any]:
         """Stop recording and save episode to LeRobotDataset.
 
-        idempotent - calling when not recording succeeds with a
+        Idempotent - a bare call when not recording succeeds with a
         'Was not recording' message so callers can safely call it unconditionally.
+        When ``bucket=`` / ``run_id=`` / ``push_to_hub=True`` are passed while
+        NOT recording, they are never silently dropped (AGENTS.md: forward all
+        advertised kwargs): ``bucket=`` syncs the last-finalized dataset of this
+        sim (the ``last_dataset_root`` stashed at ``start_recording``) so the
+        "re-run stop_recording(bucket=...) as the daily sync" workflow works;
+        ``push_to_hub=True`` (or ``run_id=`` without ``bucket=``) returns a
+        structured ``status="error"`` because there is nothing to publish.
 
         Returns a structured ``status="error"`` when the recording captured no
         frames (the dataset would contain only ``meta/info.json``), rather than
@@ -168,14 +175,17 @@ class DatasetRecordingMixin:
             output_path: Unused legacy arg (kept for back-compat).
             push_to_hub: Publish to a versioned HF *dataset* repo (the finished
                 artifact). Overrides the ``push_to_hub`` set at start_recording.
+                Requires an open recording session; on the idle path this
+                returns ``status="error"`` instead of a silent no-op.
             bucket: If set (e.g. ``"my-org/robot-fave"``), sync the dataset into
                 a mutable HF Storage Bucket instead of/in addition to the dataset
                 repo - the Phase 1/2 collection target (Xet-deduped, overwrite in
-                place).
+                place). When no recording is open, syncs the last dataset this
+                sim finalized (errors if there is none).
             run_id: Optional subpath inside the bucket (defaults to dataset name).
         """
         if self._world is None or not self._world._backend_state.get("recording", False):
-            return {"status": "success", "content": [{"text": "Was not recording."}]}
+            return self._stop_recording_idle(push_to_hub=push_to_hub, bucket=bucket, run_id=run_id)
 
         self._world._backend_state["recording"] = False
         recorder = self._world._backend_state.get("dataset_recorder", None)
@@ -333,6 +343,103 @@ class DatasetRecordingMixin:
                         "root": root,
                     }
                 },
+            ],
+        }
+
+    def _stop_recording_idle(
+        self,
+        *,
+        push_to_hub: bool,
+        bucket: str | None,
+        run_id: str | None,
+    ) -> dict[str, Any]:
+        """Handle ``stop_recording`` when no recording session is open.
+
+        A bare ``stop_recording()`` stays the idempotent success no-op so
+        callers (including ``run_policy``'s finally block) can invoke it
+        unconditionally. But when the caller passed upload kwargs, dropping
+        them behind a ``status="success"`` is a silent-drop bug (AGENTS.md:
+        "Forward all advertised kwargs" / "No silent defaults on error") - the
+        agent believes data was uploaded when nothing happened:
+
+        * ``bucket=``: sync the last dataset this sim finalized (the
+          ``last_dataset_root`` stashed at ``start_recording``). This is the
+          documented "call stop_recording(bucket=...) again as the daily
+          sync" workflow - the sync only needs the on-disk dataset, not a
+          live recorder. Errors when this sim never recorded anything.
+        * ``push_to_hub=True``: structured error - publishing a versioned
+          dataset repo requires the recorder of an open session.
+        * ``run_id=`` without ``bucket=``: structured error - it only applies
+          together with ``bucket=``.
+        """
+        if not push_to_hub and not bucket and not run_id:
+            return {"status": "success", "content": [{"text": "Was not recording."}]}
+
+        if push_to_hub or (run_id and not bucket):
+            detail = "push_to_hub=True" if push_to_hub else f"run_id={run_id!r} without bucket="
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"stop_recording: {detail} given but no recording session is "
+                            "open - nothing was published or synced. push_to_hub requires "
+                            "an open session (start_recording -> run_policy -> "
+                            "stop_recording(push_to_hub=True)); run_id= only applies "
+                            "together with bucket=."
+                        )
+                    }
+                ],
+            }
+
+        last_root = self._world._backend_state.get("last_dataset_root") if self._world is not None else None
+        if not last_root:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"stop_recording: bucket={bucket!r} given but no recording "
+                            "session is open and this sim has no previously recorded "
+                            "dataset to sync - nothing was uploaded. Record first "
+                            "(start_recording -> run_policy -> stop_recording), or pass "
+                            "bucket= on the stop_recording call that closes the session."
+                        )
+                    }
+                ],
+            }
+
+        # Lazy import: keeps this engine-agnostic mixin free of the
+        # dataset_recorder import (numpy) at module load, matching the lazy
+        # DatasetRecorder import in each backend's start_recording.
+        from strands_robots.dataset_recorder import sync_dataset_to_bucket
+
+        # Every no-bucket combination returned above, so bucket is set here.
+        assert bucket is not None
+        sync_result = sync_dataset_to_bucket(str(last_root), bucket, run_id=run_id)
+        if sync_result.get("status") == "success":
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            "Was not recording; synced the last recorded dataset instead.\n"
+                            f"Local: {last_root}\n"
+                            f"Synced to bucket: {sync_result['bucket_uri']}"
+                        )
+                    }
+                ],
+            }
+        return {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        "stop_recording: was not recording, and syncing the last recorded "
+                        f"dataset ({last_root}) to bucket {bucket!r} FAILED: "
+                        f"{sync_result.get('message')}"
+                    )
+                }
             ],
         }
 

--- a/tests/simulation/mujoco/test_stop_recording_finalize.py
+++ b/tests/simulation/mujoco/test_stop_recording_finalize.py
@@ -164,6 +164,120 @@ class TestStopRecordingFinalize:
         assert "push_to_hub FAILED: auth denied" in result["content"][0]["text"]
 
 
+class TestStopRecordingIdleKwargs:
+    """Idle-path kwargs are never silently dropped (#1498).
+
+    ``stop_recording(bucket=...)`` on a sim with no open recording session used
+    to return the bare idempotent ``"Was not recording."`` success and skip the
+    bucket sync entirely - the agent believed the upload happened when nothing
+    ran. Contract now:
+
+    * bare ``stop_recording()`` stays the idempotent success no-op;
+    * ``bucket=`` syncs the last-finalized dataset (``last_dataset_root``
+      stashed at start_recording), the documented daily-sync workflow;
+    * ``bucket=`` with no prior dataset is a structured error, not success;
+    * ``push_to_hub=True`` / ``run_id=`` without ``bucket=`` are structured
+      errors (publishing needs an open session; run_id needs bucket).
+    """
+
+    def test_idle_bucket_never_returns_bare_was_not_recording_success(self, recording_sim, monkeypatch):
+        """Regression pin: bucket= on an idle sim must not be a silent no-op."""
+        result = recording_sim.stop_recording(bucket="org/buck")
+        text = result["content"][0]["text"]
+        assert not (result["status"] == "success" and text == "Was not recording.")
+
+    def test_idle_bare_stop_stays_idempotent_success(self, recording_sim):
+        result = recording_sim.stop_recording()
+        assert result["status"] == "success"
+        assert "Was not recording" in result["content"][0]["text"]
+
+    def test_idle_bucket_with_no_prior_dataset_errors(self, recording_sim):
+        # Never recorded on this sim: nothing to sync -> loud error.
+        assert recording_sim._world._backend_state.get("last_dataset_root") is None
+        result = recording_sim.stop_recording(bucket="org/buck")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "nothing was uploaded" in text
+        assert "start_recording" in text
+
+    def test_idle_bucket_syncs_last_finalized_dataset(self, recording_sim, monkeypatch):
+        # The daily-sync workflow: session already closed, bucket= re-syncs the
+        # dataset stashed as last_dataset_root at start_recording.
+        from strands_robots import dataset_recorder as dr
+
+        recording_sim._world._backend_state["last_dataset_root"] = "/tmp/last_ds"
+        seen = {}
+
+        def _fake_sync(local_root, bucket, run_id=None, **kwargs):
+            seen["args"] = (local_root, bucket, run_id)
+            return {"status": "success", "bucket_uri": f"hf://buckets/{bucket}/run7"}
+
+        monkeypatch.setattr(dr, "sync_dataset_to_bucket", _fake_sync)
+
+        result = recording_sim.stop_recording(bucket="org/buck", run_id="run7")
+        assert result["status"] == "success"
+        assert seen["args"] == ("/tmp/last_ds", "org/buck", "run7")
+        text = result["content"][0]["text"]
+        assert "Synced to bucket: hf://buckets/org/buck/run7" in text
+        assert "/tmp/last_ds" in text
+
+    def test_idle_bucket_sync_failure_is_error(self, recording_sim, monkeypatch):
+        # Unlike the open-session path (where the dataset was still saved), the
+        # ONLY requested effect on the idle path is the sync - a failed sync
+        # fails the call.
+        from strands_robots import dataset_recorder as dr
+
+        recording_sim._world._backend_state["last_dataset_root"] = "/tmp/last_ds"
+        monkeypatch.setattr(
+            dr,
+            "sync_dataset_to_bucket",
+            lambda *a, **k: {"status": "error", "message": "bucket unreachable"},
+        )
+
+        result = recording_sim.stop_recording(bucket="org/buck")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "FAILED" in text
+        assert "bucket unreachable" in text
+
+    def test_idle_push_to_hub_errors(self, recording_sim):
+        # Publishing a versioned dataset repo needs the open session's recorder.
+        result = recording_sim.stop_recording(push_to_hub=True)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "push_to_hub" in text
+        assert "no recording session" in text
+
+    def test_idle_run_id_without_bucket_errors(self, recording_sim):
+        result = recording_sim.stop_recording(run_id="run7")
+        assert result["status"] == "error"
+        assert "run_id" in result["content"][0]["text"]
+
+    def test_idle_bucket_after_real_stop_cycle_resyncs(self, recording_sim, monkeypatch):
+        # Full repro from #1498: record -> stop (session closed) -> explicit
+        # stop_recording(bucket=...) must sync, not silently succeed.
+        from strands_robots import dataset_recorder as dr
+
+        rec = _FakeRecorder()
+        _arm(recording_sim, rec)
+        recording_sim._world._backend_state["last_dataset_root"] = rec.root
+        first = recording_sim.stop_recording()
+        assert first["status"] == "success"
+        assert recording_sim._world._backend_state["recording"] is False
+
+        synced = {}
+
+        def _fake_sync(root, bucket, run_id=None, **_k):
+            synced["args"] = (root, bucket)
+            return {"status": "success", "bucket_uri": f"hf://buckets/{bucket}/x"}
+
+        monkeypatch.setattr(dr, "sync_dataset_to_bucket", _fake_sync)
+        second = recording_sim.stop_recording(bucket="org/buck")
+        assert second["status"] == "success"
+        assert synced["args"] == (rec.root, "org/buck")
+        assert "Synced to bucket" in second["content"][0]["text"]
+
+
 class TestStopRecordingEmptyDataset:
     """stop_recording must fail loudly when no frames were captured, but must
     NOT fail a dataset that was filled via per-episode save_episode.

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1859,6 +1859,48 @@ def test_sync_to_bucket_delete_flag_forwards_to_sync(tmp_path, monkeypatch):
     assert "--delete" in calls[0]
 
 
+def test_sync_dataset_to_bucket_standalone_needs_no_recorder(tmp_path, monkeypatch):
+    """The module-level ``sync_dataset_to_bucket`` syncs an on-disk dataset with
+    no live DatasetRecorder (lifecycle-independent daily-sync path used by
+    ``stop_recording(bucket=...)`` on an idle sim)."""
+    import subprocess
+
+    from strands_robots import dataset_recorder as dr
+
+    root = tmp_path / "robot-fave"
+    root.mkdir()
+    _write_meta(root)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, *_a, **_k):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = dr.sync_dataset_to_bucket(str(root), "my-org/robot-fave")
+
+    assert result["status"] == "success"
+    # run_id defaults to the dataset directory name when no recorder exists.
+    assert result["bucket_uri"] == "hf://buckets/my-org/robot-fave/robot-fave"
+    assert calls[0][:3] == ["hf", "buckets", "create"]
+    assert calls[1][:2] == ["hf", "sync"] and calls[1][2] == str(root)
+
+
+def test_sync_dataset_to_bucket_standalone_requires_finalized_meta(tmp_path, monkeypatch):
+    """The standalone sync refuses a dataset root without ``meta/``."""
+    from strands_robots import dataset_recorder as dr
+
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
+
+    result = dr.sync_dataset_to_bucket(str(tmp_path), "my-org/robot-fave")
+
+    assert result["status"] == "error"
+    assert "meta/" in result["message"]
+
+
 def test_hf_executable_prefers_interpreter_env_over_path(tmp_path, monkeypatch):
     """`_hf_executable` finds the ``hf`` next to the running interpreter before
     falling back to PATH, so sync works from a venv whose bin is not activated.


### PR DESCRIPTION
Closes #1498.

## What changed

`stop_recording(bucket=...)` called on a sim with no open recording session used to hit the idempotent early-return (`strands_robots/simulation/recording.py:177-178`) and report `status="success"` (`"Was not recording."`) while **silently dropping** the `bucket=` / `run_id=` / `push_to_hub=` kwargs - no sync, no upload, no signal. This is the exact pattern the streaming-data-loop workflow publishes (agent prompt ends with "then stop recording", so the follow-up explicit `sim.stop_recording(bucket=...)` was a no-op), and it violates AGENTS.md ("Forward all advertised kwargs - silent drops are bugs" / "No silent defaults on error").

### New idle-path contract (`DatasetRecordingMixin._stop_recording_idle`)

| Call while idle | Before | After |
|---|---|---|
| `stop_recording()` | success no-op | success no-op (unchanged - `run_policy`'s finally block relies on it) |
| `stop_recording(bucket=...)` | **silent success, nothing synced** | syncs the last dataset this sim finalized (`last_dataset_root` stashed at `start_recording`) - the documented "call `stop_recording(bucket=...)` again as the daily sync" workflow. Failed sync => `status="error"`; no prior dataset => `status="error"` |
| `stop_recording(push_to_hub=True)` | silent success, nothing published | `status="error"` (publishing a versioned dataset repo requires the open session's recorder) |
| `stop_recording(run_id=...)` w/o `bucket=` | silent success | `status="error"` (run_id only applies with bucket) |

Both sim backends (MuJoCo + Newton) get the fix via the shared mixin.

### Mechanics (issue options 1 + 2)

The `hf` CLI orchestration and the `bucket`/`run_id` allowlist validation (LLM-input-safety surface) moved from `DatasetRecorder.sync_to_bucket` into a module-level `sync_dataset_to_bucket(local_root, bucket, run_id=None, ...)` in `strands_robots/dataset_recorder.py` that needs **no live recorder** (run_id defaults to the dataset dir name). The method now delegates to it (adding its episode/frame counters to the payload), and the idle path calls it directly - validation and subprocess handling exist exactly once. Open-session `stop_recording(bucket=...)` behavior is unchanged.

Option 3 from the issue (promoting a public `strands_robots.sync_dataset_to_bucket` helper) is explicitly out of scope here and tracked separately per the issue text - the helper exists at module level and can be exported in a follow-up.

## Test surface

- `tests/simulation/mujoco/test_stop_recording_finalize.py::TestStopRecordingIdleKwargs` (8 new tests): regression pin that idle `bucket=` never returns the bare `"Was not recording."` success; full `record -> stop -> stop(bucket=)` repro re-syncs; sync failure => error; no-prior-dataset => error; `push_to_hub` / orphan `run_id` => error; bare idle stop stays the idempotent success.
- `tests/test_dataset_recorder.py` (2 new tests): the standalone `sync_dataset_to_bucket` works recorder-free (run_id defaults from the root dir name) and still requires a finalized `meta/`.
- All 12 pre-existing `sync_to_bucket` validation/CLI tests (both test files) pass unchanged against the delegating method, pinning that the refactor preserved the allowlist ordering (hf CLI -> bucket regex -> meta/ -> run_id regex) and the injection-prevention contract.

## Acceptance criteria from #1498

- [x] `bucket=` on the idle path is no longer a silent drop (option 1: structured error when nothing to sync)
- [x] Idle path with `bucket=` syncs the `last_dataset_root` stashed at `start_recording` (option 2: the daily-sync workflow now works)
- [x] Regression test: `stop_recording(bucket=...)` on an idle sim does NOT return a bare success with the sync skipped (`test_idle_bucket_never_returns_bare_was_not_recording_success`)
- [ ] Option 3 (public lifecycle-independent helper export) - tracked separately per the issue text

## Validation

- `hatch run format` / `hatch run lint`: clean (ruff + mypy).
- Targeted: 296 passed across `test_stop_recording_finalize.py`, `test_dataset_recorder.py`, `test_streaming_dataset.py`, newton `test_dataset_recording.py`, `test_agenttool_contract.py`, `test_run_policy.py`, `test_recording_lifecycle_accessors.py`.
- Full `hatch run test` (with `MUJOCO_GL=egl`): **14 failed, 11045 passed, 197 skipped**. All 14 failures are environmental on this dev box (pynput X11 keyboard backend import - no display) in `test_teleoperator_factory.py` / `test_lerobot_teleoperate.py` / `test_use_lerobot.py`; they pass in isolation both on `upstream/main` and with this diff, and touch no recording code. Without EGL the full run core-dumps in MuJoCo's GL renderer init (pre-existing, also environmental).

## Project board

Please move #1498 to "In review" on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2) (PAT on this box lacks project-write).
