### PR TITLE
feat(sim): analytic motion primitives - move_to / set_gripper / rotate_wrist backed by shared mink IK (closes #1645)

### DIFF
--- a/strands_robots/policies/cosmos3/sim_ik.py
+++ b/strands_robots/policies/cosmos3/sim_ik.py
@@ -5,15 +5,17 @@ end-effector pose trajectory in Cartesian space. MuJoCo arm actuators are
 commanded in **joint space**, so closing the sim loop needs an IK step that
 maps each Cartesian target to joint angles.
 
-:class:`MinkIKBridge` wraps `mink <https://github.com/kevinzakka/mink>`_, a
-differential-IK library that works directly on the same ``mujoco.MjModel`` (no
-URDF or second kinematics engine). Per pose it runs a damped least-squares
-``solve_ik`` with a Cartesian :class:`mink.FrameTask` on the end-effector body
-plus a :class:`mink.PostureTask` regularizer, integrating the joint velocity
-over the control timestep. ``mink`` + ``mujoco`` are imported lazily so the
-``cosmos3-diffusers`` extra alone (no sim) stays importable; a missing stack
-raises an actionable install error (AGENTS.md key convention #6, no silent
-default).
+The generic damped-least-squares solver wrapper is the shared
+:class:`strands_robots.simulation.ik.MinkIKBridge` (one home for the mink
+``FrameTask`` + ``PostureTask`` solve loop; the VERA provider and the
+simulation motion primitives use the same class). This module subclasses it
+only to brand the install errors with the ``cosmos3-sim`` extra, and keeps the
+Cosmos-specific decode glue (:func:`decode_cosmos_chunk_to_targets`) local so a
+change to another model's action semantics can never silently break Cosmos.
+
+``mink`` + ``mujoco`` are imported lazily so the ``cosmos3-diffusers`` extra
+alone (no sim) stays importable; a missing stack raises an actionable install
+error (AGENTS.md key convention #6, no silent default).
 
 This is a geometric post-step applied *after* Cosmos, not part of the model.
 The Cosmos "modes" (``policy`` / ``forward_dynamics`` / ``inverse_dynamics``)
@@ -23,13 +25,17 @@ are world-model conditioning modes, not robot kinematics.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
-if TYPE_CHECKING:
-    import mujoco
+from strands_robots.simulation.ik import (
+    _PREFERRED_QP_SOLVERS,  # noqa: F401  (back-compat re-export)
+    resolve_qp_solver,
+)
+from strands_robots.simulation.ik import MinkIKBridge as _SharedMinkIKBridge
 
+if TYPE_CHECKING:
     from .embodiments import Cosmos3Embodiment
 
 logger = logging.getLogger(__name__)
@@ -47,208 +53,46 @@ def _install_hint() -> str:
     )
 
 
-_PREFERRED_QP_SOLVERS = ("daqp", "quadprog", "osqp", "proxqp", "cvxopt", "scs")
+_NO_BACKEND_MSG = (
+    "No qpsolvers backend is installed; the Cosmos 3 IK bridge needs one "
+    "(e.g. 'daqp' or 'quadprog'). Install the cosmos3-sim extra: "
+    "uv pip install 'strands-robots[cosmos3-sim]'."
+)
 
 
 def _resolve_qp_solver(requested: str | None) -> str:
     """Pick an installed ``qpsolvers`` backend for ``mink.solve_ik``.
 
-    ``mink`` defaults to (and pins) ``daqp``, but environments commonly ship
-    only ``quadprog``. Auto-selecting from ``qpsolvers.available_solvers``
-    (preferring daqp, then quadprog) keeps the IK bridge working everywhere
-    without forcing an extra QP dependency. An explicit ``requested`` name is
-    honoured when installed; if it is not, we fail with an actionable error that
-    lists what *is* available (AGENTS.md #6 - no silent fallback to a solver the
-    caller did not ask for, but also no opaque KeyError deep in qpsolvers).
+    Delegates to the shared :func:`strands_robots.simulation.ik.resolve_qp_solver`
+    with Cosmos 3-branded errors: the install hint and no-backend message name
+    the ``cosmos3-sim`` extra so a clean-install user is pointed at the right
+    dependency set (AGENTS.md #6 - no silent fallback to an unrequested solver,
+    but also no opaque KeyError deep in qpsolvers).
     """
-    try:
-        from qpsolvers import available_solvers
-    except ImportError as e:
-        raise ImportError(_install_hint()) from e
-    available = list(available_solvers)
-    if not available:
-        raise RuntimeError(
-            "No qpsolvers backend is installed; the Cosmos 3 IK bridge needs one "
-            "(e.g. 'daqp' or 'quadprog'). Install the cosmos3-sim extra: "
-            "uv pip install 'strands-robots[cosmos3-sim]'."
-        )
-    if requested is not None:
-        if requested not in available:
-            raise ValueError(
-                f"Requested qpsolvers backend {requested!r} is not installed. "
-                f"Available: {available}. Install it (e.g. pip install "
-                f"'qpsolvers[{requested}]') or pass an available solver / None."
-            )
-        return requested
-    for name in _PREFERRED_QP_SOLVERS:
-        if name in available:
-            return name
-    return available[0]
+    return resolve_qp_solver(requested, install_hint=_install_hint(), no_backend_msg=_NO_BACKEND_MSG)
 
 
-class MinkIKBridge:
+class MinkIKBridge(_SharedMinkIKBridge):
     """Differential-IK bridge from EE poses to MuJoCo joint configurations.
 
-    Args:
-        model: The ``mujoco.MjModel`` for the arm being controlled.
-        ee_frame_name: Name of the end-effector frame (a body or site) the
-            Cartesian task tracks (e.g. ``"hand"`` for a Franka/Panda).
-        ee_frame_type: ``"body"`` (default), ``"site"``, or ``"geom"`` - the
-            ``mink.FrameTask`` frame type for ``ee_frame_name``.
-        position_cost: Cartesian position task weight.
-        orientation_cost: Cartesian orientation task weight.
-        posture_cost: Posture (joint-regularizer) task weight - keeps the solve
-            near the current configuration so it stays smooth and avoids
-            flipping between IK branches.
-        solver: ``qpsolvers`` backend name passed to ``mink.solve_ik``.
-            ``None`` (default) auto-selects an installed backend - preferring
-            ``"daqp"`` (what ``mink`` pins), then ``"quadprog"``, then whatever
-            ``qpsolvers.available_solvers`` reports - so the bridge runs whether
-            the env has daqp or only quadprog. Pass an explicit name to force one.
-        damping: Levenberg-Marquardt damping for ``solve_ik``.
-        max_iters: Max differential-IK iterations per target pose.
-        dt: Integration timestep for each IK iteration (s).
-        pos_threshold: Convergence threshold on position error (m).
-        ori_threshold: Convergence threshold on orientation error (rad).
-
-    Raises:
-        ImportError: If ``mink``/``mujoco`` are not importable (with an
-            actionable install hint).
+    The Cosmos 3 branding of the shared
+    :class:`strands_robots.simulation.ik.MinkIKBridge` (same solver, tasks, and
+    convergence behavior): a missing ``mink``/``qpsolvers`` stack raises the
+    ``cosmos3-sim`` install hint instead of the generic ``sim-mujoco`` one.
+    See the shared class for the full constructor/solve contract.
     """
 
-    def __init__(
-        self,
-        model: mujoco.MjModel,
-        ee_frame_name: str,
-        ee_frame_type: str = "body",
-        *,
-        position_cost: float = 1.0,
-        orientation_cost: float = 1.0,
-        posture_cost: float = 1e-2,
-        solver: str | None = None,
-        damping: float = 1e-3,
-        max_iters: int = 20,
-        dt: float = 1e-2,
-        pos_threshold: float = 1e-3,
-        ori_threshold: float = 1e-3,
-    ) -> None:
-        try:
-            import mink
-        except ImportError as e:
-            raise ImportError(_install_hint()) from e
-
-        self._mink = mink
-        self.model = model
-        self.ee_frame_name = ee_frame_name
-        self.ee_frame_type = ee_frame_type
-        self.solver = _resolve_qp_solver(solver)
-        self.damping = damping
-        self.max_iters = max_iters
-        self.dt = dt
-        self.pos_threshold = pos_threshold
-        self.ori_threshold = ori_threshold
-
-        self._configuration = mink.Configuration(model)
-        self._frame_task = mink.FrameTask(
-            frame_name=ee_frame_name,
-            frame_type=ee_frame_type,
-            position_cost=position_cost,
-            orientation_cost=orientation_cost,
-            lm_damping=1.0,
-        )
-        self._posture_task = mink.PostureTask(model=model, cost=posture_cost)
-        self._tasks = [self._frame_task, self._posture_task]
-        logger.info(
-            "MinkIKBridge ready [ee=%s/%s solver=%s nq=%d]",
-            ee_frame_type,
-            ee_frame_name,
-            solver,
-            model.nq,
-        )
+    _INSTALL_HINT: ClassVar[str] = _install_hint()
+    _NO_BACKEND_MSG: ClassVar[str] = _NO_BACKEND_MSG
+    _LOG_LABEL: ClassVar[str] = "Cosmos3 MinkIKBridge"
 
     def ee_pose(self, qpos: np.ndarray) -> np.ndarray:
         """Forward kinematics: ``(4, 4)`` EE pose at a joint configuration.
 
-        Args:
-            qpos: Joint configuration of length ``model.nq``.
-
-        Returns:
-            The end-effector frame's absolute ``(4, 4)`` homogeneous pose.
+        Cosmos 3 contract: returns ``float32`` (the dtype the Cosmos decode
+        pipeline was built around; the shared bridge returns ``float64``).
         """
-        self._configuration.update(np.asarray(qpos, dtype=np.float64))
-        transform = self._configuration.get_transform_frame_to_world(self.ee_frame_name, self.ee_frame_type)
-        return np.asarray(transform.as_matrix(), dtype=np.float32)
-
-    def solve(self, target_pose: np.ndarray, q_init: np.ndarray) -> np.ndarray:
-        """Solve IK for a single Cartesian target from a seed configuration.
-
-        Args:
-            target_pose: Desired EE ``(4, 4)`` homogeneous pose.
-            q_init: Seed joint configuration (length ``model.nq``); the solve is
-                warm-started here and the posture task regularizes toward it.
-
-        Returns:
-            The solved joint configuration (length ``model.nq``, ``float64``).
-        """
-        mink = self._mink
-        q = np.asarray(q_init, dtype=np.float64).copy()
-        self._configuration.update(q)
-        self._posture_task.set_target(q)
-
-        target = mink.SE3.from_matrix(np.asarray(target_pose, dtype=np.float64))
-        self._frame_task.set_target(target)
-
-        for _ in range(self.max_iters):
-            velocity = mink.solve_ik(self._configuration, self._tasks, self.dt, self.solver, self.damping)
-            self._configuration.integrate_inplace(velocity, self.dt)
-            err = self._frame_task.compute_error(self._configuration)
-            if np.linalg.norm(err[:3]) <= self.pos_threshold and np.linalg.norm(err[3:]) <= self.ori_threshold:
-                break
-        return np.asarray(self._configuration.q, dtype=np.float64).copy()
-
-    def solve_trajectory(self, poses: np.ndarray, q_init: np.ndarray) -> np.ndarray:
-        """Solve IK for an EE-pose trajectory, warm-starting each step.
-
-        Args:
-            poses: Absolute EE poses of shape ``[N, 4, 4]``.
-            q_init: Seed joint configuration for the first pose; each subsequent
-                solve warm-starts from the previous solution so the joint
-                trajectory stays continuous.
-
-        Returns:
-            Joint configurations of shape ``[N, model.nq]`` (``float64``).
-        """
-        poses = np.asarray(poses, dtype=np.float64)
-        if poses.ndim != 3 or poses.shape[1:] != (4, 4):
-            raise ValueError(f"poses must be [N, 4, 4]; got {poses.shape}")
-        q = np.asarray(q_init, dtype=np.float64).copy()
-        out = []
-        for pose in poses:
-            q = self.solve(pose, q)
-            out.append(q.copy())
-        return np.stack(out) if out else np.empty((0, self.model.nq), dtype=np.float64)
-
-    def tracking_error(self, poses: np.ndarray, qpos_traj: np.ndarray) -> dict[str, float]:
-        """Cartesian position tracking error between targets and solved poses.
-
-        Args:
-            poses: Target EE poses ``[N, 4, 4]``.
-            qpos_traj: Solved joint configs ``[N, nq]`` (from
-                :meth:`solve_trajectory`).
-
-        Returns:
-            ``{"mean_mm": float, "max_mm": float}`` - mean / max Euclidean
-            position error in millimetres across the trajectory.
-        """
-        poses = np.asarray(poses, dtype=np.float32)
-        errs = []
-        for target, q in zip(poses, np.asarray(qpos_traj), strict=True):
-            achieved = self.ee_pose(q)
-            errs.append(float(np.linalg.norm(achieved[:3, 3] - target[:3, 3])))
-        errs_arr = np.asarray(errs, dtype=np.float32)
-        if errs_arr.size == 0:
-            return {"mean_mm": 0.0, "max_mm": 0.0}
-        return {"mean_mm": float(errs_arr.mean() * 1000.0), "max_mm": float(errs_arr.max() * 1000.0)}
+        return super().ee_pose(qpos).astype(np.float32)
 
 
 def decode_cosmos_chunk_to_targets(

--- a/strands_robots/policies/cosmos3/sim_ik.py
+++ b/strands_robots/policies/cosmos3/sim_ik.py
@@ -29,11 +29,8 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
-from strands_robots.simulation.ik import (
-    _PREFERRED_QP_SOLVERS,  # noqa: F401  (back-compat re-export)
-    resolve_qp_solver,
-)
 from strands_robots.simulation.ik import MinkIKBridge as _SharedMinkIKBridge
+from strands_robots.simulation.ik import resolve_qp_solver
 
 if TYPE_CHECKING:
     from .embodiments import Cosmos3Embodiment

--- a/strands_robots/policies/vera/ee_frame.py
+++ b/strands_robots/policies/vera/ee_frame.py
@@ -3,162 +3,22 @@
 VERA's ``eef_delta`` (mimicgen) and ``cartesian_delta`` (droid) embodiments emit
 end-effector pose *deltas*; driving a MuJoCo arm needs an IK target frame (the
 body/site the Cartesian task tracks). The robot registry does **not** record an
-ee-frame, so we discover it from the compiled ``mujoco.MjModel`` with a robust,
-namespace-aware heuristic - making eef-delta embodiments **zero-config**.
+ee-frame, so it is discovered from the compiled ``mujoco.MjModel`` with a
+robust, namespace-aware heuristic - making eef-delta embodiments **zero-config**.
 
-Heuristic (first match wins), scoped to the robot's ``namespace`` (``<robot>/``):
-  1. A **site** whose name hints at the tool point:
-     ``attachment_site`` | ``grasp`` | ``ee`` | ``tcp`` | ``pinch`` | ``flange``
-     - these are the conventional MuJoCo IK targets (e.g. menagerie Panda ships
-     ``attachment_site``). Sites are preferred: they are the intended TCP.
-  2. A **body** whose name hints at the hand/tool:
-     ``hand`` | ``gripper`` | ``tool`` | ``ee`` | ``tcp`` | ``wrist`` | ``flange``.
-  3. The **leaf body** of the robot's kinematic chain (the descendant of the
-     robot's joints that has no child body) - the last link, where a tool mounts.
+The heuristic now lives in the shared :mod:`strands_robots.simulation.ik`
+module (one home for IK target-frame discovery, used by the VERA provider and
+the simulation motion primitives alike); this module re-exports
+:func:`discover_ee_frame` so existing imports keep working. See the shared
+module for the full heuristic contract (site hints, body hints, leaf-body
+fallback) and namespace scoping semantics.
 
-Returns ``(frame_name, frame_type)`` ready for ``mink.FrameTask`` /
-``MinkIKBridge`` (frame_type ∈ {``"site"``, ``"body"``}); names keep the robot
-namespace so they resolve in the shared world model. Returns ``None`` when the
-arm cannot be resolved (caller then warns + asks for an explicit frame).
-
-``mujoco`` is imported lazily so importing this module in the light base env is
-free.
+``mujoco`` is imported lazily inside the shared function, so importing this
+module in the light base env is free.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import Any
+from strands_robots.simulation.ik import discover_ee_frame
 
-logger = logging.getLogger(__name__)
-
-_SITE_HINTS = ("attachment_site", "attachment", "grasp", "pinch", "tcp", "ee_site", "ee", "flange")
-_BODY_HINTS = ("hand", "gripper", "tool", "tcp", "ee", "wrist", "flange", "end_effector", "eef")
-
-
-def _names_of(model: Any, obj_type: int) -> list[tuple[int, str]]:
-    """Return ``[(id, name), ...]`` for all objects of ``obj_type`` in the model."""
-    import mujoco as mj
-
-    out: list[tuple[int, str]] = []
-    n = {
-        mj.mjtObj.mjOBJ_SITE: model.nsite,
-        mj.mjtObj.mjOBJ_BODY: model.nbody,
-    }[obj_type]
-    for i in range(n):
-        nm = mj.mj_id2name(model, obj_type, i)
-        if nm:
-            out.append((i, nm))
-    return out
-
-
-def _scoped(name: str, namespace: str | None) -> bool:
-    """True when ``name`` belongs to the robot's namespace (or no namespace set)."""
-    if not namespace:
-        return True
-    return name.startswith(namespace)
-
-
-def _basename(name: str, namespace: str | None) -> str:
-    """Strip the robot namespace prefix for hint matching."""
-    if namespace and name.startswith(namespace):
-        return name[len(namespace) :]
-    return name
-
-
-def discover_ee_frame(model: Any, namespace: str | None = None) -> tuple[str, str] | None:
-    """Discover an IK end-effector frame ``(name, type)`` for a robot.
-
-    Args:
-        model: The compiled ``mujoco.MjModel`` (the shared world model).
-        namespace: The robot's body/site namespace prefix (e.g. ``"panda/"``).
-            Discovery is scoped to this so multi-robot worlds resolve correctly.
-
-    Returns:
-        ``(frame_name, frame_type)`` where ``frame_type`` ∈ {``"site"``,
-        ``"body"``}, names keep the namespace; or ``None`` if nothing resolves.
-    """
-    try:
-        import mujoco  # noqa: F401  (lazy availability check)
-    except ImportError:
-        logger.debug("mujoco not importable; cannot auto-discover ee-frame")
-        return None
-
-    # 1) Prefer a TCP-like SITE.
-    sites = [(i, n) for i, n in _names_of(model, _site_obj()) if _scoped(n, namespace)]
-    for hint in _SITE_HINTS:
-        for _i, name in sites:
-            if hint in _basename(name, namespace).lower():
-                logger.info("VERA ee-frame: site %r (hint %r)", name, hint)
-                return name, "site"
-
-    # 2) A hand/tool BODY.
-    bodies = [(i, n) for i, n in _names_of(model, _body_obj()) if _scoped(n, namespace)]
-    for hint in _BODY_HINTS:
-        for _i, name in bodies:
-            if hint in _basename(name, namespace).lower():
-                logger.info("VERA ee-frame: body %r (hint %r)", name, hint)
-                return name, "body"
-
-    # 3) Leaf body of the namespace's kinematic chain.
-    leaf = _leaf_body(model, namespace, bodies)
-    if leaf is not None:
-        logger.info("VERA ee-frame: leaf body %r (kinematic chain tail)", leaf)
-        return leaf, "body"
-
-    logger.warning(
-        "VERA ee-frame: could not auto-discover an end-effector frame for "
-        "namespace %r; pass ee_frame_name explicitly to set_ik_target(...).",
-        namespace,
-    )
-    return None
-
-
-def _site_obj() -> int:
-    import mujoco as mj
-
-    return mj.mjtObj.mjOBJ_SITE
-
-
-def _body_obj() -> int:
-    import mujoco as mj
-
-    return mj.mjtObj.mjOBJ_BODY
-
-
-def _leaf_body(model: Any, namespace: str | None, bodies: list[tuple[int, str]]) -> str | None:
-    """The deepest body in the namespace's chain (a body with no in-namespace child).
-
-    MuJoCo stores ``body_parentid``; the leaf (no children within the namespace)
-    that sits furthest from the world is the tool-mount link. Among multiple
-    leaves we pick the one with the greatest depth from the world body.
-    """
-    if not bodies:
-        return None
-    ids = {i for i, _ in bodies}
-    id_to_name = {i: n for i, n in bodies}
-    # Children count within the namespace.
-    has_child = set()
-    for i in ids:
-        parent = int(model.body_parentid[i])
-        if parent in ids:
-            has_child.add(parent)
-    leaves = [i for i in ids if i not in has_child]
-    if not leaves:
-        return None
-
-    # Depth from world for tie-break (more joints between world and body = tip).
-    def depth(bi: int) -> int:
-        d, cur = 0, bi
-        seen = set()
-        while cur not in seen:
-            seen.add(cur)
-            p = int(model.body_parentid[cur])
-            if p == cur or p == 0:
-                break
-            cur = p
-            d += 1
-        return d
-
-    leaves.sort(key=depth, reverse=True)
-    return id_to_name[leaves[0]]
+__all__ = ["discover_ee_frame"]

--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -6,15 +6,15 @@ rotation) plus an optional gripper column. MuJoCo arm actuators are commanded in
 **joint space**, so closing the sim loop needs an IK step that maps each
 Cartesian *delta* onto an absolute target pose and solves it to joint angles.
 
-This module is **copied** from (and intentionally independent of) the cosmos3
-IK bridge, :mod:`~strands_robots.policies.cosmos3.sim_ik`: that module decodes
-an *absolute* EE pose trajectory
-(translation + rot6d) for its in-process diffusers backend, whereas VERA emits
-*relative* deltas. Copying (rather than sharing) keeps the two providers'
-kinematics decoupled - a change to one model's action semantics can never
-silently break the other. The shared piece is only the generic ``mink`` solver
-wrapper (:class:`MinkIKBridge`); the VERA-specific decode lives in
-:func:`decode_vera_delta_chunk_to_targets`.
+The generic damped-least-squares solver wrapper is the shared
+:class:`strands_robots.simulation.ik.MinkIKBridge` (one home for the mink
+``FrameTask`` + ``PostureTask`` solve loop; the cosmos3 provider - which
+decodes *absolute* EE pose trajectories in
+:mod:`~strands_robots.policies.cosmos3.sim_ik` - and the simulation motion
+primitives use the same class). This module subclasses it only to brand the
+install errors with the ``sim-mujoco`` extra, and keeps the VERA-specific
+decode glue (:func:`decode_vera_delta_chunk_to_targets`) local so a change to
+one model's action semantics can never silently break the other.
 
 ``mink`` + ``mujoco`` are imported lazily so importing the VERA provider in the
 light base env (no torch / no sim) stays cheap; a missing stack raises an
@@ -24,12 +24,15 @@ actionable install error rather than a silent default.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any, ClassVar
 
 import numpy as np
 
-if TYPE_CHECKING:
-    import mujoco
+from strands_robots.simulation.ik import (
+    _PREFERRED_QP_SOLVERS,  # noqa: F401  (back-compat re-export)
+    resolve_qp_solver,
+)
+from strands_robots.simulation.ik import MinkIKBridge as _SharedMinkIKBridge
 
 logger = logging.getLogger(__name__)
 
@@ -46,36 +49,22 @@ def _install_hint() -> str:
     )
 
 
