### PR TITLE
test(simulation): pin actuate_robot_in_scene rollback on a mid-surgery exception

### DIFF
--- a/tests/simulation/mujoco/test_scene_ops_guardrails.py
+++ b/tests/simulation/mujoco/test_scene_ops_guardrails.py
@@ -13,6 +13,8 @@ fail loudly and predictably rather than crash mid-mutation.
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 pytest.importorskip("mujoco")
@@ -634,6 +636,46 @@ class TestSpecSurgeryFailureRecovery:
         # Not poisoned: the restored spec still recompiles, so a subsequent real
         # scene mutation succeeds end-to-end.
         monkeypatch.setattr(scene_ops, "_recompile_preserving_state", orig_recompile)
+        assert (
+            sim.add_object(name="probe", shape="box", size=[0.05, 0.05, 0.05], position=[0.1, 0.1, 0.5])["status"]
+            == "success"
+        )
+        assert int(two_body_world._model.nbody) == nbody_before + 1
+
+    def test_actuate_surgery_exception_restores_spec_and_leaves_scene_usable(
+        self, sim: Simulation, two_body_world: SimWorld
+    ) -> None:
+        """A spec edit that *raises* mid-surgery (before the recompile) must also
+        restore the pre-surgery snapshot -- not just a recompile that returns
+        False. Here the actuator loop flips the integrator and appends an
+        actuator onto the live spec, then a non-numeric ``kp`` makes
+        ``float(kp)`` raise ``ValueError`` inside the surgery block. The half-
+        applied edit (an orphan actuator targeting a joint that does not exist)
+        would make every later recompile fail, so the snapshot restore is what
+        keeps the scene usable.
+        """
+        nbody_before = int(two_body_world._model.nbody)
+        robot = SimRobot(name="ghostarm", urdf_path="x.xml", namespace="ghostarm/")
+
+        assert (
+            scene_ops.actuate_robot_in_scene(
+                two_body_world,
+                robot,
+                # a deliberately non-numeric kp: float(...) raises ValueError mid-surgery
+                {"pan": cast(float, "not-a-number")},
+                damping=1.0,
+                armature=0.01,
+                gravity_compensation=True,
+                disable_self_collision=True,
+            )
+            is False
+        )
+        # Compiled model unchanged by the failed surgery.
+        assert int(two_body_world._model.nbody) == nbody_before
+
+        # Not poisoned: the restored spec still recompiles, so a subsequent real
+        # scene mutation succeeds. Without the snapshot restore the orphan
+        # actuator left on the spec would fail this recompile.
         assert (
             sim.add_object(name="probe", shape="box", size=[0.05, 0.05, 0.05], position=[0.1, 0.1, 0.5])["status"]
             == "success"


### PR DESCRIPTION
## What
Add a regression test for the exception branch of `actuate_robot_in_scene` (`strands_robots/simulation/mujoco/scene_ops.py`): a spec edit that *raises mid-surgery*, before the recompile, must restore the pre-surgery XML snapshot.

## Why
`actuate_robot_in_scene` documents an atomicity contract: it snapshots the spec (XML round-trip), then flips the integrator and appends actuators plus joint edits onto the live spec before recompiling; any failure must restore the snapshot so no partial edit lingers. `TestSpecSurgeryFailureRecovery` already pins the recompile-returns-False path (the snapshot restore at the end of the function). The other failure mode -- an exception raised inside the surgery block itself, after the live spec was already mutated -- was the sole unexercised path in the function. That is the more dangerous case: at the raise point the integrator is already flipped and an actuator is already appended, so without the restore the live spec carries an orphan actuator targeting a joint that does not exist, and every later recompile fails.

## Test
`test_actuate_surgery_exception_restores_spec_and_leaves_scene_usable` drives a non-numeric `kp` so `float(kp)` raises `ValueError` mid-surgery (after the integrator flip and actuator append), then asserts:
- the call returns `False`,
- the compiled model is unchanged (`nbody` steady), and
- the scene is not poisoned: a subsequent `add_object` recompiles and succeeds.

The last assertion has teeth -- if the snapshot restore were dropped, the orphan actuator left on the spec makes that recompile fail (`unknown transmission target`), so the test fails.

## Coverage
`strands_robots/simulation/mujoco/scene_ops.py`: the surgery-exception rollback lines go from uncovered to covered; `tests/simulation/mujoco/test_scene_ops_guardrails.py` stays green (44 passed).

Test-only; no behavior change, so no visual artifact applies.