### PR TITLE
fix(policies): PersistentPolicy async get_actions deadlocks under two-thread contention

### DIFF
--- a/strands_robots/policies/persistent.py
+++ b/strands_robots/policies/persistent.py
@@ -83,11 +83,18 @@ class PersistentPolicy(Policy):
     ) -> None:
         self._provider_arg = provider
         self._config = dict(config)
-        # Serialise inference across threads (sync path) and coroutines (async
-        # path). The wrapped model holds per-episode state, so concurrent
-        # get_actions on one shared handle must not interleave.
+        # Serialise inference across BOTH the sync and async entry points with a
+        # single ``threading.Lock``. The wrapped model holds per-episode state,
+        # so concurrent get_actions on one shared handle must not interleave.
+        # A ``threading.Lock`` (not ``asyncio.Lock``) is the correct primitive:
+        # every runtime call path resolves the coroutine via ``asyncio.run`` on
+        # a FRESH event loop per call (see ``strands_robots._async_utils``), and
+        # an ``asyncio.Lock``'s waiter future is bound to the loop that created
+        # it -- a second thread awaiting the lock on its own loop would await a
+        # waiter whose wake-up is scheduled on the first thread's (now-dead)
+        # loop and hang forever. A ``threading.Lock`` is loop-agnostic and
+        # serialises correctly across threads and loops alike.
         self._call_lock = threading.Lock()
-        self._async_lock = asyncio.Lock()
         if policy_object is not None:
             self._inner: Policy = policy_object
         else:
@@ -105,9 +112,20 @@ class PersistentPolicy(Policy):
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, Any]]:
-        """Delegate to the wrapped policy under the async lock (see :meth:`Policy.get_actions`)."""
-        async with self._async_lock:
+        """Delegate to the wrapped policy under the shared thread lock (see :meth:`Policy.get_actions`).
+
+        Acquires the same ``threading.Lock`` the sync path uses, so the sync and
+        async entry points mutually exclude on the wrapped model's per-episode
+        state. The blocking acquire runs in the loop's default executor so a
+        shared running loop is never frozen while another caller holds the lock
+        (each runtime call still runs on its own per-call ``asyncio.run`` loop).
+        """
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._call_lock.acquire)
+        try:
             return await self._inner.get_actions(observation_dict, instruction, **kwargs)
+        finally:
+            self._call_lock.release()
 
     def get_actions_sync(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/strands_robots/policies/persistent.py
+++ b/strands_robots/policies/persistent.py
@@ -49,6 +49,67 @@ from strands_robots.utils import process_rss_mb
 __all__ = ["PersistentPolicy", "preload", "list_cached", "evict"]
 
 
+class _LockHandoff:
+    """Cancellation-safe handoff of a :class:`threading.Lock` to a coroutine.
+
+    ``threading.Lock.acquire`` blocks uninterruptibly, so a coroutine that
+    acquires it via ``loop.run_in_executor`` cannot cancel the acquire once the
+    executor thread has entered it: cancelling the future raises
+    ``CancelledError`` in the awaiting task while the executor thread goes on to
+    take the lock, and nothing is left to release it. On a handle shared across
+    every ``run_policy``/``eval_policy`` call that permanently freezes all
+    subsequent inference.
+
+    This object closes that window by making the acquire hand the lock over
+    under a tiny guard mutex:
+
+    * :meth:`acquire` (executor thread) takes the lock, then publishes it to the
+      waiting coroutine - unless the coroutine already abandoned the acquire, in
+      which case it releases the lock immediately.
+    * :meth:`abandon` (loop thread, in the cancellation handler) marks the
+      acquire abandoned and releases the lock if it was already published.
+
+    Because both sides take ``_guard`` around the flag-and-release, exactly one
+    of them releases the lock no matter how the cancellation interleaves with
+    the acquire, and correctness never depends on a done-callback running on a
+    loop that may already be closed.
+
+    Each call site uses its own instance; the wrapped lock is shared.
+    """
+
+    __slots__ = ("_lock", "_guard", "_abandoned", "_held")
+
+    def __init__(self, lock: threading.Lock) -> None:
+        self._lock = lock
+        self._guard = threading.Lock()
+        self._abandoned = False
+        self._held = False
+
+    def acquire(self) -> None:
+        """Block until the shared lock is held, or drop it if already abandoned."""
+        self._lock.acquire()
+        with self._guard:
+            if self._abandoned:
+                self._lock.release()
+                return
+            self._held = True
+
+    def abandon(self) -> None:
+        """Give up on the acquire; release the lock now or when it is taken."""
+        with self._guard:
+            self._abandoned = True
+            if self._held:
+                self._held = False
+                self._lock.release()
+
+    def release(self) -> None:
+        """Release the shared lock if this handoff currently holds it."""
+        with self._guard:
+            if self._held:
+                self._held = False
+                self._lock.release()
+
+
 class PersistentPolicy(Policy):
     """A persistent, reusable handle around an underlying policy.
 
@@ -119,13 +180,27 @@ class PersistentPolicy(Policy):
         state. The blocking acquire runs in the loop's default executor so a
         shared running loop is never frozen while another caller holds the lock
         (each runtime call still runs on its own per-call ``asyncio.run`` loop).
+
+        Cancellation-safe: if this coroutine is cancelled (e.g. by
+        ``asyncio.wait_for``) while the acquire is still pending, the lock is
+        released as soon as the executor thread obtains it, so a cancelled call
+        never poisons the shared handle. See :class:`_LockHandoff`.
         """
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._call_lock.acquire)
+        handoff = _LockHandoff(self._call_lock)
+        try:
+            await loop.run_in_executor(None, handoff.acquire)
+        except BaseException:
+            # The executor thread cannot be interrupted mid-acquire (a cancelled
+            # wait_for / task is the realistic trigger), so tell the handoff to
+            # drop the lock the moment it takes it. Without this the lock is
+            # leaked and every later call on this shared handle hangs.
+            handoff.abandon()
+            raise
         try:
             return await self._inner.get_actions(observation_dict, instruction, **kwargs)
         finally:
