### PR TITLE
fix(safety): harden e-stop/lockout reliability across four paths

### DIFF
--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -214,6 +214,23 @@ class ReachyMiniDriver(DeviceDriver):
         await self._send_cmd({"torque": True, "ids": ids})
         return {"status": "success", "enabled": motor_ids or "all"}
 
+    async def _disable_motors_impl(self, motor_ids: str = "") -> dict[str, Any]:
+        """Disable motors / torque off (un-gated core; callers enforce authz).
+
+        The emergency-stop handler invokes this directly so the ``@rpc()``
+        rpc-scope gate -- which sees a ``None`` caller in event-handler context
+        and would fail-closed under ``DEVICE_CONNECT_RPC_ALLOW`` -- cannot
+        silently deny the torque-off and leave motors live. ``_send_cmd``
+        raises when the hardware link is down, so a failed torque-off surfaces
+        to the caller rather than reporting a false ack.
+
+        Args:
+            motor_ids: Comma-separated motor IDs (empty = all).
+        """
+        ids = [s.strip() for s in motor_ids.split(",") if s.strip()] or None
+        await self._send_cmd({"torque": False, "ids": ids})
+        return {"status": "success", "disabled": motor_ids or "all"}
+
     @rpc()
     async def disableMotors(self, motor_ids: str = "") -> dict[str, Any]:
         """Disable motors (torque off).
@@ -224,9 +241,7 @@ class ReachyMiniDriver(DeviceDriver):
         caller = get_rpc_source_device()
         if not is_authorized_caller(caller, scope="rpc"):
             return authz_error(caller, "disableMotors")
-        ids = [s.strip() for s in motor_ids.split(",") if s.strip()] or None
-        await self._send_cmd({"torque": False, "ids": ids})
-        return {"status": "success", "disabled": motor_ids or "all"}
+        return await self._disable_motors_impl(motor_ids)
 
     # ── Move RPCs (REST) ──────────────────────────────────────
 
@@ -345,12 +360,18 @@ class ReachyMiniDriver(DeviceDriver):
         )
         return {"status": "success", "result": result}
 
-    @rpc()
-    async def stopMotion(self) -> dict[str, Any]:
-        """Stop all current motion."""
-        caller = get_rpc_source_device()
-        if not is_authorized_caller(caller, scope="rpc"):
-            return authz_error(caller, "stopMotion")
+    async def _stop_motion_impl(self) -> dict[str, Any]:
+        """Stop all current motion (un-gated core; callers enforce authz).
+
+        The emergency-stop handler invokes this directly so the ``@rpc()``
+        rpc-scope gate (``None`` caller in event context) cannot fail-closed
+        and drop the stop.
+
+        Surfaces daemon transport failure: :func:`reachy_transport.api`
+        returns ``{"error": ...}`` on any HTTP/connection failure WITHOUT
+        raising, so a stop issued against a down daemon would otherwise report
+        ``status="success"``. Raise instead so the caller sees a real failure.
+        """
         result = await asyncio.to_thread(
             api,
             self._host,
@@ -358,7 +379,17 @@ class ReachyMiniDriver(DeviceDriver):
             "/api/move/stop",
             "POST",
         )
+        if isinstance(result, dict) and "error" in result:
+            raise RuntimeError(f"stopMotion transport failure: {result['error']}")
         return {"status": "success", "result": result}
+
+    @rpc()
+    async def stopMotion(self) -> dict[str, Any]:
+        """Stop all current motion."""
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "stopMotion")
+        return await self._stop_motion_impl()
 
     @rpc()
     async def getDaemonStatus(self) -> dict[str, Any]:
@@ -394,5 +425,31 @@ class ReachyMiniDriver(DeviceDriver):
             logger.warning("Ignoring emergencyStop from unauthorized source %s", device_id)
             return
         logger.warning("Emergency stop received from %s - disabling motors", device_id)
-        await self.stopMotion()
-        await self.disableMotors()
+        # Call the UN-GATED impls directly. The ``@rpc()``-decorated
+        # ``stopMotion`` / ``disableMotors`` re-check ``get_rpc_source_device()``,
+        # which is ``None`` in an event-handler context; with
+        # ``DEVICE_CONNECT_RPC_ALLOW`` set that gate fail-closes and the returned
+        # ``authz_error`` dicts were discarded, so the motors stayed live. This
+        # handler is already authorized above on ``scope="estop"``, so bypassing
+        # the rpc-scope gate here is correct.
+        #
+        # Attempt BOTH stop actions even if one fails (a safety handler must not
+        # skip torque-off because stopMotion's REST call errored) and surface
+        # any failure loudly instead of masking it behind a false ack. Torque
+        # off runs first so the definitive motor kill lands even if the REST
+        # stop hangs or errors.
+        failures: list[str] = []
+        try:
+            await self._disable_motors_impl()
+        except (RuntimeError, OSError) as exc:
+            failures.append(f"disableMotors: {exc}")
+        try:
+            await self._stop_motion_impl()
+        except (RuntimeError, OSError) as exc:
+            failures.append(f"stopMotion: {exc}")
+        if failures:
+            logger.critical(
+                "Emergency stop from %s did NOT fully complete: %s",
+                device_id,
+                "; ".join(failures),
+            )

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -441,11 +441,17 @@ class ReachyMiniDriver(DeviceDriver):
         failures: list[str] = []
         try:
             await self._disable_motors_impl()
-        except (RuntimeError, OSError) as exc:
+        # Recovery path: catch broadly. Hardware links raise transport-specific
+        # exceptions outside (RuntimeError, OSError) -- e.g. the Lite variant's
+        # WebSocketLink raises websockets.exceptions.ConnectionClosed
+        # (WebSocketException -> Exception) and the Zenoh variant raises its own
+        # publish errors. A safety handler must attempt BOTH stops regardless of
+        # the failing link type, so record and continue rather than crash out.
+        except Exception as exc:  # noqa: BLE001 - attempt-both e-stop recovery
             failures.append(f"disableMotors: {exc}")
         try:
             await self._stop_motion_impl()
-        except (RuntimeError, OSError) as exc:
+        except Exception as exc:  # noqa: BLE001 - attempt-both e-stop recovery
             failures.append(f"stopMotion: {exc}")
         if failures:
             logger.critical(

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -2678,8 +2678,14 @@ class Mesh(SensorLoopsMixin):
         msg = {"sender_id": self.peer_id, "turn_id": turn, "command": cmd, "timestamp": time.time()}
         try:
             self.publish("strands/broadcast", msg)
-            event.wait(timeout=timeout)
-            time.sleep(0.3)
+            # A broadcast has no single expected responder, so collect acks for
+            # the FULL window. ``event`` fires on the FIRST response
+            # (``event.set()`` in ``_on_response``); waiting on it returned
+            # ~0.3s after ack #1 and systematically under-reported the fleet --
+            # an operator could not distinguish "1 of 12 stopped" from "all
+            # stopped". Wait on the shutdown event instead so the window is
+            # honoured in full yet still interruptible when the mesh is closing.
+            self._stop_event.wait(timeout=timeout)
         finally:
             with self._rpc_lock:
                 resps = self._responses.pop(turn, [])
@@ -3056,15 +3062,24 @@ class Mesh(SensorLoopsMixin):
         # ``source_zid`` is absent (bridge / IoT). Bound as a
         # deterministic JSON blob (sort_keys, no whitespace) so issuer
         # and receiver compute the same digest byte-for-byte.
-        local_zid = self._local_session_zid()
+        # Decide the publish path BEFORE computing the proof. ``_safety_wire_zid``
+        # returns the wire ``source_zid`` only when the Zenoh-native path will
+        # actually carry it; on the fallback ``put()`` path (which strips
+        # ``source_zid`` from the body) it returns ``None``. Binding the MAC to
+        # ``_local_session_zid()`` while the envelope is later published on the
+        # fallback path made every receiver recompute the proof over a byte
+        # string that lacked ``source_zid`` -- so remote lockout resume never
+        # verified and the fleet stayed e-stopped. Binding to the exact wire
+        # form the receiver will see keeps issuer and receiver in agreement.
+        wire_zid = self._safety_wire_zid("strands/safety/resume")
         mac_fields: dict[str, Any] = {
             "peer_id": self.peer_id,
             "t": envelope_t,
             "lockout_elapsed_s": elapsed,
             "proof_nonce": proof_nonce,
         }
-        if local_zid is not None:
-            mac_fields["source_zid"] = local_zid
+        if wire_zid is not None:
+            mac_fields["source_zid"] = wire_zid
         mac_input = json.dumps(
             mac_fields,
             sort_keys=True,
@@ -3082,8 +3097,8 @@ class Mesh(SensorLoopsMixin):
             "proof_nonce": proof_nonce,
             "override_proof": override_proof,
         }
-        if local_zid is not None:
-            envelope["source_zid"] = local_zid
+        if wire_zid is not None:
+            envelope["source_zid"] = wire_zid
         self._publish_safety_envelope("strands/safety/resume", envelope)
         logger.warning("[safety] %s: resume after %.1fs lockout", self.peer_id, elapsed)
         # success is also generic on the wire; the local audit
@@ -3135,6 +3150,41 @@ class Mesh(SensorLoopsMixin):
             return None
         zid_str = str(zid)
         return zid_str or None
+
+    def _safety_wire_zid(self, key: str) -> str | None:
+        """Return the wire ``source_zid`` a safety envelope on *key* will carry.
+
+        Returns the local Zenoh session ZID only when the full native
+        publish path is ready (session open, publisher declarable, and the
+        ``zenoh.SourceInfo`` constructor present). Returns ``None`` when the
+        SourceInfo-less fallback ``put()`` path -- which strips ``source_zid``
+        from the body -- will be taken instead.
+
+        This is the single decision point an issuer must consult BEFORE
+        binding ``source_zid`` into an HMAC (the resume override proof) so the
+        proof is computed over the exact body form that reaches the wire. If
+        the proof is bound to :meth:`_local_session_zid` but the envelope is
+        then published on the fallback path, every receiver recomputes the MAC
+        over a byte string that lacks ``source_zid`` and the proof never
+        verifies -- leaving the fleet stuck in lockout.
+
+        A runtime ``publisher.put`` failure after this returns a zid still
+        degrades to the stripped fallback; for a resume that means the proof
+        will not verify and the peer stays locked out -- the fail-safe
+        direction. See :meth:`_publish_safety_envelope`.
+        """
+        local_zid = self._local_session_zid()
+        if local_zid is None:
+            return None
+        if self._safety_publisher_for(key) is None:
+            return None
+        try:
+            import zenoh
+        except ImportError:
+            return None
+        if not hasattr(zenoh, "SourceInfo"):
+            return None
+        return local_zid
 
     def _safety_publisher_for(self, key: str) -> Any | None:
         """Lazily declare and cache a Zenoh ``Publisher`` for *key*.
