### PR TITLE
fix(sim): add_object rejects a mass it cannot honor and never bricks the scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `add_object` rejects a mass it cannot honor, and a refused add never bricks the scene
+
+`add_object` validated `position`, `orientation`, `color` and `size` but wrote
+`mass` straight into the spec, even though `set_body_properties` - which writes
+the same `body_mass` field - has always required a finite value `> 0`:
+
+```python
+sim.add_object("neighbour", shape="box", position=[0, 0, 0.6], mass=1.0)
+sim.add_object("blackhole", shape="box", position=[0.4, 0, 0.6], mass=float("inf"))
+# -> success. One step later every qpos/qvel in the world is nan, including
+#    'neighbour', which stops falling and never moves again.
+```
+
+`mass=0`, negatives and `nan` took the other route: the recompile refused them
+and the result read `Failed to inject 'crate': spec recompile refused.` -
+MuJoCo's actual reason ("mass and inertia of moving bodies must be larger than
+mjMINVAL") only reached the log. A positive mass below `mjMINVAL` behaved the
+same way.
+
+Worse, a mass the spec write itself rejected (a non-numeric value) raised
+*after* the body had been inserted, and the injector rolled back only the mesh
+asset. The half-built body stayed in the spec, so every later scene mutation
+failed to recompile - a valid `add_object`, an `add_camera`, anything - and one
+bad call bricked the world for good. An unsupported `shape` leaked the same way
+(its type lookup also raises after the insert), leaving the name permanently
+taken so a corrected retry failed with `repeated name`.
+
+Now the mass domain is a shared `SimEngine._validate_mass` used by both
+`add_object` and `set_body_properties` (their accepted values cannot diverge),
+MuJoCo's `mjMINVAL` floor is named rather than left to the compiler, and
+`SpecBuilder.add_object` is atomic over its own mutation: a raise after the body
+is inserted (an unsupported shape, or a name that collides with a body already
+in the scene) rolls back only the body this call added and re-raises, so the
+error a caller receives is the actual reason and the object name stays reusable.
+The rollback deletes the surplus body by enumeration rather than by name: on a
+name collision MuJoCo raises `repeated name` but still inserts the duplicate,
+and resolving the name would have deleted the pre-existing healthy body and left
+the empty orphan holding its name - corrupting the very scene the guard protects.
+`SpecBuilder.remove_body` also scans `spec.bodies` when `spec.body(name)` cannot
+see a body added since the last compile - previously such a rollback silently
+removed nothing. `mass` remains ignored for `is_static=True` objects, where
+MuJoCo derives it from the geom density.
+
 ### Fixed: `add_object` honors every `color` component or rejects the vector
 
 A MuJoCo geom stores its colour in a 4-component `rgba` row, so only an RGB

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -159,6 +159,31 @@ sim.add_object("crate", shape="box", size=[0.5])
 sim.add_object("crate", shape="box", size=[0.5, 0.5, 0.5])   # 50 cm crate
 ```
 
+## Object mass
+
+`mass` (kg) applies to dynamic objects and must be a finite number greater than
+zero - the same domain `set_body_properties(mass=...)` enforces when it writes
+the same body. A mass outside it is rejected up front, naming the parameter,
+instead of surfacing as a recompile failure:
+
+```python
+sim.add_object("crate", shape="box", mass=0)
+# status=error: add_object: 'mass' must be a finite number > 0, got 0.0
+sim.add_object("crate", shape="box", mass=1e-16)
+# status=error: add_object: 'mass' must be >= MuJoCo's mjMINVAL (1e-15 kg) ...
+```
+
+This matters beyond the one object: a body's mass divides every force acting on
+it, and the solver keeps a single state vector, so an infinite mass turns the
+whole world's `qpos`/`qvel` to `nan` on the next step - every other body
+included. `is_static=True` needs no mass (MuJoCo derives it from the geom's
+density), so `mass` is ignored there.
+
+Whatever the reason for a rejection - mass, `size`, an unsupported `shape`, an
+unloadable mesh - the scene is rolled back to its previous compilable state and
+the object name stays reusable, so a corrected retry under the same name works
+and one bad add never bricks later scene edits.
+
 ## Mesh objects
 
 Beyond primitives, `add_object` can inject a triangle-mesh asset (STL/OBJ) into

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -551,6 +551,12 @@ class SimEngine(ABC):
         the backend's default colour paints a surface the caller never asked
         for under a success result.
 
+        ``mass`` must be a finite number greater than zero for a dynamic
+        object. A backend MUST NOT establish a body on a mass its own
+        ``set_body_properties`` would refuse: a non-finite mass makes the first
+        integration step produce ``nan`` and, because the solver shares one
+        state vector, poisons every other body in the world too.
+
         ``material`` (optional): backend-specific visual material/texture
         spec. ``None`` keeps the flat ``color`` rgba (unchanged); a backend
         that supports it (MuJoCo) attaches a real material so surfaces can be
@@ -1102,6 +1108,53 @@ class SimEngine(ABC):
             return {"status": "error", "content": [{"text": message}]}
         if not math.isfinite(value) or value <= 0:
             return {"status": "error", "content": [{"text": message}]}
+        return None
+
+    @staticmethod
+    def _validate_mass(mass: Any, method: str, param: str = "mass") -> dict[str, Any] | None:
+        """Reject a body mass the physics engine cannot honor.
+
+        A dynamic body's mass is the divisor of every force applied to it, so a
+        value outside ``(0, inf)`` does not merely mis-size one object - it
+        poisons the whole world on the next step. ``inf`` makes the very first
+        integration produce ``nan`` acceleration, and because the solver shares
+        one state vector, every *other* body's ``qpos``/``qvel`` goes ``nan``
+        with it. ``0`` and negatives violate MuJoCo's
+        "mass and inertia of moving bodies must be larger than mjMINVAL"
+        invariant, which surfaces as a compile refusal that names neither the
+        parameter nor the reason. This is the same domain
+        :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.set_body_properties`
+        already enforces when it writes the same ``body_mass`` field, so a mass
+        cannot be established at creation on terms the setter would refuse.
+
+        Args:
+            mass: The caller-supplied value. Anything ``float()`` accepts is
+                coerced (so a NumPy scalar passes); ``bool`` is rejected
+                explicitly since ``True`` would act as a silent 1 kg body.
+            method: Public method name, used to prefix the error message.
+            param: Parameter name to quote in the message.
+
+        Returns:
+            A structured ``{"status": "error", ...}`` dict to surface, or
+            ``None`` when the value is usable.
+        """
+        if isinstance(mass, bool):
+            return {
+                "status": "error",
+                "content": [{"text": f"{method}: '{param}' must be a positive number, got {mass!r}"}],
+            }
+        try:
+            value = float(mass)
+        except (TypeError, ValueError):
+            return {
+                "status": "error",
+                "content": [{"text": f"{method}: '{param}' must be a positive number, got {mass!r}"}],
+            }
+        if not math.isfinite(value) or value <= 0:
+            return {
+                "status": "error",
+                "content": [{"text": f"{method}: '{param}' must be a finite number > 0, got {value}"}],
+            }
         return None
 
     @staticmethod

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -362,11 +362,19 @@ class PhysicsMixin:
         _lock: "threading.RLock"
         _world: "SimWorld | None"
 
-        def _require_no_running_policy(
-            self, action_name: str, robot_name: str | None = None
-        ) -> dict[str, Any] | None: ...
-        def _require_world(self) -> dict[str, Any] | None: ...
-        def _unknown_robot_msg(self, requested: str) -> str: ...
+        # Bodies are one-line docstrings rather than ``...`` because an
+        # ellipsis body is an expression statement with no effect.
+        def _require_no_running_policy(self, action_name: str, robot_name: str | None = None) -> dict[str, Any] | None:
+            """Refuse a mutation while a policy thread is stepping the world."""
+
+        def _require_world(self) -> dict[str, Any] | None:
+            """Refuse a call made before ``create_world``."""
+
+        def _unknown_robot_msg(self, requested: str) -> str:
+            """Build the "robot not found" message with close-match hints."""
+
+        def _validate_mass(self, mass: Any, method: str, param: str = "mass") -> dict[str, Any] | None:
+            """Reject a body mass the physics engine cannot honor."""
 
     # State Checkpointing
 
@@ -1479,20 +1487,12 @@ class PhysicsMixin:
         if err := self._require_no_running_policy("set_body_properties"):
             return err
 
-        # mass must be > 0 (physics invariant)
+        # mass must be > 0 (physics invariant). Shared with add_object so a
+        # mass cannot be established at creation on terms this setter refuses.
         if mass is not None:
-            try:
-                mass = float(mass)
-            except (TypeError, ValueError):
-                return {
-                    "status": "error",
-                    "content": [{"text": f"set_body_properties: 'mass' must be a positive number, got {mass!r}"}],
-                }
-            if not math.isfinite(mass) or mass <= 0:
-                return {
-                    "status": "error",
-                    "content": [{"text": f"set_body_properties: 'mass' must be a finite number > 0, got {mass}"}],
-                }
+            if err := self._validate_mass(mass, "set_body_properties"):
+                return err
+            mass = float(mass)
 
         mj = _ensure_mujoco()
         model = self._world._model

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -183,6 +183,14 @@ def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
     Without the rollback the orphan lingers and every later scene mutation,
     including a corrected retry under the same name, keeps failing to recompile
     (``repeated name`` collisions), bricking the whole scene after one bad add.
+
+    The same rollback applies when ``SpecBuilder.add_object`` itself raises
+    part-way through, which it can do *after* inserting the body (the geom's
+    type lookup rejects an unsupported shape; the mass write rejects a
+    non-numeric value). That error is then re-raised rather than folded into a
+    ``False`` return, so the caller can report the actual reason - a swallowed
+    ``ValueError`` left the caller with nothing but "spec recompile refused"
+    while the actionable message went to the log.
     """
     spec = _get_spec(world)
     if spec is None or world._model is None:
@@ -196,10 +204,17 @@ def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
         if obj.shape == "mesh" and obj.mesh_path:
             spec.add_mesh(name=f"mesh_{obj.name}", file=obj.mesh_path)
         SpecBuilder.add_object(spec, obj)
-    except (ValueError, RuntimeError) as e:
-        logger.error("Object add failed for '%s': %s", obj.name, e)
+    except (ValueError, RuntimeError):
+        # add_object is atomic over its own body mutation: a raise there (an
+        # unsupported shape, or a name that collides with an existing scene
+        # body) rolls the half-built body back out itself, so only the mesh
+        # asset registered here still needs undoing. Removing it keeps the spec
+        # compilable, then the error propagates: the caller turns it into a
+        # structured result, and the reason - e.g. the exact unsupported shape
+        # and the supported list - is what a caller needs instead of a generic
+        # recompile refusal.
         SpecBuilder.remove_mesh(spec, f"mesh_{obj.name}")
-        return False
+        raise
 
     if not _recompile_preserving_state(world, spec):
         # Roll the just-added body (and any mesh asset) back out so the spec

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2401,8 +2401,9 @@ class MuJoCoSimEngine(
                 than completed from the backend default, because a completed
                 colour paints a surface the caller never asked for while
                 reporting success.
-            mass: Body mass in kg for dynamic objects (default 0.1); ignored when
-                ``is_static``.
+            mass: Body mass in kg for dynamic objects (default 0.1); must be a
+                finite number > 0 (the same domain ``set_body_properties``
+                enforces). Ignored when ``is_static``.
             is_static: Fix the body in the world. ``shape="plane"`` forces this
                 True; other shapes default to dynamic.
             mesh_path: Mesh asset path; required and only used when
@@ -2415,8 +2416,9 @@ class MuJoCoSimEngine(
             ``size`` contains a non-finite (``nan``/``inf``) or non-numeric
             element or ``position``/``orientation``/``color`` is the wrong length
             (3 / 4 / 3-or-4), ``size`` has a non-positive extent or a component
-            count the shape cannot consume, ``shape="mesh"`` is missing
-            ``mesh_path``, or the recompile fails.
+            count the shape cannot consume, ``mass`` is not a finite number > 0
+            for a dynamic object, ``shape="mesh"`` is missing ``mesh_path``, or
+            the recompile fails.
 
         Example:
             >>> sim.add_object("cube", shape="box", size=[0.05, 0.05, 0.05])  # 5 cm cube
@@ -2506,6 +2508,38 @@ class MuJoCoSimEngine(
         # caller gets a clear error rather than a confusing recompile failure.
         if size is not None and (size_err := _validate_size(shape, list(size))) is not None:
             return {"status": "error", "content": [{"text": size_err}]}
+
+        # A dynamic body's mass divides every force acting on it, so a value
+        # outside (0, inf) is unusable: inf compiled successfully and made the
+        # first step produce nan, which the shared state vector then spread to
+        # every OTHER body in the world, while 0/negative/nan aborted the
+        # recompile with a generic "spec recompile refused" that named neither
+        # the parameter nor MuJoCo's mjMINVAL invariant. Checked only for a
+        # dynamic body, which is where the value reaches body_mass - a static
+        # body has no mass in the compiled model, and the result says "static"
+        # rather than quoting a mass, so nothing is silently dishonored there.
+        if not is_static:
+            if (mass_err := self._validate_mass(mass, "add_object")) is not None:
+                return mass_err
+            # MuJoCo additionally refuses to compile a moving body lighter than
+            # mjMINVAL ("mass and inertia of moving bodies must be larger than
+            # mjMINVAL"), which is the last mass value that reached the generic
+            # recompile refusal. Name the floor instead, so every mass this
+            # method accepts is one the compiler accepts.
+            minimum = float(_ensure_mujoco().mjMINVAL)
+            if float(mass) < minimum:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"add_object: 'mass' must be >= MuJoCo's mjMINVAL ({minimum:g} kg) "
+                                f"for a dynamic body, got {float(mass)!r}; a lighter body cannot be "
+                                "integrated. Use is_static=True for an immovable body."
+                            )
+                        }
+                    ],
+                }
 
         # A material key the builder cannot honor (typo / another renderer's
         # field name) would otherwise be dropped and the object would compile

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -526,38 +526,56 @@ class SpecBuilder:
         # leaves an orphan body behind.
         material_name = SpecBuilder._build_material(spec, obj) if obj.material is not None else None
 
