### PR TITLE
fix(sim): control_substeps is honored or rejected, never silently clamped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `control_substeps` is honored or rejected, never silently clamped
+
+`control_substeps` sets how many physics steps are integrated per applied
+action. `PolicyRunner._control_substeps` resolved an explicit value with
+`max(1, int(override))`, so every value it could not honor was accepted and
+collapsed to a single physics step - reinstating exactly the under-integration
+that helper exists to prevent (a position-servo arm reaches ~10% of each target
+before the next action overwrites `ctrl`, so the rollout reports success while
+the policy looks like a no-op):
+
+```python
+sim.run_policy(robot_name="panda", n_steps=120, control_frequency=50.0,
+               control_substeps=0)
+# -> success: "120 steps | sim_t=0.240s"   (0.240 s of physics for 2.4 s of
+#                                           control - 1 substep, not 10)
+sim.run_policy(..., control_substeps=-5)     # -> success, same single step
+sim.run_policy(..., control_substeps=2.7)    # -> success, truncated to 2
+sim.run_policy(..., control_substeps=True)   # -> success, acts as 1
+sim.run_policy(..., control_substeps=float("nan"))
+# -> error: "Policy failed: cannot convert float NaN to integer"
+#           (bare ValueError from inside the runner; never names the parameter)
+```
+
+Every sibling knob on those signatures was already guarded (`action_horizon`
+>= 1, `n_episodes` / `max_steps` positive ints, `control_frequency` > 0).
+`control_substeps` now shares that contract: `SimEngine._validate_control_substeps`
+accepts `None` (auto-derive from the backend physics timestep) and otherwise
+requires a positive integer, rejecting `bool` explicitly as
+`_validate_positive_frequency` does, and is called from `run_policy`,
+`eval_policy` and `evaluate_benchmark` before any policy is built:
+
+```python
+sim.run_policy(..., control_substeps=0)
+# -> error: "run_policy: control_substeps must be a positive integer, got 0."
+```
+
+`PolicyRunner._control_substeps` now raises `ValueError` on such an override
+instead of clamping it, so callers driving the runner directly also fail loudly,
+and `PolicyRunner.run` resolves substeps through that shared helper rather than
+its own inline copy of the derivation.
 ### Fixed: rollout entry points reject a `duration` they cannot run
 
 `duration` is the DEFAULT rollout horizon: with no `n_steps` / `max_steps` the

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -957,6 +957,50 @@ class SimEngine(ABC):
         return None
 
     @staticmethod