-_PREFERRED_QP_SOLVERS = ("daqp", "quadprog", "osqp", "proxqp", "cvxopt", "scs")
+_NO_BACKEND_MSG = (
+    "No qpsolvers backend is installed; the VERA IK bridge needs one "
+    "(e.g. 'daqp' or 'quadprog'). Install: "
+    "uv pip install 'strands-robots[sim-mujoco]' 'qpsolvers[quadprog]'."
+)
 
 
 def _resolve_qp_solver(requested: str | None) -> str:
     """Pick an installed ``qpsolvers`` backend for ``mink.solve_ik``.
 
-    ``mink`` pins ``daqp``, but many envs ship only ``quadprog``. Auto-select
-    from ``qpsolvers.available_solvers`` (prefer daqp, then quadprog) so the IK
-    works everywhere; honour an explicit ``requested`` name when installed, else
-    fail with an actionable error (no silent fallback to an unrequested solver).
+    Delegates to the shared :func:`strands_robots.simulation.ik.resolve_qp_solver`
+    with VERA-branded errors: the install hint and no-backend message name the
+    ``sim-mujoco`` extra so a clean-install user is pointed at the right
+    dependency set (no silent fallback to an unrequested solver).
     """
-    try:
-        from qpsolvers import available_solvers
-    except ImportError as e:
-        raise ImportError(_install_hint()) from e
-    available = list(available_solvers)
-    if not available:
-        raise RuntimeError(
-            "No qpsolvers backend is installed; the VERA IK bridge needs one "
-            "(e.g. 'daqp' or 'quadprog'). Install: "
-            "uv pip install 'strands-robots[sim-mujoco]' 'qpsolvers[quadprog]'."
-        )
-    if requested is not None:
-        if requested not in available:
-            raise ValueError(f"Requested qpsolvers backend {requested!r} is not installed. Available: {available}.")
-        return requested
-    for name in _PREFERRED_QP_SOLVERS:
-        if name in available:
-            return name
-    return available[0]
+    return resolve_qp_solver(requested, install_hint=_install_hint(), no_backend_msg=_NO_BACKEND_MSG)
 
 
 def rot6d_to_matrix(rot6d: np.ndarray) -> np.ndarray:
@@ -113,92 +102,19 @@ def delta_to_matrix(rot_delta: np.ndarray, rotation_dim: int) -> np.ndarray:
     raise ValueError(f"unsupported rotation_dim {rotation_dim!r}; use 3 (axis-angle) or 6 (rot6d)")
 
 
-class MinkIKBridge:
+class MinkIKBridge(_SharedMinkIKBridge):
     """Differential-IK bridge from EE poses to MuJoCo joint configurations.
 
-    A copy of the cosmos3 bridge's generic solver wrapper (the model-agnostic
-    part). See module docstring for why VERA keeps its own copy.
-
-    Args:
-        model: The ``mujoco.MjModel`` for the arm being controlled.
-        ee_frame_name: End-effector frame the Cartesian task tracks.
-        ee_frame_type: ``"body"`` (default), ``"site"`` or ``"geom"``.
-        position_cost / orientation_cost / posture_cost: task weights.
-        solver: qpsolvers backend (``None`` auto-selects).
-        damping / max_iters / dt / pos_threshold / ori_threshold: solver knobs.
+    The VERA branding of the shared
+    :class:`strands_robots.simulation.ik.MinkIKBridge` (same solver, tasks, and
+    convergence behavior): a missing ``mink``/``qpsolvers`` stack raises the
+    ``sim-mujoco`` install hint. See the shared class for the full
+    constructor/solve contract.
     """
 
