### PR TITLE
docs(policies): document every public member of the built-in Policy classes + pin a guard

### DIFF
--- a/strands_robots/policies/composite.py
+++ b/strands_robots/policies/composite.py
@@ -121,6 +121,7 @@ class CompositePolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Provider name for identification (always ``"composite"``)."""
         return "composite"
 
     @property

--- a/strands_robots/policies/mock.py
+++ b/strands_robots/policies/mock.py
@@ -19,6 +19,7 @@ class MockPolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Provider name for identification (always ``"mock"``)."""
         return "mock"
 
     @property
@@ -27,6 +28,7 @@ class MockPolicy(Policy):
         return False
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        """Record the ordered joint keys used to name the sinusoidal action dict."""
         self.robot_state_keys = robot_state_keys
 
     async def get_actions(

--- a/strands_robots/policies/persistent.py
+++ b/strands_robots/policies/persistent.py
@@ -105,40 +105,50 @@ class PersistentPolicy(Policy):
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, Any]]:
+        """Delegate to the wrapped policy under the async lock (see :meth:`Policy.get_actions`)."""
         async with self._async_lock:
             return await self._inner.get_actions(observation_dict, instruction, **kwargs)
 
     def get_actions_sync(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, Any]]:
+        """Delegate to the wrapped policy under the per-call lock (see :meth:`Policy.get_actions_sync`)."""
         with self._call_lock:
             return self._inner.get_actions_sync(observation_dict, instruction, **kwargs)
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        """Forward the robot state keys to the wrapped policy."""
         self._inner.set_robot_state_keys(robot_state_keys)
 
     def reset(self, seed: int | None = None) -> None:
+        """Reset the wrapped policy's per-episode state (weights stay resident)."""
         self._inner.reset(seed)
 
     def set_control_frequency(self, hz: float) -> None:
+        """Forward the executing loop's control rate to the wrapped policy."""
         self._inner.set_control_frequency(hz)
 
     def set_rtc_observed_delay(self, steps: int | None) -> None:
+        """Forward the observed inference delay (RTC steps) to the wrapped policy."""
         self._inner.set_rtc_observed_delay(steps)
 
     @property
     def requires_images(self) -> bool:
+        """Whether the wrapped policy needs camera frames in its observation."""
         return self._inner.requires_images
 
     @property
     def execution_horizon(self) -> int:
+        """Actions consumed from one ``get_actions`` chunk, from the wrapped policy."""
         return self._inner.execution_horizon
 
     def is_chunk_emitting(self) -> bool:
+        """Whether the wrapped policy returns multi-action chunks per ``get_actions``."""
         return self._inner.is_chunk_emitting()
 
     @property
     def provider_name(self) -> str:
+        """Provider name of the wrapped policy (identifies the resident model)."""
         return self._inner.provider_name
 
     def __getattr__(self, name: str) -> Any:

