### PR TITLE
build(deps): raise lerobot floor to >=0.6.1 so repo_type='bucket' streaming is resolver-guaranteed

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ graph TB
 | Extra | Pulls in | When |
 |-------|----------|------|
 | `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg` | `Robot(mode="sim")` |
-| `[lerobot]` | `lerobot>=0.6.0,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
+| `[lerobot]` | `lerobot>=0.6.1,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` ZMQ |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | (none) | core only - Robot factory, registry, lazy imports | Inspect the catalog, write tools |
 | `[sim]` | `robot_descriptions` | Sim asset resolution without MuJoCo |
 | `[sim-mujoco]` | `sim` + `mujoco`, `imageio`, `imageio-ffmpeg` | Any `Robot()` with default `mode="sim"` |
-| `[lerobot]` | `lerobot>=0.6.0,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
+| `[lerobot]` | `lerobot>=0.6.1,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` (ZMQ to a GR00T container) |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh discovery + RPC |

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -196,7 +196,7 @@ lerobot PR #3604 and first released in 0.6.0 - so it resolves straight from
 PyPI with no git-from-source install. The `[molmoact2]` extra layers the
 auxiliary deps MolmoAct2's modeling and processor code needs
 (`transformers>=5.4.0,<5.6.0`, `peft`, `scipy`) on top of
