### PR TITLE
feat(sim): run_policy(stop_when=...) ends a rollout on a world state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `run_policy(stop_when=...)` ends a rollout on a world state, plus `stopped_reason` telemetry
+
+`duration` / `n_steps` gave a rollout only an arithmetic horizon, so an agent
+using a policy as a retryable primitive had to guess an episode length and then
+inspect the world afterwards to find out whether the guess was long enough.
+`run_policy` (and `eval_policy`'s sibling `success_fn`) now has a semantic
+horizon: `stop_when=` takes a predicate-DSL clause - the same schema a benchmark
+spec's `success` clause uses - and the rollout returns as soon as the world
+satisfies it:
+
+```python
+sim.run_policy(
+    robot_name="so100",
+    instruction="pick up the red cube",
+    n_steps=300,                                              # budget
+    stop_when={"predicate": "body_above_z", "body": "cube", "z": 0.2},
+)
+# -> success, n_steps=41, stopped_reason="predicate"
+```
+
+A single call or an `{"all": [...]}` / `{"any": [...]}` group is accepted, over
+the closed `PREDICATE_REGISTRY` (`grasped`, `body_on`, `body_inside`,
+`contact_between`, `distance_less_than`, ...); programmatic callers may pass a
+`(sim) -> bool` callable. Predicates are evaluated against the sim after every
+applied action on both the synchronous and the async-RTC path. The clause is
+compiled before the policy is built, so an unknown predicate name, a clause that
+names no predicate (`{}`, `{"all": []}`) or a non-dict value is a structured
+caller error naming `stop_when` - never a condition that is accepted and then
+silently never checked. Nothing in a clause reaches `eval`/`exec`, so
+`stop_when` is exposed in the simulation tool schema and `describe()`.
+
+The rollout result json also carries `stopped_reason`:
+`"budget"` (ran the full horizon), `"predicate"` (`stop_when` fired),
+`"cancelled"` (a cooperative stop such as `stop_policy()`) or `"error"`.
+`stopped_early` was `True` for all three non-budget outcomes, so an agent
+deciding whether to retry could not tell a goal-reaching rollout from a
+cancelled one. `stop_when` composes with capture - the frame that satisfied the
+condition is in an active dataset recording and in a `video={...}` MP4 - and
+`n_episodes=N` applies the condition per episode.
+
 ### Fixed: `set_geom_properties` honors every vector component or rejects the vector
 
 `color`, `friction` and `size` each target a MuJoCo buffer with a fixed component

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -129,7 +129,7 @@ A vector lets a policy's raw action chunk drive the arm directly without first z
 
 | Action | Key params |
 |--------|-----------|
-| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None`, `seed=None`, `async_rtc=None`, `rtc_inference_timeout_s=None` |
+| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None`, `stop_when=None`, `seed=None`, `async_rtc=None`, `rtc_inference_timeout_s=None` |
 | `start_policy` | same args, async/non-blocking |
 | `stop_policy` | `robot_name` (optional, defaults to `""`) |
 | `list_policies_running` | - |
@@ -141,6 +141,41 @@ When a policy is run via `run_policy` / `eval_policy` / `run_multi_policy`, the 
 The step horizon is given either as `duration` (seconds) or as `n_steps` (`duration = n_steps / control_frequency`; `n_steps` wins when both are set, and the legacy `max_steps` is an alias for `n_steps`). A non-positive `n_steps` or `control_frequency` is rejected up front with a structured `status="error"` dict naming the bad parameter - `start_policy` validates synchronously before the background rollout starts, so a malformed horizon never returns a false "started" success. `eval_policy` likewise rejects a non-positive `n_episodes`, `max_steps`, or `control_frequency` at the entry point (before `create_policy`), so a typo cannot produce a "successful" evaluation over zero or negative episodes. The same entry-point check covers the two provider keyword bags: `policy_config` (splatted into `create_policy`) and `policy_kwargs` (splatted into `policy.get_actions`) must be dicts, so a `policy_config="host=127.0.0.1"` string returns a structured error naming the parameter instead of a bare `TypeError` from the splat - and, on the `start_policy` path, instead of a false "started" for a rollout that never produced an action.
 
 Pass `seed=` to `run_policy` / `start_policy` for a reproducible single rollout: it reseeds Python / NumPy / torch / cuDNN and forwards `policy.reset(seed=...)`, so a stochastic policy (VLA action-chunk sampling, diffusion noise) produces the same trajectory on re-run of the same scene. Without a seed the rollout draws from the process-global RNG and can differ run to run. `eval_policy` already seeds per episode via the same mechanism.
+
+### Stopping on a world state (`stop_when`)
+
+`duration` / `n_steps` give a rollout an *arithmetic* horizon. `stop_when=` gives it a **semantic** one: the rollout returns as soon as the world reaches a state, so a policy call becomes a retryable primitive an agent can invoke, inspect and re-invoke rather than a fixed-length episode it has to guess the length of.
+
+```python
+result = sim.run_policy(
+    robot_name="so100",
+    policy_provider="lerobot_local",
+    policy_config={"pretrained_name_or_path": "lerobot/act_so100"},
+    instruction="pick up the red cube",
+    n_steps=300,                                 # budget - the upper bound
+    stop_when={"predicate": "body_above_z", "body": "cube", "z": 0.2},
+)
+```
+
+The clause uses the same predicate DSL as a benchmark spec's `success` clause, so anything a benchmark can score, a rollout can stop on:
+
+- a single call - `{"predicate": "grasped", "body": "cube", "gripper_prefix": "so100"}`
+- an `all` group (every predicate must hold) or an `any` group (at least one), each a list of calls
+
+Predicate names come from the closed registry in `strands_robots.simulation.predicates` (`body_above_z`, `body_below_z`, `body_on`, `body_inside`, `grasped`, `contact_between`, `distance_less_than`, `inside_region`, `joint_above`, `joint_below`, ...); `PREDICATE_REGISTRY` is the full list. Nothing in a clause reaches `eval` / `exec` - names are looked up in that registry and the remaining keys are forwarded to the factory as kwargs - so a clause is safe to accept from an agent, and `stop_when` is exposed in the simulation tool schema for exactly that reason. Programmatic callers may pass a `(sim) -> bool` callable instead, mirroring `eval_policy(success_fn=...)`.
+
+Predicates are evaluated against the **sim** (matching benchmark semantics, not the observation dict) after every applied action, on both the synchronous and the async-RTC path - on the latter within one action of the condition becoming true, since the check runs per applied action rather than per chunk. The clause is compiled *before* the policy is built, so an unknown predicate name, an empty clause, or a non-dict value is a structured `status="error"` naming `stop_when` rather than a rollout that silently runs to its budget while reporting success.
+
+The result json reports **why** the rollout ended, as `stopped_reason`:
+
+| `stopped_reason` | Meaning |
+|------------------|---------|
+| `budget` | Ran the full `n_steps` / `duration` horizon |
+| `predicate` | `stop_when` fired; `n_steps` is the steps actually executed |
+| `cancelled` | A cooperative stop (`stop_policy()`, or an `on_frame` hook raising `CooperativeStop`) |
+| `error` | The rollout failed, including a `stop_when` condition that raised |
+
+`stopped_early` remains `True` for all three non-budget outcomes; `stopped_reason` is what lets a caller tell "the goal was reached" from "someone cancelled me" without parsing prose. `stop_when` composes with capture: the frame that satisfied the condition is included in an active dataset recording and in a `video={...}` MP4, and `n_episodes=N` applies the condition per episode, so a collection run yields N goal-reaching episodes of exactly the length each one needed.
 
 ### Async-RTC chunk pipeline (latency masking)
 
@@ -179,7 +214,7 @@ A healthy masked rollout shows `rtc_prefetch_hits` near the chunk count and `rtc
 
 **Async-RTC in `eval_policy` (opt-in).** The success-rate eval path (`eval_policy` / `evaluate(success_fn=...)`) accepts the same `async_rtc` and `rtc_inference_timeout_s`, but defaults to `async_rtc=False`. The synchronous eval pauses the world during inference, so the success-rate is bit-stable and reproducible (the policy always sees the seam observation). Setting `async_rtc=True` evaluates a chunk-emitting policy under the realistic control latency it faces in deployment: the prefetch feeds the policy a slightly staler (mid-chunk) observation at the seam, so the measured success-rate can shift - that is the point, it measures robustness to inference latency. Either way the eval `{"json": {...}}` payload now carries the same six `rtc_*` fields (inference timing is reported even on the synchronous path). `async_rtc=True` is rejected on the benchmark/spec path (`evaluate_benchmark` / `evaluate(spec=...)`), which stays synchronous for bit-stable reproducibility; use `run_policy(async_rtc=...)` for benchmark-style wall-clock latency masking.
 
-`run_policy` returns a `{"json": {...}}` content block alongside the human-readable `text`, mirroring `eval_policy`. The json block carries the rollout facts as typed fields - `robot_name`, `policy`, `instruction`, `n_steps`, `elapsed_s`, `stopped_early`, `action_errors`, `video_path` (`None` when no MP4 was written), `video_frames`, `sim_time_s` (when the backend reports it) and the six `rtc_*` async-RTC telemetry fields above - so an agent can read the outcome programmatically (did it move? how many steps? was inference masked?) without regex-parsing the prose. The `status` reflects whether the robot *moved*, not merely whether every key resolved: a run where **no** step resolved any key (the robot never moved) returns `status="error"`, while a run where some keys resolve every step - e.g. a policy trained on a superset embodiment that emits one extra key the robot lacks - is operational and returns `status="success"` with a non-fatal `N/M action steps had unresolved keys` note and a `partial_action_failure_rate`.
+`run_policy` returns a `{"json": {...}}` content block alongside the human-readable `text`, mirroring `eval_policy`. The json block carries the rollout facts as typed fields - `robot_name`, `policy`, `instruction`, `n_steps` (the steps actually executed), `elapsed_s`, `stopped_early`, `stopped_reason` (`budget` / `predicate` / `cancelled` / `error`), `action_errors`, `video_path` (`None` when no MP4 was written), `video_frames`, `sim_time_s` (when the backend reports it) and the six `rtc_*` async-RTC telemetry fields above - so an agent can read the outcome programmatically (did it move? how many steps? was inference masked?) without regex-parsing the prose. The `status` reflects whether the robot *moved*, not merely whether every key resolved: a run where **no** step resolved any key (the robot never moved) returns `status="error"`, while a run where some keys resolve every step - e.g. a policy trained on a superset embodiment that emits one extra key the robot lacks - is operational and returns `status="success"` with a non-fatal `N/M action steps had unresolved keys` note and a `partial_action_failure_rate`.
 
 `eval_policy` accepts the same `video={...}` recording config as `run_policy` (`path` enables it, plus `fps` / `camera` / `width` / `height` - an unknown key or a non-positive size is a caller error, never silently ignored), but writes **one MP4 per episode** with `_ep{i}` inserted into the filename (`eval.mp4` -> `eval_ep0.mp4`, `eval_ep1.mp4`, ...), so a multi-episode evaluation can be *watched* to see why episodes fail rather than only read as an aggregate `success_rate`. The written files are listed in the result json `video_paths`; the output path is validated and the camera probed up-front, so a bad camera fails the eval immediately instead of after N episodes of empty MP4s. `evaluate_benchmark` accepts the same `video={...}` config and records one MP4 per episode too, so a benchmark evaluation can be watched to see why episodes fail. Frames are captured synchronously on the eval thread (render is read-only over `mjData`), so recording does not perturb the bit-stable benchmark rollout.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1009,6 +1009,52 @@ class SimEngine(ABC):
         return SimEngine._validate_positive_int(control_substeps, "control_substeps", method)
 
     @staticmethod
+    def _compile_stop_when(
+        stop_when: Any, method: str
+    ) -> tuple[Callable[[SimEngine], bool] | None, dict[str, Any] | None]:
+        """Resolve a ``stop_when`` argument into a callable condition.
+
+        ``stop_when`` is the rollout's semantic horizon: it ends the rollout
+        when the world reaches a state, instead of when the step budget runs
+        out. Two forms are accepted - a predicate-DSL clause (the same schema a
+        benchmark spec's ``success`` clause uses, which is the only form an
+        agent tool call can express) and, for programmatic callers, a plain
+        ``(sim) -> bool`` callable, mirroring
+        :meth:`~strands_robots.simulation.policy_runner.PolicyRunner.evaluate`'s
+        ``success_fn``.
+
+        A malformed clause is reported as a structured caller error rather than
+        being dropped: a rollout that silently ignored the condition would run
+        the full budget and report ``status="success"``, so the caller would
+        read "the condition never fired" from a run that never checked it.
+        Compilation happens here, before the expensive ``create_policy`` weight
+        load, so a typo in a predicate name costs nothing.
+
+        Args:
+            stop_when: ``None``, a callable, or a predicate-DSL clause dict.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            ``(condition, None)`` on success (``condition`` is ``None`` when no
+            ``stop_when`` was supplied), or ``(None, error_dict)``.
+        """
+        if stop_when is None:
+            return None, None
+        if callable(stop_when):
+            return stop_when, None
+        # Imported here (not at module scope) to keep the predicate-DSL compiler
+        # off the import path of every engine; base.py is imported by all of them.
+        from strands_robots.simulation.benchmark_spec import compile_bool_clause
+
+        try:
+            return compile_bool_clause(stop_when, context=f"{method}: stop_when"), None
+        except (ValueError, TypeError) as exc:
+            return None, {
+                "status": "error",
+                "content": [{"text": str(exc)}],
+            }
+
+    @staticmethod
     def _validate_positive_frequency(control_frequency: Any, method: str) -> dict[str, Any] | None:
         """Reject a non-positive or non-numeric ``control_frequency`` at the public API.
 
@@ -1277,6 +1323,7 @@ class SimEngine(ABC):
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
         wbc_install_torque_control: bool = True,
+        stop_when: dict[str, Any] | Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -1408,12 +1455,35 @@ class SimEngine(ABC):
                 falls over without it. Set ``False`` to manage the controller
                 yourself or to drive a torque-actuated scene directly. No-op for
                 non-WBC policies and on backends without the hook.
+            stop_when: Optional semantic stop condition - the rollout returns as
+                soon as the world reaches a state, instead of only when the step
+                budget runs out. Either a predicate-DSL clause using the same
+                schema as a benchmark spec's ``success`` clause - a single call
+                ``{"predicate": "body_above_z", "body": "cube", "z": 0.2}`` or an
+                ``{"all": [...]}`` / ``{"any": [...]}`` group over the predicates
+                in
+                :data:`~strands_robots.simulation.predicates.PREDICATE_REGISTRY`
+                - or, for programmatic callers, a ``(sim) -> bool`` callable.
+                Predicates are evaluated against the SIM (matching benchmark
+                semantics), after every applied action, on both the synchronous
+                and the async-RTC path; the clause is compiled and validated
+                before the policy is built, so an unknown predicate name or an
+                empty clause is a caller error rather than a rollout that
+                quietly never stops. The DSL never reaches ``eval``/``exec``, so
+                a clause is safe to accept from an agent. Composes with an active
+                recording: frames up to and including the stopping step are
+                captured, and episode-flush semantics are unchanged. ``None``
+                (default) runs the full horizon.
 
         Returns:
             Standard status dict with an agent-consumable ``{"json": {...}}``
             content block alongside the human-readable ``text``. The json block
-            carries the rollout facts as typed fields (``n_steps``,
-            ``elapsed_s``, ``stopped_early``, ``action_errors``, ``video_path``,
+            carries the rollout facts as typed fields (``n_steps`` - the steps
+            actually executed, which is below the requested horizon when
+            ``stop_when`` fired - ``elapsed_s``, ``stopped_early``,
+            ``stopped_reason`` (``"budget"`` | ``"predicate"`` | ``"cancelled"``
+            | ``"error"``, so a caller can tell a goal-reaching rollout from a
+            cancelled or exhausted one), ``action_errors``, ``video_path``,
             ``video_frames``, ``positional_fallback_used``,
             ``generic_state_keys_used``, ``missing_state_keys_used``, ...) so callers can self-correct
             programmatically without parsing the text. The two routing-
@@ -1464,6 +1534,9 @@ class SimEngine(ABC):
             return err
         if err := self._validate_control_substeps(control_substeps, "run_policy"):
             return err
+        stop_condition, stop_when_error = self._compile_stop_when(stop_when, "run_policy")
+        if stop_when_error is not None:
+            return stop_when_error
 
         if robot_name not in self.list_robots():
             return {
@@ -1540,6 +1613,7 @@ class SimEngine(ABC):
                     seed=seed,
                     async_rtc=async_rtc,
                     rtc_inference_timeout_s=rtc_inference_timeout_s,
+                    stop_when=stop_condition,
                 )
                 completed = 1 if result.get("status") == "success" else 0
                 contract = self._episode_contract_fields(
@@ -1571,6 +1645,7 @@ class SimEngine(ABC):
                 reset_between=reset_between,
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
+                stop_when=stop_condition,
             )
         finally:
             if controller_cleanup is not None:
@@ -1597,6 +1672,7 @@ class SimEngine(ABC):
         reset_between: bool,
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
+        stop_when: Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """Run ``n_episodes`` sequential rollouts; shared multi-episode driver.
 
@@ -1607,7 +1683,11 @@ class SimEngine(ABC):
         ``False`` - so a single call yields N correctly delimited dataset
         episodes instead of one merged episode. Aborts early (returning a
         structured error with the episodes completed so far) if a rollout, an
-        episode flush, or a reset fails.
+        episode flush, or a reset fails. A ``stop_when`` condition is applied
+        per episode: each rollout ends as soon as the condition holds, so a
+        multi-episode collection run yields N episodes of exactly the length
+        each one needed (the per-episode ``stopped_reason`` records which ended
+        on the condition and which ran out of budget).
         """
         episodes: list[dict[str, Any]] = []
         episodes_saved = 0
@@ -1633,6 +1713,7 @@ class SimEngine(ABC):
                 seed=ep_seed,
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
+                stop_when=stop_when,
             )
             ep_json = self._extract_json_payload(result)
             ep_record: dict[str, Any] = {"episode": ep, **ep_json}
@@ -2753,7 +2834,15 @@ class SimEngine(ABC):
                     "add_robot, completing the add/remove pair alongside "
                     "remove_object"
                 ),
-                "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, reset_between=True, ...) -> dict",
+                "run_policy": (
+                    "(robot_name: str, policy_provider='mock', n_episodes=1, "
+                    "reset_between=True, stop_when=None, ...) -> dict  # stop_when "
+                    "takes a predicate-DSL clause ({'predicate': 'body_above_z', "
+                    "'body': 'cube', 'z': 0.2} or an all/any group over the same "
+                    "predicates a benchmark success clause uses) and ends the "
+                    "rollout as soon as the world reaches that state; the result "
+                    "json reports stopped_reason=budget|predicate|cancelled|error"
+                ),
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "eval_policy": (
                     "(robot_name: str, policy_provider='mock', n_episodes=1, "

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -142,6 +142,86 @@ def _compile_bool_group(
     return check
 
 
+def compile_bool_clause(clause: Any, *, context: str) -> Callable[[SimEngine], bool]:
+    """Compile a predicate-DSL bool clause into a single ``(sim) -> bool`` callable.
+
+    Accepts either shape the DSL uses for a boolean condition:
+
+    * a single predicate call - ``{"predicate": "body_above_z", "body": "cube", "z": 0.2}``
+    * an ``{"all": [...]}`` / ``{"any": [...]}`` group, as used by a spec's
+      ``success`` / ``failure`` clauses
+
+    This is the entry point for callers that take a bool condition outside a
+    benchmark spec (``run_policy(stop_when=...)``). Unlike a spec clause there
+    is no meaningful default: a clause that names no predicate would compile to
+    a condition that never fires, so the caller's condition would be accepted
+    and then silently ignored. Such a clause is rejected instead.
+
+    Nothing here reaches ``eval`` / ``exec`` - predicate names are looked up in
+    the closed :data:`~strands_robots.simulation.predicates.PREDICATE_REGISTRY`
+    and the remaining keys are forwarded to the factory as kwargs - so a clause
+    is safe to accept from untrusted (LLM-authored) input.
+
+    Args:
+        clause: The predicate call or all/any group to compile.
+        context: Name used to prefix error messages (e.g. ``"stop_when"``).
+
+    Returns:
+        A callable evaluating the clause against a live engine.
+
+    Raises:
+        ValueError: If the clause is not a dict, mixes a single call with a
+            group, names an unknown predicate, names no predicate at all, or
+            supplies kwargs the predicate factory rejects.
+    """
+    if not isinstance(clause, dict):
+        raise ValueError(
+            f"{context}: expected a predicate call like "
+            "{'predicate': 'body_above_z', 'body': 'cube', 'z': 0.2} or an "
+            f"{{'all': [...]}} / {{'any': [...]}} group, got {type(clause).__name__}"
+        )
+    try:
+        return _compile_clause_body(clause, context=context)
+    except ValueError as exc:
+        # The DSL compiler prefixes its own messages with ``context``, but an
+        # unknown predicate name propagates verbatim from ``make_predicate``
+        # (it already carries the valid list). Prefix it here so the caller also
+        # learns WHICH argument was wrong, without double-prefixing the rest.
+        message = str(exc)
+        raise ValueError(message if message.startswith(context) else f"{context}: {message}") from exc
+
+
+def _compile_clause_body(clause: dict[str, Any], *, context: str) -> Callable[[SimEngine], bool]:
+    """Compile a validated-as-dict bool clause; see :func:`compile_bool_clause`."""
+    if "predicate" in clause:
+        group_keys = sorted(set(clause) & {"all", "any"})
+        if group_keys:
+            raise ValueError(
+                f"{context}: a single predicate call cannot also carry {group_keys}; "
+                "either drop 'predicate' and list the calls under 'all'/'any', or drop "
+                "the group keys"
+            )
+        call = _compile_call(clause, context=context, require_kind="bool")
+        # ``_compile_call`` is typed ``-> Callable[[SimEngine], Any]`` because it
+        # also compiles float-valued reward terms; ``require_kind="bool"`` has
+        # already rejected those, so coercing here only narrows the type.
+        return lambda sim: bool(call(sim))
+
+    unknown = set(clause) - {"all", "any"}
+    if unknown:
+        raise ValueError(
+            f"{context}: unknown keys {sorted(unknown)}; expected a single predicate call "
+            "('predicate' plus its kwargs) or an 'all' / 'any' group"
+        )
+    if not (clause.get("all") or clause.get("any")):
+        raise ValueError(
+            f"{context}: names no predicate, so the condition could never fire. "
+            "Provide a predicate call or a non-empty 'all' / 'any' list; omit the "
+            "argument entirely to run without this condition."
+        )
+    return _compile_bool_group(clause, default=False, context=context)
+
+
 def _compile_call(entry: Any, *, context: str, require_kind: str | None = None) -> Callable[[SimEngine], Any]:
     """Compile one ``{predicate: <name>, **kwargs}`` entry to a callable.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3812,6 +3812,7 @@ class MuJoCoSimEngine(
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
         wbc_install_torque_control: bool = True,
+        stop_when: dict[str, Any] | Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -3827,7 +3828,12 @@ class MuJoCoSimEngine(
         :meth:`SimEngine.run_policy` for first-class multi-episode dataset
         collection: ``n_episodes > 1`` runs that many rollouts back-to-back,
         flushing a ``save_episode`` boundary after each (when recording) and
-        resetting between episodes. See :meth:`SimEngine.run_policy`.
+        resetting between episodes. ``stop_when`` is forwarded likewise, so a
+        rollout driven through this backend can end on a world state (see
+        :meth:`SimEngine.run_policy` for the clause schema and the
+        ``stopped_reason`` telemetry). Every parameter here is forwarded
+        verbatim; the override adds only the pre-flight world check and the
+        cancellation flag cleanup. See :meth:`SimEngine.run_policy`.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -3860,6 +3866,7 @@ class MuJoCoSimEngine(
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
                 wbc_install_torque_control=wbc_install_torque_control,
+                stop_when=stop_when,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -394,6 +394,11 @@
       "description": "Provider-specific config dict forwarded to strands_robots.policies.create_policy. Contents depend on policy_provider. For 'groot': host, port, api_token, observation_mapping, action_mapping. For 'lerobot_local': pretrained_name_or_path, device, trust_remote_code, actions_per_step, use_processor, processor_overrides, observation_mapping, action_mapping. For 'mock': {} is fine.",
       "additionalProperties": true
     },
+    "stop_when": {
+      "type": "object",
+      "description": "Semantic stop condition for run_policy: the rollout returns as soon as the world reaches this state instead of running the whole step budget. Either one predicate call - {\"predicate\": \"body_above_z\", \"body\": \"cube\", \"z\": 0.2} - or a group {\"all\": [call, ...]} / {\"any\": [call, ...]}. Predicate names come from the closed predicate registry used by benchmark success clauses (body_above_z, body_below_z, body_on, body_inside, grasped, contact_between, distance_less_than, inside_region, joint_above, joint_below, ...); an unknown name or an empty clause is rejected. The result json reports stopped_reason='predicate' when it fired, 'budget' when the horizon ran out.",
+      "additionalProperties": true
+    },
     "cameras": {
       "type": "array",
       "items": {

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -605,6 +605,19 @@ class CooperativeStop(BaseException):
     """
 
 
+class StopConditionMet(CooperativeStop):
+    """Raised inside :meth:`PolicyRunner.run` when ``stop_when`` fires.
+
+    A subclass of :class:`CooperativeStop` so both end the rollout on the same
+    graceful path (``stopped_early=True``, ``status="success"``), while staying
+    distinguishable in the result: a ``stop_when`` condition that fired reports
+    ``stopped_reason="predicate"`` and a caller-requested stop reports
+    ``stopped_reason="cancelled"``. An agent deciding whether to retry a
+    rollout needs that distinction - "the world reached the goal state" and
+    "someone cancelled me" are opposite outcomes.
+    """
+
+
 class _ChunkPipeline:
     """Yield ``(observation, action)`` pairs for a policy rollout.
 
@@ -892,6 +905,7 @@ class PolicyRunner:
         seed: int | None = None,
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
+        stop_when: Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """Run ``policy`` on ``robot_name`` for ``duration`` seconds.
 
@@ -992,6 +1006,20 @@ class PolicyRunner:
                 :meth:`run` returns), so the abort is bounded by ONE inference,
                 not the whole rollout. ``None`` (default) waits without a deadline
                 (historical behaviour). Ignored on the synchronous path.
+            stop_when: Optional semantic stop condition ``(sim) -> bool``,
+                evaluated against the live engine after every applied action on
+                both the synchronous and the async-RTC path. When it returns
+                truthy the rollout returns immediately with
+                ``status="success"``, ``stopped_early=True`` and
+                ``stopped_reason="predicate"`` - so a rollout ends when the
+                world reaches a state, not only when the step budget runs out.
+                The condition is evaluated AFTER the ``on_frame`` hook and the
+                video capture for that step, so a recording or MP4 contains the
+                frame that satisfied it. An exception raised by the condition is
+                not swallowed: it ends the rollout with ``status="error"`` and
+                ``stopped_reason="error"``, because a condition that cannot be
+                evaluated cannot be reported as either met or unmet.
+                ``None`` (default) runs to the step budget.
 
         Returns:
             ``{"status": "success"|"error", "content": [{"text": ...},
@@ -1092,6 +1120,12 @@ class PolicyRunner:
             return _video_err
 
         stopped_early = False
+        # Why the rollout ended, as a typed field an agent can branch on:
+        # "budget" (ran the full horizon), "predicate" (``stop_when`` fired),
+        # "cancelled" (a ``CooperativeStop`` from the on_frame hook, e.g.
+        # ``stop_policy()``) or "error". ``stopped_early`` alone conflates the
+        # last three.
+        stopped_reason = "budget"
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
         # Open-loop chunk replay consumes H actions from ONE observation. That
@@ -1273,6 +1307,16 @@ class PolicyRunner:
                 if vwriter is not None:
                     vwriter.capture(step_count)
 
+                # Semantic stop, checked after the frame for this step has been
+                # recorded/captured so the dataset and the MP4 both contain the
+                # state that satisfied the condition. Raising (rather than
+                # setting a flag) is what makes the check work identically on the
+                # synchronous and the async-RTC path: _apply is the single point
+                # both funnel actions through, and the exception unwinds the
+                # chunk loop without draining the rest of the chunk.
+                if stop_when is not None and stop_when(self.sim):
+                    raise StopConditionMet
+
                 if not fast_mode:
                     time.sleep(action_sleep)
 
@@ -1453,21 +1497,31 @@ class PolicyRunner:
                             step_obs = observation
                         _apply(step_obs, action_dict)
 
+        except StopConditionMet:
+            # Subclass of CooperativeStop, so it must be caught first.
+            stopped_early = True
+            stopped_reason = "predicate"
         except CooperativeStop:
             stopped_early = True
+            stopped_reason = "cancelled"
         except Exception as e:
             if vwriter is not None:
                 vwriter.close()
             logger.exception("PolicyRunner.run failed")
             return {
                 "status": "error",
-                "content": [{"text": f"Policy failed: {e}"}, {"json": _rtc_telemetry()}],
+                "content": [
+                    {"text": f"Policy failed: {e}"},
+                    {"json": {**_rtc_telemetry(), "stopped_reason": "error"}},
+                ],
             }
 
         # Either finished all steps or was cooperatively stopped
         elapsed = time.time() - start_time
         sim_time = self._maybe_sim_time()
         prefix = "Policy stopped" if stopped_early else "Policy complete"
+        if stopped_reason == "predicate":
+            prefix = "Policy stopped (stop_when condition met)"
         text = (
             f"{prefix} on '{robot_name}'\n{type(policy).__name__} | {instruction}\n{elapsed:.1f}s | {step_count} steps"
         )
@@ -1512,6 +1566,7 @@ class PolicyRunner:
             "n_steps": step_count,
             "elapsed_s": round(elapsed, 3),
             "stopped_early": stopped_early,
+            "stopped_reason": stopped_reason,
             "action_errors": _action_errors,
             "video_path": None,
             "video_frames": 0,

--- a/tests/simulation/test_run_policy_stop_when.py
+++ b/tests/simulation/test_run_policy_stop_when.py
@@ -1,0 +1,332 @@
+"""``run_policy(stop_when=...)`` ends a rollout on a world state, not only on a budget.
+
+A rollout used as a retryable primitive needs a semantic horizon: "run until the
+cube is lifted", not "run 300 steps and hope". These tests pin the contract of
+the ``stop_when`` predicate clause and of the ``stopped_reason`` telemetry that
+tells a caller WHY a rollout ended - a goal reached, a budget exhausted, a
+cancellation, or a failure. ``stopped_early`` alone conflates the last three.
+
+The falling cube is the oracle throughout: free fall from a known height is
+deterministic, so a condition on its height fires at a step count that does not
+depend on what the driving policy does to the arm.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.policy_runner import CooperativeStop, PolicyRunner
+
+CUBE_START_Z = 0.6
+# Free fall from CUBE_START_Z crosses this height in ~0.14 s, i.e. ~7 control
+# steps at 50 Hz - comfortably inside the 200-step budget the tests request, so
+# an early return is unambiguous.
+CUBE_STOP_Z = 0.4
+BUDGET = 200
+
+
+@pytest.fixture
+def sim():
+    """MuJoCo world with an arm to drive and a cube in free fall."""
+    s = Simulation(tool_name="stop_when_test", mesh=False)
+    s.create_world()
+    s.add_robot(name="alice", data_config="so100")
+    s.add_object(
+        name="cube",
+        shape="box",
+        size=[0.05, 0.05, 0.05],
+        position=[0.4, 0.0, CUBE_START_Z],
+        mass=0.1,
+    )
+    yield s
+    s.cleanup()
+
+
+def rollout_json(result: dict[str, Any]) -> dict[str, Any]:
+    """Return the agent-consumable json block of a rollout result."""
+    for block in result["content"]:
+        if "json" in block:
+            return dict(block["json"])
+    raise AssertionError(f"result carries no json block: {result}")
+
+
+def cube_height(sim: Simulation) -> float:
+    """Cube z read from the live engine (the same source the predicate reads)."""
+    return float(rollout_json(sim.get_body_state("cube"))["position"][2])
+
+
+def cube_below_stop_z(sim: Simulation) -> bool:
+    return cube_height(sim) < CUBE_STOP_Z
+
+
+class TestStopWhenEndsTheRollout:
+    def test_predicate_clause_returns_early_and_reports_the_predicate(self, sim):
+        """The rollout stops the step the world satisfies the clause."""
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=BUDGET,
+            fast_mode=True,
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": CUBE_STOP_Z},
+        )
+        assert result["status"] == "success"
+        payload = rollout_json(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["stopped_early"] is True
+        # n_steps is the steps actually executed, so it is the caller's
+        # "how long did this take" number - well below the requested budget.
+        assert 0 < payload["n_steps"] < BUDGET
+        # And the world really is in the state the clause named.
+        assert cube_below_stop_z(sim)
+
+    def test_group_clause_requires_every_member_of_all(self, sim):
+        """An ``all`` group only fires once every listed predicate holds."""
+        unreachable = sim.run_policy(
+            robot_name="alice",
+            n_steps=20,
+            fast_mode=True,
+            stop_when={
+                "all": [
+                    {"predicate": "body_below_z", "body": "cube", "z": CUBE_STOP_Z},
+                    {"predicate": "body_below_z", "body": "cube", "z": -5.0},
+                ]
+            },
+        )
+        assert rollout_json(unreachable)["stopped_reason"] == "budget"
+
+        sim.reset()
+        satisfiable = sim.run_policy(
+            robot_name="alice",
+            n_steps=BUDGET,
+            fast_mode=True,
+            stop_when={
+                "any": [
+                    {"predicate": "body_below_z", "body": "cube", "z": -5.0},
+                    {"predicate": "body_below_z", "body": "cube", "z": CUBE_STOP_Z},
+                ]
+            },
+        )
+        assert rollout_json(satisfiable)["stopped_reason"] == "predicate"
+
+    def test_callable_condition_is_accepted_and_receives_the_engine(self, sim):
+        """Programmatic callers may pass a ``(sim) -> bool`` instead of a clause."""
+        seen: list[Any] = []
+
+        def condition(engine: Any) -> bool:
+            seen.append(engine)
+            return cube_below_stop_z(engine)
+
+        result = sim.run_policy(robot_name="alice", n_steps=BUDGET, fast_mode=True, stop_when=condition)
+        payload = rollout_json(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["n_steps"] < BUDGET
+        # The engine itself is handed to the condition, so it can query any part
+        # of the world - not just whatever the observation dict happens to carry.
+        assert seen and all(engine is sim for engine in seen)
+
+    def test_condition_that_cannot_be_evaluated_fails_the_rollout(self, sim):
+        """A raising condition is an error, never a silently-unmet condition."""
+
+        def broken(_engine: Any) -> bool:
+            raise RuntimeError("cannot read the world")
+
+        result = sim.run_policy(robot_name="alice", n_steps=20, fast_mode=True, stop_when=broken)
+        assert result["status"] == "error"
+        assert "cannot read the world" in result["content"][0]["text"]
+        assert rollout_json(result)["stopped_reason"] == "error"
+
+
+class TestStoppedReason:
+    def test_exhausted_budget_reports_budget(self, sim):
+        """A condition that never holds runs the full horizon and says so."""
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=10,
+            fast_mode=True,
+            stop_when={"predicate": "body_above_z", "body": "cube", "z": 99.0},
+        )
+        payload = rollout_json(result)
+        assert payload["stopped_reason"] == "budget"
+        assert payload["stopped_early"] is False
+        assert payload["n_steps"] == 10
+
+    def test_rollout_without_a_condition_still_reports_budget(self, sim):
+        """``stopped_reason`` is always present, so callers can branch on it."""
+        payload = rollout_json(sim.run_policy(robot_name="alice", n_steps=5, fast_mode=True))
+        assert payload["stopped_reason"] == "budget"
+
+    def test_cancellation_reports_cancelled_not_predicate(self, sim):
+        """A cooperative stop (e.g. ``stop_policy``) is a different outcome."""
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("alice"))
+
+        def cancel_on_third_step(step: int, _obs: dict, _action: dict) -> None:
+            if step >= 2:
+                raise CooperativeStop
+
+        result = PolicyRunner(sim).run(
+            "alice",
+            policy,
+            n_steps=BUDGET,
+            control_frequency=50,
+            fast_mode=True,
+            on_frame=cancel_on_third_step,
+            stop_when=lambda _engine: False,
+        )
+        payload = rollout_json(result)
+        assert result["status"] == "success"
+        assert payload["stopped_early"] is True
+        assert payload["stopped_reason"] == "cancelled"
+
+
+class TestStopWhenRejection:
+    """A condition the rollout cannot honor is a caller error, never a no-op."""
+
+    def test_unknown_predicate_is_rejected_before_the_policy_runs(self, sim):
+        policy = MagicMock()
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=BUDGET,
+            policy_object=policy,
+            stop_when={"predicate": "cube_lifted", "body": "cube"},
+        )
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "stop_when" in text and "cube_lifted" in text
+        # The valid set is listed, so the caller can self-correct.
+        assert "body_above_z" in text
+        # Nothing ran: rejection happens before the policy is driven.
+        policy.get_actions.assert_not_called()
+
+    def test_clause_naming_no_predicate_is_rejected(self, sim):
+        """An empty clause would compile to a condition that never fires."""
+        for empty in ({}, {"all": []}, {"any": []}):
+            result = sim.run_policy(robot_name="alice", n_steps=5, stop_when=empty)
+            assert result["status"] == "error", empty
+            assert "names no predicate" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("bad", ["grasped", ["grasped"], 3])
+    def test_non_mapping_clause_is_rejected(self, sim, bad):
+        result = sim.run_policy(robot_name="alice", n_steps=5, stop_when=bad)
+        assert result["status"] == "error"
+        assert "stop_when" in result["content"][0]["text"]
+
+    def test_single_call_mixed_with_a_group_is_rejected(self, sim):
+        """``{predicate: ..., any: [...]}`` is ambiguous - half of it would be dropped."""
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=5,
+            stop_when={
+                "predicate": "body_below_z",
+                "body": "cube",
+                "z": CUBE_STOP_Z,
+                "any": [{"predicate": "body_above_z", "body": "cube", "z": 1.0}],
+            },
+        )
+        assert result["status"] == "error"
+        assert "cannot also carry" in result["content"][0]["text"]
+
+    def test_reward_term_is_rejected_as_a_stop_condition(self, sim):
+        """A float-valued term read as a bool would stop the rollout instantly."""
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=5,
+            stop_when={"predicate": "distance_neg", "body_a": "cube", "body_b": "cube"},
+        )
+        assert result["status"] == "error"
+        assert "reward term" in result["content"][0]["text"]
+
+
+class TestStopWhenComposesWithCapture:
+    def test_video_holds_exactly_the_executed_steps(self, sim, tmp_path):
+        """The frame that satisfied the condition is in the MP4."""
+        path = tmp_path / "rollout.mp4"
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=BUDGET,
+            fast_mode=True,
+            control_frequency=30.0,
+            # One captured frame per control step (fps == control_frequency), so
+            # the MP4 frame count IS the executed step count.
+            video={"path": str(path), "fps": 30, "width": 160, "height": 120},
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": CUBE_STOP_Z},
+        )
+        payload = rollout_json(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["video_frames"] == payload["n_steps"]
+        assert payload["video_path"] == str(path)
+        assert path.exists() and path.stat().st_size > 0
+
+    def test_recorded_dataset_holds_exactly_the_executed_steps(self, sim, tmp_path):
+        """Round trip: a stopped rollout records the frames it ran, no more."""
+        pytest.importorskip("lerobot")
+        root = tmp_path / "ds"
+        assert (
+            sim.start_recording(repo_id="local/stop_when", task="drop", fps=30, root=str(root))["status"] == "success"
+        )
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=BUDGET,
+            fast_mode=True,
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": CUBE_STOP_Z},
+        )
+        payload = rollout_json(result)
+        assert sim.stop_recording()["status"] == "success"
+
+        info_files = list(Path(root).rglob("meta/info.json"))
+        assert info_files, f"no dataset written under {root}"
+        info = json.loads(info_files[0].read_text())
+        assert info["total_episodes"] == 1
+        assert info["total_frames"] == payload["n_steps"]
+
+    def test_multi_episode_run_applies_the_condition_per_episode(self, sim):
+        """Each episode ends on the condition, so N episodes are N goal-reaching rollouts."""
+        result = sim.run_policy(
+            robot_name="alice",
+            n_steps=BUDGET,
+            n_episodes=2,
+            fast_mode=True,
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": CUBE_STOP_Z},
+        )
+        assert result["status"] == "success"
+        episodes = rollout_json(result)["episodes"]
+        assert len(episodes) == 2
+        assert [ep["stopped_reason"] for ep in episodes] == ["predicate", "predicate"]
+        assert all(ep["n_steps"] < BUDGET for ep in episodes)
+
+
+class TestStopWhenIsReachableFromAnAgent:
+    def test_agent_tool_dispatch_forwards_the_clause(self, sim):
+        """The router must forward ``stop_when``, not drop it as unknown."""
+        result = sim._dispatch_action(
+            "run_policy",
+            {
+                "robot_name": "alice",
+                "n_steps": BUDGET,
+                "fast_mode": True,
+                "stop_when": {"predicate": "body_below_z", "body": "cube", "z": CUBE_STOP_Z},
+            },
+        )
+        assert result["status"] == "success"
+        payload = rollout_json(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["n_steps"] < BUDGET
+
+    def test_tool_spec_advertises_stop_when(self):
+        """An LLM only forms calls from the schema it is handed."""
+        spec_path = Path(__file__).resolve().parents[2] / "strands_robots/simulation/mujoco/tool_spec.json"
+        props = json.loads(spec_path.read_text())["properties"]
+        assert "stop_when" in props, "tool_spec.json must advertise run_policy's stop_when"
+        assert props["stop_when"]["type"] == "object"
+
+    def test_describe_documents_stop_when(self, sim):
+        """``describe()`` is the discovery surface for the run_policy signature."""
+        assert "stop_when" in sim.describe()["methods"]["run_policy"]


### PR DESCRIPTION
Closes #1644.

## Problem

A rollout could only be bounded arithmetically - `duration` or `n_steps`. A caller driving a policy as a retryable primitive (invoke -> inspect -> re-invoke) therefore had to guess an episode length, run it to the end, and only then query the world to find out whether the guess was long enough. Every ingredient for a semantic horizon already existed but none was reachable from `run_policy`: the closed predicate registry and its DSL compiler were used only by benchmark `success`/`failure` clauses, and `PolicyRunner.run`'s per-step `on_frame` hook is built internally so a caller cannot inject one.

The result payload was equally lossy: `stopped_early=True` covered a user cancellation, a hook abort and every other non-budget exit, so an agent deciding whether to retry could not tell "the goal was reached" from "someone cancelled me".

## Change

`run_policy(stop_when=...)` accepts a predicate-DSL clause - the same schema a benchmark spec's `success` clause uses - and the rollout returns as soon as the world satisfies it:

```python
sim.run_policy(
    robot_name="so100",
    instruction="pick up the red cube",
    n_steps=300,                                              # budget
    stop_when={"predicate": "body_above_z", "body": "cube", "z": 0.2},
)
# -> success, n_steps=41, stopped_reason="predicate"
```

- A single call or an `{"all": [...]}` / `{"any": [...]}` group over `PREDICATE_REGISTRY` (`grasped`, `body_on`, `body_inside`, `contact_between`, `distance_less_than`, ...). Programmatic callers may pass a `(sim) -> bool` callable, mirroring `eval_policy(success_fn=...)`.
- Predicates evaluate against the **sim** (benchmark semantics), checked in `PolicyRunner._apply` - the one point the synchronous and the async-RTC loops both funnel actions through - so both paths honor the condition within one applied action, and the check cannot drift between them.
- The clause is compiled **before** the policy is built, via a new public `compile_bool_clause` in `benchmark_spec` (the group compiler is spec-internal and accepts only `all`/`any`, so it could not express the single-call form the issue asks for). Nothing reaches `eval`/`exec`, so `stop_when` is safe to accept from an agent and is advertised in the MuJoCo `tool_spec.json` + `describe()`.

Rejected rather than silently ignored (a dropped condition would run the full budget and report success, so the caller would read "never fired" from a run that never checked):

| Clause | Result |
|---|---|
| `{"predicate": "cube_lifted", ...}` | error naming `stop_when`, listing the valid predicates |
| `{}`, `{"all": []}`, `{"any": []}` | error - "names no predicate, so the condition could never fire" |
| `{"predicate": ..., "any": [...]}` | error - ambiguous, half of it would be dropped |
| `{"predicate": "distance_neg", ...}` | error - a float reward term read as a bool stops instantly |
| `"grasped"`, `["grasped"]`, `3` | error naming `stop_when` and the accepted shapes |

### `stopped_reason` telemetry

| `stopped_reason` | Meaning |
|---|---|
| `budget` | Ran the full `n_steps` / `duration` horizon |
| `predicate` | `stop_when` fired; `n_steps` is the steps actually executed |
| `cancelled` | Cooperative stop (`stop_policy()`, an `on_frame` `CooperativeStop`) |
| `error` | The rollout failed, including a `stop_when` condition that raised |

`StopConditionMet` subclasses `CooperativeStop`, so both end on the existing graceful path while staying distinguishable. A condition that raises is **not** swallowed: a condition that cannot be evaluated is not reported as unmet.

On `steps_used`: the json block's `n_steps` is already the steps actually executed, so a second field would be two names for one value. Its docstring now says so explicitly instead.

### Composition

`stop_when` is checked after the `on_frame` hook and the video capture for that step, so the frame that satisfied it is present in an active dataset recording and in a `video={...}` MP4. `n_episodes=N` applies the condition per episode, so a collection run yields N goal-reaching episodes of exactly the length each needed. `MuJoCoSimEngine.run_policy` forwards it verbatim (no silent kwarg drop). `eval_policy` / `evaluate_benchmark` semantics are untouched - they already terminate on `spec.is_success`.

## Rollout artifact (MuJoCo, headless EGL)

Same scene, same policy, same `n_steps=200` budget. Left: no condition - the rollout keeps running for 183 steps after the cube has landed. Right: `stop_when={"predicate": "body_on", "body_a": "cube", "body_b": "tray", "require_contact": true}` - returns at step 17 with `stopped_reason="predicate"`.

![run_policy stop_when comparison](https://raw.githubusercontent.com/cagataycali/robots/artifacts/stop-when/stop_when_demo.gif)

| Run | `stop_when` | `n_steps` | `stopped_reason` | `video_frames` |
|---|---|---|---|---|
| left | `None` | 200 / 200 | `budget` | 200 |
| right | `body_on(cube, tray)` | **17** / 200 | `predicate` | 17 |

Source MP4s: [without](https://raw.githubusercontent.com/cagataycali/robots/artifacts/stop-when/stop_when_off.mp4) / [with](https://raw.githubusercontent.com/cagataycali/robots/artifacts/stop-when/stop_when_on.mp4). `video_frames == n_steps` on the right panel is the capture-composition assertion: the frame that satisfied the condition is in the MP4.

## Tests

`tests/simulation/test_run_policy_stop_when.py` - 20 tests, **all 20 fail on current `main`** (the parameter does not exist) and pass with this change. The falling cube is the oracle: free fall from a known height is deterministic, so the firing step does not depend on what the driving policy does to the arm.

Covered: early return + reason + the world really being in the named state; `all` vs `any` group semantics; callable form receiving the live engine; a raising condition -> `status=error` + `stopped_reason="error"`; budget exhaustion; a rollout with no condition still reporting `budget`; cancellation reporting `cancelled` not `predicate`; the five rejection cases above, with the unknown-predicate case proving nothing ran (`policy.get_actions` never called); MP4 frame count == executed steps; LeRobot dataset round trip (`total_frames == n_steps`, one episode); `n_episodes=2` applying the condition per episode; agent-tool dispatch forwarding the clause; `tool_spec.json` and `describe()` advertising it.

## Gate

`ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean (891 source files). Full suite `MUJOCO_GL=egl pytest tests`: **11985 passed, 254 skipped** (11965 on `main` + 20 new), 421s.

## Docs

`docs/simulation/overview.md`: a "Stopping on a world state (`stop_when`)" section (clause shapes, sim-vs-observation semantics, the `stopped_reason` table, capture composition), the `run_policy` parameter-table row, and `stopped_reason` added to the documented result fields. CHANGELOG `[Unreleased]` entry included.