### PR TITLE
test(streaming): pin repo_type='bucket' fail-fast is robust to unresolvable lerobot version metadata

### DIFF
--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -94,6 +94,41 @@ def test_repo_type_bucket_raises_when_unsupported(monkeypatch):
         sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
 
 
+def test_lerobot_version_unknown_when_metadata_unresolvable(monkeypatch):
+    """_lerobot_version() degrades to 'unknown' instead of raising when the
+    installed-distribution metadata for lerobot cannot be resolved (e.g. a
+    source checkout without dist-info). The value only ever enriches an error
+    message, so a PackageNotFoundError here must not escape."""
+    import importlib.metadata as md
+
+    def _raise(_name):
+        raise md.PackageNotFoundError("lerobot")
+
+    monkeypatch.setattr(md, "version", _raise)
+    assert sd._lerobot_version() == "unknown"
+
+
+def test_bucket_guard_message_survives_unresolvable_lerobot_version(monkeypatch):
+    """The repo_type='bucket' fail-fast must surface as the actionable
+    RuntimeError even when lerobot's version metadata is unresolvable: the
+    version lookup that enriches the message must not raise a secondary
+    PackageNotFoundError that masks the primary, upgrade-actionable error."""
+    import importlib.metadata as md
+
+    class _Narrow:
+        def __init__(self, repo_id):
+            raise AssertionError("constructor must never be reached")
+
+    def _raise(_name):
+        raise md.PackageNotFoundError("lerobot")
+
+    monkeypatch.setattr(md, "version", _raise)
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+    with pytest.raises(RuntimeError, match=r"installed: unknown") as exc:
+        sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+    assert "repo_type='bucket' requires lerobot>=0.6.1" in str(exc.value)
+
+
 def test_repo_type_bucket_forwarded_via_var_kwargs(monkeypatch):
     """A constructor with **kwargs accepts repo_type; the guard must not fire."""
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)


### PR DESCRIPTION
## Problem

`StreamingDatasetReader.open(..., repo_type="bucket")` fails fast on a lerobot whose `StreamingLeRobotDataset` does not accept `repo_type`, and enriches that `RuntimeError` with the installed lerobot version:

```python
raise RuntimeError(
    f"repo_type={repo_type!r} requires lerobot>=0.6.1 "
    f"(installed: {_lerobot_version()}): ..."
)
```

`_lerobot_version()` deliberately degrades to `"unknown"` when `importlib.metadata` cannot resolve lerobot's distribution (e.g. a source checkout without dist-info) so a secondary `PackageNotFoundError` never masks the primary, upgrade-actionable error. That fallback branch (`streaming_dataset.py` lines 86-87) was untested — the module sat at 98%, and the existing `repo_type='bucket'` test only exercised the path with resolvable metadata.

## Change

Test-only. Two focused regression tests in `tests/test_streaming_dataset.py`:

- `test_lerobot_version_unknown_when_metadata_unresolvable` — `_lerobot_version()` returns `"unknown"` instead of raising when `importlib.metadata.version` raises `PackageNotFoundError`.
- `test_bucket_guard_message_survives_unresolvable_lerobot_version` — the observable contract: with metadata unresolvable, `open(repo_type="bucket")` still raises the actionable `RuntimeError` (message intact, `installed: unknown`) rather than a `PackageNotFoundError` that would mask it.

Both tests **fail** if the `except (ImportError, PackageNotFoundError)` fallback is removed (verified: the observable test then raises `PackageNotFoundError` from inside the error-message construction, masking the real guidance).

## Verification

- `streaming_dataset.py` coverage 98% -> 100%.
- `tests/test_streaming_dataset.py`: 49 passed.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` — no issues in 821 source files.

No behavior change (no code touched), so no docs or asset updates apply.