### PR TITLE
fix(sim): joint setters reject joint names they cannot write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,42 @@ action vector whose length does not match the actuator count), and a malformed
 `action_key_map` - a bare string, a non-string entry, a duplicate key or an empty
 list - is rejected before the dataset is fetched.
 
+### Fixed: joint setters reject joint names they cannot write
+
+The dict form of `set_joint_positions` / `set_joint_velocities` resolved each
+joint name inside the write loop and skipped the ones MuJoCo did not know, then
+answered `status="success"`:
+
+```python
+sim.set_joint_positions({"joint1": 0.8, "joint_2": -0.6, "joint4": -2.0})
+# -> success: "Set 2/3 joint positions, FK updated (ignored: ['joint_2'])"
+```
+
+A caller branching on `status` was told the pose had been applied. With every
+key misspelled nothing was written at all; with one key misspelled the *other*
+half of the pose was written, leaving the arm in a configuration nobody asked
+for - and a partially-posed scene silently becomes the initial state of the next
+rollout or recorded episode.
+
+Both sibling contracts already reject what they cannot apply: the ordered-list
+form of the same two methods errors on a joint-count mismatch, and `send_action`
+errors on action keys it cannot resolve. The dict form now matches them. Every
+key is resolved before any `qpos` / `qvel` write, so the write is
+all-or-nothing, and an unresolvable key returns an error that names it, offers a
+close match, lists the model's joints and points at `robot_joint_names`:
+
+```
+set_joint_positions: 1 of 3 'positions' keys are not joints in this model, so
+nothing was written (the write is all-or-nothing). Joint 'joint_2' not found.
+Did you mean: panda/joint2, panda/joint7, panda/joint1? Available joints: [...].
+Use action='robot_joint_names' to see one robot's joints.
+```
+
+An empty mapping is rejected on the same grounds (it reported a successful
+"Set 0/0" no-op). Valid input is unchanged, including short joint names that
+resolve through a robot namespace.
+
+
 ### Fixed: `randomize` / `set_obs_noise` reject parameters they cannot honor
 
 Both methods declare `**kwargs` to match the `**kwargs`-typed

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -561,7 +561,7 @@ class PhysicsMixin:
         The ``"<Kind> 'X' not found."`` prefix is preserved so the consistent
         error shape (T15 in ``test_agenttool_contract``) is unaffected.
 