--- a/tests/policies/test_builtin_policy_docstrings.py
+++ b/tests/policies/test_builtin_policy_docstrings.py
@@ -1,0 +1,87 @@
+"""Built-in ``Policy`` implementations must document every public method/property.
+
+The :class:`~strands_robots.policies.base.Policy` ABC documents its runtime
+contract (``get_actions`` / ``get_actions_sync`` / ``set_robot_state_keys`` /
+``reset`` / ``set_control_frequency`` / ``set_rtc_observed_delay`` /
+``requires_images`` / ``execution_horizon`` / ``is_chunk_emitting`` /
+``provider_name``) with rich docstrings. The dependency-free built-in policies
+that ship in the core package - :class:`~strands_robots.policies.mock.MockPolicy`
+(the testing reference), :class:`~strands_robots.policies.composite.CompositePolicy`
+(the lower/upper body split), and
+:class:`~strands_robots.policies.persistent.PersistentPolicy` (the load-once
+reusable handle) - override or delegate those members, and each override needs
+its own docstring rather than silently leaning on the inherited one: a
+``PersistentPolicy`` method that forwards to the wrapped policy still has
+wrapper-specific behavior (locking, cache residency) worth stating.
+
+This guard walks the core policy modules by AST (no import, so it never needs
+any optional policy backend installed) and fails if any public method or
+property of a policy class defines no docstring.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.policies as policies_pkg
+
+_PACKAGE_DIR = Path(policies_pkg.__file__).parent
+
+# Core, dependency-free policy modules: the ABC plus the three built-in
+# implementations that ship without any optional backend. Backend-specific
+# providers (groot, cosmos3, lerobot_local, ...) live in subpackages guarded by
+# optional deps and are out of scope for this import-free guard.
+_CORE_MODULES = ("base.py", "mock.py", "composite.py", "persistent.py")
+
+_EXPECTED_CLASSES = {
+    "base.py::Policy",
+    "base.py::ChunkedPolicy",
+    "mock.py::MockPolicy",
+    "composite.py::CompositePolicy",
+    "persistent.py::PersistentPolicy",
+}
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring."""
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _policy_classes() -> dict[str, ast.ClassDef]:
+    """Map ``module.py::ClassName`` -> ClassDef for every public class in the core modules."""
+    classes: dict[str, ast.ClassDef] = {}
+    for module in _CORE_MODULES:
+        source_file = _PACKAGE_DIR / module
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{module}::{node.name}"] = node
+    return classes
+
+
+def test_core_modules_define_expected_policy_classes() -> None:
+    """Guard: the scan actually found the built-in policy classes it protects."""
+    assert set(_policy_classes()) == _EXPECTED_CLASSES, set(_policy_classes())
+
+
+def test_builtin_policy_public_members_have_docstrings() -> None:
+    offenders = {
+        qualname: missing
+        for qualname, node in _policy_classes().items()
+        if (missing := _public_members_without_docstring(node))
+    }
+    assert not offenders, (
+        "Every public method/property of a built-in Policy class must have a "
+        "docstring describing its behavior (the base ABC already does; a "
+        "delegating wrapper still states its wrapper-specific behavior). "
+        "Undocumented members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem

The `Policy` ABC (`strands_robots/policies/base.py`) documents its full runtime contract with rich docstrings, but the built-in, dependency-free implementations left public overrides undocumented, relying implicitly on the inherited docstring:

- `MockPolicy` -> `provider_name`, `set_robot_state_keys`
- `CompositePolicy` -> `provider_name`
- `PersistentPolicy` -> all ten delegating members (`get_actions`, `get_actions_sync`, `set_robot_state_keys`, `reset`, `set_control_frequency`, `set_rtc_observed_delay`, `requires_images`, `execution_horizon`, `is_chunk_emitting`, `provider_name`)

A delegating wrapper still has wrapper-specific behavior worth stating (e.g. `PersistentPolicy` serializes inference under a per-call/async lock and keeps weights resident across calls), so leaning on the inherited docstring loses that information at the point a reader looks.

## Change

- Add a concise, behavior-specific docstring to each of the 13 undocumented public members across `mock.py`, `composite.py`, and `persistent.py`. No code/behavior changes.
- Add `tests/policies/test_builtin_policy_docstrings.py`: an AST-based guard (mirroring the existing `tests/training/test_trainer_provider_docstrings.py`) that walks the core policy modules and fails if any public method/property of a built-in `Policy` class lacks a docstring. It parses source rather than importing, so it needs no optional policy backend installed.

## Tests

The guard fails on pre-change source (reports all 13 offenders) and passes after. Full run:

- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues in 852 files.
- `pytest tests/policies/ tests/test_docstring_xref_roles_resolve.py tests/test_docstrings_no_dangling_doc_refs.py` -> 1721 passed, 2 skipped (the new `:meth:`/`:class:` cross-refs resolve).

Docs-and-test only; no runtime behavior changes.