-    def __init__(
-        self,
-        model: mujoco.MjModel,
-        ee_frame_name: str,
-        ee_frame_type: str = "body",
-        *,
-        position_cost: float = 1.0,
-        orientation_cost: float = 1.0,
-        posture_cost: float = 1e-2,
-        solver: str | None = None,
-        damping: float = 1e-3,
-        max_iters: int = 20,
-        dt: float = 1e-2,
-        pos_threshold: float = 1e-3,
-        ori_threshold: float = 1e-3,
-    ) -> None:
-        try:
-            import mink
-        except ImportError as e:
-            raise ImportError(_install_hint()) from e
-
-        self._mink = mink
-        self.model = model
-        self.ee_frame_name = ee_frame_name
-        self.ee_frame_type = ee_frame_type
-        self.solver = _resolve_qp_solver(solver)
-        self.damping = damping
-        self.max_iters = max_iters
-        self.dt = dt
-        self.pos_threshold = pos_threshold
-        self.ori_threshold = ori_threshold
-
-        self._configuration = mink.Configuration(model)
-        self._frame_task = mink.FrameTask(
-            frame_name=ee_frame_name,
-            frame_type=ee_frame_type,
-            position_cost=position_cost,
-            orientation_cost=orientation_cost,
-            lm_damping=1.0,
-        )
-        self._posture_task = mink.PostureTask(model=model, cost=posture_cost)
-        self._tasks = [self._frame_task, self._posture_task]
-        logger.info(
-            "VERA MinkIKBridge ready [ee=%s/%s solver=%s nq=%d]",
-            ee_frame_type,
-            ee_frame_name,
-            self.solver,
-            model.nq,
-        )
-
-    def ee_pose(self, qpos: np.ndarray) -> np.ndarray:
-        """Forward kinematics: the EE frame's absolute ``(4, 4)`` pose at ``qpos``."""
-        self._configuration.update(np.asarray(qpos, dtype=np.float64))
-        transform = self._configuration.get_transform_frame_to_world(self.ee_frame_name, self.ee_frame_type)
-        return np.asarray(transform.as_matrix(), dtype=np.float64)
-
-    def solve(self, target_pose: np.ndarray, q_init: np.ndarray) -> np.ndarray:
-        """Solve IK for one Cartesian target from a seed configuration."""
-        mink = self._mink
-        q = np.asarray(q_init, dtype=np.float64).copy()
-        self._configuration.update(q)
-        self._posture_task.set_target(q)
-        target = mink.SE3.from_matrix(np.asarray(target_pose, dtype=np.float64))
-        self._frame_task.set_target(target)
-        for _ in range(self.max_iters):
-            velocity = mink.solve_ik(self._configuration, self._tasks, self.dt, self.solver, self.damping)
-            self._configuration.integrate_inplace(velocity, self.dt)
-            err = self._frame_task.compute_error(self._configuration)
-            if np.linalg.norm(err[:3]) <= self.pos_threshold and np.linalg.norm(err[3:]) <= self.ori_threshold:
-                break
-        return np.asarray(self._configuration.q, dtype=np.float64).copy()
+    _INSTALL_HINT: ClassVar[str] = _install_hint()
+    _NO_BACKEND_MSG: ClassVar[str] = _NO_BACKEND_MSG
+    _LOG_LABEL: ClassVar[str] = "VERA MinkIKBridge"
 
 
 def decode_vera_delta_chunk_to_targets(

--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -28,11 +28,8 @@ from typing import Any, ClassVar
 
 import numpy as np
 
-from strands_robots.simulation.ik import (
-    _PREFERRED_QP_SOLVERS,  # noqa: F401  (back-compat re-export)
-    resolve_qp_solver,
-)
 from strands_robots.simulation.ik import MinkIKBridge as _SharedMinkIKBridge
+from strands_robots.simulation.ik import resolve_qp_solver
 
 logger = logging.getLogger(__name__)
 

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -1,0 +1,429 @@
+"""Shared inverse-kinematics utilities: mink IK bridge + EE-frame discovery.
+
+The single home for the generic differential-IK solver wrapper
+(:class:`MinkIKBridge`) and the end-effector frame auto-discovery heuristic
+(:func:`discover_ee_frame`) that were previously duplicated per policy provider
+(:mod:`strands_robots.policies.cosmos3.sim_ik` and
+:mod:`strands_robots.policies.vera.sim_ik` each carried a copy of the bridge;
+the discovery heuristic lived in :mod:`strands_robots.policies.vera.ee_frame`).
+Those modules now re-export from here, keeping their provider-specific decode
+glue (action-chunk semantics) in place - a change to one model's action
+semantics still cannot break the other, because only the model-agnostic solver
+wrapper is shared.
+
+:class:`MinkIKBridge` wraps `mink <https://github.com/kevinzakka/mink>`_, a
+differential-IK library that works directly on the same ``mujoco.MjModel`` (no
+URDF or second kinematics engine). Per target pose it runs a damped
+least-squares ``solve_ik`` with a Cartesian :class:`mink.FrameTask` on the
+end-effector frame plus a :class:`mink.PostureTask` regularizer, integrating
+the joint velocity over the control timestep.
+
+``mink`` + ``mujoco`` + ``qpsolvers`` are imported lazily so importing this
+module in the light base env (no sim extras) stays free; a missing stack
+raises an actionable install error rather than a silent default (AGENTS.md key
+convention: no silent defaults on error). Provider subclasses customize the
+install hint / no-backend message via the ``_INSTALL_HINT`` / ``_NO_BACKEND_MSG``
+class attributes so the error a user sees names the extra they actually need.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import mujoco
+
+logger = logging.getLogger(__name__)
+
+_PREFERRED_QP_SOLVERS = ("daqp", "quadprog", "osqp", "proxqp", "cvxopt", "scs")
+
+_DEFAULT_INSTALL_HINT = (
+    "The mink IK bridge needs 'mink' + 'mujoco' + a qpsolvers backend, which "
+    "were not importable. Install the sim extra:\n"
+    "  uv pip install 'strands-robots[sim-mujoco]' mink\n"
+    "This pulls mink (differential IK on the MuJoCo model) and mujoco, turning "
+    "Cartesian end-effector targets into joint configurations the arm can track."
+)
+
+_DEFAULT_NO_BACKEND_MSG = (
+    "No qpsolvers backend is installed; the mink IK bridge needs one "
+    "(e.g. 'daqp' or 'quadprog'). Install: "
+    "uv pip install 'strands-robots[sim-mujoco]' 'qpsolvers[quadprog]'."
+)
+
+
+def resolve_qp_solver(
+    requested: str | None,
+    *,
+    install_hint: str = _DEFAULT_INSTALL_HINT,
+    no_backend_msg: str = _DEFAULT_NO_BACKEND_MSG,
+) -> str:
+    """Pick an installed ``qpsolvers`` backend for ``mink.solve_ik``.
+
+    ``mink`` defaults to (and pins) ``daqp``, but environments commonly ship
+    only ``quadprog``. Auto-selecting from ``qpsolvers.available_solvers``
+    (preferring daqp, then quadprog) keeps the IK bridge working everywhere
+    without forcing an extra QP dependency. An explicit ``requested`` name is
+    honoured when installed; if it is not, we fail with an actionable error
+    that lists what *is* available (no silent fallback to a solver the caller
+    did not ask for, but also no opaque KeyError deep in qpsolvers).
+
+    Args:
+        requested: Explicit backend name to force, or ``None`` to auto-select.
+        install_hint: Message raised when ``qpsolvers`` itself is missing.
+        no_backend_msg: Message raised when ``qpsolvers`` reports zero backends.
+
+    Returns:
+        The resolved backend name.
+
+    Raises:
+        ImportError: ``qpsolvers`` is not importable (with ``install_hint``).
+        RuntimeError: No QP backend is installed (with ``no_backend_msg``).
+        ValueError: ``requested`` names a backend that is not installed.
+    """
+    try:
+        from qpsolvers import available_solvers
+    except ImportError as e:
+        raise ImportError(install_hint) from e
+    available = list(available_solvers)
+    if not available:
+        raise RuntimeError(no_backend_msg)
+    if requested is not None:
+        if requested not in available:
+            raise ValueError(
+                f"Requested qpsolvers backend {requested!r} is not installed. "
+                f"Available: {available}. Install it (e.g. pip install "
+                f"'qpsolvers[{requested}]') or pass an available solver / None."
+            )
+        return requested
+    for name in _PREFERRED_QP_SOLVERS:
+        if name in available:
+            return name
+    return available[0]
+
+
+class MinkIKBridge:
+    """Differential-IK bridge from EE poses to MuJoCo joint configurations.
+
+    Args:
+        model: The ``mujoco.MjModel`` for the arm being controlled.
+        ee_frame_name: Name of the end-effector frame (a body or site) the
+            Cartesian task tracks (e.g. ``"hand"`` for a Franka/Panda).
+        ee_frame_type: ``"body"`` (default), ``"site"``, or ``"geom"`` - the
+            ``mink.FrameTask`` frame type for ``ee_frame_name``.
+        position_cost: Cartesian position task weight.
+        orientation_cost: Cartesian orientation task weight (``0.0`` yields a
+            position-only solve - important for arms with fewer than 6 DOF).
+        posture_cost: Posture (joint-regularizer) task weight - keeps the solve
+            near the current configuration so it stays smooth and avoids
+            flipping between IK branches.
+        solver: ``qpsolvers`` backend name passed to ``mink.solve_ik``.
+            ``None`` (default) auto-selects an installed backend - preferring
+            ``"daqp"`` (what ``mink`` pins), then ``"quadprog"``, then whatever
+            ``qpsolvers.available_solvers`` reports. Pass an explicit name to
+            force one.
+        damping: Levenberg-Marquardt damping for ``solve_ik``.
+        max_iters: Max differential-IK iterations per target pose.
+        dt: Integration timestep for each IK iteration (s).
+        pos_threshold: Convergence threshold on position error (m).
+        ori_threshold: Convergence threshold on orientation error (rad).
+
+    Raises:
+        ImportError: If ``mink``/``mujoco`` are not importable (with an
+            actionable install hint).
+    """
+
+    # Provider subclasses override these so failures name the extra the user
+    # actually needs (e.g. cosmos3-sim vs sim-mujoco).
+    _INSTALL_HINT: ClassVar[str] = _DEFAULT_INSTALL_HINT
+    _NO_BACKEND_MSG: ClassVar[str] = _DEFAULT_NO_BACKEND_MSG
+    _LOG_LABEL: ClassVar[str] = "MinkIKBridge"
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        ee_frame_name: str,
+        ee_frame_type: str = "body",
+        *,
+        position_cost: float = 1.0,
+        orientation_cost: float = 1.0,
+        posture_cost: float = 1e-2,
+        solver: str | None = None,
+        damping: float = 1e-3,
+        max_iters: int = 20,
+        dt: float = 1e-2,
+        pos_threshold: float = 1e-3,
+        ori_threshold: float = 1e-3,
+    ) -> None:
+        try:
+            import mink
+        except ImportError as e:
+            raise ImportError(self._INSTALL_HINT) from e
+
+        self._mink = mink
+        self.model = model
+        self.ee_frame_name = ee_frame_name
+        self.ee_frame_type = ee_frame_type
+        self.solver = resolve_qp_solver(solver, install_hint=self._INSTALL_HINT, no_backend_msg=self._NO_BACKEND_MSG)
+        self.damping = damping
+        self.max_iters = max_iters
+        self.dt = dt
+        self.pos_threshold = pos_threshold
+        self.ori_threshold = ori_threshold
+
+        self._configuration = mink.Configuration(model)
+        self._frame_task = mink.FrameTask(
+            frame_name=ee_frame_name,
+            frame_type=ee_frame_type,
+            position_cost=position_cost,
+            orientation_cost=orientation_cost,
+            lm_damping=1.0,
+        )
+        self._posture_task = mink.PostureTask(model=model, cost=posture_cost)
+        self._tasks = [self._frame_task, self._posture_task]
+        logger.info(
+            "%s ready [ee=%s/%s solver=%s nq=%d]",
+            self._LOG_LABEL,
+            ee_frame_type,
+            ee_frame_name,
+            self.solver,
+            model.nq,
+        )
+
+    def ee_pose(self, qpos: np.ndarray) -> np.ndarray:
+        """Forward kinematics: ``(4, 4)`` EE pose at a joint configuration.
+
+        Args:
+            qpos: Joint configuration of length ``model.nq``.
+
+        Returns:
+            The end-effector frame's absolute ``(4, 4)`` homogeneous pose
+            (``float64``).
+        """
+        self._configuration.update(np.asarray(qpos, dtype=np.float64))
+        transform = self._configuration.get_transform_frame_to_world(self.ee_frame_name, self.ee_frame_type)
+        return np.asarray(transform.as_matrix(), dtype=np.float64)
+
+    def solve(self, target_pose: np.ndarray, q_init: np.ndarray) -> np.ndarray:
+        """Solve IK for a single Cartesian target from a seed configuration.
+
+        Args:
+            target_pose: Desired EE ``(4, 4)`` homogeneous pose.
+            q_init: Seed joint configuration (length ``model.nq``); the solve is
+                warm-started here and the posture task regularizes toward it.
+
+        Returns:
+            The solved joint configuration (length ``model.nq``, ``float64``).
+        """
+        mink = self._mink
+        q = np.asarray(q_init, dtype=np.float64).copy()
+        self._configuration.update(q)
+        self._posture_task.set_target(q)
+
+        target = mink.SE3.from_matrix(np.asarray(target_pose, dtype=np.float64))
+        self._frame_task.set_target(target)
+
+        for _ in range(self.max_iters):
+            velocity = mink.solve_ik(self._configuration, self._tasks, self.dt, self.solver, self.damping)
+            self._configuration.integrate_inplace(velocity, self.dt)
+            err = self._frame_task.compute_error(self._configuration)
+            if np.linalg.norm(err[:3]) <= self.pos_threshold and np.linalg.norm(err[3:]) <= self.ori_threshold:
+                break
+        return np.asarray(self._configuration.q, dtype=np.float64).copy()
+
+    def solve_trajectory(self, poses: np.ndarray, q_init: np.ndarray) -> np.ndarray:
+        """Solve IK for an EE-pose trajectory, warm-starting each step.
+
+        Args:
+            poses: Absolute EE poses of shape ``[N, 4, 4]``.
+            q_init: Seed joint configuration for the first pose; each subsequent
+                solve warm-starts from the previous solution so the joint
+                trajectory stays continuous.
+
+        Returns:
+            Joint configurations of shape ``[N, model.nq]`` (``float64``).
+        """
+        poses = np.asarray(poses, dtype=np.float64)
+        if poses.ndim != 3 or poses.shape[1:] != (4, 4):
+            raise ValueError(f"poses must be [N, 4, 4]; got {poses.shape}")
+        q = np.asarray(q_init, dtype=np.float64).copy()
+        out = []
+        for pose in poses:
+            q = self.solve(pose, q)
+            out.append(q.copy())
+        return np.stack(out) if out else np.empty((0, self.model.nq), dtype=np.float64)
+
+    def tracking_error(self, poses: np.ndarray, qpos_traj: np.ndarray) -> dict[str, float]:
+        """Cartesian position tracking error between targets and solved poses.
+
+        Args:
+            poses: Target EE poses ``[N, 4, 4]``.
+            qpos_traj: Solved joint configs ``[N, nq]`` (from
+                :meth:`solve_trajectory`).
+
+        Returns:
+            ``{"mean_mm": float, "max_mm": float}`` - mean / max Euclidean
+            position error in millimetres across the trajectory.
+        """
+        poses = np.asarray(poses, dtype=np.float32)
+        errs = []
+        for target, q in zip(poses, np.asarray(qpos_traj), strict=True):
+            achieved = self.ee_pose(q)
+            errs.append(float(np.linalg.norm(achieved[:3, 3] - target[:3, 3])))
+        errs_arr = np.asarray(errs, dtype=np.float32)
+        if errs_arr.size == 0:
+            return {"mean_mm": 0.0, "max_mm": 0.0}
+        return {"mean_mm": float(errs_arr.mean() * 1000.0), "max_mm": float(errs_arr.max() * 1000.0)}
+
+
+# --------------------------------------------------------------------------
+# End-effector frame auto-discovery
+#
+# Driving a MuJoCo arm in Cartesian space needs an IK target frame (the
+# body/site the Cartesian task tracks). The robot registry does NOT record an
+# ee-frame, so we discover it from the compiled ``mujoco.MjModel`` with a
+# robust, namespace-aware heuristic - making Cartesian control zero-config.
+#
+# Heuristic (first match wins), scoped to the robot's ``namespace``:
+#   1. A **site** whose name hints at the tool point (``attachment_site`` /
+#      ``grasp`` / ``tcp`` / ...) - the conventional MuJoCo IK targets (e.g.
+#      menagerie Panda ships ``attachment_site``). Sites are preferred: they
+#      are the intended TCP.
+#   2. A **body** whose name hints at the hand/tool (``hand`` / ``gripper`` /
+#      ``wrist`` / ...).
+#   3. The **leaf body** of the robot's kinematic chain (the descendant of the
+#      robot's joints with no child body) - the last link, where a tool mounts.
+# --------------------------------------------------------------------------
+
+_SITE_HINTS = ("attachment_site", "attachment", "grasp", "pinch", "tcp", "ee_site", "ee", "flange")
+_BODY_HINTS = ("hand", "gripper", "tool", "tcp", "ee", "wrist", "flange", "end_effector", "eef")
+
+
+def _names_of(model: Any, obj_type: Any) -> list[tuple[int, str]]:
+    """Return ``[(id, name), ...]`` for all objects of ``obj_type`` in the model."""
+    import mujoco as mj
+
+    out: list[tuple[int, str]] = []
+    n = {
+        mj.mjtObj.mjOBJ_SITE: model.nsite,
+        mj.mjtObj.mjOBJ_BODY: model.nbody,
+    }[obj_type]
+    for i in range(n):
+        nm = mj.mj_id2name(model, obj_type, i)
+        if nm:
+            out.append((i, nm))
+    return out
+
+
+def _scoped(name: str, namespace: str | None) -> bool:
+    """True when ``name`` belongs to the robot's namespace (or no namespace set)."""
+    if not namespace:
+        return True
+    return name.startswith(namespace)
+
+
+def _basename(name: str, namespace: str | None) -> str:
+    """Strip the robot namespace prefix for hint matching."""
+    if namespace and name.startswith(namespace):
+        return name[len(namespace) :]
+    return name
+
+
+def discover_ee_frame(model: Any, namespace: str | None = None) -> tuple[str, str] | None:
+    """Discover an IK end-effector frame ``(name, type)`` for a robot.
+
+    Args:
+        model: The compiled ``mujoco.MjModel`` (the shared world model).
+        namespace: The robot's body/site namespace prefix (e.g. ``"panda/"``).
+            Discovery is scoped to this so multi-robot worlds resolve correctly.
+
+    Returns:
+        ``(frame_name, frame_type)`` where ``frame_type`` is ``"site"`` or
+        ``"body"``, names keep the namespace; or ``None`` if nothing resolves.
+    """
+    try:
+        import mujoco  # noqa: F401  (lazy availability check)
+    except ImportError:
+        logger.debug("mujoco not importable; cannot auto-discover ee-frame")
+        return None
+
+    # 1) Prefer a TCP-like SITE.
+    sites = [(i, n) for i, n in _names_of(model, _site_obj()) if _scoped(n, namespace)]
+    for hint in _SITE_HINTS:
+        for _i, name in sites:
+            if hint in _basename(name, namespace).lower():
+                logger.info("ee-frame: site %r (hint %r)", name, hint)
+                return name, "site"
+
+    # 2) A hand/tool BODY.
+    bodies = [(i, n) for i, n in _names_of(model, _body_obj()) if _scoped(n, namespace)]
+    for hint in _BODY_HINTS:
+        for _i, name in bodies:
+            if hint in _basename(name, namespace).lower():
+                logger.info("ee-frame: body %r (hint %r)", name, hint)
+                return name, "body"
+
+    # 3) Leaf body of the namespace's kinematic chain.
+    leaf = _leaf_body(model, namespace, bodies)
+    if leaf is not None:
+        logger.info("ee-frame: leaf body %r (kinematic chain tail)", leaf)
+        return leaf, "body"
+
+    logger.warning(
+        "ee-frame: could not auto-discover an end-effector frame for namespace %r; pass an explicit frame.",
+        namespace,
+    )
+    return None
+
+
+def _site_obj() -> Any:
+    import mujoco as mj
+
+    return mj.mjtObj.mjOBJ_SITE
+
+
+def _body_obj() -> Any:
+    import mujoco as mj
+
+    return mj.mjtObj.mjOBJ_BODY
+
+
+def _leaf_body(model: Any, namespace: str | None, bodies: list[tuple[int, str]]) -> str | None:
+    """The deepest body in the namespace's chain (a body with no in-namespace child).
+
+    MuJoCo stores ``body_parentid``; the leaf (no children within the namespace)
+    that sits furthest from the world is the tool-mount link. Among multiple
+    leaves we pick the one with the greatest depth from the world body.
+    """
+    if not bodies:
+        return None
+    ids = {i for i, _ in bodies}
+    id_to_name = {i: n for i, n in bodies}
+    # Children count within the namespace.
+    has_child = set()
+    for i in ids:
+        parent = int(model.body_parentid[i])
+        if parent in ids:
+            has_child.add(parent)
+    leaves = [i for i in ids if i not in has_child]
+    if not leaves:
+        return None
+
+    # Depth from world for tie-break (more joints between world and body = tip).
+    def depth(bi: int) -> int:
+        d, cur = 0, bi
+        seen = set()
+        while cur not in seen:
+            seen.add(cur)
+            p = int(model.body_parentid[cur])
+            if p == cur or p == 0:
+                break
+            cur = p
+            d += 1
+        return d
+
+    leaves.sort(key=depth, reverse=True)
+    return id_to_name[leaves[0]]

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -1,0 +1,764 @@
+"""Analytic motion primitives - ``move_to`` / ``set_gripper`` / ``rotate_wrist``.
+
+Agent-facing staging/transport/release vocabulary (GH #1645, motivated by
+Harness VLA, arXiv:2607.08448): a fixed library of analytic primitives lets an
+LLM agent position the robot *around* a learned policy's competence region
+instead of asking the policy to absorb every distribution shift. On LIBERO the
+paper reports ``move_to`` alone is 61.8% of all primitive calls; the frozen VLA
+is invoked as a contact-rich primitive inside a larger analytic scaffold.
+
+Primitives (mirroring the paper's Table 1, minimal set first):
+
+* :meth:`MotionPrimitivesMixin.move_to` - Cartesian end-effector transport:
+  solve IK to a world-frame target (shared mink damped-least-squares bridge,
+  :class:`strands_robots.simulation.ik.MinkIKBridge`; position-only when no
+  orientation is given - important for 5-DOF arms like SO-101), then drive the
+  position-servo actuators until the EE is within ``tol`` or ``max_steps``
+  control ticks elapse.
+* :meth:`MotionPrimitivesMixin.set_gripper` - atomic open/close set-point on
+  the gripper actuator(s).
+* :meth:`MotionPrimitivesMixin.rotate_wrist` - wrist-yaw joint set-point while
+  the other arm joints hold their current positions (so the Cartesian EE
+  position is preserved up to servo compliance).
+
+Contract notes (shared by all three):
+
+* **Not collision-aware.** ``move_to`` hides the solver backend (the paper's
+  contract: "operational-space servo, Jacobian controller, or IK planner ...
+  exposed semantics identical"); a future collision-aware backend (curobo) can
+  replace the solver without changing this surface.
+* **Errors are structured dicts** (``{"status": "error", ...}``), never raised
+  through the tool surface. A target the IK cannot reach returns the residual.
+* **Refuse while a policy runs** on the same robot
+  (``_require_no_running_policy``, per-robot scope) - a primitive and a
+  ``PolicyRunner`` would otherwise race on ``data.ctrl``.
+* **Self-locking**: these actions are in ``_SELF_LOCKING_ACTIONS`` and acquire
+  ``self._lock`` per control tick (the ``step()`` pattern), so ``stop_policy``,
+  renders, and MJPEG threads can interleave during a long primitive. Runtime is
+  bounded by ``max_steps`` (hard cap ``_MAX_PRIMITIVE_STEPS``); if the world is
+  destroyed/recompiled or a policy starts mid-run, the loop aborts with a
+  structured error instead of stepping a stale model.
+* **Dataset-recording interplay** (pinned by test): primitive motion does NOT
+  feed frames into an active ``start_recording`` dataset session - only
+  ``run_policy``'s per-frame hook records episodes. Camera MP4 recording
+  (``start_cameras_recording``) still captures primitive motion, since it
+  samples the live scene on its own thread.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import numbers
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG
+
+logger = logging.getLogger(__name__)
+
+# Name hints (lowercased substring match on the namespace-stripped actuator /
+# joint name) used to resolve the gripper DOF. Matches the existing runtime
+# precedent (vera provider / cosmos3 policy use gripper|finger; SO-100/SO-101's
+# gripper joint is the "Jaw"). The registry carries no gripper metadata, so a
+# name heuristic is the only zero-config option; an unresolvable gripper
+# returns a structured error listing the actuators so the agent can fall back
+# to send_action.
+_GRIPPER_HINTS = ("gripper", "finger", "jaw")
+
+# Wrist-yaw joint hints, most-specific first. Fallback: the last non-gripper
+# hinge joint in the robot's chain (the distal roll joint on most serial arms).
+_WRIST_HINTS = ("wrist_roll", "wrist_yaw", "wrist_rotate", "wrist")
+
+# Physics substeps per control tick. Each move_to/rotate_wrist "step" (and each
+# set_gripper "step") re-asserts ctrl then advances this many mj_step calls, so
+# the default budgets stay bounded: move_to(max_steps=200) is at most
+# 200 * 5 = 1000 physics steps (2 s of sim time at the 0.002 s default).
+_SUBSTEPS_PER_TICK = 5
+
+# Hard ceiling on max_steps / steps to prevent unbounded primitive runtime.
+_MAX_PRIMITIVE_STEPS = 10_000
+
+# Workspace sanity radius: a move_to target further than this from the robot's
+# spawn position is rejected up front (meters). Generous on purpose - it guards
+# against unit mistakes (mm vs m), not reachability; true reachability is
+# checked by the IK residual.
+_WORKSPACE_SANITY_RADIUS_M = 5.0
+
+# Deterministic IK restart seeds tried when the direct solve from the live
+# configuration stalls in a local minimum (see move_to). Bounded so the worst
+# case is still a sub-second solve budget.
+_IK_RESTART_SEEDS = 8
+
+
+def _is_finite_real(value: Any) -> bool:
+    """True when ``value`` is a real, finite scalar (bool rejected)."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return False
+    return math.isfinite(float(value))
+
+
+def _err(text: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Structured error tool-result, optionally with a json details block."""
+    content: list[dict[str, Any]] = [{"text": text}]
+    if payload is not None:
+        content.append({"json": payload})
+    return {"status": "error", "content": content}
+
+
+class MotionPrimitivesMixin:
+    """Analytic motion primitives mixed into ``Simulation``.
+
+    **Coupling** (see the :mod:`simulation` top-level docstring): reaches into
+    ``self._world``, ``self._lock``, ``self._mj``, and the guard helpers.
+    ``TYPE_CHECKING`` stubs below exist so mypy accepts those lookups; they are
+    a documentary contract, not an enforceable protocol.
+    """
+
+    if TYPE_CHECKING:
+        from strands_robots.simulation.models import SimWorld
+
+        _world: SimWorld | None
+        _lock: Any  # threading.RLock from Simulation
+        _mj: Any  # cached ``mujoco`` module reference from Simulation
+
+        def _require_no_running_policy(self, action_name: str, robot_name: str | None = None) -> dict[str, Any] | None:
+            """Provided by ``Simulation``; declared here for type-checkers."""
+
+        def _unknown_robot_msg(self, requested: str) -> str:
+            """Provided by ``Simulation``; declared here for type-checkers."""
+
+        def _resolve_single_robot(self, robot_name: str | None) -> str:
+            """Provided by ``SimEngine``; declared here for type-checkers."""
+
+        def _apply_kinematic_attachments(self) -> None:
+            """Provided by ``Simulation``; declared here for type-checkers."""
+
+    # -- shared guards / resolution -----------------------------------------
+
+    def _primitive_resolve_robot(self, action: str, robot_name: str | None) -> tuple[str | None, dict[str, Any] | None]:
+        """Common primitive preamble: world + robot + no-running-policy guards.
+
+        Returns ``(robot_name, None)`` on success or ``(None, error_dict)``.
+        Callers should hold ``self._lock`` (the checks read shared state).
+        """
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return None, _err(_NO_WORLD_MSG)
+        if robot_name is None:
+            try:
+                robot_name = self._resolve_single_robot(None)
+            except ValueError as e:
+                return None, _err(str(e))
+        if robot_name not in self._world.robots:
+            return None, _err(self._unknown_robot_msg(robot_name))
+        guard = self._require_no_running_policy(action, robot_name=robot_name)
+        if guard is not None:
+            return None, guard
+        return robot_name, None
+
+    def _primitive_abort_reason(self, action: str, robot_name: str, model: Any) -> dict[str, Any] | None:
+        """Mid-loop cancellation check (call under ``self._lock``).
+
+        The primitive loops release the lock between control ticks, so the
+        world can legitimately be destroyed, the model recompiled, or a policy
+        started while a primitive runs. Each of those aborts the primitive
+        with a structured error rather than stepping a stale/contended model.
+        """
+        world = self._world
+        if world is None or world._model is not model or world._data is None:
+            return _err(f"{action}: world was destroyed or the model was recompiled mid-run; aborting.")
+        robot = world.robots.get(robot_name)
+        if robot is None:
+            return _err(f"{action}: robot '{robot_name}' was removed mid-run; aborting.")
+        if robot.policy_running:
+            return _err(
+                f"{action}: a policy started on '{robot_name}' mid-run; aborting. "
+                f"Stop it first: action='stop_policy', name='{robot_name}'."
+            )
+        return None
+
+    def _primitive_tick(self, model: Any, data: Any, ctrl_targets: dict[int, float]) -> None:
+        """One control tick: assert ctrl targets, advance physics, refresh FK.
+
+        Must be called under ``self._lock``. Mirrors ``step()``'s bookkeeping
+        (kinematic attachments, ``sim_time`` / ``step_count``) and finishes
+        with ``mj_kinematics`` so the caller reads current frame poses.
+        """
+        mj = self._mj
+        assert self._world is not None  # callers must check
+        for act_id, value in ctrl_targets.items():
+            data.ctrl[act_id] = value
+        has_kinematic_attachments = bool(self._world._backend_state.get("kinematic_attachments"))
+        for _ in range(_SUBSTEPS_PER_TICK):
+            mj.mj_step(model, data)
+            if has_kinematic_attachments:
+                self._apply_kinematic_attachments()
+        self._world.sim_time = data.time
+        self._world.step_count += _SUBSTEPS_PER_TICK
+        mj.mj_kinematics(model, data)
+
+    def _joint_actuator_map(self, model: Any, robot: Any) -> dict[int, int]:
+        """Map ``jnt_id -> act_id`` for the robot's joint-transmission actuators.
+
+        Only hinge/slide joints with a JOINT / JOINTINPARENT transmission
+        actuator are included (the DOFs a position set-point can drive).
+        Tendon-driven actuators (e.g. a Franka split gripper) have no matching
+        joint and are excluded - ``set_gripper`` resolves those by name instead.
+        """
+        mj = self._mj
+        joint_trn = {int(mj.mjtTrn.mjTRN_JOINT), int(mj.mjtTrn.mjTRN_JOINTINPARENT)}
+        settable = {int(mj.mjtJoint.mjJNT_HINGE), int(mj.mjtJoint.mjJNT_SLIDE)}
+        joint_ids = {int(j) for j in (robot.joint_ids or [])}
+        out: dict[int, int] = {}
+        for act_id in range(model.nu):
+            if int(model.actuator_trntype[act_id]) not in joint_trn:
+                continue
+            jnt_id = int(model.actuator_trnid[act_id, 0])
+            if jnt_id in joint_ids and int(model.jnt_type[jnt_id]) in settable:
+                out[jnt_id] = act_id
+        return out
+
+    def _short_name(self, name: str | None, namespace: str) -> str:
+        """Strip the robot namespace prefix for hint matching."""
+        if name and namespace and name.startswith(namespace):
+            return name[len(namespace) :]
+        return name or ""
+
+    def _frame_world_pose(
+        self, model: Any, data: Any, frame_name: str, frame_type: str
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """World position + wxyz quaternion of a site/body frame from live data.
+
+        Callers must have run a kinematics pass so ``xpos``/``xmat`` are
+        current, and must hold ``self._lock``.
+        """
+        mj = self._mj
+        if frame_type == "site":
+            sid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, frame_name)
+            pos = np.array(data.site_xpos[sid], dtype=np.float64)
+            quat = np.zeros(4, dtype=np.float64)
+            mj.mju_mat2Quat(quat, np.asarray(data.site_xmat[sid], dtype=np.float64).reshape(9))
+            return pos, quat
+        bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, frame_name)
+        return np.array(data.xpos[bid], dtype=np.float64), np.array(data.xquat[bid], dtype=np.float64)
+
+    # -- primitives ----------------------------------------------------------
+
+    def move_to(
+        self,
+        robot_name: str | None = None,
+        position: list[float] | None = None,
+        orientation: list[float] | None = None,
+        tol: float = 0.01,
+        max_steps: int = 200,
+    ) -> dict[str, Any]:
+        """Move the end-effector to a world-frame Cartesian target via IK.
+
+        Composite analytic primitive (the staging/transport verb): solves
+        inverse kinematics to the target with the shared mink
+        damped-least-squares bridge, then drives the arm's position-servo
+        actuators toward the solved configuration until the end-effector is
+        within ``tol`` meters of the target or ``max_steps`` control ticks
+        elapse (each tick advances a few physics substeps).
+
+        The end-effector frame is auto-discovered per robot namespace
+        (:func:`strands_robots.simulation.ik.discover_ee_frame`: TCP-like site,
+        else hand/tool body, else the chain's leaf body) - the same heuristic
+        eef-delta policies use, so multi-robot scenes resolve the right arm.
+
+        NOT collision-aware: the straight servo descent can sweep through
+        obstacles. Collision-aware transport is the curobo provider's job; this
+        primitive deliberately hides the solver backend so that upgrade cannot
+        change the surface. Motion is NOT recorded into an active dataset
+        recording session (see module docstring).
+
+        Args:
+            robot_name: Robot to move; defaults to the single robot in the
+                world (errors if ambiguous).
+            position: World-frame target ``[x, y, z]`` in meters (required).
+            orientation: Optional target orientation quaternion ``[w, x, y, z]``.
+                When omitted the solve is position-only - the right choice for
+                arms with fewer than 6 DOF (e.g. SO-100/SO-101), which cannot
+                realize an arbitrary full pose.
+            tol: Position convergence tolerance in meters (> 0).
+            max_steps: Max control ticks before returning a not-reached error
+                (1..10000).
+
+        Returns:
+            ``{"status": "success", ...}`` with a json block
+            ``{reached, steps, position_error_m, ik_residual_m, ee_position,
+            ee_orientation_wxyz, frame, frame_type}`` on arrival;
+            ``{"status": "error", ...}`` with the same json block (including
+            the residual) when the target is unreachable (IK residual > tol)
+            or servo convergence times out. Never raises.
+        """
+        # ---- parameter validation (before touching the world) ----
+        if position is None:
+            return _err("move_to requires 'position' ([x, y, z] target in meters).")
+        if len(position) != 3 or not all(_is_finite_real(c) for c in position):
+            return _err("move_to: 'position' must be 3 finite numbers [x, y, z] in meters.")
+        if orientation is not None:
+            if len(orientation) != 4 or not all(_is_finite_real(c) for c in orientation):
+                return _err("move_to: 'orientation' must be 4 finite numbers [w, x, y, z] (unit quaternion).")
+            quat_norm = float(np.linalg.norm(np.asarray(orientation, dtype=np.float64)))
+            if quat_norm < 1e-8:
+                return _err("move_to: 'orientation' quaternion has ~zero norm; pass a valid [w, x, y, z].")
+        if not _is_finite_real(tol) or float(tol) <= 0.0:
+            return _err(f"move_to: 'tol' must be a positive number of meters, got {tol!r}.")
+        err = self._validate_step_budget("move_to", "max_steps", max_steps)
+        if err is not None:
+            return err
+        max_steps = int(max_steps)
+        target = np.asarray([float(c) for c in position], dtype=np.float64)
+
+        # ---- setup under the lock: guards, EE frame, IK solve ----
+        with self._lock:
+            robot_name_resolved, error = self._primitive_resolve_robot("move_to", robot_name)
+            if error is not None:
+                return error
+            assert robot_name_resolved is not None
+            robot_name = robot_name_resolved
+            assert self._world is not None
+            model, data = self._world._model, self._world._data
+            robot = self._world.robots[robot_name]
+            namespace = robot.namespace or ""
+
+            base = np.asarray(robot.position or (0.0, 0.0, 0.0), dtype=np.float64)
+            base_dist = float(np.linalg.norm(target - base))
+            if base_dist > _WORKSPACE_SANITY_RADIUS_M:
+                return _err(
+                    f"move_to: target {target.tolist()} is {base_dist:.2f} m from robot "
+                    f"'{robot_name}' base - outside the {_WORKSPACE_SANITY_RADIUS_M:.0f} m workspace "
+                    "sanity box. Check units (meters, world frame)."
+                )
+
+            from strands_robots.simulation.ik import discover_ee_frame
+
+            frame = discover_ee_frame(model, namespace or None)
+            if frame is None:
+                return _err(
+                    f"move_to: could not auto-discover an end-effector frame for robot "
+                    f"'{robot_name}' (namespace {namespace!r}). The model has no TCP-like "
+                    "site or hand/tool body to track."
+                )
+            frame_name, frame_type = frame
+
+            jact = self._joint_actuator_map(model, robot)
+            if not jact:
+                return _err(
+                    f"move_to: robot '{robot_name}' has no joint-transmission actuators to "
+                    "drive. If it was loaded from a bare URDF, add position servos first: "
+                    "action='actuate_robot'."
+                )
+
+            try:
+                from strands_robots.simulation.ik import MinkIKBridge
+
+                # max_iters is raised well above the bridge default (20): the
+                # policy decode paths solve small re-anchored per-step deltas,
+                # whereas move_to jumps from the current pose to an arbitrary
+                # workspace point in one solve and needs the extra integration
+                # budget to converge from far seeds.
+                bridge = MinkIKBridge(
+                    model,
+                    frame_name,
+                    frame_type,
+                    orientation_cost=1.0 if orientation is not None else 0.0,
+                    max_iters=200,
+                )
+            except (ImportError, RuntimeError, ValueError) as e:
+                return _err(f"move_to: IK bridge unavailable: {e}")
+
+            q0 = np.array(data.qpos, dtype=np.float64, copy=True)
+            target_pose = np.eye(4, dtype=np.float64)
+            target_pose[:3, 3] = target
+            if orientation is not None:
+                quat = np.asarray([float(c) for c in orientation], dtype=np.float64)
+                quat = quat / np.linalg.norm(quat)
+                rot = np.zeros(9, dtype=np.float64)
+                self._mj.mju_quat2Mat(rot, quat)
+                target_pose[:3, :3] = rot.reshape(3, 3)
+            else:
+                # Position-only: keep the current EE orientation in the target
+                # pose (the zero orientation cost makes it a soft no-op).
+                target_pose[:3, :3] = bridge.ee_pose(q0)[:3, :3]
+
+            q_star = bridge.solve(target_pose, q0)
+            ik_residual = float(np.linalg.norm(bridge.ee_pose(q_star)[:3, 3] - target))
+
+            # Damped-least-squares IK is a local method: from a distant seed it
+            # can stall in a joint-limit / elbow-branch local minimum even for a
+            # reachable target. When the direct solve misses, retry from a few
+            # DETERMINISTIC restart seeds (the robot's own hinge/slide joints
+            # set uniformly within their ranges; everything else - other
+            # robots, object free joints - stays at the live state) and keep
+            # the best solution. Bounded and reproducible: same target, same
+            # answer.
+            if ik_residual > float(tol):
+                rng = np.random.default_rng(0)
+                settable_qadr = [int(model.jnt_qposadr[jnt_id]) for jnt_id in jact]
+                ranges = [
+                    (float(model.jnt_range[jnt_id][0]), float(model.jnt_range[jnt_id][1]))
+                    if bool(model.jnt_limited[jnt_id])
+                    else (-np.pi, np.pi)
+                    for jnt_id in jact
+                ]
+                for _ in range(_IK_RESTART_SEEDS):
+                    q_seed = q0.copy()
+                    for qadr, (lo, hi) in zip(settable_qadr, ranges, strict=True):
+                        q_seed[qadr] = rng.uniform(lo, hi)
+                    q_try = bridge.solve(target_pose, q_seed)
+                    residual_try = float(np.linalg.norm(bridge.ee_pose(q_try)[:3, 3] - target))
+                    if residual_try < ik_residual:
+                        q_star, ik_residual = q_try, residual_try
+                    if ik_residual <= float(tol):
+                        break
+
+            if ik_residual > float(tol):
+                return _err(
+                    f"move_to: target {target.tolist()} is unreachable for '{robot_name}' "
+                    f"within tol={float(tol)} m - best IK solution leaves a residual of "
+                    f"{ik_residual:.4f} m. Choose a closer target or loosen tol.",
+                    {
+                        "reached": False,
+                        "steps": 0,
+                        "ik_residual_m": ik_residual,
+                        "frame": frame_name,
+                        "frame_type": frame_type,
+                    },
+                )
+
+            ctrl_targets = {act_id: float(q_star[int(model.jnt_qposadr[jnt_id])]) for jnt_id, act_id in jact.items()}
+
+        # ---- servo loop: self-locking per control tick ----
+        steps_used = 0
+        reached = False
+        position_error = math.inf
+        ee_pos = target
+        ee_quat = np.array([1.0, 0.0, 0.0, 0.0])
+        for _ in range(max_steps):
+            with self._lock:
+                abort = self._primitive_abort_reason("move_to", robot_name, model)
+                if abort is not None:
+                    return abort
+                self._primitive_tick(model, data, ctrl_targets)
+                ee_pos, ee_quat = self._frame_world_pose(model, data, frame_name, frame_type)
+            steps_used += 1
+            position_error = float(np.linalg.norm(ee_pos - target))
+            if position_error <= float(tol):
+                reached = True
+                break
+
+        payload = {
+            "reached": reached,
+            "steps": steps_used,
+            "position_error_m": position_error,
+            "ik_residual_m": ik_residual,
+            "ee_position": [float(v) for v in ee_pos],
+            "ee_orientation_wxyz": [float(v) for v in ee_quat],
+            "frame": frame_name,
+            "frame_type": frame_type,
+        }
+        if reached:
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            f"move_to: '{robot_name}' EE ({frame_type} '{frame_name}') reached "
+                            f"{target.tolist()} within {float(tol)} m in {steps_used} steps "
+                            f"(error {position_error:.4f} m)."
+                        )
+                    },
+                    {"json": payload},
+                ],
+            }
+        return _err(
+            f"move_to: '{robot_name}' did not reach {target.tolist()} within tol={float(tol)} m "
+            f"after max_steps={max_steps} (residual {position_error:.4f} m; IK residual was "
+            f"{ik_residual:.4f} m). The servo may need more steps, or the pose fights joint "
+            "limits/contacts.",
+            payload,
+        )
+
+    def set_gripper(
+        self,
+        robot_name: str | None = None,
+        state: str | None = None,
+        steps: int = 12,
+    ) -> dict[str, Any]:
+        """Drive the gripper to an open/close set-point (atomic primitive).
+
+        Resolves the gripper actuator(s) by name heuristic (actuator or driven
+        joint short-name containing ``gripper`` / ``finger`` / ``jaw`` - the
+        registry carries no gripper metadata) and commands the actuator
+        ctrlrange end-point: ``"open"`` drives to the HIGH end, ``"close"`` to
+        the LOW end. That is the convention for SO-100/SO-101 (the jaw closes
+        toward the low/negative end of its range - the sign trap documented in
+        the so101_curobo example) and for the Franka split gripper (0=closed,
+        255=open). Motion is NOT recorded into an active dataset recording
+        session (see module docstring).
+
+        Args:
+            robot_name: Robot whose gripper to drive; defaults to the single
+                robot in the world (errors if ambiguous).
+            state: ``"open"`` or ``"close"`` (required).
+            steps: Control ticks to hold the set-point (1..10000); each tick
+                advances a few physics substeps so the fingers actually travel.
+
+        Returns:
+            ``{"status": "success", ...}`` with a json block
+            ``{state, actuators, targets, gripper_joint_positions}``;
+            structured error when the gripper cannot be resolved or the
+            ctrlrange gives no usable set-points. Never raises.
+        """
+        if state not in ("open", "close"):
+            return _err(f'set_gripper: \'state\' must be "open" or "close", got {state!r}.')
+        err = self._validate_step_budget("set_gripper", "steps", steps)
+        if err is not None:
+            return err
+        steps = int(steps)
+
+        with self._lock:
+            robot_name_resolved, error = self._primitive_resolve_robot("set_gripper", robot_name)
+            if error is not None:
+                return error
+            assert robot_name_resolved is not None
+            robot_name = robot_name_resolved
+            assert self._world is not None
+            model, data = self._world._model, self._world._data
+            robot = self._world.robots[robot_name]
+            namespace = robot.namespace or ""
+            mj = self._mj
+
+            jact = self._joint_actuator_map(model, robot)
+            jnt_by_act = {act_id: jnt_id for jnt_id, act_id in jact.items()}
+            gripper_acts: list[int] = []
+            act_ids = [int(a) for a in (robot.actuator_ids or [])]
+            for act_id in act_ids:
+                act_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id), namespace).lower()
+                jnt_id = jnt_by_act.get(act_id)
+                jnt_name = ""
+                if jnt_id is not None:
+                    jnt_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id), namespace).lower()
+                if any(h in act_name or (jnt_name and h in jnt_name) for h in _GRIPPER_HINTS):
+                    gripper_acts.append(act_id)
+            if not gripper_acts:
+                names = [
+                    self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, a), namespace) for a in act_ids
+                ]
+                return _err(
+                    f"set_gripper: could not resolve a gripper actuator for '{robot_name}' - no "
+                    f"actuator/joint name contains {list(_GRIPPER_HINTS)}. Actuators: {names}. "
+                    "Drive it directly with action='send_action' instead."
+                )
+
+            targets: dict[int, float] = {}
+            for act_id in gripper_acts:
+                lo = float(model.actuator_ctrlrange[act_id][0])
+                hi = float(model.actuator_ctrlrange[act_id][1])
+                if not (hi > lo):
+                    act_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id)
+                    return _err(
+                        f"set_gripper: actuator '{act_name}' has no usable ctrlrange "
+                        f"({lo}, {hi}); cannot infer open/close set-points. Drive it directly "
+                        "with action='send_action'."
+                    )
+                targets[act_id] = hi if state == "open" else lo
+
+        for _ in range(steps):
+            with self._lock:
+                abort = self._primitive_abort_reason("set_gripper", robot_name, model)
+                if abort is not None:
+                    return abort
+                self._primitive_tick(model, data, targets)
+
+        with self._lock:
+            joint_positions: dict[str, float] = {}
+            for act_id in gripper_acts:
+                jnt_id = jnt_by_act.get(act_id)
+                if jnt_id is not None:
+                    jname = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id), namespace)
+                    joint_positions[jname] = float(data.qpos[int(model.jnt_qposadr[jnt_id])])
+            act_names = [
+                self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, a), namespace) for a in gripper_acts
+            ]
+        payload = {
+            "state": state,
+            "actuators": act_names,
+            "targets": {n: targets[a] for n, a in zip(act_names, gripper_acts, strict=True)},
+            "gripper_joint_positions": joint_positions,
+        }
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": f"set_gripper: '{robot_name}' gripper commanded {state} ({steps} ticks, actuators {act_names})."
+                },
+                {"json": payload},
+            ],
+        }
+
+    def rotate_wrist(
+        self,
+        robot_name: str | None = None,
+        target_yaw: float | None = None,
+        tol: float = 0.02,
+        max_steps: int = 200,
+    ) -> dict[str, Any]:
+        """Rotate the wrist-yaw joint to a set-point, holding the arm posture.
+
+        Atomic primitive: resolves the wrist-roll/yaw joint by name heuristic
+        (``wrist_roll`` / ``wrist_yaw`` / ``wrist_rotate`` / ``wrist``, else
+        the last non-gripper hinge joint - the distal roll joint on most serial
+        arms), commands it to ``target_yaw`` while every other arm actuator
+        holds its current joint position, and servoes until the joint is within
+        ``tol`` radians or ``max_steps`` control ticks elapse. Holding the
+        other joints preserves the Cartesian EE position up to servo
+        compliance. Motion is NOT recorded into an active dataset recording
+        session (see module docstring).
+
+        Args:
+            robot_name: Robot whose wrist to rotate; defaults to the single
+                robot in the world (errors if ambiguous).
+            target_yaw: Wrist joint set-point in radians (required; must lie
+                within the joint's range when the joint is limited).
+            tol: Joint-angle convergence tolerance in radians (> 0).
+            max_steps: Max control ticks before returning a not-reached error
+                (1..10000).
+
+        Returns:
+            ``{"status": "success", ...}`` with a json block
+            ``{reached, steps, wrist_joint, target_yaw, final_yaw,
+            yaw_error_rad}``; structured error (with the residual) when the
+            joint cannot be resolved, the target is out of range, or servo
+            convergence times out. Never raises.
+        """
+        if target_yaw is None:
+            return _err("rotate_wrist requires 'target_yaw' (wrist joint set-point in radians).")
+        if not _is_finite_real(target_yaw):
+            return _err(f"rotate_wrist: 'target_yaw' must be a finite number of radians, got {target_yaw!r}.")
+        if not _is_finite_real(tol) or float(tol) <= 0.0:
+            return _err(f"rotate_wrist: 'tol' must be a positive number of radians, got {tol!r}.")
+        err = self._validate_step_budget("rotate_wrist", "max_steps", max_steps)
+        if err is not None:
+            return err
+        max_steps = int(max_steps)
+        target_yaw = float(target_yaw)
+
+        with self._lock:
+            robot_name_resolved, error = self._primitive_resolve_robot("rotate_wrist", robot_name)
+            if error is not None:
+                return error
+            assert robot_name_resolved is not None
+            robot_name = robot_name_resolved
+            assert self._world is not None
+            model, data = self._world._model, self._world._data
+            robot = self._world.robots[robot_name]
+            namespace = robot.namespace or ""
+            mj = self._mj
+
+            jact = self._joint_actuator_map(model, robot)
+            if not jact:
+                return _err(
+                    f"rotate_wrist: robot '{robot_name}' has no joint-transmission actuators to "
+                    "drive. If it was loaded from a bare URDF, add position servos first: "
+                    "action='actuate_robot'."
+                )
+
+            def jnt_short(jnt_id: int) -> str:
+                return self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id), namespace)
+
+            hinge = int(mj.mjtJoint.mjJNT_HINGE)
+            candidates = [j for j in jact if int(model.jnt_type[j]) == hinge]
+            non_gripper = [j for j in candidates if not any(h in jnt_short(j).lower() for h in _GRIPPER_HINTS)]
+            wrist_jnt: int | None = None
+            for hint in _WRIST_HINTS:
+                matches = [j for j in non_gripper if hint in jnt_short(j).lower()]
+                if matches:
+                    wrist_jnt = matches[-1]  # most distal on a name tie
+                    break
+            if wrist_jnt is None and non_gripper:
+                # Fallback: the last (most distal) non-gripper hinge joint.
+                wrist_jnt = max(non_gripper)
+            if wrist_jnt is None:
+                names = [jnt_short(j) for j in jact]
+                return _err(
+                    f"rotate_wrist: could not resolve a wrist joint for '{robot_name}'. "
+                    f"Actuated hinge joints: {names}. Drive one directly with "
+                    "action='send_action' instead."
+                )
+            wrist_name = jnt_short(wrist_jnt)
+
+            if bool(model.jnt_limited[wrist_jnt]):
+                lo = float(model.jnt_range[wrist_jnt][0])
+                hi = float(model.jnt_range[wrist_jnt][1])
+                if not (lo <= target_yaw <= hi):
+                    return _err(
+                        f"rotate_wrist: target_yaw={target_yaw} rad is outside joint "
+                        f"'{wrist_name}' range [{lo:.3f}, {hi:.3f}] rad."
+                    )
+
+            # Hold every other actuated joint at its CURRENT position; command
+            # only the wrist to the set-point.
+            ctrl_targets: dict[int, float] = {}
+            for jnt_id, act_id in jact.items():
+                qadr = int(model.jnt_qposadr[jnt_id])
+                ctrl_targets[act_id] = target_yaw if jnt_id == wrist_jnt else float(data.qpos[qadr])
+            wrist_qadr = int(model.jnt_qposadr[wrist_jnt])
+
+        steps_used = 0
+        reached = False
+        yaw_error = math.inf
+        final_yaw = 0.0
+        for _ in range(max_steps):
+            with self._lock:
+                abort = self._primitive_abort_reason("rotate_wrist", robot_name, model)
+                if abort is not None:
+                    return abort
+                self._primitive_tick(model, data, ctrl_targets)
+                final_yaw = float(data.qpos[wrist_qadr])
+            steps_used += 1
+            yaw_error = abs(final_yaw - target_yaw)
+            if yaw_error <= float(tol):
+                reached = True
+                break
+
+        payload = {
+            "reached": reached,
+            "steps": steps_used,
+            "wrist_joint": wrist_name,
+            "target_yaw": target_yaw,
+            "final_yaw": final_yaw,
+            "yaw_error_rad": yaw_error,
+        }
+        if reached:
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            f"rotate_wrist: '{robot_name}' joint '{wrist_name}' reached "
+                            f"{target_yaw:.3f} rad within {float(tol)} rad in {steps_used} steps."
+                        )
+                    },
+                    {"json": payload},
+                ],
+            }
+        return _err(
+            f"rotate_wrist: '{robot_name}' joint '{wrist_name}' did not reach {target_yaw:.3f} rad "
+            f"within tol={float(tol)} rad after max_steps={max_steps} (residual {yaw_error:.4f} rad).",
+            payload,
+        )
+
+    # -- validation helpers ---------------------------------------------------
+
+    @staticmethod
+    def _validate_step_budget(action: str, param: str, value: Any) -> dict[str, Any] | None:
+        """Validate an integer control-tick budget (1..``_MAX_PRIMITIVE_STEPS``)."""
+        if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+            return _err(f"{action}: '{param}' must be an integer, got {type(value).__name__}.")
+        if not (1 <= int(value) <= _MAX_PRIMITIVE_STEPS):
+            return _err(f"{action}: '{param}' must be between 1 and {_MAX_PRIMITIVE_STEPS}, got {int(value)}.")
+        return None

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -225,6 +225,32 @@ class MotionPrimitivesMixin:
             return name[len(namespace) :]
         return name or ""
 
+    def _gripper_actuator_ids(self, model: Any, robot: Any) -> set[int]:
+        """Actuator ids on *robot* classified as gripper drives by the name heuristic.
+
+        The shared classification behind ``set_gripper`` (which commands these
+        actuators) and ``move_to`` (which must NOT command them - the gripper
+        DOF is kinematically irrelevant to the EE task, so an IK solve would
+        pass whatever seed value it was given straight through, and a random
+        restart seed would then servo the jaw to a random point of its range,
+        dropping a held object mid-transport). An actuator qualifies when its
+        short name, or its driven joint's short name, contains one of
+        :data:`_GRIPPER_HINTS`. Callers must hold ``self._lock``.
+        """
+        mj = self._mj
+        namespace = robot.namespace or ""
+        jnt_by_act = {act_id: jnt_id for jnt_id, act_id in self._joint_actuator_map(model, robot).items()}
+        out: set[int] = set()
+        for act_id in (int(a) for a in (robot.actuator_ids or [])):
+            act_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id), namespace).lower()
+            jnt_id = jnt_by_act.get(act_id)
+            jnt_name = ""
+            if jnt_id is not None:
+                jnt_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id), namespace).lower()
+            if any(h in act_name or (jnt_name and h in jnt_name) for h in _GRIPPER_HINTS):
+                out.add(act_id)
+        return out
+
     def _frame_world_pose(
         self, model: Any, data: Any, frame_name: str, frame_type: str
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -266,6 +292,13 @@ class MotionPrimitivesMixin:
         (:func:`strands_robots.simulation.ik.discover_ee_frame`: TCP-like site,
         else hand/tool body, else the chain's leaf body) - the same heuristic
         eef-delta policies use, so multi-robot scenes resolve the right arm.
+
+        GRASP PRESERVATION (contract): gripper actuators (resolved by the same
+        name heuristic ``set_gripper`` uses) are excluded from the IK solve
+        and its restart seeding, and are HELD at their live position for the
+        whole servo descent - a closed gripper stays closed through staging
+        and transport, so ``set_gripper("close") -> move_to(...)`` carries the
+        held object rather than releasing it.
 
         NOT collision-aware: the straight servo descent can sweep through
         obstacles. Collision-aware transport is the curobo provider's job; this
@@ -351,6 +384,23 @@ class MotionPrimitivesMixin:
                     "drive. If it was loaded from a bare URDF, add position servos first: "
                     "action='actuate_robot'."
                 )
+            # Split arm vs gripper DOFs: the gripper is kinematically
+            # irrelevant to the EE task (mink passes its seed value straight
+            # through), so it must be excluded from IK seeding and from the
+            # solved command set - otherwise a restart seed would randomize
+            # the jaw and move_to would servo it there, dropping a held
+            # object mid-transport. The gripper channel is instead HELD at
+            # its live position (not omitted: _primitive_tick writes
+            # data.ctrl every tick, and an unwritten channel would let a
+            # stale ctrl from another path drive it).
+            grip_acts = self._gripper_actuator_ids(model, robot)
+            arm_jact = {j: a for j, a in jact.items() if a not in grip_acts}
+            if not arm_jact:
+                return _err(
+                    f"move_to: robot '{robot_name}' has no non-gripper joint-transmission "
+                    "actuators to drive - every actuated joint matches the gripper name "
+                    f"heuristic {list(_GRIPPER_HINTS)}. Nothing can move the end-effector."
+                )
 
             try:
                 from strands_robots.simulation.ik import MinkIKBridge
@@ -390,24 +440,36 @@ class MotionPrimitivesMixin:
             # Damped-least-squares IK is a local method: from a distant seed it
             # can stall in a joint-limit / elbow-branch local minimum even for a
             # reachable target. When the direct solve misses, retry from a few
-            # DETERMINISTIC restart seeds (the robot's own hinge/slide joints
-            # set uniformly within their ranges; everything else - other
-            # robots, object free joints - stays at the live state) and keep
-            # the best solution. Bounded and reproducible: same target, same
-            # answer.
+            # DETERMINISTIC restart seeds and keep the best solution: the first
+            # restart uses the model's home keyframe when one exists (for a
+            # from-home arm that is usually the branch that converges, and it
+            # is free), the rest set the robot's own ARM hinge/slide joints
+            # uniformly within their ranges. Gripper DOFs and everything else
+            # (other robots, object free joints) stay at the live state.
+            # Bounded and reproducible: same target, same answer.
             if ik_residual > float(tol):
+                # The RNG is deliberately reconstructed with a fixed seed PER
+                # CALL (not module-level): identical calls draw identical seed
+                # sequences, which is what makes move_to reproducible. Two
+                # calls to different targets sharing the sequence is fine -
+                # do not "fix" this into a shared RNG, that would make a
+                # call's outcome depend on call history.
                 rng = np.random.default_rng(0)
-                settable_qadr = [int(model.jnt_qposadr[jnt_id]) for jnt_id in jact]
+                settable_qadr = [int(model.jnt_qposadr[jnt_id]) for jnt_id in arm_jact]
                 ranges = [
                     (float(model.jnt_range[jnt_id][0]), float(model.jnt_range[jnt_id][1]))
                     if bool(model.jnt_limited[jnt_id])
                     else (-np.pi, np.pi)
-                    for jnt_id in jact
+                    for jnt_id in arm_jact
                 ]
-                for _ in range(_IK_RESTART_SEEDS):
+                for restart in range(_IK_RESTART_SEEDS):
                     q_seed = q0.copy()
-                    for qadr, (lo, hi) in zip(settable_qadr, ranges, strict=True):
-                        q_seed[qadr] = rng.uniform(lo, hi)
+                    if restart == 0 and int(model.nkey) > 0:
+                        for qadr in settable_qadr:
+                            q_seed[qadr] = float(model.key_qpos[0][qadr])
+                    else:
+                        for qadr, (lo, hi) in zip(settable_qadr, ranges, strict=True):
+                            q_seed[qadr] = rng.uniform(lo, hi)
                     q_try = bridge.solve(target_pose, q_seed)
                     residual_try = float(np.linalg.norm(bridge.ee_pose(q_try)[:3, 3] - target))
                     if residual_try < ik_residual:
@@ -429,7 +491,20 @@ class MotionPrimitivesMixin:
                     },
                 )
 
-            ctrl_targets = {act_id: float(q_star[int(model.jnt_qposadr[jnt_id])]) for jnt_id, act_id in jact.items()}
+            # Command ARM joints to the solve; HOLD gripper joints at their
+            # live position (see the arm/gripper split above - this is the
+            # grasp-preservation contract, and mirrors rotate_wrist's
+            # hold-everything-else behaviour).
+            ctrl_targets = {
+                act_id: float(q_star[int(model.jnt_qposadr[jnt_id])]) for jnt_id, act_id in arm_jact.items()
+            }
+            ctrl_targets.update(
+                {
+                    act_id: float(data.qpos[int(model.jnt_qposadr[jnt_id])])
+                    for jnt_id, act_id in jact.items()
+                    if act_id in grip_acts
+                }
+            )
 
         # ---- servo loop: self-locking per control tick ----
         steps_used = 0
@@ -534,16 +609,10 @@ class MotionPrimitivesMixin:
 
             jact = self._joint_actuator_map(model, robot)
             jnt_by_act = {act_id: jnt_id for jnt_id, act_id in jact.items()}
-            gripper_acts: list[int] = []
             act_ids = [int(a) for a in (robot.actuator_ids or [])]
-            for act_id in act_ids:
-                act_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id), namespace).lower()
-                jnt_id = jnt_by_act.get(act_id)
-                jnt_name = ""
-                if jnt_id is not None:
-                    jnt_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id), namespace).lower()
-                if any(h in act_name or (jnt_name and h in jnt_name) for h in _GRIPPER_HINTS):
-                    gripper_acts.append(act_id)
+            # Shared arm/gripper classification (also the exclusion set that
+            # keeps move_to's IK from commanding the jaw).
+            gripper_acts = sorted(self._gripper_actuator_ids(model, robot))
             if not gripper_acts:
                 names = [
                     self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, a), namespace) for a in act_ids

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -75,6 +75,7 @@ from strands_robots.simulation.mujoco.backend import (
     filter_mujoco_attach_noise,
 )
 from strands_robots.simulation.mujoco.manipulation import ManipulationMixin
+from strands_robots.simulation.mujoco.motion_primitives import MotionPrimitivesMixin
 from strands_robots.simulation.mujoco.physics import PhysicsMixin
 from strands_robots.simulation.mujoco.randomization import RandomizationMixin
 from strands_robots.simulation.mujoco.recording import RecordingMixin
@@ -212,6 +213,7 @@ class MuJoCoSimEngine(
     RecordingMixin,
     RandomizationMixin,
     ManipulationMixin,
+    MotionPrimitivesMixin,
     SimEngine,
     AgentTool,
 ):
@@ -1757,6 +1759,25 @@ class MuJoCoSimEngine(
         base["methods"]["zero_dynamics"] = (
             "(robot_name: str | None = None) -> dict  # zero qvel/qacc/warmstart "
             "(world-wide, or one robot's joints) after kinematic qpos writes"
+        )
+        # Analytic motion primitives (GH #1645): the agent-facing staging/
+        # transport/release vocabulary around a learned policy (Harness VLA).
+        base["methods"]["move_to"] = (
+            "(robot_name=None, position, orientation=None, tol=0.01, "
+            "max_steps=200) -> dict  # move the end-effector to a world-frame "
+            "[x, y, z] target via IK (position-only when orientation is "
+            "omitted - right for <6-DOF arms); NOT collision-aware; returns "
+            "reached/residual, structured error when unreachable"
+        )
+        base["methods"]["set_gripper"] = (
+            "(robot_name=None, state='open'|'close', steps=12) -> dict  # "
+            "drive the gripper actuator(s) to the open (ctrlrange HIGH) or "
+            "close (ctrlrange LOW) set-point"
+        )
+        base["methods"]["rotate_wrist"] = (
+            "(robot_name=None, target_yaw, tol=0.02, max_steps=200) -> dict  "
+            "# rotate the wrist-yaw joint to a set-point (radians) while the "
+            "other arm joints hold position"
         )
         # Robot-registry + robot-removal surface. describe() calls add_robot
         # "the first scene-construction step" and advertises the object/camera
@@ -3554,7 +3575,7 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (72 total): "
+                "Actions (75 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
@@ -3566,6 +3587,8 @@ class MuJoCoSimEngine(
                 "get_total_mass, get_ground_height, get_sensor_data, get_jacobian, get_mass_matrix, inverse_dynamics, "
                 "forward_kinematics, save_state, load_state, set_body_properties, set_geom_properties; "
                 "[Manipulation] attach_bodies, detach_bodies, actuate_robot, zero_dynamics; "
+                "[Motion primitives] move_to (Cartesian EE transport via IK; not collision-aware), "
+                "set_gripper (open/close set-point), rotate_wrist (wrist-yaw set-point holding position); "
                 "[Scene MJCF] replace_scene_mjcf, patch_scene_mjcf, raycast, multi_raycast; "
                 "[Recording] start_recording, save_episode, stop_recording, get_recording_status, "
                 "start_cameras_recording, stop_cameras_recording, get_cameras_recording_status; "
@@ -4188,7 +4211,12 @@ class MuJoCoSimEngine(
     # Dispatched actions that manage their own locking and MUST NOT run
     # under the blanket dispatch RLock (see _dispatch_action). Each one
     # acquires self._lock internally around its own model/data access.
-    _SELF_LOCKING_ACTIONS: frozenset[str] = frozenset({"step", "stop_policy", "remove_robot"})
+    # The motion primitives (move_to / set_gripper / rotate_wrist) lock per
+    # control tick (the step() pattern) so stop_policy / renders can
+    # interleave during a long primitive.
+    _SELF_LOCKING_ACTIONS: frozenset[str] = frozenset(
+        {"step", "stop_policy", "remove_robot", "move_to", "set_gripper", "rotate_wrist"}
+    )
 
     _ACTION_ALIASES = {
         "list_robots": "list_robots_info",

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -76,7 +76,10 @@
         "attach_bodies",
         "detach_bodies",
         "actuate_robot",
-        "zero_dynamics"
+        "zero_dynamics",
+        "move_to",
+        "set_gripper",
+        "rotate_wrist"
       ]
     },
     "scene_path": {
@@ -286,7 +289,24 @@
     },
     "max_steps": {
       "type": "integer",
-      "description": "Max steps per eval episode"
+      "description": "Max steps per eval episode; for move_to / rotate_wrist: max control ticks before returning a not-reached error"
+    },
+    "tol": {
+      "type": "number",
+      "description": "move_to / rotate_wrist convergence tolerance: meters for move_to (EE position, default 0.01), radians for rotate_wrist (joint angle, default 0.02)"
+    },
+    "state": {
+      "type": "string",
+      "enum": ["open", "close"],
+      "description": "set_gripper set-point: 'open' drives the gripper actuator(s) to the HIGH end of ctrlrange, 'close' to the LOW end (SO-100/SO-101 jaw closes toward the low end)"
+    },
+    "steps": {
+      "type": "integer",
+      "description": "set_gripper: control ticks to hold the set-point (each tick advances a few physics substeps); default 12"
+    },
+    "target_yaw": {
+      "type": "number",
+      "description": "rotate_wrist: wrist-yaw joint set-point in radians (must lie within the joint's range)"
     },
     "success_fn": {
       "type": "string",

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -25,6 +25,7 @@ IK-dependent tests ``importorskip`` on ``mink`` (the dev env ships it; a clean
 base install skips them), everything else runs on bare ``mujoco``.
 """
 
+import concurrent.futures
 import sys
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -116,6 +117,21 @@ def _json_block(result: dict[str, Any]) -> dict[str, Any]:
         if isinstance(block, dict) and "json" in block:
             return block["json"]
     raise AssertionError(f"no json block in result: {result}")
+
+
+def _drain_policy_thread(s: Simulation, robot_name: str, timeout: float = 10.0) -> None:
+    """Wait for a stopped policy's worker thread to exit before touching the robot.
+
+    Uses :func:`concurrent.futures.wait` rather than ``fut.result()`` because a
+    policy stopped mid-run may legitimately have raised inside the worker; these
+    tests only require that the thread has finished (so the per-robot policy
+    guard clears), and a thread that fails to stop is a hard test failure.
+    """
+    fut = s._policy_threads.get(robot_name)
+    if fut is None:
+        return
+    done, _ = concurrent.futures.wait([fut], timeout=timeout)
+    assert fut in done, f"policy thread for {robot_name!r} did not stop within {timeout}s"
 
 
 def _joint_positions(s: Simulation) -> dict[str, float]:
@@ -270,22 +286,12 @@ class TestGuards:
                 assert "policy is running" in result["content"][0]["text"], (action, result)
         finally:
             sim.stop_policy("arm")
-            fut = sim._policy_threads.get("arm")
-            if fut is not None:
-                try:
-                    fut.result(timeout=10.0)
-                except Exception:
-                    pass
+            _drain_policy_thread(sim, "arm")
 
     def test_allowed_after_policy_stopped(self, sim):
         assert sim.start_policy("arm", policy_provider="mock", duration=10.0, fast_mode=True)["status"] == "success"
         sim.stop_policy("arm")
-        fut = sim._policy_threads.get("arm")
-        if fut is not None:
-            try:
-                fut.result(timeout=10.0)
-            except Exception:
-                pass
+        _drain_policy_thread(sim, "arm")
         result = _dispatch(sim, "set_gripper", robot_name="arm", state="open", steps=2)
         assert result["status"] == "success", result
 

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -344,6 +344,53 @@ class TestMoveTo:
         assert "mink" in result["content"][0]["text"]
 
 
+class TestGraspPreservation:
+    """``move_to`` must never command the gripper (review on #1654).
+
+    The gripper DOF is kinematically irrelevant to the EE task, so mink passes
+    its seed value straight through; the pre-fix restart loop randomized the
+    jaw over its full range and then servoed it there - the
+    stage -> close -> transport sequence silently dropped whatever it held.
+    These tests pin the fix: gripper actuators are excluded from the IK
+    seeding/command set and HELD at their live position.
+    """
+
+    def test_restart_path_move_to_preserves_closed_gripper(self, sim):
+        """A target the direct solve misses (restart branch engaged) must not
+        move a closed jaw. [-0.3, 0.0, 0.25] has a direct-solve residual of
+        ~0.65 m on this arm - the exact repro from the review."""
+        pytest.importorskip("mink")
+        r = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=30)
+        assert r["status"] == "success", r
+        jaw_before = _jaw_pos(sim)
+        assert jaw_before < 0.0, f"jaw did not close: {jaw_before}"
+
+        r = _dispatch(sim, "move_to", robot_name="arm", position=[-0.3, 0.0, 0.25], tol=0.03, max_steps=400)
+        assert r["status"] == "success", r
+        assert _json_block(r)["reached"] is True
+
+        jaw_after = _jaw_pos(sim)
+        assert abs(jaw_after - jaw_before) < 0.05, (
+            f"move_to moved the gripper: jaw {jaw_before:.3f} -> {jaw_after:.3f} "
+            f"(ctrlrange [-0.2, 1.5]; the restart path must not command the jaw)"
+        )
+
+    def test_direct_path_move_to_preserves_open_gripper(self, sim):
+        """The direct-solve path must hold the jaw too (the gripper channel is
+        written every tick with the LIVE position, not left to stale ctrl)."""
+        pytest.importorskip("mink")
+        r = _dispatch(sim, "set_gripper", robot_name="arm", state="open", steps=40)
+        assert r["status"] == "success", r
+        jaw_before = _jaw_pos(sim)
+        assert jaw_before > 1.0, f"jaw did not open: {jaw_before}"
+
+        r = _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, tol=0.03, max_steps=400)
+        assert r["status"] == "success", r
+
+        jaw_after = _jaw_pos(sim)
+        assert abs(jaw_after - jaw_before) < 0.05, f"move_to moved the gripper: jaw {jaw_before:.3f} -> {jaw_after:.3f}"
+
+
 class TestSetGripper:
     """Open/close set-point semantics (LOW end = closed, HIGH end = open)."""
 

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -1,0 +1,421 @@
+"""Analytic motion primitives - ``move_to`` / ``set_gripper`` / ``rotate_wrist``.
+
+GH #1645: the agent-facing staging/transport/release vocabulary (Harness VLA,
+arXiv:2607.08448) that positions the robot around a learned policy's competence
+region. These tests pin the whole tool contract on a genuine MuJoCo scene (an
+inline MJCF arm - no asset downloads):
+
+* discovery: the actions are advertised in ``tool_spec.json`` and ``describe()``;
+* dispatch: kwargs are forwarded end-to-end (no silent drops), vector params
+  are validated at the router;
+* guards: no-world, unknown-robot, and refuse-while-policy-running (per-robot,
+  the ``_require_no_running_policy`` regression from the issue's acceptance
+  criteria);
+* semantics: ``move_to`` reaches a reachable target, returns a structured
+  error with the IK residual for an unreachable one (never a hang or raise),
+  rejects targets outside the workspace sanity box, and degrades to a
+  structured error (not a raise) when ``mink`` is missing; ``set_gripper``
+  drives toward the correct ctrlrange end per state; ``rotate_wrist`` reaches
+  a set-point and rejects out-of-range targets;
+* recording interplay (the #1498 bug class): primitive motion does NOT feed
+  the dataset recorder - pinned explicitly so a silent zero-frame "recording"
+  can never masquerade as a recorded episode.
+
+IK-dependent tests ``importorskip`` on ``mink`` (the dev env ships it; a clean
+base install skips them), everything else runs on bare ``mujoco``.
+"""
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# A stable 4-DOF positioner + jaw with conventional names so the primitives'
+# heuristics resolve everything: an ``ee_site`` TCP site (EE-frame discovery),
+# a ``wrist_roll`` hinge (rotate_wrist), and a ``jaw`` joint whose LOW range
+# end is "closed" (set_gripper, the SO-101 convention). Position servos use
+# dampratio + joint armature/damping so the servo loop is stable at the
+# default 0.002 s timestep.
+ARM_XML = """
+<mujoco model="prim_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002" gravity="0 0 0"/>
+  <default>
+    <joint armature="0.05" damping="0.5"/>
+    <geom density="2000"/>
+  </default>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <geom type="cylinder" size="0.04 0.02"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+        <body name="link2" pos="0 0 0.2">
+          <joint name="shoulder_lift" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+          <geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.02"/>
+          <body name="link3" pos="0.15 0 0">
+            <joint name="elbow" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+            <geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.018"/>
+            <body name="link4" pos="0.15 0 0">
+              <joint name="wrist_roll" type="hinge" axis="1 0 0" range="-3.0 3.0"/>
+              <geom type="capsule" fromto="0 0 0 0.05 0 0" size="0.015"/>
+              <site name="ee_site" pos="0.05 0 0"/>
+              <body name="jaw_body" pos="0.05 0 0">
+                <joint name="jaw" type="hinge" axis="0 0 1" range="-0.2 1.5" armature="0.01" damping="0.1"/>
+                <geom type="box" size="0.01 0.01 0.02" contype="0" conaffinity="0"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan" joint="shoulder_pan" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="shoulder_lift" joint="shoulder_lift" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="elbow" joint="elbow" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="wrist_roll" joint="wrist_roll" kp="5" dampratio="1" ctrlrange="-3.0 3.0"/>
+    <position name="jaw" joint="jaw" kp="2" dampratio="1" ctrlrange="-0.2 1.5"/>
+  </actuator>
+</mujoco>
+"""
+
+# Reachable for the arm above (the ee_site sweeps a shell around the shoulder
+# at (0, 0, 0.25) with reach 0.35); verified against the real solver.
+REACHABLE = [0.2, 0.1, 0.2]
+UNREACHABLE = [1.5, 0.0, 0.2]  # inside the sanity box, outside the workspace
+
+
+@pytest.fixture
+def arm_path(tmp_path):
+    path = tmp_path / "prim_arm.xml"
+    path.write_text(ARM_XML)
+    return str(path)
+
+
+@pytest.fixture
+def sim(arm_path):
+    s = Simulation(tool_name="test_motion_primitives", mesh=False)
+    assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+    assert s.add_robot("arm", urdf_path=arm_path)["status"] == "success"
+    yield s
+    s.cleanup(policy_stop_timeout=2.0)
+
+
+def _dispatch(s: Simulation, action: str, **fields: Any) -> dict[str, Any]:
+    return s._dispatch_action(action, {"action": action, **fields})
+
+
+def _json_block(result: dict[str, Any]) -> dict[str, Any]:
+    for block in result["content"]:
+        if isinstance(block, dict) and "json" in block:
+            return block["json"]
+    raise AssertionError(f"no json block in result: {result}")
+
+
+def _joint_positions(s: Simulation) -> dict[str, float]:
+    state = _json_block(s.get_robot_state("arm"))["state"]
+    return {joint: float(entry["position"]) for joint, entry in state.items()}
+
+
+def _jaw_pos(s: Simulation) -> float:
+    return _joint_positions(s)["jaw"]
+
+
+class TestDiscoverySurface:
+    """tool_spec + describe() advertise the primitives (acceptance criterion)."""
+
+    def test_tool_spec_enum_contains_primitives(self):
+        s = Simulation(tool_name="spec_probe", mesh=False)
+        try:
+            actions = s.tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"]
+            for action in ("move_to", "set_gripper", "rotate_wrist"):
+                assert action in actions
+            description = s.tool_spec["description"]
+            for action in ("move_to", "set_gripper", "rotate_wrist"):
+                assert action in description
+        finally:
+            s.cleanup()
+
+    def test_tool_spec_declares_primitive_params(self):
+        s = Simulation(tool_name="spec_probe", mesh=False)
+        try:
+            props = s.tool_spec["inputSchema"]["json"]["properties"]
+            assert props["tol"]["type"] == "number"
+            assert props["state"]["enum"] == ["open", "close"]
+            assert props["steps"]["type"] == "integer"
+            assert props["target_yaw"]["type"] == "number"
+        finally:
+            s.cleanup()
+
+    def test_describe_advertises_primitives(self, sim):
+        methods = sim.describe()["methods"]
+        for action in ("move_to", "set_gripper", "rotate_wrist"):
+            assert action in methods, f"describe() missing {action}"
+        assert "collision-aware" in methods["move_to"]
+
+
+class TestDispatchForwarding:
+    """Every advertised kwarg reaches the method (no silent drops)."""
+
+    def _capture(self, captured: dict[str, Any], sim: Simulation, method_name: str):
+        import inspect
+        from functools import wraps
+
+        original = getattr(sim, method_name)
+
+        @wraps(original)
+        def fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            bound = inspect.signature(original).bind_partial(*args, **kwargs)
+            captured.clear()
+            captured.update(bound.arguments)
+            return {"status": "success", "content": [{"text": "ok"}]}
+
+        return fake
+
+    def test_move_to_kwargs_forwarded(self, sim):
+        captured: dict[str, Any] = {}
+        with patch.object(sim, "move_to", self._capture(captured, sim, "move_to")):
+            result = _dispatch(
+                sim,
+                "move_to",
+                robot_name="arm",
+                position=[0.1, 0.2, 0.3],
+                orientation=[1, 0, 0, 0],
+                tol=0.05,
+                max_steps=7,
+            )
+        assert result["status"] == "success"
+        assert captured == {
+            "robot_name": "arm",
+            "position": [0.1, 0.2, 0.3],
+            "orientation": [1, 0, 0, 0],
+            "tol": 0.05,
+            "max_steps": 7,
+        }
+
+    def test_set_gripper_kwargs_forwarded(self, sim):
+        captured: dict[str, Any] = {}
+        with patch.object(sim, "set_gripper", self._capture(captured, sim, "set_gripper")):
+            result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=5)
+        assert result["status"] == "success"
+        assert captured == {"robot_name": "arm", "state": "close", "steps": 5}
+
+    def test_rotate_wrist_kwargs_forwarded(self, sim):
+        captured: dict[str, Any] = {}
+        with patch.object(sim, "rotate_wrist", self._capture(captured, sim, "rotate_wrist")):
+            result = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=0.5, tol=0.01, max_steps=9)
+        assert result["status"] == "success"
+        assert captured == {"robot_name": "arm", "target_yaw": 0.5, "tol": 0.01, "max_steps": 9}
+
+    def test_move_to_position_vector_validated_at_router(self, sim):
+        result = _dispatch(sim, "move_to", robot_name="arm", position=[0.1, 0.2])
+        assert result["status"] == "error"
+        assert "must be a list of 3 numbers" in result["content"][0]["text"]
+
+    def test_move_to_orientation_vector_validated_at_router(self, sim):
+        result = _dispatch(sim, "move_to", robot_name="arm", position=[0.1, 0.2, 0.3], orientation=[1, 0, 0])
+        assert result["status"] == "error"
+        assert "must be a list of 4 numbers" in result["content"][0]["text"]
+
+    def test_unknown_param_rejected(self, sim):
+        result = _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, speed=2.0)
+        assert result["status"] == "error"
+        assert "Unknown parameter 'speed'" in result["content"][0]["text"]
+
+
+class TestGuards:
+    """World / robot / policy-running guards return structured errors."""
+
+    def test_no_world_errors(self):
+        s = Simulation(tool_name="no_world", mesh=False)
+        try:
+            for action, fields in (
+                ("move_to", {"position": REACHABLE}),
+                ("set_gripper", {"state": "open"}),
+                ("rotate_wrist", {"target_yaw": 0.1}),
+            ):
+                result = _dispatch(s, action, **fields)
+                assert result["status"] == "error", (action, result)
+                assert "No world" in result["content"][0]["text"]
+        finally:
+            s.cleanup()
+
+    def test_unknown_robot_errors(self, sim):
+        for action, fields in (
+            ("move_to", {"position": REACHABLE}),
+            ("set_gripper", {"state": "open"}),
+            ("rotate_wrist", {"target_yaw": 0.1}),
+        ):
+            result = _dispatch(sim, action, robot_name="nope", **fields)
+            assert result["status"] == "error", (action, result)
+            assert "Robot 'nope' not found" in result["content"][0]["text"]
+
+    def test_refused_while_policy_running(self, sim):
+        """Acceptance criterion: primitives refuse while a policy runs on the robot."""
+        assert sim.start_policy("arm", policy_provider="mock", duration=10.0, fast_mode=True)["status"] == "success"
+        try:
+            for action, fields in (
+                ("move_to", {"position": REACHABLE}),
+                ("set_gripper", {"state": "open"}),
+                ("rotate_wrist", {"target_yaw": 0.1}),
+            ):
+                result = _dispatch(sim, action, robot_name="arm", **fields)
+                assert result["status"] == "error", (action, result)
+                assert "policy is running" in result["content"][0]["text"], (action, result)
+        finally:
+            sim.stop_policy("arm")
+            fut = sim._policy_threads.get("arm")
+            if fut is not None:
+                try:
+                    fut.result(timeout=10.0)
+                except Exception:
+                    pass
+
+    def test_allowed_after_policy_stopped(self, sim):
+        assert sim.start_policy("arm", policy_provider="mock", duration=10.0, fast_mode=True)["status"] == "success"
+        sim.stop_policy("arm")
+        fut = sim._policy_threads.get("arm")
+        if fut is not None:
+            try:
+                fut.result(timeout=10.0)
+            except Exception:
+                pass
+        result = _dispatch(sim, "set_gripper", robot_name="arm", state="open", steps=2)
+        assert result["status"] == "success", result
+
+
+class TestMoveTo:
+    """Cartesian transport semantics (real mink solver)."""
+
+    def test_reaches_reachable_target(self, sim):
+        pytest.importorskip("mink")
+        result = _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, tol=0.02)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        assert payload["position_error_m"] <= 0.02
+        assert payload["frame"] == "arm/ee_site"
+        assert payload["frame_type"] == "site"
+
+    def test_unreachable_target_returns_structured_error_with_residual(self, sim):
+        """Acceptance criterion: unreachable -> structured error + residual, no hang/raise."""
+        pytest.importorskip("mink")
+        result = _dispatch(sim, "move_to", robot_name="arm", position=UNREACHABLE, tol=0.01)
+        assert result["status"] == "error", result
+        assert "unreachable" in result["content"][0]["text"]
+        payload = _json_block(result)
+        assert payload["reached"] is False
+        assert payload["ik_residual_m"] > 0.01
+
+    def test_sanity_box_rejects_far_target(self, sim):
+        result = _dispatch(sim, "move_to", robot_name="arm", position=[50.0, 0.0, 0.2])
+        assert result["status"] == "error"
+        assert "sanity box" in result["content"][0]["text"]
+
+    def test_missing_position_errors(self, sim):
+        result = _dispatch(sim, "move_to", robot_name="arm")
+        assert result["status"] == "error"
+        assert "position" in result["content"][0]["text"]
+
+    def test_bad_tol_and_max_steps_rejected(self, sim):
+        assert _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, tol=0.0)["status"] == "error"
+        assert _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, tol=-1)["status"] == "error"
+        assert _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, max_steps=0)["status"] == "error"
+        assert _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, max_steps=10**9)["status"] == "error"
+
+    def test_missing_mink_degrades_to_structured_error(self, sim, monkeypatch):
+        """A missing IK stack is a structured error through the tool surface, not a raise."""
+        monkeypatch.setitem(sys.modules, "mink", None)  # forces `import mink` to ImportError
+        result = _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE)
+        assert result["status"] == "error"
+        assert "IK bridge unavailable" in result["content"][0]["text"]
+        assert "mink" in result["content"][0]["text"]
+
+
+class TestSetGripper:
+    """Open/close set-point semantics (LOW end = closed, HIGH end = open)."""
+
+    def test_close_drives_toward_low_end(self, sim):
+        result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=40)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["targets"]["jaw"] == pytest.approx(-0.2)
+        assert _jaw_pos(sim) < -0.1  # traveled toward the low (closed) end
+
+    def test_open_drives_toward_high_end(self, sim):
+        _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=40)
+        result = _dispatch(sim, "set_gripper", robot_name="arm", state="open", steps=80)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["targets"]["jaw"] == pytest.approx(1.5)
+        assert _jaw_pos(sim) > 1.0  # traveled toward the high (open) end
+
+    def test_invalid_state_rejected(self, sim):
+        result = _dispatch(sim, "set_gripper", robot_name="arm", state="ajar")
+        assert result["status"] == "error"
+        assert '"open" or "close"' in result["content"][0]["text"]
+
+    def test_missing_state_rejected(self, sim):
+        result = _dispatch(sim, "set_gripper", robot_name="arm")
+        assert result["status"] == "error"
+
+    def test_bad_steps_rejected(self, sim):
+        assert _dispatch(sim, "set_gripper", robot_name="arm", state="open", steps=0)["status"] == "error"
+
+
+class TestRotateWrist:
+    """Wrist-yaw set-point semantics."""
+
+    def test_reaches_target_yaw(self, sim):
+        result = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=0.7)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        assert payload["wrist_joint"] == "wrist_roll"
+        assert payload["final_yaw"] == pytest.approx(0.7, abs=0.03)
+
+    def test_holds_other_joints(self, sim):
+        before = _joint_positions(sim)
+        result = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=0.5)
+        assert result["status"] == "success", result
+        after = _joint_positions(sim)
+        for joint in ("shoulder_pan", "shoulder_lift", "elbow"):
+            assert abs(after[joint] - before[joint]) < 0.05, joint
+
+    def test_out_of_range_target_rejected(self, sim):
+        result = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=10.0)
+        assert result["status"] == "error"
+        assert "outside joint" in result["content"][0]["text"]
+
+    def test_missing_target_yaw_rejected(self, sim):
+        result = _dispatch(sim, "rotate_wrist", robot_name="arm")
+        assert result["status"] == "error"
+        assert "target_yaw" in result["content"][0]["text"]
+
+
+class TestRecordingInterplay:
+    """Primitive motion does NOT feed the dataset recorder (documented + pinned).
+
+    Only ``run_policy``'s per-frame hook records dataset episodes; a primitive
+    stepping physics directly must not add frames (and must not pretend to).
+    Camera MP4 recording is a separate live-sampling path and is unaffected.
+    """
+
+    def test_primitive_does_not_feed_dataset_recorder(self, sim):
+        recorder = MagicMock()
+        assert sim._world is not None
+        sim._world._backend_state["recording"] = True
+        sim._world._backend_state["dataset_recorder"] = recorder
+        try:
+            result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=5)
+            assert result["status"] == "success", result
+            recorder.add_frame.assert_not_called()
+        finally:
+            sim._world._backend_state["recording"] = False
+            sim._world._backend_state.pop("dataset_recorder", None)