-`strands-robots[lerobot]` (which pins `lerobot>=0.6.0,<0.7.0`):
+`strands-robots[lerobot]` (which pins `lerobot>=0.6.1,<0.7.0`):
 
 ```bash
 uv pip install "strands-robots[molmoact2]"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@ description: Error → fix table for the most common gotchas across install, sim
 |---------|--------------|-----|
 | `ModuleNotFoundError: mujoco` | Missing `[sim-mujoco]` | `uv pip install "strands-robots[sim-mujoco]"` |
 | `ModuleNotFoundError: lerobot` | Missing `[lerobot]` | `uv pip install "strands-robots[lerobot]"` |
-| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.0,<0.7.0`) |
+| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.1,<0.7.0`) |
 | `ImportError: cannot import name 'MolmoAct2Policy'` | `lerobot < 0.6` (`MolmoAct2Policy` ships in lerobot >= 0.6) | `uv pip install "strands-robots[molmoact2]"` |
 | pyav build fails on Jetson/aarch64 | No prebuilt wheel for sm_110 | Use `--no-build-isolation` or install `torchcodec>=0.7` and skip pyav. See [installation](getting-started/installation.md#molmoact2-on-jetson) |
 | numpy ABI mismatch on Jetson | System pandas vs pip numpy | `uv pip install "numpy<2" "pandas==2.1.4"` then reinstall |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ lerobot = [
     # marker. NOTE: torch/torchcodec ship as +cuXXX wheels resolved by
     # UV_TORCH_BACKEND; a plain `pip install` on Thor may need the matching CUDA
     # index -- see the README Installation section for the Thor/Jetson caveat.
-    "lerobot[feetech,dataset]>=0.6.0,<0.7.0",
+    "lerobot[feetech,dataset]>=0.6.1,<0.7.0",
 ]
 # Remote/offloaded inference via lerobot's native async-inference gRPC
 # transport (the `lerobot_async` policy provider, LerobotAsyncPolicy). Layers
@@ -193,7 +193,7 @@ lerobot = [
 # it here, so the gRPC/protobuf floor tracks lerobot.
 lerobot-async = [
     "strands-robots[lerobot]",
-    "lerobot[async]>=0.6.0,<0.7.0",
+    "lerobot[async]>=0.6.1,<0.7.0",
 ]
 # MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
 # MolmoAct2Policy class ships in lerobot >= 0.6 (it landed via lerobot PR #3604

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -160,28 +160,54 @@ from packaging.requirements import Requirement  # noqa: E402
 from packaging.version import Version  # noqa: E402
 
 
-def _lerobot_extra_requirement() -> Requirement:
+def _lerobot_requirement(extra: str) -> Requirement:
     data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
-    extra = data["project"]["optional-dependencies"]["lerobot"]
-    for spec in extra:
+    specs = data["project"]["optional-dependencies"][extra]
+    for spec in specs:
         req = Requirement(spec)
         if req.name == "lerobot":
             return req
-    raise AssertionError("no `lerobot` requirement found in the [lerobot] extra")
+    raise AssertionError(f"no `lerobot` requirement found in the [{extra}] extra")
 
 
-def test_lerobot_extra_requires_at_least_0_6() -> None:
-    """The ``[lerobot]`` extra must floor lerobot at >= 0.6.0.
+def test_lerobot_extra_requires_at_least_0_6_1() -> None:
+    """The ``[lerobot]`` extra must floor lerobot at >= 0.6.1.
 
-    The 0.5.1-era torch/torchcodec overrides were removed because lerobot 0.6's
-    own markers resolve the decoder stack correctly; that only holds for
-    lerobot >= 0.6, so the floor must not regress below it.
+    Two guarantees ride on this floor:
+
+    * The 0.5.1-era torch/torchcodec overrides were removed because lerobot 0.6's
+      own markers resolve the decoder stack correctly, so the floor must not
+      regress into the 0.5.x range.
+    * The flagship bucket-streaming path (``StreamingDatasetReader.open(...,
+      repo_type="bucket")``) needs ``StreamingLeRobotDataset`` to accept a
+      ``repo_type`` parameter, which first shipped in lerobot 0.6.1. Flooring at
+      0.6.1 turns that guarantee from a runtime error on 0.6.0 into an
+      install-time resolution.
     """
-    req = _lerobot_extra_requirement()
-    assert Version("0.6.0") in req.specifier, f"lerobot floor must admit 0.6.0, got {req.specifier}"
+    req = _lerobot_requirement("lerobot")
+    assert Version("0.6.1") in req.specifier, f"lerobot floor must admit 0.6.1, got {req.specifier}"
+    assert Version("0.6.0") not in req.specifier, (
+        f"lerobot floor must exclude 0.6.0 (repo_type='bucket' streaming needs "
+        f"the repo_type parameter that first ships in lerobot 0.6.1), got {req.specifier}"
+    )
     assert Version("0.5.9") not in req.specifier, (
         f"lerobot floor must exclude 0.5.x (the overrides that compensated for "
         f"lerobot 0.5.1's decoder markers were removed), got {req.specifier}"
+    )
+
+
+def test_lerobot_async_extra_floor_matches_lerobot_extra() -> None:
+    """The ``[lerobot-async]`` extra must carry the same >= 0.6.1 floor.
+
+    ``[lerobot-async]`` pins its own ``lerobot[async]`` requirement rather than
+    inheriting the specifier from ``[lerobot]``, so its floor can drift. It must
+    track the same 0.6.1 minimum or the resolver could install a lerobot whose
+    async transport predates the bucket-streaming guarantee.
+    """
+    req = _lerobot_requirement("lerobot-async")
+    assert Version("0.6.1") in req.specifier, f"lerobot-async floor must admit 0.6.1, got {req.specifier}"
+    assert Version("0.6.0") not in req.specifier, (
+        f"lerobot-async floor must exclude 0.6.0 to match the [lerobot] extra, got {req.specifier}"
     )
 
 


### PR DESCRIPTION
## Problem

The flagship bucket-streaming path, `StreamingDatasetReader.open(..., repo_type="bucket")`, needs `StreamingLeRobotDataset` to accept a `repo_type` parameter, which first shipped in **lerobot 0.6.1**. The `[lerobot]` and `[lerobot-async]` extras floored lerobot at `>=0.6.0`, so the resolver could install a 0.6.0 that fails the flagship path at runtime. The 0.6.1 requirement previously lived only in docs (recording guide, notebooks) and was unenforced by the resolver.

## Change

Raise both extra floors from `>=0.6.0` to `>=0.6.1` (keeping the `<0.7.0` cap per the dependency-bounds convention):

```toml
lerobot        = [ ..., "lerobot[feetech,dataset]>=0.6.1,<0.7.0" ]
lerobot-async  = [ ..., "lerobot[async]>=0.6.1,<0.7.0" ]
```

This moves the guarantee from a runtime `RuntimeError` on 0.6.0 to install-time resolution.

The `open()`-time `RuntimeError` guard in `streaming_dataset.py` stays untouched: it still protects environments that carry a pre-existing older lerobot in the interpreter (where the resolver never ran).

## Tests

`tests/test_dependency_audit.py`:
- `test_lerobot_extra_requires_at_least_0_6_1` now asserts the floor admits 0.6.1 and excludes 0.6.0 (and still excludes 0.5.x).
- Adds `test_lerobot_async_extra_floor_matches_lerobot_extra` — the `[lerobot-async]` extra pins its own `lerobot[async]` requirement rather than inheriting `[lerobot]`'s specifier, so its floor is verified independently.

Both tests fail on the pre-change 0.6.0 floor and pass after the bump. Full `tests/test_dependency_audit.py` suite green (12 passed); ruff + mypy clean.

## Docs

Synced the four exact-pin references (`installation.md`, `architecture.md`, `troubleshooting.md`, `policies/lerobot-local.md`) from `lerobot>=0.6.0,<0.7.0` to `>=0.6.1,<0.7.0`. Loose `lerobot >= 0.6` mentions tied to `MolmoAct2Policy` availability (which shipped in 0.6.0) are intentionally left as-is.

Aarch64 wheel availability for the 0.6.x line is confirmed (lerobot 0.6.1 resolves and imports on linux/aarch64).

Closes #1516. Closes #1506.