### PR TITLE
fix(sim): add_object honors every color component or rejects the vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `add_object` honors every `color` component or rejects the vector
+
+A MuJoCo geom stores its colour in a 4-component `rgba` row, so only an RGB
+triple (completed with the opaque alpha that row defaults to) or a full RGBA
+quadruple can be applied to it. `add_object` validated that `color` held finite
+numbers but never checked the count, so the parameter failed three different
+ways:
+
+```python
+sim.add_object("cube", shape="box", color=[])
+# -> success: compiled rgba [0.5, 0.5, 0.5, 1.0]  (the default grey, silently)
+sim.add_object("cube", shape="box", color=[1.0, 0.0, 0.0])
+# -> error: "Failed to inject 'cube': spec recompile refused."
+#    (MuJoCo's actionable "rgba should be a list/array of size 4" only logged)
+sim.add_object("cube", shape="box", color=np.array([1.0, 0.0, 0.0, 1.0]))
+# -> ValueError: The truth value of an array with more than one element is
+#    ambiguous  (raised past the tool-result contract)
+```
+
+The empty vector fell through a `color or <default>` coalescing that read it as
+"omitted", and that same truth test raised on any multi-element NumPy colour -
+for example a `geom_rgba` row read back from the model.
+
+`color` is now coerced through the contract the runtime mutator
+`set_geom_properties(color=...)` already enforced: 3 components are read as RGB
+and completed with an opaque alpha, 4 are read as RGBA verbatim, and any other
+count is rejected with a message naming the parameter, the accepted counts and
+the layout. Both entry points share one coercion helper, so their accepted
+domains cannot diverge. The agent-tool router's vector table now carries the
+component counts a parameter can honor rather than a single length, so it stops
+rejecting the RGB triple both methods accept.
+
+
 ### Fixed: `set_geom_properties` honors every vector component or rejects the vector
 
 `color`, `friction` and `size` each target a MuJoCo buffer with a fixed component

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -544,6 +544,13 @@ class SimEngine(ABC):
         differently-sized object while reporting success -- and the reported
         size echoes what was asked for, not what was built.
 
