### PR TITLE
fix(sim): honor a gripper command identically for actuator-name and joint-name keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a gripper command is honored the same way whichever name the action key spells
+
+`send_action` accepts an action key as either the actuator name (`actuator8` on
+the Panda) or a joint name that actuator drives (`finger_joint1`). Both resolve
+to the same actuator, but only the joint-name branch mapped a logical `[0, 1]`
+open/close fraction onto a tendon gripper's wide ctrlrange. The actuator-name
+branch wrote the value verbatim, so the same command meant opposite things:
+
+```python
+sim.send_action({"finger_joint1": 1.0}, robot_name="panda")
+# -> ctrl 255.0, finger gap 0.0400 m (fully OPEN)
+sim.send_action({"actuator8": 1.0}, robot_name="panda")
+# -> ctrl   1.0, finger gap 0.0002 m (CLOSED - 0.4% of the [0, 255] range)
+```
+
+The actuator name is the spelling the engine advertises: `robot_action_keys()`
+returns actuator names, a policy receives them through
+`set_robot_state_keys()`, and a positional action vector (`send_action([...])`,
+`replay_episode`) binds to them in order. Every policy rollout and dataset
+replay therefore took the unscaled branch and could not open a tendon gripper,
+so a scripted top-down pick left the object on the ground instead of lifting
+it. Both branches now write through one shared path, so the two spellings
+cannot diverge again. Direct joint/position/torque actuators are unchanged (the
+unit mapping applies to tendon transmissions only), and a mapped tendon command
+no longer emits a spurious "MuJoCo will clamp it" warning through the
+actuator-name spelling.
+
 ### Fixed: `add_object` rejects a mass it cannot honor, and a refused add never bricks the scene
 
 `add_object` validated `position`, `orientation`, `color` and `size` but wrote

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -571,9 +571,7 @@ class RenderingMixin:
         for key, value in action_dict.items():
             act_id = _lookup(mj.mjtObj.mjOBJ_ACTUATOR, key)
             if act_id >= 0:
-                fval = float(value)
-                self._warn_ctrl_clamp(model, act_id, pfx, key, fval, mj)
-                data.ctrl[act_id] = fval
+                self._write_ctrl(model, data, act_id, pfx, key, value, mj)
                 continue
 
             # Fallback: key is a joint name. Find the actuator that drives
@@ -601,24 +599,51 @@ class RenderingMixin:
                 unresolved.append(key)
                 continue
 
-            # Scale a logical command into the actuator's ctrlrange when the
-            # transmission is a tendon (gripper ctrlrange is e.g. [0, 255]
-            # tendon units, not a finger-joint position). Direct JOINT
-            # actuators keep the raw value (positions/torques in joint units).
-            ctrl_value = self._scale_ctrl_for_actuator(model, ai, float(value), mj)
-            # A direct JOINT actuator writes the value verbatim, so an
-            # out-of-ctrlrange joint-addressed command is silently clamped by
-            # MuJoCo exactly as the actuator-addressed branch above is - apply
-            # the same no-silent-clamp warning here so the contract does not
-            # depend on whether the caller keyed by actuator or by joint name.
-            # Tendon drives are skipped: _scale_ctrl_for_actuator has already
-            # mapped/clamped the command into the ctrlrange on purpose, so a
-            # clamp warning would be spurious.
-            if int(model.actuator_trntype[ai]) != int(mj.mjtTrn.mjTRN_TENDON):
-                self._warn_ctrl_clamp(model, ai, pfx, key, ctrl_value, mj)
-            data.ctrl[ai] = ctrl_value
+            self._write_ctrl(model, data, ai, pfx, key, value, mj)
 
         return unresolved
