### PR TITLE
test(policies/lerobot_async): pin the offline fallback when lerobot's async constants are unimportable

### DIFF
--- a/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
+++ b/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
@@ -20,6 +20,7 @@ assertion here fails on pre-fix code.
 from __future__ import annotations
 
 import pickle
+import sys
 import time
 from concurrent import futures
 
@@ -507,6 +508,23 @@ def test_fallback_is_a_faithful_snapshot_of_lerobot() -> None:
         "_SUPPORTED_POLICY_TYPES_FALLBACK drifted from lerobot's SUPPORTED_POLICIES; "
         "update the fallback tuple to match the current lerobot constant."
     )
+
+
+def test_supported_policy_types_falls_back_when_lerobot_constants_unimportable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail-soft: an unimportable lerobot constants module yields the snapshot.
+
+    ``_supported_policy_types`` sources the servable set live from
+    ``lerobot.async_inference.constants.SUPPORTED_POLICIES``. If lerobot moves or
+    renames that module (a real risk when tracking lerobot from source), the
+    client must degrade to :data:`_SUPPORTED_POLICY_TYPES_FALLBACK` rather than
+    raise at import time - otherwise merely importing the provider would crash.
+    The ``None`` sentinel in ``sys.modules`` forces the ``from ... import`` to
+    raise ``ImportError`` even though lerobot is installed here.
+    """
+    monkeypatch.setitem(sys.modules, "lerobot.async_inference.constants", None)
+    assert async_policy._supported_policy_types() == async_policy._SUPPORTED_POLICY_TYPES_FALLBACK
 
 
 def test_validation_tracks_a_newly_added_lerobot_policy(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

`_supported_policy_types()` in `strands_robots/policies/lerobot_async/policy.py` sources the set of servable policy types live from `lerobot.async_inference.constants.SUPPORTED_POLICIES`, and is meant to degrade to the offline snapshot `_SUPPORTED_POLICY_TYPES_FALLBACK` when that import fails:

```python
try:
    from lerobot.async_inference.constants import SUPPORTED_POLICIES
except (ImportError, AttributeError):
    return _SUPPORTED_POLICY_TYPES_FALLBACK
return tuple(sorted(SUPPORTED_POLICIES))
```

The existing drift-guard suite covers the live path, the snapshot-in-sync invariant, and a newly-added type, but never exercises the fail-soft branch itself. Every one of those tests `pytest.importorskip`s / skips when lerobot is absent, so with lerobot installed the `except` arm and its fallback `return` are never executed and stay unpinned. This is the one branch that matters most when tracking lerobot's fast-moving API: if lerobot moves or renames `async_inference.constants`, merely importing the provider (which computes `SUPPORTED_POLICY_TYPES = _supported_policy_types()` at module import) must not crash.

## Change

Add one focused regression test in the existing drift-guard section that forces the `from ... import` to raise `ImportError` via a `None` sentinel in `sys.modules` (works even though lerobot is installed) and asserts `_supported_policy_types()` returns `_SUPPORTED_POLICY_TYPES_FALLBACK`.

## Tests

- `test_supported_policy_types_falls_back_when_lerobot_constants_unimportable` covers the previously-unreached `except`/fallback lines.
- Regression-verified: removing the `except (ImportError, AttributeError)` arm makes the test fail with `ModuleNotFoundError` (import of the sentinel-poisoned module propagates); it passes with the fail-soft branch present.
- Full `lerobot_async` suite: 26 passed.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues.

Test-only change; no runtime behavior change.