### PR TITLE
docs(simulation): document the MuJoCo AgentTool interface members + pin a public-member guard

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3384,10 +3384,17 @@ class MuJoCoSimEngine(
 
     @property
     def tool_name(self) -> str:
+        """The tool name the agent invokes this simulation under.
+
+        Defaults to ``"mujoco_simulation"`` but is settable via the
+        ``tool_name`` constructor argument so several engines can coexist in
+        one agent's tool registry under distinct names.
+        """
         return self.tool_name_str
 
     @property
     def tool_type(self) -> str:
+        """The Strands ``AgentTool`` category for this tool (always ``"simulation"``)."""
         return "simulation"
 
     def _require_world(self) -> dict[str, Any] | None:
@@ -3480,6 +3487,13 @@ class MuJoCoSimEngine(
 
     @property
     def tool_spec(self) -> ToolSpec:
+        """The Strands ``ToolSpec`` (name, description, JSON input schema) the agent sees.
+
+        The description enumerates the full action surface (create_world,
+        add_robot, run_policy, render, ...) and the input schema is the
+        module-level ``_TOOL_SPEC_SCHEMA`` cached at import time, so building
+        the spec is allocation-cheap on every access.
+        """
         # schema cached at module load; see _TOOL_SPEC_SCHEMA
         return {
             "name": self.tool_name_str,
@@ -3518,6 +3532,14 @@ class MuJoCoSimEngine(
     async def stream(
         self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any
     ) -> AsyncGenerator[ToolResultEvent, None]:
+        """Dispatch one agent tool call and yield its single ``ToolResultEvent``.
+
+        Reads the ``action`` (and its arguments) from ``tool_use["input"]``,
+        runs it against this stateful session, and yields exactly one result
+        event carrying the originating ``toolUseId``. Any exception is caught
+        and surfaced as a ``status="error"`` result rather than propagating
+        past dispatch, per the agent-tool contract.
+        """
         try:
             tool_use_id = tool_use.get("toolUseId", "")
             input_data = tool_use.get("input", {})

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -1,0 +1,148 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The MuJoCo backend public API must document every public member.
+
+The ``strands_robots.simulation.mujoco`` package is the default simulation
+backend: :class:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine`
+is a Strands ``AgentTool`` that hosts one stateful MuJoCo world, composed from
+the behaviour mixins (:class:`~strands_robots.simulation.mujoco.physics.PhysicsMixin`,
+:class:`~strands_robots.simulation.mujoco.rendering.RenderingMixin`,
+:class:`~strands_robots.simulation.mujoco.recording.RecordingMixin`,
+:class:`~strands_robots.simulation.mujoco.manipulation.ManipulationMixin`,
+:class:`~strands_robots.simulation.mujoco.randomization.RandomizationMixin`) plus
+the :class:`~strands_robots.simulation.mujoco.spec_builder.SpecBuilder` and the
+``scene_ops`` MJCF surgery helpers. Agents drive this surface through docstrings
+alone, so the ``AgentTool`` interface members (``tool_name``, ``tool_type``,
+``tool_spec``, ``stream``) must state their OWN behaviour rather than lean on
+the base ABC.
+
+This guard walks the package modules by AST (no import, so it never needs the
+optional ``sim-mujoco`` extra installed) and fails if any public class, public
+method/property, or public module-level function lacks a docstring.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.simulation.mujoco as mujoco_pkg
+
+_PACKAGE_DIR = Path(mujoco_pkg.__file__).parent
+
+# The public-API modules of the package (``__init__`` only re-exports). All are
+# scanned by AST, so the walk needs no optional dependency installed.
+_MODULES = (
+    "backend.py",
+    "manipulation.py",
+    "physics.py",
+    "randomization.py",
+    "recording.py",
+    "rendering.py",
+    "scene_ops.py",
+    "simulation.py",
+    "spec_builder.py",
+)
+
+# Every public class the package exposes, keyed ``module.py::ClassName``. Pinned
+# so a refactor that drops or renames a class trips the completeness guard
+# instead of silently shrinking the scan.
+_EXPECTED_CLASSES = {
+    "manipulation.py::ManipulationMixin",
+    "physics.py::PhysicsMixin",
+    "randomization.py::RandomizationMixin",
+    "recording.py::RecordingMixin",
+    "rendering.py::RenderingMixin",
+    "simulation.py::MuJoCoSimEngine",
+    "spec_builder.py::SpecBuilder",
+}
+
+# Every public module-level function the package exposes.
+_EXPECTED_FUNCTIONS = {
+    "backend.py::capture_stderr_fd",
+    "backend.py::filter_mujoco_attach_noise",
+    "scene_ops.py::actuate_robot_in_scene",
+    "scene_ops.py::add_weld_constraint",
+    "scene_ops.py::eject_body_from_scene",
+    "scene_ops.py::eject_robot_from_scene",
+    "scene_ops.py::inject_camera_into_scene",
+    "scene_ops.py::inject_object_into_scene",
+    "scene_ops.py::inject_robot_into_scene",
+    "scene_ops.py::patch_scene_mjcf",
+    "scene_ops.py::remove_equality_constraint",
+    "scene_ops.py::replace_scene_mjcf",
+    "scene_ops.py::reposition_body_in_scene",
+}
+
+
+def _module_tree(module: str) -> ast.Module:
+    """Parse one package module into an AST (no import)."""
+    source_file = _PACKAGE_DIR / module
+    return ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring.
+
+    Dunder methods (``__init__`` and friends) are out of scope: their contract
+    is documented on the class docstring itself.
+    """
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _public_classes() -> dict[str, ast.ClassDef]:
+    """Map ``module.py::ClassName`` -> ClassDef for every public class in the modules."""
+    classes: dict[str, ast.ClassDef] = {}
+    for module in _MODULES:
+        for node in _module_tree(module).body:
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{module}::{node.name}"] = node
+    return classes
+
+
+def _public_functions() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Map ``module.py::func`` -> FunctionDef for every public module-level function."""
+    funcs: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for module in _MODULES:
+        for node in _module_tree(module).body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and not node.name.startswith("_"):
+                funcs[f"{module}::{node.name}"] = node
+    return funcs
+
+
+def test_modules_define_expected_public_surface() -> None:
+    """Guard: the scan actually found the classes and functions it protects."""
+    assert set(_public_classes()) == _EXPECTED_CLASSES, set(_public_classes())
+    assert set(_public_functions()) == _EXPECTED_FUNCTIONS, set(_public_functions())
+
+
+def test_public_classes_and_members_have_docstrings() -> None:
+    offenders: dict[str, list[str]] = {}
+    for qualname, node in _public_classes().items():
+        missing = _public_members_without_docstring(node)
+        if ast.get_docstring(node) is None:
+            missing = ["<class docstring>", *missing]
+        if missing:
+            offenders[qualname] = missing
+    assert not offenders, (
+        "Every public class in strands_robots.simulation.mujoco -- and every "
+        "public method/property it defines -- must have a docstring describing "
+        "its behavior (the AgentTool interface members on MuJoCoSimEngine must "
+        "not lean on the base ABC's text). Undocumented members: " + repr(offenders)
+    )
+
+
+def test_public_module_functions_have_docstrings() -> None:
+    offenders = [qualname for qualname, node in _public_functions().items() if ast.get_docstring(node) is None]
+    assert not offenders, (
+        "Every public module-level function in strands_robots.simulation.mujoco "
+        "must have a docstring. Undocumented functions: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine` is a Strands `AgentTool`, but its four `AgentTool` interface members carried no docstrings:

- `tool_name` (property)
- `tool_type` (property)
- `tool_spec` (property)
- `stream` (async dispatch)

An agent introspecting the tool saw only the inherited ABC text rather than the engine's own contract, and `strands_robots.simulation.mujoco` had no completeness guard to keep its public surface documented (unlike `inference`, `mesh`, `rendering`, `rtps`, `benchmarks`, `tools`).

## Change

- Document all four `AgentTool` interface members in place on `MuJoCoSimEngine`, each stating its own behavior (`tool_type` is always `"simulation"`; `stream` catches exceptions into a `status="error"` result per the agent-tool contract; etc.).
- Add `tests/simulation/mujoco/test_public_member_docstrings.py`, a package-wide guard matching the existing per-package guards. It walks every `strands_robots.simulation.mujoco` module by AST (no import, so it needs no optional `sim-mujoco` extra) and fails if any public class, method/property, or module-level function lacks a docstring. It also pins the expected public class/function surface, so a rename or drop trips the completeness check instead of silently shrinking the scan.

## Tests

The guard fails on the pre-fix tree with exactly the four offenders:

```
Undocumented members: {'simulation.py::MuJoCoSimEngine': ['tool_name', 'tool_type', 'tool_spec', 'stream']}
```

and passes once they are documented. Full local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports `Success: no issues found`, and the new guard plus the docstring cross-reference guard pass.

Documentation-only change (docstrings + a test); no behavior change.