### PR TITLE
fix(verify-dataset): localise partial episode-parquet corruption instead of crashing or blanking the report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,30 @@ An orthographic free camera (`<visual><global orthographic="true"/>`) is now
 refused with an actionable `ValueError` instead of being handed perspective
 intrinsics no parallel projection can satisfy.
 
+### Fixed: one corrupt episode parquet no longer crashes or blanks dataset verification
+
+`meta/episodes/**/*.parquet` is read shard by shard, and damage is usually
+confined to a file or two (an interrupted rsync or hub download truncates one
+shard of twenty). Two defects turned that partial damage into a total loss of
+diagnosis:
+
+- **`SimEngine.verify_dataset_episodes` raised instead of reporting.** It caught
+  only `FileNotFoundError` / `ImportError` from `read_dataset_episode_indices`,
+  so a truncated shard surfaced as `pyarrow.lib.ArrowInvalid` out of an
+  agent-callable facade documented to return a status dict. It now returns the
+  structured error dict for any unreadable/corrupt parquet, and refuses to
+  certify a dataset whose shards are partly unreadable even when the readable
+  episode count happens to equal `expected` (the count is a lower bound). The
+  `json` diagnostics block gained `unreadable_files`.
+- **`verify-dataset` collapsed the whole report.** The first unreadable shard
+  aborted the read, so a dataset with 19 intact shards reported
+  `total_episodes: 0` and skipped every remaining check (info.json drift,
+  per-episode video files, dead control columns). `read_dataset_episode_indices`
+  now skips the unreadable shards, returns the readable episode truth plus an
+  `unreadable_files` list (`"<path>: <error>"`), and raises only when NO shard is
+  readable. `verify_dataset` names each broken shard as a problem and runs the
+  remaining checks against the readable files.
+
 ### Fixed: AWS IoT mesh backend dead paths (peer discovery, camera ref, profile scoping, reconnect leak)
 
 Seven verified defects that left the pure-`iot` and `bridge` mesh backends

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -242,6 +242,16 @@ it exists to flag. A corrupt or foreign `meta/episodes` parquet, a non-v3
 string in the report (and a non-zero exit code), not surfaced as a raw
 traceback.
 
+Corruption confined to SOME episode parquet shards (the usual outcome of an
+interrupted rsync or hub download) is localised rather than fatal: each
+unreadable shard is named as a problem, the readable shards still supply
+`total_episodes` / `frames_per_episode`, and the info.json, video, and
+dead-column checks still run against them. Only a `meta/episodes` tree with no
+readable shard at all reports zero episodes. The same holds for
+`verify_dataset_episodes`, which additionally refuses to certify a dataset with
+unreadable shards even when the readable count matches `expected` - the count is
+then only a lower bound, reported in the `unreadable_files` diagnostics.
+
 ## Recording paths
 
 | Method | Extra needed | Output |

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1335,11 +1335,23 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
             Returned alongside the parquet truth so callers can cross-check the
             two metadata sources for agreement - a healthy dataset has
             ``info_total_episodes == total_episodes``.
+          - ``unreadable_files``: ``"<path relative to root>: <error>"`` for
+            every ``meta/episodes`` parquet that could not be read (empty list
+            for a healthy dataset). A partially-corrupt dataset - one truncated
+            file out of twenty, the usual outcome of an interrupted sync or hub
+            download - still yields the episode truth of the readable files, so
+            callers can localise the damage instead of seeing zero episodes.
+            The episode counts above cover ONLY the readable files, so any
+            non-empty ``unreadable_files`` means the totals are a lower bound
+            and the dataset must not be certified as complete.
 
     Raises:
         ImportError: If ``pyarrow`` is not installed.
         FileNotFoundError: If no ``meta/episodes`` parquet exists under ``root``
             (no episode was ever flushed - the dataset is empty/unfinalized).
