### PR TITLE
fix(lerobot_local): thread revision= + norm_tag= through the processor bridge

### DIFF
--- a/strands_robots/policies/lerobot_local/norm_stats.py
+++ b/strands_robots/policies/lerobot_local/norm_stats.py
@@ -264,6 +264,7 @@ def load_norm_stats(
     pretrained_name_or_path: str,
     *,
     filename: str = "norm_stats.json",
+    revision: str | None = None,
 ) -> dict[str, Any] | None:
     """Load a ``norm_stats.json`` payload from a local dir or the HF Hub.
 
@@ -274,6 +275,8 @@ def load_norm_stats(
     Args:
         pretrained_name_or_path: HF repo id or local checkpoint directory.
         filename: Default norm-stats filename to look for.
+        revision: Optional Hub branch/tag/SHA to pin the download to, so the
+            norm-stats file matches revision-pinned policy weights.
 
     Returns:
         Parsed JSON payload dict, or ``None`` when unavailable.
@@ -306,14 +309,14 @@ def load_norm_stats(
         from huggingface_hub import hf_hub_download
 
         try:
-            cfg_path = hf_hub_download(pretrained_name_or_path, "config.json")
+            cfg_path = hf_hub_download(pretrained_name_or_path, "config.json", revision=revision)
             cfg = _read_json(Path(cfg_path))
             if cfg and cfg.get("norm_stats_filename"):
                 resolved_filename = str(cfg["norm_stats_filename"])
         except Exception as exc:  # noqa: BLE001 - config.json is optional
             logger.debug("norm_stats: no config.json on hub: %s", exc)
 
-        downloaded = hf_hub_download(pretrained_name_or_path, resolved_filename)
+        downloaded = hf_hub_download(pretrained_name_or_path, resolved_filename, revision=revision)
         return _read_json(Path(downloaded))
     except Exception as exc:  # noqa: BLE001 - network/repo errors are non-fatal
         logger.debug("norm_stats: could not fetch %s from hub: %s", resolved_filename, exc)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -861,6 +861,8 @@ class LerobotLocalPolicy(Policy):
                 overrides=self.processor_overrides or {},
                 policy_type=self.policy_type,
                 policy_config=getattr(self._policy, "config", None),
+                revision=self.revision,
+                norm_tag=self._molmoact2_norm_tag,
             )
         except (FileNotFoundError, ValueError, ImportError) as exc:
             # Processor bridge is optional - models work without it via the raw

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -26,7 +26,7 @@ PREPROCESSOR_CONFIG = "policy_preprocessor.json"
 POSTPROCESSOR_CONFIG = "policy_postprocessor.json"
 
 
-def _load_checkpoint_state_dict(pretrained_name_or_path: str) -> dict[str, Any] | None:
+def _load_checkpoint_state_dict(pretrained_name_or_path: str, revision: str | None = None) -> dict[str, Any] | None:
     """Load a checkpoint's single-file ``model.safetensors`` state dict.
 
     Resolves a local directory first, then the HF Hub (cached). Returns ``None``
@@ -65,7 +65,7 @@ def _load_checkpoint_state_dict(pretrained_name_or_path: str) -> dict[str, Any] 
         from huggingface_hub import hf_hub_download
         from huggingface_hub.errors import HfHubHTTPError
 
-        path = hf_hub_download(pretrained_name_or_path, "model.safetensors")
+        path = hf_hub_download(pretrained_name_or_path, "model.safetensors", revision=revision)
         return load_file(path)
     except ImportError:
         return None
@@ -206,6 +206,7 @@ class ProcessorBridge:
         policy_type: str | None = None,
         norm_tag: str | None = None,
         policy_config: Any | None = None,
