### PR TITLE
fix(sim): replay_episode reports the frames it could not apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `replay_episode` reports the frames it could not apply
+
+`replay_episode` mapped each recorded action-vector index onto an action key and
+wrote it through `send_action`, then **discarded** `send_action`'s result -
+including the `status="error"` + `unresolved_keys` breakdown it returns precisely
+so callers can self-correct instead of silently losing commands. Every way of
+getting the mapping wrong therefore reported a full-fidelity replay that never
+reached the robot:
+
+```python
+sim.replay_episode("user/ds", robot_name="so101", action_key_map=["shoulder_pan", ...])
+# -> success: "Frames: 120/120"   (wrong namespace: nothing applied, arm motionless)
+sim.replay_episode("user/ds", robot_name="so101", action_key_map="gripper")
+# -> success: "Frames: 120/120"   (a bare string is consumed one key PER CHARACTER)
+sim.replay_episode("user/ds", robot_name="so101", action_key_map=["1", "2"])
+# -> success: "Frames: 120/120"   (a 6-DOF recording's last four joints dropped)
+```
+
+`run_policy` already inspects `send_action`'s status (it counts action errors and
+fail-fasts a rollout where nothing resolves); replay now does too. A frame that
+could not be applied aborts the replay with `status="error"`, the frame index,
+how many frames were applied and the backend's unresolved-key breakdown, so a
+`"success"` status means every recorded frame reached the actuators.
+
+A recorded vector whose width differs from the action-key map is also rejected
+instead of positionally truncated (matching `send_action`, which rejects a raw
+action vector whose length does not match the actuator count), and a malformed
+`action_key_map` - a bare string, a non-string entry, a duplicate key or an empty
+list - is rejected before the dataset is fetched.
+
 ### Fixed: `randomize` / `set_obs_noise` reject parameters they cannot honor
 
 Both methods declare `**kwargs` to match the `**kwargs`-typed

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -375,6 +375,45 @@ ds = LeRobotDataset(repo_id="user/my_dataset", root="/tmp/my_dataset")
 print(len(ds), ds[0].keys())
 ```
 
+## Replay an episode
+
+`sim.replay_episode(repo_id, robot_name=..., episode=0, root=None, speed=1.0)`
+plays a recorded episode back through the sim: each recorded frame is one
+control step, applied via `send_action` and integrated for a full control period
+derived from the dataset fps, so a position-servo robot reproduces the recorded
+trajectory. `speed` scales only the wall-clock playback rate.
+
+Each recorded action index is bound to an action key. By default those are
+`robot_action_keys(robot_name)` — the robot's **actuator** keys, which is the
+ordering the recorder writes the `action` column in. Pass `action_key_map` only
+when the dataset's action ordering differs:
+
+```python
+sim.replay_episode(
+    "user/my_dataset",
+    robot_name="so101",
+    root="/tmp/my_dataset",
+    action_key_map=["1", "2", "3", "4", "5", "6"],  # one key per action index
+)
+```
+
+`action_key_map` must be a non-empty list/tuple of unique strings whose length
+equals the recorded action vector's width. A bare string (consumed one key per
+character), a non-string entry, a duplicate key, or a width mismatch is rejected
+with an actionable error before the dataset is fetched — never truncated to fit.
+
+A `"success"` status means **every** frame reached the actuators. If a recorded
+action cannot be applied — e.g. the mapped keys resolve to no actuator on this
+robot — the replay aborts at that frame and returns `status="error"` with the
+frame index, how many frames were applied, and the unresolved keys:
+
+```python
+result = sim.replay_episode("user/my_dataset", robot_name="so101", action_key_map=["wrong"] * 6)
+result["status"]                                  # "error"
+result["content"][1]["json"]["unresolved_keys"]   # ['wrong', ...]
+result["content"][1]["json"]["frames_applied"]    # 0
+```
+
 ## Stream back (no full download)
 
 `sim.stream_dataset()` is the in-process counterpart to `start_recording` /

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1799,6 +1799,15 @@ class SimEngine(ABC):
         the dataset fps), so a position-servo robot reproduces the recorded
         trajectory instead of under-integrating it.
 
+        ``action_key_map`` binds recorded action-vector indices to action keys
+        (default: :meth:`robot_action_keys`). It must be a non-empty list/tuple
+        of unique strings whose length matches the recorded action width; a bare
+        string, a non-string entry, a duplicate key or a width mismatch is
+        rejected rather than truncated to fit. A ``"success"`` status therefore
+        means every recorded frame actually reached the actuators - a frame that
+        ``send_action`` could not apply aborts the replay with the frame index,
+        the frames applied so far and the unresolved keys.
+
         Override per backend for optimised replay (e.g. direct ctrl
         writes) only when measured necessary.
         """
@@ -2490,7 +2499,10 @@ class SimEngine(ABC):
                 "replay_episode": (
                     "(repo_id: str, robot_name=None, episode=0, root=None, "
                     "speed=1.0, action_key_map=None) -> dict  # replay a recorded "
-                    "LeRobotDataset episode through the sim"
+                    "LeRobotDataset episode through the sim; action_key_map needs "
+                    "one unique key per recorded action index (default: "
+                    "robot_action_keys) and status='success' means every frame "
+                    "reached the actuators"
                 ),
                 "list_robots": "() -> list[str]",
                 "get_features": (

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -544,6 +544,55 @@ def _extract_result_json(result: object) -> dict[str, Any] | None:
     return None
 
 
+def _validate_action_key_map(action_key_map: Any) -> dict[str, Any] | None:
+    """Reject a ``replay`` ``action_key_map`` no backend could honor.
+
+    ``action_key_map`` binds recorded action-vector indices to the action keys
+    ``send_action`` resolves, so it must be an ordered collection of unique
+    strings. Three shapes are silently unusable and are rejected here:
+
+    * a bare ``str`` - ``list("gripper")`` yields one key per character;
+    * a non-string entry - it cannot name an actuator or joint;
+    * a duplicate key - two recorded indices would write the same actuator,
+      the later index silently overwriting the earlier one.
+
+    An empty collection is rejected too: it maps no recorded value at all.
+
+    Args:
+        action_key_map: The caller-supplied map (``None`` selects the default
+            ``robot_action_keys`` ordering and is always accepted).
+
+    Returns:
+        An agent-tool error dict describing the problem, or ``None`` when the
+        map is usable.
+    """
+    if action_key_map is None:
+        return None
+
+    def _error(text: str) -> dict[str, Any]:
+        return {"status": "error", "content": [{"text": f"replay: {text}"}]}
+
+    if isinstance(action_key_map, str | bytes):
+        return _error(
+            f"action_key_map must be a list of action keys, not a bare string (got {action_key_map!r}); "
+            "a string is consumed one character per action index."
+        )
+    if not isinstance(action_key_map, list | tuple):
+        return _error(f"action_key_map must be a list or tuple of action keys (got {type(action_key_map).__name__}).")
+    if not action_key_map:
+        return _error("action_key_map is empty; pass one action key per recorded action-vector index.")
+    bad = [key for key in action_key_map if not isinstance(key, str)]
+    if bad:
+        return _error(f"action_key_map entries must be action-key strings; got non-string entries {bad!r}.")
+    duplicates = sorted({key for key in action_key_map if action_key_map.count(key) > 1})
+    if duplicates:
+        return _error(
+            f"action_key_map has duplicate keys {duplicates}; each recorded action index needs its own key "
+            "(a repeated key silently overwrites the earlier index's value)."
+        )
+    return None
+
+
 class CooperativeStop(BaseException):
     """Raised by an ``on_frame`` hook to cooperatively stop a run.
 
@@ -1581,9 +1630,19 @@ class PolicyRunner:
                 *actuator* keys, which is the ordering the LeRobotDataset
                 recorder writes the ``action`` column in (a robot's actuators
                 are not always its joints; see :meth:`SimEngine.robot_action_keys`).
+                Must be a non-empty list/tuple of unique strings; a bare
+                string, a non-string entry or a duplicate key is rejected with
+                a structured error. Its length must equal the recorded action
+                vector's width - a mismatch is rejected rather than
+                positionally truncated.
 
         Returns:
-            Standard status dict with per-frame stats.
+            Standard status dict with per-frame stats. Replay aborts with an
+            ``"error"`` status when a recorded frame cannot actually be applied
+            (unresolvable action keys, or a recorded vector whose width does not
+            match the action-key map), reporting how many frames were applied
+            before the abort. A successful status therefore means every frame
+            reached the actuators.
         """
         # ``speed`` is a playback-rate multiplier used as the divisor in
         # ``frame_interval = 1 / (dataset_fps * speed)`` and, once computed,
@@ -1621,6 +1680,17 @@ class PolicyRunner:
         # bare "object cannot be interpreted as an integer" TypeError in
         # ``time.sleep`` and is not natively JSON-serialisable.
         speed = float(speed)
+
+        # ``action_key_map`` binds recorded action-vector indices to action keys
+        # ``send_action`` must resolve. A malformed map cannot be honored by any
+        # backend, and pre-fix nothing checked its shape: a bare string was
+        # ``list()``-ed into one key PER CHARACTER, a duplicate key made two
+        # recorded indices write the same actuator (the later one silently
+        # winning), and neither showed up in the result. Reject the shape here,
+        # before the (potentially multi-minute) dataset download.
+        key_map_error = _validate_action_key_map(action_key_map)
+        if key_map_error is not None:
+            return key_map_error
 
         try:
             from strands_robots.dataset_recorder import load_lerobot_episode
@@ -1714,13 +1784,85 @@ class PolicyRunner:
                 if hasattr(action_vals, "tolist"):
                     action_vals = action_vals.tolist()
 
-                action_dict: dict[str, Any] = {}
-                for i, val in enumerate(action_vals):
-                    if i >= len(action_keys):
-                        break
-                    action_dict[action_keys[i]] = float(val)
+                # A recorded vector whose width differs from the action-key
+                # map cannot be replayed faithfully: the surplus values have no
+                # key (silently DROPPED pre-fix, e.g. a 2-key map swallowing a
+                # 6-DOF recording's last four joints) or the surplus keys never
+                # receive a value. Reject it with the recorded-vs-expected
+                # widths, mirroring how ``send_action`` rejects a raw action
+                # vector whose length does not match the actuator count instead
+                # of truncating it.
+                if len(action_vals) != len(action_keys):
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"Replay aborted at frame {frame_idx}: recorded action vector has "
+                                    f"{len(action_vals)} values but {len(action_keys)} action keys are "
+                                    f"mapped ({action_keys}). Applied {frames_applied}/{episode_length} "
+                                    "frames. Pass an action_key_map with one key per recorded action "
+                                    f"value, or replay onto a robot whose actuators match the recording."
+                                )
+                            },
+                            {
+                                "json": {
+                                    "episode": episode,
+                                    "robot_name": resolved_robot,
+                                    "frame": frame_idx,
+                                    "recorded_action_width": len(action_vals),
+                                    "action_keys": action_keys,
+                                    "frames_applied": frames_applied,
+                                    "total_frames": episode_length,
+                                }
+                            },
+                        ],
+                    }
 
-                self.sim.send_action(action_dict, robot_name=resolved_robot, n_substeps=n_substeps)
+                action_dict: dict[str, Any] = {action_keys[i]: float(val) for i, val in enumerate(action_vals)}
+
+                # ``send_action`` reports unresolvable keys as an "error" status
+                # (with an ``unresolved_keys`` json block). Pre-fix that result
+                # was DISCARDED, so a typo'd action_key_map dropped every value
+                # at the actuator boundary while replay still reported
+                # ``status="success"`` and ``Frames: N/N`` - the recorded
+                # trajectory never reached the robot. Abort on the first
+                # unapplied frame instead of finishing a replay that is not
+                # happening.
+                send_result = self.sim.send_action(action_dict, robot_name=resolved_robot, n_substeps=n_substeps)
+                if isinstance(send_result, dict) and send_result.get("status") == "error":
+                    detail = next(
+                        (
+                            str(block["text"])
+                            for block in send_result.get("content", []) or []
+                            if isinstance(block, dict) and "text" in block
+                        ),
+                        "",
+                    )
+                    payload: dict[str, Any] = {
+                        "episode": episode,
+                        "robot_name": resolved_robot,
+                        "frame": frame_idx,
+                        "action_keys": action_keys,
+                        "frames_applied": frames_applied,
+                        "total_frames": episode_length,
+                    }
+                    send_json = _extract_result_json(send_result)
+                    if send_json is not None:
+                        payload.update(send_json)
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"Replay aborted at frame {frame_idx}: the recorded action could not be "
+                                    f"applied to '{resolved_robot}'. Applied {frames_applied}/{episode_length} "
+                                    f"frames. {detail}"
+                                )
+                            },
+                            {"json": payload},
+                        ],
+                    }
                 frames_applied += 1
 
             sleep_time = frame_interval - (time.time() - step_start)

--- a/tests/simulation/mujoco/test_replay_reports_unapplied_frames.py
+++ b/tests/simulation/mujoco/test_replay_reports_unapplied_frames.py
@@ -1,0 +1,160 @@
+"""Regression: replay reports failure when recorded frames never reach the robot.
+
+``PolicyRunner.replay`` maps each recorded action-vector index onto an action key
+and writes it through ``send_action``. ``send_action`` is explicit about failure:
+keys it cannot resolve to an actuator or joint come back as ``status="error"``
+with an ``unresolved_keys`` json block, precisely so callers can self-correct
+instead of silently losing commands.
+
+Replay discarded that result. The consequences were all silent:
+
+* a typo'd / wrong-namespace ``action_key_map`` dropped EVERY recorded value at
+  the actuator boundary, yet replay returned ``status="success"`` with
+  ``Frames: N/N`` - the robot never moved;
+* ``action_key_map="gripper"`` (a bare string) was consumed one key per
+  character, so six single-letter keys resolved to nothing - again "success";
+* a map shorter than the recorded vector positionally truncated the surplus
+  DOFs (a 2-key map swallowing a 6-DOF recording's last four joints) and still
+  reported a full-fidelity replay.
+
+``run_policy`` already inspects ``send_action``'s status (it counts action
+errors and fail-fasts on a rollout where nothing resolves). These tests pin the
+same honesty for ``replay``: a success status means every frame was applied, and
+an unapplied frame aborts with the frame index, the frames applied so far and
+the backend's unresolved-key detail.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def recorded_so101():
+    """A real 5-frame so101 recording plus its sim, shared by the tests below.
+
+    Recording through the real recorder (no cameras -> action-only, fast) keeps
+    the fixture honest: the ``action`` column really is written in actuator
+    order, which is what replay maps back onto.
+    """
+    pytest.importorskip("lerobot")
+    sim = Simulation()
+    sim.create_world(ground_plane=True)
+    sim.add_robot("so101")
+    root = tempfile.mkdtemp(prefix="replay_unapplied_")
+    repo = "local/replay_unapplied"
+    assert sim.start_recording(repo_id=repo, task="rt", fps=30, root=root, cameras=[])["status"] == "success"
+    assert (
+        sim.run_policy(robot_name="so101", policy_provider="mock", n_steps=5, control_frequency=30, fast_mode=True)[
+            "status"
+        ]
+        == "success"
+    )
+    assert sim.stop_recording()["status"] == "success"
+    yield sim, repo, root, 5
+    sim.cleanup()
+
+
+def _replay(sim, repo, root, **kw):
+    return PolicyRunner(sim).replay(repo, robot_name="so101", root=root, speed=1000.0, **kw)
+
+
+def test_default_map_replays_every_frame(recorded_so101):
+    """Control: the default (``robot_action_keys``) map still succeeds N/N.
+
+    Without this the error assertions below could pass for a broken replay.
+    """
+    sim, repo, root, n_frames = recorded_so101
+    result = _replay(sim, repo, root)
+    assert result["status"] == "success", result
+    payload = result["content"][1]["json"]
+    assert payload["frames_applied"] == n_frames == payload["total_frames"]
+
+
+def test_unresolvable_action_keys_abort_instead_of_reporting_success(recorded_so101):
+    """Keys no actuator can absorb fail the replay and surface the valid keys.
+
+    Pre-fix: ``status="success"``, ``Frames: 5/5``, robot motionless.
+    """
+    sim, repo, root, n_frames = recorded_so101
+    valid = sim.robot_action_keys("so101")
+    result = _replay(sim, repo, root, action_key_map=[f"not_{k}" for k in valid])
+
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert "frame 0" in text
+    assert "Applied 0/5 frames" in text
+    payload = result["content"][1]["json"]
+    assert payload["frames_applied"] == 0
+    assert payload["total_frames"] == n_frames
+    # The backend's per-key breakdown is forwarded so the caller can self-correct.
+    assert payload["unresolved_keys"] == [f"not_{k}" for k in valid]
+    assert payload["applied"] == []
+
+
+def test_map_shorter_than_recorded_vector_is_rejected(recorded_so101):
+    """A too-short map would drop recorded DOFs; reject rather than truncate."""
+    sim, repo, root, _ = recorded_so101
+    valid = sim.robot_action_keys("so101")
+    result = _replay(sim, repo, root, action_key_map=valid[:2])
+
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert f"{len(valid)} values" in text
+    assert "2 action keys" in text
+    assert result["content"][1]["json"]["recorded_action_width"] == len(valid)
+
+
+def test_map_longer_than_recorded_vector_is_rejected(recorded_so101):
+    """A too-long map leaves trailing keys unfed; reject it symmetrically."""
+    sim, repo, root, _ = recorded_so101
+    valid = sim.robot_action_keys("so101")
+    result = _replay(sim, repo, root, action_key_map=[*valid, "surplus"])
+
+    assert result["status"] == "error", result
+    assert f"{len(valid) + 1} action keys" in result["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    ("bad_map", "expected"),
+    [
+        ("gripper", "not a bare string"),
+        (b"gripper", "not a bare string"),
+        ({"1": "shoulder"}, "must be a list or tuple"),
+        ([], "is empty"),
+        (["1", 2, None], "non-string entries"),
+        (["1", "2", "2", "3", "3", "4"], "duplicate keys"),
+    ],
+)
+def test_malformed_action_key_map_rejected_before_dataset_load(bad_map, expected, monkeypatch):
+    """Unusable map shapes are rejected up front, before any dataset download.
+
+    A bare string is the sharpest case: ``list("gripper")`` yields one key per
+    character, so every recorded value landed on a nonexistent single-letter
+    actuator. The loader is monkeypatched to fail loudly if it is ever reached,
+    pinning that a malformed map costs no multi-minute dataset fetch.
+    """
+    import strands_robots.dataset_recorder as dr
+
+    def _must_not_load(*args, **kwargs):
+        raise AssertionError("dataset loader reached despite a malformed action_key_map")
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", _must_not_load, raising=False)
+
+    sim = Simulation()
+    sim.create_world(ground_plane=True)
+    sim.add_robot("so101")
+    try:
+        result = PolicyRunner(sim).replay("local/never_loaded", robot_name="so101", action_key_map=bad_map)
+    finally:
+        sim.cleanup()
+
+    assert result["status"] == "error", result
+    assert expected in result["content"][0]["text"]

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -254,9 +254,18 @@ def test_replay_with_tensor_like_actions(monkeypatch):
     assert r["status"] == "success"
 
 
-def test_replay_with_action_vector_larger_than_joint_count(monkeypatch):
-    """When dataset has more action dims than robot joints, replay truncates
-    (``break`` path in the replay loop)."""
+def test_replay_rejects_action_vector_wider_than_action_keys(monkeypatch):
+    """A recorded vector wider than the action-key map is rejected, not truncated.
+
+    Replay's contract is fidelity: reproduce the recorded trajectory. A dataset
+    with 5 action dims cannot be reproduced on a 3-actuator robot -- the last two
+    recorded DOFs have no key to be written through. Truncating them (the former
+    behaviour) reported ``status="success"`` with ``Frames: 2/2`` for a replay
+    that dropped 40% of every commanded action, so the caller had no signal that
+    the dataset and the robot did not match. ``send_action`` already rejects a
+    raw action vector whose length differs from the actuator count instead of
+    truncating it; replay now matches that.
+    """
 
     class _FatDataset:
         fps = 30
@@ -265,7 +274,7 @@ def test_replay_with_action_vector_larger_than_joint_count(monkeypatch):
             return 2
 
         def __getitem__(self, idx):
-            # 5 values but robot only has 3 joints → extras must be dropped
+            # 5 recorded values but the robot exposes only 3 action keys.
             return {"action": [0.1, 0.2, 0.3, 0.4, 0.5]}
 
     def loader(repo_id, episode, root):
@@ -278,7 +287,13 @@ def test_replay_with_action_vector_larger_than_joint_count(monkeypatch):
     monkeypatch.setattr(dr, "load_lerobot_episode", loader, raising=False)
 
     r = PolicyRunner(sim).replay(repo_id="fake/fat", speed=100.0)
-    assert r["status"] == "success"
+    assert r["status"] == "error"
+    text = r["content"][0]["text"]
+    assert "5 values" in text and "3 action keys" in text
+    # Nothing was applied, and the report says so instead of claiming 2/2.
+    assert "Applied 0/2 frames" in text
+    # No action reached the sim: the mismatch is caught before the first send.
+    assert not [c for c in sim.calls if c[0] == "send_action"]
 
 
 def test_replay_reads_actions_without_video_decode(monkeypatch):


### PR DESCRIPTION
## Problem

`replay_episode` maps each recorded action-vector index onto an action key and writes it through `send_action`. `send_action` is explicit about failure: keys it cannot resolve to an actuator or joint come back as `status="error"` with an `unresolved_keys` json block, precisely so callers can self-correct instead of silently losing commands.

Replay **discarded that result**. Every way of getting the mapping wrong reported a full-fidelity replay that never reached the robot:

```python
sim.replay_episode("user/ds", robot_name="so101", action_key_map=["shoulder_pan", ...])
# -> success: "Frames: 60/60"   wrong namespace: nothing applied, arm motionless

