### PR TITLE
fix(isaac): honor/reject params in send_action, create_world, add_robot

### DIFF
--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -751,6 +751,67 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     }
                 ],
             }
+        # Isaac's ``PhysicsContext.set_gravity`` takes a single signed scalar
+        # (the gravity along -Z); the backend cannot apply an off-axis vector.
+        # A non-Z-aligned override was previously silently reduced to its
+        # z-component -- so ``gravity=[0, -9.81, 0]`` yielded ZERO gravity --
+        # while the result echoed the full input vector as if applied. Validate
+        # up front and reject anything the backend cannot honour, rather than
+        # applying a gravity the caller never asked for.
+        if gravity is not None:
+            if isinstance(gravity, (list, tuple)):
+                if len(gravity) != 3:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"create_world: gravity vector must have 3 components [gx, gy, gz], "
+                                    f"got {len(gravity)}."
+                                )
+                            }
+                        ],
+                    }
+                try:
+                    gvec = [float(g) for g in gravity]
+                except (TypeError, ValueError):
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"create_world: gravity components must be numbers, got {gravity!r}."}],
+                    }
+                if not all(np.isfinite(gvec)):
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"create_world: gravity components must be finite, got {gravity!r}."}],
+                    }
+                if gvec[0] != 0.0 or gvec[1] != 0.0:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"create_world: the Isaac backend only supports Z-aligned gravity "
+                                    f"(its PhysicsContext.set_gravity takes a signed scalar); a non-Z-aligned "
+                                    f"vector like {gravity!r} cannot be honoured. Pass a scalar or a "
+                                    f"[0, 0, gz] vector, or use create_simulation(backend='mujoco') for "
+                                    f"arbitrary-direction gravity."
+                                )
+                            }
+                        ],
+                    }
+            elif isinstance(gravity, (int, float)):
+                if not np.isfinite(gravity):
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"create_world: gravity must be finite, got {gravity!r}."}],
+                    }
+            else:
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": f"create_world: gravity must be a scalar or [gx, gy, gz] vector, got {gravity!r}."}
+                    ],
+                }
         with self._lock:
             if self._world_created:
                 return {
@@ -1128,7 +1189,13 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         urdf_path : str, optional
             Path to URDF file.
         mjcf_path : str, optional
-            Path to MJCF file.
+            Path to an MJCF file. The Isaac backend has no MJCF importer for
+            robots (it loads USD natively and converts URDF via the Omniverse
+            URDF importer), so a non-None value is rejected with an actionable
+            error rather than being silently ignored -- previously a name that
+            also matched the procedural registry would silently spawn the
+            procedural stub instead. Convert the MJCF to URDF/USD, or use
+            create_simulation(backend="mujoco") to load MJCF directly.
         usd_path : str, optional
             Path to USD file (native Isaac format).
         data_config : str, optional
@@ -1136,7 +1203,14 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         position : list[float], optional
             Base position [x, y, z].
         orientation : list[float], optional
-            Base orientation as quaternion [w, x, y, z].
+            Base orientation as quaternion [w, x, y, z]. The Isaac ``add_robot``
+            spawn path does not yet apply a base orientation (the USD/URDF
+            loaders position the articulation but ignore rotation), so a
+            non-identity quaternion is rejected with an actionable error rather
+            than being silently dropped. Omit it (or pass identity
+            ``[1, 0, 0, 0]``) for the default upright spawn, or use
+            create_simulation(backend="mujoco") to spawn at an arbitrary
+            orientation.
         keyframe : str | int, optional
             Canonical-pose keyframe (e.g. panda ``"home"``). The Isaac
             backend does not parse the MuJoCo ``<keyframe>`` block this
@@ -1165,6 +1239,38 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                             "create_simulation(backend='mujoco') to spawn at a "
                             "keyframe, or omit keyframe for the default zero-pose "
                             "spawn."
+                        )
+                    }
+                ],
+            }
+        if mjcf_path is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"add_robot: mjcf_path={mjcf_path!r} is not supported on the Isaac "
+                            "backend (it has no MJCF robot importer; it loads USD natively and "
+                            "converts URDF). Convert the MJCF to URDF/USD and pass urdf_path/"
+                            "usd_path, or use create_simulation(backend='mujoco') to load MJCF."
+                        )
+                    }
+                ],
+            }
+        # The default None means identity; only a non-identity quaternion is
+        # rejected (parity with the keyframe/terrain guards -- reject an
+        # unsupported request rather than silently dropping the rotation).
+        if orientation is not None and list(orientation) != [1.0, 0.0, 0.0, 0.0]:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"add_robot: orientation={orientation!r} is not applied on the Isaac "
+                            "backend spawn path (the USD/URDF loaders position the articulation but "
+                            "ignore base rotation). Omit orientation (or pass identity "
+                            "[1, 0, 0, 0]) for the default upright spawn, or use "
+                            "create_simulation(backend='mujoco') to spawn at an orientation."
                         )
                     }
                 ],