+        revision: str | None = None,
     ) -> "ProcessorBridge":
         """Load processor pipelines from a pretrained model.
 
@@ -226,6 +227,14 @@ class ProcessorBridge:
             policy_config: The loaded policy's ``PreTrainedConfig``. Enables the
                 in-model-normalization fallback (see Notes) for OLD-FORMAT
                 checkpoints; when None that fallback is skipped.
+            revision: Optional Hub branch/tag/commit SHA. Pins the processor
+                config JSONs, the ``norm_stats.json`` fallback, and the
+                single-file ``model.safetensors`` download to the SAME revision
+                as the policy weights. Without it a revision-pinned load would
+                silently run default-branch preprocessor/postprocessor pipelines
+                and normalization buffers against pinned weights. Degrades to an
+                unpinned load with a warning on an older lerobot pipeline loader
+                that predates the kwarg.
 
         Returns:
             ProcessorBridge instance with loaded pipelines.
@@ -272,6 +281,7 @@ class ProcessorBridge:
             overrides or {},
             device,
             kind="preprocessor",
+            revision=revision,
         )
         postprocessor = cls._load_pipeline(
             DataProcessorPipeline,
@@ -280,6 +290,7 @@ class ProcessorBridge:
             overrides or {},
             device,
             kind="postprocessor",
+            revision=revision,
         )
 
         # Fallback: a checkpoint may ship NEITHER standard pipeline config but a
@@ -288,7 +299,9 @@ class ProcessorBridge:
         # un-normalized -- the single biggest cause of off-policy arm motion on
         # such checkpoints. Build quantile/min-max/mean-std normalizers instead.
         if preprocessor is None and postprocessor is None:
-            preprocessor, postprocessor = cls._load_norm_stats_fallback(pretrained_name_or_path, norm_tag=norm_tag)
+            preprocessor, postprocessor = cls._load_norm_stats_fallback(
+                pretrained_name_or_path, norm_tag=norm_tag, revision=revision
+            )
 
         # Third fallback: an OLD-FORMAT checkpoint ships no processor configs and
         # no norm_stats.json, but carries in-model normalization buffers that
@@ -297,7 +310,7 @@ class ProcessorBridge:
         # instead of flailing on raw MEAN_STD actions. Needs the policy config.
         if preprocessor is None and postprocessor is None and policy_config is not None:
             preprocessor, postprocessor = cls._load_in_model_normalization_fallback(
-                pretrained_name_or_path, policy_config, device
+                pretrained_name_or_path, policy_config, device, revision=revision
             )
 
         return cls(
@@ -314,6 +327,7 @@ class ProcessorBridge:
         overrides: dict[str, Any],
         device: str | None,
         kind: str,
+        revision: str | None = None,
     ) -> Any | None:
         """Load one processor pipeline, reconciling a device-pinned step.
 
@@ -341,12 +355,42 @@ class ProcessorBridge:
             The loaded pipeline, or ``None`` when the checkpoint genuinely ships
             no such config.
         """
-        try:
-            pipeline = pipeline_cls.from_pretrained(
+
+        def _from_pretrained(step_overrides: dict[str, Any]) -> Any:
+            # Pin the pipeline config + normalization buffers to the same
+            # ``revision`` as the policy weights. Pass revision only when set,
+            # and degrade gracefully on an older lerobot pipeline loader whose
+            # from_pretrained predates the kwarg (mirrors the policy-side
+            # from_pretrained_kwargs guard): retry unpinned with a warning
+            # rather than crashing the load.
+            if revision:
+                try:
+                    return pipeline_cls.from_pretrained(
+                        pretrained_name_or_path,
+                        config_filename=config_filename,
+                        overrides=step_overrides,
+                        revision=revision,
+                    )
+                except TypeError as type_exc:
+                    if "revision" not in str(type_exc):
+                        raise
+                    logger.warning(
+                        "%s: installed lerobot DataProcessorPipeline.from_pretrained does not "
+                        "accept revision=; loading %s from the default branch instead of "
+                        "revision '%s'. Upgrade lerobot to pin the processor pipeline. Error: %s",
+                        kind,
+                        config_filename,
+                        revision,
+                        type_exc,
+                    )
+            return pipeline_cls.from_pretrained(
                 pretrained_name_or_path,
                 config_filename=config_filename,
-                overrides=overrides,
+                overrides=step_overrides,
             )
+
+        try:
+            pipeline = _from_pretrained(overrides)
             logger.info("Loaded %s from %s: %d steps", kind, pretrained_name_or_path, len(pipeline))
             return pipeline
         except _missing_config_errors() as exc:
@@ -365,11 +409,7 @@ class ProcessorBridge:
             ):
                 retry_overrides = {**overrides, "device_processor": {"device": device}}
                 try:
-                    pipeline = pipeline_cls.from_pretrained(
-                        pretrained_name_or_path,
-                        config_filename=config_filename,
-                        overrides=retry_overrides,
-                    )
+                    pipeline = _from_pretrained(retry_overrides)
                     logger.warning(
                         "%s ships a device-pinned 'device_processor' step that is "
                         "unavailable on this host; reconciled it onto '%s' so "
@@ -389,6 +429,7 @@ class ProcessorBridge:
     def _load_norm_stats_fallback(
         pretrained_name_or_path: str,
         norm_tag: str | None = None,
+        revision: str | None = None,
     ) -> tuple[Any | None, Any | None]:
         """Build pre/post pipelines from a ``norm_stats.json`` when present.
 
