### PR TITLE
test(mesh/audit): pin that blank lines in read_audit_log skip silently, not as corruption

### DIFF
--- a/tests/mesh/test_audit_read_walker_defenses.py
+++ b/tests/mesh/test_audit_read_walker_defenses.py
@@ -168,3 +168,43 @@ def test_read_audit_log_skips_malformed_json_line(tmp_path, monkeypatch, caplog)
     assert any("skipping malformed line" in m for m in caplog.messages), (
         f"expected a DEBUG breadcrumb for the skipped line, got {caplog.messages}"
     )
+
+
+def test_read_audit_log_skips_blank_lines_without_a_corruption_breadcrumb(tmp_path, monkeypatch, caplog):
+    """Blank / whitespace-only lines are skipped silently, not as corruption.
+
+    An append-only JSONL audit log routinely carries blank lines: the trailing
+    newline after the final record yields an empty last line, and a torn write
+    (process killed between the newline and the next record) can leave a
+    whitespace-only line. The reader guards these with an explicit empty-line
+    skip *before* the ``json.loads`` attempt, so a blank line never reaches the
+    malformed-JSON branch. That distinction matters: the "skipping malformed
+    line" DEBUG breadcrumb is the operator's only signal that a real corrupt
+    record may have under-seeded the ``_load_seq_counters`` seq walk. Emitting
+    it for an ordinary trailing newline would drown that signal in
+    false positives, so a blank line must be dropped without any breadcrumb.
+    """
+    active = audit.audit_log_path()
+    active.parent.mkdir(parents=True, exist_ok=True)
+    active.write_text(
+        "\n".join(
+            [
+                '{"event": "before", "payload": {"i": 1}}',
+                "",
+                "   ",
+                '{"event": "after", "payload": {"i": 2}}',
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("DEBUG", logger="strands_robots.mesh.audit"):
+        records = audit.read_audit_log()
+
+    events = [r.get("event") for r in records]
+    assert events == ["before", "after"], f"blank lines must be skipped while valid records are kept, got {events}"
+    assert not any("skipping malformed line" in m for m in caplog.messages), (
+        f"a blank line is not corruption; it must not emit a malformed-line breadcrumb, got {caplog.messages}"
+    )


### PR DESCRIPTION
## Problem

`read_audit_log` (the mesh audit forensic reader and the seed source for `_load_seq_counters`) iterates an append-only JSONL log line by line. That log routinely carries blank lines:

- the trailing newline after the final record leaves an empty last line, and
- a torn write (process killed between the newline and the next record) can leave a whitespace-only line.

The reader guards these with an explicit empty-line skip *before* the `json.loads` attempt:

```python
raw = raw.strip()
if not raw:
    continue
try:
    record = json.loads(raw)
except json.JSONDecodeError as parse_exc:
    logger.debug("[audit] skipping malformed line ...")
```

That guard is load-bearing but had **no direct regression coverage**. If it were removed, a blank line would fall through to `json.loads("")`, raise `JSONDecodeError`, and be logged as `"[audit] skipping malformed line"`. That breadcrumb is the operator's only signal that a *real* corrupt record may have under-seeded the `_load_seq_counters` seq walk; emitting it for an ordinary trailing newline drowns that signal in false positives.

## Change

Adds one focused regression test to `tests/mesh/test_audit_read_walker_defenses.py` (the file already dedicated to `read_audit_log` reader defenses). It writes a log containing empty and whitespace-only lines interleaved with valid records and asserts:

- the valid records around the blank lines are still returned, and
- **no** `"skipping malformed line"` breadcrumb is emitted for a blank line.

## Verification

- Fails on pre-fix code (guard removed): blank lines emit three spurious `skipping malformed line` breadcrumbs -> assertion fails.
- Passes with the guard in place.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean.
- `pytest tests/mesh -k audit` -> 174 passed.

Test-only; no production code changes.