### PR TITLE
fix(device_connect,mesh): bind start_task/_execute_task_sync by keyword

### DIFF
--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -100,12 +100,17 @@ class RobotDeviceDriver(DeviceDriver):
         if not is_safe_policy_provider(policy_provider):
             return {"status": "error", "reason": f"policy_provider not allowed: {policy_provider!r}"}
 
+        # Call by keyword: HardwareRobot.start_task is
+        # (instruction, policy_port, policy_host, policy_provider, duration).
+        # A positional call here silently misroutes the arguments (the provider
+        # string lands in policy_port, the port in policy_host, and "localhost"
+        # in policy_provider), so bind them explicitly to their target fields.
         return self._robot.start_task(
             instruction,
-            policy_provider,
-            policy_port or None,
-            "localhost",
-            duration,
+            policy_port=policy_port or None,
+            policy_host="localhost",
+            policy_provider=policy_provider,
+            duration=duration,
         )
 
     @rpc()

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1650,12 +1650,33 @@ class Mesh(SensorLoopsMixin):
                     duration=duration,
                     extra=extra,
                 )
+            # Bind by keyword: the hardware entry points are
+            # (instruction, policy_port, policy_host, policy_provider, duration).
+            # A positional call would misroute the provider into policy_port,
+            # the port into policy_host, and the allowlist-checked policy_host
+            # into policy_provider -- defeating the host guard above.
             if action == "execute" and hasattr(r, "_execute_task_sync"):
                 return dict(
-                    r._execute_task_sync(instruction, policy_provider, policy_port, policy_host, duration, **extra)
+                    r._execute_task_sync(
+                        instruction,
+                        policy_port=policy_port,
+                        policy_host=policy_host,
+                        policy_provider=policy_provider,
+                        duration=duration,
+                        **extra,
+                    )
                 )
             if action == "start" and hasattr(r, "start_task"):
-                return dict(r.start_task(instruction, policy_provider, policy_port, policy_host, duration, **extra))
+                return dict(
+                    r.start_task(
+                        instruction,
+                        policy_port=policy_port,
+                        policy_host=policy_host,
+                        policy_provider=policy_provider,
+                        duration=duration,
+                        **extra,
+                    )
+                )
         if action == "step" and hasattr(r, "step"):
             return dict(r.step(cmd.get("steps", 1)))
         if action == "reset" and hasattr(r, "reset"):

--- a/tests/mesh/test_deep_mesh.py
+++ b/tests/mesh/test_deep_mesh.py
@@ -104,10 +104,14 @@ class FakeRobot:
     def reset(self):
         return {"reset": True}
 
-    def _execute_task_sync(self, instruction, provider, port, host, duration, **kw):
-        return {"executed": instruction, "provider": provider}
+    def _execute_task_sync(
+        self, instruction, policy_port=None, policy_host="localhost", policy_provider="groot", duration=30.0, **kw
+    ):
+        return {"executed": instruction, "provider": policy_provider}
 
-    def start_task(self, instruction, provider, port, host, duration, **kw):
+    def start_task(
+        self, instruction, policy_port=None, policy_host="localhost", policy_provider="groot", duration=30.0, **kw
+    ):
         return {"started": instruction}
 
 

--- a/tests/mesh/test_dispatch_policy_host_guard.py
+++ b/tests/mesh/test_dispatch_policy_host_guard.py
@@ -34,16 +34,28 @@ class _RecordingRobot:
         return {"status": "idle"}
 
     def _execute_task_sync(
-        self, instruction: str, provider: str, port: Any, host: str, duration: float, **kw: Any
+        self,
+        instruction: str,
+        policy_port: Any = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        **kw: Any,
     ) -> dict[str, Any]:
         self.executed = True
-        return {"executed": instruction, "host": host}
+        return {"executed": instruction, "host": policy_host}
 
     def start_task(
-        self, instruction: str, provider: str, port: Any, host: str, duration: float, **kw: Any
+        self,
+        instruction: str,
+        policy_port: Any = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        **kw: Any,
     ) -> dict[str, Any]:
         self.started = True
-        return {"started": instruction, "host": host}
+        return {"started": instruction, "host": policy_host}
 
 
 def test_dispatch_rejects_off_allowlist_policy_host_execute() -> None:

--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -54,13 +54,25 @@ class _FakeRobot:
         return {"ok": True}
 
     def _execute_task_sync(
-        self, instruction: str, provider: str, port, host: str, duration: float, **kw: Any
+        self,
+        instruction: str,
+        policy_port: Any = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        **kw: Any,
     ) -> dict[str, Any]:
-        self.calls.append(("execute", {"instruction": instruction, "provider": provider, "duration": duration}))
+        self.calls.append(("execute", {"instruction": instruction, "provider": policy_provider, "duration": duration}))
         return {"executed": instruction}
 
     def start_task(
-        self, instruction: str, provider: str, port, host: str, duration: float, **kw: Any
+        self,
+        instruction: str,
+        policy_port: Any = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        **kw: Any,
     ) -> dict[str, Any]:
         self.calls.append(("start", {"instruction": instruction}))
         return {"started": instruction}

--- a/tests/test_device_connect_all_robots.py
+++ b/tests/test_device_connect_all_robots.py
@@ -279,7 +279,9 @@ class TestRobotDriverAllRobots:
         robot = _make_mock_robot(robot_name, robot_info)
         driver = RobotDeviceDriver(robot)
         result = asyncio.run(driver.execute("pick up cube", "groot", 30.0, 0))
-        robot.start_task.assert_called_once_with("pick up cube", "groot", None, "localhost", 30.0)
+        robot.start_task.assert_called_once_with(
+            "pick up cube", policy_port=None, policy_host="localhost", policy_provider="groot", duration=30.0
+        )
         assert result["status"] == "success"
 
     @pytest.mark.parametrize("robot_name,robot_info", ALL_ROBOTS, ids=[r[0] for r in ALL_ROBOTS])