@@ -405,7 +446,7 @@ class ProcessorBridge:
         """
         from . import norm_stats as _norm_stats
 
-        payload = _norm_stats.load_norm_stats(pretrained_name_or_path)
+        payload = _norm_stats.load_norm_stats(pretrained_name_or_path, revision=revision)
         if not _norm_stats.is_norm_stats_payload(payload):
             return None, None
         assert payload is not None  # narrowed by is_norm_stats_payload
@@ -420,6 +461,7 @@ class ProcessorBridge:
         pretrained_name_or_path: str,
         policy_config: Any,
         device: str | None = None,
+        revision: str | None = None,
     ) -> tuple[Any | None, Any | None]:
         """Rebuild pre/post pipelines from OLD-FORMAT in-model normalization buffers.
 
@@ -475,7 +517,7 @@ class ProcessorBridge:
             logger.debug("In-model normalization recovery unavailable: %s", exc)
             return None, None
 
-        state_dict = _load_checkpoint_state_dict(pretrained_name_or_path)
+        state_dict = _load_checkpoint_state_dict(pretrained_name_or_path, revision=revision)
         if not state_dict:
             return None, None
         stats = extract_normalization_stats(state_dict)

--- a/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
+++ b/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
@@ -189,7 +189,7 @@ def test_missing_single_file_weights_stays_passthrough(monkeypatch, tmp_path):
     """
     import strands_robots.policies.lerobot_local.processor as proc
 
-    monkeypatch.setattr(proc, "_load_checkpoint_state_dict", lambda _path: None)
+    monkeypatch.setattr(proc, "_load_checkpoint_state_dict", lambda _path, revision=None: None)
 
     pre, post = ProcessorBridge._load_in_model_normalization_fallback(
         str(tmp_path), policy_config=_act_config(), device="cpu"

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -2034,6 +2034,7 @@ class TestLoadModelPostprocessorWarning:
         policy.actions_per_step = 1
         policy.cache_model = False
         policy.revision = None
+        policy._molmoact2_norm_tag = None
         return policy
 
     def test_warns_without_postprocessor(self, caplog):

--- a/tests/policies/lerobot_local/test_processor_revision_norm_tag_threading.py
+++ b/tests/policies/lerobot_local/test_processor_revision_norm_tag_threading.py
@@ -1,0 +1,202 @@
+"""Revision + norm_tag threading through the lerobot_local processor bridge.
+
+``LerobotLocalPolicy`` accepts ``revision=`` to pin a checkpoint to a branch,
+tag, or commit SHA and ``norm_tag=`` to select which embodiment's stats a
+multi-tag ``norm_stats.json`` applies. Both must reach the processor pipeline
+loader, not just the policy weights: otherwise a revision-pinned load silently
+runs the DEFAULT-branch preprocessor/postprocessor JSONs and normalization
+buffers against pinned weights (worst case: wrong normalization stats), and a
+generic checkpoint ignores the user's ``norm_tag`` on the norm-stats fallback.
+
+These tests pin:
+  * the ``_load_processor_bridge`` call site forwards ``revision`` + ``norm_tag``
+    to ``ProcessorBridge.from_pretrained``;
+  * ``ProcessorBridge.from_pretrained`` threads ``revision`` into every
+    ``DataProcessorPipeline.from_pretrained`` call (preprocessor + postprocessor);
+  * an older lerobot pipeline loader whose ``from_pretrained`` predates the
+    ``revision`` kwarg degrades to an unpinned load instead of crashing;
+  * ``revision`` + ``norm_tag`` both reach the ``norm_stats.json`` fallback; and
+  * a user ``norm_tag`` selects that tag from a multi-tag payload.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from strands_robots.policies.lerobot_local import norm_stats, processor
+from strands_robots.policies.lerobot_local.norm_stats import (
+    MOLMOACT2_NORM_STATS_FORMAT,
+    select_norm_tag,
+)
+from strands_robots.policies.lerobot_local.policy import (
+    LerobotLocalPolicy,
+    clear_model_cache,
+)
+from strands_robots.policies.lerobot_local.processor import (
+    POSTPROCESSOR_CONFIG,
+    PREPROCESSOR_CONFIG,
+    ProcessorBridge,
+)
+
+
+def _generic_inner():
+    inner = MagicMock()
+    inner.config = MagicMock(
+        input_features={"observation.state": MagicMock(shape=(6,))},
+        output_features={"action": MagicMock(shape=(6,))},
+        device="cpu",
+    )
+    inner.eval.return_value = None
+    return inner
+
+
+class TestBridgeCallSiteForwarding:
+    """The policy call site must forward revision + norm_tag to the bridge."""
+
+    def setup_method(self):
+        clear_model_cache()
+
+    def teardown_method(self):
+        clear_model_cache()
+
+    def test_load_processor_bridge_forwards_revision_and_norm_tag(self):
+        captured: dict = {}
+
+        def _fake_bridge(_path, **kwargs):
+            captured.update(kwargs)
+            return MagicMock(is_active=False)
+
+        mock_cls = MagicMock()
+        mock_cls.from_pretrained.side_effect = lambda _p, **_kw: _generic_inner()
+        with (
+            patch(
+                "strands_robots.policies.lerobot_local.policy.resolve_policy_class_by_name",
+                return_value=mock_cls,
+            ),
+            patch(
+                "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+                side_effect=_fake_bridge,
+            ),
+        ):
+            LerobotLocalPolicy(
+                pretrained_name_or_path="test/model",
+                policy_type="act",
+                device="cpu",
+                cache_model=False,
+                revision="v1.2.3",
+                norm_tag="so101",
+            )
+        assert captured.get("revision") == "v1.2.3"
+        assert captured.get("norm_tag") == "so101"
+
+
+class _RecordingPipeline:
+    """Stub pipeline loader that records each from_pretrained call."""
+
+    calls: list[dict] = []
+
+    @classmethod
+    def from_pretrained(cls, path, *, config_filename, overrides, revision=None, **_kw):
+        cls.calls.append({"config_filename": config_filename, "revision": revision})
+        return [object()]  # len()==1 so the load-diagnostic logger works
+
+
+class _OldPipeline:
+    """Stub loader whose from_pretrained predates the ``revision`` kwarg."""
+
+    seen: list[str] = []
+
+    @classmethod
+    def from_pretrained(cls, path, *, config_filename, overrides, **kwargs):
+        if "revision" in kwargs:
+            raise TypeError("from_pretrained() got an unexpected keyword argument 'revision'")
+        cls.seen.append(config_filename)
+        return [object()]
+
+
+class TestBridgeThreadsRevisionToPipeline:
+    def test_revision_reaches_every_pipeline_loader_call(self, monkeypatch):
+        _RecordingPipeline.calls = []
+        monkeypatch.setattr(processor, "_try_import_processor", lambda: _RecordingPipeline)
+        monkeypatch.setattr(processor, "_register_policy_processor_steps", lambda *_a, **_k: None)
+
+        ProcessorBridge.from_pretrained("owner/model", revision="deadbeef", policy_type=None)
+
+        by_config = {c["config_filename"]: c["revision"] for c in _RecordingPipeline.calls}
+        assert by_config[PREPROCESSOR_CONFIG] == "deadbeef"
+        assert by_config[POSTPROCESSOR_CONFIG] == "deadbeef"
+
+    def test_no_revision_keeps_unpinned_pipeline_load(self, monkeypatch):
+        _RecordingPipeline.calls = []
+        monkeypatch.setattr(processor, "_try_import_processor", lambda: _RecordingPipeline)
+        monkeypatch.setattr(processor, "_register_policy_processor_steps", lambda *_a, **_k: None)
+
+        ProcessorBridge.from_pretrained("owner/model", policy_type=None)
+
+        assert _RecordingPipeline.calls  # loader was invoked
+        assert all(c["revision"] is None for c in _RecordingPipeline.calls)
+
+    def test_old_pipeline_loader_degrades_to_unpinned(self, monkeypatch, caplog):
+        _OldPipeline.seen = []
+        monkeypatch.setattr(processor, "_try_import_processor", lambda: _OldPipeline)
+        monkeypatch.setattr(processor, "_register_policy_processor_steps", lambda *_a, **_k: None)
+
+        with caplog.at_level("WARNING"):
+            bridge = ProcessorBridge.from_pretrained("owner/model", revision="v1", policy_type=None)
+
+        # Both pipelines loaded (unpinned retry) instead of crashing on TypeError.
+        assert PREPROCESSOR_CONFIG in _OldPipeline.seen
+        assert POSTPROCESSOR_CONFIG in _OldPipeline.seen
+        assert bridge.is_active
+        assert any("does not accept revision" in r.message for r in caplog.records)
+
+
+def _multi_tag_payload():
+    stats = {
+        "min": [0.0] * 6,
+        "max": [1.0] * 6,
+    }
+    return {
+        "format": MOLMOACT2_NORM_STATS_FORMAT,
+        "norm_mode": "min_max",
+        "metadata_by_tag": {
+            "so100": {"state_stats": stats, "action_stats": stats},
+            "so101": {"state_stats": stats, "action_stats": stats},
+        },
+    }
+
+
+class TestNormStatsFallbackReceivesRevisionAndTag:
+    def test_revision_and_norm_tag_reach_norm_stats_fallback(self, monkeypatch):
+        # No processor JSONs -> both pipelines None -> norm_stats fallback runs.
+        class _NoConfigPipeline:
+            @classmethod
+            def from_pretrained(cls, *_a, **_k):
+                raise FileNotFoundError("no processor config shipped")
+
+        monkeypatch.setattr(processor, "_try_import_processor", lambda: _NoConfigPipeline)
+        monkeypatch.setattr(processor, "_register_policy_processor_steps", lambda *_a, **_k: None)
+
+        captured: dict = {}
+
+        def _fake_load(path, *, revision=None, **_kw):
+            captured["load_revision"] = revision
+            return _multi_tag_payload()
+
+        def _fake_build(payload, norm_tag=None, **_kw):
+            captured["build_norm_tag"] = norm_tag
+            return ("PRE", "POST")
+
+        monkeypatch.setattr(norm_stats, "load_norm_stats", _fake_load)
+        monkeypatch.setattr(norm_stats, "build_norm_stats_processors", _fake_build)
+
+        bridge = ProcessorBridge.from_pretrained("owner/model", revision="rev9", norm_tag="so101", policy_type=None)
+        assert captured["load_revision"] == "rev9"
+        assert captured["build_norm_tag"] == "so101"
+        assert bridge.has_preprocessor
+
+    def test_requested_norm_tag_selected_from_multi_tag_payload(self):
+        # Acceptance criterion: an explicit norm_tag wins over auto-resolution.
+        assert select_norm_tag(_multi_tag_payload(), "so101") == "so101"
+        # Unresolvable without a hint (multiple tags, no matching default).
+        assert select_norm_tag(_multi_tag_payload()) is None