-        body = spec.worldbody.add_body(
-            name=obj.name,
-            pos=list(obj.position),
-            quat=list(obj.orientation),
-        )
+        # ``add_body(name=...)`` raises ``repeated name`` on a collision with an
+        # existing scene body BUT still inserts the duplicate, and the steps
+        # after it (the geom type lookup, ``add_geom``) can raise as well. Any
+        # raise in this block must undo only what THIS call inserted, then
+        # re-raise so the caller reports the real reason. Deleting by name
+        # (``spec.body(name)`` / :meth:`remove_body`) is unsafe on the collision
+        # path: that accessor resolves the ORIGINAL body present at the last
+        # compile, so it would delete the pre-existing healthy body and leave
+        # the empty orphan holding its name - a silent scene corruption. Instead
+        # record how many bodies already carry this name and, on failure, delete
+        # only the surplus this call produced (the orphan is appended, so it is
+        # the tail of that run). This can never touch a body it did not create.
+        pre_count = sum(1 for b in spec.bodies if b.name == obj.name)
+        try:
+            body = spec.worldbody.add_body(
+                name=obj.name,
+                pos=list(obj.position),
+                quat=list(obj.orientation),
+            )
 
-        if not obj.is_static:
-            body.add_freejoint(name=f"{obj.name}_joint")
-            body.mass = float(obj.mass)
-            body.inertia = [0.001, 0.001, 0.001]
-            body.ipos = [0.0, 0.0, 0.0]
-            body.explicitinertial = True
+            if not obj.is_static:
+                body.add_freejoint(name=f"{obj.name}_joint")
+                body.mass = float(obj.mass)
+                body.inertia = [0.001, 0.001, 0.001]
+                body.ipos = [0.0, 0.0, 0.0]
+                body.explicitinertial = True
 
