### PR TITLE
test(lerobot_local): pin reset() propagation to the processor bridge

### DIFF
--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1144,6 +1144,24 @@ class TestReset:
         policy.reset()
         policy._policy.reset.assert_called_once()
 
+    def test_reset_propagates_to_processor_bridge(self):
+        """reset() resets the processor bridge so a finished episode's
+        preprocessor / normalizer state cannot leak into the next one.
+
+        The docstring for reset() guarantees cross-episode isolation, but every
+        other reset test nulls ``_processor_bridge``, leaving that propagation
+        unpinned. A live bridge must have its ``reset()`` called exactly once.
+        """
+        policy = _make_policy()
+        policy._loaded = True
+        policy._policy = MagicMock()
+        bridge = MagicMock()
+        policy._processor_bridge = bridge
+        policy.reset()
+        bridge.reset.assert_called_once_with()
+        # Inner policy is still reset in the same pass.
+        policy._policy.reset.assert_called_once()
+
     def test_reset_safe_when_not_loaded(self):
         policy = _make_policy()
         assert policy._policy is None


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy.reset()` documents that it clears per-episode state so a finished episode's preprocessor / normalizer / RTC buffers cannot leak into the next one. Part of that contract is propagating the reset to the processor bridge:

```python
if self._processor_bridge is not None:
    self._processor_bridge.reset()
```

That branch was untested. Every existing `reset()` test sets `_processor_bridge = None` (`test_reset_delegates_to_inner_policy`, `test_reset_clears_rtc_state`, `test_reset_clears_observed_delay`), so the live-bridge path never executed and the cross-episode-isolation guarantee for stateful processor pipelines was unpinned.

## Change

Add one focused test to `TestReset` that installs a bridge on a policy and asserts `reset()` calls `bridge.reset()` exactly once, while still resetting the inner policy in the same pass. It pins the documented isolation contract rather than internals.

## Coverage

`strands_robots/policies/lerobot_local/policy.py` line 496 (`self._processor_bridge.reset()`) went from uncovered to covered; it no longer appears in the `--cov term-missing` report for the module.

## Tests

Test-only change, no behavior change. Local gate green:

- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - clean
- `mypy strands_robots tests tests_integ` - Success, no issues in 819 source files
- `pytest tests/policies/lerobot_local/test_policy.py` - 161 passed