### PR TITLE
fix(mujoco): engine locking discipline (remove_robot deadlock, dead step batch-release, load_scene world loss, unlocked render/move_object)

### DIFF
--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -892,12 +892,21 @@ class RenderingMixin:
                     }
                 label = camera_name
 
-            if cam_id >= 0:
-                renderer.update_scene(self._world._data, camera=cam_id, scene_option=self._get_viz_option())
-            else:
-                renderer.update_scene(self._world._data, scene_option=self._get_viz_option())
-
-            img = renderer.render().copy()
+            # Reading mjData (update_scene copies xpos/xquat/xmat/geom poses,
+            # and render() dereferences data.contact) races a concurrent
+            # mj_step from a policy worker or the step() loop, producing torn
+            # frames in recorded MP4s (upstream MuJoCo #191) and risking a
+            # native crash. The recorder daemon calls render() on its own
+            # thread, so this path is NOT covered by the blanket dispatch lock;
+            # serialize the mjData read + frame copy under self._lock. The
+            # .copy() inside the lock hands back an independent buffer so the
+            # PNG encoding below runs unlocked.
+            with self._lock:
+                if cam_id >= 0:
+                    renderer.update_scene(self._world._data, camera=cam_id, scene_option=self._get_viz_option())
+                else:
+                    renderer.update_scene(self._world._data, scene_option=self._get_viz_option())
+                img = renderer.render().copy()
             # Additive camera jitter (set_obs_noise); no-op when disabled.
             img = self._maybe_jitter_frame(img)
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -607,16 +607,19 @@ class MuJoCoSimEngine(
         if not os.path.exists(scene_path):
             return {"status": "error", "content": [{"text": f"Scene file not found: {scene_path}"}]}
 
+        # Compile the new scene into LOCAL model/data first. A malformed MJCF
+        # must NOT destroy the currently-live world: previously self._world was
+        # reassigned to a fresh SimWorld BEFORE the spec compiled, so a bad
+        # file discarded the live scene and still returned an error dict. We
+        # only swap self._world in after a successful compile + forward.
         try:
-            self._world = SimWorld()
             # Load the scene as a live MjSpec - this gives us a mutable AST
             # for downstream add_object/add_robot operations, matching the
             # contract produced by _compile_world for fresh worlds.
             spec = SpecBuilder.from_file(scene_path)
-            self._world._backend_state["spec"] = spec
             with filter_mujoco_attach_noise():
-                self._world._model = spec.compile()
-            self._world._data = mj.MjData(self._world._model)
+                model = spec.compile()
+            data = mj.MjData(model)
             # Forward the freshly-allocated MjData so derived state
             # (xpos / xquat / xmat / sensor data) is populated. Without
             # this, ``Renderer.update_scene`` finds the body transforms
@@ -627,36 +630,48 @@ class MuJoCoSimEngine(
             # Cost: O(model.nbody) - negligible for typical scenes.
             # Failure here is genuinely a bug in the loaded MJCF
             # (e.g. inconsistent qpos vs joint definitions), so let it
-            # propagate to the outer ``except Exception`` below where
-            # it gets converted to a structured error response.
-            mj.mj_forward(self._world._model, self._world._data)
-            self._world.status = SimStatus.IDLE
+            # propagate to the ``except`` below where it gets converted
+            # to a structured error response - with the old world intact.
+            mj.mj_forward(model, data)
+        except Exception as e:
+            logger.error("Failed to load scene: %s", e)
+            return {"status": "error", "content": [{"text": f"Failed to load scene: {e}"}]}
+
+        # Compile succeeded - atomically swap in the new world under the lock
+        # so a concurrent render/recorder thread never observes a half-built
+        # world (load_scene runs under the blanket dispatch lock, so this
+        # acquisition is a reentrant no-op there and the real guard when the
+        # method is called directly).
+        with self._lock:
+            world = SimWorld()
+            world._backend_state["spec"] = spec
+            world._model = model
+            world._data = data
+            world.status = SimStatus.IDLE
 
             # Cache the canonical serialisation; legacy readers use this.
             try:
                 with filter_mujoco_attach_noise():
-                    self._world._backend_state["xml"] = spec.to_xml()
+                    world._backend_state["xml"] = spec.to_xml()
             except Exception as xml_err:
                 logger.debug("spec.to_xml() on loaded scene failed: %s", xml_err)
 
-            self._world._backend_state["scene_loaded"] = True
-            self._world._backend_state["scene_base_dir"] = os.path.dirname(os.path.abspath(scene_path))
+            world._backend_state["scene_loaded"] = True
+            world._backend_state["scene_base_dir"] = os.path.dirname(os.path.abspath(scene_path))
+            self._world = world
 
-            return {
-                "status": "success",
-                "content": [
-                    {
-                        "text": (
-                            f"Scene loaded from {os.path.basename(scene_path)}\n"
-                            f"Bodies: {self._world._model.nbody}, Joints: {self._world._model.njnt}, Actuators: {self._world._model.nu}\n"
-                            "Use action='get_state' to inspect, action='step' to simulate"
-                        )
-                    }
-                ],
-            }
-        except Exception as e:
-            logger.error("Failed to load scene: %s", e)
-            return {"status": "error", "content": [{"text": f"Failed to load scene: {e}"}]}
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": (
+                        f"Scene loaded from {os.path.basename(scene_path)}\n"
+                        f"Bodies: {model.nbody}, Joints: {model.njnt}, Actuators: {model.nu}\n"
+                        "Use action='get_state' to inspect, action='step' to simulate"
+                    )
+                }
+            ],
+        }
 
     def replace_scene_mjcf(self, xml: str) -> dict[str, Any]:
         """Atomically replace the entire scene with agent-authored MJCF.
@@ -1499,14 +1514,23 @@ class MuJoCoSimEngine(
         # rebuilds the spec from the remaining world.robots dict, so the robot
         # we want to drop must no longer be in it.
         robot_obj = self._world.robots[name]
-        del self._world.robots[name]
 
-        # Detach the robot's per-peer mesh (if any) BEFORE the XML rebuild
-        # so external peers see the peer leave the mesh promptly. This is
-        # the inverse of the announce in ``add_robot`` / ``_attach_robot_to_mesh``.
-        self._detach_robot_from_mesh(robot_obj)
+        # The cooperative stop + no-running-policy gate above guarantee no
+        # PolicyRunner worker is mid-mj_step. The XML round-trip below still
+        # reallocates model/data, so serialize it under self._lock to exclude
+        # the render/recorder daemon (rendering.py reads mjData under the same
+        # lock). remove_robot is dispatched WITHOUT the blanket lock (see
+        # _SELF_LOCKING_ACTIONS), so this acquisition is the real critical
+        # section, not a reentrant no-op.
+        with self._lock:
+            del self._world.robots[name]
 
-        ejected = eject_robot_from_scene(self._world, name)
+            # Detach the robot's per-peer mesh (if any) BEFORE the XML rebuild
+            # so external peers see the peer leave the mesh promptly. This is
+            # the inverse of the announce in ``add_robot`` / ``_attach_robot_to_mesh``.
+            self._detach_robot_from_mesh(robot_obj)
+
+            ejected = eject_robot_from_scene(self._world, name)
         if not ejected:
             # Unlikely - rebuild from world state with one fewer robot.
             return {
@@ -2559,51 +2583,57 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": oerr}]}
 
         mj = self._mj
-        model, data = self._world._model, self._world._data
-
-        jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
-        if jnt_id >= 0:
-            # Dynamic object: a freejoint carries its pose, so move it cheaply
-            # through data.qpos + a forward pass (no recompile).
-            qpos_addr = model.jnt_qposadr[jnt_id]
-            moved = False
-            if position:
-                data.qpos[qpos_addr : qpos_addr + 3] = position
-                self._world.objects[name].position = position
-                moved = True
-            if orientation:
-                data.qpos[qpos_addr + 3 : qpos_addr + 7] = orientation
-                self._world.objects[name].orientation = orientation
-                moved = True
-            if moved:
-                # Place the object AT REST at the new pose. A freejoint retains
-                # its 6-DOF linear+angular velocity across a bare data.qpos
-                # write, so without this a repositioned object keeps its prior
-                # momentum: a settling object teleports and immediately shoots
-                # off, and an eval/benchmark loop that repositions objects
-                # between episodes starts each episode with the object drifting
-                # (silently non-reproducible). This matches add_object (spawns
-                # at rest), reset (zeroes velocities), and the Newton backend
-                # (rebuilds from the builder at rest).
-                dof_addr = model.jnt_dofadr[jnt_id]
-                data.qvel[dof_addr : dof_addr + 6] = 0.0
-            mj.mj_forward(model, data)
-        elif position is not None or orientation is not None:
-            # Static object: welded to the worldbody with no freejoint, so it
-            # has no data.qpos slice to write - the old code fell through here
-            # and returned success while moving nothing (a silent no-op).
-            # Reposition it by editing the spec body pose and recompiling
-            # (preserving other joints' state), mirroring add_object /
-            # remove_object.
-            if not reposition_body_in_scene(self._world, name, position=position, orientation=orientation):
-                return {
-                    "status": "error",
-                    "content": [{"text": f"Failed to reposition '{name}' in the live scene."}],
-                }
-            if position is not None:
-                self._world.objects[name].position = position
-            if orientation is not None:
-                self._world.objects[name].orientation = orientation
+        # move_object writes data.qpos/qvel + mj_forward (dynamic path) or
+        # recompiles the scene (static path); serialize both against a
+        # concurrent mj_step/render under self._lock, matching every sibling
+        # mutator (send_action, step, reset, set_gravity). The
+        # _require_no_running_policy gate above stops a policy worker; the
+        # lock additionally excludes the render/recorder daemon.
+        with self._lock:
+            model, data = self._world._model, self._world._data
+            jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
+            if jnt_id >= 0:
+                # Dynamic object: a freejoint carries its pose, so move it cheaply
+                # through data.qpos + a forward pass (no recompile).
+                qpos_addr = model.jnt_qposadr[jnt_id]
+                moved = False
+                if position:
+                    data.qpos[qpos_addr : qpos_addr + 3] = position
+                    self._world.objects[name].position = position
+                    moved = True
+                if orientation:
+                    data.qpos[qpos_addr + 3 : qpos_addr + 7] = orientation
+                    self._world.objects[name].orientation = orientation
+                    moved = True
+                if moved:
+                    # Place the object AT REST at the new pose. A freejoint retains
+                    # its 6-DOF linear+angular velocity across a bare data.qpos
+                    # write, so without this a repositioned object keeps its prior
+                    # momentum: a settling object teleports and immediately shoots
+                    # off, and an eval/benchmark loop that repositions objects
+                    # between episodes starts each episode with the object drifting
+                    # (silently non-reproducible). This matches add_object (spawns
+                    # at rest), reset (zeroes velocities), and the Newton backend
+                    # (rebuilds from the builder at rest).
+                    dof_addr = model.jnt_dofadr[jnt_id]
+                    data.qvel[dof_addr : dof_addr + 6] = 0.0
+                mj.mj_forward(model, data)
+            elif position is not None or orientation is not None:
+                # Static object: welded to the worldbody with no freejoint, so it
+                # has no data.qpos slice to write - the old code fell through here
+                # and returned success while moving nothing (a silent no-op).
+                # Reposition it by editing the spec body pose and recompiling
+                # (preserving other joints' state), mirroring add_object /
+                # remove_object.
+                if not reposition_body_in_scene(self._world, name, position=position, orientation=orientation):
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"Failed to reposition '{name}' in the live scene."}],
+                    }
+                if position is not None:
+                    self._world.objects[name].position = position
+                if orientation is not None:
+                    self._world.objects[name].orientation = orientation
 
         return {"status": "success", "content": [{"text": f"'{name}' moved to {position or 'same'}"}]}
 
@@ -4108,6 +4138,11 @@ class MuJoCoSimEngine(
         }
 
     # Action name aliases (tool-action -> method-name)
+    # Dispatched actions that manage their own locking and MUST NOT run
+    # under the blanket dispatch RLock (see _dispatch_action). Each one
+    # acquires self._lock internally around its own model/data access.
+    _SELF_LOCKING_ACTIONS: frozenset[str] = frozenset({"step", "stop_policy", "remove_robot"})
+
     _ACTION_ALIASES = {
         "list_robots": "list_robots_info",
         "list_cameras": "list_cameras_info",
@@ -4292,11 +4327,27 @@ class MuJoCoSimEngine(
         if err is not None:
             return err
         assert kwargs is not None
-        # All dispatched actions are serialized under self._lock (RLock).
-        # This is the single chokepoint that prevents concurrent reads/writes
-        # to MuJoCo model/data from the agent thread while a PolicyRunner
-        # worker is mid-mj_step. Individual methods that also acquire the
-        # lock are harmless (RLock is reentrant on the same thread).
+        # Most dispatched actions are serialized under self._lock (RLock): the
+        # single chokepoint that prevents concurrent reads/writes to MuJoCo
+        # model/data from the agent thread while a PolicyRunner worker is
+        # mid-mj_step. Individual methods that also acquire the lock are
+        # harmless (RLock is reentrant on the same thread).
+        #
+        # A few actions in _SELF_LOCKING_ACTIONS must run WITHOUT the blanket
+        # lock because they manage their own concurrency:
+        #   * remove_robot joins on the target robot's PolicyRunner Future;
+        #     that worker needs self._lock to observe the cooperative-stop
+        #     flag, so holding the lock across the join deadlocks (the join
+        #     then swallows the TimeoutError and rebuilds the scene under a
+        #     still-live worker holding stale model/data ids).
+        #   * step acquires+releases self._lock in bounded batches so
+        #     stop_policy and the recorder/MJPEG threads can interleave on long
+        #     runs; the blanket lock would hold it for the whole call and
+        #     defeat the batching.
+        #   * stop_policy only flips a bool and needs no lock; keeping it off
+        #     the blanket lock lets it interrupt a long-running step.
+        if method_name in self._SELF_LOCKING_ACTIONS:
+            return method(**kwargs)
         with self._lock:
             return method(**kwargs)
 

--- a/tests/simulation/mujoco/test_engine_locking_discipline.py
+++ b/tests/simulation/mujoco/test_engine_locking_discipline.py
@@ -1,0 +1,299 @@
+"""Locking-discipline regression tests for the MuJoCo simulation engine.
+
+Each test pins a concurrency defect that races the agent-dispatch thread
+against a PolicyRunner worker or the recorder/render daemon:
+
+* ``remove_robot`` dispatched during an active policy must return promptly
+  (no swallowed cooperative-stop timeout) and let the worker exit cleanly,
+  instead of stalling on a join held under the dispatch lock and then
+  rebuilding the scene under a still-live worker.
+* A long-running dispatched ``step`` must not block ``stop_policy`` (or any
+  other lightweight action): ``step`` releases the engine lock between
+  batches and ``stop_policy`` runs without the blanket dispatch lock.
+* A failed ``load_scene`` must leave the previously-live world intact.
+* ``move_object`` must mutate ``qpos``/``qvel`` (and recompile static bodies)
+  under the engine lock, like every sibling mutator.
+* ``render`` must read ``mjData`` under the engine lock so a concurrent
+  ``mj_step`` cannot tear the frame or crash on ``data.contact``.
+"""
+
+import threading
+import time
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+requires_gl = pytest.mark.skipif(
+    not _can_render(),
+    reason="No OpenGL context available (headless without EGL/OSMesa)",
+)
+
+_ARM_XML = """
+<mujoco model="lock_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def arm_xml_path(tmp_path):
+    path = tmp_path / "lock_arm.xml"
+    path.write_text(_ARM_XML)
+    return str(path)
+
+
+@pytest.fixture
+def sim_with_arm(arm_xml_path):
+    sim = Simulation(tool_name="test_locking", mesh=False)
+    assert sim.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+    assert sim.add_robot("arm1", urdf_path=arm_xml_path)["status"] == "success"
+    yield sim
+    sim.cleanup(policy_stop_timeout=1.0)
+
+
+class _SlowPolicy:
+    """A trivial policy whose per-step inference sleeps, keeping the worker
+    demonstrably alive while ``remove_robot`` races it."""
+
+    provider_name = "slow_test"
+    requires_images = False
+
+    def set_robot_state_keys(self, keys):  # noqa: D401 - test stub
+        pass
+
+    def reset(self, seed=None):
+        pass
+
+    def get_actions_sync(self, observation, instruction):
+        time.sleep(0.05)
+        return {"shoulder_pan": 0.1}
+
+    async def get_actions(self, observation, instruction):
+        return {"shoulder_pan": 0.1}
+
+
+def test_remove_robot_during_active_policy_returns_and_worker_exits_clean(sim_with_arm, arm_xml_path):
+    """remove_robot dispatched while a policy runs returns promptly.
+
+    Pre-fix, the dispatch path held the reentrant engine lock across the
+    cooperative-stop join; the worker (which needs that same lock to observe
+    the stop flag) could never exit, so the join hit its 5s timeout, the
+    TimeoutError was swallowed, and the scene was rebuilt under a live worker
+    holding stale model/data ids. The dispatched call therefore stalled ~5s
+    and left the worker crashing on freed state.
+
+    Post-fix, remove_robot runs without the blanket lock, so the worker sees
+    the stop flag and exits cleanly and the call returns near-instantly.
+    """
+    sim = sim_with_arm
+    started = sim.start_policy(robot_name="arm1", policy_object=_SlowPolicy(), duration=30.0, control_frequency=50.0)
+    assert started["status"] == "success"
+    # Let the worker enter its control loop.
+    time.sleep(0.3)
+    assert "arm1" in sim._policy_threads
+
+    # Dispatch through __call__ -> _dispatch_action (the path that used to
+    # hold the blanket lock across the join).
+    start = time.monotonic()
+    result = sim(action="remove_robot", name="arm1")
+    elapsed = time.monotonic() - start
+
+    assert result["status"] == "success", result
+    # The swallowed timeout was 5s; anything under 3s proves no deadlock/stall.
+    assert elapsed < 3.0, f"remove_robot stalled {elapsed:.2f}s (cooperative-stop deadlock)"
+    assert "arm1" not in sim.list_robots()
+
+    # Clean scene integrity: the worker unwound without corrupting the rebuilt
+    # scene, so the same name can be re-added and the engine still steps.
+    re_added = sim.add_robot("arm1", urdf_path=arm_xml_path)
+    assert re_added["status"] == "success", re_added
+    assert sim.step(n_steps=1)["status"] == "success"
+
+
+def test_long_running_step_does_not_block_stop_policy(sim_with_arm, monkeypatch):
+    """A dispatched multi-batch step must not gate a concurrent stop_policy.
+
+    Pre-fix, step ran entirely under the blanket dispatch lock, so any other
+    dispatched action (here stop_policy) blocked until the whole step
+    finished. Post-fix, step releases the lock between batches and stop_policy
+    dispatches without the blanket lock, so it returns while step is still
+    running.
+    """
+    sim = sim_with_arm
+    real_mj = sim._mj
+
+    class _SlowMj:
+        """Delegates to the real mujoco module but sleeps in mj_step so a
+        multi-batch step() takes a measurable, deterministic wall-time."""
+
+        def mj_step(self, model, data):
+            time.sleep(0.003)
+            return real_mj.mj_step(model, data)
+
+        def __getattr__(self, name):
+            return getattr(real_mj, name)
+
+    monkeypatch.setattr(sim, "_mj", _SlowMj())
+
+    step_done = threading.Event()
+    timings = {}
+
+    def _long_step():
+        t0 = time.monotonic()
+        # > _STEPS_PER_BATCH (1000) so the batched lock-release path is taken.
+        sim(action="step", n_steps=1500)
+        timings["step"] = time.monotonic() - t0
+        step_done.set()
+
+    stepper = threading.Thread(target=_long_step)
+    stepper.start()
+    try:
+        time.sleep(0.2)  # ensure step is underway
+        t0 = time.monotonic()
+        stop_result = sim(action="stop_policy", robot_name="arm1")
+        stop_elapsed = time.monotonic() - t0
+        step_running_when_stop_returned = not step_done.is_set()
+    finally:
+        step_done.wait(30.0)
+        stepper.join(timeout=30.0)
+
+    assert stop_result["status"] == "success"
+    # The killer discriminator: pre-fix, stop_policy only returns AFTER step
+    # finishes (blanket lock), so step is no longer running. Post-fix it
+    # returns mid-step.
+    assert step_running_when_stop_returned, "stop_policy blocked until step finished (blanket lock)"
+    assert stop_elapsed < 1.0, f"stop_policy took {stop_elapsed:.2f}s while step ran {timings.get('step')}s"
+
+
+def test_load_scene_failure_preserves_live_world(sim_with_arm, tmp_path):
+    """A malformed MJCF must not destroy the currently-live world.
+
+    Pre-fix, load_scene reassigned self._world to a fresh empty SimWorld
+    before compiling, so a bad file discarded the live scene AND returned an
+    error dict. Post-fix, the scene compiles into locals first and self._world
+    is only swapped on success.
+    """
+    sim = sim_with_arm
+    live_model = sim._world._model
+    assert "arm1" in sim._world.robots
+
+    bad = tmp_path / "bad.xml"
+    bad.write_text("<mujoco><worldbody><geom type='box' size='oops'/></worldbody></mujoco>")
+
+    result = sim(action="load_scene", scene_path=str(bad))
+    assert result["status"] == "error"
+    # World intact: same live model object, robot still present, still steppable.
+    assert sim._world is not None
+    assert sim._world._model is live_model
+    assert "arm1" in sim._world.robots
+    assert sim.step(n_steps=1)["status"] == "success"
+
+
+def test_load_scene_success_still_swaps_world(sim_with_arm, arm_xml_path):
+    """The happy path still replaces the world (guards against over-correction)."""
+    sim = sim_with_arm
+    result = sim(action="load_scene", scene_path=arm_xml_path)
+    assert result["status"] == "success"
+    assert sim._world is not None and sim._world._model is not None
+    assert sim._world._backend_state.get("scene_loaded") is True
+
+
+def test_move_object_mutates_under_engine_lock(sim_with_arm):
+    """move_object must hold self._lock while writing qpos/qvel + mj_forward.
+
+    Deterministic proof: hold the engine lock on the main thread, then invoke
+    move_object from a worker thread. Post-fix the worker blocks until the
+    lock is released; pre-fix (no lock) it completes immediately.
+    """
+    sim = sim_with_arm
+    added = sim.add_object("ball", shape="sphere", position=[0.2, 0.0, 0.5], size=[0.05], is_static=False)
+    assert added["status"] == "success"
+
+    done = threading.Event()
+
+    sim._lock.acquire()
+    try:
+        worker = threading.Thread(target=lambda: (sim.move_object("ball", position=[0.3, 0.1, 0.5]), done.set()))
+        worker.start()
+        # Blocked because a different thread holds the RLock.
+        assert not done.wait(0.4), "move_object did not serialize under the engine lock"
+    finally:
+        sim._lock.release()
+
+    assert done.wait(3.0), "move_object never completed after lock release"
+    worker.join(timeout=3.0)
+
+
+@requires_gl
+def test_render_reads_mjdata_under_engine_lock(sim_with_arm):
+    """render must read mjData under self._lock so a concurrent mj_step cannot
+    tear the frame or crash on data.contact.
+
+    Deterministic proof mirrors move_object: hold the lock, render from a
+    worker thread, assert it blocks until release.
+    """
+    sim = sim_with_arm
+    result_box = {}
+    done = threading.Event()
+
+    sim._lock.acquire()
+    try:
+        worker = threading.Thread(
+            target=lambda: (
+                result_box.__setitem__("r", sim.render(camera_name="default", width=64, height=64)),
+                done.set(),
+            )
+        )
+        worker.start()
+        assert not done.wait(0.4), "render did not serialize its mjData read under the engine lock"
+    finally:
+        sim._lock.release()
+
+    assert done.wait(10.0), "render never completed after lock release"
+    worker.join(timeout=10.0)
+    assert result_box["r"]["status"] == "success"
+
+
+@requires_gl
+def test_concurrent_render_and_step_do_not_crash(sim_with_arm):
+    """Smoke: a render loop concurrent with a stepping loop must not SIGSEGV
+    or raise (both now serialize on the engine lock)."""
+    sim = sim_with_arm
+    errors = []
+    stop = threading.Event()
+
+    def _render_loop():
+        try:
+            while not stop.is_set():
+                r = sim.render(camera_name="default", width=64, height=64)
+                if r["status"] != "success":
+                    errors.append(f"render: {r}")
+                    return
+        except Exception as e:  # noqa: BLE001 - surface any crash as a failure
+            errors.append(f"render raised: {e}")
+
+    renderer = threading.Thread(target=_render_loop)
+    renderer.start()
+    try:
+        for _ in range(50):
+            sim.step(n_steps=5)
+    finally:
+        stop.set()
+        renderer.join(timeout=10.0)
+    assert not errors, errors


