### PR TITLE
fix(sim): add_object honors every size component or rejects the vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `add_object` honors every `size` component or rejects the vector
+
+The MuJoCo backend documents an exact per-shape `size` layout (full extents in
+meters). A vector shorter than the shape consumes was replaced *wholesale* by a
+hardcoded default, discarding the extents the caller did pass while reporting
+success - and echoing back the requested size, not the one that was built:
+
+```python
+sim.add_object("crate", shape="box", size=[0.5], position=[0, 0, 0.25])
+# -> success: "'crate' added: box at [0.0, 0.0, 0.25], size=[0.5], 0.1kg"
+#    compiled geom_size == [0.05, 0.05, 0.05] -> a 10 cm cube, not 50 cm.
+#    It then falls 20 cm and rests at z=0.05 instead of the expected z=0.25.
+
+sim.add_object("dish", shape="ellipsoid", size=[0.3, 0.3])   # -> success, 5 cm
+sim.add_object("post", shape="cylinder", size=[0.2])         # -> success, 10 cm tall
+sim.add_object("void", shape="box", size=[])                 # -> success, 5 cm
+sim.add_object("over", shape="box", size=[0.1, 0.1, 0.1, 0.1])
+# -> error: "Failed to inject 'over': spec recompile refused."  (never names size)
+```
+
+Three different fallback defaults were in play across two layers (the
+documented `[0.05, 0.05, 0.05]`, plus `(0.1, 0.1, 0.1)` for a short box and
+`0.025` / `1.0` inside the normalizer), so which wrong size you got depended on
+how short the vector was.
+
+`_validate_size` now checks the component count against the per-shape layout
+before any scene mutation, so both entry points that normalize a size
+(`add_object` and the `patch_scene_mjcf` `add_geom` op) reject a vector they
+cannot honor with a message naming the shape, the required components and the
+full-extent convention. The now-unreachable padding defaults are removed from
+`_normalize_size`, which raises for direct builder callers. The legitimately
+shorter documented layouts still work (`sphere=[diameter]`, `plane=[x]`), a
+4-component size is rejected up front instead of failing the recompile, and
+omitting `size` still yields the documented 5 cm box. The `size` parameter now
+carries the per-shape component count in the agent tool spec.
+
 ### Fixed: `control_substeps` is honored or rejected, never silently clamped
 
 `control_substeps` sets how many physics steps are integrated per applied

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -132,6 +132,33 @@ for i in range(5):
     )
 ```
 
+## Object size
+
+`size` is the **full extent in meters** along each local axis - not MuJoCo's
+native half-extent. It is halved when the geom is compiled, so
+`size=[0.05, 0.05, 0.05]` is a 5 cm cube.
+
+Pass every component the shape consumes; a partial vector is rejected rather
+than completed from a default, because a completed vector compiles a
+differently-sized object while `add_object` reports success:
+
+| Shape | Components consumed |
+|-------|---------------------|
+| `box` / `ellipsoid` | `[x, y, z]` - all three full edge lengths / diameters |
+| `cylinder` / `capsule` | `[diameter, unused, full height]` - three (index 1 is ignored) |
+| `sphere` | `[diameter]` - one is enough |
+| `plane` | `[x]` or `[x, y]` visual half-widths (`y` mirrors `x` when omitted) |
+| `mesh` | none - the asset's own units define the extent |
+
+At most 3 components are accepted; omit `size` entirely for the 5 cm default.
+
+```python
+sim.add_object("crate", shape="box", size=[0.5])
+# status=error: box needs 3 'size' component(s) [x, y, z] full edge lengths,
+#               got 1 (size=[0.5]). ...
+sim.add_object("crate", shape="box", size=[0.5, 0.5, 0.5])   # 50 cm crate
+```
+
 ## Mesh objects
 
 Beyond primitives, `add_object` can inject a triangle-mesh asset (STL/OBJ) into

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -536,6 +536,22 @@ class SimEngine(ABC):
         ``add_object`` docstring for the exact per-shape semantics and an
         example. Returns an agent-tool status dict.
 
+        A backend MUST NOT discard ``size`` components the caller did supply.
+        When the vector is shorter than the shape consumes it either rejects it
+        (MuJoCo: the per-shape component count is part of the contract) or pads
+        only the missing *trailing* components from a documented default
+        (Isaac). Replacing the whole vector with a backend default compiles a
+        differently-sized object while reporting success -- and the reported
+        size echoes what was asked for, not what was built.
+
+        A backend MUST NOT discard ``size`` components the caller did supply.
+        When the vector is shorter than the shape consumes it either rejects it
+        (MuJoCo: the per-shape component count is part of the contract) or pads
+        the missing *trailing* components from a documented default (Isaac).
+        Replacing the whole vector with a backend default compiles a
+        differently-sized object while reporting success -- and the reported
+        size echoes what was asked for, not what was built.
+
         ``material`` (optional): backend-specific visual material/texture
         spec. ``None`` keeps the flat ``color`` rgba (unchanged); a backend
         that supports it (MuJoCo) attaches a real material so surfaces can be

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -544,14 +544,6 @@ class SimEngine(ABC):
         differently-sized object while reporting success -- and the reported
         size echoes what was asked for, not what was built.
 
-        A backend MUST NOT discard ``size`` components the caller did supply.
-        When the vector is shorter than the shape consumes it either rejects it
-        (MuJoCo: the per-shape component count is part of the contract) or pads
-        the missing *trailing* components from a documented default (Isaac).
-        Replacing the whole vector with a backend default compiles a
-        differently-sized object while reporting success -- and the reported
-        size echoes what was asked for, not what was built.
-
         ``material`` (optional): backend-specific visual material/texture
         spec. ``None`` keeps the flat ``color`` rgba (unchanged); a backend
         that supports it (MuJoCo) attaches a real material so surfaces can be

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2380,8 +2380,15 @@ class MuJoCoSimEngine(
                 origin).
             orientation: wxyz quaternion (default identity).
             size: Full extents in meters per the per-shape table above. Defaults
-                to ``[0.05, 0.05, 0.05]`` (a 5 cm box). Every meaningful
-                component must be > 0; a non-positive extent is rejected.
+                to ``[0.05, 0.05, 0.05]`` (a 5 cm box) when omitted. Must carry
+                every component the shape consumes -- 3 for ``box`` /
+                ``ellipsoid`` / ``cylinder`` / ``capsule``, at least 1 for
+                ``sphere`` / ``plane`` -- and at most 3 in total. A partial
+                vector (``size=[0.5]`` on a box) is rejected rather than
+                completed from a backend default, because a completed vector
+                compiles a differently-sized object while reporting success.
+                Every consumed component must be > 0; a non-positive extent is
+                rejected.
             color: RGBA in 0..1 (default mid-grey).
             mass: Body mass in kg for dynamic objects (default 0.1); ignored when
                 ``is_static``.
@@ -2396,8 +2403,9 @@ class MuJoCoSimEngine(
             running, the name is taken, ``position``/``orientation``/``color``/
             ``size`` contains a non-finite (``nan``/``inf``) or non-numeric
             element or ``position``/``orientation`` is the wrong length (3 / 4),
-            ``size`` has a non-positive extent,
-            ``shape="mesh"`` is missing ``mesh_path``, or the recompile fails.
+            ``size`` has a non-positive extent or a component count the shape
+            cannot consume, ``shape="mesh"`` is missing ``mesh_path``, or the
+            recompile fails.
 
         Example:
             >>> sim.add_object("cube", shape="box", size=[0.05, 0.05, 0.05])  # 5 cm cube
@@ -2488,7 +2496,11 @@ class MuJoCoSimEngine(
             shape=shape,
             position=position or [0.0, 0.0, 0.0],
             orientation=orientation or [1.0, 0.0, 0.0, 0.0],
-            size=size or [0.05, 0.05, 0.05],
+            # ``size is None`` means "omitted" -> the documented 5 cm default. An
+            # explicitly supplied vector is passed through verbatim: ``or`` would
+            # read an empty list as omitted and substitute the default for a
+            # request _validate_size has already rejected.
+            size=[0.05, 0.05, 0.05] if size is None else list(size),
             color=color or [0.5, 0.5, 0.5, 1.0],
             mass=mass,
             mesh_path=mesh_path,

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -138,16 +138,62 @@ def _geom_type(shape: str) -> int:
         raise ValueError(f"Unsupported shape {shape!r}. Supported: {supported}.") from e
 
 
+# Per-shape ``size`` contract: how many leading components the shape actually
+# consumes, plus the layout to quote back at a caller who supplied the wrong
+# count. A shape that consumes component i needs a vector of at least i + 1
+# components -- a shorter one cannot express the request at all, so it is
+# rejected instead of being padded from a backend default (which would compile
+# a differently-sized object while reporting success). ``plane`` needs only its
+# x half-width (y mirrors x when omitted); ``mesh`` takes its extent from the
+# asset and consumes nothing.
+_SIZE_LAYOUT: dict[str, tuple[int, str]] = {
+    "box": (3, "[x, y, z] full edge lengths"),
+    "ellipsoid": (3, "[x, y, z] full diameters"),
+    "sphere": (1, "[diameter]"),
+    "cylinder": (3, "[diameter, unused, full height]"),
+    "capsule": (3, "[diameter, unused, full height]"),
+    "plane": (1, "[x] or [x, y] visual half-widths"),
+    "mesh": (0, "unused - the asset's own units define the extent"),
+}
+
+# ``SimObject.size`` is a 3-vector, and every shape above consumes at most its
+# first three components, so a longer vector carries values no shape can honor.
+_MAX_SIZE_COMPONENTS = 3
+
+
 def _validate_size(shape: str, size: list[float]) -> str | None:
-    """Return an error message if ``size`` has a non-positive meaningful extent.
+    """Return an error message if ``size`` cannot be honored for ``shape``.
 
     ``size`` follows the full-extent convention used by
     :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.add_object`