@@ -3238,7 +3288,22 @@ class Mesh(SensorLoopsMixin):
 
         In the fallback case the body-level HMAC binding still holds;
         only the additional cross-session-forge defence is omitted.
+
+        The body's ``source_zid`` presence is authoritative: a wire
+        ``SourceInfo`` is attached ONLY when the body advertises
+        ``source_zid``, so body and wire always agree at the receiver
+        (which hard-rejects a wire-present/body-absent mismatch). Issuers
+        that bind ``source_zid`` into an HMAC (the resume proof) pre-decide
+        via :meth:`_safety_wire_zid` so the body carries ``source_zid`` only
+        when the native path is ready to back it with a matching wire zid.
         """
+        if "source_zid" not in payload:
+            # No wire attribution requested (non-Zenoh transport, no open
+            # session, or an issuer that pre-decided the fallback path). Plain
+            # put keeps body and wire consistently zid-less so the receiver's
+            # transport-agnostic accept-without-zid contract holds.
+            put(key, payload)
+            return
         pub = self._safety_publisher_for(key)
         if pub is None:
             put(key, self._strip_wire_zid(payload))

--- a/strands_robots/mesh/iot/bootstrap.py
+++ b/strands_robots/mesh/iot/bootstrap.py
@@ -59,7 +59,7 @@ ESTOP_LAMBDA_RESERVED_CONCURRENCY = 2
 #: Finding #16: dedup window (seconds). Two estop envelopes with the same
 #: (peer_id, t) within this window invoke the fan-out only once.
 ESTOP_DEDUP_TTL_S = 30
-_LAMBDA_VERSION = 2  # Bump whenever _ESTOP_LAMBDA_SOURCE changes
+_LAMBDA_VERSION = 3  # Bump whenever _ESTOP_LAMBDA_SOURCE changes
 RULE_SAFETY_TO_DYNAMODB = "strands_safety_to_dynamodb"
 RULE_ESTOP_FANOUT = "strands_estop_fanout"
 PROVISIONING_TEMPLATE = "strands-mesh-fleet-provisioning"
@@ -157,9 +157,20 @@ _ESTOP_LAMBDA_SOURCE = textwrap.dedent(
                         qos=1,
                         payload=json.dumps({
                             "sender_id": "strands-mesh-estop-fanout",
-                            "turn_id": "estop-fanout",
+                            # turn_id MUST be unique per fan-out: robots dedup on
+                            # (sender_id, turn_id) in _exec_cmd, so a constant
+                            # "estop-fanout" made every e-stop after the first be
+                            # dropped fleet-wide as a replay. aws_request_id is
+                            # unique per Lambda invocation (== per logical
+                            # e-stop) but shared across the robots fanned out in
+                            # one invocation, so each robot still dedups its own
+                            # duplicate deliveries.
+                            "turn_id": context.aws_request_id,
                             "command": {"action": "stop"},
-                            "timestamp": context.aws_request_id,
+                            # timestamp is a numeric epoch seconds field; feeding
+                            # it the aws_request_id UUID broke any consumer that
+                            # treated it as a number.
+                            "timestamp": time.time(),
                         }).encode(),
                     )
                     published += 1

--- a/tests/mesh/test_broadcast_full_window.py
+++ b/tests/mesh/test_broadcast_full_window.py
@@ -1,0 +1,60 @@
+"""Regression: broadcast() must collect acks for the FULL window, not return
+~0.3s after the first response.
+
+``broadcast`` waited on an Event that ``_on_response`` sets on the FIRST reply,
+then slept only 0.3s more -- so ``emergency_stop``'s ``responses_received``
+systematically under-counted the fleet: an operator could not distinguish
+"1 of N robots acknowledged the stop" from "all N acknowledged". The window
+must be honoured in full so every peer that replies within it is counted.
+"""
+
+import json
+import threading
+import time
+import types
+
+from strands_robots.mesh import core
+
+
+def _sample(payload: dict) -> object:
+    s = types.SimpleNamespace()
+    s.payload = types.SimpleNamespace(to_bytes=lambda: json.dumps(payload).encode())
+    return s
+
+
+def test_broadcast_collects_responses_across_the_full_window(monkeypatch):
+    m = core.Mesh(robot=object(), peer_id="op")
+    m._running = True
+    monkeypatch.setattr(core._security, "validate_command", lambda cmd: cmd)
+
+    def fake_publish(key, msg):
+        turn = msg["turn_id"]
+
+        def responder():
+            # ack #1 arrives immediately (old code returned ~0.3s after this)
+            time.sleep(0.05)
+            m._on_response(_sample({"turn_id": turn, "responder_id": "r1", "result": 1}))
+            # acks #2 and #3 arrive AFTER the old 0.3s early-return window
+            time.sleep(0.5)
+            m._on_response(_sample({"turn_id": turn, "responder_id": "r2", "result": 2}))
+            m._on_response(_sample({"turn_id": turn, "responder_id": "r3", "result": 3}))
+
+        threading.Thread(target=responder, daemon=True).start()
+
+    monkeypatch.setattr(m, "publish", fake_publish)
+
+    start = time.monotonic()
+    resps = m.broadcast({"action": "stop"}, timeout=1.0)
+    elapsed = time.monotonic() - start
+
+    # All three peers that replied within the window are counted (old code
+    # returned after ack #1 only).
+    assert len(resps) == 3
+    # The full window was honoured rather than returning right after ack #1.
+    assert elapsed >= 0.9
+
+
+def test_broadcast_returns_empty_when_not_running():
+    m = core.Mesh(robot=object(), peer_id="op")
+    m._running = False
+    assert m.broadcast({"action": "stop"}, timeout=0.1) == []

--- a/tests/mesh/test_estop_fanout_turn_id_unique.py
+++ b/tests/mesh/test_estop_fanout_turn_id_unique.py
@@ -1,0 +1,85 @@
+"""Regression: the cloud e-stop fan-out Lambda must stamp each fan-out with a
+unique turn_id (and a numeric timestamp).
+
+Robots dedup inbound commands on ``(sender_id, turn_id)`` in ``_exec_cmd``.
+The fan-out Lambda published a constant ``turn_id="estop-fanout"`` with a
+constant ``sender_id``, so the SECOND-ever cloud e-stop -- and every one after
+-- was dropped fleet-wide as a replay of the first. ``timestamp`` was also fed
+``context.aws_request_id`` (a UUID) into a numeric epoch-seconds field.
+
+We exec the deployed Lambda source with AWS mocked and invoke the handler for
+two consecutive e-stops, asserting each robot command carries a distinct
+turn_id equal to that invocation's aws_request_id, and a numeric timestamp.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+
+import boto3
+
+from strands_robots.mesh.iot import bootstrap as boot_mod
+
+
+class _FakePaginator:
+    def paginate(self, **_kw):
+        return [
+            {
+                "things": [
+                    {"thingName": "robot-a", "attributes": {"strands-mesh-role": "robot"}},
+                    {"thingName": "robot-b", "attributes": {"strands-mesh-role": "robot"}},
+                ]
+            }
+        ]
+
+
+def _run_fanout(monkeypatch, *, request_id: str, estop_t: str) -> list[dict]:
+    """Exec the deployed Lambda source and invoke it once. Returns the list of
+    decoded command payloads published to robot /cmd inboxes."""
+    published: list[dict] = []
+
+    iot = types.SimpleNamespace(get_paginator=lambda _name: _FakePaginator())
+
+    def _publish(topic, qos, payload):
+        published.append(json.loads(payload.decode()))
+
+    iot_data = types.SimpleNamespace(publish=_publish)
+    # ddb.put_item succeeds (no ConditionalCheckFailed) -> not a duplicate.
+    ddb = types.SimpleNamespace(
+        put_item=lambda **_kw: {},
+        exceptions=types.SimpleNamespace(ConditionalCheckFailedException=type("CCFE", (Exception,), {})),
+    )
+    fakes = {"iot": iot, "iot-data": iot_data, "dynamodb": ddb}
+    monkeypatch.setattr(boto3, "client", lambda name, *a, **k: fakes[name])
+
+    ns: dict = {}
+    exec(boot_mod._ESTOP_LAMBDA_SOURCE, ns)  # noqa: S102 - deployed source under test
+    handler = ns["lambda_handler"]
+
+    ctx = types.SimpleNamespace(aws_request_id=request_id)
+    event = {"peer_id": "op-1", "t": estop_t, "responses_received": 3}
+    handler(event, ctx)
+    return published
+
+
+def test_two_consecutive_fanouts_carry_distinct_turn_ids(monkeypatch):
+    first = _run_fanout(monkeypatch, request_id="req-aaaa", estop_t="100.0")
+    second = _run_fanout(monkeypatch, request_id="req-bbbb", estop_t="200.0")
+
+    assert first and second
+    # Every command in one invocation shares that invocation's request id...
+    assert {p["turn_id"] for p in first} == {"req-aaaa"}
+    assert {p["turn_id"] for p in second} == {"req-bbbb"}
+    # ...and the two invocations use DIFFERENT turn_ids, so a robot deduping on
+    # (sender_id, turn_id) does not reject the second e-stop as a replay.
+    assert first[0]["turn_id"] != second[0]["turn_id"]
+
+
+def test_fanout_timestamp_is_numeric(monkeypatch):
+    published = _run_fanout(monkeypatch, request_id="req-cccc", estop_t="300.0")
+    assert published
+    for p in published:
+        assert isinstance(p["timestamp"], (int, float))
+        # Not the request-id UUID that used to leak into the numeric field.
+        assert p["timestamp"] != "req-cccc"

