### PR TITLE
test(sim/mujoco): pin render() fail-soft contract for unexpected pipeline errors

### DIFF
--- a/tests/simulation/mujoco/test_error_paths.py
+++ b/tests/simulation/mujoco/test_error_paths.py
@@ -279,6 +279,32 @@ def test_render_unknown_camera_falls_back(ready_sim):
     assert r["status"] in ("success", "error")
 
 
+@requires_gl
+def test_render_surfaces_unexpected_renderer_error_as_status_error(ready_sim, monkeypatch):
+    """An unexpected exception inside the render pipeline must be caught.
+
+    Camera validation and the no-GL-context guard already return structured
+    errors, but a fault raised deeper in the pipeline (a MuJoCo renderer that
+    throws on ``update_scene`` after the camera resolved, e.g. a lost GL context
+    mid-render) must NOT bubble a raw exception past the AgentTool boundary. It
+    has to come back as ``status=error`` carrying the fault text, so the LLM
+    sees a recoverable tool result instead of an unhandled traceback.
+    """
+
+    class _BoomRenderer:
+        def update_scene(self, data, camera=None, scene_option=None):
+            raise RuntimeError("GL context lost mid-render")
+
+    # The free camera ("default") skips name validation, so the fault lands in
+    # the render body itself - the path the catch-all guards.
+    monkeypatch.setattr(ready_sim, "_get_renderer", lambda w, h: _BoomRenderer())
+    r = ready_sim.render(camera_name="default", width=32, height=24)
+    assert r["status"] == "error"
+    text = r["content"][0]["text"]
+    assert "Render failed" in text
+    assert "GL context lost mid-render" in text
+
+
 # ─ Tool-spec dispatch: unknown action + error routing───────────
 
 


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.render()` is an agent-facing tool method: it must return a structured `{"status": "error", ...}` result and never let a raw exception bubble past the tool boundary. It already does this for the two anticipated failure modes:

- an unresolved camera name -> `"Camera '<name>' not found. Available: [...]"`
- a missing GL context -> `"Rendering unavailable (no OpenGL context)..."`

Both are covered. But the method also wraps its whole body in a catch-all `except Exception` that surfaces any *unanticipated* fault -- e.g. the MuJoCo renderer throwing on `update_scene` after the camera resolved, such as a GL context lost mid-render -- as `"Render failed: <e>"`. That catch-all was the one untested branch in the method, so the contract "an unexpected render-pipeline fault comes back as a recoverable tool result, not an unhandled traceback" was unpinned and could silently rot.

## Change

Add one focused regression test (`test_render_surfaces_unexpected_renderer_error_as_status_error`) to `tests/simulation/mujoco/test_error_paths.py`, whose stated charter is exactly this contract ("the LLM-facing surface must never bubble a raw exception"). It injects a renderer whose `update_scene` raises via the same `_get_renderer` monkeypatch seam the existing depth-render tests already use, renders the free camera (so name validation is skipped and the fault lands in the render body), and asserts the result is `status=error` carrying the fault text.

This is test-only; there is no production-code change, so rendering behavior is unchanged (no visual artifact applies).

## Verification

- The `except Exception` branch in `render()` was uncovered before this test and is covered after (confirmed by scoped `--cov-report=term-missing`).
- `tests/simulation/mujoco/test_error_paths.py`: 39 passed (headless, `MUJOCO_GL=egl`).
- `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues.