### PR TITLE
fix(sim): set_geom_properties honors every vector component or rejects the vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `set_geom_properties` honors every vector component or rejects the vector
+
+`color`, `friction` and `size` each target a MuJoCo buffer with a fixed component
+layout, but the mutator wrote whatever it was given component by component: it
+sliced `geom_size[gid, :min(len(size), 3)]`, zero-padded `friction`, and appended
+an alpha to `color[:3]`. A vector that did not match its target's layout was
+therefore applied as a mix of the caller's components and fabricated ones - under
+a `status="success"` result - or crashed with a bare NumPy error:
+
+```python
+sim.add_object("crate", shape="box", size=[0.2, 0.3, 0.4])   # half-extents 0.1/0.15/0.2
+sim.set_geom_properties(geom_name="crate", size=[0.5])
+# -> success: "size -> [0.5, 0.15, 0.2]"   (a slab; only x was applied)
+sim.set_geom_properties(geom_name="crate", size=[])
+# -> success: "size -> [0.5, 0.15, 0.2]"   (nothing written, a resize reported)
+sim.set_geom_properties(geom_name="crate", friction=[1.0])
+# -> success: "friction -> [1.0, 0.0, 0.0]"  (torsional 0.5 and rolling 0.001,
+#                                             never mentioned, zeroed)
+sim.set_geom_properties(geom_name="crate", color=[0.5])
+# -> ValueError: could not broadcast input array from shape (2,) into shape (4,)
+#    (raised past the tool envelope)
+sim.set_geom_properties(geom_name="crate", color=[])
+# -> success: "color -> [1.0, 1.0, 1.0, 1.0]"  (repainted opaque white)
+```
+
+Each vector's component count is now validated before any model write, alongside
+the existing finite/positive element checks, so the call is all-or-nothing:
+
+- `color` must be 3 (RGB, alpha set to 1.0) or 4 (RGBA).
+- `friction` must be the 3 MuJoCo coefficients (sliding, torsional, rolling);
+  MuJoCo has no per-component default to fall back on, so a shorter vector cannot
+  be honored.
+- `size` must carry exactly the components the geom's compiled type defines -
+  1 (sphere), 2 (capsule, cylinder) or 3 (box, ellipsoid, plane). A mesh, height
+  field or SDF geom takes its extent from asset data and defines no `geom_size`
+  component, so `size` is refused for it and the error names the alternatives.
+
+The errors name the parameter, the count the geom's own type requires and what
+the components mean, and `describe()` advertises the counts so a caller does not
+have to discover them by trial. Rejected calls leave `geom_size` / `geom_friction`
+/ `geom_rgba` and the derived collision bounds untouched.
+
 ### Fixed: `add_object` honors every `size` component or rejects the vector
 
 The MuJoCo backend documents an exact per-shape `size` layout (full extents in

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -59,6 +59,41 @@ for episode in range(N):
                              success_fn=my_fn)
 ```
 
+## Targeted per-geom / per-body perturbation
+
+`randomize()` perturbs the whole scene; `set_geom_properties` /
+`set_body_properties` perturb one entity, which is what you want when only the
+manipuland's friction or the table's height should change between episodes.
+
+```python
+sim.set_geom_properties(geom_name="crate", color=[0.8, 0.2, 0.2],   # RGB or RGBA
+                        friction=[0.6, 0.01, 0.001],                # sliding, torsional, rolling
+                        size=[0.2, 0.2, 0.05])                      # box: three half-extents
+sim.set_body_properties(body_name="crate", mass=1.4)                # inertia scales with it
+```
+
+**Every vector must carry the exact component count its target defines.** There
+is no meaningful value to invent for a component you omit, so a partial vector is
+rejected instead of being mixed with the compiled one:
+
+| Parameter | Accepted components |
+|---|---|
+| `color` | 3 (RGB, alpha set to 1.0) or 4 (RGBA) |
+| `friction` | 3 (sliding, torsional, rolling) |
+| `size` | whatever the geom's type defines: sphere 1, capsule/cylinder 2, box/ellipsoid/plane 3 |
+
+```python
+sim.set_geom_properties(geom_name="crate", size=[0.4])
+# status=error: 'size' must have exactly 3 component(s) (box: three half-extents),
+#               got 1: [0.4]. Pass every component - a partial 'size' cannot be
+#               applied without inventing the missing values.
+```
+
+A mesh / height-field / SDF geom takes its extent from asset data and defines no
+`geom_size` component, so `size` is refused for it (resize the asset instead).
+Growing a size-defined primitive refreshes its broadphase and mid-phase collision
+bounds, so other bodies collide with the new extent rather than passing through it.
+
 ## Sensor noise
 
 `set_obs_noise` adds Gaussian measurement noise to observations so a policy is

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -37,6 +37,8 @@ def _coerce_finite_vector(
     *,
     min_value: float | None = None,
     strict_min: bool = False,
+    accepted_lengths: tuple[int, ...] | None = None,
+    layout: str = "",
 ) -> tuple[list[float] | None, dict[str, Any] | None]:
     """Coerce a numeric vector to ``float`` and validate every element.
 
@@ -46,6 +48,13 @@ def _coerce_finite_vector(
     An optional lower bound enforces physics invariants (non-negative friction,
     positive geom extent).
 
+    ``accepted_lengths`` enforces the component count the target buffer defines.
+    A vector shorter than its target cannot be written without inventing the
+    missing components (leaving them at their compiled value, or padding with a
+    fabricated one), and a longer vector can only be written by discarding its
+    tail -- both apply a value the caller never asked for, so the count is
+    rejected instead.
+
     Args:
         values: The input sequence (list / tuple / NumPy array).
         name: Parameter name, used in error text.
@@ -53,11 +62,14 @@ def _coerce_finite_vector(
         min_value: If set, every element must be ``>= min_value`` (or ``>`` when
             ``strict_min`` is True).
         strict_min: Use a strict ``>`` comparison against ``min_value``.
+        accepted_lengths: If set, the component counts that can be honored.
+        layout: Human-readable meaning of the components, used in the
+            component-count error text.
 
     Returns:
         ``(floats, None)`` on success, or ``(None, error_dict)`` on the first
-        invalid element -- matching the structured-error tool contract so the
-        caller never raises past dispatch.
+        invalid element or an unusable component count -- matching the
+        structured-error tool contract so the caller never raises past dispatch.
     """
     try:
         seq = list(values)
@@ -87,6 +99,22 @@ def _coerce_finite_vector(
                 "content": [{"text": f"{method}: '{name}' values must be {rel} {min_value}, got {values!r}"}],
             }
         out.append(f)
+    if accepted_lengths is not None and len(out) not in accepted_lengths:
+        expected = " or ".join(str(n) for n in accepted_lengths)
+        detail = f" ({layout})" if layout else ""
+        return None, {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        f"{method}: '{name}' must have exactly {expected} "
+                        f"component(s){detail}, got {len(out)}: {out}. Pass every "
+                        f"component - a partial '{name}' cannot be applied "
+                        "without inventing the missing values."
+                    )
+                }
+            ],
+        }
     return out, None
 
 
@@ -236,6 +264,38 @@ def _recompute_primitive_geom_bounds(mj: Any, model: Any, gid: int) -> bool:
     # geom_aabb layout is [center(3), half-extent(3)]; primitives are centered.
     model.geom_aabb[gid, 3:6] = half
     return True
+
+
+# Number of ``geom_size`` components each MuJoCo geom type defines, plus the
+# meaning of each one. MuJoCo stores every geom's extent in a 3-wide
+# ``geom_size`` row, but only the leading components its type defines carry
+# meaning - a sphere reads one, a capsule two, a box three. A type whose extent
+# comes from asset data (mesh, height field, SDF) defines none.
+_GEOM_SIZE_LAYOUTS: dict[str, tuple[int, str]] = {
+    "plane": (3, "x half-extent, y half-extent, grid spacing"),
+    "sphere": (1, "radius"),
+    "capsule": (2, "radius, half-length"),
+    "ellipsoid": (3, "three semi-axes"),
+    "cylinder": (2, "radius, half-length"),
+    "box": (3, "three half-extents"),
+}
+
+
+def _geom_type_name(mj: Any, geom_type: int) -> str:
+    """Return a geom type's short lowercase name (``"box"``, ``"mesh"``, ...).
+
+    Args:
+        mj: The imported ``mujoco`` module.
+        geom_type: A ``model.geom_type`` entry (an ``mjtGeom`` value).
+
+    Returns:
+        The ``mjtGeom`` name with its ``mjGEOM_`` prefix stripped and lowercased,
+        or ``"type_<n>"`` if the value is not a known ``mjtGeom`` member.
+    """
+    try:
+        return str(mj.mjtGeom(int(geom_type)).name).removeprefix("mjGEOM_").lower()
+    except ValueError:
+        return f"type_{int(geom_type)}"
 
 
 class PhysicsMixin:
@@ -1439,15 +1499,44 @@ class PhysicsMixin:
         primitive (sphere/capsule/cylinder/ellipsoid/box), the geom's collision
         bounding volumes (``geom_rbound`` for broadphase, ``geom_aabb`` for
         mid-phase) are recomputed so a grown geom collides correctly instead of
-        letting other bodies pass through it. Mesh/plane/height-field geoms take
-        their extent from asset data, so a ``size`` write is inert for them.
+        letting other bodies pass through it. A plane's bounds are type-derived,
+        so only its stored ``geom_size`` changes.
+
+        Every vector must carry the exact number of components its target
+        defines, because there is no meaningful value to invent for a component
+        the caller omitted:
+
+        * ``color``: 3 (RGB, alpha set to 1.0) or 4 (RGBA).
+        * ``friction``: 3 (sliding, torsional, rolling).
+        * ``size``: whatever the geom's compiled type defines - 1 for a sphere,
+          2 for a capsule/cylinder, 3 for a box/ellipsoid/plane. Mesh, height
+          field and SDF geoms take their extent from asset data and define no
+          ``geom_size`` component, so ``size`` is refused for them.
 
         All numeric inputs are validated before any model write: ``color``,
         ``friction`` and ``size`` must contain only finite numbers (``nan`` /
         ``inf`` are rejected), ``friction`` coefficients must be ``>= 0`` and
         ``size`` half-extents must be ``> 0``. An invalid value returns a
         structured ``status="error"`` result and leaves the model untouched,
-        rather than silently corrupting the solver or broadphase bounds.
+        rather than silently corrupting the solver or broadphase bounds, or
+        applying a shape/appearance the caller never asked for.
+
+        Args:
+            geom_name: Name of the geom to modify. The owning object's name is
+                accepted as an alias for an ``add_object`` geom (``"<name>"`` for
+                ``"<name>_geom"``).
+            geom_id: Geom id, as an alternative to ``geom_name``.
+            color: RGB (3) or RGBA (4) components in ``[0, 1]``.
+            friction: The three MuJoCo friction coefficients (sliding,
+                torsional, rolling), each ``>= 0``.
+            size: The geom's half-extents, with exactly as many components as
+                its type defines, each ``> 0``.
+
+        Returns:
+            A tool-result dict; ``status="error"`` if the world is missing, a
+            policy is running, the geom is not found, or a vector's values or
+            component count cannot be honored, otherwise ``status="success"``
+            summarizing the changes applied.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1476,16 +1565,67 @@ class PhysicsMixin:
         # broadphase bounds (geom_rbound becomes inf) while the tool still
         # reports success. Friction coefficients are non-negative and a geom's
         # size (half-extent) must be strictly positive.
+        #
+        # Component counts are validated in the same pass. A vector shorter than
+        # its target buffer used to be written component-wise (or padded with
+        # zeros / an invented alpha), so a partial value silently mixed the
+        # caller's components with the compiled ones - a one-element size on a
+        # box resized only x and left y/z at their old half-extents, while a
+        # one-element friction zeroed the torsional and rolling coefficients the
+        # caller never mentioned. A longer vector had its tail discarded. Both
+        # applied a shape / appearance / contact model nobody asked for under a
+        # status="success" result, so the exact count is now required.
         if color is not None:
-            color, err = _coerce_finite_vector(color, "color", "set_geom_properties")
+            color, err = _coerce_finite_vector(
+                color,
+                "color",
+                "set_geom_properties",
+                accepted_lengths=(3, 4),
+                layout="RGB, or RGBA with alpha",
+            )
             if err:
                 return err
         if friction is not None:
-            friction, err = _coerce_finite_vector(friction, "friction", "set_geom_properties", min_value=0.0)
+            friction, err = _coerce_finite_vector(
+                friction,
+                "friction",
+                "set_geom_properties",
+                min_value=0.0,
+                accepted_lengths=(3,),
+                layout="sliding, torsional, rolling",
+            )
             if err:
                 return err
         if size is not None:
-            size, err = _coerce_finite_vector(size, "size", "set_geom_properties", min_value=0.0, strict_min=True)
+            gtype = _geom_type_name(mj, model.geom_type[gid])
+            geom_layout = _GEOM_SIZE_LAYOUTS.get(gtype)
+            if geom_layout is None:
+                # mesh / hfield / sdf: the extent comes from the asset, so no
+                # component of the requested size can be honored. Storing it
+                # anyway would report a resize that never happens.
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"set_geom_properties: geom '{geom_name or gid}' has type "
+                                f"'{gtype}', whose extent comes from its asset data and "
+                                "defines no 'size' component - resize the asset, or use a "
+                                "size-defined primitive geom "
+                                f"({', '.join(sorted(_GEOM_SIZE_LAYOUTS))}) instead."
+                            )
+                        }
+                    ],
+                }
+            size, err = _coerce_finite_vector(
+                size,
+                "size",
+                "set_geom_properties",
+                min_value=0.0,
+                strict_min=True,
+                accepted_lengths=(geom_layout[0],),
+                layout=f"{gtype}: {geom_layout[1]}",
+            )
             if err:
                 return err
 
@@ -1494,17 +1634,19 @@ class PhysicsMixin:
 
         with self._lock:
             if color is not None:
-                model.geom_rgba[gid] = color[:4] if len(color) >= 4 else color[:3] + [1.0]
+                # Validated as 3 or 4 components; RGB gets an opaque alpha.
+                model.geom_rgba[gid] = color if len(color) == 4 else [*color, 1.0]
                 changes.append(f"color → {model.geom_rgba[gid].tolist()}")
 
             if friction is not None:
-                fric = friction[:3] if len(friction) >= 3 else friction + [0.0] * (3 - len(friction))
-                model.geom_friction[gid] = fric
-                changes.append(f"friction → {fric}")
+                # Validated as exactly the three MuJoCo coefficients.
+                model.geom_friction[gid] = friction
+                changes.append(f"friction → {friction}")
 
             if size is not None:
-                n = min(len(size), 3)
-                model.geom_size[gid, :n] = size[:n]
+                # Validated as exactly the component count this geom's type
+                # defines; the unused tail of the 3-wide row stays as compiled.
+                model.geom_size[gid, : len(size)] = size
                 # geom_rbound (broadphase) and geom_aabb (mid-phase) are derived
                 # from geom_size at compile time and are not refreshed by the
                 # solver; without recomputing them a grown geom keeps its old,

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1947,7 +1947,9 @@ class MuJoCoSimEngine(
         )
         base["methods"]["set_geom_properties"] = (
             "(geom_name=None, geom_id=None, color=None, friction=None, size=None) "
-            "-> dict  # set a geom's color (RGBA), friction, or size; "
+            "-> dict  # set a geom's color (RGB or RGBA), friction (3: sliding, "
+            "torsional, rolling) or size (every component the geom type defines: "
+            "sphere 1, capsule/cylinder 2, box/ellipsoid/plane 3); "
             "domain-randomize appearance + contact dynamics (identify the geom by "
             "name or id)"
         )

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -739,8 +739,7 @@ class TestRuntimeModification:
     def test_set_geom_size_resizes_geom(self, sim):
         """set_geom_properties(size=...) writes the new half-extents into the
         live model so the next step / render sees the resized geom (no
-        recompile). Only the leading ``min(len(size), 3)`` entries are set,
-        matching MuJoCo's per-type geom_size layout."""
+        recompile). A box defines three half-extents, so all three are set."""
         geom_id = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_GEOM, "box_geom")
         result = sim.set_geom_properties(geom_name="box_geom", size=[0.25, 0.3, 0.35])
         assert result["status"] == "success"
@@ -750,16 +749,23 @@ class TestRuntimeModification:
         assert new_size[1] == pytest.approx(0.3)
         assert new_size[2] == pytest.approx(0.35)
 
-    def test_set_geom_size_shorter_than_three_leaves_tail_untouched(self, sim):
-        """A partial size list updates only the entries provided and leaves the
-        remaining half-extents at their compiled value."""
+    def test_set_geom_size_shorter_than_the_type_defines_is_rejected(self, sim):
+        """A size vector shorter than the geom's type defines is refused.
+
+        This previously wrote the components provided and left the rest at their
+        compiled value, so ``size=[0.2]`` on a box resized x only and reported
+        success for a box the caller never described (0.2 x old_y x old_z). There
+        is no meaningful value to invent for the omitted components, so the whole
+        write is refused and the compiled half-extents stay intact.
+        """
         geom_id = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_GEOM, "box_geom")
-        original_tail = float(sim._world._model.geom_size[geom_id][2])
+        original = sim._world._model.geom_size[geom_id].copy()
         result = sim.set_geom_properties(geom_name="box_geom", size=[0.2])
-        assert result["status"] == "success"
-        new_size = sim._world._model.geom_size[geom_id]
-        assert new_size[0] == pytest.approx(0.2)
-        assert float(new_size[2]) == pytest.approx(original_tail)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "exactly 3 component(s)" in text
+        assert "box" in text
+        assert sim._world._model.geom_size[geom_id] == pytest.approx(original)
 
     def test_set_geom_size_grow_recomputes_rbound_and_aabb(self, sim):
         """Growing a size-defined primitive refreshes its collision bounds.

--- a/tests/simulation/mujoco/test_set_geom_properties_vector_component_count.py
+++ b/tests/simulation/mujoco/test_set_geom_properties_vector_component_count.py
@@ -1,0 +1,273 @@
+"""``set_geom_properties`` honors every vector component or rejects the vector.
+
+``color`` / ``friction`` / ``size`` are vector-valued, and each targets a MuJoCo
+model buffer with a fixed component layout: ``geom_rgba`` is RGBA, ``geom_friction``
+is (sliding, torsional, rolling), and ``geom_size`` carries as many half-extents as
+the geom's compiled type defines. The mutator used to write whatever it was given,
+component by component:
+
+* ``size`` wrote ``geom_size[gid, :min(len(size), 3)]``, so a one-element vector
+  resized x on a box and left y/z at their compiled value - a shape the caller
+  never described, reported as ``status="success"``. A longer vector had its tail
+  silently discarded, and an empty one changed nothing while reporting a resize.
+* ``friction`` padded with zeros, so ``friction=[1.0]`` also zeroed the torsional
+  and rolling coefficients the caller never mentioned (and ``friction=[]`` made the
+  geom frictionless).
+* ``color`` appended an alpha to ``color[:3]``, so a one- or two-element vector
+  produced a 2/3-wide array and crashed with a bare NumPy broadcast ``ValueError``
+  past the tool envelope, while ``color=[]`` repainted the geom opaque white.
+
+These pin the contract: a vector whose component count cannot be honored is
+rejected with an actionable structured error, the model is left untouched, and the
+exact counts each type defines still apply.
+"""
+
+import mujoco
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco import Simulation
+
+# Inline scene with one geom per size-defined primitive plus a mesh geom whose
+# extent comes from asset data (vertices are inline, so no asset file is needed).
+_SCENE = """
+<mujoco>
+  <asset>
+    <mesh name="tetra" vertex="0 0 0  0.1 0 0  0 0.1 0  0 0 0.1"/>
+  </asset>
+  <worldbody>
+    <geom name="ground" type="plane" size="5 5 0.1"/>
+    <body name="b_box" pos="0 0 1"><freejoint/>
+      <geom name="box_g" type="box" size="0.1 0.15 0.2"/></body>
+    <body name="b_sphere" pos="1 0 1"><freejoint/>
+      <geom name="sphere_g" type="sphere" size="0.1"/></body>
+    <body name="b_capsule" pos="2 0 1"><freejoint/>
+      <geom name="capsule_g" type="capsule" size="0.05 0.2"/></body>
+    <body name="b_cylinder" pos="3 0 1"><freejoint/>
+      <geom name="cylinder_g" type="cylinder" size="0.05 0.2"/></body>
+    <body name="b_ellipsoid" pos="4 0 1"><freejoint/>
+      <geom name="ellipsoid_g" type="ellipsoid" size="0.1 0.2 0.3"/></body>
+    <body name="b_mesh" pos="5 0 1"><freejoint/>
+      <geom name="mesh_g" type="mesh" mesh="tetra"/></body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim():
+    """A sim whose scene carries one geom of every geom_size layout."""
+    s = Simulation(tool_name="test_geom_component_count", mesh=False)
+    s.create_world()
+    assert s.replace_scene_mjcf(_SCENE)["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _gid(sim, name):
+    return mujoco.mj_name2id(sim._world._model, mujoco.mjtObj.mjOBJ_GEOM, name)
+
+
+def _snapshot(sim, name):
+    model, gid = sim._world._model, _gid(sim, name)
+    return {
+        "size": model.geom_size[gid].copy(),
+        "friction": model.geom_friction[gid].copy(),
+        "rgba": model.geom_rgba[gid].copy(),
+        "rbound": float(model.geom_rbound[gid]),
+    }
+
+
+def _assert_untouched(sim, name, before):
+    after = _snapshot(sim, name)
+    for key in ("size", "friction", "rgba"):
+        assert after[key] == pytest.approx(before[key]), f"{key} was mutated by a rejected call"
+    assert after["rbound"] == pytest.approx(before["rbound"])
+
+
+@pytest.mark.parametrize(
+    ("geom", "bad_size"),
+    [
+        # Short: the omitted components would keep their compiled value.
+        ("box_g", [0.2]),
+        ("box_g", [0.2, 0.3]),
+        ("ellipsoid_g", [0.2, 0.3]),
+        ("capsule_g", [0.05]),
+        ("cylinder_g", [0.05]),
+        ("ground", [8.0, 8.0]),
+        # Long: the tail would be discarded.
+        ("box_g", [0.2, 0.3, 0.4, 0.5]),
+        ("sphere_g", [0.2, 0.3]),
+        ("capsule_g", [0.05, 0.2, 0.3]),
+        # Empty: nothing would be written at all.
+        ("box_g", []),
+        ("sphere_g", []),
+    ],
+)
+def test_size_component_count_mismatch_rejected_and_model_untouched(sim, geom, bad_size):
+    """A size vector that does not match the geom type's component count is refused."""
+    before = _snapshot(sim, geom)
+    result = sim.set_geom_properties(geom_name=geom, size=bad_size)
+    assert result["status"] == "error", f"{geom} accepted size={bad_size!r}"
+    _assert_untouched(sim, geom, before)
+
+
+@pytest.mark.parametrize(
+    ("geom", "expected", "layout_word"),
+    [
+        ("sphere_g", 1, "radius"),
+        ("capsule_g", 2, "half-length"),
+        ("cylinder_g", 2, "half-length"),
+        ("box_g", 3, "half-extents"),
+        ("ellipsoid_g", 3, "semi-axes"),
+        ("ground", 3, "grid spacing"),
+    ],
+)
+def test_size_error_names_the_type_its_count_and_its_layout(sim, geom, expected, layout_word):
+    """The error teaches the caller the exact vector the geom's type needs.
+
+    A component-count rejection is only actionable if it says how many components
+    this particular geom wants and what they mean - the count is type-dependent,
+    so a generic "wrong length" leaves the caller guessing.
+    """
+    result = sim.set_geom_properties(geom_name=geom, size=[0.1, 0.2, 0.3, 0.4])
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert f"exactly {expected} component(s)" in text
+    assert layout_word in text
+    assert "'size'" in text
+
+
+@pytest.mark.parametrize(
+    ("geom", "good_size", "expected_prefix"),
+    [
+        ("sphere_g", [0.3], [0.3]),
+        ("capsule_g", [0.06, 0.25], [0.06, 0.25]),
+        ("cylinder_g", [0.06, 0.25], [0.06, 0.25]),
+        ("box_g", [0.2, 0.3, 0.4], [0.2, 0.3, 0.4]),
+        ("ellipsoid_g", [0.15, 0.25, 0.4], [0.15, 0.25, 0.4]),
+        ("ground", [8.0, 8.0, 0.2], [8.0, 8.0, 0.2]),
+    ],
+)
+def test_exact_component_count_still_applies(sim, geom, good_size, expected_prefix):
+    """Every size-defined primitive still resizes when given its exact vector."""
+    result = sim.set_geom_properties(geom_name=geom, size=good_size)
+    assert result["status"] == "success", result["content"][0]["text"]
+    gid = _gid(sim, geom)
+    written = sim._world._model.geom_size[gid][: len(expected_prefix)].tolist()
+    assert written == pytest.approx(expected_prefix)
+
+
+def test_size_refused_for_a_geom_whose_extent_comes_from_its_asset(sim):
+    """A mesh geom defines no ``geom_size`` component, so ``size`` is refused.
+
+    ``geom_size`` is ignored by the compiler for mesh / height-field / SDF geoms:
+    their extent comes from the asset. Storing the requested value would report a
+    resize that never happens, so the call is refused and names the alternatives.
+    """
+    before = _snapshot(sim, "mesh_g")
+    result = sim.set_geom_properties(geom_name="mesh_g", size=[0.2, 0.2, 0.2])
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "mesh" in text
+    assert "asset" in text
+    assert "box" in text and "sphere" in text
+    _assert_untouched(sim, "mesh_g", before)
+
+
+@pytest.mark.parametrize("bad_friction", [[], [1.0], [1.0, 0.5]])
+def test_partial_friction_rejected_instead_of_zero_padded(sim, bad_friction):
+    """A friction vector shorter than three coefficients is refused, not padded.
+
+    Zero-padding silently replaced the torsional and rolling coefficients with 0.0,
+    which is not MuJoCo's default and lets a resting object spin and roll freely -
+    a contact model the caller never asked for under a success result.
+    """
+    before = _snapshot(sim, "box_g")
+    result = sim.set_geom_properties(geom_name="box_g", friction=bad_friction)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "exactly 3 component(s)" in text
+    assert "sliding, torsional, rolling" in text
+    _assert_untouched(sim, "box_g", before)
+
+
+def test_full_friction_vector_still_applies(sim):
+    """The three-coefficient vector is written verbatim."""
+    result = sim.set_geom_properties(geom_name="box_g", friction=[0.8, 0.02, 0.002])
+    assert result["status"] == "success"
+    gid = _gid(sim, "box_g")
+    assert sim._world._model.geom_friction[gid].tolist() == pytest.approx([0.8, 0.02, 0.002])
+
+
+@pytest.mark.parametrize("bad_color", [[], [0.5], [0.5, 0.5], [1.0, 0.0, 0.0, 1.0, 1.0]])
+def test_color_component_count_mismatch_rejected_not_raised(sim, bad_color):
+    """A color that is not RGB or RGBA returns a structured error, never raises.
+
+    One- and two-element colors used to reach ``geom_rgba[gid] = color[:3] + [1.0]``
+    and crash with a bare NumPy broadcast ``ValueError`` past the tool envelope,
+    while an empty color repainted the geom opaque white and a five-element one had
+    its tail dropped.
+    """
+    before = _snapshot(sim, "box_g")
+    result = sim.set_geom_properties(geom_name="box_g", color=bad_color)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "exactly 3 or 4 component(s)" in text
+    assert "'color'" in text
+    _assert_untouched(sim, "box_g", before)
+
+
+@pytest.mark.parametrize(
+    ("color", "expected_rgba"),
+    [
+        ([0.2, 0.4, 0.6], [0.2, 0.4, 0.6, 1.0]),
+        ([0.2, 0.4, 0.6, 0.5], [0.2, 0.4, 0.6, 0.5]),
+    ],
+)
+def test_rgb_and_rgba_colors_still_apply(sim, color, expected_rgba):
+    """RGB gets an opaque alpha; RGBA is written verbatim."""
+    result = sim.set_geom_properties(geom_name="box_g", color=color)
+    assert result["status"] == "success"
+    gid = _gid(sim, "box_g")
+    assert sim._world._model.geom_rgba[gid].tolist() == pytest.approx(expected_rgba, abs=1e-6)
+
+
+def test_rejected_vector_does_not_partially_apply_the_other_vectors(sim):
+    """Validation precedes every write, so one bad vector aborts the whole call.
+
+    ``color`` / ``friction`` / ``size`` are applied under a single lock; a valid
+    color must not land while an unusable size is rejected, or the caller has to
+    reason about which half of its request survived.
+    """
+    before = _snapshot(sim, "box_g")
+    result = sim.set_geom_properties(
+        geom_name="box_g",
+        color=[1.0, 0.0, 0.0, 1.0],
+        friction=[0.9, 0.01, 0.001],
+        size=[0.2],
+    )
+    assert result["status"] == "error"
+    _assert_untouched(sim, "box_g", before)
+
+
+def test_grown_box_still_recomputes_collision_bounds(sim):
+    """The exact-count path keeps the broadphase/mid-phase bound recompute."""
+    model = sim._world._model
+    gid = _gid(sim, "box_g")
+    result = sim.set_geom_properties(geom_name="box_g", size=[0.25, 0.25, 0.02])
+    assert result["status"] == "success"
+    assert float(model.geom_rbound[gid]) == pytest.approx(float(np.linalg.norm([0.25, 0.25, 0.02])))
+    assert model.geom_aabb[gid][3:6].tolist() == pytest.approx([0.25, 0.25, 0.02])
+
+
+def test_describe_advertises_the_component_counts(sim):
+    """describe() teaches the counts, so a caller need not discover them by trial.
+
+    The component count is type-dependent and cannot be guessed from the signature,
+    which is exactly the knowledge gap that produced partial-vector calls.
+    """
+    advertised = sim.describe()["methods"]["set_geom_properties"]
+    assert "RGB" in advertised
+    assert "sliding" in advertised
+    assert "sphere 1" in advertised


### PR DESCRIPTION
## Problem

`set_geom_properties(color=, friction=, size=)` writes into MuJoCo buffers with fixed component layouts - `geom_rgba` is RGBA, `geom_friction` is (sliding, torsional, rolling), and `geom_size` carries as many half-extents as the geom's compiled *type* defines. The mutator wrote whatever it was given, component by component: `geom_size[gid, :min(len(size), 3)]`, `friction + [0.0] * (3 - len(friction))`, and `color[:3] + [1.0]`. A vector that did not match its target layout was therefore applied as a mix of the caller's components and fabricated ones - under a `status="success"` result - or crashed outright.

On a box compiled at half-extents `0.1 / 0.15 / 0.2`:

```python
sim.set_geom_properties(geom_name="crate", size=[0.5])
# success: "size -> [0.5, 0.15, 0.2]"     only x applied; y/z are the compiled values
sim.set_geom_properties(geom_name="crate", size=[])
# success: "size -> [0.5, 0.15, 0.2]"     nothing written, a resize reported
sim.set_geom_properties(geom_name="crate", size=[0.11, 0.12, 0.13, 0.14, 0.15])
# success: "size -> [0.11, 0.12, 0.13]"   tail silently discarded
sim.set_geom_properties(geom_name="crate", friction=[1.0])
# success: "friction -> [1.0, 0.0, 0.0]" torsional 0.5 and rolling 0.001 zeroed
sim.set_geom_properties(geom_name="crate", friction=[])
# success: "friction -> [0.0, 0.0, 0.0]" a frictionless geom from an empty list
sim.set_geom_properties(geom_name="crate", color=[])
# success: "color -> [1.0, 1.0, 1.0, 1.0]" repainted opaque white
sim.set_geom_properties(geom_name="crate", color=[0.5])
# ValueError: could not broadcast input array from shape (2,) into shape (4,)
#             raised past the tool envelope
```

Each case is a value the caller never asked for: a partial `size` produces a geometry nobody described (and the derived `geom_rbound` / `geom_aabb` are then recomputed for it, so collision follows the wrong shape); zero-padded `friction` is not MuJoCo's default and lets a resting object spin and roll freely; and the 1-2 element `color` path violates the tool contract by raising past dispatch. The finite / positive element checks were already in place - only the component count was unvalidated (`_coerce_finite_vector` explicitly deferred it).

## Change

`_coerce_finite_vector` gains an `accepted_lengths` contract, and `set_geom_properties` validates every vector's count before any model write, so the call stays all-or-nothing:

| Parameter | Accepted components |
|---|---|
| `color` | 3 (RGB, alpha set to 1.0) or 4 (RGBA) |
| `friction` | 3 (sliding, torsional, rolling) - MuJoCo has no per-component default to fall back on |
| `size` | exactly what the geom's compiled type defines: sphere 1, capsule/cylinder 2, box/ellipsoid/plane 3 |

A mesh / height-field / SDF geom takes its extent from asset data and defines no `geom_size` component, so `size` is refused for it and the error names the size-defined alternatives (previously the value was stored and reported as a resize that never happens).

Because the count is type-dependent, the error has to teach it:

```
set_geom_properties: 'size' must have exactly 3 component(s) (box: three half-extents),
got 1: [0.4]. Pass every component - a partial 'size' cannot be applied without
inventing the missing values.
```

`describe()` now advertises the counts (`color (RGB or RGBA)`, `friction (3: sliding, torsional, rolling)`, `size (sphere 1, capsule/cylinder 2, box/ellipsoid/plane 3)`) so a caller does not have to discover them by trial. The write paths simplify accordingly - no slicing, no padding, no invented alpha - and the exact-count calls that already worked are unchanged, including the broadphase/mid-phase bound recompute on a grown primitive.

## Visual verification

MuJoCo rollout in sim (headless EGL). A caller asks for a 0.4 cube with `size=[0.4]`, then the object settles on the floor.

![set_geom_properties size component count: before vs after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/geom-size-component-count/geom_size_component_count.png)

| | `size=[0.4]` result | compiled half-extents | resting z |
|---|---|---|---|
| before | `status=success` | `0.4 x 0.075 x 0.1` (plank) | `0.0999` |
| after | `status=error`, then `size=[0.4, 0.4, 0.4]` | `0.4 x 0.4 x 0.4` (cube) | `0.3895` |

## Tests

`tests/simulation/mujoco/test_set_geom_properties_vector_component_count.py` (37 cases, one geom per `geom_size` layout plus an inline-vertex mesh geom):

- short / long / empty `size` rejected for box, sphere, capsule, cylinder, ellipsoid and plane, with `geom_size`, `geom_friction`, `geom_rgba` and `geom_rbound` all unchanged;
- the error names the type, its component count and the component meanings;
- exact-count `size` still resizes each primitive, and a grown box still recomputes `geom_rbound` / `geom_aabb`;
- `size` refused on a mesh geom, naming the asset as the extent source;
- partial `friction` rejected instead of zero-padded; the 3-coefficient vector still applies;
- 0/1/2/5-element `color` returns a structured error instead of raising; RGB gains an opaque alpha and RGBA is written verbatim;
- one unusable vector aborts the whole call, so a valid `color` does not land beside a rejected `size`;
- `describe()` advertises the counts.

`tests/simulation/mujoco/test_physics.py::TestRuntimeModification::test_set_geom_size_shorter_than_three_leaves_tail_untouched` pinned the old partial write as intended behavior; it is renamed to `test_set_geom_size_shorter_than_the_type_defines_is_rejected` and its docstring states why the contract flipped.

Pre-fix, against this branch's tests on `main`: **28 failed, 10 passed** (two of the failures are the bare `ValueError` broadcast crashes). Post-fix: **37 passed**.

Full suite: `MUJOCO_GL=egl python -m pytest tests` -> **11934 passed, 254 skipped** (11897 on `main` + 37 new). Gate clean: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ`.

## Docs

`docs/simulation/domain-randomization.md` gains a "Targeted per-geom / per-body perturbation" section with the accepted-component table and the rejection example, plus a CHANGELOG entry.