### PR TITLE
fix(sim): reject a rollout duration that cannot run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: rollout entry points reject a `duration` they cannot run
+
+`duration` is the DEFAULT rollout horizon: with no `n_steps` / `max_steps` the
+rollout length is `int(duration * control_frequency)` control steps. The step
+count and the frequency were both validated; the duration was not, so a rollout
+that could never execute a single step reported success:
+
+```python
+sim.run_policy(robot_name="arm1", duration=-1.0)
+# -> success: "Policy complete on 'arm1' | 0.0s | 0 steps"   (nothing ran)
+
+sim.run_policy(robot_name="arm1", duration=0, video={"path": "/tmp/rollout.mp4"})
+# -> success: "Video requested but 0 frames captured"        (no MP4 written)
+
+sim.start_policy(robot_name="arm1", duration=-1.0)
+# -> success: "Policy started on 'arm1' (async)"             (nothing ran)
+
+sim.run_multi_policy(policies, duration=0.0)
+# -> success: "0 synchronized steps"
+
+sim.run_policy(robot_name="arm1", duration=float("nan"))
+# -> error: "Policy failed: cannot convert float NaN to integer"
+```
+
+The `start_policy` case is the damaging one: the caller is told the policy
+started and the robot is marked running, with no later signal that zero steps
+executed. The `video` case silently breaks the artifact contract - success with
+no file on disk. `nan`/`inf` never survived the arithmetic at all and surfaced
+as a `ValueError`/`OverflowError` message naming a library internal instead of
+the parameter to fix.
+
+`duration` is now validated at every public entry point that accepts it
+(`run_policy`, `start_policy`, `run_multi_policy`) before a policy is created or
+a background thread is submitted, by the new `SimEngine._validate_duration`.
+Its accepted domain mirrors `_validate_positive_frequency` - the other factor in
+the same `duration * control_frequency` product - so the two cannot diverge: any
+finite positive real scalar (NumPy scalars included), with `bool` and
+`nan`/`inf` rejected explicitly.
+
+The guard fires only when `duration` actually sets the horizon: passing an
+explicit `n_steps` recomputes `duration` from it, so `run_policy(n_steps=2,
+duration=0)` still runs its two steps rather than rejecting a value the rollout
+never reads.
+
+`run_multi_policy` resolved its horizon with an inline copy of the conversion
+whose guard only fired on the `n_steps` path; it now uses the shared
+`_resolve_horizon` + `_validate_positive_frequency` + `_validate_duration`, so a
+zero control frequency on the duration path is reported instead of reaching
+`1 / control_frequency`. Horizon errors also now name the method the caller
+actually called (`start_policy: n_steps must be > 0`, `run_multi_policy: ...`)
+rather than always `run_policy`.
+
+
 ### Fixed: `create_world` rejects a timestep / gravity it cannot honor
 
 `set_timestep` and `set_gravity` have always validated their input and returned

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -853,6 +853,7 @@ class SimEngine(ABC):
         max_steps: int | None,
         control_frequency: float,
         duration: float,