-        geom_kwargs: dict[str, Any] = {
-            "name": f"{obj.name}_geom",
-            "type": _geom_type(obj.shape),
-            "rgba": list(obj.color),
-            "condim": 3,
-        }
-        if obj.shape == "mesh":
-            geom_kwargs["meshname"] = f"mesh_{obj.name}"
-        else:
-            geom_kwargs["size"] = _normalize_size(obj.shape, list(obj.size))
+            geom_kwargs: dict[str, Any] = {
+                "name": f"{obj.name}_geom",
+                "type": _geom_type(obj.shape),
+                "rgba": list(obj.color),
+                "condim": 3,
+            }
+            if obj.shape == "mesh":
+                geom_kwargs["meshname"] = f"mesh_{obj.name}"
+            else:
+                geom_kwargs["size"] = _normalize_size(obj.shape, list(obj.size))
 
-        # Legacy code only set explicit friction on boxes; preserve parity.
-        if obj.shape == "box":
-            geom_kwargs["friction"] = [1.0, 0.5, 0.001]
+            # Legacy code only set explicit friction on boxes; preserve parity.
+            if obj.shape == "box":
+                geom_kwargs["friction"] = [1.0, 0.5, 0.001]
 
-        if material_name is not None:
-            geom_kwargs["material"] = material_name
+            if material_name is not None:
+                geom_kwargs["material"] = material_name
 
-        body.add_geom(**geom_kwargs)
+            body.add_geom(**geom_kwargs)
+        except (ValueError, RuntimeError):
+            for surplus in [b for b in spec.bodies if b.name == obj.name][pre_count:]:
+                spec.delete(surplus)
+            raise
 
     # material build
     @staticmethod
@@ -734,15 +752,31 @@ class SpecBuilder:
         Returns ``True`` if the body existed and was removed, ``False``
         otherwise (to match the legacy scene_ops API).
 
