### PR TITLE
feat(examples/libero): migrate run_mujoco.py + run_mujoco_agent.py from robots-sim (closes #1538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: LIBERO MuJoCo example drivers (`examples/libero/run_mujoco.py`, `run_mujoco_agent.py`)
+
+The default-backend LIBERO drivers promised by the epic-#1269 migration are
+now in-tree: `run_mujoco.py` (scripted `sim.evaluate_benchmark(...)` eval with
+GR00T container auto-orchestration, whole-run MP4 recording, and the two
+grep-stable result lines `libero_backend_matrix.py` parses) and
+`run_mujoco_agent.py` (the natural-language Strands `Agent` sibling). The
+backend matrix's `mujoco` row flips from `unavailable (file missing)` to a
+real result. The drivers use the new public `LiberoAdapter.ensure_scene()`
+for the pre-recording scene warm-up instead of the private
+`_generate_scene_from_bddl()`, and import smoke tests
+(`tests/test_examples_libero_drivers.py`) pin the library surface they call
+so example/library drift fails CI. Verified end-to-end on GPU:
+`--policy groot` scores 4/5 on `libero-10-LIVING_ROOM_SCENE5` (see the
+driver docstring); `--policy mock` runs green on a GPU-less host.
+
+### Fixed: `send_action` accepts single-element sequence values (GR00T-LIBERO eval regression)
+
+The #1179 up-front scalar validation in `_coerce_action` rejected ANY
+sequence-typed dict value - including the length-1 lists the
+`Policy.get_actions -> list[dict]` contract emits for 1-DOF keys. GR00T's
+service unpack produces exactly that shape for the LIBERO delta-EEF layout
+(`{"x": [0.05], "y": [-0.08], ...}`), so since #1179 every `send_action` in a
+GR00T LIBERO eval returned a structured error, no action ever reached the
+adapter's OSC controller, and the benchmark silently no-opped to
+`success_rate=0` on a green exit-0 run. A single-element sequence/array value
+carries exactly one unambiguous scalar and is now unwrapped before
+validation/apply; multi-element values (the actual #1179 crash class) are
+still rejected atomically, and a sized-but-unindexable value (a set) gets a
+structured error rather than a crash. Applies to both the MuJoCo and Newton
+backends via the shared base. Pinned by
+`tests/simulation/mujoco/test_send_action_vector.py::TestSendActionSingleElementUnwrap`.
+
+### Fixed: camera-recording MP4 flush honors its never-raise contract on mixed frame sizes
+
+A benchmark's per-episode scene reload can re-install a camera at different
+dimensions mid-recording (the LIBERO wrist camera does), leaving the
+daemon-thread recorder's buffer with mixed frame shapes. Pre-fix, imageio's
+`append_data` raised `ValueError: All images in a movie should have same
+size` out of `stop_cameras_recording` - aborting the caller's teardown path
+despite the flush's best-effort, never-raise contract. The flush now encodes
+the dominant-size run, reports skipped frames per camera
+(`frames_skipped_size_mismatch`) and any writer failure (`flush_error`) in
+the structured result instead of raising.
+
+### Fixed: `gr00t_inference` checkpoint-download idempotency probe keys on the requested subfolder
+
+With `hf_subfolder` set, the "already downloaded" probe checked whether the
+shared `local_dir` was non-empty - so a cache holding a DIFFERENT
+sub-checkpoint (e.g. `libero_spatial/` when `libero_10` was requested)
+short-circuited the download, the container started against a missing
+checkpoint path, and the model never loaded. The probe now targets
+`local_dir/<hf_subfolder>` when a subfolder filters the download.
+
+### Added: public `LiberoAdapter.ensure_scene()`
+
+Driver scripts need the LIBERO scene - and the cameras it supplies (`image` /
+`wrist_image`) - available *before* `evaluate_benchmark` runs, so
+`start_cameras_recording` can resolve the camera names. Pre-fix they had to
+call the private `_generate_scene_from_bddl()`. `ensure_scene()` is the
+public equivalent: idempotent, stores + returns the resolved `scene_path`,
+and (unlike the lazy warn-and-fall-back path inside `on_episode_start`)
+propagates generation failures to the caller - an explicit pre-warm request
+that cannot be satisfied fails loudly.
+
 ### Docs: streaming-data-loop notebook states the minimum `strands-robots` version for the bucket path
 
 The streaming-data-loop notebook (`examples/notebooks/05_streaming_data_loop.ipynb`,

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,8 @@ record→train→deploy loop) as Jupyter notebooks - all CPU-only, no hardware o
 | [`wbc/wbc_g1_torque_deploy.py`](wbc/wbc_g1_torque_deploy.py) | GR00T-WBC (SONIC) locomotion on the Unitree G1 via the torque-control deploy loop |
 | [`lerobot/hub_to_hardware.py`](lerobot/hub_to_hardware.py) | Full agent-driven pipeline: record, train, deploy |
 | [`so101_curobo/`](so101_curobo/) | SO-101 tabletop pick-and-place: cuRobo motion planning + LeRobot dataset capture. Backend-agnostic (`SimEngine`): MuJoCo today, Isaac when `strands-robots[sim-isaac]` is installed. **GPU: Optional** (cuRobo / Isaac) |
+| [`libero/run_mujoco.py`](libero/run_mujoco.py) | LIBERO benchmark eval on the default MuJoCo backend with whole-run MP4 recording. **GPU: Optional** (`--policy mock` is CPU-only; `--policy groot` needs Docker + NVIDIA GPU) |
+| [`libero/run_mujoco_agent.py`](libero/run_mujoco_agent.py) | LIBERO-on-MuJoCo driven by a Strands `Agent` in natural language. **GPU: Optional** (needs LLM API) |
 | [`libero/run_isaac.py`](libero/run_isaac.py) | LIBERO benchmark eval on the Isaac Sim backend (`create_simulation("isaac")`) with rollout-MP4 recording. **GPU: Yes** (Isaac Sim 6.0+) |
 | [`libero/run_isaac_agent.py`](libero/run_isaac_agent.py) | LIBERO-on-Isaac driven by a Strands `Agent` in natural language. **GPU: Yes** (Isaac Sim 6.0+, needs LLM API) |
 | [`libero/libero_backend_matrix.py`](libero/libero_backend_matrix.py) | Run one LIBERO task across every installed backend, side-by-side `success_rate` / `wall_time` table |

--- a/examples/libero/README.md
+++ b/examples/libero/README.md
@@ -1,17 +1,20 @@
-# LIBERO on the Isaac Sim backend
+# LIBERO manipulation-benchmark evaluation
 
-LIBERO manipulation-benchmark evaluation driven by the in-tree Isaac Sim
-backend (`strands_robots.simulation.isaac.IsaacSimulation`, resolved via
-`create_simulation("isaac")`). Companions to the MuJoCo LIBERO path: same CLI
-shape, same two grep-stable output lines, same `evaluate_benchmark(...)` driver.
-The Isaac files differ in backend choice, real-asset (USD/URDF) robot loading,
-and an explicit `add_camera(...)` call (Isaac does not auto-attach viewport
-cameras the way MuJoCo does).
+LIBERO manipulation-benchmark evaluation driven by the in-tree simulation
+backends: the default MuJoCo backend (`strands_robots.simulation.Simulation`)
+and the Isaac Sim backend (`strands_robots.simulation.isaac.IsaacSimulation`,
+resolved via `create_simulation("isaac")`). All drivers share the same CLI
+shape, the same two grep-stable output lines, and the same
+`evaluate_benchmark(...)` driver. The Isaac files differ in backend choice,
+real-asset (USD/URDF) robot loading, and an explicit `add_camera(...)` call
+(Isaac does not auto-attach viewport cameras the way MuJoCo does).
 
 ## Files
 
 | File | What it shows |
 |------|--------------|
+| [`run_mujoco.py`](run_mujoco.py) | LIBERO eval on the default MuJoCo backend: `Simulation()` -> `create_world` -> `add_robot` -> LIBERO scene pre-warm -> `evaluate_benchmark`, with whole-run MP4 recording. Emits two grep-stable lines for the backend matrix. GPU optional (`--policy mock` runs headless on CPU). |
+| [`run_mujoco_agent.py`](run_mujoco_agent.py) | Same eval, driven by a Strands `Agent` in natural language over the full registered `Simulation` tool surface; the script keeps container lifecycle, scene pre-warm, and recording deterministic. |
 | [`run_isaac.py`](run_isaac.py) | LIBERO eval on Isaac Sim: `create_simulation("isaac")` -> `create_world` -> `add_robot` (real Franka USD) -> `add_camera` -> `evaluate_benchmark`, with a synchronous rollout-MP4 recorder. Emits two grep-stable lines for the backend matrix. |
 | [`run_isaac_agent.py`](run_isaac_agent.py) | Same eval, driven by a Strands `Agent` in natural language via a single `@tool`-wrapped `evaluate_isaac_benchmark`. |
 | [`libero_backend_matrix.py`](libero_backend_matrix.py) | Runs one LIBERO task across whichever per-backend driver scripts the host can execute (subprocess-and-parse) and prints a side-by-side `success_rate` / `wall_time` table. Missing drivers show `unavailable`; hosts without Isaac Sim show `skip`. |
@@ -19,15 +22,23 @@ cameras the way MuJoCo does).
 
 ## Install
 
+```bash
+# run_mujoco.py / libero_backend_matrix.py
+pip install "strands-robots[sim-mujoco,benchmark-libero]"
+
+# run_mujoco_agent.py additionally needs the Strands agent SDK + an LLM provider
+pip install "strands-robots[sim-mujoco,benchmark-libero]" strands-agents
+```
+
 The Isaac backend imports stay lazy - installing the extra never imports Isaac
-Sim - but running the eval needs a working Isaac Sim 6.0+ host (RTX GPU,
+Sim - but running the Isaac eval needs a working Isaac Sim 6.0+ host (RTX GPU,
 Ubuntu 22.04+, CUDA 12+, Python 3.12; installed via the Omniverse Launcher,
 Isaac Lab, or the `nvcr.io/nvidia/isaac-sim:6.0` NGC docker image). A pure
 `pip install` does not provide the full `isaacsim-extscache-*` extension set
 `SimulationApp` needs to boot.
 
 ```bash
-# run_isaac.py / libero_backend_matrix.py
+# run_isaac.py
 pip install "strands-robots[sim-isaac,benchmark-libero]"
 
 # run_isaac_agent.py additionally needs the Strands agent SDK + an LLM provider
@@ -37,7 +48,17 @@ pip install "strands-robots[sim-isaac,benchmark-libero]" strands-agents
 ## Run
 
 ```bash
-# Smoke test (mock policy; needs Isaac Sim on the host). Loads the bundled
+# Smoke test on the default MuJoCo backend (mock policy; no GPU / Docker):
+python examples/libero/run_mujoco.py --policy mock --n-episodes 5
+
+# Real LIBERO eval against nvidia/GR00T-N1.7-LIBERO (Docker + NVIDIA GPU +
+# ~30 GB free disk for the checkpoint; auto-orchestrates the GR00T container):
+python examples/libero/run_mujoco.py --policy groot --port 8000 --n-episodes 50
+
+# Agent-driven MuJoCo variant (needs a configured LLM provider for Strands):
+python examples/libero/run_mujoco_agent.py --policy mock --n-episodes 5
+
+# Smoke test on Isaac Sim (needs Isaac Sim on the host). Loads the bundled
 # Franka Panda USD resolved from the Isaac assets root over the Omniverse CDN:
 python examples/libero/run_isaac.py --policy mock --n-episodes 5
 
@@ -45,11 +66,10 @@ python examples/libero/run_isaac.py --policy mock --n-episodes 5
 python examples/libero/run_isaac.py --policy mock --robot-usd /path/to/robot.usd
 python examples/libero/run_isaac.py --policy mock --robot-urdf /path/to/robot.urdf
 
-# Real LIBERO eval against nvidia/GR00T-N1.7-LIBERO (Docker + NVIDIA GPU +
-# ~30 GB free disk for the checkpoint; auto-orchestrates the GR00T container):
+# Real LIBERO eval on Isaac against nvidia/GR00T-N1.7-LIBERO:
 python examples/libero/run_isaac.py --policy groot --port 8000 --n-episodes 50
 
-# Agent-driven variant (needs a configured LLM provider for Strands):
+# Agent-driven Isaac variant (needs a configured LLM provider for Strands):
 python examples/libero/run_isaac_agent.py --policy mock --n-episodes 5
 
 # Side-by-side across every installed backend (mock by default; missing
@@ -57,11 +77,10 @@ python examples/libero/run_isaac_agent.py --policy mock --n-episodes 5
 python examples/libero/libero_backend_matrix.py
 ```
 
-The `mujoco` and `isaac-4096` rows of `libero_backend_matrix.py` reference
-per-backend drivers (`run_mujoco.py`, `run_isaac_fleet.py`) that are migrated
-under separate epic-#1269 child items; until those land, the matrix prints an
-`unavailable (no <driver>.py)` row for them and evaluates the Isaac
-single-env (`isaac-1`) row.
+The `isaac-4096` row of `libero_backend_matrix.py` references a fleet driver
+(`run_isaac_fleet.py`) that has not been migrated yet; until it lands, the
+matrix prints an `unavailable (no run_isaac_fleet.py)` row for it and
+evaluates the `mujoco` and Isaac single-env (`isaac-1`) rows.
 
 ## Environment variables
 
@@ -78,5 +97,3 @@ single-env (`isaac-1`) row.
   GR00T checkpoint download (`--policy groot`).
 - `STRANDS_GR00T_SERVER_SEED` / `STRANDS_GR00T_STRICT_DETERMINISTIC` - consumed
   by `gr00t_server_deterministic_wrapper.py` inside the GR00T container.
-</content>
-</invoke>

--- a/examples/libero/run_mujoco.py
+++ b/examples/libero/run_mujoco.py
@@ -272,7 +272,10 @@ def main() -> None:
     if args.policy == "groot" and args.auto_server:
         from pathlib import Path
 
-        from strands_robots.tools import gr00t_inference
+        # Import the function from its defining module (not the lazy
+        # `strands_robots.tools` re-export) so static analysis resolves
+        # the callable instead of the same-named submodule.
+        from strands_robots.tools.gr00t_inference import gr00t_inference
 
         _configure_gr00t_image(args.image)
 
@@ -490,7 +493,7 @@ def main() -> None:
         sim.destroy()
         # Tear down the GR00T inference container if we brought it up.
         if server_handle is not None:
-            from strands_robots.tools import gr00t_inference
+            from strands_robots.tools.gr00t_inference import gr00t_inference
 
             gr00t_inference(action="lifecycle", lifecycle="teardown", container_name=args.container)
 

--- a/examples/libero/run_mujoco.py
+++ b/examples/libero/run_mujoco.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""LIBERO on the default MuJoCo backend shipped by ``strands-robots``.
+
+One-shot programmatic flow: a scripted ``sim.evaluate_benchmark(...)``
+call - the "if you just want to run LIBERO from a Python script" file.
+For the natural-language / ``Agent``-driven version, see
+``run_mujoco_agent.py`` (sibling file). For the same eval on the Isaac
+Sim backend, see ``run_isaac.py`` - it mirrors this file's CLI shape
+and lifecycle.
+
+Consumed by the backend-matrix harness (``libero_backend_matrix.py``),
+which subprocess-runs this file and parses two grep-stable lines
+(``benchmark_name=...`` and
+``policy=... task=... success_rate=... wall_time=...s``).
+
+Usage
+-----
+::
+
+    # 1) Smoke test, no GPU required:
+    python examples/libero/run_mujoco.py --policy mock --n-episodes 5
+
+    # 2) Real LIBERO eval against `nvidia/GR00T-N1.7-LIBERO`. By default
+    #    the script auto-orchestrates the GR00T inference service via the
+    #    `gr00t_inference(action="lifecycle", lifecycle="full", ...)`
+    #    tool - it builds the n1.7 container if missing, downloads the
+    #    right `libero_<suite>/` sub-checkpoint, runs the container, and
+    #    starts the inference server before the eval, then tears down on
+    #    exit. Each step is idempotent so re-runs are cheap.
+    #
+    #    Pre-condition: HF token at `~/.cache/huggingface/token` with
+    #    access to `nvidia/Cosmos-Reason2-2B` (the gated VLM backbone) +
+    #    Docker + an NVIDIA GPU.
+    python examples/libero/run_mujoco.py --policy groot --port 8000 --n-episodes 50
+
+    # 2b) If you'd rather manage the inference service yourself
+    #     (multi-eval session, custom container config, etc.), pass
+    #     --no-auto-server and run the `gr00t_inference` lifecycle tool
+    #     ahead of time.
+    python examples/libero/run_mujoco.py --policy groot --no-auto-server --port 8000
+
+    # 3) Different LIBERO suite + task. Suite is auto-derived from --task,
+    #    so the lifecycle tool downloads the matching `libero_<suite>/`
+    #    sub-checkpoint:
+    python examples/libero/run_mujoco.py \\
+        --policy groot --port 8000 \\
+        --task libero-10-LIVING_ROOM_SCENE5_put_the_white_mug_on_the_left_plate_…
+
+Requires
+--------
+``pip install 'strands-robots[sim-mujoco,benchmark-libero]'``
+
+Imports only from ``strands_robots`` - no backend-specific packages
+are imported at module level.
+
+Notes on the MP4 output
+-----------------------
+``Simulation.evaluate_benchmark`` does not expose a per-episode
+``record_video`` plumb. This script wraps the whole run in a single
+``start_cameras_recording`` / ``stop_cameras_recording`` pair, so each
+invocation produces one MP4 per camera (third-person ``image`` and
+gripper ``wrist_image`` for the GR00T eval; bare ``default`` for the
+mock smoke) capturing every episode in sequence. Filename encodes
+``--task=<benchmark_name>``, ``--policy=mock|groot``, ``--n_eps=N``,
+and ``--seed=S`` so post-hoc analysis can tell what produced it.
+
+Verification status (`--policy=groot` end-to-end)
+-------------------------------------------------
+Measured 2026-07-22 on an L4 / Docker dev box against
+``nvidia/GR00T-N1.7-LIBERO/libero_10``,
+``libero-10-LIVING_ROOM_SCENE5_put_the_white_mug_…``, 5 episodes:
+
+* ``--policy=mock``: ~14 s/ep (success_rate=0.0; mock can't satisfy goals).
+* ``--policy=groot --seed=42``: ~33 s/ep, **success_rate=0.80 (4/5)** in 165.0 s.
+
+Wall-time covers engine + scene + policy + I/O round-trip end-to-end.
+
+Optional server-side determinism wrapper
+-----------------------------------------
+
+For users who need bit-exact run-to-run reproducibility (e.g. CI
+pinning a specific success_rate), a drop-in docker wrapper is
+available at ``examples/libero/gr00t_server_deterministic_wrapper.py``.
+It sets ``cudnn.deterministic=True`` + ``cudnn.benchmark=False`` +
+``CUBLAS_WORKSPACE_CONFIG=":4096:8"`` server-side and monkey-patches
+``Gr00tPolicy.reset`` to apply the client-supplied per-episode seed.
+The example file works WITHOUT this wrapper (verified at 4/5 above) -
+it's only needed when you want the GPU's CUDA backend to produce
+identical actions across re-runs of the same seed.
+
+Mount with::
+
+    docker run … -v examples/libero/gr00t_server_deterministic_wrapper.py:/srv_wrap.py \\
+        gr00t:latest python /srv_wrap.py --model-path … --use-sim-policy-wrapper --port 8000
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import time
+
+from strands_robots.benchmarks.libero import load_libero_suite
+from strands_robots.simulation import Simulation
+
+
+def _date_dir(date_root: str = "rollouts") -> str:
+    out = os.path.join(date_root, _dt.date.today().strftime("%Y_%m_%d"))
+    os.makedirs(out, exist_ok=True)
+    return out
+
+
+def _suite_for_task(task: str) -> str:
+    """Auto-derive a LIBERO suite name from a benchmark task ID.
+
+    Task IDs follow the ``libero-<suite>-<task_stem>`` pattern (see
+    ``strands_robots.benchmarks.libero.suite``), so the suite is the
+    second hyphen-separated segment.
+
+    >>> _suite_for_task("libero-spatial-pick_up_the_red_cube")
+    'libero_spatial'
+    >>> _suite_for_task("libero-10-LIVING_ROOM_SCENE5_x")
+    'libero_10'
+    """
+    parts = task.split("-", 2)
+    if len(parts) < 3 or parts[0] != "libero":
+        raise ValueError(
+            f"--task must look like 'libero-<suite>-<task_stem>', got {task!r}. "
+            "See `load_libero_suite` for registered names."
+        )
+    return f"libero_{parts[1]}"
+
+
+def _default_checkpoint_dir() -> str:
+    """Default ``--checkpoint-dir`` that clears ``gr00t_inference``'s mount guard.
+
+    ``gr00t_inference`` downloads to ``~/.strands_robots/checkpoints/`` by
+    default, but its ``start_container`` step refuses to bind-mount any
+    path under ``/home`` (a "protected host path" guard). Those two
+    defaults are mutually inconsistent, so the OOTB ``--policy groot``
+    lifecycle would abort at ``start_container``.
+
+    We default to a non-``/home`` cache so the mount guard is satisfied
+    without the user having to pass ``--checkpoint-dir`` manually. Honor an
+    explicit ``STRANDS_ROBOTS_CHECKPOINT_DIR`` override, then fall back to
+    ``$XDG_CACHE_HOME`` only when it lives outside ``/home``, else
+    ``/tmp/strands_robots/checkpoints``.
+    """
+    override = os.environ.get("STRANDS_ROBOTS_CHECKPOINT_DIR")
+    if override:
+        return override
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg and not os.path.realpath(xdg).startswith("/home"):
+        return os.path.join(xdg, "strands_robots", "checkpoints")
+    return "/tmp/strands_robots/checkpoints"
+
+
+def _explain_lifecycle_failure(result: dict, checkpoint_dir: str, container: str) -> str:
+    """Turn a ``gr00t_inference`` lifecycle failure into an actionable message.
+
+    Surfaces the two most common OOTB blockers with a concrete next step:
+
+    * the ``/home`` "protected host path" mount guard (see
+      :func:`_default_checkpoint_dir`),
+    * a stale ``gr00t-libero-*`` container that ``start_container`` won't
+      recreate without ``force=True``.
+    """
+    blob = repr(result)
+    hint = ""
+    if "protected host path" in blob:
+        hint = (
+            "\n\nHINT: the checkpoint dir is under a path `gr00t_inference` refuses to "
+            "bind-mount (the `/home` mount guard). Pass `--checkpoint-dir` (or set "
+            f"$STRANDS_ROBOTS_CHECKPOINT_DIR) to a non-`/home` path; current value: {checkpoint_dir!r}."
+        )
+    elif "already in use" in blob or "Conflict" in blob or "is already" in blob:
+        hint = (
+            f"\n\nHINT: a stale container named {container!r} is blocking `start_container` "
+            f"(it won't recreate an existing one without force=True). Remove it with "
+            f"`docker rm -f {container}` and retry."
+        )
+    return f"gr00t_inference lifecycle=full failed: {result}{hint}"
+
+
+def _configure_gr00t_image(image: str) -> None:
+    """Point ``gr00t_inference`` at *image* via operator env config.
+
+    The GR00T docker image is not a ``gr00t_inference`` kwarg - it's
+    operator-configured through the ``STRANDS_GR00T_IMAGE`` env var and
+    validated against ``STRANDS_GR00T_IMAGE_ALLOW`` (defaults:
+    ``gr00t:*`` and ``nvcr.io/nvidia/isaac-gr00t:*``). This sets the env
+    var to the requested ``--image`` and, when the image doesn't already
+    match the allowlist, appends it so resolution doesn't fail closed.
+    """
+    os.environ["STRANDS_GR00T_IMAGE"] = image
+    allow = os.environ.get("STRANDS_GR00T_IMAGE_ALLOW", "")
+    patterns = [p.strip() for p in allow.split(",") if p.strip()]
+    default_allow = ("gr00t:", "nvcr.io/nvidia/isaac-gr00t:")
+    already_allowed = (
+        image in patterns
+        or any(image.startswith(prefix) for prefix in default_allow)
+        or any(p.endswith("*") and image.startswith(p[:-1]) for p in patterns)
+    )
+    if not already_allowed:
+        patterns.append(image)
+        os.environ["STRANDS_GR00T_IMAGE_ALLOW"] = ",".join(patterns)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--policy", choices=["mock", "groot"], default="mock")
+    p.add_argument("--port", type=int, default=8000, help="GR00T inference port (only used with --policy=groot)")
+    p.add_argument(
+        "--task",
+        default="libero-spatial-pick_up_the_red_cube",
+        help="Any registered LIBERO benchmark name; suite is auto-derived.",
+    )
+    p.add_argument("--n-episodes", type=int, default=10)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--auto-server",
+        dest="auto_server",
+        action="store_true",
+        default=True,
+        help="(--policy=groot only) Bring up the GR00T inference service via "
+        "`gr00t_inference(action='lifecycle', lifecycle='full', ...)` before "
+        "the eval and tear it down on exit. Default: enabled.",
+    )
+    p.add_argument(
+        "--no-auto-server",
+        dest="auto_server",
+        action="store_false",
+        help="(--policy=groot only) Don't manage the inference service; "
+        "expect one to already be listening on `--port`.",
+    )
+    p.add_argument(
+        "--image",
+        default="gr00t:latest",
+        help="(--auto-server only) Docker image tag of the GR00T container. "
+        "The image is operator-configured via the STRANDS_GR00T_IMAGE env var "
+        "(validated against STRANDS_GR00T_IMAGE_ALLOW); this flag sets that "
+        "env var (and extends the allowlist if needed) before calling "
+        "`gr00t_inference`.",
+    )
+    p.add_argument(
+        "--container",
+        default="gr00t-libero-mujoco",
+        help="(--auto-server only) Docker container name to (re)use.",
+    )
+    p.add_argument(
+        "--checkpoint-dir",
+        default=None,
+        help="(--auto-server only) Where to cache the HF checkpoint. "
+        "Default: a non-`/home` path (`$STRANDS_ROBOTS_CHECKPOINT_DIR`, an "
+        "outside-`/home` `$XDG_CACHE_HOME/strands_robots/checkpoints`, or "
+        "`/tmp/strands_robots/checkpoints`). This avoids `gr00t_inference`'s "
+        "`start_container` mount guard, which refuses to bind-mount any path "
+        "under `/home`.",
+    )
+    args = p.parse_args()
+
+    suite = _suite_for_task(args.task)
+
+    # When `--policy=groot --auto-server` (default), bring up the GR00T
+    # inference service via the lifecycle tool: build the n1.7 container
+    # if missing -> download the right `libero_<suite>/` sub-checkpoint
+    # -> start the container -> start the server. Each sub-step is
+    # idempotent so re-runs are cheap. Pass `--no-auto-server` if you're
+    # managing the service yourself.
+    server_handle = None
+    if args.policy == "groot" and args.auto_server:
+        from pathlib import Path
+
+        from strands_robots.tools import gr00t_inference
+
+        _configure_gr00t_image(args.image)
+
+        # Default the checkpoint cache to a non-`/home` path so the
+        # downloaded checkpoint clears `gr00t_inference`'s `start_container`
+        # mount guard. When the user passes `--checkpoint-dir` explicitly we
+        # honor it verbatim.
+        if args.checkpoint_dir is None:
+            args.checkpoint_dir = _default_checkpoint_dir()
+        print(f"[setup] checkpoint dir: {args.checkpoint_dir}")
+
+        hf_token_path = Path("~/.cache/huggingface/token").expanduser()
+        if not hf_token_path.is_file():
+            raise RuntimeError(
+                "--policy groot needs an HF token (Cosmos-Reason2-2B is gated). "
+                "Run `huggingface-cli login` first, then retry."
+            )
+        result = gr00t_inference(
+            action="lifecycle",
+            lifecycle="full",
+            hf_repo="nvidia/GR00T-N1.7-LIBERO",
+            hf_subfolder=suite,
+            hf_local_dir=args.checkpoint_dir,
+            container_name=args.container,
+            hf_token=hf_token_path.read_text().strip(),
+            # The lifecycle tool mounts `hf_local_dir` (or its default cache
+            # dir when `None`) -> `/data/checkpoints`, and the HF download
+            # places `<suite>/...` directly under that. So the in-container
+            # path is `/data/checkpoints/<suite>`, NOT
+            # `/data/checkpoints/GR00T-N1.7-LIBERO/<suite>`.
+            checkpoint_path=f"/data/checkpoints/{suite}",
+            embodiment_tag="libero_sim",
+            protocol="n1.7",
+            use_sim_policy_wrapper=True,
+            port=args.port,
+        )
+        if result.get("status") != "success":
+            raise RuntimeError(_explain_lifecycle_failure(result, args.checkpoint_dir, args.container))
+        server_handle = result
+        print(f"[setup] {result.get('message')}")
+
+        # The lifecycle tool returns success when the server's port is
+        # bound, but the model itself loads asynchronously after that -
+        # a too-eager `evaluate_benchmark` call can race the load and
+        # hang on the first inference request. Wait until GPU memory
+        # crosses a heuristic load-complete threshold before continuing;
+        # remove this loop once `gr00t_inference` blocks until ready.
+        import subprocess
+        from time import monotonic, sleep
+
+        deadline = monotonic() + 180
+        # N1.7 loads to ~6.3 GB on the L4; gate at 4 GiB so the readiness
+        # check fires once the model is resident (a 10 GiB gate never
+        # tripped - the model footprint is below it - so --auto-server
+        # always timed out at 180 s).
+        loaded_threshold_mib = 4_000
+        while monotonic() < deadline:
+            try:
+                used = int(
+                    subprocess.check_output(["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"])
+                    .decode()
+                    .strip()
+                    .splitlines()[0]
+                )
+            except Exception:
+                used = 0
+            if used > loaded_threshold_mib:
+                print(f"[setup] GR00T model loaded (gpu_mem={used} MiB)")
+                break
+            sleep(5)
+        else:
+            raise RuntimeError(
+                "GR00T model didn't reach load threshold within 180 s. Check `docker logs <container>` for stderr."
+            )
+
+    if args.policy == "groot":
+        # Client-side `data_config="libero_panda"` - this is the registered
+        # key in the GR00T data-config registry that tells the local
+        # `Gr00tPolicy` how to format LIBERO observations into the
+        # GR00T-N1.7 input layout. Note this is *separate from* the server's
+        # `--embodiment-tag libero_sim` (an alias of `LIBERO_PANDA` per the
+        # checkpoint's `embodiment_id.json`); the two sides happen to mean
+        # the same thing but the strings are not interchangeable.
+        # `groot_version="n1.7"` is required when the client doesn't have
+        # the upstream `gr00t` package installed (auto-detection only works
+        # when it does); without it the client serializes 4D video and the
+        # N1.7 server rejects with "must be (B, T, H, W, C), got (B, H, W, C)".
+        policy_kwargs = {
+            "policy_provider": "groot",
+            "policy_config": {
+                "host": "localhost",
+                "port": args.port,
+                "data_config": "libero_panda",
+                "groot_version": "n1.7",
+            },
+        }
+    else:
+        policy_kwargs = {"policy_provider": "mock"}
+
+    sim = Simulation(tool_name="libero_sim", mesh=False)
+    try:
+        sim.create_world()
+        # Pre-add a Panda named ``robot`` so:
+        #   1. evaluate_benchmark's pre-flight check (`No robots in sim`)
+        #      passes BEFORE on_episode_start runs scene loading.
+        #   2. The resolved-name `evaluate_benchmark` picks up here
+        #      survives the rename that LIBERO scene MJCFs do - the
+        #      scenes ship a Franka Panda named `robot` (LIBERO/RoboSuite
+        #      convention), so picking the same name client-side keeps
+        #      the resolved robot stable across `on_episode_start`.
+        sim.add_robot("robot", data_config="panda")
+
+        registered = load_libero_suite(suite)
+        if not registered:
+            raise RuntimeError(
+                f"load_libero_suite({suite!r}) registered 0 tasks. "
+                "Check that the [benchmark-libero] extra is installed."
+            )
+        if args.task not in registered:
+            # The default name `libero-spatial-pick_up_the_red_cube` is
+            # aspirational - real LIBERO ships ~10 spatial tasks but
+            # none of them is literally that string. If we hit the default
+            # and it doesn't resolve, fall back to the first registered
+            # task with a clear note. User-supplied unknown tasks still
+            # error loudly.
+            if args.task == "libero-spatial-pick_up_the_red_cube":
+                fallback = next(iter(registered))
+                print(
+                    f"NOTE: default --task {args.task!r} isn't in real LIBERO "
+                    f"(it's an aspirational placeholder); falling back "
+                    f"to first registered task {fallback!r}."
+                )
+                args.task = fallback
+            else:
+                raise RuntimeError(
+                    f"--task {args.task!r} is not in the {suite} suite. Available: {sorted(registered)[:3]}…"
+                )
+
+        ts = _dt.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        rec_name = f"{ts}--task={args.task}--n_eps={args.n_episodes}--seed={args.seed}--policy={args.policy}"
+        video_dir = _date_dir()
+        # Pick the camera to record from. The LIBERO scene auto-loaded by
+        # `LiberoAdapter` supplies cameras named `image` (third-person
+        # agentview) and `wrist_image` (gripper view). Without LIBERO
+        # loaded - e.g. on `--policy=mock` paths that hit the scene-gen
+        # ImportError fallback - only the world's `default` camera exists.
+        recording_camera = "image" if args.policy == "groot" else "default"
+        recording_cameras = ["image", "wrist_image"] if args.policy == "groot" else ["default"]
+
+        # Pre-warm the scene so `image` actually exists at recording-start
+        # time. `start_cameras_recording` looks up the camera by name in
+        # the live model and resolving fails if the scene hasn't been
+        # loaded yet - but `on_episode_start` (where scene-load happens)
+        # only runs *inside* `evaluate_benchmark`. We force the
+        # auto-generation + load here so the camera is registered before
+        # the recorder starts; subsequent per-episode reloads in the eval
+        # loop reuse the cached scene_path so the camera name stays
+        # stable across them.
+        if args.policy == "groot":
+            from strands_robots.simulation.benchmark import get_benchmark
+
+            spec = get_benchmark(args.task)
+            if hasattr(spec, "ensure_scene"):
+                spec.ensure_scene()
+            if spec.scene_path:
+                sim.load_scene(spec.scene_path)
+                # Prewarm BEFORE the redundant-Panda check below, so
+                # prewarm's robot registration wraps the scene-supplied
+                # Panda first -> list_robots() returns ['robot'] -> the
+                # if-check below is False -> no redundant add_robot
+                # recompile that would change model.nq away from the
+                # LIBERO width init_states[0] is sized for.
+                if hasattr(spec, "prewarm"):
+                    spec.prewarm(sim)
+                # Defensive fallback for non-LIBERO benchmarks that
+                # don't expose `prewarm` and don't ship a Panda in
+                # the loaded scene MJCF.
+                if "robot" not in sim.list_robots():
+                    sim.add_robot("robot", data_config="panda")
+
+        sim.start_cameras_recording(cameras=recording_cameras, output_dir=video_dir, name=rec_name)
+        try:
+            t0 = time.time()
+            result = sim.evaluate_benchmark(
+                benchmark_name=args.task,
+                # robot_name omitted on purpose - `LiberoAdapter`'s scene
+                # auto-generation loads a scene that names its Panda
+                # ``robot`` (LIBERO/RoboSuite convention), so any
+                # specific name we pre-resolve here is gone after
+                # `on_episode_start`. `evaluate_benchmark` auto-picks
+                # when there's only one robot, which is the LIBERO case.
+                n_episodes=args.n_episodes,
+                seed=args.seed,
+                **policy_kwargs,
+            )
+            wall_time = time.time() - t0
+        finally:
+            sim.stop_cameras_recording()
+
+        json_payload = next(c["json"] for c in result["content"] if "json" in c)
+        success_rate = json_payload["success_rate"]
+        video_path = os.path.join(video_dir, f"{rec_name}__{recording_camera}.mp4")
+
+        # Two grep-stable lines for `libero_backend_matrix.py` to
+        # subprocess-and-parse. Keep the exact format (`policy=`, `task=`,
+        # `success_rate=`, `wall_time=`, `videos=`) stable across rebases /
+        # refactors.
+        print(f"benchmark_name={args.task}")
+        print(
+            f"policy={args.policy}  task={args.task}  "
+            f"success_rate={success_rate:.2f}  "
+            f"wall_time={wall_time:.1f}s  videos={video_path}"
+        )
+    finally:
+        sim.destroy()
+        # Tear down the GR00T inference container if we brought it up.
+        if server_handle is not None:
+            from strands_robots.tools import gr00t_inference
+
+            gr00t_inference(action="lifecycle", lifecycle="teardown", container_name=args.container)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/libero/run_mujoco_agent.py
+++ b/examples/libero/run_mujoco_agent.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""LIBERO on MuJoCo, driven by a Strands ``Agent`` in natural language.
+
+The agent receives a single prompt describing the eval, picks
+``evaluate_benchmark`` on the registered ``Simulation`` tool, sets the
+kwargs from prompt context, runs, and returns a natural-language
+summary. For the scripted / deterministic version of the same eval,
+see ``run_mujoco.py`` (sibling file); for the Isaac Sim equivalent,
+see ``run_isaac_agent.py``.
+
+What the script handles deterministically (NOT the agent)
+---------------------------------------------------------
+LLM agents are reliable at "pick the right tool from a small set, fill
+its kwargs from prompt context, summarise the result". They are *not*
+reliable at multi-step infrastructure orchestration where each step
+has a brittle invariant (docker container names, HF-cache locations,
+recorder API selection, scene pre-warm timing). So this script keeps
+the latter under deterministic Python control and gives the agent the
+one decision it's actually good at: invoking ``evaluate_benchmark``.
+
+Owned by the script:
+
+* GR00T inference container lifecycle (start, wait-for-load, teardown
+  on exit) via ``gr00t_inference(action='lifecycle', ...)`` - same
+  block as ``run_mujoco.py``. Idempotent: reuses an already-running
+  container with the matching name on ``--port``; no redundant
+  checkpoint re-download if the cache is already populated.
+* LIBERO scene pre-warm: ``spec.ensure_scene()`` ->
+  ``sim.load_scene(...)`` -> ``spec.prewarm(sim)``. Without this the
+  GR00T server rejects the first observation with ``Video key
+  'video.image' must be in observation`` because the scene's cameras
+  haven't been registered yet.
+* MP4 recording via ``start_cameras_recording`` (daemon-thread
+  recorder, same path as ``run_mujoco.py``). Under Strands ``Agent``
+  tool dispatch the eval runs on a worker thread distinct from the
+  recorder thread, and the two race on shared ``mjData``; in practice
+  this means lower frame coverage and the occasional greenish GL
+  clear-colour artifact. The synchronous-mode alternative -
+  ``start_cameras_recording_synchronous`` + ``evaluate_benchmark(
+  on_frame=...)`` - eliminates the race by capturing one frame per
+  sim step from the eval thread, but its on_frame closure can't cross
+  the agent's tool-dispatch JSON boundary, so wiring it requires a
+  ``@tool`` wrapper that captures the closure in Python scope.
+  Earlier shapes of this file used that wrapper and produced
+  bit-exact 1-frame-per-step videos at the cost of (a) a 5-6x
+  wall-time multiplier from per-step render, (b) ~70 lines of
+  closure-plumbing, (c) reducing the agent's tool surface from the
+  full ``Simulation`` action enum to a single wrapper. We chose
+  the simpler daemon-thread shape here for matrix-quality wall-time
+  and so the agent demo exercises the natural-language -> action-pick
+  -> kwarg-fill flow over the real ``Simulation`` surface; users who
+  need guaranteed-clean video should use ``run_mujoco.py``
+  programmatically. The agent does *not* pick a recorder API -
+  earlier shapes of this script let the agent decide and it
+  consistently picked LeRobot's ``Dataset`` recorder which then
+  crashed on ``[Errno 17] File exists: 'rollouts'``.
+
+Owned by the agent: the single ``evaluate_benchmark(...)`` call with
+benchmark_name + n_episodes + seed + policy_provider + policy_config
+filled from natural language, picked from the registered
+``Simulation`` tool's multi-action enum (the prompt names the action
+explicitly to prevent verb-matching to ``run_policy`` /
+``eval_policy`` which skip the LIBERO observation adapter), plus the
+natural-language summary at the end.
+
+Usage
+-----
+::
+
+    # 1) Smoke test (mock policy; no GPU / Docker needed):
+    python examples/libero/run_mujoco_agent.py --policy mock --n-episodes 5
+
+    # 2) Real run against `nvidia/GR00T-N1.7-LIBERO`. Script auto-
+    #    orchestrates the GR00T inference container (idempotent). Pre-
+    #    condition: HF token at `~/.cache/huggingface/token` (gated
+    #    Cosmos-Reason2-2B backbone) + Docker + an NVIDIA GPU.
+    python examples/libero/run_mujoco_agent.py --policy groot --port 8000 --n-episodes 5
+
+    # 2b) Reuse an already-running container instead of letting the
+    #     script manage one (e.g. for multi-eval sessions):
+    python examples/libero/run_mujoco_agent.py --policy groot --no-auto-server --port 8000
+
+    # 3) Different LIBERO suite + task; suite auto-derived from --task,
+    #    so the lifecycle tool downloads the matching `libero_<suite>/`
+    #    sub-checkpoint:
+    python examples/libero/run_mujoco_agent.py \\
+        --policy groot --port 8000 \\
+        --task libero-10-LIVING_ROOM_SCENE5_put_the_white_mug_…
+
+Requires
+--------
+- ``pip install 'strands-robots[sim-mujoco,benchmark-libero]' strands-agents``
+- A configured LLM provider for Strands. Default is Anthropic Claude
+  via AWS Bedrock - see https://strandsagents.com/ for setup. Without
+  one the ``Agent(...)`` call below raises an authentication /
+  configuration error pointing at the SDK setup docs.
+- For ``--policy=groot``: Docker + an NVIDIA GPU + ~30 GB free disk for
+  the GR00T checkpoint (cached across re-runs).
+
+Notes
+-----
+- Output is non-deterministic by design (LLM-generated summary). The
+  backend matrix (``libero_backend_matrix.py``) does not ingest this
+  file; the deterministic numbers live in ``run_mujoco.py`` (sibling
+  file).
+- Records video to ``rollouts/YYYY_MM_DD/`` with a filename that ends
+  ``--policy=mock|groot--agent`` so post-hoc analysis can tell which
+  driver produced it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import time
+
+from strands import Agent
+
+from strands_robots.benchmarks.libero import load_libero_suite
+from strands_robots.simulation import Simulation
+from strands_robots.tools import gr00t_inference
+
+
+def _date_dir(date_root: str = "rollouts") -> str:
+    out = os.path.join(date_root, _dt.date.today().strftime("%Y_%m_%d"))
+    os.makedirs(out, exist_ok=True)
+    return out
+
+
+def _suite_for_task(task: str) -> str:
+    """Auto-derive a LIBERO suite name from a benchmark task ID.
+
+    Same shape as ``run_mujoco.py``'s helper; see that file for the
+    canonical doctest examples.
+    """
+    parts = task.split("-", 2)
+    if len(parts) < 3 or parts[0] != "libero":
+        raise ValueError(
+            f"--task must look like 'libero-<suite>-<task_stem>', got {task!r}. "
+            "See `load_libero_suite` for registered names."
+        )
+    return f"libero_{parts[1]}"
+
+
+def _default_checkpoint_dir() -> str:
+    """Default ``--checkpoint-dir`` that clears ``gr00t_inference``'s mount guard.
+
+    ``gr00t_inference`` downloads to ``~/.strands_robots/checkpoints/`` by
+    default, but its ``start_container`` step refuses to bind-mount any
+    path under ``/home`` (a "protected host path" guard), so the OOTB
+    ``--policy groot`` lifecycle would abort. Default to a non-``/home``
+    cache: honor an explicit ``STRANDS_ROBOTS_CHECKPOINT_DIR`` override,
+    then fall back to ``$XDG_CACHE_HOME`` only when it lives outside
+    ``/home``, else ``/tmp/strands_robots/checkpoints``.
+    """
+    override = os.environ.get("STRANDS_ROBOTS_CHECKPOINT_DIR")
+    if override:
+        return override
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg and not os.path.realpath(xdg).startswith("/home"):
+        return os.path.join(xdg, "strands_robots", "checkpoints")
+    return "/tmp/strands_robots/checkpoints"
+
+
+def _explain_lifecycle_failure(result: dict, checkpoint_dir: str, container: str) -> str:
+    """Turn a ``gr00t_inference`` lifecycle failure into an actionable message.
+
+    Surfaces the two most common OOTB blockers with a concrete next step:
+    the ``/home`` "protected host path" mount guard (see
+    :func:`_default_checkpoint_dir`), and a stale ``gr00t-libero-*``
+    container that ``start_container`` won't recreate without
+    ``force=True``.
+    """
+    blob = repr(result)
+    hint = ""
+    if "protected host path" in blob:
+        hint = (
+            "\n\nHINT: the checkpoint dir is under a path `gr00t_inference` refuses to "
+            "bind-mount (the `/home` mount guard). Pass `--checkpoint-dir` (or set "
+            f"$STRANDS_ROBOTS_CHECKPOINT_DIR) to a non-`/home` path; current value: {checkpoint_dir!r}."
+        )
+    elif "already in use" in blob or "Conflict" in blob or "is already" in blob:
+        hint = (
+            f"\n\nHINT: a stale container named {container!r} is blocking `start_container` "
+            f"(it won't recreate an existing one without force=True). Remove it with "
+            f"`docker rm -f {container}` and retry."
+        )
+    return f"gr00t_inference lifecycle=full failed: {result}{hint}"
+
+
+def _configure_gr00t_image(image: str) -> None:
+    """Point ``gr00t_inference`` at *image* via operator env config.
+
+    The GR00T docker image is not a ``gr00t_inference`` kwarg - it's
+    operator-configured through the ``STRANDS_GR00T_IMAGE`` env var and
+    validated against ``STRANDS_GR00T_IMAGE_ALLOW`` (defaults:
+    ``gr00t:*`` and ``nvcr.io/nvidia/isaac-gr00t:*``). This sets the env
+    var to the requested ``--image`` and, when the image doesn't already
+    match the allowlist, appends it so resolution doesn't fail closed.
+    """
+    os.environ["STRANDS_GR00T_IMAGE"] = image
+    allow = os.environ.get("STRANDS_GR00T_IMAGE_ALLOW", "")
+    patterns = [p.strip() for p in allow.split(",") if p.strip()]
+    default_allow = ("gr00t:", "nvcr.io/nvidia/isaac-gr00t:")
+    already_allowed = (
+        image in patterns
+        or any(image.startswith(prefix) for prefix in default_allow)
+        or any(p.endswith("*") and image.startswith(p[:-1]) for p in patterns)
+    )
+    if not already_allowed:
+        patterns.append(image)
+        os.environ["STRANDS_GR00T_IMAGE_ALLOW"] = ",".join(patterns)
+
+
+def _bring_up_gr00t_server(args: argparse.Namespace, suite: str) -> dict | None:
+    """Start the GR00T inference container and block until model is loaded.
+
+    Mirrors the lifecycle block in ``run_mujoco.py`` so the agent file
+    has identical "real-eval" plumbing. Returns the lifecycle handle
+    (or ``None`` if ``--policy=mock`` / ``--no-auto-server``).
+    """
+    if args.policy != "groot" or not args.auto_server:
+        return None
+
+    import subprocess
+    from pathlib import Path
+    from time import monotonic, sleep
+
+    _configure_gr00t_image(args.image)
+
+    # Default the checkpoint cache to a non-`/home` path so the downloaded
+    # checkpoint clears `gr00t_inference`'s `start_container` mount guard.
+    # Explicit `--checkpoint-dir` wins.
+    if args.checkpoint_dir is None:
+        args.checkpoint_dir = _default_checkpoint_dir()
+    print(f"[setup] checkpoint dir: {args.checkpoint_dir}")
+
+    hf_token_path = Path("~/.cache/huggingface/token").expanduser()
+    if not hf_token_path.is_file():
+        raise RuntimeError(
+            "--policy groot needs an HF token (Cosmos-Reason2-2B is gated). "
+            "Run `huggingface-cli login` first, then retry."
+        )
+    result = gr00t_inference(
+        action="lifecycle",
+        lifecycle="full",
+        hf_repo="nvidia/GR00T-N1.7-LIBERO",
+        hf_subfolder=suite,
+        hf_local_dir=args.checkpoint_dir,
+        container_name=args.container,
+        hf_token=hf_token_path.read_text().strip(),
+        checkpoint_path=f"/data/checkpoints/{suite}",
+        embodiment_tag="libero_sim",
+        protocol="n1.7",
+        use_sim_policy_wrapper=True,
+        port=args.port,
+    )
+    if result.get("status") != "success":
+        raise RuntimeError(_explain_lifecycle_failure(result, args.checkpoint_dir, args.container))
+    print(f"[setup] {result.get('message')}")
+
+    # Same readiness wait as run_mujoco.py - the lifecycle tool returns
+    # success when the port is bound, but the model loads asynchronously
+    # after that. Block until GPU memory crosses a heuristic threshold.
+    deadline = monotonic() + 180
+    # N1.7 loads to ~6.3 GB on the L4; gate at 4 GiB so the readiness check
+    # fires once the model is resident (a 10 GiB gate never tripped - the
+    # model footprint is below it - so --auto-server always timed out).
+    loaded_threshold_mib = 4_000
+    while monotonic() < deadline:
+        try:
+            used = int(
+                subprocess.check_output(
+                    [
+                        "nvidia-smi",
+                        "--query-gpu=memory.used",
+                        "--format=csv,noheader,nounits",
+                    ]
+                )
+                .decode()
+                .strip()
+                .splitlines()[0]
+            )
+        except Exception:
+            used = 0
+        if used > loaded_threshold_mib:
+            print(f"[setup] GR00T model loaded (gpu_mem={used} MiB)")
+            return result
+        sleep(5)
+    raise RuntimeError(
+        "GR00T model didn't reach load threshold within 180 s. Check `docker logs <container>` for stderr."
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--policy", choices=["mock", "groot"], default="mock")
+    p.add_argument("--port", type=int, default=8000, help="GR00T inference port (only used with --policy=groot)")
+    p.add_argument(
+        "--task",
+        default="libero-spatial-pick_up_the_red_cube",
+        help="Any registered LIBERO benchmark name; suite is auto-derived.",
+    )
+    p.add_argument("--n-episodes", type=int, default=10)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--auto-server",
+        dest="auto_server",
+        action="store_true",
+        default=True,
+        help="(--policy=groot only) Bring up the GR00T inference service via "
+        "`gr00t_inference(action='lifecycle', lifecycle='full', ...)` before "
+        "the eval and tear it down on exit. Default: enabled.",
+    )
+    p.add_argument(
+        "--no-auto-server",
+        dest="auto_server",
+        action="store_false",
+        help="(--policy=groot only) Don't manage the inference service; "
+        "expect one to already be listening on `--port`.",
+    )
+    p.add_argument(
+        "--image",
+        default="gr00t:latest",
+        help="(--auto-server only) Docker image tag of the GR00T container. "
+        "The image is operator-configured via the STRANDS_GR00T_IMAGE env var "
+        "(validated against STRANDS_GR00T_IMAGE_ALLOW); this flag sets that "
+        "env var (and extends the allowlist if needed) before calling "
+        "`gr00t_inference`.",
+    )
+    p.add_argument(
+        "--container",
+        default="gr00t-libero-mujoco",
+        help="(--auto-server only) Docker container name to (re)use.",
+    )
+    p.add_argument(
+        "--checkpoint-dir",
+        default=None,
+        help="(--auto-server only) Where to cache the HF checkpoint. "
+        "Default: a non-`/home` path (`$STRANDS_ROBOTS_CHECKPOINT_DIR`, an "
+        "outside-`/home` `$XDG_CACHE_HOME/strands_robots/checkpoints`, or "
+        "`/tmp/strands_robots/checkpoints`). This avoids `gr00t_inference`'s "
+        "`start_container` mount guard, which refuses to bind-mount any path "
+        "under `/home`.",
+    )
+    args = p.parse_args()
+
+    suite = _suite_for_task(args.task)
+
+    # Build the policy_config dict that the agent will pass through to
+    # `evaluate_benchmark`. We construct it deterministically here so
+    # the agent doesn't have to invent dict literals from the prompt.
+    if args.policy == "groot":
+        policy_phrase = (
+            f"using the GR00T policy with `policy_provider='groot'` and "
+            f"`policy_config={{'host': 'localhost', 'port': {args.port}, "
+            f"'data_config': 'libero_panda', 'groot_version': 'n1.7'}}`"
+        )
+    else:
+        policy_phrase = "using the mock policy (`policy_provider='mock'`)"
+
+    server_handle = _bring_up_gr00t_server(args, suite)
+
+    sim = Simulation(tool_name="libero_sim", mesh=False)
+    try:
+        sim.create_world()
+        # Pre-add a Panda named ``robot`` so:
+        #   1. evaluate_benchmark's pre-flight check (`No robots in
+        #      sim`) passes BEFORE on_episode_start runs scene loading.
+        #   2. The resolved-name `evaluate_benchmark` picks up here
+        #      survives the rename that LIBERO scene MJCFs do - the
+        #      scenes ship a Franka Panda named `robot` (LIBERO/
+        #      RoboSuite convention), so picking the same name here
+        #      keeps the resolved robot stable across `on_episode_start`.
+        sim.add_robot("robot", data_config="panda")
+
+        registered = load_libero_suite(suite)
+        if not registered:
+            raise RuntimeError(
+                f"load_libero_suite({suite!r}) registered 0 tasks. "
+                "Check that the [benchmark-libero] extra is installed."
+            )
+        if args.task not in registered:
+            # The default `libero-spatial-pick_up_the_red_cube` is
+            # aspirational; fall back to the first registered task.
+            if args.task == "libero-spatial-pick_up_the_red_cube":
+                fallback = next(iter(registered))
+                print(
+                    f"NOTE: default --task {args.task!r} isn't in real LIBERO "
+                    f"(it's an aspirational placeholder); falling back "
+                    f"to first registered task {fallback!r}."
+                )
+                args.task = fallback
+            else:
+                raise RuntimeError(
+                    f"--task {args.task!r} is not in the {suite} suite. Available: {sorted(registered)[:3]}…"
+                )
+
+        ts = _dt.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        rec_name = f"{ts}--task={args.task}--n_eps={args.n_episodes}--seed={args.seed}--policy={args.policy}--agent"
+        video_dir = _date_dir()
+        recording_cameras = ["image", "wrist_image"] if args.policy == "groot" else ["default"]
+
+        # Pre-warm the LIBERO scene so the cameras the GR00T server
+        # expects (`image`, `wrist_image`) are registered before
+        # recording / inference starts. Same block as run_mujoco.py;
+        # see that file for the longer rationale on ordering.
+        if args.policy == "groot":
+            from strands_robots.simulation.benchmark import get_benchmark
+
+            spec = get_benchmark(args.task)
+            if hasattr(spec, "ensure_scene"):
+                spec.ensure_scene()
+            if spec.scene_path:
+                sim.load_scene(spec.scene_path)
+                if hasattr(spec, "prewarm"):
+                    spec.prewarm(sim)
+                if "robot" not in sim.list_robots():
+                    sim.add_robot("robot", data_config="panda")
+
+        # Let the agent pick `evaluate_benchmark` from the full
+        # `Simulation` action surface via natural language. Trade-off:
+        # must use the daemon-thread recorder (`start_cameras_recording`,
+        # NOT the synchronous variant) because the synchronous mode
+        # returns Python closures that can't cross Strands' tool-dispatch
+        # JSON boundary. Daemon-thread recording under the Strands worker
+        # thread races with the eval thread on shared `mjData` and
+        # produces reduced frame capture plus occasional greenish
+        # artifacts - see the module docstring for the full trade-off.
+        sim.start_cameras_recording(cameras=recording_cameras, output_dir=video_dir, name=rec_name)
+        try:
+            agent = Agent(tools=[sim])
+            t0 = time.time()
+            # Explicit instruction to use the `evaluate_benchmark`
+            # action - the Simulation tool exposes dozens of sub-actions
+            # and the agent will otherwise verb-match "run" -> `run_policy`
+            # or "eval" -> `eval_policy`, both of which skip the LIBERO
+            # observation adapter and trigger server-side rejections
+            # like "State key 'state.x' must be in observation".
+            result = agent(
+                f"Make exactly one tool call: invoke the `libero_sim` "
+                f"tool with `action='evaluate_benchmark'`, "
+                f"`benchmark_name='{args.task}'`, "
+                f"`n_episodes={args.n_episodes}`, `seed={args.seed}`, "
+                f"`robot_name='robot'`, {policy_phrase}. Do not call "
+                f"any other action - the world, robot, scene, and "
+                f"video recording have already been set up. When the "
+                f"call returns, parse the `success_rate` field from "
+                f"the JSON payload and report it as a percentage of "
+                f"the {args.n_episodes} episodes."
+            )
+            wall_time = time.time() - t0
+            print(result)
+            video_path = os.path.join(video_dir, f"{rec_name}__{recording_cameras[0]}.mp4")
+            print(f"[agent-eval] policy={args.policy} task={args.task} wall_time={wall_time:.1f}s videos={video_path}")
+        finally:
+            sim.stop_cameras_recording()
+    finally:
+        try:
+            sim.destroy()
+        except Exception:
+            pass
+        # Tear down the GR00T inference container if we brought it up.
+        if server_handle is not None:
+            gr00t_inference(action="lifecycle", lifecycle="teardown", container_name=args.container)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/libero/run_mujoco_agent.py
+++ b/examples/libero/run_mujoco_agent.py
@@ -119,7 +119,11 @@ from strands import Agent
 
 from strands_robots.benchmarks.libero import load_libero_suite
 from strands_robots.simulation import Simulation
-from strands_robots.tools import gr00t_inference
+
+# Import the function from its defining module (not the lazy
+# `strands_robots.tools` re-export) so static analysis resolves the
+# callable instead of the same-named submodule.
+from strands_robots.tools.gr00t_inference import gr00t_inference
 
 
 def _date_dir(date_root: str = "rollouts") -> str:
@@ -459,8 +463,11 @@ def main() -> None:
     finally:
         try:
             sim.destroy()
-        except Exception:
-            pass
+        except Exception as exc:
+            # Best-effort teardown: destroy() can fail if the world was
+            # already torn down mid-eval. Report it, but never let cleanup
+            # mask the primary error or skip the container teardown below.
+            print(f"[agent-eval] warning: sim.destroy() failed during cleanup: {exc}")
         # Tear down the GR00T inference container if we brought it up.
         if server_handle is not None:
             gr00t_inference(action="lifecycle", lifecycle="teardown", container_name=args.container)

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -766,7 +766,7 @@ class LiberoAdapter(BenchmarkProtocol):
         """
         if self.scene_path is None and self._auto_generate_scene:
             try:
-                generated = self._generate_scene_from_bddl()
+                self.ensure_scene()
             except Exception as e:  # noqa: BLE001 - never abort eval on a setup-time error
                 logger.warning(
                     "LiberoAdapter: scene auto-generation failed (%s); falling back to bare Panda. "
@@ -774,9 +774,6 @@ class LiberoAdapter(BenchmarkProtocol):
                     "or pass scene_path= explicitly to silence this warning.",
                     e,
                 )
-                generated = None
-            if generated is not None:
-                self.scene_path = generated
 
         scene_was_loaded = False
         # Detect "prewarm-fresh ep0": the example script called
@@ -995,6 +992,45 @@ class LiberoAdapter(BenchmarkProtocol):
         # #168 behaviour for ACTION_LOG via the controller's
         # reset() call inside _install_action_controller above).
         self._state_log_step = 0
+
+    def ensure_scene(self) -> str | None:
+        """Resolve :attr:`scene_path`, auto-generating the scene MJCF if needed.
+
+        Public entry point for the scene-resolution step that
+        :meth:`on_episode_start` otherwise runs lazily inside the first
+        episode of ``evaluate_benchmark``. Call this (followed by
+        ``sim.load_scene(...)`` and :meth:`prewarm`) when a driver script
+        needs the scene - and the cameras it supplies (``image`` /
+        ``wrist_image``) - available *before* the eval starts, e.g. so
+        ``sim.start_cameras_recording`` can resolve the LIBERO camera
+        names, which only exist once the scene is loaded.
+
+        Behavior:
+
+        * :attr:`scene_path` already set -> returned unchanged (idempotent).
+        * :attr:`scene_path` unset and ``auto_generate_scene=True`` ->
+          builds the scene MJCF from the BDDL via the upstream ``libero``
+          package (SHA256-keyed on-disk cache, so repeat calls and
+          subsequent processes skip the generator), stores the result on
+          :attr:`scene_path`, and returns it.
+        * No BDDL source recoverable, or ``auto_generate_scene=False`` ->
+          returns ``None`` without side effects.
+
+        Unlike the lazy path inside :meth:`on_episode_start` - which
+        warns and falls back to a bare Panda so an eval never aborts on a
+        setup-time error - this method propagates generation failures to
+        the caller: an explicit pre-warm request that cannot be satisfied
+        should fail loudly.
+
+        Returns:
+            The resolved scene path, or ``None`` when no scene source is
+            available.
+        """
+        if self.scene_path is None and self._auto_generate_scene:
+            generated = self._generate_scene_from_bddl()
+            if generated is not None:
+                self.scene_path = generated
+        return self.scene_path
 
     def prewarm(self, sim: SimEngine) -> None:
         """Idempotent setup that should run BEFORE ``sim.start_cameras_recording``.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -629,9 +629,12 @@ class SimEngine(ABC):
         count exactly; a mismatch is reported as a caller error rather than
         silently truncated (which would drop commands - e.g. a gripper axis). A
         mapping is returned unchanged once every value is confirmed to coerce to
-        a scalar float; a non-scalar value (a list / multi-element array) is
-        rejected with an actionable error rather than raised as an unhandled
-        ``TypeError`` deep in the actuator-application loop.
+        a scalar float; a *single-element* sequence/array value (e.g. GR00T's
+        per-key ``[0.05]`` rows - the documented ``list[float]`` shape of the
+        ``Policy.get_actions`` contract for a 1-DOF key) is unwrapped to its
+        scalar, while a *multi-element* value is rejected with an actionable
+        error rather than raised as an unhandled ``TypeError`` deep in the
+        actuator-application loop.
 
         Args:
             action: A ``{name: value}`` mapping, or an ordered numeric vector
@@ -652,10 +655,28 @@ class SimEngine(ABC):
             # the caller mid-rollout, after partially applying the earlier keys.
             # Validate every value coerces to a scalar float up front so the whole
             # action is rejected atomically with an actionable message, symmetric
-            # with the vector-form non-numeric-entry validation below. Values are
-            # returned unchanged (the downstream ``float(value)`` accepts scalars,
-            # numeric strings, and length-1 arrays exactly as before).
+            # with the vector-form non-numeric-entry validation below.
+            #
+            # Single-element unwrap (#1538 GR00T-LIBERO regression): the
+            # ``Policy.get_actions -> list[dict]`` contract emits ``list[float]``
+            # for vector-valued keys, which for a 1-DOF key yields a length-1
+            # list (GR00T's service unpack emits ``{"x": [0.05], ...}`` for the
+            # LIBERO delta-EEF layout). Such a value carries exactly one scalar
+            # and is unambiguous, so unwrap it instead of rejecting - the
+            # pre-validation code path applied it fine via the LIBERO action
+            # controller's own scalar coercion, and rejecting it silently
+            # no-ops an entire GR00T eval to success_rate=0. Multi-element
+            # values (the actual #1179 crash class) are still rejected
+            # atomically.
+            normalized: dict[str, Any] = {}
             for key, value in action.items():
+                if (
+                    not isinstance(value, (str, bytes, Mapping))
+                    and hasattr(value, "__len__")
+                    and hasattr(value, "__getitem__")
+                    and len(value) == 1
+                ):
+                    value = value[0]
                 try:
                     float(value)
                 except (TypeError, ValueError):
@@ -671,7 +692,8 @@ class SimEngine(ABC):
                             }
                         ],
                     }
