### PR TITLE
feat(training): preflight quantile stats for QUANTILES-normalizing policies (molmoact2, pi05)

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -258,6 +258,28 @@ TrainSpec(
 Only `pi0` / `pi05` / `pi0_fast` expose `use_relative_actions`; the flag is
 rejected (not silently ignored) for any other policy type.
 
+#### Quantile normalization (molmoact2, pi05)
+
+Some policies normalize `STATE`/`ACTION` with `NormalizationMode.QUANTILES`
+(currently `molmoact2` and `pi05`) rather than mean/std or min/max. Quantile
+normalization reads the dataset stats' quantile keys (`q01`..`q99`); a dataset
+recorded *before* quantile stats existed carries only mean/std/min/max, so
+lerobot either raises or silently mis-normalizes deep inside its stats plumbing
+at train time. `validate()` catches this at spec time: when the resolved policy
+normalizes with quantiles and a local `meta/stats.json` lacks the quantile keys,
+it returns an actionable problem naming lerobot's remedy:
+
+```bash
+python -m lerobot.scripts.augment_dataset_quantile_stats \
+    --repo-id=<your-dataset-repo-id> --root=/data/my_v3_dataset
+```
+
+Datasets recorded by `Robot.start_recording()` / `DatasetRecorder` on current
+lerobot already include quantile stats (lerobot's `compute_episode_stats`
+computes them by default), so they train `molmoact2` / `pi05` with no manual
+stats surgery. The check is conservative: a Hub dataset with no local cache is
+left unflagged (its quantiles are verified by lerobot when the shards load).
+
 #### Streaming a large Hub dataset (no full download)
 
 Real datasets (BitRobot / HIW-500, ~50-500 GB) do not fit on a single edge node.

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -95,6 +95,22 @@ _RELATIVE_ACTION_POLICY_TYPES_FALLBACK = frozenset({"pi0", "pi05", "pi0_fast", "
 # Currently pi0, pi05, and smolvla expose the field (pi0_fast does NOT).
 _EXPERT_ONLY_POLICY_TYPES_FALLBACK = frozenset({"pi0", "pi05", "smolvla"})
 
+# LeRobot policy types whose config normalizes STATE/ACTION with QUANTILES
+# (``NormalizationMode.QUANTILES``). Such a policy needs the dataset's stats to
+# carry the quantile keys (q01, q10, q50, q90, q99); a dataset recorded before
+# quantile stats existed only has mean/std/min/max, so training either fails or
+# mis-normalizes deep inside lerobot's stats plumbing. Discovered live per
+# policy type off the config class's ``normalization_mapping`` default
+# (see :func:`_policy_uses_quantile_norm`); the static set is the offline
+# FALLBACK. Currently molmoact2 and the pi05 family normalize with quantiles.
+_QUANTILE_NORM_POLICY_TYPES_FALLBACK = frozenset({"molmoact2", "pi05"})
+
+# Quantile stat keys lerobot writes for ``DEFAULT_QUANTILES`` = [0.01, 0.10,
+# 0.50, 0.90, 0.99] (``qNN`` where NN = int(q * 100)). A dataset carries quantile
+# stats when ANY feature's stats dict holds one of these keys (mirrors lerobot's
+# own ``augment_dataset_quantile_stats.has_quantile_stats``).
+_QUANTILE_STAT_KEYS = ("q01", "q10", "q50", "q90", "q99")
+
 # RA-BC (Reward-Aligned Behavior Cloning) is surfaced to the agent through the
 # ``extra['sample_weighting']`` dict. lerobot >= 0.5.2 configures sample
 # weighting via a NESTED ``SampleWeightingConfig`` on ``TrainPipelineConfig``
@@ -194,6 +210,62 @@ def _policy_supports_expert_only(ptype: str) -> bool:
     if reg is not None and ptype in reg:
         return any(f.name == "train_expert_only" for f in dataclasses.fields(reg[ptype]))
     return ptype in _EXPERT_ONLY_POLICY_TYPES_FALLBACK
+
+
+def _policy_uses_quantile_norm(ptype: str) -> bool:
+    """Whether ``ptype``'s lerobot config normalizes any feature with QUANTILES.
+
+    A quantile-normalizing policy (molmoact2, pi05, ...) requires the training
+    dataset's stats to carry quantile keys (q01..q99); without them lerobot
+    either fails or silently mis-normalizes. Probed live off the registry config
+    *class*'s ``normalization_mapping`` field default (a ``dataclasses.field``
+    ``default_factory`` call - no config instantiation, so no device warnings or
+    construction cost), so any policy lerobot adds with quantile normalization is
+    recognized with zero per-type maintenance. Falls back to the documented
+    static set when lerobot's registry is unavailable offline.
+    """
+    reg = _policy_registry()
+    if reg is None or ptype not in reg:
+        return ptype in _QUANTILE_NORM_POLICY_TYPES_FALLBACK
+    for f in dataclasses.fields(reg[ptype]):
+        if f.name == "normalization_mapping" and f.default_factory is not dataclasses.MISSING:
+            try:
+                mapping = f.default_factory()
+            except Exception:  # noqa: BLE001 - a broken default falls back to the static set
+                return ptype in _QUANTILE_NORM_POLICY_TYPES_FALLBACK
+            return any(getattr(mode, "value", mode) == "QUANTILES" for mode in mapping.values())
+    return False
+
+
+def _stats_have_quantiles(stats: dict[str, Any] | None) -> bool:
+    """Whether a LeRobotDataset stats dict carries quantile keys for any feature.
+
+    Mirrors lerobot's ``augment_dataset_quantile_stats.has_quantile_stats``: the
+    stats are ``{feature: {stat: value}}`` and quantiles are present when ANY
+    feature holds one of ``q01..q99``.
+    """
+    if not isinstance(stats, dict):
+        return False
+    return any(isinstance(feat, dict) and any(q in feat for q in _QUANTILE_STAT_KEYS) for feat in stats.values())
+
+
+def _dataset_quantile_stats_present(dataset_root: str) -> bool | None:
+    """Tri-state quantile-stats probe for a local LeRobotDataset v3 root.
+
+    Reads ``meta/stats.json`` (lerobot's ``STATS_PATH``, the aggregate stats
+    ``load_stats`` feeds to normalization). Returns ``True`` when quantile keys
+    are present, ``False`` when the file exists but lacks them, and ``None`` when
+    the file is absent or unreadable (unknown - e.g. a Hub dataset with no
+    materialized local cache), so a definite miss can be flagged without false
+    positives on the unknown case.
+    """
+    stats_path = os.path.join(dataset_root, "meta", "stats.json")
+    try:
+        with open(stats_path, encoding="utf-8") as fh:
+            stats = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return _stats_have_quantiles(stats)
 
 
 def _reward_registry() -> dict[str, type] | None:
@@ -563,7 +635,41 @@ class LerobotTrainer(Trainer):
             for k, v in sw.items():
                 if isinstance(v, str) and v.startswith("-"):
                     problems.append(f"sample_weighting['{k}'] must not start with '-' (would parse as a stray flag)")
+
+        problems.extend(self._quantile_stats_problems(spec, ptype))
         return problems
+
+    def _quantile_stats_problems(self, spec: TrainSpec, ptype: str) -> list[str]:
+        """Preflight the dataset's quantile stats for a QUANTILES-normalizing policy.
+
+        A policy that normalizes STATE/ACTION with ``NormalizationMode.QUANTILES``
+        (molmoact2, pi05, ...) reads the dataset stats' quantile keys (q01..q99)
+        to normalize. A dataset recorded before quantile stats existed carries
+        only mean/std/min/max, so lerobot either raises or silently
+        mis-normalizes deep inside its stats plumbing at train time. This lifts
+        that failure to spec-validation time with an actionable message naming
+        lerobot's ``augment_dataset_quantile_stats`` remedy.
+
+        Read-only and conservative: it only flags a DEFINITE miss (a local
+        ``meta/stats.json`` present but lacking quantile keys). A Hub dataset with
+        no materialized local cache is left unflagged (stats unknown without a
+        download); its quantiles are validated by lerobot when the shards load.
+        Datasets recorded by the current DatasetRecorder already include quantile
+        stats (lerobot's ``compute_episode_stats`` computes them by default), so
+        they pass cleanly.
+        """
+        if not (spec.dataset_root and _policy_uses_quantile_norm(ptype)):
+            return []
+        if _dataset_quantile_stats_present(spec.dataset_root) is not False:
+            return []
+        repo_id = spec.dataset_repo_id or "<your-dataset-repo-id>"
+        return [
+            f"policy_type '{ptype}' normalizes STATE/ACTION with QUANTILES but the dataset at "
+            f"'{spec.dataset_root}' has no quantile stats (missing q01/q99 in meta/stats.json); "
+            "lerobot would mis-normalize or fail at train time. Add quantile stats first: "
+            f"python -m lerobot.scripts.augment_dataset_quantile_stats --repo-id={repo_id} "
+            f"--root={spec.dataset_root} (datasets recorded with current lerobot already include them)."
+        ]
 
     def _validate_reward_model(self, spec: TrainSpec, rm: dict[str, Any]) -> list[str]:
         """Reward-model training preflight (the ``cfg.reward_model`` path).

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -89,6 +89,96 @@ class TestValidate:
         assert any("val_episodes" in p for p in problems)
 
 
+_AUGMENT_HINT = "augment_dataset_quantile_stats"
+
+
+def _write_stats(dataset_root, *, with_quantiles):
+    """Write a minimal v3 meta/stats.json with or without quantile keys."""
+    import os
+
+    stats = {
+        "observation.state": {"mean": [0.0], "std": [1.0], "min": [-1.0], "max": [1.0]},
+        "action": {"mean": [0.0], "std": [1.0], "min": [-1.0], "max": [1.0]},
+    }
+    if with_quantiles:
+        for feat in stats.values():
+            feat["q01"] = [-0.9]
+            feat["q99"] = [0.9]
+    meta = os.path.join(dataset_root, "meta")
+    with open(os.path.join(meta, "stats.json"), "w", encoding="utf-8") as fh:
+        json.dump(stats, fh)
+
+
+class TestQuantileStatsPreflight:
+    """A QUANTILES-normalizing policy (molmoact2, pi05) needs the dataset stats
+    to carry quantile keys; validate() must flag a definite miss at spec time
+    instead of letting it fail deep inside lerobot's normalization.
+    """
+
+    def test_quantile_policy_missing_stats_flagged(self, spec):
+        spec.extra["policy_type"] = "molmoact2"
+        _write_stats(spec.dataset_root, with_quantiles=False)
+        problems = LerobotTrainer().validate(spec)
+        offending = [p for p in problems if _AUGMENT_HINT in p]
+        assert offending, f"expected augment-script guidance, got {problems}"
+        assert "QUANTILES" in offending[0]
+        assert spec.dataset_root in offending[0]
+
+    def test_quantile_policy_with_stats_is_clean(self, spec):
+        spec.extra["policy_type"] = "molmoact2"
+        _write_stats(spec.dataset_root, with_quantiles=True)
+        problems = LerobotTrainer().validate(spec)
+        assert not any(_AUGMENT_HINT in p for p in problems), problems
+
+    def test_pi05_missing_stats_flagged(self, spec):
+        spec.extra["policy_type"] = "pi05"
+        _write_stats(spec.dataset_root, with_quantiles=False)
+        problems = LerobotTrainer().validate(spec)
+        assert any(_AUGMENT_HINT in p for p in problems), problems
+
+    def test_non_quantile_policy_not_flagged(self, spec):
+        # act normalizes with MEAN_STD/MIN_MAX; a pre-quantile dataset is fine.
+        spec.extra["policy_type"] = "act"
+        _write_stats(spec.dataset_root, with_quantiles=False)
+        problems = LerobotTrainer().validate(spec)
+        assert not any(_AUGMENT_HINT in p for p in problems), problems
+
+    def test_no_local_stats_json_not_flagged(self, spec):
+        # meta/stats.json absent -> unknown (e.g. Hub dataset) -> no false positive.
+        spec.extra["policy_type"] = "molmoact2"
+        problems = LerobotTrainer().validate(spec)
+        assert not any(_AUGMENT_HINT in p for p in problems), problems
+
+
+class TestQuantileHelpers:
+    def test_policy_uses_quantile_norm_live_registry(self):
+        from strands_robots.training.lerobot import _policy_uses_quantile_norm
+
+        assert _policy_uses_quantile_norm("molmoact2") is True
+        assert _policy_uses_quantile_norm("pi05") is True
+        assert _policy_uses_quantile_norm("act") is False
+
+    def test_stats_have_quantiles(self):
+        from strands_robots.training.lerobot import _stats_have_quantiles
+
+        assert _stats_have_quantiles({"action": {"mean": [0.0], "q01": [-1.0]}}) is True
+        assert _stats_have_quantiles({"action": {"mean": [0.0], "std": [1.0]}}) is False
+        assert _stats_have_quantiles(None) is False
+
+    def test_dataset_quantile_stats_present_tristate(self, tmp_path):
+        import os
+
+        from strands_robots.training.lerobot import _dataset_quantile_stats_present
+
+        root = str(tmp_path)
+        assert _dataset_quantile_stats_present(root) is None  # no stats.json
+        os.makedirs(os.path.join(root, "meta"))
+        _write_stats(root, with_quantiles=False)
+        assert _dataset_quantile_stats_present(root) is False
+        _write_stats(root, with_quantiles=True)
+        assert _dataset_quantile_stats_present(root) is True
+
+
 class TestBuildCommand:
     def test_single_gpu_core_flags(self, spec):
         cmd = LerobotTrainer(device="cpu").build_command(spec)


### PR DESCRIPTION
## Problem

Some LeRobot policies normalize `STATE`/`ACTION` with `NormalizationMode.QUANTILES` (currently `molmoact2` and `pi05`) rather than mean/std or min/max. Quantile normalization reads the dataset stats' quantile keys (`q01`..`q99`).

Fine-tuning such a policy on a dataset recorded **before quantile stats existed** fails or mis-normalizes: the dataset's `meta/stats.json` carries only `mean`/`std`/`min`/`max`, so the failure surfaces deep inside lerobot's normalization stack at train time instead of at spec-validation time. `LerobotTrainer.validate()` did no stats validation, and there was no reference to lerobot's remedy script.

## Change

`LerobotTrainer.validate()` now preflights the dataset's quantile stats. When the resolved policy normalizes with quantiles and a local `meta/stats.json` lacks the quantile keys, it returns an actionable problem naming lerobot's remedy with the exact command:

```
policy_type 'molmoact2' normalizes STATE/ACTION with QUANTILES but the dataset at
'/data/ds' has no quantile stats (missing q01/q99 in meta/stats.json); lerobot would
mis-normalize or fail at train time. Add quantile stats first: python -m
lerobot.scripts.augment_dataset_quantile_stats --repo-id=<id> --root=/data/ds
(datasets recorded with current lerobot already include them).
```

Design notes:

- **Live discovery, zero per-type maintenance.** Quantile-normalization support is probed off the policy config *class*'s `normalization_mapping` field default (a `dataclasses.field` `default_factory` call, no instantiation, no device warnings), so any policy lerobot adds with quantile normalization is recognized automatically. A documented static fallback (`molmoact2`, `pi05`) covers the offline case where lerobot's registry is unavailable and training can't run anyway.
- **Conservative, tri-state stats probe.** Reads `meta/stats.json` (lerobot's `STATS_PATH`). Flags only a *definite* miss (file present but lacking quantile keys). A Hub dataset with no materialized local cache is left unflagged (stats unknown without a download; lerobot verifies quantiles when the shards load), avoiding false positives.
- **Read-only.** `validate()` keeps its pure-preflight contract; it fails fast with guidance rather than mutating/pushing the dataset.
- Because the `train_policy` tool and `LerobotTrainer.train()` both gate on `validate()`, the check propagates to every entry point with a single change point.

Datasets recorded by the current `DatasetRecorder` / `Robot.start_recording()` already include quantile stats (lerobot's `compute_episode_stats` computes them by default), so they train `molmoact2` / `pi05` with no manual stats surgery and pass validation cleanly.

## Tests

Adds `TestQuantileStatsPreflight` and `TestQuantileHelpers` in `tests/training/test_lerobot.py` (all fail on pre-fix code):

- molmoact2 / pi05 with a stats.json lacking quantiles -> flagged with augment-script guidance.
- molmoact2 with quantile stats present -> clean.
- non-quantile policy (`act`) with a pre-quantile dataset -> not flagged.
- no local stats.json (Hub/unknown) -> not flagged (no false positive).
- unit tests for `_policy_uses_quantile_norm` (live registry), `_stats_have_quantiles`, and the tri-state `_dataset_quantile_stats_present`.

Full local gate green: `ruff check` + `ruff format --check` clean, `mypy strands_robots/training/lerobot.py` clean, `pytest tests/training/` = 442 passed, 4 skipped.

Docs: adds a "Quantile normalization (molmoact2, pi05)" subsection to `docs/training/overview.md`.