-        ``kind`` is one of ``"Body" | "Site" | "Geom" | "Sensor"``.
+        ``kind`` is one of ``"Body" | "Site" | "Geom" | "Sensor" | "Joint"``.
         """
         import mujoco as _mj
 
@@ -574,6 +574,7 @@ class PhysicsMixin:
             "Site": (_mj.mjtObj.mjOBJ_SITE, model.nsite),
             "Geom": (_mj.mjtObj.mjOBJ_GEOM, model.ngeom),
             "Sensor": (_mj.mjtObj.mjOBJ_SENSOR, model.nsensor),
+            "Joint": (_mj.mjtObj.mjOBJ_JOINT, model.njnt),
         }[kind]
         known = [nm for i in range(int(count)) if (nm := _mj.mj_id2name(model, obj_type, i)) and nm != "world"]
         if known:
@@ -583,10 +584,18 @@ class PhysicsMixin:
             if matches:
                 msg += " Did you mean: " + ", ".join(matches) + "?"
             shown = known if len(known) <= 30 else known[:30] + ["..."]
-            plural = {"Body": "bodies", "Site": "sites", "Geom": "geoms", "Sensor": "sensors"}[kind]
+            plural = {
+                "Body": "bodies",
+                "Site": "sites",
+                "Geom": "geoms",
+                "Sensor": "sensors",
+                "Joint": "joints",
+            }[kind]
             msg += f" Available {plural}: {shown}."
             if kind == "Body":
                 msg += " Use action='list_bodies' to see all."
+            elif kind == "Joint":
+                msg += " Use action='robot_joint_names' to see one robot's joints."
         return msg
 
     def raycast(
@@ -970,6 +979,75 @@ class PhysicsMixin:
 
     # Direct Joint Control
 
+    def _resolve_joint_write_targets(
+        self,
+        values: dict[str, float],
+        name: str,
+        method: str,
+    ) -> tuple[dict[str, int], dict[str, Any] | None]:
+        """Resolve every joint name to a MuJoCo joint id before any state write.
+
+        The dict form of :meth:`set_joint_positions` / :meth:`set_joint_velocities`
+        used to skip names it could not resolve and still answer
+        ``status="success"``, so a typo (or a namespaced name from the wrong
+        robot) wrote nothing - or worse, wrote only part of the requested pose -
+        while the caller was told the pose had been applied. Resolving up front
+        makes the write all-or-nothing, matching the list form (which already
+        rejects a joint-count mismatch) and ``send_action`` (which already
+        rejects action keys it cannot resolve).
+
+        Args:
+            values: The ``{joint_name: value}`` mapping about to be written.
+            name: Parameter name (``"positions"`` / ``"velocities"``), used in error text.
+            method: Calling method name, used in error text.
+
+        Returns:
+            ``({joint_name: joint_id}, None)`` when every name resolves, else
+            ``({}, error_dict)`` naming the unresolved names, the joints the
+            model does have, and the discovery action - the structured-error
+            tool contract, so the caller never raises past dispatch.
+        """
+        mj = _ensure_mujoco()
+        if not values:
+            return {}, {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"{method}: '{name}' is empty, so there is nothing to write. "
+                            "Pass at least one joint (dict form) or a full ordered vector (list form); "
+                            "use action='robot_joint_names' to see one robot's joints."
+                        )
+                    }
+                ],
+            }
+
+        resolved: dict[str, int] = {}
+        unresolved: list[str] = []
+        for jnt_name in values:
+            jnt_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_JOINT, jnt_name)
+            if jnt_id >= 0:
+                resolved[jnt_name] = jnt_id
+            else:
+                unresolved.append(jnt_name)
+        if not unresolved:
+            return resolved, None
+
+        detail = self._unknown_mj_entity_msg("Joint", unresolved[0])
+        if len(unresolved) > 1:
+            detail = f"Unresolved '{name}' keys: {unresolved}. {detail}"
+        return {}, {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        f"{method}: {len(unresolved)} of {len(values)} '{name}' keys are not joints "
+                        f"in this model, so nothing was written (the write is all-or-nothing). {detail}"
+                    )
+                }
+            ],
+        }
+
     def set_joint_positions(
         self,
         positions: dict[str, float] | list[float] | None = None,
@@ -992,6 +1070,13 @@ class PhysicsMixin:
         ``status="error"`` and leaves ``qpos`` untouched, rather than corrupting
         the kinematic state (``mj_forward`` propagates a ``nan`` everywhere) or
         raising past the tool-dispatch contract.
+
+        The write is all-or-nothing: every dict key must name a joint of the
+        model (verbatim or resolvable through a robot namespace). A key that
+        does not resolve returns ``status="error"`` listing the model's joints
+        and leaves ``qpos`` untouched -- a typo can no longer report success
+        while silently applying a partial pose (or no pose at all). An empty
+        mapping is likewise rejected instead of reporting a successful no-op.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1009,7 +1094,6 @@ class PhysicsMixin:
             }
 
         # normalize list input to dict using a deterministic joint ordering
-        ignored: list[str] = []
         if isinstance(positions, (list, tuple)):
             robots = list(self._world.robots.values())
             if robot_name is not None:
@@ -1073,26 +1157,21 @@ class PhysicsMixin:
         if err:
             return err
 
-        set_count = 0
+        joint_ids, err = self._resolve_joint_write_targets(positions, "positions", "set_joint_positions")
+        if err:
+            return err
+
         with self._lock:
             for jnt_name, value in positions.items():
-                jnt_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_JOINT, jnt_name)
-                if jnt_id >= 0:
-                    qpos_adr = model.jnt_qposadr[jnt_id]
-                    data.qpos[qpos_adr] = float(value)
-                    set_count += 1
-                else:
-                    ignored.append(jnt_name)
-                    logger.warning("Joint '%s' not found, skipping", jnt_name)
+                qpos_adr = model.jnt_qposadr[joint_ids[jnt_name]]
+                data.qpos[qpos_adr] = float(value)
 
             mj.mj_forward(model, data)
 
-        msg = f"Set {set_count}/{len(positions)} joint positions, FK updated"
-        if ignored:
-            msg += f" (ignored: {ignored})"
+        count = len(positions)
         return {
             "status": "success",
-            "content": [{"text": msg}],
+            "content": [{"text": f"Set {count}/{count} joint positions, FK updated"}],
         }
 
     def set_joint_velocities(
@@ -1109,6 +1188,10 @@ class PhysicsMixin:
         ``nan`` / ``inf`` or a non-numeric value returns a structured
         ``status="error"`` and leaves ``qvel`` untouched, rather than blowing up
         the integrator on the next step or raising past the tool-dispatch contract.
+
+        The write is all-or-nothing on the same terms as
+        :meth:`set_joint_positions`: an unresolvable joint name (or an empty
+        mapping) returns ``status="error"`` and leaves ``qvel`` untouched.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1124,7 +1207,6 @@ class PhysicsMixin:
                 "content": [{"text": "set_joint_velocities: 'velocities' is required (list or dict)."}],
             }
 
-        ignored: list[str] = []
         if isinstance(velocities, (list, tuple)):
             robots = list(self._world.robots.values())
             if robot_name is not None:
@@ -1184,20 +1266,17 @@ class PhysicsMixin:
         if err:
             return err
 
-        set_count = 0
+        joint_ids, err = self._resolve_joint_write_targets(velocities, "velocities", "set_joint_velocities")
+        if err:
+            return err
+
         with self._lock:
             for jnt_name, value in velocities.items():
-                jnt_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_JOINT, jnt_name)
-                if jnt_id >= 0:
-                    dof_adr = model.jnt_dofadr[jnt_id]
-                    data.qvel[dof_adr] = float(value)
-                    set_count += 1
-                else:
-                    ignored.append(jnt_name)
+                dof_adr = model.jnt_dofadr[joint_ids[jnt_name]]
+                data.qvel[dof_adr] = float(value)
 
-        msg = f"Set {set_count}/{len(velocities)} joint velocities"
-        if ignored:
-            msg += f" (ignored: {ignored})"
+        count = len(velocities)
+        msg = f"Set {count}/{count} joint velocities"
         return {
             "status": "success",
             "content": [{"text": msg}],

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1957,12 +1957,15 @@ class MuJoCoSimEngine(
             "(positions: dict[str, float] | list[float], robot_name=None) -> dict "
             "# write qpos directly and run forward kinematics (teleport / set an "
             "initial pose, bypassing the actuators). dict is per-joint; list is "
-            "ordered and must match one robot's joint count (see get_features)"
+            "ordered and must match one robot's joint count (see get_features). "
+            "The write is all-or-nothing: a dict key that is not a joint of the "
+            "model is an error, not a silent skip (see robot_joint_names)"
         )
         base["methods"]["set_joint_velocities"] = (
             "(velocities: dict[str, float] | list[float], robot_name=None) -> dict "
             "# write qvel directly (set an initial dynamic state); dict or "
-            "ordered-list form mirrors set_joint_positions"
+            "ordered-list form mirrors set_joint_positions, including its "
+            "all-or-nothing rejection of unknown joint names"
         )
 
         # Background-policy lifecycle. MuJoCo overrides start_policy to run in a

--- a/tests/simulation/mujoco/test_error_paths.py
+++ b/tests/simulation/mujoco/test_error_paths.py
@@ -129,12 +129,19 @@ def test_set_joint_velocities_none_dict_errors(ready_sim):
     assert "'velocities' is required" in r["content"][0]["text"]
 
 
-def test_set_joint_positions_unknown_joint_is_skipped_not_raised(ready_sim):
-    """Unknown joint names are logged and skipped - not fatal."""
+def test_set_joint_positions_unknown_joint_rejects_whole_write(ready_sim):
+    """An unknown joint name is a structured error, not a partial write.
+
+    This used to assert ``success`` on the grounds that "the valid joint still
+    applied" - which is exactly the defect: the caller asked for a two-joint
+    pose, got a one-joint pose, and was told the call succeeded. The write is
+    now all-or-nothing and reports the name it could not resolve.
+    """
     joints = ready_sim.robot_joint_names("arm")
     assert len(joints) > 0, "Fixture robot must have joints"
     r = ready_sim.set_joint_positions(positions={joints[0]: 0.1, "__nope__": 0.2})
-    assert r["status"] == "success"  # the valid joint still applied
+    assert r["status"] == "error"
+    assert "__nope__" in r["content"][0]["text"]
 
 
 def test_apply_force_torque_only(ready_sim):

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -454,11 +454,15 @@ class TestSetJointVelocitiesForms:
         assert res["status"] == "error"
         assert "must be a dict or list" in res["content"][0]["text"]
 
-    def test_dict_form_unknown_joint_is_skipped_not_fatal(self, sim_with_robot):
-        """Unknown joint names are reported as ignored, not raised."""
+    def test_dict_form_unknown_joint_is_rejected(self, sim_with_robot):
+        """An unknown joint name errors instead of reporting a 0-of-1 success.
+
+        The previous contract answered ``success`` with "Set 0/1 joint
+        velocities (ignored: ['nope'])", so a caller branching on ``status``
+        could not tell that nothing had been written.
+        """
         res = sim_with_robot.set_joint_velocities(velocities={"nope": 1.0})
-        assert res["status"] == "success"
-        assert "0/1" in res["content"][0]["text"]
+        assert res["status"] == "error"
         assert "nope" in res["content"][0]["text"]
 
 

--- a/tests/simulation/mujoco/test_joint_setter_unknown_names_rejected.py
+++ b/tests/simulation/mujoco/test_joint_setter_unknown_names_rejected.py
@@ -1,0 +1,133 @@
+"""Regression tests: the joint setters must reject joint names they cannot write.
+
+``set_joint_positions`` / ``set_joint_velocities`` accept a
+``{joint_name: value}`` mapping. The dict form used to resolve each name inside
+the write loop and simply ``continue`` past the ones MuJoCo did not know,
+answering ``status="success"`` afterwards::
+
+    sim.set_joint_positions({"shoulder_pan": 0.4})   # scene names it "shoulder"
+    # -> success: "Set 0/1 joint positions, FK updated (ignored: ['shoulder_pan'])"
+
+so a typo, a name taken from the wrong robot, or a name that needed a namespace
+prefix was reported as an applied pose while ``qpos`` never changed. A mapping
+that mixed one good name with one bad one was worse: half the requested pose
+landed in ``qpos`` and the call still reported success, leaving the scene in a
+state the caller never asked for.
+
+Both sibling contracts already reject what they cannot apply - the ordered-list
+form errors on a joint-count mismatch, and ``send_action`` errors on action keys
+it cannot resolve - so these pin the same all-or-nothing contract for the dict
+form: unknown (or empty) input is a structured error, nothing is written, and
+the message names the joints the model does have.
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+ARM_XML = """
+<mujoco model="joint_setter_test">
+  <compiler angle="radian"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01"/>
+    <body name="link1" pos="0 0 0.1">
+      <joint name="shoulder" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+      <geom name="link1_geom" type="capsule" size="0.02 0.1"/>
+      <body name="link2" pos="0 0 0.2">
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+        <geom name="link2_geom" type="capsule" size="0.015 0.08"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_joint_setter_names", mesh=False)
+    s.create_world()
+    assert s.replace_scene_mjcf(ARM_XML)["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _state(sim):
+    return sim._world._data.qpos.copy(), sim._world._data.qvel.copy()
+
+
+def test_positions_unknown_joint_rejected_and_qpos_untouched(sim):
+    """A typo'd joint name is an error, not a success with nothing written."""
+    qpos, _ = _state(sim)
+    result = sim.set_joint_positions(positions={"shouldr": 0.4})
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert "Joint 'shouldr' not found" in text  # consistent not-found prefix
+    assert "shoulder" in text  # close match / available joints
+    assert "robot_joint_names" in text  # discovery pointer
+    assert np.array_equal(sim._world._data.qpos, qpos)
+
+
+def test_positions_partial_mapping_writes_nothing(sim):
+    """One bad name must not leave the good half of the pose applied."""
+    qpos, _ = _state(sim)
+    result = sim.set_joint_positions(positions={"shoulder": 0.4, "wrist": -0.2})
+    assert result["status"] == "error", result
+    assert "1 of 2" in result["content"][0]["text"]
+    assert np.array_equal(sim._world._data.qpos, qpos), "partial write leaked into qpos"
+
+
+def test_velocities_unknown_joint_rejected_and_qvel_untouched(sim):
+    _, qvel = _state(sim)
+    result = sim.set_joint_velocities(velocities={"elbo": 1.5, "wrist": 0.5})
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert "2 of 2" in text
+    assert "wrist" in text and "elbo" in text  # every unresolved key is named
+    assert np.array_equal(sim._world._data.qvel, qvel)
+
+
+@pytest.mark.parametrize(
+    ("method", "param"),
+    [("set_joint_positions", "positions"), ("set_joint_velocities", "velocities")],
+)
+def test_empty_mapping_rejected(sim, method, param):
+    """An empty mapping writes nothing, so reporting success is misleading."""
+    result = getattr(sim, method)(**{param: {}})
+    assert result["status"] == "error", result
+    assert "empty" in result["content"][0]["text"]
+
+
+def test_known_joints_still_applied(sim):
+    """The corrected guard must not reject names the model does know."""
+    result = sim.set_joint_positions(positions={"shoulder": 0.5, "elbow": -0.3})
+    assert result["status"] == "success", result
+    assert "2/2" in result["content"][0]["text"]
+    model, data = sim._world._model, sim._world._data
+    for name, expected in (("shoulder", 0.5), ("elbow", -0.3)):
+        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, name)
+        assert data.qpos[model.jnt_qposadr[jid]] == pytest.approx(expected)
+
+    vel = sim.set_joint_velocities(velocities={"shoulder": 1.0})
+    assert vel["status"] == "success", vel
+    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "shoulder")
+    assert data.qvel[model.jnt_dofadr[jid]] == pytest.approx(1.0)
+
+
+def test_namespaced_robot_joint_short_name_still_resolves():
+    """A short name that only resolves via a robot namespace must keep working."""
+    s = Simulation(tool_name="test_joint_setter_namespace", mesh=False)
+    try:
+        s.create_world()
+        if s.add_robot(name="so101_follower")["status"] != "success":
+            pytest.skip("so101_follower assets unavailable")
+        joints = s.robot_joint_names("so101_follower")
+        assert joints, "fixture robot must expose joint names"
+        result = s.set_joint_positions(positions={joints[0]: 0.1})
+        assert result["status"] == "success", result
+    finally:
+        s.cleanup()