-    (meters along each axis, halved internally to MuJoCo's half-extents). Only
-    the components a given shape actually consumes are checked, so a cylinder
-    may legitimately pass ``size[1] == 0`` (it is ignored). ``mesh`` ignores
-    ``size`` entirely. Returns ``None`` when the size is acceptable.
+    (meters along each axis, halved internally to MuJoCo's half-extents). Two
+    classes are rejected:
+
+    * A **component count** the shape cannot consume -- fewer components than
+      :data:`_SIZE_LAYOUT` requires (a box needs all three), or more than three
+      (nothing consumes a fourth). A short vector used to be replaced wholesale
+      by a hardcoded default, so ``size=[0.5]`` on a box compiled a 10 cm cube
+      while the call reported success and echoed the requested ``[0.5]``.
+    * A **non-positive** value in a component the shape consumes. Only consumed
+      components are checked, so a cylinder may legitimately pass
+      ``size[1] == 0`` (it is ignored).
+
+    Returns ``None`` when the size is acceptable.
     """
+    required, layout = _SIZE_LAYOUT.get(shape, (0, ""))
+    if len(size) > _MAX_SIZE_COMPONENTS:
+        return (
+            f"add_object: 'size' takes at most {_MAX_SIZE_COMPONENTS} components, got "
+            f"{len(size)} (size={list(size)}). 'size' is the full extent in meters "
+            "along each axis (not MuJoCo's half-extent)."
+        )
+    if len(size) < required:
+        return (
+            f"add_object: {shape} needs {required} 'size' component(s) {layout}, got "
+            f"{len(size)} (size={list(size)}). 'size' is the full extent in meters "
+            "along each axis (not MuJoCo's half-extent); pass every component the "
+            "shape consumes rather than a partial vector."
+        )
     if shape == "mesh":
         return None
     if shape in ("box", "ellipsoid"):
@@ -162,8 +208,6 @@ def _validate_size(shape: str, size: list[float]) -> str | None:
         # Unknown shapes are rejected by _geom_type; nothing to validate here.
         return None
     for idx, axis in used:
-        if idx >= len(size):
-            continue
         if size[idx] <= 0:
             return (
                 f"add_object: {shape} {axis} extent must be > 0, got "
@@ -186,31 +230,31 @@ def _normalize_size(shape: str, size: list[float]) -> list[float]:
     * ``plane``:     ``[hx, hy, grid_spacing]`` (hx/hy are half-sizes)
     * ``mesh``:      ``[]``            (mesh asset dictates extent; size ignored)
 
-    ``SimObject.size`` is always 3 floats. Box/ellipsoid use all 3 as full
-    extents, sphere uses ``size[0]`` as diameter (MuJoCo halves it to radius),
-    cylinder/capsule use ``size[0]`` as diameter and ``size[2]`` as full height
-    (both halved). Plane is the one exception: ``size[0]``/``size[1]`` are
-    passed through unchanged as MuJoCo's visual half-widths (a plane is
-    infinite for collision, so only its rendered grid extent matters).
+    Box/ellipsoid use all 3 components as full extents, sphere uses ``size[0]``
+    as diameter (MuJoCo halves it to radius), cylinder/capsule use ``size[0]``
+    as diameter and ``size[2]`` as full height (both halved). Plane is the one
+    exception: ``size[0]``/``size[1]`` are passed through unchanged as MuJoCo's
+    visual half-widths (a plane is infinite for collision, so only its rendered
+    grid extent matters) and ``size[1]`` mirrors ``size[0]`` when omitted.
+
+    Raises:
+        ValueError: When :func:`_validate_size` rejects ``size`` -- too few
+            components for the shape to consume, more than three, or a
+            non-positive consumed extent. Every component this function reads
+            is guaranteed present by that check, so a partial vector is never
+            silently completed from a default.
     """
     if (msg := _validate_size(shape, size)) is not None:
         raise ValueError(msg)
-    if shape == "box":
-        sx, sy, sz = size if len(size) >= 3 else (0.1, 0.1, 0.1)
-        return [sx / 2, sy / 2, sz / 2]
+    if shape in ("box", "ellipsoid"):
+        return [size[0] / 2, size[1] / 2, size[2] / 2]
     if shape == "sphere":
         # Legacy builder used size[0]/2 as radius - preserve that.
-        radius = size[0] / 2 if size else 0.025
-        return [radius, 0.0, 0.0]
+        return [size[0] / 2, 0.0, 0.0]
     if shape in ("cylinder", "capsule"):
-        radius = size[0] / 2 if size else 0.025
-        half_h = size[2] / 2 if len(size) > 2 else 0.05
-        return [radius, half_h, 0.0]
-    if shape == "ellipsoid":
-        sx, sy, sz = size if len(size) >= 3 else (0.05, 0.05, 0.05)
-        return [sx / 2, sy / 2, sz / 2]
+        return [size[0] / 2, size[2] / 2, 0.0]
     if shape == "plane":
-        sx = size[0] if size else 1.0
+        sx = size[0]
         sy = size[1] if len(size) > 1 else sx
         return [sx, sy, 0.01]
     if shape == "mesh":

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -149,7 +149,8 @@
       "type": "array",
       "items": {
         "type": "number"
-      }
+      },
+      "description": "Object size for add_object, as FULL extents in meters per axis (not MuJoCo half-extents). Pass every component the shape consumes: box/ellipsoid [x,y,z], cylinder/capsule [diameter,unused,height], sphere [diameter], plane [x] or [x,y] half-widths; mesh ignores it. At most 3 components. A partial vector (e.g. [0.5] for a box) is rejected, not padded - omit size entirely for the 5 cm default."
     },
     "color": {
       "type": "array",

--- a/tests/simulation/mujoco/test_add_object_size_component_count.py
+++ b/tests/simulation/mujoco/test_add_object_size_component_count.py
@@ -1,0 +1,177 @@
+"""``add_object`` honors every ``size`` component or rejects the vector.
+
+The MuJoCo backend documents an exact per-shape ``size`` layout (full extents in
+meters: ``box``/``ellipsoid`` need all three components, ``cylinder``/``capsule``
+need the diameter and the height at index 2, ``sphere``/``plane`` need only their
+leading component). A vector shorter than the shape consumes used to be replaced
+wholesale by a hardcoded default, so ``add_object("crate", shape="box",
+size=[0.5])`` reported success -- echoing the requested ``[0.5]`` -- while
+compiling a 10 cm cube, and a vector longer than three components died with a
+generic "spec recompile refused" that never named the parameter.
+
+These tests pin the contract at both entry points that normalize a size (the
+``add_object`` action and the ``patch_scene_mjcf`` ``add_geom`` op) plus the
+shared helpers, and pin that the legitimately shorter layouts
+(``sphere=[diameter]``, ``plane=[x]``) keep working.
+"""
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.mujoco.spec_builder import (  # noqa: E402
+    _normalize_size,
+    _validate_size,
+)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_size_count_sim", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def _geom_id(sim, geom_name):
+    return mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_GEOM, geom_name)
+
+
+def _half_extents(sim, geom_name):
+    gid = _geom_id(sim, geom_name)
+    assert gid >= 0, f"geom {geom_name!r} missing from the compiled model"
+    return list(sim._world._model.geom_size[gid])
+
+
+# Shapes/lengths that previously returned success while compiling a default-sized
+# geom: the caller's extents were dropped entirely, not padded.
+PARTIAL_SIZES = [
+    ("box", [0.5]),
+    ("box", [0.4, 0.3]),
+    ("box", []),
+    ("ellipsoid", [0.3, 0.3]),
+    ("cylinder", [0.2]),
+    ("capsule", [0.2]),
+    ("sphere", []),
+    ("plane", []),
+]
+
+
+@pytest.mark.parametrize(("shape", "size"), PARTIAL_SIZES)
+def test_partial_size_is_rejected_and_nothing_is_added(sim, shape, size):
+    """A size the shape cannot consume is refused, leaving the scene untouched."""
+    result = sim.add_object("part", shape=shape, size=size, is_static=shape == "plane")
+
+    assert result["status"] == "error"
+    message = result["content"][0]["text"]
+    assert "size" in message
+    assert str(len(size)) in message  # names the count it actually got
+    # The refusal must not half-apply: no registry entry, no compiled geom.
+    assert "part" not in sim._world.objects
+    assert _geom_id(sim, "part_geom") < 0
+
+
+def test_partial_box_size_error_names_the_shape_and_required_layout(sim):
+    """The message is self-correcting: shape, required count, layout, convention."""
+    result = sim.add_object("crate", shape="box", size=[0.5])
+
+    message = result["content"][0]["text"]
+    assert "box" in message
+    assert "3" in message
+    assert "[x, y, z] full edge lengths" in message
+    assert "full extent in meters" in message
+    assert "[0.5]" in message  # echoes what was passed
+
+
+def test_size_longer_than_three_components_is_rejected_before_recompile(sim):
+    """A 4-component size names the parameter instead of failing the recompile.
+
+    It previously reached the spec compiler and surfaced as
+    "spec recompile refused." -- no mention of ``size`` or of the real reason.
+    """
+    result = sim.add_object("over", shape="box", size=[0.1, 0.1, 0.1, 0.1])
+
+    assert result["status"] == "error"
+    message = result["content"][0]["text"]
+    assert "size" in message
+    assert "at most 3" in message
+    assert "recompile" not in message
+    assert "over" not in sim._world.objects
+
+
+def test_complete_size_vectors_are_honored(sim):
+    """The honored path is unchanged: full extents halve into MuJoCo geom sizes."""
+    assert sim.add_object("cube", shape="box", size=[0.5, 0.4, 0.3])["status"] == "success"
+    assert _half_extents(sim, "cube_geom") == pytest.approx([0.25, 0.2, 0.15])
+
+    assert sim.add_object("can", shape="cylinder", size=[0.08, 0.0, 0.2])["status"] == "success"
+    can = _half_extents(sim, "can_geom")
+    assert can[0] == pytest.approx(0.04)  # radius from diameter
+    assert can[1] == pytest.approx(0.1)  # half-height from full height
+
+
+def test_shapes_that_document_a_shorter_layout_still_accept_it(sim):
+    """The guard must not over-reject: sphere and plane consume fewer components."""
+    assert sim.add_object("ball", shape="sphere", size=[0.06])["status"] == "success"
+    assert _half_extents(sim, "ball_geom")[0] == pytest.approx(0.03)
+
+    assert sim.add_object("mat", shape="plane", size=[2.0], is_static=True)["status"] == "success"
+    mat = _half_extents(sim, "mat_geom")
+    assert mat[0] == pytest.approx(2.0)
+    assert mat[1] == pytest.approx(2.0)  # y mirrors x when omitted
+
+
+def test_omitted_size_uses_the_documented_default(sim):
+    """``size=None`` still means the documented 5 cm box (2.5 cm half-extents)."""
+    assert sim.add_object("default_box")["status"] == "success"
+    assert _half_extents(sim, "default_box_geom") == pytest.approx([0.025, 0.025, 0.025])
+
+
+def test_patch_scene_mjcf_add_geom_rejects_partial_size(sim):
+    """The scene-patch entry point normalizes sizes too, and rolls the batch back."""
+    result = sim.patch_scene_mjcf(
+        [
+            {"op": "add_body", "name": "pbody", "pos": [1.0, 0.0, 1.0]},
+            {"op": "add_geom", "body": "pbody", "name": "pgeom", "type": "box", "size": [0.4]},
+        ]
+    )
+
+    assert result["status"] == "error"
+    assert "size" in result["content"][0]["text"]
+    # Atomic rollback: neither op survives, so no default-sized geom is left behind.
+    assert _geom_id(sim, "pgeom") < 0
+    assert mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, "pbody") < 0
+
+
+class TestValidateSizeComponentCount:
+    """Unit-level contract of the shared size validator/normalizer."""
+
+    @pytest.mark.parametrize(("shape", "size"), PARTIAL_SIZES)
+    def test_short_vectors_report_an_error(self, shape, size):
+        assert _validate_size(shape, size) is not None
+
+    def test_more_than_three_components_reports_an_error(self):
+        assert "at most 3" in (_validate_size("sphere", [0.1, 0.1, 0.1, 0.1]) or "")
+
+    @pytest.mark.parametrize(
+        ("shape", "size"),
+        [
+            ("box", [0.2, 0.4, 0.6]),
+            ("ellipsoid", [0.1, 0.2, 0.3]),
+            ("cylinder", [0.1, 0.0, 0.4]),
+            ("capsule", [0.1, 0.0, 0.4]),
+            ("sphere", [0.1]),
+            ("plane", [2.0]),
+            ("mesh", []),
+        ],
+    )
+    def test_documented_layouts_pass(self, shape, size):
+        assert _validate_size(shape, size) is None
+
+    def test_normalize_raises_instead_of_padding_a_short_vector(self):
+        """Direct builder callers get a loud ValueError, not a defaulted geom."""
+        with pytest.raises(ValueError, match=r"needs 3 'size' component"):
+            _normalize_size("box", [0.5])
+        with pytest.raises(ValueError, match=r"needs 3 'size' component"):
+            _normalize_size("ellipsoid", [])

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -84,10 +84,14 @@ class TestNormalizeSize:
         # An ellipsoid's three full diameters become per-axis radii (each /2).
         assert _normalize_size("ellipsoid", [0.1, 0.2, 0.3]) == [0.05, 0.1, 0.15]
 