+    def _validate_control_substeps(control_substeps: Any, method: str) -> dict[str, Any] | None:
+        """Reject a ``control_substeps`` override the rollout cannot honor.
+
+        ``control_substeps`` is how many physics steps are integrated per
+        applied action. ``None`` (the default) means "derive it from the
+        backend's physics timestep so the arm tracks the full control period",
+        which is why ``None`` is accepted here. Any explicit value must be a
+        positive integer: ``0`` / a negative value was previously clamped to a
+        single physics step by ``max(1, int(override))``, which is precisely the
+        under-integration pathology
+        :meth:`~strands_robots.simulation.policy_runner.PolicyRunner._control_substeps`
+        exists to avoid - the arm integrates ~2 ms of a 20 ms control period, so
+        the rollout reports ``status="success"`` while the policy looks like a
+        no-op. A float (``2.7``) was silently truncated, ``True`` acted as a
+        silent 1 substep (``bool`` is an ``int`` subclass, so it is rejected
+        explicitly as in :meth:`_validate_positive_frequency`), and ``nan`` /
+        ``inf`` reached ``int()`` deep inside the runner and surfaced as a bare
+        ``ValueError``/``OverflowError`` instead of the structured tool-error
+        dict the public API contracts.
+
+        The positive-integer domain itself is delegated to
+        :meth:`_validate_positive_int` so this guard and the rollout count knobs
+        cannot drift apart.
+
+        Args:
+            control_substeps: The caller-supplied value to validate.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            An error dict naming the offending parameter, or ``None`` when the
+            value is valid (including ``None``, which means "auto-derive").
+        """
+        if control_substeps is None:
+            return None
+        if isinstance(control_substeps, bool):
+            return {
+                "status": "error",
+                "content": [
+                    {"text": f"{method}: control_substeps must be a positive integer, got {control_substeps!r}."}
+                ],
+            }
+        return SimEngine._validate_positive_int(control_substeps, "control_substeps", method)
+
+    @staticmethod
     def _validate_positive_frequency(control_frequency: Any, method: str) -> dict[str, Any] | None:
         """Reject a non-positive or non-numeric ``control_frequency`` at the public API.
 
@@ -1253,6 +1297,14 @@ class SimEngine(ABC):
             control_frequency: Target Hz for policy queries. Must be a
                 positive number; a non-positive, non-numeric, or bool value
                 is reported as a structured caller error.
+            control_substeps: Explicit physics steps to integrate per applied
+                action, overriding the ``control_frequency``-derived value.
+                Must be a positive integer; ``0``, a negative value, a float,
+                or a bool is reported as a structured caller error rather than
+                collapsing to a single physics step (which under-integrates
+                each control period so the arm barely moves while the rollout
+                still reports success). ``None`` (default) derives it from
+                ``control_frequency`` and the backend's physics timestep.
             action_horizon: Lower bound on actions consumed from each
                 policy chunk before re-querying. The effective interval is
                 ``max(action_horizon, policy.execution_horizon)`` (see
@@ -1401,6 +1453,8 @@ class SimEngine(ABC):
         if err := self._validate_policy_mapping(policy_kwargs, "policy_kwargs", "run_policy"):
             return err
         if err := self._validate_action_horizon(action_horizon, "run_policy"):
+            return err
+        if err := self._validate_control_substeps(control_substeps, "run_policy"):
             return err
 
         if robot_name not in self.list_robots():
@@ -2068,7 +2122,10 @@ class SimEngine(ABC):
         :meth:`PolicyRunner.evaluate` so the eval loop steps physics for the
         full control period per action (same servo-tracking semantics as
         :meth:`run_policy`). Without these the arm under-steps and the policy
-        looks like a no-op (the arm under-steps each control period).
+        looks like a no-op (the arm under-steps each control period). An explicit
+        ``control_substeps`` must be a positive integer - ``0``/negative/float
+        is rejected with a structured error instead of collapsing to a single
+        physics step, which would reinstate that same no-op.
 
         ``async_rtc`` (default ``False``) opts into overlapping policy
         inference with action-chunk execution, evaluating a chunk-emitting
@@ -2151,6 +2208,8 @@ class SimEngine(ABC):
         if err := self._validate_positive_int(max_steps, "max_steps", "eval_policy"):
             return err
         if err := self._validate_positive_frequency(control_frequency, "eval_policy"):
+            return err
+        if err := self._validate_control_substeps(control_substeps, "eval_policy"):
             return err
         # Coerce to a plain Python float now the value is validated: a NumPy
         # scalar (accepted above via numbers.Real) flows into 1 / control_frequency
@@ -2290,7 +2349,10 @@ class SimEngine(ABC):
                 effective episode horizon.
             control_substeps: Explicit physics substeps per action, overriding
                 the ``control_frequency``-derived value (mirrors
-                :meth:`eval_policy`). ``None`` (default) derives it from
+                :meth:`eval_policy`). Must be a positive integer; ``0``,
+                negative, float and bool values are rejected with a structured
+                error rather than collapsing to a single under-integrated
+                physics step. ``None`` (default) derives it from
                 ``control_frequency``.
             policy_object: An already-built :class:`Policy` to evaluate,
                 skipping the ``create_policy`` round-trip (mirrors
@@ -2330,6 +2392,8 @@ class SimEngine(ABC):
         if err := self._validate_positive_int(n_episodes, "n_episodes", "evaluate_benchmark"):
             return err
         if err := self._validate_positive_frequency(control_frequency, "evaluate_benchmark"):
+            return err
+        if err := self._validate_control_substeps(control_substeps, "evaluate_benchmark"):
             return err
         # Coerce to a plain Python float now the value is validated: a NumPy
         # scalar (accepted above via numbers.Real) flows into 1 / control_frequency

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -789,9 +789,28 @@ class PolicyRunner:
         ``mj_step``), so the arm integrated ~10% of the way toward each target
         before the next action overwrote ``ctrl`` - rollouts looked like the
         policy was a no-op even when commanding valid targets.
+
+        Args:
+            control_frequency: Control-loop rate in Hz, used with the backend's
+                physics timestep to derive the substep count.
+            override: Explicit substeps per action, or ``None`` to derive.
+
+        Returns:
+            Physics steps to advance per applied action (always ``>= 1``).
+
+        Raises:
+            ValueError: If ``override`` is not a positive integer. It used to be
+                clamped with ``max(1, int(override))``, so ``0``/``-5`` silently
+                collapsed to a single physics step - reinstating the exact
+                under-integration this helper exists to prevent - and a float
+                was truncated. The public entry points reject such a value with
+                a structured error before reaching the runner; this raise is the
+                guarantee for callers driving ``PolicyRunner`` directly.
         """
         if override is not None:
-            return max(1, int(override))
+            if isinstance(override, bool) or not isinstance(override, int) or override < 1:
+                raise ValueError(f"control_substeps must be a positive integer, got {override!r}.")
+            return override
         dt = None
         try:
             dt = self.sim.physics_timestep()
@@ -1126,18 +1145,10 @@ class PolicyRunner:
             # per action and barely moves - the policy looks like a no-op even
             # though it is sending valid targets. Derive substeps from the
             # backend's physics timestep; fall back to 1 when unknown.
-            if control_substeps is not None:
-                n_substeps = max(1, int(control_substeps))
-            else:
-                _dt = None
-                try:
-                    _dt = self.sim.physics_timestep()
-                except Exception:  # noqa: BLE001 - never fail the run on a probe
-                    _dt = None
-                if _dt and _dt > 0 and control_frequency > 0:
-                    n_substeps = max(1, round((1.0 / control_frequency) / _dt))
-                else:
-                    n_substeps = 1
+            # Single source of truth for the derivation AND for the
+            # positive-integer contract on an explicit override: an inline copy
+            # here drifted from the shared helper the eval paths use.
+            n_substeps = self._control_substeps(control_frequency, control_substeps)
             logger.info(
                 "PolicyRunner: control_frequency=%.1f Hz, physics substeps/action=%d",
                 control_frequency,

--- a/tests/simulation/mujoco/test_control_substeps_validation.py
+++ b/tests/simulation/mujoco/test_control_substeps_validation.py
@@ -1,0 +1,232 @@
+"""``control_substeps`` must be honored or rejected, never silently clamped.
+
+``control_substeps`` is how many physics steps are integrated per applied
+action. ``PolicyRunner._control_substeps`` exists precisely because integrating
+a single ~2 ms ``mj_step`` per action leaves a position-servo arm ~10% of the
+way to each target before the next action overwrites ``ctrl`` - the rollout
+reports success while the policy looks like a no-op.
+
+That helper resolved an explicit override with ``max(1, int(override))``, so the
+public entry points accepted values they could not honor and reinstated the very
+pathology the helper prevents:
+
+* ``control_substeps=0`` / ``-5`` collapsed to 1 substep and returned
+  ``status="success"`` (2 steps at 50 Hz advanced sim time 0.004 s instead of
+  0.04 s - a 10x under-integration);
+* ``control_substeps=2.7`` was truncated to 2 without a word;
+* ``control_substeps=True`` acted as a silent 1 substep (``bool`` is an ``int``
+  subclass);
+* ``control_substeps=float("nan")`` reached ``int()`` inside the runner and
+  surfaced as a bare ``ValueError`` wrapped in a dead-end "Policy failed"
+  message that never names the parameter.
+
+Every sibling knob on the same signatures was already guarded
+(``action_horizon`` >= 1, ``n_episodes``/``max_steps`` positive ints,
+``control_frequency`` > 0), so these assert the same contract for
+``control_substeps`` on all three entry points that expose it, plus the loud
+raise for callers driving ``PolicyRunner`` directly.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
+
+ROBOT_XML = """
+<mujoco model="substep_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05" rgba="0.3 0.3 0.8 1"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+      <body name="link1" pos="0 0 0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 0.2" rgba="0.8 0.3 0.3 1"/>
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="10"/>
+    <position name="elbow_act" joint="elbow" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+# Values the rollout cannot honor: (value, why it used to slip through).
+INVALID_SUBSTEPS = [
+    pytest.param(0, id="zero"),
+    pytest.param(-5, id="negative"),
+    pytest.param(2.7, id="float-truncated"),
+    pytest.param(True, id="bool-acts-as-one"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param("4", id="string"),
+]
+
+
+@pytest.fixture
+def sim_with_robot():
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "arm.xml")
+    with open(path, "w") as f:
+        f.write(ROBOT_XML)
+    s = Simulation(tool_name="substeps_validation_sim", mesh=False)
+    s.create_world()
+    s.add_robot("arm1", urdf_path=path)
+    yield s
+    s.cleanup()
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _spy_substeps(sim) -> list[int]:
+    """Record the ``n_substeps`` every ``send_action`` is driven with."""
+    captured: list[int] = []
+    orig = sim.send_action
+
+    def _spy(action, robot_name=None, n_substeps: int = 1):
+        captured.append(int(n_substeps))
+        return orig(action, robot_name=robot_name, n_substeps=n_substeps)
+
+    sim.send_action = _spy  # type: ignore[method-assign]
+    return captured
+
+
+def _error_text(result: dict) -> str:
+    return " ".join(block.get("text", "") for block in result.get("content", []) if "text" in block)
+
+
+@pytest.mark.parametrize("value", INVALID_SUBSTEPS)
+def test_run_policy_rejects_control_substeps_it_cannot_honor(sim_with_robot, value):
+    """run_policy names the bad parameter and never steps physics."""
+    captured = _spy_substeps(sim_with_robot)
+    sim_time_before = sim_with_robot.get_state()["content"][0]
+
+    result = sim_with_robot.run_policy(
+        robot_name="arm1",
+        policy_object=MockPolicy(),
+        n_steps=2,
+        control_frequency=50.0,
+        control_substeps=value,
+    )
+
+    assert result["status"] == "error", result
+    text = _error_text(result)
+    assert "control_substeps" in text, text
+    assert "positive integer" in text, text
+    assert "run_policy" in text, text
+    # Rejected at the entry point: no action was ever applied.
+    assert captured == [], captured
+    assert sim_with_robot.get_state()["content"][0] == sim_time_before
+
+
+@pytest.mark.parametrize("value", INVALID_SUBSTEPS)
+def test_eval_policy_rejects_control_substeps_it_cannot_honor(sim_with_robot, value):
+    """eval_policy applies the identical contract to its sibling run_policy."""
+    captured = _spy_substeps(sim_with_robot)
+
+    result = sim_with_robot.eval_policy(
+        robot_name="arm1",
+        policy_object=MockPolicy(),
+        n_episodes=1,
+        max_steps=2,
+        control_substeps=value,
+    )
+
+    assert result["status"] == "error", result
+    text = _error_text(result)
+    assert "control_substeps" in text, text
+    assert "eval_policy" in text, text
+    assert captured == [], captured
+
+
+def test_evaluate_benchmark_rejects_control_substeps_before_any_lookup(sim_with_robot):
+    """evaluate_benchmark rejects the value before resolving the benchmark.
+
+    The unknown benchmark name would also be an error; the assertion is that the
+    caller hears about the parameter they got wrong, and that the rejection
+    happens before any benchmark lookup or policy construction.
+    """
+    result = sim_with_robot.evaluate_benchmark(
+        benchmark_name="no_such_benchmark",
+        robot_name="arm1",
+        n_episodes=1,
+        policy_object=MockPolicy(),
+        control_substeps=0,
+    )
+
+    assert result["status"] == "error", result
+    text = _error_text(result)
+    assert "control_substeps" in text, text
+    assert "evaluate_benchmark" in text, text
+    assert "no_such_benchmark" not in text, text
+
+
+def test_valid_control_substeps_is_honored(sim_with_robot):
+    """A positive integer override still drives exactly that many substeps."""
+    captured = _spy_substeps(sim_with_robot)
+
+    result = sim_with_robot.run_policy(
+        robot_name="arm1",
+        policy_object=MockPolicy(),
+        n_steps=3,
+        control_frequency=50.0,
+        control_substeps=7,
+    )
+
+    assert result["status"] == "success", result
+    assert set(captured) == {7}, sorted(set(captured))
+
+
+def test_omitted_control_substeps_still_derives_the_control_period(sim_with_robot):
+    """``None`` keeps deriving substeps from the physics timestep (0.002 s)."""
+    captured = _spy_substeps(sim_with_robot)
+
+    result = sim_with_robot.run_policy(
+        robot_name="arm1",
+        policy_object=MockPolicy(),
+        n_steps=3,
+        control_frequency=50.0,
+    )
+
+    assert result["status"] == "success", result
+    # 50 Hz control period (0.02 s) over a 0.002 s physics dt -> 10 substeps.
+    assert set(captured) == {10}, sorted(set(captured))
+
+
+@pytest.mark.parametrize("value", [0, -5, 2.7, True, float("nan")])
+def test_policy_runner_raises_on_an_override_it_cannot_honor(sim_with_robot, value):
+    """Direct PolicyRunner callers get a loud ValueError, not a silent clamp."""
+    runner = PolicyRunner(sim_with_robot)
+    with pytest.raises(ValueError, match="control_substeps"):
+        runner._control_substeps(50.0, override=value)
+
+
+def test_policy_runner_run_and_evaluate_share_the_substep_contract(sim_with_robot):
+    """``run`` no longer carries an inline copy of the derivation.
+
+    Both rollout paths resolve substeps through ``_control_substeps``, so an
+    explicit override and the derived value agree between them.
+    """
+    runner = PolicyRunner(sim_with_robot)
+    assert runner._control_substeps(50.0) == 10
+    assert runner._control_substeps(25.0) == 20
+    assert runner._control_substeps(50.0, override=3) == 3
+
+    captured = _spy_substeps(sim_with_robot)
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim_with_robot.robot_joint_names("arm1"))
+    result = runner.run("arm1", policy, n_steps=2, control_frequency=25.0, fast_mode=True)
+    assert result["status"] == "success", result
+    assert set(captured) == {20}, sorted(set(captured))

