### PR TITLE
test(sim): pin get_ground_height world-less flat-ground contract

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -573,8 +573,10 @@ class SimEngine(ABC):
         terrain-relative locomotion predicates (``base_below_z``) and the
         spawn/reset base-seating; this exposes it as a facade query.
 
-        Returns ``0.0`` for a flat ground plane and for any backend without a
-        heightfield, so a non-terrain world reports a flat surface.
+        Returns ``0.0`` for a flat ground plane, for any backend without a
+        heightfield, and before ``create_world`` (a world-less engine has no
+        terrain), so a non-terrain -- or not-yet-built -- world reports a flat
+        surface rather than raising, unlike the world-scoped physics queries.
 
         Args:
             x: World x coordinate. Any object convertible to ``float``

--- a/tests/simulation/mujoco/test_ground_height_query.py
+++ b/tests/simulation/mujoco/test_ground_height_query.py
@@ -126,3 +126,47 @@ def test_get_ground_height_accepts_numpy_scalars() -> None:
         assert sim.get_ground_height(np.float64("inf"), 0.0)["status"] == "error"
     finally:
         sim.destroy()
+
+
+def test_get_ground_height_world_less_reports_flat_ground() -> None:
+    """A world-less engine (before ``create_world``) reports flat ground.
+
+    ``get_ground_height`` is deliberately *not* world-scoped like the sibling
+    physics queries (``get_total_mass`` and friends return ``_NO_WORLD_MSG``
+    before a world exists). A caller sizing a scene may ask where the ground is
+    before building the world, and the documented contract is that any
+    surface without a heightfield -- including a not-yet-built world -- reads as
+    a flat ``0.0`` rather than raising. This pins that public behaviour so a
+    later no-world guard cannot silently turn the query into an error.
+    """
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim.get_ground_height(1.0, 2.0)
+        assert r["status"] == "success"
+        payload = r["content"][1]["json"]
+        assert payload["x"] == 1.0 and payload["y"] == 2.0
+        assert payload["height"] == 0.0
+        # The internal sampler that backs the locomotion predicates agrees.
+        assert sim._ground_height_at(1.0, 2.0) == 0.0
+        # And dispatching through the agent-tool router is equally safe.
+        ok = sim(action="get_ground_height", x=1.0, y=2.0)
+        assert ok["status"] == "success"
+        assert ok["content"][1]["json"]["height"] == 0.0
+    finally:
+        sim.destroy()
+
+
+def test_seat_floating_bases_on_terrain_world_less_is_noop() -> None:
+    """Terrain base-seating is a safe no-op before a world is built.
+
+    ``_seat_floating_bases_on_terrain`` runs once per spawn / reset cycle. Its
+    world-less guard must return without touching physics state (there is no
+    model / data to seat onto), so an errant early call cannot raise.
+    """
+    sim = MuJoCoSimEngine()
+    try:
+        # Must not raise and must leave the engine world-less.
+        sim._seat_floating_bases_on_terrain()
+        assert sim._world is None
+    finally:
+        sim.destroy()


### PR DESCRIPTION
## Problem

`get_ground_height(x, y)` is deliberately *not* world-scoped like the sibling physics queries: `get_total_mass` and friends return a no-world error before `create_world`, but a caller sizing a scene may reasonably ask where the ground is before the world is built. The intended contract is that any surface without a heightfield -- including a not-yet-built world -- reads as a flat `0.0` rather than raising.

That world-less path was untested. The `_ground_height_at` and `_seat_floating_bases_on_terrain` no-world guards had no coverage, so a later no-world guard (e.g. copied from `get_total_mass`) could silently turn the query into an error dict and no test would notice.

## Change

- Add two focused regression tests to `tests/simulation/mujoco/test_ground_height_query.py`:
  - `get_ground_height` on a world-less engine returns `success` with `height == 0.0` (via the facade, the internal `_ground_height_at` sampler, and the agent-tool router), pinning the flat-ground contract.
  - `_seat_floating_bases_on_terrain` is a safe no-op before a world exists (returns without touching physics state, leaves the engine world-less).
- Clarify the `get_ground_height` docstring in `strands_robots/simulation/base.py` to state the not-yet-built case explicitly (flat `0.0` rather than raising, unlike the world-scoped physics queries).

These cover the previously-unhit `_ground_height_at` and `_seat_floating_bases_on_terrain` no-world guards. The remaining degenerate-heightfield branches (nrow/ncol < 2, non-positive radii) are unreachable via MuJoCo compile and left as defensive guards.

## Verification

- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean (819 files).
- `MUJOCO_GL=egl pytest` green across the terrain/ground-height cluster (26 passed), including the two new tests.
- No behaviour change: docstring clarification + tests only.