### PR TITLE
feat(sim/isaac): IsaacRecordingMixin - LeRobotDataset recording parity with MuJoCo/Newton (closes #1550)

### DIFF
--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -1,0 +1,498 @@
+"""Isaac recording mixin - LeRobotDataset schema declaration + per-step capture.
+
+The engine-independent recording lifecycle (``stop_recording`` /
+``save_episode`` / ``get_recording_status`` / ``stream_dataset`` and the
+``_is_recording`` / ``_active_recorder`` / ``_active_dataset_root`` overrides)
+lives in :class:`~strands_robots.simulation.recording.DatasetRecordingMixin`,
+which is backend-agnostic. This subclass adds the two Isaac-specific halves:
+
+* :meth:`start_recording` declares the dataset schema from the live Isaac
+  scene - joint names from every robot (namespaced for multi-robot scenes) and
+  the RTX cameras registered via ``add_camera``, each at the resolution its
+  render product actually produces (probed from one ``get_observation`` call,
+  because RTX cameras render at a DLSS-safe native size that can differ from
+  the requested output size).
+* :meth:`_make_run_policy_hook` returns the ``on_frame`` closure the shared
+  :class:`~strands_robots.simulation.base.SimEngine` run-policy loop calls
+  every control step. Unlike the MuJoCo/Newton hooks it does not render:
+  Isaac's ``get_observation`` already carries a fresh RGB frame per camera
+  (refreshing every RTX render product first when more than one camera exists,
+  so multi-cam recordings never capture a stale secondary product), and
+  ``IsaacSimulation.get_observation`` forces images on while a recording is
+  active even when the driving policy sets ``requires_images = False``.
+
+**State seam**: Isaac's ``self._world`` is the Isaac Sim ``World`` handle, not
+the :class:`~strands_robots.simulation.models.SimWorld` the shared mixin's
+default accessor expects, so :meth:`_recording_state` overrides the seam to
+return the engine-owned ``self._recording_state_dict`` instead. Everything
+else in the shared lifecycle runs unchanged.
+
+**Pacing**: the recorded ``fps`` is dataset metadata; the actual frame cadence
+is ``run_policy(control_frequency=...)`` (one recorded frame per control
+step). The RTX renderer produces new frames at ``IsaacConfig.rendering_dt``
+(default 1/30 s), so a control frequency above ``1 / rendering_dt`` records
+duplicate frames from the same render product. For distinct per-step images
+keep ``control_frequency <= 1 / rendering_dt`` and set ``fps`` to match the
+control frequency.
+
+**Threading**: schema declaration probes ``get_observation`` once. When the
+main-thread pump (:meth:`IsaacSimulation.run_pump_forever`) owns the renderer
+and ``start_recording`` is called from a worker thread (a Gradio-style host),
+that probe is routed through :meth:`IsaacSimulation.run_on_main` so the RTX
+render-product refresh never runs off the owning thread. Per-step capture
+rides the ``run_policy`` thread's own ``get_observation`` calls, which hosts
+already route via ``run_on_main`` when driving rollouts from worker threads.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from strands_robots.simulation.recording import DatasetRecordingMixin
+
+if TYPE_CHECKING:
+    import threading
+
+    from strands_robots.simulation.isaac.config import IsaacConfig
+
+logger = logging.getLogger(__name__)
+
+
+class IsaacRecordingMixin(DatasetRecordingMixin):
+    """Isaac dataset recording mixed into :class:`IsaacSimulation`.
+
+    Inherits the engine-independent lifecycle from
+    :class:`DatasetRecordingMixin` and supplies the Isaac-specific state seam
+    (:meth:`_recording_state`), schema declaration (:meth:`start_recording`)
+    and per-step capture hook (:meth:`_make_run_policy_hook`).
+    """
+
+    if TYPE_CHECKING:
+        _world_created: bool
+        _robots: dict[str, Any]
+        _cameras: dict[str, Any]
+        _config: IsaacConfig
+        _lock: threading.RLock
+        _sim_time: float
+        _pump_running: bool
+        _recording_state_dict: dict[str, Any]
+
+        def robot_action_keys(self, robot_name: str) -> list[str]:
+            """Actuator-ordered action keys (concrete on SimEngine)."""
+
+        def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, Any]:
+            """Type-only stub for the engine-provided observation method."""
+
+        def run_on_main(self, fn: Any, timeout: float | None = None) -> Any:
+            """Type-only stub for the engine-provided main-thread executor."""
+
+        def _on_main_thread(self) -> bool:
+            """Type-only stub for the engine-provided thread check."""
+
+    def _recording_state(self) -> dict[str, Any] | None:
+        """Engine-owned recording-state dict (the Isaac state seam).
+
+        Overrides :meth:`DatasetRecordingMixin._recording_state`: Isaac's
+        ``self._world`` is the Isaac Sim ``World`` handle (no
+        ``_backend_state``), so the recording flag / trajectory mirror /
+        recorder handle live in ``self._recording_state_dict`` instead
+        (initialised in ``IsaacSimulation.__init__`` and reset by
+        ``destroy``). Returns ``None`` before ``create_world`` so the shared
+        lifecycle reports the documented no-world responses.
+        """
+        if not getattr(self, "_world_created", False):
+            return None
+        return self._recording_state_dict
+
+    def start_recording(
+        self,
+        repo_id: str = "local/sim_recording",
+        task: str = "",
+        fps: int = 30,
+        root: str | None = None,
+        push_to_hub: bool = False,
+        vcodec: str = "h264",
+        overwrite: bool = False,
+        cameras: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Start recording the Isaac scene to LeRobotDataset format.
+
+        Declares the dataset schema from the live scene - joint names from
+        every robot (namespaced ``robot__joint`` when more than one robot is
+        present, matching the MuJoCo/Newton backends), action columns from
+        :meth:`robot_action_keys`, and the RTX cameras registered via
+        ``add_camera``. Camera resolutions are probed from one
+        ``get_observation`` call because RTX cameras render at a DLSS-safe
+        native size that can exceed the requested output size; declaring the
+        probed shape keeps ``add_frame`` from rejecting every image. Per-step
+        frames are then captured by the ``on_frame`` hook
+        (:meth:`_make_run_policy_hook`) during ``run_policy``.
+
+        In ``render_mode="headless"`` no RTX frames exist, so the dataset
+        records joint state and action only (a valid proprio-only LeRobot
+        dataset); a warning is logged when cameras are registered but cannot
+        be recorded. Use ``render_mode="rtx_realtime"`` (or pathtracing) for
+        camera columns.
+
+        Pacing: ``fps`` is dataset metadata - the actual cadence is one frame
+        per ``run_policy`` control step, and the renderer produces new frames
+        at ``IsaacConfig.rendering_dt`` (default 1/30 s). Keep
+        ``control_frequency <= 1 / rendering_dt`` and ``fps`` equal to the
+        control frequency for temporally-faithful video.
+
+        Requires the ``lerobot`` extra for the dataset schema.
+
+        Args:
+            repo_id: HuggingFace dataset id (``owner/name``) or a local path.
+            task: Default task description recorded with every frame.
+            fps: Recording frame rate (metadata; see pacing note above).
+            root: Explicit on-disk dataset directory (overrides the repo_id
+                cache-path resolution).
+            push_to_hub: Publish to the Hub at ``stop_recording``.
+            vcodec: Video codec for the per-camera MP4 streams. Defaults to
+                "h264" (H.264), universally decodable including by OpenCV's
+                VideoCapture. Use "libsvtav1" (AV1) for smaller files;
+                LeRobot read-back handles AV1 but OpenCV wheels commonly
+                cannot decode it and silently yield 0 frames.
+            overwrite: Wipe and recreate an existing dataset dir instead of
+                appending to it.
+            cameras: Camera names to record into the dataset. When ``None``
+                (default) every registered RTX camera is recorded. Pass a
+                subset to scope the dataset to exactly those views - matching
+                the MuJoCo/Newton backends so ``run_policy(dataset_cameras=...)``
+                behaves identically across engines. Names may be given in
+                either the raw camera name or the schema-safe form (``/``
+                collapsed to ``__``); an unknown name fails loudly, listing
+                the available cameras.
+
+        Returns:
+            Standard status dict. ``status="error"`` when no world exists, no
+            robots exist, the ``lerobot`` extra is missing, or recorder init
+            fails.
+        """
+        state = self._recording_state()
+        if state is None:
+            return {"status": "error", "content": [{"text": "No world created. Call create_world() first."}]}
+        if not self._robots:
+            return {
+                "status": "error",
+                "content": [{"text": "No robots in the world. Call add_robot() before start_recording()."}],
+            }
+
+        _DatasetRecorder: Any = None
+        _has_lerobot = False
+        try:
+            from strands_robots.dataset_recorder import DatasetRecorder as _DatasetRecorder
+            from strands_robots.dataset_recorder import has_lerobot_dataset as _check_lerobot
+
+            _has_lerobot = _check_lerobot()
+        except ImportError:
+            # lerobot extra not installed; handled by the _has_lerobot guard below.
+            pass
+
+        if not _has_lerobot or _DatasetRecorder is None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "start_recording produces a LeRobotDataset (parquet + video) and "
+                            "requires the lerobot extra: pip install 'strands-robots[lerobot]'.\n"
+                            "For plain MP4 video, use start_cameras_recording instead."
+                        )
+                    }
+                ],
+            }
+
+        # Probe one observation to learn each camera's real produced
+        # resolution BEFORE taking the lock: when the main-thread pump owns
+        # the renderer and this runs on a worker thread, the probe must run
+        # on the pump thread (run_on_main), and holding self._lock across
+        # that handoff would deadlock against the probe re-acquiring it.
+        probe_obs = self._probe_recording_observation()
+
+        with self._lock:
+            state["recording"] = True
+            state["trajectory"] = []
+            state["push_to_hub"] = push_to_hub
+
+            # Resolve the on-disk dataset dir with the same resolver
+            # DatasetRecorder.create() uses (honours $HF_LEROBOT_HOME) and
+            # stash it so verify_dataset_episodes can find the parquet after
+            # stop_recording drops the recorder.
+            from strands_robots.dataset_recorder import resolve_dataset_dir
+
+            dataset_dir = resolve_dataset_dir(repo_id, root)
+            state["last_dataset_root"] = str(dataset_dir)
+
+            try:
+                # Create-vs-resume semantics shared with MuJoCo/Newton: resume
+                # an existing dataset, clear a pre-existing EMPTY root, wipe on
+                # overwrite. See DatasetRecordingMixin._prepare_dataset_target.
+                resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
+
+                (
+                    joint_names,
+                    action_names,
+                    camera_keys,
+                    camera_dims,
+                    robot_type,
+                    recording_cameras,
+                ) = self._collect_recording_schema(probe_obs)
+
+                # Optional camera scoping (parity with MuJoCo/Newton). Names
+                # may be raw (``arm0/wrist``) or schema-safe (``arm0__wrist``);
+                # an unknown name fails loudly listing what exists.
+                if cameras is not None:
+                    raw_to_safe = {src: safe for src, safe, _w, _h in recording_cameras}
+                    safe_to_raw = {safe: src for src, safe in raw_to_safe.items()}
+                    selected_safe: list[str] = []
+                    selected_raw: set[str] = set()
+                    unknown: list[str] = []
+                    for requested in cameras:
+                        if requested in raw_to_safe:  # raw camera name
+                            raw, safe = requested, raw_to_safe[requested]
+                        elif requested in safe_to_raw:  # already schema-safe
+                            raw, safe = safe_to_raw[requested], requested
+                        else:
+                            unknown.append(requested)
+                            continue
+                        if safe not in selected_safe:
+                            selected_safe.append(safe)
+                            selected_raw.add(raw)
+                    if unknown:
+                        state["recording"] = False
+                        available = sorted(raw_to_safe)
+                        return {
+                            "status": "error",
+                            "content": [
+                                {
+                                    "text": (
+                                        f"start_recording: unknown camera(s) {unknown} in cameras=. "
+                                        f"Available scene cameras: {available}. Add them with "
+                                        "add_camera(...) before recording, or omit cameras= to "
+                                        "record all of them."
+                                    )
+                                }
+                            ],
+                        }
+                    camera_keys = selected_safe
+                    camera_dims = {safe: camera_dims[safe] for safe in selected_safe}
+                    recording_cameras = [tpl for tpl in recording_cameras if tpl[0] in selected_raw]
+
+                state["recording_cameras"] = recording_cameras
+
+                if resume_existing:
+                    logger.info("Resuming existing dataset for append: %s", dataset_dir)
+                    resumed = _DatasetRecorder.resume(repo_id=repo_id, root=root, task=task, vcodec=vcodec)
+                    self._verify_resume_schema(resumed, joint_names, camera_keys, camera_dims, action_names)
+                    state["dataset_recorder"] = resumed
+                else:
+                    state["dataset_recorder"] = _DatasetRecorder.create(
+                        repo_id=repo_id,
+                        fps=fps,
+                        robot_type=robot_type,
+                        joint_names=joint_names,
+                        action_names=action_names,
+                        camera_keys=camera_keys,
+                        camera_dims=camera_dims,
+                        task=task,
+                        root=root,
+                        vcodec=vcodec,
+                        video_width=int(self._config.camera_width),
+                        video_height=int(self._config.camera_height),
+                    )
+                return {
+                    "status": "success",
+                    "content": [
+                        {
+                            "text": (
+                                f"Recording Isaac scene to LeRobotDataset: {repo_id}\n"
+                                f"{len(joint_names)} joints, {len(camera_keys)} cameras @ {fps}fps\n"
+                                f"Codec: {vcodec} | Task: {task or '(set per policy)'}\n"
+                                f"Run policies to capture frames, then stop_recording to save the episode"
+                            )
+                        }
+                    ],
+                }
+            except Exception as e:
+                state["recording"] = False
+                logger.error("Dataset recorder init failed: %s", e)
+                return {"status": "error", "content": [{"text": f"Dataset init failed: {e}"}]}
+
+    def _probe_recording_observation(self) -> dict[str, Any]:
+        """One ``get_observation`` probe used to size the camera schema.
+
+        RTX cameras render at a DLSS-safe native resolution that can exceed
+        the requested output size (see ``add_camera``), and ``get_observation``
+        returns frames at that native size - so the schema must declare the
+        shape the observation stream actually produces, not the requested one.
+        Routed through :meth:`run_on_main` when the main-thread pump owns the
+        renderer and the caller is a worker thread (Gradio-style hosts), since
+        the multi-camera render-product refresh may only run on the owning
+        thread. In headless render mode the probe returns no images and the
+        schema falls back to proprio-only.
+        """
+        first_robot = next(iter(self._robots))
+        if getattr(self, "_pump_running", False) and not self._on_main_thread():
+            return self.run_on_main(lambda: self.get_observation(robot_name=first_robot))
+        return self.get_observation(robot_name=first_robot)
+
+    def _collect_recording_schema(
+        self, probe_obs: dict[str, Any]
+    ) -> tuple[list[str], list[str], list[str], dict[str, tuple[int, int]], str, list[tuple[str, str, int, int]]]:
+        """Build the dataset schema from the live Isaac scene.
+
+        Args:
+            probe_obs: One observation from :meth:`_probe_recording_observation`,
+                used to size each camera at the resolution its render product
+                actually emits.
+
+        Returns:
+            A 6-tuple of:
+              * ``joint_names``: ordered state joint ids (namespaced
+                ``robot__joint`` when more than one robot exists).
+              * ``action_names``: actuator-ordered action column names
+                (namespaced like the joints).
+              * ``camera_keys``: sanitized camera feature names (``/`` -> ``__``).
+              * ``camera_dims``: map of camera feature name -> ``(height, width)``.
+              * ``robot_type``: the dataset ``robot_type`` string.
+              * ``recording_cameras``: per-camera ``(source_name, safe_name,
+                width, height)`` tuples the on_frame hook maps observation
+                keys through each step.
+        """
+        joint_names: list[str] = []
+        action_names: list[str] = []
+        robot_type = "unknown"
+        multi_robot = len(self._robots) > 1
+        for rname, robot in self._robots.items():
+            if multi_robot:
+                joint_names.extend(f"{rname}__{jn}" for jn in robot.joint_names)
+                action_names.extend(f"{rname}__{ak}" for ak in self.robot_action_keys(rname))
+            else:
+                joint_names.extend(robot.joint_names)
+                action_names.extend(self.robot_action_keys(rname))
+            robot_type = getattr(robot, "data_config", None) or rname
+
+        camera_keys: list[str] = []
+        camera_dims: dict[str, tuple[int, int]] = {}
+        recording_cameras: list[tuple[str, str, int, int]] = []
+        if self._config.render_mode == "headless" and self._cameras:
+            # get_observation never emits frames in headless render mode, so a
+            # camera column would record nothing. Warn loudly and record a
+            # proprio-only dataset rather than silently declaring dead columns.
+            logger.warning(
+                "start_recording: %d camera(s) %s are registered but render_mode='headless' "
+                "produces no RTX frames - recording a proprio-only dataset. Construct the "
+                "sim with render_mode='rtx_realtime' to record camera columns.",
+                len(self._cameras),
+                sorted(self._cameras),
+            )
+            return joint_names, action_names, camera_keys, camera_dims, robot_type, recording_cameras
+
+        for cam_name, cam in self._cameras.items():
+            safe_name = cam_name.replace("/", "__")
+            frame = probe_obs.get(cam_name)
+            if isinstance(frame, np.ndarray) and frame.ndim == 3:
+                height, width = int(frame.shape[0]), int(frame.shape[1])
+            else:
+                # Probe frame unavailable (render product not warmed yet).
+                # Fall back to the camera's native render size, which is what
+                # get_observation emits once the product accumulates a frame.
+                width, height = int(cam.width), int(cam.height)
+                logger.warning(
+                    "start_recording: probe observation carried no frame for camera %r; "
+                    "declaring its native render size %dx%d. If recorded frames arrive at "
+                    "a different resolution, add_frame will reject them - step the sim a "
+                    "few times before start_recording to warm the render product.",
+                    cam_name,
+                    width,
+                    height,
+                )
+            camera_keys.append(safe_name)
+            camera_dims[safe_name] = (height, width)
+            recording_cameras.append((cam_name, safe_name, width, height))
+        return joint_names, action_names, camera_keys, camera_dims, robot_type, recording_cameras
+
+    def _make_run_policy_hook(self, robot_name: str, instruction: str) -> Any:
+        """Build the per-step ``on_frame`` recording hook for Isaac.
+
+        Returns an ``on_frame(step, observation, action)`` closure that, while
+        a recording session is active, appends a step to the trajectory mirror
+        and forwards the frame to the active
+        :class:`~strands_robots.dataset_recorder.DatasetRecorder`. Camera
+        frames are consumed from the observation itself (Isaac's
+        ``get_observation`` carries a fresh RGB frame per camera and refreshes
+        every RTX render product when more than one camera exists, so
+        multi-cam recordings never duplicate a stale secondary product) and
+        renamed to their schema-safe names; cameras outside the
+        ``start_recording(cameras=...)`` scope are dropped. In multi-robot
+        scenes scalar observation/action keys are namespaced
+        (``robot__joint``) to match the declared schema.
+
+        Returns ``None`` when there is no world or the robot is unknown, so
+        the base run-policy loop runs without recording.
+        """
+        import time
+
+        from strands_robots.simulation.models import TrajectoryStep
+
+        state = self._recording_state()
+        if state is None or robot_name not in self._robots:
+            return None
+
+        robot = self._robots[robot_name]
+        robot.policy_running = True
+        robot.policy_instruction = instruction
+        robot.policy_steps = 0
+        multi_robot = len(self._robots) > 1
+
+        def _hook(step: int, observation: dict[str, Any], action: dict[str, Any]) -> None:
+            robot.policy_steps = step + 1
+            if not state.get("recording", False):
+                return
+            rec = state.get("dataset_recorder")
+            if rec is None:
+                return
+
+            # Split the observation: camera ndarrays are renamed raw -> safe
+            # and scoped to the declared recording cameras; scalars feed
+            # observation.state. Resolved per step (not captured at hook build
+            # time) so a start_recording issued after run_policy launched
+            # still scopes correctly.
+            raw_to_safe = {src: safe for src, safe, _w, _h in state.get("recording_cameras", [])}
+            scalars: dict[str, Any] = {}
+            images: dict[str, Any] = {}
+            for k, v in observation.items():
+                if isinstance(v, np.ndarray) and v.ndim >= 2:
+                    safe = raw_to_safe.get(k)
+                    if safe is not None:
+                        images[safe] = v
+                else:
+                    scalars[k] = v
+
+            state["trajectory"].append(
+                TrajectoryStep(
+                    timestamp=time.time(),
+                    sim_time=self._sim_time,
+                    robot_name=robot_name,
+                    observation=scalars,
+                    action=action,
+                    instruction=instruction,
+                )
+            )
+
+            if multi_robot:
+                obs = {f"{robot_name}__{k}": v for k, v in scalars.items()}
+                obs.update(images)
+                act = {f"{robot_name}__{k}": v for k, v in action.items()}
+                rec.add_frame(observation=obs, action=act, task=instruction)
+            else:
+                obs = dict(scalars)
+                obs.update(images)
+                rec.add_frame(observation=obs, action=action, task=instruction)
+
+        return _hook

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -35,6 +35,7 @@ import numpy as np
 
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
 
 logger = logging.getLogger(__name__)
 
