### PR TITLE
fix(sim): add_object material rejects keys it cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `add_object(material=...)` rejects keys it cannot honor
+
+Every key of the `material` spec is optional and was read with `dict.get()`, so
+any key the builder does not recognise was dropped while `add_object` still
+answered `status="success"`:
+
+```python
+sim.add_object("tile", material={"builtin": "checker", "rgb_1": [1, 0, 0], "rgb_2": [0, 0, 1]})
+# -> success: "'tile' added: box at [0.0, 0.0, 0.05], ..."   (default grey checker)
+sim.add_object("ball", material={"roughness": 0.2})
+# -> success                                                  (glossy default, no material effect)
+sim.add_object("cube", material={})
+# -> success                                                  (glossy default)
+```
+
+The point of `material=` is to narrow the sim-to-real visual gap, so a silently
+dropped key produces exactly the wrong thing: the synthetic-looking default
+surface, reported as applied. `rgb1`/`rgb2`/`texdim` without a `builtin` had the
+same shape - they only colour/size a procedural texture, so alone they compiled
+the plain default. A non-dict `material` raised a bare `AttributeError` out of
+the builder instead of a structured error.
+
+`material` specs are now validated against a single accepted-key set before any
+scene mutation, on both the direct `SpecBuilder` path and the live
+`Simulation.add_object` / agent-tool path. Unknown keys are named with a
+suggestion when they are near-misses:
+
+```
+add_object material for 'tile': unknown material key(s): 'rgb_1' (did you mean
+'rgb1'?), 'rgb_2' (did you mean 'rgb2'?). Accepted keys: builtin, reflectance,
+rgb1, rgb2, shininess, specular, texdim, texrepeat, texture.
+```
+
+Honored specs are unchanged, and a rejected add leaves no object registered and
+no orphan asset behind, so the same name re-adds cleanly.
+
+
 ### Fixed: `replay_episode` reports the frames it could not apply
 
 `replay_episode` mapped each recorded action-vector index onto an action key and

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -185,7 +185,21 @@ sim.add_object("floor_tile", shape="box", size=[0.3, 0.3, 0.01], is_static=True,
 Specify **either** `texture` **or** `builtin`, not both. An invalid texture
 path, an unknown `builtin` name, or specifying both fails loudly with a
 `ValueError` (returned as a `status=error` dict through the agent tool) - there
-is no silent fallback to the flat-plastic default. For natural surfaces prefer
+is no silent fallback to the flat-plastic default.
+
+Only the keys in the table above are accepted. A key outside it (a typo such as
+`rgb_1`, or a field borrowed from another renderer such as `roughness`), an
+empty `material={}`, or `rgb1`/`rgb2`/`texdim` without `builtin` is rejected the
+same way - the alternative is an object that compiles with MuJoCo's glossy
+defaults while `add_object` reports success:
+
+```python
+sim.add_object("cube", material={"builtin": "checker", "rgb_1": [1, 0, 0]})
+# status=error: unknown material key(s): 'rgb_1' (did you mean 'rgb1'?).
+#               Accepted keys: builtin, reflectance, rgb1, rgb2, shininess, ...
+```
+
+For natural surfaces prefer
 an **image texture**; the `checker` builtin reads as a literal checkerboard.
 Materials are currently supported by the MuJoCo backend; the Newton backend
 rejects a non-`None` `material` rather than silently ignoring it.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -529,7 +529,10 @@ class SimEngine(ABC):
         spec. ``None`` keeps the flat ``color`` rgba (unchanged); a backend
         that supports it (MuJoCo) attaches a real material so surfaces can be
         matte or textured. Backends that do not support it should reject a
-        non-``None`` ``material`` loudly rather than silently ignore it.
+        non-``None`` ``material`` loudly rather than silently ignore it. A
+        supporting backend must likewise reject material keys it cannot honor
+        (a typo, or a field from another renderer) instead of dropping them --
+        a dropped key renders the backend default while reporting success.
         """
         ...
 
@@ -2457,7 +2460,8 @@ class SimEngine(ABC):
                     "(cube/sphere/.../mesh) to the scene. material is an optional "
                     "dict for matte/textured surfaces: keys reflectance|specular|"
                     "shininess (0..1), texture (abs image path) OR builtin "
-                    "(checker|gradient|flat) + rgb1/rgb2/texdim, texrepeat [u,v]"
+                    "(checker|gradient|flat) + rgb1/rgb2/texdim, texrepeat [u,v]; "
+                    "any other key (or an empty dict) is rejected, never ignored"
                 ),
                 "remove_object": "(name: str) -> dict  # remove a previously added object",
                 "remove_robot": (

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -89,7 +89,11 @@ from strands_robots.simulation.mujoco.scene_ops import (
     replace_scene_mjcf,
     reposition_body_in_scene,
 )
-from strands_robots.simulation.mujoco.spec_builder import SpecBuilder, _validate_size
+from strands_robots.simulation.mujoco.spec_builder import (
+    SpecBuilder,
+    _validate_size,
+    material_spec_error,
+)
 from strands_robots.simulation.policy_runner import CooperativeStop
 from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_difficulty, validate_terrain
 from strands_robots.teleop_mixin import TeleopMixin
@@ -2386,7 +2390,11 @@ class MuJoCoSimEngine(
         procedural builtin (``{"builtin": "checker", "rgb1": [...], "rgb2":
         [...]}``). See :meth:`SpecBuilder._build_material` for the full schema;
         an invalid texture path or unknown builtin fails loudly (no silent
-        fallback to flat plastic).
+        fallback to flat plastic). Only the keys in
+        :data:`~strands_robots.simulation.mujoco.spec_builder.MATERIAL_KEYS`
+        are accepted -- a misspelled or unsupported key (``"rgb_1"``,
+        ``"roughness"``) is rejected rather than dropped, because a dropped key
+        renders the default glossy surface while still reporting success.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -2447,6 +2455,12 @@ class MuJoCoSimEngine(
         # caller gets a clear error rather than a confusing recompile failure.
         if size is not None and (size_err := _validate_size(shape, list(size))) is not None:
             return {"status": "error", "content": [{"text": size_err}]}
+
+        # A material key the builder cannot honor (typo / another renderer's
+        # field name) would otherwise be dropped and the object would compile
+        # with MuJoCo's glossy defaults while this call reported success.
+        if material is not None and (mat_err := material_spec_error(name, material)) is not None:
+            return {"status": "error", "content": [{"text": mat_err}]}
 
         obj = SimObject(
             name=name,

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -19,9 +19,11 @@ transformation goes through MuJoCo's own AST.
 
 from __future__ import annotations
 
+import difflib
 import logging
 import os
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, Final
 
 import numpy as np
 
@@ -37,6 +39,72 @@ from strands_robots.simulation.terrain import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Accepted keys of the ``add_object(material=...)`` spec. Single source of truth
+# shared by :func:`material_spec_error` and :meth:`SpecBuilder._build_material`.
+MATERIAL_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "reflectance",
+        "specular",
+        "shininess",
+        "texrepeat",
+        "texture",
+        "builtin",
+        "rgb1",
+        "rgb2",
+        "texdim",
+    }
+)
+
+# Keys that only mean something for a procedural (``builtin``) texture.
+_BUILTIN_ONLY_KEYS: Final[tuple[str, ...]] = ("rgb1", "rgb2", "texdim")
+
+
+def material_spec_error(obj_name: str, material: Any) -> str | None:
+    """Validate an ``add_object(material=...)`` spec's shape.
+
+    Every key of the material spec is optional, so a key the builder does not
+    recognise (a typo such as ``"rgb_1"``, or a field borrowed from another
+    renderer such as ``"roughness"``) would otherwise be dropped and the
+    surface would compile with MuJoCo's glossy defaults while the call still
+    reported success. Reject those keys instead.
+
+    Args:
+        obj_name: Object name, used to make the message actionable.
+        material: The caller-supplied material spec.
+
+    Returns:
+        An error message, or ``None`` when the spec's shape is honorable.
+        Value-level checks (texture file exists, ``builtin`` name known,
+        ``texture``/``builtin`` mutually exclusive) live in
+        :meth:`SpecBuilder._build_material`.
+    """
+    accepted = ", ".join(sorted(MATERIAL_KEYS))
+    prefix = f"add_object material for {obj_name!r}: "
+    if not isinstance(material, Mapping):
+        return f"{prefix}expected a dict of material options, got {type(material).__name__}. Accepted keys: {accepted}."
+    if not material:
+        return (
+            f"{prefix}material={{}} has no effect - omit material= to keep the "
+            f"flat 'color' rgba, or set at least one of: {accepted}."
+        )
+    unknown = [key for key in material if key not in MATERIAL_KEYS]
+    if unknown:
+        described = []
+        for key in sorted(unknown, key=str):
+            close = difflib.get_close_matches(str(key).lower(), sorted(MATERIAL_KEYS), n=1, cutoff=0.7)
+            described.append(f"{key!r}" + (f" (did you mean {close[0]!r}?)" if close else ""))
+        return f"{prefix}unknown material key(s): {', '.join(described)}. Accepted keys: {accepted}."
+    if material.get("builtin") is None:
+        orphans = [key for key in _BUILTIN_ONLY_KEYS if material.get(key) is not None]
+        if orphans:
+            return (
+                f"{prefix}{', '.join(orphans)} only colour/size a procedural "
+                "texture and are ignored without it - set builtin='checker'|'gradient'|'flat', "
+                "or drop them (an image 'texture' is coloured by the file itself, tinted by "
+                "the geom 'color' rgba)."
+            )
+    return None
 
 
 # MuJoCo geom-type enum mapping. Populated lazily on first call so module
@@ -468,14 +536,18 @@ class SpecBuilder:
               texture, coloured by ``rgb1`` / ``rgb2`` (each ``[r, g, b]``)
               and sized ``texdim`` (default 512) per side.
 
-        Fails loudly (``ValueError``) on a missing texture file, an unknown
-        ``builtin`` name, or both ``texture`` and ``builtin`` set -- there is
-        no silent fallback to the flat-plastic default. The geom keeps its
-        ``rgba`` (which tints an image/solid material), so callers can still
-        colour a procedural/solid surface via ``color=``.
+        Fails loudly (``ValueError``) on a key outside :data:`MATERIAL_KEYS`,
+        an empty spec, ``rgb1``/``rgb2``/``texdim`` without ``builtin``, a
+        missing texture file, an unknown ``builtin`` name, or both ``texture``
+        and ``builtin`` set -- there is no silent fallback to the flat-plastic
+        default. The geom keeps its ``rgba`` (which tints an image/solid
+        material), so callers can still colour a procedural/solid surface via
+        ``color=``.
         """
+        if (shape_err := material_spec_error(obj.name, obj.material)) is not None:
+            raise ValueError(shape_err)
         mujoco = _ensure_mujoco()
-        mat_spec = obj.material or {}
+        mat_spec: Mapping[str, Any] = obj.material or {}
         mat_name = f"{obj.name}_mat"
         tex_name = f"{obj.name}_tex"
 

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -168,7 +168,7 @@
     },
     "material": {
       "type": "object",
-      "description": "Optional visual material/texture for add_object (MuJoCo backend). Keys: reflectance|specular|shininess (float 0..1; specular=0,shininess=0 = matte), texture (absolute image path) OR builtin (checker|gradient|flat) with rgb1/rgb2 ([r,g,b]) + texdim (int, default 512), texrepeat ([u,v]). Omit for a flat color-only surface. Invalid texture path or unknown builtin fails loudly.",
+      "description": "Optional visual material/texture for add_object (MuJoCo backend). Keys: reflectance|specular|shininess (float 0..1; specular=0,shininess=0 = matte), texture (absolute image path) OR builtin (checker|gradient|flat) with rgb1/rgb2 ([r,g,b]) + texdim (int, default 512), texrepeat ([u,v]). Omit for a flat color-only surface. Invalid texture path, unknown builtin, empty {}, rgb1/rgb2/texdim without builtin, or any key outside the list above fails loudly (never silently ignored).",
       "properties": {
         "reflectance": { "type": "number" },
         "specular": { "type": "number" },

--- a/tests/simulation/mujoco/test_object_materials.py
+++ b/tests/simulation/mujoco/test_object_materials.py
@@ -9,6 +9,10 @@ These tests pin the new behaviour:
 * ``material=None`` is byte-for-byte the old behaviour (``matid == -1``).
 * Invalid material specs fail loudly (``ValueError``) -- no silent fallback to
   the flat-plastic default.
+* A material key the builder cannot honor (a typo, another renderer's field
+  name, an empty spec, or ``rgb1``/``rgb2``/``texdim`` without ``builtin``) is
+  rejected instead of dropped -- dropping one compiles the glossy default while
+  reporting success.
 
 They exercise the full path ``Simulation.add_object`` -> ``SimObject`` ->
 ``SpecBuilder._build_material`` -> compiled ``MjModel`` so the assertions are on
@@ -187,5 +191,75 @@ def test_simulation_add_object_bad_material_reports_error(tmp_path):
         retry = sim.add_object("ball", shape="sphere", material={"specular": 0.0})
         assert retry["status"] == "success", retry
         assert _matid(sim._world._model, "ball_geom") >= 0
+    finally:
+        sim.destroy()
+
+
+@pytest.mark.parametrize(
+    ("material", "expected"),
+    [
+        # A typo in a procedural colour key silently dropped the caller's
+        # colours and compiled the default grey checker.
+        ({"builtin": "checker", "rgb_1": [1.0, 0.0, 0.0]}, "did you mean 'rgb1'"),
+        # Another renderer's field name: no MuJoCo equivalent, so it did nothing.
+        ({"roughness": 0.2}, "'roughness'"),
+        ({"tex_repeat": [4, 4]}, "did you mean 'texrepeat'"),
+        # Real mjMaterial field that this schema does not plumb through.
+        ({"emission": 0.5}, "'emission'"),
+        ({"specular": 0.0, "shininess": 0.0, "bogus": 1}, "'bogus'"),
+        # rgb1/rgb2/texdim only colour a procedural texture.
+        ({"rgb1": [1.0, 0.0, 0.0], "rgb2": [0.0, 0.0, 1.0]}, "only colour/size a procedural"),
+        ({"texture": "/tmp/x.png", "texdim": 256}, "only colour/size a procedural"),
+        # An empty spec cannot express anything: it compiled MuJoCo's defaults.
+        ({}, "has no effect"),
+    ],
+)
+def test_unhonorable_material_keys_fail_loudly(material, expected):
+    """A material key the builder cannot honor must raise, not be dropped."""
+    obj = SimObject(name="x", shape="box", material=material)
+    with pytest.raises(ValueError, match=expected):
+        _compile(obj)
+
+
+def test_non_mapping_material_fails_loudly():
+    """A non-dict material must raise a ValueError, not an opaque AttributeError."""
+    obj = SimObject(name="x", shape="box", material=["specular", 0.0])
+    with pytest.raises(ValueError, match="expected a dict of material options, got list"):
+        _compile(obj)
+
+
+def test_simulation_add_object_rejects_unknown_material_key():
+    """The live path reports status=error and leaves no object registered.
+
+    Pre-fix this returned ``status=success`` with the unknown key dropped, so
+    the caller believed a red checkerboard had been applied while the compiled
+    geom carried the default grey checker.
+    """
+    import strands_robots as sr
+
+    sim = sr.Simulation()
+    try:
+        sim.create_world(ground_plane=True)
+        result = sim.add_object(
+            "cube",
+            shape="box",
+            material={"builtin": "checker", "rgb_1": [1.0, 0.0, 0.0], "rgb2": [0.0, 0.0, 1.0]},
+        )
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "rgb_1" in text and "rgb1" in text
+        # Accepted keys are listed so the caller can self-correct.
+        assert "texrepeat" in text
+        assert "cube" not in sim._world.objects
+        # The corrected spelling is accepted and reaches the compiled model.
+        retry = sim.add_object(
+            "cube",
+            shape="box",
+            material={"builtin": "checker", "rgb1": [1.0, 0.0, 0.0], "rgb2": [0.0, 0.0, 1.0]},
+        )
+        assert retry["status"] == "success", retry
+        matid = _matid(sim._world._model, "cube_geom")
+        assert matid >= 0
+        assert int(sim._world._model.mat_texid[matid][mujoco.mjtTextureRole.mjTEXROLE_RGB]) >= 0
     finally:
         sim.destroy()

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -72,6 +72,7 @@ _EXPECTED_FUNCTIONS = {
     "scene_ops.py::remove_equality_constraint",
     "scene_ops.py::replace_scene_mjcf",
     "scene_ops.py::reposition_body_in_scene",
+    "spec_builder.py::material_spec_error",
 }
 
 


### PR DESCRIPTION
## Problem

Every key of the `add_object(material=...)` spec is optional and was read with `dict.get()`, so any key the builder does not recognise was dropped while the call still answered `status="success"`:

```python
sim.add_object("tile", material={"builtin": "checker", "rgb_1": [.85, .1, .1], "rgb_2": [.1, .2, .75]})
# -> success: "'tile' added: box at [0.0, 0.0, 0.05], ..."   (default grey checker)
sim.add_object("ball", material={"roughness": 0.2})
# -> success                                                (glossy default, no material effect)
sim.add_object("cube", material={})
# -> success                                                (glossy default)
```

`material=` exists to narrow the sim-to-real visual gap for VLM/VLA policies, so a dropped key produces exactly the wrong thing: the synthetic-looking default surface, reported as applied. Two related shapes had the same defect:

- `rgb1`/`rgb2`/`texdim` without a `builtin` only colour/size a procedural texture, so alone they compiled the plain default.
- A non-dict `material` (e.g. a list) raised a bare `AttributeError` out of `SpecBuilder._build_material`, escaping the structured-error contract of the agent tool.

The `material` object is also exposed in the MuJoCo `tool_spec.json`, so an agent inventing `rgb_1` or borrowing `roughness` from another renderer got a success answer and a wrong-looking scene.

## Visual proof

Headless MuJoCo render (`MUJOCO_GL=egl`) of the same `add_object` call. Left: what the dropped-key path actually compiled for `{"builtin": "checker", "rgb_1": ..., "rgb_2": ...}` while returning success. Right: the honored spec with the correct `rgb1`/`rgb2` spelling, which this PR steers callers to.

![material dropped key comparison](https://raw.githubusercontent.com/cagataycali/robots/artifacts/material-keys/material_dropped_key.png)

## Change

One accepted-key set (`MATERIAL_KEYS`) plus a `material_spec_error(obj_name, material)` validator in `spec_builder`, used by both entry points before any scene mutation:

- `SpecBuilder._build_material` raises `ValueError` (covers the direct/`load_scene` path).
- `MuJoCoSimEngine.add_object` returns the `status=error` envelope up front, so no `SimObject` is registered and no orphan material/texture asset is created.

Rejected shapes: unknown key, empty `{}`, `rgb1`/`rgb2`/`texdim` without `builtin`, non-mapping `material`. Near-misses get a `difflib` suggestion:

```
add_object material for 'tile': unknown material key(s): 'rgb_1' (did you mean 'rgb1'?),
'rgb_2' (did you mean 'rgb2'?). Accepted keys: builtin, reflectance, rgb1, rgb2,
shininess, specular, texdim, texrepeat, texture.
```

Value-level checks (texture file exists, `builtin` name known, `texture`/`builtin` mutually exclusive) stay where they are in `_build_material`; the new validator only covers the spec's shape. Honored specs are byte-for-byte unchanged, and `material=None` still compiles with `geom_matid == -1`.

Docs updated in the same change: the `material` table section in `docs/simulation/world-building.md`, the MuJoCo `add_object` docstring, the `SimEngine.add_object` ABC contract (a supporting backend must reject keys it cannot honor, matching the existing rule for backends that do not support `material` at all), the `describe()` line, and the agent `tool_spec.json` description.

## Tests

10 new cases in `tests/simulation/mujoco/test_object_materials.py`, all failing pre-fix (`10 failed` on the unpatched source, `19 passed` after):

- parametrized rejection of `rgb_1`, `roughness`, `tex_repeat`, `emission`, an extra `bogus` alongside valid keys, `rgb1`/`rgb2` without `builtin`, `texture` + `texdim`, and `{}`
- non-mapping `material` raises `ValueError`, not `AttributeError`
- the live `Simulation.add_object` path returns `status=error`, names both the typo and the suggestion, registers nothing, and the corrected spelling then reaches the compiled model with a bound RGB texture

`spec_builder.py::material_spec_error` is pinned in the public-member docstring guard.

Local gate on the current base (`fe8ba32e`): `ruff check strands_robots tests tests_integ` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; full `MUJOCO_GL=egl pytest tests` 11798 passed / 254 skipped (405s). Pre-fix re-verified on this base by reverting only the source files with the tests in place: 10 failed / 9 passed.

## §13 Changelog

### Round 3
- **Rebased onto current `main` (`fe8ba32e`) to clear a CHANGELOG-only merge conflict** created by #1631 and #1634 landing ahead of this branch. The `[Unreleased]` entry now sits above the `replay_episode` entry; no other file conflicted. `strands_robots/simulation/base.py` is co-touched by #1634, but in disjoint regions (`add_object` contract at ~L529 and the `add_object` `describe()` line vs. #1634's `replay_episode` docstring/`describe()` line), so its #1634 content is preserved intact - verified by diffing this branch's non-CHANGELOG patch against the pre-rebase head: identical apart from one `@@` hunk offset.
- Re-ran the full gate on the new base and refreshed the quoted suite count (11788 -> 11798, the delta being tests merged in #1631/#1634).

### Round 2
- **docs-only, non-blocking review nit**: the Materials example closing code fence in `docs/simulation/world-building.md` carried trailing text (`` ``` For natural surfaces prefer``), which per CommonMark leaves the fence open and swallows the following prose plus the `## Cameras` heading into the code block. Split the trailing prose onto its own line after a bare closing fence. Verified with a CommonMark parser (`markdown-it`): `## Cameras` now renders as an `<h2>` and the prose renders as a `<p>`. No source/test changes; honored-spec behaviour and the pinned guard are untouched.