### PR DESCRIPTION
## Problem

The dict form of `set_joint_positions` / `set_joint_velocities` resolved each joint name *inside* the write loop and skipped the names MuJoCo did not know, then reported success:

```python
sim.set_joint_positions({"joint1": 0.8, "joint_2": -0.6, "joint4": -2.0})
# -> {"status": "success"}: "Set 2/3 joint positions, FK updated (ignored: ['joint_2'])"
```

A caller branching on `status` was told the pose had been applied. Two failure shapes:

- **every key misspelled** -> `Set 0/1 ... (ignored: [...])`, `status="success"`, `qpos` never touched. The teleport/IK/initial-pose step is a no-op and the rollout starts from the wrong state.
- **one key misspelled** -> the *other* half of the pose is written and the call still succeeds, leaving the arm in a configuration nobody asked for. That partially-posed scene silently becomes the initial state of the next rollout or recorded episode.

Both sibling contracts already reject what they cannot apply: the ordered-list form of these same two methods errors on a joint-count mismatch (`list length 3 does not match robot 'arm' joint count 6`), and `send_action` errors on action keys it cannot resolve. Only the dict form silently degraded.

## Change

`_resolve_joint_write_targets` resolves every key to a MuJoCo joint id **before** any `qpos` / `qvel` write, so the write is all-or-nothing. An unresolvable key returns a structured error that names it, offers a close match, lists the joints the model does have, and points at the discovery action:

```
set_joint_positions: 1 of 3 'positions' keys are not joints in this model, so nothing
was written (the write is all-or-nothing). Joint 'joint_2' not found. Did you mean:
panda/joint2, panda/joint7, panda/joint1? Available joints: [...]. Use
action='robot_joint_names' to see one robot's joints.
```

The suggestion/available-list shape reuses the existing `_unknown_mj_entity_msg` helper, extended with a `"Joint"` kind so the message matches the `Body` / `Geom` / `Sensor` / `Site` lookups (the `"<Kind> 'X' not found."` prefix is preserved).

An empty mapping is rejected on the same grounds - it reported a successful `Set 0/0` no-op. Valid input is unchanged, including short joint names that only resolve through a robot namespace (`{"1": 0.1}` on a namespaced `so101_follower`).

## Visual verification

MuJoCo headless (`MUJOCO_GL=egl`) renders of the same three-joint request on a `panda`: the intended pose, the partial pose the old code wrote while reporting success, and the rejected call that leaves `qpos` untouched.

![joint setter partial write](https://raw.githubusercontent.com/cagataycali/robots/artifacts/joint-setter-partial-write/joint_setter_partial_write.png)

## Tests

`tests/simulation/mujoco/test_joint_setter_unknown_names_rejected.py` (7 tests, 5 fail on pre-fix code):

- typo'd key -> error, `qpos` bit-identical, message carries the not-found prefix, a close match and `robot_joint_names`
- mixed good/bad mapping -> error and **no partial write leaked into `qpos`**
- velocities path -> error, `qvel` untouched, every unresolved key named
- empty mapping rejected for both methods (parametrized)
- known joints still applied (`2/2`, values verified in `qpos` / `qvel`)
- short name resolved through a robot namespace still succeeds (no false rejection)

Two existing tests pinned the old leniency as intended behaviour and are updated to the corrected contract, with the reason recorded in their docstrings:

- `test_error_paths.py::test_set_joint_positions_unknown_joint_is_skipped_not_raised` -> `..._unknown_joint_rejects_whole_write` (it asserted `success` because "the valid joint still applied" - that is the defect)
- `test_input_validation.py::test_dict_form_unknown_joint_is_skipped_not_fatal` -> `..._is_rejected`

Gate: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean; full suite `MUJOCO_GL=egl pytest tests` **11785 passed, 254 skipped**.

Docs: both docstrings state the all-or-nothing contract, the `describe()` entries for both methods advertise it, and a CHANGELOG entry is included.

## §13 Changelog

| Round | Concern | Commit | Pin test |
|-------|---------|--------|----------|
| 1 | Initial implementation | `0aa5922` | `tests/simulation/mujoco/test_joint_setter_unknown_names_rejected.py` |
| 2 | Rebased onto current main (`fe8ba32`) to clear CHANGELOG-only merge conflict created by #1632 and #1634 landing ahead | `cedd046` | (no code change, conflict-only rebase) |