### PR DESCRIPTION
## Summary

The MuJoCo `SimEngine` serialized every dispatched action under one blanket reentrant `self._lock`. That single chokepoint broke several concurrency invariants; this PR moves to per-site locking discipline.

### remove_robot cooperative-stop deadlock (native-crash risk)
`remove_robot` stops the target robot's policy cooperatively by joining its `PolicyRunner` worker Future. But that worker can only observe the stop flag by acquiring `self._lock` (through `get_observation` / `send_action`). Because the dispatch path already held that lock across the whole call, the worker could never make progress: the join hit its 5s timeout, the `TimeoutError` was swallowed, the Future was deleted, `_require_no_running_policy` then passed, and the scene was rebuilt (model/data reallocated) while the worker still held stale ids.

### step's batched lock-release was dead code
`step()` deliberately releases `self._lock` between 1000-step batches so `stop_policy` and recorder threads can interleave on long runs. The blanket dispatch lock held it for the entire call, so a dispatched `step(100_000)` monopolized the engine and blocked every other caller.

**Fix:** a small `_SELF_LOCKING_ACTIONS` set (`step`, `stop_policy`, `remove_robot`) dispatches WITHOUT the blanket lock and manages its own locking. `remove_robot` now joins unlocked, then rebuilds the scene under `self._lock`; `step`'s batched release works again; `stop_policy` (a bool flip) is never gated.