+        ValueError: If every ``meta/episodes`` parquet is unreadable, so there
+            is no episode ground truth at all. The message lists each file and
+            its read error.
     """
     try:
         import pyarrow.parquet as pq
@@ -1356,8 +1368,21 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
 
     pairs: list[tuple[int, int]] = []
     seen: set[int] = set()
+    unreadable_files: list[str] = []
+    readable_files = 0
     for pf in parquet_files:
-        table = pq.read_table(pf)
+        # A corrupt / truncated / foreign parquet raises ArrowInvalid (a
+        # ValueError subclass); an unreadable one raises OSError. Damage is
+        # usually confined to a few files (interrupted rsync, partial hub
+        # download), so record which file failed and keep reading the rest -
+        # aborting the whole read here would report zero episodes for a dataset
+        # that is mostly intact and hide which file is actually broken.
+        try:
+            table = pq.read_table(pf)
+        except (ValueError, OSError) as e:
+            unreadable_files.append(f"{pf.relative_to(root_path)}: {e}")
+            continue
+        readable_files += 1
         cols = table.column_names
         if "episode_index" not in cols:
             continue
@@ -1371,6 +1396,12 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
             seen.add(ep_int)
             length = int(lengths[i]) if lengths is not None and lengths[i] is not None else 0
             pairs.append((ep_int, length))
+
+    if unreadable_files and readable_files == 0:
+        # Nothing readable at all: there is no ground truth to return, so this
+        # is a hard read failure rather than a partial one.
+        detail = "; ".join(unreadable_files)
+        raise ValueError(f"No readable meta/episodes parquet under {root_path}: {detail}")
 
     pairs.sort(key=lambda p: p[0])
     episode_indices = [p[0] for p in pairs]
@@ -1398,4 +1429,5 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
         "total_frames": sum(frames_per_episode) if has_lengths else 0,
         "frames_per_episode": frames_per_episode if has_lengths else [],
         "info_total_episodes": info_total_episodes,
+        "unreadable_files": unreadable_files,
     }

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1496,12 +1496,15 @@ class SimEngine(ABC):
             holds exactly ``expected`` episodes, else ``"error"``. The
             ``{"json": {...}}`` block carries ``expected``, ``actual``,
             ``info_total_episodes``, ``sources_agree``, ``episode_indices``,
-            ``total_frames``, ``total_frames_per_ep`` and ``root`` so a caller
-            (or CI) can fail loudly programmatically. ``status`` is ``"error"``
-            both when the parquet count differs from ``expected`` AND when the
-            parquet disagrees with ``meta/info.json``'s ``total_episodes``
-            (``sources_agree`` is then ``False``) - the two metadata sources
-            must agree, never just one.
+            ``total_frames``, ``total_frames_per_ep``, ``unreadable_files`` and
+            ``root`` so a caller (or CI) can fail loudly programmatically.
+            ``status`` is ``"error"`` when the parquet count differs from
+            ``expected``, when the parquet disagrees with ``meta/info.json``'s
+            ``total_episodes`` (``sources_agree`` is then ``False``) - the two
+            metadata sources must agree, never just one - and when any episode
+            parquet file could not be read (``unreadable_files`` non-empty),
+            since the episodes found are then only a lower bound. An unreadable
+            or corrupt parquet is reported as this same error dict, never raised.
         """
         if not isinstance(expected, int) or expected < 0:
             return {
@@ -1529,7 +1532,12 @@ class SimEngine(ABC):
 
         try:
             info = read_dataset_episode_indices(root)
-        except FileNotFoundError as e:
+        except (ValueError, OSError) as e:
+            # OSError covers the empty/unfinalized dataset (FileNotFoundError -
+            # no episode parquet yet) and an unreadable file; ValueError covers a
+            # corrupt / truncated / foreign parquet (pyarrow raises ArrowInvalid,
+            # a ValueError subclass). This facade is agent-callable, so both must
+            # surface as a structured error dict, never as an escaping traceback.
             return {
                 "status": "error",
                 "content": [
@@ -1543,6 +1551,7 @@ class SimEngine(ABC):
                             "episode_indices": [],
                             "total_frames": 0,
                             "total_frames_per_ep": [],
+                            "unreadable_files": [],
                             "root": str(root),
                         }
                     },
@@ -1553,6 +1562,7 @@ class SimEngine(ABC):
 
         actual = info["total_episodes"]
         info_total = info.get("info_total_episodes")
+        unreadable = info.get("unreadable_files") or []
 
         # Two independent truths must agree: the parquet episode count AND the
         # meta/info.json total_episodes header. A dataset can report the right
@@ -1561,10 +1571,21 @@ class SimEngine(ABC):
         # True when info.json is absent (parquet is then the sole truth) or when
         # the header matches the parquet.
         sources_agree = info_total is None or info_total == actual
-        ok = actual == expected and sources_agree
+        # A dataset with unreadable episode parquet files can never be certified:
+        # the readable files are a LOWER BOUND on the episode count, so a count
+        # that happens to equal ``expected`` proves nothing about the whole
+        # dataset. Fail loud and name the broken files.
+        ok = actual == expected and sources_agree and not unreadable
         status = "success" if ok else "error"
 
-        if not sources_agree:
+        if unreadable:
+            text = (
+                f"verify_dataset_episodes: UNREADABLE - {len(unreadable)} episode "
+                f"parquet file(s) could not be read, so the {actual} episode(s) found "
+                f"are a lower bound (expected {expected}): {'; '.join(unreadable)}. "
+                f"Root: {root}"
+            )
+        elif not sources_agree:
             verdict = "MISMATCH"
             text = (
                 f"verify_dataset_episodes: {verdict} - meta/info.json reports "
@@ -1592,6 +1613,7 @@ class SimEngine(ABC):
                         "episode_indices": info["episode_indices"],
                         "total_frames": info["total_frames"],
                         "total_frames_per_ep": info["frames_per_episode"],
+                        "unreadable_files": list(unreadable),
                         "root": str(root),
                     }
                 },

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -36,6 +36,11 @@ Usage:
     strands-robots verify-dataset /path/to/dataset --expected 20
     python -m strands_robots verify-dataset ~/.cache/huggingface/lerobot/user/ds
 
