### PR TITLE
fix(sim): randomize/set_obs_noise reject parameters they cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `randomize` / `set_obs_noise` reject parameters they cannot honor
+
+Both methods declare `**kwargs` to match the `**kwargs`-typed
+`SimEngine.randomize` / `SimEngine.set_obs_noise` base signatures, and neither
+forwards it anywhere - so every keyword the method did not declare was dropped
+and the call still answered `status="success"`:
+
+```python
+sim.randomize(randomize_position=True, position_noise=0.05)   # singular typo
+# -> success: "Domain Randomization applied: Colors ... Lighting ..."   (positions untouched)
+sim.set_obs_noise(joint_pos_stdev=0.05)                       # "stdev" typo
+# -> success: "Sensor noise: joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0"
+```
+
+A data-collection or eval loop asking for object-position randomization or
+sensor noise was therefore told the request had been applied while the world and
+the observations were never perturbed. The action dispatcher's own
+unknown-parameter guard (`Unknown parameter 'nsteps' for action 'step'. Valid:
+['n_steps']`) is skipped for `**kwargs` methods, so the direct Python API and the
+agent dispatch path both silently accepted the misspelling.
+
+Both methods now return an error naming the unusable keys and the valid set, on
+the MuJoCo and Newton backends. Newton still answers a truthy
+`randomize_positions` with its specific unsupported-axis error (that key, and its
+`position_noise` companion, stay accepted for MuJoCo-signature parity). The
+dispatcher now forwards residual keys to `**kwargs` methods instead of dropping
+them, so a genuine forwarding sink (`attach_teleop`, `stream_dataset`) also
+receives the options an agent passes.
+
+
 ### Fixed: MuJoCo `get_camera_params` answers for the free (`"default"`) camera
 
 `get_frame` renders the free camera (`None` / `""` / `"default"` / `"free"`) and

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -18,6 +18,21 @@ sim.randomize(
 )
 ```
 
+**Unknown parameters are rejected.** `randomize()` and `set_obs_noise()` both
+declare `**kwargs` to match the backend-agnostic `SimEngine` signature, so a
+keyword they do not honor (`randomize_position` singular, `position_range`,
+`joint_pos_stdev`) would otherwise be dropped and the call still reported as
+applied. Instead they return `status=error` naming the unusable keys and the
+valid set - a misspelled axis can never look like a successful randomization:
+
+```python
+sim.randomize(randomize_position=True)   # singular
+# status=error: Unknown parameter(s) ['randomize_position'] for action 'randomize'.
+#              Valid: ['color_range', 'friction_range', 'mass_range', 'position_noise',
+#                      'randomize_colors', 'randomize_lighting', 'randomize_physics',
+#                      'randomize_positions', 'seed']
+```
+
 **Destructive** - writes into MuJoCo model arrays. To restore: `load_scene(...)` or recreate the sim.
 
 `randomize()` leaves the sim in a forwarded, render-ready state: the next `render()` / `get_observation()` reflects the perturbation immediately, with no manual `step()` in between. This matters for lighting in particular - the renderer reads light positions from the derived `data.light_xpos`, not `model.light_pos`, so a light-position jitter only reaches a render after a forward.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -94,6 +94,42 @@ def reject_setup_kwargs(kwargs: Mapping[str, Any]) -> None:
     )
 
 
+def unknown_kwargs_error(method: str, kwargs: Mapping[str, Any], accepted: Sequence[str]) -> dict[str, Any] | None:
+    """Return a tool-envelope error for keyword arguments a method cannot use.
+
+    Some engine methods declare ``**kwargs`` only to keep the ``**kwargs``-typed
+    :class:`SimEngine` base signature, then drop the residual keys. For a
+    *forwarding* sink (``attach_teleop``, ``stream_dataset``) dropping is right -
+    the keys belong to the callee. For a *discarding* sink it turns a misspelled
+    or invented parameter into a successful no-op: a caller asking for
+    object-position randomization or sensor noise is told the request was
+    applied when nothing happened. Discarding sinks call this helper instead, so
+    an unusable parameter is named rather than swallowed - the same contract the
+    action dispatcher already enforces for methods without ``**kwargs``.
+
+    Args:
+        method: Method (and action) name to quote in the message.
+        kwargs: The residual keyword arguments the method would otherwise drop.
+        accepted: Every keyword the method honors, including any it reads out of
+            its own ``**kwargs`` (Newton's ``randomize`` answers
+            ``randomize_positions`` with a dedicated unsupported-axis error).
+            Also listed as the "Valid:" hint.
+
+    Returns:
+        ``None`` when every key in ``kwargs`` is accepted, otherwise a
+        ``status="error"`` result dict naming the unusable keys. An error dict
+        rather than a raised exception because these methods are dispatched as
+        agent tool actions, which must not raise past dispatch.
+    """
+    unexpected = sorted(k for k in kwargs if k not in accepted)
+    if not unexpected:
+        return None
+    return {
+        "status": "error",
+        "content": [{"text": (f"Unknown parameter(s) {unexpected} for action '{method}'. Valid: {sorted(accepted)}")}],
+    }
+
+
 class SimEngine(ABC):
     """Abstract base class for simulation engines.
 
@@ -2247,7 +2283,11 @@ class SimEngine(ABC):
     def randomize(self, **kwargs: Any) -> dict[str, Any]:
         """Apply domain randomization.
 
-        Concrete backends define their own parameter signatures.
+        Concrete backends define their own parameter signatures. Because this
+        base signature is ``**kwargs``-typed, an override inherits a sink that
+        would swallow any keyword it does not declare; backends must reject the
+        residual keys (see :func:`unknown_kwargs_error`) so a misspelled axis
+        cannot report success while leaving that axis untouched.
         Override per backend.
         """
         raise NotImplementedError("randomize not implemented by this backend")
@@ -2257,7 +2297,9 @@ class SimEngine(ABC):
 
         Models real-sensor measurement noise (joint encoders, camera frames)
         so policies are not trained on noise-free observations. Concrete
-        backends define their own parameter signatures. Override per backend.
+        backends define their own parameter signatures and, as for
+        :meth:`randomize`, must reject keywords they do not declare rather than
+        let this ``**kwargs``-typed signature swallow them. Override per backend.
         """
         raise NotImplementedError("set_obs_noise not implemented by this backend")
 

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -5,9 +5,33 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from strands_robots.simulation.base import unknown_kwargs_error
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
 
 logger = logging.getLogger(__name__)
+
+# Parameter names ``randomize`` / ``set_obs_noise`` actually honor. Both declare
+# ``**kwargs`` to match the ``**kwargs``-typed SimEngine base signature, but
+# neither forwards it anywhere - so anything landing there is a caller mistake
+# and is rejected instead of dropped (test_domain_randomization_rejects_unknown_params
+# pins these tuples to the live signatures).
+_RANDOMIZE_PARAMS: tuple[str, ...] = (
+    "randomize_colors",
+    "randomize_lighting",
+    "randomize_physics",
+    "randomize_positions",
+    "position_noise",
+    "color_range",
+    "friction_range",
+    "mass_range",
+    "seed",
+)
+_OBS_NOISE_PARAMS: tuple[str, ...] = (
+    "joint_pos_std",
+    "joint_vel_std",
+    "camera_jitter_px",
+    "seed",
+)
 
 
 class RandomizationMixin:
@@ -80,7 +104,20 @@ class RandomizationMixin:
             friction_range:       (lo, hi) multiplicative scale on friction[0].
             mass_range:           (lo, hi) multiplicative scale on body_mass.
             seed:                 Optional np.random seed for reproducibility.
+            **kwargs:             Declared only to match the ``**kwargs``-typed
+                                  ``SimEngine.randomize`` signature; nothing is
+                                  forwarded, so any keyword arriving here is
+                                  rejected with an error naming the valid
+                                  parameters. A misspelled axis (e.g.
+                                  ``randomize_position``) must not report
+                                  success while leaving that axis untouched.
+
+        Returns:
+            Status dict listing the axes applied, or an error dict when a
+            keyword is unknown, no world exists, or a policy is running.
         """
+        if err := unknown_kwargs_error("randomize", kwargs, _RANDOMIZE_PARAMS):
+            return err
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # domain randomization mutates model arrays; a running policy racing with it is UB
@@ -211,13 +248,18 @@ class RandomizationMixin:
             camera_jitter_px: Max integer pixel shift applied to rendered
                 frames (uniform in ``[-px, px]`` per axis).
             seed: Optional seed for a reproducible noise stream.
-            **kwargs: Accepted for ``SimEngine.set_obs_noise`` signature
-                compatibility; ignored by the MuJoCo backend.
+            **kwargs: Declared only to match the ``**kwargs``-typed
+                ``SimEngine.set_obs_noise`` signature; nothing is forwarded, so
+                any keyword arriving here is rejected with an error naming the
+                valid parameters rather than reporting an all-zero (no-op) noise
+                configuration as success.
 
         Returns:
-            Status dict echoing the configured noise, or an error dict when any
-            value is negative or non-finite.
+            Status dict echoing the configured noise, or an error dict when a
+            keyword is unknown or a value is negative or non-finite.
         """
+        if err := unknown_kwargs_error("set_obs_noise", kwargs, _OBS_NOISE_PARAMS):
+            return err
         for label, value in (
             ("joint_pos_std", joint_pos_std),
             ("joint_vel_std", joint_vel_std),

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4190,7 +4190,11 @@ class MuJoCoSimEngine(
         """
         # Strip self + VAR_POSITIONAL (*args) + VAR_KEYWORD (**kwargs) for signature
         # introspection; **kwargs methods accept arbitrary inputs, so we skip the
-        # unknown-key check for them.
+        # unknown-key check for them. Those methods own the check instead: the
+        # forwarding sinks (attach_teleop, stream_dataset) hand the residual keys
+        # to their callee, and the discarding ones (randomize, set_obs_noise)
+        # reject them via unknown_kwargs_error - otherwise skipping here would
+        # make a misspelled parameter a silent no-op on exactly those actions.
         named_params = {
             n: p
             for n, p in sig.parameters.items()
@@ -4273,6 +4277,14 @@ class MuJoCoSimEngine(
                     "status": "error",
                     "content": [{"text": f"Action '{action}' requires parameter '{param_name}'."}],
                 }
+
+        # 4) Residual keys for **kwargs methods. The unknown-key check above is
+        # skipped for them, so dropping the keys here too would leave the input
+        # unvalidated AND unused: a forwarding sink would never see the option
+        # the caller asked for, and a discarding sink could not reject a
+        # misspelling. Hand them over and let the method decide.
+        if method_has_var_keyword:
+            kwargs.update({k: v for k, v in remapped.items() if k not in accepted_field_names})
 
         return kwargs, None
 

--- a/strands_robots/simulation/newton/randomization.py
+++ b/strands_robots/simulation/newton/randomization.py
@@ -30,7 +30,35 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from strands_robots.simulation.base import unknown_kwargs_error
+
 logger = logging.getLogger(__name__)
+
+# Parameter names ``randomize`` / ``set_obs_noise`` accept. Both declare
+# ``**kwargs`` to match the ``**kwargs``-typed SimEngine base signature, and
+# ``randomize`` reads ``randomize_positions`` out of it for the MuJoCo-parity
+# error below - but nothing else there is used, so any other keyword is a caller
+# mistake and is rejected instead of dropped. ``randomize_positions`` and
+# ``position_noise`` stay accepted (not unknown) so code written against the
+# MuJoCo signature keeps producing Newton's explicit unsupported-axis error
+# rather than a confusing "unknown parameter".
+_RANDOMIZE_PARAMS: tuple[str, ...] = (
+    "randomize_colors",
+    "randomize_lighting",
+    "randomize_physics",
+    "randomize_positions",
+    "position_noise",
+    "mass_range",
+    "friction_range",
+    "color_range",
+    "seed",
+)
+_OBS_NOISE_PARAMS: tuple[str, ...] = (
+    "joint_pos_std",
+    "joint_vel_std",
+    "camera_jitter_px",
+    "seed",
+)
 
 
 class DomainRandomizationMixin:
@@ -98,15 +126,21 @@ class DomainRandomizationMixin:
             friction_range: ``(lo, hi)`` multiplicative scale on shape friction.
             color_range: ``(lo, hi)`` for uniform RGB sampling.
             seed: Optional seed for reproducible randomization.
-            **kwargs: Tolerated for MuJoCo-signature parity. Passing a truthy
-                ``randomize_positions`` returns an error: Newton does not yet
-                support object-position randomization.
+            **kwargs: Tolerated for MuJoCo-signature parity: ``randomize_positions``
+                and ``position_noise`` are accepted keywords, and a truthy
+                ``randomize_positions`` returns an error (Newton does not yet
+                support object-position randomization). Nothing else is
+                forwarded, so any other keyword is rejected with an error naming
+                the valid parameters instead of being silently dropped.
 
         Returns:
             Status dict. On success the ``json`` block carries the applied
-            multipliers; an error dict is returned when no world exists, a
-            range is invalid, or an unsupported axis is requested.
+            multipliers; an error dict is returned when a keyword is unknown, no
+            world exists, a range is invalid, or an unsupported axis is
+            requested.
         """
+        if kwargs_error := unknown_kwargs_error("randomize", kwargs, _RANDOMIZE_PARAMS):
+            return kwargs_error
         if self._world is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
         if kwargs.get("randomize_positions"):
@@ -254,13 +288,18 @@ class DomainRandomizationMixin:
             camera_jitter_px: Max integer pixel shift applied to rendered
                 frames (uniform in ``[-px, px]`` per axis).
             seed: Optional seed for a reproducible noise stream.
-            **kwargs: Accepted for ``SimEngine.set_obs_noise`` signature
-                compatibility; ignored by the Newton backend.
+            **kwargs: Declared only to match the ``**kwargs``-typed
+                ``SimEngine.set_obs_noise`` signature; nothing is forwarded, so
+                any keyword arriving here is rejected with an error naming the
+                valid parameters rather than reporting an all-zero (no-op) noise
+                configuration as success.
 
         Returns:
-            Status dict echoing the configured noise, or an error dict when any
-            value is negative or non-finite.
+            Status dict echoing the configured noise, or an error dict when a
+            keyword is unknown or a value is negative or non-finite.
         """
+        if kwargs_error := unknown_kwargs_error("set_obs_noise", kwargs, _OBS_NOISE_PARAMS):
+            return kwargs_error
         for label, value in (
             ("joint_pos_std", joint_pos_std),
             ("joint_vel_std", joint_vel_std),

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -177,16 +177,18 @@ class TestRouterNameRobotNameAlias:
 
 
 class TestRouterKwargsPassthrough:
-    """Methods with **kwargs in signature accept unknown params without error."""
+    """Methods declaring **kwargs receive the residual keys and own the check.
 
-    def test_router_skips_unknown_check_for_var_keyword_methods(self, sim):
-        # The router's unknown-parameter guard is skipped only for methods that
-        # genuinely declare **kwargs; extra keys are dropped (not rejected).
-        # Verified directly against the validator, because no dispatchable
-        # action currently relies on this branch: add_object used to, but its
-        # signature is identical across backends and now rejects unknown params
-        # instead of silently dropping them (see
-        # test_add_object_rejects_unknown_kwargs.py).
+    The router's unknown-parameter guard is skipped for those methods, so it
+    must hand the residual keys over rather than drop them: dropping would leave
+    the input neither validated nor used, which is how ``randomize`` /
+    ``set_obs_noise`` came to report a misspelled parameter as a successful
+    no-op (see test_domain_randomization_rejects_unknown_params.py). A
+    forwarding sink passes the keys to its callee; a discarding sink rejects
+    them. Verified directly against the validator with a signature-only stub.
+    """
+
+    def test_router_forwards_residual_keys_to_var_keyword_methods(self, sim):
         import inspect
 
         def fake(self, name, **kwargs):  # noqa: ANN001, ANN002, ANN202
@@ -195,8 +197,18 @@ class TestRouterKwargsPassthrough:
         sig = inspect.signature(fake)
         kwargs, err = sim._validate_and_build_kwargs("fake", "fake", sig, {"name": "x", "future_flag": True})
         assert err is None
-        # only declared params are forwarded; the extra key is dropped silently
-        assert kwargs == {"name": "x"}
+        assert kwargs == {"name": "x", "future_flag": True}
+
+    def test_router_still_rejects_unknown_keys_without_var_keyword(self, sim):
+        import inspect
+
+        def fake(self, name):  # noqa: ANN001, ANN202
+            """Signature-only stub; never called, its body is irrelevant."""
+
+        sig = inspect.signature(fake)
+        kwargs, err = sim._validate_and_build_kwargs("fake", "fake", sig, {"name": "x", "future_flag": True})
+        assert kwargs is None
+        assert err is not None and "future_flag" in err["content"][0]["text"]
 
 
 class TestToolSpecMethodParity:

--- a/tests/simulation/mujoco/test_domain_randomization_rejects_unknown_params.py
+++ b/tests/simulation/mujoco/test_domain_randomization_rejects_unknown_params.py
@@ -1,0 +1,140 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``randomize`` / ``set_obs_noise`` reject keywords they cannot honor.
+
+Both methods declare ``**kwargs`` to match the ``**kwargs``-typed
+:class:`~strands_robots.simulation.base.SimEngine` base signature, and neither
+forwards it anywhere. That made every misspelled or invented parameter a silent
+no-op reported as success: ``randomize(randomize_position=True)`` (singular)
+answered "Domain Randomization applied" with object positions untouched, and
+``set_obs_noise(joint_pos_stdev=0.05)`` answered with an all-zero noise config,
+so a data-collection run believed it was perturbing a world it never touched.
+The action dispatcher's own unknown-parameter guard is skipped for
+``**kwargs`` methods, so both the direct Python API and the agent dispatch path
+were affected.
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation import Simulation
+from strands_robots.simulation.base import unknown_kwargs_error
+from strands_robots.simulation.mujoco.randomization import _OBS_NOISE_PARAMS, _RANDOMIZE_PARAMS
+
+pytest.importorskip("mujoco")
+
+
+@pytest.fixture
+def sim():
+    s = Simulation()
+    s.create_world()
+    s.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.2, 0.0, 0.02])
+    yield s
+    s.cleanup()
+
+
+def _cube_xy(sim) -> np.ndarray:
+    """Return the cube's free-joint xy slice straight from MuJoCo data."""
+    import mujoco
+
+    model, data = sim._world._model, sim._world._data
+    jnt = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "cube_joint")
+    addr = model.jnt_qposadr[jnt]
+    return np.array(data.qpos[addr : addr + 2], dtype=float)
+
+
+class TestRandomizeRejectsUnknownParams:
+    def test_misspelled_axis_errors_instead_of_reporting_success(self, sim):
+        before = _cube_xy(sim)
+        result = sim.randomize(randomize_position=True, position_noise=0.05, seed=1)
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "randomize_position" in text
+        assert "randomize_positions" in text  # the valid spelling is offered
+        assert np.allclose(_cube_xy(sim), before)
+
+    def test_invented_parameters_are_all_named(self, sim):
+        result = sim.randomize(objects=["cube"], position_range=0.05)
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "objects" in text and "position_range" in text
+
+    def test_valid_call_still_randomizes_positions(self, sim):
+        before = _cube_xy(sim)
+        result = sim.randomize(
+            randomize_colors=False,
+            randomize_lighting=False,
+            randomize_positions=True,
+            position_noise=0.05,
+            seed=7,
+        )
+
+        assert result["status"] == "success"
+        assert not np.allclose(_cube_xy(sim), before)
+
+    def test_agent_dispatch_path_rejects_too(self, sim):
+        result = sim._dispatch_action("randomize", {"action": "randomize", "randomize_position": True})
+
+        assert result["status"] == "error"
+        assert "randomize_position" in result["content"][0]["text"]
+
+    def test_accepted_names_match_the_signature(self):
+        declared = {
+            name
+            for name, p in inspect.signature(Simulation.randomize).parameters.items()
+            if name != "self" and p.kind is not inspect.Parameter.VAR_KEYWORD
+        }
+        assert set(_RANDOMIZE_PARAMS) == declared
+
+
+class TestSetObsNoiseRejectsUnknownParams:
+    def test_misspelled_std_errors_instead_of_configuring_zero_noise(self, sim):
+        result = sim.set_obs_noise(joint_pos_stdev=0.05, seed=0)
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "joint_pos_stdev" in text and "joint_pos_std" in text
+        assert sim._obs_noise is None  # nothing was configured
+
+    def test_valid_call_still_configures_noise(self, sim):
+        result = sim.set_obs_noise(joint_pos_std=0.02, seed=0)
+
+        assert result["status"] == "success"
+        assert sim._obs_noise["joint_pos_std"] == pytest.approx(0.02)
+
+    def test_agent_dispatch_path_rejects_too(self, sim):
+        result = sim._dispatch_action("set_obs_noise", {"action": "set_obs_noise", "joint_pos_stdev": 0.05})
+
+        assert result["status"] == "error"
+        assert "joint_pos_stdev" in result["content"][0]["text"]
+
+    def test_accepted_names_match_the_signature(self):
+        declared = {
+            name
+            for name, p in inspect.signature(Simulation.set_obs_noise).parameters.items()
+            if name != "self" and p.kind is not inspect.Parameter.VAR_KEYWORD
+        }
+        assert set(_OBS_NOISE_PARAMS) == declared
+
+
+class TestUnknownKwargsErrorHelper:
+    def test_no_residual_kwargs_is_not_an_error(self):
+        assert unknown_kwargs_error("randomize", {}, ("seed",)) is None
+
+    def test_residual_key_the_method_honors_is_not_an_error(self):
+        # Newton reads randomize_positions out of its own **kwargs to answer
+        # with a dedicated unsupported-axis error; it must not be called unknown.
+        assert unknown_kwargs_error("randomize", {"randomize_positions": True}, ("randomize_positions",)) is None
+
+    def test_message_names_every_unexpected_key_and_the_valid_set(self):
+        result = unknown_kwargs_error("randomize", {"b": 1, "a": 2}, ("seed", "color_range"))
+
+        assert result is not None and result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "['a', 'b']" in text  # deterministic order, all keys reported
+        assert "['color_range', 'seed']" in text
+        assert "'randomize'" in text

--- a/tests/simulation/newton/test_domain_randomization.py
+++ b/tests/simulation/newton/test_domain_randomization.py
@@ -18,12 +18,15 @@ The integration tests use the ``featherstone`` solver so they do not require
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import threading
 
 import numpy as np
 import pytest
 
 from strands_robots.simulation.newton.randomization import (
+    _OBS_NOISE_PARAMS,
+    _RANDOMIZE_PARAMS,
     DomainRandomizationMixin,
     _validate_range,
 )
@@ -47,6 +50,53 @@ class _NoiseHost(DomainRandomizationMixin):
         self._dr_light_dir = None
         self._obs_noise = None
         self._obs_noise_rng = None
+
+
+class TestUnknownParamsRejected:
+    """Keywords the backend cannot honor are named, not swallowed.
+
+    ``randomize`` / ``set_obs_noise`` declare ``**kwargs`` for MuJoCo-signature
+    parity, which used to make a misspelled parameter a successful no-op. The
+    keys Newton genuinely reads out of that sink (``randomize_positions`` and
+    its ``position_noise`` companion) stay accepted so backend-agnostic code
+    still gets the explicit unsupported-axis error.
+    """
+
+    def test_randomize_rejects_misspelled_axis(self):
+        result = _NoiseHost().randomize(randomize_physic=True)
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "randomize_physic" in text and "randomize_physics" in text
+
+    def test_randomize_keeps_the_unsupported_positions_message(self):
+        host = _NoiseHost()
+        host._world = object()  # non-None so the world guard passes
+        result = host.randomize(randomize_positions=True)
+
+        assert result["status"] == "error"
+        assert "not supported by the Newton backend" in result["content"][0]["text"]
+
+    def test_set_obs_noise_rejects_misspelled_std(self):
+        host = _NoiseHost()
+        result = host.set_obs_noise(joint_pos_stdev=0.05)
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "joint_pos_stdev" in text and "joint_pos_std" in text
+        assert host._obs_noise is None
+
+    def test_accepted_names_cover_the_signatures(self):
+        for method, accepted, extra in (
+            (DomainRandomizationMixin.randomize, _RANDOMIZE_PARAMS, {"randomize_positions", "position_noise"}),
+            (DomainRandomizationMixin.set_obs_noise, _OBS_NOISE_PARAMS, set()),
+        ):
+            declared = {
+                name
+                for name, p in inspect.signature(method).parameters.items()
+                if name != "self" and p.kind is not inspect.Parameter.VAR_KEYWORD
+            }
+            assert set(accepted) == declared | extra
 
 
 class TestValidateRange:


### PR DESCRIPTION
## Problem

`randomize` and `set_obs_noise` declare `**kwargs` to match the `**kwargs`-typed `SimEngine.randomize` / `SimEngine.set_obs_noise` base signatures, and neither forwards it anywhere. Every keyword the method did not declare was therefore dropped while the call still answered `status="success"`:

```python
sim.randomize(randomize_position=True, position_noise=0.05)   # singular typo
# success: "Domain Randomization applied: Colors: 31 geoms | Lighting: 2 lights"
#          object positions untouched