--- a/tests/mesh/test_resume_proof_fallback_path.py
+++ b/tests/mesh/test_resume_proof_fallback_path.py
@@ -1,0 +1,99 @@
+"""Regression: remote lockout resume must verify on the SourceInfo-less
+fallback publish path.
+
+The resume override proof is an ``HMAC(override_code, <envelope fields>)``.
+When a Zenoh build lacks ``SourceInfo`` (or no session/publisher is available)
+the safety envelope is published on the fallback ``put()`` path, which strips
+``source_zid`` from the body. If the issuer binds ``source_zid`` into the MAC
+while the published body has it stripped, every receiver recomputes the proof
+over a different byte string -- the proof never verifies and the fleet stays
+e-stopped forever.
+
+This pins the round trip: an issuer that publishes on the fallback path
+produces an envelope that a receiver accepts and that clears the lockout.
+"""
+
+import json
+import types
+from unittest.mock import MagicMock
+
+from strands_robots.mesh import core
+
+
+def _fallback_sample(payload: dict) -> object:
+    """A wire sample with NO source_info (the fallback / bridge transport):
+    _extract_sample_source_zid() returns None for it."""
+    sample = types.SimpleNamespace()
+    sample.payload = types.SimpleNamespace(to_bytes=lambda: json.dumps(payload).encode())
+    # deliberately no ``source_info`` attribute -> wire_zid resolves to None
+    return sample
+
+
+def test_resume_proof_verifies_when_published_on_fallback_path(monkeypatch):
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "operator-secret")
+
+    # --- Issuer: an open session (so _local_session_zid resolves a real zid)
+    # but the native SourceInfo path is unavailable, so the envelope is
+    # published on the fallback path that strips source_zid. ---
+    issuer = core.Mesh(robot=object(), peer_id="issuer")
+    issuer.publish_safety_event = MagicMock()
+    monkeypatch.setattr(issuer, "_local_session_zid", lambda: "deadbeefdeadbeef")
+    # No native publisher available -> fallback path (and _safety_wire_zid None).
+    monkeypatch.setattr(issuer, "_safety_publisher_for", lambda key: None)
+
+    published: dict = {}
+
+    def capture_put(key, payload):
+        published["key"] = key
+        published["payload"] = payload
+
+    monkeypatch.setattr(core, "put", capture_put)
+
+    # Engage the local lockout, then resume with the correct override code.
+    issuer._estop_lockout.set()
+    issuer._last_estop_ts = core.time.time()
+    result = issuer._resume_lockout("operator-secret")
+    assert result == {"status": "ok"}
+
+    assert published["key"] == "strands/safety/resume"
+    envelope = published["payload"]
+    # Fallback path stripped source_zid from the body...
+    assert "source_zid" not in envelope
+    # ...and the proof is bound to that exact (zid-less) body.
+    assert "override_proof" in envelope
+
+    # --- Receiver on the same fallback transport (no wire source_zid). ---
+    receiver = core.Mesh(robot=object(), peer_id="receiver")
+    receiver.publish_safety_event = MagicMock()
+    receiver._estop_lockout.set()
+    assert receiver._estop_lockout.is_set()
+
+    receiver._on_safety_resume(_fallback_sample(envelope))
+
+    # The proof verified against the published body -> lockout cleared.
+    assert receiver._estop_lockout.is_set() is False
+
+
+def test_safety_wire_zid_none_when_source_info_unavailable(monkeypatch):
+    """_safety_wire_zid returns None on a zenoh build lacking SourceInfo, so
+    the proof is bound to the zid-less body that the fallback path publishes."""
+    import sys
+
+    m = core.Mesh(robot=object(), peer_id="t1")
+    monkeypatch.setattr(m, "_local_session_zid", lambda: "abc123")
+    monkeypatch.setattr(m, "_safety_publisher_for", lambda key: object())
+    fake_zenoh = types.ModuleType("zenoh")  # no SourceInfo attribute
+    monkeypatch.setitem(sys.modules, "zenoh", fake_zenoh)
+    assert m._safety_wire_zid("strands/safety/resume") is None
+
+
+def test_safety_wire_zid_returns_zid_on_native_path(monkeypatch):
+    import sys
+
+    m = core.Mesh(robot=object(), peer_id="t1")
+    monkeypatch.setattr(m, "_local_session_zid", lambda: "abc123")
+    monkeypatch.setattr(m, "_safety_publisher_for", lambda key: object())
+    fake_zenoh = types.ModuleType("zenoh")
+    fake_zenoh.SourceInfo = object  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "zenoh", fake_zenoh)
+    assert m._safety_wire_zid("strands/safety/resume") == "abc123"