sim.replay_episode("user/ds", robot_name="so101", action_key_map="gripper")
# -> success: "Frames: 60/60"   a bare string is consumed one key PER CHARACTER

sim.replay_episode("user/ds", robot_name="so101", action_key_map=["1", "2"])
# -> success: "Frames: 60/60"   a 6-DOF recording's last four joints dropped
```

That is the exact silent round-trip corruption the actuator-vs-joint mapping fix already hardened the *default* path against; the caller-supplied override had no guard at all. `run_policy` already inspects `send_action`'s status (it counts action errors and fail-fasts a rollout where no key resolves), so replay was the odd one out.

## Change

`strands_robots/simulation/policy_runner.py`:

1. **Propagate `send_action`'s status.** A frame that could not be applied aborts the replay with `status="error"`, the frame index, `frames_applied`/`total_frames`, and the backend's `unresolved_keys` / `applied` breakdown forwarded into the result json (via the existing `_extract_result_json` helper). A `"success"` status now means every recorded frame reached the actuators. Replay is a fidelity operation against a fixed ground-truth trajectory and the map is static caller config, so the first unapplied frame aborts rather than being counted as an operational partial failure (which is the right call for a live `run_policy` rollout, where the next chunk can compensate).
2. **Reject a width mismatch instead of truncating.** A recorded vector whose length differs from the action-key map is reported with both widths. Previously the loop `break`-truncated the surplus values, so a 2-key map silently swallowed a 6-DOF recording's last four joints. This matches `send_action`, which already rejects a raw action vector whose length does not match the actuator count rather than truncating it.
3. **Validate the map shape up front**, before the (potentially multi-minute) dataset fetch: a bare `str`/`bytes`, a non-list/tuple, an empty list, a non-string entry, or a duplicate key (two recorded indices writing the same actuator, the later silently winning) are all rejected with an actionable message.

## Visual verification

60-frame `so101` episode recorded through the LeRobot recorder, then replayed, rendered in MuJoCo headless. Left: the recorded ground truth. Middle: replay with valid action keys. Right: replay with a wrong-namespace `action_key_map` - the case that used to report `Frames: 60/60` success.

![replay fidelity](https://raw.githubusercontent.com/cagataycali/robots/artifacts/replay-fidelity/replay_fidelity.gif)

[replay_fidelity.mp4](https://raw.githubusercontent.com/cagataycali/robots/artifacts/replay-fidelity/replay_fidelity.mp4)

Frame-differenced against the recording, the honest replay is bit-faithful and the wrong-key panel never receives the commanded trajectory:

| panel | mean abs pixel diff vs recording | motion first -> last frame (pixels changed) |
|---|---|---|
| recorded (ground truth) | - | 5832 |
| replay, valid keys -> `success` | **0.00** | 5857 |
| replay, wrong keys -> was `success` | 2.98 | 1215 (gravity sag only) |

## Tests

`tests/simulation/mujoco/test_replay_reports_unapplied_frames.py` (new, 10 tests) records a real 5-frame `so101` episode and pins: the default map still succeeds N/N (control, so the error assertions cannot pass for a broken replay); unresolvable keys abort at frame 0 with `frames_applied=0` and the forwarded `unresolved_keys`; a too-short and a too-long map are both rejected; and every malformed map shape is rejected *before* the dataset loader (monkeypatched to fail loudly if reached).

`tests/simulation/test_policy_runner_paths.py::test_replay_with_action_vector_larger_than_joint_count` pinned the truncation as intended behaviour ("replay truncates (`break` path)"). It is renamed to `test_replay_rejects_action_vector_wider_than_action_keys` and now pins the rejection, with the reasoning in its docstring: a 5-dim recording cannot be reproduced on a 3-actuator robot, and reporting `Frames: 2/2` success for a replay that dropped 40% of every action gave the caller no signal that dataset and robot did not match.

All 10 new tests fail on pre-change code (9 with a bogus `success`, 1 by reaching the dataset loader) and pass after.

## Verification

- `ruff check` / `ruff format --check` / `mypy` on `strands_robots tests tests_integ`: clean.
- Full suite headless (`MUJOCO_GL=egl python -m pytest tests`): **11788 passed, 254 skipped** in 393s.

## Docs

- `docs/recording.md`: new "Replay an episode" section covering the `action_key_map` contract and the honest status, with the error-result shape.
- `SimEngine.replay_episode` docstring, `PolicyRunner.replay` docstring, and the `describe()` entry for `replay_episode` state that a `"success"` status means every frame reached the actuators.
- CHANGELOG entry under `[Unreleased]`.