sim.set_obs_noise(joint_pos_stdev=0.05)                       # "stdev" typo
# success: "Sensor noise: joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0"
```

A collection or eval loop asking for object-position randomization or sensor noise was told the request had been applied while the world and the observations were never perturbed - the dataset looks randomized in the log and is not.

The action dispatcher already guards this for every other action (`Unknown parameter 'nsteps' for action 'step'. Valid: ['n_steps']`), but the check is skipped for `**kwargs` methods, so the direct Python API and the agent dispatch path were both affected. The dispatcher additionally *dropped* the residual keys rather than forwarding them, so they were neither validated nor used: a genuine forwarding sink (`attach_teleop`, `stream_dataset`) never received an option a caller passed either.

## Change

- New `strands_robots.simulation.base.unknown_kwargs_error(method, kwargs, accepted)` returns a `status="error"` result naming the unusable keys and the valid set (an error dict, not an exception: these run as agent tool actions, which must not raise past dispatch). Message shape mirrors the dispatcher's existing one.
- MuJoCo and Newton `randomize` / `set_obs_noise` call it before doing any work. Newton still answers a truthy `randomize_positions` with its specific unsupported-axis error - that key and its `position_noise` companion stay *accepted* so code written against the MuJoCo signature keeps getting the informative message instead of "unknown parameter".
- `_validate_and_build_kwargs` now forwards residual keys to methods that declare `**kwargs`, so the method owns the decision: forward onward, or reject.
- `SimEngine.randomize` / `set_obs_noise` docstrings state the contract for future backends; the `**kwargs` entries that claimed the keys were "ignored" now say they are rejected.

No change to any valid call: parameter names, defaults, sampling and the applied axes are untouched.

## Verification

Same script before and after, on MuJoCo:

```
before  success  Domain Randomization applied: | Colors: 31 geoms | Lighting: 2 lights
after   error    Unknown parameter(s) ['randomize_position'] for action 'randomize'.
                 Valid: ['color_range', 'friction_range', 'mass_range', 'position_noise',
                         'randomize_colors', 'randomize_lighting', 'randomize_physics',
                         'randomize_positions', 'seed']
