### PR TITLE
fix(teleoperate): pin --dataset.root for record so timestamp-stamped repo_id keeps datasets findable; expose resume

### DIFF
--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -198,6 +198,7 @@ def build_lerobot_command(
     dataset_root: str | None = None,
     dataset_video: bool = True,
     dataset_push_to_hub: bool = False,
+    record_resume: bool = False,
     replay_episode: int = 0,
     display_data: bool = False,
     fps: int = 60,
@@ -225,6 +226,11 @@ def build_lerobot_command(
         robot_type: Follower robot type (e.g. ``"so101_follower"``).
         dataset_repo_id: HuggingFace dataset id; presence enables record mode for
             ``start`` and is required for ``replay``.
+        record_resume: For record mode, emit ``--resume true`` to append to an
+            existing dataset (preserving its repo_id) instead of creating a fresh
+            one. A fresh record always emits an explicit ``--dataset.root``
+            (resolved from ``dataset_repo_id``) so lerobot HEAD's repo_id
+            timestamp-stamping never relocates the on-disk dataset.
         replay_episode: Episode index to replay (``--dataset.episode``).
 
     Returns:
@@ -251,6 +257,8 @@ def build_lerobot_command(
     if action == "start":
         if dataset_repo_id:
             # Recording mode -> lerobot-record (pure data collection via teleop).
+            from strands_robots.dataset_recorder import resolve_dataset_dir
+
             cmd = ["python", "-m", "lerobot.scripts.lerobot_record"]
             cmd.extend(
                 _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
@@ -263,8 +271,17 @@ def build_lerobot_command(
             cmd.extend(["--dataset.fps", str(dataset_fps)])
             cmd.extend(["--dataset.episode_time_s", str(dataset_episode_time_s)])
             cmd.extend(["--dataset.reset_time_s", str(dataset_reset_time_s)])
-            if dataset_root:
-                cmd.extend(["--dataset.root", dataset_root])
+            # Always pin --dataset.root to a resolved on-disk path. On a fresh
+            # (non-resume) recording, lerobot-record calls
+            # ``cfg.dataset.stamp_repo_id()`` which rewrites repo_id to
+            # ``{repo_id}_YYYYMMDD_HHMMSS`` -- moving the on-disk dataset and Hub
+            # push target off the requested id. Stamping only rewrites repo_id;
+            # an explicit root pins where the data lands, so downstream steps
+            # (train, verify, path reporting) find it at the requested location.
+            cmd.extend(["--dataset.root", str(resolve_dataset_dir(dataset_repo_id, dataset_root))])
+            # Append to an existing dataset (skips stamping, preserves repo_id).
+            if record_resume:
+                cmd.extend(["--resume", "true"])
             cmd.extend(["--dataset.push_to_hub", "true" if dataset_push_to_hub else "false"])
             cmd.extend(["--dataset.video", "true" if dataset_video else "false"])
             if display_data:
@@ -358,6 +375,7 @@ def lerobot_teleoperate(
     dataset_root: str | None = None,
     dataset_video: bool = True,
     dataset_push_to_hub: bool = False,
+    record_resume: bool = False,
     # Replay configuration
     replay_episode: int = 0,
     # Common options
@@ -525,9 +543,20 @@ def lerobot_teleoperate(
         dataset_fps: Recording frame rate
         dataset_episode_time_s: Episode duration in seconds
         dataset_reset_time_s: Reset time between episodes
-        dataset_root: Local dataset storage directory
+        dataset_root: Local dataset storage directory. When omitted for a
+            recording, an explicit root is still pinned (resolved from
+            ``dataset_repo_id`` under ``$HF_LEROBOT_HOME``) and returned as
+            ``dataset_root`` in the result. lerobot HEAD stamps a fresh record's
+            ``repo_id`` with a ``_YYYYMMDD_HHMMSS`` timestamp (affecting the Hub
+            push target and dataset metadata); pinning the root keeps the on-disk
+            data at the requested location regardless, so downstream train/verify
+            steps find it. Use ``record_resume=True`` to append instead.
         dataset_video: Enable video encoding
         dataset_push_to_hub: Upload dataset to HuggingFace Hub
+        record_resume: Append to an existing dataset at the resolved root
+            (lerobot-record ``--resume true``) instead of creating a fresh one.
+            Resume preserves the existing (already-stamped) repo_id rather than
+            re-stamping, so repeated sessions accumulate in one dataset.
 
         replay_episode: Episode number to replay
 
@@ -587,6 +616,7 @@ def lerobot_teleoperate(
                     dataset_root=dataset_root,
                     dataset_video=dataset_video,
                     dataset_push_to_hub=dataset_push_to_hub,
+                    record_resume=record_resume,
                     replay_episode=replay_episode,
                     display_data=display_data,
                     fps=fps,
@@ -599,6 +629,17 @@ def lerobot_teleoperate(
                 )
             except Exception as e:
                 return {"status": "error", "content": [{"text": f"Command build failed: {str(e)}"}]}
+
+            # Resolve the on-disk dataset location so downstream consumers (train,
+            # verify, path reporting) use the true path. lerobot HEAD stamps a
+            # fresh record's repo_id with a timestamp; the pinned --dataset.root
+            # (see build_lerobot_command) keeps the data at this resolved path
+            # regardless, so this is the authoritative on-disk location.
+            resolved_dataset_root: str | None = None
+            if dataset_repo_id:
+                from strands_robots.dataset_recorder import resolve_dataset_dir
+
+                resolved_dataset_root = str(resolve_dataset_dir(dataset_repo_id, dataset_root))
 
             if background:
                 # Start in background
@@ -651,6 +692,8 @@ def lerobot_teleoperate(
                     "robot_type": robot_type,
                     "teleop_type": teleop_type,
                     "dataset_repo_id": dataset_repo_id,
+                    "dataset_root": resolved_dataset_root,
+                    "resume": record_resume,
                 }
                 session_manager.add_session(session_name, session_info)
 
@@ -672,6 +715,9 @@ def lerobot_teleoperate(
                                 "command": " ".join(cmd),
                                 "log_file": str(log_file),
                                 "background": True,
+                                "dataset_repo_id": dataset_repo_id,
+                                "dataset_root": resolved_dataset_root,
+                                "resume": record_resume,
                             }
                         },
                     ],
@@ -696,6 +742,9 @@ def lerobot_teleoperate(
                                 "return_code": result.returncode,
                                 "stdout": result.stdout,
                                 "stderr": result.stderr,
+                                "dataset_repo_id": dataset_repo_id,
+                                "dataset_root": resolved_dataset_root,
+                                "resume": record_resume,
                             }
                         },
                     ],

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -258,6 +258,139 @@ def test_build_start_record_argv_matches_lerobot_record_fields() -> None:
             assert flag in record_fields, f"{flag} not a RecordConfig field"
 
 
+# ---------------------------------------------------------------------------
+# lerobot HEAD repo_id stamping: record must pin --dataset.root + expose --resume
+#
+# At lerobot HEAD, lerobot-record calls ``cfg.dataset.stamp_repo_id()`` on every
+# fresh recording, rewriting repo_id to ``{repo_id}_YYYYMMDD_HHMMSS``. Without an
+# explicit ``--dataset.root`` the on-disk dataset (and Hub push) moves to the
+# stamped id, so downstream train/verify/path-reporting look at the requested id
+# and find nothing. The record command must therefore always pin an explicit
+# root and expose ``--resume`` for appending.
+
+
+def test_build_record_command_always_pins_dataset_root_when_root_omitted() -> None:
+    """Fresh record with no explicit root must still emit --dataset.root.
+
+    lerobot HEAD timestamp-stamps a fresh record's repo_id; pinning an explicit
+    root (resolved from the repo_id under $HF_LEROBOT_HOME) keeps the on-disk
+    dataset at the requested location regardless of the stamp.
+    """
+    from strands_robots.dataset_recorder import resolve_dataset_dir
+
+    cmd = build_lerobot_command(
+        action="start",
+        robot_type="so101_follower",
+        robot_port="/dev/ttyACM0",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
+        dataset_repo_id="user/cubes",
+    )
+    assert "lerobot.scripts.lerobot_record" in cmd
+    assert "--dataset.root" in cmd
+    assert cmd[cmd.index("--dataset.root") + 1] == str(resolve_dataset_dir("user/cubes", None))
+
+
+def test_build_record_command_respects_explicit_dataset_root() -> None:
+    """An explicit dataset_root is forwarded verbatim (overrides the resolved default)."""
+    cmd = build_lerobot_command(
+        action="start",
+        robot_type="so101_follower",
+        robot_port="/dev/ttyACM0",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
+        dataset_repo_id="user/cubes",
+        dataset_root="/data/lerobot/cubes",
+    )
+    assert cmd[cmd.index("--dataset.root") + 1] == "/data/lerobot/cubes"
+
+
+def test_build_record_command_emits_resume_flag_when_requested() -> None:
+    """record_resume=True must emit lerobot-record's --resume true for appending."""
+    cmd = build_lerobot_command(
+        action="start",
+        robot_type="so101_follower",
+        robot_port="/dev/ttyACM0",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
+        dataset_repo_id="user/cubes",
+        record_resume=True,
+    )
+    assert "--resume" in cmd
+    assert cmd[cmd.index("--resume") + 1] == "true"
+
+
+def test_build_record_command_omits_resume_by_default() -> None:
+    """A fresh record (record_resume left False) must not emit --resume."""
+    cmd = build_lerobot_command(
+        action="start",
+        robot_type="so101_follower",
+        robot_port="/dev/ttyACM0",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
+        dataset_repo_id="user/cubes",
+    )
+    assert "--resume" not in cmd
+
+
+def test_build_teleop_command_has_no_dataset_root_or_resume() -> None:
+    """Plain teleoperation (no dataset) must not carry record-only flags."""
+    cmd = build_lerobot_command(
+        action="start",
+        robot_type="so101_follower",
+        robot_port="/dev/ttyACM0",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
+    )
+    assert "lerobot.scripts.lerobot_teleoperate" in cmd
+    assert "--dataset.root" not in cmd
+    assert "--resume" not in cmd
+
+
+def test_record_result_reports_pinned_dataset_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A background record start returns the true on-disk dataset root + repo_id.
+
+    Downstream consumers (train, verify, path reporting) read ``dataset_root``
+    from the result rather than deriving it from the requested repo_id, which
+    lerobot HEAD would have stamped.
+    """
+    from strands_robots.dataset_recorder import resolve_dataset_dir
+
+    monkeypatch.setattr(tele_mod.subprocess, "Popen", lambda *a, **k: _FakeProc(pid=os.getpid()))
+    result = lerobot_teleoperate(
+        action="start",
+        session_name="rec_report",
+        robot_type="so101_follower",
+        teleop_type="so101_leader",
+        dataset_repo_id="user/cubes",
+        auto_accept_calibration=False,
+    )
+    assert result["status"] == "success"
+    payload = tool_json(result)
+    assert payload["dataset_repo_id"] == "user/cubes"
+    assert payload["dataset_root"] == str(resolve_dataset_dir("user/cubes", None))
+    assert payload["resume"] is False
+    _assert_ascii(_texts(result))
+
+
+def test_record_result_reports_resume_when_appending(monkeypatch: pytest.MonkeyPatch) -> None:
+    """record_resume=True is reflected in the session result payload."""
+    monkeypatch.setattr(tele_mod.subprocess, "Popen", lambda *a, **k: _FakeProc(pid=os.getpid()))
+    result = lerobot_teleoperate(
+        action="start",
+        session_name="rec_resume",
+        robot_type="so101_follower",
+        teleop_type="so101_leader",
+        dataset_repo_id="user/cubes",
+        record_resume=True,
+        auto_accept_calibration=False,
+    )
+    assert result["status"] == "success"
+    payload = tool_json(result)
+    assert payload["resume"] is True
+    assert "--resume true" in payload["command"]
+
+
 def test_build_start_teleop_command_without_dataset() -> None:
     cmd = build_lerobot_command(
         action="start",


### PR DESCRIPTION
## Problem

`lerobot-record` rewrites a fresh recording's `repo_id` to `{repo_id}_YYYYMMDD_HHMMSS` via `DatasetRecordConfig.stamp_repo_id()`, which it calls unconditionally on the dataset-create path. When `lerobot_teleoperate` records (it passes `--dataset.repo_id` but leaves `--dataset.root` unset when the caller omits it), the on-disk dataset and any Hub push land at the *stamped* id, while downstream steps that derive the path from the *requested* `repo_id` (training on the recorded dataset, dataset verification, path reporting back to the caller) look at the unstamped location and find nothing.

Reproduction against a current lerobot checkout:

```
from lerobot.configs.dataset import DatasetRecordConfig
cfg = DatasetRecordConfig(repo_id="user/pick_cube", single_task="pick the cube")
cfg.stamp_repo_id()
print(cfg.repo_id)   # -> user/pick_cube_20260725_152333
# no explicit root -> dataset lands at $HF_LEROBOT_HOME/user/pick_cube_20260725_152333
# callers that expect $HF_LEROBOT_HOME/user/pick_cube find an empty path
```

## Change

Stamping only rewrites `repo_id`; an explicit root pins the on-disk location. The record command builder now **always** emits an explicit `--dataset.root`, resolved from the requested `repo_id` via the existing `resolve_dataset_dir` helper (honoring `$HF_LEROBOT_HOME`). Recordings therefore land where downstream consumers expect regardless of stamping. The resolved root is returned in the tool result as `dataset_root` (alongside `dataset_repo_id`) for both background and foreground sessions, so callers use the true on-disk path rather than re-deriving it from a `repo_id` that lerobot may have stamped.

Also exposes `lerobot-record`'s resume flag: a new `record_resume: bool = False` parameter emits `--resume true` to append to an existing dataset. Resume preserves the existing (already-stamped) `repo_id` rather than re-stamping, so repeated sessions accumulate in one dataset.

## Tests

Adds regression tests (fail on the pre-change builder):
- fresh record always pins `--dataset.root` even when `dataset_root` is omitted (value equals `resolve_dataset_dir(repo_id)`);
- explicit `dataset_root` still forwarded verbatim;
- `record_resume=True` emits `--resume true`; default omits it;
- plain teleoperation (no dataset) carries neither `--dataset.root` nor `--resume`;
- the tool result reports the pinned `dataset_root` and `resume` state.

Full local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues, and `tests/tools/test_lerobot_teleoperate.py` passes (57 tests).

## Verification (recording round-trip on lerobot HEAD)

End-to-end proof that pinning the root keeps the dataset findable despite `repo_id` stamping, run headless (MuJoCo `MUJOCO_GL=egl`):

```
[DRIFT] stamp_repo_id() rewrote repo_id -> harness_demo/pick_cube_20260725_152333
        no explicit root -> $HF_LEROBOT_HOME/harness_demo/pick_cube_20260725_152333
        callers look in    $HF_LEROBOT_HOME/harness_demo/pick_cube   (MISMATCH)
[FIX]   pin --dataset.root = $HF_LEROBOT_HOME/harness_demo/pick_cube
        wrote 1 episode at pinned root exists=True
[ROUND-TRIP] reopened -> episodes=1 frames=20
[ARTIFACT] camera MP4 -> videos/observation.images.front/chunk-000/file-000.mp4 (942652 bytes)
```

Produced dataset camera MP4 from that round-trip (synthetic frames — no hardware camera attached; the artifact demonstrates a valid `create -> add_frame -> save_episode -> finalize -> reopen` cycle at a pinned root): https://github.com/cagataycali/robots/releases/download/record-fix-artifact-210/record_fix_front.mp4