### PR TITLE
test(quality): reject PR-review/verification provenance in source comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Quality: reject PR-review/verification provenance in source comments
+
+The review-archaeology guard (`tests/test_source_strings_no_review_archaeology.py`)
+already rejected `review thread <file>.py:<line>` back-pointers and review-round
+narration (`review round N`, `R7-5`). It now also rejects a PR/issue number
+immediately followed by `review` or `verification` (`#166 review finding`,
+`#168 verification showed ...`, `caught in PR #60 review`) and the compact
+`R<round> review` tag (`R3 review fix`) -- narration of which PR review or
+verification pass produced a change, which rots and misdirects the reader and
+belongs in git history, not the source. Fifteen such comments across
+`benchmarks/libero/adapter.py`, `mesh/security.py`, `simulation/isaac/simulation.py`,
+and three `simulation/mujoco/` modules were reworded to state why the code is
+shaped the way it is; the `review`/`verification` token must follow the number,
+so prose like `review 5 frames` is not matched. Comment-only change; no runtime
+behaviour is affected.
+
 ### Docs: streaming-data-loop notebook states the minimum `strands-robots` version for the bucket path
 
 The streaming-data-loop notebook (`examples/notebooks/05_streaming_data_loop.ipynb`,

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -490,8 +490,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # first observation are then visually identical (#168 bug D-residual).
         self._episode_count: int = 0
         # Snapshot-and-restore fallback for procedurally-generated MJCFs that
-        # don't ship a <keyframe> (the case the post-#168 verification
-        # exposed). Captured on the first episode after super() +
+        # don't ship a <keyframe>. Captured on the first episode after super() +
         # _install_libero_cameras have run; replayed on every subsequent
         # episode so qpos/qvel land on the same canonical state every time.
         self._canonical_qpos: np.ndarray | None = None
@@ -518,7 +517,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # (#168) so a single eval run captures both sides of the
         # policy interface for offline bisection.
         #
-        # #168 verification showed ``arm_qpos`` advances and
+        # In practice ``arm_qpos`` advances and
         # ``eef_pos`` tracks deltas, but the policy is commanding tiny
         # deltas (~0.01 in [-1, +1] normalized space). The remaining
         # `success_rate=0` is on the state-input side - GR00T sees an
@@ -749,7 +748,7 @@ class LiberoAdapter(BenchmarkProtocol):
            compiled model so the static-pose fallbacks only fire when the
            scene genuinely didn't provide them - this matters for not
            recompiling the spec on top of our just-restored canonical
-           state (#166 review finding).
+           state.
         6. ``_install_render_options`` - populate
            ``sim._world._backend_state["viz_option"]`` with an
            ``mjvOption`` matching upstream LIBERO's
@@ -911,8 +910,8 @@ class LiberoAdapter(BenchmarkProtocol):
         # Apply canonical state RIGHT AFTER load_scene + pre-register so
         # the snapshot captures the post-load + post-add_robot state -
         # before super() and install_cameras get a chance to do anything
-        # else (#166 review: snapshot taken at the wrong lifecycle point
-        # was the prior round's failure mode).
+        # else. Snapshotting at the wrong lifecycle point would capture
+        # a non-canonical restore state.
         #
         # Always runs - including on the prewarm-fresh-ep0 fast-path
         # (#168 user-flagged fix). The fast-path used to skip
@@ -1182,9 +1181,8 @@ class LiberoAdapter(BenchmarkProtocol):
         # main-thread render on the same camera primes that shared
         # state so the recorder thread's first call lands warm.
         #
-        # Rounds 11-13 attempted thread-side warmup loops, which
-        # #168 verification showed don't help (GL context is
-        # thread-bound and the per-thread Renderer is cold). The
+        # Thread-side warmup loops don't help here: the GL context is
+        # thread-bound and the per-thread Renderer is cold. The
         # main-thread approach here is different: it primes the
         # process-shared driver state, not the per-thread Renderer.
         # If the driver state assumption is wrong (no shared state),
@@ -1300,7 +1298,7 @@ class LiberoAdapter(BenchmarkProtocol):
             # bumps ``nq`` past what the LIBERO ``init_states[0]`` was
             # sized for, and prewarm silently no-ops here. Visible at
             # WARNING level, users can spot the mistake without enabling
-            # debug logging (#168 verification).
+            # debug logging.
             logger.warning(
                 "LiberoAdapter.prewarm: init_state[0] width %d != 1+nq+nv=%d; skipping init-state apply. "
                 "This usually means sim.add_robot (or another spec-recompiling call) ran between "
@@ -1863,10 +1861,10 @@ class LiberoAdapter(BenchmarkProtocol):
         if self._scene_camera_aliases:
             xml = _rename_mjcf_cameras(xml, self._scene_camera_aliases)
 
-        # #168 used to apply ``_apply_libero_visual_fixes(xml)`` here -
-        # rgba alpha=0 on collision geoms + a custom ``<visual>`` block
-        # with a stacked ``<headlight>``. #168 verification showed that
-        # was the wrong direction:
+        # An earlier version applied ``_apply_libero_visual_fixes(xml)``
+        # here - rgba alpha=0 on collision geoms + a custom ``<visual>``
+        # block with a stacked ``<headlight>`` - but that was the wrong
+        # direction:
         #
         # * Upstream LIBERO's ``OffScreenRenderEnv`` emits exactly
         #   ``<visual><map znear="0.001"/></visual>`` (verified
@@ -2288,7 +2286,7 @@ class LiberoAdapter(BenchmarkProtocol):
         gripper). Without this controller, ``_apply_sim_action`` looks
         up GR00T's action keys by name in the model's actuator/joint
         tables, finds no match, and silently drops every action - the
-        policy effectively sends zero torque (#168 verification).
+        policy effectively sends zero torque.
 
         This installs a :class:`_LiberoOSCController` instance in
         ``world._backend_state["action_controller"]``. The rendering
@@ -3649,7 +3647,6 @@ class _LiberoOSCController:
         # substeps per policy action. Mismatch ⇒ the OSC controller
         # under-/over-shoots its delta target every step, manifesting as
         # `success_rate=0` even though motion looks correct in cameras.
-        # See PR #168 (verification then fix in subsequent commits).
         self.physics_substeps_per_control = max(1, int(physics_substeps_per_control))
 
         # Stateful ``current_action`` for the gripper, mirroring
@@ -3682,8 +3679,8 @@ class _LiberoOSCController:
         # log line per ``apply()`` call for the first
         # ``STRANDS_LIBERO_ACTION_LOG_MAX`` (default 50) calls per
         # episode. Captures action keys, delta scale, gripper polarity,
-        # EEF tracking, and qpos/ctrl deltas - answers the diagnostic
-        # questions in PR #168 verification.
+        # EEF tracking, and qpos/ctrl deltas - surfaces the diagnostic
+        # signals for offline bisection.
         self._action_log_enabled = os.environ.get("STRANDS_LIBERO_ACTION_LOG", "").strip().lower() in (
             "1",
             "true",
@@ -3863,7 +3860,7 @@ class _LiberoOSCController:
         # ``mujoco.MjData(model)`` accessible at ``sim_shim.data._data``.
         # That fresh data buffer is DISCONNECTED from our sim's
         # actual ``data`` - the controller would compute torques from
-        # a stale, never-stepped buffer (#168 verification).
+        # a stale, never-stepped buffer.
         # Hot-patch ``sim_shim.data._data`` to point at our actual
         # data so ``controller.run_controller()`` reads/writes the
         # same buffer the eval is stepping.

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -493,7 +493,8 @@ def is_safe_model_path(path: str, *, hf_only: bool = False) -> bool:
         # and ``nvidia/repo/`` (trailing slash). HF would 404 on these,
         # but the validator's job is to enforce the wire contract at the
         # boundary -- not to rely on downstream rejection. Same posture
-        # as R1's reject of ``nvidia/etc/passwd``. (R3 review fix.)
+        # as the ``nvidia/etc/passwd`` reject: enforce the exact
+        # ``owner/repo`` shape here rather than defer to a 404.
         if any(seg in ("", ".") for seg in parts):
             return False
         if len(parts) != 2:

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -1733,7 +1733,7 @@ class IsaacSimulation(SimEngine):
             # cylinder / capsule pattern below; previously this branch
             # was all-or-nothing, so e.g. ``size=[0.10]`` silently fell
             # back to ``[0.05, 0.05, 0.05]`` instead of the documented
-            # ``[0.10, 0.05, 0.05]`` -- caught in PR #60 review.
+            # ``[0.10, 0.05, 0.05]``.
             size_list = list(size) if size else []
             sx = float(size_list[0]) if len(size_list) >= 1 else 0.05
             sy = float(size_list[1]) if len(size_list) >= 2 else 0.05

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1461,21 +1461,14 @@ class RenderingMixin:
             # render calls per camera return the GL clear-colour
             # gradient before the context settles.
             #
-            # History: rounds 11/12/13 added thread-side warmup; round
-            # 14 reverted because the load-scene-without-mj_forward
-            # bug was bigger. #168 fixed mj_forward in load_scene,
-            # which made warmup unnecessary IN THE SLOW PATH. Round
-            # 17's prewarm-fresh-ep0 fast-path skips load_scene,
-            # leaving no per-recorder-thread render before capture.
-            # #168 tried main-thread warmup (thread-isolation
-            # made it ineffective). #168 re-applied the
-            # 2-pass thread-side warmup. #168 verification showed
-            # 2 passes was insufficient: image channel stayed cold for
-            # ~15 frames while wrist cleared at frame 3 - per-camera
-            # warmup latency varies across cameras (likely GPU
-            # command-buffer flush ordering).
-            #
-            # #168 (this code): replace fixed-pass warmup with an
+            # A fixed number of warmup passes is not enough: the image
+            # channel can stay cold for ~15 frames while the wrist
+            # camera clears by frame 3, because per-camera warmup
+            # latency varies across cameras (likely GPU command-buffer
+            # flush ordering). A main-thread warmup does not help
+            # either - the GL context is thread-bound, so priming the
+            # main thread leaves this daemon thread cold. So replace
+            # the fixed-pass warmup with an
             # adaptive warmup loop. Render each camera until it
             # produces output with column-stddev above the cold-
             # gradient threshold. The cold gradient artifact is uniform

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -619,10 +619,8 @@ class MuJoCoSimEngine(
             # (xpos / xquat / xmat / sensor data) is populated. Without
             # this, ``Renderer.update_scene`` finds the body transforms
             # unset and returns a skybox-only gradient on the first
-            # render call after load_scene - the bug-D pattern that
-            # rounds 11/12/13 in #168 chased through several wrong
-            # directions before #168 verification isolated it to
-            # this missing forward call (#168).
+            # render call after load_scene. Forwarding here populates
+            # that derived state before the first render.
             #
             # Cost: O(model.nbody) - negligible for typical scenes.
             # Failure here is genuinely a bug in the loaded MJCF

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -708,7 +708,7 @@ class SpecBuilder:
         # ``create_world(ground_plane=...)``) is the single source of truth;
         # robots contribute only their own bodies/joints/actuators. See #320.
         #
-        # Three guards from the #360 review (#363):
+        # Three guards keep this strip safe:
         #   1. Conditional strip -- only remove the robot's floor when the world
         #      actually owns a ground plane to replace it. Under
         #      ``create_world(ground_plane=False)`` the world has no ground, so

--- a/tests/test_source_strings_no_review_archaeology.py
+++ b/tests/test_source_strings_no_review_archaeology.py
@@ -25,6 +25,12 @@ rejects these review-archaeology shapes:
     ``PR#221 R3``, ``#317 R3``). Which review pass produced a change is exactly
     the provenance that belongs in git history, not the source; the number rots
     and misdirects the reader.
+  * a PR/issue number followed by ``review`` or ``verification`` (``#166
+    review finding``, ``#168 verification showed ...``, ``caught in PR #60
+    review``), plus the compact ``R<round> review`` (``R3 review fix``) --
+    narration of the PR review/verification pass that produced a change. The
+    flattener strips the leading ``#``/``(``-adjacent noise so ``(#168
+    verification)`` arrives as ``168 verification`` and is caught.
 
 References to *upstream* files (e.g. ``run_mujoco_gear_wbc.py:47-50``) and to
 stable, named anchors (``AGENTS.md > Review Learnings``, a bare issue number
@@ -60,6 +66,12 @@ import strands_robots
 #     never mistaken for a round tag; after the flattener strips ``#``/``PR``,
 #     ``PR#221 R3`` and ``#317 R3`` arrive as ``221 R3`` / ``317 R3`` and are
 #     caught by the ``<digits> R<round>`` alternative.
+#   * ``<digits> review`` / ``<digits> verification`` and ``R<round> review``
+#     -- a PR/issue number (or round tag) narrating the review or verification
+#     pass that produced a change (``#166 review finding``, ``#168
+#     verification showed ...``, ``R3 review fix``). ``review``/``verification``
+#     must FOLLOW the number, so prose where the word precedes a count
+#     (``review 5 frames``, ``verification of 3 shards``) is not matched.
 # Upstream ``<file>.py:<line>`` references (not preceded by ``review``), named
 # anchors like ``Review Learnings``, and bare issue numbers are not matched.
 _REVIEW_ARCHAEOLOGY = re.compile(
@@ -71,6 +83,8 @@ _REVIEW_ARCHAEOLOGY = re.compile(
     r"|\b\d+\s+round\s+\d+[a-z]?\b"
     r"|\b(?-i:R)\d+-\d+\b"
     r"|\b\d+\s+(?-i:R)\d+\b"
+    r"|\b\d+\s+(?:review|verification)\b"
+    r"|\b(?-i:R)\d+\s+review\b"
     r")"
 )
 
@@ -126,6 +140,12 @@ def test_review_round_provenance_is_matched() -> None:
         "and _load_acl_file. Addressed in PR-224 R1.",
         "PR 221 R3 (issue 238): the seq lockfile is a symlink",  # was "PR#221 R3"
         "default localhost:8000 ( 317 R3)",  # was "(#317 R3)"
+        "168 verification",  # was "#168 verification"
+        "the post- 168 verification exposed",  # was "post-#168 verification"
+        "166 review finding",  # was "#166 review finding"
+        "caught in PR 60 review",  # was "caught in PR #60 review"
+        "guards from the 360 review ( 363)",  # was "#360 review (#363)"
+        "R3 review fix",  # compact round tag + review
     ]
     for text in offenders:
         assert _REVIEW_ARCHAEOLOGY.search(text), f"should be flagged: {text!r}"
@@ -145,6 +165,9 @@ def test_legitimate_references_are_not_matched() -> None:
         "resolve to localhost:8000 by default",  # bare port, no round tag
         "step 3 runs 5 revisions",  # lowercase 'r', not the uppercase round tag
         "the SO-101 arm has 6 joints",  # digit-dash-digit but no leading 'R'
+        "review 5 candidate frames before capture",  # 'review' precedes the count
+        "verification of 3 shards succeeded",  # 'verification' precedes the count
+        "the 2nd verification pass warms the context",  # '2nd' is not digits+space
     ]
     for text in allowed:
         assert not _REVIEW_ARCHAEOLOGY.search(text), f"false positive: {text!r}"


### PR DESCRIPTION
## Problem

The review-archaeology guard (`tests/test_source_strings_no_review_archaeology.py`) enforces the "code is the single source of truth" doctrine: source comments should explain *why* the code is shaped the way it is, not narrate the review thread that produced it. It already rejects review-thread line-pointers (`review <file>.py:<line>`) and review-round narration (`review round N`, `N round N`, `R7-5`, `#317 R3`).

A whole class of the same provenance still slips through: a PR/issue number immediately followed by `review` or `verification`, narrating *which* review or verification pass produced a change. Fifteen such comments exist across the package:

- `#166 review finding`, `#166 review: snapshot taken at the wrong lifecycle point`
- `#168 verification showed ...`, `(#168 verification)`, `PR #168 verification`
- `caught in PR #60 review`
- `#360 review (#363)`
- `R3 review fix`

The PR-review-pass number rots on the next edit and misdirects the reader; it belongs in git history, not the source.

## Change

Extend `_REVIEW_ARCHAEOLOGY` with two alternatives:

```
\b\d+\s+(?:review|verification)\b     # #166 review finding, #168 verification
\b(?-i:R)\d+\s+review\b               # R3 review fix
```

The flattener already strips `#`, so `(#168 verification)` arrives as `168 verification` and is caught. `review`/`verification` must **follow** the number, so incidental prose where the word precedes a count (`review 5 frames`, `verification of 3 shards`, `the 2nd verification pass`) is not matched -- new negative examples pin this.

Then reword the 15 flagged comments to state the technical rationale, keeping stable bare issue anchors that are not review-pass provenance (e.g. `#168 bug D-residual`, `See #320`). Touched: `benchmarks/libero/adapter.py`, `mesh/security.py`, `simulation/isaac/simulation.py`, `simulation/mujoco/{rendering,simulation,spec_builder}.py`.

Comment-only edits to production modules; **no runtime behaviour changes**.

## Tests

- New positive examples (`168 verification`, `166 review finding`, `caught in PR 60 review`, `360 review (363)`, `R3 review fix`) and negative examples (word-precedes-count prose) in the guard's example-based tests.
- The package scan (`test_no_review_thread_line_pointers_in_package_sources`) **fails on `main`** with 15 offenders and passes after the rewordings -- verified by running the extended pattern against the pre-change sources.
- `hatch run lint` clean (ruff + ruff format + mypy). Full simulation / mesh / benchmarks / source-string suites pass locally (`MUJOCO_GL=egl`).