+A corrupt ``meta/episodes`` parquet is itself reported rather than raised: each
+unreadable file is named as a problem and the remaining checks still run against
+the readable files, so partial corruption (one truncated file out of twenty)
+localises the damage instead of collapsing the whole report to "0 episodes".
+
 Exit code is 0 when every check passes, 1 otherwise - so it drops straight into
 CI as a dataset-integrity gate.
 """
@@ -83,7 +88,9 @@ def verify_dataset(
           - ``root``: the resolved dataset root as a string.
           - ``total_episodes`` / ``total_frames`` / ``episode_indices`` /
             ``frames_per_episode``: parquet ground truth (zeros/empties when the
-            dataset is empty or unreadable).
+            dataset is empty or wholly unreadable; the truth of the READABLE
+            files when only some episode parquet files are corrupt, with each
+            broken file named in ``problems``).
           - ``expected``: the requested count (or ``None``).
           - ``info_total_episodes`` / ``info_total_frames``: values declared in
             ``meta/info.json`` (``None`` when the file is absent or lacks them).
@@ -129,6 +136,21 @@ def verify_dataset(
     except (FileNotFoundError, ImportError, ValueError, OSError) as e:
         problems.append(f"could not read episode parquet: {e}")
         return report
+
+    # A dataset whose damage is confined to SOME episode parquet files (one
+    # truncated file out of twenty - an interrupted rsync or hub download)
+    # still yields the episode truth of the readable files. Report each broken
+    # file by name and keep going through the remaining checks: collapsing the
+    # whole report to zero episodes would hide both which file is broken and
+    # every other defect in the dataset.
+    # ``unreadable_files`` entries are documented as "<relative path>: <error>";
+    # the paths feed the video / stats checks so one broken shard is reported
+    # once rather than once per check that also cannot read it.
+    unreadable_paths: set[str] = set()
+    for unreadable in info["unreadable_files"]:
+        problems.append(f"could not read episode parquet {unreadable}")
+        unreadable_paths.add(unreadable.partition(": ")[0])
+    known_unreadable = frozenset(unreadable_paths)
 
     report["total_episodes"] = info["total_episodes"]
     report["total_frames"] = info["total_frames"]
@@ -189,7 +211,7 @@ def verify_dataset(
     # episode counts, missing pixels. This is the video-modality sibling of the
     # mega-episode class above.
     if check_videos:
-        checked, video_problems = _verify_video_files(root_path)
+        checked, video_problems = _verify_video_files(root_path, known_unreadable=known_unreadable)
         report["video_files_checked"] = checked
         problems.extend(video_problems)
 
@@ -202,7 +224,7 @@ def verify_dataset(
     # episode and frame counts stay correct. The per-episode feature stats
     # LeRobot v3 writes inline make this a cheap, decoder-independent check.
     if check_stats:
-        stats_checked, stats_problems = _verify_feature_stats(root_path)
+        stats_checked, stats_problems = _verify_feature_stats(root_path, known_unreadable=known_unreadable)
         report["stats_vectors_checked"] = stats_checked
         problems.extend(stats_problems)
 
@@ -244,7 +266,7 @@ def _video_frame_count(path: Path) -> int | None:
     return int(n) if isinstance(n, int) and n > 0 else None
 
 
-def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
+def _verify_video_files(root_path: Path, *, known_unreadable: frozenset[str] = frozenset()) -> tuple[int, list[str]]:
     """Resolve and integrity-check every per-episode video file in a dataset.
 
     For each video feature declared in ``meta/info.json`` (``dtype == "video"``)