-    def test_ellipsoid_falls_back_to_default_radii_when_size_too_short(self):
-        # A malformed (<3 component) size must not raise; it falls back to the
-        # documented 0.05 default extents (-> 0.025 per-axis radius).
-        assert _normalize_size("ellipsoid", []) == [0.025, 0.025, 0.025]
+    def test_ellipsoid_size_too_short_raises_instead_of_defaulting(self):
+        # Corrected contract: a <3 component ellipsoid size cannot express the
+        # request, and completing it from a hardcoded default compiled a
+        # differently-sized geom while add_object reported success (echoing the
+        # size the caller asked for). It is now rejected, so the caller learns
+        # which components the shape consumes.
+        with pytest.raises(ValueError, match=r"needs 3 'size' component"):
+            _normalize_size("ellipsoid", [])
 
     def test_unknown_shape_raises(self):
         with pytest.raises(ValueError, match="Cannot normalize size"):


### PR DESCRIPTION
## Problem

The MuJoCo backend documents an exact per-shape `size` layout (full extents in meters: `box`/`ellipsoid` need all three components, `cylinder`/`capsule` need the diameter and the height at index 2, `sphere`/`plane` need only their leading component). A vector shorter than the shape consumes was replaced **wholesale** by a hardcoded default, discarding the extents the caller *did* pass while reporting success -- and echoing back the requested size, not the one that was built:

```python
sim.add_object("crate", shape="box", size=[0.5], position=[0, 0, 0.25])
# -> success: "'crate' added: box at [0.0, 0.0, 0.25], size=[0.5], 0.1kg"
#    compiled geom_size == [0.05, 0.05, 0.05]  -> a 10 cm cube, not 50 cm
#    it then falls 20 cm and rests at z=0.0499 instead of the documented z=0.25

sim.add_object("dish", shape="ellipsoid", size=[0.3, 0.3])  # -> success, 5 cm
sim.add_object("post", shape="cylinder", size=[0.2])        # -> success, 10 cm tall
sim.add_object("void", shape="box", size=[])                # -> success, 5 cm
sim.add_object("over", shape="box", size=[0.1, 0.1, 0.1, 0.1])
# -> error: "Failed to inject 'over': spec recompile refused."   (never names size)
```

Two mechanisms were involved:

- `_validate_size` checked only the *values* of consumed components and `continue`d past indices the vector did not have, so the count was never checked. `_validate_finite_vector`'s docstring already deferred that check ("Length is NOT checked here ... size is shape-dependent") -- nothing downstream performed it.
- `_normalize_size` then substituted a default for the whole vector (`sx, sy, sz = size if len(size) >= 3 else (0.1, 0.1, 0.1)`), and `add_object` coalesced an explicit `[]` with `size or [0.05, 0.05, 0.05]`.

