### PR TITLE
build(deps): raise lerobot floor to >=0.6.1 so bucket streaming is resolver-guaranteed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Changed: `[lerobot]` / `[lerobot-async]` extras floor lerobot at `>=0.6.1`
+
+The `[lerobot]` and `[lerobot-async]` extras now pin `lerobot>=0.6.1,<0.7.0` (was `>=0.6.0`). The flagship bucket-streaming path -- `StreamingDatasetReader.open(..., repo_type="bucket")` via `sim.stream_dataset` -- requires lerobot 0.6.1, the first release whose `StreamingLeRobotDataset` accepts the `repo_type` parameter. On lerobot 0.6.0 the kwarg is silently dropped by the tolerant-forwarding shim, so the guarantee previously lived only in docs. Flooring at 0.6.1 makes it resolver-time (install fails fast) instead of a runtime surprise. No API change; the `[molmoact2]` extra inherits the raised floor via `strands-robots[lerobot]`. Pinned by `tests/test_dependency_audit.py::test_lerobot_extra_requires_at_least_0_6_1`.
+
 ### Added: LIBERO MuJoCo example drivers (`examples/libero/run_mujoco.py`, `run_mujoco_agent.py`)
 
 The default-backend LIBERO drivers promised by the epic-#1269 migration are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ graph TB
 | Extra | Pulls in | When |
 |-------|----------|------|
 | `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg` | `Robot(mode="sim")` |
-| `[lerobot]` | `lerobot>=0.6.0,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
+| `[lerobot]` | `lerobot>=0.6.1,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` ZMQ |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | (none) | core only - Robot factory, registry, lazy imports | Inspect the catalog, write tools |
 | `[sim]` | `robot_descriptions` | Sim asset resolution without MuJoCo |
 | `[sim-mujoco]` | `sim` + `mujoco`, `imageio`, `imageio-ffmpeg` | Any `Robot()` with default `mode="sim"` |
-| `[lerobot]` | `lerobot>=0.6.0,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
+| `[lerobot]` | `lerobot>=0.6.1,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` (ZMQ to a GR00T container) |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh discovery + RPC |

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -196,7 +196,7 @@ lerobot PR #3604 and first released in 0.6.0 - so it resolves straight from
 PyPI with no git-from-source install. The `[molmoact2]` extra layers the
 auxiliary deps MolmoAct2's modeling and processor code needs
 (`transformers>=5.4.0,<5.6.0`, `peft`, `scipy`) on top of