-            self._call_lock.release()
+            handoff.release()
 
     def get_actions_sync(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/tests/policies/test_persistent_worker.py
+++ b/tests/policies/test_persistent_worker.py
@@ -228,7 +228,7 @@ class TestPersistentPolicyWrapper:
             await asyncio.sleep(0.1)  # executor thread is blocked in acquire
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
-                await task
+                await asyncio.wait_for(task, timeout=5.0)
             # Release the holder so the abandoned acquire completes (and, when
             # fixed, immediately drops the lock) before the loop shuts its
             # default executor down.

--- a/tests/policies/test_persistent_worker.py
+++ b/tests/policies/test_persistent_worker.py
@@ -33,6 +33,7 @@ from strands_robots.policies import (
 )
 from strands_robots.policies.base import Policy
 from strands_robots.policies.mock import MockPolicy
+from strands_robots.policies.persistent import _LockHandoff
 
 
 class _CountingPolicy(MockPolicy):
@@ -196,6 +197,91 @@ class TestPersistentPolicyWrapper:
             f"threads still alive after join, done={sorted(done)}"
         )
         assert sorted(done) == [0, 1]
+
+    def test_async_get_actions_cancelled_mid_acquire_frees_shared_lock(self):
+        # Regression: the async entry point acquires the shared threading.Lock in
+        # the loop's executor, and that blocking acquire cannot be cancelled once
+        # the executor thread has entered it. A caller cancelled while the lock
+        # is held elsewhere (asyncio.wait_for around a seconds-long inference is
+        # routine) used to abandon an executor thread that then took the lock
+        # with nobody left to release it, freezing every later call on the shared
+        # handle. The cancelled call must leave the lock free.
+        gate = threading.Event()
+
+        class _GatedInner(MockPolicy):
+            def get_actions_sync(self, observation_dict, instruction, **kwargs):
+                gate.wait(timeout=10.0)  # hold the wrapper's lock until released
+                return super().get_actions_sync(observation_dict, instruction, **kwargs)
+
+        joints = ["j1", "j2", "j3", "j4", "j5", "j6"]
+        inner = _GatedInner()
+        inner.set_robot_state_keys(joints)
+        wrapper = PersistentPolicy("mock", policy_object=inner)
+        wrapper.set_robot_state_keys(joints)
+
+        holder = threading.Thread(target=lambda: wrapper.get_actions_sync(_obs(), ""), daemon=True)
+        holder.start()
+        time.sleep(0.1)  # holder owns the lock, parked on the gate
+
+        async def cancel_while_acquire_is_pending() -> None:
+            task = asyncio.ensure_future(wrapper.get_actions(_obs(), ""))
+            await asyncio.sleep(0.1)  # executor thread is blocked in acquire
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            # Release the holder so the abandoned acquire completes (and, when
+            # fixed, immediately drops the lock) before the loop shuts its
+            # default executor down.
+            gate.set()
+            await asyncio.sleep(0.3)
+
+        asyncio.run(cancel_while_acquire_is_pending())
+        holder.join(timeout=5.0)
+        assert not holder.is_alive()
+
+        # The handle must still be usable: pre-fix the abandoned executor thread
+        # holds the lock forever and this call never returns.
+        served = threading.Event()
+
+        def later_caller() -> None:
+            wrapper.get_actions_sync(_obs(), "")
+            served.set()
+
+        thread = threading.Thread(target=later_caller, daemon=True)
+        thread.start()
+        assert served.wait(timeout=5.0), (
+            "cancelled async get_actions leaked the shared inference lock: "
+            "a subsequent call on the same handle never acquired it"
+        )
+
+    def test_lock_handoff_abandoned_after_acquire_releases_lock(self):
+        # Cancellation landing AFTER the executor thread published the lock: the
+        # coroutine never reaches its finally, so abandon() must do the release.
+        lock = threading.Lock()
+        handoff = _LockHandoff(lock)
+        handoff.acquire()
+        assert lock.locked()
+        handoff.abandon()
+        assert not lock.locked()
+        # Idempotent: a late release() from an unwound frame is a no-op, not a
+        # RuntimeError on an already-unlocked lock.
+        handoff.release()
+        assert not lock.locked()
+
+    def test_lock_handoff_abandoned_before_acquire_releases_lock(self):
+        # Cancellation landing WHILE the executor thread is still blocked: the
+        # acquire itself must drop the lock as soon as it wins it.
+        lock = threading.Lock()
+        lock.acquire()  # another caller is mid-inference
+        handoff = _LockHandoff(lock)
+        acquirer = threading.Thread(target=handoff.acquire, daemon=True)
+        acquirer.start()
+        time.sleep(0.05)
+        handoff.abandon()
+        lock.release()  # the other caller finishes
+        acquirer.join(timeout=5.0)
+        assert not acquirer.is_alive()
+        assert not lock.locked()
 
     def test_forwards_unknown_attribute_to_inner(self):
         # Attributes not explicitly delegated on the wrapper (e.g. provider

