### PR TITLE
docs(device_connect): document public accessors + link methods of the driver classes + pin a guard

### DIFF
--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -58,6 +58,12 @@ class ReachyMiniDriver(DeviceDriver):
 
     @property
     def identity(self) -> DeviceIdentity:
+        """Static Device Connect identity for the Reachy Mini head.
+
+        Returns a :class:`~device_connect_edge.types.DeviceIdentity` reporting
+        ``device_type="reachy_mini"``, the ``Pollen Robotics`` manufacturer, and
+        the configured host in the model string.
+        """
         return DeviceIdentity(
             device_type="reachy_mini",
             manufacturer="Pollen Robotics",
@@ -67,6 +73,11 @@ class ReachyMiniDriver(DeviceDriver):
 
     @property
     def status(self) -> DeviceStatus:
+        """Availability of the Reachy Mini; always reports ``"idle"``.
+
+        The head has no long-running task state, so it advertises itself as
+        available for commands at all times.
+        """
         return DeviceStatus(availability="idle")
 
     async def connect(self) -> None:

--- a/strands_robots/device_connect/reachy_transport.py
+++ b/strands_robots/device_connect/reachy_transport.py
@@ -211,6 +211,13 @@ class ZenohLink(HardwareLink):
         self._prefix = prefix
 
     async def start(self, on_joints: JointsCallback, on_imu: ImuCallback) -> None:
+        """Subscribe to the Zenoh joint-position and IMU topics.
+
+        Wires ``on_joints`` / ``on_imu`` to the ``<prefix>/joint_positions`` and
+        ``<prefix>/imu_data`` topics; malformed frames are dropped so the
+        subscription stays alive.
+        """
+
         async def _on_joints(data: bytes, _reply=None):
             try:
                 on_joints(json.loads(data.decode()))
@@ -227,9 +234,11 @@ class ZenohLink(HardwareLink):
         await self._transport.subscribe(f"{self._prefix}/imu_data", _on_imu)
 
     async def stop(self) -> None:
+        """No-op; the shared Zenoh transport is torn down by the DeviceRuntime."""
         pass  # Transport teardown handled by DeviceRuntime
 
     async def send_cmd(self, cmd: dict[str, Any]) -> None:
+        """Publish a command dict as JSON to the ``<prefix>/command`` topic."""
         await self._transport.publish(f"{self._prefix}/command", json.dumps(cmd).encode())
 
 
@@ -250,6 +259,13 @@ class WebSocketLink(HardwareLink):
         self._read_task: asyncio.Task[None] | None = None
 
     async def start(self, on_joints: JointsCallback, on_imu: ImuCallback) -> None:
+        """Open the daemon WebSocket and start the sensor read loop.
+
+        Connects to ``ws(s)://<host>:<port>/ws/sdk`` (bearer-authenticating when a
+        daemon token is configured, warning once when it is not) and spawns the
+        background task that dispatches incoming frames to ``on_joints`` /
+        ``on_imu``.
+        """
         import websockets
 
         # Security hardening: authenticate to the daemon when a token is
@@ -288,12 +304,19 @@ class WebSocketLink(HardwareLink):
                 pass  # skip malformed frame; keep reading
 
     async def stop(self) -> None:
+        """Cancel the read loop and close the WebSocket connection."""
         if self._read_task:
             self._read_task.cancel()
         if self._ws:
             await self._ws.close()
 
     async def send_cmd(self, cmd: dict[str, Any]) -> None:
+        """Translate the first recognised command key to the daemon wire format.
+
+        Maps ``head_pose`` / ``antennas_joint_positions`` / ``body_yaw`` /
+        ``torque`` to their WebSocket message shape and sends it; a no-op when the
+        socket is not connected or no known key is present.
+        """
         if not self._ws:
             return
         for key, fn in self._WS_CMD_MAP.items():

--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -35,6 +35,12 @@ class RobotDeviceDriver(DeviceDriver):
 
     @property
     def identity(self) -> DeviceIdentity:
+        """Static Device Connect identity for the wrapped robot.
+
+        Returns a :class:`~device_connect_edge.types.DeviceIdentity` reporting
+        ``device_type="strands_robot"``, the ``strands-robots`` manufacturer, and
+        the robot's ``tool_name_str`` as the model (falling back to ``"robot"``).
+        """
         return DeviceIdentity(
             device_type="strands_robot",
             manufacturer="strands-robots",
@@ -44,6 +50,12 @@ class RobotDeviceDriver(DeviceDriver):
 
     @property
     def status(self) -> DeviceStatus:
+        """Live availability of the wrapped robot.
+
+        Returns a :class:`~device_connect_edge.types.DeviceStatus` that is
+        ``"busy"`` (``busy_score`` 1.0) while a task is running and ``"idle"``
+        (``busy_score`` 0.0) otherwise, derived from the robot's task state.
+        """
         task = getattr(self._robot, "_task_state", None)
         is_busy = task is not None and hasattr(task, "status") and getattr(task.status, "value", "idle") == "running"
         return DeviceStatus(

--- a/strands_robots/device_connect/sim_driver.py
+++ b/strands_robots/device_connect/sim_driver.py
@@ -34,6 +34,13 @@ class SimulationDeviceDriver(DeviceDriver):
 
     @property
     def identity(self) -> DeviceIdentity:
+        """Static Device Connect identity for the wrapped simulation.
+
+        Returns a :class:`~device_connect_edge.types.DeviceIdentity` reporting
+        ``device_type="strands_sim"``, the ``strands-robots`` manufacturer, and
+        the simulation's ``tool_name_str`` as the model (falling back to
+        ``"simulation"``).
+        """
         return DeviceIdentity(
             device_type="strands_sim",
             manufacturer="strands-robots",
@@ -43,6 +50,12 @@ class SimulationDeviceDriver(DeviceDriver):
 
     @property
     def status(self) -> DeviceStatus:
+        """Live availability of the wrapped simulation.
+
+        Returns a :class:`~device_connect_edge.types.DeviceStatus` that is
+        ``"busy"`` (``busy_score`` 1.0) when any robot in the world is running a
+        policy and ``"idle"`` (``busy_score`` 0.0) otherwise.
+        """
         world = getattr(self._sim, "_world", None)
         is_busy = False
         if world:

--- a/tests/test_device_connect_public_member_docstrings.py
+++ b/tests/test_device_connect_public_member_docstrings.py
@@ -1,0 +1,99 @@
+"""Every public class in the ``strands_robots.device_connect`` package must
+document each of its public methods and properties.
+
+The device_connect package is the surface that exposes a strands-robots
+:class:`~strands_robots.robot.Robot`, a
+:class:`~strands_robots.simulation.Simulation`, and a Pollen Reachy Mini head to
+Device Connect's device registry as ``DeviceDriver`` adapters
+(:class:`~strands_robots.device_connect.robot_driver.RobotDeviceDriver`,
+:class:`~strands_robots.device_connect.sim_driver.SimulationDeviceDriver`,
+:class:`~strands_robots.device_connect.reachy_mini_driver.ReachyMiniDriver`) plus
+the real-time hardware links
+(:class:`~strands_robots.device_connect.reachy_transport.ZenohLink` /
+``WebSocketLink``). Several of these classes carried a rich class docstring but
+left the ``identity`` / ``status`` accessors and the ``start`` / ``stop`` /
+``send_cmd`` link methods undocumented, so a reader driving the driver blind
+could not tell what an accessor returns or what a link method does without
+reading its body. This mirrors the mesh guard
+(``tests/mesh/test_public_member_docstrings.py``) and the policy guard
+(``tests/policies/test_builtin_policy_docstrings.py``).
+
+The check walks every module across the device_connect tree by AST (no import,
+so it needs none of the optional extras - ``device_connect_edge``, ``zenoh``,
+``websockets`` - installed) and fails if any public method or property of a
+public class defines no docstring. Property setters and deleters are exempt: a
+``@x.setter`` mirrors its documented getter and a docstring on it is noise,
+matching the convention elsewhere in the tree.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots
+
+_PACKAGE_DIR = Path(strands_robots.__file__).parent / "device_connect"
+
+
+def _is_setter_or_deleter(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the function is a ``@<name>.setter`` or ``@<name>.deleter``."""
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Attribute) and dec.attr in ("setter", "deleter"):
+            return True
+    return False
+
+
+def _is_overload(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the function is a ``@typing.overload`` stub (body is documented once)."""
+    for dec in node.decorator_list:
+        name = dec.attr if isinstance(dec, ast.Attribute) else getattr(dec, "id", "")
+        if name == "overload":
+            return True
+    return False
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring."""
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if _is_setter_or_deleter(node) or _is_overload(node):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _public_classes() -> dict[str, ast.ClassDef]:
+    """Map ``relpath::ClassName`` -> ClassDef for every public class in the tree."""
+    classes: dict[str, ast.ClassDef] = {}
+    for path in sorted(_PACKAGE_DIR.rglob("*.py")):
+        rel = path.relative_to(_PACKAGE_DIR)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{rel}::{node.name}"] = node
+    return classes
+
+
+def test_device_connect_dir_exists() -> None:
+    """The device_connect package directory resolves and contains modules."""
+    assert _PACKAGE_DIR.is_dir()
+    assert any(_PACKAGE_DIR.rglob("*.py"))
+
+
+def test_every_public_class_member_has_docstring() -> None:
+    """No public method/property of a public device_connect class may lack a docstring."""
+    missing: dict[str, list[str]] = {}
+    for qualname, class_node in _public_classes().items():
+        offenders = _public_members_without_docstring(class_node)
+        if offenders:
+            missing[qualname] = offenders
+
+    assert not missing, "Public members missing docstrings:\n" + "\n".join(
+        f"  {qualname}: {', '.join(names)}" for qualname, names in sorted(missing.items())
+    )


### PR DESCRIPTION
## Problem

The `strands_robots.device_connect` `DeviceDriver` adapters carried rich class docstrings but left their public members undocumented. A reader driving the driver API blind could not tell what an accessor returns or what a link method does without reading its body:

- `RobotDeviceDriver.identity` / `.status`
- `SimulationDeviceDriver.identity` / `.status`
- `ReachyMiniDriver.identity` / `.status`
- `ZenohLink.start` / `.stop` / `.send_cmd`
- `WebSocketLink.start` / `.stop` / `.send_cmd`

These are exactly the accessors Device Connect surfaces (`identity` / `status` feed the device registry) and the real-time hardware-link methods a Reachy Mini integration calls, so the gap is user-facing.

## Change

Document all 12 offenders with summaries that state what each accessor returns (the `DeviceStatus` availability / `busy_score` mapping, the `DeviceIdentity` fields) and what each link method does (topic wiring, WebSocket connect + read loop, command-key translation).

Pin an AST guard, `tests/test_device_connect_public_member_docstrings.py`, that walks the `device_connect` tree **without importing it** (so it needs none of the optional extras: `device_connect_edge`, `zenoh`, `websockets`) and fails if any public method or property of a public class lacks a docstring. Property setters/deleters and `@overload` stubs are exempt. This mirrors the existing mesh guard (`tests/mesh/test_public_member_docstrings.py`) and policy guard (`tests/policies/test_builtin_policy_docstrings.py`).

## Tests

The guard fails pre-change listing all 12 offenders and passes after documenting them:

```
reachy_mini_driver.py::ReachyMiniDriver: identity, status
reachy_transport.py::WebSocketLink: start, stop, send_cmd
reachy_transport.py::ZenohLink: start, stop, send_cmd
robot_driver.py::RobotDeviceDriver: identity, status
sim_driver.py::SimulationDeviceDriver: identity, status
```

Local gate green: `ruff check`, `ruff format --check`, `mypy` all clean; the docstring cross-reference guards (`test_docstrings_no_dangling_doc_refs`, `test_docstring_xref_roles_resolve`) and the device_connect driver/transport suites pass (186 passed). Docs-only + test change; no behavioral change.