### PR TITLE
docs(rendering): document the concrete BackgroundRenderer render overrides + pin a public-member guard

### DIFF
--- a/strands_robots/rendering/backgrounds.py
+++ b/strands_robots/rendering/backgrounds.py
@@ -129,6 +129,21 @@ class PanoramaBackground:
     # ----- BackgroundRenderer interface ----- #
 
     def render(self, cam: CameraParams) -> tuple[np.ndarray, np.ndarray]:
+        """Sample the equirectangular panorama along ``cam``'s per-pixel rays.
+
+        Casts one world-space ray per output pixel, maps each ray direction to
+        spherical ``(theta, phi)`` coordinates, applies the configured yaw
+        rotation, and bilinearly samples the panorama texture. Depth is a
+        constant ``cam.zfar`` plane so any MuJoCo foreground always wins the
+        compositor's depth test.
+
+        Args:
+            cam: pinhole camera parameters at the desired image size.
+
+        Returns:
+            ``(rgb, depth)`` with ``rgb`` as ``(H, W, 3) uint8`` and ``depth``
+            as ``(H, W) float32`` filled with ``cam.zfar`` meters.
+        """
         pano = self._ensure_panorama()  # (Hp, Wp, 3) uint8
         H, W = cam.height, cam.width
 
@@ -471,6 +486,28 @@ class GsplatBackground:
     # ----- BackgroundRenderer interface ----- #
 
     def render(self, cam: CameraParams) -> tuple[np.ndarray, np.ndarray]:
+        """Rasterize the loaded 3D Gaussian Splatting scene from ``cam``.
+
+        Lazily loads the ``.ply``/``.spz`` splats on first call, builds the
+        gaussian->camera view matrix (converting the stored camera->world
+        MuJoCo/OpenGL pose and the scene-alignment transform into gsplat's
+        OpenCV convention), and rasterizes in ``RGB+D`` mode. Splat RGB is
+        alpha-composited over the neutral background fill so unobserved regions
+        read as plain sky/ceiling rather than black, and zero-contribution
+        pixels are promoted to ``cam.zfar`` depth so they lose the depth test
+        against any MuJoCo foreground.
+
+        Args:
+            cam: pinhole camera parameters at the desired image size.
+
+        Returns:
+            ``(rgb, depth)`` with ``rgb`` as ``(H, W, 3) uint8`` and ``depth``
+            as ``(H, W) float32`` in meters (camera frame).
+
+        Raises:
+            ImportError: if the ``sim-gs`` extra (``torch`` + ``gsplat``) is
+                not installed.
+        """
         if self._splats is None:
             self._load()
         import torch