--- a/tests/test_device_connect_drivers.py
+++ b/tests/test_device_connect_drivers.py
@@ -7,6 +7,7 @@ All external dependencies (Zenoh, LeRobot, device_connect_edge, strands) are moc
 """
 
 import asyncio
+import inspect
 import json
 import os
 import sys
@@ -249,14 +250,18 @@ class TestRobotDeviceDriver(unittest.TestCase):
         robot = _make_mock_robot()
         driver = RobotDeviceDriver(robot)
         result = asyncio.run(driver.execute("pick up cube", "groot", 30.0, 0))
-        robot.start_task.assert_called_once_with("pick up cube", "groot", None, "localhost", 30.0)
+        robot.start_task.assert_called_once_with(
+            "pick up cube", policy_port=None, policy_host="localhost", policy_provider="groot", duration=30.0
+        )
         self.assertEqual(result["status"], "success")
 
     def test_execute_rpc_with_port(self):
         robot = _make_mock_robot()
         driver = RobotDeviceDriver(robot)
         asyncio.run(driver.execute("wave", "groot", 10.0, 50051))
-        robot.start_task.assert_called_once_with("wave", "groot", 50051, "localhost", 10.0)
+        robot.start_task.assert_called_once_with(
+            "wave", policy_port=50051, policy_host="localhost", policy_provider="groot", duration=10.0
+        )
 
     def test_stop_rpc(self):
         robot = _make_mock_robot()
@@ -1103,6 +1108,77 @@ class TestReachyTransport(unittest.TestCase):
         # IP should pass through unchanged
         result = resolve_host("192.168.1.1")
         self.assertEqual(result, "192.168.1.1")
+
+
+class TestRobotDriverStartTaskArgBinding(unittest.TestCase):
+    """Regression: RobotDeviceDriver.execute must bind start_task by keyword.
+
+    HardwareRobot.start_task is
+    ``(instruction, policy_port, policy_host, policy_provider, duration)``.
+    A positional call in the driver silently misroutes the arguments (provider
+    string into policy_port, port into policy_host, "localhost" into
+    policy_provider). This stub mirrors the real signature so a misorder shows
+    up as a wrong-field value instead of passing.
+    """
+
+    class _SignatureStubRobot:
+        tool_name_str = "so100"
+
+        def __init__(self) -> None:
+            self.captured: dict | None = None
+            self._task_state = FakeTaskState(status=FakeTaskStatus("idle"))
+
+        def start_task(
+            self,
+            instruction,
+            policy_port=None,
+            policy_host="localhost",
+            policy_provider="groot",
+            duration=30.0,
+            **kw,
+        ):
+            self.captured = {
+                "instruction": instruction,
+                "policy_port": policy_port,
+                "policy_host": policy_host,
+                "policy_provider": policy_provider,
+                "duration": duration,
+            }
+            return {"status": "success", "content": [{"text": "Task started"}]}
+
+    def test_execute_binds_start_task_kwargs_to_correct_fields(self):
+        robot = self._SignatureStubRobot()
+        driver = RobotDeviceDriver(robot)
+        result = asyncio.run(driver.execute("pick up cube", "mock", 12.0, 50051))
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(
+            robot.captured,
+            {
+                "instruction": "pick up cube",
+                "policy_port": 50051,
+                "policy_host": "localhost",
+                "policy_provider": "mock",
+                "duration": 12.0,
+            },
+        )
+
+    def test_execute_zero_port_becomes_none(self):
+        robot = self._SignatureStubRobot()
+        driver = RobotDeviceDriver(robot)
+        asyncio.run(driver.execute("wave", "mock", 5.0, 0))
+        assert robot.captured is not None
+        self.assertIsNone(robot.captured["policy_port"])
+        self.assertEqual(robot.captured["policy_provider"], "mock")
+
+    def test_stub_signature_matches_real_hardware_robot(self):
+        # Anti-drift: pin the stub against the production signature so a future
+        # rename/reorder of HardwareRobot.start_task is caught here rather than
+        # silently re-introducing the positional misorder.
+        from strands_robots.hardware_robot import Robot as HardwareRobot
+
+        real = list(inspect.signature(HardwareRobot.start_task).parameters)
+        stub = list(inspect.signature(self._SignatureStubRobot.start_task).parameters)
+        self.assertEqual(stub[: len(real)], real)
 
 
 if __name__ == "__main__":

--- a/tests/test_device_connect_hardening.py
+++ b/tests/test_device_connect_hardening.py
@@ -67,12 +67,22 @@ class _FakeRobot:
         self.started = None
         self.stopped = False
 
-    def start_task(self, instruction, policy_provider, policy_port, host, duration):
+    def start_task(
+        self,
+        instruction,
+        policy_port=None,
+        policy_host="localhost",
+        policy_provider="groot",
+        duration=30.0,
+        **kw,
+    ):
+        # Real HardwareRobot.start_task signature so a positional misorder in
+        # the caller surfaces as a wrong-field value instead of passing.
         self.started = dict(
             instruction=instruction,
             policy_provider=policy_provider,
             policy_port=policy_port,
-            host=host,
+            policy_host=policy_host,
             duration=duration,
         )
         return {"status": "success", "instruction": instruction}


### PR DESCRIPTION
## Problem

`RobotDeviceDriver.execute` (`strands_robots/device_connect/robot_driver.py`) and the mesh dispatch paths (`strands_robots/mesh/core.py`) call the hardware entry points **positionally in the wrong order**.

Both entry points are:

```python
start_task(instruction, policy_port=None, policy_host="localhost", policy_provider="groot", duration=30.0)
_execute_task_sync(instruction, policy_port=None, policy_host="localhost", policy_provider="groot", duration=30.0, ...)
```

but the callers passed `(instruction, policy_provider, policy_port, policy_host, duration)`. On real hardware every field is misrouted:

- the policy **provider** string lands in `policy_port`
- the **port** lands in `policy_host`
- in the mesh path the allowlist-checked `policy_host` lands in `policy_provider`; in the device_connect path the literal `"localhost"` lands in `policy_provider`

So a device-connect `execute` on hardware runs with `policy_provider="localhost"`, and the mesh host-allowlist guard is defeated because the vetted `policy_host` never reaches the `policy_host` parameter.

The existing tests passed only because their fakes mirrored the same wrong argument order, pinning the bug.

## Change

- Bind all three dispatch call sites (`robot_driver.py` `start_task`; `mesh/core.py` `_execute_task_sync` and `start_task`) by keyword so each argument reaches its intended field.
- Update the test fakes across `test_device_connect_hardening.py`, `test_mesh_rpc.py`, `test_deep_mesh.py`, and `test_dispatch_policy_host_guard.py` to mirror the real signature instead of the wrong order.
- Update the MagicMock assertions in `test_device_connect_drivers.py` and `test_device_connect_all_robots.py` to the keyword form.

## Tests

Added `TestRobotDriverStartTaskArgBinding` which drives `execute()` against a real-signature stub `HardwareRobot` and asserts each argument lands in its target field (`policy_provider`, `policy_port`, `policy_host`, `duration`), plus an anti-drift check that pins the stub against `HardwareRobot.start_task` via `inspect.signature`.

Pre-fix, the new binding tests and the updated driver/hardening assertions fail:

```
Expected: start_task('pick up cube', policy_port=None, policy_host='localhost', policy_provider='groot', duration=30.0)
  Actual: start_task('pick up cube', 'groot', None, 'localhost', 30.0)
...
AssertionError: assert 'localhost' == 'mock'   # policy_provider misrouted
```

Post-fix the full device_connect + mesh + hardware-robot-lifecycle suites pass (3356 passed, 10 skipped). Lint gate clean: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all pass.

No behavior/rendering/asset change, so no visual artifact applies — this is a pure argument-binding correctness fix.