### PR TITLE
test(mesh/safety): pin audit-publish fail-soft on the redundant + per-issuer-cap estop/resume branches

### DIFF
--- a/tests/mesh/test_estop_audit_publish_failure_nonblocking.py
+++ b/tests/mesh/test_estop_audit_publish_failure_nonblocking.py
@@ -141,3 +141,96 @@ def test_replay_rejected_audit_valueerror_is_swallowed_and_lockout_preserved():
     assert len(calls) == 1
     assert calls[0]["event_type"] == "estop_replay_rejected"
     assert mesh._estop_lockout.is_set()
+
+
+def test_redundant_estop_audit_valueerror_is_swallowed_and_lockout_preserved():
+    """A malformed-payload (ValueError) failure while auditing a
+    ``remote_estop_redundant`` event must not propagate out of the safety
+    handler, and the already-engaged lockout must stay latched.
+
+    A second, legitimate estop (fresh ``t``, distinct issuer) arriving while
+    the lockout is already engaged is recorded as ``remote_estop_redundant``
+    so forensics keep the signal that another operator also tried to engage.
+    That forensic publish is best-effort: a flaky audit sink must not abort
+    handling and drop the fleet into a half-state.
+    """
+    mesh = _stub_mesh()
+    calls = []
+
+    def raising_audit(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("event_type") == "remote_estop_redundant":
+            raise ValueError("bad audit payload shape")
+
+    mesh.publish_safety_event = raising_audit  # type: ignore[method-assign]
+
+    # Lockout already engaged by a prior estop; the cache is empty so this
+    # envelope takes the fresh-slot path (issuer under cap) and lands in the
+    # ``lockout_was_engaged`` branch that emits ``remote_estop_redundant``.
+    mesh._estop_lockout.set()
+    mesh._last_estop_ts = time.time() - 5.0
+    mesh._last_estop_mono = time.monotonic() - 5.0
+
+    result = mesh._on_safety_estop(
+        _envelope_with_wire_zid(
+            t=time.time(),
+            peer_id="operator-B",
+            wire_zid=_OPERATOR_B_ZID,
+            reason="second operator estop while already locked out",
+        )
+    )
+
+    assert result is None
+    redundant = [c for c in calls if c.get("event_type") == "remote_estop_redundant"]
+    assert len(redundant) == 1
+    # The failing audit did not clear the already-engaged lockout.
+    assert mesh._estop_lockout.is_set()
+
+
+def test_estop_per_issuer_cap_audit_oserror_is_swallowed_and_lockout_engages(monkeypatch):
+    """A disk failure (OSError) while auditing an
+    ``estop_per_issuer_cap_exceeded`` event must not propagate, the flooding
+    issuer's cache slot must not be added, and the legitimate safety event
+    must still engage the lockout.
+
+    The per-issuer fairness bound refuses a new replay-cache slot once one
+    issuer holds ``per_issuer_cap`` entries, but -- unlike a refused resume --
+    a refused estop slot still engages the lockout (the safety event is
+    preserved even when the cache cannot hold it). The over-cap audit is
+    best-effort and its failure must not abort that engagement.
+    """
+    # cache max 8 -> per_issuer_cap = max(1, 8 // 4) == 2.
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8")
+    mesh = _stub_mesh()
+    calls = []
+
+    def raising_audit(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("event_type") == "estop_per_issuer_cap_exceeded":
+            raise OSError("audit log volume full")
+
+    mesh.publish_safety_event = raising_audit  # type: ignore[method-assign]
+
+    # Pre-fill the flooder's cap with two fresh entries at distinct cache keys
+    # (so eviction keeps them and the incoming envelope takes a new key).
+    now_mono = time.monotonic()
+    mesh._estop_replay_cache[1.0] = ("op-flooder", now_mono, _OPERATOR_A_ZID)
+    mesh._estop_replay_cache[2.0] = ("op-flooder", now_mono, _OPERATOR_A_ZID)
+
+    result = mesh._on_safety_estop(
+        _envelope_with_wire_zid(
+            t=time.time(),
+            peer_id="op-flooder",
+            wire_zid=_OPERATOR_A_ZID,
+            reason="third estop from a flooding issuer",
+        )
+    )
+
+    assert result is None
+    cap_calls = [c for c in calls if c.get("event_type") == "estop_per_issuer_cap_exceeded"]
+    assert len(cap_calls) == 1
+    # Cap enforced despite the failing audit sink: no new slot for the flooder.
+    flooder_slots = sum(1 for issuer, _mono, _zid in mesh._estop_replay_cache.values() if issuer == "op-flooder")
+    assert flooder_slots == 2
+    # The legitimate safety event still engaged the lockout.
+    assert mesh._estop_lockout.is_set()

--- a/tests/mesh/test_resume_audit_publish_failure_nonblocking.py
+++ b/tests/mesh/test_resume_audit_publish_failure_nonblocking.py
@@ -134,3 +134,37 @@ def test_per_issuer_cap_audit_valueerror_is_swallowed_and_cap_enforced(monkeypat
     assert flooder_slots == 2
     # The refused (third) resume must NOT clear the lockout.
     assert m._estop_lockout.is_set() is True
+
+
+def test_redundant_resume_audit_oserror_is_swallowed_and_lockout_stays_clear(monkeypatch):
+    """A disk failure (OSError) while auditing a ``remote_resume_redundant``
+    event must not propagate out of the safety handler.
+
+    A fully-validated resume that arrives while the lockout is already clear
+    still consumed a replay-cache slot, so forensics record it as
+    ``remote_resume_redundant`` (issue #271). That forensic publish is
+    best-effort: a flaky audit sink must not abort handling. The lockout was
+    already clear and must stay clear.
+    """
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+
+    calls = []
+
+    def audit(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("event_type") == "remote_resume_redundant":
+            raise OSError("audit log volume full")
+
+    m.publish_safety_event = audit
+
+    # Lockout is NOT engaged, so a valid resume lands in the redundant branch.
+    assert m._estop_lockout.is_set() is False
+    env = _make_envelope("secret", peer_id="op-1")
+    m._on_safety_resume(_sample(env))  # must not raise despite the audit OSError
+
+    redundant = [c for c in calls if c.get("event_type") == "remote_resume_redundant"]
+    assert len(redundant) == 1
+    # Lockout was clear before and stays clear (a redundant resume is a no-op
+    # on lockout state).
+    assert m._estop_lockout.is_set() is False


### PR DESCRIPTION
## Problem
The mesh safety handlers emit best-effort forensic audit events via `publish_safety_event`. AGENTS.md mandates that a failing audit sink must never propagate out of the safety path and abort handling: a flaky or full-disk audit backend must not drop the fleet into a half-state. Each such publish is wrapped in `except (TypeError, ValueError, OSError)` (malformed payload -> TypeError/ValueError, disk failure -> OSError).

The corroborated / replay-rejected siblings of these branches are already pinned by tests, but three fail-soft branches in `strands_robots/mesh/core.py` were unverified:

- `remote_estop_redundant` (`_on_safety_estop`) - a second legitimate estop arriving while the lockout is already engaged.
- `estop_per_issuer_cap_exceeded` (`_on_safety_estop`) - a flooding issuer that trips the per-issuer replay-cache fairness bound.
- `remote_resume_redundant` (`_on_safety_resume`) - a valid resume that arrives on an already-clear lockout.

A regression that narrowed or removed any of these `except` clauses would crash the safety handler and go uncaught today.

## Change
Extend the two existing behavior-named test modules (no production change):

- `tests/mesh/test_estop_audit_publish_failure_nonblocking.py`: add coverage for `remote_estop_redundant` (audit raises ValueError) and `estop_per_issuer_cap_exceeded` (audit raises OSError).
- `tests/mesh/test_resume_audit_publish_failure_nonblocking.py`: add coverage for `remote_resume_redundant` (audit raises OSError).

Each test drives `publish_safety_event` to raise the relevant error on the target event type and asserts the handler returns cleanly with safety state intact:
- redundant estop keeps the already-engaged lockout latched;
- an over-cap estop adds no new replay-cache slot yet still engages the lockout (the legitimate safety event is preserved even when the cache cannot hold it);
- a redundant resume is a lockout no-op (was clear, stays clear).

## Tests
- 7 tests pass in the two modules (4 pre-existing + 3 new).
- Full `tests/mesh/` suite green: 2105 passed, 3 skipped.
- Regression-guard verified: narrowing the `remote_estop_redundant` except clause makes the new test fail with the raised `ValueError`, confirming the test pins the fail-soft contract.
- `ruff check` / `ruff format --check` clean.

This raises `mesh/core.py` line coverage by closing the previously-missing lines at the three audit-failure branches.