+        method: str = "run_policy",
     ) -> tuple[float, int | None, dict[str, Any] | None]:
         """Resolve a step horizon into a wall-clock duration.
 
@@ -869,7 +870,10 @@ class SimEngine(ABC):
                 is ``None``.
             control_frequency: Target control-loop frequency in Hz.
             duration: Fallback wall-clock duration used when no step horizon
-                is given.
+                is given. Returned unchanged when no horizon is given, so the
+                caller must still validate it with :meth:`_validate_duration`
+                (this helper only owns the horizon-to-duration conversion).
+            method: Public method name, used to prefix the error message.
 
         Returns:
             A ``(duration, n_steps, error)`` tuple. When ``error`` is non-None
@@ -887,7 +891,7 @@ class SimEngine(ABC):
                     n_steps,
                     {
                         "status": "error",
-                        "content": [{"text": f"run_policy: n_steps must be > 0, got {n_steps}."}],
+                        "content": [{"text": f"{method}: n_steps must be > 0, got {n_steps}."}],
                     },
                 )
             # control_frequency is validated as a positive number at the public
@@ -1099,6 +1103,51 @@ class SimEngine(ABC):
         return components, None
 
     @staticmethod
+    def _validate_duration(duration: Any, method: str) -> dict[str, Any] | None:
+        """Reject a rollout ``duration`` that cannot produce a single control step.
+
+        ``duration`` is the default horizon knob: when no ``n_steps`` /
+        ``max_steps`` is given, the rollout length is ``int(duration *
+        control_frequency)`` control steps. A value ``<= 0`` yields zero steps,
+        which used to be reported as ``status="success"`` for a rollout that
+        never queried the policy and never stepped physics - and, when a
+        ``video`` was requested, wrote no MP4 while still claiming success. A
+        non-finite value never reached that arithmetic intact either: ``nan``
+        surfaced as a bare ``ValueError`` ("cannot convert float NaN to
+        integer") naming a library internal, and ``inf`` as an
+        ``OverflowError``. Validating at the public entry point - before any
+        policy is created or a background thread is submitted - turns all of
+        these into an actionable caller error.
+
+        The accepted domain mirrors :meth:`_validate_positive_frequency` (the
+        other knob in the same ``duration * control_frequency`` product), so
+        the two cannot diverge: any finite positive real scalar, including a
+        NumPy scalar such as ``np.float32(2.5)``; ``bool`` is rejected
+        explicitly (an ``int`` subclass, ``True`` would act as a silent 1
+        second) and ``nan``/``inf`` are rejected before the ``<= 0`` comparison
+        so a ``nan`` - which is never ``<= 0`` - cannot slip through.
+
+        Args:
+            duration: The caller-supplied value to validate.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            An error dict naming the offending parameter, or ``None`` when the
+            value is valid.
+        """
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, numbers.Real)
+            or not math.isfinite(float(duration))
+            or float(duration) <= 0
+        ):
+            return {
+                "status": "error",
+                "content": [{"text": f"{method}: duration must be > 0, got {duration!r}."}],
+            }
+        return None
+
+    @staticmethod
     def _validate_video_config(video: Any, method: str) -> dict[str, Any] | None:
         """Reject a ``video`` recording config the rollout cannot honor.
 
@@ -1195,7 +1244,12 @@ class SimEngine(ABC):
                 ``use_processor``, ``processor_overrides``, ``device``,
                 ...). Forwarded verbatim to ``create_policy``.
             instruction: Natural-language instruction for the policy.
-            duration: Wall-clock seconds to run.
+            duration: Wall-clock seconds to run. Used only when no ``n_steps``
+                / ``max_steps`` is given (the step count wins and ``duration``
+                is recomputed from it). Must be a finite positive number; a
+                non-positive, non-finite, non-numeric, or bool value is
+                reported as a structured caller error rather than running a
+                zero-step rollout that reports success.
             control_frequency: Target Hz for policy queries. Must be a
                 positive number; a non-positive, non-numeric, or bool value
                 is reported as a structured caller error.
@@ -1329,6 +1383,13 @@ class SimEngine(ABC):
         duration, n_steps, horizon_error = self._resolve_horizon(n_steps, max_steps, control_frequency, duration)
         if horizon_error is not None:
             return horizon_error
