### PR TITLE
test(sim): pin evaluate_benchmark cooperative-stop + video-cleanup contract

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1919,7 +1919,15 @@ class SimEngine(ABC):
                 pattern and produces 2-3% frame-capture rates with
                 greenish GL clear-colour artifacts. Pair with
                 :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`
-                for the recorder side. See #191.
+                for the recorder side. See #191. Raising
+                :class:`~strands_robots.simulation.policy_runner.CooperativeStop`
+                from the hook ends the benchmark gracefully after the
+                episodes completed so far - the result json carries
+                ``stopped_early=True`` and ``episodes_completed`` (matching
+                :meth:`run_policy` / :meth:`eval_policy`); any in-progress
+                episode's partial video is closed cleanly and is NOT listed
+                in ``video_paths``. A non-``CooperativeStop`` hook exception
+                is logged at WARN and never aborts the eval.
             policy_kwargs: Per-call goal payload forwarded verbatim to every
                 ``policy.get_actions(obs, instruction, **policy_kwargs)`` call
                 (same contract as :meth:`run_policy` / :meth:`eval_policy`).

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -1540,3 +1540,71 @@ class TestCooperativeStop:
         payload = next(c["json"] for c in result["content"] if "json" in c)
         assert payload["stopped_early"] is False
         assert payload["episodes_completed"] == 2
+
+    def test_evaluate_benchmark_docstring_documents_cooperative_stop(self):
+        """The ``evaluate_benchmark`` facade must document the cooperative-stop
+        contract, matching its ``eval_policy`` / ``run_policy`` siblings.
+
+        A caller relying only on the facade docstring otherwise cannot discover
+        that raising ``CooperativeStop`` from ``on_frame`` ends the eval
+        gracefully (rather than crashing with an uncaught ``BaseException``) and
+        that the result reports ``stopped_early`` / ``episodes_completed``.
+        """
+        doc = SimEngine.evaluate_benchmark.__doc__ or ""
+        assert "CooperativeStop" in doc, "evaluate_benchmark doc must name CooperativeStop"
+        assert "stopped_early" in doc, "evaluate_benchmark doc must document stopped_early"
+        assert "episodes_completed" in doc, "evaluate_benchmark doc must document episodes_completed"
+
+    def test_spec_cooperative_stop_closes_in_progress_video(self, tmp_path: Path):
+        """A cooperative stop mid-episode with recording active closes the
+        in-progress episode's video writer cleanly and drops it from
+        ``video_paths`` (the episode never completed), while the eval still
+        returns a graceful ``stopped_early`` result.
+        """
+        import base64
+        import io
+
+        import numpy as np
+        from PIL import Image
+
+        def _png_b64() -> str:
+            buf = io.BytesIO()
+            Image.fromarray(np.zeros((16, 16, 3), dtype=np.uint8)).save(buf, format="PNG")
+            return base64.b64encode(buf.getvalue()).decode()
+
+        class _RenderingFakeSim(FakeSim):
+            """FakeSim that returns a decodable PNG so the rollout video writer
+            actually opens and captures frames (base FakeSim renders no image)."""
+
+            def render(self, camera_name="default", width=None, height=None):
+                return {
+                    "status": "success",
+                    "content": [{"image": {"format": "png", "source": {"bytes": _png_b64()}}}],
+                }
+
+        sim = _RenderingFakeSim()
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+
+        def hook(step, obs, action):
+            # Fire during episode 0 (max_steps=20) so the episode never completes
+            # and its video writer is still open when the stop propagates.
+            if step >= 4:
+                raise CooperativeStop("user stopped benchmark")
+
+        video_path = tmp_path / "rollout.mp4"
+        result = PolicyRunner(sim).evaluate(
+            "fake_robot",
+            policy,
+            spec=_CountingBenchmark(),
+            n_episodes=5,
+            on_frame=hook,
+            video={"path": str(video_path), "fps": 30, "camera": "default"},
+        )
+        assert result["status"] == "success"
+        payload = next(c["json"] for c in result["content"] if "json" in c)
+        assert payload["stopped_early"] is True
+        # Stop fired inside episode 0 -> no episode fully completed.
+        assert payload["episodes_completed"] == 0
+        # The interrupted episode's partial video is closed but never reported.
+        assert payload["video_paths"] == []


### PR DESCRIPTION
## Problem

`evaluate_benchmark` already honours a `CooperativeStop` raised from its `on_frame` hook: it ends the eval gracefully after the episodes completed so far, reports `stopped_early=True` / `episodes_completed`, and closes any in-progress episode video writer -- the same contract `run_policy` and `eval_policy` implement. Two facets of that contract were unguarded:

1. The `evaluate_benchmark` facade docstring documented the `on_frame` hook but omitted the cooperative-stop behaviour that its `eval_policy` sibling spells out. A caller reading only `evaluate_benchmark` could not discover that raising `CooperativeStop` stops gracefully (instead of crashing with an uncaught `BaseException`) nor that the result reports `stopped_early` / `episodes_completed`.
2. The video-writer cleanup branch taken when the stop fires mid-episode with recording active -- the in-progress MP4 is closed cleanly but deliberately **not** reported in `video_paths` (the episode never completed) -- had no test.

## Change

- Document the cooperative-stop contract in the `evaluate_benchmark` docstring, matching `run_policy` / `eval_policy` (names `CooperativeStop`, `stopped_early`, `episodes_completed`, and the in-progress-video handling).
- Add two tests to the existing `TestCooperativeStop`:
  - `test_evaluate_benchmark_docstring_documents_cooperative_stop` -- pins the facade doc contract (fails without the docstring addition).
  - `test_spec_cooperative_stop_closes_in_progress_video` -- drives `evaluate` with `video=` and an `on_frame` that raises `CooperativeStop` mid-episode; asserts the graceful `stopped_early` result and that the interrupted episode's partial video is dropped from `video_paths`. This covers the previously-untested writer-cleanup branch.

No runtime behaviour change -- docstring + tests only.

## Verification

- New docstring test fails on pre-change code (`AssertionError: evaluate_benchmark doc must name CooperativeStop`) and passes after.
- The behavioural test exercises the writer-close branch (now covered).
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (819 files, no issues).
- `pytest tests/simulation/test_policy_runner_benchmark.py tests/simulation/test_evaluate_benchmark_video.py` -> 63 passed (MuJoCo headless, `MUJOCO_GL=egl`).