### PR TITLE
docs(policies): document ancillary public-class members + pin a tree-wide public-member guard

### DIFF
--- a/strands_robots/policies/groot/client.py
+++ b/strands_robots/policies/groot/client.py
@@ -37,11 +37,13 @@ class MsgSerializer:
 
     @staticmethod
     def to_bytes(data: dict) -> bytes:
+        """Pack a request dict to msgpack bytes, encoding numpy arrays and ModalityConfig values via the custom hook."""
         msgpack = _load_msgpack()
         return msgpack.packb(data, default=MsgSerializer._encode)
 
     @staticmethod
     def from_bytes(data: bytes) -> dict:
+        """Unpack msgpack bytes back into a dict, decoding numpy arrays and ModalityConfig values."""
         msgpack = _load_msgpack()
         return msgpack.unpackb(data, object_hook=MsgSerializer._decode)
 

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -339,6 +339,7 @@ def register_pack_state_step() -> type | None:
         joint_mids: list[float] = field(default_factory=list)
 
         def observation(self, observation: dict[str, Any]) -> dict[str, Any]:
+            """Compose the declared scalar joint keys into ``observation.state`` (passthrough when already packed)."""
             if "observation.state" in observation:
                 return observation  # already packed -> passthrough
 
@@ -405,6 +406,7 @@ def register_pack_state_step() -> type | None:
             return out
 
         def get_config(self) -> dict[str, Any]:
+            """Return the JSON-serializable config (``state_keys``, ``expected_dim``, ``dim_policy``) for checkpoint round-trip."""
             return {
                 "state_keys": list(self.state_keys),
                 "expected_dim": self.expected_dim,
@@ -412,6 +414,7 @@ def register_pack_state_step() -> type | None:
             }
 
         def transform_features(self, features):  # type: ignore[no-untyped-def]
+            """Return ``features`` unchanged: packing reshapes only the runtime obs, not the model's declared feature set."""
             # State vector composition doesn't change the model's declared
             # feature set (the normalizer already knows observation.state);
             # we only reshape the runtime obs. Pass features through.

--- a/strands_robots/policies/lerobot_local/norm_stats.py
+++ b/strands_robots/policies/lerobot_local/norm_stats.py
@@ -400,11 +400,13 @@ def _make_step_classes() -> tuple[type, type] | None:
             self._state_key = state_key
 
         def observation(self, observation: dict[str, Any]) -> dict[str, Any]:
+            """Normalize ``observation.state`` in place via the feature normalizer (passthrough when the key is absent)."""
             if self._state_key in observation and observation[self._state_key] is not None:
                 observation[self._state_key] = self._normalizer.normalize(observation[self._state_key])
             return observation
 
         def transform_features(self, features: Any) -> Any:
+            """Return ``features`` unchanged: normalization does not alter the feature schema."""
             return features
 
     class NormStatsPostprocessorStep(ActionProcessorStep):  # type: ignore[misc,valid-type]
@@ -414,11 +416,13 @@ def _make_step_classes() -> tuple[type, type] | None:
             self._normalizer = normalizer
 
         def action(self, action: Any) -> Any:
+            """Unnormalize the policy ``action`` back into robot units (passthrough when ``None``)."""
             if action is None:
                 return action
             return self._normalizer.unnormalize(action)
 
         def transform_features(self, features: Any) -> Any:
+            """Return ``features`` unchanged: unnormalization does not alter the feature schema."""
             return features
 
     return NormStatsPreprocessorStep, NormStatsPostprocessorStep

--- a/strands_robots/policies/moveit2/client.py
+++ b/strands_robots/policies/moveit2/client.py
@@ -47,6 +47,7 @@ class MsgSerializer:
 
     @staticmethod
     def to_bytes(data: dict[str, Any]) -> bytes:
+        """Pack a JSON-shaped request dict to msgpack bytes (``use_bin_type`` keeps str and bytes distinct on the wire)."""
         msgpack = _load_msgpack()
         # use_bin_type=True keeps str / bytes distinct on the wire
         # (matches msgpack >=1.0 default but explicit is better than
@@ -55,6 +56,7 @@ class MsgSerializer:
 
     @staticmethod
     def from_bytes(data: bytes) -> dict[str, Any]:
+        """Unpack msgpack bytes into a dict, decoding msgpack ``str`` back to Python ``str`` (``raw=False``)."""
         msgpack = _load_msgpack()
         # raw=False decodes msgpack ``str`` types back to Python ``str``
         # (msgpack >=1.0 default); strict_map_key=False allows

--- a/strands_robots/policies/vera/client.py
+++ b/strands_robots/policies/vera/client.py
@@ -139,6 +139,7 @@ class VeraWebsocketClient:
         return self._mnp.unpackb(resp)
 
     def close(self) -> None:
+        """Close the underlying websocket if open (best-effort and idempotent)."""
         if self._ws is not None:
             try:
                 self._ws.close()

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -201,6 +201,7 @@ class VeraConfig:
 
     @property
     def server_uri(self) -> str:
+        """Websocket URI the client connects to (``ws://<host>:<server_port>``)."""
         return f"ws://{self.host}:{self.server_port}"
 
     def server_env(self) -> dict[str, str]:

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -119,6 +119,7 @@ class VeraServerRunner:
     # -- lifecycle ----------------------------------------------------------
 
     def is_running(self) -> bool:
+        """Return True while the launched server subprocess is alive (has not exited)."""
         return self._proc is not None and self._proc.poll() is None
 
     def start(self) -> None:
@@ -312,6 +313,7 @@ class DockerServerRunner:
     # -- lifecycle ----------------------------------------------------------
 
     def is_running(self) -> bool:
+        """Return True while the server container is running."""
         return self._container_running()
 
     def start(self) -> None:

--- a/tests/policies/test_public_member_docstrings.py
+++ b/tests/policies/test_public_member_docstrings.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Every public class across ``strands_robots.policies`` must document its public members.
+
+:mod:`tests.policies.test_provider_policy_docstrings` already pins the docstring
+contract for the backend *provider* Policy classes (GR00T, cuRobo, cosmos3, the
+two lerobot providers, MotionBricks, MoveIt2, VERA, the two WBC controllers) and
+:mod:`tests.policies.test_builtin_policy_docstrings` pins the dependency-free
+built-ins. Neither reaches the *ancillary* public classes the providers lean on:
+the ZMQ ``MsgSerializer`` wire codecs, the VERA websocket client / config /
+server runners, and the LeRobot :class:`ProcessorStep` subclasses that pack and
+normalize observations. An agent reading the tree to drive a provider blind
+still lands on those helpers, so each of their public methods and properties
+needs its own docstring rather than leaning silently on an inherited one (a
+``transform_features`` override that is a deliberate passthrough has to say so).
+
+This guard walks every module across the policies tree by AST (no import, so it
+needs none of the optional policy backends -- ``[groot]`` / ``[cosmos3]`` /
+``[vera]`` / ``[moveit2]`` / ``[wbc]`` / ``[lerobot]`` -- installed) and fails
+if any public method or property of a public class defines no docstring. It
+mirrors the tools-package guard (``tests/tools/test_public_member_docstrings.py``).
+Property setters and deleters are exempt: a ``@x.setter`` mirrors its documented
+getter and a docstring on it is noise, matching the convention elsewhere.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.policies as policies_pkg
+
+_PACKAGE_DIR = Path(policies_pkg.__file__).parent
+
+
+def _is_setter_or_deleter(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the function is a ``@<name>.setter`` or ``@<name>.deleter``."""
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Attribute) and dec.attr in ("setter", "deleter"):
+            return True
+    return False
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring."""
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if _is_setter_or_deleter(node):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _public_classes() -> dict[str, ast.ClassDef]:
+    """Map ``relpath::ClassName`` -> ClassDef for every public class across the policies tree.
+
+    ``ast.walk`` reaches classes defined inside ``if _HAVE_<dep>:`` / ``if
+    TYPE_CHECKING:`` guards (the LeRobot ProcessorStep subclasses live inside a
+    factory guarded that way) as well as at module top level.
+    """
+    classes: dict[str, ast.ClassDef] = {}
+    for source_file in sorted(_PACKAGE_DIR.rglob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        rel = source_file.relative_to(_PACKAGE_DIR)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{rel}::{node.name}"] = node
+    return classes
+
+
+def test_policies_tree_has_ancillary_public_classes() -> None:
+    """Guard: the scan walked the tree and reached the helper classes the provider guard misses."""
+    found = set(_public_classes())
+    for expected in (
+        "groot/client.py::MsgSerializer",
+        "vera/client.py::VeraWebsocketClient",
+        "vera/server_runner.py::VeraServerRunner",
+    ):
+        assert expected in found, (expected, found)
+
+
+def test_policies_public_members_have_docstrings() -> None:
+    offenders = {
+        qualname: missing
+        for qualname, node in _public_classes().items()
+        if (missing := _public_members_without_docstring(node))
+    }
+    assert not offenders, (
+        "Every public method/property of a public class in strands_robots.policies "
+        "must have a docstring describing what it returns or does (a rich class "
+        "docstring does not document its individual accessors). Undocumented "
+        "members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem
The policies package has two docstring guards: `test_provider_policy_docstrings` pins the backend *provider* `Policy` classes, and `test_builtin_policy_docstrings` pins the dependency-free built-ins. Neither reaches the *ancillary* public classes those providers lean on. Fifteen public methods/properties across the tree carried no docstring, so an agent reading the tree to drive a provider blind had to read the body to learn, e.g., what `MsgSerializer.to_bytes` encodes on the wire, whether `VeraWebsocketClient.close` is idempotent, or whether a `ProcessorStep.transform_features` override is a deliberate passthrough.

## Change
Document the undocumented public members:
- `groot/client.py`, `moveit2/client.py`: `MsgSerializer.to_bytes` / `from_bytes`
- `vera/client.py`: `VeraWebsocketClient.close`
- `vera/config.py`: `VeraConfig.server_uri`
- `vera/server_runner.py`: `VeraServerRunner` / `DockerServerRunner` `is_running`
- `lerobot_local/embodiment.py`: `PackStateProcessorStep.observation` / `get_config` / `transform_features`
- `lerobot_local/norm_stats.py`: `NormStatsPreprocessorStep.observation` / `transform_features`, `NormStatsPostprocessorStep.action` / `transform_features`

Pin a tree-wide public-member docstring guard for `strands_robots.policies` (`tests/policies/test_public_member_docstrings.py`), mirroring the tools-package guard: it walks every module by AST (no optional backend needed) and fails if any public method/property of a public class lacks a docstring. Property setters/deleters are exempt.

## Tests
The new guard fails on the pre-change tree (reporting exactly the fifteen members above) and passes after. Verified by stashing the source edits -> guard red -> restore -> green.

```
ruff check strands_robots tests tests_integ   # clean
ruff format --check strands_robots tests tests_integ   # clean
mypy strands_robots tests tests_integ   # Success: no issues found in 863 source files
pytest tests/policies/   # 1719 passed, 2 skipped
```

Docs-only change (docstrings + a test); no runtime behavior changes.