+        The same rule applies to ``color``: a backend either honors the
+        component count it was given or rejects it, and may complete only
+        components it documents a default for (MuJoCo completes an RGB triple
+        with an opaque alpha, and rejects every other count). Falling back to
+        the backend's default colour paints a surface the caller never asked
+        for under a success result.
+
         ``material`` (optional): backend-specific visual material/texture
         spec. ``None`` keeps the flat ``color`` rgba (unchanged); a backend
         that supports it (MuJoCo) attaches a real material so surfaces can be

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -118,6 +118,46 @@ def _coerce_finite_vector(
     return out, None
 
 
+# A MuJoCo geom stores its colour as a 4-component ``rgba`` row. Alpha is the
+# only component with a meaningful default (opaque), so an RGB triple can be
+# completed without inventing a colour, while any other count cannot.
+_RGBA_ACCEPTED_LENGTHS: tuple[int, ...] = (3, 4)
+_RGBA_LAYOUT = "RGB, or RGBA with alpha"
+
+
+def _coerce_rgba(color: Any, method: str, name: str = "color") -> tuple[list[float] | None, dict[str, Any] | None]:
+    """Coerce a caller-supplied colour to the 4 components a geom's rgba stores.
+
+    Single source of the backend's colour contract, shared by the scene creator
+    (``add_object``) and the runtime mutator (``set_geom_properties``) so their
+    accepted domains cannot diverge: 3 components are read as RGB and completed
+    with an opaque alpha -- the one component MuJoCo defines a default for -- 4
+    are read as RGBA verbatim, and any other count is rejected because it can
+    only be applied by fabricating or discarding components the caller did not
+    ask about. An empty vector is rejected for the same reason: substituting the
+    backend default paints a colour nobody requested under a success result.
+
+    Args:
+        color: The caller's colour sequence (list / tuple / NumPy array).
+        method: Calling method name, used in error text.
+        name: Parameter name, used in error text.
+
+    Returns:
+        ``(rgba, None)`` with exactly 4 finite floats, or ``(None, error_dict)``
+        matching the structured-error tool contract.
+    """
+    floats, err = _coerce_finite_vector(
+        color,
+        name,
+        method,
+        accepted_lengths=_RGBA_ACCEPTED_LENGTHS,
+        layout=_RGBA_LAYOUT,
+    )
+    if floats is None:
+        return None, err
+    return (floats if len(floats) == 4 else [*floats, 1.0]), None
+
+
 def _coerce_finite_joint_map(
     values: dict[str, Any],
     name: str,
@@ -1576,13 +1616,7 @@ class PhysicsMixin:
         # applied a shape / appearance / contact model nobody asked for under a
         # status="success" result, so the exact count is now required.
         if color is not None:
-            color, err = _coerce_finite_vector(
-                color,
-                "color",
-                "set_geom_properties",
-                accepted_lengths=(3, 4),
-                layout="RGB, or RGBA with alpha",
-            )
+            color, err = _coerce_rgba(color, "set_geom_properties")
             if err:
                 return err
         if friction is not None:
@@ -1634,8 +1668,8 @@ class PhysicsMixin:
 
         with self._lock:
             if color is not None:
-                # Validated as 3 or 4 components; RGB gets an opaque alpha.
-                model.geom_rgba[gid] = color if len(color) == 4 else [*color, 1.0]
+                # Already coerced to 4 components (RGB got an opaque alpha).
+                model.geom_rgba[gid] = color
                 changes.append(f"color → {model.geom_rgba[gid].tolist()}")
 
             if friction is not None:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -75,7 +75,7 @@ from strands_robots.simulation.mujoco.backend import (
     filter_mujoco_attach_noise,
 )
 from strands_robots.simulation.mujoco.manipulation import ManipulationMixin
-from strands_robots.simulation.mujoco.physics import PhysicsMixin
+from strands_robots.simulation.mujoco.physics import PhysicsMixin, _coerce_rgba
 from strands_robots.simulation.mujoco.randomization import RandomizationMixin
 from strands_robots.simulation.mujoco.recording import RecordingMixin
 from strands_robots.simulation.mujoco.rendering import RenderingMixin
@@ -157,9 +157,12 @@ def _validate_finite_vector(method: str, param_name: str, vec: Any) -> str | Non
 
     A numpy real scalar per element is accepted (``float(np.float64(...))``
     succeeds), matching the "accept NumPy scalar components" behaviour of the
-    other sim setters. Length is NOT checked here (color is 3-or-4, size is
-    shape-dependent); use :func:`_validate_pose_vector` for a fixed length.
-    Returns ``None`` when every element is a finite real number.
+    other sim setters. Length is NOT checked here (size is shape-dependent, so
+    its count is checked against the shape afterwards); use
+    :func:`_validate_pose_vector` for a fixed length, or the rgba coercion in
+    :mod:`strands_robots.simulation.mujoco.physics` for a colour, whose count
+    the geom's rgba row defines. Returns ``None`` when every element is a finite
+    real number.
     """
     try:
         iter(vec)
@@ -2391,7 +2394,13 @@ class MuJoCoSimEngine(
                 compiles a differently-sized object while reporting success.
                 Every consumed component must be > 0; a non-positive extent is
                 rejected.
-            color: RGBA in 0..1 (default mid-grey).
+            color: ``[r, g, b]`` or ``[r, g, b, a]`` in 0..1 (default mid-grey).
+                An RGB triple is completed with an opaque alpha -- the one
+                component the geom's rgba row defines a default for. Any other
+                component count, including an empty vector, is rejected rather
+                than completed from the backend default, because a completed
+                colour paints a surface the caller never asked for while
+                reporting success.
             mass: Body mass in kg for dynamic objects (default 0.1); ignored when
                 ``is_static``.
             is_static: Fix the body in the world. ``shape="plane"`` forces this
@@ -2404,10 +2413,10 @@ class MuJoCoSimEngine(
             ``{"status": "error", ...}`` when no world exists, a policy is
             running, the name is taken, ``position``/``orientation``/``color``/
             ``size`` contains a non-finite (``nan``/``inf``) or non-numeric
-            element or ``position``/``orientation`` is the wrong length (3 / 4),
-            ``size`` has a non-positive extent or a component count the shape
-            cannot consume, ``shape="mesh"`` is missing ``mesh_path``, or the
-            recompile fails.
+            element or ``position``/``orientation``/``color`` is the wrong length
+            (3 / 4 / 3-or-4), ``size`` has a non-positive extent or a component
+            count the shape cannot consume, ``shape="mesh"`` is missing
+            ``mesh_path``, or the recompile fails.
 
         Example:
             >>> sim.add_object("cube", shape="box", size=[0.05, 0.05, 0.05])  # 5 cm cube
@@ -2476,10 +2485,21 @@ class MuJoCoSimEngine(
             and (e := _validate_pose_vector("add_object", "orientation", orientation, 4)) is not None
         ):
             return {"status": "error", "content": [{"text": e}]}
-        if color is not None and (e := _validate_finite_vector("add_object", "color", color)) is not None:
-            return {"status": "error", "content": [{"text": e}]}
         if size is not None and (e := _validate_finite_vector("add_object", "size", size)) is not None:
             return {"status": "error", "content": [{"text": e}]}
+
+        # 'color' targets the geom's 4-component rgba row, so its component
+        # count is part of the contract - the same one set_geom_properties
+        # enforces on a live geom. Without the count check an RGB triple (or any
+        # other partial vector) reached MuJoCo's add_geom and aborted the
+        # recompile with "spec recompile refused", hiding the actionable reason,
+        # and an empty vector fell through the `color or <default>` coalescing
+        # below and painted the default grey under a success result.
+        color_rgba: list[float] | None = None
+        if color is not None:
+            color_rgba, color_err = _coerce_rgba(color, "add_object")
+            if color_err is not None:
+                return color_err
 
         # 'size' is the full extent in meters per the docstring; reject a
         # non-positive (degenerate) extent before mutating scene state so the
@@ -2503,7 +2523,11 @@ class MuJoCoSimEngine(
             # read an empty list as omitted and substitute the default for a
             # request _validate_size has already rejected.
             size=[0.05, 0.05, 0.05] if size is None else list(size),
-            color=color or [0.5, 0.5, 0.5, 1.0],
+            # ``color is None`` means "omitted" -> the documented mid-grey
+            # default. A supplied colour arrives here already coerced to 4
+            # components; ``or`` would read an empty list as omitted and paint
+            # the default for a request the rgba contract has already rejected.
+            color=[0.5, 0.5, 0.5, 1.0] if color_rgba is None else color_rgba,
             mass=mass,
             mesh_path=mesh_path,
             material=material,
@@ -4212,20 +4236,22 @@ class MuJoCoSimEngine(
     # and must not be reported as "unknown" by the router.
     _ROUTER_PASSTHROUGH = {"action"}
 
-    # Vector params with expected length (for dimension validation before
-    # numpy/MuJoCo sees them). Length 3 = xyz unless noted.
-    _VECTOR_PARAM_LENGTHS: dict[str, int] = {
-        "position": 3,
-        "target": 3,
-        "origin": 3,
-        "force": 3,
-        "torque": 3,
-        "torque_vec": 3,
-        "gravity": 3,
-        "direction": 3,
-        "point": 3,
-        "orientation": 4,  # quaternion (w,x,y,z)
-        "color": 4,  # rgba
+    # Vector params with the component counts the target buffer can honor (for
+    # dimension validation before numpy/MuJoCo sees them). 3 = xyz unless noted.
+    # A param with several honorable counts lists them all, so the router never
+    # rejects a vector the method itself accepts.
+    _VECTOR_PARAM_LENGTHS: dict[str, tuple[int, ...]] = {
+        "position": (3,),
+        "target": (3,),
+        "origin": (3,),
+        "force": (3,),
+        "torque": (3,),
+        "torque_vec": (3,),
+        "gravity": (3,),
+        "direction": (3,),
+        "point": (3,),
+        "orientation": (4,),  # quaternion (w,x,y,z)
+        "color": (3, 4),  # rgb (opaque alpha) or rgba
     }
 
     def _validate_and_build_kwargs(
@@ -4276,18 +4302,19 @@ class MuJoCoSimEngine(
             }
 
         # 2) Vector dimension validation (applies before method runs)
-        for vparam, expected_len in self._VECTOR_PARAM_LENGTHS.items():
+        for vparam, accepted_lens in self._VECTOR_PARAM_LENGTHS.items():
             if vparam not in remapped:
                 continue
             val = remapped[vparam]
             if val is None:
                 continue
+            expected_len = " or ".join(str(n) for n in accepted_lens)
             if not hasattr(val, "__len__"):
                 return None, {
                     "status": "error",
                     "content": [{"text": f"Parameter '{vparam}' must be a list of {expected_len} numbers."}],
                 }
-            if len(val) != expected_len:
+            if len(val) not in accepted_lens:
                 return None, {
                     "status": "error",
                     "content": [

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -156,7 +156,8 @@
       "type": "array",
       "items": {
         "type": "number"
-      }
+      },
+      "description": "Colour in 0..1: [r, g, b] (opaque alpha added) or [r, g, b, a]. Any other component count, including an empty list, is rejected - omit color entirely for the default mid-grey."
     },
     "mass": {
       "type": "number"

--- a/tests/simulation/mujoco/test_add_object_camera_vector_validation.py
+++ b/tests/simulation/mujoco/test_add_object_camera_vector_validation.py
@@ -87,28 +87,30 @@ def test_add_object_rejects_nonnumeric(sim, kwargs, expect):
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "expect"),
     [
-        {"color": 5},
-        {"color": np.float64(1.0)},
-        {"size": 0.05},
-        {"size": np.float32(0.05)},
+        ({"color": 5}, "must be a sequence of numbers"),
+        ({"color": np.float64(1.0)}, "must be a sequence of numbers"),
+        ({"size": 0.05}, "must be a list/tuple of numbers"),
+        ({"size": np.float32(0.05)}, "must be a list/tuple of numbers"),
     ],
 )
-def test_add_object_rejects_scalar_color_size(sim, kwargs):
+def test_add_object_rejects_scalar_color_size(sim, kwargs, expect):
     """A bare scalar ``color`` / ``size`` is rejected, not raised as a TypeError.
 
-    ``color`` and ``size`` are variable-length vectors (color is 3-or-4, size is
-    shape-dependent), so they are content-validated without a fixed length. A
-    caller passing a single number instead of a vector is a non-iterable that
+    A caller passing a single number instead of a vector is a non-iterable that
     would otherwise reach ``iter(vec)`` / MuJoCo's ``add_geom`` and raise a bare
     ``TypeError``, escaping the ``{"status": "error"}`` tool-result contract.
     The guard turns it into a structured error naming the offending parameter.
+    ``size`` is content-validated without a fixed length (its count is
+    shape-dependent and checked against the shape afterwards); ``color`` shares
+    the rgba coercion with ``set_geom_properties``, so it reports that helper's
+    wording.
     """
     result = sim.add_object("bad", shape="box", **kwargs)
     assert result["status"] == "error", result
     text = result["content"][0]["text"]
-    assert "must be a list/tuple of numbers" in text
+    assert expect in text
     assert next(iter(kwargs)) in text
     assert "bad" not in sim._world.objects
 

--- a/tests/simulation/mujoco/test_add_object_color_component_count.py
+++ b/tests/simulation/mujoco/test_add_object_color_component_count.py
@@ -1,0 +1,162 @@
+"""``add_object`` honors every ``color`` component or rejects the vector.
+
+A MuJoCo geom stores its colour in a 4-component ``rgba`` row, so only two
+component counts can be applied to it: an RGB triple (completed with the opaque
+alpha the row defaults to) and a full RGBA quadruple. ``add_object`` used to
+content-validate ``color`` without checking that count, which produced two
+failures on the same parameter:
+
+* An empty vector fell through the ``color or <default>`` coalescing and painted
+  the mid-grey default under a ``status="success"`` result -- the caller asked
+  for a colour and got the backend's.
+* Any other partial vector (an RGB triple, a single component) reached MuJoCo's
+  ``add_geom``, which refuses a non-4 ``rgba``, so the call died with a generic
+  "spec recompile refused" while the actionable reason stayed in the log.
+
+The same contract already governs the runtime mutator
+(``set_geom_properties(color=...)``), which honors 3 or 4 components, so these
+tests pin the creator to it -- including at the agent-tool dispatch boundary,
+whose fixed-length table used to reject an RGB triple the method honors.
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Counts a 4-component rgba row cannot be given without fabricating or
+# discarding components the caller never mentioned.
+UNHONORABLE_COLORS = [[], [1.0], [1.0, 0.0], [1.0, 0.0, 0.0, 1.0, 9.0]]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_add_object_color_count_sim", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def _rgba(sim, name):
+    gid = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_GEOM, f"{name}_geom")
+    assert gid >= 0, f"geom for {name!r} missing from the compiled model"
+    return [round(float(c), 6) for c in sim._world._model.geom_rgba[gid]]
+
+
+class TestAddObjectColorComponentCount:
+    """The creator applies the colour it was given, or names why it cannot."""
+
+    @pytest.mark.parametrize("color", UNHONORABLE_COLORS)
+    def test_unhonorable_component_count_rejected(self, sim, color):
+        """A colour the rgba row cannot hold is refused, and nothing is added.
+
+        ``color=[]`` previously reported success with the default grey compiled,
+        and the other counts previously died with "spec recompile refused".
+        """
+        result = sim.add_object("blob", shape="box", color=color)
+
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "'color'" in text
+        assert "3 or 4" in text
+        assert "recompile" not in text
+        assert "blob" not in sim._world.objects
+        assert mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_GEOM, "blob_geom") < 0
+
+    def test_rejection_leaves_the_name_free_and_the_scene_mutable(self, sim):
+        """A refused colour does not consume the name or block later mutations."""
+        assert sim.add_object("crate", shape="box", color=[0.2, 0.4])["status"] == "error"
+
+        assert sim.add_object("crate", shape="box", color=[0.2, 0.4, 0.6])["status"] == "success"
+        assert _rgba(sim, "crate") == [0.2, 0.4, 0.6, 1.0]
+
+    def test_rgb_triple_completed_with_an_opaque_alpha(self, sim):
+        """An RGB triple is honored -- alpha is the one component with a default."""
+        result = sim.add_object("ball", shape="sphere", size=[0.1], color=[1.0, 0.0, 0.0])
+
+        assert result["status"] == "success", result
+        assert _rgba(sim, "ball") == [1.0, 0.0, 0.0, 1.0]
+
+    def test_rgba_applied_verbatim_including_alpha(self, sim):
+        """A 4-component colour keeps the alpha the caller chose."""
+        assert sim.add_object("glass", shape="box", color=[0.1, 0.2, 0.3, 0.25])["status"] == "success"
+
+        assert _rgba(sim, "glass") == [0.1, 0.2, 0.3, 0.25]
+
+    @pytest.mark.parametrize("color", [np.array([0.0, 1.0, 0.0]), np.array([0.0, 1.0, 0.0, 0.5])])
+    def test_numpy_color_accepted(self, sim, color):
+        """A NumPy colour (e.g. a ``geom_rgba`` row read back) is accepted.
+
+        It used to reach ``color or <default>``, whose truth test on a multi
+        element array raised ``ValueError`` past the tool-result contract.
+        """
+        assert sim.add_object("np_cube", shape="box", color=color)["status"] == "success"
+
+        expected = [round(float(c), 6) for c in color]
+        assert _rgba(sim, "np_cube") == (expected if len(expected) == 4 else [*expected, 1.0])
+
+    def test_omitted_color_uses_the_documented_default(self, sim):
+        """Only an omitted colour gets the mid-grey default, never a partial one."""
+        assert sim.add_object("plain", shape="box")["status"] == "success"
+
+        assert _rgba(sim, "plain") == [0.5, 0.5, 0.5, 1.0]
+
+
+class TestColorContractSharedWithTheMutator:
+    """The creator and the runtime mutator accept the same colour counts."""
+
+    @pytest.mark.parametrize("color", [[0.1, 0.2, 0.3], [0.1, 0.2, 0.3, 0.4]])
+    def test_both_entry_points_honor_the_same_counts(self, sim, color):
+        assert sim.add_object("shared", shape="box", color=color)["status"] == "success"
+        expected = [*color, 1.0] if len(color) == 3 else color
+        assert _rgba(sim, "shared") == expected
+
+        assert sim.set_geom_properties(geom_name="shared", color=color)["status"] == "success"
+        assert _rgba(sim, "shared") == expected
+
+    @pytest.mark.parametrize("color", UNHONORABLE_COLORS)
+    def test_both_entry_points_reject_the_same_counts(self, sim, color):
+        assert sim.add_object("shared", shape="box", color=[0.5, 0.5, 0.5, 1.0])["status"] == "success"
+        before = _rgba(sim, "shared")
+
+        assert sim.add_object("other", shape="box", color=color)["status"] == "error"
+        assert sim.set_geom_properties(geom_name="shared", color=color)["status"] == "error"
+        assert _rgba(sim, "shared") == before
+
+
+class TestColorComponentCountAtDispatch:
+    """The agent-tool router forwards every count the method can honor."""
+
+    def test_rgb_triple_reaches_the_method(self, sim):
+        """The router used to reject an RGB triple that add_object honors."""
+        result = sim._dispatch_action("add_object", {"name": "routed", "shape": "box", "color": [1.0, 0.0, 0.0]})
+
+        assert result["status"] == "success", result
+        assert _rgba(sim, "routed") == [1.0, 0.0, 0.0, 1.0]
+
+    def test_rgb_triple_reaches_the_mutator(self, sim):
+        assert sim.add_object("mutated", shape="box")["status"] == "success"
+
+        result = sim._dispatch_action("set_geom_properties", {"geom_name": "mutated", "color": [0.0, 1.0, 0.0]})
+
+        assert result["status"] == "success", result
+        assert _rgba(sim, "mutated") == [0.0, 1.0, 0.0, 1.0]
+
+    @pytest.mark.parametrize("color", [[1.0, 0.0], [1.0, 0.0, 0.0, 1.0, 9.0]])
+    def test_unhonorable_count_rejected_at_the_boundary(self, sim, color):
+        result = sim._dispatch_action("add_object", {"name": "routed_bad", "shape": "box", "color": color})
+
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "'color'" in text
+        assert "3 or 4" in text
+        assert "routed_bad" not in sim._world.objects
+
+    def test_fixed_length_vector_params_still_report_their_single_count(self, sim):
+        """Widening the table must not blur a param with one honorable count."""
+        result = sim._dispatch_action("add_object", {"name": "bad_pos", "shape": "box", "position": [0.0, 1.0]})
+
+        assert result["status"] == "error", result
+        assert "must be a list of 3 numbers, got 2." in result["content"][0]["text"]

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -120,14 +120,24 @@ class TestRouterValidatesVectorDims:
         assert result["status"] == "error"
         assert "'orientation'" in result["content"][0]["text"]
 
