### PR TITLE
fix(verify-dataset): always produce a report on corrupt input instead of crashing

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -236,6 +236,12 @@ never written. It resolves each camera's MP4 from `meta/info.json`'s
 `strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1, check_videos=True)`,
 which returns the same report dict.
 
+`verify-dataset` always produces a report - it never crashes on the corruption
+it exists to flag. A corrupt or foreign `meta/episodes` parquet, a non-v3
+`video_path` template, or a truncated / unreadable MP4 is reported as a problem
+string in the report (and a non-zero exit code), not surfaced as a raw
+traceback.
+
 ## Recording paths
 
 | Method | Extra needed | Output |

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -119,14 +119,15 @@ def verify_dataset(
         problems.append(f"expected must be a non-negative int, got {expected!r}")
         return report
 
-    # Parquet ground truth.
+    # Parquet ground truth. A corrupt or foreign parquet under meta/episodes
+    # makes pyarrow raise ArrowInvalid (a ValueError subclass); an unreadable
+    # file raises OSError. The checker's contract is "always produce a report",
+    # so surface these as problems rather than letting them escape as a
+    # traceback - this is exactly the corruption verify_dataset exists to flag.
     try:
         info = read_dataset_episode_indices(root_path)
-    except FileNotFoundError as e:
-        problems.append(str(e))
-        return report
-    except ImportError as e:
-        problems.append(str(e))
+    except (FileNotFoundError, ImportError, ValueError, OSError) as e:
+        problems.append(f"could not read episode parquet: {e}")
         return report
 
     report["total_episodes"] = info["total_episodes"]
@@ -231,9 +232,14 @@ def _video_frame_count(path: Path) -> int | None:
             if not container.streams.video:
                 return None
             n = container.streams.video[0].frames
-    except (OSError, ValueError, RuntimeError):
-        # Unreadable/corrupt header (incl. av.error.InvalidDataError, a
-        # ValueError subclass): treat as "cannot confirm" and skip the compare.
+    except Exception:
+        # Best-effort probe: a corrupt/truncated container can raise any of
+        # PyAV's ~29 av.error.* classes - most are bare Exception subclasses
+        # (only InvalidDataError happens to subclass ValueError), so a narrow
+        # (OSError, ValueError, RuntimeError) tuple lets the rest escape. Treat
+        # every read failure as "cannot confirm" (never "zero frames") and skip
+        # the compare so a genuine mismatch is never masked and an unreadable
+        # header never false-positives.
         return None
     return int(n) if isinstance(n, int) and n > 0 else None
 
@@ -285,6 +291,19 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
             "template - cannot locate the per-episode MP4 files"
         ]
 
+    # Validate the template resolves with the LeRobot v3 keys we supply. A
+    # non-v3 template (e.g. a v2-style ``videos/{episode_chunk:03d}/...``)
+    # raises KeyError/IndexError from str.format; a malformed format spec raises
+    # ValueError. Surface it as a problem instead of letting it escape
+    # verify_dataset as a traceback - the checker must always produce a report.
+    try:
+        template.format(video_key="", chunk_index=0, file_index=0)
+    except (KeyError, IndexError, ValueError) as e:
+        return 0, [
+            f"meta/info.json 'video_path' template {template!r} is not a LeRobot v3 "
+            f"template (cannot resolve with video_key/chunk_index/file_index): {e!r}"
+        ]
+
     try:
         import pyarrow.parquet as pq
     except ImportError:  # pragma: no cover - pyarrow ships with the lerobot extra
@@ -301,8 +320,13 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
     # episode carried no ``length`` (the column is optional in some writers).
     unknown_len_files: set[tuple[str, int, int]] = set()
     keys_with_refs: set[str] = set()
+    problems: list[str] = []
     for pf in parquet_files:
-        table = pq.read_table(pf)
+        try:
+            table = pq.read_table(pf)
+        except (ValueError, OSError) as e:
+            problems.append(f"could not read {pf.relative_to(root_path)}: {e}")
+            continue
         cols = set(table.column_names)
         data = table.to_pydict()
         episodes = data.get("episode_index", [])
