### PR TITLE
fix(libero): register real BDDL goals, fix default-rng NameError and jitter default contradiction

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -35,6 +35,7 @@ import importlib
 import json
 import logging
 import os
+import random
 import re
 from collections.abc import Callable
 from pathlib import Path
@@ -55,8 +56,6 @@ from strands_robots.simulation.models import SimCamera, SimRobot
 from strands_robots.utils import get_base_dir, require_optional
 
 if TYPE_CHECKING:
-    import random
-
     from strands_robots.simulation.base import SimEngine
 
 logger = logging.getLogger(__name__)
@@ -3147,7 +3146,7 @@ def _walk_predicate_tree(node: Any, sim: SimEngine) -> list[tuple[str, bool]]:
 
     Each reported leaf string includes the actual body positions
     looked up via ``sim.get_body_state`` so we can see why a position-
-    based predicate (``on``, ``inside``, etc.) returned its verdict -
+    based predicate (``on``, ``in``, etc.) returned its verdict -
     distinguishes between "name doesn't resolve" (None pos), "wrong
     geometric threshold" (positions present but predicate still False),
     and "true success" (positions present and predicate True).

--- a/strands_robots/benchmarks/libero/bddl_parser.py
+++ b/strands_robots/benchmarks/libero/bddl_parser.py
@@ -31,7 +31,7 @@ Scope of this parser (matches what LIBERO actually uses):
 * Top-level form: ``(define (problem <name>) ...)``
 * Section markers: ``:domain``, ``:objects``, ``:init``, ``:goal``, ``:language``
 * Boolean combinators: ``and``, ``or``, ``not``
