### PR TITLE
build(deps): raise [wbc] huggingface_hub floor to >=1.0 so hf buckets/sync subcommands are resolver-guaranteed (closes #1549)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,10 +137,14 @@ wbc = [
     # Required so create_policy("wbc") with no local checkpoint works out of the
     # box - WBCPolicy._maybe_download_checkpoint raises RuntimeError naming the
     # [wbc] extra when it is absent.
-    # Cap the MAJOR only (<2.0.0): a <1.0.0 cap conflicts with lerobot, which
-    # requires huggingface-hub>=1.0.0 - and [wbc] is pulled into [all] alongside
-    # lerobot, so the two must co-resolve.
-    "huggingface_hub>=0.20.0,<2.0.0",
+    # Floor at >=1.0 (cap the MAJOR only, <2.0.0): the docs' bucket-sync
+    # guidance (README streamed-training section + dataset_recorder.sync_to_bucket)
+    # instructs `pip install -U "huggingface_hub>=1.0"` because the `hf buckets`/
+    # `hf sync` CLI subcommands only exist on huggingface_hub>=1.0; a <1.0 floor
+    # lets a fresh resolve land on 0.36.x, whose `hf` entry point lacks those
+    # subcommands. >=1.0 also matches lerobot (huggingface-hub>=1.0.0) - and
+    # [wbc] is pulled into [all] alongside lerobot, so the two co-resolve.
+    "huggingface_hub>=1.0,<2.0.0",
 ]
 motionbricks = [
     # MotionBricks (NVlabs/GR00T-WholeBodyControl `motionbricks/`) generative

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -211,3 +211,39 @@ def test_dataset_recorder_codec_docs_track_the_supported_lerobot_floor() -> None
     # and the current allowlist symbols/entries are the ones documented
     assert "HW_VIDEO_CODECS" in text
     assert "libaom-av1" in text
+
+
+# --- positive contract: the [wbc] extra's huggingface_hub floor must guarantee
+#     the `hf buckets`/`hf sync` CLI subcommands the bucket-sync docs instruct.
+#     Those subcommands only exist on huggingface_hub>=1.0; the docs (README
+#     streamed-training section + dataset_recorder.sync_to_bucket, pinned by
+#     test_hf_cli_install_guidance_pins_huggingface_hub_1_0) tell users to
+#     `pip install -U "huggingface_hub>=1.0"`, so a fresh
+#     `pip install strands-robots[wbc]` that resolves an `hf` entry point WITHOUT
+#     those subcommands (huggingface_hub 0.36.x satisfies a <1.0 floor) silently
+#     reproduces the exact "hf CLI not found / no such subcommand" failure the
+#     docs' own error message calls out. Floor the direct pin at >=1.0 so the
+#     resolver can't drift below the documented minimum. See issue #1549. ---
+
+
+def _wbc_huggingface_hub_spec() -> str:
+    """The exact version specifier the ``[wbc]`` extra declares for huggingface_hub."""
+    for spec in _extras()["wbc"]:
+        # normalize the dist name (huggingface_hub / huggingface-hub) before matching
+        name = spec.split(">")[0].split("<")[0].split("=")[0].split("[")[0]
+        if name.replace("-", "_").strip() == "huggingface_hub":
+            return spec
+    raise AssertionError("no huggingface_hub pin found in the [wbc] extra")
+
+
+def test_wbc_extra_huggingface_hub_floor_is_at_least_1_0() -> None:
+    spec = _wbc_huggingface_hub_spec()
+    # floor at >=1.0 so the resolved `hf` CLI carries the buckets/sync subcommands
+    assert ">=1.0" in spec, (
+        f"[wbc] huggingface_hub floor must be >=1.0 (the `hf buckets`/`hf sync` "
+        f"CLI subcommands the bucket-sync docs instruct only exist on >=1.0); got {spec!r}"
+    )
+    # the dead pre-1.0 floor must not linger
+    assert ">=0.20.0" not in spec, f"[wbc] still pins the dead pre-1.0 huggingface_hub floor: {spec!r}"
+    # keep the MAJOR cap (<2.0.0) per repo convention (>=1.0 deps cap the major)
+    assert "<2.0.0" in spec, f"[wbc] huggingface_hub pin lost its <2.0.0 major cap: {spec!r}"


### PR DESCRIPTION
## Summary

The `[wbc]` extra pinned `huggingface_hub>=0.20.0,<2.0.0`, but the bucket-sync docs corrected in #1509 (README streamed-training section + `strands_robots/dataset_recorder.py` `sync_to_bucket` docstring and the "hf CLI not found" error message) instruct users to `pip install -U "huggingface_hub>=1.0"` — because the `hf buckets` / `hf sync` CLI subcommands only exist on `huggingface_hub>=1.0`.

A fresh `pip install strands-robots[wbc]` could resolve `huggingface_hub==0.36.x` (which satisfies a `<1.0` floor) and land an `hf` entry point without `buckets`/`sync`, silently reproducing the exact failure mode the doc's own error message calls out.

## Fix

Raise the direct floor to `>=1.0`, keeping the `<2.0.0` major cap per repo convention (`>=1.0` deps cap the major):

```toml
"huggingface_hub>=1.0,<2.0.0",
```

This is consistent with the surrounding stack: lerobot already requires `huggingface-hub>=1.0.0`, and `[wbc]` is pulled into `[all]` alongside lerobot, so the two co-resolve unchanged. The comment on the pin is updated to document the positive reason for the floor (the CLI-subcommand guarantee) rather than only the major-cap rationale.

## Test contract

Per #1549, extends `tests/test_lerobot_dependency_docs.py` with a dedicated, self-contained pin:

- `test_wbc_extra_huggingface_hub_floor_is_at_least_1_0` — parses the `[wbc]` extra's `huggingface_hub` specifier from `pyproject.toml` and asserts the `>=1.0` floor is present, the dead `>=0.20.0` floor is gone, and the `<2.0.0` major cap remains.

This is a new test function (not the doc-guidance `test_hf_cli_install_guidance_pins_huggingface_hub_1_0` added in #1509), so it pins the pyproject floor independently of the doc guidance and can't drift again.

## Verification

- `pytest tests/test_lerobot_dependency_docs.py` — 13 passed.
- Regression-confirmed: reverting the floor to `>=0.20.0` makes the new test FAIL; restoring `>=1.0` makes it pass.
- `ruff check` + `ruff format --check` — clean.

Closes #1549.

---

### §13 Round changelog

**Round 1 (initial):** `[wbc]` `huggingface_hub` floor `>=0.20.0` → `>=1.0` (`<2.0.0` cap retained) + comment update + `test_wbc_extra_huggingface_hub_floor_is_at_least_1_0` regression pin.