### PR TITLE
style(docs): ruff format the python code blocks in three doc files

### DIFF
--- a/strands_robots/device_connect/GUIDE.md
+++ b/strands_robots/device_connect/GUIDE.md
@@ -35,10 +35,13 @@ From another process, discover and invoke:
 ```python
 from strands_robots.tools.robot_mesh import robot_mesh
 
-robot_mesh(action="peers")                           # discover (read-only)
-robot_mesh(action="tell", target="so100-lab-1",      # invoke (HITL-approved)
-           instruction="pick up the cube")
-robot_mesh(action="emergency_stop")                   # e-stop all (HITL-approved)
+robot_mesh(action="peers")  # discover (read-only)
+robot_mesh(
+    action="tell",
+    target="so100-lab-1",  # invoke (HITL-approved)
+    instruction="pick up the cube",
+)
+robot_mesh(action="emergency_stop")  # e-stop all (HITL-approved)
 ```
 
 > **Heads up:** the actuation actions - `tell`, `send`, `stop`, `broadcast`,
@@ -361,11 +364,11 @@ Use the mesh's `subscribe()` to read Reachy's native Zenoh topics directly:
 sim = Robot("so100")
 
 # Subscribe to Reachy's head pose
-sim.mesh.subscribe("reachy_mini/head_pose",
-    lambda topic, data: print(f"Reachy looking at: {data}"))
+sim.mesh.subscribe("reachy_mini/head_pose", lambda topic, data: print(f"Reachy looking at: {data}"))
 
 # Subscribe to Reachy's joint positions
 sim.mesh.subscribe("reachy_mini/joint_positions", name="reachy_joints")
+
 
 # Mirror Reachy's movements in simulation
 def mirror_reachy(topic, data):
@@ -373,6 +376,7 @@ def mirror_reachy(topic, data):
     if joints:
         # Map Reachy joints to sim joints...
         pass
+
 
 sim.mesh.subscribe("reachy_mini/joint_positions", mirror_reachy)
 ```
@@ -421,8 +425,8 @@ runtime = DeviceRuntime(
 await runtime.run()
 
 # Now any agent can discover and control it:
-invoke('device(reachy-mini-1).function(look)', {"pitch": -15, "yaw": 30})
-invoke('device(reachy-mini-1).function(nod)')
+invoke("device(reachy-mini-1).function(look)", {"pitch": -15, "yaw": 30})
+invoke("device(reachy-mini-1).function(nod)")
 ```
 
 ### E2E Demo

--- a/strands_robots/policies/vera/README.md
+++ b/strands_robots/policies/vera/README.md
@@ -7,8 +7,8 @@ install — only the tiny `websockets`+`msgpack` client transport.
 
 ```python
 from strands_robots.policies import create_policy
-policy = create_policy("vera", embodiment="mimicgen", server_mode="docker",
-                       ckpt_root="/abs/path/vera-ckpts")
+
+policy = create_policy("vera", embodiment="mimicgen", server_mode="docker", ckpt_root="/abs/path/vera-ckpts")
 chunk = policy.get_actions_sync(observation, "stack the red block on the green block")
 ```
 

--- a/strands_robots/policies/vera/docker/README.md
+++ b/strands_robots/policies/vera/docker/README.md
@@ -75,11 +75,11 @@ from strands_robots.policies import create_policy
 policy = create_policy(
     "vera",
     embodiment="pusht",
-    server_mode="docker",            # <- manage the container, not a subprocess
+    server_mode="docker",  # <- manage the container, not a subprocess
     ckpt_root="/abs/path/vera-ckpts",
 )
 chunk = policy.get_actions_sync(obs, "push the T to the goal")
-policy.close()                       # stops the container it started
+policy.close()  # stops the container it started
 ```
 
 ## Checkpoint wiring


### PR DESCRIPTION
## Problem

`main` is red on `call-test-lint`. The hatch `lint` env pins `ruff>=0.4.0,<1.0.0`, so CI resolves the latest ruff (0.16.0). That formatter reformats fenced `python` code blocks inside markdown, and three docs currently carry hand-aligned code blocks the formatter rewrites:

- `strands_robots/device_connect/GUIDE.md`
- `strands_robots/policies/vera/README.md`
- `strands_robots/policies/vera/docker/README.md`

Because `hatch run lint` runs `ruff format --check strands_robots tests tests_integ` over those directories, the check fails on `3 files would be reformatted`. This is unrelated to any feature branch, so **every open PR that runs `call-test-lint` inherits a red status** on a diff it never touched.

## Change

Run `ruff format` on the three files so the code blocks match the formatter's canonical shape. No prose is changed and the code semantics are identical:

- `device_connect/GUIDE.md`: expand a multi-line `robot_mesh(...)` call, collapse a wrapped `subscribe(...)` lambda onto one line, add the two blank lines before top-level `def`s, and double-quote the `invoke(...)` device strings.
- `policies/vera/README.md`: collapse the wrapped `create_policy(...)` call.
- `policies/vera/docker/README.md`: normalize inline-comment spacing.

## Tests

`ruff format --check strands_robots tests tests_integ` -> `854 files already formatted` (was `3 files would be reformatted`). `ruff check` clean. Diff is 16 insertions / 12 deletions across the three files, all inside ` ```python ` fences.

## Note

This is the minimal unblock. The underlying drift vector -- an unpinned ruff range letting the formatter's behaviour move under the repo, and ruff formatting markdown code blocks at all -- is a separate policy decision (pin ruff, or exclude `*.md` from the format target). Happy to open a follow-up issue if maintainers want that hardened.