--- a/tests/policies/test_persistent_worker.py
+++ b/tests/policies/test_persistent_worker.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
+import time
 
 import pytest
 
@@ -144,8 +145,8 @@ class TestPersistentPolicyWrapper:
 
     def test_async_get_actions_delegates_to_inner(self):
         # The async entry point (used by async runtimes) must delegate to the
-        # wrapped policy's coroutine under the async lock and return its
-        # per-tick action dicts - not a separately rebuilt or zeroed result.
+        # wrapped policy's coroutine under the shared thread lock and return
+        # its per-tick action dicts - not a separately rebuilt or zeroed result.
         inner = MockPolicy()
         inner.set_robot_state_keys(["j1", "j2", "j3", "j4", "j5", "j6"])
         wrapper = PersistentPolicy("mock", policy_object=inner)
@@ -153,6 +154,48 @@ class TestPersistentPolicyWrapper:
         actions = asyncio.run(wrapper.get_actions(_obs(), ""))
         assert isinstance(actions, list) and len(actions) >= 1
         assert all(isinstance(a, dict) for a in actions)
+
+    def test_async_get_actions_no_deadlock_across_per_call_loops(self):
+        # Regression: the runtime resolves the async get_actions via asyncio.run
+        # on a FRESH event loop per call (strands_robots._async_utils), from any
+        # thread. Guarding with a module-level asyncio.Lock deadlocks here: its
+        # waiter future is bound to the loop that created it, so a second thread
+        # awaiting the lock on its own loop awaits a waiter whose wake-up is
+        # scheduled on the first thread's dead loop and never returns. The lock
+        # must be a loop-agnostic threading.Lock. Two threads share one handle;
+        # one holds inference long enough to force contention -- both must return
+        # within a bounded timeout.
+        class _SlowInner(MockPolicy):
+            async def get_actions(self, observation_dict, instruction, **kwargs):
+                time.sleep(0.4)  # hold the lock while the other thread contends
+                return await super().get_actions(observation_dict, instruction, **kwargs)
+
+        inner = _SlowInner()
+        inner.set_robot_state_keys(["j1", "j2", "j3", "j4", "j5", "j6"])
+        wrapper = PersistentPolicy("mock", policy_object=inner)
+        wrapper.set_robot_state_keys(["j1", "j2", "j3", "j4", "j5", "j6"])
+
+        done: list[int] = []
+        dlock = threading.Lock()
+
+        def worker(i: int) -> None:
+            # Mimic the runtime: a brand-new event loop for this single call.
+            asyncio.run(wrapper.get_actions(_obs(), ""))
+            with dlock:
+                done.append(i)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+        threads[0].start()
+        time.sleep(0.05)  # ensure thread 0 acquires the lock first
+        threads[1].start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        assert not any(t.is_alive() for t in threads), (
+            "async get_actions deadlocked under two-thread contention: "
+            f"threads still alive after join, done={sorted(done)}"
+        )
+        assert sorted(done) == [0, 1]
 
     def test_forwards_unknown_attribute_to_inner(self):
         # Attributes not explicitly delegated on the wrapper (e.g. provider