@@ -353,11 +354,16 @@ class _RobotState:
         joint_names: list[str],
         articulation: Any = None,
         actual_prim_path: str | None = None,
+        data_config: str | None = None,
     ):
         self.name = name
         self.prim_path = prim_path
         self.joint_names = joint_names
         self.articulation = articulation
+        # Registry data-config the robot was added under (e.g. ``so100``).
+        # Recorded as the LeRobotDataset ``robot_type`` so datasets collected
+        # on Isaac carry the same embodiment metadata as MuJoCo/Newton ones.
+        self.data_config = data_config
         # The prim path the URDF importer / USD reference actually
         # placed the robot at, which can differ from ``prim_path`` when
         # the importer ignores the requested destination (Isaac Sim 4.5
@@ -407,11 +413,15 @@ class _ObjectState:
         self.handle = handle
 
 
-class IsaacSimulation(SimEngine):
+class IsaacSimulation(IsaacRecordingMixin, SimEngine):
     """GPU-native simulation backend built on NVIDIA Isaac Sim.
 
     Implements the ``SimEngine`` ABC. Provides photorealistic rendering,
     RTX sensors, USD scene management, and fleet replication via Cloner.
+    LeRobotDataset recording (``start_recording`` / ``save_episode`` /
+    ``stop_recording`` / ``stream_dataset``) comes from
+    :class:`~strands_robots.simulation.isaac.recording.IsaacRecordingMixin`,
+    matching the MuJoCo and Newton backends.
 
     Parameters
     ----------
@@ -507,6 +517,14 @@ class IsaacSimulation(SimEngine):
         # Synchronous rollout-video recorder state (set by
         # start_cameras_recording, cleared by stop_cameras_recording).
         self._cams_rec_state: dict[str, Any] | None = None
+
+        # LeRobotDataset recording state - the Isaac side of the
+        # DatasetRecordingMixin state seam. MuJoCo/Newton keep this dict on
+        # their SimWorld (``_backend_state``); Isaac's ``self._world`` is the
+        # Isaac Sim World handle, so the engine owns the dict directly and
+        # IsaacRecordingMixin._recording_state() returns it. Reset by
+        # destroy() alongside the rest of the world state.
+        self._recording_state_dict: dict[str, Any] = {}
 
         # Thread safety
         self._lock = threading.RLock()
@@ -893,6 +911,18 @@ class IsaacSimulation(SimEngine):
             # Drop any in-flight recorder state (buffers reference RTX
             # frames that are meaningless after the stage tears down).
             self._cams_rec_state = None
+            # Same for the LeRobotDataset recording session: a live recorder
+            # holds an OPEN LeRobot episode buffer whose camera frames came
+            # from this stage. Mirror the MuJoCo/Newton behaviour (their
+            # state dict dies with the SimWorld) by resetting the seam dict;
+            # warn when a session was still open so the data loss is visible.
+            if self._recording_state_dict.get("recording", False):
+                logger.warning(
+                    "destroy() called while a dataset recording was active; the unsaved "
+                    "episode buffer is discarded. Call stop_recording() before destroy() "
+                    "to flush and finalize the dataset."
+                )
+            self._recording_state_dict = {}
 
             # Reset state
             self._world_created = False
@@ -1159,6 +1189,7 @@ class IsaacSimulation(SimEngine):
                     name=name,
                     prim_path=prim_path,
                     joint_names=joint_names,
+                    data_config=data_config,
                 )
                 self._robots[name] = robot_state
 
@@ -1210,6 +1241,7 @@ class IsaacSimulation(SimEngine):
                     joint_names=joint_names,
                     articulation=articulation,
                     actual_prim_path=getattr(articulation, "_strands_actual_prim_path", None),
+                    data_config=data_config,
                 )
                 self._robots[name] = robot_state
 
@@ -1273,6 +1305,7 @@ class IsaacSimulation(SimEngine):
                     joint_names=joint_names,
                     articulation=articulation,
                     actual_prim_path=getattr(articulation, "_strands_actual_prim_path", None),
+                    data_config=data_config,
                 )
                 self._robots[name] = robot_state
 
@@ -2107,6 +2140,17 @@ class IsaacSimulation(SimEngine):
             # headless render mode (no RTX frames). Best-effort per camera: a
             # camera whose RTX product hasn't warmed up is omitted rather than
             # failing the whole observation.
+            #
+            # Recording override (parity with MuJoCo/Newton): a non-image
+            # policy (requires_images=False, e.g. the default mock) makes
+            # PolicyRunner pass skip_images=True, but while a dataset
+            # recording is active the recorded frames MUST carry the camera
+            # images the schema declared - so images are forced on for the
+            # duration of the session.
+            if skip_images:
+                rec_state = self._recording_state()
+                if rec_state is not None and rec_state.get("recording", False):
+                    skip_images = False
             if not skip_images and self._config.render_mode != "headless":
                 # Multi-camera refresh: a single ``world.step(render=True)`` in
                 # the substep loop reliably refreshes only the PRIMARY render
@@ -4150,6 +4194,59 @@ class IsaacSimulation(SimEngine):
             UsdGeom.Xformable(fill.GetPrim()).AddRotateXYZOp().Set(Gf.Vec3f(-60.0, 0.0, 180.0))
         except (ImportError, AttributeError, RuntimeError):
             logger.debug("Could not add scene lighting", exc_info=True)
+
+    def describe(self) -> dict[str, Any]:
+        """Return the Isaac engine's live discovery surface.
+
+        Extends the base :meth:`SimEngine.describe` contract with the backend
+        identity, the registered RTX camera names, world state, and the
+        LeRobotDataset recording family
+        (:class:`~strands_robots.simulation.isaac.recording.IsaacRecordingMixin`)
+        so an agent enumerating ``describe()["methods"]`` discovers the
+        record-and-stream workflow (``start_recording`` -> ``run_policy`` ->
+        ``save_episode`` -> ``stop_recording`` -> ``stream_dataset``) exactly
+        as it does on the MuJoCo and Newton backends.
+        """
+        desc = super().describe()
+        desc["backend"] = "isaac"
+        desc["cameras"] = sorted(self._cameras)
+        desc["world_created"] = self._world_created
+        desc["methods"].update(
+            {
+                "add_camera": (
+                    "(name='default', position=None, target=None, width=None, "
+                    "height=None, fov=60.0) -> dict  # register an RTX camera "
+                    "(rendered frames ride get_observation and recordings)"
+                ),
+                "remove_camera": "(name: str) -> dict  # remove a registered RTX camera",
+                "start_recording": (
+                    "(repo_id='local/sim_recording', task='', fps=30, root=None, "
+                    "push_to_hub=False, vcodec='h264', overwrite=False, cameras=None) -> dict  "
+                    "# record joint state + action + RTX cameras to a LeRobotDataset "
+                    "(needs render_mode='rtx_realtime' for camera columns)"
+                ),
+                "save_episode": (
+                    "() -> dict  # flush the current rollout as one episode; prefer "
+                    "run_policy(n_episodes=N) which flushes a boundary per episode"
+                ),
+                "stop_recording": "(push_to_hub=False, bucket=None, run_id=None) -> dict",
+                "get_recording_status": "() -> dict",
+                "stream_dataset": (
+                    "(repo_id: str, **kwargs) -> StreamingDatasetReader  # lazily read a "
+                    "recorded LeRobotDataset back (root=, episodes=, delta_timestamps=, ...)"
+                ),
+                "verify_dataset_episodes": (
+                    "(expected: int) -> dict  # after stop_recording, read the parquet and "
+                    "confirm the dataset holds exactly `expected` episodes; status=error on mismatch"
+                ),
+                "start_cameras_recording": (
+                    "(cameras=None, output_dir=None, fps=30, name=None, max_frames_per_camera=3000) -> dict  "
+                    "# raw per-camera MP4 capture (no lerobot dependency)"
+                ),
+                "stop_cameras_recording": "() -> dict  # finalize the raw MP4 capture",
+            }
+        )
+        return desc
 
     def cleanup(self) -> None:
         """Release all resources.

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -4,9 +4,10 @@ The :class:`DatasetRecordingMixin` holds the parts of the recording workflow
 that have no engine-specific physics dependency: querying recording state,
 flushing an episode boundary, stopping/finalizing a session, streaming a
 dataset back, and reporting status. Every method operates purely through the