+
+        # ``duration`` only sets the horizon when no step count was given - with
+        # an ``n_steps`` the resolution above recomputes it - so validate the
+        # value the rollout will actually run on, and only then.
+        if n_steps is None:
+            if err := self._validate_duration(duration, "run_policy"):
+                return err
 
         if err := self._validate_positive_int(n_episodes, "n_episodes", "run_policy"):
             return err

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3639,16 +3639,22 @@ class MuJoCoSimEngine(
 
         # Validate the step horizon synchronously, before submitting to the
         # executor. run_policy runs on a background thread, so a malformed
-        # horizon (n_steps <= 0, control_frequency <= 0) would otherwise be
-        # reported only inside the future - the caller would receive a false
-        # "started" success and the robot would be left marked as running. The
-        # control_frequency guard covers the duration path too (n_steps omitted),
-        # which _resolve_horizon only checks when n_steps is given.
+        # horizon (duration <= 0, n_steps <= 0, control_frequency <= 0) would
+        # otherwise be reported only inside the future - the caller would
+        # receive a false "started" success and the robot would be left marked
+        # as running. Both horizon knobs are covered: the step count via
+        # _resolve_horizon, and the wall-clock duration it falls back to (the
+        # default path, when n_steps is omitted) via _validate_duration.
         if err := self._validate_positive_frequency(control_frequency, "start_policy"):
             return err
-        _, _, horizon_error = self._resolve_horizon(n_steps, max_steps, control_frequency, duration)
+        resolved_duration, resolved_n_steps, horizon_error = self._resolve_horizon(
+            n_steps, max_steps, control_frequency, duration, "start_policy"
+        )
         if horizon_error is not None:
             return horizon_error
+        if resolved_n_steps is None:
+            if err := self._validate_duration(resolved_duration, "start_policy"):
+                return err
         if err := self._validate_action_horizon(action_horizon, "start_policy"):
             return err
         # Same reason as the horizon guards above: a malformed video config
@@ -3882,7 +3888,12 @@ class MuJoCoSimEngine(
                 recorded task is the first robot's instruction (LeRobot stores
                 one task per frame).
             duration: Episode length in seconds (steps = duration x freq).
+                Used only when no ``n_steps`` / ``max_steps`` is given. Must be
+                a finite positive number; a non-positive, non-finite, or
+                non-numeric value is a caller error, not a zero-step rollout
+                reported as a success.
             control_frequency: Target Hz for policy action queries / physics.
+                Must be a positive number.
             action_horizon: How many actions to consume from each policy's
                 returned chunk before re-querying it (open-loop chunk
                 execution, mirrors ``run_policy``). Either a single int applied
@@ -3954,16 +3965,21 @@ class MuJoCoSimEngine(
                 next(iter(policies)),
             )
 
-        # Resolve horizon (n_steps / max_steps override duration).
-        if n_steps is None and max_steps is not None:
-            n_steps = int(max_steps)
-        if n_steps is not None:
-            if n_steps <= 0 or control_frequency <= 0:
-                return {
-                    "status": "error",
-                    "content": [{"text": "run_multi_policy: n_steps and control_frequency must be > 0."}],
-                }
-            duration = float(n_steps) / float(control_frequency)
+        # Resolve horizon (n_steps / max_steps override duration) through the
+        # shared helpers, so this loop guards the same domain as run_policy: a
+        # hand-rolled check only fired on the n_steps path, leaving the default
+        # duration path to compute total_steps = int(duration * frequency) = 0
+        # and report a rollout that never ran as a success.
+        if err := self._validate_positive_frequency(control_frequency, "run_multi_policy"):
+            return err
+        duration, n_steps, horizon_error = self._resolve_horizon(
+            n_steps, max_steps, control_frequency, duration, "run_multi_policy"
+        )
+        if horizon_error is not None:
+            return horizon_error
+        if n_steps is None:
+            if err := self._validate_duration(duration, "run_multi_policy"):
+                return err
 
         # Normalize action_horizon to a per-robot mapping. >=1 actions are
         # consumed open-loop from each policy's chunk before re-querying.

--- a/tests/simulation/test_run_policy_horizon_validation.py
+++ b/tests/simulation/test_run_policy_horizon_validation.py
@@ -398,3 +398,137 @@ class TestNStepsExactHorizon:
         # governs: 0.2 s @ 50 Hz -> 10 steps.
         result = sim.run_policy("arm1", duration=0.2, control_frequency=50.0, fast_mode=True)
         assert _reported_n_steps(result) == 10
+
+
+class TestDurationGuards:
+    """The wall-clock ``duration`` horizon must be guarded like the step count.
+
+    ``duration`` is the DEFAULT horizon knob: with no ``n_steps`` the rollout
+    length is ``int(duration * control_frequency)`` control steps. A value
+    ``<= 0`` produced zero steps and reported ``status="success"`` for a
+    rollout that never queried the policy and never stepped physics; a
+    non-finite value did not even survive the arithmetic (``nan`` raised
+    ``ValueError: cannot convert float NaN to integer``, ``inf`` an
+    ``OverflowError``) and surfaced as a message naming a library internal
+    instead of the parameter the caller got wrong.
+    """
+
+    @pytest.mark.parametrize("bad", [0, 0.0, -1, -0.5, -50.0])
+    def test_non_positive_duration_errors(self, sim, bad):
+        text = _err_text(sim.run_policy("arm1", duration=bad, fast_mode=True))
+        assert "duration must be > 0" in text
+        assert repr(bad) in text
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_duration_errors(self, sim, bad):
+        # nan is never <= 0, so it must be rejected on finiteness before the
+        # comparison; pre-fix it reached int(nan * frequency) and raised.
+        text = _err_text(sim.run_policy("arm1", duration=bad, fast_mode=True))
+        assert "duration must be > 0" in text
+
+    @pytest.mark.parametrize("bad", ["2.0", None, [1.0]])
+    def test_non_numeric_duration_errors(self, sim, bad):
+        text = _err_text(sim.run_policy("arm1", duration=bad, fast_mode=True))
+        assert "duration must be > 0" in text
+
+    def test_bool_duration_errors(self, sim):
+        # bool is an int subclass: True would act as a silent 1-second rollout.
+        text = _err_text(sim.run_policy("arm1", duration=True, fast_mode=True))
+        assert "duration must be > 0" in text
+
+    def test_duration_error_is_ascii(self, sim):
+        text = _err_text(sim.run_policy("arm1", duration=-1.0, fast_mode=True))
+        assert text.isascii(), text
+        assert "run_policy" in text
+
+    def test_guard_runs_before_robot_lookup(self, sim):
+        # The horizon guards precede the robot lookup, so the caller is told
+        # about the parameter they control rather than about a robot name that
+        # is only wrong in passing.
+        text = _err_text(sim.run_policy("no_such_robot", duration=0, fast_mode=True))
+        assert "duration must be > 0" in text
+
+    def test_numpy_scalar_duration_accepted(self, sim):
+        # Mirrors the control_frequency contract: any finite positive real
+        # scalar is valid, including a NumPy scalar read out of a config array.
+        result = sim.run_policy("arm1", duration=np.float32(0.2), control_frequency=50.0, fast_mode=True)
+        assert result["status"] == "success", result
+        assert _reported_n_steps(result) == 10
+
+    def test_explicit_step_horizon_wins_over_unused_duration(self, sim):
+        # With an n_steps the duration is recomputed from it and never read, so
+        # the guard must not reject a value the rollout does not use.
+        result = sim.run_policy("arm1", n_steps=2, duration=0, control_frequency=50.0, fast_mode=True)
+        assert result["status"] == "success", result
+        assert _reported_n_steps(result) == 2
+
+    def test_rejected_duration_does_not_write_requested_video(self, sim, tmp_path):
+        # The most damaging shape of the bug: a recording rollout reported
+        # success while writing no MP4 at all, because zero frames were
+        # captured. The request is now refused up front.
+        out = tmp_path / "rollout.mp4"
+        text = _err_text(sim.run_policy("arm1", duration=-1.0, video={"path": str(out)}, fast_mode=True))
+        assert "duration must be > 0" in text
+        assert not out.exists()
+
+
+class TestStartPolicyDurationGuard:
+    """start_policy must reject a bad duration synchronously.
+
+    The rollout runs on a background thread, so an unguarded duration was
+    reported as "started" while the future ran zero steps - the caller had no
+    way to learn the rollout never happened.
+    """
+
+    @pytest.mark.parametrize("bad", [0, -1.0, float("nan")])
+    def test_bad_duration_errors_synchronously(self, sim, bad):
+        text = _err_text(sim.start_policy("arm1", duration=bad))
+        assert "duration must be > 0" in text
+
+    def test_rejected_start_does_not_mark_robot_running(self, sim):
+        result = sim.start_policy("arm1", duration=-1.0)
+        assert result["status"] == "error"
+        assert "arm1" not in sim._policy_threads
+        # A well-formed start on the same robot still succeeds afterwards.
+        ok = sim.start_policy("arm1", n_steps=2, control_frequency=50.0, fast_mode=True)
+        assert ok["status"] == "success", ok
+        sim.stop_policy("arm1")
+
+    def test_horizon_error_names_start_policy(self, sim):
+        text = _err_text(sim.start_policy("arm1", n_steps=0))
+        assert "start_policy: n_steps must be > 0" in text
+
+
+class TestRunMultiPolicyHorizonGuards:
+    """run_multi_policy shares the horizon contract of run_policy.
+
+    It resolved the horizon with its own inline check that only fired when an
+    explicit ``n_steps`` was passed, so the default duration path computed
+    ``total_steps = int(duration * control_frequency) == 0`` and reported a
+    synchronized multi-robot rollout that never ran as a success.
+    """
+
+    @pytest.fixture
+    def policies(self):
+        from strands_robots.policies import MockPolicy
+
+        return {"arm1": MockPolicy()}
+
+    @pytest.mark.parametrize("bad", [0, -1.0, float("nan"), "2.0"])
+    def test_bad_duration_errors(self, sim, policies, bad):
+        text = _err_text(sim.run_multi_policy(policies, duration=bad))
+        assert "run_multi_policy: duration must be > 0" in text
+
+    def test_non_positive_n_steps_errors(self, sim, policies):
+        text = _err_text(sim.run_multi_policy(policies, n_steps=0))
+        assert "run_multi_policy: n_steps must be > 0" in text
+
+    def test_non_positive_control_frequency_errors_on_duration_path(self, sim, policies):
+        # Pre-fix the frequency was only checked alongside n_steps, so the
+        # duration path reached 1 / control_frequency with a zero divisor.
+        text = _err_text(sim.run_multi_policy(policies, duration=0.2, control_frequency=0))
+        assert "run_multi_policy: control_frequency must be > 0" in text
+
+    def test_valid_horizon_still_runs(self, sim, policies):
+        result = sim.run_multi_policy(policies, n_steps=2, control_frequency=50.0)
+        assert result["status"] == "success", result


### PR DESCRIPTION
## Problem

`duration` is the DEFAULT rollout horizon: with no `n_steps` / `max_steps`, the rollout length is `int(duration * control_frequency)` control steps. The step count and the frequency are both validated at the public entry points; `duration` was not. A rollout that could never execute a single step reported success.

```python
sim.run_policy(robot_name="arm1", duration=-1.0)
# -> success: "Policy complete on 'arm1' | 0.0s | 0 steps"        (nothing ran)

sim.run_policy(robot_name="arm1", duration=0, video={"path": "/tmp/rollout.mp4"})
# -> success: "Video requested but 0 frames captured"             (no MP4 on disk)

sim.start_policy(robot_name="arm1", duration=-1.0)
# -> success: "Policy started on 'arm1' (async)"                  (nothing ran)

sim.run_multi_policy(policies, duration=0.0)
# -> success: "0 synchronized steps"

sim.run_policy(robot_name="arm1", duration=float("nan"))
# -> error: "Policy failed: cannot convert float NaN to integer"
```

`start_policy` is the damaging one: the caller is told the policy started and the robot is marked running, with no later signal that zero steps executed. The `video` case breaks the artifact contract - success with no file on disk. `nan`/`inf` never survived the `int(duration * control_frequency)` arithmetic at all and surfaced as a `ValueError`/`OverflowError` message naming a library internal rather than the parameter to fix.

This is the same shape as the guards already in place for the sibling knobs (`n_steps must be > 0`, `control_frequency must be > 0`, `n_episodes`/`max_steps must be a positive integer`) - the duration path was simply never covered. The MuJoCo `start_policy` comment even acknowledged the blind spot: "The control_frequency guard covers the duration path too (n_steps omitted), which _resolve_horizon only checks when n_steps is given" - the frequency was checked there, the duration value never was.

## Change

New `SimEngine._validate_duration(duration, method)`, called at every public entry point that accepts a duration (`run_policy`, MuJoCo `start_policy` synchronously before the executor submit, `run_multi_policy`) before a policy is created or a thread is submitted.

- Accepted domain mirrors `_validate_positive_frequency` - the other factor in the same `duration * control_frequency` product - so the two cannot diverge: any finite positive real scalar (NumPy scalars included), with `bool` rejected explicitly (an `int` subclass; `True` would act as a silent 1-second rollout) and `nan`/`inf` rejected on finiteness before the `<= 0` comparison (a `nan` is never `<= 0`).
- The guard fires only when `duration` actually sets the horizon. With an explicit `n_steps` the duration is recomputed from it and never read, so `run_policy(n_steps=2, duration=0)` still runs its two steps rather than rejecting a value the rollout does not use.
- `run_multi_policy` resolved its horizon with an inline copy of the conversion whose guard only fired on the `n_steps` path; it now uses the shared `_resolve_horizon` + `_validate_positive_frequency` + `_validate_duration`, so a zero control frequency on the duration path is reported instead of reaching `1 / control_frequency`.
- `_resolve_horizon` takes a `method` name, so horizon errors name the method the caller actually called (`start_policy: n_steps must be > 0`, `run_multi_policy: ...`) instead of always `run_policy`.

After:

```
run_policy: duration must be > 0, got -1.0.
start_policy: duration must be > 0, got nan.
run_multi_policy: duration must be > 0, got 0.
```

## Visual verification (MuJoCo, headless EGL)

Same call, same `video={...}` request, `panda` arm, mock policy.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-duration/duration_guard.png)