+        ``spec.body(name)`` only resolves bodies that existed at the last
+        ``compile()``/``recompile()``, so a body added since then - including
+        one this class inserted moments ago, before the validating recompile -
+        is invisible to it and enumerated only by ``spec.bodies``. Both lookups
+        are therefore tried: without the enumeration fallback a rollback of a
+        just-added body silently removed nothing, leaving an orphan that made
+        every later recompile fail on the duplicate name. This mirrors
+        :func:`~strands_robots.simulation.mujoco.scene_ops._find_body` and the
+        parent-body lookup in :meth:`add_camera`.
+
         Note: this removes ONLY the body; any actuators/sensors referencing
         its joints must be cleaned up separately via :meth:`remove_refs_by_prefix`.
         That's only needed for robots - for plain object bodies there are
         no actuators/sensors tied to them.
         """
+        body = None
         try:
             body = spec.body(name)
         except (KeyError, ValueError):
-            return False
+            body = None
+        if body is None:
+            for candidate in getattr(spec, "bodies", ()):
+                if candidate.name == name:
+                    body = candidate
+                    break
         if body is None:
             return False
         spec.delete(body)

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -160,7 +160,8 @@
       "description": "Colour in 0..1: [r, g, b] (opaque alpha added) or [r, g, b, a]. Any other component count, including an empty list, is rejected - omit color entirely for the default mid-grey."
     },
     "mass": {
-      "type": "number"
+      "type": "number",
+      "description": "Body mass in kg for add_object (default 0.1). Dynamic objects need a finite value > 0 and >= MuJoCo's mjMINVAL (1e-15); anything else is rejected, since a non-finite mass turns the whole world's state to nan on the next step. Ignored when is_static=true (MuJoCo derives the mass from the geom density)."
     },
     "is_static": {
       "type": "boolean"

--- a/tests/simulation/mujoco/test_add_object_mass_contract.py
+++ b/tests/simulation/mujoco/test_add_object_mass_contract.py
@@ -1,0 +1,199 @@
+"""``add_object`` accepts only a mass the compiled model can carry.
+
+A dynamic body's mass divides every force applied to it, and MuJoCo keeps one
+state vector for the whole world, so a mass outside the usable domain is not a
+local mistake - it takes the entire scene with it. ``add_object`` used to write
+whatever it was handed straight into the spec:
+
+* ``mass=inf`` compiled and reported ``status="success"``. The first ``step``
+  produced ``nan`` acceleration, and every *other* body's ``qpos``/``qvel``
+  went ``nan`` with it - a 1 kg neighbour added before the bad object stopped
+  falling and never moved again.
+* ``mass=0`` / negatives / ``nan`` aborted the recompile, surfacing as
+  ``"Failed to inject 'x': spec recompile refused."``. MuJoCo's actual reason
+  ("mass and inertia of moving bodies must be larger than mjMINVAL") went to
+  the log only, so the result named neither the parameter nor the rule.
+* ``0 < mass < mjMINVAL`` was refused by the compiler for the same reason and
+  reached the same generic message.
+* A non-numeric mass raised inside the spec mutation *after* the body had been
+  inserted. The injector rolled back only the mesh asset, so the half-built
+  body stayed in the spec and every later scene mutation - a valid
+  ``add_object``, an ``add_camera`` - failed to recompile. One bad call bricked
+  the world.
+
+The same orphan leak applied to an unsupported ``shape``: its type lookup also
+raises after the body is inserted, so the name stayed permanently taken and a
+corrected retry failed with ``repeated name``.
+
+The domain enforced here is the one
+:meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.set_body_properties`
+already applied when writing the same ``body_mass`` field (finite, ``> 0``),
+plus MuJoCo's compile-time ``mjMINVAL`` floor, so a mass cannot be established
+at creation on terms the setter would refuse.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_add_object_mass", mesh=False)
+    s.create_world()
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _body_mass(sim: Simulation, name: str) -> float:
+    assert sim._world is not None and sim._world._model is not None
+    model = sim._world._model
+    body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    assert body_id >= 0, f"body {name!r} missing from the compiled model"
+    return float(model.body_mass[body_id])
+
+
+class TestAddObjectMassDomain:
+    def test_infinite_mass_is_refused_and_the_rest_of_the_world_keeps_stepping(self, sim):
+        """The decisive case: ``inf`` used to compile and NaN the whole world.
+
+        A 1 kg neighbour is added first, so the assertion is about the world and
+        not just the rejected object: pre-fix the ``inf`` add returned success
+        and after a single step every ``qpos``/``qvel`` element was ``nan``,
+        freezing the neighbour in mid-air.
+        """
+        assert sim.add_object("neighbour", shape="box", position=[0.0, 0.0, 0.6], mass=1.0)["status"] == "success"
+
+        result = sim.add_object("blackhole", shape="box", position=[0.4, 0.0, 0.6], mass=float("inf"))
+        assert result["status"] == "error", result
+        assert "'mass'" in result["content"][0]["text"]
+        assert "blackhole" not in sim._world.objects
+
+        assert sim.step(200)["status"] == "success"
+        data = sim._world._data
+        assert np.all(np.isfinite(data.qpos)), "physics state was poisoned"
+        assert np.all(np.isfinite(data.qvel)), "physics state was poisoned"
+        # The surviving body actually fell instead of being frozen by NaNs.
+        neighbour_id = mujoco.mj_name2id(sim._world._model, mujoco.mjtObj.mjOBJ_BODY, "neighbour")
+        assert float(data.xpos[neighbour_id][2]) < 0.5
+
+    @pytest.mark.parametrize("bad", [-1.0, 0.0, float("nan"), -float("inf")])
+    def test_unusable_mass_names_the_parameter_instead_of_refusing_the_recompile(self, sim, bad):
+        result = sim.add_object("crate", shape="box", mass=bad)
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "add_object" in text and "'mass'" in text
+        assert "spec recompile refused" not in text
+        assert "crate" not in sim._world.objects
+        # The scene was never mutated, so the name is still free.
+        assert sim.add_object("crate", shape="box", mass=1.0)["status"] == "success"
+
+    def test_mass_below_the_compiler_floor_names_the_floor(self, sim):
+        """``0 < mass < mjMINVAL`` is positive yet uncompilable; say so."""
+        result = sim.add_object("dust", shape="box", mass=1e-16)
+        assert result["status"] == "error", result
+        assert "mjMINVAL" in result["content"][0]["text"]
+        # The floor itself is accepted, so the boundary is not over-tightened.
+        assert sim.add_object("speck", shape="box", mass=float(mujoco.mjMINVAL))["status"] == "success"
+
+    def test_non_numeric_mass_leaves_the_scene_usable(self, sim):
+        """Pre-fix this raised mid-mutation and bricked every later scene edit."""
+        result = sim.add_object("junk", shape="box", mass="heavy")
+        assert result["status"] == "error", result
+        assert "'mass'" in result["content"][0]["text"]
+
+        assert sim.add_object("cube", shape="box", position=[0.2, 0.0, 0.1], mass=1.0)["status"] == "success"
+        assert sim.add_camera("side", position=[1.0, 0.0, 0.5], target=[0.0, 0.0, 0.1])["status"] == "success"
+
+    def test_valid_mass_reaches_the_compiled_model(self, sim):
+        assert sim.add_object("crate", shape="box", position=[0.0, 0.0, 0.3], mass=2.5)["status"] == "success"
+        assert _body_mass(sim, "crate") == pytest.approx(2.5)
+
+    def test_static_object_ignores_mass_by_design(self, sim):
+        """A static body's mass never comes from the parameter.
+
+        Without a freejoint no explicit inertial block is written, so MuJoCo
+        derives the body mass from the geom's default density (1000 kg/m^3 x a
+        5 cm cube = 0.125 kg) whatever ``mass`` said. The guard therefore fires
+        only where the value reaches ``body_mass`` - a dynamic body - and a
+        static add keeps reporting ``static`` rather than quoting a mass, so
+        nothing is silently dishonored: the parameter is documented as ignored
+        for every value, not just this one.
+        """
+        result = sim.add_object("floor_tile", shape="box", mass=-1.0, is_static=True)
+        assert result["status"] == "success", result
+        assert "static" in result["content"][0]["text"]
+        assert _body_mass(sim, "floor_tile") == pytest.approx(0.125)
+
+
+class TestAddObjectRaisePathRollback:
+    def test_unsupported_shape_reports_the_shape_and_frees_the_name(self, sim):
+        """The shape lookup raises after the body is inserted.
+
+        Pre-fix the actionable message went to the log, the result said only
+        "spec recompile refused", and the orphan body kept the name for good -
+        the corrected retry failed with ``repeated name``.
+        """
+        result = sim.add_object("crate", shape="blob")
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "blob" in text
+        assert "box" in text and "sphere" in text, "the supported shapes should be listed"
+
+        retry = sim.add_object("crate", shape="box", position=[0.0, 0.0, 0.3], size=[0.2, 0.2, 0.2], mass=1.0)
+        assert retry["status"] == "success", retry
+        assert "crate" in sim._world.objects
+        assert _body_mass(sim, "crate") == pytest.approx(1.0)
+
+    def test_name_collision_with_a_loaded_scene_body_leaves_that_body_intact(self, sim, tmp_path):
+        """A colliding add must never delete the body it collides with.
+
+        ``load_scene`` replaces the world with a fresh registry, so a body that
+        came from the XML is invisible to ``add_object``'s ``name in
+        self._world.objects`` guard. The insert therefore reaches MuJoCo, whose
+        ``add_body`` raises ``repeated name`` *but still inserts the duplicate*.
+        The rollback used to resolve the name through ``spec.body(name)``, which
+        sees the ORIGINAL body (present at the last compile), so it deleted the
+        healthy scene body and left the empty orphan holding its name: the next
+        mutation recompiled successfully with the original geometry gone - a
+        regression from fail-loud to corrupt-quietly. The add is now atomic over
+        its own mutation, so the pre-existing body keeps its pose and geom and a
+        later add still succeeds.
+        """
+        scene = tmp_path / "scene.xml"
+        scene.write_text(
+            '<mujoco model="s"><worldbody>'
+            '<body name="table" pos="1 2 0.5"><geom type="box" size="0.2 0.2 0.2"/></body>'
+            "</worldbody></mujoco>"
+        )
+        sim.load_scene(str(scene))
+        model = sim._world._model
+        table_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "table")
+        pos_before = list(model.body_pos[table_id])
+        geomnum_before = int(model.body_geomnum[table_id])
+        assert geomnum_before == 1
+
+        collide = sim.add_object("table", shape="box", position=[0.0, 0.0, 0.6], mass=1.0)
+        assert collide["status"] == "error", collide
+        assert "repeated name" in collide["content"][0]["text"]
+
+        # A later, unrelated add must recompile - and the original 'table' must
+        # still be at its scene pose with its geom, not silently replaced by the
+        # empty orphan of the rejected call.
+        later = sim.add_object("cube", shape="box", position=[0.3, 0.0, 0.6], mass=1.0)
+        assert later["status"] == "success", later
+
+        model = sim._world._model
+        table_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "table")
+        assert list(model.body_pos[table_id]) == pos_before
+        assert int(model.body_geomnum[table_id]) == geomnum_before
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "cube") >= 0

--- a/tests/simulation/mujoco/test_inject_failure_cleanup.py
+++ b/tests/simulation/mujoco/test_inject_failure_cleanup.py
@@ -14,15 +14,18 @@ successfully right after a failed attempt: a leaked orphan would make the retry
 collide on the duplicate name at recompile time. These tests fail before the
 rollback fix (the retry errors with ``repeated name``) and pass after it.
 
-The injectors themselves catch ``(ValueError, RuntimeError)`` and return
-``False``, so ``add_object`` / ``add_camera`` also carry a defensive
-``except (ValueError, RuntimeError)`` around the injection call. That guard
-exists so an *unexpected* raise from the scene-injection layer is surfaced
-as a structured ``{'status': 'error'}`` (never re-raised past tool dispatch,
-per the tool contract) while still rolling the half-added element out of the
-``_world`` registry. The raise-path tests force the injector to raise and
-pin that contract; they fail if the guard is removed (the exception escapes)
-or if the cleanup ``pop`` is dropped (the ghost element leaks).
+``add_object`` / ``add_camera`` also carry an ``except (ValueError,
+RuntimeError)`` around the injection call. It surfaces a raise from the
+scene-injection layer as a structured ``{'status': 'error'}`` (never re-raised
+past tool dispatch, per the tool contract) while rolling the half-added element
+out of the ``_world`` registry. For objects this is a live path, not a purely
+defensive one: ``inject_object_into_scene`` rolls its spec mutation back and
+re-raises so the reason reaches the caller (see
+``test_add_object_mass_contract.py`` for the unsupported-shape case). The
+camera injector still folds a raise into ``False``, so its guard fires only on
+an unexpected error. The raise-path tests force the injector to raise and pin
+that contract; they fail if the guard is removed (the exception escapes) or if
+the cleanup ``pop`` is dropped (the ghost element leaks).
 """
 
 from __future__ import annotations

--- a/tests/simulation/mujoco/test_scene_ops_guardrails.py
+++ b/tests/simulation/mujoco/test_scene_ops_guardrails.py
@@ -82,19 +82,31 @@ class TestInjectEjectRequireCompiledWorld:
         assert scene_ops.eject_robot_from_scene(world, "r") is False
 
 
-class TestInjectFailuresReturnFalse:
-    """A spec mutation that raises (bad shape, unreadable URDF) is caught and
-    surfaced as ``False`` so the caller can emit an error dict, leaving the
-    already-compiled world intact."""
+class TestInjectFailuresLeaveTheWorldIntact:
+    """A spec mutation that fails leaves the already-compiled world intact.
 
-    def test_inject_object_with_unsupported_shape_returns_false(self, sim: Simulation) -> None:
+    How the failure is reported differs by helper.
+    ``inject_robot_into_scene`` folds a raise into ``False``, while
+    ``inject_object_into_scene`` rolls its spec mutation back and re-raises: the
+    object path can fail for reasons only the exception text explains (which
+    shape was unsupported, and which are), and swallowing it left the caller
+    with nothing but a generic "spec recompile refused" while the actionable
+    message went to the log.
+    """
+
+    def test_inject_object_with_unsupported_shape_raises_and_leaves_the_model_intact(self, sim: Simulation) -> None:
         sim.create_world()
         world = sim._world
         assert world is not None
         nbody_before = world._model.nbody
-        assert scene_ops.inject_object_into_scene(world, SimObject(name="bad", shape="not_a_shape")) is False
-        # The failed add must not have grown the compiled model.
+        with pytest.raises(ValueError, match="Unsupported shape 'not_a_shape'"):
+            scene_ops.inject_object_into_scene(world, SimObject(name="bad", shape="not_a_shape"))
+        # The failed add must not have grown the compiled model, and the
+        # half-built body must be gone from the spec so the name is reusable.
         assert world._model.nbody == nbody_before
+        spec = scene_ops._get_spec(world)
+        assert spec is not None
+        assert "bad" not in [body.name for body in spec.bodies]
 
     def test_inject_robot_with_unreadable_urdf_returns_false(self, sim: Simulation) -> None:
         sim.create_world()

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -369,6 +369,27 @@ class TestMutation:
         spec = SpecBuilder.build(SimWorld())
         assert SpecBuilder.remove_body(spec, "ghost") is False
 
+    def test_remove_body_added_since_the_last_compile(self):
+        """A body inserted after the last compile is still removable.
+
+        ``spec.body(name)`` resolves only names present at the last
+        ``compile()``/``recompile()``, so a just-added body is invisible to it
+        and reachable only through the ``spec.bodies`` enumeration. Without the
+        fallback scan, rolling back a half-added body removed nothing and the
+        orphan made every later recompile fail on the duplicate name.
+        """
+        spec = SpecBuilder.build(SimWorld())
+        model = spec.compile()
+        data = mujoco.MjData(model)
+
+        spec.worldbody.add_body(name="latecomer")
+        assert spec.body("latecomer") is None, "precondition: invisible to the typed accessor"
+
+        assert SpecBuilder.remove_body(spec, "latecomer") is True
+        assert [b.name for b in spec.bodies] == ["world"]
+        # The spec still compiles, and the name is free for a real object.
+        spec.recompile(model, data)
+
     def test_add_camera_then_recompile(self):
         w = SimWorld()
         spec = SpecBuilder.build(w)


### PR DESCRIPTION
## Problem

`add_object` validates `position`, `orientation`, `color` and `size`, but writes `mass` straight into the spec - even though `set_body_properties`, which writes the same `body_mass` field, has always required a finite value `> 0`. The creator accepted values its own setter refused, in three distinct ways.

**1. `mass=inf` compiled and reported success, then NaN'd the entire world.** A body's mass divides every force acting on it, and the solver keeps one state vector for the whole scene, so this is not a local mistake:

```python
sim.add_object("neighbour",  shape="box", position=[0, 0, 0.6], mass=1.0)      # healthy 1 kg body
sim.add_object("blackhole", shape="box", position=[0.4, 0, 0.6], mass=float("inf"))
# -> success: "'blackhole' added: box at [0.4, 0.0, 0.6], size=[...], infkg"

