### PR TITLE
fix(sim): create_world rejects a timestep/gravity it cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `create_world` rejects a timestep / gravity it cannot honor
+
+`set_timestep` and `set_gravity` have always validated their input and returned
+a structured error. `create_world`, which sets those same two values before any
+setter can be called, validated neither, so a world could be created on terms
+the setters would refuse:
+
+```python
+sim.create_world(timestep=-0.002)
+# -> success: "Timestep: -0.002s (-500Hz physics)"
+sim.step(250)
+# -> success: "+250 steps | t=-0.5000s"   (integrator running backwards;
+#                                          a dropped ball rises)
+sim.create_world(timestep=0)
+# -> success: "Timestep: 0.002s (500Hz physics)"   (value silently discarded)
+sim.create_world(timestep=float("nan"))
+# -> success: "Timestep: nans (nanHz physics)"
+sim.create_world(gravity=[0, -9.81])
+# -> TypeError: incompatible function arguments ... mujoco._specs.MjOption
+sim.create_world(gravity=["0", "0", "-9.81"])
+# -> success: "Gravity: ['0', '0', '-9.81']"   (echoes input, not what was applied)
+```
+
+A bad `dt` poisons the world rather than one call: every later `step`,
+`run_policy` and `eval_policy` still reports `status="success"` while physics
+integrates backwards or to `nan`. `timestep=0` was coalesced by a
+`timestep or self.default_timestep` fallback, so a caller that asked for `0`
+was silently given `0.002`.
+
+`timestep` and `gravity` are now validated at `create_world` on exactly the
+setters' terms - shared helpers (`SimEngine._validate_timestep`,
+`SimEngine._normalize_gravity`) are the single source of truth for both entry
+points, so their accepted domains cannot diverge:
+
+```
+create_world: timestep must be a finite positive number, got -0.002.
+create_world: 'gravity' must be a 3-element list [x,y,z], got 2
+```
+
+The effective timestep is validated, so an unusable engine default
+(`Simulation(default_timestep=-0.002)`) is reported under its own name instead
+of compiling into the world. Gravity is stored coerced, so the result reports
+the floats the model received. The MuJoCo, Newton and Isaac backends all apply
+the guard; `0` is now an error rather than a silent fallback to the default.
+
+
 ### Fixed: rollout entry points reject a `policy_config` / `policy_kwargs` they cannot splat
 
 `policy_config` (provider kwargs for `create_policy`) and `policy_kwargs` (per-call

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -24,7 +24,7 @@ import numbers
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, SupportsFloat
+from typing import TYPE_CHECKING, Any, SupportsFloat, cast
 
 if TYPE_CHECKING:
     import numpy as np
@@ -328,6 +328,17 @@ class SimEngine(ABC):
         the local terrain surface (raised by the heightfield height beneath
         it) at ``add_robot`` and on ``reset()``, so its feet are not buried
         below the raised terrain.
+
+        ``timestep`` (seconds) and ``gravity`` must be values the engine can
+        honor, on the same terms the ``set_timestep`` / ``set_gravity`` setters
+        enforce: ``timestep`` a finite number ``> 0`` (``0`` is rejected, never
+        coalesced to the engine default), ``gravity`` a 3-element vector of
+        finite numbers or a real scalar taken as the z-component. A value the
+        backend cannot apply is rejected with a structured error rather than
+        compiled into the world - a world built around a negative or ``nan``
+        ``dt`` integrates backwards or to ``nan`` while every subsequent call
+        still reports ``status="success"``. ``None`` means "use the engine
+        default".
         """
         ...
 
@@ -989,6 +1000,103 @@ class SimEngine(ABC):
                 "content": [{"text": f"{method}: control_frequency must be > 0, got {control_frequency!r}."}],
             }
         return None
+
+    @staticmethod
+    def _validate_timestep(timestep: Any, method: str, param: str = "timestep") -> dict[str, Any] | None:
+        """Reject a physics timestep the integrator cannot honor.
+
+        The timestep is the ``dt`` every physics substep advances by, so a
+        non-positive or non-finite value poisons the whole world rather than
+        one call: a negative ``dt`` runs the integrator backwards (sim time
+        counts down, accelerations blow up) and a ``nan`` makes every state
+        ``nan`` - both while the creating call still reports
+        ``status="success"``. ``0`` is equally unusable, and must be rejected
+        rather than coalesced to the engine default: a caller that passed
+        ``0`` and was silently given ``0.002`` never learns its value was
+        discarded. This is the same contract
+        :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.set_timestep`
+        already enforces, so the value cannot be set at world creation on
+        terms the setter would refuse.
+
+        Args:
+            timestep: The caller-supplied value. Anything ``float()`` accepts
+                is coerced (so a NumPy scalar passes); ``bool`` is rejected
+                explicitly since ``True`` would act as a silent 1-second step.
+            method: Public method name, used to prefix the error message.
+            param: Parameter name to quote - ``"timestep"`` for a caller
+                argument, or the name of the engine default it fell back to.
+
+        Returns:
+            A structured ``{"status": "error", ...}`` dict to surface, or
+            ``None`` when the value is usable.
+        """
+        message = f"{method}: {param} must be a finite positive number, got {timestep!r}."
+        if isinstance(timestep, bool):
+            return {"status": "error", "content": [{"text": message}]}
+        try:
+            value = float(timestep)
+        except (TypeError, ValueError):
+            return {"status": "error", "content": [{"text": message}]}
+        if not math.isfinite(value) or value <= 0:
+            return {"status": "error", "content": [{"text": message}]}
+        return None
+
+    @staticmethod
+    def _normalize_gravity(
+        gravity: Any, method: str, param: str = "gravity"
+    ) -> tuple[list[float] | None, dict[str, Any] | None]:
+        """Coerce a gravity argument to three finite floats, or explain why not.
+
+        Gravity reaches the engine as a raw vector assignment (MuJoCo:
+        ``model.opt.gravity[:] = ...``), so a mis-shaped value either raises a
+        binding-level ``TypeError`` naming the physics library's internals
+        instead of the parameter the caller got wrong, or - for values that
+        happen to be assignable - lands in the world while the result echoes
+        the caller's input as if it had been applied. Callers therefore
+        normalize through this helper and store the returned components, so
+        what the result reports is what the engine received.
+
+        Exactly one element of the returned tuple is non-``None``.
+
+        Args:
+            gravity: A 3-element ``[x, y, z]`` sequence, or a real scalar taken
+                as the z-component (``[0, 0, z]``, matching
+                :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.set_gravity`).
+            method: Public method name, used to prefix the error message.
+            param: Parameter name to quote in the message.
+
+        Returns:
+            ``(components, None)`` with three finite floats, or
+            ``(None, error_dict)`` describing what is wrong with the value.
+        """
+        # Accept any real scalar (numbers.Real) as a z-only gravity so a value
+        # computed as a NumPy scalar (np.float32 / np.int64) is treated like a
+        # plain float. A NumPy array is not numbers.Real, so it still takes the
+        # vector path below.
+        if isinstance(gravity, numbers.Real):
+            components = [0.0, 0.0, float(gravity)]
+        else:
+            try:
+                vector = cast("Sequence[Any]", gravity)
+                if len(vector) != 3:
+                    return None, {
+                        "status": "error",
+                        "content": [
+                            {"text": f"{method}: '{param}' must be a 3-element list [x,y,z], got {len(vector)}"}
+                        ],
+                    }
+                components = [float(g) for g in vector]
+            except (TypeError, ValueError) as e:
+                return None, {
+                    "status": "error",
+                    "content": [{"text": f"{method}: '{param}' must be a 3-element list of numbers ({e})"}],
+                }
+        if not all(math.isfinite(g) for g in components):
+            return None, {
+                "status": "error",
+                "content": [{"text": f"{method}: all components must be finite, got {components}"}],
+            }
+        return components, None
 
     @staticmethod
     def _validate_video_config(video: Any, method: str) -> dict[str, Any] | None:

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -751,6 +751,13 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     }
                 ],
             }
+        # A world must not be built around a dt the integrator cannot honor
+        # (negative, zero, nan): physics_dt drives every stage step, so an
+        # unusable value corrupts the world rather than one call.
+        effective_timestep = self._config.physics_dt if timestep is None else timestep
+        timestep_param = "physics_dt" if timestep is None else "timestep"
+        if err := self._validate_timestep(effective_timestep, "create_world", timestep_param):
+            return err
         # Isaac's ``PhysicsContext.set_gravity`` takes a single signed scalar
         # (the gravity along -Z); the backend cannot apply an off-axis vector.
         # A non-Z-aligned override was previously silently reduced to its

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -509,6 +509,14 @@ class MuJoCoSimEngine(
         height beneath it) at ``add_robot`` and on every ``reset()``, rather
         than at the flat-ground keyframe height that would leave its feet
         buried below the raised terrain.
+
+        ``timestep`` and ``gravity`` are validated exactly as
+        :meth:`set_timestep` / :meth:`set_gravity` validate them - a finite
+        ``timestep > 0`` (``0`` is an error, not a silent fallback to the
+        engine default) and a 3-element finite ``gravity`` vector (or a real
+        scalar taken as the z-component). A value MuJoCo cannot integrate is
+        rejected with a structured error instead of being compiled into
+        ``model.opt``. ``None`` selects the engine default for either.
         """
         # mujoco verified at __init__
 
