### PR TITLE
test(sim/benchmark): pin on_episode_start skips robots listed but absent from world.robots

### DIFF
--- a/tests/simulation/test_benchmark.py
+++ b/tests/simulation/test_benchmark.py
@@ -8,7 +8,8 @@ Covers:
 * Registry operations (:func:`register_benchmark` / :func:`get_benchmark` /
   :func:`list_benchmarks` / :func:`unregister_benchmark`), including
   idempotent-overwrite and thread safety.
-* Robot compatibility validation via :meth:`BenchmarkProtocol.on_episode_start`.
+* Robot compatibility validation via :meth:`BenchmarkProtocol.on_episode_start`,
+  including reconciliation when ``sim.list_robots()`` and ``world.robots`` diverge.
 """
 
 from __future__ import annotations
@@ -255,6 +256,44 @@ class TestRobotCompatibility:
         sim = FakeSim()
         bench = _MinimalBenchmark(supported=["so100"], default="so100")
         # Must not raise even though arm1 has unknown data_config.
+        bench.on_episode_start(sim, random.Random(0))  # type: ignore[arg-type]
+
+    def test_skips_robot_listed_but_absent_from_world(self):
+        """A robot returned by ``sim.list_robots()`` but missing from
+        ``world.robots`` is skipped, not treated as a compat failure.
+
+        The compatibility gate reconciles two independent robot views: the
+        engine's ``list_robots()`` and the backend world's ``robots`` mapping.
+        Those can legitimately diverge (a robot registered with the engine
+        before it is composed into the world). Looking the name up with
+        ``world.robots.get(name)`` and skipping a ``None`` result keeps the
+        gate robust; a direct ``world.robots[name]`` index would raise
+        ``KeyError`` and abort every episode on such a divergence.
+        """
+
+        class _Robot:
+            data_config = "panda"  # not in supported -- would raise if reached
+
+        class FakeSimWithGhost:
+            def __init__(self):
+                # world knows only "present"; list_robots also reports "ghost".
+                self._world = type(
+                    "World",
+                    (),
+                    {"robots": {"present": _Robot()}},
+                )()
+
+            def list_robots(self):
+                return ["ghost", "present"]
+
+            def add_robot(self, **kw):  # pragma: no cover
+                raise AssertionError("should not be called")
+
+        sim = FakeSimWithGhost()
+        # supported includes "present"'s config so only the divergence path is
+        # exercised: "ghost" (absent from world.robots) must be skipped, and
+        # "present" (config in supported) must pass -- neither raises.
+        bench = _MinimalBenchmark(supported=["so100", "panda"], default="so100")
         bench.on_episode_start(sim, random.Random(0))  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
## Problem

`Benchmark.on_episode_start` (`strands_robots/simulation/benchmark.py`) is the compatibility gate that runs before every eval episode. It reconciles two independent robot views: the engine's `sim.list_robots()` and the backend world's `world.robots` mapping. These can legitimately diverge — e.g. a robot registered with the engine before it is composed into the world — so the gate looks each name up with `world.robots.get(name)` and skips a `None` result rather than indexing directly.

That reconciliation branch was the only uncovered line in the module. It is not merely a defensive no-op: a refactor to `world.robots[name]` would raise `KeyError` and abort **every** eval episode whenever the two views diverge, with no test to catch the regression.

## Change

Add a focused regression test to `TestRobotCompatibility` that pins the contract: a benchmark whose `list_robots()` reports a `ghost` robot absent from `world.robots` — alongside a `present`, compatible robot — must have `on_episode_start` skip the ghost and not raise.

## Verification

- New test passes on current code; module coverage `strands_robots/simulation/benchmark.py` 95% -> 98% (the reconciliation branch is now covered).
- Regression-guard proof: temporarily changing `world.robots.get(rname)` to `world.robots[rname]` makes the new test fail with `KeyError: 'ghost'`, confirming it guards the real code path (not a shallow assert).
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues; the benchmark test suites pass (`tests/simulation/test_benchmark.py`, `test_builtin_benchmarks.py`, `test_policy_runner_benchmark.py` — 135 passed).

Test-only change; no runtime behavior, policy, sim, rendering, recording, or asset is modified.