--- a/tests/simulation/test_policy_runner_behaviour.py
+++ b/tests/simulation/test_policy_runner_behaviour.py
@@ -448,9 +448,13 @@ class TestControlSubsteps:
         assert dt and dt > 0
         # 50 Hz control over a 2 ms physics dt -> 10 substeps per action.
         assert runner._control_substeps(50.0) == round((1.0 / 50.0) / dt)
-        # Explicit override wins and is floored at 1.
+        # Explicit override wins. A non-positive override is NOT floored to 1:
+        # clamping it silently reinstated the single-physics-step
+        # under-integration this helper exists to prevent, so it raises (the
+        # public entry points reject it with a structured error first).
         assert runner._control_substeps(50.0, override=7) == 7
-        assert runner._control_substeps(50.0, override=0) == 1
+        with pytest.raises(ValueError, match="control_substeps"):
+            runner._control_substeps(50.0, override=0)
 
     def test_evaluate_steps_full_control_period(self, sim_with_robot):
         """A constant-target policy must actually move the arm in evaluate().


### PR DESCRIPTION
## Problem

`control_substeps` sets how many physics steps are integrated per applied action. `PolicyRunner._control_substeps` exists precisely because integrating a single ~2 ms `mj_step` per action leaves a position-servo arm ~10% of the way to each target before the next action overwrites `ctrl` - its own docstring says rollouts then "looked like the policy was a no-op even when commanding valid targets".

That helper resolved an explicit override with `max(1, int(override))`, so the public entry points accepted values they could not honor and silently reinstated the very pathology the helper prevents:

```python
sim.run_policy(robot_name="panda", n_steps=120, control_frequency=50.0,
               control_substeps=0)
# -> success: "120 steps | sim_t=0.240s"
#    0.240 s of physics for 2.4 s of control - 1 substep per action, not 10

sim.run_policy(..., control_substeps=-5)    # -> success, same single step
sim.run_policy(..., control_substeps=2.7)   # -> success, truncated to 2
sim.run_policy(..., control_substeps=True)  # -> success, acts as 1 (bool is an int subclass)
sim.run_policy(..., control_substeps="4")   # -> success, int("4") happens to parse

sim.run_policy(..., control_substeps=float("nan"))
# -> error: "Policy failed: cannot convert float NaN to integer"
#    a bare ValueError from inside the runner; never names the parameter
```

`eval_policy` and `evaluate_benchmark` behaved identically. Meanwhile every sibling knob on the same signatures was already guarded - `action_horizon` >= 1, `n_episodes` / `max_steps` positive ints, `control_frequency` > 0:

```python
sim.run_policy(..., action_horizon=0)
# -> error: "run_policy: action_horizon must be a positive integer, got 0."
```

So the one knob whose whole purpose is to keep physics integration correct was the one knob that accepted a value guaranteeing incorrect integration - and reported success.

## Change

`SimEngine._validate_control_substeps` accepts `None` (auto-derive from the backend physics timestep) and otherwise requires a positive integer. The positive-integer domain is delegated to the existing `_validate_positive_int` so the two guards cannot drift apart; `bool` is rejected explicitly, exactly as `_validate_positive_frequency` already does for the same reason (`True` would act as a silent 1). It is called from `run_policy`, `eval_policy` and `evaluate_benchmark` before any policy is built:

```python
sim.run_policy(..., control_substeps=0)
# -> error: "run_policy: control_substeps must be a positive integer, got 0."
```

`PolicyRunner._control_substeps` now raises `ValueError` on such an override instead of clamping it, so callers driving the runner directly also fail loudly rather than getting a 10x under-integrated rollout. And `PolicyRunner.run` now resolves substeps through that shared helper: it carried a line-for-line inline copy of the derivation, which is how the override contract came to exist in two places at once.

Valid values are untouched - an explicit `7` still drives exactly 7 substeps per action, and `None` still derives 10 substeps for 50 Hz control over a 2 ms physics timestep.

## Visual: the accepted `0` vs the honored value

Same 120-step mock sine rollout on a panda, MuJoCo headless (`MUJOCO_GL=egl`), rendered once per control step. Left is the pre-fix behavior of `control_substeps=0` (accepted, `status="success"`); right is the derived value. The left arm lags visibly - it is integrating one 2 ms physics step per 20 ms control period.

![control_substeps rollout comparison](https://raw.githubusercontent.com/cagataycali/robots/artifacts/control-substeps/control_substeps.gif)

| | reported status | reported steps | sim time advanced | substeps/action |
|---|---|---|---|---|
| `control_substeps=0` (pre-fix) | success | 120 | **0.240 s** | 1 |
| `control_substeps=None` (derived) | success | 120 | **2.400 s** | 10 |
| `control_substeps=0` (this PR) | error, names the parameter | - | 0 s (nothing runs) | - |

120 control steps at 50 Hz is 2.4 s of robot time; the accepted `0` delivered a tenth of it under a success banner.

## Tests

24 new pins in `tests/simulation/mujoco/test_control_substeps_validation.py`, driving real MuJoCo physics (inline MJCF, dt=0.002, no rendering) and asserting through a `send_action` spy:

- `run_policy` and `eval_policy` reject `0`, `-5`, `2.7`, `True`, `nan`, `inf` and `"4"` with a structured error naming `control_substeps`, and no action is ever applied (sim state unchanged);
- `evaluate_benchmark` rejects the value before any benchmark lookup or policy construction;
- an explicit `7` still drives exactly 7 substeps; omitting it still derives 10 at 50 Hz over a 2 ms dt;
- `PolicyRunner._control_substeps` raises `ValueError` naming the parameter, and `run` / the eval paths agree on both the derived and the overridden value.

`tests/simulation/test_policy_runner_behaviour.py::TestControlSubsteps::test_control_substeps_derivation` asserted `_control_substeps(50.0, override=0) == 1` - it pinned the clamp as intended behavior. It is flipped to the corrected contract with the reason in a comment, rather than shimming the code to keep the old assertion green.

Pre-fix on this branch's base (source reverted, tests kept): **21 failed, 3 passed**, including `DID NOT RAISE ValueError` and the `nan` case failing on `Actual message: 'cannot convert float NaN to integer'`. Post-fix: 24 passed.

## Gate

- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - 891 files already formatted
- `mypy strands_robots tests tests_integ` - no issues in 888 source files
- `MUJOCO_GL=egl python -m pytest tests -q` - **11868 passed, 254 skipped** (400 s)

## Docs

CHANGELOG `[Unreleased]` entry; `control_substeps` documented in `run_policy`'s Args (it had no entry at all), plus the tightened contract in the `eval_policy` prose and the `evaluate_benchmark` Args.