### PR TITLE
fix(sim): report camera params for the MuJoCo free ("default") camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: MuJoCo `get_camera_params` answers for the free (`"default"`) camera
+
+`get_frame` renders the free camera (`None` / `""` / `"default"` / `"free"`) and
+`list_cameras()` advertises `"default"` first, but `get_camera_params` rejected
+those tokens with `ValueError("The free camera has no model-fixed
+pose/intrinsics")`. The two halves of the raw-frame API therefore disagreed on
+which cameras exist, and `HybridCompositor.render()` - whose own signature
+defaults to `camera_name="default"` - raised on the documented zero-config path:
+
+```python
+frame = HybridCompositor(sim, background=PanoramaBackground()).render()  # ValueError
+```
+
+The premise was wrong: MuJoCo's free view is a deterministic function of the
+compiled model. `get_camera_params` now reconstructs it from
+`mjv_defaultFreeCamera` - the same defaults `mujoco.Renderer.update_scene(data)`
+uses for `cam_id = -1` (`vis.global_.{azimuth,elevation}` orbiting `stat.center`
+at `1.5 * stat.extent`, vertical FOV from `vis.global_.fovy`) - so the reported
+pose/intrinsics describe exactly the frame `get_frame("default")` returns
+(verified pixel-for-pixel against an equivalent named camera). Named-camera
+behaviour is unchanged.
+
+An orthographic free camera (`<visual><global orthographic="true"/>`) is now
+refused with an actionable `ValueError` instead of being handed perspective
+intrinsics no parallel projection can satisfy.
+
 ### Fixed: AWS IoT mesh backend dead paths (peer discovery, camera ref, profile scoping, reconnect leak)
 
 Seven verified defects that left the pure-`iot` and `bridge` mesh backends

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2297,7 +2297,10 @@ class SimEngine(ABC):
 
         Args:
             camera_name: name of a camera previously added via ``add_camera``.
-                The free camera has no model-fixed pose and is rejected.
+                Backends with a free camera also accept their free-cam tokens
+                here, reporting the same view :meth:`get_frame` renders, so the
+                two APIs stay symmetric (MuJoCo: ``None`` / ``""`` /
+                ``"default"`` / ``"free"``).
             width: image width to compute ``K`` for; ``None`` uses the
                 camera's configured resolution.
             height: image height to compute ``K`` for; ``None`` uses the
@@ -2305,8 +2308,9 @@ class SimEngine(ABC):
 
         Raises:
             KeyError: unknown camera name.
-            ValueError: free camera requested, or a resolution the backend
-                cannot honor.
+            ValueError: a camera whose projection no pinhole ``K`` can
+                represent (e.g. an orthographic camera), or a resolution the
+                backend cannot honor.
             RuntimeError: no world created.
             NotImplementedError: backend has no camera-params path.
         """

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1237,7 +1237,7 @@ class RenderingMixin:
     ) -> "CameraParams":
         """Return pinhole :class:`~strands_robots.rendering.CameraParams`.
 
-        Intrinsics ``K`` come from the camera's vertical FOV
+        Named cameras: intrinsics ``K`` come from the camera's vertical FOV
         (``model.cam_fovy``, square pixels, principal point at the image
         center); the world-from-camera pose comes from
         ``data.cam_xpos`` / ``data.cam_xmat``. MuJoCo's camera basis already
@@ -1245,28 +1245,38 @@ class RenderingMixin:
         so the pose maps across without correction. Clip planes are
         ``model.vis.map.{znear,zfar} * model.stat.extent``.
 
-        Holds ``self._lock`` and forward-steps kinematics (``mj_forward``, a
-        write to ``mj_data``) so freshly placed cameras have a valid pose even
-        before the first ``step()``.
+        Free camera (``None`` / ``""`` / ``"default"`` / ``"free"``): the same
+        view :meth:`get_frame` and :meth:`render` produce for ``cam_id = -1``,
+        so the two APIs stay symmetric and the hybrid compositor can composite
+        the default view. The pose is reconstructed from
+        ``mjv_defaultFreeCamera`` -- MuJoCo's own free-camera defaults, i.e.
+        ``model.vis.global_.{azimuth,elevation}`` about ``model.stat.center``
+        at ``1.5 * model.stat.extent`` -- and ``K`` from
+        ``model.vis.global_.fovy``. That view is a deterministic function of
+        the compiled model, so the params describe exactly what the renderer
+        draws.
+
+        Holds ``self._lock``. For a named camera it also forward-steps
+        kinematics (``mj_forward``, a write to ``mj_data``) so freshly placed
+        cameras have a valid pose even before the first ``step()``; the free
+        camera is derived from the model alone and needs no such write.
 
         Args:
-            camera_name: a named camera. The free camera has no model-fixed
-                pose and is rejected with ``ValueError``.
+            camera_name: a named camera, or a free-camera token (``None`` /
+                ``""`` / ``"default"`` / ``"free"``).
             width: image width to compute ``K`` for; ``None`` uses the
-                camera's configured resolution.
+                camera's configured resolution (the engine default for the
+                free camera).
             height: image height to compute ``K`` for.
 
         Raises:
             RuntimeError: no world created.
-            ValueError: free camera requested.
+            ValueError: the free camera is orthographic (``<visual><global
+                orthographic="true"/>``), which no pinhole ``K`` can represent.
             KeyError: unknown camera name.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             raise RuntimeError(_NO_WORLD_MSG)
-        if camera_name in (None, "", "default", "free"):
-            raise ValueError(
-                "The free camera has no model-fixed pose/intrinsics; use a named camera added via add_camera()."
-            )
 
         mj = _ensure_mujoco()
         import numpy as _np
@@ -1274,24 +1284,22 @@ class RenderingMixin:
         from strands_robots.rendering import CameraParams
 
         model = self._world._model
-        cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
-        if cam_id < 0:
-            raise KeyError(f"Camera '{camera_name}' not found. Available: {self._list_camera_names()}")
+        # The free camera is not a model camera: it has no name to resolve and
+        # no SimCamera entry, so its resolution and default size differ.
+        free_camera = camera_name in (None, "", "default", "free")
+        cam_cfg = None if free_camera else self._world.cameras.get(camera_name)
 
-        cam_cfg = self._world.cameras.get(camera_name)
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else int(width)
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else int(height)
 
         with self._lock:
-            # Make sure cam_xpos / cam_xmat reflect the latest qpos (a WRITE
-            # to mj_data -- hence the lock).
-            mj.mj_forward(model, self._world._data)
-            R = self._world._data.cam_xmat[cam_id].reshape(3, 3).copy()
-            t = self._world._data.cam_xpos[cam_id].copy()
-            fovy_deg = float(model.cam_fovy[cam_id])
             extent = float(model.stat.extent)
             znear = extent * float(model.vis.map.znear)
             zfar = extent * float(model.vis.map.zfar)
+            if free_camera:
+                R, t, fovy_deg = self._free_camera_pose(mj, _np, model)
+            else:
+                R, t, fovy_deg = self._named_camera_pose(mj, model, self._world._data, camera_name)
 
         fy = 0.5 * h / _np.tan(_np.deg2rad(fovy_deg) / 2.0)
         fx = fy  # MuJoCo uses square pixels; intrinsics from vertical FOV are symmetric.
@@ -1300,6 +1308,88 @@ class RenderingMixin:
         T_world_cam[:3, :3] = R
         T_world_cam[:3, 3] = t
         return CameraParams(K=K, T_world_cam=T_world_cam, width=w, height=h, znear=znear, zfar=zfar)