@@ -542,15 +550,25 @@ class MuJoCoSimEngine(
                 "content": [{"text": "World already exists. Use action='destroy' first, or action='reset'."}],
             }
 
+        # Validate the physics parameters on the same terms set_timestep /
+        # set_gravity enforce: a world must not be created with a dt or a
+        # gravity vector the setters would refuse. The effective timestep is
+        # checked (not just the argument) so an unusable engine default is
+        # reported under its own name instead of compiling into the world.
+        effective_timestep = self.default_timestep if timestep is None else timestep
+        timestep_param = "default_timestep" if timestep is None else "timestep"
+        if err := self._validate_timestep(effective_timestep, "create_world", timestep_param):
+            return err
         if gravity is None:
             _gravity = [0.0, 0.0, -9.81]
-        elif isinstance(gravity, (int, float)):
-            _gravity = [0.0, 0.0, float(gravity)]
         else:
-            _gravity = list(gravity)
+            normalized, gravity_error = self._normalize_gravity(gravity, "create_world")
+            if normalized is None:
+                return cast("dict[str, Any]", gravity_error)
+            _gravity = normalized
 
         self._world = SimWorld(
-            timestep=timestep or self.default_timestep,
+            timestep=float(effective_timestep),
             gravity=_gravity,
             ground_plane=ground_plane,
             terrain=terrain,
@@ -3124,35 +3142,12 @@ class MuJoCoSimEngine(
         # set_gravity during a running policy races the worker thread
         if err := self._require_no_running_policy("set_gravity"):
             return err
-        # Accept any real scalar (numbers.Real) as a z-only gravity so a value
-        # computed as a NumPy scalar (np.float32 / np.int64 / np.degrees(...)) is
-        # treated like a plain float, not refused with a misleading "has no len()".
-        # A NumPy array is not numbers.Real, so it still takes the vector path.
-        if isinstance(gravity, numbers.Real):
-            components = [0.0, 0.0, float(gravity)]
-        else:
-            # Any other value must be a 3-element sized vector (list / tuple /
-            # NumPy array). Validate length/dtype before the numpy broadcast.
-            try:
-                vector = cast("Sequence[float]", gravity)
-                if len(vector) != 3:
-                    return {
-                        "status": "error",
-                        "content": [
-                            {"text": f"set_gravity: 'gravity' must be a 3-element list [x,y,z], got {len(vector)}"}
-                        ],
-                    }
-                components = [float(g) for g in vector]
-            except (TypeError, ValueError) as e:
-                return {
-                    "status": "error",
-                    "content": [{"text": f"set_gravity: 'gravity' must be a 3-element list of numbers ({e})"}],
-                }
-        if not all(math.isfinite(g) for g in components):
-            return {
-                "status": "error",
-                "content": [{"text": f"set_gravity: all components must be finite, got {components}"}],
-            }
+        # Shape/dtype/finiteness live in the shared normalizer so create_world
+        # accepts exactly what this setter accepts (a 3-element vector, or a
+        # real scalar - including a NumPy scalar - as the z-component).
+        components, gravity_error = self._normalize_gravity(gravity, "set_gravity")
+        if components is None:
+            return cast("dict[str, Any]", gravity_error)
         with self._lock:
             self._world._model.opt.gravity[:] = components
             self._world.gravity = components
@@ -3173,19 +3168,11 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("set_timestep"):
             return err
-        # reject non-positive; warn on huge values
-        try:
-            timestep = float(timestep)
-        except (TypeError, ValueError):
-            return {
-                "status": "error",
-                "content": [{"text": f"set_timestep: must be a positive number, got {timestep!r}"}],
-            }
-        if not math.isfinite(timestep) or timestep <= 0:
-            return {
-                "status": "error",
-                "content": [{"text": f"set_timestep: must be a finite positive number, got {timestep}"}],
-            }
+        # Shared with create_world so a world cannot be created with a dt this
+        # setter would refuse; warn (not reject) on huge-but-usable values.
+        if err := self._validate_timestep(timestep, "set_timestep"):
+            return err
+        timestep = float(timestep)
         warn = ""
         if timestep > 0.1:
             warn = f" Warning: unusually large timestep (>{0.1}s); physics may be unstable"

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -31,7 +31,7 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -289,10 +289,25 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     }
                 ],
             }