@@ -328,7 +352,6 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
                 else:
                     expected_frames[key] = expected_frames.get(key, 0) + int(length)
 
-    problems: list[str] = []
     for vk in video_keys:
         if vk not in keys_with_refs:
             problems.append(
@@ -424,7 +447,11 @@ def _verify_feature_stats(root_path: Path) -> tuple[int, list[str]]:
     checked = 0
     problems: list[str] = []
     for pf in parquet_files:
-        table = pq.read_table(pf)
+        try:
+            table = pq.read_table(pf)
+        except (ValueError, OSError) as e:
+            problems.append(f"could not read {pf.relative_to(root_path)} for stats: {e}")
+            continue
         cols = set(table.column_names)
         if "episode_index" not in cols:
             continue

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -975,3 +975,100 @@ class TestFeatureStatsEdgeCases:
         checked, problems = _verify_feature_stats(tmp_path)
         assert checked == 1
         assert any("identically zero" in p and "all frames" in p for p in problems)
+
+
+def _write_garbage_parquet(root: Path) -> Path:
+    """Write a meta/episodes tree whose parquet is not a valid parquet file.
+
+    pyarrow raises ``ArrowInvalid`` (a ValueError subclass) when it tries to
+    open this - the corruption class the verifier exists to report.
+    """
+    ep_dir = root / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    (ep_dir / "episodes_000.parquet").write_bytes(b"this is not a parquet file at all")
+    return root
+
+
+class TestCorruptInputProducesReport:
+    """The checker's contract is "always produce a report" - even on exactly the
+    corrupt datasets it exists to flag. A corrupt/foreign parquet, a non-v3
+    ``video_path`` template, or a truncated MP4 must yield a structured report
+    listing the problem, never an escaping traceback / non-report crash.
+    """
+
+    def test_garbage_parquet_returns_report_not_traceback(self, tmp_path: Path) -> None:
+        # A foreign/corrupt meta/episodes parquet makes pyarrow raise
+        # ArrowInvalid (a ValueError subclass) out of read_dataset_episode_indices.
+        # verify_dataset used to catch only FileNotFoundError/ImportError, so it
+        # escaped as a stack trace; now it is reported.
+        _write_garbage_parquet(tmp_path)
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        assert report["ok"] is False
+        assert any("could not read episode parquet" in p for p in report["problems"])
+
+    def test_garbage_parquet_cli_exits_1_without_traceback(self, tmp_path: Path) -> None:
+        _write_garbage_parquet(tmp_path)
+        assert verify_main([str(tmp_path)]) == 1
+
+    def test_non_v3_video_path_template_returns_report_not_keyerror(self, tmp_path: Path) -> None:
+        # A v2-style template carries an {episode_chunk} placeholder we never
+        # supply, so str.format raised KeyError out of verify_dataset. It is now
+        # surfaced as a problem.
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam"],
+            frames_per_episode=[3],
+            write_files=set(),
+            video_path="videos/{episode_chunk:03d}/{video_key}/file-{file_index:03d}.mp4",
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        assert any("not a LeRobot v3 template" in p for p in report["problems"])
+
+    def test_truncated_mp4_frame_probe_never_raises(self, tmp_path: Path) -> None:
+        # A truncated / garbage MP4 can make PyAV raise any of ~29 av.error.*
+        # classes, most of which are bare Exception subclasses (only
+        # InvalidDataError subclasses ValueError). The best-effort frame probe
+        # must swallow all of them and return None ("cannot confirm"), never
+        # propagate and never claim zero frames.
+        bad = tmp_path / "truncated.mp4"
+        bad.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\xff" * 256)
+        assert _video_frame_count(bad) is None
+
+    def test_frame_probe_swallows_bare_exception_av_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Most of PyAV's ~29 av.error.* classes subclass bare Exception, not
+        # OSError/ValueError/RuntimeError - so a corrupt container that raised
+        # e.g. DecoderNotFoundError escaped the old narrow probe catch. Simulate
+        # one (its constructor takes (code, message)) and assert the probe
+        # swallows it and returns None ("cannot confirm"), never propagates.
+        av = pytest.importorskip("av")
+        exc_cls = av.error.DecoderNotFoundError
+
+        def _raise(*_args: object, **_kwargs: object) -> object:
+            raise exc_cls(0, "simulated missing decoder")
+
+        real = tmp_path / "real.mp4"
+        _write_real_mp4(real, n_frames=3)  # write before patching av.open
+        monkeypatch.setattr(av, "open", _raise)
+        assert _video_frame_count(real) is None
+
+    def test_all_three_corruptions_together_produce_report(self, tmp_path: Path) -> None:
+        # End-to-end: a dataset that is simultaneously the video-template case
+        # still returns a structured report (single verify_dataset call) with no
+        # traceback and exit-code semantics preserved.
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0, 1],
+            video_keys=["observation.images.cam"],
+            frames_per_episode=[3, 3],
+            write_files=set(),
+            video_path="videos/{episode_chunk:03d}/{video_key}/file-{file_index:03d}.mp4",
+        )
+        report = verify_dataset(tmp_path)
+        assert isinstance(report["problems"], list)
+        assert report["status"] == "error"
+        assert verify_main([str(tmp_path)]) == 1


