### PR TITLE
feat(sim): get_world_point(camera, pixels) - agent-facing pixel-to-world grounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ frame = sim.render(camera_name="topdown")   # {status, content:[text, image]}
   `list_urdfs`, `register_urdf`, `get_features`.
 - **Objects**: `add_object`, `remove_object`, `move_object`, `list_objects`.
 - **Cameras & rendering**: `add_camera`, `remove_camera`, `render`,
-  `render_depth`, `render_all`, `start_cameras_recording`,
+  `render_depth`, `render_all`, `get_world_point`, `start_cameras_recording`,
   `stop_cameras_recording`, `get_cameras_recording_status`.
 - **Physics**: `step`, `set_timestep`, `set_gravity`, `apply_force`, `raycast`,
   `multi_raycast`, `get_contacts`, `get_contact_forces`, `get_body_state`,

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -78,15 +78,16 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `render(camera_name="default", width=None, height=None)` | PNG in `content[...]["image"]["source"]["bytes"]`; no `frame` key |
 | `render_depth(camera_name="default", width=None, height=None)` | Viewable grayscale depth PNG `image` block (near=bright, far=dark) + metric `depth_min`/`depth_max` (meters) in the `json` block |
 | `render_all(cameras=None, width=None, height=None)` | One `image` block per camera (multi-view snapshot) |
+| `get_world_point(camera_name="default", pixels=[[u, v], ...])` | Ground picked pixels to metric world coordinates via the depth buffer; `point` is the median over the valid samples, `points` aligns with the input pixels |
 | `open_viewer` / `close_viewer` | Interactive MuJoCo passive viewer |
 
 !!! note "Get a numpy frame"
     `sim.get_observation(robot_name)[camera_name]` → `np.uint8 (H, W, 3)`
 
 !!! tip "Discover the render surface"
-    `render`, `render_depth`, and `render_all` are all listed in
-    `sim.describe()["methods"]`, so an agent can enumerate the full rendering
-    surface in one call instead of guessing method names.
+    `render`, `render_depth`, `render_all`, and `get_world_point` are all
+    listed in `sim.describe()["methods"]`, so an agent can enumerate the full
+    rendering surface in one call instead of guessing method names.
 
 ## Physics
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2746,7 +2746,10 @@ class SimEngine(ABC):
            something else.
         3. Sample SEVERAL pixels on the same surface (typically 3-9): the
            returned ``point`` is the median over the valid samples, which
-           rejects stray outliers.
+           rejects stray outliers. The median is PER-COMPONENT, so on a
+           strongly tilted surface the combined ``[x, y, z]`` may lie on no
+           single sampled point - treat it as a robust surface estimate, not
+           as one of ``points``.
         4. Pixels with no depth (background / far plane) are dropped, not
            zero-filled; check ``n_valid`` against the count you sent.
         5. Re-localize after any robot, camera, or object motion -- world
@@ -2792,7 +2795,17 @@ class SimEngine(ABC):
         def _err(msg: str) -> dict[str, Any]:
             return {"status": "error", "content": [{"text": msg}]}
 
