### PR TITLE
test(rendering): pin the mjpeg_frames client-disconnect contract

### DIFF
--- a/tests/rendering/test_video.py
+++ b/tests/rendering/test_video.py
@@ -88,3 +88,28 @@ def test_mjpeg_frames_non_strict_skips_bad_frames() -> None:
     chunks = list(mjpeg_frames(flaky, fps=1000.0, max_frames=1))
     assert len(chunks) == 1  # stream survived the bad frame
     assert calls["n"] >= 2
+
+
+def test_mjpeg_frames_closes_cleanly_on_client_disconnect() -> None:
+    """Closing the stream (client disconnect) stops it without raising.
+
+    A live MJPEG generator feeds an ``<img src=...>`` consumer that can
+    vanish at any moment; the browser dropping the socket surfaces as a
+    ``GeneratorExit`` thrown into the suspended ``yield``. That must
+    terminate the stream cleanly -- a stray ``finally`` or a swallowed
+    close would either leak the render loop or re-raise into the WSGI
+    server, so pin the disconnect contract explicitly.
+    """
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    # No max_frames -> an otherwise-infinite stream; only a disconnect ends it.
+    gen = mjpeg_frames(lambda: frame, fps=1000.0)
+    first = next(gen)  # emit one chunk, then suspend at the yield
+    assert first.startswith(b"--frame\r\nContent-Type: image/jpeg\r\n\r\n")
+
+    gen.close()  # simulates the consumer disconnecting
+
+    # The generator is finished: it does not resume or emit further chunks.
+    with pytest.raises(StopIteration):
+        next(gen)
+    # close() on an already-finished generator stays a no-op (never raises).
+    gen.close()

--- a/tests/rendering/test_video.py
+++ b/tests/rendering/test_video.py
@@ -106,10 +106,10 @@ def test_mjpeg_frames_closes_cleanly_on_client_disconnect() -> None:
     first = next(gen)  # emit one chunk, then suspend at the yield
     assert first.startswith(b"--frame\r\nContent-Type: image/jpeg\r\n\r\n")
 
-    gen.close()  # simulates the consumer disconnecting
+    gen.close()  # type: ignore[attr-defined]  # simulates consumer disconnect
 
     # The generator is finished: it does not resume or emit further chunks.
     with pytest.raises(StopIteration):
         next(gen)
     # close() on an already-finished generator stays a no-op (never raises).
-    gen.close()
+    gen.close()  # type: ignore[attr-defined]


### PR DESCRIPTION
## What
Add a focused test covering the `GeneratorExit` branch of `strands_robots.rendering.video.mjpeg_frames` — the client-disconnect path.

## Why
`mjpeg_frames` powers live `<img src=...>` MJPEG streams. A browser dropping the socket surfaces as a `GeneratorExit` thrown into the suspended `yield`. The stream must terminate cleanly rather than leak the render loop or re-raise into the serving layer. That contract was the sole unexercised line in the media utils, so a future refactor (e.g. a stray `finally`, or wrapping the loop in a handler that mishandles close) could silently break disconnect handling with nothing to catch it.

## Test
`test_mjpeg_frames_closes_cleanly_on_client_disconnect` emits one chunk, suspends at the yield, then calls `gen.close()` (the disconnect signal) and asserts:
- the stream is finished (`next` raises `StopIteration`), and
- `close()` on the already-finished generator stays a no-op (never raises).

## Coverage
`strands_robots/rendering/video.py`: 98% -> 100% (focused run). Full `tests/rendering/` suite green (77 passed, 2 skipped).

Test-only; no behavior change, so no visual artifact applies.

---

## §13 Changelog

| Round | Concern | Fix commit | Pin test path |
|-------|---------|------------|---------------|
| 1 | mypy `attr-defined` on `Iterator.close()` -- `mjpeg_frames` is typed `Iterator[bytes]` but at runtime yields (a Generator); `.close()` is the generator-protocol method this test pins | `52c889b` | `tests/rendering/test_video.py::test_mjpeg_frames_closes_cleanly_on_client_disconnect` |