### PR TITLE
test(lerobot_local): cover PackStateProcessorStep degrees units conversion

### DIFF
--- a/tests/policies/lerobot_local/test_embodiment.py
+++ b/tests/policies/lerobot_local/test_embodiment.py
@@ -4,6 +4,8 @@ These tests exercise the REAL mapping path (not mocked) to close the gap that
 let B7/B12 slip past the mock-heavy existing suite.
 """
 
+import math
+
 import numpy as np
 import pytest
 
@@ -300,6 +302,73 @@ def test_pack_state_passthrough_when_no_state_keys_present():
     out = s.observation(dict(obs))
     assert "observation.state" not in out
     assert "observation.images.image" in out
+
+
+# SO-arm degrees units on the declarative packing step. The direct
+# EmbodimentMap.sim_state_to_model conversion is covered in test_so_arm_units;
+# these pin the SAME rad->deg / gripper-0..100 conversion where it actually runs
+# at inference time: inside PackStateProcessorStep.observation when the
+# embodiment declares state_units="degrees". A native step must leave the raw
+# radian/joint values untouched, so the two together lock the boundary.
+
+# so101 sim gripper joint range (matches test_so_arm_units.GRIPPER_RANGE).
+_SO_GRIPPER_RANGE = [-0.175, 1.745]
+
+
+def test_pack_state_degrees_units_converts_radians_to_model_units():
+    """A degrees embodiment must convert the packed observation.state from sim
+    radians to the model's training units: arm joints in degrees, gripper in
+    RANGE_0_100. pi/2 rad arm joints -> 90 deg; a mid-range gripper -> 50."""
+    Step = _require_pack_state()
+    s = Step(
+        state_keys=["1", "2", "3", "4", "5", "6"],
+        expected_dim=6,
+        dim_policy="strict",
+        state_units="degrees",
+        gripper_index=5,
+        gripper_joint_range=_SO_GRIPPER_RANGE,
+    )
+    lo, hi = _SO_GRIPPER_RANGE
+    obs = {"1": math.pi / 2, "2": math.pi / 2, "3": math.pi / 2, "4": math.pi / 2, "5": math.pi / 2, "6": (lo + hi) / 2}
+    out = list(s.observation(obs)["observation.state"])
+    for i in range(5):
+        assert math.isclose(out[i], 90.0, abs_tol=1e-4), (i, out)
+    assert math.isclose(out[5], 50.0, abs_tol=1e-4), out
+
+
+def test_pack_state_degrees_units_applies_joint_mids():
+    """When the embodiment supplies per-joint calibration mids (degrees), the
+    degrees packing path must subtract them (mid-centered degrees, matching
+    lerobot motors_bus DEGREES mode), not emit the absolute joint angle."""
+    Step = _require_pack_state()
+    mids = [10.0, -20.0, 30.0, -5.0, 15.0, 0.0]
+    s = Step(
+        state_keys=["1", "2", "3", "4", "5", "6"],
+        expected_dim=6,
+        dim_policy="strict",
+        state_units="degrees",
+        gripper_index=5,
+        gripper_joint_range=_SO_GRIPPER_RANGE,
+        joint_mids=mids,
+    )
+    lo, hi = _SO_GRIPPER_RANGE
+    obs = {k: math.pi / 2 for k in ("1", "2", "3", "4", "5")}
+    obs["6"] = (lo + hi) / 2
+    out = list(s.observation(obs)["observation.state"])
+    for i in range(5):
+        assert math.isclose(out[i], 90.0 - mids[i], abs_tol=1e-4), (i, out)
+    assert math.isclose(out[5], 50.0, abs_tol=1e-4), out
+
+
+def test_pack_state_native_units_leaves_values_unconverted():
+    """The default native step is the boundary case: raw radian arm values pass
+    through unchanged (no rad->deg), so observation.state carries sim units."""
+    Step = _require_pack_state()
+    s = Step(state_keys=["1", "2", "3"], expected_dim=3, dim_policy="strict")
+    out = list(s.observation({"1": math.pi / 2, "2": 0.5, "3": -1.0})["observation.state"])
+    assert math.isclose(out[0], math.pi / 2, abs_tol=1e-6), out
+    assert math.isclose(out[1], 0.5, abs_tol=1e-6)
+    assert math.isclose(out[2], -1.0, abs_tol=1e-6)
 
 
 def test_pack_state_transform_features_is_passthrough():


### PR DESCRIPTION
## Problem

The declarative observation-packing step `PackStateProcessorStep` (registered as `strands_pack_state`, run inside the lerobot processor pipeline at inference time) applies the SO-arm sim->model units conversion when an embodiment declares `state_units="degrees"`: arm joints radians->degrees, the gripper column to RANGE_0_100, with optional per-joint calibration mids subtracted (mid-centered degrees, matching lerobot `motors_bus` DEGREES mode).

The direct `EmbodimentMap.sim_state_to_model` helper is well covered by `test_so_arm_units`, but the branch that wires that conversion into the actual pipeline packing path (`PackStateProcessorStep.observation`, `state_units == "degrees"`) had no test. That is the code path that actually runs during declarative-embodiment inference, so a silent regression there (e.g. dropping the conversion, or mishandling mids/gripper) would ship the arm raw radians as if they were degrees and freeze the arm - exactly the failure `test_so_arm_units` was written to prevent, but on the pipeline path rather than the helper.

## Change

Add three focused, behavior-pinning tests to `tests/policies/lerobot_local/test_embodiment.py`, alongside the existing `PackStateProcessorStep` tests:

- `test_pack_state_degrees_units_converts_radians_to_model_units`: a degrees embodiment converts pi/2 rad arm joints -> 90 deg and a mid-range gripper -> 50 (RANGE_0_100).
- `test_pack_state_degrees_units_applies_joint_mids`: per-joint calibration mids are subtracted on the packing path (mid-centered degrees).
- `test_pack_state_native_units_leaves_values_unconverted`: the default native step is the boundary case - raw radian values pass through unchanged.

The assertions check converted numeric outputs (90.0, not pi/2), so they fail if the degrees branch stops running - they pin behavior, not implementation.

## Tests

Test-only; no source/behavior change.

- `MUJOCO_GL=egl pytest tests/policies/lerobot_local/test_embodiment.py` -> 37 passed.
- Coverage of `strands_robots/policies/lerobot_local/embodiment.py`: the `state_units == "degrees"` packing branch is now exercised (previously uncovered).
- `ruff check` / `ruff format --check` / `mypy` clean on the changed file.