--- a/tests/rendering/test_public_member_docstrings.py
+++ b/tests/rendering/test_public_member_docstrings.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The hybrid-rendering public API must document every public member.
+
+The ``strands_robots.rendering`` package is the library home of the
+Gaussian-splat hybrid-render layer: the :class:`BackgroundRenderer` protocol
+with its :class:`PanoramaBackground` (zero-ML-deps) and
+:class:`GsplatBackground` (``sim-gs`` extra) implementations, the
+:class:`HybridCompositor` depth-compare layer, the :class:`CameraParams`
+camera description, and the ``encode_clip`` / ``mjpeg_frames`` media
+utilities. Agents and integrators read these docstrings to drive the surface,
+so each concrete override needs its own docstring rather than silently leaning
+on inherited protocol text -- a ``render`` override, for instance, should state
+its own depth convention and optional-dependency contract.
+
+This guard walks the package modules by AST (no import, so it never needs the
+optional ``sim-gs`` / ``imageio`` extras installed) and fails if any public
+class, public method/property, or public module-level function lacks a
+docstring.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.rendering as rendering_pkg
+
+_PACKAGE_DIR = Path(rendering_pkg.__file__).parent
+
+# The public-API modules of the package (``__init__`` only re-exports). All are
+# scanned by AST, so the walk needs no optional backend installed.
+_MODULES = ("backgrounds.py", "camera.py", "compositor.py", "video.py")
+
+# Every public class the package exposes, keyed ``module.py::ClassName``. Pinned
+# so a refactor that drops or renames a class trips the completeness guard
+# instead of silently shrinking the scan.
+_EXPECTED_CLASSES = {
+    "backgrounds.py::BackgroundRenderer",
+    "backgrounds.py::PanoramaBackground",
+    "backgrounds.py::GsplatBackground",
+    "camera.py::CameraParams",
+    "compositor.py::FrameSource",
+    "compositor.py::CompositeFrame",
+    "compositor.py::HybridCompositor",
+}
+
+# Every public module-level function the package exposes.
+_EXPECTED_FUNCTIONS = {
+    "backgrounds.py::gsplat_rasterizer_available",
+    "backgrounds.py::gsplat_scene_names",
+    "backgrounds.py::gsplat_skybox_scene_names",
+    "backgrounds.py::gsplat_skybox_align_for",
+    "backgrounds.py::download_gsplat_scene",
+    "backgrounds.py::bake_gsplat_panorama",
+    "compositor.py::feather_mask",
+    "video.py::encode_clip",
+    "video.py::mjpeg_frames",
+}
+
+
+def _module_tree(module: str) -> ast.Module:
+    """Parse one package module into an AST (no import)."""
+    source_file = _PACKAGE_DIR / module
+    return ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring.
+
+    Dunder methods (``__init__`` and friends) are out of scope: their contract
+    is documented on the class docstring itself.
+    """
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _public_classes() -> dict[str, ast.ClassDef]:
+    """Map ``module.py::ClassName`` -> ClassDef for every public class in the modules."""
+    classes: dict[str, ast.ClassDef] = {}
+    for module in _MODULES:
+        for node in _module_tree(module).body:
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{module}::{node.name}"] = node
+    return classes
+
+
+def _public_functions() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Map ``module.py::func`` -> FunctionDef for every public module-level function."""
+    funcs: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for module in _MODULES:
+        for node in _module_tree(module).body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and not node.name.startswith("_"):
+                funcs[f"{module}::{node.name}"] = node
+    return funcs
+
+
+def test_modules_define_expected_public_surface() -> None:
+    """Guard: the scan actually found the classes and functions it protects."""
+    assert set(_public_classes()) == _EXPECTED_CLASSES, set(_public_classes())
+    assert set(_public_functions()) == _EXPECTED_FUNCTIONS, set(_public_functions())
+
+
+def test_public_classes_and_members_have_docstrings() -> None:
+    offenders: dict[str, list[str]] = {}
+    for qualname, node in _public_classes().items():
+        missing = _public_members_without_docstring(node)
+        if ast.get_docstring(node) is None:
+            missing = ["<class docstring>", *missing]
+        if missing:
+            offenders[qualname] = missing
+    assert not offenders, (
+        "Every public class in strands_robots.rendering -- and every public "
+        "method/property it defines -- must have a docstring describing its "
+        "behavior (concrete overrides must not lean on inherited protocol "
+        "text). Undocumented members: " + repr(offenders)
+    )
+
+
+def test_public_module_functions_have_docstrings() -> None:
+    offenders = [qualname for qualname, node in _public_functions().items() if ast.get_docstring(node) is None]
+    assert not offenders, (
+        "Every public module-level function in strands_robots.rendering must "
+        "have a docstring. Undocumented functions: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem

`strands_robots.rendering` is the library home of the hybrid-render layer, and its public classes are read directly by integrators. Two concrete implementations of the `BackgroundRenderer` protocol carried no docstring of their own:

- `PanoramaBackground.render`
- `GsplatBackground.render`

Both leaned on the inherited protocol docstring, which does not state the specifics a caller actually needs: the panorama path fills a constant `cam.zfar` depth plane (so any MuJoCo foreground always wins the compositor depth test), and the gsplat path lazily loads the splats, rasterizes in `RGB+D`, alpha-composites over the neutral fill, and requires the `sim-gs` extra (raising `ImportError` when it is missing). A reader of the concrete class saw none of that.

## Change

- Add a docstring to each `render` override describing its own depth convention, and for the gsplat path its `ImportError` optional-dependency contract.
- Pin `tests/rendering/test_public_member_docstrings.py`: an AST guard (parses the modules, no import, so it needs no optional `sim-gs` / `imageio` extra) that fails if any public class, public method/property, or public module-level function in the package lacks a docstring. A companion completeness assertion pins the exact set of public classes and functions so the scan cannot silently shrink under a refactor.

## Why it is a real regression guard

On the pre-docstring code the guard fails with `{'backgrounds.py::PanoramaBackground': ['render'], 'backgrounds.py::GsplatBackground': ['render']}`; with the docstrings in place all three guard cases pass. Docs-only -- no behavior change, no rendering output change.

## Tests

`MUJOCO_GL=egl python -m pytest tests/rendering/` -> 72 passed, 2 skipped (incl. the 3 new guard tests). Local gate clean: `ruff check` / `ruff format --check` / `mypy` on the changed module and the new test.