@@ -260,6 +282,9 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
 
     Args:
         root_path: Dataset root directory (the dir that contains ``meta/``).
+        known_unreadable: Episode-parquet paths (relative to ``root_path``) the
+            caller has already reported as unreadable. They are skipped without
+            a second problem string, so one broken shard is reported once.
 
     Returns:
         A ``(checked, problems)`` tuple where ``checked`` is the number of
@@ -322,10 +347,13 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
     keys_with_refs: set[str] = set()
     problems: list[str] = []
     for pf in parquet_files:
+        rel = str(pf.relative_to(root_path))
+        if rel in known_unreadable:
+            continue
         try:
             table = pq.read_table(pf)
         except (ValueError, OSError) as e:
-            problems.append(f"could not read {pf.relative_to(root_path)}: {e}")
+            problems.append(f"could not read {rel}: {e}")
             continue
         cols = set(table.column_names)
         data = table.to_pydict()
@@ -394,7 +422,7 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
     return len(referenced), problems
 
 
-def _verify_feature_stats(root_path: Path) -> tuple[int, list[str]]:
+def _verify_feature_stats(root_path: Path, *, known_unreadable: frozenset[str] = frozenset()) -> tuple[int, list[str]]:
     """Flag dead (identically-zero) control columns via per-episode stats.
 
     LeRobot v3 writes per-episode feature statistics inline in
@@ -417,6 +445,9 @@ def _verify_feature_stats(root_path: Path) -> tuple[int, list[str]]:
 
     Args:
         root_path: Dataset root directory (the dir that contains ``meta/``).
+        known_unreadable: Episode-parquet paths (relative to ``root_path``) the
+            caller has already reported as unreadable. They are skipped without
+            a second problem string, so one broken shard is reported once.
 
     Returns:
         A ``(checked, problems)`` tuple where ``checked`` is the number of
@@ -447,10 +478,13 @@ def _verify_feature_stats(root_path: Path) -> tuple[int, list[str]]:
     checked = 0
     problems: list[str] = []
     for pf in parquet_files:
+        rel = str(pf.relative_to(root_path))
+        if rel in known_unreadable:
+            continue
         try:
             table = pq.read_table(pf)
         except (ValueError, OSError) as e:
-            problems.append(f"could not read {pf.relative_to(root_path)} for stats: {e}")
+            problems.append(f"could not read {rel} for stats: {e}")
             continue
         cols = set(table.column_names)
         if "episode_index" not in cols:

--- a/tests/simulation/test_simengine_facade_guardrails.py
+++ b/tests/simulation/test_simengine_facade_guardrails.py
@@ -327,6 +327,62 @@ def test_verify_dataset_episodes_missing_parquet_reports_json_diagnostics(monkey
     assert diagnostics["root"] == "/tmp/does-not-exist-dataset-root"
 
 
+def test_verify_dataset_episodes_corrupt_parquet_is_structured_error(tmp_path):
+    """A corrupt episode parquet is reported, not raised past the facade.
+
+    ``pyarrow`` raises ``ArrowInvalid`` (a ``ValueError`` subclass) on a
+    truncated / foreign parquet. The facade caught only ``FileNotFoundError``
+    and ``ImportError``, so this escaped as a traceback out of an agent-callable
+    method that documents a status dict.
+    """
+    ep_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True)
+    (ep_dir / "file-000.parquet").write_bytes(b"truncated, not a parquet file")
+
+    class RootedSim(FakeSim):
+        def _active_dataset_root(self) -> str:
+            return str(tmp_path)
+
+    result = RootedSim().verify_dataset_episodes(2)
+
+    assert result["status"] == "error"
+    assert "verify_dataset_episodes" in result["content"][0]["text"]
+    diagnostics = result["content"][1]["json"]
+    assert diagnostics["expected"] == 2
+    assert diagnostics["actual"] == 0
+    assert diagnostics["sources_agree"] is False
+
+
+def test_verify_dataset_episodes_rejects_matching_count_with_unreadable_shard(tmp_path):
+    """Unreadable shards make the episode count a lower bound, so never certify.
+
+    With one shard readable (2 episodes) and one corrupt, an ``expected=2``
+    check must NOT pass: the corrupt shard may hold further episodes, so the
+    dataset cannot be certified complete. The broken file is named and reported
+    in the ``unreadable_files`` diagnostics.
+    """
+    pa_mod = pytest.importorskip("pyarrow")
+    pq_mod = pytest.importorskip("pyarrow.parquet")
+
+    ep_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True)
+    pq_mod.write_table(pa_mod.table({"episode_index": [0, 1], "length": [4, 4]}), ep_dir / "file-000.parquet")
+    (ep_dir / "file-001.parquet").write_bytes(b"truncated, not a parquet file")
+
+    class RootedSim(FakeSim):
+        def _active_dataset_root(self) -> str:
+            return str(tmp_path)
+
+    result = RootedSim().verify_dataset_episodes(2)
+
+    assert result["status"] == "error"
+    assert "UNREADABLE" in result["content"][0]["text"]
+    diagnostics = result["content"][1]["json"]
+    assert diagnostics["actual"] == 2
+    assert len(diagnostics["unreadable_files"]) == 1
+    assert "file-001.parquet" in diagnostics["unreadable_files"][0]
+
+
 def test_verify_dataset_episodes_import_error_is_structured_error(monkeypatch):
     """A missing optional dep behind the reader degrades to a structured error."""
     import strands_robots.dataset_recorder as dr

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1612,6 +1612,53 @@ def test_read_dataset_episode_indices_dedups_and_skips_columnless_parquet(tmp_pa
     assert result["frames_per_episode"] == [3, 5]  # first-seen length for ep 0
     assert result["total_frames"] == 8
     assert result["info_total_episodes"] is None  # no meta/info.json written
+    assert result["unreadable_files"] == []  # every shard was readable
+
+
+def test_read_dataset_episode_indices_keeps_readable_shards_when_one_is_corrupt(tmp_path):
+    """One corrupt shard must not erase the episode truth of the readable ones.
+
+    Partial damage is the common case (an interrupted rsync or hub download
+    truncates a file or two of many). The reader reports the broken shard by
+    relative path in ``unreadable_files`` and still returns the episodes it
+    could read, so a caller can localise the damage instead of seeing an empty
+    dataset.
+    """
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    from strands_robots.dataset_recorder import read_dataset_episode_indices
+
+    ep_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True)
+    pq.write_table(pa.table({"episode_index": [0, 1], "length": [10, 12]}), ep_dir / "file-000.parquet")
+    (ep_dir / "file-001.parquet").write_bytes(b"truncated, not a parquet file")
+
+    result = read_dataset_episode_indices(tmp_path)
+
+    assert result["episode_indices"] == [0, 1]
+    assert result["total_frames"] == 22
+    assert len(result["unreadable_files"]) == 1
+    assert result["unreadable_files"][0].startswith("meta/episodes/chunk-000/file-001.parquet: ")
+
+
+def test_read_dataset_episode_indices_raises_when_no_shard_is_readable(tmp_path):
+    """With no readable shard there is no ground truth, so the read fails loud.
+
+    Returning an empty episode list would be indistinguishable from a genuinely
+    empty dataset, so a wholly unreadable ``meta/episodes`` tree raises with
+    every file and its read error named.
+    """
+    pytest.importorskip("pyarrow")
+
+    from strands_robots.dataset_recorder import read_dataset_episode_indices
+
+    ep_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True)
+    (ep_dir / "file-000.parquet").write_bytes(b"not a parquet file")
+
+    with pytest.raises(ValueError, match=r"No readable meta/episodes parquet"):
+        read_dataset_episode_indices(tmp_path)
 
 
 class _FakeSyncDataset:

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -25,7 +25,12 @@ pytest.importorskip("pyarrow")
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from strands_robots.verify_dataset import _verify_feature_stats, _video_frame_count, verify_dataset
+from strands_robots.verify_dataset import (
+    _verify_feature_stats,
+    _verify_video_files,
+    _video_frame_count,
+    verify_dataset,
+)
 from strands_robots.verify_dataset import main as verify_main
 
 
@@ -1006,6 +1011,81 @@ class TestCorruptInputProducesReport:
         assert report["status"] == "error"
         assert report["ok"] is False
         assert any("could not read episode parquet" in p for p in report["problems"])
+
+    def test_partly_corrupt_parquet_still_reports_the_readable_episodes(self, tmp_path: Path) -> None:
+        """One broken shard names itself; the readable episodes are still reported.
+
+        Partial damage (an interrupted rsync/hub download truncating a file or
+        two of many) used to collapse the whole report to "0 episodes", hiding
+        both which file broke and how much of the dataset survived. The report
+        now carries the readable ground truth plus the broken file's path.
+        """
+        ep_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+        ep_dir.mkdir(parents=True)
+        pq.write_table(pa.table({"episode_index": [0, 1], "length": [10, 12]}), ep_dir / "file-000.parquet")
+        (ep_dir / "file-001.parquet").write_bytes(b"truncated, not a parquet file")
+
+        report = verify_dataset(tmp_path, check_videos=False, check_stats=False)
+
+        assert report["ok"] is False
+        assert report["total_episodes"] == 2
+        assert report["frames_per_episode"] == [10, 12]
+        assert report["total_frames"] == 22
+        assert any("file-001.parquet" in p for p in report["problems"])
+
+    def test_partly_corrupt_parquet_still_runs_the_remaining_checks(self, tmp_path: Path) -> None:
+        """A broken shard does not disable the info.json / video / stats checks.
+
+        Every check after the parquet read used to be skipped on a corrupt
+        shard, so an operator diagnosing a damaged dataset learned nothing about
+        metadata drift or missing pixels. All of them now run against the
+        readable files and report independently.
+        """
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0, 1],
+            video_keys=["observation.images.cam"],
+            frames_per_episode=[10, 12],
+            write_files={"observation.images.cam:0"},  # episode 1's MP4 is missing
+        )
+        # info.json declares 3 episodes: drift against the 2 readable ones.
+        info_path = tmp_path / "meta" / "info.json"
+        info = json.loads(info_path.read_text(encoding="utf-8"))
+        info["total_episodes"] = 3
+        info_path.write_text(json.dumps(info), encoding="utf-8")
+        (tmp_path / "meta" / "episodes" / "chunk-000" / "episodes_001.parquet").write_bytes(b"not a parquet file")
+
+        report = verify_dataset(tmp_path)
+
+        assert report["ok"] is False
+        assert report["info_total_episodes"] == 3
+        assert report["video_files_checked"] > 0
+        assert any("total_episodes=3 disagrees with parquet" in p for p in report["problems"])
+        assert any("missing" in p and "observation.images.cam" in p for p in report["problems"])
+        # The broken shard is reported ONCE, not once per check that also
+        # cannot read it (the video and stats passes skip known-bad shards).
+        assert sum("episodes_001.parquet" in p for p in report["problems"]) == 1
+
+    def test_video_and_stats_checks_report_a_corrupt_shard_when_called_directly(self, tmp_path: Path) -> None:
+        """Standalone, the video and stats passes report shards they cannot read.
+
+        ``verify_dataset`` tells them which shards it has already reported, but
+        called on their own (no ``known_unreadable``) each pass must still name
+        the unreadable shard rather than skipping it silently.
+        """
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam"],
+            frames_per_episode=[4],
+        )
+        (tmp_path / "meta" / "episodes" / "chunk-000" / "episodes_001.parquet").write_bytes(b"not a parquet file")
+
+        _checked, video_problems = _verify_video_files(tmp_path)
+        _stats_checked, stats_problems = _verify_feature_stats(tmp_path)
+
+        assert any("could not read" in p and "episodes_001.parquet" in p for p in video_problems)
+        assert any("for stats" in p and "episodes_001.parquet" in p for p in stats_problems)
 
     def test_garbage_parquet_cli_exits_1_without_traceback(self, tmp_path: Path) -> None:
         _write_garbage_parquet(tmp_path)


### PR DESCRIPTION
## Problem

`meta/episodes/**/*.parquet` is a sharded tree, and real-world damage is almost always confined to a file or two - an interrupted `rsync`, a partial hub download, a truncated write. Two defects turned that partial damage into a total loss of diagnosis, on exactly the paths that exist to diagnose dataset corruption.

**1. `SimEngine.verify_dataset_episodes` raised instead of reporting.** It caught only `FileNotFoundError` / `ImportError` from `read_dataset_episode_indices`. A truncated shard makes pyarrow raise `ArrowInvalid` (a `ValueError` subclass), so the exception escaped an agent-callable facade whose docstring promises a "Standard status dict":

```
pyarrow.lib.ArrowInvalid: Could not open Parquet input source '.../meta/episodes/chunk-000/file-001.parquet':
Parquet magic bytes not found in footer. Either the file is corrupted or this is not a parquet file.
```

This is the facade sibling of the crash already fixed for the CLI in #1624.

**2. `verify-dataset` collapsed the whole report.** `read_dataset_episode_indices` read shards in a bare loop, so the FIRST unreadable shard aborted the read. A dataset with 19 intact shards and 1 truncated one reported:

```
total_episodes: 0, total_frames: 0, info_total_episodes: null,
video_files_checked: 0, stats_vectors_checked: 0
```

Every remaining check (info.json drift, per-episode video files, dead control columns) was skipped, and the operator learned neither how much of the dataset survived nor anything else about its health.

## Change

- `read_dataset_episode_indices` reads each shard under its own `except (ValueError, OSError)`: unreadable shards are collected into a new `unreadable_files` entry (`"<path relative to root>: <error>"`) and the readable shards still supply the episode truth. It raises `ValueError` only when NO shard is readable - an empty episode list there would be indistinguishable from a genuinely empty dataset.
- `verify_dataset` names each broken shard as a problem and then runs every remaining check against the readable shards. It passes the known-bad paths down to the video and stats passes, so one broken shard yields exactly one problem line instead of one per check that also cannot read it (those passes keep their own reporting when called standalone).
- `verify_dataset_episodes` catches `(ValueError, OSError)` and returns the structured error dict for any unreadable/corrupt parquet, and refuses to certify a dataset with unreadable shards **even when the readable count equals `expected`** - the readable count is only a lower bound, so a coincidental match proves nothing. The `json` diagnostics block gained `unreadable_files`.

## Verification on a real recorded dataset

Recorded 3 episodes of an SO-101 rollout in MuJoCo (headless EGL, `run_policy(n_episodes=3, video=...)`), verified the healthy dataset, then truncated one episode shard to simulate an interrupted sync.

![SO-101 rollout used to record the verification dataset](https://github.com/cagataycali/robots/releases/download/artifacts-verify-dataset-202607252255/verify_demo.gif)

[rollout_ep0.mp4](https://github.com/cagataycali/robots/releases/download/artifacts-verify-dataset-202607252255/rollout_ep0.mp4) - 45 frames, 480x360, 30 fps, `camera="front"`.

Healthy dataset (unchanged behaviour):

```
verify_dataset_episodes(3): matches - expected 3, found 3 episode(s) in parquet (135 total frames)
verify_dataset:  ok=True  total_episodes=3  total_frames=135  video_files_checked=1  stats_vectors_checked=6  problems=[]
```

After truncating `meta/episodes/chunk-000/file-001.parquet`:

```
verify_dataset:  ok=False  total_episodes=3  total_frames=135  info_total_episodes=3
                 video_files_checked=1  stats_vectors_checked=6
                 problems=["could not read episode parquet meta/episodes/chunk-000/file-001.parquet: ..."]   # exactly one
verify_dataset_episodes(3): status=error
                 "UNREADABLE - 1 episode parquet file(s) could not be read, so the 3 episode(s) found are a lower bound"
```

Before this change the same damaged dataset reported `total_episodes=0` with every other check skipped, and `verify_dataset_episodes(3)` raised `ArrowInvalid`.

## Tests (each fails on pre-fix code)

- `tests/test_dataset_recorder.py`: one corrupt shard keeps the readable episodes and names the bad shard in `unreadable_files`; a wholly unreadable tree raises `ValueError`; the healthy-dataset case asserts `unreadable_files == []`.
- `tests/test_verify_dataset.py`: a partly corrupt tree reports the readable episodes/frames; the info.json drift, video, and stats checks still run and the broken shard appears exactly once; the video and stats passes still report unreadable shards when called standalone.
- `tests/simulation/test_simengine_facade_guardrails.py`: a corrupt shard is a structured error with `json` diagnostics (pre-fix: `ArrowInvalid` escapes); a readable count matching `expected` alongside an unreadable shard is rejected with the broken file named.

Full suite green (`MUJOCO_GL=egl`): 11698 passed, 254 skipped. `ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`. `strands_robots/verify_dataset.py` coverage 97% -> 99%.

Docs: `docs/recording.md` documents the localised-corruption contract for both entry points; `CHANGELOG.md` under `[Unreleased]`.

---

### Maintenance: rebased onto `main`

Rebased onto current `main` to clear a `CHANGELOG.md` `[Unreleased]` conflict introduced when #1622 and #1629 landed. The only conflict was in the changelog (both sides added `[Unreleased]` entries); both entries are kept. The single fix commit is otherwise unchanged and `strands_robots/simulation/base.py` auto-merged cleanly against #1629. No code behaviour changed; re-running CI on the rebased head.