+        # Same contract as set_timestep / set_gravity (and the MuJoCo backend):
+        # never build a world around a dt or gravity vector the setters would
+        # refuse. The effective timestep is validated so an unusable engine
+        # default surfaces under its own name rather than driving the solver.
+        effective_timestep = self.default_timestep if timestep is None else timestep
+        timestep_param = "default_timestep" if timestep is None else "timestep"
+        if err := self._validate_timestep(effective_timestep, "create_world", timestep_param):
+            return err
+        if gravity is None:
+            components = [0.0, 0.0, -9.81]
+        else:
+            normalized, gravity_error = self._normalize_gravity(gravity, "create_world")
+            if normalized is None:
+                return cast("dict[str, Any]", gravity_error)
+            components = normalized
         with self._lock:
             self._world = SimWorld(
-                timestep=timestep or self.default_timestep,
-                gravity=gravity or [0.0, 0.0, -9.81],
+                timestep=float(effective_timestep),
+                gravity=components,
                 ground_plane=ground_plane,
             )
             self._rebuild()

--- a/tests/simulation/mujoco/test_create_world_physics_param_validation.py
+++ b/tests/simulation/mujoco/test_create_world_physics_param_validation.py
@@ -1,0 +1,146 @@
+"""``create_world`` must reject a timestep / gravity the engine cannot honor.
+
+``set_timestep`` and ``set_gravity`` have always validated their input (finite
+positive dt, 3-element finite vector or real scalar) and returned a structured
+error. ``create_world`` -- which sets those same two values, before any setter
+can be called -- validated neither, so a world could be created on terms the
+setters would refuse:
+
+* ``create_world(timestep=-1)`` reported ``status="success"`` and compiled a
+  negative ``dt`` into ``model.opt``; stepping then ran the integrator
+  backwards (``t=-1.0000s``) and produced non-finite accelerations while every
+  call still reported success.
+* ``create_world(timestep=0)`` was coalesced to the engine default by a
+  ``timestep or self.default_timestep`` fallback, so the caller's value was
+  discarded silently and the result advertised a dt it had never been asked for.
+* ``create_world(timestep=float("nan"))`` produced a ``nan`` world advertised as
+  ``"nans (nanHz physics)"``.
+* ``create_world(gravity=[0, -9.81])`` raised a bare binding-level
+  ``TypeError`` naming MuJoCo's internals out of a method that contracts a
+  status dict.
+* ``create_world(gravity=["0", "0", "-9.81"])`` echoed the caller's raw input as
+  the applied gravity instead of the coerced floats the model received.
+
+These pin the rejection, the parity with the setters, and that a rejected call
+leaves no world behind.
+"""
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# ``None`` is absent on purpose: it is the "use the engine default" sentinel,
+# covered by test_unusable_engine_default_rejected.
+_UNUSABLE_TIMESTEPS = [-1, 0, 0.0, float("nan"), float("inf"), "fast", True]
+
+
+@pytest.fixture
+def sim():
+    """A simulation with no world yet (create_world is under test)."""
+    engine = Simulation(tool_name="test_create_world_physics_params", mesh=False)
+    yield engine
+    engine.destroy()
+
+
+def _text(result):
+    return result["content"][0]["text"]
+
+
+class TestTimestepValidation:
+    @pytest.mark.parametrize("timestep", _UNUSABLE_TIMESTEPS)
+    def test_unusable_timestep_rejected(self, sim, timestep):
+        """Every dt the integrator cannot advance by is a structured error."""
+        result = sim.create_world(timestep=timestep)
+        assert result["status"] == "error"
+        assert "timestep" in _text(result)
+        # A rejected create_world must not leave a half-built world behind.
+        assert sim.step(1)["status"] == "error"
+
+    def test_zero_timestep_is_not_coalesced_to_the_default(self, sim):
+        """``0`` must be reported, not silently replaced by the default dt."""
+        result = sim.create_world(timestep=0)
+        assert result["status"] == "error"
+        assert "0.002" not in _text(result)
+        assert "timestep must be a finite positive number" in _text(result)
+
+    def test_unusable_engine_default_rejected(self):
+        """A bad engine default cannot slip in through ``timestep=None``."""
+        engine = Simulation(
+            tool_name="test_create_world_bad_default",
+            mesh=False,
+            default_timestep=-0.002,
+        )
+        try:
+            result = engine.create_world()
+            assert result["status"] == "error"
+            assert "default_timestep" in _text(result)
+            assert engine.step(1)["status"] == "error"
+        finally:
+            engine.destroy()
+
+    def test_valid_timestep_is_applied(self, sim):
+        """A usable dt still reaches the model and is reported accurately."""
+        result = sim.create_world(timestep=0.004)
+        assert result["status"] == "success"
+        assert "0.004s (250Hz physics)" in _text(result)
+        assert sim.physics_timestep() == pytest.approx(0.004)
+
+    @pytest.mark.parametrize("timestep", [-1, 0, float("nan"), "fast"])
+    def test_create_world_matches_set_timestep(self, sim, timestep):
+        """A dt rejected by ``set_timestep`` is rejected by ``create_world``.
+
+        The two entry points write the same ``model.opt.timestep``, so their
+        accepted domains must not diverge.
+        """
+        assert sim.create_world(timestep=timestep)["status"] == "error"
+        assert sim.create_world()["status"] == "success"
+        assert sim.set_timestep(timestep)["status"] == "error"
+        # The world kept the default dt: the refused value was never applied.
+        assert sim.physics_timestep() == pytest.approx(0.002)
+
+
+class TestGravityValidation:
+    @pytest.mark.parametrize(
+        "gravity",
+        [[0.0, -9.81], [0.0, 0.0, -9.81, 0.0], "0,0,-9.81", [0.0, 0.0, float("nan")], ["x", 0.0, 0.0]],
+    )
+    def test_unusable_gravity_rejected(self, sim, gravity):
+        """A mis-shaped gravity is a status dict, never a raised TypeError."""
+        result = sim.create_world(gravity=gravity)
+        assert result["status"] == "error"
+        assert "gravity" in _text(result) or "components" in _text(result)
+        assert sim.step(1)["status"] == "error"
+
+    def test_numeric_string_vector_reports_the_applied_floats(self, sim):
+        """The result must echo what the model received, not the raw input."""
+        result = sim.create_world(gravity=["0", "0", "-3.0"])
+        assert result["status"] == "success"
+        assert "Gravity: [0.0, 0.0, -3.0]" in _text(result)
+
+    def test_scalar_gravity_is_the_z_component(self, sim):
+        """Scalar form keeps parity with ``set_gravity``."""
+        result = sim.create_world(gravity=-3.0)
+        assert result["status"] == "success"
+        assert "Gravity: [0.0, 0.0, -3.0]" in _text(result)
+
+    def test_zero_gravity_is_honored_not_defaulted(self, sim):
+        """An all-zero vector is a legitimate request, not a falsy no-value."""
+        result = sim.create_world(gravity=[0.0, 0.0, 0.0])
+        assert result["status"] == "success"
+        assert "Gravity: [0.0, 0.0, 0.0]" in _text(result)
+
+
+class TestAgentToolDispatch:
+    """The agent-tool router validates vector params by name but no numeric
+    ranges, so the timestep hole was reachable from the tool as well."""
+
+    def test_dispatch_rejects_negative_timestep(self, sim):
+        result = sim._dispatch_action("create_world", {"timestep": -1})
+        assert result["status"] == "error"
+        assert "timestep" in _text(result)
+
+    def test_dispatch_accepts_valid_world(self, sim):
+        result = sim._dispatch_action("create_world", {"timestep": 0.002, "gravity": [0.0, 0.0, -9.81]})
+        assert result["status"] == "success"


