### PR TITLE
docs(tools): document SessionManager public lifecycle methods + pin a guard

### DIFF
--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -231,20 +231,57 @@ class SessionManager:
             logger.error(f"Error saving sessions: {e}")
 
     def add_session(self, name: str, info: dict[str, Any]) -> None:
+        """Persist a training session record under ``name``.
+
+        Loads the current on-disk sessions, upserts ``name`` -> ``info``
+        (an existing entry with the same name is overwritten), and writes the
+        map back to disk.
+
+        Args:
+            name: session key (e.g. the run/job name) to store the record under.
+            info: session metadata to persist (typically ``pid``, ``log_file``,
+                ``dataset``, and start timestamp).
+        """
         sessions = self._load_sessions()
         sessions[name] = info
         self._save_sessions(sessions)
 
     def remove_session(self, name: str) -> None:
+        """Delete the session stored under ``name`` if one exists.
+
+        A no-op when ``name`` is not tracked, so callers need not check first.
+
+        Args:
+            name: session key to remove.
+        """
         sessions = self._load_sessions()
         if name in sessions:
             del sessions[name]
             self._save_sessions(sessions)
 
     def get_session(self, name: str) -> dict[str, Any] | None:
+        """Return the stored metadata for a single session.
+
+        Args:
+            name: session key to look up.
+
+        Returns:
+            The session's info dict, or ``None`` if no session is tracked under
+            ``name``. Dead processes are pruned on load, so a returned record is
+            one whose PID either is still running or belonged to a finished run.
+        """
         return self._load_sessions().get(name)
 
     def list_sessions(self) -> dict[str, Any]:
+        """Return every currently-tracked session keyed by name.
+
+        Returns:
+            A ``name -> info`` map. Sessions whose PID is no longer a running
+            process are not dropped -- they are retained so ``status`` can still
+            report the final log tail -- but the load step is what derives the
+            live/finished distinction, so this never reports a stale PID as
+            running.
+        """
         return self._load_sessions()
 
 

--- a/tests/tools/test_public_member_docstrings.py
+++ b/tests/tools/test_public_member_docstrings.py
@@ -1,0 +1,84 @@
+"""Every public class in the ``strands_robots.tools`` package must document each
+of its public methods and properties.
+
+The tools package is the agent-facing command surface: each ``@tool`` entry
+point plus the small stateful helpers those tools drive. One such helper,
+:class:`~strands_robots.tools.lerobot_train.SessionManager`, tracks detached
+training runs on disk (add / get / list / remove) but left its public lifecycle
+methods undocumented, so a reader driving the training-session API blind could
+not tell what ``get_session`` returns for an unknown name, or that
+``remove_session`` is a no-op when the name is untracked, without reading the
+body. This mirrors the mesh-package guard
+(``tests/mesh/test_public_member_docstrings.py``), the policy-package guard
+(``tests/policies/test_builtin_policy_docstrings.py``), and the tools docstring
+cross-reference guard (``tests/tools/test_docstring_module_xrefs.py``).
+
+The check walks every module across the tools tree by AST (no import, so it
+needs none of the optional tool backends installed) and fails if any public
+method or property of a public class defines no docstring. Property setters and
+deleters are exempt: a ``@x.setter`` mirrors its documented getter and a
+docstring on it is noise, matching the convention elsewhere in the tree.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.tools as tools_pkg
+
+_PACKAGE_DIR = Path(tools_pkg.__file__).parent
+
+
+def _is_setter_or_deleter(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the function is a ``@<name>.setter`` or ``@<name>.deleter``."""
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Attribute) and dec.attr in ("setter", "deleter"):
+            return True
+    return False
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring."""
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if _is_setter_or_deleter(node):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _public_classes() -> dict[str, ast.ClassDef]:
+    """Map ``relpath::ClassName`` -> ClassDef for every public class across the tools tree."""
+    classes: dict[str, ast.ClassDef] = {}
+    for source_file in sorted(_PACKAGE_DIR.rglob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        rel = source_file.relative_to(_PACKAGE_DIR)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{rel}::{node.name}"] = node
+    return classes
+
+
+def test_tools_tree_has_public_classes() -> None:
+    """Guard: the scan actually walked the tools tree and found the class to protect."""
+    found = set(_public_classes())
+    assert any(q.endswith("::SessionManager") for q in found), found
+
+
+def test_tools_public_members_have_docstrings() -> None:
+    offenders = {
+        qualname: missing
+        for qualname, node in _public_classes().items()
+        if (missing := _public_members_without_docstring(node))
+    }
+    assert not offenders, (
+        "Every public method/property of a public tools class must have a "
+        "docstring describing what it returns or does (a rich class docstring "
+        "does not document its individual accessors). Undocumented members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem
`SessionManager` (`strands_robots.tools.lerobot_train`) tracks detached training runs on disk, but its four public lifecycle methods carried no docstrings:

- `add_session(name, info)`
- `remove_session(name)`
- `get_session(name)`
- `list_sessions()`

The class has a rich class docstring, but that does not document its individual accessors. A reader driving the training-session API blind could not tell that `get_session` returns `None` for an unknown name, or that `remove_session` is a no-op when the name is untracked, without reading the method body.

## Change
Document all four methods with a summary line plus `Args`/`Returns`, capturing the non-obvious contracts: upsert-on-duplicate for `add_session`, no-op-when-absent for `remove_session`, `None`-for-unknown for `get_session`, and the load-time dead-PID pruning that keeps `list_sessions` from reporting a stale PID as running while retaining finished runs for log-tail reporting.

Pin an AST-based public-member docstring guard for the whole `tools` tree (`tests/tools/test_public_member_docstrings.py`), mirroring `tests/mesh/test_public_member_docstrings.py` and `tests/policies/test_builtin_policy_docstrings.py`. It walks every module by AST (no import, so no optional tool backend is required), and fails if any public method or property of a public tools class lacks a docstring; property setters/deleters are exempt.

## Tests
The guard fails on the pre-doc tree, flagging exactly:
```
{'lerobot_train.py::SessionManager': ['add_session', 'remove_session', 'get_session', 'list_sessions']}
```
and passes after the docstrings are added. `SessionManager` is the only undocumented public-member offender across the entire `tools` package, so this closes the package's public-member doc debt and guards it going forward.

Local gate: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests` clean, `pytest tests/tools/` -> 800 passed, 1 skipped. Docstring-only change; no behavior change.