Three different fallback values were in play across those two layers (the documented `[0.05, 0.05, 0.05]`, `(0.1, 0.1, 0.1)` for a short box, `0.025`/`1.0` inside the normalizer), so *which* wrong size you got depended on how short the vector was. The 4-component case never reached a validator at all: it raised `too many values to unpack` inside the builder and surfaced as a generic recompile failure.

The Isaac backend already fixed this class for itself by padding only the missing *trailing* components against a documented contract (see the comment in `_make_primitive`: "previously this branch was all-or-nothing, so e.g. `size=[0.10]` silently fell back to `[0.05, 0.05, 0.05]`"). MuJoCo still had the all-or-nothing behaviour, and its documented contract states an exact per-shape layout with no padding rule -- so honoring-or-rejecting is the fix that matches its own docs.

## Change

`_validate_size` now checks the component count against one per-shape layout table (`_SIZE_LAYOUT`) before any scene mutation:

| Shape | Components consumed |
|-------|---------------------|
| `box` / `ellipsoid` | 3 -- `[x, y, z]` full edge lengths / diameters |
| `cylinder` / `capsule` | 3 -- `[diameter, unused, full height]` |
| `sphere` | 1 -- `[diameter]` |
| `plane` | 1 -- `[x]` or `[x, y]` visual half-widths |
| `mesh` | 0 -- the asset's own units define the extent |