### PR DESCRIPTION
## Problem

`set_timestep` and `set_gravity` validate their input and return a structured error. `create_world` sets those same two values -- before any setter can be called -- and validated neither, so a world could be created on terms the setters would refuse:

```python
sim.create_world(timestep=-0.002)
# -> success: "Timestep: -0.002s (-500Hz physics)"
sim.step(250)
# -> success: "+250 steps | t=-0.5000s | total=250"

sim.create_world(timestep=0)
# -> success: "Timestep: 0.002s (500Hz physics)"     value silently discarded
sim.create_world(timestep=float("nan"))
# -> success: "Timestep: nans (nanHz physics)"

sim.create_world(gravity=[0, -9.81])
# -> TypeError: (): incompatible function arguments ... mujoco._specs.MjOption
sim.create_world(gravity=["0", "0", "-9.81"])
# -> success: "Gravity: ['0', '0', '-9.81']"        echoes input, not what was applied
```

A bad `dt` poisons the *world*, not one call: every later `step` / `run_policy` / `eval_policy` keeps reporting `status="success"` while the integrator runs backwards or to `nan`. `timestep=0` was swallowed by a `timestep or self.default_timestep` fallback, so a caller that asked for `0` was silently handed `0.002`. The mis-shaped `gravity` cases either raised a binding-level `TypeError` naming MuJoCo internals out of a method that contracts a status dict, or landed in the world while the result echoed the caller's raw input as if applied.

