### PR TITLE
docs(mesh): document public accessors of core mesh classes + pin an AST guard

### DIFF
--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -750,10 +750,19 @@ class Mesh(SensorLoopsMixin):
 
     @property
     def alive(self) -> bool:
+        """``True`` while this peer is joined to the mesh (between
+        :meth:`join` and :meth:`leave`); ``False`` once it has left.
+        """
         return self._running
 
     @property
     def peers(self) -> list[dict[str, Any]]:
+        """Presence dicts for every *other* peer currently on the mesh.
+
+        Excludes this peer itself. Discovery is asynchronous, so the list
+        grows as presence beacons arrive. Use :attr:`peers_by_id` for O(1)
+        lookup by ``peer_id`` or :meth:`get_peer` for a ``None``-safe fetch.
+        """
         return [p for p in _session_get_peers() if p.get("peer_id") != self.peer_id]
 
     @property

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -132,10 +132,19 @@ class InputPublisher:
 
     @property
     def topic(self) -> str:
+        """Mesh key this publisher writes to:
+        ``strands/{own_peer_id}/input/{device_name}``. A remote
+        :class:`InputReceiver` subscribes to this exact key to mirror the
+        actions locally.
+        """
         return f"strands/{self.mesh.peer_id}/input/{self.device_name}"
 
     @property
     def stats(self) -> dict[str, Any]:
+        """Live publishing counters: the target device/method, whether the
+        loop is ``running``, cumulative ``frames`` published and ``errors``
+        hit, and the achieved vs. requested rate (``hz_actual`` / ``hz_target``).
+        """
         elapsed = time.time() - self._start_time if self._start_time else 0
         return {
             "device": self.device_name,
@@ -287,10 +296,21 @@ class InputReceiver:
 
     @property
     def topic(self) -> str:
+        """Mesh key this receiver subscribes to:
+        ``strands/{source_peer_id}/input/{device_name}`` - the stream the
+        remote peer's :class:`InputPublisher` writes to.
+        """
         return f"strands/{self.source_peer_id}/input/{self.device_name}"
 
     @property
     def stats(self) -> dict[str, Any]:
+        """Live receive counters: the ``source`` peer and device, whether the
+        subscription is ``running``, ``frames_received``, ``errors``, and the
+        loss/back-pressure breakdown - out-of-order ``drops``, ``rejected``
+        frames (E-stop lockout, replay-freshness, or ACL checks), and
+        ``rate_dropped`` frames (shed to hold the apply-rate cap) -
+        plus the achieved ``hz_actual``.
+        """
         elapsed = time.time() - self._start_time if self._start_time else 0
         return {
             "source": self.source_peer_id,

--- a/strands_robots/mesh/transport/base.py
+++ b/strands_robots/mesh/transport/base.py
@@ -63,7 +63,6 @@ class SubHandle(Protocol):
         preferred. Zenoh maps this to ``Subscriber.undeclare()``; MQTT
         backends send the broker ``unsubscribe`` packet.
         """
-        ...
 
 
 @runtime_checkable

--- a/strands_robots/mesh/transport/base.py
+++ b/strands_robots/mesh/transport/base.py
@@ -56,7 +56,14 @@ class SubHandle(Protocol):
     code is transport-agnostic.
     """
 
-    def undeclare(self) -> None: ...
+    def undeclare(self) -> None:
+        """Tear down the subscription, releasing its transport resources.
+
+        Called by Mesh teardown; idempotent-safe implementations are
+        preferred. Zenoh maps this to ``Subscriber.undeclare()``; MQTT
+        backends send the broker ``unsubscribe`` packet.
+        """
+        ...
 
 
 @runtime_checkable

--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -607,18 +607,30 @@ class BridgeTransport:
     # Inspection
 
     def is_alive(self) -> bool:
+        """``True`` if *either* underlying transport is still connected.
+
+        The bridge stays usable while one side survives, so callers can keep
+        publishing to whichever leg is up.
+        """
         return self._zenoh.is_alive() or self._iot.is_alive()
 
     @property
     def zenoh(self) -> ZenohTransport:
+        """The wrapped local-mesh Zenoh transport (always published to)."""
         return self._zenoh
 
     @property
     def iot(self) -> IotMqttTransport:
+        """The wrapped AWS IoT MQTT transport (published to only for
+        bridged topics).
+        """
         return self._iot
 
     @property
     def bridge_suffixes(self) -> frozenset[str]:
+        """Topic suffixes whose messages are mirrored onto the IoT leg; all
+        other topics stay Zenoh-local.
+        """
         return self._bridge_suffixes
 
     @property

--- a/strands_robots/mesh/transport/iot_transport.py
+++ b/strands_robots/mesh/transport/iot_transport.py
@@ -389,6 +389,9 @@ class IotMqttTransport:
 
     @property
     def thing_name(self) -> str:
+        """The AWS IoT thing name this transport authenticates as, or ``""``
+        if unset. Used as the MQTT client id and mTLS identity.
+        """
         return self._thing_name or ""
 
     # Pub/Sub

--- a/tests/mesh/test_public_member_docstrings.py
+++ b/tests/mesh/test_public_member_docstrings.py
@@ -1,0 +1,88 @@
+"""Every public class in the ``strands_robots.mesh`` package must document each
+of its public methods and properties.
+
+The mesh package is the fleet-coordination surface an agent drives directly -
+:class:`~strands_robots.mesh.core.Mesh` (presence, pub/sub, peer discovery), the
+teleop input pump (:class:`~strands_robots.mesh.input.InputPublisher` /
+:class:`~strands_robots.mesh.input.InputReceiver`), and the pluggable transports
+(:class:`~strands_robots.mesh.transport.base.MeshTransport` and its Zenoh / AWS
+IoT / bridge implementations). Several classes carried a rich class docstring
+but left public accessors - ``Mesh.alive`` / ``Mesh.peers``, the publisher /
+receiver ``topic`` / ``stats`` properties, ``SubHandle.undeclare``, the
+``BridgeTransport`` inspection properties, ``IotMqttTransport.thing_name`` -
+undocumented, so a reader driving the API blind could not tell what an accessor
+returns without reading its body. This mirrors the policy-package guard
+(``tests/policies/test_builtin_policy_docstrings.py``) and the mesh docstring
+cross-reference guard (``tests/mesh/test_docstring_module_xrefs.py``).
+
+The check walks every module across the mesh tree by AST (no import, so it needs
+none of the optional mesh backends - zenoh, awscrt - installed) and fails if any
+public method or property of a public class defines no docstring. Property
+setters and deleters are exempt: a ``@x.setter`` mirrors its documented getter
+and a docstring on it is noise, matching the convention elsewhere in the tree.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.mesh as mesh_pkg
+
+_PACKAGE_DIR = Path(mesh_pkg.__file__).parent
+
+
+def _is_setter_or_deleter(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the function is a ``@<name>.setter`` or ``@<name>.deleter``."""
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Attribute) and dec.attr in ("setter", "deleter"):
+            return True
+    return False
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring."""
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if _is_setter_or_deleter(node):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _public_classes() -> dict[str, ast.ClassDef]:
+    """Map ``relpath::ClassName`` -> ClassDef for every public class across the mesh tree."""
+    classes: dict[str, ast.ClassDef] = {}
+    for source_file in sorted(_PACKAGE_DIR.rglob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        rel = source_file.relative_to(_PACKAGE_DIR)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{rel}::{node.name}"] = node
+    return classes
+
+
+def test_mesh_tree_has_public_classes() -> None:
+    """Guard: the scan actually walked the mesh tree and found public classes to protect."""
+    found = set(_public_classes())
+    assert any(q.endswith("::Mesh") for q in found), found
+    assert any(q.endswith("::InputPublisher") for q in found), found
+    assert any(q.endswith("::BridgeTransport") for q in found), found
+
+
+def test_mesh_public_members_have_docstrings() -> None:
+    offenders = {
+        qualname: missing
+        for qualname, node in _public_classes().items()
+        if (missing := _public_members_without_docstring(node))
+    }
+    assert not offenders, (
+        "Every public method/property of a public mesh class must have a "
+        "docstring describing what it returns or does (a rich class docstring "
+        "does not document its individual accessors). Undocumented members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem

The `strands_robots.mesh` fleet-coordination classes carry rich *class* docstrings but leave their public *accessors* undocumented, so a reader driving the API blind cannot tell what an accessor returns without reading its body:

- `Mesh.alive`, `Mesh.peers` (`core.py`) - while `Mesh.peers_by_id` / `get_peer` right beside them are fully documented.
- `InputPublisher.topic` / `stats` and `InputReceiver.topic` / `stats` (`input.py`).
- `SubHandle.undeclare` (`transport/base.py`) - the teardown contract of the transport-agnostic subscription handle.
- `BridgeTransport.is_alive` / `zenoh` / `iot` / `bridge_suffixes` (`transport/bridge_transport.py`).
- `IotMqttTransport.thing_name` (`transport/iot_transport.py`).

## Change

Each public method/property above now carries its own docstring describing what it returns or does (topic-key format, stat-dict fields including the loss/back-pressure breakdown, the bridge inspection semantics, the IoT identity). No behavior changes.

## Tests

Adds `tests/mesh/test_public_member_docstrings.py`, an AST guard that walks every public class across the mesh tree and fails if any public method or property lacks a docstring. It imports nothing (pure `ast.parse`), so it needs none of the optional mesh backends (zenoh, awscrt) installed - the same import-free approach as the existing `tests/policies/test_builtin_policy_docstrings.py` and `tests/mesh/test_docstring_module_xrefs.py`. Property setters/deleters are exempt (a `@x.setter` mirrors its documented getter). The guard fails on pre-change `main` listing exactly the members above, and passes after.

Local gate: `ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`; `tests/mesh/` green (2108 passed, 3 skipped).

## Changelog

### Round 2

Addressed the one code-scanning finding on this diff (statement has no effect, `transport/base.py`). Adding the docstring to `SubHandle.undeclare` turned its trailing `...` into a redundant expression-statement after the docstring - a docstring alone is a complete Protocol method body. Dropped the `...`; `undeclare` remains a valid docstring-only stub and the AST guard (which keys on docstring presence, not `...`) still passes. The four sibling stubs in the same file keep their pre-existing `docstring + ...` shape - they are not introduced by this diff and harmonizing them is out of scope for a docs PR. Local re-gate clean: `ruff check` / `ruff format --check` / `mypy` clean on `base.py`; guard passes (0 offenders, sentinel classes present).