-* Predicate vocabulary: ``on``, ``near``, ``inside``, ``open``, ``closed``,
+* Predicate vocabulary: ``on``, ``near``, ``in``, ``open``, ``closed``,
   ``grasped``, ``upright``
 
 Everything else is either dropped silently (typed-object annotations like
@@ -222,9 +222,9 @@ def _near_kwargs(args: list[str]) -> dict[str, Any]:
     return {"body_a": args[0], "body_b": args[1], "threshold": 0.1}
 
 
-def _inside_kwargs(args: list[str]) -> dict[str, Any]:
+def _in_kwargs(args: list[str]) -> dict[str, Any]:
     if len(args) != 2:
-        raise BDDLParseError(f"(inside ...) expects 2 args, got {len(args)}: {args}")
+        raise BDDLParseError(f"(in ...) expects 2 args, got {len(args)}: {args}")
     return {"body": args[0], "container": args[1]}
 
 
@@ -262,7 +262,7 @@ def _upright_kwargs(args: list[str]) -> dict[str, Any]:
 PREDICATE_VOCABULARY: dict[str, tuple[str, Callable[[list[str]], dict[str, Any]]]] = {
     "on": ("body_on", _on_kwargs),
     "near": ("distance_less_than", _near_kwargs),
-    "inside": ("body_inside", _inside_kwargs),
+    "in": ("body_inside", _in_kwargs),
     "open": ("joint_above", _open_kwargs),
     "closed": ("joint_below", _closed_kwargs),
     "grasped": ("grasped", _grasped_kwargs),

--- a/strands_robots/benchmarks/libero/suite.py
+++ b/strands_robots/benchmarks/libero/suite.py
@@ -256,7 +256,7 @@ def load_libero_suite(
     bddl_dir: str | Path | None = None,
     scene_dir: str | Path | None = None,
     max_steps: int | None = None,
-    init_jitter: float = 0.02,
+    init_jitter: float = 0.0,
     key_prefix: str = "libero",
     load_init_states: bool = True,
 ) -> dict[str, LiberoAdapter]:
@@ -273,7 +273,12 @@ def load_libero_suite(
             <task>.xml`` if the file exists; otherwise scene is left as
             ``None`` and the adapter assumes the scene is already loaded.
         max_steps: Forwarded to every :class:`LiberoAdapter`.
-        init_jitter: Forwarded to every :class:`LiberoAdapter`.
+        init_jitter: Per-episode xy jitter (metres) forwarded to every
+            :class:`LiberoAdapter`. Defaults to ``0.0`` to match
+            :class:`LiberoAdapter`'s own default - non-zero jitter perturbs
+            the canonical init states and puts checkpoints such as
+            ``nvidia/GR00T-N1.7-LIBERO`` out of distribution, so callers must
+            opt in explicitly.
         key_prefix: Registry key format is ``<key_prefix>-<suite>-<task>``.
             Pass ``key_prefix=""`` for ``<suite>-<task>``.
         load_init_states: When ``True`` (default), lazily import

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -651,7 +651,7 @@ def _body_on(
 
 
 def _body_inside(body: str, container: str, xy_tol: float = 0.15, z_tol: float = 0.15) -> BoolPredicate:
-    """Approximate ``(inside A B)`` predicate - A contained within B's volume.
+    """Approximate ``(in A B)`` predicate - A contained within B's volume.
 
     True when A's position is within an axis-aligned box centered on B with
     half-extents (``xy_tol``, ``xy_tol``, ``z_tol``). LIBERO-typical use is

--- a/tests/benchmarks/libero/test_bddl_parser.py
+++ b/tests/benchmarks/libero/test_bddl_parser.py
@@ -202,7 +202,7 @@ class TestPredicateVocabulary:
         sample_args = {
             "on": "cube_1 table_1",
             "near": "cube_1 gripper_1",
-            "inside": "cube_1 basket_1",
+            "in": "cube_1 basket_1",
             "open": "drawer_joint",
             "closed": "drawer_joint",
             "grasped": "cube_1",
@@ -539,14 +539,17 @@ class TestRoundTrip:
         sim = _BodyStateSim({"bottle_1": {"quaternion": [1.0, 0, 0, 0]}})
         assert fn(sim) is True
 
-    def test_inside_task(self):
+    def test_in_task(self):
+        # Upstream LIBERO writes the containment goal as ``(In obj container)``
+        # (see ``libero.libero.envs.predicates.VALIDATE_PREDICATE_FN_DICT``);
+        # the parser normalises the head to lowercase ``in``.
         text = """
-            (define (problem libero_put_inside)
-              (:goal (inside cube_1 basket_1)))
+            (define (problem libero_put_in)
+              (:goal (In cube_1 basket_1)))
         """
         problem = parse_bddl(text)
         fn = compile_goal(problem.goal)  # type: ignore[arg-type]
-        # Approximate-inside uses default tolerances (0.15, 0.15).
+        # Approximate-containment uses default tolerances (0.15, 0.15).
         sim = _BodyStateSim({"cube_1": {"position": [0.05, 0.02, 0.1]}, "basket_1": {"position": [0, 0, 0.1]}})
         assert fn(sim) is True
 
@@ -673,7 +676,7 @@ class TestArityRejection:
         "expr,token",
         [
             ("(near cube_1)", "near"),
-            ("(inside cube_1)", "inside"),
+            ("(in cube_1)", "in"),
             ("(open drawer_joint extra)", "open"),
             ("(closed drawer_joint extra)", "closed"),
         ],

--- a/tests/benchmarks/libero/test_libero_canonical_state_default_rng.py
+++ b/tests/benchmarks/libero/test_libero_canonical_state_default_rng.py
@@ -55,7 +55,7 @@ class _Sim:
         self._world = world
 
 
-def _make_sim() -> _Sim:
+def _make_sim() -> Any:
     model = mujoco.MjModel.from_xml_string(_SCENE_XML)
     data = mujoco.MjData(model)
     return _Sim(_World(model, data))

--- a/tests/benchmarks/libero/test_libero_canonical_state_default_rng.py
+++ b/tests/benchmarks/libero/test_libero_canonical_state_default_rng.py
@@ -1,0 +1,106 @@
+"""Regression: ``_apply_canonical_state`` must run with the documented default rng.
+
+The init-state branch of :meth:`LiberoAdapter._apply_canonical_state` samples a
+row via ``random.Random()`` when the caller passes no ``rng`` (the documented
+``rng=None`` default) on episodes 1+. ``random`` used to be imported only under
+``if TYPE_CHECKING``, so at runtime the fallback raised ``NameError: name
+'random' is not defined`` - a hard crash on the eval path any time a second
+episode ran without an explicit rng. These tests pin that the default-rng path
+works end to end against a real (tiny) compiled MuJoCo model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.benchmarks.libero import LiberoAdapter
+
+mujoco = pytest.importorskip("mujoco")
+
+PICK_CUBE_BDDL = """
+(define (problem libero_spatial_pick_cube)
+  (:domain kitchen)
+  (:language "pick up the cube")
+  (:objects cube_1 - object)
+  (:goal (grasped cube_1)))
+"""
+
+# One slide joint -> nq == nv == 1, so a flat init state is [time, qpos, qvel].
+_SCENE_XML = """
+<mujoco>
+  <worldbody>
+    <body name="slider">
+      <joint name="slide_x" type="slide" axis="1 0 0"/>
+      <geom type="box" size="0.1 0.1 0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+class _World:
+    def __init__(self, model: Any, data: Any) -> None:
+        self._model = model
+        self._data = data
+        self._backend_state: dict[str, Any] = {}
+
+
+class _Sim:
+    """Minimal sim exposing the compiled model/data the branch reads."""
+
+    def __init__(self, world: Any) -> None:
+        self._world = world
+
+
+def _make_sim() -> _Sim:
+    model = mujoco.MjModel.from_xml_string(_SCENE_XML)
+    data = mujoco.MjData(model)
+    return _Sim(_World(model, data))
+
+
+def _make_adapter(init_states: np.ndarray) -> LiberoAdapter:
+    return LiberoAdapter.from_text(
+        PICK_CUBE_BDDL,
+        auto_generate_scene=False,
+        init_jitter=0.0,
+        init_states=init_states,
+    )
+
+
+def test_apply_canonical_state_default_rng_episode1_no_nameerror():
+    """Episode 1+ with default rng samples a row without raising NameError."""
+    # Two rows so the RNG branch has a range to sample from.
+    init_states = np.array([[0.0, 0.1, 0.0], [0.0, 0.2, 0.0]], dtype=np.float64)
+    adapter = _make_adapter(init_states)
+    sim = _make_sim()
+
+    # Force the "episode 1+" branch that hits the ``random.Random()`` fallback.
+    adapter._episode_count = 1
+
+    # Must not raise (pre-fix: NameError: name 'random' is not defined).
+    adapter._apply_canonical_state(sim)
+
+    # A row was applied: qpos is one of the provided init states.
+    assert float(sim._world._data.qpos[0]) in {0.1, 0.2}
+
+
+def test_apply_canonical_state_seeded_rng_is_reproducible():
+    """A supplied seed reproduces the same sampled init state (episode 1+)."""
+    import random
+
+    init_states = np.array(
+        [[0.0, float(i), 0.0] for i in range(8)],
+        dtype=np.float64,
+    )
+
+    def sample(seed: int) -> float:
+        adapter = _make_adapter(init_states)
+        adapter._episode_count = 1
+        sim = _make_sim()
+        adapter._apply_canonical_state(sim, random.Random(seed))
+        return float(sim._world._data.qpos[0])
+
+    assert sample(1234) == sample(1234)

--- a/tests/benchmarks/libero/test_libero_suite.py
+++ b/tests/benchmarks/libero/test_libero_suite.py
@@ -140,6 +140,88 @@ class TestLoadLiberoSuite:
         assert registered == {}
 
 
+# Upstream-predicate registration + jitter default (issue: LIBERO dead e2e)
+
+
+class TestUpstreamPredicateVocabulary:
+    """Regression: real upstream LIBERO goals must register, not silently skip.
+
+    Every ``libero_object`` task ships a goal of the form
+    ``(:goal (And (In <obj> <container>)))`` (verified against the installed
+    ``libero`` 0.1.1 corpus). The parser normalises the predicate head to
+    lowercase, so the containment predicate must be registered under ``in``.
+    Before the fix the vocabulary only carried ``inside``; ``(In ...)`` raised
+    ``BDDLParseError`` and ``load_libero_suite`` returned ``{}`` (zero tasks).
+    """
+
+    def _libero_object_goal(self, obj: str, container: str) -> str:
+        # Mirrors the pinned upstream BDDL goal casing/structure exactly.
+        return (
+            f"(define (problem LIBERO_Floor_Manipulation)\n"
+            f"  (:language pick the {obj} and place it in the {container})\n"
+            f"  (:objects {obj} - object {container} - object)\n"
+            f"  (:goal (And (In {obj} {container}))))\n"
+        )
+
+    def test_libero_object_style_goal_registers(self, tmp_path):
+        suite_dir = tmp_path / "libero_object"
+        tasks = {
+            "pick_up_the_alphabet_soup_and_place_it_in_the_basket": (
+                "alphabet_soup_1",
+                "basket_1_contain_region",
+            ),
+            "pick_up_the_cream_cheese_and_place_it_in_the_basket": (
+                "cream_cheese_1",
+                "basket_1_contain_region",
+            ),
+        }
+        for stem, (obj, container) in tasks.items():
+            _write(suite_dir / f"{stem}.bddl", self._libero_object_goal(obj, container))
+
+        registered = load_libero_suite("libero_object", bddl_dir=suite_dir)
+
+        # Full task set registers (pre-fix this was {} - zero tasks).
+        assert len(registered) == len(tasks)
+        assert set(registered) == {f"libero-object-{stem}" for stem in tasks}
+        for name in registered:
+            assert get_benchmark(name) is not None
+
+    def test_in_goal_compiles_to_containment_predicate(self, tmp_path):
+        suite_dir = tmp_path / "libero_object"
+        _write(
+            suite_dir / "t.bddl",
+            self._libero_object_goal("milk_1", "basket_1_contain_region"),
+        )
+        registered = load_libero_suite("libero_object", bddl_dir=suite_dir)
+        adapter = registered["libero-object-t"]
+        # The compiled goal is a callable success predicate, not a no-op.
+        assert callable(adapter._success_fn)
+
+
+class TestSuiteJitterDefault:
+    """Regression: suite default jitter must match the adapter's own default.
+
+    A non-zero suite default silently perturbed every task's canonical init
+    state, putting checkpoints such as ``nvidia/GR00T-N1.7-LIBERO`` out of
+    distribution even for callers who never asked for jitter.
+    """
+
+    def test_suite_default_matches_adapter_default(self):
+        import inspect
+
+        from strands_robots.benchmarks.libero.adapter import LiberoAdapter
+
+        suite_default = inspect.signature(load_libero_suite).parameters["init_jitter"].default
+        adapter_default = inspect.signature(LiberoAdapter.__init__).parameters["init_jitter"].default
+        assert suite_default == adapter_default == 0.0
+
+    def test_registered_adapters_have_zero_jitter_by_default(self, tmp_path):
+        suite_dir = tmp_path / "libero_spatial"
+        _write(suite_dir / "t.bddl", "(define (problem t) (:goal (grasped cube)))")
+        registered = load_libero_suite("libero_spatial", bddl_dir=suite_dir)
+        assert registered["libero-spatial-t"]._init_jitter == 0.0
+
+
 # Package-root resolution (_resolve_libero_root)
 
 


### PR DESCRIPTION
## Problem

The LIBERO benchmark suites do not load or evaluate against real upstream BDDL files, verified against the installed `libero` 0.1.1 corpus:

1. **Predicate vocabulary mismatch registers zero tasks.** Upstream LIBERO writes the containment goal as `(In <obj> <container>)` — this is *every* `libero_object` task, and it appears 63x across the suites (see `libero.libero.envs.predicates.VALIDATE_PREDICATE_FN_DICT`, key `"in"`). The parser normalises the predicate head to lowercase (`In` -> `in`) but only registered `inside`, so `parse_bddl` raised `BDDLParseError` and `load_libero_suite("libero_object")` returned `{}` — **zero tasks registered**, with only a log warning.

2. **`NameError` on the documented default rng.** `LiberoAdapter._apply_canonical_state`'s init-state branch samples a row via `random.Random()` when the caller passes no `rng` (the documented `rng=None` default) on episodes 1+. But `import random` lived under `if TYPE_CHECKING`, so at runtime the fallback raised `NameError: name 'random' is not defined` — a hard crash on the eval path whenever a second episode ran without an explicit rng.

3. **Jitter default contradiction.** `load_libero_suite` defaulted `init_jitter=0.02` while `LiberoAdapter` deliberately defaults `0.0`. Non-zero jitter perturbs the canonical init states restored from the suite's init-state rows and puts checkpoints such as `nvidia/GR00T-N1.7-LIBERO` out of distribution — for callers who never asked for jitter.

## Change

- **`bddl_parser.py`**: rename the containment vocabulary entry `inside` -> `in` (and `_inside_kwargs` -> `_in_kwargs`) so real `(In ...)` goals parse. This aligns the vocabulary key with upstream LIBERO's own predicate name rather than keeping a near-miss alias.
- **`adapter.py`**: move `import random` out of the `if TYPE_CHECKING` block to a real runtime import.
- **`suite.py`**: change `load_libero_suite` default `init_jitter` `0.02` -> `0.0` to match the adapter, and document why jitter is opt-in.
- Updated stale `(inside A B)` docstring references to `(in A B)`.

## Tests (fail on pre-fix code)

- `TestUpstreamPredicateVocabulary`: `libero_object`-style `(:goal (And (In obj container)))` goals register the full task set (pre-fix: `len({}) == 0`).
- `test_apply_canonical_state_default_rng_episode1_no_nameerror`: the default-rng canonical-state apply runs against a real compiled `MjModel` without raising (pre-fix: `NameError: name 'random'`).
- `TestSuiteJitterDefault`: suite `init_jitter` default equals the adapter default (`0.0`) (pre-fix: `0.02 != 0.0`).
- Updated `test_bddl_parser.py` to exercise upstream `(In ...)` casing.

All 445 `tests/benchmarks/libero/` tests pass; `ruff check`, `ruff format --check`, and `mypy` on the touched modules are clean.

## End-to-end verification against the real upstream corpus

Running `load_libero_suite(..., bddl_dir=<installed libero 0.1.1 bddl_files>)`:

```
libero_object:  registered 10 tasks   (pre-fix: 0)
libero_spatial: registered 10 tasks
libero_goal:    registered  9 tasks   (1 skipped: turn_on_the_stove.bddl)
```

## Out of scope (follow-up)

Articulated-object *success semantics* — `(Open X)` / `(Close X)` / `(TurnOn X)` / `(TurnOff X)` — are intentionally not addressed here. A correct fix is a distinct, larger change: those predicates operate on an articulation joint (drawer/cabinet/microwave/stove) that is **not** in `get_observation` (which exposes only the robot's joints), and each object type has direction- and threshold-specific open/close ranges (e.g. WoodenCabinet opens at `qpos < -0.14`, ShortCabinet at `qpos > 0.10`, Microwave at `qpos < -1.3`). That needs a joint-qpos-by-name query surface on `SimEngine` + a per-object physics table + real-scene validation. Note the `turn_on_the_stove.bddl` skip above is now a clear diagnostic (`unknown predicate 'Turnon'. Supported: [...]`) rather than a silent 0% success rate.