### PR TITLE
docs(policies): document backend provider Policy public members + pin a guard

### DIFF
--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -302,6 +302,7 @@ class Cosmos3Policy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"cosmos3"``)."""
         return "cosmos3"
 
     @property

--- a/strands_robots/policies/curobo/policy.py
+++ b/strands_robots/policies/curobo/policy.py
@@ -269,6 +269,7 @@ class CuroboPolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"curobo"``)."""
         return "curobo"
 
     @property

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -649,6 +649,7 @@ class Gr00tPolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"groot"``)."""
         return "groot"
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
@@ -717,6 +718,14 @@ class Gr00tPolicy(Policy):
         logger.debug("Gr00tPolicy.reset: local-mode reseed applied (seed=%r)", seed)
 
     async def get_actions(self, observation_dict: dict[str, Any], instruction: str, **kwargs) -> list[dict[str, Any]]:
+        """Predict an action chunk for one observation.
+
+        Dispatches to local in-process inference when the policy was loaded in
+        ``"local"`` mode, otherwise forwards the observation to the GR00T
+        inference service. Returns a list of per-timestep action dicts keyed by
+        actuator name; ``instruction`` is the language goal and extra ``kwargs``
+        are ignored by this provider.
+        """
         if self._mode == "local":
             return self._local_get_actions(observation_dict, instruction)
         return self._service_get_actions(observation_dict, instruction)

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -229,9 +229,15 @@ class LerobotAsyncPolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"lerobot_async"``)."""
         return "lerobot_async"
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        """Record the robot's ordered joint/state keys.
+
+        Stored as the state-vector layout sent to the async inference server on
+        each observation.
+        """
         self.robot_state_keys = list(robot_state_keys)
 
     def reset(self, seed: int | None = None) -> None:

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -406,6 +406,7 @@ class LerobotLocalPolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"lerobot_local"``)."""
         return "lerobot_local"
 
     @property

--- a/strands_robots/policies/motionbricks/policy.py
+++ b/strands_robots/policies/motionbricks/policy.py
@@ -266,6 +266,7 @@ class MotionBricksPolicy(Policy):
     # ------------------------------------------------------------------
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"motionbricks"``)."""
         return "motionbricks"
 
     @property
@@ -275,6 +276,7 @@ class MotionBricksPolicy(Policy):
 
     @property
     def config(self) -> MotionBricksConfig | None:
+        """Resolved :class:`MotionBricksConfig`, or ``None`` when unconfigured."""
         return self._config
 
     @property

--- a/strands_robots/policies/moveit2/policy.py
+++ b/strands_robots/policies/moveit2/policy.py
@@ -135,6 +135,7 @@ class MoveIt2Policy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"moveit2"``)."""
         return "moveit2"
 
     @property

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -209,13 +209,16 @@ class VeraPolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"vera"``)."""
         return "vera"
 
     @property
     def requires_images(self) -> bool:
+        """VERA conditions on camera frames - always needs images."""
         return True
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        """Record the robot's ordered joint/state keys used to build the state vector."""
         self._robot_state_keys = list(robot_state_keys)
 
     def set_ik_target(

--- a/strands_robots/policies/wbc/gait.py
+++ b/strands_robots/policies/wbc/gait.py
@@ -343,6 +343,7 @@ class WBCGaitPolicy(WBCPolicy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"wbc_gait"``)."""
         return "wbc_gait"
 
     def _resolve_config(self, config: str | dict[str, Any] | WBCConfig | None, checkpoint: str | None) -> WBCConfig:

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -320,6 +320,7 @@ class WBCPolicy(Policy):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this provider (``"wbc"``)."""
         return "wbc"
 
     @property
@@ -329,6 +330,7 @@ class WBCPolicy(Policy):
 
     @property
     def config(self) -> WBCConfig:
+        """Resolved :class:`WBCConfig` this controller runs with."""
         return self._config
 
     @property

--- a/tests/policies/test_provider_policy_docstrings.py
+++ b/tests/policies/test_provider_policy_docstrings.py
@@ -1,0 +1,139 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Backend policy *providers* must document every public member they override.
+
+:mod:`~strands_robots.policies.base.Policy` documents its runtime contract, and
+:mod:`tests.policies.test_builtin_policy_docstrings` already pins that guard for
+the dependency-free built-ins (``MockPolicy`` / ``CompositePolicy`` /
+``PersistentPolicy``). The backend providers - GR00T, cuRobo, cosmos3, the two
+lerobot providers, MotionBricks, MoveIt2, VERA and the two WBC controllers -
+each override public members such as ``provider_name``, ``get_actions``,
+``requires_images`` and ``config``. An agent picking a provider reads those
+docstrings to learn which one it is holding and what it needs, so every public
+override needs its own docstring rather than silently leaning on the inherited
+one (a ``provider_name`` override still has to state the registry key it maps
+to).
+
+This guard walks the provider policy modules by AST (no import), so it never
+needs any optional policy backend (``[groot]`` / ``[cosmos3]`` / ``[vera]`` /
+``[moveit2]`` / ``[wbc]`` ...) installed. It descends one level into
+module-level ``if`` blocks because a provider class may be defined under an
+optional-dependency guard. The pinned provider set is cross-checked against the
+``policies.json`` registry so that registering a new ``strands_robots.policies``
+provider without documenting it trips this guard instead of shrinking the scan.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import strands_robots.policies as policies_pkg
+
+_PACKAGE_DIR = Path(policies_pkg.__file__).parent
+_REGISTRY = Path(policies_pkg.__file__).parents[1] / "registry" / "policies.json"
+
+# Provider policy source file (relative to the policies package) -> class name.
+# Pinned so a rename or a dropped provider trips the completeness guard below
+# instead of silently narrowing the docstring scan.
+_PROVIDER_POLICIES = {
+    "groot/policy.py": "Gr00tPolicy",
+    "lerobot_local/policy.py": "LerobotLocalPolicy",
+    "lerobot_async/policy.py": "LerobotAsyncPolicy",
+    "cosmos3/policy.py": "Cosmos3Policy",
+    "moveit2/policy.py": "MoveIt2Policy",
+    "curobo/policy.py": "CuroboPolicy",
+    "wbc/policy.py": "WBCPolicy",
+    "wbc/gait.py": "WBCGaitPolicy",
+    "vera/provider.py": "VeraPolicy",
+    "motionbricks/policy.py": "MotionBricksPolicy",
+}
+
+# Built-in policy classes documented by test_builtin_policy_docstrings; the
+# ``remote`` provider's RemotePolicy lives in strands_robots.inference and is
+# guarded by tests/inference. Neither is a backend provider under this scan.
+_CORE_CLASSES = {"MockPolicy", "CompositePolicy", "PersistentPolicy", "RemotePolicy"}
+
+
+def _iter_defs(module: ast.Module) -> list[ast.stmt]:
+    """Yield class/function defs at module top level and inside its top-level ``if`` blocks.
+
+    A provider class may sit under an ``if _HAVE_<dep>:`` / ``if TYPE_CHECKING:``
+    guard so the module imports without the optional backend; the walk descends
+    one level into module-level ``if`` bodies to reach it.
+    """
+    defs: list[ast.stmt] = []
+    for node in module.body:
+        if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+            defs.append(node)
+        elif isinstance(node, ast.If):
+            for inner in [*node.body, *node.orelse]:
+                if isinstance(inner, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                    defs.append(inner)
+    return defs
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring.
+
+    Dunder and ``_private`` members are out of scope: their contract belongs on
+    the class docstring or is internal.
+    """
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _provider_class_node(rel_path: str, class_name: str) -> ast.ClassDef:
+    """Locate the pinned provider class in its source file by AST (no import)."""
+    source_file = _PACKAGE_DIR / rel_path
+    tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+    for node in _iter_defs(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    raise AssertionError(f"{class_name} not found at top level of {rel_path}")
+
+
+def test_pinned_providers_match_registry() -> None:
+    """Guard: the pinned set matches every backend provider in policies.json.
+
+    Any ``strands_robots.policies`` provider registered in ``policies.json`` that
+    is not a core built-in must be pinned here, so a newly registered provider
+    cannot ship without a documentation guard entry.
+    """
+    registry = json.loads(_REGISTRY.read_text(encoding="utf-8"))["providers"]
+    registered_backend_classes = {
+        info["class"]
+        for info in registry.values()
+        if info.get("module", "").startswith("strands_robots.policies.") and info["class"] not in _CORE_CLASSES
+    }
+    assert registered_backend_classes == set(_PROVIDER_POLICIES.values()), (
+        "The pinned provider set drifted from policies.json. Registered backend "
+        f"providers: {sorted(registered_backend_classes)}; pinned: "
+        f"{sorted(_PROVIDER_POLICIES.values())}"
+    )
+
+
+def test_provider_policy_public_members_have_docstrings() -> None:
+    """Every public method/property of a backend provider policy is documented."""
+    offenders: dict[str, list[str]] = {}
+    for rel_path, class_name in _PROVIDER_POLICIES.items():
+        node = _provider_class_node(rel_path, class_name)
+        missing = _public_members_without_docstring(node)
+        if ast.get_docstring(node) is None:
+            missing = ["<class docstring>", *missing]
+        if missing:
+            offenders[f"{rel_path}::{class_name}"] = missing
+    assert not offenders, (
+        "Every public method/property of a backend policy provider must have a "
+        "docstring (the base Policy ABC already documents the contract; an "
+        "override still states its provider-specific behavior, e.g. the "
+        "registry key provider_name maps to). Undocumented members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem

The `Policy` ABC documents its runtime contract, and `tests/policies/test_builtin_policy_docstrings.py` already pins that guard for the dependency-free built-ins (`MockPolicy` / `CompositePolicy` / `PersistentPolicy`). The **backend providers**, however, each override public members without their own docstrings, silently leaning on the inherited one:

```
groot/policy.py::Gr00tPolicy          provider_name, get_actions
lerobot_local/policy.py               provider_name
lerobot_async/policy.py               provider_name, set_robot_state_keys
cosmos3/policy.py::Cosmos3Policy      provider_name
moveit2/policy.py::MoveIt2Policy      provider_name
curobo/policy.py::CuroboPolicy        provider_name
wbc/policy.py::WBCPolicy              provider_name, config
wbc/gait.py::WBCGaitPolicy            provider_name
vera/provider.py::VeraPolicy         provider_name, requires_images, set_robot_state_keys
motionbricks/policy.py                provider_name, config
```

An agent selecting a provider reads these docstrings to learn which provider it is holding and what it needs. A bare `provider_name` that just returns `"groot"` with no docstring is a dead-end for the reader.

## Change

Document every undocumented public override across the ten backend provider `Policy` classes (a `provider_name` override states the registry key it maps to; `get_actions` states its local-vs-service dispatch; `config`/`requires_images`/`set_robot_state_keys` state provider-specific behavior).

Pin a new AST-based guard `tests/policies/test_provider_policy_docstrings.py` that walks the provider policy modules **without importing them** (so it never needs any optional backend extra installed) and fails if any public member lacks a docstring. It descends one level into module-level `if` blocks so a class defined under an optional-dependency guard is still reached. The pinned provider set is cross-checked against `registry/policies.json`, so registering a new `strands_robots.policies` provider without documenting it trips the guard instead of silently shrinking the scan.

This continues the built-in-policy docstring guard to the provider surface; no runtime behavior changes.

## Tests

- New guard **fails on pre-change code** (reports all 18 undocumented members across the 10 providers) and **passes after** the docstrings are added.
- `test_pinned_providers_match_registry` confirms the pinned set equals the non-core `strands_robots.policies` providers in `policies.json`.
- Full `tests/policies/` suite green: 1717 passed, 2 skipped.
- `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean (861 source files, no issues).