### PR TITLE
fix(registry): stop register_robot bricking lookups, parse vera:// URLs, resolve alias-less names

### DIFF
--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -109,6 +109,19 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
                     if match:
                         kwargs["host"] = match.group(1)
                         kwargs["port"] = int(match.group(2) or 8000)
+                elif pattern.startswith("^vera://"):
+                    # VERA service-mode URL: vera://host[:port] -> kwargs.
+                    # Mirrors the cosmos3 branch (#317): the pattern matches but
+                    # without this parser nothing populates host/server_port, so
+                    # create_policy("vera://gpu-box:9000") silently connects to
+                    # the default 127.0.0.1. VERA's port kwarg is server_port;
+                    # leave it unset when the URL omits a port so the
+                    # per-embodiment default still applies.
+                    match = re.match(r"vera://([^:/]+):?(\d+)?", policy)
+                    if match:
+                        kwargs["host"] = match.group(1)
+                        if match.group(2):
+                            kwargs["server_port"] = int(match.group(2))
                 elif pattern.startswith("^zmq://"):
                     match = re.match(r"zmq://([^:]+):(\d+)", policy)
                     if match:

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -50,16 +50,22 @@ def resolve_name(name: str) -> str:
     """
     normalized = name.lower().strip().replace("-", "_")
     alias_map = _build_alias_map()
+    # Canonical names come straight from the registry keys. Using
+    # ``alias_map.values()`` here was wrong: it only contains robots that
+    # declare at least one alias, so the 16 alias-less robots (ur5e, reachy2,
+    # ...) were treated as unknown and a normalized form like "reachy-2" ->
+    # "reachy_2" never resolved to canonical "reachy2".
+    canonical_names = set(_load("robots").get("robots", {}))
     if normalized in alias_map:
         return alias_map[normalized]
-    if normalized in alias_map.values():  # already canonical
+    if normalized in canonical_names:  # already canonical
         return normalized
     # Fallback: try with all underscores stripped (e.g. "so_100" -> "so100").
     # Only return the stripped form if it actually matches something we know.
     stripped = normalized.replace("_", "")
     if stripped in alias_map:
         return alias_map[stripped]
-    if stripped in alias_map.values():
+    if stripped in canonical_names:
         return stripped
     return normalized
 

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -160,7 +160,10 @@ def register_robot(
         The registered robot definition dict.
 
     Raises:
-        ValueError: If name already exists and ``overwrite`` is False.
+        ValueError: If name already exists and ``overwrite`` is False, or if an
+            ``aliases`` entry collides with an existing canonical robot name or
+            another robot's alias (the same constraint the loader enforces at
+            read time, checked here so the registration cannot brick lookups).
         FileNotFoundError: If ``model_xml`` doesn't exist at the resolved path.
 
     Example::
@@ -204,34 +207,6 @@ def register_robot(
     # This matches how resolve_model_path works: search_dir / asset["dir"] / xml
     dir_name = resolved_dir.name
 
-    # Alias collision detection - warn (don't fail) when a user alias shadows a
-    # canonical name or another alias.  Doing this at registration surfaces the
-    # problem immediately instead of at silent resolution-order time.
-    if aliases and not overwrite:
-        try:
-            from .robots import get_robot as _pkg_get_robot
-            from .robots import list_robots as _pkg_list_robots
-
-            pkg_canonical = {r["name"] for r in _pkg_list_robots()}
-            pkg_aliases: set[str] = set()
-            for r in _pkg_list_robots():
-                pkg_aliases.update(r.get("aliases", []) or [])
-        except Exception:
-            pkg_canonical = set()
-            pkg_aliases = set()
-
-        user_existing = data.get("robots", {})
-        user_canonical = set(user_existing.keys())
-        user_aliases: set[str] = set()
-        for _r in user_existing.values():
-            user_aliases.update(_r.get("aliases", []) or [])
-
-        for alias in aliases:
-            if alias in pkg_canonical or alias in user_canonical:
-                logger.warning("Alias %r shadows an existing robot canonical name.", alias)
-            elif alias in pkg_aliases or alias in user_aliases:
-                logger.warning("Alias %r is already used by another robot.", alias)
-
     # Validate model_xml exists.  Previously we only checked when
     # ``resolved_dir`` existed - which silently accepted registrations for
     # dirs that didn't exist yet and surfaced a confusing error only at
@@ -273,6 +248,14 @@ def register_robot(
 
     # Save
     data.setdefault("robots", {})[name] = entry
+
+    # Fail-closed: refuse to persist an entry the loader would reject on the
+    # next read (an alias that collides with a canonical name or another
+    # robot's alias). Without this the registration "succeeds" but every
+    # subsequent get_robot/resolve_name raises ValueError process-wide until
+    # user_robots.json is hand-edited.
+    _assert_registry_still_loads(data)
+
     _save_user_registry(data)
 
     # Invalidate loader cache so next get_robot() picks up the merge
@@ -329,6 +312,38 @@ def list_user_robots() -> list[dict[str, Any]]:
             }
         )
     return result
+
+
+def _assert_registry_still_loads(data: dict[str, Any]) -> None:
+    """Reject a registration the loader would refuse to read.
+
+    Runs the loader's own uniqueness validator on the prospective merged
+    registry (package ``robots.json`` overlaid with the pending user entries),
+    mirroring exactly what :func:`loader._merge_user_robots` +
+    :func:`loader._validate_robots` do on every read. An invalid registration
+    therefore fails loudly at write time instead of being persisted and then
+    breaking every subsequent ``get_robot``/``resolve_name`` call.
+
+    Args:
+        data: The prospective user-registry dict (already containing the new
+            entry) to validate against the merged registry.
+
+    Raises:
+        ValueError: If the merged registry would violate a uniqueness
+            constraint (e.g. an alias colliding with a canonical name or
+            another robot's alias).
+    """
+    from .loader import _REGISTRY_DIR, _validate_robots
+
+    pkg_path = _REGISTRY_DIR / "robots.json"
+    try:
+        pkg = json.loads(pkg_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        pkg = {}
+
+    merged = dict(pkg.get("robots", {}))
+    merged.update(data.get("robots", {}))
+    _validate_robots({"robots": merged})
 
 
 def _invalidate_cache() -> None:

--- a/tests/registry/test_registry_lookup_hardening.py
+++ b/tests/registry/test_registry_lookup_hardening.py
@@ -19,6 +19,7 @@ had gaps:
 """
 
 import json
+from importlib.resources import files
 
 import pytest
 
@@ -128,10 +129,8 @@ class TestCanonicalNameRoundTrip:
     """Every canonical robot name (alias-less included) must resolve to itself."""
 
     def _canonical_names(self):
-        import strands_robots.registry.robots as robots_mod
-
-        path = robots_mod.__file__.rsplit("/", 1)[0] + "/robots.json"
-        return list(json.loads(open(path, encoding="utf-8").read())["robots"])
+        data = files("strands_robots.registry").joinpath("robots.json").read_text(encoding="utf-8")
+        return list(json.loads(data)["robots"])
 
     def test_every_canonical_name_round_trips(self):
         """resolve_name(canonical) == canonical for all robots in robots.json."""

--- a/tests/registry/test_registry_lookup_hardening.py
+++ b/tests/registry/test_registry_lookup_hardening.py
@@ -1,0 +1,146 @@
+"""Registry lookups must not be brickable, silently misrouted, or name-blind.
+
+Three read/write invariants of the robot + policy registry that previously
+had gaps:
+
+1. ``register_robot`` must reject an alias that collides with an existing
+   canonical name (or another robot's alias) instead of persisting it with a
+   warning. The loader RAISES on such collisions at every subsequent read, so a
+   "successful" registration could otherwise brick every ``get_robot`` /
+   ``resolve_name`` call process-wide until ``user_robots.json`` was hand-edited.
+   Write-time validation must match the loader's read-time validation.
+2. A ``vera://host:port`` policy URL must parse its host/port into kwargs. The
+   ``^vera://`` pattern matched but had no parser branch, so
+   ``create_policy("vera://gpu-box:9000")`` silently fell back to 127.0.0.1.
+3. ``resolve_name`` must round-trip every canonical robot name, including the
+   alias-less ones. The canonical check used ``alias_map.values()`` (only robots
+   that declare an alias), so a normalized form like ``reachy-2`` -> ``reachy_2``
+   never resolved to the alias-less canonical ``reachy2``.
+"""
+
+import json
+
+import pytest
+
+from strands_robots.registry.policies import resolve_policy
+from strands_robots.registry.robots import get_robot, resolve_name
+from strands_robots.registry.user_registry import register_robot
+
+
+def _make_robot_asset(assets_dir, name="myarm", xml="myarm.xml"):
+    """Create a minimal valid MJCF asset dir the registry will accept."""
+    robot_dir = assets_dir / name
+    robot_dir.mkdir(parents=True, exist_ok=True)
+    (robot_dir / xml).write_text('<mujoco model="myarm"><worldbody/></mujoco>')
+    return name, xml
+
+
+class TestRegisterRobotFailsClosedOnAliasCollision:
+    """A registration the loader would reject must be refused at write time."""
+
+    def test_alias_colliding_with_canonical_name_raises(self, tmp_path):
+        """register_robot(aliases=[<existing canonical>]) raises ValueError."""
+        name, xml = _make_robot_asset(tmp_path / "assets")
+        with pytest.raises(ValueError, match="so100"):
+            register_robot(
+                name=name,
+                model_xml=xml,
+                description="x",
+                category="arm",
+                joints=6,
+                aliases=["so100"],
+            )
+
+    def test_registry_still_loads_after_rejected_registration(self, tmp_path):
+        """A rejected registration must not be persisted; lookups keep working."""
+        name, xml = _make_robot_asset(tmp_path / "assets")
+        with pytest.raises(ValueError):
+            register_robot(
+                name=name,
+                model_xml=xml,
+                description="x",
+                category="arm",
+                joints=6,
+                aliases=["so100"],
+            )
+        # The bricking bug: after a warn-and-save, get_robot itself would raise.
+        assert get_robot("so100") is not None
+        assert get_robot(name) is None  # never persisted
+
+    def test_unique_alias_registration_succeeds(self, tmp_path):
+        """A non-colliding alias still registers and resolves normally."""
+        name, xml = _make_robot_asset(tmp_path / "assets")
+        register_robot(
+            name=name,
+            model_xml=xml,
+            description="x",
+            category="arm",
+            joints=6,
+            aliases=["myleader"],
+        )
+        assert resolve_name("myleader") == name
+        assert get_robot("myleader") is not None
+
+    def test_reregistration_with_own_alias_and_overwrite_succeeds(self, tmp_path):
+        """Re-registering the same robot with overwrite must not self-collide."""
+        name, xml = _make_robot_asset(tmp_path / "assets")
+        register_robot(
+            name=name,
+            model_xml=xml,
+            description="v1",
+            category="arm",
+            joints=6,
+            aliases=["myleader"],
+            overwrite=True,
+        )
+        register_robot(
+            name=name,
+            model_xml=xml,
+            description="v2",
+            category="arm",
+            joints=6,
+            aliases=["myleader"],
+            overwrite=True,
+        )
+        assert get_robot("myleader") is not None
+        assert get_robot("so100") is not None
+
+
+class TestVeraUrlParsing:
+    """vera://host[:port] must populate connection kwargs, not fall to 127.0.0.1."""
+
+    def test_vera_url_parses_host_and_server_port(self):
+        """create_policy('vera://gpu-box:9000') targets gpu-box:9000."""
+        provider, kwargs = resolve_policy("vera://gpu-box:9000")
+        assert provider == "vera"
+        assert kwargs["host"] == "gpu-box"
+        assert kwargs["server_port"] == 9000
+
+    def test_vera_url_without_port_leaves_embodiment_default(self):
+        """Omitting the port keeps host but leaves server_port to the default."""
+        provider, kwargs = resolve_policy("vera://gpu-box")
+        assert provider == "vera"
+        assert kwargs["host"] == "gpu-box"
+        assert "server_port" not in kwargs
+
+
+class TestCanonicalNameRoundTrip:
+    """Every canonical robot name (alias-less included) must resolve to itself."""
+
+    def _canonical_names(self):
+        import strands_robots.registry.robots as robots_mod
+
+        path = robots_mod.__file__.rsplit("/", 1)[0] + "/robots.json"
+        return list(json.loads(open(path, encoding="utf-8").read())["robots"])
+
+    def test_every_canonical_name_round_trips(self):
+        """resolve_name(canonical) == canonical for all robots in robots.json."""
+        for canonical in self._canonical_names():
+            assert resolve_name(canonical) == canonical
+
+    def test_alias_less_robot_resolves_from_normalized_form(self):
+        """A hyphenated form of an alias-less robot resolves to its canonical."""
+        # reachy2 is alias-less; "reachy-2" normalizes to "reachy_2" which only
+        # matches after the underscore-stripping fallback checks canonical names.
+        assert resolve_name("reachy-2") == "reachy2"
+        assert get_robot("reachy-2") is not None

--- a/tests/test_user_registry.py
+++ b/tests/test_user_registry.py
@@ -189,35 +189,38 @@ class TestRegisterRobotValidation:
 
 
 class TestRegisterRobotAliasCollision:
-    """register_robot warns (does not fail) when an alias shadows an existing name.
+    """register_robot fails closed when an alias would collide at read time.
 
-    Collisions are surfaced at registration time as warnings so the user sees the
-    problem immediately rather than at silent resolution-order time. Registration
-    still succeeds.
+    The loader RAISES on an alias that shadows a canonical name or another
+    robot's alias on every subsequent read, so register_robot must reject such
+    an alias at write time rather than persist it. Otherwise a "successful"
+    registration bricks every get_robot/resolve_name call process-wide until
+    user_robots.json is hand-edited.
     """
 
-    def test_alias_shadowing_package_canonical_name_warns(self, tmp_path, caplog):
+    def test_alias_shadowing_package_canonical_name_raises(self, tmp_path):
         robot_dir = _make_robot(tmp_path / "assets", name="botA", xml_name="a.xml")
-        with caplog.at_level(logging.WARNING, logger="strands_robots.registry.user_registry"):
+        with pytest.raises(ValueError, match="so100"):
             register_robot(name="botA", model_xml="a.xml", asset_dir=str(robot_dir), aliases=["so100"])
-        assert any("shadows an existing robot canonical name" in m for m in caplog.messages)
-        # Registration still succeeds despite the warning.
-        assert get_user_robots().get("bota") is not None
+        # Nothing persisted, and the registry still loads.
+        assert get_user_robots().get("bota") is None
+        assert get_robot("so100") is not None
 
-    def test_alias_already_used_by_another_user_robot_warns(self, tmp_path, caplog):
+    def test_alias_already_used_by_another_user_robot_raises(self, tmp_path):
         first_dir = _make_robot(tmp_path / "assets", name="botB", xml_name="b.xml")
         second_dir = _make_robot(tmp_path / "assets", name="botC", xml_name="c.xml")
         register_robot(name="botB", model_xml="b.xml", asset_dir=str(first_dir), aliases=["grabber"])
-        with caplog.at_level(logging.WARNING, logger="strands_robots.registry.user_registry"):
+        with pytest.raises(ValueError, match="grabber"):
             register_robot(name="botC", model_xml="c.xml", asset_dir=str(second_dir), aliases=["grabber"])
-        assert any("is already used by another robot" in m for m in caplog.messages)
-        assert get_user_robots().get("botc") is not None
+        # The second robot is not persisted; the first is still resolvable.
+        assert get_user_robots().get("botc") is None
+        assert get_robot("grabber") is not None
 
-    def test_unique_alias_emits_no_collision_warning(self, tmp_path, caplog):
+    def test_unique_alias_registers_successfully(self, tmp_path):
         robot_dir = _make_robot(tmp_path / "assets", name="botD", xml_name="d.xml")
-        with caplog.at_level(logging.WARNING, logger="strands_robots.registry.user_registry"):
-            register_robot(name="botD", model_xml="d.xml", asset_dir=str(robot_dir), aliases=["unique_grip_xyz"])
-        assert not any("shadows" in m or "already used" in m for m in caplog.messages)
+        register_robot(name="botD", model_xml="d.xml", asset_dir=str(robot_dir), aliases=["unique_grip_xyz"])
+        assert get_user_robots().get("botd") is not None
+        assert get_robot("unique_grip_xyz") is not None
 
 
 class TestRegisterRobotAssetDirResolution:


### PR DESCRIPTION
## Problem

Three registry read/write invariants had gaps that surface as hard failures or silent misrouting.

### 1. A successful `register_robot` can brick every subsequent lookup
`register_robot` only WARNED when an alias collided with an existing canonical name (or another robot's alias) and saved anyway, but `loader._validate_robots` RAISES on that same collision on every subsequent read. So `register_robot(aliases=["so100"])` "succeeds" once, then every `get_robot` / `resolve_name` in the process (and every future process) raises `ValueError` until `user_robots.json` is hand-edited. Write-time and read-time validation disagreed.

### 2. `vera://host:port` matched the provider pattern but had no parser
The `^vera://` URL pattern matched in `resolve_policy`, but no branch parsed it, so `create_policy("vera://gpu-box:9000")` returned empty kwargs and silently connected to the default `127.0.0.1`. This is the exact bug class the adjacent `cosmos3://` branch already fixed.

### 3. `resolve_name` was blind to alias-less robots
The canonical-name check used `alias_map.values()`, which only contains robots that declare at least one alias. The 16 alias-less robots (`ur5e`, `reachy2`, `lekiwi`, ...) were treated as unknown, so a normalized form like `reachy-2` -> `reachy_2` never resolved to canonical `reachy2` and `get_robot("reachy-2")` returned `None`.

## Change

- `register_robot` now runs the loader's own validator (`_validate_robots`) on the prospective merged registry (package `robots.json` overlaid with the pending user entries) before persisting, and refuses to save an entry that would not load. Write-time == read-time. Valid registrations and idempotent `overwrite=True` re-registration are unaffected.
- Added a `vera://` branch in `resolve_policy` mirroring `cosmos3://`: it populates `host` and `server_port`, leaving `server_port` unset when the URL omits a port so VERA's per-embodiment default still applies.
- `resolve_name` now checks the registry's canonical keys directly instead of `alias_map.values()`.

## Tests

New `tests/registry/test_registry_lookup_hardening.py` covering all three acceptance criteria; the key assertions fail on pre-fix code and pass after. Updated `tests/test_user_registry.py::TestRegisterRobotAliasCollision` to assert the corrected fail-closed contract (raise, not warn-and-save). Full registry suite green (552 passed); broader registry-adjacent scope 840 passed, 1 skipped. `ruff check` + `ruff format --check` + `mypy` clean.

Acceptance verified:
- `register_robot(aliases=[<existing canonical>])` raises; registry still loads afterward.
- `resolve_policy("vera://gpu-box:9000")` -> `("vera", {"host": "gpu-box", "server_port": 9000})`.
- Every canonical name in `robots.json` round-trips through `resolve_name`; `get_robot("reachy-2")` resolves to `reachy2`.

---

## Changelog

### Round 1
- Addressed two CodeQL findings in `tests/registry/test_registry_lookup_hardening.py::_canonical_names`:
  - **File is not always closed** (alert 788): the helper read `robots.json` via `open(path, ...).read()` with no context manager. Replaced with `importlib.resources.files("strands_robots.registry").joinpath("robots.json").read_text(encoding="utf-8")`, which manages the handle internally.
  - **Module imported with both `import` and `import from`** (alert 787): the helper had a local `import strands_robots.registry.robots as robots_mod` used only to locate the JSON via `__file__`, duplicating the top-level `from strands_robots.registry.robots import ...`. Removed; `importlib.resources` locates the packaged data without a second import.
- Behavior unchanged: the same packaged `robots.json` (72 robots) is parsed and iterated; the round-trip assertions are untouched. Lint/format clean.