--- a/tests_integ/simulation/test_motion_primitives_journey.py
+++ b/tests_integ/simulation/test_motion_primitives_journey.py
@@ -54,6 +54,15 @@ def _json_block(result: dict[str, Any]) -> dict[str, Any]:
     raise AssertionError(f"no json block in result: {result}")
 
 
+def _jaw_position(s: Any) -> float:
+    """Live position of the SO-100 jaw joint (grasp-preservation probe)."""
+    state = _json_block(s.get_robot_state("arm"))["state"]
+    for joint, entry in state.items():
+        if "jaw" in joint.lower():
+            return float(entry["position"])
+    raise AssertionError(f"no jaw joint in robot state: {list(state)}")
+
+
 def test_pick_sequence_via_dispatch_only(sim):
     """move_to above cube -> close -> move_to lift -> open, dispatch-only."""
     # The auto-discovered EE frame on SO-100 is the wrist body (no TCP site in
@@ -73,6 +82,7 @@ def test_pick_sequence_via_dispatch_only(sim):
     # 2) Close the gripper (SO-100 jaw closes toward the LOW end of ctrlrange).
     result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=30)
     assert result["status"] == "success", result
+    jaw_closed = _jaw_position(sim)
 
     # 3) Lift.
     result = _dispatch(sim, "move_to", robot_name="arm", position=lift, tol=tol, max_steps=400)
