### PR TITLE
docs(simulation): document top-level public class members + pin a public-member guard

### DIFF
--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -207,6 +207,12 @@ class VideoConfig:
 
     @property
     def enabled(self) -> bool:
+        """Whether recording is on: ``True`` iff an output ``path`` was set.
+
+        The other fields (``fps``, ``camera``, ``width``, ``height``) are
+        ignored when this is ``False`` -- a falsy ``path`` opts the whole
+        rollout out of MP4 capture.
+        """
         return bool(self.path)
 
     @classmethod

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -1416,9 +1416,17 @@ class StatefulRewardTerm:
     """
 
     def __call__(self, sim: SimEngine) -> float:  # pragma: no cover - interface
+        """Score the current sim state, returning this step's reward contribution."""
         raise NotImplementedError
 
     def reset(self) -> None:  # pragma: no cover - interface
+        """Clear per-episode state at an episode boundary.
+
+        Called by :meth:`SimEnv.reset` and
+        :meth:`DeclarativeBenchmark.on_episode_start` before a new episode so
+        accumulated progress (phase counters, best-so-far distances, latched
+        successes) does not leak across episodes.
+        """
         raise NotImplementedError
 
 

--- a/tests/simulation/test_public_member_docstrings.py
+++ b/tests/simulation/test_public_member_docstrings.py
@@ -1,0 +1,91 @@
+"""Every public class defined in the top-level ``strands_robots.simulation``
+modules must document each of its public methods and properties.
+
+The simulation package root holds the backend-agnostic facades and value
+objects the whole library funnels through: the :class:`SimEngine` ABC and its
+concrete convenience layer (:mod:`~strands_robots.simulation.base`), the
+policy-rollout runner and its typed config
+(:mod:`~strands_robots.simulation.policy_runner`), the reward/predicate DSL
+(:mod:`~strands_robots.simulation.predicates`), the benchmark surfaces, and the
+backend factory. A reader driving those objects blind should learn what an
+accessor returns from its docstring, not by reading the body -- for example
+that :attr:`VideoConfig.enabled` reports whether an output path was configured,
+or that :meth:`StatefulRewardTerm.reset` clears per-episode state at an episode
+boundary. A rich class docstring does not document its individual accessors.
+
+This mirrors the MuJoCo-backend guard
+(``tests/simulation/mujoco/test_public_member_docstrings.py``) but scopes to the
+simulation package's own top-level modules; the ``mujoco/``, ``isaac/``, and
+``newton/`` backend subpackages carry (or will carry) their own guards and are
+intentionally not walked here.
+
+The check walks every top-level module by AST (no import, so it needs none of
+the optional simulation backends installed) and fails if any public method or
+property of a public class defines no docstring. Property setters and deleters
+are exempt: a ``@x.setter`` mirrors its documented getter and a docstring on it
+is noise, matching the convention elsewhere in the tree.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.simulation as simulation_pkg
+
+_PACKAGE_DIR = Path(simulation_pkg.__file__).parent
+
+
+def _is_setter_or_deleter(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the function is a ``@<name>.setter`` or ``@<name>.deleter``."""
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Attribute) and dec.attr in ("setter", "deleter"):
+            return True
+    return False
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring."""
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if _is_setter_or_deleter(node):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _public_classes() -> dict[str, ast.ClassDef]:
+    """Map ``module.py::ClassName`` -> ClassDef for public classes in top-level modules."""
+    classes: dict[str, ast.ClassDef] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                classes[f"{source_file.name}::{node.name}"] = node
+    return classes
+
+
+def test_simulation_toplevel_has_public_classes() -> None:
+    """Guard: the scan actually walked the top-level modules and found the anchors."""
+    found = set(_public_classes())
+    assert any(q.endswith("::VideoConfig") for q in found), found
+    assert any(q.endswith("::StatefulRewardTerm") for q in found), found
+
+
+def test_simulation_toplevel_public_members_have_docstrings() -> None:
+    offenders = {
+        qualname: missing
+        for qualname, node in _public_classes().items()
+        if (missing := _public_members_without_docstring(node))
+    }
+    assert not offenders, (
+        "Every public method/property of a public class in the top-level "
+        "strands_robots.simulation modules must have a docstring describing "
+        "what it returns or does (a rich class docstring does not document its "
+        "individual accessors). Undocumented members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem
The backend-agnostic simulation package root holds the value objects and facades the whole library funnels through, but two public accessors on core classes were undocumented, so a reader driving the API blind had to read the body to understand them:

- `VideoConfig.enabled` (`simulation/policy_runner.py`) - a property gating optional MP4 capture during a rollout.
- `StatefulRewardTerm.reset` (`simulation/predicates.py`) - the episode-boundary hook of the episode-stateful reward-term interface (its `__call__` was undocumented too).

Every other package (mesh, policies, tools, inference, rtps, benchmarks, the mujoco backend, the top-level module) already pins a public-member docstring guard; the simulation package's own top-level modules had only an xref guard, so these two slipped through.

## Change
- Document `VideoConfig.enabled`: reports whether recording is on (`True` iff an output `path` was set); the other video fields are ignored when it is `False`.
- Document `StatefulRewardTerm.__call__` and `reset`: the reward-term interface contract; `reset` clears per-episode state (phase counters, best-so-far distances, latched successes) at an episode boundary so progress does not leak across episodes.
- Add `tests/simulation/test_public_member_docstrings.py`, a public-member docstring guard that walks the simulation package's **top-level** modules by AST (no import, so no optional backend is required) and fails if any public method/property of a public class lacks a docstring. Setters/deleters are exempt. Scoped to the top-level modules only; the `mujoco/` backend keeps its own guard and the `isaac/`/`newton/` backend subpackages are intentionally not walked here. Mirrors the existing MuJoCo-backend guard.

No behavior change - docstrings plus a test.

## Tests
The new guard fails on pre-change code with exactly the two offenders (`VideoConfig.enabled`, `StatefulRewardTerm.reset`) and passes after documenting them.

```
tests/simulation/test_public_member_docstrings.py ..  2 passed
```

Local gate green: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests` -> `Success: no issues found in 825 source files`; the affected simulation suite (predicates / reward / policy_runner / video / benchmark DSL) passes headless (`MUJOCO_GL=egl`): `546 passed, 8 skipped`.