-    def test_color_wrong_length_rejected(self, sim):
-        # color is rgba (4)
+    def test_color_unhonorable_length_rejected(self, sim):
+        # color is rgb (3) or rgba (4); two components cannot be applied to the
+        # geom's rgba row without inventing the rest.
         result = sim._dispatch_action(
             "add_object",
-            {"name": "box1", "shape": "box", "color": [1, 0, 0]},
+            {"name": "box1", "shape": "box", "color": [1, 0]},
         )
         assert result["status"] == "error"
         assert "'color'" in result["content"][0]["text"]
+
+    def test_color_rgb_triple_forwarded(self, sim):
+        # The router used to require exactly 4 components, rejecting an RGB
+        # triple that add_object honors (alpha defaults to opaque).
+        result = sim._dispatch_action(
+            "add_object",
+            {"name": "box_rgb", "shape": "box", "color": [1, 0, 0]},
+        )
+        assert result["status"] == "success", result
 
     def test_non_numeric_vector_component_rejected(self, sim):
         result = sim._dispatch_action("set_gravity", {"gravity": [0, 0, "low"]})


### PR DESCRIPTION
## Problem

A MuJoCo geom stores its colour in a 4-component `rgba` row, so exactly two component counts can be applied to it: an RGB triple (completed with the opaque alpha that row defaults to) and a full RGBA quadruple. `add_object` validated that `color` held finite numbers but never checked the count, so one parameter failed three different ways:

```python
sim.add_object("cube", shape="box", color=[])
# -> success: "'cube' added: box at [0,0,0], ..."
#    compiled rgba = [0.5, 0.5, 0.5, 1.0]  (the default grey - a colour was asked for)

sim.add_object("cube", shape="box", color=[1.0, 0.0, 0.0])
# -> error: "Failed to inject 'cube': spec recompile refused."
#    MuJoCo's actionable reason ("rgba should be a list/array of size 4") only reaches the log

sim.add_object("cube", shape="box", color=numpy.array([1.0, 0.0, 0.0, 1.0]))
# -> ValueError: The truth value of an array with more than one element is ambiguous
#    (raised past the {"status": "error"} tool-result contract)
```

All three come from the same missing count check. The empty vector fell through a `color or [0.5, 0.5, 0.5, 1.0]` coalescing that reads `[]` as "omitted" - the hazard the adjacent `size` line already documents in a comment - and that same truth test raised on any multi-element NumPy colour, for example a `geom_rgba` row read back from the model and passed to a new object.

The count was also inconsistent across the three layers that touch it: the runtime mutator `set_geom_properties(color=...)` honors 3 or 4 components and rejects anything else with an actionable message, the direct `add_object` API checked nothing, and the agent-tool router required exactly 4 - so the router rejected an RGB triple that `set_geom_properties` itself honors.