The timestep hole is reachable from the agent tool too: the router validates vector params by name (so `gravity` is length-checked there) but has no numeric-range validation, so `_dispatch_action("create_world", {"timestep": -1})` also returned success.

## Change

Validation moves into two shared `SimEngine` helpers that both `create_world` and the setters use, so their accepted domains cannot diverge:

* `_validate_timestep(value, method, param)` -- finite, `> 0`, `bool` rejected; `set_timestep` now delegates to it.
* `_normalize_gravity(value, method, param)` -- 3-element finite vector, or a real scalar (incl. NumPy scalar) as the z-component; returns the coerced floats. `set_gravity` now delegates to it, keeping its existing messages.

```
create_world: timestep must be a finite positive number, got -0.002.
create_world: 'gravity' must be a 3-element list [x,y,z], got 2
create_world: all components must be finite, got [0.0, 0.0, nan]
```

The *effective* timestep is validated, so an unusable engine default (`Simulation(default_timestep=-0.002)`) is reported under its own name (`default_timestep must be a finite positive number`) instead of compiling into the world. Gravity is stored coerced, so the result reports the floats the model received. A rejected call leaves no world behind. MuJoCo, Newton and Isaac all apply the guard (Isaac keeps its additional Z-aligned-gravity rule). `timestep=0` is now an error rather than a silent fallback -- the only intentional behaviour change.

