### PR TITLE
test(rendering): pin the compositor 1mm depth tie-break bias

### DIFF
--- a/tests/rendering/test_compositor.py
+++ b/tests/rendering/test_compositor.py
@@ -202,3 +202,59 @@ def test_clear_caches_forces_background_recompute() -> None:
     comp.clear_caches()
     comp.render("cam")
     assert bg.render_calls == 2  # cache dropped -> background recomputed
+
+
+class FakeFiniteBackground(FakeBackground):
+    """Background at a uniform *finite* depth, to exercise the z-compare bias.
+
+    Every other fixture parks the background at ``zfar`` (100 m), so the
+    foreground/background depths are always ~99 m apart and the 1 mm tie-break
+    in :meth:`HybridCompositor.render` is never straddled. This background sits
+    at a close, finite depth so a near-tie foreground can be placed either side
+    of the bias.
+    """
+
+    def __init__(self, depth: float, color=(0, 0, 255)):
+        super().__init__(color=color)
+        self.depth = float(depth)
+
+    def render(self, cam: CameraParams):
+        rgb, _ = super().render(cam)
+        depth = np.full((cam.height, cam.width), self.depth, dtype=np.float32)
+        return rgb, depth
+
+
+def _uniform_depth(value: float) -> np.ndarray:
+    """A full-frame foreground at a single finite depth (valid geometry)."""
+    return np.full((H, W), float(value), dtype=np.float32)
+
+
+def test_foreground_within_depth_bias_loses_to_background() -> None:
+    # The winner rule is ``fg_depth + 1e-3 < bg_depth``: the foreground must be
+    # *more than* 1 mm in front to win. A foreground only 0.5 mm closer than the
+    # background is inside that bias, so the background must still show -- this
+    # is the anti-z-fighting guard that keeps a near-coincident gsplat backdrop
+    # from flickering against sim geometry.
+    bg_depth = 5.0
+    comp = HybridCompositor(
+        FakeSim(_uniform_depth(bg_depth - 0.0005)),  # 0.5 mm closer: within the 1 mm bias
+        background=FakeFiniteBackground(bg_depth),
+        feather_pixels=0,
+    )
+    frame = comp.render("cam")
+    assert not frame.foreground_mask.any()
+    assert tuple(frame.rgb[H // 2, W // 2]) == (0, 0, 255)  # background wins
+
+
+def test_foreground_beyond_depth_bias_wins() -> None:
+    # A foreground 2 mm closer than the background clears the 1 mm bias and
+    # wins the z-compare everywhere.
+    bg_depth = 5.0
+    comp = HybridCompositor(
+        FakeSim(_uniform_depth(bg_depth - 0.002)),  # 2 mm closer: beyond the 1 mm bias
+        background=FakeFiniteBackground(bg_depth),
+        feather_pixels=0,
+    )
+    frame = comp.render("cam")
+    assert frame.foreground_mask.all()
+    assert tuple(frame.rgb[H // 2, W // 2]) == (255, 255, 255)  # foreground wins


### PR DESCRIPTION
## What

Adds two regression tests pinning the 1mm depth tie-break bias in `HybridCompositor.render` (`strands_robots/rendering/compositor.py:202`):

```python
winner = valid_fg & (fg_depth + 1e-3 < bg_depth)
```

The `+ 1e-3` means the foreground must be **more than 1mm in front** of the background to win the z-compare. This is an anti-z-fighting guard: it stops a near-coincident gsplat/panorama backdrop from flickering against sim geometry sitting at nearly equal depth.

## Why

Every existing `test_compositor.py` test parks the background at `zfar` (100m) against a 1m foreground -- a ~99m gap. The 1mm bias is therefore **never straddled**, so a refactor that dropped `+ 1e-3` (using plain `fg_depth < bg_depth`) would pass the entire existing suite while silently reintroducing flicker. That is an unpinned load-bearing contract.

## How

- New `FakeFiniteBackground` fixture: a background at a uniform, close, finite depth so a near-tie foreground can be placed on either side of the bias.
- `test_foreground_within_depth_bias_loses_to_background`: foreground 0.5mm closer (inside the 1mm bias) -> background must still win.
- `test_foreground_beyond_depth_bias_wins`: foreground 2mm closer (beyond the bias) -> foreground wins.

Pure-numpy, no GL/sim deps (same posture as the rest of the file).

## Verification

Mutation-tested. With `+ 1e-3` removed on line 202:

| suite | result |
|---|---|
| 12 pre-existing tests | **PASS** (they miss the regression) |
| `test_foreground_within_depth_bias_loses_to_background` | **FAIL** (correctly catches it) |

With the bias restored: all 14 tests pass. `ruff check` + `ruff format --check` clean; test file conforms to the `tests.*` mypy override.

Test-only change; single file, +56 lines.

## §13 Changelog

- **Round 1:** initial submission.