sim.step(250)
# WARNING: Nan, Inf or huge value in QPOS at DOF 0. The simulation is unstable.
# every qpos/qvel is nan; 'neighbour' never falls - frozen at z=0.600
```

**2. `mass=0`, negatives, `nan` and `0 < mass < mjMINVAL` produced a dead-end error.** The recompile refused them and the caller got `Failed to inject 'crate': spec recompile refused.` MuJoCo's actual reason - `mass and inertia of moving bodies must be larger than mjMINVAL` - only reached the log, so the result named neither the parameter nor the rule.

**3. A rejected add could brick the scene permanently.** A non-numeric mass raises inside the spec mutation *after* the body has been inserted, and `inject_object_into_scene` rolled back only the mesh asset. The orphan body stayed in the spec, so **every later scene mutation failed to recompile**:

```python
sim.add_object("bad", shape="box", mass="heavy")        # error (as expected)
sim.add_object("cube", shape="box", mass=1.0)           # error: spec recompile refused
sim.add_camera("side", position=[1, 0, 0.5])            # error: spec recompile refused
```

An unsupported `shape` leaked the same way (its type lookup also raises after the insert), so the name stayed permanently taken and a corrected retry failed with `repeated name` - while the excellent message `_geom_type` had already produced (`Unsupported shape 'blob'. Supported: box, capsule, ...`) went only to the log. `inject_object_into_scene`'s own docstring states this must not happen: "Without the rollback the orphan lingers and every later scene mutation, including a corrected retry under the same name, keeps failing to recompile ... bricking the whole scene after one bad add."

A fourth, quieter defect underpinned #3: `SpecBuilder.remove_body` resolves names only through `spec.body(name)`, which sees bodies present at the last `compile()`/`recompile()`. A body inserted moments earlier is invisible to it, so the rollback of a just-added body silently removed nothing and returned `False`.

## Change

- **Shared mass domain.** New `SimEngine._validate_mass` (finite, `> 0`, `bool` rejected) is called by `add_object` **and** `set_body_properties`, so the value a body can be *created* with and the value it can be *set* to cannot diverge. The setter's error strings are unchanged - its existing tests in `test_input_validation.py::TestMassAndTimestepValidation` are the parity guard.
- **MuJoCo's compile floor is named.** `add_object` rejects `mass < mjMINVAL` (1e-15 kg) with a message quoting the floor, so every mass this method accepts is one the compiler accepts - no value reaches the generic recompile refusal any more. `mjMINVAL` itself is accepted, so the boundary is not over-tightened.
- **Validated only where it is honored.** The guard runs for dynamic bodies, which is where the value reaches `body_mass`. A static body gets no explicit inertial block (MuJoCo derives its mass from the geom density) and the result reports `static` rather than quoting a mass, so nothing is silently dishonored there.
- **The raise path rolls back and reports the reason.** `inject_object_into_scene` now removes the half-built body (plus any mesh asset) and re-raises, so `add_object`'s existing `except (ValueError, RuntimeError)` turns it into `Failed to inject 'crate' into live scene: Unsupported shape 'blob'. Supported: box, capsule, cylinder, ellipsoid, mesh, plane, sphere.` and the name is reusable.
- **`SpecBuilder.remove_body` falls back to the `spec.bodies` enumeration** when the typed accessor cannot see the body, mirroring `scene_ops._find_body` and the parent lookup in `add_camera`.
- **`add_object` is atomic over its own body mutation.** It records how many bodies already carry the name, wraps `add_body` plus freejoint/mass/geom writes, and on any raise deletes only the surplus bodies this call produced (the orphan is appended, so it is the tail). A rollback keyed to what this call added can never resolve a different body with the same name.
- Docs: new "Object mass" section in `docs/simulation/world-building.md`; `mass` gains a description in the MuJoCo `tool_spec.json`; abstract `SimEngine.add_object` states the contract backends must satisfy.

## Verification

Rollout in MuJoCo sim (headless, EGL): identical script both sides - a 1 kg body, then `mass=inf`, then `shape="blob"` followed by a corrected retry under the same name, then 250 steps.

![add_object mass domain, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/add-object-mass/add_object_mass.png)

| | before | after |
|---|---|---|
| `add_object(mass=inf)` | `success` | `error: 'mass' must be a finite number > 0, got inf` |
| world state after 250 steps | `qpos`/`qvel` = `nan` | all finite |
| 1 kg neighbour | frozen at z=0.600 | fell to z=0.080 (resting) |
| retry after `shape="blob"` | `error` (name bricked) | `success` (crate compiled, 1 kg) |
| `load_scene` body collision | original body destroyed silently | original body intact, collision rejected |

The left panel shows the pre-fix scene: nothing ever moved, because one accepted `inf` mass poisoned the shared state vector, and the crate is missing because its name stayed taken.

New `tests/simulation/mujoco/test_add_object_mass_contract.py` (11 tests) plus one pin each in `test_spec_builder.py` (the enumeration fallback) and `test_scene_ops_guardrails.py` (the corrected raise contract). Against the pre-fix source on this base: **11 failed, 3 passed** (the 3 that pass are the valid-mass and static-mass cases, which must not change). After: all pass.

Full suite: `11976 passed, 254 skipped` (`MUJOCO_GL=egl pytest tests`); `ruff check`, `ruff format --check` and `mypy strands_robots tests tests_integ` clean.

---

## §13 Review Rounds

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R2 | CodeQL `py/ineffectual-statement` on TYPE_CHECKING stub | `811e262` | (same suite, no new test needed - the stub body is a style fix) |
| R3 | Rollback deletes pre-existing body on name collision with a load_scene body | `52bc064` | `test_add_object_mass_contract.py::test_name_collision_with_a_loaded_scene_body_leaves_that_body_intact` |