@@ -2269,17 +2375,29 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             # being silently dropped (parity with the MuJoCo backend).
             unresolved: list[str] = []
             action_array: np.ndarray
+            # ``joint_indices`` restricts an ``ArticulationAction`` to a subset
+            # of the articulation's DOFs; ``None`` addresses every joint. For a
+            # dict action we command ONLY the named joints and leave the rest at
+            # their current PD targets (parity with the MuJoCo/Newton backends).
+            # A full zero-filled ``joint_positions`` vector would instead drive
+            # every unnamed joint to 0.0 -- e.g. ``send_action({"gripper": 0.04})``
+            # would slam the whole arm to its home pose.
+            joint_indices: np.ndarray | None
             if isinstance(action, dict):
                 joint_set = set(robot.joint_names)
                 unresolved = [k for k in action if k not in joint_set]
-                action_array = np.zeros(len(robot.joint_names), dtype=np.float32)
-                for i, jname in enumerate(robot.joint_names):
-                    if jname in action:
-                        action_array[i] = float(action[jname])
+                named = [i for i, jname in enumerate(robot.joint_names) if jname in action]
+                action_array = np.array(
+                    [float(action[robot.joint_names[i]]) for i in named],
+                    dtype=np.float32,
+                )
+                joint_indices = np.array(named, dtype=np.int32)
             elif isinstance(action, np.ndarray):
                 action_array = action.astype(np.float32).flatten()
+                joint_indices = None
             else:
                 action_array = np.array(action, dtype=np.float32)
+                joint_indices = None
 
             # Apply to articulation. Isaac Sim 6.0's articulation
             # (``isaacsim.core.prims.SingleArticulation``) drives PD position
@@ -2288,13 +2406,15 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             # on the 6.0 class (the #101 ``omni.isaac.* -> isaacsim.*`` migration
             # renamed imports but missed this articulation method). See
             # ``set_joint_positions`` below for the teleport (non-PD) counterpart.
-            if robot.articulation is not None:
+            if robot.articulation is not None and action_array.size > 0:
                 try:
                     from isaacsim.core.utils.types import (  # type: ignore[import-not-found]
                         ArticulationAction,
                     )
 
-                    robot.articulation.apply_action(ArticulationAction(joint_positions=action_array))
+                    robot.articulation.apply_action(
+                        ArticulationAction(joint_positions=action_array, joint_indices=joint_indices)
+                    )
                 except (RuntimeError, ValueError, AttributeError, ImportError) as e:
                     # apply_action raises RuntimeError on a torn-down
                     # articulation, ValueError on shape mismatch, AttributeError