-        # -- Structural validation of `pixels` (before any render work) -- #
+        # -- Structural validation (before any render work) -- #
+        # camera_name reaches backend name-lookup APIs (e.g. MuJoCo's
+        # mj_name2id) that raise TypeError on non-string input, and the
+        # dispatcher enforces no scalar types - so an LLM passing a camera
+        # INDEX must be caught here to keep the never-raises envelope.
+        if camera_name is not None and not isinstance(camera_name, str):
+            return _err(
+                f"get_world_point 'camera_name' must be a camera name string, got "
+                f"{type(camera_name).__name__} ({camera_name!r}). Cameras are addressed by "
+                "name, not index; see add_camera / get_frame."
+            )
         if pixels is None or isinstance(pixels, (str, bytes)) or not hasattr(pixels, "__len__"):
             return _err(
                 "get_world_point requires 'pixels': a non-empty list of [u, v] pixel coordinates, e.g. [[320, 240], [322, 238]]."
@@ -2833,7 +2846,10 @@ class SimEngine(ABC):
                 return _err(
                     "get_world_point is unavailable: this backend has no raw-frame path (get_frame is not implemented)."
                 )
-            except (KeyError, ValueError, RuntimeError) as e:
+            except (KeyError, ValueError, RuntimeError, TypeError) as e:
+                # TypeError included as defense-in-depth for backend lookup
+                # APIs that reject non-string names (the type is validated
+                # above, but the envelope must hold regardless).
                 return _err(f"get_world_point failed to render camera frame: {e}")
             if depth is None:
                 return _err(
@@ -2854,7 +2870,7 @@ class SimEngine(ABC):
                 return _err(
                     "get_world_point is unavailable: this backend has no camera-params path (get_camera_params is not implemented)."
                 )
-            except (KeyError, ValueError, RuntimeError) as e:
+            except (KeyError, ValueError, RuntimeError, TypeError) as e:
                 return _err(f"get_world_point failed to read camera parameters: {e}")
 
         # -- Unproject (pure math; no engine state touched past this point) -- #
@@ -2881,7 +2897,10 @@ class SimEngine(ABC):
             points.append(world_xyz)
             valid_points.append(world_xyz)
 
-        camera_label = "default" if camera_name in (None, "") else str(camera_name)
+        # One label per camera: every free-camera token (None / "" / "free" /
+        # "default") reports as "default", so the same camera never appears
+        # under two names across calls.
+        camera_label = "default" if camera_name in (None, "", "free", "default") else str(camera_name)
         if not valid_points:
             return _err(
                 f"get_world_point found no valid depth at any of the {len(parsed)} requested pixels via "

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -18,6 +18,7 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import math
 import numbers
@@ -2711,6 +2712,208 @@ class SimEngine(ABC):
             NotImplementedError: backend has no camera-params path.
         """
         raise NotImplementedError("get_camera_params not implemented by this backend")
+
+    # Hard cap on pixels per get_world_point call: bounds the per-call work an
+    # LLM can request (agents ground a handful of samples per object; a whole
+    # image belongs to get_frame, not this lookup).
+    _WORLD_POINT_MAX_PIXELS = 1024
+
+    def get_world_point(
+        self,
+        camera_name: str = "default",
+        pixels: Sequence[Sequence[SupportsFloat]] | None = None,
+        width: int | None = None,
+        height: int | None = None,
+    ) -> dict[str, Any]:
+        """Ground image pixels to metric world coordinates via the depth buffer.
+
+        The perception half of deployment-shaped grounding (Harness VLA,
+        arXiv:2607.08448, Appendix E.2): instead of reading privileged object
+        poses (:meth:`get_body_state` -- sim-only oracle truth), the agent
+        picks pixels on the visible surface of the target in the RGB frame and
+        this call unprojects each one through the pixel-aligned metric depth
+        buffer -- ``p_cam = depth * K^-1 @ [u, v, 1]`` in the OpenGL optical
+        frame, then ``p_world = T_world_cam @ p_cam``. The same call shape
+        works on hardware with an RGB-D camera, so grounding built on it
+        transfers.
+
+        Guidance for agents (the paper's localization rule):
+
+        1. Render the camera first (``render`` / ``get_frame``) and pick
+           pixels ON the visible surface of the target object.
+        2. Avoid rims, edges, reflections, transparent surfaces, and
+           background pixels -- depth there is unstable or belongs to
+           something else.
+        3. Sample SEVERAL pixels on the same surface (typically 3-9): the
+           returned ``point`` is the median over the valid samples, which
+           rejects stray outliers.
+        4. Pixels with no depth (background / far plane) are dropped, not
+           zero-filled; check ``n_valid`` against the count you sent.
+        5. Re-localize after any robot, camera, or object motion -- world
+           points are snapshots, not tracks.
+
+        Depth samples are treated as z-depth (distance along the optical
+        axis), the convention every in-tree backend emits. Pixels are indexed
+        ``[u, v]`` with ``u`` the column from the left and ``v`` the row from
+        the top; the unprojection uses the pixel center ``(u + 0.5, v + 0.5)``.
+
+        Atomicity: when the backend exposes an engine lock (``self._lock``,
+        all in-tree backends), the frame render and the camera-params read
+        happen under it, so a concurrent scene mutation cannot slip between
+        the two. All failures return a structured error dict -- this is a
+        tool-envelope method and never raises.
+
+        Args:
+            camera_name: a camera previously added via ``add_camera``
+                (backends with a free camera also accept their free-cam
+                tokens, as for :meth:`get_frame`).
+            pixels: non-empty list of ``[u, v]`` pixel coordinates
+                (integer-valued; at most ``_WORLD_POINT_MAX_PIXELS``).
+            width: image width; ``None`` uses the camera's configured
+                resolution.
+            height: image height; ``None`` uses the camera's configured
+                resolution.
+
+        Returns:
+            On success ``{"status": "success", "content": [{"text": ...},
+            {"json": {"point": [x, y, z], "points": [...], "n_valid": int,
+            "n_requested": int, "camera": str, "width": int, "height": int}}]}``
+            where ``point`` is the per-component median over the valid
+            samples and ``points`` is aligned with the input ``pixels``
+            (``None`` where the pixel had no valid depth). Backends without a
+            metric-depth path (Newton), all-invalid pixel sets, out-of-bounds
+            pixels, and malformed input all return
+            ``{"status": "error", "content": [{"text": ...}]}``.
+        """
+        # numpy stays TYPE_CHECKING-only at this module's top level; import at
+        # use time like the backends' render paths do.
+        import numpy as np
+
+        def _err(msg: str) -> dict[str, Any]:
+            return {"status": "error", "content": [{"text": msg}]}
+
+        # -- Structural validation of `pixels` (before any render work) -- #
+        if pixels is None or isinstance(pixels, (str, bytes)) or not hasattr(pixels, "__len__"):
+            return _err(
+                "get_world_point requires 'pixels': a non-empty list of [u, v] pixel coordinates, e.g. [[320, 240], [322, 238]]."
+            )
+        if len(pixels) == 0:
+            return _err("get_world_point requires at least one [u, v] pixel; got an empty list.")
+        if len(pixels) > self._WORLD_POINT_MAX_PIXELS:
+            return _err(
+                f"get_world_point accepts at most {self._WORLD_POINT_MAX_PIXELS} pixels per call, "
+                f"got {len(pixels)}. Sample a handful of pixels on the target surface instead."
+            )
+        parsed: list[tuple[int, int]] = []
+        for i, px in enumerate(pixels):
+            if isinstance(px, (str, bytes)) or not hasattr(px, "__len__") or len(px) != 2:
+                return _err(f"pixels[{i}] must be a [u, v] pair, got {px!r}.")
+            coords: list[int] = []
+            for axis, component in zip("uv", px, strict=True):
+                if not isinstance(component, numbers.Real) or isinstance(component, bool):
+                    return _err(f"pixels[{i}] {axis} must be numeric, got {type(component).__name__}.")
+                value = float(component)
+                if not math.isfinite(value):
+                    return _err(f"pixels[{i}] {axis} must be finite, got {value}.")
+                if not value.is_integer():
+                    return _err(
+                        f"pixels[{i}] {axis} must be an integer pixel index, got {value} "
+                        "(fractional pixels are rejected, never silently truncated)."
+                    )
+                coords.append(int(value))
+            parsed.append((coords[0], coords[1]))
+
+        # -- Render + camera params (atomic under the engine lock) -- #
+        lock = getattr(self, "_lock", None)
+        ctx = lock if lock is not None else contextlib.nullcontext()
+        with ctx:
+            try:
+                _rgb, depth = self.get_frame(camera_name, width=width, height=height)
+            except NotImplementedError:
+                return _err(
+                    "get_world_point is unavailable: this backend has no raw-frame path (get_frame is not implemented)."
+                )
+            except (KeyError, ValueError, RuntimeError) as e:
+                return _err(f"get_world_point failed to render camera frame: {e}")
+            if depth is None:
+                return _err(
+                    f"get_world_point is unavailable on this backend: camera '{camera_name}' produced no "
+                    "metric depth (get_frame returned depth=None; e.g. Newton's ray-traced camera has no "
+                    "depth output). Use a depth-capable backend (MuJoCo, Isaac) or an RGB-D camera."
+                )
+            h, w = int(depth.shape[0]), int(depth.shape[1])
+            for i, (u, v) in enumerate(parsed):
+                if not (0 <= u < w and 0 <= v < h):
+                    return _err(
+                        f"pixels[{i}] = [{u}, {v}] is outside the rendered {w}x{h} frame "
+                        f"(valid u: 0..{w - 1}, v: 0..{h - 1})."
+                    )
+            try:
+                cam = self.get_camera_params(camera_name, width=w, height=h)
+            except NotImplementedError:
+                return _err(
+                    "get_world_point is unavailable: this backend has no camera-params path (get_camera_params is not implemented)."
+                )
+            except (KeyError, ValueError, RuntimeError) as e:
+                return _err(f"get_world_point failed to read camera parameters: {e}")
+
+        # -- Unproject (pure math; no engine state touched past this point) -- #
+        fx, fy = float(cam.K[0, 0]), float(cam.K[1, 1])
+        cx, cy = float(cam.K[0, 2]), float(cam.K[1, 2])
+        # Background convention across backends: MuJoCo pins no-geometry
+        # pixels to exactly zfar; Isaac reports 0 or non-finite. A small
+        # relative margin below zfar absorbs float rounding at the far plane.
+        zfar_cut = float(cam.zfar) * (1.0 - 1e-6)
+        points: list[list[float] | None] = []
+        valid_points: list[list[float]] = []
+        for u, v in parsed:
+            d = float(depth[v, u])
+            if not (math.isfinite(d) and 0.0 < d < zfar_cut):
+                points.append(None)
+                continue
+            # Pixel center -> OpenGL optical frame (+X right, +Y up, -Z
+            # forward): image v grows down so y flips, and z-depth lies
+            # along -Z.
+            x_cam = (u + 0.5 - cx) / fx * d
+            y_cam = -((v + 0.5 - cy) / fy) * d
+            p_world = cam.T_world_cam @ np.array([x_cam, y_cam, -d, 1.0], dtype=np.float64)
+            world_xyz = [float(p_world[0]), float(p_world[1]), float(p_world[2])]
+            points.append(world_xyz)
+            valid_points.append(world_xyz)
+
+        camera_label = "default" if camera_name in (None, "") else str(camera_name)
+        if not valid_points:
+            return _err(
+                f"get_world_point found no valid depth at any of the {len(parsed)} requested pixels via "
+                f"camera '{camera_label}': every sample hit the background / far plane (zfar={cam.zfar:g} m) "
+                "or had no depth. Pick pixels on the visible surface of the target object -- avoid sky, "
+                "rims/edges, reflections, and background."
+            )
+
+        median = np.median(np.asarray(valid_points, dtype=np.float64), axis=0)
+        point = [float(median[0]), float(median[1]), float(median[2])]
+        n_valid = len(valid_points)
+        text = (
+            f"World point [{point[0]:.4f}, {point[1]:.4f}, {point[2]:.4f}] m "
+            f"(median over {n_valid}/{len(parsed)} valid pixels) via camera '{camera_label}'."
+        )
+        return {
+            "status": "success",
+            "content": [
+                {"text": text},
+                {
+                    "json": {
+                        "point": point,
+                        "points": points,
+                        "n_valid": n_valid,
+                        "n_requested": len(parsed),
+                        "camera": camera_label,
+                        "width": w,
+                        "height": h,
+                    }
+                },
+            ],
+        }
 
     # Discovery / introspection
 

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1237,12 +1237,19 @@ class RenderingMixin:
     ) -> "CameraParams":
         """Return pinhole :class:`~strands_robots.rendering.CameraParams`.
 
-        Named cameras: intrinsics ``K`` come from the camera's vertical FOV
-        (``model.cam_fovy``, square pixels, principal point at the image
-        center); the world-from-camera pose comes from
+        Named cameras: the world-from-camera pose comes from
         ``data.cam_xpos`` / ``data.cam_xmat``. MuJoCo's camera basis already
         matches the OpenGL optical convention (+X right, +Y up, -Z forward),
-        so the pose maps across without correction. Clip planes are
+        so the pose maps across without correction. Intrinsics ``K``: a
+        camera declared with an explicit physical sensor (MJCF
+        ``sensorsize`` / ``focal`` / ``principal`` / ``resolution``) gets its
+        ``K`` from ``model.cam_intrinsic`` / ``cam_sensorsize`` /
+        ``cam_resolution`` - non-square pixels (``fx != fy``) and an
+        off-center principal point are honored, matching what MuJoCo actually
+        rasterizes (see :meth:`_explicit_intrinsics_K` for the calibrated
+        sign conventions). All other cameras fall back to the vertical FOV
+        (``model.cam_fovy``, square pixels, principal point at the image
+        center). Clip planes are
         ``model.vis.map.{znear,zfar} * model.stat.extent``.
 
         Free camera (``None`` / ``""`` / ``"default"`` / ``"free"``): the same
@@ -1298,16 +1305,88 @@ class RenderingMixin:
             zfar = extent * float(model.vis.map.zfar)
             if free_camera:
                 R, t, fovy_deg = self._free_camera_pose(mj, _np, model)
+                K_explicit = None
             else:
                 R, t, fovy_deg = self._named_camera_pose(mj, model, self._world._data, camera_name)
+                cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+                K_explicit = self._explicit_intrinsics_K(_np, model, cam_id, w, h)
 
-        fy = 0.5 * h / _np.tan(_np.deg2rad(fovy_deg) / 2.0)
-        fx = fy  # MuJoCo uses square pixels; intrinsics from vertical FOV are symmetric.
-        K = _np.array([[fx, 0.0, 0.5 * w], [0.0, fy, 0.5 * h], [0.0, 0.0, 1.0]], dtype=_np.float64)
+        if K_explicit is not None:
+            K = K_explicit
+        else:
+            fy = 0.5 * h / _np.tan(_np.deg2rad(fovy_deg) / 2.0)
+            fx = fy  # MuJoCo uses square pixels; intrinsics from vertical FOV are symmetric.
+            K = _np.array([[fx, 0.0, 0.5 * w], [0.0, fy, 0.5 * h], [0.0, 0.0, 1.0]], dtype=_np.float64)
         T_world_cam = _np.eye(4, dtype=_np.float64)
         T_world_cam[:3, :3] = R
         T_world_cam[:3, 3] = t
         return CameraParams(K=K, T_world_cam=T_world_cam, width=w, height=h, znear=znear, zfar=zfar)
+
+    @staticmethod
+    def _explicit_intrinsics_K(np: Any, model: Any, cam_id: int, w: int, h: int) -> "np.ndarray | None":
+        """``K`` for a camera declared with explicit MJCF intrinsics, else ``None``.
+
+        MJCF cameras may declare a physical sensor (``sensorsize`` +
+        ``focal``/``focalpixel`` + ``principal``/``principalpixel`` +
+        ``resolution``). MuJoCo then rasterizes with that intrinsic model -
+        ``fovy`` is ignored, pixels may be non-square (``fx != fy``), and the
+        principal point moves off the image center - so deriving ``K`` from
+        ``fovy`` silently misplaces every unprojected point (~25 cm on the
+        review's repro camera). This helper builds ``K`` the way MuJoCo
+        actually draws.
+
+        Sign conventions were calibrated empirically against MuJoCo 3.8.1 by
+        least-squares fitting blob centroids of spheres at known camera-frame
+        positions over three sensor configurations (offset principal point,
+        non-square sensor, asymmetric focal): a positive MJCF ``principal``
+        offset shifts the principal point toward NEGATIVE ``u`` and ``v``::
+
+            fx = focal_x / (sensor_w / res_w)     fy = focal_y / (sensor_h / res_h)
+            cx = res_w/2 - principal_x / pixel_w  cy = res_h/2 - principal_y / pixel_h
+
+        (fitted (fx, fy, cx, cy) = (300, 300, 85, 80) for sensorsize
+        0.0064x0.0048, focal 0.006, principal (0.0015, 0.0008) at 320x240 -
+        exact to two decimals, and the residuals of the other two
+        configurations pin both signs.) The sensor fixes the view frustum;
+        rendering into a ``(w, h)`` viewport maps that same frustum onto the
+        full viewport, so ``K`` scales linearly per axis (verified: the blob
+        centroid at 640x480 lands at exactly 2x its 320x240 coordinates).
+
+        Args:
+            np: the imported numpy module (kept off this module's top level).
+            model: compiled ``MjModel``.
+            cam_id: camera id in ``model``.
+            w: requested image width in pixels.
+            h: requested image height in pixels.
+
+        Returns:
+            ``(3, 3)`` float64 ``K`` at ``(w, h)``, or ``None`` when the
+            camera declares no physical sensor (``cam_sensorsize`` zero -
+            the ``fovy`` path applies).
+        """
+        sensor_w = float(model.cam_sensorsize[cam_id][0])
+        sensor_h = float(model.cam_sensorsize[cam_id][1])
+        if sensor_w <= 0.0 or sensor_h <= 0.0:
+            return None
+        res_w = float(model.cam_resolution[cam_id][0])
+        res_h = float(model.cam_resolution[cam_id][1])
+        if res_w <= 0.0 or res_h <= 0.0:
+            # sensorsize without resolution does not compile in MuJoCo; be
+            # defensive anyway rather than dividing by zero.
+            return None
+        focal_x, focal_y, pp_x, pp_y = (float(v) for v in model.cam_intrinsic[cam_id])
+        pixel_w = sensor_w / res_w
+        pixel_h = sensor_h / res_h
+        fx = focal_x / pixel_w
+        fy = focal_y / pixel_h
+        cx = res_w / 2.0 - pp_x / pixel_w
+        cy = res_h / 2.0 - pp_y / pixel_h
+        sx = float(w) / res_w
+        sy = float(h) / res_h
+        return np.array(
+            [[fx * sx, 0.0, cx * sx], [0.0, fy * sy, cy * sy], [0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        )
 
     def _named_camera_pose(
         self, mj: Any, model: Any, data: Any, camera_name: str | None

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1812,6 +1812,15 @@ class MuJoCoSimEngine(
             "(camera_name='default', width=None, height=None) -> dict "
             "(viewable grayscale depth PNG image block + metric depth_min/depth_max stats)"
         )
+        base["methods"]["get_world_point"] = (
+            "(camera_name='default', pixels=[[u, v], ...], width=None, height=None) -> dict  # "
+            "pixel-to-world grounding: unprojects each [u, v] pixel through the metric depth "
+            "buffer and returns the MEDIAN world [x, y, z] over the valid samples (plus "
+            "per-pixel points and n_valid). Pick pixels ON the visible surface of the target; "
+            "avoid rims/edges/reflections/background; sample several pixels on the same "
+            "surface; re-localize after any robot/camera/object motion. The deployment-shaped "
+            "alternative to get_body_state (works identically with a real RGB-D camera)"
+        )
         base["methods"]["render_all"] = "(cameras=None, width=None, height=None) -> dict (one image block per camera)"
         base["methods"]["set_obs_noise"] = (
             "(joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0, seed=None) -> dict "
@@ -3554,13 +3563,13 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (72 total): "
+                "Actions (73 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
                 "[Cameras] add_camera, remove_camera, list_cameras; "
                 "[Policy] run_policy, start_policy, stop_policy, eval_policy, replay_episode, list_policies_running; "
-                "[Rendering] render, render_depth, render_all, open_viewer, close_viewer; "
+                "[Rendering] render, render_depth, render_all, get_world_point, open_viewer, close_viewer; "
                 "[Physics] step, set_gravity, set_timestep, set_joint_positions, set_joint_velocities, "
                 "apply_force, get_contacts, get_contact_forces, get_body_state, get_energy, "
                 "get_total_mass, get_ground_height, get_sensor_data, get_jacobian, get_mass_matrix, inverse_dynamics, "

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -30,6 +30,7 @@
         "list_policies_running",
         "render",
         "render_depth",
+        "get_world_point",
         "get_contacts",
         "step",
         "set_gravity",
@@ -221,6 +222,16 @@
     },
     "camera_name": {
       "type": "string"
+    },
+    "pixels": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "description": "get_world_point: pixel coordinates [[u, v], ...] to ground to world xyz (u = column from the left, v = row from the top; integer-valued, within the rendered resolution). Pick pixels ON the visible surface of the target (avoid rims/edges/reflections/background) and sample several on the same surface - the returned 'point' is the median over the valid samples; pixels with no depth are dropped (see n_valid). Re-localize after any robot/camera/object motion."
     },
     "n_steps": {
       "type": "integer"

--- a/tests/simulation/mujoco/test_get_world_point.py
+++ b/tests/simulation/mujoco/test_get_world_point.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``get_world_point`` on the MuJoCo backend (issue #1647).
+
+Acceptance criteria: place a box at a known pose, pick pixels on its visible
+face via a fixed camera, and assert the median world point lands on the
+ground-truth surface; sky/zfar pixels are excluded; the action is advertised
+in tool_spec + describe() and dispatches with validated params. GL-needing
+tests are gated behind the shared runtime probe; the pure-math contract lives
+in ``tests/simulation/test_get_world_point_math.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+from tests.simulation.mujoco._gl_probe import requires_gl
+
+# Ground truth: a static box whose top face is centered at [0.4, 0, 0.1].
+_BOX_POS = [0.4, 0.0, 0.05]
+_BOX_SIZE = [0.2, 0.2, 0.1]  # full extents -> top face z = 0.1, x in [0.3, 0.5], y in [-0.1, 0.1]
+_TOP_CENTER = np.array([0.4, 0.0, 0.1])
+
+
+def _make_box_sim(width: int = 96, height: int = 72):
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    # No ground plane: everything that is not the box is background (pinned to
+    # zfar by get_frame), so invalid-pixel behavior is testable.
+    sim.create_world(ground_plane=False)
+    sim.add_object(name="target_box", shape="box", position=list(_BOX_POS), size=list(_BOX_SIZE), is_static=True)
+    # The camera-to-target ray hits the box's TOP face exactly at _TOP_CENTER
+    # (it clears the front face: at y = -0.1 the ray is at z = 0.18 > 0.1).
+    sim.add_camera("front", position=[0.4, -0.5, 0.5], target=[0.4, 0.0, 0.1], width=width, height=height)
+    sim.step(n_steps=2)
+    return sim
+
+
+def _project(sim, world_point: np.ndarray, camera: str = "front") -> tuple[int, int]:
+    """Project a world point to integer pixel indices via get_camera_params."""
+    cam = sim.get_camera_params(camera)
+    p_cam = np.linalg.inv(cam.T_world_cam) @ np.array([*world_point, 1.0])
+    d = -p_cam[2]  # OpenGL optical frame: -Z forward
+    assert d > 0, "point must be in front of the camera"
+    u = p_cam[0] / d * cam.K[0, 0] + cam.K[0, 2] - 0.5
+    v = -p_cam[1] / d * cam.K[1, 1] + cam.K[1, 2] - 0.5
+    return int(round(u)), int(round(v))
+
+
+def _json_block(result: dict) -> dict:
+    assert result["status"] == "success", result
+    return result["content"][1]["json"]
+
+
+# ----- Regression: known box pose round-trip (GL required) ----- #
+
+
+@requires_gl
+def test_median_world_point_matches_box_ground_truth() -> None:
+    """5 pixels on the box's top face -> median within tolerance of sim truth.
+
+    The center pixel is the projection of the top-face center [0.4, 0, 0.1];
+    the 4 neighbors are symmetric +-3 px offsets on the same face, so the
+    per-component median must recover the center point itself. This is the
+    issue's acceptance regression: a sign/convention error in the
+    unprojection (y-flip, z-forward, pixel center) lands centimeters-to-
+    meters away and fails loudly.
+    """
+    sim = _make_box_sim()
+    try:
+        u, v = _project(sim, _TOP_CENTER)
+        pixels = [[u, v], [u - 3, v], [u + 3, v], [u, v - 3], [u, v + 3]]
+        data = _json_block(sim.get_world_point("front", pixels=pixels))
+        assert data["n_valid"] == 5, data
+        point = np.asarray(data["point"])
+        # Depth axis (top face plane): tight. Lateral: dominated by the +-3 px
+        # sampling offsets (~3 cm on the face), which the median cancels.
+        assert point[2] == pytest.approx(0.1, abs=0.01)
+        assert point[0] == pytest.approx(0.4, abs=0.02)
+        assert point[1] == pytest.approx(0.0, abs=0.03)
+        # Every individual sample stayed on the top face.
+        for p in data["points"]:
+            assert p is not None
+            assert 0.3 - 0.02 <= p[0] <= 0.5 + 0.02
+            assert -0.1 - 0.03 <= p[1] <= 0.1 + 0.03
+            assert p[2] == pytest.approx(0.1, abs=0.01)
+    finally:
+        sim.destroy()
+
+
+@requires_gl
+def test_sky_pixels_are_excluded_and_reported_in_n_valid() -> None:
+    """A background (zfar) pixel is dropped from the median, not unprojected."""
+    sim = _make_box_sim()
+    try:
+        _rgb, depth = sim.get_frame("front")
+        cam = sim.get_camera_params("front")
+        sky = np.argwhere(depth >= cam.zfar * 0.999)
+        assert len(sky) > 0, "scene with no ground plane must have background pixels"
+        sky_v, sky_u = int(sky[0][0]), int(sky[0][1])
+        u, v = _project(sim, _TOP_CENTER)
+        data = _json_block(sim.get_world_point("front", pixels=[[sky_u, sky_v], [u, v]]))
+        assert data["n_valid"] == 1 and data["n_requested"] == 2
+        assert data["points"][0] is None
+        assert np.asarray(data["point"])[2] == pytest.approx(0.1, abs=0.01)
+    finally:
+        sim.destroy()
+
+
+@requires_gl
+def test_all_sky_pixels_return_a_structured_error() -> None:
+    sim = _make_box_sim()
+    try:
+        _rgb, depth = sim.get_frame("front")
+        cam = sim.get_camera_params("front")
+        sky = np.argwhere(depth >= cam.zfar * 0.999)
+        assert len(sky) >= 3
+        pixels = [[int(p[1]), int(p[0])] for p in sky[:3]]
+        result = sim.get_world_point("front", pixels=pixels)
+        assert result["status"] == "error"
+        assert "no valid depth" in result["content"][0]["text"].lower()
+    finally:
+        sim.destroy()
+
+
+@requires_gl
+def test_out_of_bounds_pixel_is_rejected_with_the_frame_size() -> None:
+    sim = _make_box_sim(width=96, height=72)
+    try:
+        result = sim.get_world_point("front", pixels=[[96, 0]])
+        assert result["status"] == "error"
+        assert "96x72" in result["content"][0]["text"]
+    finally:
+        sim.destroy()
+
+
+@requires_gl
+def test_dispatch_route_matches_programmatic_call() -> None:
+    """The agent-facing dispatch path returns the same grounding as the
+    programmatic API -- no silent kwarg drops through the router."""
+    sim = _make_box_sim()
+    try:
+        u, v = _project(sim, _TOP_CENTER)
+        via_dispatch = sim._dispatch_action(
+            "get_world_point", {"action": "get_world_point", "camera_name": "front", "pixels": [[u, v]]}
+        )
+        direct = sim.get_world_point("front", pixels=[[u, v]])
+        assert via_dispatch["status"] == "success", via_dispatch
+        assert _json_block(via_dispatch) == _json_block(direct)
+    finally:
+        sim.destroy()
+
+
+# ----- Tool surface (no GL required) ----- #
+
+
+def _spec() -> dict:
+    spec_path = Path(__file__).resolve().parents[3] / "strands_robots" / "simulation" / "mujoco" / "tool_spec.json"
+    return json.loads(spec_path.read_text())
+
+
+def test_tool_spec_advertises_get_world_point_and_pixels() -> None:
+    spec = _spec()
+    assert "get_world_point" in spec["properties"]["action"]["enum"]
+    pixels = spec["properties"]["pixels"]
+    assert pixels["type"] == "array"
+    assert pixels["items"]["type"] == "array"
+    # The description carries the paper's localization guidance for agents.
+    for keyword in ("median", "surface", "n_valid"):
+        assert keyword in pixels["description"], keyword
+
+
+def test_describe_advertises_get_world_point() -> None:
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation(mesh=False)
+    try:
+        sim.create_world(ground_plane=False)
+        methods = sim.describe()["methods"]
+        assert "get_world_point" in methods
+        for keyword in ("pixels", "median", "surface"):
+            assert keyword.lower() in methods["get_world_point"].lower(), keyword
+    finally:
+        sim.destroy()
+
+
+def test_dispatch_without_world_is_a_structured_error() -> None:
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation(mesh=False)
+    try:
+        result = sim._dispatch_action("get_world_point", {"pixels": [[1, 1]]})
+        assert result["status"] == "error"
+        assert "No world" in result["content"][0]["text"]
+    finally:
+        sim.cleanup()
+
+
+def test_dispatch_rejects_unknown_params() -> None:
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation(mesh=False)
+    try:
+        result = sim._dispatch_action("get_world_point", {"pixels": [[1, 1]], "bogus": 1})
+        assert result["status"] == "error"
+        assert "Unknown parameter 'bogus'" in result["content"][0]["text"]
+    finally:
+        sim.cleanup()
+
+
+def test_dispatch_missing_pixels_names_the_parameter() -> None:
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation(mesh=False)
+    try:
+        result = sim._dispatch_action("get_world_point", {"camera_name": "front"})
+        assert result["status"] == "error"
+        assert "pixels" in result["content"][0]["text"]
+    finally:
+        sim.cleanup()

--- a/tests/simulation/mujoco/test_get_world_point.py
+++ b/tests/simulation/mujoco/test_get_world_point.py
@@ -160,6 +160,136 @@ def test_dispatch_route_matches_programmatic_call() -> None:
         sim.destroy()
 
 
+# ----- Explicit MJCF intrinsics (review on #1649, item 2) ----- #
+
+# A camera declared with a physical sensor: MuJoCo rasterizes with the
+# intrinsic model (offset principal point, fovy ignored). The fovy-derived K
+# put the principal point at the image center and produced ~25 cm of silent
+# world-point error on this exact camera.
+_INTRINSICS_SCENE = """
+<mujoco model="intrinsics_scene">
+  <statistic extent="2" center="0 0 0"/>
+  <visual><map znear="0.005" zfar="25"/></visual>
+  <worldbody>
+    <light pos="0 0 3" dir="0 0 -1"/>
+    <body name="ball" pos="0 0 0.1">
+      <geom type="sphere" size="0.01" rgba="1 0 0 1"/>
+    </body>
+    <camera name="poff" pos="0 -1 0.1" xyaxes="1 0 0 0 0 1"
+            sensorsize="0.0064 0.0048" focal="0.006 0.006"
+            resolution="320 240" principal="0.0015 0.0008"/>
+  </worldbody>
+</mujoco>
+"""
+
+
+class TestExplicitIntrinsicsK:
+    """``_explicit_intrinsics_K`` formula pins (no GL: model compile only).
+
+    Expected values were calibrated against MuJoCo's rasterizer by
+    least-squares fitting depth-blob centroids of spheres at known
+    camera-frame positions (six positions per configuration); a positive
+    MJCF ``principal`` offset shifts the principal point toward NEGATIVE u/v.
+    """
+
+    @staticmethod
+    def _K(camera_attrs: str, w: int, h: int):
+        import mujoco
+
+        from strands_robots.simulation.mujoco.rendering import RenderingMixin
+
+        xml = f"""
+        <mujoco>
+          <worldbody>
+            <camera name="c" pos="0 -1 0.1" xyaxes="1 0 0 0 0 1" {camera_attrs}/>
+          </worldbody>
+        </mujoco>
+        """
+        model = mujoco.MjModel.from_xml_string(xml)
+        cam_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, "c")
+        return RenderingMixin._explicit_intrinsics_K(np, model, cam_id, w, h)
+
+    def test_offset_principal_point(self) -> None:
+        K = self._K(
+            'sensorsize="0.0064 0.0048" focal="0.006 0.006" resolution="320 240" principal="0.0015 0.0008"',
+            320,
+            240,
+        )
+        assert K is not None
+        assert K[0, 0] == pytest.approx(300.0)
+        assert K[1, 1] == pytest.approx(300.0)
+        assert K[0, 2] == pytest.approx(85.0)
+        assert K[1, 2] == pytest.approx(80.0)
+
+    def test_non_square_sensor(self) -> None:
+        K = self._K('sensorsize="0.008 0.0048" focal="0.006 0.006" resolution="320 240"', 320, 240)
+        assert K is not None
+        assert K[0, 0] == pytest.approx(240.0)  # fx != fy: non-square pixels honored
+        assert K[1, 1] == pytest.approx(300.0)
+        assert K[0, 2] == pytest.approx(160.0)
+        assert K[1, 2] == pytest.approx(120.0)
+
+    def test_asymmetric_focal_negative_principal(self) -> None:
+        K = self._K(
+            'sensorsize="0.0064 0.0048" focal="0.004 0.006" resolution="320 240" principal="-0.001 0.0012"',
+            320,
+            240,
+        )
+        assert K is not None
+        assert K[0, 0] == pytest.approx(200.0)
+        assert K[1, 1] == pytest.approx(300.0)
+        assert K[0, 2] == pytest.approx(210.0)
+        assert K[1, 2] == pytest.approx(60.0)
+
+    def test_scales_linearly_with_render_size(self) -> None:
+        """The sensor fixes the frustum; a 2x viewport doubles K per axis
+        (verified against the rasterizer: the blob centroid at 640x480 lands
+        at exactly 2x its 320x240 coordinates)."""
+        attrs = 'sensorsize="0.0064 0.0048" focal="0.006 0.006" resolution="320 240" principal="0.0015 0.0008"'
+        K1 = self._K(attrs, 320, 240)
+        K2 = self._K(attrs, 640, 480)
+        assert K1 is not None and K2 is not None
+        assert np.allclose(K2[:2, :], 2.0 * K1[:2, :])
+
+    def test_fovy_camera_returns_none(self) -> None:
+        """No physical sensor declared -> the fovy path applies (fallback)."""
+        assert self._K('fovy="45"', 320, 240) is None
+
+
+@requires_gl
+def test_world_point_correct_on_explicit_intrinsics_camera(tmp_path) -> None:
+    """Round-trip on the review's repro camera, non-circularly: the target
+    pixel comes from the DEPTH-blob centroid (rasterizer truth, no K
+    involved), and the unprojected point must land on the sphere's visible
+    surface. The fovy-derived K was ~25 cm off here and reported success."""
+    from strands_robots.simulation import Simulation
+
+    scene = tmp_path / "intrinsics_scene.xml"
+    scene.write_text(_INTRINSICS_SCENE)
+    sim = Simulation(mesh=False)
+    try:
+        assert sim.create_world(ground_plane=False)["status"] == "success"
+        assert sim.load_scene(str(scene))["status"] == "success", "load_scene failed"
+        _rgb, depth = sim.get_frame("poff")
+        assert depth is not None
+        cam = sim.get_camera_params("poff")
+        mask = depth < cam.zfar * 0.5
+        assert mask.sum() > 0, "sphere not visible in depth"
+        vs, us = np.where(mask)
+        u, v = int(round(us.mean())), int(round(vs.mean()))
+        data = _json_block(sim.get_world_point("poff", pixels=[[u, v]]))
+        point = np.asarray(data["point"])
+        # Camera at (0, -1, 0.1) looking +y; the sphere (r=0.01) at
+        # (0, 0, 0.1) presents its near surface at ~(0, -0.01, 0.1).
+        expected = np.array([0.0, -0.01, 0.1])
+        assert np.linalg.norm(point - expected) < 0.02, (
+            f"world point {point.tolist()} is {np.linalg.norm(point - expected):.4f} m from "
+            f"the sphere surface {expected.tolist()} - explicit intrinsics not honored"
+        )
+    finally:
+        sim.destroy()
+
+
 # ----- Tool surface (no GL required) ----- #
 
 
@@ -215,6 +345,24 @@ def test_dispatch_rejects_unknown_params() -> None:
         assert "Unknown parameter 'bogus'" in result["content"][0]["text"]
     finally:
         sim.cleanup()
+
+
+def test_dispatch_non_string_camera_name_is_a_structured_error() -> None:
+    """A camera INDEX (int) must degrade like every sibling camera action -
+    error dict, never a TypeError out of mj_name2id through the envelope
+    (review on #1649, item 1)."""
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation(mesh=False)
+    try:
+        sim.create_world(ground_plane=False)
+        result = sim._dispatch_action("get_world_point", {"camera_name": 5, "pixels": [[1, 1]]})
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "camera_name" in text
+        assert "int" in text
+    finally:
+        sim.destroy()
 
 
 def test_dispatch_missing_pixels_names_the_parameter() -> None:

--- a/tests/simulation/newton/test_get_world_point.py
+++ b/tests/simulation/newton/test_get_world_point.py
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``get_world_point`` on the Newton backend (issue #1647).
+
+Newton's ray-traced tiled camera has no depth output path (``get_frame``
+returns ``(rgb, None)``), so pixel-to-world grounding must degrade to the
+documented structured no-depth error -- never a silent zero point. Skipped
+when Newton/Warp are not installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+_HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_NEWTON, reason="newton/warp not installed")
+
+
+@pytest.fixture
+def engine_with_camera():
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    sim = NewtonSimEngine(solver="mujoco")
+    sim.create_world()
+    sim.add_robot("so101")
+    sim.add_camera("front", position=[0.5, -0.5, 0.4], target=[0.0, 0.0, 0.1], width=64, height=48)
+    yield sim
+    sim.destroy()
+
+
+def test_get_world_point_reports_no_depth_structured_error(engine_with_camera) -> None:
+    result = engine_with_camera.get_world_point("front", pixels=[[10, 10], [12, 12]])
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "no" in text.lower() and "depth" in text
+    # The error names the remedy, not just the failure.
+    assert "MuJoCo" in text or "RGB-D" in text

--- a/tests/simulation/test_get_world_point_math.py
+++ b/tests/simulation/test_get_world_point_math.py
@@ -1,0 +1,234 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Backend-agnostic ``SimEngine.get_world_point`` contract (issue #1647).
+
+``get_world_point`` is pure math over ``get_frame`` + ``get_camera_params``,
+so its unprojection, median robustness, invalid-pixel handling, and input
+validation are all pinned here against a pure-Python stub engine -- no MuJoCo,
+no GL, no GPU. Backend-specific accuracy lives in
+``tests/simulation/mujoco/test_get_world_point.py`` (regression against a box
+at a known pose) and the gated Isaac GPU test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import CameraParams
+from strands_robots.simulation.base import SimEngine
+
+_W, _H = 64, 48
+_FX = _FY = 100.0
+_CX, _CY = _W / 2.0, _H / 2.0
+_ZFAR = 1000.0
+
+
+class _StubSim(SimEngine):
+    """Minimal engine with a synthetic depth buffer and known camera params."""
+
+    def __init__(self, depth: np.ndarray | None, T_world_cam: np.ndarray | None = None) -> None:
+        self._depth = depth
+        self._T = np.eye(4, dtype=np.float64) if T_world_cam is None else T_world_cam
+
+    # -- raw-frame surface under test -- #
+
+    def get_frame(self, camera_name="default", width=None, height=None):
+        rgb = np.zeros((_H, _W, 3), dtype=np.uint8)
+        return rgb, self._depth
+
+    def get_camera_params(self, camera_name="default", width=None, height=None):
+        K = np.array([[_FX, 0.0, _CX], [0.0, _FY, _CY], [0.0, 0.0, 1.0]], dtype=np.float64)
+        return CameraParams(K=K, T_world_cam=self._T, width=_W, height=_H, znear=0.01, zfar=_ZFAR)
+
+    # -- SimEngine abstract boilerplate -- #
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):
+        return {"status": "success"}
+
+    def destroy(self):
+        return {"status": "success"}
+
+    def reset(self):
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):
+        return {"status": "success"}
+
+    def get_state(self):
+        return {"sim_time": 0.0, "step_count": 0}
+
+    def add_robot(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_robot(self, name):
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return []
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return []
+
+    def add_object(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_object(self, name):
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        return {}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        return {"status": "success"}
+
+    def render(self, camera_name="default", width=None, height=None):
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+def _flat_depth(value: float = 2.0) -> np.ndarray:
+    return np.full((_H, _W), value, dtype=np.float32)
+
+
+def _json_block(result: dict[str, Any]) -> dict[str, Any]:
+    assert result["status"] == "success", result
+    return result["content"][1]["json"]
+
+
+# ----- Unprojection math ----- #
+
+
+def test_identity_pose_unprojection_is_exact() -> None:
+    """Pixel-center unprojection through K^-1 into the OpenGL optical frame.
+
+    Camera at the origin with the identity pose: +X right, +Y up, looking
+    along -Z. A flat depth plane at 2 m must unproject the pixel (u, v) to
+    exactly ``[(u+0.5-cx)/fx * d, -(v+0.5-cy)/fy * d, -d]`` -- pinning the
+    pixel-center convention, the image-v-grows-down y-flip, and the -Z-forward
+    z sign in one shot. A wrong sign on any axis fails by centimeters.
+    """
+    sim = _StubSim(_flat_depth(2.0))
+    result = sim.get_world_point("default", pixels=[[32, 24], [0, 0], [63, 47]])
+    data = _json_block(result)
+    assert data["n_valid"] == 3 and data["n_requested"] == 3
+    expected = [
+        [(u + 0.5 - _CX) / _FX * 2.0, -((v + 0.5 - _CY) / _FY) * 2.0, -2.0] for u, v in ((32, 24), (0, 0), (63, 47))
+    ]
+    for got, want in zip(data["points"], expected, strict=True):
+        assert got == pytest.approx(want, abs=1e-12)
+
+
+def test_world_pose_is_applied_after_unprojection() -> None:
+    """``p_world = T_world_cam @ p_cam``: a pure translation shifts the point."""
+    T = np.eye(4)
+    T[:3, 3] = [1.0, 2.0, 3.0]
+    sim = _StubSim(_flat_depth(2.0), T_world_cam=T)
+    data = _json_block(sim.get_world_point("default", pixels=[[32, 24]]))
+    cam_frame = [0.5 / _FX * 2.0, -(0.5 / _FY) * 2.0, -2.0]
+    assert data["point"] == pytest.approx([cam_frame[0] + 1.0, cam_frame[1] + 2.0, cam_frame[2] + 3.0], abs=1e-12)
+
+
+def test_median_rejects_a_depth_outlier() -> None:
+    """The paper's robustness rule is built in: one bad sample cannot move the
+    answer. Three same-column pixels at 2 m plus one outlier at 9 m must
+    report the 2 m surface, not the mean (which would drift ~1.75 m)."""
+    depth = _flat_depth(2.0)
+    depth[10, 32] = 9.0  # outlier sample
+    sim = _StubSim(depth)
+    data = _json_block(sim.get_world_point("default", pixels=[[32, 20], [32, 24], [32, 28], [32, 10]]))
+    assert data["n_valid"] == 4
+    assert data["point"][2] == pytest.approx(-2.0, abs=1e-9)
+
+
+# ----- Invalid-depth handling ----- #
+
+
+def test_background_and_nonfinite_pixels_are_dropped_not_zero_filled() -> None:
+    """zfar (MuJoCo background), 0 and non-finite (Isaac background) samples
+    are excluded from the median and reported as ``None`` in ``points`` --
+    never unprojected into a bogus world coordinate."""
+    depth = _flat_depth(2.0)
+    depth[0, 0] = _ZFAR  # MuJoCo pins sky to exactly zfar
+    depth[1, 1] = 0.0  # Isaac reports no-geometry as 0
+    depth[2, 2] = np.inf  # ... or non-finite
+    sim = _StubSim(depth)
+    data = _json_block(sim.get_world_point("default", pixels=[[0, 0], [1, 1], [2, 2], [32, 24]]))
+    assert data["n_valid"] == 1 and data["n_requested"] == 4
+    assert data["points"][0] is None and data["points"][1] is None and data["points"][2] is None
+    assert data["points"][3] is not None
+    assert data["point"][2] == pytest.approx(-2.0, abs=1e-9)
+
+
+def test_all_invalid_pixels_is_a_structured_error_not_a_zero_point() -> None:
+    sim = _StubSim(_flat_depth(_ZFAR))
+    result = sim.get_world_point("default", pixels=[[0, 0], [32, 24]])
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "no valid depth" in text.lower()
+    assert "far plane" in text
+
+
+def test_no_depth_backend_is_a_structured_error() -> None:
+    """A Newton-shaped backend (``get_frame`` -> ``(rgb, None)``) degrades to
+    the documented no-depth error, never a silent zero point."""
+    sim = _StubSim(depth=None)
+    result = sim.get_world_point("default", pixels=[[1, 1]])
+    assert result["status"] == "error"
+    assert "no" in result["content"][0]["text"].lower()
+    assert "depth" in result["content"][0]["text"]
+
+
+def test_base_facade_without_raw_frames_is_a_structured_error() -> None:
+    """An engine that never implemented get_frame gets a clear error dict
+    (tool-envelope contract: never raises), naming the missing path."""
+
+    class _NoFrames(_StubSim):
+        def get_frame(self, camera_name="default", width=None, height=None):
+            raise NotImplementedError("get_frame not implemented by this backend")
+
+    result = _NoFrames(_flat_depth()).get_world_point("default", pixels=[[1, 1]])
+    assert result["status"] == "error"
+    assert "get_frame" in result["content"][0]["text"]
+
+
+# ----- Input validation ----- #
+
+
+@pytest.mark.parametrize(
+    "pixels",
+    [None, [], "12,24", [[1]], [[1, 2, 3]], [["a", 2]], [[True, 2]], [[np.nan, 2]]],
+)
+def test_malformed_pixels_are_rejected(pixels) -> None:
+    result = _StubSim(_flat_depth()).get_world_point("default", pixels=pixels)
+    assert result["status"] == "error", result
+    assert "pixel" in result["content"][0]["text"].lower()
+
+
+def test_fractional_pixels_are_rejected_not_truncated() -> None:
+    result = _StubSim(_flat_depth()).get_world_point("default", pixels=[[10.5, 20]])
+    assert result["status"] == "error"
+    assert "fractional" in result["content"][0]["text"]
+
+
+def test_integral_floats_are_accepted() -> None:
+    """LLMs emit 32.0 for 32; integer-valued floats must not be rejected."""
+    data = _json_block(_StubSim(_flat_depth()).get_world_point("default", pixels=[[32.0, 24.0]]))
+    assert data["n_valid"] == 1
+
+
+@pytest.mark.parametrize("bad", [[-1, 0], [_W, 0], [0, -1], [0, _H]])
+def test_out_of_bounds_pixels_are_rejected_with_the_valid_range(bad) -> None:
+    result = _StubSim(_flat_depth()).get_world_point("default", pixels=[[1, 1], bad])
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "outside" in text
+    assert f"{_W}x{_H}" in text
+
+
+def test_pixel_count_is_capped() -> None:
+    too_many = [[1, 1]] * (SimEngine._WORLD_POINT_MAX_PIXELS + 1)
+    result = _StubSim(_flat_depth()).get_world_point("default", pixels=too_many)
+    assert result["status"] == "error"
+    assert str(SimEngine._WORLD_POINT_MAX_PIXELS) in result["content"][0]["text"]

--- a/tests_integ/simulation/test_isaac_world_point_gpu.py
+++ b/tests_integ/simulation/test_isaac_world_point_gpu.py
@@ -1,0 +1,84 @@
+"""GPU integration test for ``get_world_point`` on the Isaac backend (#1647).
+
+Exercises the pixel-to-world grounding path against a real RTX depth
+annotator (``distance_to_image_plane``): a camera looking at the origin of
+the default ground plane must unproject its center pixel to a world point on
+that plane (z ~ 0), and out-of-bounds pixels must be rejected with the
+structured error contract.
+
+Requirements match ``test_isaac_recording_gpu.py``: NVIDIA GPU + CUDA, Isaac
+Sim 6.0+ installed out-of-band, ``pip install 'strands-robots[sim-isaac]'``,
+and ``STRANDS_GPU_TEST=1``. Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ \\
+        tests_integ/simulation/test_isaac_world_point_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("strands_robots.simulation.isaac")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+class TestIsaacWorldPoint:
+    def test_center_pixel_grounds_to_the_ground_plane(self):
+        """Camera looking at the origin: the center pixel's median world point
+        lands on the ground plane (z ~ 0) within tolerance -- the same
+        acceptance shape as the MuJoCo box regression, on real RTX depth."""
+        import numpy as np
+
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=False, render_mode="rtx_realtime"))
+        try:
+            r = sim.create_world(ground_plane=True)
+            assert r["status"] == "success", f"create_world: {r}"
+            r = sim.add_camera("front", position=[0.0, 2.0, 1.5], target=[0.0, 0.0, 0.0])
+            assert r["status"] == "success", f"add_camera: {r}"
+            sim.reset()
+            sim.step(5)
+
+            cam = sim.get_camera_params("front")
+            cu, cv = int(cam.width // 2), int(cam.height // 2)
+            pixels = [[cu, cv], [cu - 3, cv], [cu + 3, cv], [cu, cv - 3], [cu, cv + 3]]
+
+            result = sim.get_world_point("front", pixels=pixels)
+            assert result["status"] == "success", result
+            data = result["content"][1]["json"]
+            assert data["n_valid"] >= 3, data
+            point = np.asarray(data["point"], dtype=float)
+            assert np.isfinite(point).all()
+            # The camera-to-origin ray hits the ground plane at/near the
+            # origin; the depth axis (plane height) is the tight assertion.
+            assert abs(point[2]) < 0.05, data
+            assert np.linalg.norm(point[:2]) < 0.5, data
+
+            # Out-of-bounds pixels degrade to the structured error contract.
+            bad = sim.get_world_point("front", pixels=[[cam.width, 0]])
+            assert bad["status"] == "error"
+            assert "outside" in bad["content"][0]["text"]
+        finally:
+            sim.destroy()


### PR DESCRIPTION
Closes #1647.

## What changed

Adds `SimEngine.get_world_point(camera_name, pixels, width=None, height=None)` - agent-facing pixel-to-world grounding built on the #1537 raw-frame APIs (`get_frame` + `get_camera_params`), plus the MuJoCo tool wiring (tool_spec enum + `pixels` param, `describe()`, action count 72 -> 73).

This is the perception half of the Harness VLA recipe (arXiv:2607.08448, Appendix E.2): instead of reading privileged object poses via `get_body_state` (sim-only oracle truth - still the right tool for data generation and success checking), the agent picks pixels on the visible surface of the target in RGB and this call unprojects each one through the pixel-aligned metric depth buffer: `p_cam = depth * K^-1 @ [u, v, 1]` in the OpenGL optical frame (pixel-center convention, image-v-down y-flip, -Z forward), then `p_world = T_world_cam @ p_cam`. The same call shape works on hardware with an RGB-D camera, so grounding built on it transfers, and it composes with the analytic-primitives issue (`move_to(get_world_point(...))` staging idiom).

### Design decisions

- **Concrete base implementation** (`strands_robots/simulation/base.py`), not per-backend: the operation is pure math over the two raw-frame hooks, so MuJoCo and Isaac inherit it for free. Backends without `get_frame` degrade to a structured error naming the missing path.
- **Multi-pixel median built in** (the paper's robustness rule) - per-component median over the valid samples; per-pixel `points` (aligned with input, `None` where invalid) and `n_valid` are also returned so the agent can see which samples were dropped.
- **Invalid-depth rule covers both backend conventions**: MuJoCo pins no-geometry pixels to exactly `zfar`; Isaac's `distance_to_image_plane` annotator reports 0 or non-finite. Samples outside `(0, zfar * (1 - 1e-6))` or non-finite are dropped, never unprojected. All-invalid returns a structured error telling the agent to pick pixels on a visible surface.
- **Newton returns the documented no-depth error** (`get_frame` -> `(rgb, None)`), never a silent zero point.
- **Atomicity**: frame render + camera-params read happen under the engine `RLock` (all in-tree backends), so a concurrent scene mutation cannot slip between the two. All failures return `{"status": "error", "content": [...]}` - tool-envelope contract, never raises.
- **LLM input validation** (per the PR #92 learnings): `pixels` must be a non-empty `[[u, v], ...]` list, integer-valued (fractional pixels are rejected, never silently truncated), bounds-checked against the actually-rendered frame size, capped at 1024 per call. The dispatcher rejects unknown kwargs; no silent drops.
- **Agent guidance** (the paper's 6-step localization rule) lives in the docstring, the tool_spec `pixels` description, and `describe()`: pick pixels ON visible surfaces, avoid rims/edges/reflections/background, sample several on the same surface, re-localize after any robot/camera/object motion.

## Test surface

- `tests/simulation/test_get_world_point_math.py` (22 tests, pure-Python stub engine, no GL/GPU): exact unprojection math (pixel-center, y-flip, -Z forward), world-pose application, median outlier rejection, background/non-finite dropping, all-invalid error, no-depth error, base-facade error, full input-validation matrix.
- `tests/simulation/mujoco/test_get_world_point.py` (11 tests): the acceptance regression - box at a known pose, 5 pixels on its top face located by projecting the ground-truth point through `get_camera_params`, median asserted within tolerance of sim truth (GL-gated via the shared runtime probe); sky/zfar exclusion with `n_valid` accounting; all-sky structured error; out-of-bounds rejection; dispatch-vs-programmatic equivalence; tool_spec/describe advertising; unknown-param and missing-param dispatch errors.
- `tests/simulation/newton/test_get_world_point.py`: structured no-depth error on the real Newton backend (skipped when newton/warp absent).
- `tests_integ/simulation/test_isaac_world_point_gpu.py`: gated GPU test (same `STRANDS_GPU_TEST=1` pattern as `test_isaac_recording_gpu.py`) grounding the camera-center pixel to the ground plane (z ~ 0) on real RTX depth, plus the bounds-error contract.

## Acceptance criteria (from #1647)

- [x] MuJoCo: box at a known pose, 5 pixels on its face via a fixed camera, median world point within tolerance of ground truth (regression test)
- [x] Invalid pixels (sky/zfar) excluded; all-invalid returns a structured error
- [x] Newton returns the documented no-depth error; Isaac path exercised by a gated GPU test
- [x] Advertised in tool_spec/describe; params validated; no silent kwarg drops

## Validation

- `hatch run lint`: clean (ruff check, ruff format, mypy).
- `hatch run test` with `MUJOCO_GL=egl`: **12017 passed, 246 skipped, 0 failed** - including the GL-gated box regression executed against real EGL rendering.
- Note: with the default GL backend the full suite aborts on this dev box inside pre-existing render-driving tests (`test_remote_policy_sim_rollout`, `test_mesh_tell_sim_e2e`) - verified identical on clean `main`, environmental (GL context), not introduced here.

## Out of scope / follow-ups

- Newton/Isaac tool-envelope dispatch surfaces (only MuJoCo has `tool_spec.json` today); the programmatic API works on all three backends now.
- The analytic-primitives consumer (`move_to(get_world_point(...))`) is tracked in its own issue.

Project board: please move #1647 to "In review" (item add/edit via `gh project` requires org project scopes this token lacks).