-`strands-robots[lerobot]` (which pins `lerobot>=0.6.0,<0.7.0`):
+`strands-robots[lerobot]` (which pins `lerobot>=0.6.1,<0.7.0`):
 
 ```bash
 uv pip install "strands-robots[molmoact2]"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@ description: Error → fix table for the most common gotchas across install, sim
 |---------|--------------|-----|
 | `ModuleNotFoundError: mujoco` | Missing `[sim-mujoco]` | `uv pip install "strands-robots[sim-mujoco]"` |
 | `ModuleNotFoundError: lerobot` | Missing `[lerobot]` | `uv pip install "strands-robots[lerobot]"` |
-| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.0,<0.7.0`) |
+| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.1,<0.7.0`) |
 | `ImportError: cannot import name 'MolmoAct2Policy'` | `lerobot < 0.6` (`MolmoAct2Policy` ships in lerobot >= 0.6) | `uv pip install "strands-robots[molmoact2]"` |
 | pyav build fails on Jetson/aarch64 | No prebuilt wheel for sm_110 | Use `--no-build-isolation` or install `torchcodec>=0.7` and skip pyav. See [installation](getting-started/installation.md#molmoact2-on-jetson) |
 | numpy ABI mismatch on Jetson | System pandas vs pip numpy | `uv pip install "numpy<2" "pandas==2.1.4"` then reinstall |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,12 @@ lerobot = [
     # marker. NOTE: torch/torchcodec ship as +cuXXX wheels resolved by
     # UV_TORCH_BACKEND; a plain `pip install` on Thor may need the matching CUDA
     # index -- see the README Installation section for the Thor/Jetson caveat.
-    "lerobot[feetech,dataset]>=0.6.0,<0.7.0",
+    # The floor is 0.6.1 (not 0.6.0): the flagship bucket-streaming path
+    # (StreamingDatasetReader.open(..., repo_type="bucket") via
+    # sim.stream_dataset) needs lerobot 0.6.1, the first release whose
+    # StreamingLeRobotDataset accepts the repo_type parameter. Flooring here
+    # makes that guarantee resolver-time instead of a runtime RuntimeError.
+    "lerobot[feetech,dataset]>=0.6.1,<0.7.0",
 ]
 # Remote/offloaded inference via lerobot's native async-inference gRPC
 # transport (the `lerobot_async` policy provider, LerobotAsyncPolicy). Layers
@@ -193,7 +198,7 @@ lerobot = [
 # it here, so the gRPC/protobuf floor tracks lerobot.
 lerobot-async = [
     "strands-robots[lerobot]",
-    "lerobot[async]>=0.6.0,<0.7.0",
+    "lerobot[async]>=0.6.1,<0.7.0",
 ]
 # MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
 # MolmoAct2Policy class ships in lerobot >= 0.6 (it landed via lerobot PR #3604

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -142,7 +142,7 @@ def train_policy(
         - ``lerobot_local`` + ACT/diffusion: ``pip install 'strands-robots[lerobot]'``.
         - ``lerobot_local`` + ``smolvla``/``pi0``/``pi05``: add lerobot's
           ``[smolvla]``/``[pi]`` extra on top of ``strands-robots[lerobot]``
-          (which pins ``lerobot>=0.6.0``). Those extras layer
+          (which pins ``lerobot>=0.6.1``). Those extras layer
           ``transformers>=5.4.0,<5.6.0`` (plus num2words / scipy); do NOT pin
           ``transformers==5.3.0`` - it conflicts with lerobot 0.6's transformers
           floor.

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -156,32 +156,42 @@ def test_direct_reference_check_ignores_extras_specifiers_and_markers(tmp_path):
 # resolution. This guard fails if either half regresses.
 import tomllib  # noqa: E402
 
+import pytest  # noqa: E402
 from packaging.requirements import Requirement  # noqa: E402
 from packaging.version import Version  # noqa: E402
 
 
-def _lerobot_extra_requirement() -> Requirement:
+def _lerobot_requirement(extra: str) -> Requirement:
     data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
-    extra = data["project"]["optional-dependencies"]["lerobot"]
-    for spec in extra:
+    specs = data["project"]["optional-dependencies"][extra]
+    for spec in specs:
         req = Requirement(spec)
         if req.name == "lerobot":
             return req
-    raise AssertionError("no `lerobot` requirement found in the [lerobot] extra")
+    raise AssertionError(f"no `lerobot` requirement found in the [{extra}] extra")
 
 
-def test_lerobot_extra_requires_at_least_0_6() -> None:
-    """The ``[lerobot]`` extra must floor lerobot at >= 0.6.0.
+@pytest.mark.parametrize("extra", ["lerobot", "lerobot-async"])
+def test_lerobot_extra_requires_at_least_0_6_1(extra: str) -> None:
+    """The ``[lerobot]`` / ``[lerobot-async]`` extras must floor lerobot at >= 0.6.1.
 
-    The 0.5.1-era torch/torchcodec overrides were removed because lerobot 0.6's
-    own markers resolve the decoder stack correctly; that only holds for
-    lerobot >= 0.6, so the floor must not regress below it.
+    Two coupled reasons the floor cannot regress below 0.6.1:
+
+    * The 0.5.1-era torch/torchcodec overrides were removed because lerobot 0.6's
+      own dependency markers resolve the decoder stack correctly (that only holds
+      for lerobot >= 0.6).
+    * The flagship bucket-streaming path
+      (``StreamingDatasetReader.open(..., repo_type="bucket")`` via
+      ``sim.stream_dataset``) needs lerobot 0.6.1 -- the first release whose
+      ``StreamingLeRobotDataset`` accepts the ``repo_type`` parameter. Flooring at
+      0.6.1 makes that guarantee resolver-time instead of a runtime ``RuntimeError``
+      (or, on lerobot 0.6.0, a silently dropped kwarg).
     """
-    req = _lerobot_extra_requirement()
-    assert Version("0.6.0") in req.specifier, f"lerobot floor must admit 0.6.0, got {req.specifier}"
-    assert Version("0.5.9") not in req.specifier, (
-        f"lerobot floor must exclude 0.5.x (the overrides that compensated for "
-        f"lerobot 0.5.1's decoder markers were removed), got {req.specifier}"
+    req = _lerobot_requirement(extra)
+    assert Version("0.6.1") in req.specifier, f"lerobot floor must admit 0.6.1, got {req.specifier}"
+    assert Version("0.6.0") not in req.specifier, (
+        f"lerobot floor must exclude 0.6.0 -- its StreamingLeRobotDataset lacks the "
+        f"repo_type parameter the bucket-streaming path requires, got {req.specifier}"
     )
 
 

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -1,6 +1,6 @@
 """Keep the VLA install docs consistent with the declared dependencies.
 
-The ``lerobot>=0.6.0`` bump obsoleted a body of pre-0.6 install guidance that
+The ``lerobot>=0.6.1`` bump obsoleted a body of pre-0.6 install guidance that
 lived in the ``train_policy`` tool docstring and the policy/training docs:
 
 * ``pip install 'lerobot[smolvla]==0.5.1'`` and a ``transformers==5.3.0`` pin -
@@ -12,7 +12,7 @@ lived in the ``train_policy`` tool docstring and the policy/training docs:
   longer applies to the supported range.
 * "MolmoAct2 requires lerobot **from source**" - ``MolmoAct2Policy`` ships in
   lerobot >= 0.6, so ``strands-robots[molmoact2]`` (which pulls
-  ``strands-robots[lerobot]`` -> ``lerobot>=0.6.0``) resolves it straight from
+  ``strands-robots[lerobot]`` -> ``lerobot>=0.6.1``) resolves it straight from
   PyPI; no ``git+`` install.
 
 These assertions pin the pyproject reality and forbid the stale guidance from
@@ -36,10 +36,10 @@ def _extras() -> dict[str, list[str]]:
 # --- positive contract: the pyproject reality the docs must reflect ---
 
 
-def test_lerobot_extra_requires_0_6() -> None:
+def test_lerobot_extra_requires_0_6_1() -> None:
     joined = " ".join(_extras()["lerobot"])
     assert "lerobot" in joined
-    assert ">=0.6.0" in joined, f"lerobot extra no longer pins >=0.6.0: {joined!r}"
+    assert ">=0.6.1" in joined, f"lerobot extra no longer pins >=0.6.1: {joined!r}"
 
 
 def test_molmoact2_extra_is_pure_pypi_with_transformers_5_4_plus() -> None:
@@ -109,8 +109,9 @@ def test_architecture_lerobot_extra_row_matches_pyproject_floor() -> None:
     text = _ARCHITECTURE.read_text()
     # the dependency-matrix row must not advertise the dead pre-0.6 cap
     assert "lerobot>=0.5.0,<0.6.0" not in text, "architecture.md still cites the dead <0.6.0 lerobot cap"
-    # it must reflect the real floor (>=0.6.0)
-    assert ">=0.6.0" in text, "architecture.md [lerobot] row should name the >=0.6.0 floor"
+    # it must name the exact floor the [lerobot] extra declares in pyproject
+    floor = _lerobot_floor_from_pyproject()  # e.g. ">=0.6.1,<0.7.0"
+    assert floor in text, f"architecture.md [lerobot] row must name the pyproject floor {floor!r}"
 
 
 def test_troubleshooting_version_skew_remedy_does_not_conflict_with_floor() -> None:

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1291,7 +1291,7 @@ class TestHardwareConfigV040Followups:
         because lerobot 0.5.1's own marker excluded aarch64. lerobot 0.6 fixed
         that upstream (its `torchcodec>=0.11,<0.12; aarch64` marker pulls the
         torch-ABI-matched decoder), so the strands override was dropped and the
-        guarantee now rides on the `lerobot>=0.6.0` floor. This pins that floor
+        guarantee now rides on the `lerobot>=0.6.1` floor. This pins that floor
         so a revert below 0.6 -- which would resurrect the missing-decoder bug
         without the removed override -- fails here."""
         import tomllib
@@ -1304,8 +1304,8 @@ class TestHardwareConfigV040Followups:
         data = tomllib.load(open(root / "pyproject.toml", "rb"))
         lerobot_extra = data["project"]["optional-dependencies"]["lerobot"]
         lerobot_req = next(Requirement(d) for d in lerobot_extra if Requirement(d).name == "lerobot")
-        assert Version("0.6.0") in lerobot_req.specifier and Version("0.5.9") not in lerobot_req.specifier, (
-            f"[lerobot] extra must floor lerobot at >=0.6.0 so aarch64 gets torchcodec (#378); "
+        assert Version("0.6.1") in lerobot_req.specifier and Version("0.5.9") not in lerobot_req.specifier, (
+            f"[lerobot] extra must floor lerobot at >=0.6.1 so aarch64 gets torchcodec (#378); "
             f"got {lerobot_req.specifier}"
         )
 


### PR DESCRIPTION
## Problem

The `[lerobot]` and `[lerobot-async]` extras pinned `lerobot[...]>=0.6.0,<0.7.0`, but the flagship bucket-streaming path -- `StreamingDatasetReader.open(..., repo_type="bucket")` reached via `sim.stream_dataset` -- requires **lerobot 0.6.1**, the first release whose `StreamingLeRobotDataset` accepts the `repo_type` parameter. On lerobot 0.6.0 that kwarg is silently dropped by the tolerant-forwarding shim, so the flagship path degrades quietly. The 0.6.1 requirement lived only in docs (installation/architecture/troubleshooting) and was **not enforced by the resolver** -- an install could resolve a lerobot that cannot serve the bucket path at all.

## Change

Raise the floor to `>=0.6.1,<0.7.0` in both extras so the guarantee moves from a runtime `RuntimeError` (or silent kwarg drop) to **install-time resolution**. Per the dependency-bounds convention, `<1.0` deps cap the minor, which `<0.7.0` already does. The `[molmoact2]` extra inherits the raised floor via `strands-robots[lerobot]` (no separate pin).

Docs that quote the exact pin string (architecture, installation, troubleshooting, lerobot-local) and the `train_policy` tool docstring are updated to match. CHANGELOG entry added under `[Unreleased]`.

## Tests

`tests/test_dependency_audit.py::test_lerobot_extra_requires_at_least_0_6_1` -- now parametrized over `[lerobot]` and `[lerobot-async]` -- asserts the floor admits `0.6.1` and **excludes** `0.6.0` (the version whose `StreamingLeRobotDataset` lacks `repo_type`). It fails on the pre-bump `>=0.6.0` pin and passes after. The docs-sync guard (`test_lerobot_dependency_docs.py`) now derives the architecture.md floor assertion from pyproject instead of hardcoding, and `test_robot_factory.py`'s aarch64-decoder floor guard is lifted to `0.6.1`.

Local gate: `ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`; affected pytest modules green.

Closes #1506
Closes #1516

---

## §13 Changelog

### Round 1 -- converted to DRAFT (blocked on upstream)

Review feedback identified a hard, verified blocker: `lerobot>=0.6.1` is **unsatisfiable on PyPI** -- the latest published release is `0.6.0` (verified `curl -s https://pypi.org/pypi/lerobot/json` -> `0.6.0`; release list ends at `0.6.0`). Merging as-is would turn the intended install-time *guarantee* into an install-time *failure* for every consumer of `[lerobot]`, `[lerobot-async]`, `[molmoact2]`, and `[all]`, including users who never touch bucket streaming.

The premise is confirmed correct (lerobot 0.6.0's `StreamingLeRobotDataset.__init__` genuinely lacks `repo_type`), and the bucket path already fail-fasts today via the runtime guard in `strands_robots/streaming_dataset.py` (`RuntimeError("repo_type=... requires lerobot>=0.6.1 ...")`) -- so there is **no silent degradation** on current `main` that justifies shipping an unresolvable pin early.

**Decision:** hold as DRAFT rather than merge or close. The diff is correct and pre-staged; it becomes mergeable the moment lerobot 0.6.1 lands on PyPI. Un-draft + re-verify (`curl -s https://pypi.org/pypi/lerobot/json | jq '.info.version'`) at that point. The existing runtime guard remains the correct current-state guarantee in the interim.

Correction to the original description: the "aarch64 wheel availability for the 0.6.x line is confirmed" claim holds only for `0.6.0`, not `0.6.1` -- removed above to avoid asserting availability of an unreleased version.