@@ -82,6 +92,14 @@ def test_pick_sequence_via_dispatch_only(sim):
     # Targets are 0.10 m apart in z and each end pose is within tol of its
     # target, so the realized z gain is at least 0.10 - 2*tol.
     assert lifted["ee_position"][2] - stage["ee_position"][2] > 0.10 - 2 * tol
+    # Grasp preservation on the real arm (review on #1654): transport must not
+    # command the jaw - a closed gripper stays closed through move_to. (The
+    # restart-path variant of this pin lives in the unit suite, where the
+    # synthetic arm makes the restart branch deterministic.)
+    jaw_after_lift = _jaw_position(sim)
+    assert abs(jaw_after_lift - jaw_closed) < 0.15, (
+        f"move_to moved the jaw during transport: {jaw_closed:.3f} -> {jaw_after_lift:.3f}"
+    )
 
     # 4) Release.
     result = _dispatch(sim, "set_gripper", robot_name="arm", state="open", steps=30)

--- a/tests_integ/simulation/test_motion_primitives_journey.py
+++ b/tests_integ/simulation/test_motion_primitives_journey.py
@@ -1,0 +1,107 @@
+"""Integration: analytic motion primitives drive a real SO-100 pick sequence.
+
+GH #1645 acceptance criterion: an agent can execute
+``move_to`` (above a cube) -> ``set_gripper("close")`` -> ``move_to`` (lift) ->
+``set_gripper("open")`` on a registry SO-100 arm in MuJoCo **via tool-dispatch
+actions only** (the exact `_dispatch_action` surface an LLM agent drives), with
+real mink IK and real physics - no mocks.
+
+Also journeys ``rotate_wrist`` on the real arm (the SO-100's ``Wrist_Roll``
+joint) since the wrist heuristic is name-driven and must be pinned against a
+real menagerie model, not just the synthetic unit-test arm.
+
+Skips cleanly when the SO-100 asset or the mink/qpsolvers stack is absent.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("mink")
+
+os.environ.setdefault("MUJOCO_GL", "glfw")
+
+
+@pytest.fixture
+def sim():
+    """A fresh MuJoCo world with one SO-100 arm and a graspable cube."""
+    from strands_robots.simulation import Simulation
+
+    s = Simulation()
+    assert s.create_world(timestep=0.002, gravity=[0.0, 0.0, -9.81])["status"] == "success"
+    result = s.add_robot("arm", data_config="so100", position=[0.0, 0.0, 0.0])
+    if result["status"] != "success":
+        s.destroy()
+        pytest.skip(f"so100 asset unavailable: {result['content'][0]['text']}")
+    s.add_object(name="cube", shape="box", size=[0.015, 0.015, 0.015], position=[0.2, 0.0, 0.015], color=[1, 0, 0, 1])
+    s.step(n_steps=50)  # settle
+    yield s
+    s.destroy()
+
+
+def _dispatch(s: Any, action: str, **fields: Any) -> dict[str, Any]:
+    return s._dispatch_action(action, {"action": action, **fields})
+
+
+def _json_block(result: dict[str, Any]) -> dict[str, Any]:
+    for block in result["content"]:
+        if isinstance(block, dict) and "json" in block:
+            return block["json"]
+    raise AssertionError(f"no json block in result: {result}")
+
+
+def test_pick_sequence_via_dispatch_only(sim):
+    """move_to above cube -> close -> move_to lift -> open, dispatch-only."""
+    # The auto-discovered EE frame on SO-100 is the wrist body (no TCP site in
+    # the menagerie model); the jaw hangs below it, so the staging height must
+    # clear the jaw's extent above the cube.
+    above_cube = [0.2, 0.0, 0.15]
+    lift = [0.2, 0.0, 0.25]
+    tol = 0.03
+
+    # 1) Stage above the cube (position-only IK - SO-100 is a 5-DOF arm).
+    result = _dispatch(sim, "move_to", robot_name="arm", position=above_cube, tol=tol, max_steps=400)
+    assert result["status"] == "success", result
+    stage = _json_block(result)
+    assert stage["reached"] is True
+    assert stage["position_error_m"] <= tol
+
+    # 2) Close the gripper (SO-100 jaw closes toward the LOW end of ctrlrange).
+    result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=30)
+    assert result["status"] == "success", result
+
+    # 3) Lift.
+    result = _dispatch(sim, "move_to", robot_name="arm", position=lift, tol=tol, max_steps=400)
+    assert result["status"] == "success", result
+    lifted = _json_block(result)
+    assert lifted["reached"] is True
+    # Targets are 0.10 m apart in z and each end pose is within tol of its
+    # target, so the realized z gain is at least 0.10 - 2*tol.
+    assert lifted["ee_position"][2] - stage["ee_position"][2] > 0.10 - 2 * tol
+
+    # 4) Release.
+    result = _dispatch(sim, "set_gripper", robot_name="arm", state="open", steps=30)
+    assert result["status"] == "success", result
+    payload = _json_block(result)
+    assert payload["state"] == "open"
+
+
+def test_unreachable_target_returns_residual_on_real_arm(sim):
+    """A target far outside the SO-100 workspace errors with the IK residual."""
+    result = _dispatch(sim, "move_to", robot_name="arm", position=[2.0, 0.0, 0.2], tol=0.01, max_steps=50)
+    assert result["status"] == "error", result
+    assert "unreachable" in result["content"][0]["text"]
+    assert _json_block(result)["ik_residual_m"] > 0.01
+
+
+def test_rotate_wrist_on_real_arm(sim):
+    """The wrist heuristic resolves SO-100's Wrist_Roll and reaches a set-point."""
+    result = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=0.5, tol=0.05, max_steps=400)
+    assert result["status"] == "success", result
+    payload = _json_block(result)
+    assert payload["reached"] is True
+    assert "wrist" in payload["wrist_joint"].lower()