## Change

One colour contract, shared by the creator and the mutator so their accepted domains cannot diverge:

- `_coerce_rgba` (mujoco/physics.py) wraps the existing finite-vector coercion with `accepted_lengths=(3, 4)` and returns 4 components: an RGB triple is completed with an opaque alpha (the one component the rgba row defines a default for), 4 components pass through verbatim, any other count - including `[]` - is rejected with a message naming the parameter, the accepted counts and the layout. `set_geom_properties` now uses it too, dropping its inline padding.
- `add_object` coerces `color` through that helper before any scene mutation and uses the coerced value, so `color=None` (omitted) is the only path to the documented mid-grey default.
- The router's `_VECTOR_PARAM_LENGTHS` now maps a parameter to the component counts it can honor rather than to a single length (`"color": (3, 4)`, everything else unchanged), so the boundary stops rejecting a vector the method accepts. Params with one honorable count still report it exactly (`"must be a list of 3 numbers, got 2."`).

After:

```python
sim.add_object("cube", shape="box", color=[1.0, 0.0, 0.0])      # success, rgba [1, 0, 0, 1]
sim.add_object("cube", shape="box", color=[0.1, 0.2, 0.3, 0.25])  # success, alpha kept
sim.add_object("cube", shape="box", color=[])
# -> error: "add_object: 'color' must have exactly 3 or 4 component(s)
#     (RGB, or RGBA with alpha), got 0: []. Pass every component - a partial
#     'color' cannot be applied without inventing the missing values."
```