--- a/tests/test_reachy_mini_driver.py
+++ b/tests/test_reachy_mini_driver.py
@@ -359,3 +359,59 @@ def test_emergency_stop_ignores_unauthorized_source(rmd, monkeypatch):
         _run(drv.onEmergencyStop("rogue-device", "emergencyStop", {}))
     drv._hw.send_cmd.assert_not_awaited()
     fake_api.assert_not_called()
+
+
+# -- emergency stop under an RPC allowlist (regression) ---------------------
+
+
+def test_emergency_stop_disables_motors_even_with_rpc_allowlist_set(rmd, monkeypatch):
+    """E-stop must disable motors when DEVICE_CONNECT_RPC_ALLOW is configured.
+
+    The e-stop handler runs in an event-handler context where
+    ``get_rpc_source_device()`` is ``None``. When it dispatched through the
+    ``@rpc()``-gated ``stopMotion`` / ``disableMotors``, that rpc-scope gate
+    fail-closed on the ``None`` caller under an RPC allowlist and the discarded
+    ``authz_error`` dicts left the motors LIVE. The handler is already
+    authorized on ``scope="estop"``, so it must reach the un-gated impls.
+    """
+    # estop caller is allowlisted for estop, and an RPC allowlist IS set so the
+    # rpc-scope gate would fail-close on the None caller in event context.
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", "safety-*")
+    monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", "trusted-*")
+    drv = _bare(rmd, _hw=AsyncMock())
+    with patch.object(rmd, "api", return_value={"ok": True}) as fake_api:
+        _run(drv.onEmergencyStop("safety-007", "emergencyStop", {}))
+    # Torque is cut (definitive motor kill) despite the RPC allowlist.
+    assert any(c.args[0].get("torque") is False for c in drv._hw.send_cmd.await_args_list)
+    # And the REST stop endpoint is hit.
+    assert any(call.args[2] == "/api/move/stop" for call in fake_api.call_args_list)
+
+
+def test_emergency_stop_surfaces_daemon_transport_failure(rmd, monkeypatch, caplog):
+    """A stop issued against a down daemon must be logged as a failure.
+
+    ``reachy_transport.api`` returns ``{"error": ...}`` on any HTTP/connection
+    failure without raising, so the REST stop would otherwise report success
+    against a dead daemon. The handler must surface it loudly (and still cut
+    torque, which rides the separate real-time link).
+    """
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", "safety-*")
+    drv = _bare(rmd, _hw=AsyncMock())
+    with patch.object(rmd, "api", return_value={"error": "connection refused"}):
+        with caplog.at_level("CRITICAL"):
+            _run(drv.onEmergencyStop("safety-007", "emergencyStop", {}))
+    # Torque-off still fired (runs first, on the real-time link).
+    assert any(c.args[0].get("torque") is False for c in drv._hw.send_cmd.await_args_list)
+    # The REST stop failure surfaced instead of a false success ack.
+    assert any("did NOT fully complete" in r.message for r in caplog.records)
+
+
+def test_stop_motion_impl_raises_on_transport_error(rmd):
+    """The stopMotion core raises when the daemon REST call errors, so a caller
+    cannot mistake a dead-daemon ``{"error": ...}`` for a real stop."""
+    import pytest
+
+    drv = _bare(rmd)
+    with patch.object(rmd, "api", return_value={"error": "boom"}):
+        with pytest.raises(RuntimeError, match="transport failure"):
+            _run(drv._stop_motion_impl())

