### PR TITLE
test(policies/lerobot_local): pin register_pack_state_step fail-soft when processor framework is absent

### DIFF
--- a/tests/policies/lerobot_local/test_pack_state_step_processor_degradation.py
+++ b/tests/policies/lerobot_local/test_pack_state_step_processor_degradation.py
@@ -1,0 +1,30 @@
+"""Pin the optional-dependency degradation contract of ``register_pack_state_step``.
+
+``strands_robots.policies.lerobot_local.embodiment.register_pack_state_step``
+defines and registers the ``strands_pack_state`` processor step against
+lerobot's processor framework. Its documented contract is to return ``None``
+(rather than raise) when that framework is unavailable, so a light install that
+lacks lerobot's ``processor.pipeline`` module still imports and operates without
+crashing. The full processor stack is always present in the test environment,
+so this graceful-degradation branch is otherwise never exercised; this test
+forces the import to fail and asserts the fail-soft contract.
+"""
+
+import logging
+import sys
+
+from strands_robots.policies.lerobot_local.embodiment import register_pack_state_step
+
+
+def test_register_pack_state_step_returns_none_when_processor_framework_absent(monkeypatch, caplog):
+    """A missing ``lerobot.processor.pipeline`` degrades to ``None``, never a raise."""
+    # Force the in-function ``from lerobot.processor.pipeline import ...`` to
+    # raise ImportError. setitem(..., None) makes Python's import machinery
+    # treat the submodule as unimportable; monkeypatch reverts it after the test.
+    monkeypatch.setitem(sys.modules, "lerobot.processor.pipeline", None)
+
+    with caplog.at_level(logging.DEBUG, logger="strands_robots.policies.lerobot_local.embodiment"):
+        result = register_pack_state_step()
+
+    assert result is None
+    assert any("processor framework unavailable" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## What
Add a regression test pinning the optional-dependency degradation contract of `register_pack_state_step` in `strands_robots/policies/lerobot_local/embodiment.py`.

## Why
`register_pack_state_step` defines and registers the `strands_pack_state` processor step against lerobot's processor framework. Its docstring documents that it returns `None` (rather than raising) when that framework is unavailable, so a light install without `lerobot.processor.pipeline` still imports and operates without crashing.

The full processor stack is always present in the test environment, so the `ImportError` degradation branch (`embodiment.py` lines 294-296) was never exercised. That leaves the fail-soft contract that lightweight installs rely on unprotected by tests.

## Change
A single behavior-focused test that forces the in-function `from lerobot.processor.pipeline import ...` to raise `ImportError` via `monkeypatch.setitem(sys.modules, "lerobot.processor.pipeline", None)`, then asserts the contract:
- returns `None` (no raise), and
- logs a debug breadcrumb rather than failing silently.

`monkeypatch.setitem` auto-reverts the injected module after the test, so no global state leaks to other tests.

## Verification
- New test passes; it covers previously-missing `embodiment.py:294-296` (module 99% -> 100%).
- `tests/policies/lerobot_local/` full package: 579 passed.
- `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ`: no issues in 822 source files.

Test-only change; no runtime behavior is modified.