### PR DESCRIPTION
## Problem

The `lerobot_local` checkpoint loader pins the *policy weights and config* to a caller-supplied `revision=`, but leaves the processor pipelines unpinned, and it drops a caller-supplied `norm_tag=` on the generic norm-stats fallback path. Both are silent.

### 1. `revision=` does not reach the processor pipelines

`LerobotLocalPolicy._load_model` threads `self.revision` into `PreTrainedConfig.from_pretrained` / `PreTrainedPolicy.from_pretrained`, but the processor bridge loads everything else from the checkpoint's **default branch**:

- `ProcessorBridge.from_pretrained` did not accept `revision` at all;
- `_load_pipeline` called `DataProcessorPipeline.from_pretrained(...)` without it (upstream lerobot accepts `revision=` on that loader, `lerobot/processor/pipeline.py`, and lerobot's own `policies/factory.py` threads `pretrained_revision` through);
- the `norm_stats.json` fallback (`load_norm_stats`) downloaded `config.json` + `norm_stats.json` unpinned;
- `_load_checkpoint_state_dict` downloaded `model.safetensors` unpinned (the OLD-FORMAT in-model normalization recovery path).

Net effect: a `revision=`-pinned load runs **default-branch** preprocessor/postprocessor JSONs and normalization buffers against pinned weights. Worst case: wrong normalization stats applied to the pinned policy, with no error.

### 2. Ctor `norm_tag=` never reaches the generic fallback

`ProcessorBridge.from_pretrained` already accepted `norm_tag` and used it in the norm-stats fallback, but the `_load_processor_bridge` call site never passed it. A non-molmoact2-typed checkpoint shipping a multi-tag `norm_stats.json` therefore ignored the user's `norm_tag=` and fell back to auto-resolution/`None`.

## Change

Thread `revision` through `ProcessorBridge.from_pretrained` -> `_load_pipeline` / `_load_norm_stats_fallback` / `_load_in_model_normalization_fallback` -> `_load_checkpoint_state_dict` / `norm_stats.load_norm_stats`, forwarding it to `DataProcessorPipeline.from_pretrained(..., revision=...)` and every hub download. Pass `self.revision` and the user `norm_tag` at the `_load_processor_bridge` call site.

The pipeline loader guards the new kwarg with `try/except TypeError`: an older lerobot whose `DataProcessorPipeline.from_pretrained` predates `revision=` degrades to an **unpinned load with a warning** instead of crashing (mirrors the existing `from_pretrained_kwargs` guard on the policy side). Omitting `revision` keeps the exact prior unpinned call shape.

## Tests

New `tests/policies/lerobot_local/test_processor_revision_norm_tag_threading.py` (fails pre-fix, passes post-fix):
- the `_load_processor_bridge` call site forwards `revision` + `norm_tag` to the bridge;
- `revision` reaches every `DataProcessorPipeline.from_pretrained` call (preprocessor + postprocessor), and is `None` when unset;
- an old pipeline loader lacking `revision=` degrades to an unpinned load and warns instead of raising;
- `revision` + `norm_tag` both reach the `norm_stats.json` fallback, and an explicit `norm_tag` selects that tag from a multi-tag payload.

Two existing tests whose stubs/hand-built objects predated the new signatures are updated. Full local gate green: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; `MUJOCO_GL=egl pytest tests/policies/lerobot_local/` = 592 passed.