| | `duration=-1.0` (before) | `duration=3.0` (honored path) |
|---|---|---|
| status | `success` | `success` |
| control steps | 0 | 150 |
| MP4 written | none (file absent) | 90 frames, 30 fps, 640x480, 544 KB |
| L1 vs. untouched home pose | 11 (renderer noise - nothing moved) | 4,260,291 |

The left panel is the scene after the pre-fix "successful" rollout: identical to the home pose, because no action was ever computed and no physics step was ever taken. After this change that call is refused with `run_policy: duration must be > 0, got -1.0.` and no MP4 path is opened.

The honored path, unchanged by this PR (`duration=3.0` -> 150 steps -> 90-frame MP4):

![rollout](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-duration/honored.gif)

## Tests

29 tests added to `tests/simulation/test_run_policy_horizon_validation.py` (the existing home of the horizon contracts):

- `TestDurationGuards` - non-positive (`0`, `0.0`, `-1`, `-0.5`, `-50.0`), non-finite (`nan`, `inf`, `-inf`), non-numeric (`"2.0"`, `None`, `[1.0]`), `bool`; ASCII message naming the method; guard precedes the robot lookup; NumPy scalar accepted; `n_steps` still wins over an unused `duration`; and the recording regression - a rejected duration writes no MP4.
- `TestStartPolicyDurationGuard` - rejected synchronously, robot not left marked running, a valid start still succeeds afterwards, and the horizon error names `start_policy`.
- `TestRunMultiPolicyHorizonGuards` - bad duration / non-positive `n_steps` / zero frequency on the duration path rejected; a valid horizon still runs.

**26 of the 29 fail on the pre-fix tree** (verified by reverting only the two source files and re-running: `26 failed, 11 passed`); the 3 that pass pre-fix are the honored-path pins.

Local gate on the merge base (27c2d281): `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean, full suite `11850 passed, 254 skipped` (405 s).
