### PR TITLE
test(tools/lerobot_train): pin expert-only offline fallback + snapshot drift guard

### DIFF
--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -194,6 +194,48 @@ def test_expert_only_policy_types_tracks_lerobot_registry() -> None:
     assert "pi0_fast" not in expected
 
 
+def test_expert_only_fallback_is_a_faithful_snapshot_of_lerobot() -> None:
+    """The static offline snapshot stays in sync with lerobot; drift trips this.
+
+    ``_EXPERT_ONLY_POLICIES_FALLBACK`` is only consulted when lerobot is not
+    importable, so a policy that gains or loses a ``train_expert_only`` field in
+    lerobot would silently diverge from the snapshot and hand offline callers a
+    stale set. Pinning equality here surfaces that drift the moment it happens.
+    """
+    import dataclasses
+
+    pytest.importorskip("lerobot.policies")
+    PreTrainedConfig = pytest.importorskip("lerobot.configs.policies").PreTrainedConfig
+    expected = {
+        name
+        for name, cfg_cls in PreTrainedConfig.get_known_choices().items()
+        if any(f.name == "train_expert_only" for f in dataclasses.fields(cfg_cls))
+    }
+    assert set(train_mod._EXPERT_ONLY_POLICIES_FALLBACK) == expected, (
+        "_EXPERT_ONLY_POLICIES_FALLBACK drifted from lerobot's expert-only policy "
+        "configs; update the fallback frozenset to match the current lerobot."
+    )
+
+
+def test_expert_only_policy_types_falls_back_when_lerobot_unimportable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail-soft: an unimportable lerobot yields the static snapshot, not a crash.
+
+    ``_expert_only_policy_types`` sources the supported set live from lerobot's
+    ``PreTrainedConfig`` registry. If lerobot moves or renames those modules (a
+    real risk when tracking lerobot from source), the tool must degrade to
+    :data:`_EXPERT_ONLY_POLICIES_FALLBACK` rather than raise - otherwise a stale
+    lerobot would break ``train_expert_only`` validation for every policy. The
+    ``None`` sentinel in ``sys.modules`` forces ``import lerobot.policies`` to
+    raise ``ImportError`` even though lerobot is installed here.
+    """
+    import sys
+
+    monkeypatch.setitem(sys.modules, "lerobot.policies", None)
+    assert train_mod._expert_only_policy_types() == train_mod._EXPERT_ONLY_POLICIES_FALLBACK
+
+
 def test_val_episodes_reserves_last_n_episodes(tmp_path: Path) -> None:
     root = _write_dataset(tmp_path / "ds", total_episodes=10)
     cmd = build_train_command(


### PR DESCRIPTION
## Problem

`_expert_only_policy_types()` in `strands_robots.tools.lerobot_train` sources the set of policy families that accept `--policy.train_expert_only` **live** from lerobot's `PreTrainedConfig` registry (the configs that declare a `train_expert_only` field), falling back to the static `_EXPERT_ONLY_POLICIES_FALLBACK` snapshot (`pi0`, `pi05`, `smolvla`) when lerobot is not importable.

Two behaviors of that design were unpinned:

1. **The fail-soft fallback branch was never executed.** lerobot is always installed in CI, so the `except -> return snapshot` path had no coverage. A regression that turned the fallback into a hard error (e.g. letting the `ImportError` escape) would import-crash the tool for anyone running without the training extra, and no test would catch it.
2. **Nothing guarded the snapshot against drift.** The existing `test_expert_only_policy_types_tracks_lerobot_registry` pins the *live* result but not the *static* constant, so `_EXPERT_ONLY_POLICIES_FALLBACK` could silently rot as lerobot adds or removes expert-only policies, handing offline callers a stale set.

## Change

Test-only. Adds two focused tests to `tests/tools/test_lerobot_train.py`, mirroring the pinned pattern already established for the async inference provider's supported-policy set (`_supported_policy_types` / `_SUPPORTED_POLICY_TYPES_FALLBACK`):

- `test_expert_only_policy_types_falls_back_when_lerobot_unimportable` - a `sys.modules` `None` sentinel forces `import lerobot.policies` to raise `ImportError` even though lerobot is installed, and asserts the function degrades to `_EXPERT_ONLY_POLICIES_FALLBACK` instead of raising. This exercises the previously-uncovered fail-soft branch.
- `test_expert_only_fallback_is_a_faithful_snapshot_of_lerobot` - asserts the static snapshot equals the live lerobot-derived set, so any drift trips the test with an actionable message.

No production code changes; the tests document and lock the existing contract.

## Verification

- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - clean
- `mypy strands_robots tests tests_integ` - Success, no issues in 821 source files
- Full suite (hardware markers deselected): 11063 passed, 236 skipped
- Confirmed the fallback branch is now covered (the offline-fallback lines moved out of the module's `--cov-report=term-missing` gap).