--- a/tests/test_reachy_mini_driver.py
+++ b/tests/test_reachy_mini_driver.py
@@ -406,6 +406,39 @@ def test_emergency_stop_surfaces_daemon_transport_failure(rmd, monkeypatch, capl
     assert any("did NOT fully complete" in r.message for r in caplog.records)
 
 
+def test_emergency_stop_attempts_rest_stop_when_torque_link_drops(rmd, monkeypatch, caplog):
+    """A dropped real-time link during torque-off must NOT skip the REST stop.
+
+    The hardware links raise transport-specific exceptions that are neither
+    ``RuntimeError`` nor ``OSError`` -- the Lite variant's ``WebSocketLink``
+    raises ``websockets.exceptions.ConnectionClosed`` (MRO
+    ``WebSocketException -> Exception``) and the Zenoh variant raises its own
+    publish errors. If the torque-off (which runs first, on the real-time link)
+    raises such an exception, the handler must still attempt the REST stop
+    (a separate HTTP channel that may still be alive) and log the failure --
+    honoring its own "attempt BOTH stop actions even if one fails" contract.
+    A narrow ``except (RuntimeError, OSError)`` let the exception escape,
+    aborting the handler before the REST stop.
+    """
+
+    class _ConnectionClosed(Exception):
+        """Stand-in for websockets.exceptions.ConnectionClosed: subclasses
+        Exception directly, not RuntimeError/OSError (same MRO shape)."""
+
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", "safety-*")
+    hw = AsyncMock()
+    hw.send_cmd.side_effect = _ConnectionClosed("websocket closed during torque-off")
+    drv = _bare(rmd, _hw=hw)
+    with patch.object(rmd, "api", return_value={"ok": True}) as fake_api:
+        with caplog.at_level("CRITICAL"):
+            _run(drv.onEmergencyStop("safety-007", "emergencyStop", {}))
+    # Torque-off raised a non-OSError/RuntimeError transport error, but the REST
+    # stop was still attempted on its separate channel.
+    assert any(call.args[2] == "/api/move/stop" for call in fake_api.call_args_list)
+    # The torque-off failure surfaced loudly rather than crashing the handler.
+    assert any("did NOT fully complete" in r.message for r in caplog.records)
+
+
 def test_stop_motion_impl_raises_on_transport_error(rmd):
     """The stopMotion core raises when the daemon REST call errors, so a caller
     cannot mistake a dead-daemon ``{"error": ...}`` for a real stop."""


### PR DESCRIPTION
Four independent defects each defeated emergency-stop or lockout on some path. Each is fixed here with a regression test that fails on pre-fix code and passes after.

## 1. Mesh lockout resume proof never verified on the fallback publish path
The resume override proof is `HMAC(override_code, <envelope fields incl. source_zid>)`. The issuer bound `source_zid` via `_local_session_zid()`, but the SourceInfo-less fallback `put()` path (`_publish_safety_envelope` -> `_strip_wire_zid`) strips `source_zid` from the published body. Receivers recomputed the MAC over a byte string that lacked `source_zid`, so the proof never matched and every peer stayed e-stopped. On zenoh builds without `SourceInfo` the fallback path is taken 100% of the time, so remote lockout resume was always broken there.

Fix: add `_safety_wire_zid(key)` as the single decision point that returns the wire `source_zid` only when the native path will actually carry it; consult it BEFORE computing the proof so the MAC is bound to the exact body form that reaches the wire. `_publish_safety_envelope` now attaches a wire `SourceInfo` iff the body advertises `source_zid`, so body and wire always agree at the receiver.

## 2. Cloud e-stop fan-out: second e-stop dropped as a replay
The fan-out Lambda published a constant `turn_id="estop-fanout"`. Robots dedup on `(sender_id, turn_id)` in `_exec_cmd`, so the second-ever cloud e-stop (and every one after) was dropped fleet-wide as a replay of the first. `timestamp` was also fed `context.aws_request_id` (a UUID) into a numeric epoch-seconds field.

Fix: `turn_id=context.aws_request_id` (unique per invocation, shared across the robots in one fan-out so each still dedups its own duplicate deliveries) and `timestamp=time.time()`. `_LAMBDA_VERSION` bumped so the deployed function is refreshed.

## 3. Reachy Mini e-stop no-ops under an RPC allowlist
`onEmergencyStop` dispatched through the `@rpc()`-gated `stopMotion`/`disableMotors`. In event-handler context `get_rpc_source_device()` is `None`, so with `DEVICE_CONNECT_RPC_ALLOW` set both fail-closed and the returned `authz_error` dicts were discarded, leaving motors live. Compounded by `reachy_transport.api()` returning `{"error": ...}` without raising, so a stop reported success against a down daemon.

Fix: extract un-gated `_stop_motion_impl`/`_disable_motors_impl` and call them directly from the e-stop handler (already authorized on `scope="estop"`). Torque-off runs first (definitive motor kill lands even if the REST stop hangs). Transport failures now surface (the stop impl raises on `{"error": ...}`; the handler logs CRITICAL) instead of a false success ack.

## 4. `broadcast()` undercounted e-stop acks
`broadcast` waited on an Event that `_on_response` sets on the FIRST reply, then slept only 0.3s more, so `emergency_stop`'s `responses_received` under-reported the fleet -- an operator could not distinguish "1 of 12 stopped" from "all stopped".

Fix: wait the full window (on the shutdown event, so it stays interruptible during teardown) so every peer that acks within the window is counted.

## Tests
- `tests/mesh/test_resume_proof_fallback_path.py` -- issuer publishes on the fallback path (no SourceInfo); receiver accepts and lockout clears; `_safety_wire_zid` native/fallback resolution.
- `tests/mesh/test_estop_fanout_turn_id_unique.py` -- execs the deployed Lambda source with AWS mocked; two consecutive fan-outs carry distinct `turn_id`s equal to their `aws_request_id`; `timestamp` is numeric.
- `tests/test_reachy_mini_driver.py` -- e-stop disables motors with `DEVICE_CONNECT_RPC_ALLOW` set; transport failure surfaces as CRITICAL; stop impl raises on daemon error.
- `tests/mesh/test_broadcast_full_window.py` -- broadcast collects all acks across the full window.

Green locally: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean, full mesh + reachy suites pass. Each new test was confirmed to fail on pre-fix code.

This is safety-control logic (mesh + device driver + IoT fan-out), not a policy/sim/rendering change, so there is no rollout artifact; verification is the regression suite above.

---

## §13 Review Rounds

| Round | Concern | Fix commit | Pin test |
|-------|---------|------------|----------|
| R1 | e-stop handler caught only `(RuntimeError, OSError)`, which does not cover the transport exceptions the hardware links actually raise (WebSocketLink -> `websockets.exceptions.ConnectionClosed`, MRO `WebSocketException -> Exception`; Zenoh publish errors). A dropped link during torque-off escaped the catch, aborted the handler, and skipped the REST stop -- defeating the attempt-both contract on the exact degraded-link scenario this handler hardens. Widened both catches to `except Exception` (canonical recovery path; narrow-catch rule is scoped to non-recovery paths). | `af9548a` | `test_emergency_stop_attempts_rest_stop_when_torque_link_drops` |