### PR DESCRIPTION
Closes #1645.

## What changed

Adds the **agent-facing analytic motion primitives** from Harness VLA (arXiv:2607.08448) to the MuJoCo Simulation tool - the staging/transport/release vocabulary that lets an LLM agent position the robot *around* a learned policy's competence region - and performs the **MinkIKBridge dedup** the issue calls for.

### New primitives (`strands_robots/simulation/mujoco/motion_primitives.py`, new `MotionPrimitivesMixin`)

| Primitive | Contract |
|---|---|
| `move_to(robot_name, position, orientation=None, tol=0.01, max_steps=200)` | Composite: mink DLS IK to the world-frame target (**position-only when `orientation=None`** - the right contract for 5-DOF arms like SO-101), then a position-servo drive loop until within `tol` or `max_steps` control ticks. Returns `{reached, steps, position_error_m, ik_residual_m, ee_position, ee_orientation_wxyz, frame, frame_type}`. |
| `set_gripper(robot_name, state="open"\|"close", steps=12)` | Atomic ctrlrange end-point set-point: open = HIGH end, close = LOW end (the SO-100/SO-101 jaw-closes-toward-LOW sign trap from `examples/so101_curobo` is the documented convention; matches Franka 0=closed/255=open). Gripper resolved by the existing `gripper|finger|jaw` name heuristic (registry has no gripper metadata). |
| `rotate_wrist(robot_name, target_yaw, tol=0.02, max_steps=200)` | Wrist-yaw joint set-point (name heuristic `wrist_roll`/`wrist_yaw`/..., fallback: most distal non-gripper hinge) while every other arm actuator holds its current position. Out-of-range targets rejected against `jnt_range`. |

