### PR TITLE
test(sim/mujoco): cover the 1-D-only legacy mj_fullM fallback in _full_mass_matrix

### DIFF
--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -335,6 +335,43 @@ class TestFullMassMatrixSignatureDrift:
         M = _full_mass_matrix(shim, model, data)
         assert np.allclose(M, reference)
 
+    def test_helper_falls_back_to_1d_only_legacy_signature(self, sim):
+        # Oldest binding: mj_fullM(model, dst, qM) accepts ONLY a raw 1-D sparse
+        # buffer and rejects the [m, 1] column form the first legacy attempt
+        # passes. The helper must fall through that inner TypeError to the flat
+        # 1-D call and still reconstruct the correct matrix. This pins the
+        # innermost fallback (the widest-compatibility call) the other drift
+        # tests never reach, because their shim accepts both buffer shapes.
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        reference = _full_mass_matrix(mj, model, data)
+
+        class _OneDLegacyShim:
+            """mujoco proxy whose mj_fullM accepts only (model, dst, qM_1d)."""
+
+            def __getattr__(self, attr):
+                return getattr(mj, attr)
+
+            @staticmethod
+            def mj_fullM(m, a, b):
+                # Reject the modern (model, data, dst) order.
+                import mujoco as _mj
+
+                if isinstance(a, _mj.MjData):
+                    raise TypeError("legacy binding: expected (model, dst, qM)")
+                # Reject the [m, 1] column buffer the first legacy attempt uses:
+                # only the raw 1-D sparse form is accepted here.
+                arr = np.asarray(b)
+                if arr.ndim != 1:
+                    raise TypeError("oldest binding: expected a 1-D sparse buffer")
+                assert isinstance(a, np.ndarray) and a.flags["WRITEABLE"]
+                assert arr.shape[0] == data.qM.shape[0]
+                a[...] = reference
+
+        shim = _OneDLegacyShim()
+        M = _full_mass_matrix(shim, model, data)
+        assert np.allclose(M, reference)
+
     def test_helper_returns_empty_for_zero_dof(self):
         # A model with no DoFs must return a well-typed (0, 0) array, never
         # crash in numpy on the empty buffer.


### PR DESCRIPTION
## Problem

`_full_mass_matrix` (`strands_robots/simulation/mujoco/physics.py`) reconstructs the dense inertia matrix `M(q)` and must work across the three `mj_fullM` binding signatures MuJoCo has shipped over its releases:

1. Modern `mj_fullM(model, data, dst)` - the sparse buffer is read internally.
2. Legacy `mj_fullM(model, dst, qM)` with `qM` as an `[m, 1]` column buffer.
3. Oldest legacy `mj_fullM(model, dst, qM)` that accepts only a raw 1-D sparse buffer.

The helper tries them in that order, falling through `TypeError` to the next. The existing `TestFullMassMatrixSignatureDrift` suite covered signatures (1) and (2), but its shim accepted **both** the `[m, 1]` column and the flat 1-D buffer, so the innermost fallback - the widest-compatibility flat 1-D call - was never exercised. Those two lines were uncovered, leaving the oldest-binding path unpinned: a refactor could drop it and every mass-matrix read (dynamics analysis, impedance control) would silently break only on the oldest MuJoCo bindings.

## Change

Add `test_helper_falls_back_to_1d_only_legacy_signature`, a shim that rejects the modern `(model, data, dst)` order **and** the `[m, 1]` column form, accepting only the raw 1-D sparse buffer. This forces `_full_mass_matrix` through its innermost fallback and asserts the reconstructed matrix matches the native result.

Test-only change; no library behavior is modified.

## Verification

- New test passes; the full `tests/simulation/mujoco/test_physics.py` (84 tests) passes.
- Negative control: deleting the innermost `except TypeError: mj.mj_fullM(model, dst, qm)` fallback makes the new test fail with `TypeError: oldest binding: expected a 1-D sparse buffer`, confirming it genuinely guards that branch.
- Coverage of `physics.py` lines 184-185 goes from uncovered to covered.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean (`Success: no issues found in 817 source files`).