### PR TITLE
feat(sim): attach_bodies/detach_bodies, actuate_robot, zero_dynamics primitives (part 1 of #1533)

### DIFF
--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -102,11 +102,11 @@ class ManipulationMixin:
         _world: SimWorld | None
         _lock: Any  # threading.RLock from Simulation
 
-        def _require_no_running_policy(
-            self, action_name: str, robot_name: str | None = None
-        ) -> dict[str, Any] | None: ...
+        def _require_no_running_policy(self, action_name: str, robot_name: str | None = None) -> dict[str, Any] | None:
+            """Provided by ``Simulation``; declared here for type-checkers."""
 
-        def _unknown_robot_msg(self, requested: str) -> str: ...
+        def _unknown_robot_msg(self, requested: str) -> str:
+            """Provided by ``Simulation``; declared here for type-checkers."""
 
     # -- shared guards -----------------------------------------------------
 

--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -1,0 +1,653 @@
+"""Manipulation mixin - runtime attach/detach, robot actuation, dynamics reset.
+
+Public, supported forms of the plan-execute-record primitives the
+``so101_curobo`` example used to hand-roll against private surfaces
+(GH #1533, PR 1 of the lift-the-engine plan):
+
+- :meth:`ManipulationMixin.attach_bodies` / :meth:`ManipulationMixin.detach_bodies`
+  - runtime grasp-assist. ``mode="weld"`` adds an equality constraint on the
+  live spec holding the CURRENT relative pose; ``mode="kinematic"`` teleports
+  the child body to follow the parent every physics step (the example's
+  per-waypoint ``move_object`` + qvel-zero carry, locked down and public).
+- :meth:`ManipulationMixin.actuate_robot` - add position-servo actuators to an
+  actuator-less (URDF-loaded) arm so ``send_action`` / ``run_policy`` can
+  drive it (replaces the example's ``_backend_state["spec"]`` surgery).
+- :meth:`ManipulationMixin.zero_dynamics` - clear qvel/qacc/warmstart (the
+  anti-explosion reset for kinematically teleported states).
+
+Data-honesty caveat (documented per method): welded or kinematically carried
+"grasps" are NOT physical grasps - no contact forces hold the object. Datasets
+recorded with them contain idealized transport segments; label or gate such
+episodes accordingly.
+
+Concurrency contract: every method that writes MuJoCo ``model``/``data`` or
+recompiles the spec takes ``self._lock`` and refuses to run while a policy is
+active (``_require_no_running_policy``), matching the other scene mutations.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import numbers
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
+from strands_robots.simulation.mujoco.scene_ops import (
+    actuate_robot_in_scene,
+    add_weld_constraint,
+    remove_equality_constraint,
+)
+
+logger = logging.getLogger(__name__)
+
+# Keys inside world._backend_state. "attachments" is the registry of active
+# attachments (both modes) keyed by child body name; "kinematic_attachments"
+# holds only the per-step-follow entries consumed by the step hooks.
+_ATTACH_REGISTRY_KEY = "attachments"
+_KINEMATIC_ATTACH_KEY = "kinematic_attachments"
+
+
+def _finite_positive(value: Any) -> bool:
+    """True when ``value`` is a real, finite, strictly positive scalar."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return False
+    return math.isfinite(float(value)) and float(value) > 0.0
+
+
+def _finite_non_negative(value: Any) -> bool:
+    """True when ``value`` is a real, finite, >= 0 scalar."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return False
+    return math.isfinite(float(value)) and float(value) >= 0.0
+
+
+def _relative_pose(mj: Any, data: Any, parent_id: int, child_id: int) -> tuple[list[float], list[float]]:
+    """Pose of ``child_id`` expressed in ``parent_id``'s frame, from live data.
+
+    Returns ``(relpos, relquat)`` with relquat in wxyz order. Callers must have
+    run a forward pass so ``xpos`` / ``xquat`` are current.
+    """
+    parent_neg_quat = np.zeros(4)
+    mj.mju_negQuat(parent_neg_quat, data.xquat[parent_id])
+    relquat = np.zeros(4)
+    mj.mju_mulQuat(relquat, parent_neg_quat, data.xquat[child_id])
+    relpos = np.zeros(3)
+    mj.mju_rotVecQuat(relpos, data.xpos[child_id] - data.xpos[parent_id], parent_neg_quat)
+    return [float(v) for v in relpos], [float(v) for v in relquat]
+
+
+def _find_free_joint(mj: Any, model: Any, body_id: int) -> int:
+    """Return the id of the FREE joint carried by ``body_id``, or -1."""
+    for jid in range(model.njnt):
+        if int(model.jnt_type[jid]) == int(mj.mjtJoint.mjJNT_FREE) and int(model.jnt_bodyid[jid]) == body_id:
+            return jid
+    return -1
+
+
+class ManipulationMixin:
+    """Runtime attach/actuate/zero primitives mixed into ``Simulation``.
+
+    **Coupling** (see the :mod:`simulation` top-level docstring): reaches into
+    ``self._world``, ``self._lock``, and the guard helpers. ``TYPE_CHECKING``
+    stubs below exist so mypy accepts those lookups; they are a documentary
+    contract, not an enforceable protocol.
+    """
+
+    if TYPE_CHECKING:
+        from strands_robots.simulation.models import SimWorld
+
+        _world: SimWorld | None
+        _lock: Any  # threading.RLock from Simulation
+
+        def _require_no_running_policy(
+            self, action_name: str, robot_name: str | None = None
+        ) -> dict[str, Any] | None: ...
+
+        def _unknown_robot_msg(self, requested: str) -> str: ...
+
+    # -- shared guards -----------------------------------------------------
+
+    def _attachments(self) -> dict[str, dict[str, Any]]:
+        """The attachment registry (child body name -> record), creating it lazily."""
+        assert self._world is not None  # callers must check
+        reg = self._world._backend_state.setdefault(_ATTACH_REGISTRY_KEY, {})
+        assert isinstance(reg, dict)
+        return reg
+
+    def _kinematic_attachments(self) -> dict[str, dict[str, Any]]:
+        """The per-step-follow subset of the registry, creating it lazily."""
+        assert self._world is not None  # callers must check
+        reg = self._world._backend_state.setdefault(_KINEMATIC_ATTACH_KEY, {})
+        assert isinstance(reg, dict)
+        return reg
+
+    def attachment_involving(self, body_name: str) -> str | None:
+        """Return the child key of an active attachment involving ``body_name``.
+
+        Matches ``body_name`` as parent or child, exactly or as a robot
+        namespace prefix (``"arm"`` matches an attachment whose parent is
+        ``"arm/gripper_link"``). Used by ``remove_object`` / ``remove_robot``
+        to refuse removing a body that an active attachment still references
+        (a dangling weld would fail the next recompile; a dangling kinematic
+        follow would silently detach).
+        """
+        if self._world is None:
+            return None
+        registry = self._world._backend_state.get(_ATTACH_REGISTRY_KEY) or {}
+        prefix = f"{body_name}/"
+        for child, record in registry.items():
+            parent = str(record.get("parent", ""))
+            for candidate in (parent, child):
+                if candidate == body_name or candidate.startswith(prefix):
+                    return child
+        return None
+
+    # -- attach / detach ----------------------------------------------------
+
+    def attach_bodies(
+        self,
+        parent: str,
+        child: str,
+        mode: str = "weld",
+        torquescale: float = 1.0,
+    ) -> dict[str, Any]:
+        """Rigidly attach ``child`` to ``parent`` at their CURRENT relative pose.
+
+        The supported grasp-assist primitive for synthetic-data pipelines
+        (GH #1533): after a gripper closes around an object, attach the object
+        to the gripper body so it rides along for the transport segment, then
+        :meth:`detach_bodies` at the place point.
+
+        Modes:
+
+        * ``"weld"`` (default): adds a weld equality constraint on the live
+          spec (survives later scene recompiles) holding the current relative
+          pose. The constraint is enforced by the solver, so external contacts
+          still interact with both bodies.
+        * ``"kinematic"``: every physics step, the child's freejoint pose is
+          overwritten to follow the parent and its velocity zeroed - the
+          example's teleport-carry, made public. Requires ``child`` to be a
+          dynamic body with a freejoint (e.g. ``add_object(is_static=False)``).
+
+        Data-honesty caveat: neither mode is a physical grasp - no friction or
+        contact force holds the object. Downstream consumers of recorded
+        episodes should treat the attached segment as idealized transport.
+
+        Both bodies must exist in the live model; one attachment per child at
+        a time. Attachments persist across ``reset()`` (a weld re-enforces the
+        captured relative pose against the reset qpos; a kinematic follow
+        re-teleports the child on the next step) - call :meth:`detach_bodies`
+        first if the post-reset scene must be free. ``remove_object`` /
+        ``remove_robot`` refuse to remove a body an attachment references.
+
+        Args:
+            parent: Body name the child follows (robot bodies are namespaced
+                ``<robot>/<body>``; call ``list_bodies`` to discover names).
+            child: Body name to carry. For ``mode="kinematic"`` it must own a
+                freejoint.
+            mode: ``"weld"`` or ``"kinematic"``.
+            torquescale: Weld-only: torque-to-force ratio of the constraint
+                (MuJoCo ``torquescale``). Must be finite and > 0.
+
+        Returns:
+            ``{status, content}`` tool result; ``status="error"`` when no world
+            exists, a policy is running, a name does not resolve, the child is
+            already attached, the mode is unknown, or the recompile fails.
+        """
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        if err := self._require_no_running_policy("attach_bodies"):
+            return err
+        if mode not in ("weld", "kinematic"):
+            return {
+                "status": "error",
+                "content": [{"text": f"attach_bodies: unknown mode {mode!r}. Use 'weld' or 'kinematic'."}],
+            }
+        if parent == child:
+            return {
+                "status": "error",
+                "content": [{"text": f"attach_bodies: parent and child are the same body ({parent!r})."}],
+            }
+        if not _finite_positive(torquescale):
+            return {
+                "status": "error",
+                "content": [
+                    {"text": f"attach_bodies: 'torquescale' must be a finite number > 0, got {torquescale!r}."}
+                ],
+            }
+
+        mj = _ensure_mujoco()
+        with self._lock:
+            model, data = self._world._model, self._world._data
+            parent_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, parent)
+            child_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, child)
+            for label, body_id in (("parent", parent_id), ("child", child_id)):
+                if body_id < 0:
+                    name = parent if label == "parent" else child
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"attach_bodies: {label} body '{name}' not found. Robot bodies are "
+                                    "namespaced '<robot>/<body>'; call list_bodies to discover names."
+                                )
+                            }
+                        ],
+                    }
+            registry = self._attachments()
+            if child in registry:
+                held = registry[child]
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"attach_bodies: '{child}' is already attached to "
+                                f"'{held['parent']}' (mode={held['mode']}). Detach it first."
+                            )
+                        }
+                    ],
+                }
+
+            # Capture the CURRENT relative pose from live kinematics.
+            mj.mj_forward(model, data)
+            relpos, relquat = _relative_pose(mj, data, parent_id, child_id)
+
+            if mode == "weld":
+                eq_name = f"attach_weld_{parent}__{child}"
+                if not add_weld_constraint(
+                    self._world,
+                    name=eq_name,
+                    parent=parent,
+                    child=child,
+                    relpos=relpos,
+                    relquat=relquat,
+                    torquescale=float(torquescale),
+                ):
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"attach_bodies: weld recompile failed for '{parent}' <- '{child}'."}],
+                    }
+                registry[child] = {"parent": parent, "mode": "weld", "eq_name": eq_name}
+            else:
+                free_jid = _find_free_joint(mj, model, child_id)
+                if free_jid < 0:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"attach_bodies: mode='kinematic' requires child '{child}' to be a "
+                                    "dynamic body with a freejoint (add_object(is_static=False)). "
+                                    "Use mode='weld' for bodies without one."
+                                )
+                            }
+                        ],
+                    }
+                record = {"parent": parent, "mode": "kinematic", "relpos": relpos, "relquat": relquat}
+                registry[child] = record
+                self._kinematic_attachments()[child] = record
+                # Park the child at rest immediately so it doesn't drift/fall
+                # between now and the first step-hook application.
+                dof_adr = int(model.jnt_dofadr[free_jid])
+                data.qvel[dof_adr : dof_adr + 6] = 0.0
+                mj.mj_forward(model, data)
+
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": (
+                        f"'{child}' attached to '{parent}' (mode={mode}, relpos="
+                        f"{[round(v, 4) for v in relpos]}). Note: not a physical grasp - "
+                        "detach_bodies releases it."
+                    )
+                }
+            ],
+        }
+
+    def detach_bodies(self, parent: str, child: str) -> dict[str, Any]:
+        """Release an attachment created by :meth:`attach_bodies`.
+
+        Weld mode deletes the equality constraint from the live spec and
+        recompiles (preserving state); kinematic mode stops the per-step follow
+        and leaves the child at rest at its current pose (its velocity was
+        zeroed every step while carried), so it falls/settles physically from
+        the release point.
+
+        Returns ``status="error"`` when no world exists, a policy is running,
+        no attachment exists for ``child``, or ``parent`` does not match the
+        recorded attachment.
+        """
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        if err := self._require_no_running_policy("detach_bodies"):
+            return err
+
+        with self._lock:
+            registry = self._attachments()
+            record = registry.get(child)
+            if record is None:
+                active = ", ".join(f"'{c}'<-'{r['parent']}'" for c, r in registry.items()) or "(none)"
+                return {
+                    "status": "error",
+                    "content": [{"text": f"detach_bodies: no attachment found for child '{child}'. Active: {active}."}],
+                }
+            if record["parent"] != parent:
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": (f"detach_bodies: '{child}' is attached to '{record['parent']}', not '{parent}'.")}
+                    ],
+                }
+
+            if record["mode"] == "weld":
+                if not remove_equality_constraint(self._world, record["eq_name"]):
+                    return {
+                        "status": "error",
+                        "content": [
+                            {"text": f"detach_bodies: failed to remove weld constraint for '{child}' (see logs)."}
+                        ],
+                    }
+            else:
+                self._kinematic_attachments().pop(child, None)
+            registry.pop(child, None)
+
+        return {"status": "success", "content": [{"text": f"'{child}' detached from '{parent}'."}]}
+
+    def _apply_kinematic_attachments(self) -> None:
+        """Teleport every kinematically attached child to follow its parent.
+
+        Called after each ``mj_step`` (both the ``step()`` batch loop and the
+        policy-driven ``_apply_sim_action`` substep loop). Callers MUST hold
+        ``self._lock``. Uses the parent's ``xpos``/``xquat`` from the step's
+        forward pass (one integration step of latency at the physics timestep,
+        matching the example's carry). Entries whose bodies or freejoint no
+        longer resolve (e.g. after a scene rebuild) are dropped with a warning
+        so a stale name can't silently corrupt an unrelated joint.
+        """
+        world = self._world
+        if world is None or world._model is None or world._data is None:
+            return
+        attachments = world._backend_state.get(_KINEMATIC_ATTACH_KEY)
+        if not attachments:
+            return
+        mj = _ensure_mujoco()
+        model, data = world._model, world._data
+        stale: list[str] = []
+        for child, record in attachments.items():
+            parent_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, str(record["parent"]))
+            child_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, child)
+            free_jid = _find_free_joint(mj, model, child_id) if child_id >= 0 else -1
+            if parent_id < 0 or child_id < 0 or free_jid < 0:
+                stale.append(child)
+                continue
+            world_pos = np.zeros(3)
+            mj.mju_rotVecQuat(world_pos, np.asarray(record["relpos"], dtype=float), data.xquat[parent_id])
+            world_pos += data.xpos[parent_id]
+            world_quat = np.zeros(4)
+            mj.mju_mulQuat(world_quat, data.xquat[parent_id], np.asarray(record["relquat"], dtype=float))
+            qpos_adr = int(model.jnt_qposadr[free_jid])
+            dof_adr = int(model.jnt_dofadr[free_jid])
+            data.qpos[qpos_adr : qpos_adr + 3] = world_pos
+            data.qpos[qpos_adr + 3 : qpos_adr + 7] = world_quat
+            data.qvel[dof_adr : dof_adr + 6] = 0.0
+        for child in stale:
+            attachments.pop(child, None)
+            registry = world._backend_state.get(_ATTACH_REGISTRY_KEY)
+            if isinstance(registry, dict):
+                registry.pop(child, None)
+            logger.warning(
+                "kinematic attachment for '%s' dropped: a referenced body/freejoint no longer exists",
+                child,
+            )
+
+    # -- actuate ------------------------------------------------------------
+
+    def actuate_robot(
+        self,
+        robot_name: str,
+        kp: float | dict[str, float] = 100.0,
+        damping: float = 2.0,
+        armature: float = 0.01,
+        gravity_compensation: bool = True,
+        disable_self_collision: bool = False,
+    ) -> dict[str, Any]:
+        """Convert an actuator-less (URDF-loaded) robot into a position-servo arm.
+
+        URDF-loaded arms compile with no actuators (``nu == 0``), so
+        ``send_action`` / ``run_policy`` cannot drive them - the reason the
+        ``so101_curobo`` example fell back to kinematic qpos teleports
+        (GH #1533). This adds a position actuator per hinge/slide joint
+        (fixed gain ``kp``, ~critically damped, ctrlrange inherited from the
+        joint's limits when it declares any), floors joint ``damping`` /
+        ``armature`` (bare URDFs ship none, which blows up explicit
+        integration), and switches the scene to the stable ``implicitfast``
+        integrator. The change lives on the spec, so it survives later scene
+        recompiles.
+
+        After the recompile every new actuator's ``ctrl`` is initialized to
+        the joint's CURRENT position so the arm holds its pose instead of
+        snapping to zero.
+
+        Scene-wide side effect (documented, not optional): the integrator is
+        set to ``implicitfast`` - stiff position servos on undamped URDF
+        chains diverge under the default Euler integrator.
+
+        Args:
+            robot_name: Robot to actuate (must exist, and not already have
+                actuators mapped to its joints).
+            kp: Position gain. A single number applies to every hinge/slide
+                joint; a ``{short_joint_name: kp}`` dict actuates ONLY the
+                listed joints (unknown names are rejected with the valid
+                list). Values must be finite and > 0.
+            damping: Per-joint damping floor (Ns/m or Nms/rad); existing
+                larger values are kept. Must be finite and >= 0.
+            armature: Per-joint armature (rotor inertia) floor; existing
+                larger values are kept. Must be finite and >= 0.
+            gravity_compensation: Apply ``gravcomp=1`` to the robot's bodies
+                so modest gains track tightly.
+            disable_self_collision: Zero contype/conaffinity on the robot's
+                own geoms. Planners like cuRobo ignore adjacent-link contacts,
+                which otherwise block planned motion in MuJoCo. NOTE: this
+                disables ALL collision on the robot's geoms (not just
+                link-vs-link), so add contact geoms that must keep colliding
+                (e.g. fingertip pads) AFTER this call via ``patch_scene_mjcf``.
+
+        Returns:
+            ``{status, content}`` tool result; ``status="error"`` when no world
+            exists, a policy is running, the robot is unknown or already
+            actuated, ``kp``/``damping``/``armature`` are invalid, or the
+            recompile fails.
+        """
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        if err := self._require_no_running_policy("actuate_robot", robot_name):
+            return err
+        robot = self._world.robots.get(robot_name)
+        if robot is None:
+            return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
+        if not _finite_non_negative(damping):
+            return {
+                "status": "error",
+                "content": [{"text": f"actuate_robot: 'damping' must be a finite number >= 0, got {damping!r}."}],
+            }
+        if not _finite_non_negative(armature):
+            return {
+                "status": "error",
+                "content": [{"text": f"actuate_robot: 'armature' must be a finite number >= 0, got {armature!r}."}],
+            }
+
+        mj = _ensure_mujoco()
+        with self._lock:
+            model, data = self._world._model, self._world._data
+
+            robot_joint_ids = set(robot.joint_ids)
+            for act_id in range(model.nu):
+                if int(model.actuator_trnid[act_id, 0]) in robot_joint_ids:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"actuate_robot: robot '{robot_name}' already has actuators "
+                                    "mapped to its joints; refusing to double-actuate."
+                                )
+                            }
+                        ],
+                    }
+
+            # Eligible joints: the robot's hinge/slide joints, by SHORT name.
+            prefix = robot.namespace or ""
+            eligible: dict[str, int] = {}
+            for jid in robot.joint_ids:
+                if int(model.jnt_type[jid]) not in (int(mj.mjtJoint.mjJNT_HINGE), int(mj.mjtJoint.mjJNT_SLIDE)):
+                    continue
+                full = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jid) or ""
+                short = full[len(prefix) :] if prefix and full.startswith(prefix) else full
+                if short:
+                    eligible[short] = jid
+            if not eligible:
+                return {
+                    "status": "error",
+                    "content": [{"text": f"actuate_robot: robot '{robot_name}' has no hinge/slide joints to actuate."}],
+                }
+
+            if isinstance(kp, dict):
+                unknown = sorted(set(kp) - set(eligible))
+                if unknown:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"actuate_robot: unknown joint(s) in kp: {unknown}. "
+                                    f"Valid joints for '{robot_name}': {sorted(eligible)}."
+                                )
+                            }
+                        ],
+                    }
+                if not kp:
+                    return {
+                        "status": "error",
+                        "content": [{"text": "actuate_robot: kp dict is empty - nothing to actuate."}],
+                    }
+                bad = {name: value for name, value in kp.items() if not _finite_positive(value)}
+                if bad:
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"actuate_robot: kp values must be finite numbers > 0, got {bad!r}."}],
+                    }
+                kp_by_joint = {name: float(value) for name, value in kp.items()}
+            else:
+                if not _finite_positive(kp):
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"actuate_robot: 'kp' must be a finite number > 0, got {kp!r}."}],
+                    }
+                kp_by_joint = {short: float(kp) for short in eligible}
+
+            if not actuate_robot_in_scene(
+                self._world,
+                robot,
+                kp_by_joint,
+                damping=float(damping),
+                armature=float(armature),
+                gravity_compensation=bool(gravity_compensation),
+                disable_self_collision=bool(disable_self_collision),
+            ):
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": f"actuate_robot: spec recompile failed for '{robot_name}' (spec restored, see logs)."}
+                    ],
+                }
+
+            # Hold the current pose: initialize every NEW actuator's ctrl to
+            # its joint's current qpos so the arm doesn't snap to zero on the
+            # next step. _recompile_preserving_state already re-discovered
+            # robot.actuator_ids.
+            model, data = self._world._model, self._world._data
+            for act_id in robot.actuator_ids:
+                jnt_id = int(model.actuator_trnid[act_id, 0])
+                if 0 <= jnt_id < model.njnt:
+                    data.ctrl[act_id] = data.qpos[int(model.jnt_qposadr[jnt_id])]
+            mj.mj_forward(model, data)
+            n_added = len(kp_by_joint)
+            nu = int(model.nu)
+
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": (
+                        f"Robot '{robot_name}' actuated: {n_added} position actuator(s) added "
+                        f"({sorted(kp_by_joint)}), nu={nu}, integrator=implicitfast, "
+                        f"gravcomp={'on' if gravity_compensation else 'off'}, "
+                        f"self_collision={'off' if disable_self_collision else 'on'}. "
+                        "ctrl initialized to the current pose."
+                    )
+                }
+            ],
+        }
+
+    # -- zero dynamics --------------------------------------------------------
+
+    def zero_dynamics(self, robot_name: str | None = None) -> dict[str, Any]:
+        """Zero velocities and accelerations, world-wide or for one robot.
+
+        The anti-explosion reset for kinematically written states: writing
+        ``qpos`` directly (teleports, trajectory replay) leaves ``qvel`` /
+        ``qacc`` holding pre-teleport values, and integrating explicit
+        dynamics from that discontinuity can diverge ("QACC nan"). This clears
+        ``qvel``, ``qacc``, and ``qacc_warmstart`` - for every DOF, or only
+        the named robot's joints - then re-forwards derived state.
+
+        Args:
+            robot_name: When given, only that robot's joint DOFs are zeroed
+                (object freejoints and other robots keep their momentum).
+                ``None`` zeroes every DOF in the world.
+
+        Returns:
+            ``{status, content}`` tool result; ``status="error"`` when no
+            world exists, a policy is running, or the robot is unknown.
+        """
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        if err := self._require_no_running_policy("zero_dynamics", robot_name):
+            return err
+
+        mj = _ensure_mujoco()
+        with self._lock:
+            model, data = self._world._model, self._world._data
+            if robot_name is None:
+                data.qvel[:] = 0.0
+                data.qacc[:] = 0.0
+                data.qacc_warmstart[:] = 0.0
+                scope = f"all {int(model.nv)} DOFs"
+            else:
+                robot = self._world.robots.get(robot_name)
+                if robot is None:
+                    return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
+                n_zeroed = 0
+                for jid in robot.joint_ids:
+                    jnt_type = int(model.jnt_type[jid])
+                    if jnt_type == int(mj.mjtJoint.mjJNT_FREE):
+                        width = 6
+                    elif jnt_type == int(mj.mjtJoint.mjJNT_BALL):
+                        width = 3
+                    else:
+                        width = 1
+                    dof_adr = int(model.jnt_dofadr[jid])
+                    data.qvel[dof_adr : dof_adr + width] = 0.0
+                    data.qacc[dof_adr : dof_adr + width] = 0.0
+                    data.qacc_warmstart[dof_adr : dof_adr + width] = 0.0
+                    n_zeroed += width
+                scope = f"{n_zeroed} DOFs of robot '{robot_name}'"
+            mj.mj_forward(model, data)
+
+        return {"status": "success", "content": [{"text": f"Dynamics zeroed ({scope}): qvel, qacc, qacc_warmstart."}]}

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -125,7 +125,8 @@ class RenderingMixin:
         # Provided by ManipulationMixin (attach_bodies mode="kinematic");
         # _apply_sim_action re-pins carried bodies after each substep. Stub so
         # mypy accepts the cross-mixin call.
-        def _apply_kinematic_attachments(self) -> None: ...
+        def _apply_kinematic_attachments(self) -> None:
+            """Provided by ``ManipulationMixin``; declared here for type-checkers."""
 
     def _validate_render_dims(self, width: int, height: int) -> dict[str, Any] | None:
         """reject non-positive render dims; convert MuJoCo's framebuffer

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -122,6 +122,11 @@ class RenderingMixin:
         # camera jitter through it. Stub so mypy accepts the cross-mixin call.
         def _maybe_jitter_frame(self, frame: Any) -> Any: ...
 
+        # Provided by ManipulationMixin (attach_bodies mode="kinematic");
+        # _apply_sim_action re-pins carried bodies after each substep. Stub so
+        # mypy accepts the cross-mixin call.
+        def _apply_kinematic_attachments(self) -> None: ...
+
     def _validate_render_dims(self, width: int, height: int) -> dict[str, Any] | None:
         """reject non-positive render dims; convert MuJoCo's framebuffer
         overflow to a plain-English message that tells the LLM the actual cap.
@@ -487,6 +492,10 @@ class RenderingMixin:
         if not controller_handled_stepping:
             for _ in range(max(1, n_substeps)):
                 mj.mj_step(model, data)
+                # Kinematic attachments (attach_bodies mode="kinematic")
+                # follow their parent every physics step, including the
+                # policy-driven path. Fast no-op when none are registered.
+                self._apply_kinematic_attachments()
 
         assert self._world is not None
         self._world.sim_time = data.time

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -500,6 +500,178 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     return True
 
 
+# Runtime attach / actuate primitives (GH #1533, PR 1)
+
+
+def add_weld_constraint(
+    world: SimWorld,
+    *,
+    name: str,
+    parent: str,
+    child: str,
+    relpos: list[float],
+    relquat: list[float],
+    torquescale: float = 1.0,
+) -> bool:
+    """Add a named weld equality constraint between two bodies and recompile.
+
+    ``relpos`` / ``relquat`` are the pose of ``child`` expressed in ``parent``'s
+    frame - callers capture the CURRENT runtime relative pose so the weld holds
+    the bodies exactly where they are (MuJoCo's all-zero ``relpose`` quat would
+    instead bake in the compile-time ``qpos0`` pose, which is wrong for a
+    runtime grasp-attach). The equality is stored on the live spec so it
+    survives later recompiles (``add_object`` etc.).
+
+    Returns ``True`` on success. On recompile failure the just-added equality
+    is deleted again so the spec stays compilable, and ``False`` is returned.
+    """
+    spec = _get_spec(world)
+    if spec is None or world._model is None:
+        logger.error("add_weld_constraint: no spec or model in world")
+        return False
+    mj = _ensure_mujoco()
+
+    eq = spec.add_equality()
+    eq.name = name
+    eq.type = mj.mjtEq.mjEQ_WELD
+    eq.objtype = mj.mjtObj.mjOBJ_BODY
+    eq.name1 = parent
+    eq.name2 = child
+    # mjEQ_WELD data layout (mjNEQDATA=11): [anchor(3), relpose pos(3),
+    # relpose quat(4), torquescale(1)]. anchor stays zero - relpose fully
+    # determines the held configuration.
+    data = [0.0] * 11
+    data[3:6] = [float(v) for v in relpos]
+    data[6:10] = [float(v) for v in relquat]
+    data[10] = float(torquescale)
+    eq.data = data
+
+    if not _recompile_preserving_state(world, spec):
+        spec.delete(eq)
+        return False
+    return True
+
+
+def remove_equality_constraint(world: SimWorld, name: str) -> bool:
+    """Delete a named equality constraint from the live spec and recompile.
+
+    Returns ``False`` (logged) when the constraint is missing or the recompile
+    fails, so callers can surface a clean error instead of a silent no-op.
+    """
+    spec = _get_spec(world)
+    if spec is None or world._model is None:
+        logger.error("remove_equality_constraint: no spec or model in world")
+        return False
+    for eq in spec.equalities:
+        if eq.name == name:
+            spec.delete(eq)
+            return _recompile_preserving_state(world, spec)
+    logger.warning("Equality constraint '%s' not found in spec - nothing removed", name)
+    return False
+
+
+def actuate_robot_in_scene(
+    world: SimWorld,
+    robot: SimRobot,
+    kp_by_joint: dict[str, float],
+    *,
+    damping: float,
+    armature: float,
+    gravity_compensation: bool,
+    disable_self_collision: bool,
+) -> bool:
+    """Add position-servo actuators to a robot's joints and recompile.
+
+    The supported form of the private-spec surgery the ``so101_curobo`` example
+    performed by hand (GH #1533): converts an actuator-less (URDF-loaded) arm
+    into a position-controlled one so ``send_action`` / ``run_policy`` can
+    drive it. Per joint in ``kp_by_joint`` (SHORT joint names, values = kp):
+
+    * a position actuator (``set_to_position``: fixed gain kp, affine bias with
+      ``dampratio=1.0`` for ~critical damping, ctrlrange inherited from the
+      joint's range when it declares one),
+    * joint ``damping`` / ``armature`` floors (bare URDFs ship none, which
+      blows up explicit integration),
+
+    plus, scene-wide, the stable ``implicitfast`` integrator, and optionally
+    gravity compensation on the robot's bodies and self-collision disable on
+    the robot's own geoms (cuRobo-style planners ignore adjacent-link
+    contacts, which otherwise block planned motion).
+
+    Atomicity: the spec is snapshotted (XML round-trip) before surgery; any
+    failure restores the snapshot so no partial edit (integrator flip, gravcomp,
+    half the actuators) lingers on the live spec. Returns ``True`` on success.
+    """
+    spec = _get_spec(world)
+    if spec is None or world._model is None:
+        logger.error("actuate_robot_in_scene: no spec or model in world")
+        return False
+    mj = _ensure_mujoco()
+    pfx = robot.namespace or ""
+
+    # Snapshot for atomic rollback (mirrors patch_scene_mjcf): the surgery
+    # touches option/bodies/joints/actuators/geoms, too many objects to undo
+    # piecewise.
+    try:
+        with filter_mujoco_attach_noise():
+            backup_xml = spec.to_xml()
+    except Exception as e:  # pragma: no cover - to_xml on a compiled spec is fine
+        logger.error("actuate_robot_in_scene: failed to snapshot spec: %s", e)
+        return False
+
+    try:
+        # Bare URDF chains (no damping/armature) diverge under the default
+        # Euler integrator once stiff position servos are added; implicitfast
+        # integrates joint damping implicitly and stays stable.
+        spec.option.integrator = mj.mjtIntegrator.mjINT_IMPLICITFAST
+
+        for body in spec.bodies:
+            body_name = body.name or ""
+            if pfx and body_name.startswith(pfx):
+                if gravity_compensation:
+                    body.gravcomp = 1.0
+                if disable_self_collision:
+                    for geom in body.geoms:
+                        geom.contype = 0
+                        geom.conaffinity = 0
+
+        for joint in spec.joints:
+            joint_name = joint.name or ""
+            if not (pfx and joint_name.startswith(pfx)):
+                continue
+            short = joint_name[len(pfx) :]
+            if short not in kp_by_joint:
+                continue
+            joint.damping[0] = max(float(joint.damping[0]), damping)
+            joint.armature = max(float(joint.armature), armature)
+
+        for short, kp in kp_by_joint.items():
+            act = spec.add_actuator()
+            act.name = f"{robot.name}_act_{short}"
+            act.target = f"{pfx}{short}"
+            act.trntype = mj.mjtTrn.mjTRN_JOINT
+            # Find the joint's spec range: inheritrange clamps ctrl to the
+            # joint's limits when it declares any (URDF limits map here);
+            # unlimited joints keep an unlimited ctrlrange.
+            jnt_range_defined = False
+            for joint in spec.joints:
+                if (joint.name or "") == f"{pfx}{short}":
+                    jnt_range_defined = bool(float(joint.range[0]) < float(joint.range[1]))
+                    break
+            act.set_to_position(kp=float(kp), dampratio=1.0, inheritrange=jnt_range_defined)
+    except (ValueError, RuntimeError, TypeError) as e:
+        logger.error("actuate_robot_in_scene: spec surgery failed for '%s': %s", robot.name, e)
+        world._backend_state["spec"] = SpecBuilder.from_mjcf_string(backup_xml)
+        return False
+
+    if not _recompile_preserving_state(world, spec):
+        # Restore the pre-surgery spec so the failed edit doesn't poison
+        # later scene mutations.
+        world._backend_state["spec"] = SpecBuilder.from_mjcf_string(backup_xml)
+        return False
+    return True
+
+
 # Agent-authored raw MJCF (Stage 6)
 
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -74,6 +74,7 @@ from strands_robots.simulation.mujoco.backend import (
     _ensure_mujoco,
     filter_mujoco_attach_noise,
 )
+from strands_robots.simulation.mujoco.manipulation import ManipulationMixin
 from strands_robots.simulation.mujoco.physics import PhysicsMixin
 from strands_robots.simulation.mujoco.randomization import RandomizationMixin
 from strands_robots.simulation.mujoco.recording import RecordingMixin
@@ -206,6 +207,7 @@ class MuJoCoSimEngine(
     RenderingMixin,
     RecordingMixin,
     RandomizationMixin,
+    ManipulationMixin,
     SimEngine,
     AgentTool,
 ):
@@ -1479,6 +1481,22 @@ class MuJoCoSimEngine(
         if err := self._require_no_running_policy("remove_robot"):
             return err
 
+        # An active attachment referencing one of this robot's bodies would be
+        # silently lost by the scene rebuild (weld) or dangle (kinematic).
+        # Fail fast so the caller detaches deliberately.
+        if (attached_child := self.attachment_involving(name)) is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Robot '{name}' is referenced by an active attachment "
+                            f"(child '{attached_child}'). Call detach_bodies first."
+                        )
+                    }
+                ],
+            }
+
         # Pop the robot from the registry BEFORE the rebuild - eject_robot_from_scene
         # rebuilds the spec from the remaining world.robots dict, so the robot
         # we want to drop must no longer be in it.
@@ -1675,6 +1693,26 @@ class MuJoCoSimEngine(
             "(name: str, position=None, orientation=None) -> dict  # reposition "
             "an existing object; position is [x, y, z] meters, orientation is a "
             "[w, x, y, z] quaternion (either may be omitted to leave it unchanged)"
+        )
+        # Manipulation primitives (GH #1533): runtime grasp-assist attach/
+        # detach, URDF-arm actuation, and the anti-explosion dynamics reset.
+        base["methods"]["attach_bodies"] = (
+            "(parent: str, child: str, mode='weld', torquescale=1.0) -> dict  # "
+            "rigidly attach child to parent at their CURRENT relative pose "
+            "(grasp-assist; mode='weld' adds an equality constraint, "
+            "mode='kinematic' teleport-follows every step). NOT a physical grasp"
+        )
+        base["methods"]["detach_bodies"] = "(parent: str, child: str) -> dict  # release an attach_bodies attachment"
+        base["methods"]["actuate_robot"] = (
+            "(robot_name: str, kp=100.0, damping=2.0, armature=0.01, "
+            "gravity_compensation=True, disable_self_collision=False) -> dict  # "
+            "add position-servo actuators to an actuator-less (URDF-loaded) arm "
+            "so send_action / run_policy can drive it (kp: number for all "
+            "hinge/slide joints, or {joint: kp} for a subset)"
+        )
+        base["methods"]["zero_dynamics"] = (
+            "(robot_name: str | None = None) -> dict  # zero qvel/qacc/warmstart "
+            "(world-wide, or one robot's joints) after kinematic qpos writes"
         )
         # Robot-registry + robot-removal surface. describe() calls add_robot
         # "the first scene-construction step" and advertises the object/camera
@@ -2449,6 +2487,21 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": self._unknown_object_msg(name)}]}
         if err := self._require_no_running_policy("remove_object"):
             return err
+        # An active attachment referencing this body would make the ejection
+        # recompile fail (dangling weld) or silently drop a kinematic carry.
+        # Fail fast so the caller detaches deliberately.
+        if (attached_child := self.attachment_involving(name)) is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Object '{name}' is referenced by an active attachment "
+                            f"(child '{attached_child}'). Call detach_bodies first."
+                        )
+                    }
+                ],
+            }
         del self._world.objects[name]
         # spec-based path: eject_body_from_scene looks up the body in the
         # live MjSpec, deletes it, and recompiles preserving remaining state.
@@ -2831,6 +2884,10 @@ class MuJoCoSimEngine(
                 ],
             }
         mj = self._mj
+        # Kinematic attachments (attach_bodies mode="kinematic") follow their
+        # parent every physics step. Resolved once here; the per-step call is
+        # a fast no-op when the registry is empty.
+        has_kinematic_attachments = bool(self._world._backend_state.get("kinematic_attachments"))
         # Process in batches, releasing lock between batches so stop_policy
         # and other actions can interleave on long runs.
         remaining = n_steps
@@ -2839,6 +2896,13 @@ class MuJoCoSimEngine(
             with self._lock:
                 for _ in range(batch):
                     mj.mj_step(self._world._model, self._world._data)
+                    if has_kinematic_attachments:
+                        self._apply_kinematic_attachments()
+                if has_kinematic_attachments:
+                    # Re-forward so the carried bodies' derived state (xpos,
+                    # cam xforms) reflects the final teleport for the next
+                    # render/observation.
+                    mj.mj_forward(self._world._model, self._world._data)
                 self._world.sim_time = self._world._data.time
                 self._world.step_count += batch
             remaining -= batch
@@ -3430,7 +3494,7 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (68 total): "
+                "Actions (72 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
@@ -3441,6 +3505,7 @@ class MuJoCoSimEngine(
                 "apply_force, get_contacts, get_contact_forces, get_body_state, get_energy, "
                 "get_total_mass, get_ground_height, get_sensor_data, get_jacobian, get_mass_matrix, inverse_dynamics, "
                 "forward_kinematics, save_state, load_state, set_body_properties, set_geom_properties; "
+                "[Manipulation] attach_bodies, detach_bodies, actuate_robot, zero_dynamics; "
                 "[Scene MJCF] replace_scene_mjcf, patch_scene_mjcf, raycast, multi_raycast; "
                 "[Recording] start_recording, save_episode, stop_recording, get_recording_status, "
                 "start_cameras_recording, stop_cameras_recording, get_cameras_recording_status; "

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -72,7 +72,11 @@
         "list_benchmarks",
         "register_benchmark_from_file",
         "register_builtin_benchmarks",
-        "evaluate_benchmark"
+        "evaluate_benchmark",
+        "attach_bodies",
+        "detach_bodies",
+        "actuate_robot",
+        "zero_dynamics"
       ]
     },
     "scene_path": {
@@ -418,6 +422,43 @@
     "spec_path": {
       "type": "string",
       "description": "Path to a declarative benchmark spec file (.json, .yaml, .yml). Used by register_benchmark_from_file."
+    },
+    "parent": {
+      "type": "string",
+      "description": "Parent body name for attach_bodies/detach_bodies (robot bodies are namespaced '<robot>/<body>'; call list_bodies to discover names)"
+    },
+    "child": {
+      "type": "string",
+      "description": "Child body name to attach/detach (mode='kinematic' requires it to be a dynamic body with a freejoint)"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["weld", "kinematic"],
+      "description": "attach_bodies mode: 'weld' adds an equality constraint holding the current relative pose; 'kinematic' teleport-follows the parent every physics step. Neither is a physical grasp."
+    },
+    "torquescale": {
+      "type": "number",
+      "description": "attach_bodies weld-only: torque-to-force ratio of the constraint (finite, > 0; default 1.0)"
+    },
+    "kp": {
+      "type": ["number", "object"],
+      "description": "actuate_robot position gain: a number applies to every hinge/slide joint; a {joint_name: kp} object actuates only the listed joints. Values must be finite and > 0."
+    },
+    "damping": {
+      "type": "number",
+      "description": "actuate_robot per-joint damping floor (finite, >= 0; default 2.0)"
+    },
+    "armature": {
+      "type": "number",
+      "description": "actuate_robot per-joint armature floor (finite, >= 0; default 0.01)"
+    },
+    "gravity_compensation": {
+      "type": "boolean",
+      "description": "actuate_robot: apply gravcomp=1 to the robot's bodies (default true)"
+    },
+    "disable_self_collision": {
+      "type": "boolean",
+      "description": "actuate_robot: zero contype/conaffinity on ALL the robot's geoms so planner-ignored self-contacts cannot block motion (default false)"
     }
   },
   "required": [

--- a/tests/simulation/mujoco/test_actuate_robot.py
+++ b/tests/simulation/mujoco/test_actuate_robot.py
@@ -1,0 +1,213 @@
+"""Regression tests for ``actuate_robot`` and ``zero_dynamics`` (GH #1533, PR 1).
+
+``actuate_robot`` is the supported form of the ``so101_curobo`` example's
+private-spec surgery (``sim._world._backend_state["spec"]`` + hand-added
+position actuators): it converts an actuator-less URDF arm into a
+position-servo arm so ``send_action`` / ``run_policy`` can drive it.
+Contracts pinned here:
+
+* an actuator-less URDF arm gains one position actuator per hinge/slide
+  joint and tracks ``send_action`` targets,
+* ``ctrl`` is initialized to the CURRENT pose (no snap to zero),
+* the integrator flips to ``implicitfast`` and the change lives on the spec
+  (survives later scene recompiles),
+* a ``{joint: kp}`` dict actuates only the listed joints; unknown joints and
+  non-positive gains are structured errors,
+* double actuation is refused,
+* ``zero_dynamics`` clears qvel/qacc world-wide or robot-scoped only.
+"""
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+MINI_ARM_URDF = """<?xml version="1.0"?>
+<robot name="mini_arm">
+  <link name="base_link">
+    <inertial><mass value="1.0"/><inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/></inertial>
+    <visual><geometry><box size="0.05 0.05 0.05"/></geometry></visual>
+    <collision><geometry><box size="0.05 0.05 0.05"/></geometry></collision>
+  </link>
+  <link name="link1">
+    <inertial><mass value="0.5"/><inertia ixx="0.005" ixy="0" ixz="0" iyy="0.005" iyz="0" izz="0.005"/></inertial>
+    <visual><origin xyz="0 0 0.1"/><geometry><box size="0.03 0.03 0.2"/></geometry></visual>
+    <collision><origin xyz="0 0 0.1"/><geometry><box size="0.03 0.03 0.2"/></geometry></collision>
+  </link>
+  <link name="link2">
+    <inertial><mass value="0.25"/><inertia ixx="0.002" ixy="0" ixz="0" iyy="0.002" iyz="0" izz="0.002"/></inertial>
+    <visual><origin xyz="0 0 0.075"/><geometry><box size="0.02 0.02 0.15"/></geometry></visual>
+    <collision><origin xyz="0 0 0.075"/><geometry><box size="0.02 0.02 0.15"/></geometry></collision>
+  </link>
+  <joint name="shoulder" type="revolute">
+    <parent link="base_link"/><child link="link1"/>
+    <origin xyz="0 0 0.05"/><axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57" effort="10" velocity="2"/>
+  </joint>
+  <joint name="elbow" type="revolute">
+    <parent link="link1"/><child link="link2"/>
+    <origin xyz="0 0 0.2"/><axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57" effort="10" velocity="2"/>
+  </joint>
+</robot>
+"""
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_actuate_robot_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup(policy_stop_timeout=0.5)
+
+
+@pytest.fixture
+def arm_sim(sim, tmp_path):
+    """A world with an actuator-less 2-joint URDF arm named 'arm'."""
+    urdf = tmp_path / "mini_arm.urdf"
+    urdf.write_text(MINI_ARM_URDF)
+    result = sim.add_robot(name="arm", urdf_path=str(urdf))
+    assert result["status"] == "success", result
+    assert sim._world._model.nu == 0, "URDF arm must load actuator-less for this test"
+    return sim
+
+
+def _joint_qpos(sim, name):
+    m, d = sim._world._model, sim._world._data
+    jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, name)
+    assert jid >= 0, f"joint {name!r} not found"
+    return float(d.qpos[m.jnt_qposadr[jid]])
+
+
+class TestActuateRobot:
+    def test_send_action_drives_urdf_arm_after_actuation(self, arm_sim):
+        """The headline contract: an actuator-less URDF arm becomes drivable."""
+        result = arm_sim.actuate_robot("arm", kp=200.0)
+        assert result["status"] == "success", result
+        assert arm_sim._world._model.nu == 2
+
+        arm_sim.send_action({"shoulder": 0.5, "elbow": -0.4}, robot_name="arm", n_substeps=500)
+        assert _joint_qpos(arm_sim, "arm/shoulder") == pytest.approx(0.5, abs=0.05)
+        assert _joint_qpos(arm_sim, "arm/elbow") == pytest.approx(-0.4, abs=0.05)
+
+    def test_ctrl_initialized_to_current_pose(self, arm_sim):
+        """The arm holds its pose after actuation instead of snapping to zero."""
+        m, d = arm_sim._world._model, arm_sim._world._data
+        jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, "arm/shoulder")
+        d.qpos[m.jnt_qposadr[jid]] = 0.7
+        mj.mj_forward(m, d)
+
+        assert arm_sim.actuate_robot("arm", kp=300.0)["status"] == "success"
+        arm_sim.step(500)
+        assert _joint_qpos(arm_sim, "arm/shoulder") == pytest.approx(0.7, abs=0.05), (
+            "actuated arm must hold its pre-actuation pose, not snap to 0"
+        )
+
+    def test_integrator_switched_and_survives_recompile(self, arm_sim):
+        assert arm_sim.actuate_robot("arm")["status"] == "success"
+        assert arm_sim._world._model.opt.integrator == int(mj.mjtIntegrator.mjINT_IMPLICITFAST)
+        # Actuation lives on the spec: a later scene recompile keeps nu + integrator.
+        assert arm_sim.add_object("cube", shape="box", size=[0.04, 0.04, 0.04], position=[0.3, 0, 0.5])["status"] == (
+            "success"
+        )
+        assert arm_sim._world._model.nu == 2
+        assert arm_sim._world._model.opt.integrator == int(mj.mjtIntegrator.mjINT_IMPLICITFAST)
+
+    def test_kp_dict_actuates_subset_only(self, arm_sim):
+        result = arm_sim.actuate_robot("arm", kp={"shoulder": 250.0})
+        assert result["status"] == "success", result
+        m = arm_sim._world._model
+        assert m.nu == 1
+        assert mj.mj_id2name(m, mj.mjtObj.mjOBJ_ACTUATOR, 0) == "arm_act_shoulder"
+
+    def test_kp_dict_unknown_joint_error(self, arm_sim):
+        result = arm_sim.actuate_robot("arm", kp={"wrist_flex": 100.0})
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "wrist_flex" in text
+        assert "shoulder" in text, "the error must name the valid joints"
+        assert arm_sim._world._model.nu == 0, "a rejected call must not mutate the scene"
+
+    def test_kp_value_validation(self, arm_sim):
+        for bad in (0.0, -5.0, float("inf")):
+            result = arm_sim.actuate_robot("arm", kp=bad)
+            assert result["status"] == "error", f"kp={bad!r} must be rejected"
+        result = arm_sim.actuate_robot("arm", kp={"shoulder": -1.0})
+        assert result["status"] == "error"
+        assert arm_sim._world._model.nu == 0
+
+    def test_double_actuation_refused(self, arm_sim):
+        assert arm_sim.actuate_robot("arm")["status"] == "success"
+        result = arm_sim.actuate_robot("arm")
+        assert result["status"] == "error"
+        assert "already has actuators" in result["content"][0]["text"]
+        assert arm_sim._world._model.nu == 2, "the refused call must not add duplicates"
+
+    def test_unknown_robot_error(self, sim):
+        result = sim.actuate_robot("ghost")
+        assert result["status"] == "error"
+
+    def test_disable_self_collision_zeroes_robot_geom_masks(self, arm_sim):
+        assert arm_sim.actuate_robot("arm", disable_self_collision=True)["status"] == "success"
+        m = arm_sim._world._model
+        robot_geoms = 0
+        for gid in range(m.ngeom):
+            body_name = mj.mj_id2name(m, mj.mjtObj.mjOBJ_BODY, m.geom_bodyid[gid]) or ""
+            if body_name.startswith("arm/"):
+                robot_geoms += 1
+                assert int(m.geom_contype[gid]) == 0
+                assert int(m.geom_conaffinity[gid]) == 0
+        assert robot_geoms > 0, "the arm must contribute geoms to the check"
+
+    def test_dispatch_via_action_router(self, arm_sim):
+        result = arm_sim._dispatch_action("actuate_robot", {"robot_name": "arm", "kp": 150.0})
+        assert result["status"] == "success", result
+        assert arm_sim._world._model.nu == 2
+
+
+class TestZeroDynamics:
+    def test_zeroes_all_dofs(self, sim):
+        sim.add_object("cube", shape="box", size=[0.04, 0.04, 0.04], position=[0, 0, 0.6])
+        sim.step(40)  # build up fall velocity
+        m, d = sim._world._model, sim._world._data
+        assert any(abs(float(v)) > 0.1 for v in d.qvel), "cube should be falling"
+
+        result = sim.zero_dynamics()
+        assert result["status"] == "success", result
+        assert [float(v) for v in d.qvel] == pytest.approx([0.0] * m.nv, abs=1e-12)
+        assert [float(v) for v in d.qacc_warmstart] == pytest.approx([0.0] * m.nv, abs=1e-12)
+
+    def test_robot_scope_leaves_object_momentum(self, sim, tmp_path):
+        urdf = tmp_path / "mini_arm.urdf"
+        urdf.write_text(MINI_ARM_URDF)
+        assert sim.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+        sim.add_object("cube", shape="box", size=[0.04, 0.04, 0.04], position=[0.5, 0, 0.6])
+        m, d = sim._world._model, sim._world._data
+        # Give the arm's shoulder a spin and let the cube fall.
+        jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, "arm/shoulder")
+        d.qvel[m.jnt_dofadr[jid]] = 2.0
+        sim.step(30)
+        m, d = sim._world._model, sim._world._data
+        cube_jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, "cube_joint")
+        cube_adr = int(m.jnt_dofadr[cube_jid])
+        cube_vz_before = float(d.qvel[cube_adr + 2])
+        assert abs(cube_vz_before) > 0.1, "cube should be falling"
+
+        result = sim.zero_dynamics(robot_name="arm")
+        assert result["status"] == "success", result
+        jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, "arm/shoulder")
+        assert float(d.qvel[m.jnt_dofadr[jid]]) == 0.0
+        assert float(d.qvel[cube_adr + 2]) == pytest.approx(cube_vz_before, abs=1e-9), (
+            "robot-scoped zero_dynamics must not touch the cube's freejoint"
+        )
+
+    def test_unknown_robot_error(self, sim):
+        result = sim.zero_dynamics(robot_name="ghost")
+        assert result["status"] == "error"
+
+    def test_dispatch_via_action_router(self, sim):
+        sim.add_object("cube", shape="box", size=[0.04, 0.04, 0.04], position=[0, 0, 0.6])
+        sim.step(40)
+        result = sim._dispatch_action("zero_dynamics", {})
+        assert result["status"] == "success", result

--- a/tests/simulation/mujoco/test_attach_bodies.py
+++ b/tests/simulation/mujoco/test_attach_bodies.py
@@ -1,0 +1,265 @@
+"""Regression tests for ``attach_bodies`` / ``detach_bodies`` (GH #1533, PR 1).
+
+The runtime grasp-assist primitives the ``so101_curobo`` example used to
+hand-roll (per-waypoint ``move_object`` teleports + raw ``qvel`` zeroing).
+Contracts pinned here:
+
+* **weld** adds an equality constraint holding the CURRENT runtime relative
+  pose (not the compile-time ``qpos0`` pose - MuJoCo's all-zero ``relpose``
+  shortcut would silently weld at the spawn offset).
+* **kinematic** teleport-follows the parent every physics step through both
+  the ``step()`` batch loop and the policy-driven ``send_action`` substep
+  loop, with the child's freejoint velocity zeroed (no teleport fling).
+* ``detach_bodies`` releases: a welded child no longer follows; a kinematic
+  child falls physically from the release point.
+* Error contract: structured error dicts (never raises) for unknown bodies,
+  duplicate attachments, bad mode, bad torquescale, kinematic children
+  without a freejoint, and mismatched detach parents.
+* ``remove_object`` / ``remove_robot`` refuse to remove a body an active
+  attachment references (a dangling weld would fail the next recompile).
+"""
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_attach_bodies_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup(policy_stop_timeout=0.5)
+
+
+def _body_xpos(sim, name):
+    m, d = sim._world._model, sim._world._data
+    bid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_BODY, name)
+    assert bid >= 0, f"body {name!r} not found"
+    return [float(v) for v in d.xpos[bid]]
+
+
+def _freejoint_qvel(sim, name):
+    m, d = sim._world._model, sim._world._data
+    jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
+    assert jid >= 0
+    adr = m.jnt_dofadr[jid]
+    return [float(v) for v in d.qvel[adr : adr + 6]]
+
+
+def _offset(sim, parent, child):
+    p = _body_xpos(sim, parent)
+    c = _body_xpos(sim, child)
+    return [c[i] - p[i] for i in range(3)]
+
+
+@pytest.fixture
+def two_boxes(sim):
+    """A big dynamic 'carrier' box and a small 'cube', both airborne."""
+    assert sim.add_object("carrier", shape="box", size=[0.1, 0.1, 0.1], position=[0, 0, 0.6])["status"] == "success"
+    assert sim.add_object("cube", shape="box", size=[0.04, 0.04, 0.04], position=[0.2, 0, 0.6])["status"] == "success"
+    return sim
+
+
+class TestWeldAttach:
+    def test_weld_holds_current_runtime_pose_not_spawn_pose(self, two_boxes):
+        """The weld must capture the pose AT ATTACH TIME - the core honesty fix.
+
+        Move the cube away from its spawn offset first; after attaching, the
+        held offset must be the runtime one (0.3 m), not the spawn one (0.2 m).
+        """
+        sim = two_boxes
+        assert sim.move_object("cube", position=[0.3, 0.0, 0.6])["status"] == "success"
+        result = sim.attach_bodies("carrier", "cube", mode="weld")
+        assert result["status"] == "success", result
+
+        sim.step(150)  # both fall + settle under gravity
+        off = _offset(sim, "carrier", "cube")
+        assert off[0] == pytest.approx(0.3, abs=0.02), f"weld must hold the RUNTIME offset, got {off}"
+
+    def test_weld_survives_later_scene_recompile(self, two_boxes):
+        """The equality lives on the spec, so add_object recompiles keep it."""
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        assert sim.add_object("bystander", shape="box", size=[0.05, 0.05, 0.05], position=[1, 1, 0.5])["status"] == (
+            "success"
+        )
+        sim.step(150)
+        off = _offset(sim, "carrier", "cube")
+        assert off[0] == pytest.approx(0.2, abs=0.02), f"weld lost across recompile: {off}"
+
+    def test_detach_releases_weld(self, two_boxes):
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        result = sim.detach_bodies("carrier", "cube")
+        assert result["status"] == "success", result
+        # Model must hold no equality constraints anymore.
+        assert sim._world._model.neq == 0
+        # And the pair can re-attach cleanly.
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+
+
+class TestKinematicAttach:
+    def test_child_follows_parent_through_step(self, two_boxes):
+        """The carrier free-falls; the kinematically attached cube rides along."""
+        sim = two_boxes
+        start_off = _offset(sim, "carrier", "cube")
+        result = sim.attach_bodies("carrier", "cube", mode="kinematic")
+        assert result["status"] == "success", result
+
+        sim.step(200)  # carrier falls ~ to the ground
+        assert _body_xpos(sim, "carrier")[2] < 0.3, "carrier should have fallen"
+        off = _offset(sim, "carrier", "cube")
+        for i in range(3):
+            assert off[i] == pytest.approx(start_off[i], abs=0.01), f"cube did not follow: {off} vs {start_off}"
+
+    def test_child_velocity_zeroed_while_carried(self, two_boxes):
+        """No teleport fling: the carried child's freejoint velocity is zero."""
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="kinematic")["status"] == "success"
+        sim.step(50)
+        assert _freejoint_qvel(sim, "cube") == pytest.approx([0.0] * 6, abs=1e-12)
+
+    def test_child_follows_through_send_action_path(self, sim):
+        """The policy-driven substep loop (_apply_sim_action) also re-pins.
+
+        A torque-actuated pusher scene drives via send_action; the attached
+        cube must follow the pusher body, not stay behind.
+        """
+        r = sim.replace_scene_mjcf(
+            "<mujoco><worldbody>"
+            '<geom type="plane" size="2 2 0.1"/>'
+            '<body name="pusher" pos="0 0 0.1">'
+            '<joint name="slide_x" type="slide" axis="1 0 0"/>'
+            '<geom type="box" size="0.05 0.05 0.05" mass="1"/>'
+            "</body>"
+            '<body name="cube" pos="0.2 0 0.05">'
+            '<joint name="cube_joint" type="free"/>'
+            '<geom type="box" size="0.02 0.02 0.02" mass="0.05"/>'
+            "</body>"
+            "</worldbody>"
+            "<actuator>"
+            '<velocity name="drive_x" joint="slide_x" kv="10"/>'
+            "</actuator></mujoco>"
+        )
+        assert r["status"] == "success", r
+        # Register a robot handle so send_action can route to the actuator.
+        from strands_robots.simulation.models import SimRobot
+
+        robot = SimRobot(name="pusher_bot", urdf_path="")
+        robot.joint_names = ["slide_x"]
+        robot.joint_ids = [mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_JOINT, "slide_x")]
+        robot.actuator_ids = [0]
+        sim._world.robots["pusher_bot"] = robot
+
+        assert sim.attach_bodies("pusher", "cube", mode="kinematic")["status"] == "success"
+        start_off = _offset(sim, "pusher", "cube")
+        sim.send_action({"drive_x": 0.5}, robot_name="pusher_bot", n_substeps=400)
+        assert _body_xpos(sim, "pusher")[0] > 0.05, "pusher should have moved"
+        off = _offset(sim, "pusher", "cube")
+        assert off[0] == pytest.approx(start_off[0], abs=0.01), f"cube did not follow the driven pusher: {off}"
+
+    def test_detach_drops_child_physically(self, two_boxes):
+        """After detach the cube is free again: it falls from the release point."""
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="kinematic")["status"] == "success"
+        sim.step(20)
+        assert sim.detach_bodies("carrier", "cube")["status"] == "success"
+        z_release = _body_xpos(sim, "cube")[2]
+        sim.step(100)
+        assert _body_xpos(sim, "cube")[2] < z_release - 0.01, "detached cube should fall freely"
+
+    def test_kinematic_requires_child_freejoint(self, sim):
+        sim.add_object("carrier", shape="box", size=[0.1, 0.1, 0.1], position=[0, 0, 0.5])
+        sim.add_object("fixture", shape="box", size=[0.05, 0.05, 0.05], position=[0.3, 0, 0.025], is_static=True)
+        result = sim.attach_bodies("carrier", "fixture", mode="kinematic")
+        assert result["status"] == "error"
+        assert "freejoint" in result["content"][0]["text"]
+
+
+class TestAttachErrorContract:
+    def test_unknown_bodies_error(self, two_boxes):
+        sim = two_boxes
+        for parent, child, which in (("nope", "cube", "parent"), ("carrier", "nope", "child")):
+            result = sim.attach_bodies(parent, child)
+            assert result["status"] == "error"
+            assert f"{which} body 'nope' not found" in result["content"][0]["text"]
+
+    def test_unknown_mode_error(self, two_boxes):
+        result = two_boxes.attach_bodies("carrier", "cube", mode="magnetic")
+        assert result["status"] == "error"
+        assert "unknown mode" in result["content"][0]["text"]
+
+    def test_self_attach_error(self, two_boxes):
+        result = two_boxes.attach_bodies("cube", "cube")
+        assert result["status"] == "error"
+        assert "same body" in result["content"][0]["text"]
+
+    def test_bad_torquescale_error(self, two_boxes):
+        for bad in (0.0, -1.0, float("nan"), "high"):
+            result = two_boxes.attach_bodies("carrier", "cube", torquescale=bad)
+            assert result["status"] == "error", f"torquescale={bad!r} must be rejected"
+            assert "torquescale" in result["content"][0]["text"]
+
+    def test_double_attach_error(self, two_boxes):
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        result = sim.attach_bodies("carrier", "cube", mode="kinematic")
+        assert result["status"] == "error"
+        assert "already attached" in result["content"][0]["text"]
+
+    def test_detach_unknown_attachment_error(self, two_boxes):
+        result = two_boxes.detach_bodies("carrier", "cube")
+        assert result["status"] == "error"
+        assert "no attachment" in result["content"][0]["text"]
+
+    def test_detach_wrong_parent_error(self, two_boxes):
+        sim = two_boxes
+        sim.add_object("other", shape="box", size=[0.05, 0.05, 0.05], position=[1, 1, 0.5])
+        assert sim.attach_bodies("carrier", "cube", mode="kinematic")["status"] == "success"
+        result = sim.detach_bodies("other", "cube")
+        assert result["status"] == "error"
+        assert "attached to 'carrier'" in result["content"][0]["text"]
+
+
+class TestRemovalGuards:
+    def test_remove_object_refuses_attached_child(self, two_boxes):
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        for name in ("cube", "carrier"):
+            result = sim.remove_object(name)
+            assert result["status"] == "error", f"remove_object({name!r}) must refuse while attached"
+            assert "detach_bodies" in result["content"][0]["text"]
+        # After detaching, removal succeeds.
+        assert sim.detach_bodies("carrier", "cube")["status"] == "success"
+        assert sim.remove_object("cube")["status"] == "success"
+
+    def test_remove_robot_refuses_attached_parent(self, sim, tmp_path):
+        urdf = tmp_path / "mini.urdf"
+        urdf.write_text(
+            '<?xml version="1.0"?><robot name="mini">'
+            '<link name="base_link"><inertial><mass value="1.0"/>'
+            '<inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/></inertial>'
+            '<visual><geometry><box size="0.05 0.05 0.05"/></geometry></visual></link>'
+            "</robot>"
+        )
+        assert sim.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+        sim.add_object("cube", shape="box", size=[0.04, 0.04, 0.04], position=[0.2, 0, 0.5])
+        assert sim.attach_bodies("arm/base_link", "cube", mode="kinematic")["status"] == "success"
+        result = sim.remove_robot("arm")
+        assert result["status"] == "error"
+        assert "detach_bodies" in result["content"][0]["text"]
+        assert sim.detach_bodies("arm/base_link", "cube")["status"] == "success"
+        assert sim.remove_robot("arm")["status"] == "success"
+
+
+class TestDispatch:
+    def test_attach_detach_dispatch_via_action_router(self, two_boxes):
+        """The agent-facing dispatcher routes the new actions end to end."""
+        sim = two_boxes
+        result = sim._dispatch_action("attach_bodies", {"parent": "carrier", "child": "cube", "mode": "kinematic"})
+        assert result["status"] == "success", result
+        result = sim._dispatch_action("detach_bodies", {"parent": "carrier", "child": "cube"})
+        assert result["status"] == "success", result

--- a/tests/simulation/mujoco/test_no_world_guard_contract.py
+++ b/tests/simulation/mujoco/test_no_world_guard_contract.py
@@ -73,6 +73,11 @@ GUARDED_CALLS: list[tuple[str, tuple, dict]] = [
     ("forward_kinematics", (), {}),
     ("get_total_mass", (), {}),
     ("export_xml", (), {}),
+    # ManipulationMixin - attach/actuate/zero primitives (GH #1533).
+    ("attach_bodies", ("parent", "child"), {}),
+    ("detach_bodies", ("parent", "child"), {}),
+    ("actuate_robot", ("arm",), {}),
+    ("zero_dynamics", (), {}),
     # RandomizationMixin.
     ("randomize", (), {}),
     # RenderingMixin - render + contact-query + camera-recording entry points.


### PR DESCRIPTION
Part 1 of the #1533 plan ("PR 1 - sim primitives"). Lifts the generic runtime primitives that `examples/so101_curobo/` hand-rolled against private surfaces into supported, locked, agent-dispatchable `Simulation` methods on the MuJoCo backend.

## What changed

### `attach_bodies(parent, child, mode="weld"|"kinematic", torquescale=1.0)` / `detach_bodies(parent, child)`
Runtime grasp-assist (replaces the example's per-waypoint `move_object` teleports + raw `d.qvel` zeroing, collector.py:813-862 / 376-396):

- **weld**: adds a named equality constraint on the live `MjSpec` capturing the **current runtime relative pose** - explicitly NOT MuJoCo's all-zero-`relpose` shortcut, which would silently weld at the compile-time `qpos0` offset. Lives on the spec, so it survives later scene recompiles (`add_object`, etc.). Regression test pins the runtime-pose-not-spawn-pose behavior.
- **kinematic**: the child's freejoint is re-pinned to follow the parent after **every** `mj_step` - both the `step()` batch loop and the policy-driven `_apply_sim_action` substep loop - with velocity zeroed (no teleport fling). Requires the child to own a freejoint; structured error otherwise.
- Data-honesty caveat documented on both modes and echoed in the success text: neither is a physical grasp.
- One attachment per child; `remove_object` / `remove_robot` now **fail fast** when an active attachment references the body (a dangling weld would fail the next recompile; a dangling kinematic follow would silently detach).

### `actuate_robot(robot_name, kp=100.0 | {joint: kp}, damping=2.0, armature=0.01, gravity_compensation=True, disable_self_collision=False)`
The supported form of the example's `sim._world._backend_state["spec"]` surgery (scene.py:233-325): converts an actuator-less URDF arm (`nu == 0`) into a position-servo arm so `send_action` / `run_policy` can drive it.

- Position actuators via `MjsActuator.set_to_position(kp, dampratio=1.0)` (principled critical damping instead of the example's hand-rolled `kv = 2*sqrt(kp)`), ctrlrange inherited from the joint's limits when declared.
- Damping/armature **floors** on the robot's joints + `implicitfast` integrator (documented scene-wide side effect; bare URDF chains diverge under Euler with stiff servos).
- Spec snapshot + restore keeps the mutation atomic on any failure (no half-actuated arm, no lingering integrator flip).
- `ctrl` initialized to the current pose after recompile, so the arm holds instead of snapping to zero (pinned by a test).
- kp as a dict actuates only the listed joints; unknown joints / non-positive gains / double actuation are structured errors that leave the scene untouched.

### `zero_dynamics(robot_name=None)`
The anti-explosion reset (collector.py `_zero_arm_dynamics` / `_zero_cube_velocity`): clears `qvel` / `qacc` / `qacc_warmstart` world-wide or scoped to one robot's joint DOFs (object freejoints keep their momentum - pinned by a test), then re-forwards.

### Wiring
- All four actions in `tool_spec.json` (enum + new `parent`/`child`/`mode`/`torquescale`/`kp`/`damping`/`armature`/`gravity_compensation`/`disable_self_collision` properties), the tool description ("Actions (72 total)" + new `[Manipulation]` family - the description/enum drift tests enforce this), `describe()` discovery entries, and the generic dispatcher.
- New `ManipulationMixin` (`strands_robots/simulation/mujoco/manipulation.py`) following the existing mixin pattern; spec surgery lives in `scene_ops.py` next to its siblings (`add_weld_constraint`, `remove_equality_constraint`, `actuate_robot_in_scene`).

## Safety rails (per AGENTS.md)
- Every model/data mutation holds `self._lock`; every method refuses to run mid-policy (`_require_no_running_policy`); every failure path returns a structured error dict (never raises past dispatch).
- LLM-input validation: `parent`/`child` must resolve to existing bodies before any name is interpolated into the spec; `kp`/`damping`/`armature`/`torquescale` validated finite + range-checked up front.
- The four new methods are added to the `test_no_world_guard_contract.py` GUARDED_CALLS table.

## Test surface
33 new regression tests across `tests/simulation/mujoco/test_attach_bodies.py` and `test_actuate_robot.py`, covering: weld holds the runtime pose and survives recompiles; detach releases (weld `neq==0`, kinematic child falls physically); kinematic follow through **both** stepping paths (`step()` and `send_action`); carried-child velocity stays zero; URDF arm drivable end-to-end after actuation; pose-hold on actuation; integrator persistence across recompiles; kp-dict subset/validation; double-actuation refusal; self-collision mask zeroing; removal guards; robot-scoped vs world zero_dynamics; dispatcher round-trips.

Validation: `hatch run format` + `hatch run lint` clean (ruff + mypy). Full suite under `MUJOCO_GL=egl`: **11140 passed, 212 skipped, 0 failed** (93.3% coverage). Note: with the default GLFW backend the full suite aborts (core dump) in `tests/inference/test_remote_policy_sim_rollout.py` on this headless box - reproduced identically on clean `upstream/main`, so it is a pre-existing environmental GL issue, not introduced here (the test passes in isolation and under EGL).

## Acceptance criteria from #1533 (PR 1 scope)
- [x] `attach_bodies(parent, child, mode="weld"|"kinematic", ...)` / `detach_bodies(...)` - weld via spec equality + `_recompile_preserving_state`; kinematic per-step follow (locked + public)
- [x] Data-honesty caveat documented (welded "grasps" are not physical grasps)
- [x] `actuate_robot(robot_name, kp: dict[str, float] | float, disable_self_collision=False)` as a supported method (spec mutation + recompile-preserving-state, under `self._lock`, `_require_no_running_policy`)
- [x] `zero_dynamics(robot_name=None)` (the anti-explosion qvel/qacc clear)
- [x] Lock all model/data mutations; error dicts from tool actions; regression tests for each

Note on `offset=`: `attach_bodies` deliberately captures the current relative pose instead of taking an `offset` parameter - the example's own final design ("capture in place - no ease, no teleport into a mouth -> no visible jump", collector.py:842). Callers wanting a different seat pose can `move_object` the child before attaching. Can add an explicit offset kwarg in a follow-up if the pick_place provider (PR 3) needs it.

## Out of scope / follow-ups (tracked in #1533)
- PR 2: `curobo_config_from_urdf` (cuRobo-from-URDF)
- PR 3: `PickPlacePolicy` provider + `PickPlaceRobotProfile`
- PR 4: success-gated `collect_dataset` + `pick_place_cube` benchmark spec
- PR 5: slim `examples/so101_curobo/` onto PRs 1-4
- Isaac hybrid-carry stays example-side (per the issue's scope decision); this PR is MuJoCo-scoped.

This PR does NOT close #1533 (it is part 1 of 5). Project board: please move #1533 to "In review" for this slice, or leave it "In progress" until PRs 2-5 land.
