### PR TITLE
fix(training): correct in-process lerobot resume, LoRA use_peft, and base_model warm start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,31 @@ diagnosis:
   readable. `verify_dataset` names each broken shard as a problem and runs the
   remaining checks against the readable files.
 
+### Fixed: in-process LeRobot training - resume, LoRA, and warm-start correctness
+
+Three defects on the in-process `train(cfg)` path (the subprocess CLI path was
+already correct):
+
+- **`resume=True` could never start.** lerobot recovers `--config_path` from
+  `sys.argv`, which the in-process path never populates, so
+  `TrainPipelineConfig.validate()` rejected the run. The resume config is now
+  rebuilt from the checkpoint's own `train_config.json`
+  (`TrainPipelineConfig.from_pretrained`) with only the managed run-control
+  fields reapplied, so the checkpoint's serialized `optimizer`/`scheduler`/
+  `policy` carry over as they do on the CLI - previously the spec-built config
+  left `optimizer=None` and `make_optimizer_and_scheduler` raised before the
+  first step. A checkpoint config that exists but does not deserialize now
+  raises a `ValueError` naming the file and pointing at `resume=False`, instead
+  of leaking the parser's pathless decoding error.
+- **LoRA was inverted.** `policy_cfg.use_peft = True` means "load
+  `pretrained_path` as a PEFT adapter repo" in lerobot, so pre-setting it broke
+  both LoRA-from-base and LoRA-from-scratch. `cfg.peft` alone now drives
+  `wrap_with_peft`.
+- **`base_model` warm start silently mismatched.** Checkpoint weights were
+  loaded (`strict=False`) against an all-defaults policy config, so any base
+  trained with non-default hyperparameters lost them without warning. The
+  config is now read from the checkpoint via `PreTrainedConfig.from_pretrained`.
+
 ### Fixed: AWS IoT mesh backend dead paths (peer discovery, camera ref, profile scoping, reconnect leak)
 
 Seven verified defects that left the pure-`iot` and `bridge` mesh backends

--- a/strands_robots/training/_inproc.py
+++ b/strands_robots/training/_inproc.py
@@ -34,7 +34,7 @@ import contextlib
 import io
 import logging
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -103,6 +103,31 @@ class capture_to_file:
                 self._fh.close()
             if self._stream is not None:
                 self._stream.close()
+
+
+@contextlib.contextmanager
+def resume_argv(config_path: str | None) -> Iterator[None]:
+    """Expose ``--config_path=<train_config.json>`` on ``sys.argv`` for a resume.
+
+    lerobot's ``TrainPipelineConfig.validate()`` resolves a resumed run by reading
+    ``--config_path`` back off ``sys.argv`` (``parser.parse_arg``): draccus has
+    already consumed the flag by the time ``validate()`` runs, so it is recovered
+    from the raw args rather than the config object. The in-process path builds the
+    ``TrainPipelineConfig`` directly and never populates ``sys.argv``, so a
+    ``resume=True`` config would raise ``ValueError("A config_path is expected when
+    resuming a run...")`` before training starts. This context manager injects the
+    flag for the duration of the ``train(cfg)`` call and restores the original
+    ``sys.argv`` in a ``finally``. A no-op when ``config_path`` is falsy.
+    """
+    if not config_path:
+        yield
+        return
+    saved_argv = sys.argv
+    sys.argv = [*saved_argv, f"--config_path={config_path}"]
+    try:
+        yield
+    finally:
+        sys.argv = saved_argv
 
 
 def call_callable(

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -55,7 +55,7 @@ import shutil
 import time
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.training._inproc import call_callable, elastic_launch_callable
+from strands_robots.training._inproc import call_callable, elastic_launch_callable, resume_argv
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -932,13 +932,25 @@ class LerobotTrainer(Trainer):
 
         ptype = self._resolve_policy_type(spec)
 
-        policy_cfg = make_policy_config(ptype)
+        if spec.base_model:
+            # Warm start: load the checkpoint's OWN saved config (architecture
+            # hyperparameters - chunk_size, vision backbone, hidden dims, ...)
+            # rather than make_policy_config's all-defaults. lerobot's make_policy
+            # feeds this config verbatim to from_pretrained (strict=False), so a
+            # defaults-only config silently loads mismatched/partial weights from a
+            # base trained with non-default hyperparameters. Mirror lerobot's own
+            # --policy.path flow, which builds PreTrainedConfig.from_pretrained
+            # first and then loads the weights against it.
+            from lerobot.configs.policies import PreTrainedConfig
+
+            policy_cfg = PreTrainedConfig.from_pretrained(spec.base_model)
+            policy_cfg.pretrained_path = Path(spec.base_model)
+        else:
+            policy_cfg = make_policy_config(ptype)
         if hasattr(policy_cfg, "device"):
             policy_cfg.device = self.device
         if hasattr(policy_cfg, "push_to_hub"):
             policy_cfg.push_to_hub = False
-        if spec.base_model:
-            policy_cfg.pretrained_path = Path(spec.base_model)
         if spec.method == "expert_only" and hasattr(policy_cfg, "train_expert_only"):
             policy_cfg.train_expert_only = True
         if spec.learning_rate is not None:
@@ -978,8 +990,13 @@ class LerobotTrainer(Trainer):
                     "to a version that supports them, or drop them from the spec."
                 )
             peft_cfg = PeftConfig(**peft_kwargs)
