### PR TITLE
fix(_dyld): never re-exec stdin programs (python -) — silent no-op exit 0

### DIFF
--- a/strands_robots/_dyld.py
+++ b/strands_robots/_dyld.py
@@ -94,9 +94,13 @@ def _is_safe_to_reexec() -> bool:
     # Test runners - re-exec would detach from the collector.
     if "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ:
         return False
-    # ``python -c '...'`` sets argv[0] to '-c'; nothing safe to re-run.
+    # ``python -c '...'`` sets argv[0] to '-c' and ``python -`` / ``cmd |
+    # python`` / ``python - <<EOF`` set it to '-' (program read from stdin).
+    # Re-exec'ing either replays a stdin that has already been consumed, so the
+    # fresh interpreter reads EOF and exits 0 having run nothing - a silent
+    # no-op. Neither is safe to re-run; export the env var for children instead.
     argv0 = sys.argv[0] if sys.argv else ""
-    if argv0 in ("", "-c"):
+    if argv0 in ("", "-c", "-"):
         return False
     return True
 

--- a/tests/test_dyld_ffmpeg_shim.py
+++ b/tests/test_dyld_ffmpeg_shim.py
@@ -106,6 +106,20 @@ def test_is_safe_to_reexec_false_for_dash_c(monkeypatch):
     assert _dyld._is_safe_to_reexec() is False
 
 
+def test_is_safe_to_reexec_false_for_stdin_dash(monkeypatch):
+    """``python -`` / ``cmd | python`` / ``python - <<EOF`` set argv[0] to '-'.
+
+    Re-exec'ing would replay an already-consumed stdin, so the fresh
+    interpreter reads EOF and exits 0 having run nothing. That silent no-op is
+    exactly the failure this guard prevents, so a stdin program is never safe
+    to re-run.
+    """
+    _clear_reexec_blockers(monkeypatch)
+    monkeypatch.setattr(_dyld.sys, "argv", ["-"])
+
+    assert _dyld._is_safe_to_reexec() is False
+
+
 def _arm_macos_ffmpeg(monkeypatch, tmp_path):
     """Set up the happy path: macOS + torchcodec + ffmpeg dir, no opt-out/guard."""
     monkeypatch.setattr(_dyld.sys, "platform", "darwin")
@@ -178,3 +192,19 @@ def test_ensure_noop_when_no_ffmpeg_dir(monkeypatch):
 
     assert _dyld.ensure_ffmpeg_on_dyld_path() is False
     assert _dyld._DYLD_VAR not in _dyld.os.environ
+
+
+def test_ensure_does_not_reexec_stdin_program(monkeypatch, tmp_path):
+    """Regression: a ``python -`` (stdin) invocation must export the child env
+    but never re-exec, which would silently discard the already-read program.
+    """
+    _arm_macos_ffmpeg(monkeypatch, tmp_path)
+    _clear_reexec_blockers(monkeypatch)
+    monkeypatch.setattr(_dyld.sys, "argv", ["-"])
+    monkeypatch.setattr(_dyld.os, "execv", lambda *a: pytest.fail("must not re-exec a stdin program"))
+
+    result = _dyld.ensure_ffmpeg_on_dyld_path()
+
+    # Child processes still inherit the ffmpeg dir; current process is untouched.
+    assert result is False
+    assert str(tmp_path) in _dyld.os.environ[_dyld._DYLD_VAR]


### PR DESCRIPTION
## Problem

`strands_robots._dyld._is_safe_to_reexec()` rejected `argv0 in ("", "-c")` but not `"-"`. `"-"` is what CPython sets `sys.argv[0]` to when the program is read from stdin — `python -`, `cmd | python`, and `python - <<EOF`.

When the macOS dyld ffmpeg shim decided a re-exec was needed, it ran `os.execv(sys.executable, [sys.executable, "-"])`. But stdin had already been consumed to reach the `import strands_robots` line, so the fresh interpreter read EOF and exited 0 having executed nothing further. Any heredoc or pipe wrapper that imports `strands_robots` would **silently succeed while running zero assertions** — a green pipeline that did nothing.

This only fires on macOS where torchcodec + a Homebrew ffmpeg lib dir are present and `DYLD_FALLBACK_LIBRARY_PATH` is unset (the re-exec path); on Linux/Jetson and torchcodec-less installs the shim never re-execs, so it went unnoticed.

## Change

Add `"-"` to the rejected `argv0` set alongside `"-c"`. Neither a `-c` snippet nor a stdin program has anything safe to replay across a re-exec. Child processes still inherit the exported `DYLD_FALLBACK_LIBRARY_PATH`, so `num_workers>0` DataLoaders and subprocess training keep working; only the catastrophic self-re-exec is suppressed.

## Tests (fail pre-fix, pass post-fix)

Added to `tests/test_dyld_ffmpeg_shim.py`:
- `test_is_safe_to_reexec_false_for_stdin_dash` — `_is_safe_to_reexec()` returns `False` for `argv[0] == "-"`.
- `test_ensure_does_not_reexec_stdin_program` — with an armed macOS/torchcodec/ffmpeg environment and a stdin invocation, `ensure_ffmpeg_on_dyld_path()` exports the child env but never calls `os.execv`.

Both fail on the pre-fix code (2 failed) and pass after (full file: 15 passed). Local gate green: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` all clean.

## Acceptance

`echo 'import strands_robots; open("/tmp/ok","w").write("ran")' | python -` now leaves the marker file on a machine where the shim would otherwise re-exec.