### PR TITLE
fix(sim): checkpoint save/load full integration state (incl. ctrl) + guard stale checkpoints

### DIFF
--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -192,3 +192,9 @@ class SimWorld:
     # Kept as a top-level field - requested by @yinsong1986 during review to
     # avoid monkey-patching when ``reset()`` creates a fresh ``SimWorld``.
     _checkpoints: dict[str, Any] = field(default_factory=dict)
+    # Monotonically-incremented generation counter bumped on every
+    # spec.recompile (scene_ops._recompile_preserving_state). Checkpoints
+    # stamp this value so load_state can detect a same-shape recompile
+    # (remove one free-jointed object, add another) that the nq/nv/na/nu
+    # counts alone cannot distinguish.
+    _recompile_generation: int = 0

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -271,10 +271,23 @@ class PhysicsMixin:
     # State Checkpointing
 
     def save_state(self, name: str = "default") -> dict[str, Any]:
-        """Save the full physics state (qpos, qvel, act, time) to a named checkpoint.
+        """Save the full integration state to a named checkpoint.
 
-        Uses mj_getState with mjSTATE_FULLPHYSICS for complete state capture
-        including ctrl and qfrc_applied buffers.
+        Captures the complete ``mjSTATE_INTEGRATION`` vector - qpos, qvel,
+        act, ctrl, qfrc_applied, xfrc_applied, mocap pose, eq_active, plugin
+        state and time - so a subsequent ``load_state`` restores the servo
+        targets (``ctrl``) and latched external forces, not just positions.
+        ``mjSTATE_FULLPHYSICS`` (used previously) silently excluded ``ctrl``
+        and ``qfrc_applied``, so the first step after a restore drove toward
+        the pre-restore targets - contradicting this docstring and
+        ``describe()``.
+
+        The checkpoint is stamped with the model's structural fingerprint
+        (state size + nq/nv/na/nu). A scene recompile that changes the model
+        shape (e.g. ``add_object`` inserts a free joint) invalidates the
+        stored vector; ``load_state`` detects the mismatch and returns a
+        structured error instead of raising a raw ``ValueError`` or silently
+        applying a misaligned vector.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -283,15 +296,18 @@ class PhysicsMixin:
         model, data = self._world._model, self._world._data
 
         with self._lock:
-            state_size = mj.mj_stateSize(model, mj.mjtState.mjSTATE_FULLPHYSICS)
+            state_size = mj.mj_stateSize(model, mj.mjtState.mjSTATE_INTEGRATION)
             state = np.zeros(state_size)
-            mj.mj_getState(model, data, state, mj.mjtState.mjSTATE_FULLPHYSICS)
+            mj.mj_getState(model, data, state, mj.mjtState.mjSTATE_INTEGRATION)
+            fingerprint = (int(model.nq), int(model.nv), int(model.na), int(model.nu))
 
         if not hasattr(self._world, "_checkpoints"):
             self._world._checkpoints = {}
 
         self._world._checkpoints[name] = {
             "state": state.copy(),
+            "state_size": int(state_size),
+            "fingerprint": fingerprint,
             "sim_time": self._world.sim_time,
             "step_count": self._world.step_count,
         }
@@ -303,7 +319,7 @@ class PhysicsMixin:
                     "text": (
                         f"State '{name}' saved\n"
                         f"  t={self._world.sim_time:.4f}s, step={self._world.step_count}\n"
-                        f"State vector: {state_size} floats\n"
+                        f"State vector: {state_size} floats (mjSTATE_INTEGRATION, incl. ctrl)\n"
                         f"Checkpoints: {list(self._world._checkpoints.keys())}"
                     )
                 }
@@ -311,7 +327,14 @@ class PhysicsMixin:
         }
 
     def load_state(self, name: str = "default") -> dict[str, Any]:
-        """Restore physics state from a named checkpoint."""
+        """Restore integration state (incl. ctrl) from a named checkpoint.
+
+        Refuses to apply a checkpoint whose structural fingerprint no longer
+        matches the live model - a scene recompile since ``save_state`` (e.g.
+        ``add_object`` / ``remove_robot``) resized the state vector, so
+        applying it would raise a raw ``ValueError`` or silently misalign
+        qpos/ctrl. In that case a structured error is returned.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # load_state during a running policy races worker thread
@@ -331,7 +354,27 @@ class PhysicsMixin:
         checkpoint = checkpoints[name]
 
         with self._lock:
-            mj.mj_setState(model, data, checkpoint["state"], mj.mjtState.mjSTATE_FULLPHYSICS)
+            current_size = mj.mj_stateSize(model, mj.mjtState.mjSTATE_INTEGRATION)
+            current_fp = (int(model.nq), int(model.nv), int(model.na), int(model.nu))
+            saved_size = checkpoint.get("state_size", checkpoint["state"].shape[0])
+            saved_fp = checkpoint.get("fingerprint")
+            if current_size != saved_size or (saved_fp is not None and current_fp != saved_fp):
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"Checkpoint '{name}' is stale: the scene was recompiled since it "
+                                f"was saved (saved nq/nv/na/nu={saved_fp}, size={saved_size}; "
+                                f"current={current_fp}, size={current_size}). Applying it would "
+                                f"misalign the physics state. Save a fresh checkpoint after scene "
+                                f"mutations such as add_object / remove_robot."
+                            )
+                        }
+                    ],
+                }
+
+            mj.mj_setState(model, data, checkpoint["state"], mj.mjtState.mjSTATE_INTEGRATION)
             mj.mj_forward(model, data)
 
             self._world.sim_time = checkpoint["sim_time"]

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -299,7 +299,13 @@ class PhysicsMixin:
             state_size = mj.mj_stateSize(model, mj.mjtState.mjSTATE_INTEGRATION)
             state = np.zeros(state_size)
             mj.mj_getState(model, data, state, mj.mjtState.mjSTATE_INTEGRATION)
-            fingerprint = (int(model.nq), int(model.nv), int(model.na), int(model.nu))
+            fingerprint = (
+                int(model.nq),
+                int(model.nv),
+                int(model.na),
+                int(model.nu),
+                self._world._recompile_generation,
+            )
 
         if not hasattr(self._world, "_checkpoints"):
             self._world._checkpoints = {}
@@ -355,7 +361,13 @@ class PhysicsMixin:
 
         with self._lock:
             current_size = mj.mj_stateSize(model, mj.mjtState.mjSTATE_INTEGRATION)
-            current_fp = (int(model.nq), int(model.nv), int(model.na), int(model.nu))
+            current_fp = (
+                int(model.nq),
+                int(model.nv),
+                int(model.na),
+                int(model.nu),
+                self._world._recompile_generation,
+            )
             saved_size = checkpoint.get("state_size", checkpoint["state"].shape[0])
             saved_fp = checkpoint.get("fingerprint")
             if current_size != saved_size or (saved_fp is not None and current_fp != saved_fp):

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -90,6 +90,10 @@ def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
     world._model = new_model
     world._data = new_data
 
+    # Bump recompile generation so save_state/load_state can detect stale
+    # checkpoints even when nq/nv/na/nu happen to stay the same (e.g.
+    # remove one free-jointed object, add another of the same shape).
+    world._recompile_generation += 1
     # Forward pass so newly-injected bodies have valid xpos/xquat and any
     # camera xforms are populated. Without this, the next render() call
     # after add_object / add_robot / add_camera returns a 100% black frame

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -409,6 +409,47 @@ class TestStateCheckpointing:
         result = sim.load_state(name="doesnt_exist")
         assert result["status"] == "error"
 
+    def test_save_load_round_trips_ctrl(self, sim):
+        # ctrl (servo targets) MUST survive a checkpoint round-trip. Previously
+        # save_state used mjSTATE_FULLPHYSICS, which excludes ctrl/qfrc_applied,
+        # so the first step after load_state drove toward the pre-restore
+        # targets. Regression for that silent drop.
+        sim._world._data.ctrl[0] = 0.8
+        mj.mj_forward(sim._world._model, sim._world._data)
+
+        result = sim.save_state(name="ctrl_ckpt")
+        assert result["status"] == "success"
+
+        # Clobber ctrl after the checkpoint.
+        sim._world._data.ctrl[0] = -0.5
+        mj.mj_forward(sim._world._model, sim._world._data)
+        assert sim._world._data.ctrl[0] == pytest.approx(-0.5)
+
+        result = sim.load_state(name="ctrl_ckpt")
+        assert result["status"] == "success"
+        assert sim._world._data.ctrl[0] == pytest.approx(0.8)
+
+    def test_load_state_after_recompile_returns_structured_error(self, sim):
+        # A scene recompile that resizes the state vector (add_object inserts a
+        # free joint -> nq/nv grow) must invalidate an earlier checkpoint. The
+        # stale vector must NOT be applied: previously mj_setState raised a raw
+        # ValueError or silently misaligned qpos. Expect a structured error dict.
+        result = sim.save_state(name="pre_add")
+        assert result["status"] == "success"
+
+        add = sim.add_object(name="dropped_cube", shape="box", size=[0.05, 0.05, 0.05])
+        assert add["status"] == "success"
+
+        result = sim.load_state(name="pre_add")
+        assert result["status"] == "error"
+        assert "stale" in result["content"][0]["text"].lower()
+
+        # The checkpoint saved AFTER the mutation applies cleanly.
+        result = sim.save_state(name="post_add")
+        assert result["status"] == "success"
+        result = sim.load_state(name="post_add")
+        assert result["status"] == "success"
+
 
 class TestInverseDynamics:
     @staticmethod

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -448,6 +448,36 @@ class TestStateCheckpointing:
         result = sim.save_state(name="post_add")
         assert result["status"] == "success"
         result = sim.load_state(name="post_add")
+
+    def test_load_state_after_same_shape_recompile_returns_error(self, sim):
+        # A same-shape recompile (remove one free-jointed object, add another)
+        # leaves nq/nv/na/nu unchanged but the joint addresses now map to
+        # different bodies. The recompile-generation stamp must catch this and
+        # return a structured error - applying the stale vector would silently
+        # teleport the new object into the old objects saved pose/velocity.
+        add1 = sim.add_object(name="obj_a", shape="sphere", size=[0.03])
+        assert add1["status"] == "success"
+
+        result = sim.save_state(name="with_a")
+        assert result["status"] == "success"
+
+        # Remove obj_a, add obj_b - same shape (one free joint each), so
+        # nq/nv/na/nu are identical after both mutations.
+        rm = sim.remove_object(name="obj_a")
+        assert rm["status"] == "success"
+        add2 = sim.add_object(name="obj_b", shape="sphere", size=[0.03])
+        assert add2["status"] == "success"
+
+        # The fingerprint must detect the stale checkpoint.
+        result = sim.load_state(name="with_a")
+        assert result["status"] == "error"
+        assert "stale" in result["content"][0]["text"].lower()
+
+        # A fresh checkpoint saved after the mutation applies cleanly.
+        result = sim.save_state(name="with_b")
+        assert result["status"] == "success"
+        result = sim.load_state(name="with_b")
+        assert result["status"] == "success"
         assert result["status"] == "success"
 
 

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -448,6 +448,7 @@ class TestStateCheckpointing:
         result = sim.save_state(name="post_add")
         assert result["status"] == "success"
         result = sim.load_state(name="post_add")
+        assert result["status"] == "success"
 
     def test_load_state_after_same_shape_recompile_returns_error(self, sim):
         # A same-shape recompile (remove one free-jointed object, add another)
@@ -477,7 +478,6 @@ class TestStateCheckpointing:
         result = sim.save_state(name="with_b")
         assert result["status"] == "success"
         result = sim.load_state(name="with_b")
-        assert result["status"] == "success"
         assert result["status"] == "success"
 
 


### PR DESCRIPTION
## Problem

`Simulation.save_state` / `load_state` (MuJoCo backend, `simulation/mujoco/physics.py`) captured state with `mjSTATE_FULLPHYSICS`. That spec covers `qpos/qvel/act/time/warmstart` but **excludes `ctrl` and `qfrc_applied`** — yet both the docstring and `describe()` advertise the checkpoint as capturing `ctrl`.

Consequences:

1. **Servo targets dropped on restore.** After `load_state`, `data.ctrl` still held whatever was commanded *after* the checkpoint. The first `mj_step` then drove position/velocity actuators back toward the pre-restore targets instead of holding the restored pose. Latched external forces in `qfrc_applied` were lost too.
2. **Stale checkpoints across a recompile.** Checkpoints were only keyed by name. A scene mutation that resizes the state vector (`add_object` inserts a free joint -> `nq/nv` grow) left the stored vector the wrong length. `load_state` then hit a raw `TypeError`/`ValueError` from `mj_setState` past the tool dispatch boundary, or, when sizes happened to coincide, silently applied a misaligned vector and reported success.

## Change

- Use `mjSTATE_INTEGRATION` in both `save_state` and `load_state` so `qpos/qvel/act/ctrl/qfrc_applied/xfrc_applied/mocap/eq_active/plugin` all round-trip — matching the documented contract.
- Stamp each checkpoint with the model's structural fingerprint (`mj_stateSize(INTEGRATION)` + `(nq, nv, na, nu)` + **recompile generation**). `load_state` compares it against the live model and returns a **structured error** dict when the scene was recompiled since the checkpoint, instead of raising past dispatch or silently misaligning state.
- The recompile generation is a monotonically-incremented counter bumped on every `_recompile_preserving_state` call, closing the same-shape recompile hole (remove one free-jointed object, add another with the same joint shape) that counts-only fingerprints cannot distinguish.
- Docstrings updated to describe the actual state spec and the staleness guard.

No serialized/back-compat surface: checkpoints live in-memory in `SimWorld._checkpoints` for the session only.

## Tests

Added to `TestStateCheckpointing` in `tests/simulation/mujoco/test_physics.py`; all fail on pre-fix code:

- `test_save_load_round_trips_ctrl` — sets `ctrl`, saves, clobbers `ctrl`, loads; asserts `ctrl` is restored. Pre-fix: restored value is the clobbered one.
- `test_load_state_after_recompile_returns_structured_error` — `save_state -> add_object -> load_state` returns `status=error` ("stale"), and a checkpoint saved *after* the mutation applies cleanly. Pre-fix: raw `TypeError` from `mj_setState`.
- `test_load_state_after_same_shape_recompile_returns_error` — `save_state -> remove_object -> add_object` (same joint shape) -> `load_state` returns `status=error`. Pre-fix: silently applied a misaligned vector.

Full `MUJOCO_GL=egl pytest tests/simulation/mujoco/` green; ruff + mypy clean.

## Visual proof (MuJoCo, headless EGL)

A 2-DOF position-servo arm: drive to a pose via `ctrl`, `save_state`, command a different pose (arm swings away), then `load_state`. With the fix, `ctrl` is restored and stepping drives the arm **back** to the saved pose.

![ctrl restore rollout](https://github.com/cagataycali/robots/releases/download/artifact-ctrl-restore-1785017212/ctrl_restore.gif)

[MP4](https://github.com/cagataycali/robots/releases/download/artifact-ctrl-restore-1785017212/ctrl_restore.mp4)

---

## §13 Review Round Log

| Round | Concern | Fix commit | Pin test |
|-------|---------|-----------|----------|
| R1 | Same-shape recompile defeats counts-only fingerprint (data corruption). Fixed via a monotonically-incremented `_recompile_generation` stamp bumped in `_recompile_preserving_state` and folded into the checkpoint fingerprint. | `c4daad4` | `test_load_state_after_same_shape_recompile_returns_error` |
| R2 | CodeQL (unused local variable, test_physics.py:450): the R1 test method was inserted between `load_state(name="post_add")` and its assertion, leaving that load unasserted (unused `result`) and surfacing the stolen assertion as a duplicate trailing assert in the new test. Restored the assertion on the post_add load (re-establishing the post-condition and consuming the variable) and removed the duplicate. | `2c98fec` | `test_load_state_after_recompile_returns_structured_error` |