### PR TITLE
docs(sim): correct set_eval_seed docstring to match its public contract

### DIFF
--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -91,12 +91,11 @@ def set_eval_seed(seed: int) -> None:
       are scoped to torch (not the broader environment) so the side
       effect surface is acceptable.
 
-    Public since #179: standalone integration tests
-    (``tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate``)
-    bypass :meth:`evaluate_benchmark` and need to call this directly to
-    get reproducible policy rollouts. Despite the leading ``_``, this
-    function is the supported way to seed an eval and is part of the
-    public API.
+    Public API - the single supported RNG-seeding entry point, exported
+    via ``__all__``. :meth:`evaluate_benchmark` calls it once before an
+    eval, but standalone callers that drive a policy rollout without
+    going through ``evaluate_benchmark`` can call it directly to get
+    reproducible rollouts.
 
     NumPy / torch are imported lazily so this helper works on minimal
     installs that don't have torch (e.g. ``policy_provider="mock"``

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -847,11 +847,10 @@ class TestEvalSeeding:
         """``set_eval_seed`` is the single public RNG-seeding entry point
         (no leading underscore, exported via ``__all__``).
 
-        #179 renamed the helper to the public ``set_eval_seed`` (standalone
-        integration tests such as
-        ``tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate``
-        call it directly for reproducible rollouts). A private
-        ``_set_eval_seed`` back-compat alias lingered afterwards; it is
+        The helper was renamed from a private ``_set_eval_seed`` to the
+        public ``set_eval_seed`` so standalone callers (integration tests
+        that drive a rollout without ``evaluate_benchmark``) can seed
+        directly. A private back-compat alias lingered afterwards; it is
         now removed so the module exposes exactly one name. Pin that
         single-name contract: the private alias must not reappear.
         """
@@ -864,6 +863,28 @@ class TestEvalSeeding:
         assert "set_eval_seed" in policy_runner.__all__
         # The private back-compat alias is gone (single public name only).
         assert not hasattr(policy_runner, "_set_eval_seed")
+
+    def test_set_eval_seed_docstring_matches_public_contract(self):
+        """The docstring must describe the function as it actually is:
+        a public, no-underscore name.
+
+        Regression pin: the docstring previously carried a stale line
+        ("Despite the leading ``_``...") from before the private-to-public
+        rename, and cited a specific test-file path. Both contradict the
+        docstring convention (describe the public contract, reference
+        behavior not test files) and confuse a reader who sees no leading
+        underscore on the actual symbol.
+        """
+        from strands_robots.simulation.policy_runner import set_eval_seed
+
+        doc = set_eval_seed.__doc__ or ""
+        # No stale claim of a leading-underscore / private name.
+        assert "leading ``_``" not in doc
+        assert "leading _" not in doc
+        # No test-file-path citation embedded in the public docstring.
+        assert "tests_integ/" not in doc
+        # The symbol itself is public.
+        assert not set_eval_seed.__name__.startswith("_")
 
     def test_set_eval_seed_torch_reproducibility(self):
         """#179 - ``set_eval_seed`` seeds torch's CPU + CUDA RNGs and


### PR DESCRIPTION
## Problem

`strands_robots.simulation.policy_runner.set_eval_seed` is a public API symbol (exported via `__all__`, with the old private `_set_eval_seed` alias removed). Its docstring, however, was never updated after that promotion. It still read:

> Public since #179: standalone integration tests (`tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate`) bypass `evaluate_benchmark` ... **Despite the leading `_`**, this function is the supported way to seed an eval and is part of the public API.

Two problems in that paragraph:

1. It claims the function has a **leading `_`** - but the actual symbol is `set_eval_seed`, no underscore. A reader who looks at the code sees no underscore and the docstring is simply wrong.
2. It embeds a specific **test-file path**, so the public docstring documents a test location rather than the behavior/contract.

## Change

Rewrite the paragraph to describe the public contract on its own terms - the single supported RNG-seeding entry point, exported via `__all__`, callable directly by standalone rollout callers that do not go through `evaluate_benchmark`. No stale private-name claim, no test-file citation. Code behavior is unchanged (docstring only).

## Tests

Adds `test_set_eval_seed_docstring_matches_public_contract`, which pins that the docstring no longer describes a leading-underscore / private name and carries no test-file path, and that the symbol itself is public. The test **fails on the pre-fix docstring** (verified by reverting only the source change) and passes after. The existing `test_set_eval_seed_is_public` docstring is also cleaned of the same stale test-file citation.

Local gate: `ruff check` / `ruff format --check` clean, `mypy strands_robots/simulation/policy_runner.py` clean, full `tests/simulation/test_policy_runner_benchmark.py` (58 tests) green under `MUJOCO_GL=egl`.