### Three mutation sites that relied on the blanket lock
- **load_scene destroyed the live scene on failure** - it reassigned `self._world = SimWorld()` before compiling, so a malformed MJCF discarded the running world and still returned an error dict. It now compiles into locals and swaps `self._world` (under the lock) only on a successful compile + forward, matching `replace_scene_mjcf`.
- **move_object** wrote `qpos`/`qvel` + `mj_forward` (and recompiled static bodies) with no lock, racing a concurrent `mj_step`. Now under `self._lock`, like every sibling mutator (`send_action`, `step`, `reset`, `set_gravity`).
- **render()** read `mjData` (`update_scene`, and `data.contact` inside `render()`) with no lock while the recorder daemon calls it concurrently with `mj_step`, tearing recorded frames and risking a native crash. The `mjData` read + frame copy are now under `self._lock`; PNG encoding stays unlocked on the copied buffer.

## Tests
`tests/simulation/mujoco/test_engine_locking_discipline.py` (7 tests) pins each behavior; every one fails on pre-fix code:
- `remove_robot` during an active policy returns in <3s (was a swallowed 5s stall) and the worker exits cleanly; the rebuilt scene is intact (robot re-addable and steppable).
- a long multi-batch dispatched `step` no longer blocks `stop_policy` (stop returns while the step is still running).
- a failed `load_scene` leaves the previous world intact and steppable; the happy path still swaps the world.
- `move_object` and `render` serialize their `mjData` access under the engine lock (deterministic lock-blocking proof: hold the lock on one thread, assert the other blocks until release).
- a render loop concurrent with a stepping loop does not crash.

Full `tests/simulation/mujoco` suite: **1559 passed**. `ruff check` / `ruff format --check` / `mypy` clean.

## Rollout (headless MuJoCo sim, EGL)
Render + recording pipeline verified healthy under the new locking: a 150-frame rollout recorded to MP4 (480x360). A render loop interleaved with a stepping loop produced 128 renders with 0 errors/crashes.

![rollout](https://github.com/cagataycali/robots/releases/download/artifact-mujoco-locking-1785018777/rollout_locking_demo.gif)