### PR TITLE
docs(recording): correct DatasetRecorder codec-routing comment to lerobot 0.6 allowlist symbols

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -33,14 +33,16 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
-# Every LeRobot surface in the supported ``>=0.5.0,<0.6.0`` range validates the
-# codec against the same codec-name allowlist - ``video_utils.VALID_VIDEO_CODECS
-# = {"h264", "hevc", "libsvtav1", "auto"} | HW_ENCODERS`` - and *rejects* the
-# ffmpeg library names ("libx264"/"libx265"). This holds for the flat ``vcodec``
-# kwarg (0.5.0/0.5.1) just as much as for the ``RGBEncoderConfig`` /
-# ``VideoEncoderConfig`` surfaces a later minor may expose. So there is exactly
-# one correct normalization direction: ffmpeg name -> codec name, applied to
-# whichever surface is present. Callers may pass either spelling.
+# Every LeRobot codec surface validates the requested codec against the same
+# codec-name allowlist - ``configs.video.VALID_VIDEO_CODECS = {"h264", "hevc",
+# "libsvtav1", "libaom-av1", "auto"} | HW_VIDEO_CODECS`` - and *rejects* the
+# ffmpeg library names ("libx264"/"libx265"). This holds for the current
+# ``rgb_encoder=RGBEncoderConfig(vcodec=...)`` surface (lerobot >=0.6.0,<0.7.0,
+# the supported range) exactly as it did for the flat ``vcodec`` kwarg and the
+# interim ``camera_encoder=VideoEncoderConfig(...)`` surface the tolerant
+# routing below still handles. So there is exactly one correct normalization
+# direction: ffmpeg name -> codec name, applied to whichever surface is present.
+# Callers may pass either spelling.
 _ENCODER_CODEC_NAMES = {"libx264": "h264", "libx265": "hevc"}
 
 
