### PR TITLE
test(mesh/transport): pin IotMqttTransport.connect() fail-soft when awsiotsdk is absent

### DIFF
--- a/tests/mesh/test_transport.py
+++ b/tests/mesh/test_transport.py
@@ -196,6 +196,24 @@ class TestMqttMatcher:
 class TestIotMqttTransportConfig:
     """Transport config validation without touching a live broker."""
 
+    def test_missing_awsiotsdk_returns_false(self, monkeypatch):
+        """connect() fails soft (returns False) when awsiotsdk is absent.
+
+        The SDK-import guard runs before any config validation, so a fully
+        configured transport must still refuse to connect - returning False
+        rather than raising ImportError - when the ``[mesh-iot]`` extra is
+        not installed. Forcing ``awsiot`` to None in ``sys.modules`` makes
+        ``from awsiot import ...`` raise ImportError deterministically,
+        regardless of whether the SDK is present in the test environment.
+        """
+        import sys
+
+        monkeypatch.setenv("STRANDS_IOT_THING_NAME", "test-thing")
+        monkeypatch.setenv("STRANDS_IOT_ENDPOINT", "x.iot.us-west-2.amazonaws.com")
+        monkeypatch.setitem(sys.modules, "awsiot", None)
+        t = IotMqttTransport()
+        assert t.connect() is False
+
     def test_missing_thing_name_returns_false(self, monkeypatch):
         monkeypatch.delenv("STRANDS_IOT_THING_NAME", raising=False)
         monkeypatch.delenv("STRANDS_IOT_ENDPOINT", raising=False)


### PR DESCRIPTION
## Problem
`IotMqttTransport.connect()` guards its `from awsiot import mqtt5_client_builder` with a `try/except ImportError` that logs an install hint and returns `False`, so a missing `[mesh-iot]` extra disables the IoT transport gracefully instead of raising. That fail-soft branch had no test coverage: `TestIotMqttTransportConfig` pins the missing-thing / missing-endpoint / missing-cert guards but not the SDK-absent path, and any environment with `awsiotsdk` installed never exercises the branch, so it showed up as uncovered.

## Change
Add `test_missing_awsiotsdk_returns_false` to `TestIotMqttTransportConfig`. It forces `awsiot` to `None` in `sys.modules` so `from awsiot import ...` raises `ImportError` deterministically, independent of whether the SDK is installed in the test environment, and asserts `connect()` returns `False`. The transport is given a valid thing name and endpoint on purpose: the SDK-import guard runs before config validation, so a passing test proves the guard alone short-circuits rather than a downstream config check.

## Verification
- New test passes.
- Confirmed it is a real regression guard: removing the `try/except ImportError` (leaving the import unguarded) makes the test fail with `ModuleNotFoundError` propagating out of `connect()`.
- The previously-uncovered SDK-absent fail-soft block in `iot_transport.py` is now covered.
- Full mesh suite green (`2103 passed, 3 skipped`); `ruff check`, `ruff format --check`, and `mypy` all clean.

Test-only change; no library behavior is modified.