Both entry points that normalize a size (the `add_object` action and the `patch_scene_mjcf` `add_geom` op) now reject a vector they cannot honor, with a message naming the shape, the required components and the full-extent convention:

```
add_object: box needs 3 'size' component(s) [x, y, z] full edge lengths, got 1
(size=[0.5]). 'size' is the full extent in meters along each axis (not MuJoCo's
half-extent); pass every component the shape consumes rather than a partial vector.
```

More than three components is rejected up front (`'size' takes at most 3 components, got 4`) instead of failing the recompile. The now-unreachable padding defaults are deleted from `_normalize_size`, which raises for direct builder callers and documents that in `Raises:`. `add_object` distinguishes `size is None` (omitted -> the documented 5 cm default) from an explicitly supplied vector, so `or` can no longer read `[]` as "omitted".

Behaviour preserved: the legitimately shorter documented layouts (`sphere=[diameter]`, `plane=[x]` with `y` mirroring `x`, the `{"op": "add_geom", "type": "sphere", "size": [0.1]}` patch op in `patch_scene_mjcf`'s own docstring) all still work, `cylinder` still ignores `size[1]`, and omitting `size` still yields the 5 cm box.

Scope is the MuJoCo backend plus the abstract contract. The `SimEngine.add_object` docstring now states the rule backends must satisfy -- do not discard components the caller supplied; reject the vector (MuJoCo) or pad only missing trailing components from a documented default (Isaac) -- so the two backends' existing behaviours are both legible instead of one being an undocumented accident.

## Verification in simulation

A 0.5 m crate placed at its documented rest height (`size_z / 2` above `z=0`), rendered headless after 400 steps. Left: the pre-fix "successful" call. Right: the partial vector rejected, then the complete request honored.

![add_object size before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/add-object-size/add_object_size.png)

| | `size=[0.5]` (pre-fix) | `size=[0.5]` (post-fix) | `size=[0.5, 0.5, 0.5]` |
|---|---|---|---|
| status | `success` | `error`, names shape + 3 required components | `success` |
| reported size | `[0.5]` | -- | `[0.5, 0.5, 0.5]` |
| compiled `geom_size` | `[0.05, 0.05, 0.05]` (10 cm cube) | nothing compiled | `[0.25, 0.25, 0.25]` (50 cm crate) |
| rest height | `z=0.0499` | -- | `z=0.2499` |

L1 difference between the two panels: 2.74e6 (the object genuinely changes size).

## Tests

New `tests/simulation/mujoco/test_add_object_size_component_count.py` (31 tests): every shape/length combination that previously returned success is pinned as an error with nothing added to the registry and no geom compiled; the message content is pinned (shape, count, layout, convention, echoed input); the 4-component case is pinned to name `size` and *not* mention the recompile; the `patch_scene_mjcf` entry point is pinned including atomic rollback; and the honored paths (complete vectors, `sphere=[d]`, `plane=[x]`, omitted `size`) are pinned so the guard cannot over-reject.

On pre-fix code: **21 failed, 10 passed**. After: **31 passed**.

`test_spec_builder.py::test_ellipsoid_falls_back_to_default_radii_when_size_too_short` pinned the substitution as intended behaviour ("a malformed size must not raise"). It is renamed to `test_ellipsoid_size_too_short_raises_instead_of_defaulting` and flipped, with the reason in the test body -- the correct call versus shimming the code to keep it green.

Full local gate: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean; full suite **11905 passed, 254 skipped** (403 s, `MUJOCO_GL=egl`).

## Docs

New "Object size" section in `docs/simulation/world-building.md` with the per-shape component table and the rejection example; `add_object` Args/Returns updated; the `size` parameter in the MuJoCo agent tool spec now carries the per-shape component count so an agent gets it from discovery rather than from a wrong guess; CHANGELOG entry under `[Unreleased]`.

---

## Round 1 changelog

- **Deduplicated the `SimEngine.add_object` size contract paragraph in `base.py`** (review feedback). The abstract-contract note was pasted twice near-verbatim; kept the single copy with the precise "pads only the missing *trailing* components" wording (matching the Isaac `_make_primitive` comment) and removed the duplicate. Docstring-only, no behaviour change, gate re-checked clean (`f0e3e91`).