### PR TITLE
test(sim): pin SimEngine base get_frame/get_camera_params raise-loud contract

### DIFF
--- a/tests/simulation/test_simengine_facade_guardrails.py
+++ b/tests/simulation/test_simengine_facade_guardrails.py
@@ -360,6 +360,33 @@ def test_get_contacts_not_implemented_on_base_facade():
         FakeSim().get_contacts()
 
 
+def test_get_frame_not_implemented_on_base_facade():
+    """The raw-frame path (``get_frame``) is a backend hook: a subclass that
+    provides ``render`` but no raw ``(rgb, depth)`` path must fail loud.
+
+    ``get_frame`` is the numeric-array counterpart of ``render`` used by the
+    in-process consumers (hybrid compositor, dataset recorders, video writers).
+    Its contract states backends must never substitute silently wrong pixels --
+    failures raise. This pins that a backend which never overrides it inherits a
+    clear ``NotImplementedError`` naming the method, not a silent ``None`` or a
+    zero frame that would corrupt a recording downstream.
+    """
+    with pytest.raises(NotImplementedError, match="get_frame"):
+        FakeSim().get_frame()
+
+
+def test_get_camera_params_not_implemented_on_base_facade():
+    """Pinhole intrinsics/extrinsics (``get_camera_params``) are a backend hook.
+
+    A backend that has not implemented the camera-params path must raise a clear
+    ``NotImplementedError`` naming the method rather than returning bogus
+    intrinsics, so consumers (calibration, projection, synthetic-data export)
+    never silently trust a wrong camera model.
+    """
+    with pytest.raises(NotImplementedError, match="get_camera_params"):
+        FakeSim().get_camera_params()
+
+
 # Actionable "robot not found" on the policy-execution sites (#1306 follow-up)
 #
 # run_policy / eval_policy / evaluate_benchmark used to emit a bare


### PR DESCRIPTION
## Problem

The `SimEngine` facade-guardrails suite (`tests/simulation/test_simengine_facade_guardrails.py`) has a dedicated section — *"Backend hooks the base facade leaves unimplemented"* — that pins the *raise-loudly, never-silent* contract for hooks a concrete backend is expected to override: `set_obs_noise` and `get_contacts` each assert a clear `NotImplementedError`.

The two public raw-frame hooks on the base engine, `get_frame` and `get_camera_params`, were left unpinned at the ABC level, even though `get_frame`'s own docstring explicitly promises:

> Backends must never substitute silently wrong pixels -- failures raise.

So the base defaults (`raise NotImplementedError(...)` in `strands_robots/simulation/base.py`) had no test guarding them. A future edit that degraded either to a silent `None`/zero-frame would slip through: a recorder would write corrupt frames, or calibration/projection would trust bogus camera intrinsics, with no loud failure.

## Change

Add the two missing pins to the same section, reusing the existing pure-Python `FakeSim` (it implements `render` but neither raw-frame path, so it inherits the base defaults):

- `test_get_frame_not_implemented_on_base_facade`
- `test_get_camera_params_not_implemented_on_base_facade`

Each asserts the base hook raises `NotImplementedError` naming the method, matching the established `set_obs_noise` / `get_contacts` pattern. This closes the two previously-uncovered `NotImplementedError` lines on the base engine and turns the docstring's "failures raise" promise into an enforced regression guard.

## Tests

```
MUJOCO_GL=egl pytest tests/simulation/test_simengine_facade_guardrails.py
# 30 passed (was 28)
```

Both new lines are now covered on `strands_robots/simulation/base.py`. Test-only; no production behavior change. `ruff check` / `ruff format --check` / `mypy` all clean on the touched file.