### PR TITLE
docs(notebooks): optional Isaac backend-swap step in nb05 + factory-path GPU drift-pin

### DIFF
--- a/examples/notebooks/05_streaming_data_loop.ipynb
+++ b/examples/notebooks/05_streaming_data_loop.ipynb
@@ -25,7 +25,10 @@
     "\n",
     "Bucket steps need `hf auth login` + LeRobot >= 0.6.1. Training on GPU needs\n",
     "`lerobot[training]`. The sim-only path (record + stream from local root) runs\n",
-    "on any laptop, no GPU, no credentials."
+    "on any laptop, no GPU, no credentials.\n",
+    "\n",
+    "The optional Step 7 (Isaac backend swap) additionally needs an RTX GPU +\n",
+    "Isaac Sim 6.0+ and the `sim-isaac` extra; it self-skips otherwise."
    ]
   },
   {
@@ -262,6 +265,65 @@
     "policy = create_policy(result.checkpoint_dir)\n",
     "print(f\"loaded: {type(policy).__name__}\")\n",
     "print(\"record -> stream -> train -> load: the data loop closes.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Same loop, different backend: Isaac (optional - RTX GPU + Isaac Sim)\n",
+    "\n",
+    "The record -> stream loop above ran on the default MuJoCo backend - no GPU, no\n",
+    "credentials. Backend parity for recording landed in #1552 (`IsaacRecordingMixin`),\n",
+    "so the *same* loop runs on NVIDIA Isaac Sim with a single `backend=\"isaac\"` swap.\n",
+    "\n",
+    "This step is optional and self-skips unless you have:\n",
+    "\n",
+    "- an RTX GPU and Isaac Sim 6.0+ installed out-of-band, and\n",
+    "- `pip install 'strands-robots[sim-isaac,lerobot]'`.\n",
+    "\n",
+    "One pacing difference from the MuJoCo cells above: Isaac renders at\n",
+    "`rendering_dt = 1/30` by default, so keep `control_frequency <= 1 / rendering_dt`.\n",
+    "We use `fps=10` / `control_frequency=10.0` here (not the MuJoCo cells' `fps=30`)\n",
+    "so every recorded frame reflects a freshly rendered product."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from strands_robots.simulation.isaac import IsaacSimulation\n",
+    "\n",
+    "available, reason = IsaacSimulation.is_available()\n",
+    "if not available:\n",
+    "    print(f\"Isaac Sim not available - skipping the backend-swap demo: {reason}\")\n",
+    "else:\n",
+    "    ROOT_ISAAC = \"/tmp/nb5_isaac_dataset\"\n",
+    "    shutil.rmtree(ROOT_ISAAC, ignore_errors=True)\n",
+    "    isaac = Robot(\"so100\", backend=\"isaac\", mesh=False)  # same loop, one kwarg changed\n",
+    "    isaac.add_camera(name=\"front\", position=[0.5, 0.0, 0.4], target=[0.2, 0.0, 0.05])\n",
+    "    isaac.start_recording(\n",
+    "        repo_id=\"local/nb5_isaac\",\n",
+    "        root=ROOT_ISAAC,\n",
+    "        fps=10,\n",
+    "        task=\"pick up the red cube\",\n",
+    "        cameras=[\"front\"],\n",
+    "        overwrite=True,\n",
+    "    )\n",
+    "    isaac.run_policy(\n",
+    "        robot_name=\"so100\",\n",
+    "        policy_object=MockPolicy(),\n",
+    "        n_steps=20,\n",
+    "        control_frequency=10.0,\n",
+    "        fast_mode=True,\n",
+    "        instruction=\"pick up the red cube\",\n",
+    "    )\n",
+    "    isaac.stop_recording()\n",
+    "    reader = isaac.stream_dataset(\"local/nb5_isaac\", root=ROOT_ISAAC, shuffle=False)\n",
+    "    print(f\"isaac dataset: episodes={reader.num_episodes} frames={reader.num_frames}\")\n",
+    "    isaac.destroy()"
    ]
   },
   {

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -30,7 +30,7 @@ always wins.
 | 2 | [`02_record_and_stream.ipynb`](02_record_and_stream.ipynb) | Record a LeRobotDataset, then stream it back with `stream_dataset()` |
 | 3 | [`03_record_train_deploy.ipynb`](03_record_train_deploy.ipynb) | The full loop: record, train an ACT policy on CPU, export, and load it back |
 | 4 | [`04_discover_lerobot.ipynb`](04_discover_lerobot.ipynb) | Discover the LeRobot API with `use_lerobot`: list robots, policies, teleoperators, cameras, and inspect any class |
-| 5 | [`05_streaming_data_loop.ipynb`](05_streaming_data_loop.ipynb) | The streaming data loop: record, render, stream back, train, and load, in one notebook (the optional Storage Bucket sync needs `strands-robots >= 0.4.2` + LeRobot >= 0.6.1) |
+| 5 | [`05_streaming_data_loop.ipynb`](05_streaming_data_loop.ipynb) | The streaming data loop: record, render, stream back, train, and load, in one notebook (the optional Storage Bucket sync needs `strands-robots >= 0.4.2` + LeRobot >= 0.6.1; an optional final step reruns the loop on the Isaac backend with `backend="isaac"` when an RTX GPU + `sim-isaac` are present) |
 
 Read them in order; each builds on the previous one. Notebook 3 trains a real
 policy on CPU with a tiny dataset and two steps - raise the step count and run on

--- a/tests_integ/simulation/test_isaac_recording_gpu.py
+++ b/tests_integ/simulation/test_isaac_recording_gpu.py
@@ -153,6 +153,100 @@ class TestIsaacDatasetRecording:
         finally:
             sim.destroy()
 
+    def test_robot_factory_backend_swap_round_trip(self, tmp_path):
+        """Robot("so100", backend="isaac") record-and-stream: the notebook pin.
+
+        This is the exact entry point demonstrated by the optional Isaac step
+        in examples/notebooks/05_streaming_data_loop.ipynb - the factory route
+        (create_simulation("isaac") + add_robot(data_config="so100"),
+        strands_robots/robot.py) rather than the raw IsaacSimulation + Franka
+        USD form the tests above use. Pinning it here means the notebook's
+        one-kwarg backend-swap story can never silently drift from reality
+        (issue #1536: never ship example code CI cannot verify).
+
+        Known risk: so100 registry resolution on Isaac has not been executed on
+        a GPU host before this test (issue #1552 used a Franka USD). If this
+        fails for asset/registry reasons (not recording reasons), the agreed
+        fallback is to switch both this test and the notebook cell to the
+        Franka-USD form and file a follow-up for so100-on-Isaac resolution.
+        """
+        from strands_robots import MockPolicy, Robot
+        from strands_robots.dataset_recorder import read_dataset_episode_indices
+
+        _skip_if_isaac_unavailable()
+        root = str(tmp_path / "isaac_factory_ds")
+
+        # Factory route: same call the notebook makes; returns the backend sim.
+        sim = Robot("so100", backend="isaac", mesh=False)
+        try:
+            r = sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0.0, 0.05])
+            assert r["status"] == "success", f"add_camera: {r}"
+
+            r = sim.start_recording(
+                repo_id="local/nb5_isaac",
+                root=root,
+                fps=10,
+                task="pick up the red cube",
+                cameras=["front"],
+                overwrite=True,
+            )
+            assert r["status"] == "success", f"start_recording: {r}"
+
+            # control_frequency <= 1/rendering_dt (Isaac default 30Hz) so each
+            # recorded frame reflects a freshly rendered product - matches the
+            # notebook cell's fps=10 / control_frequency=10.0 pacing.
+            r = sim.run_policy(
+                robot_name="so100",
+                policy_object=MockPolicy(),
+                n_steps=10,
+                control_frequency=10.0,
+                fast_mode=True,
+                instruction="pick up the red cube",
+            )
+            assert r["status"] == "success", f"run_policy: {r}"
+
+            r = sim.save_episode()
+            assert r["status"] == "success", f"save_episode: {r}"
+
+            r = sim.stop_recording()
+            assert r["status"] == "success", f"stop_recording: {r}"
+
+            r = sim.verify_dataset_episodes(1)
+            assert r["status"] == "success", f"verify_dataset_episodes: {r}"
+
+            # Round-trip: reopen the on-disk dataset and assert its truth.
+            info = read_dataset_episode_indices(root)
+            assert info["total_episodes"] == 1, info
+            assert info["total_frames"] == 10, info
+            assert (Path(root) / "meta" / "info.json").exists()
+
+            mp4s = sorted(Path(root).glob("videos/**/*.mp4"))
+            keys = {part for p in mp4s for part in p.parts if part.startswith("observation.images.")}
+            assert keys == {"observation.images.front"}, keys
+            assert all(p.stat().st_size > 0 for p in mp4s)
+
+            # Train-shape == read-shape: the schema declared in meta/info.json
+            # must match what stream_dataset actually emits on read-back, so
+            # training consumers never see a different image shape than the
+            # schema promises (mirrors the raw-API test above).
+            info_json = json.loads((Path(root) / "meta" / "info.json").read_text())
+            declared = {
+                key: tuple(int(d) for d in feat["shape"])
+                for key, feat in info_json["features"].items()
+                if key.startswith("observation.images.")
+            }
+            assert set(declared) == keys, declared
+            reader = sim.stream_dataset("local/nb5_isaac", root=root, shuffle=False)
+            frame = next(iter(reader))
+            for key, (c, h, w) in declared.items():
+                emitted = tuple(int(d) for d in frame[key].shape[-3:])
+                assert emitted in ((c, h, w), (h, w, c)), (
+                    f"{key}: schema declares CHW {(c, h, w)} but stream_dataset "
+                    f"emitted {emitted} - factory-path probe and read-back shape diverged"
+                )
+        finally:
+            sim.destroy()
+
     def test_multi_camera_frames_are_distinct(self, tmp_path):
         """Two cameras with different vantages record distinct pixel content.
 


### PR DESCRIPTION
## Summary

Implements #1571. Adds an **optional, self-skipping Isaac-backend section** to `examples/notebooks/05_streaming_data_loop.ipynb` demonstrating that the record-and-stream loop now runs on NVIDIA Isaac Sim after a single `backend="isaac"` swap (capability landed in #1552, `IsaacRecordingMixin`), and **pins that exact snippet with a factory-path GPU integration test** so the notebook can never silently drift from reality (the #1536 lesson: never ship example code CI cannot verify).

Design decisions were fixed in the issue; implemented as specified.

## Changes

**Deliverable 1 - notebook appendix (`examples/notebooks/05_streaming_data_loop.ipynb`)**
- One markdown + one code cell inserted after the load-checkpoint step. Section is numbered **Step 7**: Step 6 is already the existing load-checkpoint section, so numbering it 7 keeps the sequence collision-free (the issue's "6." referred to the section title, not the ordinal).
- The default laptop path (MuJoCo, no GPU, no credentials) is **byte-for-byte untouched**; "run all cells" stays green on a GPU-less host because the Isaac cell self-skips via `IsaacSimulation.is_available()`.
- Pacing rule honored: `fps=10` / `control_frequency=10.0` (i.e. `control_frequency <= 1/rendering_dt`, Isaac default `rendering_dt=1/30`) - deliberately **not** the MuJoCo cells' `fps=30`.
- Reuses `shutil` / `Robot` / `MockPolicy` already imported by earlier cells (no re-import).
- Cell 0 requirements: one added line noting optional Step 7 needs an RTX GPU + Isaac Sim 6.0+ and the `sim-isaac` extra, self-skips otherwise. The `strands-robots >= 0.4.2` pin is preserved (`tests/test_notebook_min_version_docs.py` stays green).
- `examples/notebooks/README.md`: nb05 row mentions the optional Isaac step.

**Deliverable 2 - factory-path GPU drift-pin (`tests_integ/simulation/test_isaac_recording_gpu.py`)**
- New `test_robot_factory_backend_swap_round_trip` pins the notebook's exact entry point `Robot("so100", backend="isaac", mesh=False)` (factory route: `create_simulation("isaac")` + `add_robot(data_config="so100")`), not the raw `IsaacSimulation` + Franka-USD form the existing tests use.
- `add_camera("front")` -> `start_recording(fps=10, cameras=["front"])` -> `run_policy(MockPolicy, n_steps=10, control_frequency=10.0, fast_mode=True)` -> `save_episode` -> `stop_recording` -> `verify_dataset_episodes(1)`.
- Round-trip: reopens the on-disk dataset (`read_dataset_episode_indices`), asserts episodes/frames, per-camera MP4 non-empty, and a declared-vs-emitted image-shape check mirroring the existing raw-API test.
- Same gating as the existing tests (`pytest.mark.gpu`, `STRANDS_GPU_TEST=1`, `_skip_if_isaac_unavailable`, `sim.destroy()` in `finally`).

## Known risk + fallback

`Robot("so100", backend="isaac")` is structurally supported (Isaac `add_robot` accepts `data_config`), but **so100 registry resolution on Isaac has never been executed on a GPU host** (#1552 used a Franka USD). This test is how we find out. If it fails on the GPU host for asset/registry reasons (not recording reasons), the agreed fallback is to switch **both** the notebook cell and the test to the Franka-USD form and file a follow-up issue for so100-on-Isaac resolution.

## Verification (GPU-less dev host)

- `tests/test_notebook_min_version_docs.py` - 3 passed (min-version pin + no bare-PyPI-install guidance intact).
- `tests/test_no_host_paths.py` - 2 passed (only `/tmp/...` paths used).
- `tests_integ/simulation/test_isaac_recording_gpu.py` - collects and **skips cleanly** with no GPU/Isaac.
- `ruff check` + `ruff format --check` - clean on the edited test file.
- Non-ASCII sweep on edited files - clean.
- Notebook JSON valid; 17 cells, sequential section numbering 1-7 then "Where to go from here".

## Merge gate (per #1571)

**Do not merge** until the new GPU test has passed once on an Isaac host:
```
STRANDS_GPU_TEST=1 hatch run test-integ tests_integ/simulation/test_isaac_recording_gpu.py -m gpu -v
```
Result (or fallback switch) will be stated here once the Isaac runner reports.

Closes #1571

## §13 Round-N changelog

- **round-1** (initial): notebook Step 7 (md + code, self-skipping), cell 0 + README bookkeeping, factory-path GPU drift-pin test. All GPU-less checks green; awaiting the mandatory GPU-host test pass before merge.