## Visual verification

MuJoCo, headless (`MUJOCO_GL=egl`): a 0.5 kg sphere dropped from `z=0.60 m`, `step(250)` = 0.5 s of requested simulation, rendered from the default camera.

![create_world timestep validation](https://raw.githubusercontent.com/cagataycali/robots/artifacts/create-world-timestep/create_world_timestep_validation.png)

| | before | after |
|---|---|---|
| `create_world(timestep=-0.002)` | `status=success` | `status=error` (message above) |
| sim time after `step(250)` | `t = -0.5000 s` | `t = +0.5000 s` (valid `dt=0.002` world) |
| ball z (dropped from 0.60 m) | **1.90 m** (rises) | **0.04 m** (rests on the ground) |

## Tests

`tests/simulation/mujoco/test_create_world_physics_param_validation.py` (24 tests): unusable timesteps (`-1`, `0`, `nan`, `inf`, `"fast"`, `True`), `0` not coalesced to the default, unusable engine default, valid dt applied (`physics_timestep() == 0.004`), `create_world`/`set_timestep` domain parity, mis-shaped gravity (short/long/string/`nan`/non-numeric entry), coerced-float reporting, scalar and all-zero gravity honored, and the agent-tool dispatch path. **20 of the 24 fail on pre-fix code** (`status=success` where an error is expected, plus 3 raised `TypeError`s).

Local gate on the current base (`27c2d281`): `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; full suite `11845 passed, 254 skipped` (400 s, `MUJOCO_GL=egl`). Pre-fix failure re-verified against this base: 20 failed, 4 passed.

Docs: `create_world` contract documented on the ABC and on the MuJoCo override; CHANGELOG entry under Unreleased.