### PR TITLE
fix: RealSense config kwarg + stop forwarding invalid video_backend="auto" decode default

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -554,7 +554,7 @@ class DatasetRecorder:
         vcodec: str = "h264",
         streaming_encoding: bool = True,
         image_writer_threads: int = 4,
-        video_backend: str = "auto",
+        video_backend: str | None = None,
         video_width: int = 640,
         video_height: int = 480,
         camera_key_map: dict[str, str] | None = None,
@@ -594,7 +594,10 @@ class DatasetRecorder:
                 wheels commonly cannot decode it and silently yield 0 frames.
             streaming_encoding: Stream-encode video during capture
             image_writer_threads: Threads for writing image frames
-            video_backend: Video backend for encoding ("auto" for HW encoder auto-detect)
+            video_backend: LeRobot video *decode* backend for read-back
+                ("torchcodec" or "pyav"). Left as None by default so LeRobot
+                picks its platform default; only forwarded when explicitly set.
+                Encoder selection is controlled by ``vcodec`` (not this param).
             camera_key_map: Optional remap of observed camera stream names to the
                 declared schema names (e.g. {"front_camera": "image",
                 "wrist_camera": "wrist_image"}). Bare names or fully-qualified
@@ -658,7 +661,7 @@ class DatasetRecorder:
         # streaming_encoding / video_backend only in newer LeRobot versions
         if "streaming_encoding" in create_params:
             create_kwargs["streaming_encoding"] = streaming_encoding
-        if "video_backend" in create_params:
+        if "video_backend" in create_params and video_backend is not None:
             create_kwargs["video_backend"] = video_backend
 
         # Resolve create-vs-crash for an existing target BEFORE calling
@@ -690,7 +693,7 @@ class DatasetRecorder:
         vcodec: str = "h264",
         streaming_encoding: bool = True,
         image_writer_threads: int = 4,