-            return dict(action), None
+                normalized[key] = value
+            return normalized, None
 
         # ``str``/``bytes`` are iterable but never a valid multi-joint action;
         # a scalar has no length. Reject both with an actionable message instead

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1655,30 +1655,69 @@ class RenderingMixin:
             path = state["paths"][cam]
             errors = state["errors"][cam]
             frames_written = 0
+            frames_skipped = 0
             size_kb = 0.0
+            flush_error = None
             if frames_buffer:
-                writer = imageio.get_writer(path, fps=state["fps"], quality=8, macro_block_size=1)
+                # An MP4 stream requires a constant frame size, but the
+                # capture loop records whatever the live model renders -
+                # and a benchmark's per-episode scene reload can re-install
+                # a camera at different dimensions mid-recording (e.g. the
+                # LIBERO wrist camera). Encode the dominant-size run and
+                # count the rest as skipped instead of letting imageio's
+                # "All images in a movie should have same size" ValueError
+                # abort the whole flush (this method's contract is
+                # never-raise, best-effort).
+                shape_counts: dict[tuple[int, ...], int] = {}
+                for arr in frames_buffer:
+                    shape_counts[arr.shape] = shape_counts.get(arr.shape, 0) + 1
+                target_shape = max(shape_counts, key=lambda s: shape_counts[s])
                 try:
-                    for arr in frames_buffer:
-                        writer.append_data(arr)
-                        frames_written += 1
-                finally:
-                    writer.close()
+                    writer = imageio.get_writer(path, fps=state["fps"], quality=8, macro_block_size=1)
+                    try:
+                        for arr in frames_buffer:
+                            if arr.shape != target_shape:
+                                frames_skipped += 1
+                                continue
+                            writer.append_data(arr)
+                            frames_written += 1
+                    finally:
+                        writer.close()
+                except Exception as e:  # noqa: BLE001 - best-effort flush must never raise
+                    flush_error = f"{type(e).__name__}: {e}"
+                    logger.warning("camera recorder flush failed for %r -> %s: %s", cam, path, flush_error)
+                if frames_skipped:
+                    logger.warning(
+                        "camera recorder flush for %r skipped %d/%d frames whose size didn't match "
+                        "the dominant %s (camera re-installed at different dimensions mid-recording?)",
+                        cam,
+                        frames_skipped,
+                        len(frames_buffer),
+                        target_shape,
+                    )
                 if _os.path.exists(path):
                     size_kb = _os.path.getsize(path) / 1024
-            lines.append(
+            line = (
                 f"   {cam:20s} {frames_written:>5d} frames  {size_kb:>7.1f} KB  "
                 f"({errors} errors)  -> {_os.path.basename(path)}"
             )
-            artifacts.append(
-                {
-                    "camera": cam,
-                    "path": path,
-                    "frames": frames_written,
-                    "errors": errors,
-                    "size_kb": size_kb,
-                }
-            )
+            if frames_skipped:
+                line += f"  [{frames_skipped} skipped: size mismatch]"
+            if flush_error:
+                line += f"  [flush failed: {flush_error}]"
+            lines.append(line)
+            artifact = {
+                "camera": cam,
+                "path": path,
+                "frames": frames_written,
+                "errors": errors,
+                "size_kb": size_kb,
+            }
+            if frames_skipped:
+                artifact["frames_skipped_size_mismatch"] = frames_skipped
+            if flush_error:
+                artifact["flush_error"] = flush_error
+            artifacts.append(artifact)
 
         return {
             "status": "success",

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -1322,8 +1322,13 @@ def _download_checkpoint(
 ) -> dict[str, Any]:
     """Download a HuggingFace checkpoint via ``huggingface_hub.snapshot_download``.
 
-    Idempotent: when ``local_dir`` already exists and is non-empty AND
-    ``force=False``, returns success without touching the network. Pass
+    Idempotent: when the target is already populated AND ``force=False``,
+    returns success without touching the network. "Already populated" is
+    keyed on the artefact actually requested: with ``hf_subfolder`` set,
+    ``local_dir/<hf_subfolder>`` must exist and be non-empty (a shared
+    ``local_dir`` cache holding *other* sub-checkpoints - e.g.
+    ``libero_spatial/`` when ``libero_10`` was requested - must not
+    short-circuit the download); without it, ``local_dir`` itself. Pass
     ``force=True`` to refresh.
 
     HF token resolution order:
@@ -1343,14 +1348,18 @@ def _download_checkpoint(
 
     local_dir = Path(hf_local_dir).expanduser() if hf_local_dir else _checkpoints_dir() / hf_repo.replace("/", "__")
 
-    if not force and local_dir.is_dir() and any(local_dir.iterdir()):
+    # The presence probe must target the requested artefact: when
+    # `hf_subfolder` filters the download to one sub-checkpoint, only that
+    # subdir being populated counts as "already downloaded".
+    probe_dir = local_dir / hf_subfolder if hf_subfolder else local_dir
+    if not force and probe_dir.is_dir() and any(probe_dir.iterdir()):
         return {
             "status": "success",
             "hf_repo": hf_repo,
             "hf_subfolder": hf_subfolder,
             "local_dir": str(local_dir),
             "skipped": True,
-            "message": f"Checkpoint already at {local_dir}; skipping download (use force=True to refresh)",
+            "message": f"Checkpoint already at {probe_dir}; skipping download (use force=True to refresh)",
         }
 
     token = hf_token or os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")

--- a/tests/benchmarks/libero/test_libero_ensure_scene.py
+++ b/tests/benchmarks/libero/test_libero_ensure_scene.py
@@ -1,0 +1,112 @@
+"""Tests for :meth:`LiberoAdapter.ensure_scene` - the public scene-resolution API.
+
+Driver scripts (``examples/libero/run_mujoco.py`` /
+``run_mujoco_agent.py``) need the LIBERO scene - and the cameras it
+supplies - available *before* ``evaluate_benchmark`` runs, so
+``start_cameras_recording`` can resolve the camera names. Pre-fix they
+had to call the private ``_generate_scene_from_bddl()``; ``ensure_scene``
+is the public equivalent. Contract pinned here:
+
+* idempotent: an already-set ``scene_path`` is returned unchanged and
+  the generator is never invoked;
+* generates + stores + returns the path when ``scene_path`` is unset
+  and ``auto_generate_scene=True``;
+* returns ``None`` without side effects when ``auto_generate_scene=False``
+  or the generator can't recover a BDDL source;
+* propagates generation failures (unlike the lazy warn-and-fall-back
+  path inside ``on_episode_start``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from strands_robots.benchmarks.libero import LiberoAdapter
+
+PICK_CUBE_BDDL = """
+(define (problem libero_spatial_pick_cube)
+  (:domain kitchen)
+  (:language "pick up the red cube and place it on the plate")
+  (:objects cube_1 plate_1 table_1 - object)
+  (:init (on cube_1 table_1))
+  (:goal (on cube_1 plate_1)))
+"""
+
+
+def _adapter(**kwargs) -> LiberoAdapter:
+    kwargs.setdefault("init_jitter", 0.0)
+    kwargs.setdefault("install_cameras", False)
+    return LiberoAdapter.from_text(PICK_CUBE_BDDL, **kwargs)
+
+
+def test_ensure_scene_is_public_api() -> None:
+    """The method drivers call must be public (no leading underscore)."""
+    assert hasattr(LiberoAdapter, "ensure_scene")
+    assert not LiberoAdapter.ensure_scene.__name__.startswith("_")
+
+
+def test_existing_scene_path_returned_unchanged_without_generation(tmp_path) -> None:
+    explicit = str(tmp_path / "explicit.xml")
+    adapter = _adapter(scene_path=explicit)
+
+    with patch.object(adapter, "_generate_scene_from_bddl") as mock_gen:
+        assert adapter.ensure_scene() == explicit
+
+    mock_gen.assert_not_called()
+    assert adapter.scene_path == explicit
+
+
+def test_generates_stores_and_returns_path_when_unset(tmp_path) -> None:
+    generated = str(tmp_path / "generated.xml")
+    adapter = _adapter()
+    assert adapter.scene_path is None
+
+    with patch.object(adapter, "_generate_scene_from_bddl", return_value=generated) as mock_gen:
+        assert adapter.ensure_scene() == generated
+
+    mock_gen.assert_called_once()
+    assert adapter.scene_path == generated
+
+
+def test_idempotent_second_call_skips_generator(tmp_path) -> None:
+    generated = str(tmp_path / "generated.xml")
+    adapter = _adapter()
+
+    with patch.object(adapter, "_generate_scene_from_bddl", return_value=generated) as mock_gen:
+        adapter.ensure_scene()
+        adapter.ensure_scene()
+
+    mock_gen.assert_called_once()
+
+
+def test_auto_generate_scene_false_returns_none_without_side_effects() -> None:
+    adapter = _adapter(auto_generate_scene=False)
+
+    with patch.object(adapter, "_generate_scene_from_bddl") as mock_gen:
+        assert adapter.ensure_scene() is None
+
+    mock_gen.assert_not_called()
+    assert adapter.scene_path is None
+
+
+def test_unrecoverable_bddl_source_returns_none() -> None:
+    adapter = _adapter()
+
+    with patch.object(adapter, "_generate_scene_from_bddl", return_value=None):
+        assert adapter.ensure_scene() is None
+
+    assert adapter.scene_path is None
+
+
+def test_generation_failure_propagates_to_caller() -> None:
+    """Unlike ``on_episode_start``'s lazy path, an explicit ``ensure_scene``
+    call must fail loudly when generation raises."""
+    adapter = _adapter()
+
+    with patch.object(adapter, "_generate_scene_from_bddl", side_effect=ImportError("'libero' is required")):
+        with pytest.raises(ImportError, match="libero"):
+            adapter.ensure_scene()
+
+    assert adapter.scene_path is None

--- a/tests/simulation/mujoco/test_recording_synchronous.py
+++ b/tests/simulation/mujoco/test_recording_synchronous.py
@@ -496,3 +496,92 @@ class TestCamerasRecordingOutputIsAscii:
             assert "[idle]" in text
         finally:
             sim.destroy()
+
+
+class TestFlushMixedFrameSizes:
+    """``_flush_cameras_recording_state`` must honor its never-raise contract
+    when a camera's buffer holds frames of different sizes.
+
+    Regression for the LIBERO ``--policy groot`` whole-run recording path
+    (``examples/libero/run_mujoco.py``): a benchmark's per-episode scene
+    reload can re-install a camera at different dimensions mid-recording,
+    so the daemon-thread buffer ends up with mixed frame shapes. Pre-fix,
+    imageio's ``append_data`` raised ``ValueError: All images in a movie
+    should have same size`` out of ``stop_cameras_recording`` - aborting
+    the caller's teardown path despite the flush docstring promising a
+    best-effort, never-raise structured result.
+    """
+
+    @staticmethod
+    def _state(tmp_path: Path, frames: list[np.ndarray]) -> dict[str, Any]:
+        import time as _time
+
+        return {
+            "running": False,
+            "name": "mixed",
+            "cameras": ["cam"],
+            "fps": 30,
+            "buffers": {"cam": frames},
+            "paths": {"cam": str(tmp_path / "mixed__cam.mp4")},
+            "errors": {"cam": 0},
+            "output_dir": str(tmp_path),
+            "started_at": _time.time(),
+        }
+
+    def test_mixed_size_buffer_flushes_dominant_run_without_raising(self, tmp_path: Path):
+        sim = Simulation()
+        try:
+            rng = np.random.default_rng(0)
+            big = [rng.integers(0, 255, size=(24, 32, 3), dtype=np.uint8) for _ in range(6)]
+            small = [np.zeros((12, 16, 3), dtype=np.uint8) for _ in range(2)]
+            frames = [small[0], *big, small[1]]
+
+            result = sim._flush_cameras_recording_state(self._state(tmp_path, frames))
+
+            assert result["status"] == "success"
+            payload = next(c["json"] for c in result["content"] if "json" in c)
+            artifact = payload["artifacts"][0]
+            assert artifact["frames"] == 6
+            assert artifact["frames_skipped_size_mismatch"] == 2
+            # Round-trip: the MP4 exists and holds the dominant-size run.
+            path = Path(artifact["path"])
+            assert path.is_file() and path.stat().st_size > 0
+            reader = imageio.get_reader(str(path))
+            try:
+                decoded = sum(1 for _ in reader)
+            finally:
+                reader.close()
+            assert decoded == 6
+        finally:
+            sim.destroy()
+
+    def test_uniform_buffer_reports_no_skips(self, tmp_path: Path):
+        sim = Simulation()
+        try:
+            frames = [np.full((24, 32, 3), 90, dtype=np.uint8) for _ in range(4)]
+            result = sim._flush_cameras_recording_state(self._state(tmp_path, frames))
+            assert result["status"] == "success"
+            artifact = next(c["json"] for c in result["content"] if "json" in c)["artifacts"][0]
+            assert artifact["frames"] == 4
+            assert "frames_skipped_size_mismatch" not in artifact
+            assert "flush_error" not in artifact
+        finally:
+            sim.destroy()
+
+    def test_writer_failure_reported_not_raised(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        import imageio.v2 as imageio_v2
+
+        def _boom(*_a, **_kw):
+            raise OSError("ffmpeg exploded")
+
+        monkeypatch.setattr(imageio_v2, "get_writer", _boom)
+        sim = Simulation()
+        try:
+            frames = [np.full((24, 32, 3), 90, dtype=np.uint8) for _ in range(3)]
+            result = sim._flush_cameras_recording_state(self._state(tmp_path, frames))
+            assert result["status"] == "success"
+            artifact = next(c["json"] for c in result["content"] if "json" in c)["artifacts"][0]
+            assert artifact["frames"] == 0
+            assert "ffmpeg exploded" in artifact["flush_error"]
+        finally:
+            sim.destroy()

--- a/tests/simulation/mujoco/test_send_action_vector.py
+++ b/tests/simulation/mujoco/test_send_action_vector.py
@@ -127,3 +127,56 @@ class TestSendActionScalarValues:
             n_substeps=2,
         )
         assert result["status"] == "success", result
+
+
+class TestSendActionSingleElementUnwrap:
+    """A length-1 sequence/array dict value unwraps to its scalar.
+
+    Regression for the GR00T-LIBERO eval path (#1538): the
+    ``Policy.get_actions -> list[dict]`` contract emits ``list[float]`` for
+    vector-valued keys, which for a 1-DOF key yields a length-1 list -
+    GR00T's service unpack produces ``{"x": [0.05], "y": [-0.08], ...}`` for
+    the LIBERO delta-EEF layout. The #1179 scalar validation rejected those
+    values atomically, so EVERY ``send_action`` in a GR00T LIBERO eval
+    errored and the benchmark silently no-opped to ``success_rate=0``
+    (`examples/libero/run_mujoco.py --policy groot`). A single-element value
+    carries exactly one unambiguous scalar; it must apply, while
+    multi-element values stay rejected (the actual #1179 crash class).
+    """
+
+    def test_length1_list_value_applies(self, sim):
+        result = sim.send_action({"1": [0.3], "2": [0.2]}, robot_name="so101", n_substeps=2)
+        assert result["status"] == "success", result
+
+    def test_length1_numpy_array_value_applies(self, sim):
+        result = sim.send_action({"1": np.array([0.3], dtype=np.float32)}, robot_name="so101", n_substeps=2)
+        assert result["status"] == "success", result
+
+    def test_groot_shaped_action_dict_moves_the_arm(self, sim):
+        """The exact per-step dict shape GR00T's service unpack emits
+        (every value a length-1 list) drives the joints away from rest."""
+        joints = sim.robot_joint_names("so101")
+        action = {j: [v] for j, v in zip(joints, [0.6, 0.5, 0.4, 0.0, 0.0, 0.0])}
+        before = sim.get_observation(robot_name="so101", skip_images=True)
+        result = sim.send_action(action, robot_name="so101", n_substeps=60)
+        assert result["status"] == "success", result
+        after = sim.get_observation(robot_name="so101", skip_images=True)
+        moved = sum(abs(float(after[j]) - float(before[j])) for j in joints if j in before and j in after)
+        assert moved > 1e-3, f"arm did not move under a GR00T-shaped action dict (delta={moved})"
+
+    def test_length1_non_numeric_value_still_rejected(self, sim):
+        result = sim.send_action({"1": ["oops"]}, robot_name="so101")
+        assert result["status"] == "error"
+        assert "scalar" in result["content"][0]["text"]
+
+    def test_multielement_value_still_rejected(self, sim):
+        """The unwrap must not weaken the #1179 protection."""
+        result = sim.send_action({"1": [0.1, 0.2, 0.3]}, robot_name="so101")
+        assert result["status"] == "error"
+        assert "scalar" in result["content"][0]["text"]
+
+    def test_unindexable_length1_value_is_error_not_crash(self, sim):
+        """A sized-but-unindexable value (a set) returns a structured error."""
+        result = sim.send_action({"1": {0.5}}, robot_name="so101")
+        assert result["status"] == "error"
+        assert "scalar" in result["content"][0]["text"]

--- a/tests/test_examples_libero_drivers.py
+++ b/tests/test_examples_libero_drivers.py
@@ -1,0 +1,185 @@
+"""Import + API-drift smoke tests for the LIBERO example drivers.
+
+The ``examples/libero`` driver scripts are not part of the installed
+package, so nothing else in CI imports them - an API rename in
+``strands_robots`` can silently break the documented smoke path
+(``python examples/libero/run_mujoco.py --policy mock --n-episodes 5``)
+without any test going red. These tests pin the contract:
+
+1. Each MuJoCo driver imports cleanly against the *current* library
+   (module-level imports are the first thing that breaks on drift).
+2. The library symbols the drivers call still exist with the expected
+   surface (``evaluate_benchmark`` kwargs, camera-recording pair,
+   ``LiberoAdapter.ensure_scene``, ``gr00t_inference``).
+3. The grep-stable result line ``run_mujoco.py`` prints stays
+   byte-compatible with ``libero_backend_matrix.py``'s ``_RE_RESULT``
+   parser - drift there produces empty ``success_rate`` matrix cells
+   rather than a crash, so only a test catches it.
+4. The examples do not depend on private (``_``-prefixed) LiberoAdapter
+   methods.
+
+The Isaac drivers (``run_isaac.py`` / ``run_isaac_agent.py``) are
+excluded from the import smoke: they intentionally guard their heavy
+imports behind ``IsaacSimulation.is_available`` at runtime, but their
+module docstrings + argparse setup still get covered by the repo-wide
+example lint tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+_EXAMPLES_LIBERO = Path(__file__).resolve().parent.parent / "examples" / "libero"
+
+# The MuJoCo drivers import `Simulation` (the MuJoCo backend) at module
+# level, so the import smoke needs mujoco installed.
+pytest.importorskip("mujoco")
+
+
+def _load_example(filename: str):
+    """Import an example script by path under a test-unique module name."""
+    path = _EXAMPLES_LIBERO / filename
+    assert path.is_file(), f"expected example driver at {path}"
+    module_name = f"_example_smoke_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+@pytest.mark.parametrize("filename", ["run_mujoco.py", "run_mujoco_agent.py", "libero_backend_matrix.py"])
+def test_driver_imports_cleanly(filename: str) -> None:
+    module = _load_example(filename)
+    assert callable(module.main)
+
+
+def test_run_mujoco_helper_surface() -> None:
+    """``run_isaac.py`` docstrings cross-reference these helpers by name;
+    keep the canonical MuJoCo file exposing them."""
+    module = _load_example("run_mujoco.py")
+    assert callable(module._date_dir)
+    assert callable(module._suite_for_task)
+    assert module._suite_for_task("libero-spatial-pick_up_the_red_cube") == "libero_spatial"
+    assert module._suite_for_task("libero-10-LIVING_ROOM_SCENE5_x") == "libero_10"
+    with pytest.raises(ValueError, match="libero-<suite>-<task_stem>"):
+        module._suite_for_task("not-a-libero-task")
+    with pytest.raises(ValueError, match="libero-<suite>-<task_stem>"):
+        module._suite_for_task("libero-spatial")
+
+
+def test_result_line_matches_backend_matrix_parser() -> None:
+    """The line run_mujoco.py prints must parse with _RE_RESULT.
+
+    Build the sample line with the same format specs the driver uses
+    (`success_rate={sr:.2f}`, `wall_time={wt:.1f}s`); if either side
+    changes shape, this goes red before the matrix silently prints
+    empty cells.
+    """
+    matrix = _load_example("libero_backend_matrix.py")
+    sr, wt = 0.8, 123.4
+    task = "libero-spatial-pick_up_the_black_bowl_between_the_plate_and_the_ramekin_and_place_it_on_the_plate"
+    line = f"policy=mock  task={task}  success_rate={sr:.2f}  wall_time={wt:.1f}s  videos=rollouts/x.mp4"
+    match = matrix._RE_RESULT.search(line)
+    assert match is not None, f"_RE_RESULT failed to parse the driver's result-line shape: {line!r}"
+    assert float(match.group("sr")) == pytest.approx(sr)
+    assert float(match.group("wt")) == pytest.approx(wt)
+
+
+def test_backend_matrix_has_mujoco_row() -> None:
+    """The first matrix row must point at run_mujoco.py, and the file it
+    references must exist (pre-migration it printed `unavailable`)."""
+    matrix = _load_example("libero_backend_matrix.py")
+    rows = {label: filename for label, filename, _ in matrix._BACKEND_ROWS}
+    assert rows.get("mujoco") == "run_mujoco.py"
+    assert (_EXAMPLES_LIBERO / "run_mujoco.py").is_file()
+
+
+@pytest.mark.parametrize("filename", ["run_mujoco.py", "run_mujoco_agent.py"])
+def test_drivers_do_not_call_private_scene_generation(filename: str) -> None:
+    """Public-API hygiene: the drivers must use ``LiberoAdapter.ensure_scene``
+    (public), never the private ``_generate_scene_from_bddl``."""
+    source = (_EXAMPLES_LIBERO / filename).read_text(encoding="utf-8")
+    assert "_generate_scene_from_bddl" not in source, (
+        f"{filename} references the private LiberoAdapter._generate_scene_from_bddl; "
+        "use the public ensure_scene() instead."
+    )
+    assert "ensure_scene" in source
+
+
+def test_library_surface_the_drivers_depend_on() -> None:
+    """Pin the exact library API the drivers call, so a rename fails here
+    with a readable message instead of at example runtime."""
+    from strands_robots.benchmarks.libero import LiberoAdapter, load_libero_suite
+    from strands_robots.simulation import Simulation, get_benchmark
+
+    # Import the tool function from its submodule, not via the package's
+    # lazy `strands_robots.tools.__getattr__`: when another test has already
+    # imported the `strands_robots.tools.gr00t_inference` *module*, Python
+    # binds the module object as the package attribute, shadowing the lazy
+    # function resolution - so the package-level import is order-dependent
+    # under the full test suite. (The drivers themselves run in fresh
+    # interpreters, where the lazy path deterministically yields the
+    # function.)
+    from strands_robots.tools.gr00t_inference import gr00t_inference
+
+    assert callable(load_libero_suite)
+    assert callable(get_benchmark)
+    assert callable(gr00t_inference)
+
+    # LiberoAdapter public pre-warm surface used by the scene pre-warm block.
+    assert callable(LiberoAdapter.ensure_scene)
+    assert callable(LiberoAdapter.prewarm)
+
+    # Simulation methods the drivers call.
+    for method in (
+        "create_world",
+        "add_robot",
+        "load_scene",
+        "list_robots",
+        "start_cameras_recording",
+        "stop_cameras_recording",
+        "evaluate_benchmark",
+        "destroy",
+    ):
+        assert callable(getattr(Simulation, method)), f"Simulation.{method} missing"
+
+    # evaluate_benchmark kwargs the drivers pass.
+    params = inspect.signature(Simulation.evaluate_benchmark).parameters
+    for kwarg in ("benchmark_name", "n_episodes", "seed", "policy_provider", "policy_config", "robot_name"):
+        assert kwarg in params, f"evaluate_benchmark lost the {kwarg!r} kwarg the LIBERO drivers pass"
+
+    # start_cameras_recording kwargs the drivers pass.
+    rec_params = inspect.signature(Simulation.start_cameras_recording).parameters
+    for kwarg in ("cameras", "output_dir", "name"):
+        assert kwarg in rec_params, f"start_cameras_recording lost the {kwarg!r} kwarg the LIBERO drivers pass"
+
+    # gr00t_inference lifecycle kwargs the drivers pass. The @tool
+    # decorator preserves the underlying signature via functools.wraps;
+    # fall back to the raw function if not.
+    tool_fn = inspect.unwrap(gr00t_inference)
+    tool_params = inspect.signature(tool_fn).parameters
+    for kwarg in (
+        "action",
+        "lifecycle",
+        "hf_repo",
+        "hf_subfolder",
+        "hf_local_dir",
+        "container_name",
+        "hf_token",
+        "checkpoint_path",
+        "embodiment_tag",
+        "protocol",
+        "use_sim_policy_wrapper",
+        "port",
+    ):
+        assert kwarg in tool_params, f"gr00t_inference lost the {kwarg!r} kwarg the LIBERO drivers pass"

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -495,6 +495,48 @@ class TestDownloadCheckpoint:
         assert result["status"] == "success"
         assert result["skipped"] is True
 
+    def test_subfolder_probe_ignores_sibling_subcheckpoints(self, tmp_path):
+        """A shared cache dir holding a DIFFERENT sub-checkpoint must not
+        short-circuit the download of the requested one.
+
+        Regression: `hf_local_dir` populated with `libero_spatial/` made the
+        `hf_subfolder="libero_10"` download report skipped=True, so the
+        container started against a missing /data/checkpoints/libero_10 and
+        the model never loaded (examples/libero/run_mujoco.py's multi-suite
+        `--task libero-10-...` flow timed out at the readiness gate).
+        """
+        local = tmp_path / "ckpt"
+        (local / "libero_spatial").mkdir(parents=True)
+        (local / "libero_spatial" / "config.json").write_text("{}")
+
+        fake_hub = MagicMock()
+        with patch("strands_robots.tools.gr00t_inference.require_optional", return_value=fake_hub):
+            result = _download_checkpoint(
+                hf_repo="nvidia/GR00T-N1.7-LIBERO",
+                hf_subfolder="libero_10",
+                hf_local_dir=str(local),
+                hf_token=None,
+                force=False,
+            )
+        assert result["status"] == "success"
+        assert result["skipped"] is False
+        assert fake_hub.snapshot_download.call_args.kwargs["allow_patterns"] == ["libero_10/*"]
+
+    def test_subfolder_probe_skips_when_requested_subfolder_populated(self, tmp_path):
+        local = tmp_path / "ckpt"
+        (local / "libero_10").mkdir(parents=True)
+        (local / "libero_10" / "config.json").write_text("{}")
+
+        result = _download_checkpoint(
+            hf_repo="nvidia/GR00T-N1.7-LIBERO",
+            hf_subfolder="libero_10",
+            hf_local_dir=str(local),
+            hf_token=None,
+            force=False,
+        )
+        assert result["status"] == "success"
+        assert result["skipped"] is True
+
     def test_force_redownloads(self, tmp_path):
         local = tmp_path / "ckpt"
         local.mkdir()


### PR DESCRIPTION
# feat(examples/libero): migrate run_mujoco.py + run_mujoco_agent.py from robots-sim

Closes #1538 - the epic-#1269 remainder: the default-backend LIBERO drivers.

## What changed

### Migrated examples

- **`examples/libero/run_mujoco.py`** - scripted `sim.evaluate_benchmark(...)` LIBERO eval on the default MuJoCo backend. Auto-orchestrates the GR00T inference container via `gr00t_inference(action="lifecycle", lifecycle="full", ...)` (idempotent build/download/run/teardown), `--no-auto-server` escape hatch, suite auto-derived from `--task`, whole-run MP4 via `start_cameras_recording`/`stop_cameras_recording`, and the two grep-stable output lines the backend matrix parses.
- **`examples/libero/run_mujoco_agent.py`** - the natural-language sibling: a Strands `Agent` picks `evaluate_benchmark` on the registered `Simulation` tool and fills kwargs from the prompt, while the script keeps brittle infrastructure deterministic (container lifecycle, LIBERO scene pre-warm, MP4 recording).
- `examples/libero/README.md` - MuJoCo rows/install/run sections; drops the "until those land" caveat for the `mujoco` matrix row (the `isaac-4096` fleet-driver caveat remains, out of scope per the issue). Also removes two stray `</content></invoke>` artifact lines that had landed at the end of the file.
- `examples/README.md` - index rows for both drivers.

### Library fixes surfaced by re-validation (the #1536 lesson, issue requirement 2)

Re-running the drivers against the CURRENT library API on GPU surfaced four defects, each fixed with pinned regression tests:

1. **`send_action` rejected every GR00T action since #1179 (silent `success_rate=0`).** The #1179 up-front scalar validation in `_coerce_action` rejects any sequence-typed dict value - including the length-1 lists the `Policy.get_actions -> list[dict]` contract emits for 1-DOF keys. GR00T's service unpack produces exactly that shape for the LIBERO delta-EEF layout (`{"x": [0.05], "y": [-0.08], ...}`), so every `send_action` in a GR00T LIBERO eval returned a structured error, no action ever reached the adapter's OSC controller, and the benchmark silently no-opped to `success_rate=0.00` on a green exit-0 run. Single-element sequence/array values are now unwrapped to their scalar before validation/apply; multi-element values (the actual #1179 crash class) stay rejected atomically, and a sized-but-unindexable value (a set) gets a structured error rather than a crash. Shared `base.py` fix, applies to MuJoCo + Newton. Pinned by `TestSendActionSingleElementUnwrap` (6 tests).
2. **Public `LiberoAdapter.ensure_scene()`** (issue requirement 3). The robots-sim originals called the private `_generate_scene_from_bddl()` for the pre-recording scene warm-up. `ensure_scene()` is the public equivalent: idempotent, stores + returns the resolved `scene_path`, and (unlike the lazy warn-and-fall-back path inside `on_episode_start`) propagates generation failures loudly. `on_episode_start` now routes through it. Pinned by `tests/benchmarks/libero/test_libero_ensure_scene.py` (7 tests), including a no-private-API source check on both drivers.
3. **Camera-recording MP4 flush violated its never-raise contract on mixed frame sizes.** The LIBERO per-episode scene reload re-installs the wrist camera at different dimensions mid-recording; imageio's `append_data` then raised `ValueError: All images in a movie should have same size` out of `stop_cameras_recording`, aborting the caller's teardown. The flush now encodes the dominant-size run and reports `frames_skipped_size_mismatch` / `flush_error` in the structured result. (Observed live: 1/3000 frames skipped per GR00T run.) Pinned by `TestFlushMixedFrameSizes` (3 tests).
4. **`gr00t_inference` checkpoint-download idempotency probe keyed on the wrong dir.** With `hf_subfolder` set, a shared cache holding a *different* sub-checkpoint (e.g. `libero_spatial/` when `libero_10` was requested) short-circuited the download, so the container started against a missing checkpoint path and the model never loaded (readiness gate timeout). The probe now targets `local_dir/<hf_subfolder>`. Pinned by 2 tests in `TestDownloadCheckpoint`.

### Drift-pinning tests (issue requirement on import smoke)

`tests/test_examples_libero_drivers.py` (7 tests): import smoke for both MuJoCo drivers + the matrix, helper-surface pins (`_date_dir` / `_suite_for_task`, which `run_isaac.py` cross-references), byte-compat of the result line with `libero_backend_matrix._RE_RESULT` (requirement 4), the `mujoco` matrix-row wiring, the no-private-scene-generation source check, and signature pins for every library symbol the drivers call (`evaluate_benchmark`, `start_cameras_recording`, `gr00t_inference` lifecycle kwargs, `ensure_scene`/`prewarm`).

## Acceptance criteria (from #1538)

- [x] `python examples/libero/run_mujoco.py --policy mock --n-episodes 5` runs green on a GPU-less host (verified: 72.3 s, both grep-stable lines emitted)
- [x] `python examples/libero/libero_backend_matrix.py` flips the `mujoco` row from `unavailable` to a real result (verified: `mujoco 0.00 30.2s ok` alongside `isaac-1 skip` / `isaac-4096 unavailable`)
- [x] Import smoke tests covering the new files so example/library drift fails CI
- [x] Private-API call flagged and resolved: drivers use the new public `ensure_scene()`, enforced by test
- [x] Grep-stable result lines byte-compatible with `_RE_RESULT`, enforced by test
- [x] README caveat updated for the MuJoCo row
- [x] Conventions: no per-dir requirements/pyproject; install line in README; `examples/README.md` index rows; no residual robots-sim issue refs

## End-to-end verification (GPU, 4x L4 + Docker)

- `--policy groot --n-episodes 5 --seed 42` on `libero-10-LIVING_ROOM_SCENE5_put_the_white_mug_...`: **success_rate=0.80 (4/5) in 165.0 s**, full auto-orchestrated lifecycle (container build reuse, sub-checkpoint download skip, readiness gate, teardown). The driver docstring's verification section is updated to this run (the robots-sim-era 5/5 numbers predate library changes).
- `run_mujoco_agent.py --policy mock --n-episodes 2` with a Bedrock provider: agent made exactly one `evaluate_benchmark` tool call and reported the success rate (38.5 s).
- Pre-fix baseline for library fix 1: same groot command scored 0.00 with the robot frozen after the first settle - the regression class this PR's `send_action` fix + tests pin against.

## Test surface

`hatch run lint` clean; `hatch run test`: **11161 passed, 239 skipped** (was 11155; +18 new tests, net of parametrization). Full suite run with `MUJOCO_GL=egl` - without a GL backend override the suite aborts in `test_remote_policy_sim_rollout` on this headless box (pre-existing environmental, not introduced here).

## Out of scope / follow-ups

- `run_isaac_fleet.py` (the `isaac-4096` matrix row) remains unmigrated, per the issue's explicit scoping; the README caveat for it is retained.
- The `success_rate=0` silent no-op mode (every `send_action` erroring while `evaluate_benchmark` still exits green) suggests the runner's total-failure fail-fast probe did not trip on the coerce-reject path; worth a follow-up issue if maintainers agree.

Project board: please move #1538 to "In review" (or I can via `gh project item-edit`).