before  success  Sensor noise: joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0
after   error    Unknown parameter(s) ['joint_pos_stdev'] for action 'set_obs_noise'.
                 Valid: ['camera_jitter_px', 'joint_pos_std', 'joint_vel_std', 'seed']
```

15 new tests, all failing on pre-fix code:

- `tests/simulation/mujoco/test_domain_randomization_rejects_unknown_params.py` - misspelled axis and invented parameters rejected (and the cube's `qpos` verified unmoved), the valid `randomize_positions=True` call still perturbs positions, `set_obs_noise` leaves nothing configured on a typo, the agent dispatch path rejects too, plus a drift guard pinning the accepted-name tuples to the live signatures.
- `tests/simulation/newton/test_domain_randomization.py::TestUnknownParamsRejected` - same on the Newton mixin (no Newton/Warp needed) and the unsupported-`randomize_positions` message preserved.
- `tests/simulation/mujoco/test_agenttool_contract.py::TestRouterKwargsPassthrough` updated to pin the new router contract (residual keys forwarded for `**kwargs` methods, still rejected for methods without one). Its previous assertion pinned the drop behaviour this fix removes.

Local gate: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean; full `pytest tests` under `MUJOCO_GL=egl`: 11744 passed, 254 skipped.

## What the swallowed parameter was supposed to do

Rendered headless in MuJoCo (`MUJOCO_GL=egl`), identical scene and seed. Left: the state after the misspelled call - unchanged, which pre-fix was reported as a successful randomization. Right: the same request spelled correctly.

![domain randomization: swallowed vs honored position randomization](https://raw.githubusercontent.com/cagataycali/robots/artifacts/dr-unknown-params/dr_unknown_params.png)

---

## §13 Review Rounds

| Round | Concern | Commit | Pin Test |
|-------|---------|--------|----------|
| R1 | Merge conflict (CHANGELOG.md) with upstream/main | `1e255c2` | N/A (merge-only, no code change) |

---

<sub>This contribution was made autonomously by an AI agent ([strands-agents](https://github.com/strands-agents)). All code changes are validated by CI and reviewed by project maintainers before merge.</sub>