-        video_backend: str = "auto",
+        video_backend: str | None = None,
         camera_key_map: dict[str, str] | None = None,
     ) -> "DatasetRecorder":
         """Resume recording into an EXISTING LeRobotDataset (append episodes).
@@ -718,7 +721,9 @@ class DatasetRecorder:
                 config). See create() for the H.264-vs-AV1 trade-off.
             streaming_encoding: Stream-encode video during capture.
             image_writer_threads: Threads for writing image frames.
-            video_backend: Video backend for encoding.
+            video_backend: LeRobot video *decode* backend for read-back
+                ("torchcodec" or "pyav"); None uses LeRobot's platform default.
+                Encoder selection is controlled by ``vcodec`` (not this param).
             camera_key_map: Optional remap of observed camera stream names to
                 the declared schema names (see create()).
 
@@ -747,7 +752,7 @@ class DatasetRecorder:
             resume_kwargs["streaming_encoding"] = streaming_encoding
         if "image_writer_threads" in resume_sig:
             resume_kwargs["image_writer_threads"] = image_writer_threads
-        if "video_backend" in resume_sig:
+        if "video_backend" in resume_sig and video_backend is not None:
             resume_kwargs["video_backend"] = video_backend
 
         dataset = LeRobotDatasetCls.resume(**resume_kwargs)

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -987,7 +987,7 @@ def _create_camera(
         return OpenCVCamera(config)
 
     elif camera_type.lower() == "realsense" and REALSENSE_AVAILABLE:
-        config = RealSenseCameraConfig(serial_number=str(camera_id), fps=fps, width=width, height=height)
+        config = RealSenseCameraConfig(serial_number_or_name=str(camera_id), fps=fps, width=width, height=height)
         return RealSenseCamera(config)
 
     else:

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1115,6 +1115,100 @@ def test_create_wraps_vcodec_in_camera_encoder_on_052(monkeypatch):
     assert constructed[0].vcodec == "libsvtav1"
 
 
+class _VideoBackendProbeCreate:
+    """create() declares video_backend with a distinctive sentinel default so a
+    test can tell whether the recorder forwarded a value or left it untouched."""
+
+    _UNSET = "__unset__"
+    last_create_kwargs: dict = {}
+
+    def __init__(self, repo_id, root=None) -> None:
+        self.repo_id = repo_id
+        self.root = root
+
+    @classmethod
+    def create(
+        cls,
+        repo_id,
+        fps=30,
+        root=None,
+        robot_type="unknown",
+        features=None,
+        use_videos=True,
+        image_writer_threads=4,
+        camera_encoder=None,
+        streaming_encoding=True,
+        video_backend="__unset__",
+    ):
+        cls.last_create_kwargs = {"video_backend": video_backend}
+        return cls(repo_id, root=root)
+
+
+class _VideoBackendProbeResume:
+    """resume() counterpart of _VideoBackendProbeCreate."""
+
+    _UNSET = "__unset__"
+    last_resume_kwargs: dict = {}
+
+    def __init__(self, repo_id, root=None, meta=None) -> None:
+        self.repo_id = repo_id
+        self.root = root
+        self.meta = meta or _ResumeMeta(total_episodes=0, total_frames=0)
+
+    @classmethod
+    def resume(
+        cls,
+        repo_id,
+        root=None,
+        camera_encoder=None,
+        image_writer_threads=4,
+        video_backend="__unset__",
+    ):
+        cls.last_resume_kwargs = {"video_backend": video_backend}
+        return cls(repo_id, root=root)
+
+
+def test_create_omits_video_backend_by_default(monkeypatch):
+    """Regression: video_backend defaults to None and must NOT be forwarded to
+    LeRobot.create() unless explicitly set.
+
+    ``video_backend`` is LeRobot's video *decode* backend; valid values are
+    "torchcodec"/"pyav" ("video_reader" is a deprecated alias). The old default
+    of "auto" was never a valid decode backend, so read-back through the created
+    dataset (e.g. dataset[0]) raised ``ValueError: Unsupported video backend:
+    auto``. With the fix, the default is None and the kwarg is left off so
+    LeRobot picks its own platform default. The fake's sentinel default proves
+    the recorder sent nothing (pre-fix it forwarded "auto" and this fails).
+    """
+    _install_video_encoder_config(monkeypatch)
+    _patch_lerobot_dataset(monkeypatch, _VideoBackendProbeCreate)
+
+    DatasetRecorder.create("user/data", joint_names=["j1"], vcodec="libsvtav1")
+
+    assert _VideoBackendProbeCreate.last_create_kwargs["video_backend"] == "__unset__"
+
+
+def test_resume_omits_video_backend_by_default(monkeypatch):
+    """Regression: resume() must not forward video_backend when left at its
+    None default (see test_create_omits_video_backend_by_default)."""
+    _install_video_encoder_config(monkeypatch)
+    _patch_lerobot_dataset(monkeypatch, _VideoBackendProbeResume)
+
+    DatasetRecorder.resume("user/data", vcodec="libsvtav1")
+
+    assert _VideoBackendProbeResume.last_resume_kwargs["video_backend"] == "__unset__"
+
+
+def test_create_forwards_video_backend_when_explicitly_set(monkeypatch):
+    """When a caller explicitly passes a valid decode backend, it IS forwarded."""
+    _install_video_encoder_config(monkeypatch)
+    _patch_lerobot_dataset(monkeypatch, _VideoBackendProbeCreate)
+
+    DatasetRecorder.create("user/data", joint_names=["j1"], vcodec="libsvtav1", video_backend="pyav")
+
+    assert _VideoBackendProbeCreate.last_create_kwargs["video_backend"] == "pyav"
+
+
 def test_create_warns_when_video_encoder_config_missing(monkeypatch, caplog):
     """If create() wants camera_encoder= but VideoEncoderConfig can't be
     imported, the recorder warns and proceeds with camera_encoder unset rather