Shared contract (all three):
- **Structured errors, never raises** through the tool surface. An unreachable `move_to` target returns `status="error"` **with the IK residual** in a json block - no hang, no raise.
- **Refuse while a policy runs** on the same robot (per-robot `_require_no_running_policy`), pinned by a regression test.
- **Self-locking** (added to `_SELF_LOCKING_ACTIONS`): the loops take `self._lock` per control tick (the `step()` batching pattern) so `stop_policy`, renders, and MJPEG threads interleave; mid-run world destruction / model recompile / policy start aborts with a structured error.
- **EE frame auto-discovery** per robot namespace via the same `discover_ee_frame` heuristic eef-delta policies use, so multi-robot scenes resolve the right arm.
- **Workspace sanity box**: `move_to` targets > 5 m from the robot base are rejected up front (guards unit mistakes; true reachability is the IK residual's job).
- **Deterministic multi-start IK**: DLS is a local method; when the direct solve from the live configuration stalls, up to 8 seeded restarts (fixed RNG seed - same target, same answer) over the robot's own joint ranges rescue elbow-branch/joint-limit local minima. Needed for real from-home SO-100 transport solves.
- **Not collision-aware** (documented on the surface): the solver backend is hidden per the paper's contract, so a future collision-aware backend (curobo, #1533) can replace it without changing the semantics.
- **Recording interplay decided + pinned** (the #1498 bug class): primitive motion does NOT feed the dataset recorder (only `run_policy`'s frame hook records); documented in the module/method docstrings and pinned by `test_primitive_does_not_feed_dataset_recorder`. Camera MP4 recording still captures primitives (separate live-sampling path).

### IK dedup (`strands_robots/simulation/ik.py`, new shared module)

- The two `MinkIKBridge` copies (`policies/cosmos3/sim_ik.py`, `policies/vera/sim_ik.py`) are lifted into one shared class (superset: `solve` / `solve_trajectory` / `tracking_error` / `ee_pose`), together with `resolve_qp_solver` and `discover_ee_frame` (moved from `policies/vera/ee_frame.py` so the simulation layer does not depend on a policy provider for frame discovery; the vera module re-exports).
- cosmos3/vera keep **thin subclasses** that brand the install errors with their extras (`cosmos3-sim` vs `sim-mujoco`) and keep their provider-specific decode glue local - a change to one model's action semantics still cannot break the other.
- Behavior pinned by the existing suites (`test_sim_ik*`, `test_ee_frame_discovery`, `test_vera_autoconfig_ik`, ... - all green unchanged); cosmos3's `float32` `ee_pose` contract is preserved via a narrow override.

### Wiring

- `tool_spec.json`: `move_to` / `set_gripper` / `rotate_wrist` enum entries + `tol` / `state` (enum open|close) / `steps` / `target_yaw` params; `max_steps` description extended.
- `describe()`: three new method entries; action-count text 72 -> 75. Existing `position`(3)/`orientation`(4) router vector validation applies to the new actions for free.

## Test surface

- **29 unit tests** (`tests/simulation/mujoco/test_motion_primitives.py`, inline MJCF arm - no asset downloads): discovery surface (tool_spec enum + params + describe), kwarg forwarding end-to-end (no silent drops), router vector validation, unknown-param rejection, no-world / unknown-robot / **policy-running guards**, reachable + unreachable (+ residual) + sanity-box `move_to`, missing-`mink` degradation to a structured error, gripper open/close direction, wrist set-point + posture hold + range rejection, and the recording pin. IK-dependent tests `importorskip("mink")`.
- **3 integration tests** (`tests_integ/simulation/test_motion_primitives_journey.py`): the issue's acceptance sequence - `move_to` above a cube -> `set_gripper("close")` -> `move_to` lift -> `set_gripper("open")` on a **real registry SO-100** in MuJoCo **via `_dispatch_action` only**, plus unreachable-residual and `rotate_wrist` (real `Wrist_Roll`) journeys. All pass locally with real mink IK + physics.

## Validation

- `hatch run lint` - clean (ruff + ruff format + mypy).
- `hatch run test` with `MUJOCO_GL=egl`: **12014 passed, 245 skipped, 0 failed**.
- Environmental note: under default (glfw, no X11) the full-suite run aborts natively in `mujoco ... Renderer.__init__` at `tests/inference/test_remote_policy_sim_rollout.py` - reproduced identically on unmodified `upstream/main`, i.e. pre-existing on the dev box and unrelated to this change; EGL runs the whole suite green.
- `hatch run test-integ tests_integ/simulation/test_motion_primitives_journey.py` - 3 passed.

## Acceptance criteria (from #1645)

- [x] Agent executes `move_to` above cube -> `set_gripper("close")` -> `move_to` lift -> `set_gripper("open")` on SO-100 in MuJoCo via tool-dispatch actions only (integration test).
- [x] `move_to` with unreachable target returns a structured error with the residual, not a hang or raise.
- [x] Refuses while a policy is running (`_require_no_running_policy` regression test).
- [x] tool_spec/describe advertise the primitives; kwargs forwarded end-to-end (forwarding tests).
- [x] IK dedup: cosmos3 + vera import the shared bridge; behavior pinned by existing tests.

## Out of scope / follow-ups

- Newton/Isaac backend parity for the primitives (issue scopes MuJoCo first; Newton "if trivial" deferred - it has its own actuation surface).
- Collision-aware `move_to` backend (curobo provider, #1533) - the surface is deliberately backend-hiding so it can ride in later.
- Registry gripper metadata (joint name / open-close direction) to replace the name heuristic - worth its own issue if a robot lands whose gripper defies the heuristic.

Project board: please move #1645 to "In review" (or I'll note it on the board).