## Visual proof

Same four-call script rendered in MuJoCo headless (`MUJOCO_GL=egl`, offscreen camera, 640x480). Left is the prior behaviour, right is this branch; L1 difference between the two panels is 2.56e6.

![add_object colour contract, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/add-object-color-contract/add_object_color_contract.png)

Before: the three RGB requests all die with "spec recompile refused" so no colour lands, and the `color=[]` request succeeds as the default grey box. After: the three RGB objects compile with the requested colours (alpha completed to 1.0) and the empty vector is refused by name.

## Tests

`tests/simulation/mujoco/test_add_object_color_component_count.py` (22 tests): unhonorable counts (`[]`, 1, 2, 5) rejected with a message that names `'color'`, says `3 or 4` and does not say "recompile", with nothing added and the name left free; RGB completed with an opaque alpha; RGBA applied verbatim including a non-opaque alpha; NumPy colours of both counts accepted; omitted colour still mid-grey; creator and mutator accept and reject the same counts (the anti-divergence pin); the router forwards an RGB triple to both methods and rejects an unhonorable count at the boundary; fixed-length vector params still report their single count.

Against the pre-change source these fail 13 / pass 7 (the empty vector reports success, the RGB triple reports "spec recompile refused", the NumPy colour raises `ValueError`, and the router answers "must be a list of 4 numbers, got 3"); after the change 22 / 22 pass.

Two existing tests pinned the old divergence and were corrected rather than shimmed:
- `test_agenttool_contract.py::test_color_wrong_length_rejected` asserted the router rejects an RGB triple. Renamed to `test_color_unhonorable_length_rejected` (now using a genuinely unhonorable 2-component vector), plus `test_color_rgb_triple_forwarded` for the count the methods honor.
- `test_add_object_camera_vector_validation.py::test_add_object_rejects_scalar_color_size` asserted the old wording for a bare scalar `color`; the case now expects the shared coercion's "must be a sequence of numbers" (the `size` cases are unchanged), and the docstring no longer claims `color` is length-unchecked.

Gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean (`Success: no issues found in 891 source files`); `MUJOCO_GL=egl pytest tests` -> 11987 passed, 254 skipped in 408s.

## Docs

`add_object` docstring (`color` argument + the Returns error list), the abstract `SimEngine.add_object` contract (the "MUST NOT discard components the caller supplied" rule now covers `color`, with the completion rule stated), the agent tool schema description for `color`, the `_validate_finite_vector` docstring (it claimed colour length is not checked anywhere), and a CHANGELOG entry.