--- a/tests/tools/test_lerobot_camera.py
+++ b/tests/tools/test_lerobot_camera.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -442,12 +443,17 @@ def test_performance_async_branch_reports_speedup(fake_camera: FakeCamera) -> No
 
 def test_create_camera_builds_realsense_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
     """When the RealSense SDK is present, _create_camera routes a 'realsense'
-    request to the RealSense config + camera classes with the serial number."""
+    request to the RealSense config + camera classes with the serial number.
+
+    The config field is ``serial_number_or_name`` in LeRobot's
+    RealSenseCameraConfig - the fake mirrors that exact kwarg so the test
+    validates the real dataclass contract rather than a bug-mirroring alias.
+    """
     seen: dict[str, Any] = {}
 
-    def fake_config(serial_number, fps, width, height):
-        seen["serial"] = serial_number
-        return SimpleNamespace(serial_number=serial_number)
+    def fake_config(serial_number_or_name, fps, width, height):
+        seen["serial"] = serial_number_or_name
+        return SimpleNamespace(serial_number_or_name=serial_number_or_name)
 
     monkeypatch.setattr(cam_mod, "REALSENSE_AVAILABLE", True)
     monkeypatch.setattr(cam_mod, "RealSenseCameraConfig", fake_config)
@@ -455,7 +461,33 @@ def test_create_camera_builds_realsense_when_available(monkeypatch: pytest.Monke
 
     cam = cam_mod._create_camera("realsense", "0123", 640, 480, 30, "RGB", "NO_ROTATION")
     assert seen["serial"] == "0123"
-    assert cam.config.serial_number == "0123"
+    assert cam.config.serial_number_or_name == "0123"
+
+
+def test_create_camera_realsense_uses_real_config_dataclass_field() -> None:
+    """Regression: _create_camera must construct RealSenseCameraConfig with the
+    field name the real LeRobot dataclass actually declares
+    (``serial_number_or_name``). The pre-fix code passed ``serial_number=``,
+    which never existed as a field and raised
+    ``TypeError: unexpected keyword argument`` on every realsense action.
+
+    This drives the real (SDK-free-importable) config dataclass and a stub
+    camera, so it fails on the old kwarg and passes on the corrected one -
+    without any RealSense hardware.
+    """
+    from lerobot.cameras.realsense.configuration_realsense import (
+        RealSenseCameraConfig,
+    )
+
+    with (
+        mock.patch.object(cam_mod, "REALSENSE_AVAILABLE", True),
+        mock.patch.object(cam_mod, "RealSenseCameraConfig", RealSenseCameraConfig),
+        mock.patch.object(cam_mod, "RealSenseCamera", lambda config: SimpleNamespace(config=config)),
+    ):
+        cam = cam_mod._create_camera("realsense", "944622072361", 640, 480, 30, "RGB", "NO_ROTATION")
+
+    assert cam.config.serial_number_or_name == "944622072361"
+    assert cam.config.fps == 30
 
 
 def test_create_camera_realsense_without_sdk_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Two one-line lerobot kwarg bugs

### 1. RealSense camera: wrong ctor kwarg -> TypeError on every realsense action
`strands_robots/tools/lerobot_camera.py` constructed `RealSenseCameraConfig(serial_number=...)`. The dataclass field is `serial_number_or_name` (both at lerobot HEAD and 0.5.1); `serial_number` never existed as a field name, so any `camera_type="realsense"` call raised `TypeError: unexpected keyword argument 'serial_number'`. Fixed to `serial_number_or_name=`.

### 2. DatasetRecorder forwarded `video_backend="auto"` - not a valid decode backend
`DatasetRecorder.create`/`resume` defaulted `video_backend="auto"` and forwarded it to `LeRobotDataset.create`/`.resume`. Upstream `video_backend` is the video **decode** backend; valid values are `torchcodec`/`pyav` (`video_reader` is a deprecated alias) - anything else raises `ValueError: Unsupported video backend: ...` (`lerobot/datasets/video_utils.py`). Encoder auto-detect is `vcodec`, handled separately and correctly. This was a latent break: encoding succeeded, but the first decode through the recorder's dataset object (e.g. `dataset[0]` verification reads) blew up.

Fix: default `video_backend=None`, forward only when explicitly set, and correct the misleading docstrings (they described it as an encoder auto-detect).

## Tests
- `test_create_camera_realsense_uses_real_config_dataclass_field`: drives the real (SDK-free-importable) `RealSenseCameraConfig` dataclass with a stub camera; fails on the old `serial_number=` kwarg (`TypeError`), passes on `serial_number_or_name=`. No RealSense hardware needed.
- The existing realsense mock test was mirroring the buggy kwarg name; updated to the real field name so it validates the true dataclass contract.
- `test_create_omits_video_backend_by_default` / `test_resume_omits_video_backend_by_default`: sentinel-default fakes prove the recorder no longer forwards a value by default (pre-fix forwarded `"auto"` and these fail).
- `test_create_forwards_video_backend_when_explicitly_set`: an explicit valid backend is still forwarded.

All three new regression tests were verified to FAIL on pre-fix code and PASS after. Full `tests/test_dataset_recorder.py` + `tests/tools/test_lerobot_camera.py` green (173 passed). `ruff check`, `ruff format --check`, and `mypy strands_robots tests` all clean.

Recording note: bug 2 is a kwarg-forwarding fix; the encode path is unchanged, so there is no change to what gets recorded. The regression tests assert the exact forwarding contract that caused the `dataset[0]` decode `ValueError`.