@@ -55,16 +57,16 @@ def _codec_create_kwargs(sig_params: Any, vcodec: str, *, context: str = "create
       * 0.5.0 / 0.5.1: a flat ``create/resume(..., vcodec=...)`` kwarg.
       * an interim build briefly exposed
         ``camera_encoder=VideoEncoderConfig(vcodec=...)``.
-      * a later minor may move the codec into
+      * lerobot >= 0.6 (the supported range) moved the codec into
         ``rgb_encoder=RGBEncoderConfig(vcodec=...)``.
 
     Every one of these surfaces validates against LeRobot's codec-name allowlist
-    (``{"h264", "hevc", "libsvtav1", "auto"} | HW_ENCODERS``) and rejects the
-    ffmpeg library names ("libx264"/"libx265"). So the codec is normalized to its
-    codec-name spelling once and routed onto whichever surface is present. The
-    caller may pass either spelling ("h264" or "libx264"). An unknown codec
-    raises loudly (LeRobot's own ValueError) rather than silently falling back
-    to the default.
+    (``{"h264", "hevc", "libsvtav1", "libaom-av1", "auto"} | HW_VIDEO_CODECS``)
+    and rejects the ffmpeg library names ("libx264"/"libx265"). So the codec is
+    normalized to its codec-name spelling once and routed onto whichever surface
+    is present. The caller may pass either spelling ("h264" or "libx264"). An
+    unknown codec raises loudly (LeRobot's own ValueError) rather than silently
+    falling back to the default.
 
     Args:
         sig_params: ``inspect.Signature.parameters`` of ``create``/``resume``.

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -186,3 +186,28 @@ def test_no_userfacing_file_invokes_removed_lerobot_scripts_train() -> None:
         assert "lerobot.scripts.lerobot_train" in text, (
             f"{path.name} lost its `lerobot.scripts.lerobot_train` reference"
         )
+
+
+# --- negative contract: lerobot 0.6 relocated + renamed the codec allowlist.
+#     ``VALID_VIDEO_CODECS`` moved from ``lerobot.datasets.video_utils`` to
+#     ``lerobot.configs.video``, the hardware-encoder set was renamed
+#     ``HW_ENCODERS`` -> ``HW_VIDEO_CODECS``, and ``libaom-av1`` joined the set.
+#     ``dataset_recorder.py``'s codec-routing header/docstring still documented
+#     the pre-0.6 snapshot (a ``>=0.5.0,<0.6.0`` "supported range" and a
+#     ``video_utils.VALID_VIDEO_CODECS ... | HW_ENCODERS`` allowlist) even though
+#     the ``[lerobot]`` extra floors lerobot at >=0.6.0 - so the code comment
+#     contradicted both the pyproject floor and the installed lerobot API. ---
+
+_DATASET_RECORDER = _REPO_ROOT / "strands_robots" / "dataset_recorder.py"
+
+
+def test_dataset_recorder_codec_docs_track_the_supported_lerobot_floor() -> None:
+    text = _DATASET_RECORDER.read_text()
+    # the dead pre-0.6 "supported range" claim is gone (the extra floors >=0.6.0)
+    assert ">=0.5.0,<0.6.0" not in text, "dataset_recorder.py still cites the dead pre-0.6 supported lerobot range"
+    # the hardware-encoder set was renamed in lerobot 0.6; the stale symbol must
+    # not linger in the documented allowlist
+    assert "HW_ENCODERS" not in text, "dataset_recorder.py cites the renamed HW_ENCODERS symbol (now HW_VIDEO_CODECS)"
+    # and the current allowlist symbols/entries are the ones documented
+    assert "HW_VIDEO_CODECS" in text
+    assert "libaom-av1" in text


### PR DESCRIPTION
## Problem

The `DatasetRecorder` codec-routing header comment and the `_codec_create_kwargs` docstring in `strands_robots/dataset_recorder.py` documented a pre-0.6 snapshot of LeRobot's codec allowlist that no longer matches either the declared dependency floor or the installed API:

- They cited a `>=0.5.0,<0.6.0` "supported range", but the `[lerobot]` extra floors lerobot at `>=0.6.0,<0.7.0` — the comment named a range that excludes the entire currently-supported line.
- They referenced `video_utils.VALID_VIDEO_CODECS = {"h264", "hevc", "libsvtav1", "auto"} | HW_ENCODERS`. In lerobot 0.6 that allowlist moved from `lerobot.datasets.video_utils` to `lerobot.configs.video`, the hardware-encoder set was renamed `HW_ENCODERS` -> `HW_VIDEO_CODECS`, and `libaom-av1` was added. Neither `VALID_VIDEO_CODECS` under `video_utils` nor `HW_ENCODERS` exists in lerobot 0.6, so a maintainer reading the comment to trace codec validation is pointed at removed symbols.
- They described `rgb_encoder=RGBEncoderConfig(vcodec=...)` as a surface "a later minor may expose", although it is the current codec surface on lerobot >= 0.6 (`LeRobotDataset.create(..., rgb_encoder=RGBEncoderConfig(...))`).

## Change

Documentation-only correctness fix. The routing logic is unchanged and verified correct on lerobot 0.6.1: `_codec_create_kwargs` routes the normalized codec onto `rgb_encoder=RGBEncoderConfig(vcodec=...)` when `create`/`resume` expose that kwarg. This PR only updates the header comment and docstring to name the current lerobot symbols (`configs.video.VALID_VIDEO_CODECS`, `HW_VIDEO_CODECS`, `libaom-av1`), state the correct supported range (`>=0.6.0,<0.7.0`), and describe `rgb_encoder` as the current surface rather than a speculative future one.

## Test

Adds `test_dataset_recorder_codec_docs_track_the_supported_lerobot_floor` to `tests/test_lerobot_dependency_docs.py`, matching the existing convention there of pinning version docs to the declared dependency reality. It asserts the dead `>=0.5.0,<0.6.0` range and the renamed `HW_ENCODERS` symbol are gone and that the current `HW_VIDEO_CODECS` / `libaom-av1` allowlist is documented. The test fails on the pre-fix file and passes after.

Gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean (no issues in 816 files); `tests/test_lerobot_dependency_docs.py tests/test_dataset_recorder.py tests/test_dependency_audit.py` all pass (117 passed).