+
+    def _named_camera_pose(
+        self, mj: Any, model: Any, data: Any, camera_name: str | None
+    ) -> "tuple[np.ndarray, np.ndarray, float]":
+        """Return ``(R, t, fovy_deg)`` for the model camera ``camera_name``.
+
+        Caller must hold ``self._lock``: this forward-steps kinematics
+        (``mj_forward``, a WRITE to ``mj_data``) so that a camera placed since
+        the last ``step()`` still reports a valid ``cam_xpos``/``cam_xmat``.
+
+        Args:
+            mj: the imported ``mujoco`` module.
+            model: the compiled ``MjModel``.
+            data: the ``MjData`` whose kinematics are forward-stepped and read.
+            camera_name: name of a camera in the compiled model.
+
+        Returns:
+            ``(R, t, fovy_deg)`` -- 3x3 world-from-camera rotation, camera
+            position in world coordinates, and the vertical FOV in degrees.
+
+        Raises:
+            KeyError: no camera of that name exists in the model.
+        """
+        cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+        if cam_id < 0:
+            raise KeyError(f"Camera '{camera_name}' not found. Available: {self._list_camera_names()}")
+        mj.mj_forward(model, data)
+        R = data.cam_xmat[cam_id].reshape(3, 3).copy()
+        t = data.cam_xpos[cam_id].copy()
+        return R, t, float(model.cam_fovy[cam_id])
+
+    @staticmethod
+    def _free_camera_pose(mj: Any, np_mod: Any, model: Any) -> "tuple[np.ndarray, np.ndarray, float]":
+        """Return ``(R, t, fovy_deg)`` for the free camera of ``model``.
+
+        ``mujoco.Renderer.update_scene(data)`` (no camera argument, i.e. the
+        view :meth:`render` and :meth:`get_frame` draw) builds its camera with
+        ``mjv_defaultFreeCamera``, so this reads the same defaults back:
+        ``azimuth``/``elevation`` (degrees) orbiting ``lookat`` at
+        ``distance``, with the vertical FOV from ``model.vis.global_.fovy``.
+
+        The azimuth/elevation -> basis conversion mirrors MuJoCo's internal
+        ``mjv_updateCamera``: ``forward`` is the unit vector at those spherical
+        angles, ``up`` is the same vector rotated a quarter turn in the
+        elevation plane, and the eye sits ``distance`` back along ``-forward``.
+        The returned rotation is the world-from-camera basis in the OpenGL
+        optical convention (columns ``[right, up, -forward]``), matching the
+        named-camera path's ``cam_xmat``.
+
+        Args:
+            mj: the imported ``mujoco`` module.
+            np_mod: the imported ``numpy`` module.
+            model: the compiled ``MjModel``.
+
+        Returns:
+            ``(R, t, fovy_deg)`` -- 3x3 world-from-camera rotation, camera
+            position in world coordinates, and the vertical FOV in degrees.
+
+        Raises:
+            ValueError: the free camera is orthographic, which has no pinhole
+                intrinsics (a silently wrong perspective ``K`` is worse than a
+                loud refusal).
+        """
+        cam = mj.MjvCamera()
+        cam.type = mj.mjtCamera.mjCAMERA_FREE
+        mj.mjv_defaultFreeCamera(model, cam)
+        if bool(cam.orthographic):
+            raise ValueError(
+                'The free camera is orthographic (<visual><global orthographic="true"/>); '
+                "a pinhole CameraParams cannot represent an orthographic projection. "
+                "Add a perspective camera with add_camera() and pass its name."
+            )
+        az = float(np_mod.deg2rad(cam.azimuth))
+        el = float(np_mod.deg2rad(cam.elevation))
+        cos_el, sin_el = np_mod.cos(el), np_mod.sin(el)
+        forward = np_mod.array([cos_el * np_mod.cos(az), cos_el * np_mod.sin(az), sin_el], dtype=np_mod.float64)
+        up = np_mod.array([-sin_el * np_mod.cos(az), -sin_el * np_mod.sin(az), cos_el], dtype=np_mod.float64)
+        t = np_mod.asarray(cam.lookat, dtype=np_mod.float64).copy() - float(cam.distance) * forward
+        z_axis = -forward
+        x_axis = np_mod.cross(up, z_axis)
+        R = np_mod.column_stack([x_axis, up, z_axis])
+        return R, t, float(model.vis.global_.fovy)
 
     def _list_camera_names(self) -> list[str]:
         """helper to list all camera names (model-defined + SimCamera aliases)

--- a/tests/simulation/mujoco/test_get_frame_camera_params.py
+++ b/tests/simulation/mujoco/test_get_frame_camera_params.py
@@ -70,13 +70,84 @@ def test_get_camera_params_width_height_override() -> None:
         sim.destroy()
 
 
-def test_get_camera_params_rejects_free_camera_and_unknown_names() -> None:
+def test_get_camera_params_rejects_unknown_names() -> None:
     sim = _make_sim()
     try:
-        with pytest.raises(ValueError, match="free camera"):
-            sim.get_camera_params("default")
         with pytest.raises(KeyError, match="not found"):
             sim.get_camera_params("nope")
+    finally:
+        sim.destroy()
+
+
+def test_get_camera_params_free_camera_tokens_all_report_the_same_view() -> None:
+    """Every free-camera token ``get_frame`` accepts also resolves here.
+
+    ``get_frame`` documents ``None`` / ``""`` / ``"default"`` / ``"free"`` as
+    interchangeable free-camera tokens and ``list_cameras()`` advertises
+    ``"default"`` first, so the params API must answer for the same set --
+    otherwise a caller that renders the default view (the hybrid compositor
+    does, by default) cannot obtain its intrinsics/extrinsics.
+    """
+    sim = _make_sim()
+    try:
+        reference = sim.get_camera_params("default", width=64, height=48)
+        assert reference.width == 64 and reference.height == 48
+        for token in (None, "", "free"):
+            cam = sim.get_camera_params(token, width=64, height=48)
+            assert np.allclose(cam.K, reference.K)
+            assert np.allclose(cam.T_world_cam, reference.T_world_cam)
+            assert (cam.znear, cam.zfar) == (reference.znear, reference.zfar)
+    finally:
+        sim.destroy()
+
+
+def test_get_camera_params_free_camera_math_and_conventions() -> None:
+    """The free-camera pose/intrinsics follow MuJoCo's own free-camera defaults.
+
+    MuJoCo derives the free view from the compiled model: ``vis.global_.fovy``
+    for the vertical FOV and an ``azimuth``/``elevation`` orbit of
+    ``stat.center`` at ``1.5 * stat.extent``. Pin those relations (and the
+    OpenGL optical basis) so a refactor cannot quietly report a different
+    camera than the one MuJoCo renders.
+    """
+    sim = _make_sim()
+    try:
+        model = sim.mj_model
+        cam = sim.get_camera_params("default", width=64, height=48)
+
+        fy_expected = 0.5 * 48 / np.tan(np.deg2rad(float(model.vis.global_.fovy)) / 2.0)
+        assert cam.K[1, 1] == pytest.approx(fy_expected, rel=1e-9)
+        assert cam.K[0, 0] == pytest.approx(cam.K[1, 1])
+        assert (cam.K[0, 2], cam.K[1, 2]) == pytest.approx((32.0, 24.0))
+
+        R = cam.T_world_cam[:3, :3]
+        assert np.allclose(R @ R.T, np.eye(3), atol=1e-9)
+        assert np.linalg.det(R) == pytest.approx(1.0)
+
+        # The eye orbits stat.center at 1.5 * stat.extent, looking at it.
+        eye = cam.T_world_cam[:3, 3]
+        lookat = np.asarray(model.stat.center, dtype=float)
+        assert np.linalg.norm(eye - lookat) == pytest.approx(1.5 * float(model.stat.extent), rel=1e-6)
+        forward = -R[:, 2]  # OpenGL optical: -Z is the view direction
+        to_target = lookat - eye
+        assert np.allclose(forward, to_target / np.linalg.norm(to_target), atol=1e-9)
+    finally:
+        sim.destroy()
+
+
+def test_get_camera_params_rejects_orthographic_free_camera() -> None:
+    """An orthographic free camera is refused, not given a bogus pinhole ``K``.
+
+    ``<visual><global orthographic="true"/>`` makes MuJoCo render a parallel
+    projection, which no pinhole ``K`` can describe. Reporting perspective
+    intrinsics anyway would misproject every compositing/unprojection consumer
+    silently, so the call must fail loudly instead.
+    """
+    sim = _make_sim()
+    try:
+        sim.mj_model.vis.global_.orthographic = 1
+        with pytest.raises(ValueError, match="orthographic"):
+            sim.get_camera_params("default")
     finally:
         sim.destroy()
 
@@ -143,5 +214,75 @@ def test_hybrid_compositor_end_to_end_over_mujoco() -> None:
         # Both regimes present: some robot pixels won, some background shows.
         assert bool(frame.foreground_mask.any())
         assert not bool(frame.foreground_mask.all())
+    finally:
+        sim.destroy()
+
+
+@requires_gl
+def test_free_camera_params_describe_the_frame_get_frame_renders() -> None:
+    """The reported free-camera pose/FOV reproduce the free view pixel-for-pixel.
+
+    Params that do not match the rendered frame are worse than no params: the
+    compositor would blend a backdrop rendered from a different viewpoint. So
+    plant a *named* camera at the reported free-camera pose and FOV (the
+    already-trusted ``cam_xpos``/``cam_xmat`` path) and require the two renders
+    to agree.
+    """
+    sim = _make_sim(width=128, height=96)
+    try:
+        free = sim.get_camera_params("default", width=128, height=96)
+        eye = free.T_world_cam[:3, 3]
+        forward = -free.T_world_cam[:3, 2]
+        fovy_deg = float(np.rad2deg(2.0 * np.arctan(0.5 * free.height / free.K[1, 1])))
+        sim.add_camera(
+            "free_mirror",
+            position=list(eye),
+            target=list(eye + forward),
+            fov=fovy_deg,
+            width=128,
+            height=96,
+        )
+
+        rgb_free, depth_free = sim.get_frame("default", width=128, height=96)
+        rgb_mirror, depth_mirror = sim.get_frame("free_mirror", width=128, height=96)
+
+        # Same viewpoint => same pixels (allow only encoder-level rounding).
+        assert np.abs(rgb_free.astype(np.int16) - rgb_mirror.astype(np.int16)).max() <= 2
+        assert depth_free is not None and depth_mirror is not None
+        assert np.abs(depth_free - depth_mirror).max() == pytest.approx(0.0, abs=1e-4)
+    finally:
+        sim.destroy()
+
+
+@requires_gl
+def test_hybrid_compositor_composites_the_default_free_camera() -> None:
+    """``HybridCompositor(sim).render()`` works on its own default argument.
+
+    ``render`` defaults to ``camera_name="default"``, so the zero-config path
+    (no user-added camera, just the free view MuJoCo already renders) must
+    composite rather than dead-end on the camera-params lookup.
+    """
+    from strands_robots.rendering import HybridCompositor
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    # ground_plane=False is the documented recipe for photoreal backdrops: with
+    # MuJoCo's floor filling the frame, every pixel has geometry and nothing
+    # would be left for the background to fill.
+    sim.create_world(ground_plane=False)
+    sim.add_object(name="cube", shape="box", position=[0.0, 0.0, 0.1], size=[0.05, 0.05, 0.05])
+    sim.step(n_steps=5)
+    try:
+        frame = HybridCompositor(sim, default_width=96, default_height=72, feather_pixels=0).render()
+        assert frame.rgb.shape == (72, 96, 3)
+        assert frame.rgb.dtype == np.uint8
+        assert frame.camera.width == 96 and frame.camera.height == 72
+        # Both regimes present: the cube won some pixels, the backdrop shows elsewhere.
+        assert bool(frame.foreground_mask.any())
+        assert not bool(frame.foreground_mask.all())
+        # And the depth test actually selected between the two sources.
+        mask = frame.foreground_mask
+        assert np.array_equal(frame.rgb[mask], frame.foreground_rgb[mask])
+        assert np.array_equal(frame.rgb[~mask], frame.background_rgb[~mask])
     finally:
         sim.destroy()


### PR DESCRIPTION
## Problem

`get_frame()` renders the free camera (`None` / `""` / `"default"` / `"free"`) and `list_cameras()` advertises `"default"` first, but `get_camera_params()` rejected exactly those tokens:

```
ValueError: The free camera has no model-fixed pose/intrinsics; use a named camera added via add_camera().
```

So the two halves of the raw-frame API disagreed on which cameras exist, and `HybridCompositor.render()` -- whose own signature defaults to `camera_name="default"` -- raised on the documented zero-config path:

```python
sim = Simulation(); sim.create_world(); sim.add_robot("arm", data_config="so101")
HybridCompositor(sim, background=PanoramaBackground()).render()   # ValueError
```

Same dead end for anything that enumerates `list_cameras()` and asks for each camera's intrinsics.

## Change

The rejection's premise was wrong: MuJoCo's free view is a deterministic function of the compiled model, not an unknowable interactive pose. `mujoco.Renderer.update_scene(data)` (no camera argument -- what `render()`/`get_frame()` draw for `cam_id = -1`) builds its camera with `mjv_defaultFreeCamera`, so `get_camera_params()` now reads the same defaults back:

- pose: `vis.global_.{azimuth,elevation}` orbiting `stat.center` at `1.5 * stat.extent`, converted to the OpenGL optical basis (columns `[right, up, -forward]`) exactly as MuJoCo's internal `mjv_updateCamera` does -- cross-checked against `mjv_updateCamera` output over five azimuth/elevation/FOV combinations (agreement within 3e-8);
- intrinsics: `K` from `vis.global_.fovy` with square pixels and a centered principal point, matching the named-camera path;
- clip planes: unchanged (`vis.map.{znear,zfar} * stat.extent`).

The two selection modes are now symmetric helpers -- `_free_camera_pose()` and `_named_camera_pose()` -- each returning `(R, t, fovy_deg)`. The camera id stays local to the named helper that resolves, validates and indexes with it, so there is no sentinel id shared across the branches. Only the named path performs the `mj_forward` write to `mj_data` (documented on that helper, together with its lock requirement); the free path reads the model alone. Named-camera behaviour is untouched.

An orthographic free camera (`<visual><global orthographic="true"/>`) is now refused with an actionable `ValueError` rather than handed perspective intrinsics no parallel projection can satisfy (silent wrong output being the worse failure).

## Verification

Tests in `tests/simulation/mujoco/test_get_frame_camera_params.py`, all failing on pre-fix code:

1. every free-cam token (`None` / `""` / `"default"` / `"free"`) returns the same params;
2. the pose/FOV follow MuJoCo's free-camera defaults (eye at `1.5 * stat.extent` from `stat.center`, `-Z` pointing at it, `fy` from `vis.global_.fovy`, orthonormal right-handed `R`);
3. **params match the frame that is actually rendered**: a *named* camera planted at the reported free-camera pose/FOV (the already-trusted `cam_xpos`/`cam_xmat` path) renders the free view pixel-for-pixel -- max RGB delta <= 2, depth delta 0.0;
4. `HybridCompositor(sim).render()` composites the default view, and the composite equals the foreground where the mask won and the background elsewhere;
5. an orthographic free camera is rejected.

Both selection arms stay pinned: `test_get_camera_params_rejects_unknown_names` requires `KeyError` (naming the available cameras) for a bogus name, so an unresolvable name can never be served the free view; the token test requires all four free tokens to agree.

Full suite green locally under `MUJOCO_GL=egl` (11710 passed, 254 skipped, rebased onto `main` at 32fb25a2); `ruff check`, `ruff format --check` and `mypy` clean on `strands_robots tests tests_integ`. Coverage of `simulation/mujoco/rendering.py` 97% -> 98%.

## Visual proof (MuJoCo headless, EGL)

SO-101 arm + cube composited over a `PanoramaBackground` **through the free `"default"` camera** -- the call that raised before this change. The backdrop stays locked to the reported camera pose while the arm moves, which is what a correct `T_world_cam`/`K` buys:

![free-camera hybrid rollout](https://github.com/cagataycali/robots/releases/download/free-cam-params-1785037844/free_cam_hybrid.gif)

Full-quality MP4: https://github.com/cagataycali/robots/releases/download/free-cam-params-1785037844/free_cam_hybrid.mp4

Foreground (sim) | background (panorama rendered from the free-camera params) | composite:

![foreground, background, composite](https://github.com/cagataycali/robots/releases/download/free-cam-params-1785037844/free_cam_triptych.png)

## Scope

MuJoCo backend only (`get_camera_params` + the base-class docstring contract) plus tests and a CHANGELOG entry. No new dependency, no new env var, no public signature change.