--- a/tests/simulation/isaac/test_backend_parity.py
+++ b/tests/simulation/isaac/test_backend_parity.py
@@ -1,0 +1,189 @@
+"""Isaac backend parity + honesty for action/world/robot setup.
+
+These tests pin three behaviours where the Isaac backend previously accepted a
+parameter and then silently ignored or misapplied it, diverging from the
+MuJoCo/Newton backends. None of them require NVIDIA Isaac Sim to be installed:
+
+  * A partial dict ``send_action`` must command ONLY the named joints and leave
+    every unnamed joint at its current PD target (parity with MuJoCo/Newton).
+    The pre-fix code built a full zero-filled ``joint_positions`` vector, which
+    drove every unnamed joint to 0.0 -- ``send_action({"gripper": 0.04})``
+    slammed the whole arm to its home pose.
+  * ``create_world`` must reject a non-Z-aligned gravity vector up front instead
+    of silently reducing it to its (zero) z-component while echoing the full
+    vector as applied.
+  * ``add_robot`` must reject an ``mjcf_path`` (no MJCF importer) and a
+    non-identity ``orientation`` (never applied) rather than silently spawning a
+    procedural stub / dropping the rotation.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+
+
+class _FakeArticulationAction:
+    """Stand-in for isaacsim.core.utils.types.ArticulationAction."""
+
+    def __init__(self, joint_positions=None, joint_indices=None):
+        self.joint_positions = joint_positions
+        self.joint_indices = joint_indices
+
+
+class _FakeArticulation:
+    """Records the last ArticulationAction handed to apply_action."""
+
+    def __init__(self):
+        self.last_action = None
+
+    def apply_action(self, action):
+        self.last_action = action
+
+    def get_joint_positions(self):
+        return None
+
+
+class _FakeWorld:
+    """Minimal Isaac World: send_action only needs step()."""
+
+    def step(self, render=False):  # noqa: ARG002 - signature parity
+        return None
+
+
+@pytest.fixture
+def fake_isaacsim_types(monkeypatch):
+    """Inject a fake ``isaacsim.core.utils.types`` exposing ArticulationAction.
+
+    ``send_action`` imports ``ArticulationAction`` lazily inside the method, so a
+    fake module tree lets the apply-action path run with no Omniverse install.
+    """
+    mods = {}
+    for name in ("isaacsim", "isaacsim.core", "isaacsim.core.utils", "isaacsim.core.utils.types"):
+        mod = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, mod)
+        mods[name] = mod
+    mods["isaacsim.core.utils.types"].ArticulationAction = _FakeArticulationAction
+    # Wire the submodule attributes so `import isaacsim.core.utils.types` resolves.
+    mods["isaacsim"].core = mods["isaacsim.core"]
+    mods["isaacsim.core"].utils = mods["isaacsim.core.utils"]
+    mods["isaacsim.core.utils"].types = mods["isaacsim.core.utils.types"]
+    return mods
+
+
+def _seed_running_world(sim, joint_names, articulation):
+    sim._world = _FakeWorld()
+    sim._world_created = True
+    sim._robots = {
+        "arm": _RobotState(
+            name="arm",
+            prim_path="/World/Robots/arm",
+            joint_names=list(joint_names),
+            articulation=articulation,
+        )
+    }
+
+
+class TestSendActionPartialDict:
+    JOINTS = ["shoulder", "elbow", "wrist", "gripper"]
+
+    def test_partial_dict_commands_only_named_joints(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        art = _FakeArticulation()
+        _seed_running_world(sim, self.JOINTS, art)
+
+        result = sim.send_action({"gripper": 0.04}, robot_name="arm")
+        assert result["status"] == "success", result
+
+        act = art.last_action
+        assert act is not None, "apply_action was never called"
+        # Only the gripper joint (index 3) is commanded; the shoulder/elbow/wrist
+        # are left at their current PD targets (joint_indices excludes them).
+        assert act.joint_indices is not None, "joint_indices must scope the command"
+        assert list(np.asarray(act.joint_indices)) == [3]
+        assert list(np.asarray(act.joint_positions)) == pytest.approx([0.04])
+        # Regression guard: the command must NOT be a full 4-vector homing the arm.
+        assert np.asarray(act.joint_positions).shape == (1,)
+
+    def test_full_dict_commands_all_joints(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        art = _FakeArticulation()
+        _seed_running_world(sim, self.JOINTS, art)
+
+        result = sim.send_action({"shoulder": 0.1, "elbow": 0.2, "wrist": 0.3, "gripper": 0.04}, robot_name="arm")
+        assert result["status"] == "success", result
+        act = art.last_action
+        assert list(np.asarray(act.joint_indices)) == [0, 1, 2, 3]
+        assert list(np.asarray(act.joint_positions)) == pytest.approx([0.1, 0.2, 0.3, 0.04])
+
+    def test_vector_action_addresses_all_joints(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        art = _FakeArticulation()
+        _seed_running_world(sim, self.JOINTS, art)
+
+        result = sim.send_action([0.1, 0.2, 0.3, 0.04], robot_name="arm")
+        assert result["status"] == "success", result
+        act = art.last_action
+        # A positional vector addresses every joint -> joint_indices None (all).
+        assert act.joint_indices is None
+        assert list(np.asarray(act.joint_positions)) == pytest.approx([0.1, 0.2, 0.3, 0.04])
+
+
+class TestCreateWorldGravity:
+    def test_non_z_aligned_vector_rejected(self):
+        sim = IsaacSimulation()
+        result = sim.create_world(gravity=[0.0, -9.81, 0.0])
+        assert result["status"] == "error"
+        text = result["content"][0]["text"].lower()
+        assert "z-aligned" in text or "z-aligned gravity" in text
+
+    def test_wrong_length_vector_rejected(self):
+        sim = IsaacSimulation()
+        result = sim.create_world(gravity=[0.0, -9.81])
+        assert result["status"] == "error"
+        assert "3 components" in result["content"][0]["text"]
+
+    def test_non_finite_gravity_rejected(self):
+        sim = IsaacSimulation()
+        result = sim.create_world(gravity=[0.0, 0.0, float("nan")])
+        assert result["status"] == "error"
+        assert "finite" in result["content"][0]["text"].lower()
+
+    def test_z_aligned_vector_passes_validation(self):
+        # A Z-aligned vector clears validation and proceeds to the Isaac import
+        # (which fails on a host without Isaac Sim) -- NOT the gravity error.
+        sim = IsaacSimulation()
+        result = sim.create_world(gravity=[0.0, 0.0, -9.81])
+        assert result["status"] == "error"
+        assert "z-aligned" not in result["content"][0]["text"].lower()
+        assert "3 components" not in result["content"][0]["text"]
+
+
+class TestAddRobotUnsupportedParams:
+    def test_mjcf_path_rejected(self):
+        sim = IsaacSimulation()
+        # so100 matches the procedural registry: pre-fix this silently spawned
+        # the procedural stub and ignored mjcf_path.
+        result = sim.add_robot(name="so100", mjcf_path="/tmp/so100.xml")
+        assert result["status"] == "error"
+        assert "mjcf_path" in result["content"][0]["text"]
+
+    def test_non_identity_orientation_rejected(self):
+        sim = IsaacSimulation()
+        result = sim.add_robot(name="so100", orientation=[0.707, 0.0, 0.707, 0.0])
+        assert result["status"] == "error"
+        assert "orientation" in result["content"][0]["text"]
+
+    def test_identity_orientation_not_rejected(self):
+        # Identity quaternion must pass the guard (it reaches the world-created
+        # check, since no world exists here).
+        sim = IsaacSimulation()
+        result = sim.add_robot(name="so100", orientation=[1.0, 0.0, 0.0, 0.0])
+        assert result["status"] == "error"
+        assert "orientation" not in result["content"][0]["text"]
+        assert "No world created" in result["content"][0]["text"]


### PR DESCRIPTION
## Problem

The Isaac backend accepts three parameters and then silently ignores or misapplies them, diverging from the MuJoCo and Newton backends:

1. **`send_action` dict path homes the whole arm.** A dict action built a full zero-filled `joint_positions` vector and applied it to the entire articulation. A partial command like `send_action({"gripper": 0.04})` therefore drove *every unnamed joint to 0.0*, slamming the arm to its home pose. MuJoCo/Newton apply only the resolved keys and leave the rest at their current targets.
2. **`create_world(gravity=[0, -9.81, 0])` silently applies zero gravity.** Isaac's `PhysicsContext.set_gravity` takes a signed scalar (gravity along -Z), so only `grav[2]` was read while the result echoed the full input vector as applied. An off-axis vector became zero gravity with no warning.
3. **`add_robot` accepts `mjcf_path` and `orientation`, documents them, and ignores both.** The procedural-fallback guard checked only `usd_path`/`urdf_path`, so `mjcf_path=` on a name that also matched the procedural registry silently spawned the procedural stub. `orientation` was never applied by the USD/URDF spawn path.

## Change

- **`send_action`**: command only the named joints via `ArticulationAction(joint_indices=...)`, leaving unnamed joints at their current PD targets. A positional vector still addresses every joint (`joint_indices=None`).
- **`create_world`**: validate `gravity` up front and reject a non-Z-aligned, wrong-length, or non-finite vector (and non-finite scalar) with an actionable error, instead of applying a gravity the caller never asked for. A scalar or `[0, 0, gz]` vector is honored. Validation runs before the Isaac runtime import so it is testable without an Omniverse install.
- **`add_robot`**: reject `mjcf_path` (no MJCF robot importer on this backend) and a non-identity `orientation` (spawn path does not apply base rotation) with actionable errors, matching the existing `keyframe`/`terrain`/`difficulty` guards. Identity orientation and `None` pass through unchanged. Docstrings updated to match.

## Tests

`tests/simulation/isaac/test_backend_parity.py` (new) pins all three behaviours and requires no Isaac Sim install (a fake `isaacsim.core.utils.types.ArticulationAction` module lets the apply-action path run headless). The regression tests fail on pre-fix code and pass after. Full `tests/simulation/isaac/` suite: 107 passed. Lint gate clean (ruff + mypy, no issues).

## Visual proof (MuJoCo, headless EGL)

The fix makes Isaac match the MuJoCo/Newton reference behaviour. Rollout below drives an SO-100 arm to a raised pose, then issues partial `send_action({"Jaw": ...})` commanding *only* the jaw. The arm joints hold their targets (drift < 0.006 rad) while the jaw closes 0.00 -> 0.89 rad -- i.e. unnamed joints are not homed:

![partial send_action parity](https://github.com/cagataycali/robots/releases/download/isaac-send-action-parity-artifacts/isaac_send_action_parity.gif)

```
Rotation     before=+0.4875  after=+0.4908  drift=+0.0033
Pitch        before=-0.9013  after=-0.9061  drift=-0.0048
Elbow        before=+1.2825  after=+1.2883  drift=+0.0058
Wrist_Pitch  before=+0.5874  after=+0.5916  drift=+0.0042
Jaw          before=-0.0000  after=+0.8861  (commanded)
```

[MP4](https://github.com/cagataycali/robots/releases/download/isaac-send-action-parity-artifacts/isaac_send_action_parity.mp4)

## Scope

Focused on the three silent-divergence defects in `isaac/simulation.py` world/robot/action setup that are fully unit-testable without an Omniverse install. The remaining Isaac/Newton items (pump `IndexError` guard + locking, whole-stage `gripper_frame_pose`, MJCF loader rotation/angle units, recording rmtree-before-validate, Newton `HF_LEROBOT_HOME`) touch code paths that need the Isaac runtime or the recording/loader modules and are better reviewed as their own focused PRs.