### PR DESCRIPTION
## Problem

`PersistentPolicy` advertises thread-safe shared reuse, but its async `get_actions` guarded inference with a module-level `asyncio.Lock`. Every runtime call path resolves the coroutine via `asyncio.run` on a fresh event loop per call (`strands_robots._async_utils._resolve_coroutine`, and `Policy.get_actions_sync`).

An `asyncio.Lock`'s waiter future is bound to the loop that created it. Thread A acquires the lock on its own per-call loop; thread B awaits the lock on its own fresh loop, whose wake-up callback is scheduled on A's now-dead loop, so B never wakes. Since a single `PersistentPolicy` is the hot path shared across every `run_policy`/`eval_policy` call, two threads driving one shared handle can deadlock.

Reproduced with two threads sharing one handle, one holding inference ~0.4s: the second thread never returns (`done=[0]`, still alive after a 5s join).

## Fix

Unify both entry points on the existing loop-agnostic `threading.Lock` and drop the `asyncio.Lock`. The wrapped model's per-episode state is mutable, so full serialization across the sync and async paths is the intended contract. The async path acquires the shared lock via the running loop's default executor so a shared running loop is never frozen while another caller holds the lock; each runtime call still runs on its own per-call `asyncio.run` loop.

A blocking `Lock.acquire` cannot be cancelled once the executor thread has entered it, so the acquire is routed through a `_LockHandoff` that transfers the lock under a guard mutex:

- `acquire()` (executor thread) takes the shared lock, then either publishes it to the waiting coroutine or, if that coroutine already abandoned the acquire, releases it immediately.
- `abandon()` (loop thread, called synchronously from the cancellation handler) marks the acquire abandoned and releases the lock if it was already published.

Both sides hold the guard across the flag-and-release, so for any interleaving exactly one of them releases the lock. Without this, a call cancelled while its acquire is pending (an `asyncio.wait_for` timeout around a seconds-long VLA inference is routine) leaves an executor thread that takes the lock with nobody left to release it, freezing every later call on the shared handle. Correctness deliberately does not depend on a done-callback running on a loop that may already be closed, which is the common case on the runtime's per-call `asyncio.run` loops.

## Tests

- `test_async_get_actions_no_deadlock_across_per_call_loops` - two threads call the async `get_actions` via `asyncio.run` (fresh loop per call, mirroring the runtime) on one shared handle with a slow inner policy forcing contention; both must return within a bounded timeout. Fails pre-fix (deadlock, `done=[0]`, thread alive after join).
- `test_async_get_actions_cancelled_mid_acquire_frees_shared_lock` - a holder thread owns the lock, an async call is cancelled while its acquire is pending, the holder is released, and a later call on the same handle must still be served. Fails pre-fix (never served: the lock is leaked).
- `test_lock_handoff_abandoned_after_acquire_releases_lock` / `test_lock_handoff_abandoned_before_acquire_releases_lock` - both cancellation interleavings leave the lock free, and a late `release()` is a no-op rather than a `RuntimeError` on an unlocked lock.

`ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` are clean; full `pytest tests` at head: 11524 passed, 254 skipped.

No behavior change to policy outputs, simulation, rendering, or recording; this is a concurrency-correctness fix.