### PR TITLE
fix(examples/isaac_gs): consume _render_frame instead of the stale render() envelope (closes #1536)

### DIFF
--- a/examples/isaac_gs/camera_utils.py
+++ b/examples/isaac_gs/camera_utils.py
@@ -11,7 +11,9 @@ equivalent from the ``omni.isaac.sensor.Camera`` handle that
 
 * ``camera.get_intrinsics_matrix()`` -> ``K``
 * ``camera.get_world_pose()`` -> ``(position, quaternion)`` -> ``T_world_cam``
-* ``sim.render(camera_name)`` (#62) -> RGB + metric depth
+* ``sim._render_frame(camera_name)`` -> raw RGB + metric depth (the
+  public ``sim.render()`` returns only the ``{status, content}``
+  tool-result envelope; see TODO(#1537) on :func:`render_rgb_and_depth`)
 
 Isaac's USD camera convention matches the OpenGL convention the
 background renderers expect (+X right, +Y up, **-Z forward**), so the
@@ -131,18 +133,26 @@ def get_camera_params(
 def render_rgb_and_depth(sim: "object", camera_name: str) -> "tuple[np.ndarray, np.ndarray]":
     """Render the Isaac RTX foreground RGB + metric depth for a camera.
 
-    Thin wrapper over ``sim.render(camera_name)`` (#62) that normalises
-    the envelope into ``(rgb_uint8_HxWx3, depth_float32_HxW)``.
+    Thin wrapper over ``IsaacSimulation._render_frame(camera_name)`` that
+    normalises the raw frame into ``(rgb_uint8_HxWx3, depth_float32_HxW)``.
+
+    TODO(#1537): ``_render_frame`` is a private helper -- the public
+    ``sim.render()`` returns only the ``{status, content}`` tool-result
+    envelope (raw arrays are forbidden as top-level keys), and there is no
+    public API today that yields the raw ``(rgb, depth)`` pair. The GS-layer
+    library refactor (#1537) adds a public raw-frame API
+    (``get_frame``-style); switch to it and drop this private reach-through
+    when it lands.
 
     Pixels with no geometry (sky / background) come back from Isaac as
     very large / inf depth; the compositor treats those as "see the
     background through here".
     """
-    result = sim.render(camera_name=camera_name)
-    if result.get("status") != "success":
-        raise RuntimeError(f"sim.render({camera_name!r}) failed: {result}")
-    rgb = np.asarray(result["rgb"])
+    rgb, depth, meta = sim._render_frame(camera_name=camera_name)
+    if rgb is None:
+        raise RuntimeError(f"_render_frame({camera_name!r}) failed: {meta.get('error', meta)}")
+    rgb = np.asarray(rgb)
     if rgb.ndim == 3 and rgb.shape[2] == 4:
         rgb = rgb[..., :3]
-    depth = np.asarray(result["depth"], dtype=np.float32)
+    depth = np.asarray(depth, dtype=np.float32)
     return rgb.astype(np.uint8), depth

--- a/tests/test_examples_isaac_gs_imports.py
+++ b/tests/test_examples_isaac_gs_imports.py
@@ -1,0 +1,125 @@
+"""Import + contract smoke tests for the ``examples/isaac_gs`` hybrid-render demo.
+
+Pins two clean-checkout breakages from #1536:
+
+1. **Example-vs-repo drift**: ``examples/isaac_gs`` hard-imports its sibling
+   ``examples.mujoco_gs`` (``CameraParams``, ``BackgroundRenderer``,
+   ``PanoramaBackground``, the gsplat preset helpers). #1280 originally merged
+   isaac_gs before that dependency existed on ``main``; it only appeared to work
+   on dev boxes where a stale ``robots-sim`` checkout was on ``sys.path``.
+   Importing the modules here makes CI fail loudly if the sibling example (or a
+   symbol it re-exports) ever drifts again - per AGENTS.md "test import paths
+   must match production".
+
+2. **Stale ``render()`` envelope**: ``render_rgb_and_depth`` used to read raw
+   ``result["rgb"]`` / ``result["depth"]`` off the ``sim.render()`` tool-result
+   envelope, which carries ONLY ``{status, content}`` (the tool-result contract
+   forbids extra top-level keys) - a guaranteed ``KeyError``. It now consumes
+   ``IsaacSimulation._render_frame`` (raw ``(rgb, depth, meta)``; the private
+   reach-through is a documented TODO(#1537) until a public raw-frame API
+   exists). The behavioral tests below pin that consumption contract with a
+   stub sim - no Isaac install needed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ``examples`` is a PEP 420 namespace package rooted at the repo top level.
+# pytest's rootdir insertion usually covers this, but make it explicit so the
+# test cannot silently resolve ``examples.mujoco_gs`` from some OTHER checkout
+# earlier on sys.path (the exact failure mode that let #1280 ship broken).
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+_ISAAC_GS_MODULES = [
+    "examples.isaac_gs.camera_utils",
+    "examples.isaac_gs.compositor",
+    "examples.isaac_gs.background",
+]
+
+
+@pytest.mark.parametrize("module_name", _ISAAC_GS_MODULES)
+def test_isaac_gs_module_imports_from_this_repo(module_name: str) -> None:
+    """Each isaac_gs module imports on a clean checkout, resolved from THIS repo."""
+    module = importlib.import_module(module_name)
+    assert module.__file__ is not None
+    resolved = Path(module.__file__).resolve()
+    assert resolved.is_relative_to(_REPO_ROOT), (
+        f"{module_name} resolved to {resolved}, outside this checkout "
+        f"({_REPO_ROOT}). A stale sibling checkout on sys.path is masking "
+        "missing files - the exact failure mode of #1536."
+    )
+
+
+def test_isaac_gs_mujoco_gs_dependency_resolves_in_repo() -> None:
+    """The ``examples.mujoco_gs`` symbols isaac_gs depends on exist in this repo."""
+    backgrounds = importlib.import_module("examples.mujoco_gs.backgrounds")
+    for symbol in (
+        "BackgroundRenderer",
+        "PanoramaBackground",
+        "GsplatBackground",
+        "download_gsplat_scene",
+        "gsplat_skybox_align_for",
+        "gsplat_skybox_scene_names",
+    ):
+        assert hasattr(backgrounds, symbol), f"examples.mujoco_gs.backgrounds lost {symbol}"
+    camera_utils = importlib.import_module("examples.mujoco_gs.camera_utils")
+    assert hasattr(camera_utils, "CameraParams")
+    assert backgrounds.__file__ is not None
+    assert Path(backgrounds.__file__).resolve().is_relative_to(_REPO_ROOT)
+
+
+class _StubSim:
+    """Stub of the ``IsaacSimulation._render_frame`` raw-frame surface."""
+
+    def __init__(self, rgb, depth, meta=None):
+        self._rgb = rgb
+        self._depth = depth
+        self._meta = meta or {"text": "Rendered (stub)"}
+
+    def _render_frame(self, camera_name: str = "default", width=None, height=None):
+        return self._rgb, self._depth, self._meta
+
+    def render(self, camera_name: str = "default", **_: object):
+        raise AssertionError(
+            "render_rgb_and_depth must NOT call the public render() - its "
+            "{status, content} envelope carries no raw arrays (#1536)."
+        )
+
+
+def test_render_rgb_and_depth_consumes_render_frame() -> None:
+    """Happy path: raw ``_render_frame`` arrays come back as (uint8 RGB, float32 depth)."""
+    from examples.isaac_gs.camera_utils import render_rgb_and_depth
+
+    h, w = 4, 6
+    rgba = np.zeros((h, w, 4), dtype=np.uint8)
+    rgba[..., 0] = 200  # red channel; alpha stays 0 to prove it's sliced away
+    depth_in = np.full((h, w), 1.5, dtype=np.float64)
+
+    rgb, depth = render_rgb_and_depth(_StubSim(rgba, depth_in), "cam0")
+
+    assert rgb.shape == (h, w, 3)
+    assert rgb.dtype == np.uint8
+    assert int(rgb[0, 0, 0]) == 200
+    assert depth.shape == (h, w)
+    assert depth.dtype == np.float32
+    assert float(depth[0, 0]) == pytest.approx(1.5)
+
+
+def test_render_rgb_and_depth_raises_on_render_failure() -> None:
+    """Failure path: ``rgb is None`` surfaces the meta error, never a KeyError."""
+    from examples.isaac_gs.camera_utils import render_rgb_and_depth
+
+    sim = _StubSim(None, None, meta={"error": "No world created."})
+    with pytest.raises(RuntimeError, match="No world created"):
+        render_rgb_and_depth(sim, "cam0")


### PR DESCRIPTION
## Summary

Fixes #1536 - `examples/isaac_gs/` was broken on a clean checkout in two independent ways. It only appeared to work on dev boxes where a stale `robots-sim` checkout was on `sys.path`.

### Breakage 1: imports of `examples.mujoco_gs` (structurally resolved, now pinned)

`examples/isaac_gs` hard-imports `examples.mujoco_gs.*` (`CameraParams`, `BackgroundRenderer`, `PanoramaBackground`, `GsplatBackground`, the gsplat preset helpers). When #1280 merged, that sibling did not exist on `main`. It has since landed via #1282, so the imports now resolve on a clean clone - **verified in this PR with import smoke tests** that also assert the modules resolve from *this* checkout (`Path(module.__file__).is_relative_to(repo_root)`), so a stale sibling checkout on `sys.path` can never mask missing files again. This is the CI-collectible drift pin the issue asked for (item 3 of the interim mitigation).

### Breakage 2: stale `render()` envelope contract (fixed)

`render_rgb_and_depth` read raw `result["rgb"]` / `result["depth"]` off `sim.render()`'s tool-result envelope. `IsaacSimulation.render` returns ONLY `{status, content}` (the tool-result contract forbids extra top-level keys), so this was a guaranteed `KeyError` on every current build.

It now consumes `IsaacSimulation._render_frame(camera_name)` - the raw `(rgb, depth, meta)` tuple and the only surface that yields the raw pair today - exactly as the issue's interim mitigation (item 2) suggests. The private reach-through carries a loud `TODO(#1537)` in both the function docstring and the module docstring: the GS-layer library refactor adds the public raw-frame API this example actually needs; switch and drop the reach-through when it lands.

## Changes

- `examples/isaac_gs/camera_utils.py` - `render_rgb_and_depth` consumes `_render_frame` (raw arrays) instead of the envelope; failure path raises `RuntimeError` with `meta["error"]` instead of `KeyError`; docstrings updated with `TODO(#1537)`.
- `tests/test_examples_isaac_gs_imports.py` (new) - 6 tests:
  - parametrized import smoke test for `examples.isaac_gs.{camera_utils,compositor,background}`, asserting in-repo resolution
  - dependency-symbol pin for the `examples.mujoco_gs.backgrounds` / `camera_utils` surface isaac_gs reuses
  - behavioral pins for `render_rgb_and_depth` with a stub sim (no Isaac install needed): RGBA -> RGB slicing, uint8/float32 normalisation, `RuntimeError` on `rgb is None`, and the stub's `render()` raises `AssertionError` so any regression back to the envelope fails loudly

## Acceptance criteria from #1536 (interim mitigation)

- [x] 1. `examples.mujoco_gs` exists on `main` - landed independently via #1282; this PR pins it so drift fails CI
- [x] 2. `render_rgb_and_depth` points at a working surface (`_render_frame`, with a loud TODO referencing #1537 since no public equivalent exists)
- [x] 3. CI-collectible import smoke test for `examples.isaac_gs.{compositor,camera_utils,background}` (guarded by `pytest.importorskip("numpy")`)

## Test surface

- `hatch run lint` - clean (ruff check, ruff format, mypy: 0 errors)
- `hatch run test` (with `MUJOCO_GL=egl`) - **11116 passed, 6 failed, 237 skipped**; all 6 failures (`test_recording_decode_fidelity`, 3x `test_recording_paths`, `test_lerobot_e2e`) reproduce identically on unmodified `upstream/main` on this box (missing `libtorchcodec` - environmental), i.e. **zero new failures**
- New file: 6/6 pass in 3.7s
- Note: the behavioral tests fail on pre-fix code by construction (the stub's `render()` raises), per the regression-pin convention

## Out of scope / follow-ups

- #1537 - the GS-layer library refactor (public `get_frame`-style raw-frame API, `strands_robots/rendering/` with compositor + backgrounds). When it lands, `render_rgb_and_depth`'s private `_render_frame` reach-through goes away.
- `examples/` is not in the `hatch run lint` targets; pre-existing UP037/UP045 findings in `examples/isaac_gs/*.py` are untouched to keep this diff minimal.

Project board: please move #1536 to "In review" (item may need manual move).
