### PR TITLE
test(robot): pin SO-follower field forwarding against lerobot's required port

### DIFF
--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1091,7 +1091,8 @@ class TestRealModeConfigDiscovery:
 
         _ensure_lerobot_robots_registered()
         ConfigClass = RobotConfig.get_choice_class("so101_follower")
-        real_fields = {f.name for f in dataclasses.fields(ConfigClass)}
+        fields = list(dataclasses.fields(ConfigClass))
+        real_fields = {f.name for f in fields}
 
         # Import from production code -- single source of truth (no drift).
         forwardable_set = set(_FORWARDABLE_KWARGS)
@@ -1101,12 +1102,30 @@ class TestRealModeConfigDiscovery:
 
         target_field = sorted(dataclass_only_fields)[0]
 
+        # Satisfy every required (no-default) field so construction fails ONLY
+        # if the forwarding of ``target_field`` is broken -- never because of an
+        # unrelated required field. lerobot #4142 added optional PID-gain fields
+        # (position_p/i/d_coefficient) to SO-follower configs; when one of those
+        # sorts first as ``target_field`` the config still declares a required
+        # ``port``, so a fixed ``cameras``/``target_field`` kwarg pair alone left
+        # ``port`` unset and the construction raised a ValueError unrelated to
+        # the forwarding contract under test. Fill required fields dynamically so
+        # the test stays pinned on forwarding as lerobot evolves its dataclass.
+        required = {
+            f.name: "placeholder"
+            for f in fields
+            if f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING
+            and f.name not in {"cameras", "id"}
+        }
+        kwargs = {**required, target_field: "test_value"}
+
         hw = HwRobot.__new__(HwRobot)
         hw.tool_name_str = "test_forward"
-        # Pass the dataclass-only field -- should NOT raise ValueError
-        cfg = hw._create_minimal_config("so101_follower", cameras={}, **{target_field: "test_value"})
-        # The field should have been forwarded to the config
-        assert hasattr(cfg, target_field)
+        # Pass the dataclass-only field -- should NOT raise ValueError, and the
+        # value must round-trip verbatim (forwarded, not dropped).
+        cfg = hw._create_minimal_config("so101_follower", cameras={}, **kwargs)
+        assert getattr(cfg, target_field) == "test_value"
 
 
 class TestMinimalConfigContractBranches:


### PR DESCRIPTION
## Problem

`TestRealModeConfigDiscovery::test_dataclass_declared_field_accepted_without_forwardable_entry` verifies that a kwarg absent from the cross-robot `_FORWARDABLE_KWARGS` allowlist but declared on the target lerobot `RobotConfig` dataclass is still forwarded (future-proofing new lerobot fields without a strands_robots release).

The test discovers its target field dynamically: it takes `sorted(real_fields - forwardable - {id, cameras})[0]` for `so101_follower`. A recent lerobot change made the SO-follower position-mode PID gains configurable, adding `position_p_coefficient`, `position_i_coefficient`, and `position_d_coefficient` to `SOFollowerConfig`. None are in the allowlist, so `position_d_coefficient` now sorts first and becomes the target field.

The test constructed the config with only `cameras={}` plus that one target field. But `SOFollowerConfig` still declares a **required** `port`, so construction now raises:

```
ValueError: Failed to construct SOFollowerRobotConfig for robot type 'so101_follower':
SOFollowerRobotConfig.__init__() missing 1 required positional argument: 'port'.
Config: {'id': 'test_forward', 'cameras': {}, 'position_d_coefficient': 'test_value'}
```

The failure is unrelated to the forwarding contract under test - it is purely an unsatisfied, incidental required field. Before the PID fields existed, `so101_follower` had no allowlist-external dataclass field, so the test hit its `pytest.skip` guard and never exercised this path; the new field turned the skip into a hard failure.

## Change

Fill every required (no-default, no-default_factory) dataclass field dynamically before constructing the config, excluding `cameras`/`id`. Construction then fails only if forwarding of the discovered target field is broken - never because lerobot later adds another required field. Also assert the forwarded value round-trips verbatim (`getattr(cfg, target_field) == "test_value"`) instead of only checking attribute presence, so a silently-dropped kwarg would be caught.

Production code is unchanged - `_create_minimal_config` already forwards dataclass-declared fields and correctly raises `ValueError` when a required field is missing; only the test's construction was under-specified.

## Tests

- Fails on pre-change test code against current lerobot (the `ValueError` above).
- Passes after the change.
- `TestRealModeConfigDiscovery` + `TestMinimalConfigContractBranches`: 21 passed.
- Scoped gate clean: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` (Success: no issues found in 851 source files).