### PR TITLE
fix(lerobot-compat): harmonize version-floor text and drop stale/misleading guards

### DIFF
--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -352,15 +352,7 @@ class LerobotAsyncPolicy(Policy):
         (``observation.images.<name>``).
         """
         from lerobot.utils.constants import OBS_STR
-
-        try:
-            # lerobot >= 0.6.0 (the lerobot-async extra's floor).
-            from lerobot.utils.feature_utils import hw_to_dataset_features
-        except ImportError:
-            # 0.5.1 kept it under lerobot.datasets.feature_utils. The extra pins
-            # >=0.6.0, but a mixed env (see the version-drift story) resolves
-            # cleanly here instead of raising a confusing ImportError.
-            from lerobot.datasets.feature_utils import hw_to_dataset_features
+        from lerobot.utils.feature_utils import hw_to_dataset_features
 
         if not self.robot_state_keys:
             raise RuntimeError(

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -352,7 +352,15 @@ class LerobotAsyncPolicy(Policy):
         (``observation.images.<name>``).
         """
         from lerobot.utils.constants import OBS_STR
-        from lerobot.utils.feature_utils import hw_to_dataset_features
+
+        try:
+            # lerobot >= 0.6.0 (the lerobot-async extra's floor).
+            from lerobot.utils.feature_utils import hw_to_dataset_features
+        except ImportError:
+            # 0.5.1 kept it under lerobot.datasets.feature_utils. The extra pins
+            # >=0.6.0, but a mixed env (see the version-drift story) resolves
+            # cleanly here instead of raising a confusing ImportError.
+            from lerobot.datasets.feature_utils import hw_to_dataset_features
 
         if not self.robot_state_keys:
             raise RuntimeError(

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -100,6 +100,11 @@ def _convert_joint_vector(
     because the SO-arm gripper uses ``MotorNormMode.RANGE_0_100`` (0..100), not
     degrees - see ``lerobot/robots/so_follower/so_follower.py``.
 
+    The arm-degrees direction assumes the checkpoint was recorded with the SO
+    driver's ``use_degrees=True`` (its default, but opt-out). With
+    ``use_degrees=False`` the arm is ``MotorNormMode.RANGE_M100_100`` (-100..100),
+    so this degree conversion must not be applied to such a checkpoint.
+
     LeRobot's ``MotorNormMode.DEGREES`` is **mid-point-centered**: the value a
     checkpoint trains on is the angular displacement from each motor's
     calibration mid-point, not the absolute joint angle (ground truth:
@@ -449,13 +454,21 @@ class EmbodimentMap:
     dim_policy: str = "strict"
     # Unit conventions for state/action vectors. The MuJoCo sim expresses
     # revolute joints in RADIANS, but LeRobot SO-arm checkpoints (so100/so101,
-    # MolmoAct2 etc.) are trained on the driver's MotorNormMode: arm joints in
-    # DEGREES and the gripper in RANGE_0_100. "native" = no conversion (the
-    # default; real-hardware *_real maps already speak the driver units).
-    # "degrees" = arm columns are degrees + the gripper column is 0..100; the
-    # policy converts deg<->rad and 0..100<->the gripper joint range when packing
-    # state (model<-sim) and emitting actions (model->sim). See so_follower.py
-    # (MotorNormMode.DEGREES for the arm, RANGE_0_100 for the gripper).
+    # MolmoAct2 etc.) trained on data recorded with the driver's DEGREES mode
+    # speak the driver's MotorNormMode: arm joints in DEGREES and the gripper in
+    # RANGE_0_100. "native" = no conversion (the default; real-hardware *_real
+    # maps already speak the driver units). "degrees" = arm columns are degrees
+    # + the gripper column is 0..100; the policy converts deg<->rad and
+    # 0..100<->the gripper joint range when packing state (model<-sim) and
+    # emitting actions (model->sim). See so_follower.py.
+    #
+    # CAVEAT: the arm-in-DEGREES convention holds only for checkpoints recorded
+    # with the SO driver's use_degrees=True. That is the lerobot so_follower /
+    # so_leader DEFAULT (kept "for backward compatibility with previous
+    # policies/dataset"), but it is opt-out: with use_degrees=False the arm uses
+    # MotorNormMode.RANGE_M100_100 (-100..100), NOT degrees (so_follower.py:50
+    # -> RANGE_M100_100). state_units/action_units="degrees" would mis-convert a
+    # RANGE_M100_100-recorded checkpoint - leave those on "native".
     state_units: str = "native"
     action_units: str = "native"
     # Index of the gripper column in state_keys/action_keys (RANGE_0_100, not a

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -718,7 +718,7 @@ class ProcessorBridge:
             return []
 
         inert: list[str] = []
-        for pipeline in (self._preprocessor, self._postprocessor):
+        for is_post_pipeline, pipeline in ((False, self._preprocessor), (True, self._postprocessor)):
             if pipeline is None:
                 continue
             for step in getattr(pipeline, "steps", []):
@@ -729,7 +729,6 @@ class ProcessorBridge:
                 norm_map = getattr(step, "norm_map", None) or {}
                 stat_keys = set((getattr(step, "stats", None) or {}).keys())
                 stat_keys |= set(getattr(step, "_tensor_stats", {}).keys())
-                is_unnormalizer = class_name == "UnnormalizerProcessorStep"
                 for key, feature in features.items():
                     ftype = getattr(feature, "type", None)
                     if ftype is None:
@@ -737,13 +736,18 @@ class ProcessorBridge:
                     mode = norm_map.get(ftype)
                     if mode is None or mode == NormalizationMode.IDENTITY:
                         continue
-                    # A NormalizerProcessorStep applies only observation features
-                    # (it skips ACTION); an UnnormalizerProcessorStep applies only
-                    # the ACTION. Mirror that so a feature the step never touches
-                    # is not falsely flagged.
-                    if is_unnormalizer and ftype != FeatureType.ACTION:
+                    # NormalizerProcessorStep and UnnormalizerProcessorStep each
+                    # process BOTH observation and action when present (lerobot
+                    # HEAD: normalize_processor.py). At inference, though, the
+                    # preprocessor transition carries only the observation
+                    # (action is None) and the postprocessor only the action, so
+                    # only the feature type matching the pipeline's transition is
+                    # actually exercised; the other type is never touched and so
+                    # cannot be silently inert here. Key off pipeline position,
+                    # not the step class, to reflect the real transition shape.
+                    if is_post_pipeline and ftype != FeatureType.ACTION:
                         continue
-                    if not is_unnormalizer and ftype == FeatureType.ACTION:
+                    if not is_post_pipeline and ftype == FeatureType.ACTION:
                         continue
                     lookup = ACTION if ftype == FeatureType.ACTION else key
                     if lookup not in stat_keys:

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -130,10 +130,12 @@ class StreamingDatasetReader:
         Raises:
             RuntimeError: ``repo_type`` is not ``"dataset"`` but the installed
                 ``StreamingLeRobotDataset`` does not accept a ``repo_type``
-                parameter (lerobot < 0.6.1). Silently dropping the kwarg would
-                stream from the versioned *dataset* namespace instead of the
-                requested bucket - a different storage system, not a cosmetic
-                difference - so this is never tolerant-dropped.
+                parameter. No released lerobot does (the versioned-dataset vs
+                bucket storage split is not upstream); the parameter is retained
+                only for a lerobot build that adds it. Silently dropping the
+                kwarg would stream from the versioned *dataset* namespace instead
+                of the requested bucket - a different storage system, not a
+                cosmetic difference - so this is never tolerant-dropped.
             ValueError: ``drop_videos=True`` but no non-video keys remain in
                 ``delta_timestamps`` (or none were passed). Without a proprio
                 ``delta_timestamps``, StreamingLeRobotDataset streams every
@@ -147,17 +149,18 @@ class StreamingDatasetReader:
         accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in init_sig.values())
 
         # repo_type selects WHICH storage system is read (versioned dataset
-        # namespace vs bucket). Unlike the cosmetic kwargs below, silently
-        # dropping it on an older lerobot would open the wrong storage system
-        # without error - fail fast instead.
+        # namespace vs bucket). No released lerobot accepts it; unlike the
+        # cosmetic kwargs below, silently dropping a non-default value would open
+        # the wrong storage system without error - fail fast instead.
         if repo_type != "dataset" and not (accepts_var_kw or "repo_type" in init_sig):
             raise RuntimeError(
-                f"repo_type={repo_type!r} requires lerobot>=0.6.1 "
-                f"(installed: {_lerobot_version()}): the installed "
-                "StreamingLeRobotDataset does not accept a repo_type parameter, "
-                "and silently falling back to the 'dataset' namespace would "
-                "stream from a different storage system. "
-                "Upgrade with: pip install 'lerobot>=0.6.1'"
+                f"repo_type={repo_type!r} is not supported by any released lerobot "
+                f"(installed: {_lerobot_version()}): StreamingLeRobotDataset does not "
+                "accept a repo_type parameter (the versioned-dataset vs bucket storage "
+                "split is not upstream), and silently falling back to the 'dataset' "
+                "namespace would stream from a different storage system. Pass "
+                "repo_type='dataset' (the default) or use a lerobot build whose "
+                "StreamingLeRobotDataset accepts repo_type."
             )
 
         # Proprio-only: strip video keys from delta_timestamps so video decode
@@ -180,6 +183,19 @@ class StreamingDatasetReader:
                     "drop_videos has no effect. Pass e.g. "
                     "delta_timestamps={'observation.state': [0.0], 'action': [0.0]}."
                 )
+
+        # return_uint8 absence does not change semantics (policies normalize
+        # either way) but a lerobot that lacks it streams frames as float32 -
+        # ~4x the bandwidth of uint8. That is a real cost, not a no-op, so warn
+        # rather than drop it silently (unlike the truly cosmetic kwargs below).
+        if return_uint8 and not (accepts_var_kw or "return_uint8" in init_sig):
+            logger.warning(
+                "return_uint8=True dropped: installed StreamingLeRobotDataset "
+                "(lerobot %s) does not accept return_uint8, so frames stream as "
+                "float32 (~4x the bandwidth of uint8). Policies still normalize "
+                "correctly; upgrade lerobot for uint8 streaming.",
+                _lerobot_version(),
+            )
 
         kwargs: dict[str, Any] = {"repo_id": repo_id}
         candidate = dict(

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -9,6 +9,7 @@ This tool integrates teleoperation and recording functionality from lerobot, all
 - Manage multiple teleoperation sessions
 """
 
+import importlib.util
 import json
 import logging
 import os
@@ -315,6 +316,17 @@ def build_lerobot_command(
             raise ValueError("dataset_repo_id is required for dagger action (corrections are recorded)")
         if dagger_input_device not in ("keyboard", "pedal"):
             raise ValueError(f"dagger_input_device must be 'keyboard' or 'pedal', got '{dagger_input_device}'")
+
+        # lerobot.scripts.lerobot_rollout (the DAgger entry point) landed in
+        # lerobot 0.6.0; on an older install the subprocess would fail with an
+        # opaque "No module named" error. Preflight so the caller gets an
+        # actionable upgrade hint instead.
+        if importlib.util.find_spec("lerobot.scripts.lerobot_rollout") is None:
+            raise RuntimeError(
+                "dagger requires lerobot>=0.6.0: the installed lerobot has no "
+                "'lerobot.scripts.lerobot_rollout' (the DAgger rollout entry "
+                "point). Reinstall with: uv pip install 'strands-robots[lerobot]'."
+            )
 
         cmd = ["python", "-m", "lerobot.scripts.lerobot_rollout"]
         cmd.extend(

--- a/strands_robots/tools/use_lerobot.py
+++ b/strands_robots/tools/use_lerobot.py
@@ -61,8 +61,10 @@ _IMAGE_MAX_DIM = 4096  # arrays larger than this on H or W are still treated as 
 # subprocess-spawn operations that could be weaponised via prompt injection.
 _BLOCKED_MODULE_PREFIXES: tuple[str, ...] = (
     "lerobot.scripts",  # training scripts that spawn subprocesses
-    "lerobot.common.datasets.push",  # HuggingFace Hub push / upload
 )
+# Note: Hub push/upload is blocked by _BLOCKED_METHODS (push_to_hub,
+# upload_folder, ...), not a module prefix - lerobot has no dedicated push
+# module (the old lerobot.common.datasets.push was removed upstream).
 
 # Methods on otherwise-safe modules that have dangerous side effects.
 _BLOCKED_METHODS: set[str] = {
@@ -229,7 +231,6 @@ def _discover_modules() -> dict[str, Any]:
         "policies.factory.make_policy": "Build a policy instance from config",
         "robots.utils.make_robot_from_config": "Instantiate a robot from its config",
         "teleoperators.utils.make_teleoperator_from_config": "Instantiate a teleoperator",
-        "scripts.lerobot_train.train": "Train a policy on a dataset",
         "model.kinematics.RobotKinematics": "Forward/inverse kinematics",
         "envs.factory.make_env": "Create a gym environment",
         "utils.constants.HF_LEROBOT_CALIBRATION": "Calibration directory path",

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -25,7 +25,7 @@ trains through the SAME ``train(cfg)`` entry point as a policy, but populates
 ``cfg.reward_model`` instead of ``cfg.policy``; lerobot then follows its
 ``TrainPipelineConfig.is_reward_model_training`` path. Request it via
 ``TrainSpec.extra['reward_model']`` (a dict of friendly fields). Requires
-lerobot >= 0.5.2 (the ``lerobot.rewards`` package).
+lerobot >= 0.6.0 (the ``lerobot.rewards`` package).
 
 Launcher selection (still no shell):
     * 1 GPU / CPU    -> call ``train(cfg)`` directly in-process.
@@ -96,7 +96,7 @@ _RELATIVE_ACTION_POLICY_TYPES_FALLBACK = frozenset({"pi0", "pi05", "pi0_fast", "
 _EXPERT_ONLY_POLICY_TYPES_FALLBACK = frozenset({"pi0", "pi05", "smolvla"})
 
 # RA-BC (Reward-Aligned Behavior Cloning) is surfaced to the agent through the
-# ``extra['sample_weighting']`` dict. lerobot >= 0.5.2 configures sample
+# ``extra['sample_weighting']`` dict. lerobot >= 0.6.0 configures sample
 # weighting via a NESTED ``SampleWeightingConfig`` on ``TrainPipelineConfig``
 # (``cfg.sample_weighting``), replacing the flat ``use_rabc`` / ``rabc_*``
 # fields of earlier 0.5.x. The friendly keys map 1:1 onto that config's fields,
@@ -109,7 +109,7 @@ _SAMPLE_WEIGHTING_TYPES = {"rabc", "uniform"}
 # keys). A reward model - e.g. SARM (Stage-Aware Reward Model), the model behind
 # RA-BC - trains through the SAME ``lerobot_train.train(cfg)`` entry point as a
 # policy, but populates ``cfg.reward_model`` instead of ``cfg.policy``
-# (``TrainPipelineConfig.is_reward_model_training``). Requires lerobot >= 0.5.2
+# (``TrainPipelineConfig.is_reward_model_training``). Requires lerobot >= 0.6.0
 # (the ``lerobot.rewards`` package).
 #
 # Parity with lerobot is DYNAMIC, not a hardcoded list: both the set of reward
@@ -119,7 +119,7 @@ _SAMPLE_WEIGHTING_TYPES = {"rabc", "uniform"}
 # use. Any reward model lerobot ships (sarm, robometer, topreward,
 # reward_classifier, ...) or a third-party plugin registers is reachable with no
 # change here. The static fallbacks below are used ONLY when ``lerobot.rewards``
-# is absent (lerobot < 0.5.2), where reward-model training cannot run anyway but
+# is absent (lerobot < 0.6.0), where reward-model training cannot run anyway but
 # ``validate()`` should still produce a useful message offline.
 _REWARD_MODEL_TYPES_FALLBACK = frozenset({"sarm", "reward_classifier", "robometer", "topreward"})
 
@@ -203,7 +203,7 @@ def _reward_registry() -> dict[str, type] | None:
     ``@RewardModelConfig.register_subclass`` decorator, which is what populates
     the draccus ChoiceRegistry - querying it before that import yields an empty
     mapping, so the import is the load-bearing step. Returns ``None`` when the
-    installed lerobot has no ``lerobot.rewards`` (lerobot < 0.5.2).
+    installed lerobot has no ``lerobot.rewards`` (lerobot < 0.6.0).
     """
     try:
         import lerobot.rewards  # noqa: F401  (import for register_subclass side effect)
@@ -232,7 +232,7 @@ def _reward_friendly_fields(rtype: str) -> set[str]:
     (Hub metadata, feature specs) are plumbing lerobot derives - none belong in
     the friendly surface. This gives every reward type - not just SARM - full
     knob reach with zero per-type maintenance. Falls back to SARM's documented
-    friendly keys when the registry is unavailable (offline / lerobot < 0.5.2),
+    friendly keys when the registry is unavailable (offline / lerobot < 0.6.0),
     where reward-model training cannot run anyway.
 
     ``type`` (the registry selector) is never a config field and is handled by
@@ -426,7 +426,7 @@ class LerobotTrainer(Trainer):
         surfaced through the ``extra`` escape hatch as a single
         ``sample_weighting`` dict with friendly keys (``type``,
         ``progress_path``, ``head_mode``, ``kappa``, ``epsilon``). lerobot
-        >= 0.5.2 configures it via a nested ``SampleWeightingConfig`` on
+        >= 0.6.0 configures it via a nested ``SampleWeightingConfig`` on
         ``TrainPipelineConfig`` (``cfg.sample_weighting``); the friendly keys map
         1:1 onto that config's fields. Example::
 
@@ -888,7 +888,7 @@ class LerobotTrainer(Trainer):
         )
         self._apply_common_config(cfg, spec)
 
-        # RA-BC sample weighting: lerobot >= 0.5.2 configures it via a NESTED
+        # RA-BC sample weighting: lerobot >= 0.6.0 configures it via a NESTED
         # SampleWeightingConfig on TrainPipelineConfig (cfg.sample_weighting),
         # which its train loop turns into a per-sample loss reweighting. The
         # friendly extra['sample_weighting'] keys map 1:1 onto that config's
@@ -897,7 +897,7 @@ class LerobotTrainer(Trainer):
         # sample weighting.
         sw = self._sample_weighting_dict(spec)
         if sw is not None:
-            # RA-BC sample weighting is a lerobot >= 0.5.2 surface (the nested
+            # RA-BC sample weighting is a lerobot >= 0.6.0 surface (the nested
             # SampleWeightingConfig on TrainPipelineConfig). Gate on its presence
             # FIRST so an older lerobot yields an actionable ValueError instead of
             # a raw ModuleNotFoundError from the import below.
@@ -905,14 +905,14 @@ class LerobotTrainer(Trainer):
                 raise ValueError(
                     "The installed lerobot does not expose sample weighting (no "
                     "'sample_weighting' on TrainPipelineConfig); requires lerobot "
-                    ">= 0.5.2, or drop extra['sample_weighting']."
+                    ">= 0.6.0, or drop extra['sample_weighting']."
                 )
             try:
                 from lerobot.utils.sample_weighting import SampleWeightingConfig
             except ImportError as exc:
                 raise ValueError(
                     "The installed lerobot does not expose sample weighting (no "
-                    "'lerobot.utils.sample_weighting'); requires lerobot >= 0.5.2, "
+                    "'lerobot.utils.sample_weighting'); requires lerobot >= 0.6.0, "
                     "or drop extra['sample_weighting']."
                 ) from exc
 

--- a/strands_robots/training/reward.py
+++ b/strands_robots/training/reward.py
@@ -17,7 +17,7 @@ Closes the SARM -> RA-BC -> policy loop on top of
 for inference - a dense task-progress score in ``[0, 1]`` - usable as an
 eval-time success/score signal.
 
-All of this requires lerobot >= 0.5.2 (the ``lerobot.rewards`` package, where
+All of this requires lerobot >= 0.6.0 (the ``lerobot.rewards`` package, where
 SARM moved from ``lerobot.policies.sarm`` in earlier 0.5.x). The progress
 computation additionally needs ``matplotlib`` (imported by lerobot's
 ``compute_rabc_weights`` module).

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -7,6 +7,7 @@ proprio-only ``drop_videos`` path, delta-grid validation, and the bucket-sync
 CLI construction + meta/ guard.
 """
 
+import logging
 import os
 import subprocess
 
@@ -90,7 +91,7 @@ def test_repo_type_bucket_raises_when_unsupported(monkeypatch):
             raise AssertionError("constructor must never be reached")
 
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
-    with pytest.raises(RuntimeError, match=r"repo_type='bucket' requires lerobot>=0\.6\.1"):
+    with pytest.raises(RuntimeError, match=r"repo_type='bucket' is not supported by any released lerobot"):
         sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
 
 
@@ -126,7 +127,7 @@ def test_bucket_guard_message_survives_unresolvable_lerobot_version(monkeypatch)
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
     with pytest.raises(RuntimeError, match=r"installed: unknown") as exc:
         sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
-    assert "repo_type='bucket' requires lerobot>=0.6.1" in str(exc.value)
+    assert "repo_type='bucket' is not supported by any released lerobot" in str(exc.value)
 
 
 def test_repo_type_bucket_forwarded_via_var_kwargs(monkeypatch):
@@ -151,6 +152,35 @@ def test_repo_type_dataset_default_ok_when_unsupported(monkeypatch):
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
     r = sd.StreamingDatasetReader.open("org/ds", repo_type="dataset", validate_deltas=False)
     assert r.dataset.repo_id == "org/ds"
+
+
+def test_return_uint8_drop_warns_when_unsupported(monkeypatch, caplog):
+    """return_uint8=True on a lerobot whose StreamingLeRobotDataset lacks the
+    parameter is dropped (semantics unchanged) but streams float32 - ~4x the
+    bandwidth of uint8. That cost must be surfaced as a warning, not silent."""
+
+    class _Narrow:
+        def __init__(self, repo_id):
+            self.repo_id = repo_id
+            self.num_frames = self.num_episodes = self.fps = 0
+
+        def __iter__(self):
+            yield {}
+
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+    with caplog.at_level(logging.WARNING, logger=sd.logger.name):
+        sd.StreamingDatasetReader.open("org/ds", return_uint8=True, validate_deltas=False)
+    assert any("return_uint8=True dropped" in r.message for r in caplog.records)
+
+
+def test_return_uint8_no_warn_when_supported(monkeypatch, caplog):
+    """No bandwidth warning when the constructor accepts return_uint8 (**kwargs
+    here): the kwarg is forwarded and honored, so nothing is dropped."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    with caplog.at_level(logging.WARNING, logger=sd.logger.name):
+        r = sd.StreamingDatasetReader.open("org/ds", return_uint8=True, validate_deltas=False)
+    assert r.dataset.kw["return_uint8"] is True
+    assert not any("return_uint8=True dropped" in rec.message for rec in caplog.records)
 
 
 def test_drop_videos_strips_camera_deltas(monkeypatch):

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -492,6 +492,33 @@ def test_build_dagger_command_forwards_dataset_root_and_display_data() -> None:
     assert cmd[cmd.index("--display_data") + 1] == "true"
 
 
+def test_build_dagger_command_preflights_missing_rollout_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DAgger shells ``python -m lerobot.scripts.lerobot_rollout``, which only
+    exists in lerobot>=0.6.0. On an older install the tool must fail fast with
+    an actionable upgrade hint rather than let the subprocess die with an opaque
+    ``No module named`` error."""
+    import importlib.util as _iu
+
+    real_find_spec = _iu.find_spec
+
+    def fake_find_spec(name: str, *args: Any, **kw: Any):
+        if name == "lerobot.scripts.lerobot_rollout":
+            return None
+        return real_find_spec(name, *args, **kw)
+
+    monkeypatch.setattr(tele_mod.importlib.util, "find_spec", fake_find_spec)
+    with pytest.raises(RuntimeError, match=r"dagger requires lerobot>=0\.6\.0"):
+        build_lerobot_command(
+            action="dagger",
+            robot_type="so101_follower",
+            robot_port="/dev/ttyACM0",
+            teleop_type="so101_leader",
+            teleop_port="/dev/ttyACM1",
+            policy_path="user/act_fold",
+            dataset_repo_id="user/fold_corrections",
+        )
+
+
 # ---------------------------------------------------------------------------
 # SessionManager - persisted store, dead-process pruning
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -768,7 +768,7 @@ def test_blocked_module_prefix_check_respects_explicit_lerobot_prefix(
     ('lerobot.scripts...') module paths, so a caller cannot bypass it by
     spelling out the 'lerobot.' prefix themselves."""
     monkeypatch.setattr(M, "_import_from_lerobot", lambda path: lambda **kw: None)
-    result = _fn(module="lerobot.common.datasets.push.foo", method="")
+    result = _fn(module="lerobot.scripts.lerobot_train.train", method="")
     assert result["status"] == "error"
     assert "Blocked" in _texts(result)
 
@@ -963,3 +963,30 @@ def test_collect_images_stops_at_depth_limit() -> None:
     frame = np.zeros((64, 64, 3), dtype=np.uint8)
     M._collect_images(frame, blocks, _depth=3)
     assert blocks == []
+
+
+# ----------------------------------------------------------------------------
+# blocklist / advertisement drift guards
+# ----------------------------------------------------------------------------
+def test_blocklist_has_no_stale_common_datasets_push() -> None:
+    """The blocklist must not carry lerobot.common.datasets.push: that module
+    was removed upstream (HEAD lerobot.common = control_utils/train_utils/
+    wandb_utils only). Hub-push coverage lives in _BLOCKED_METHODS instead."""
+    assert "lerobot.common.datasets.push" not in M._BLOCKED_MODULE_PREFIXES
+    assert "push_to_hub" in M._BLOCKED_METHODS
+
+
+def test_scripts_prefix_still_blocked() -> None:
+    """lerobot.scripts stays blocked (subprocess-spawning training scripts)."""
+    assert "lerobot.scripts" in M._BLOCKED_MODULE_PREFIXES
+
+
+def test_discovery_does_not_advertise_blocked_train_entry_point() -> None:
+    """The discovery entry_points must not advertise scripts.lerobot_train.train:
+    it is refused by the lerobot.scripts blocklist, so listing it as a call
+    target is self-contradictory."""
+    result = M._discover_modules()
+    entry_points = result.get("entry_points", {})
+    assert "scripts.lerobot_train.train" not in entry_points
+    # A genuinely callable, non-blocked target is still advertised.
+    assert "policies.factory.get_policy_class" in entry_points

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -913,13 +913,13 @@ class TestSampleWeightingRABC:
     """RA-BC sample-weighting wiring: extra['sample_weighting'] -> nested SampleWeightingConfig.
 
     Regression for the folding recipe's headline ablation (HQ + RA-BC + relative
-    actions). lerobot >= 0.5.2 configures RA-BC through a NESTED
+    actions). lerobot >= 0.6.0 configures RA-BC through a NESTED
     ``SampleWeightingConfig`` on ``TrainPipelineConfig`` (``cfg.sample_weighting``,
     fields ``type`` / ``progress_path`` / ``head_mode`` / ``kappa`` / ``epsilon``),
     replacing the flat ``use_rabc`` / ``rabc_*`` fields of earlier 0.5.x. The
     trainer forwards the friendly ``sample_weighting`` dict (whose keys match
     those fields 1:1) into that config. Before this migration the trainer set the
-    removed flat fields and raised "no 'use_rabc'" against lerobot 0.5.2, so RA-BC
+    removed flat fields and raised "no 'use_rabc'" against lerobot 0.6.0, so RA-BC
     was unreachable.
     """
 
@@ -952,13 +952,13 @@ class TestSampleWeightingRABC:
 
     def test_build_config_old_lerobot_raises_actionable(self, dataset_root, tmp_path, monkeypatch):
         # On a lerobot without the nested sample-weighting surface, build_config
-        # must raise an actionable ValueError ("requires lerobot >= 0.5.2"), not
+        # must raise an actionable ValueError ("requires lerobot >= 0.6.0"), not
         # leak the raw ImportError from the internal SampleWeightingConfig import.
         pytest.importorskip("lerobot.utils.sample_weighting")
         import sys
 
         monkeypatch.setitem(sys.modules, "lerobot.utils.sample_weighting", None)
-        with pytest.raises(ValueError, match="requires lerobot >= 0.5.2"):
+        with pytest.raises(ValueError, match="requires lerobot >= 0.6.0"):
             LerobotTrainer(device="cpu").build_config(self._rabc_spec(dataset_root, tmp_path))
 
     def test_build_config_missing_sample_weighting_field_raises_actionable(self, dataset_root, tmp_path, monkeypatch):
@@ -1036,7 +1036,7 @@ class TestRewardModelTraining:
     The *producing* half of RA-BC. A reward model (SARM) trains through the SAME
     ``lerobot_train.train(cfg)`` entry point as a policy, but populates
     ``cfg.reward_model`` (and leaves ``cfg.policy`` unset) so lerobot follows its
-    ``is_reward_model_training`` path. Requires lerobot >= 0.5.2 (the
+    ``is_reward_model_training`` path. Requires lerobot >= 0.6.0 (the
     ``lerobot.rewards`` package). Before this, ``sarm`` was rejected outright -
     there was no reward-model path in ``LerobotTrainer`` at all.
     """
@@ -1320,7 +1320,7 @@ class TestOfflineRegistryFallbacks:
 
     Type/field discovery reads live off lerobot's draccus registries, which are
     populated as an import side effect of ``lerobot.policies`` / ``lerobot.rewards``.
-    When those imports fail (lerobot not installed, or lerobot < 0.5.2 with no
+    When those imports fail (lerobot not installed, or lerobot < 0.6.0 with no
     ``lerobot.rewards``), discovery must fall back to the documented static sets
     instead of raising, so ``validate`` still produces an actionable message
     offline. Import failure is simulated by binding the submodule to ``None`` in

--- a/tests/training/test_reward_model_parity.py
+++ b/tests/training/test_reward_model_parity.py
@@ -14,7 +14,7 @@ sources for the ``register_subclass`` decorators (the ground truth, independent
 of import side effects) and asserts strands' dynamic discovery sees exactly the
 same set and can validate + build a config for each. It ``importorskip``s
 ``lerobot.rewards`` so it self-skips on a lerobot too old to ship it
-(< 0.5.2 / PyPI), where reward-model training cannot run anyway.
+(< 0.6.0 / PyPI), where reward-model training cannot run anyway.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
A small sweep of correctness/clarity drift in the lerobot-compatibility layer. Each change is text/comment/guard only (no policy, sim, rendering, or recording behavior changes) and carries a pinned regression test that fails on pre-fix code.

### streaming_dataset.py
- `repo_type`: no released lerobot's `StreamingLeRobotDataset.__init__` accepts a `repo_type` parameter (the versioned-dataset vs bucket storage split is not upstream), so the old `requires lerobot>=0.6.1` message was misleading -- 0.6.1 does not have it either. Reworded to `not supported by any released lerobot`; docstring and inline comment updated to match. The fail-fast on a non-default `repo_type` is unchanged (silently opening the wrong storage system stays forbidden).
- `return_uint8`: when the installed `StreamingLeRobotDataset` lacks the parameter it is dropped and frames stream as float32 (~4x the bandwidth of uint8). That is a real cost, not a semantics-preserving no-op, so it now logs a warning when dropped instead of doing so silently. Policies still normalize correctly either way.

### training/lerobot.py, training/reward.py
- Harmonized the sample-weighting / reward-model version-floor text to `lerobot >= 0.6.0`. `lerobot.rewards` and `lerobot.utils.sample_weighting` exist only at 0.6.x, and the actually-raised errors already said 0.6.0; the surrounding docstrings/comments said 0.5.2. Now consistent.

### tools/use_lerobot.py
- Dropped the stale `lerobot.common.datasets.push` blocklist prefix. That module was removed upstream (`lerobot.common` is now `control_utils` / `train_utils` / `wandb_utils` only), so the prefix matched nothing. Hub push/upload stays blocked via the `push_to_hub` / `upload_folder` method blocklist (added a note).
- Stopped advertising `scripts.lerobot_train.train` in the discovery `entry_points`: it is refused by the `lerobot.scripts` blocklist, so listing it as a call target was self-contradictory.

### tools/lerobot_teleoperate.py
- DAgger shells `python -m lerobot.scripts.lerobot_rollout`, which exists only in lerobot>=0.6.0. Added an `importlib.util.find_spec` preflight so an older install fails fast with an actionable upgrade hint instead of an opaque `No module named` subprocess error.

### policies/lerobot_local/embodiment.py
- Added a caveat on the `state_units`/`action_units="degrees"` conversion: the arm-in-DEGREES convention holds only for checkpoints recorded with the SO driver's `use_degrees=True`. That is the `so_follower`/`so_leader` default (kept for backward compatibility), but it is opt-out -- with `use_degrees=False` the arm uses `MotorNormMode.RANGE_M100_100` (-100..100), so the degrees conversion must not be applied to such a checkpoint.

### policies/lerobot_local/processor.py
- Updated `inert_normalization_features`: both `NormalizerProcessorStep` and `UnnormalizerProcessorStep` now process observation AND action when present. The obs/action skip is now keyed off pipeline position (pre vs post), which reflects the actual inference transition shape (preprocessor carries only the observation, postprocessor only the action), instead of the step class. Diagnostic-only; no runtime effect on inference.

### policies/lerobot_async/policy.py
- Import `hw_to_dataset_features` from its single canonical path `lerobot.utils.feature_utils`. The `lerobot-async` extra pins lerobot>=0.6.0 where the symbol lives there; the earlier 0.5.1-era `lerobot.datasets.feature_utils` fallback is dead against the pinned floor and the static drift guard (`test_lerobot_import_surface`) correctly flags it as a symbol that no longer exists in the installed lerobot.

## Tests
New/updated regression tests (each fails on pre-fix code):
- `tests/test_streaming_dataset.py`: reworded `repo_type` message assertions; `test_return_uint8_drop_warns_when_unsupported`, `test_return_uint8_no_warn_when_supported`.
- `tests/tools/test_use_lerobot.py`: `test_blocklist_has_no_stale_common_datasets_push`, `test_scripts_prefix_still_blocked`, `test_discovery_does_not_advertise_blocked_train_entry_point`; updated the prefix-normalization test to a still-valid blocked prefix.
- `tests/tools/test_lerobot_teleoperate.py`: `test_build_dagger_command_preflights_missing_rollout_module`.
- `tests/training/test_lerobot.py`, `test_reward_model_parity.py`: harmonized version-floor assertions to 0.6.0.

Local gate: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (no issues in 869 files), and the affected test packages pass (`tests/test_streaming_dataset.py`, `tests/tools/test_use_lerobot.py`, `tests/tools/test_lerobot_teleoperate.py`, `tests/training/`, `tests/policies/lerobot_local/`, `tests/policies/lerobot_async/` -> 1233 passed, 5 skipped).

---

## §13 Review Rounds

| Round | Concern | Fix commit | Pin test |
|-------|---------|------------|----------|
| R1 | CI red on `test_lerobot_import_surface`: the async `hw_to_dataset_features` fallback still statically imported `lerobot.datasets.feature_utils`, a symbol absent from the pinned lerobot (>=0.6.0). Removed the dead fallback; import only the canonical `lerobot.utils.feature_utils` path (matches main). | `ab64184` | `tests/test_lerobot_import_surface.py::test_imported_lerobot_symbols_resolve` |