+
+    def _write_ctrl(
+        self,
+        model: Any,
+        data: Any,
+        act_id: int,
+        pfx: str,
+        key: str,
+        value: Any,
+        mj: Any,
+    ) -> None:
+        """Write one action value to ``data.ctrl[act_id]``, unit-mapping tendon drives.
+
+        The single ctrl-write path for BOTH spellings an action key may take -
+        the actuator name (``actuator8``) and the joint name
+        (``finger_joint1``). Both resolve to the same actuator, so both must
+        write the same ctrl value: a tendon gripper addressed by its actuator
+        name previously wrote the logical command verbatim, so the same
+        ``1.0`` that fully OPENED the gripper through the joint-name key left
+        it CLOSED (``1.0`` of a ``[0, 255]`` tendon ctrlrange) through the
+        actuator name - which is the spelling :meth:`robot_action_keys`
+        advertises and that a policy action vector binds to positionally.
+
+        Applies :meth:`_scale_ctrl_for_actuator` (a no-op for non-tendon
+        transmissions, so direct joint/position/torque actuators still write
+        the raw value) and then warns once on a silent MuJoCo clamp. Tendon
+        drives skip the clamp warning: the scaling has already mapped the
+        command into the ctrlrange on purpose, so a warning would be spurious.
+
+        Args:
+            model: Live ``mujoco.MjModel``.
+            data: Live ``mujoco.MjData`` (caller holds ``self._lock``).
+            act_id: Resolved actuator id to write.
+            pfx: Robot namespace prefix, for de-duplicated warnings.
+            key: Action key as the caller spelled it, for warnings.
+            value: Commanded value in the caller's logical units.
+            mj: The ``mujoco`` module.
+        """
+        ctrl_value = self._scale_ctrl_for_actuator(model, act_id, float(value), mj)
+        if int(model.actuator_trntype[act_id]) != int(mj.mjtTrn.mjTRN_TENDON):
+            self._warn_ctrl_clamp(model, act_id, pfx, key, ctrl_value, mj)
+        data.ctrl[act_id] = ctrl_value
 
     def _warn_unresolved_action_key(self, pfx: str, key: str, reason: str) -> None:
         """Warn once per (prefix, key) that an action key could not be applied.

--- a/tests/simulation/mujoco/test_gripper_action_key_equivalence.py
+++ b/tests/simulation/mujoco/test_gripper_action_key_equivalence.py
@@ -1,0 +1,181 @@
+"""A gripper command must not depend on which name the action key spells.
+
+``send_action`` accepts an action key as EITHER the actuator name
+(``actuator8`` on the Panda) or a joint name the actuator drives
+(``finger_joint1``). Both resolve to the same actuator, so both must write the
+same ``data.ctrl`` value.
+
+They did not. Only the joint-name branch ran ``_scale_ctrl_for_actuator``, which
+maps a logical ``[0, 1]`` open/close fraction onto a tendon gripper's wide
+ctrlrange (the Panda's ``[0, 255]``). The actuator-name branch wrote the value
+verbatim, so a normalised ``1.0`` meant "fully open" through the joint name and
+"0.4% of range - closed" through the actuator name.
+
+The actuator name is the spelling the engine advertises: ``robot_action_keys()``
+returns actuator names, a policy receives them via ``set_robot_state_keys``, and
+a positional action vector (``send_action([...])``, ``replay_episode``) binds to
+them in order. So every policy and dataset-replay path took the unscaled branch
+and could not open a tendon gripper at all.
+
+These tests pin the equivalence on a synthetic model (no asset download): one
+direct-joint actuator plus one tendon actuator with a Panda-like ``[0, 255]``
+ctrlrange.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.rendering import RenderingMixin  # noqa: E402
+
+# One hinge driven directly ("arm_act") + two finger slides wrapped by a
+# "split" tendon driven by "grip_act" with the Panda's remapped [0, 255] range.
+_XML = """
+<mujoco model="key_equivalence">
+  <worldbody>
+    <body name="link">
+      <joint name="arm_joint" type="hinge" axis="0 0 1" range="-3 3"/>
+      <geom type="capsule" size="0.02 0.1" fromto="0 0 0 0 0 0.2"/>
+      <body name="hand" pos="0 0 0.2">
+        <geom type="box" size="0.03 0.03 0.02"/>
+        <body name="finger1" pos="0.03 0 0">
+          <joint name="finger_joint1" type="slide" axis="1 0 0" range="0 0.04"/>
+          <geom type="box" size="0.005 0.01 0.02"/>
+        </body>
+        <body name="finger2" pos="-0.03 0 0">
+          <joint name="finger_joint2" type="slide" axis="-1 0 0" range="0 0.04"/>
+          <geom type="box" size="0.005 0.01 0.02"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="split">
+      <joint joint="finger_joint1" coef="1"/>
+      <joint joint="finger_joint2" coef="1"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <position name="arm_act" joint="arm_joint" ctrlrange="-3 3"/>
+    <position name="grip_act" tendon="split" ctrlrange="0 255" kp="1"/>
+  </actuator>
+</mujoco>
+"""
+
+# A tendon whose ctrlrange spans zero is already the normalised command space,
+# so a symmetric command passes through clamped instead of being re-mapped.
+_XML_SYMMETRIC = """
+<mujoco model="key_equivalence_symmetric">
+  <worldbody>
+    <body name="hand">
+      <body name="f1" pos="0.03 0 0">
+        <joint name="fj1" type="slide" axis="1 0 0" range="-1 1"/>
+        <geom type="box" size="0.005 0.01 0.02"/>
+      </body>
+      <body name="f2" pos="-0.03 0 0">
+        <joint name="fj2" type="slide" axis="-1 0 0" range="-1 1"/>
+        <geom type="box" size="0.005 0.01 0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="sym_split">
+      <joint joint="fj1" coef="1"/>
+      <joint joint="fj2" coef="1"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <position name="sym_act" tendon="sym_split" ctrlrange="-1 1" kp="1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def model():
+    return mujoco.MjModel.from_xml_string(_XML)
+
+
+def _aid(model, name):
+    return mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
+
+
+def _ctrl_after(model, action):
+    """Apply ``action`` to a fresh MjData and return the ctrl vector."""
+    data = mujoco.MjData(model)
+    RenderingMixin()._apply_action_by_name(model, data, action, "", mujoco)
+    return data.ctrl.copy()
+
+
+@pytest.mark.parametrize("command", [0.0, 0.25, 0.5, 1.0])
+def test_actuator_name_and_joint_name_write_the_same_gripper_ctrl(model, command):
+    """The same logical gripper command must land identically for both spellings.
+
+    Pre-fix the actuator-name key wrote ``command`` verbatim (1.0 of a
+    [0, 255] range = closed) while the joint-name key wrote the mapped
+    fraction (255 = open) - the same call, opposite physical outcome.
+    """
+    grip = _aid(model, "grip_act")
+    by_actuator = _ctrl_after(model, {"grip_act": command})[grip]
+    by_joint = _ctrl_after(model, {"finger_joint1": command})[grip]
+    assert by_actuator == pytest.approx(by_joint)
+    assert by_actuator == pytest.approx(command * 255.0)
+
+
+def test_actuator_name_open_command_fully_opens_tendon_gripper(model):
+    """A normalised fully-open command through the actuator name reaches hi.
+
+    This is the key spelling ``robot_action_keys()`` advertises and that a
+    policy action vector binds to positionally, so it is the path every policy
+    rollout and dataset replay takes.
+    """
+    grip = _aid(model, "grip_act")
+    assert _ctrl_after(model, {"grip_act": 1.0})[grip] == pytest.approx(255.0)
+
+
+def test_actuator_name_in_range_tendon_command_still_passes_verbatim(model):
+    """An already-in-ctrlrange tendon command is trusted, not re-mapped."""
+    grip = _aid(model, "grip_act")
+    assert _ctrl_after(model, {"grip_act": 128.0})[grip] == pytest.approx(128.0)
+
+
+def test_actuator_name_direct_joint_command_stays_raw(model):
+    """A direct-transmission actuator keeps writing the raw value.
+
+    The unit mapping applies to tendon transmissions only, so joint-position
+    and torque actuators addressed by actuator name are unchanged.
+    """
+    arm = _aid(model, "arm_act")
+    assert _ctrl_after(model, {"arm_act": 0.5})[arm] == pytest.approx(0.5)
+
+
+def test_actuator_name_symmetric_tendon_command_passes_verbatim():
+    """A tendon ctrlrange spanning zero is itself the normalised space."""
+    m = mujoco.MjModel.from_xml_string(_XML_SYMMETRIC)
+    sym = _aid(m, "sym_act")
+    data = mujoco.MjData(m)
+    RenderingMixin()._apply_action_by_name(m, data, {"sym_act": -0.5}, "", mujoco)
+    assert data.ctrl[sym] == pytest.approx(-0.5)
+
+
+def test_direct_actuator_name_out_of_range_still_warns(model, caplog):
+    """The no-silent-clamp warning still fires for direct actuators."""
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.rendering"):
+        _ctrl_after(model, {"arm_act": 99.0})
+    assert any("outside" in r.message and "ctrlrange" in r.message for r in caplog.records)
+
+
+def test_tendon_actuator_name_does_not_warn_about_clamping(model, caplog):
+    """A mapped tendon command must not report a spurious clamp.
+
+    ``_scale_ctrl_for_actuator`` deliberately maps the command into the
+    ctrlrange, so warning that MuJoCo "will clamp it" would be noise at every
+    control step - and it was emitted for the actuator-name spelling only.
+    """
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.rendering"):
+        _ctrl_after(model, {"grip_act": 1.0})
+    assert not [r for r in caplog.records if "ctrlrange" in r.message]


### PR DESCRIPTION
## Problem

`send_action` resolves an action key to an actuator through either spelling: the actuator's own name (`actuator8` on the Panda) or a joint name that actuator drives (`finger_joint1`). Both land on the same actuator, so both must write the same `data.ctrl` value.

They did not. Only the joint-name branch ran `_scale_ctrl_for_actuator`, which maps a logical `[0, 1]` open/close fraction onto a tendon gripper's wide ctrlrange (the Panda's remapped `[0, 255]`). The actuator-name branch wrote the value verbatim:

```python
sim.add_robot(name="panda")
sim.robot_action_keys("panda")
# ['actuator1', ..., 'actuator7', 'actuator8']

sim.send_action({"finger_joint1": 1.0}, robot_name="panda")   # ctrl 255.00 -> gap 0.03999 m (OPEN)
sim.send_action({"actuator8":     1.0}, robot_name="panda")   # ctrl   1.00 -> gap 0.00016 m (CLOSED)
sim.send_action({"finger_joint1": 0.5}, robot_name="panda")   # ctrl 127.50 -> gap 0.01999 m
sim.send_action({"actuator8":     0.5}, robot_name="panda")   # ctrl   0.50 -> gap 0.00008 m
```

One logical command, opposite physical outcomes, both reported `status="success"`.

The actuator name is the spelling the engine itself advertises, so the broken branch is the one every automated caller takes:

- `robot_action_keys()` returns actuator names,
- `run_policy` hands those to the policy via `set_robot_state_keys(self.robot_action_keys(rname))`,
- a positional action vector (`send_action([...])`, `replay_episode`) binds to them in order,
- `DatasetRecorder` names its action columns after them.

So a policy or dataset replay could not open a tendon gripper at all: a normalised `1.0` ("fully open") wrote `1.0` onto a `[0, 255]` range, i.e. 0.4% of travel - closed. The correct behaviour was reachable only through the joint-name spelling, which no discovery surface returns.

Same class as #318, which fixed tendon grippers for the joint-name path only. The actuator-name path was left behind, and it is the primary one.

## Change

Both branches of `_apply_action_by_name` now write through one `_write_ctrl(model, data, act_id, pfx, key, value, mj)` helper, so the two spellings cannot diverge again. It applies `_scale_ctrl_for_actuator` (a no-op for non-tendon transmissions) and then the existing no-silent-clamp warning, skipping that warning for tendon drives whose command the mapping deliberately placed inside the ctrlrange.

Scope: only TENDON-transmission actuators addressed by actuator name change behaviour. Direct joint/position/torque actuators still write the raw value, and an out-of-ctrlrange direct command still warns.

## Effect on grasping

Scripted top-down Panda pick in MuJoCo (headless), identical waypoints, 50 Hz control, 500 Hz physics: approach open -> descend -> close -> lift. The only difference between the two runs is this patch.

| | finger gap on `actuator8 = 1.0` | cube z after lift | outcome |
|---|---|---|---|
| before | 0.00016 m | 0.0199 m (still on the ground) | fingers never opened; the closed hand bumped the cube aside |
| after | 0.03999 m | 0.0903 m | cube grasped and lifted 7 cm |

![before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gripper-action-key/grasp_before_after.gif)

Final frame of both rollouts:

![final frames](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gripper-action-key/grasp_last.png)

## Tests

New `tests/simulation/mujoco/test_gripper_action_key_equivalence.py` (10 tests, synthetic model, no asset download):

- the same command through the actuator name and through a driven joint name writes the same ctrl (parametrised over 0.0 / 0.25 / 0.5 / 1.0),
- a normalised fully-open command through the actuator name reaches `hi`,
- an already-in-range tendon command is still trusted verbatim,
- a direct-transmission actuator still writes the raw value,
- a symmetric `[-1, 1]` tendon ctrlrange still passes a negative command through,
- the clamp warning still fires for a direct actuator and no longer fires for a mapped tendon command.

Pre-fix, 4 of them fail (`Obtained: 1.0 / Expected: 255.0`); all 10 pass after. The existing #318 suite (`test_tendon_actuator.py`, 14 tests) is unchanged and green.

## Gate

`ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean (`Success: no issues found in 891 source files`); `MUJOCO_GL=egl pytest tests` -> **11975 passed, 254 skipped** (11965 on this base + the 10 new).

---

### Changelog

**Round 2** - rebased onto current `main` to clear a `CHANGELOG.md` conflict after #1642/#1643/#1657 merged. Code and tests unchanged from the approved revision; only the `[Unreleased]` changelog section was re-ordered so the gripper entry sits alongside the newly-landed entries. Force-push was a rebase (new base), not an amend of reviewed content.