-shared ``self._world._backend_state`` dict and the backend-agnostic
-:class:`~strands_robots.dataset_recorder.DatasetRecorder`, so both the MuJoCo
-and Newton backends mix it in unchanged.
+state mapping returned by :meth:`DatasetRecordingMixin._recording_state` (by
+default the shared ``self._world._backend_state`` dict) and the
+backend-agnostic :class:`~strands_robots.dataset_recorder.DatasetRecorder`, so
+the MuJoCo, Newton, and Isaac backends all mix it in unchanged.
 
 Each backend supplies the engine-specific half separately:
 
@@ -15,9 +16,13 @@ Each backend supplies the engine-specific half separately:
 * ``_make_run_policy_hook`` - captures per-step observations/cameras and feeds
   them to the active recorder.
 
-**Coupling**: the mixin reaches into ``self._world._backend_state`` for the
-recording flag, trajectory buffer, and ``dataset_recorder`` handle. The
-``TYPE_CHECKING`` stub documents that contract for mypy; it is not an
+**Coupling**: every method operates on the mutable state mapping returned by
+:meth:`DatasetRecordingMixin._recording_state`. The default accessor reaches
+into ``self._world._backend_state`` (the ``SimWorld`` contract the MuJoCo and
+Newton backends share); backends whose world object is not a ``SimWorld``
+(Isaac Sim's ``self._world`` is the Isaac ``World`` handle) override the
+accessor to supply their own dict instead of forking the mixin. The
+``TYPE_CHECKING`` stub documents the default contract for mypy; it is not an
 enforceable protocol.
 """
 
@@ -46,6 +51,29 @@ class DatasetRecordingMixin:
         _world: "SimWorld | None"
         default_width: int
         default_height: int
+
+    def _recording_state(self) -> dict[str, Any] | None:
+        """Mutable recording-state mapping, or ``None`` when no world exists.
+
+        This is the single seam every engine-independent lifecycle method goes
+        through to reach the recording flag, trajectory mirror,
+        ``dataset_recorder`` handle, ``recording_cameras`` scope and
+        ``last_dataset_root``. The default implementation reads
+        ``self._world._backend_state`` - the ``SimWorld`` contract shared by
+        the MuJoCo and Newton backends, which need no override. Backends whose
+        ``self._world`` is not a ``SimWorld`` (the Isaac backend holds the
+        Isaac Sim ``World`` handle there) override this accessor to return
+        their own dict, keeping one shared mixin instead of a fork.
+
+        Returns:
+            The live state dict, or ``None`` when there is no world (recording
+            is then reported as inactive and lifecycle calls degrade to their
+            documented no-world responses).
+        """
+        world = self._world
+        if world is None:
+            return None
+        return world._backend_state
 
     @staticmethod
     def _prepare_dataset_target(dataset_dir: Path, overwrite: bool) -> bool:
@@ -112,7 +140,8 @@ class DatasetRecordingMixin:
         ``run_policy`` loop flushes an episode boundary after each rollout
         only while a recording is open.
         """
-        return self._world is not None and bool(self._world._backend_state.get("recording", False))
+        state = self._recording_state()
+        return state is not None and bool(state.get("recording", False))
 
     def _active_recorder(self) -> Any:
         """Live dataset recorder, or ``None`` when no session is open.
@@ -120,9 +149,10 @@ class DatasetRecordingMixin:
         Overrides :meth:`SimEngine._active_recorder` so the base ``run_policy``
         episode-contract fields can read the recorder's in-memory episode count.
         """
-        if self._world is None:
+        state = self._recording_state()
+        if state is None:
             return None
-        return self._world._backend_state.get("dataset_recorder")
+        return state.get("dataset_recorder")
 
     def _active_dataset_root(self) -> str | None:
         """On-disk root of the active or most-recently-recorded dataset.
@@ -139,9 +169,10 @@ class DatasetRecordingMixin:
                 return str(recorder.root)
             except (AttributeError, TypeError):
                 pass
-        if self._world is None:
+        state = self._recording_state()
+        if state is None:
             return None
-        last = self._world._backend_state.get("last_dataset_root")
+        last = state.get("last_dataset_root")
         return str(last) if last else None
 
     def stop_recording(
@@ -174,11 +205,12 @@ class DatasetRecordingMixin:
                 place).
             run_id: Optional subpath inside the bucket (defaults to dataset name).
         """
-        if self._world is None or not self._world._backend_state.get("recording", False):
+        state = self._recording_state()
+        if state is None or not state.get("recording", False):
             return {"status": "success", "content": [{"text": "Was not recording."}]}
 
-        self._world._backend_state["recording"] = False
-        recorder = self._world._backend_state.get("dataset_recorder", None)
+        state["recording"] = False
+        recorder = state.get("dataset_recorder", None)
 
         if recorder is None:
             return {"status": "error", "content": [{"text": "No dataset recorder active."}]}
@@ -207,8 +239,8 @@ class DatasetRecordingMixin:
         if pending > 0:
             save_result = recorder.save_episode()
             if isinstance(save_result, dict) and save_result.get("status") == "error":
-                self._world._backend_state["dataset_recorder"] = None
-                self._world._backend_state["trajectory"] = []
+                state["dataset_recorder"] = None
+                state["trajectory"] = []
                 return {
                     "status": "error",
                     "content": [
@@ -222,8 +254,8 @@ class DatasetRecordingMixin:
                     ],
                 }
         elif captured == 0:
-            self._world._backend_state["dataset_recorder"] = None
-            self._world._backend_state["trajectory"] = []
+            state["dataset_recorder"] = None
+            state["trajectory"] = []
             return {
                 "status": "error",
                 "content": [
@@ -291,15 +323,15 @@ class DatasetRecordingMixin:
             else:
                 extra += f"\nBucket sync FAILED: {sync_result.get('message')}"
         # Versioned dataset-repo publish (Phase 4 hand-off).
-        if push_to_hub or self._world._backend_state.get("push_to_hub", False):
+        if push_to_hub or state.get("push_to_hub", False):
             push_result = recorder.push_to_hub(tags=["strands-robots", "sim"])
             if push_result and push_result.get("status") == "success":
                 extra += "\nPushed to HuggingFace Hub"
             elif push_result:
                 extra += f"\npush_to_hub FAILED: {push_result.get('message')}"
 
-        self._world._backend_state["dataset_recorder"] = None
-        self._world._backend_state["trajectory"] = []
+        state["dataset_recorder"] = None
+        state["trajectory"] = []
 
         # #708 - if recorder.episode_count and parquet disagree, surface
         # it in the human-readable text too so an operator scanning the
@@ -373,7 +405,8 @@ class DatasetRecordingMixin:
             episode index and frame count; a structured ``status="error"`` is
             returned when no recording is active or the underlying flush fails.
         """
-        if self._world is None or not self._world._backend_state.get("recording", False):
+        state = self._recording_state()
+        if state is None or not state.get("recording", False):
             return {
                 "status": "error",
                 "content": [
@@ -386,7 +419,7 @@ class DatasetRecordingMixin:
                 ],
             }
 
-        recorder = self._world._backend_state.get("dataset_recorder", None)
+        recorder = state.get("dataset_recorder", None)
         if recorder is None:
             return {"status": "error", "content": [{"text": "No dataset recorder active."}]}
 
@@ -409,9 +442,9 @@ class DatasetRecordingMixin:
             # The recorder marks itself closed on a failed flush (the LeRobot
             # episode buffer is in an undefined state); drop it so callers do
             # not keep appending into a poisoned recorder.
-            self._world._backend_state["recording"] = False
-            self._world._backend_state["dataset_recorder"] = None
-            self._world._backend_state["trajectory"] = []
+            state["recording"] = False
+            state["dataset_recorder"] = None
+            state["trajectory"] = []
             return {
                 "status": "error",
                 "content": [{"text": f"save_episode failed: {save_result.get('message')}"}],
@@ -419,7 +452,7 @@ class DatasetRecordingMixin:
 
         # Reset the in-memory trajectory mirror so get_recording_status reports
         # the NEXT episode from zero (matching the recorder's per-episode reset).
-        self._world._backend_state["trajectory"] = []
+        state["trajectory"] = []
 
         episode = save_result.get("episode")
         ep_frames = save_result.get("episode_frames")
@@ -483,14 +516,15 @@ class DatasetRecordingMixin:
         """Returns success in every lifecycle state (no world / not
         recording / recording) with a distinguishing message so callers can
         poll it unconditionally without try/except."""
-        if self._world is None:
+        state = self._recording_state()
+        if state is None:
             return {
                 "status": "success",
                 "content": [{"text": "No world. Call create_world to start recording."}],
             }
 
-        recording = self._world._backend_state.get("recording", False)
-        steps = len(self._world._backend_state.get("trajectory", []))
+        recording = state.get("recording", False)
+        steps = len(state.get("trajectory", []))
 
         if recording:
             text = f"[recording] {steps} steps captured"

--- a/tests/simulation/isaac/test_dataset_recording.py
+++ b/tests/simulation/isaac/test_dataset_recording.py
@@ -1,0 +1,474 @@
+"""Isaac dataset-recording correctness (start/stop/save_episode -> parquet).
+
+Verifies the Isaac backend records a LeRobotDataset satisfying the canonical
+parquet-correctness contract shared with the MuJoCo/Newton backends: a session
+of N rollouts, each flushed with ``save_episode``, must produce a dataset with
+``total_episodes == N``, N rows in the episode metadata parquet, and N
+distinct ``episode_index`` values (no merged ``episode_index=0``
+mega-episode) - round-trip verified by reopening the on-disk dataset.
+
+The engine is exercised through a skeleton ``IsaacSimulation`` built with
+``__new__`` (mirroring the Newton unit tests) so the recording lifecycle runs
+without the Isaac Sim Kit runtime: the recorder and episode bookkeeping are
+engine-independent, and the per-step capture hook is the REAL
+``IsaacSimulation._make_run_policy_hook`` closure fed by observation dicts of
+the exact shape ``IsaacSimulation.get_observation`` emits (joint scalars +
+per-camera RGB ndarrays keyed by raw camera name). The multi-camera
+render-product freshness contract and the recording-forces-images override are
+pinned against the real ``get_observation`` with stub camera handles.
+
+GPU integration coverage (real SimulationApp + RTX frames) lives in
+``tests_integ/simulation/test_isaac_recording_gpu.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import (
+    IsaacSimulation,
+    _CameraState,
+    _RobotState,
+)
+
+_SO100_JOINTS = ["Rotation", "Pitch", "Elbow", "Wrist_Pitch", "Wrist_Roll", "Jaw"]
+
+
+class _FakeCameraHandle:
+    """Stub RTX camera handle: ``get_rgba()`` returns a settable RGBA buffer."""
+
+    def __init__(self, rgba: np.ndarray) -> None:
+        self.rgba = rgba
+
+    def get_rgba(self) -> np.ndarray:
+        return self.rgba
+
+
+class _StubWorld:
+    """Stub Isaac ``World`` counting render ticks from the product refresh."""
+
+    def __init__(self) -> None:
+        self.render_steps = 0
+
+    def step(self, render: bool = False) -> None:
+        if render:
+            self.render_steps += 1
+
+
+def _make_engine(
+    robots: dict[str, _RobotState] | None = None,
+    cameras: dict[str, _CameraState] | None = None,
+    render_mode: str = "rtx_realtime",
+) -> IsaacSimulation:
+    """Build a skeleton IsaacSimulation without booting the Isaac Kit runtime.
+
+    ``IsaacSimulation.__init__`` is CPU-safe but seeds pump/env-var state this
+    test does not need; ``__new__`` + the exact attributes the recording path
+    reads keeps the fixture honest about what the mixin depends on.
+    """
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig(render_mode=render_mode)
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = robots if robots is not None else {}
+    engine._cameras = cameras if cameras is not None else {}
+    engine._objects = {}
+    engine._prim_registry = []
+    engine._cams_rec_state = None
+    engine._recording_state_dict = {}
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._replicated = False
+    engine._num_envs_active = 1
+    engine._pump_running = False
+    engine._main_tid = threading.get_ident()
+    return engine
+
+
+def _robot(name: str = "so100", joints: list[str] | None = None) -> _RobotState:
+    return _RobotState(
+        name=name,
+        prim_path=f"/World/Robots/{name}",
+        joint_names=list(joints or _SO100_JOINTS),
+        data_config="so100",
+    )
+
+
+def _camera(name: str, width: int = 64, height: int = 48, fill: int = 0) -> _CameraState:
+    cam = _CameraState(name=name, prim_path=f"/World/Cameras/{name}", width=width, height=height)
+    rgba = np.full((height, width, 4), fill, dtype=np.uint8)
+    cam.handle = _FakeCameraHandle(rgba)
+    return cam
+
+
+def _drive_episode(engine: IsaacSimulation, robot_name: str, instruction: str, n_frames: int) -> None:
+    """Run one mock rollout: call the real on_frame hook ``n_frames`` times.
+
+    The observation dict mirrors what ``IsaacSimulation.get_observation``
+    emits: joint scalars keyed by joint name plus one RGB ndarray per camera
+    keyed by the RAW camera name.
+    """
+    hook = engine._make_run_policy_hook(robot_name, instruction)
+    assert hook is not None
+    joints = engine._robots[robot_name].joint_names
+    for step in range(n_frames):
+        obs: dict = {j: float(step) * 0.01 for j in joints}
+        for cam_name, cam in engine._cameras.items():
+            obs[cam_name] = np.asarray(cam.handle.get_rgba())[..., :3].astype(np.uint8)
+        action = {j: float(step) * 0.01 + 0.001 for j in joints}
+        hook(step, obs, action)
+
+
+# --- guards (no lerobot required) -------------------------------------------
+
+
+def test_start_recording_without_world_errors() -> None:
+    engine = _make_engine(robots={"so100": _robot()})
+    engine._world_created = False
+    result = engine.start_recording(repo_id="local/nope")
+    assert result["status"] == "error"
+    assert "No world" in result["content"][0]["text"]
+
+
+def test_start_recording_without_robots_errors() -> None:
+    result = _make_engine().start_recording(repo_id="local/nope")
+    assert result["status"] == "error"
+    assert "add_robot" in result["content"][0]["text"]
+
+
+def test_save_episode_without_recording_errors() -> None:
+    result = _make_engine(robots={"so100": _robot()}).save_episode()
+    assert result["status"] == "error"
+    assert "not recording" in result["content"][0]["text"].lower()
+
+
+def test_stop_recording_when_idle_is_graceful() -> None:
+    result = _make_engine(robots={"so100": _robot()}).stop_recording()
+    assert result["status"] == "success"
+    assert "not recording" in result["content"][0]["text"].lower()
+
+
+def test_hook_is_none_for_unknown_robot() -> None:
+    engine = _make_engine(robots={"so100": _robot()})
+    assert engine._make_run_policy_hook("typo", "task") is None
+
+
+def test_recording_state_seam_is_engine_owned_dict() -> None:
+    """The Isaac state seam returns the engine dict, never a SimWorld field.
+
+    Pins the DatasetRecordingMixin seam override: Isaac's ``self._world`` is
+    the Isaac Sim World handle (here ``None``), so the shared lifecycle must
+    read ``self._recording_state_dict`` and report no-world before
+    ``create_world``.
+    """
+    engine = _make_engine(robots={"so100": _robot()})
+    assert engine._recording_state() is engine._recording_state_dict
+    assert engine._is_recording() is False
+    engine._recording_state_dict["recording"] = True
+    assert engine._is_recording() is True
+    engine._world_created = False
+    assert engine._recording_state() is None
+    assert engine._is_recording() is False
+
+
+def test_destroy_resets_recording_state() -> None:
+    """destroy() drops any in-flight recorder so no stale session survives.
+
+    A recorder left in the seam dict across destroy()/create_world() would
+    reference RTX frames from a torn-down stage; the next session must start
+    from a clean dict (mirroring MuJoCo/Newton, whose state dict dies with
+    the SimWorld).
+    """
+    engine = _make_engine(robots={"so100": _robot()})
+    engine._recording_state_dict.update({"recording": True, "dataset_recorder": object()})
+    destroyed = engine.destroy()
+    assert destroyed["status"] == "success"
+    assert engine._recording_state() is None  # world gone
+    engine._world_created = True  # simulate the next create_world()
+    assert engine._recording_state() == {}
+    assert engine._is_recording() is False
+
+
+def test_get_observation_forces_images_while_recording() -> None:
+    """skip_images=True still yields camera frames during a recording session.
+
+    Parity with MuJoCo/Newton: a non-image policy (requires_images=False, e.g.
+    MockPolicy) makes PolicyRunner pass skip_images=True, but the recorded
+    frames must carry the camera images the schema declared.
+    """
+    engine = _make_engine(
+        robots={"so100": _robot()},
+        cameras={"front": _camera("front", fill=7)},
+    )
+    obs = engine.get_observation("so100", skip_images=True)
+    assert "front" not in obs  # not recording: skip honoured
+
+    engine._recording_state_dict["recording"] = True
+    obs = engine.get_observation("so100", skip_images=True)
+    assert "front" in obs, "recording must force camera frames into the observation"
+    assert obs["front"].shape == (48, 64, 3)
+
+
+def test_get_observation_refreshes_render_products_for_multi_camera() -> None:
+    """>1 camera triggers the render-product refresh before frame read-back.
+
+    Regression pin for the stale-render-product wrinkle: without the refresh a
+    second camera's ``get_rgba`` returns a stale buffer and multi-cam
+    recordings duplicate frames. One camera must NOT pay the refresh cost.
+    """
+    world = _StubWorld()
+    engine = _make_engine(
+        robots={"so100": _robot()},
+        cameras={"front": _camera("front", fill=1), "top": _camera("top", fill=2)},
+    )
+    engine._world = world
+    obs = engine.get_observation("so100")
+    assert world.render_steps >= 1, "multi-camera observation must refresh the render products"
+    assert not np.array_equal(obs["front"], obs["top"]), "each camera must contribute its own frame"
+
+    single = _make_engine(robots={"so100": _robot()}, cameras={"front": _camera("front")})
+    single_world = _StubWorld()
+    single._world = single_world
+    single.get_observation("so100")
+    assert single_world.render_steps == 0, "single-camera observation must skip the refresh"
+
+
+def test_describe_advertises_recording_family() -> None:
+    """describe() exposes the record-and-stream workflow, like MuJoCo/Newton.
+
+    An agent enumerating ``describe()["methods"]`` must discover
+    ``start_recording`` -> ``save_episode`` -> ``stop_recording`` ->
+    ``stream_dataset`` (and the parquet-truth gate) without guessing names,
+    and every advertised name must resolve to a real callable.
+    """
+    import inspect
+
+    sim = IsaacSimulation()  # CPU-safe: heavy omni imports are deferred
+    desc = sim.describe()
+    assert desc["backend"] == "isaac"
+    methods = desc["methods"]
+    for name in (
+        "start_recording",
+        "save_episode",
+        "stop_recording",
+        "get_recording_status",
+        "stream_dataset",
+        "verify_dataset_episodes",
+        "start_cameras_recording",
+        "stop_cameras_recording",
+        "add_camera",
+        "remove_camera",
+    ):
+        assert name in methods, f"describe() omits recording-family method {name!r}"
+        assert callable(getattr(sim, name, None)), f"{name!r} advertised but not callable"
+    # The advertised start_recording signature names the real parameters so a
+    # caller (or run_policy's dataset_cameras= forwarding) can invoke it.
+    sig = set(inspect.signature(sim.start_recording).parameters)
+    for param in ("repo_id", "task", "fps", "root", "vcodec", "overwrite", "cameras"):
+        assert param in methods["start_recording"]
+        assert param in sig
+
+
+# --- LeRobotDataset round-trips (need the lerobot extra) --------------------
+
+lerobot = pytest.importorskip("lerobot")
+pq = pytest.importorskip("pyarrow.parquet")
+
+from pathlib import Path  # noqa: E402
+
+from strands_robots.dataset_recorder import read_dataset_episode_indices  # noqa: E402
+
+
+def test_three_episode_rollout_parquet_correctness(tmp_path) -> None:
+    """3 rollouts -> 3 distinct episodes; the reopened parquet is the truth."""
+    root = str(tmp_path / "isaac_ds")
+    engine = _make_engine(robots={"so100": _robot()})
+
+    started = engine.start_recording(repo_id="local/isaac_rec", root=root, fps=30, overwrite=True)
+    assert started["status"] == "success", started
+
+    n_episodes = 3
+    frames_per_episode = 5
+    for ep in range(n_episodes):
+        _drive_episode(engine, "so100", f"episode {ep}", frames_per_episode)
+        saved = engine.save_episode()
+        assert saved["status"] == "success", saved
+
+    stopped = engine.stop_recording()
+    assert stopped["status"] == "success", stopped
+
+    verified = engine.verify_dataset_episodes(n_episodes)
+    assert verified["status"] == "success", verified
+
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == n_episodes
+    assert sorted(set(info["episode_indices"])) == list(range(n_episodes))
+    assert info["total_frames"] == n_episodes * frames_per_episode
+
+    parquets = sorted((Path(root) / "meta" / "episodes").glob("**/*.parquet"))
+    num_rows = sum(pq.read_table(p).num_rows for p in parquets)
+    assert num_rows == n_episodes
+
+
+def test_stop_recording_flushes_trailing_episode(tmp_path) -> None:
+    """stop_recording flushes the final unsaved rollout (no explicit save)."""
+    root = str(tmp_path / "isaac_trailing")
+    engine = _make_engine(robots={"so100": _robot()})
+
+    engine.start_recording(repo_id="local/isaac_trail", root=root, fps=30, overwrite=True)
+    _drive_episode(engine, "so100", "ep0", 4)
+    engine.save_episode()
+    _drive_episode(engine, "so100", "ep1", 4)
+    stopped = engine.stop_recording()
+    assert stopped["status"] == "success", stopped
+
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == 2
+    assert info["total_frames"] == 8
+
+
+def test_camera_declared_at_probed_resolution_and_recorded(tmp_path) -> None:
+    """The schema declares each camera at the resolution the probe observed.
+
+    RTX cameras render at a DLSS-safe NATIVE size that can differ from the
+    requested output size; ``get_observation`` emits the native frame. The
+    schema must match that stream or every ``add_frame`` is rejected. Here the
+    ``_CameraState`` claims 640x480 but the probe frame is 64x48 - the probe
+    must win, and the round-trip must land a real MP4 on disk.
+    """
+    root = str(tmp_path / "isaac_cam")
+    cam = _CameraState(name="front", prim_path="/World/Cameras/front", width=640, height=480)
+    cam.handle = _FakeCameraHandle(np.full((48, 64, 4), 9, dtype=np.uint8))
+    engine = _make_engine(robots={"so100": _robot()}, cameras={"front": cam})
+
+    started = engine.start_recording(repo_id="local/isaac_cam", root=root, fps=30, overwrite=True)
+    assert started["status"] == "success", started
+
+    recorder = engine._recording_state_dict["dataset_recorder"]
+    feat = recorder.dataset.features["observation.images.front"]
+    shape = tuple(feat["shape"]) if isinstance(feat, dict) else tuple(feat.shape)
+    assert 48 in shape and 64 in shape, f"probed 64x48 must define the schema, got {shape}"
+
+    _drive_episode(engine, "so100", "with camera", 4)
+    engine.save_episode()
+    stopped = engine.stop_recording()
+    assert stopped["status"] == "success", stopped
+
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == 1
+    assert info["total_frames"] == 4
+    mp4s = sorted(Path(root).glob("videos/**/*.mp4"))
+    assert mp4s, "camera recording must land per-camera MP4 files on disk"
+    assert all(p.stat().st_size > 0 for p in mp4s)
+
+
+def test_two_cameras_record_two_video_columns(tmp_path) -> None:
+    """Both cameras land distinct feature columns and MP4 streams."""
+    root = str(tmp_path / "isaac_two_cams")
+    engine = _make_engine(
+        robots={"so100": _robot()},
+        cameras={"front": _camera("front", fill=10), "top": _camera("top", fill=200)},
+    )
+
+    started = engine.start_recording(repo_id="local/isaac_two", root=root, fps=30, overwrite=True)
+    assert started["status"] == "success", started
+
+    recorder = engine._recording_state_dict["dataset_recorder"]
+    image_feats = {k for k in recorder.dataset.features if k.startswith("observation.images.")}
+    assert image_feats == {"observation.images.front", "observation.images.top"}
+
+    _drive_episode(engine, "so100", "two cams", 3)
+    engine.save_episode()
+    stopped = engine.stop_recording()
+    assert stopped["status"] == "success", stopped
+
+    mp4s = sorted(Path(root).glob("videos/**/*.mp4"))
+    assert mp4s, "camera recording must land two per-camera MP4 streams on disk"
+    keys = {part for p in mp4s for part in p.parts if part.startswith("observation.images.")}
+    assert keys == {"observation.images.front", "observation.images.top"}, keys
+
+
+def test_start_recording_scopes_cameras_to_subset(tmp_path) -> None:
+    """``cameras=`` records only the requested subset (parity with MuJoCo/Newton)."""
+    root = str(tmp_path / "isaac_scope")
+    engine = _make_engine(
+        robots={"so100": _robot()},
+        cameras={"front": _camera("front"), "top": _camera("top")},
+    )
+
+    started = engine.start_recording(repo_id="local/isaac_scope", root=root, fps=30, overwrite=True, cameras=["front"])
+    assert started["status"] == "success", started
+
+    recorder = engine._recording_state_dict["dataset_recorder"]
+    image_feats = {k for k in recorder.dataset.features if k.startswith("observation.images.")}
+    assert image_feats == {"observation.images.front"}, image_feats
+    scoped = [tpl[0] for tpl in engine._recording_state_dict["recording_cameras"]]
+    assert scoped == ["front"], scoped
+
+
+def test_start_recording_unknown_camera_fails_loudly(tmp_path) -> None:
+    root = str(tmp_path / "isaac_unknown_cam")
+    engine = _make_engine(robots={"so100": _robot()}, cameras={"front": _camera("front")})
+    result = engine.start_recording(repo_id="local/isaac_bad", root=root, overwrite=True, cameras=["wrist"])
+    assert result["status"] == "error"
+    assert "wrist" in result["content"][0]["text"]
+    assert "front" in result["content"][0]["text"]
+    assert engine._is_recording() is False
+
+
+def test_headless_render_mode_records_proprio_only(tmp_path, caplog) -> None:
+    """render_mode='headless' cannot produce RTX frames: proprio-only + warning."""
+    import logging
+
+    root = str(tmp_path / "isaac_headless")
+    engine = _make_engine(
+        robots={"so100": _robot()},
+        cameras={"front": _camera("front")},
+        render_mode="headless",
+    )
+    with caplog.at_level(logging.WARNING):
+        started = engine.start_recording(repo_id="local/isaac_headless", root=root, overwrite=True)
+    assert started["status"] == "success", started
+    assert any("headless" in rec.message for rec in caplog.records)
+
+    recorder = engine._recording_state_dict["dataset_recorder"]
+    image_feats = {k for k in recorder.dataset.features if k.startswith("observation.images.")}
+    assert image_feats == set(), "headless render mode must not declare camera columns"
+
+    _drive_episode(engine, "so100", "proprio", 3)
+    stopped = engine.stop_recording()
+    assert stopped["status"] == "success", stopped
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == 1
+    assert info["total_frames"] == 3
+
+
+def test_multi_robot_namespaced_schema(tmp_path) -> None:
+    """Two robots -> joint/action ids are namespaced ``robot__joint``."""
+    root = str(tmp_path / "isaac_multi")
+    engine = _make_engine(robots={"alice": _robot("alice"), "bob": _robot("bob")})
+
+    started = engine.start_recording(repo_id="local/isaac_multi", root=root, fps=30, overwrite=True)
+    assert started["status"] == "success", started
+
+    recorder = engine._recording_state_dict["dataset_recorder"]
+    state_names = recorder.dataset.features["observation.state"]["names"]
+    assert "alice__Rotation" in state_names
+    assert "bob__Jaw" in state_names
+    assert len(state_names) == 2 * len(_SO100_JOINTS)
+    action_names = recorder.dataset.features["action"]["names"]
+    assert "alice__Rotation" in action_names
+    assert "bob__Jaw" in action_names
+
+    for ep, rname in enumerate(("alice", "bob")):
+        _drive_episode(engine, rname, f"ep {ep}", 3)
+        engine.save_episode()
+    stopped = engine.stop_recording()
+    assert stopped["status"] == "success", stopped
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == 2

--- a/tests/simulation/test_recording_lifecycle_accessors.py
+++ b/tests/simulation/test_recording_lifecycle_accessors.py
@@ -34,6 +34,56 @@ def _world(**backend_state: Any) -> SimpleNamespace:
     return SimpleNamespace(_backend_state=dict(backend_state))
 
 
+# --- _recording_state (default seam) ----------------------------------------
+
+
+def test_default_recording_state_none_when_no_world() -> None:
+    assert _Engine(world=None)._recording_state() is None
+
+
+def test_default_recording_state_is_live_world_backend_state() -> None:
+    """The DEFAULT seam returns ``self._world._backend_state`` by identity.
+
+    Every engine-independent lifecycle method routes through
+    ``_recording_state()``; the MuJoCo and Newton backends rely on the default
+    accessor returning the LIVE ``SimWorld._backend_state`` dict (not a copy),
+    so mutations made through the seam land in the world state the rest of the
+    backend reads. Pinned so a future seam refactor cannot silently change the
+    default those backends depend on.
+    """
+    world = _world(recording=True)
+    state = _Engine(world)._recording_state()
+    assert state is not None
+    assert state is world._backend_state
+    # Live-dict contract: writes through the seam are visible to the world.
+    marker = object()
+    state["dataset_recorder"] = marker
+    assert world._backend_state["dataset_recorder"] is marker
+
+
+def test_mujoco_and_newton_mixins_use_default_recording_state_seam() -> None:
+    """The MuJoCo/Newton recording mixins resolve the seam to ``_backend_state``.
+
+    Only the Isaac backend overrides ``_recording_state()`` (its ``_world`` is
+    the Isaac Sim handle, not a ``SimWorld``). Exercise the seam through each
+    backend's actual mixin class so a future override there - or a change to
+    the shared default - fails this test instead of silently rerouting the
+    recording state those backends rely on.
+    """
+    from strands_robots.simulation.mujoco.recording import RecordingMixin
+    from strands_robots.simulation.newton.recording import NewtonRecordingMixin
+
+    for mixin_cls in (RecordingMixin, NewtonRecordingMixin):
+
+        class _Host(mixin_cls):  # type: ignore[misc, valid-type]
+            def __init__(self, world: Any) -> None:
+                self._world = world
+
+        world = _world(recording=True)
+        assert _Host(world)._recording_state() is world._backend_state, mixin_cls
+        assert _Host(None)._recording_state() is None, mixin_cls
+
+
 # --- _is_recording ---------------------------------------------------------
 
 

--- a/tests_integ/simulation/test_isaac_recording_gpu.py
+++ b/tests_integ/simulation/test_isaac_recording_gpu.py
@@ -17,6 +17,7 @@ and ``STRANDS_GPU_TEST=1``. Run with::
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -125,6 +126,30 @@ class TestIsaacDatasetRecording:
             keys = {part for p in mp4s for part in p.parts if part.startswith("observation.images.")}
             assert keys == {"observation.images.cam1", "observation.images.cam2"}, keys
             assert all(p.stat().st_size > 0 for p in mp4s)
+
+            # Train-shape == read-shape: the camera schema was declared from
+            # the RTX native-resolution probe (which can differ from the
+            # requested camera size - DLSS-safe render products), so the dims
+            # declared in meta/info.json must match what stream_dataset
+            # actually emits on read-back. A mismatch here means training
+            # consumers see a different image shape than the schema promises.
+            info_json = json.loads((Path(root) / "meta" / "info.json").read_text())
+            declared = {
+                key: tuple(int(d) for d in feat["shape"])
+                for key, feat in info_json["features"].items()
+                if key.startswith("observation.images.")
+            }
+            assert set(declared) == keys, declared
+            reader = sim.stream_dataset("local/isaac_gpu_rec", root=root, shuffle=False)
+            frame = next(iter(reader))
+            for key, (c, h, w) in declared.items():
+                emitted = tuple(int(d) for d in frame[key].shape[-3:])
+                # DatasetRecorder declares (C, H, W); tolerate either layout
+                # from the streaming decoder, but H/W/C must be the probed ones.
+                assert emitted in ((c, h, w), (h, w, c)), (
+                    f"{key}: schema declares CHW {(c, h, w)} but stream_dataset "
+                    f"emitted {emitted} - RTX probe shape and read-back shape diverged"
+                )
         finally:
             sim.destroy()
 

--- a/tests_integ/simulation/test_isaac_recording_gpu.py
+++ b/tests_integ/simulation/test_isaac_recording_gpu.py
@@ -1,0 +1,163 @@
+"""GPU integration tests for LeRobotDataset recording on the Isaac backend.
+
+Closes the acceptance criteria of the IsaacRecordingMixin issue: on a real
+Isaac Sim runtime, ``start_recording -> run_policy(policy_object=MockPolicy())
+-> stop_recording`` must produce a valid LeRobotDataset (parquet + per-camera
+MP4 + ``meta/``), round-trip verified by REOPENING the on-disk dataset
+(AGENTS.md: "round-trip tests for recording") - through the exact same facade
+that works on the MuJoCo and Newton backends, with only the backend swapped.
+
+Requirements match ``test_isaac_gpu.py``: NVIDIA GPU + CUDA, Isaac Sim 6.0+
+installed out-of-band, ``pip install 'strands-robots[sim-isaac,lerobot]'``,
+and ``STRANDS_GPU_TEST=1``. Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ \\
+        tests_integ/simulation/test_isaac_recording_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("strands_robots.simulation.isaac")
+pytest.importorskip("lerobot")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+def _assets_root_path() -> str:
+    """Resolve the Isaac Sim bundled-assets root (modern then legacy path)."""
+    try:
+        from isaacsim.storage.native import get_assets_root_path  # type: ignore[import-not-found]
+    except ImportError:
+        from omni.isaac.nucleus import get_assets_root_path  # type: ignore[import-not-found]
+
+    assets_root = get_assets_root_path()
+    assert assets_root, "get_assets_root_path() returned empty"
+    return assets_root
+
+
+class TestIsaacDatasetRecording:
+    """The MuJoCo/Newton record-and-stream workflow with backend='isaac'."""
+
+    def test_record_run_policy_stop_round_trip(self, tmp_path):
+        """start_recording -> run_policy(MockPolicy) -> stop_recording -> reopen.
+
+        Records two RTX cameras alongside the Franka joint state, drives the
+        rollout with the stock MockPolicy (requires_images=False - pinning the
+        recording-forces-images override on a real RTX stream), then reopens
+        the dataset from disk and asserts parquet truth + per-camera MP4s.
+        """
+        from strands_robots.dataset_recorder import read_dataset_episode_indices
+        from strands_robots.policies.mock import MockPolicy
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+        assets_root = _assets_root_path()
+        root = str(tmp_path / "isaac_gpu_ds")
+
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=False, render_mode="rtx_realtime"))
+        try:
+            r = sim.create_world()
+            assert r["status"] == "success", f"create_world: {r}"
+
+            usd_path = f"{assets_root}/Isaac/Robots/Franka/franka.usd"
+            r = sim.add_robot("franka", usd_path=usd_path)
+            assert r["status"] == "success", f"add_robot: {r}"
+
+            r = sim.add_camera("cam1")
+            assert r["status"] == "success", f"add_camera cam1: {r}"
+            r = sim.add_camera("cam2", position=[0.0, 2.5, 1.5], target=[0.0, 0.0, 0.5])
+            assert r["status"] == "success", f"add_camera cam2: {r}"
+
+            sim.reset()
+            sim.step(2)
+
+            r = sim.start_recording(repo_id="local/isaac_gpu_rec", root=root, fps=10, overwrite=True)
+            assert r["status"] == "success", f"start_recording: {r}"
+
+            # Keep control_frequency at or below 1/rendering_dt (default 30Hz)
+            # so each recorded frame reflects a freshly rendered product.
+            r = sim.run_policy(
+                robot_name="franka",
+                policy_object=MockPolicy(),
+                n_steps=10,
+                control_frequency=10.0,
+                fast_mode=True,
+            )
+            assert r["status"] == "success", f"run_policy: {r}"
+
+            r = sim.save_episode()
+            assert r["status"] == "success", f"save_episode: {r}"
+
+            r = sim.stop_recording()
+            assert r["status"] == "success", f"stop_recording: {r}"
+
+            r = sim.verify_dataset_episodes(1)
+            assert r["status"] == "success", f"verify_dataset_episodes: {r}"
+
+            # Round-trip: reopen the on-disk dataset and assert its truth.
+            info = read_dataset_episode_indices(root)
+            assert info["total_episodes"] == 1, info
+            assert info["total_frames"] == 10, info
+            assert (Path(root) / "meta" / "info.json").exists()
+
+            mp4s = sorted(Path(root).glob("videos/**/*.mp4"))
+            keys = {part for p in mp4s for part in p.parts if part.startswith("observation.images.")}
+            assert keys == {"observation.images.cam1", "observation.images.cam2"}, keys
+            assert all(p.stat().st_size > 0 for p in mp4s)
+        finally:
+            sim.destroy()
+
+    def test_multi_camera_frames_are_distinct(self, tmp_path):
+        """Two cameras with different vantages record distinct pixel content.
+
+        Regression for the stale-render-product case: without the multi-camera
+        refresh, the second camera's stream duplicates a stale buffer. Two
+        cameras looking at different parts of the scene must yield frames that
+        differ from each other within the same observation.
+        """
+        import numpy as np
+
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+        assets_root = _assets_root_path()
+
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=False, render_mode="rtx_realtime"))
+        try:
+            assert sim.create_world()["status"] == "success"
+            usd_path = f"{assets_root}/Isaac/Robots/Franka/franka.usd"
+            assert sim.add_robot("franka", usd_path=usd_path)["status"] == "success"
+            assert sim.add_camera("cam1")["status"] == "success"
+            assert sim.add_camera("cam2", position=[0.0, 2.5, 1.5], target=[0.0, 0.0, 0.5])["status"] == "success"
+            sim.reset()
+            sim.step(5)
+
+            obs = sim.get_observation("franka")
+            assert "cam1" in obs and "cam2" in obs, sorted(obs)
+            assert obs["cam1"].ndim == 3 and obs["cam2"].ndim == 3
+            assert not np.array_equal(obs["cam1"], obs["cam2"]), (
+                "cameras at different vantages returned identical frames - stale render product"
+            )
+        finally:
+            sim.destroy()


### PR DESCRIPTION
Closes #1550.

## What changed

`Robot(..., backend="isaac")` now supports the same LeRobotDataset record-and-stream workflow as the MuJoCo and Newton backends - `start_recording` -> `run_policy` -> `save_episode` -> `stop_recording` -> `stream_dataset` - with only a backend swap.

### The state-seam (no mixin fork)

`DatasetRecordingMixin` operated directly on `self._world._backend_state`, a `SimWorld` contract Isaac cannot satisfy (its `self._world` is the Isaac Sim `World` handle). Per the issue's preferred option, the mixin grew a single `_recording_state()` accessor that every engine-independent lifecycle method now goes through:

- default accessor returns `self._world._backend_state` -> **MuJoCo and Newton subclasses are untouched** (their existing `start_recording`/hooks keep writing the same dict);
- `IsaacRecordingMixin` overrides the seam to return an engine-owned `self._recording_state_dict`, reset by `destroy()`.

### The two Isaac backend halves (`strands_robots/simulation/isaac/recording.py`)

1. **`start_recording(...)`** - declares the schema from the live scene: namespaced joint names, actuator-ordered action columns (`robot_action_keys`), and RTX cameras sized from one `get_observation` probe (RTX cameras render at a DLSS-safe *native* resolution that can exceed the requested output size; the probe declares the shape the stream actually emits, exactly as the `so101_curobo` collector did). Shares `_prepare_dataset_target` create-vs-resume/overwrite semantics, `_verify_resume_schema`, `resolve_dataset_dir`, and the `cameras=` scoping contract (raw or schema-safe names; unknown names fail loudly). `render_mode="headless"` records a valid proprio-only dataset with a loud warning instead of dead camera columns.
2. **`_make_run_policy_hook(...)`** - per-step `on_frame(step, obs, action)` that appends to the trajectory mirror and feeds `recorder.add_frame(...)`, with the `recording_cameras` scope filter and multi-robot `robot__key` prefixing. Unlike MuJoCo/Newton it does not render: Isaac's `get_observation` already carries a fresh frame per camera.

### Known wrinkles from the issue, resolved

- **Render-product freshness**: capture rides `get_observation`, which calls `_refresh_all_render_products()` whenever >1 camera exists - recorded multi-cam frames are never duplicates of a stale secondary product. Pinned by a unit regression test (refresh fires for 2 cameras, not for 1, frames distinct) and a GPU test asserting two vantages yield distinct pixels.
- **Forced images while recording**: `requires_images=False` policies (MockPolicy) make `PolicyRunner` pass `skip_images=True`; `IsaacSimulation.get_observation` now forces images back on while a session is active (same override MuJoCo/Newton already had). Regression-pinned.
- **Pacing**: documented on `start_recording` - `fps` is metadata, cadence is one frame per `run_policy` control step, and the renderer produces new frames at `IsaacConfig.rendering_dt` (default 1/30 s); keep `control_frequency <= 1/rendering_dt`.
- **Threading**: the schema probe is routed through `run_on_main` when the main-thread pump owns the renderer and the caller is a worker thread; the probe deliberately runs *before* `self._lock` is taken so the main-thread handoff cannot deadlock on the RLock.

### Supporting wiring

- `IsaacSimulation(IsaacRecordingMixin, SimEngine)` - `save_episode` / `stop_recording` / `get_recording_status` / `stream_dataset` / `verify_dataset_episodes` come along from the shared mixin (`run_policy(dataset_cameras=...)` and `n_episodes=N` episode flushing work unchanged via the existing base-engine plumbing).
- `destroy()` drops any in-flight recorder (warning when a session was still open) so no stale session survives a world teardown.
- `_RobotState` now carries `data_config` so Isaac datasets record the same `robot_type` embodiment metadata as MuJoCo/Newton.
- `describe()` override advertises the recording family (+ `add_camera`/`remove_camera` and the raw-MP4 `start_cameras_recording` trio), matching the MuJoCo/Newton discovery surfaces.

## Acceptance criteria

- [x] `start_recording -> run_policy(policy_object=MockPolicy(), n_steps=N) -> stop_recording` produces a valid LeRobotDataset (parquet + per-camera MP4 + `meta/`), round-trip verified by reopening it - GPU test `test_record_run_policy_stop_round_trip` (real Franka USD + 2 RTX cameras) and unit round-trips via `read_dataset_episode_indices` + on-disk MP4 assertions.
- [x] `stop_recording(bucket=...)` / `stream_dataset(...)` unchanged - engine-agnostic mixin methods, inherited as-is (seam refactor covered by the existing `tests/simulation/test_recording_lifecycle_accessors.py`, all green).
- [x] `save_episode` returns the real implementation, not the base error stub (multi-episode parquet-correctness test: 3 rollouts -> 3 distinct `episode_index` values).
- [x] Multi-camera scene records distinct, fresh frames per camera (unit regression on the refresh contract + GPU distinct-pixels test).
- [x] Unit tests with mocked Isaac runtime (18, `tests/simulation/isaac/test_dataset_recording.py`) + integration test gated on `IsaacSimulation.is_available()` + `STRANDS_GPU_TEST=1` (`tests_integ/simulation/test_isaac_recording_gpu.py`), per AGENTS.md rule 8.

## Test surface

- `hatch run lint` - clean (ruff check, ruff format, mypy).
- `hatch run test` - **11157 passed, 237 skipped, coverage 93.6%** with `MUJOCO_GL=egl`. Without EGL the suite aborts in `tests/inference/test_remote_policy_sim_rollout.py` on this dev box - reproduced on a clean `upstream/main` checkout, i.e. pre-existing environmental (GL), not introduced here.
- GPU integration tests are written to the same gating pattern as `test_isaac_gpu.py`; they skip cleanly where Isaac Sim/GPU is absent.

## Out of scope / follow-ups

- Folding `examples/so101_curobo/collector.py`'s manual Isaac recorder glue onto this facade - the issue assigns that to #1533's PR 4/5 scope.
- #1507 (storage-buckets blog draft) is unblocked once this lands.

Project board: please move #1550 to "In review" (board write access unavailable from this account).
