### PR TITLE
docs(benchmark): document DeclarativeBenchmark public members + pin a guard

### DIFF
--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -225,14 +225,31 @@ class DeclarativeBenchmark(BenchmarkProtocol):
 
     @property
     def name(self) -> str:
+        """Unique benchmark id, from the spec's required ``name`` key.
+
+        Used as the registry key by :func:`register_benchmark_from_file`;
+        registering two specs with the same ``name`` overwrites the first.
+        """
         return self._name
 
     @property
     def supported_robots(self) -> list[str]:
+        """Registry ``data_config`` names this benchmark accepts (spec ``supported_robots``).
+
+        Implements :attr:`BenchmarkProtocol.supported_robots`. Returns a fresh
+        copy so callers cannot mutate the compiled spec. An empty list (the
+        spec omitted the key) means "any robot".
+        """
         return list(self._supported_robots)
 
     @property
     def default_robot(self) -> str:
+        """Robot loaded when the sim is empty, from the spec's required ``default_robot``.
+
+        Implements :attr:`BenchmarkProtocol.default_robot`;
+        :meth:`on_episode_start` adds it via ``sim.add_robot`` before the first
+        observation when no robot is present.
+        """
         return self._default_robot
 
     @property
@@ -290,9 +307,23 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         return StepInfo(reward=reward, done=False)
 
     def is_success(self, sim: SimEngine) -> bool:
+        """Evaluate the compiled ``success`` clause against ``sim``.
+
+        Implements :meth:`BenchmarkProtocol.is_success`. Side-effect-free (the
+        predicate closures only read sim state), so the eval loop may call it
+        multiple times per step. Returns ``True`` once the spec's ``success``
+        all/any predicates are satisfied, ending the episode with success.
+        """
         return bool(self._success_fn(sim))
 
     def is_failure(self, sim: SimEngine) -> bool:
+        """Evaluate the compiled ``failure`` clause against ``sim``.
+
+        Implements :meth:`BenchmarkProtocol.is_failure`. Side-effect-free;
+        returns ``True`` when the spec's ``failure`` all/any predicates are
+        satisfied (a spec that omits ``failure`` compiles to an always-``False``
+        clause). Failure ends the episode without marking success.
+        """
         return bool(self._failure_fn(sim))
 
     @classmethod

--- a/tests/simulation/test_declarative_benchmark_docstrings.py
+++ b/tests/simulation/test_declarative_benchmark_docstrings.py
@@ -1,0 +1,86 @@
+"""The declarative-benchmark eval surface must document every public member.
+
+:class:`~strands_robots.simulation.benchmark.BenchmarkProtocol` defines the
+contract the ``PolicyRunner`` eval loop drives (``supported_robots`` /
+``default_robot`` / ``instruction`` / ``on_episode_start`` / ``on_step`` /
+``augment_observation`` / ``is_success`` / ``is_failure``) with rich
+docstrings. :class:`~strands_robots.simulation.benchmark_spec.DeclarativeBenchmark`
+is the YAML/JSON-authored implementation agents reach through the
+``register_benchmark_from_file`` tool - it overrides those members, and each
+override needs its own docstring rather than silently leaning on the inherited
+protocol text: an accessor like ``supported_robots`` returns a defensive copy
+and ``is_success`` states its side-effect-free contract, both worth stating on
+the concrete class a spec author actually reads.
+
+This guard walks the two modules by AST (no import, so it never needs an
+optional sim backend installed) and fails if any public method or property of
+a benchmark class defines no docstring.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.simulation as simulation_pkg
+
+_PACKAGE_DIR = Path(simulation_pkg.__file__).parent
+
+# The declarative-benchmark surface: the protocol ABC + its structured helpers
+# (benchmark.py) and the DSL-backed implementation (benchmark_spec.py). Both are
+# dependency-free pure-Python modules, so the AST walk needs no optional extra.
+_MODULES = ("benchmark.py", "benchmark_spec.py")
+
+_EXPECTED_CLASSES = {
+    "benchmark.py::StepInfo",
+    "benchmark.py::BenchmarkProtocol",
+    "benchmark.py::BenchmarkCompatibilityError",
+    "benchmark_spec.py::DeclarativeBenchmark",
+}
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring.
+
+    Dunder methods (``__init__`` and friends) are out of scope - their contract
+    is documented on the class itself.
+    """
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _benchmark_classes() -> dict[str, ast.ClassDef]:
+    """Map ``module.py::ClassName`` -> ClassDef for every public class in the modules."""
+    classes: dict[str, ast.ClassDef] = {}
+    for module in _MODULES:
+        source_file = _PACKAGE_DIR / module
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{module}::{node.name}"] = node
+    return classes
+
+
+def test_modules_define_expected_benchmark_classes() -> None:
+    """Guard: the scan actually found the benchmark classes it protects."""
+    assert set(_benchmark_classes()) == _EXPECTED_CLASSES, set(_benchmark_classes())
+
+
+def test_benchmark_public_members_have_docstrings() -> None:
+    offenders = {
+        qualname: missing
+        for qualname, node in _benchmark_classes().items()
+        if (missing := _public_members_without_docstring(node))
+    }
+    assert not offenders, (
+        "Every public method/property of a benchmark class (BenchmarkProtocol "
+        "and the DeclarativeBenchmark DSL implementation) must have a docstring "
+        "describing its behavior. Undocumented members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem

`DeclarativeBenchmark` (`strands_robots/simulation/benchmark_spec.py`) is the YAML/JSON-authored `BenchmarkProtocol` implementation that agents reach through the `register_benchmark_from_file` tool. It overrides the protocol surface, but five of its public members were left undocumented while their siblings carry rich docstrings:

| documented today | bare today |
| --- | --- |
| `instruction`, `on_episode_start`, `on_step`, `from_dict` | `name`, `supported_robots`, `default_robot`, `is_success`, `is_failure` |

A spec author reading the concrete class saw an inconsistent mix of documented and bare members, and had to jump to `BenchmarkProtocol` (or the source) to learn, e.g., that `supported_robots` returns a defensive copy or that `is_success` is side-effect-free.

## Change

Document each of the five overrides with its concrete contract:

- `name` - the registry key used by `register_benchmark_from_file` (duplicate names overwrite).
- `supported_robots` / `default_robot` - restate their spec source and, for `supported_robots`, the fresh-copy return so callers cannot mutate the compiled spec.
- `is_success` / `is_failure` - state the side-effect-free evaluation of the compiled `success` / `failure` clauses (and that an omitted `failure` clause compiles to always-`False`).

No behavior change - docstrings only.

## Test

Adds `tests/simulation/test_declarative_benchmark_docstrings.py`, an AST guard (no import, so no optional sim backend needed) that fails if any public method/property of `BenchmarkProtocol` or `DeclarativeBenchmark` lacks a docstring. It also asserts the scan found the expected classes so the guard cannot silently pass by scanning nothing.

Verified the guard fails on pre-change code:

```
Undocumented members: {'benchmark_spec.py::DeclarativeBenchmark': ['name', 'supported_robots', 'default_robot', 'is_success', 'is_failure']}
```

and passes after. Local gate clean: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all pass; the benchmark + docstring-xref suites (124 tests) pass.