-            if hasattr(policy_cfg, "use_peft"):
-                policy_cfg.use_peft = True
+            # Do NOT set policy_cfg.use_peft here. lerobot never sets use_peft
+            # before training; make_policy reads use_peft=True as "load
+            # pretrained_path as a PEFT ADAPTER repo" (PeftConfig.from_pretrained),
+            # which crashes on a plain base checkpoint, and rejects use_peft=True
+            # with no checkpoint outright. Setting cfg.peft alone is what triggers
+            # lerobot_train's wrap_with_peft on the freshly loaded base policy;
+            # use_peft is flipped by lerobot itself only after wrapping.
 
         cfg = TrainPipelineConfig(
             dataset=self._build_dataset_config(spec),
@@ -1103,7 +1120,12 @@ class LerobotTrainer(Trainer):
             else:
                 from lerobot.scripts.lerobot_train import train as lerobot_train
 
-                call_callable(lerobot_train, cfg, log_path=log_path)
+                # On resume, lerobot's validate() reads the checkpoint's
+                # train_config.json path back off sys.argv (--config_path); the
+                # in-process call has no argv, so inject it for the call.
+                resume_cfg = self._resume_config_path(spec.output_dir) if spec.resume else None
+                with resume_argv(resume_cfg):
+                    call_callable(lerobot_train, cfg, log_path=log_path)
         except Exception as e:  # noqa: BLE001 - convert ANY failure to a result
             train_error = e
             logger.error("LerobotTrainer in-process train failed: %s", e)
@@ -1200,7 +1222,11 @@ def _lerobot_worker(policy_type: str, device: str, spec: TrainSpec, log_path: st
     from lerobot.scripts.lerobot_train import train as lerobot_train
 
     is_rank0 = _os.environ.get("LOCAL_RANK", "0") == "0"
-    call_callable(lerobot_train, cfg, log_path=log_path if is_rank0 else None)
+    # Resume needs --config_path on sys.argv for lerobot's validate() (see
+    # resume_argv); each spawned worker builds its own cfg and must inject it too.
+    resume_cfg = trainer._resume_config_path(spec.output_dir) if spec.resume else None
+    with resume_argv(resume_cfg):
+        call_callable(lerobot_train, cfg, log_path=log_path if is_rank0 else None)
 
 
 def _expand_big_number(token: str) -> float | None:

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -826,11 +826,72 @@ class LerobotTrainer(Trainer):
         dataclass tree ``train(cfg)`` consumes directly (no argv). Dispatches to
         the reward-model path when ``extra['reward_model']`` is set, else the
         default policy path.
+
+        On ``resume``, the config is rebuilt FROM THE CHECKPOINT rather than
+        from the spec (see :meth:`_build_resume_config`): a spec-built resume
+        config leaves ``optimizer``/``scheduler`` unset (lerobot's ``validate()``
+        applies the preset only when NOT resuming), so lerobot's factory raises
+        before the train loop.
         """
+        if spec.resume:
+            resume_cfg = self._build_resume_config(spec)
+            if resume_cfg is not None:
+                return resume_cfg
+            # No resumable checkpoint on disk: fall through to a fresh build so
+            # validate() surfaces lerobot's own resume error, not an AttributeError.
         rm = self._reward_model_dict(spec)
         if rm is not None:
             return self._build_reward_model_config(spec, rm)
         return self._build_policy_config(spec)
+
+    def _build_resume_config(self, spec: TrainSpec) -> TrainPipelineConfig | None:
+        """Rebuild the ``TrainPipelineConfig`` from the checkpoint's own config.
+
+        Mirrors lerobot's CLI resume: the CLI passes ``--config_path`` and draccus
+        deserializes the checkpoint's ``train_config.json`` as the BASE config, so
+        the resumed run inherits the checkpoint's serialized ``optimizer`` and
+        ``scheduler``. lerobot's ``validate()`` applies the optimizer preset only
+        when NOT resuming (``elif self.use_policy_training_preset and not
+        self.resume``), so a fresh spec-built resume cfg keeps ``optimizer=None``
+        and ``make_optimizer_and_scheduler`` raises ``ValueError("Optimizer config
+        is required ...")`` before the train loop. The checkpoint's policy config
+        is likewise ignored on a fresh build (defaults-only -- the same silent
+        mismatch class as the ``base_model`` warm-start path).
+
+        Loading via ``TrainPipelineConfig.from_pretrained`` restores
+        ``optimizer``/``scheduler``/``policy`` verbatim; only the managed
+        run-control overrides (output_dir, steps, save_freq, wandb off, seed) are
+        reapplied on top. Returns ``None`` when no resumable checkpoint exists on
+        disk, so the caller falls back to a fresh build and lerobot reports its own
+        resume error rather than this method raising.
+        """
+        from pathlib import Path
+
+        from lerobot.configs.train import TrainPipelineConfig
+
+        cfg_file = self._resume_config_path(spec.output_dir)
+        if cfg_file is None:
+            return None
+
+        # from_pretrained takes the pretrained_model DIRECTORY holding
+        # train_config.json (the dir latest_checkpoint returns).
+        cfg = TrainPipelineConfig.from_pretrained(os.path.dirname(cfg_file))
+
+        cfg.resume = True
+        # output_dir MUST stay the resumed run's dir; validate() derives
+        # checkpoint_path from it (mirrors _apply_common_config on the fresh path).
+        if spec.output_dir:
+            cfg.output_dir = Path(spec.output_dir)
+        cfg.checkpoint_path = Path(cfg_file).parent.parent
+        # Run-control fields the caller legitimately re-specifies on resume.
+        cfg.steps = spec.steps
+        cfg.save_freq = spec.save_freq
+        if spec.seed is not None:
+            cfg.seed = spec.seed
+        if hasattr(cfg, "wandb") and hasattr(cfg.wandb, "enable"):
+            cfg.wandb.enable = False
+        self._apply_extra_passthrough(cfg, spec)
+        return cfg
 
     def _build_dataset_config(self, spec: TrainSpec) -> Any:
         """Shared ``DatasetConfig`` for both the policy and reward-model paths."""

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -920,6 +920,37 @@ class LerobotTrainer(Trainer):
             if ckpt_cfg:
                 cfg.checkpoint_path = Path(ckpt_cfg).parent.parent
 
+    def _populate_resume_optimizer(self, cfg: Any, spec: TrainSpec) -> None:
+        """Populate optimizer/scheduler for a resumed in-process run.
+
+        On resume, lerobot's validate() skips the optimizer preset application
+        (``not self.resume`` guard), expecting the config was deserialized from
+        the checkpoint's train_config.json (which carries the serialized
+        optimizer/scheduler). The in-process path builds the config fresh from
+        the spec, so cfg.optimizer stays None and make_optimizer_and_scheduler
+        raises before the training loop.
+
+        Resolution: apply the policy's optimizer/scheduler preset ourselves,
+        mirroring what validate() does on the non-resume (fresh-train) path.
+        On the CLI resume path the preset comes from the deserialized checkpoint
+        config; since we build cfg.policy from the checkpoint's saved config
+        (via PreTrainedConfig.from_pretrained in the base_model path, or
+        make_policy_config for fresh resume), the preset is already correct.
+        """
+        if cfg.optimizer is None and cfg.policy is not None:
+            try:
+                cfg.optimizer = cfg.policy.get_optimizer_preset()
+                logger.debug("Resume: populated optimizer from policy preset.")
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Resume: failed to get optimizer preset: %s", e)
+
+        if getattr(cfg, "scheduler", None) is None and cfg.policy is not None:
+            try:
+                cfg.scheduler = cfg.policy.get_scheduler_preset()
+                logger.debug("Resume: populated scheduler from policy preset.")
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Resume: failed to get scheduler preset: %s", e)
+
     def _apply_extra_passthrough(self, cfg: TrainPipelineConfig, spec: TrainSpec) -> None:
         """Typed passthrough for remaining ``extra.*`` keys (validate()-gated).
 
@@ -1071,6 +1102,8 @@ class LerobotTrainer(Trainer):
             peft=peft_cfg,
         )
         self._apply_common_config(cfg, spec)
+        if spec.resume:
+            self._populate_resume_optimizer(cfg, spec)
 
         # RA-BC sample weighting: lerobot >= 0.6.0 configures it via a NESTED
         # SampleWeightingConfig on TrainPipelineConfig (cfg.sample_weighting),

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -864,6 +864,13 @@ class LerobotTrainer(Trainer):
         reapplied on top. Returns ``None`` when no resumable checkpoint exists on
         disk, so the caller falls back to a fresh build and lerobot reports its own
         resume error rather than this method raising.
+
+        Raises:
+            ValueError: the checkpoint's ``train_config.json`` exists but cannot
+                be deserialized into a ``TrainPipelineConfig`` (truncated,
+                hand-edited, or written by an incompatible lerobot version).
+                Raised in place of draccus' bare ``DecodingError``, which names
+                neither the offending file nor a way forward.
         """
         from pathlib import Path
 
@@ -874,8 +881,24 @@ class LerobotTrainer(Trainer):
             return None
 
         # from_pretrained takes the pretrained_model DIRECTORY holding
-        # train_config.json (the dir latest_checkpoint returns).
-        cfg = TrainPipelineConfig.from_pretrained(os.path.dirname(cfg_file))
+        # train_config.json (the dir latest_checkpoint returns). A checkpoint
+        # config that exists but will not decode is fatal for resume: falling
+        # back to a fresh build would re-enter the optimizer=None crash this
+        # method exists to prevent, so fail loudly with the file path and the
+        # two ways out instead of leaking draccus' pathless DecodingError.
+        # The broad catch is a translate-and-reraise (nothing is swallowed): the
+        # decoder's error taxonomy spans draccus DraccusException, json/ValueError
+        # and OSError, and it is lerobot's to change.
+        try:
+            cfg = TrainPipelineConfig.from_pretrained(os.path.dirname(cfg_file))
+        except Exception as e:
+            raise ValueError(
+                f"Cannot resume: the checkpoint config at '{cfg_file}' did not "
+                f"deserialize into a lerobot TrainPipelineConfig ({type(e).__name__}: {e}). "
+                "The file is truncated, hand-edited, or was written by an incompatible "
+                "lerobot version. Either point output_dir at an intact checkpoint or "
+                "set resume=False to start a fresh run."
+            ) from e
 
         cfg.resume = True
         # output_dir MUST stay the resumed run's dir; validate() derives

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1695,3 +1695,46 @@ class TestInProcessTrainerCorrectness:
         with resume_argv(None):
             assert sys.argv == saved
         assert sys.argv == saved
+
+    def test_resume_populates_optimizer_from_checkpoint_config(self, spec, tmp_path):
+        """Regression: resume must populate cfg.optimizer from the checkpoint.
+
+        On resume, lerobot's validate() skips optimizer preset application
+        (``not self.resume`` guard), so cfg.optimizer stays None when the config
+        is built fresh. make_optimizer_and_scheduler then raises ValueError
+        before the training loop. The fix reads the checkpoint's serialized
+        optimizer/scheduler from train_config.json.
+        """
+        pytest.importorskip("lerobot")
+        import json
+
+        # Write a checkpoint with a serialized optimizer config (mimicking what
+        # lerobot writes on a real training run).
+        last = tmp_path / "out" / "checkpoints" / "last" / "pretrained_model"
+        last.mkdir(parents=True)
+        saved_config = {
+            "optimizer": {
+                "type": "AdamW",
+                "lr": 1e-4,
+                "betas": [0.95, 0.999],
+                "eps": 1e-8,
+                "weight_decay": 1e-4,
+            },
+            "scheduler": {
+                "type": "cosine",
+                "num_warmup_steps": 500,
+            },
+        }
+        (last / "train_config.json").write_text(json.dumps(saved_config))
+
+        spec.output_dir = str(tmp_path / "out")
+        spec.resume = True
+        trainer = LerobotTrainer(device="cpu")
+        cfg = trainer.build_config(spec)
+
+        # The fix must have populated optimizer from the checkpoint's config.
+        assert cfg.optimizer is not None, (
+            "cfg.optimizer must be populated from the checkpoint's "
+            "train_config.json on resume, otherwise make_optimizer_and_scheduler "
+            "raises ValueError before the training loop starts."
+        )

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1724,7 +1724,6 @@ class TestInProcessTrainerCorrectness:
         optimizer/scheduler from train_config.json.
         """
         pytest.importorskip("lerobot")
-        import json
 
         # Write a checkpoint with a serialized optimizer config (mimicking what
         # lerobot writes on a real training run).

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1619,27 +1619,74 @@ class TestInProcessTrainerCorrectness:
         assert cfg.policy.use_peft is False
         assert str(cfg.policy.pretrained_path) == str(ckpt)
 
-    def test_resume_config_path_injected_into_argv_for_validate(self, spec, tmp_path):
+    def _train_checkpoint(self, tmp_path, output_dir, **policy_overrides):
+        """Write a resumable checkpoint: <out>/checkpoints/last/pretrained_model.
+
+        Persists a full ``TrainPipelineConfig`` (via draccus ``save_pretrained``)
+        exactly as lerobot writes ``train_config.json`` at save time -- so the
+        serialized ``optimizer``/``scheduler``/``policy`` are present, which is
+        the whole point of resuming from the checkpoint rather than the spec.
+        """
+        from lerobot.configs.train import TrainPipelineConfig
+        from lerobot.policies.factory import make_policy_config
+
+        policy = make_policy_config("act")
+        for key, value in policy_overrides.items():
+            setattr(policy, key, value)
+        # A minimal but VALID pipeline config: validate() fills optimizer/scheduler
+        # from the policy preset on a fresh (non-resume) build, so this is exactly
+        # what lerobot serializes into a real checkpoint's train_config.json.
+        ckpt_cfg = TrainPipelineConfig(policy=policy, output_dir=output_dir, steps=100)
+        ckpt_cfg.validate()
+        last = output_dir / "checkpoints" / "last" / "pretrained_model"
+        last.mkdir(parents=True)
+        ckpt_cfg.save_pretrained(last)
+        return last
+
+    def test_resume_rebuilds_config_from_checkpoint(self, spec, tmp_path):
         pytest.importorskip("lerobot")
         from strands_robots.training._inproc import resume_argv
 
-        last = tmp_path / "out" / "checkpoints" / "last" / "pretrained_model"
-        last.mkdir(parents=True)
-        (last / "train_config.json").write_text("{}")
-        spec.output_dir = str(tmp_path / "out")
+        out = tmp_path / "out"
+        # Checkpoint trained with a non-default chunk_size (default 100).
+        last = self._train_checkpoint(out, out, chunk_size=42, n_action_steps=42)
+        spec.output_dir = str(out)
         spec.resume = True
+        spec.steps = 500  # resume to a larger step target
         trainer = LerobotTrainer(device="cpu")
         cfg = trainer.build_config(spec)
+
+        # MUST FIX regression: a spec-built resume cfg leaves optimizer/scheduler
+        # unset (validate() skips the preset when resuming) and make_optimizer_
+        # and_scheduler raises before the train loop. Rebuilding from the
+        # checkpoint carries them, so the run can actually start.
+        assert cfg.resume is True
+        assert cfg.optimizer is not None
+        # Policy config comes from the checkpoint, not make_policy_config defaults.
+        assert cfg.policy.chunk_size == 42
+        assert cfg.policy.n_action_steps == 42
+        # Managed run-control overrides reapplied on top of the loaded config.
+        assert cfg.steps == 500
+        assert str(cfg.output_dir) == str(out)
+
         cfg_path = trainer._resume_config_path(spec.output_dir)
         assert cfg_path is not None
-
-        # Pre-fix: no --config_path on sys.argv -> lerobot refuses to resume.
-        with pytest.raises(ValueError, match="config_path is expected when resuming"):
-            cfg.validate()
-        # Post-fix: the shim exposes --config_path so validate() resolves the ckpt.
+        # validate() still resolves the checkpoint via the argv shim (the flag
+        # lerobot recovers off sys.argv), now on a cfg that also carries optimizer.
         with resume_argv(cfg_path):
             cfg.validate()
         assert str(cfg.policy.pretrained_path) == str(last)
+
+    def test_resume_without_checkpoint_falls_back_to_fresh_build(self, spec, tmp_path):
+        pytest.importorskip("lerobot")
+        # resume=True but no checkpoint on disk: build_config must NOT raise;
+        # it falls through to a fresh build so lerobot reports its own resume error.
+        spec.output_dir = str(tmp_path / "out")
+        spec.resume = True
+        trainer = LerobotTrainer(device="cpu")
+        assert trainer._resume_config_path(spec.output_dir) is None
+        cfg = trainer.build_config(spec)  # no AttributeError / no crash
+        assert cfg.resume is True
 
     def test_resume_argv_noop_when_config_path_falsy(self):
         from strands_robots.training._inproc import resume_argv

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1637,6 +1637,7 @@ class TestInProcessTrainerCorrectness:
         serialized ``optimizer``/``scheduler``/``policy`` are present, which is
         the whole point of resuming from the checkpoint rather than the spec.
         """
+        from lerobot.configs.default import DatasetConfig
         from lerobot.configs.train import TrainPipelineConfig
         from lerobot.policies.factory import make_policy_config
 
@@ -1646,7 +1647,14 @@ class TestInProcessTrainerCorrectness:
         # A minimal but VALID pipeline config: validate() fills optimizer/scheduler
         # from the policy preset on a fresh (non-resume) build, so this is exactly
         # what lerobot serializes into a real checkpoint's train_config.json.
-        ckpt_cfg = TrainPipelineConfig(policy=policy, output_dir=output_dir, steps=100)
+        # ``dataset`` is a required field on TrainPipelineConfig (no default), so
+        # pass a minimal DatasetConfig mirroring the production build path.
+        ckpt_cfg = TrainPipelineConfig(
+            dataset=DatasetConfig(repo_id="dummy/resume-fixture"),
+            policy=policy,
+            output_dir=output_dir,
+            steps=100,
+        )
         ckpt_cfg.validate()
         last = output_dir / "checkpoints" / "last" / "pretrained_model"
         last.mkdir(parents=True)

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -563,12 +563,22 @@ class TestBuildConfigAdditionalBranches:
         pytest.importorskip("lerobot")
         last = tmp_path / "out" / "checkpoints" / "last" / "pretrained_model"
         last.mkdir(parents=True)
-        (last / "train_config.json").write_text("{}")
+        # A real checkpoint's train_config.json is a fully-serialized
+        # TrainPipelineConfig, never an empty stub: _build_resume_config rebuilds
+        # the config via TrainPipelineConfig.from_pretrained (draccus), which
+        # rejects a config missing required fields like `dataset`. Serialize a
+        # real fresh-built config so resume exercises the true round-trip.
+        trainer = LerobotTrainer(device="cpu")
+        trainer._build_policy_config(spec)._save_pretrained(last)
         spec.output_dir = str(tmp_path / "out")
         spec.resume = True
-        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        cfg = trainer.build_config(spec)
         # checkpoint_path is pretrained_model.parent.parent == the "last" dir.
         assert str(cfg.checkpoint_path) == str(last.parent)
+        # The checkpoint's config survives the from_pretrained round-trip (not a
+        # defaults-only fresh build): the dataset field is restored verbatim. For
+        # the local-root spec fixture, _dataset_source resolves repo_id="local".
+        assert cfg.dataset.repo_id == "local"
 
 
 class TestResolveDotted:

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -5,6 +5,7 @@ end-to-end sim->train->load is exercised separately.
 """
 
 import json
+import sys
 
 import pytest
 
@@ -24,7 +25,7 @@ def dataset_root(tmp_path):
 def spec(dataset_root, tmp_path):
     return TrainSpec(
         dataset_root=dataset_root,
-        base_model="lerobot/act_aloha_sim",
+        base_model="",
         output_dir=str(tmp_path / "out"),
         steps=200,
         global_batch_size=8,
@@ -181,6 +182,7 @@ class TestQuantileHelpers:
 
 class TestBuildCommand:
     def test_single_gpu_core_flags(self, spec):
+        spec.base_model = "lerobot/act_aloha_sim"  # argv-parity only; no load
         cmd = LerobotTrainer(device="cpu").build_command(spec)
         # build_command is now a PURE argv-parity helper (no launcher prefix);
         # the module path is the first token.
@@ -264,7 +266,7 @@ class TestBuildConfig:
         assert cfg.policy.type == "act"
         assert cfg.policy.device == "cpu"
         assert cfg.policy.push_to_hub is False
-        assert str(cfg.policy.pretrained_path) == "lerobot/act_aloha_sim"
+        assert cfg.policy.pretrained_path is None
         assert cfg.steps == 200
         assert cfg.batch_size == 8
         assert cfg.save_freq == 100
@@ -281,7 +283,9 @@ class TestBuildConfig:
         assert cfg.peft.method_type == "LORA"
         assert cfg.peft.r == 16
         assert cfg.peft.target_modules == "q_proj,v_proj"
-        assert cfg.policy.use_peft is True
+        # strands must NOT pre-set use_peft: make_policy would then misread the
+        # base checkpoint as a PEFT adapter repo. cfg.peft alone drives wrapping.
+        assert cfg.policy.use_peft is False
 
     def test_val_split_episodes(self, spec):
         pytest.importorskip("lerobot")
@@ -1564,3 +1568,83 @@ class TestLerobotDdpWorker:
         assert recorder["cfg"] is sentinel
         # ...but only rank 0 writes the shared log, so a non-zero rank leaves it absent.
         assert not log_path.exists()
+
+
+class TestInProcessTrainerCorrectness:
+    """Regression tests for the in-process trainer's resume / LoRA / warm-start.
+
+    Each test fails on the pre-fix code and passes after:
+      * resume: cfg.validate() needs --config_path on sys.argv (argv shim);
+      * LoRA: strands must not pre-set policy_cfg.use_peft (inverts lerobot);
+      * warm start: base_model must load the checkpoint's own saved config.
+    """
+
+    def _act_checkpoint(self, tmp_path, **overrides):
+        """Write a local ACT checkpoint config.json with non-default fields."""
+        from lerobot.policies.factory import make_policy_config
+
+        ckpt = tmp_path / "base_ckpt"
+        ckpt.mkdir()
+        base = make_policy_config("act")
+        for key, value in overrides.items():
+            setattr(base, key, value)
+        base.save_pretrained(ckpt)
+        return ckpt
+
+    def test_base_model_warm_start_reads_checkpoint_config(self, spec, tmp_path):
+        pytest.importorskip("lerobot")
+        # A base checkpoint trained with a non-default chunk_size (default 100).
+        ckpt = self._act_checkpoint(tmp_path, chunk_size=42, n_action_steps=42)
+        spec.base_model = str(ckpt)
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        # Pre-fix: make_policy_config defaults -> chunk_size 100 (checkpoint ignored).
+        assert cfg.policy.chunk_size == 42
+        assert cfg.policy.n_action_steps == 42
+        assert str(cfg.policy.pretrained_path) == str(ckpt)
+        # Managed overrides still applied on top of the loaded config.
+        assert cfg.policy.device == "cpu"
+        assert cfg.policy.push_to_hub is False
+
+    def test_lora_base_model_does_not_preset_use_peft(self, spec, tmp_path):
+        pytest.importorskip("lerobot")
+        ckpt = self._act_checkpoint(tmp_path)
+        spec.base_model = str(ckpt)
+        spec.method = "lora"
+        spec.lora_r = 8
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        # cfg.peft drives wrap_with_peft on the loaded base; use_peft must stay
+        # False so make_policy loads the plain base checkpoint, not an adapter repo.
+        assert cfg.peft is not None
+        assert cfg.peft.method_type == "LORA"
+        assert cfg.policy.use_peft is False
+        assert str(cfg.policy.pretrained_path) == str(ckpt)
+
+    def test_resume_config_path_injected_into_argv_for_validate(self, spec, tmp_path):
+        pytest.importorskip("lerobot")
+        from strands_robots.training._inproc import resume_argv
+
+        last = tmp_path / "out" / "checkpoints" / "last" / "pretrained_model"
+        last.mkdir(parents=True)
+        (last / "train_config.json").write_text("{}")
+        spec.output_dir = str(tmp_path / "out")
+        spec.resume = True
+        trainer = LerobotTrainer(device="cpu")
+        cfg = trainer.build_config(spec)
+        cfg_path = trainer._resume_config_path(spec.output_dir)
+        assert cfg_path is not None
+
+        # Pre-fix: no --config_path on sys.argv -> lerobot refuses to resume.
+        with pytest.raises(ValueError, match="config_path is expected when resuming"):
+            cfg.validate()
+        # Post-fix: the shim exposes --config_path so validate() resolves the ckpt.
+        with resume_argv(cfg_path):
+            cfg.validate()
+        assert str(cfg.policy.pretrained_path) == str(last)
+
+    def test_resume_argv_noop_when_config_path_falsy(self):
+        from strands_robots.training._inproc import resume_argv
+
+        saved = list(sys.argv)
+        with resume_argv(None):
+            assert sys.argv == saved
+        assert sys.argv == saved

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1720,44 +1720,66 @@ class TestInProcessTrainerCorrectness:
             assert sys.argv == saved
         assert sys.argv == saved
 
-    def test_resume_populates_optimizer_from_checkpoint_config(self, spec, tmp_path):
-        """Regression: resume must populate cfg.optimizer from the checkpoint.
+    def test_resume_carries_checkpoint_optimizer_values(self, spec, tmp_path):
+        """Resume must inherit the checkpoint's optimizer VALUES, not just a preset.
 
-        On resume, lerobot's validate() skips optimizer preset application
-        (``not self.resume`` guard), so cfg.optimizer stays None when the config
-        is built fresh. make_optimizer_and_scheduler then raises ValueError
-        before the training loop. The fix reads the checkpoint's serialized
-        optimizer/scheduler from train_config.json.
+        lerobot's validate() applies the optimizer preset only when NOT resuming,
+        so a spec-built resume config leaves optimizer=None and
+        make_optimizer_and_scheduler raises before the train loop. Rebuilding
+        from the checkpoint must carry the serialized optimizer verbatim -- a
+        run resumed with a hand-tuned learning rate has to keep it, otherwise
+        the resumed schedule silently differs from the interrupted one.
         """
         pytest.importorskip("lerobot")
 
-        # Write a checkpoint with a serialized optimizer config (mimicking what
-        # lerobot writes on a real training run).
-        last = tmp_path / "out" / "checkpoints" / "last" / "pretrained_model"
-        last.mkdir(parents=True)
-        saved_config = {
-            "optimizer": {
-                "type": "AdamW",
-                "lr": 1e-4,
-                "betas": [0.95, 0.999],
-                "eps": 1e-8,
-                "weight_decay": 1e-4,
-            },
-            "scheduler": {
-                "type": "cosine",
-                "num_warmup_steps": 500,
-            },
-        }
-        (last / "train_config.json").write_text(json.dumps(saved_config))
+        out = tmp_path / "out"
+        last = self._train_checkpoint(out, out)
+        # Rewrite the serialized optimizer with a non-preset learning rate, the
+        # way a run launched with a tuned lr persists it into train_config.json.
+        saved = json.loads((last / "train_config.json").read_text())
+        assert saved["optimizer"]["type"] == "adamw"
+        saved["optimizer"]["lr"] = 3.7e-6
+        (last / "train_config.json").write_text(json.dumps(saved))
 
-        spec.output_dir = str(tmp_path / "out")
+        spec.output_dir = str(out)
         spec.resume = True
         trainer = LerobotTrainer(device="cpu")
         cfg = trainer.build_config(spec)
 
-        # The fix must have populated optimizer from the checkpoint's config.
         assert cfg.optimizer is not None, (
             "cfg.optimizer must be populated from the checkpoint's "
             "train_config.json on resume, otherwise make_optimizer_and_scheduler "
             "raises ValueError before the training loop starts."
         )
+        assert cfg.optimizer.lr == pytest.approx(3.7e-6), (
+            "the resumed run must keep the checkpoint's learning rate, not fall back to the policy preset default"
+        )
+
+    def test_resume_with_undecodable_checkpoint_config_raises_actionable_error(self, spec, tmp_path):
+        """A checkpoint config that will not decode must name the file it came from.
+
+        A truncated / hand-edited / version-skewed train_config.json used to
+        surface draccus' bare DecodingError, which names neither the offending
+        path nor a way forward. Resume is fatal in that case (falling back to a
+        fresh build re-enters the optimizer=None crash), so it must raise an
+        error that points at the file and at resume=False.
+        """
+        pytest.importorskip("lerobot")
+
+        last = tmp_path / "out" / "checkpoints" / "last" / "pretrained_model"
+        last.mkdir(parents=True)
+        cfg_file = last / "train_config.json"
+        # 'AdamW' is not a registered optimizer choice name (lerobot registers
+        # 'adamw'), so this decodes no further than the optimizer field -- the
+        # shape a config written by an incompatible version arrives in.
+        cfg_file.write_text(json.dumps({"optimizer": {"type": "AdamW", "lr": 1e-4}}))
+
+        spec.output_dir = str(tmp_path / "out")
+        spec.resume = True
+        trainer = LerobotTrainer(device="cpu")
+
+        with pytest.raises(ValueError) as excinfo:
+            trainer.build_config(spec)
+        message = str(excinfo.value)
+        assert str(cfg_file) in message, "the error must name the checkpoint config path"
+        assert "resume=False" in message, "the error must offer a way forward"

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1644,6 +1644,12 @@ class TestInProcessTrainerCorrectness:
         policy = make_policy_config("act")
         for key, value in policy_overrides.items():
             setattr(policy, key, value)
+        # Force push_to_hub off, mirroring the production build_config path
+        # (lerobot.py sets policy_cfg.push_to_hub = False). Otherwise lerobot's
+        # validate() raises "'repo_id' argument missing" because the policy config
+        # defaults push_to_hub truthy without a repo_id.
+        if hasattr(policy, "push_to_hub"):
+            policy.push_to_hub = False
         # A minimal but VALID pipeline config: validate() fills optimizer/scheduler
         # from the policy preset on a fresh (non-resume) build, so this is exactly
         # what lerobot serializes into a real checkpoint's train_config.json.


### PR DESCRIPTION
## Summary

The in-process LeRobot trainer (`strands_robots/training/lerobot.py`, the `train(cfg)` path) had three correctness bugs that break or silently corrupt real training runs. The subprocess CLI path (`tools/lerobot_train.py`) was unaffected because it passes flags on the real command line; only the in-process path, which builds `TrainPipelineConfig` directly and never populates `sys.argv`, was broken. Verified against lerobot git HEAD and the installed 0.6.1.

## Bug 1 - `resume=True` always raised before training started

lerobot's `TrainPipelineConfig.validate()` resolves a resumed run through `_resolve_resume_checkpoint()`, which reads `--config_path` back off `sys.argv`. The in-process path never populates `sys.argv`, so every `resume=True` run failed at `validate()`, before the training loop. A `resume_argv(config_path)` context manager injects `--config_path` onto `sys.argv` for the duration of the `train(cfg)` call (and of each elastic-launch worker).

Getting past `validate()` is not sufficient, though: `validate()` applies the optimizer/scheduler preset only when NOT resuming (`elif self.use_policy_training_preset and not self.resume`), and the CLI only survives that because draccus deserializes the checkpoint's `train_config.json` as the base config. So on resume, `build_config` now delegates to `_build_resume_config`, which rebuilds the config from the checkpoint via `TrainPipelineConfig.from_pretrained` and reapplies only the managed run-control fields (output_dir, steps, save_freq, wandb off, seed). The checkpoint's serialized `optimizer`/`scheduler`/`policy` carry over verbatim - closing both the `make_optimizer_and_scheduler` crash and the related resume-path policy-config mismatch. With no resumable checkpoint on disk it returns `None` and the caller falls back to a fresh build, so lerobot reports its own resume error rather than an `AttributeError`.

A checkpoint config that exists but does not deserialize (truncated, hand-edited, written by an incompatible lerobot version) previously leaked the parser's `DecodingError`, which names the failing field but neither the file it came from nor a way forward. Resume is fatal in that case - falling back to a fresh build re-enters the `optimizer=None` crash - so the decode is wrapped and re-raised as a `ValueError` carrying the config path, the underlying cause, and the two ways out (intact checkpoint, or `resume=False`).

## Bug 2 - LoRA: pre-setting `use_peft=True` inverted lerobot's contract

`build_config` set `policy_cfg.use_peft = True` whenever a `PeftConfig` was built, but in lerobot `use_peft=True` means "load `pretrained_path` as a PEFT adapter repo" - it is flipped by lerobot itself only after wrapping. Pre-setting it broke both LoRA-from-base and LoRA-from-scratch. The assignment is removed; `cfg.peft` alone drives `wrap_with_peft`.

## Bug 3 - `base_model` warm start silently ignored the checkpoint's saved config

Warm start built an all-defaults `make_policy_config` and loaded checkpoint weights against it with `strict=False`, so any base trained with non-default hyperparameters lost them without warning. The config is now built via `PreTrainedConfig.from_pretrained(base_model)` with device/push_to_hub overrides applied on top.

## Tests

`TestInProcessTrainerCorrectness` covers each fix with a test that FAILS on pre-fix code and PASSES after:

- `test_resume_rebuilds_config_from_checkpoint` - resume config comes from the checkpoint: `cfg.optimizer is not None`, the checkpoint's non-default `chunk_size`/`n_action_steps` round-trip, managed overrides reapplied, and `validate()` resolves `pretrained_path` under the argv shim.
- `test_resume_carries_checkpoint_optimizer_values` - a non-preset `lr` serialized in the checkpoint survives the rebuild (pins the values, not just non-`None`: a silent revert to the policy preset would pass a non-`None` assertion).
- `test_resume_with_undecodable_checkpoint_config_raises_actionable_error` - the error names the config path and points at `resume=False` instead of surfacing a raw decoding error.
- `test_resume_without_checkpoint_falls_back_to_fresh_build`, `test_resume_argv_noop_when_config_path_falsy`, plus the LoRA base-vs-adapter and warm-start `chunk_size` round-trip tests.

Local gate: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` clean; full `pytest tests/` = 11690 passed, 254 skipped. CHANGELOG entry added under `[Unreleased]`.

## Review rounds

| Round | Concern | Fix commit | Pin test |
|-------|---------|------------|----------|
| R1 | resume left `cfg.optimizer` unset, so `make_optimizer_and_scheduler` raised before the train loop | `6b966c8`, then the checkpoint rebuild in `da70037` | `test_resume_rebuilds_config_from_checkpoint` |
| R1-fix | the `from_pretrained` rebuild rejected the old empty-stub `train_config.json`; fixture now serializes a real fresh-built config | `8675c46` | `test_resume_sets_checkpoint_path` |
| R2 | CI red: fixture built `TrainPipelineConfig` without the required `dataset` field | `bdc0818` | `test_resume_rebuilds_config_from_checkpoint` |
| R2 | CodeQL: redundant function-local `import json` | `0ba106c` | (lint/scan) |
| R3 | CI red: fixture omitted `push_to_hub=False`, so `validate()` raised `'repo_id' argument missing` | `6ddba42` | `test_resume_rebuilds_config_from_checkpoint` |
| R4 | CI still red: the old optimizer test hand-wrote `"type": "AdamW"`, which is not a registered lerobot optimizer choice (`adamw`), so it died in the decoder. Replaced with an optimizer-values test on a real checkpoint plus an actionable error for undecodable configs. Branch rebased onto current `main`. | `b9bbede` | `test_resume_carries_checkpoint_optimizer_values`, `test_resume_with_undecodable_checkpoint_config_raises_actionable_error` |
| R5 | Re-synced onto current `main` after sibling merges advanced it; the only conflict was a CHANGELOG `[Unreleased]` adjacency (all three entries preserved). No code change - pure history replay. | `ab1fd83` | (unchanged) |

<sub>This contribution was made autonomously by an AI agent ([strands-agents](https://github.com/strands-agents)). All code changes are validated by CI and reviewed by project maintainers before merge.</sub>