### PR DESCRIPTION
## Problem

`strands-robots verify-dataset` is the dataset-integrity gate, yet it crashed with a raw traceback on exactly the corruption it exists to report. Three reproduced failure modes:

1. **Corrupt/foreign `meta/episodes` parquet -> `ArrowInvalid` traceback.** `read_dataset_episode_indices` raises `pyarrow.lib.ArrowInvalid` (a `ValueError` subclass), but `verify_dataset` caught only `FileNotFoundError`/`ImportError`, so it escaped as a stack trace and exited 1 with no report.
2. **Non-v3 `video_path` template -> `KeyError`.** A v2-style `videos/{episode_chunk:03d}/...` template raises `KeyError: 'episode_chunk'` out of `str.format` inside `_verify_video_files`, escaping `verify_dataset`.
3. **PyAV errors escape the best-effort frame probe.** `_video_frame_count` caught only `(OSError, ValueError, RuntimeError)`, but ~29 of PyAV's `av.error.*` classes subclass bare `Exception` (only `InvalidDataError` happens to subclass `ValueError`), so a corrupt/truncated container could propagate out of a probe that is documented as best-effort (verified against `av` 15.1.0).

## Change

The checker's contract is "always produce a report":

- Broaden the `read_dataset_episode_indices` catch to `(FileNotFoundError, ImportError, ValueError, OSError)` and append the failure as a problem string.
- Validate the `video_path` template resolves with the LeRobot v3 keys (`video_key`/`chunk_index`/`file_index`) up front; a non-v3 template is reported as a problem instead of raising.
- Change `_video_frame_count` to `except Exception` (explicitly best-effort) so any `av.error.*` class yields `None` ("cannot confirm", never "zero frames") -- a genuine mismatch is never masked and an unreadable header never false-positives.
- Wrap the per-file `pq.read_table` reads in `_verify_video_files` and `_verify_feature_stats` so a corrupt file appends a problem and continues rather than aborting the whole check.

Exit-code semantics are preserved (0 pass, 1 on any problem).

## Tests

Adds `TestCorruptInputProducesReport` (6 tests) covering all three defects plus a combined case and the CLI exit code. Each fails on pre-fix code (`ArrowInvalid`, `KeyError`, `DecoderNotFoundError`) and passes after. The defect-3 test monkeypatches `av.open` to raise a bare-`Exception` `av.error` class (`DecoderNotFoundError`), which the old narrow catch let escape.

Full `tests/test_verify_dataset.py` (54 tests) passes; `ruff check`/`ruff format --check`/`mypy` clean over `strands_robots tests tests_integ`.

Docs updated in `docs/recording.md` to state the always-produces-a-report contract.