### PR TITLE
fix(policies/groot): raise an actionable error on scalar (0-D) action values

### DIFF
--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -312,6 +312,36 @@ def _coerce_action_row(row: Any) -> float | list[float]:
     return float(row) if np.ndim(row) == 0 else list(row)
 
 
+def _action_chunk_horizon(chunk: dict[str, np.ndarray]) -> int:
+    """Return the shared time-axis length of a normalized action chunk.
+
+    Both unpack paths reduce each action value to ``(horizon,)`` or
+    ``(horizon, action_dim)`` and then iterate ``range(horizon)``. Every value
+    must therefore carry a leading time axis. A 0-D / scalar value has no time
+    axis, so a server or model that emits one is malformed; surface it as an
+    actionable error instead of the opaque ``IndexError: tuple index out of
+    range`` that a ``.shape[0]`` read on a 0-D array would otherwise raise.
+
+    Args:
+        chunk: Normalized ``{bare_key: np.ndarray}`` action mapping (non-empty).
+
+    Returns:
+        The leading-axis length shared by the chunk's values.
+
+    Raises:
+        ValueError: If any value is 0-D (has no leading time axis).
+    """
+    scalar_keys = [k for k, v in chunk.items() if v.ndim == 0]
+    if scalar_keys:
+        shapes = {k: tuple(chunk[k].shape) for k in scalar_keys}
+        raise ValueError(
+            f"GR00T returned scalar (0-D) action value(s) for {scalar_keys} "
+            f"(shapes {shapes}); expected a leading time axis of shape (horizon,) "
+            "or (horizon, action_dim). The action chunk is malformed."
+        )
+    return next(iter(chunk.values())).shape[0]
+
+
 # Gr00tPolicy
 
 
@@ -799,7 +829,7 @@ class Gr00tPolicy(Policy):
             return []
 
         assert self._action_mapping is not None, "Action mapping not initialized"
-        horizon = next(iter(squeezed.values())).shape[0]
+        horizon = _action_chunk_horizon(squeezed)
         mapped_keys = set(self._action_mapping.actions.keys())
 
         actions: list[dict[str, Any]] = []
@@ -925,7 +955,7 @@ class Gr00tPolicy(Policy):
         if not normalized:
             return []
 
-        horizon = next(iter(normalized.values())).shape[0]
+        horizon = _action_chunk_horizon(normalized)
 
         # If we have action mappings, use them for consistent key translation
         if self._action_mapping and self._action_mapping.actions:

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -1482,6 +1482,52 @@ class TestServiceUnpackWithMapping:
         assert "single_arm" in result[0]
 
 
+class TestUnpackMalformedActionChunk:
+    """Both unpack paths must survive degenerate server/model action chunks.
+
+    A well-formed chunk carries a leading time axis on every value, so the
+    unpackers read ``.shape[0]`` for the horizon. An empty chunk yields no
+    actions; a scalar (0-D) value has no time axis and must raise an actionable
+    ``ValueError`` rather than the opaque ``IndexError: tuple index out of
+    range`` that ``.shape[0]`` on a 0-D array would otherwise surface.
+    """
+
+    def test_service_empty_chunk_returns_no_actions(self):
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = None
+        assert p._unpack_service_actions({}) == []
+
+    def test_local_empty_chunk_returns_no_actions(self):
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = ActionMapping(actions={"single_arm": "joints"})
+        assert p._unpack_actions({}) == []
+
+    def test_service_scalar_value_raises_actionable_error(self):
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = None
+        with pytest.raises(ValueError, match=r"scalar \(0-D\) action value"):
+            p._unpack_service_actions({"action.single_arm": 5.0})
+
+    def test_local_scalar_value_raises_actionable_error(self):
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = ActionMapping(actions={"single_arm": "joints"})
+        with pytest.raises(ValueError, match=r"scalar \(0-D\) action value"):
+            p._unpack_actions({"action.single_arm": 5.0})
+
+    def test_scalar_error_names_offending_key(self):
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = None
+        with pytest.raises(ValueError, match="single_arm"):
+            p._unpack_service_actions({"action.single_arm": np.float64(1.0)})
+
+    def test_one_d_value_is_a_valid_horizon(self):
+        """A 1-D value is a horizon of scalars, not a malformed chunk."""
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._action_mapping = None
+        result = p._unpack_service_actions({"action.single_arm": np.ones(3)})
+        assert result == [{"single_arm": 1.0}, {"single_arm": 1.0}, {"single_arm": 1.0}]
+
+
 # (section)
 # Exports
 # (section)


### PR DESCRIPTION
## Problem

Both GR00T unpack paths, `_unpack_actions` (local mode) and `_unpack_service_actions` (service mode), normalize each action value to `(horizon,)` or `(horizon, action_dim)` (via the `while arr.ndim > 2: arr = arr[0]` reduction) and then read the horizon off the leading axis:

```python
horizon = next(iter(normalized.values())).shape[0]
```

If a server or model emits a **scalar (0-D) action value** (e.g. `{"action.single_arm": 5.0}`), that value has no leading time axis, so `.shape[0]` raises an opaque:

```
IndexError: tuple index out of range
```

deep inside the unpack loop. The caller gets no hint that the *server response was malformed* rather than that the client has a bug.

Reproduction on current `main`:

```python
p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
p._action_mapping = None
p._unpack_service_actions({"action.single_arm": 5.0})   # IndexError: tuple index out of range
```

## Change

Route both unpack paths through a single `_action_chunk_horizon()` helper that detects 0-D values and raises a clear, actionable `ValueError` naming the offending key(s) and their shapes:

```
ValueError: GR00T returned scalar (0-D) action value(s) for ['single_arm'] (shapes {'single_arm': ()}); expected a leading time axis of shape (horizon,) or (horizon, action_dim). The action chunk is malformed.
```

This matches the library convention of raising on fatal, actionable conditions rather than letting an opaque low-level error surface. Happy-path behavior is unchanged:

- an **empty** chunk still returns `[]`;
- a **1-D** value is still treated as a horizon of scalars;
- multi-dim values are unaffected.

Sharing the helper across both paths also keeps the local and service unpackers consistent (the same bug existed in both).

## Tests

Adds `TestUnpackMalformedActionChunk` covering both paths:

- `empty chunk -> []` (service + local)
- `scalar value -> ValueError` naming the offending key (service + local)
- error message includes the key name
- `1-D value -> valid horizon of scalars` (guards against over-tightening)

The scalar cases **fail on the prior code** with the exact `IndexError: tuple index out of range` this change replaces, and pass after it.

Local gate: `ruff check`/`ruff format --check` clean, `mypy` clean on the module, and the full `tests/policies/groot/` suite (220 tests) passes.

No visual artifact: this is an error-path input-validation fix; the happy-path rollout is unchanged and does not exercise the guarded branch.