### PR TITLE
feat(sim): stop_when= semantic early-return predicate on run_policy + stopped_reason telemetry

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1421,7 +1421,12 @@ class SimEngine(ABC):
                 :func:`~strands_robots.simulation.benchmark_spec.compile_stop_when`
                 against the closed predicate registry (never ``eval`` /
                 ``exec``; an unknown predicate name is rejected up front with
-                the valid list) and evaluated against the SIM after every
+                the valid list), and the clause's referenced body/joint names
+                are probed against the LIVE scene before the rollout starts -
+                a typo'd name (or a backend without body lookups) is an
+                up-front structured error instead of a clause that silently
+                never fires and burns the whole budget. The compiled clause is
+                evaluated against the SIM after every
                 applied action - matching the benchmark semantics, not the
                 observation dict - on both the synchronous and async-RTC
                 paths, so the stop lands within one control step of the
@@ -1509,13 +1514,33 @@ class SimEngine(ABC):
                 try:
                     stop_when_fn = compile_stop_when(stop_when)
                 except ValueError as e:
-                    return {"status": "error", "content": [{"text": f"run_policy: {e}"}]}
+                    return {
+                        "status": "error",
+                        "content": [
+                            {"text": f"run_policy: {e}"},
+                            {"json": {"stopped_reason": "error", "steps_used": 0, "n_steps": 0}},
+                        ],
+                    }
 
         if robot_name not in self.list_robots():
             return {
                 "status": "error",
                 "content": [{"text": self._unknown_robot_msg(robot_name)}],
             }
+
+        # Probe the clause's referenced bodies/joints against the LIVE scene.
+        # compile_stop_when validates the predicate NAMES but cannot see the
+        # scene: a typo'd body would compile clean, degrade to a constant
+        # False at evaluation time (predicates never raise), and burn the
+        # whole step budget reporting stopped_reason="budget" -
+        # indistinguishable from an honest miss. Probing here (dict clauses
+        # only - a programmatic callable is opaque) turns that silent
+        # never-fires into an up-front structured error, including on
+        # backends whose predicates cannot resolve bodies at all.
+        if stop_when_fn is not None and isinstance(stop_when, dict):
+            probe_err = self._stop_when_unresolved_error(stop_when)
+            if probe_err is not None:
+                return probe_err
 
         if policy_object is None:
             # Fail fast on a misconfiguration (e.g. camera names that cannot be
@@ -1623,6 +1648,57 @@ class SimEngine(ABC):
         finally:
             if controller_cleanup is not None:
                 controller_cleanup()
+
+    def _stop_when_unresolved_error(self, stop_when: dict[str, Any]) -> dict[str, Any] | None:
+        """Structured error if a ``stop_when`` clause references unresolvable entities.
+
+        Probes every body/joint name in the clause through the SAME lookup
+        path the predicates use at evaluation time
+        (:func:`~strands_robots.simulation.predicates.can_resolve_body` /
+        :func:`~strands_robots.simulation.predicates.can_resolve_joint`,
+        including the LIBERO ``<name>_main`` fallback), against the live
+        scene, once, before the rollout starts. Returns ``None`` when every
+        referenced entity resolves. Bodies added to the scene AFTER this
+        check are out of contract - a rollout does not create bodies.
+        """
+        from strands_robots.simulation.benchmark_spec import stop_when_referenced_entities
+        from strands_robots.simulation.predicates import can_resolve_body, can_resolve_joint, supports_body_lookup
+
+        bodies, joints = stop_when_referenced_entities(stop_when)
+
+        def _err(text: str) -> dict[str, Any]:
+            return {
+                "status": "error",
+                "content": [
+                    {"text": f"run_policy: {text}"},
+                    {"json": {"stopped_reason": "error", "steps_used": 0, "n_steps": 0}},
+                ],
+            }
+
+        if bodies and not supports_body_lookup(self):
+            return _err(
+                f"stop_when references bodies {bodies} but this backend has no body lookup "
+                "(get_body_state), so the clause could never fire and the rollout would "
+                "silently run to its step budget. Use a clause without body-referencing "
+                "predicates, or a backend that supports body lookups."
+            )
+        missing_bodies = [b for b in bodies if not can_resolve_body(self, b)]
+        if missing_bodies:
+            return _err(
+                f"stop_when references bodies not present in the scene: {missing_bodies}. "
+                "The clause would never fire and the rollout would silently run to its "
+                "step budget. Check the names against the loaded scene (get_state lists "
+                "objects; describe() lists actions)."
+            )
+        missing_joints = [j for j in joints if not can_resolve_joint(self, j)]
+        if missing_joints:
+            return _err(
+                f"stop_when references joints not present in the observation: {missing_joints}. "
+                "The clause would never fire and the rollout would silently run to its "
+                "step budget. Check the names against get_observation()'s keys "
+                "(joint names are namespaced '<robot>/<joint>')."
+            )
+        return None
 
     def _run_episodes(
         self,
@@ -1806,10 +1882,23 @@ class SimEngine(ABC):
         Mirrors the single-rollout result shape: a human-readable ``text``
         block plus an agent-consumable ``{"json": {...}}`` block carrying typed
         aggregate fields (``n_episodes_completed``, ``episodes_saved``,
-        ``total_steps``, per-episode list, ``video_paths``).
+        ``total_steps``, per-episode list, ``video_paths``). The payload keeps
+        ONE shape across episode counts: ``stopped_reason`` / ``steps_used``
+        are present here just as on the single-episode payload -
+        ``stopped_reason`` is ``"error"`` on error results and otherwise the
+        LAST episode's reason (why the call as a whole stopped running), with
+        the per-episode attribution in ``stopped_reasons`` (aligned with
+        ``episodes``); ``steps_used`` equals ``total_steps``.
         """
         completed = len(episodes)
         video_paths = [e["video_path"] for e in episodes if e.get("video_path")]
+        stopped_reasons = [e.get("stopped_reason") for e in episodes]
+        if status == "error":
+            stopped_reason = "error"
+        elif stopped_reasons and isinstance(stopped_reasons[-1], str):
+            stopped_reason = stopped_reasons[-1]
+        else:
+            stopped_reason = "budget"
         text = (
             f"Multi-episode run_policy: {completed}/{n_episodes} episode(s) completed, "
             f"{episodes_saved} flushed to dataset, {total_steps} total steps."
@@ -1828,6 +1917,9 @@ class SimEngine(ABC):
             "episodes_saved": episodes_saved,
             "dataset_episode_indices": dataset_episode_indices,
             "total_steps": total_steps,
+            "steps_used": total_steps,
+            "stopped_reason": stopped_reason,
+            "stopped_reasons": stopped_reasons,
             "episodes": episodes,
             "video_paths": video_paths,
         }

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1277,6 +1277,7 @@ class SimEngine(ABC):
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
         wbc_install_torque_control: bool = True,
+        stop_when: dict[str, Any] | Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -1408,12 +1409,39 @@ class SimEngine(ABC):
                 falls over without it. Set ``False`` to manage the controller
                 yourself or to drive a torque-actuated scene directly. No-op for
                 non-WBC policies and on backends without the hook.
+            stop_when: Optional semantic early-return condition: end the
+                rollout as soon as the WORLD reaches a state, not only when
+                the step budget runs out - which turns a monolithic rollout
+                into a retryable primitive an agent can invoke -> inspect ->
+                re-invoke. A predicate-DSL clause in the same schema as a
+                benchmark spec's ``success`` clause: a single call
+                ``{"predicate": "grasped", "body": "cube", "gripper_prefix":
+                "so100"}`` or an ``{"all": [...]}`` / ``{"any": [...]}`` group
+                of bool predicate calls. Compiled via
+                :func:`~strands_robots.simulation.benchmark_spec.compile_stop_when`
+                against the closed predicate registry (never ``eval`` /
+                ``exec``; an unknown predicate name is rejected up front with
+                the valid list) and evaluated against the SIM after every
+                applied action - matching the benchmark semantics, not the
+                observation dict - on both the synchronous and async-RTC
+                paths, so the stop lands within one control step of the
+                condition holding. Composes with an active recording session:
+                frames are captured up to the stop, so a recorded episode's
+                frame count equals the result's ``steps_used``. Programmatic
+                callers may pass a callable ``(sim) -> bool`` instead of a
+                dict (the tool surface accepts dicts only). ``None`` (default)
+                keeps the pure step-budget horizon. The result json reports
+                why the rollout ended via ``stopped_reason``.
 
         Returns:
             Standard status dict with an agent-consumable ``{"json": {...}}``
             content block alongside the human-readable ``text``. The json block
             carries the rollout facts as typed fields (``n_steps``,
-            ``elapsed_s``, ``stopped_early``, ``action_errors``, ``video_path``,
+            ``steps_used``, ``elapsed_s``, ``stopped_early``,
+            ``stopped_reason`` (``"predicate"`` | ``"budget"`` |
+            ``"cancelled"``; ``"error"`` on error results - so an agent
+            deciding whether to retry knows WHY the rollout ended),
+            ``action_errors``, ``video_path``,
             ``video_frames``, ``positional_fallback_used``,
             ``generic_state_keys_used``, ``missing_state_keys_used``, ...) so callers can self-correct
             programmatically without parsing the text. The two routing-
@@ -1464,6 +1492,24 @@ class SimEngine(ABC):
             return err
         if err := self._validate_control_substeps(control_substeps, "run_policy"):
             return err
+
+        # Compile the stop_when early-return clause BEFORE any policy is
+        # created (an unknown predicate name or bad kwargs is a caller error,
+        # not a mid-rollout crash after an expensive weight download). The
+        # tool surface only ever passes predicate-DSL dicts, resolved through
+        # the closed registry - never eval/exec; programmatic callers may pass
+        # a callable directly, mirroring PolicyRunner.evaluate's success_fn.
+        stop_when_fn: Callable[[SimEngine], bool] | None = None
+        if stop_when is not None:
+            if callable(stop_when):
+                stop_when_fn = stop_when
+            else:
+                from strands_robots.simulation.benchmark_spec import compile_stop_when
+
+                try:
+                    stop_when_fn = compile_stop_when(stop_when)
+                except ValueError as e:
+                    return {"status": "error", "content": [{"text": f"run_policy: {e}"}]}
 
         if robot_name not in self.list_robots():
             return {
@@ -1540,6 +1586,7 @@ class SimEngine(ABC):
                     seed=seed,
                     async_rtc=async_rtc,
                     rtc_inference_timeout_s=rtc_inference_timeout_s,
+                    stop_when=stop_when_fn,
                 )
                 completed = 1 if result.get("status") == "success" else 0
                 contract = self._episode_contract_fields(
@@ -1571,6 +1618,7 @@ class SimEngine(ABC):
                 reset_between=reset_between,
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
+                stop_when=stop_when_fn,
             )
         finally:
             if controller_cleanup is not None:
@@ -1597,6 +1645,7 @@ class SimEngine(ABC):
         reset_between: bool,
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
+        stop_when: Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """Run ``n_episodes`` sequential rollouts; shared multi-episode driver.
 
@@ -1608,6 +1657,12 @@ class SimEngine(ABC):
         episodes instead of one merged episode. Aborts early (returning a
         structured error with the episodes completed so far) if a rollout, an
         episode flush, or a reset fails.
+
+        ``stop_when`` (already compiled to a callable by :meth:`run_policy`)
+        is forwarded to every per-episode rollout, giving multi-episode
+        collection a per-episode success gate: each episode ends at its own
+        predicate hit (or budget), and its dataset episode is flushed with
+        exactly the frames captured up to that stop.
         """
         episodes: list[dict[str, Any]] = []
         episodes_saved = 0
@@ -1633,6 +1688,7 @@ class SimEngine(ABC):
                 seed=ep_seed,
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
+                stop_when=stop_when,
             )
             ep_json = self._extract_json_payload(result)
             ep_record: dict[str, Any] = {"episode": ep, **ep_json}
@@ -2753,7 +2809,19 @@ class SimEngine(ABC):
                     "add_robot, completing the add/remove pair alongside "
                     "remove_object"
                 ),
-                "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, reset_between=True, ...) -> dict",
+                "run_policy": (
+                    "(robot_name: str, policy_provider='mock', n_episodes=1, "
+                    "reset_between=True, stop_when=None, ...) -> dict  # "
+                    "stop_when: optional semantic early-return clause in the "
+                    "benchmark success: predicate DSL - a single "
+                    "{'predicate': <name>, ...} call or an {'all'/'any': "
+                    "[...]} group - checked against the sim after every "
+                    "applied action so the rollout ends as soon as the world "
+                    "reaches the state; the result json reports "
+                    "stopped_reason ('predicate'|'budget'|'cancelled'; "
+                    "'error' on failures) + steps_used so a caller can decide "
+                    "whether to retry"
+                ),
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "eval_policy": (
                     "(robot_name: str, policy_provider='mock', n_episodes=1, "

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -241,6 +241,59 @@ def compile_stop_when(stop_when: Any, *, context: str = "stop_when") -> Callable
     return _compile_bool_group(stop_when, default=False, context=context)
 
 
+# Predicate kwargs that name scene entities, per kind. A stop_when clause is
+# probed against the LIVE sim before the rollout starts (see
+# SimEngine.run_policy): a typo'd name would otherwise compile clean, degrade
+# to a constant False at evaluation time, and burn the whole step budget
+# reporting stopped_reason="budget" - indistinguishable from an honest miss.
+_BODY_NAME_KWARGS = frozenset({"body", "body_a", "body_b", "container"})
+_JOINT_NAME_KWARGS = frozenset({"joint"})
+
+
+def stop_when_referenced_entities(stop_when: Any) -> tuple[list[str], list[str]]:
+    """Collect the body and joint names a ``stop_when`` clause references.
+
+    Walks the same shapes :func:`compile_stop_when` accepts (a single
+    predicate call or an ``all``/``any`` group) and gathers the values of the
+    entity-naming kwargs (``body`` / ``body_a`` / ``body_b`` / ``container``
+    for bodies, ``joint`` for joints) so the caller can probe each one
+    against the live sim before arming the clause. Geom names
+    (``contact_between``) are not collected - there is no generic geom
+    lookup on the engine ABC to probe them with.
+
+    Args:
+        stop_when: A clause dict already validated by
+            :func:`compile_stop_when` (unrecognized shapes yield empty
+            results rather than raising - validation is the compiler's job).
+
+    Returns:
+        ``(bodies, joints)`` - deduplicated, insertion-ordered name lists.
+    """
+    bodies: dict[str, None] = {}
+    joints: dict[str, None] = {}
+
+    def _collect(call: Any) -> None:
+        if not isinstance(call, dict):
+            return
+        for key, value in call.items():
+            if isinstance(value, str) and value:
+                if key in _BODY_NAME_KWARGS:
+                    bodies.setdefault(value)
+                elif key in _JOINT_NAME_KWARGS:
+                    joints.setdefault(value)
+
+    if isinstance(stop_when, dict):
+        if "predicate" in stop_when:
+            _collect(stop_when)
+        else:
+            for group_key in ("all", "any"):
+                entries = stop_when.get(group_key)
+                if isinstance(entries, list):
+                    for entry in entries:
+                        _collect(entry)
+    return list(bodies), list(joints)
+
+
 def _compile_reward_terms(terms: list[Any] | None) -> list[Callable[[SimEngine], float]]:
     if terms is None:
         return []
@@ -532,4 +585,5 @@ __all__ = [
     "DeclarativeBenchmark",
     "compile_stop_when",
     "register_benchmark_from_file",
+    "stop_when_referenced_entities",
 ]

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -175,6 +175,72 @@ def _compile_call(entry: Any, *, context: str, require_kind: str | None = None) 
         raise ValueError(f"{context}: predicate '{pred_name}' compilation failed: {e}") from e
 
 
+def compile_stop_when(stop_when: Any, *, context: str = "stop_when") -> Callable[[SimEngine], bool]:
+    """Compile a ``stop_when`` early-return clause into a ``(sim) -> bool`` callable.
+
+    This is the ``run_policy(stop_when=...)`` compiler: the clause uses the
+    same predicate-DSL schema as a benchmark spec's ``success`` clause, so an
+    agent that can author a success condition can gate a rollout with the
+    identical vocabulary. Two shapes are accepted - a single predicate call::
+
+        {"predicate": "grasped", "body": "cube", "gripper_prefix": "so100"}
+
+    or an ``all`` / ``any`` group of predicate calls::
+
+        {"all": [{"predicate": "body_above_z", "body": "cube", "z": 0.2},
+                 {"predicate": "body_upright", "body": "cube"}]}
+
+    Predicates resolve through the closed registry
+    (:func:`~strands_robots.simulation.predicates.make_predicate`) - nothing
+    here reaches ``eval`` / ``exec``, so the clause is safe to accept from an
+    LLM tool call. Float-valued reward terms are rejected up front (a nonzero
+    float reads as always-``True`` and would stop the rollout on step 1), and
+    an empty clause is rejected rather than compiling to a check that never
+    fires (which would silently run the rollout to its step budget).
+
+    Args:
+        stop_when: The clause dict (single predicate call or ``all``/``any``
+            group).
+        context: Label used to prefix error messages.
+
+    Returns:
+        A side-effect-free callable evaluating the clause against the sim
+        (predicates only read sim state), suitable for per-step checking.
+
+    Raises:
+        ValueError: On a non-dict clause, an empty / never-firing clause, a
+            clause mixing the single-call and group forms, an unknown
+            predicate name (the message lists the valid set), a float-valued
+            predicate, or bad predicate kwargs.
+    """
+    if not isinstance(stop_when, dict):
+        raise ValueError(
+            f"{context}: expected a predicate call like {{'predicate': 'grasped', ...}} or an "
+            f"'all'/'any' group of them, got {type(stop_when).__name__}"
+        )
+    if "predicate" in stop_when:
+        group_keys = {"all", "any"} & set(stop_when.keys())
+        if group_keys:
+            raise ValueError(
+                f"{context}: a clause is either a single predicate call or an 'all'/'any' group, "
+                f"not both (got 'predicate' plus {sorted(group_keys)})"
+            )
+        return _compile_call(stop_when, context=context, require_kind="bool")
+    unknown = set(stop_when.keys()) - {"all", "any"}
+    if unknown:
+        raise ValueError(
+            f"{context}: unknown keys {sorted(unknown)}; pass a single "
+            "{'predicate': <name>, ...} call or an 'all'/'any' group of them"
+        )
+    if not (stop_when.get("all") or stop_when.get("any")):
+        raise ValueError(
+            f"{context}: empty clause - it would never fire and the rollout would silently run "
+            "to its step budget. Pass a predicate call or a non-empty 'all'/'any' group, or "
+            f"omit {context} entirely."
+        )
+    return _compile_bool_group(stop_when, default=False, context=context)
+
+
 def _compile_reward_terms(terms: list[Any] | None) -> list[Callable[[SimEngine], float]]:
     if terms is None:
         return []
@@ -464,5 +530,6 @@ def register_benchmark_from_file(
 
 __all__ = [
     "DeclarativeBenchmark",
+    "compile_stop_when",
     "register_benchmark_from_file",
 ]

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3812,6 +3812,7 @@ class MuJoCoSimEngine(
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
         wbc_install_torque_control: bool = True,
+        stop_when: dict[str, Any] | Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -3828,6 +3829,11 @@ class MuJoCoSimEngine(
         collection: ``n_episodes > 1`` runs that many rollouts back-to-back,
         flushing a ``save_episode`` boundary after each (when recording) and
         resetting between episodes. See :meth:`SimEngine.run_policy`.
+
+        ``stop_when`` (the semantic early-return predicate clause) is
+        forwarded verbatim to :meth:`SimEngine.run_policy`, which compiles and
+        validates it against the closed predicate registry; see its docstring
+        for the schema and the ``stopped_reason`` telemetry contract.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -3860,6 +3866,7 @@ class MuJoCoSimEngine(
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
                 wbc_install_torque_control=wbc_install_torque_control,
+                stop_when=stop_when,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -394,6 +394,11 @@
       "description": "Provider-specific config dict forwarded to strands_robots.policies.create_policy. Contents depend on policy_provider. For 'groot': host, port, api_token, observation_mapping, action_mapping. For 'lerobot_local': pretrained_name_or_path, device, trust_remote_code, actions_per_step, use_processor, processor_overrides, observation_mapping, action_mapping. For 'mock': {} is fine.",
       "additionalProperties": true
     },
+    "stop_when": {
+      "type": "object",
+      "description": "run_policy: optional semantic early-return clause -- the rollout ends as soon as the condition holds in the sim, instead of only when the step budget runs out. Same predicate DSL as a benchmark spec's success: clause: a single bool predicate call like {'predicate': 'grasped', 'body': 'cube', 'gripper_prefix': 'so100'} or {'predicate': 'body_above_z', 'body': 'cube', 'z': 0.2}, or a group {'all': [<call>, ...]} / {'any': [<call>, ...]}. Predicates resolve through the closed registry (never eval/exec); an unknown name or a float-valued reward term is rejected up front with the valid list. Checked after every applied action (also on the async-RTC path, so the stop lands within one control step). Composes with an active recording: frames are captured up to the stop. The result json reports stopped_reason ('predicate'|'budget'|'cancelled'; 'error' on failures) and steps_used so you can decide whether to retry.",
+      "additionalProperties": true
+    },
     "cameras": {
       "type": "array",
       "items": {

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -892,6 +892,7 @@ class PolicyRunner:
         seed: int | None = None,
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
+        stop_when: Callable[[SimEngine], bool] | None = None,
     ) -> dict[str, Any]:
         """Run ``policy`` on ``robot_name`` for ``duration`` seconds.
 
@@ -992,13 +993,38 @@ class PolicyRunner:
                 :meth:`run` returns), so the abort is bounded by ONE inference,
                 not the whole rollout. ``None`` (default) waits without a deadline
                 (historical behaviour). Ignored on the synchronous path.
+            stop_when: Optional semantic early-return condition - a callable
+                ``(sim) -> bool`` evaluated against the LIVE sim after every
+                applied action, on BOTH the synchronous and async-RTC paths.
+                The first ``True`` ends the rollout cleanly with
+                ``stopped_reason="predicate"``; the remaining actions of an
+                in-flight chunk are dropped, so the early-return latency bound
+                is ONE control step regardless of the policy's chunk length
+                (on the async-RTC path any in-flight prefetch is still joined
+                before :meth:`run` returns). Callers driving the runner
+                through :meth:`SimEngine.run_policy` pass a predicate-DSL dict
+                compiled via
+                :func:`~strands_robots.simulation.benchmark_spec.compile_stop_when`;
+                programmatic callers may pass any callable (mirroring
+                :meth:`evaluate`'s ``success_fn``). A raising ``stop_when`` is
+                fatal (``status="error"``): the caller asked for an
+                early-return semantics the runner can no longer honor, and
+                silently running to the step budget would misreport the
+                rollout. ``None`` (default) preserves the pure step-budget
+                horizon.
 
         Returns:
             ``{"status": "success"|"error", "content": [{"text": ...},
             {"json": {...}}]}``. The ``json`` block is agent-consumable and
             carries the rollout facts as typed fields - ``robot_name``,
-            ``policy``, ``instruction``, ``n_steps``, ``elapsed_s``,
-            ``stopped_early``, ``action_errors``, ``video_path`` (``None`` when
+            ``policy``, ``instruction``, ``n_steps``, ``steps_used`` (the
+            control steps actually executed, equal to ``n_steps``),
+            ``elapsed_s``, ``stopped_early``, ``stopped_reason``
+            (``"predicate"`` - the ``stop_when`` condition fired; ``"budget"``
+            - the step/duration horizon was exhausted; ``"cancelled"`` - a
+            cooperative stop, e.g. ``stop_policy``; on ``status="error"``
+            results the field is ``"error"``), ``action_errors``,
+            ``video_path`` (``None`` when
             no MP4 was written), ``video_frames`` and ``sim_time_s`` (when the
             backend reports sim time) - so callers can self-correct without
             regex-parsing the human-readable ``text``. The block also carries the
@@ -1092,6 +1118,15 @@ class PolicyRunner:
             return _video_err
 
         stopped_early = False
+        # Why the rollout ended, reported in the result json so an agent
+        # deciding whether to retry can distinguish "the world reached the
+        # goal state" from "the step budget ran out" from "the user cancelled"
+        # (stopped_early alone conflates the last two). "budget" is the
+        # default (the loop ran its full horizon); the CooperativeStop handler
+        # re-tags it "cancelled", a fired stop_when re-tags it "predicate",
+        # and every error return reports "error".
+        stopped_reason = "budget"
+        stop_predicate_fired = False
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
         # Open-loop chunk replay consumes H actions from ONE observation. That
@@ -1276,6 +1311,35 @@ class PolicyRunner:
                 if not fast_mode:
                     time.sleep(action_sleep)
 
+            def _stop_when_fired() -> bool:
+                """Evaluate the caller's ``stop_when`` clause against the live sim.
+
+                Called after every applied action on BOTH the synchronous and
+                async-RTC paths, so the early-return latency bound is ONE
+                control step regardless of chunk length: the check fires
+                within the current chunk-slice and the remaining actions of
+                the chunk are dropped. A raising clause is fatal - the caller
+                asked for early-return semantics the runner can no longer
+                honor, and silently running to the step budget would
+                misreport the rollout - so it surfaces as ``status="error"``
+                via the outer handler rather than being warn-and-continued.
+                """
+                nonlocal stop_predicate_fired
+                if stop_when is None:
+                    return False
+                try:
+                    fired = bool(stop_when(self.sim))
+                except Exception as e:
+                    raise RuntimeError(
+                        f"stop_when predicate raised at step {step_count}: {e!r}. The early-return "
+                        "condition cannot be evaluated, so the rollout is aborted rather than "
+                        "silently running to its step budget."
+                    ) from e
+                if fired:
+                    stop_predicate_fired = True
+                    logger.info("stop_when fired at step %d; ending rollout early", step_count)
+                return fired
+
             def _query_chunk(observation: dict[str, Any], observed_delay: int = 0) -> list[dict[str, Any]]:
                 # Resolve ONE action chunk from the policy. Never truncate below
                 # the policy's own intended chunk size: a model trained for
@@ -1428,6 +1492,14 @@ class PolicyRunner:
                             step_obs = cur_obs
                         _apply(step_obs, cur_chunk[idx])
                         idx += 1
+                        # Semantic early return: checked after EVERY applied
+                        # action, so the stop lands within one control step of
+                        # the world reaching the condition - the rest of the
+                        # in-flight chunk (and any prefetched chunk) is
+                        # dropped; the executor shutdown below joins the
+                        # in-flight prefetch worker.
+                        if _stop_when_fired():
+                            break
                 finally:
                     # Wait for any in-flight inference so no background thread
                     # touches the policy/sim after run() returns (the caller may
@@ -1452,22 +1524,43 @@ class PolicyRunner:
                         else:
                             step_obs = observation
                         _apply(step_obs, action_dict)
+                        # Semantic early return: checked after EVERY applied
+                        # action (same cadence as the benchmark eval loop), so
+                        # the remaining actions of the chunk are dropped as
+                        # soon as the condition holds.
+                        if _stop_when_fired():
+                            break
+                    if stop_predicate_fired:
+                        break
 
         except CooperativeStop:
             stopped_early = True
+            stopped_reason = "cancelled"
         except Exception as e:
             if vwriter is not None:
                 vwriter.close()
             logger.exception("PolicyRunner.run failed")
             return {
                 "status": "error",
-                "content": [{"text": f"Policy failed: {e}"}, {"json": _rtc_telemetry()}],
+                "content": [
+                    {"text": f"Policy failed: {e}"},
+                    {"json": {**_rtc_telemetry(), "stopped_reason": "error", "steps_used": step_count}},
+                ],
             }
 
-        # Either finished all steps or was cooperatively stopped
+        # Either finished all steps, hit the stop_when condition, or was
+        # cooperatively stopped.
+        if stop_predicate_fired:
+            stopped_early = True
+            stopped_reason = "predicate"
         elapsed = time.time() - start_time
         sim_time = self._maybe_sim_time()
-        prefix = "Policy stopped" if stopped_early else "Policy complete"
+        if not stopped_early:
+            prefix = "Policy complete"
+        elif stopped_reason == "predicate":
+            prefix = "Policy stopped early (stop_when condition met)"
+        else:
+            prefix = "Policy stopped"
         text = (
             f"{prefix} on '{robot_name}'\n{type(policy).__name__} | {instruction}\n{elapsed:.1f}s | {step_count} steps"
         )
@@ -1510,8 +1603,14 @@ class PolicyRunner:
             "policy": type(policy).__name__,
             "instruction": instruction,
             "n_steps": step_count,
+            # Alias of n_steps under the retry-loop name: the control steps
+            # actually executed before the rollout ended. Paired with
+            # stopped_reason it makes "the predicate fired after 37 of 200
+            # steps" queryable without arithmetic on the caller side.
+            "steps_used": step_count,
             "elapsed_s": round(elapsed, 3),
             "stopped_early": stopped_early,
+            "stopped_reason": stopped_reason,
             "action_errors": _action_errors,
             "video_path": None,
             "video_frames": 0,
@@ -1594,6 +1693,10 @@ class PolicyRunner:
                 f"-- the robot did not move. Check that the policy's output keys "
                 f"match the robot's actuator names."
             )
+            # An error result always reports stopped_reason="error": the
+            # rollout may have run its full budget, but the outcome is not a
+            # retryable "budget" completion.
+            payload["stopped_reason"] = "error"
             return {"status": "error", "content": [{"text": text}, {"json": payload}]}
         if _action_errors > 0:
             text += f"\n\n{_action_errors}/{step_count} action steps had unresolved keys."

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1115,6 +1115,12 @@ class PolicyRunner:
         # lives in _RolloutVideoWriter so run() and evaluate() record identically.
         vwriter, _video_err = _RolloutVideoWriter.open(self.sim, video, control_frequency)
         if _video_err is not None:
+            # Every error result carries the stopped_reason="error" json block
+            # (the "recorded on ALL exit paths" contract); the writer's error
+            # dict is text-only because evaluate() shares it, so tag it here.
+            _video_err.setdefault("content", []).append(
+                {"json": {"stopped_reason": "error", "steps_used": 0, "n_steps": 0}}
+            )
             return _video_err
 
         stopped_early = False
@@ -1318,15 +1324,16 @@ class PolicyRunner:
                 async-RTC paths, so the early-return latency bound is ONE
                 control step regardless of chunk length: the check fires
                 within the current chunk-slice and the remaining actions of
-                the chunk are dropped. A raising clause is fatal - the caller
-                asked for early-return semantics the runner can no longer
-                honor, and silently running to the step budget would
-                misreport the rollout - so it surfaces as ``status="error"``
-                via the outer handler rather than being warn-and-continued.
+                the chunk are dropped. Call sites guard on ``stop_when is not
+                None`` so the no-clause hot path pays no per-step call. A
+                raising clause is fatal - the caller asked for early-return
+                semantics the runner can no longer honor, and silently
+                running to the step budget would misreport the rollout - so
+                it surfaces as ``status="error"`` via the outer handler
+                rather than being warn-and-continued.
                 """
                 nonlocal stop_predicate_fired
-                if stop_when is None:
-                    return False
+                assert stop_when is not None  # call sites hoist the None guard
                 try:
                     fired = bool(stop_when(self.sim))
                 except Exception as e:
@@ -1497,8 +1504,9 @@ class PolicyRunner:
                         # the world reaching the condition - the rest of the
                         # in-flight chunk (and any prefetched chunk) is
                         # dropped; the executor shutdown below joins the
-                        # in-flight prefetch worker.
-                        if _stop_when_fired():
+                        # in-flight prefetch worker. The None guard is hoisted
+                        # so the no-clause hot path pays no per-step call.
+                        if stop_when is not None and _stop_when_fired():
                             break
                 finally:
                     # Wait for any in-flight inference so no background thread
@@ -1527,8 +1535,10 @@ class PolicyRunner:
                         # Semantic early return: checked after EVERY applied
                         # action (same cadence as the benchmark eval loop), so
                         # the remaining actions of the chunk are dropped as
-                        # soon as the condition holds.
-                        if _stop_when_fired():
+                        # soon as the condition holds. The None guard is
+                        # hoisted so the no-clause hot path pays no per-step
+                        # call.
+                        if stop_when is not None and _stop_when_fired():
                             break
                     if stop_predicate_fired:
                         break

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -1682,13 +1682,71 @@ def predicate_kind(name: str) -> str:
     return "unknown"
 
 
+def supports_body_lookup(sim: SimEngine) -> bool:
+    """Whether *sim*'s backend can resolve body names at all.
+
+    Body-referencing predicates resolve through ``get_body_state`` (MuJoCo
+    only at time of writing). On a backend without that method every
+    body-referencing predicate degrades to a constant ``False``, so callers
+    that arm such a predicate (e.g. ``run_policy(stop_when=...)``) should
+    check this up front and reject rather than silently never fire.
+
+    Args:
+        sim: The engine to probe.
+
+    Returns:
+        ``True`` when the backend implements ``get_body_state``.
+    """
+    return getattr(sim, "get_body_state", None) is not None
+
+
+def can_resolve_body(sim: SimEngine, body: str) -> bool:
+    """Whether *body* resolves in *sim* right now, via the predicate DSL's own lookup.
+
+    Uses the exact resolution path the body-referencing predicates use at
+    evaluation time (:func:`_body_position`), including the LIBERO
+    ``<name>_main`` fallback - so a ``True`` here means the predicate will
+    genuinely be evaluable against the live scene, and a ``False`` means it
+    would degrade to a constant ``False`` forever (a typo'd name, or a
+    backend without body lookups).
+
+    Args:
+        sim: The engine to probe.
+        body: The body name a predicate clause references.
+
+    Returns:
+        ``True`` when the lookup resolves to a position.
+    """
+    return _body_position(sim, body) is not None
+
+
+def can_resolve_joint(sim: SimEngine, joint: str) -> bool:
+    """Whether *joint* resolves in *sim* right now, via the predicate DSL's own lookup.
+
+    Mirrors :func:`can_resolve_body` for joint-referencing predicates
+    (``joint_above`` / ``joint_below``), using the same ``get_observation``
+    path the predicates use at evaluation time.
+
+    Args:
+        sim: The engine to probe.
+        joint: The joint name a predicate clause references.
+
+    Returns:
+        ``True`` when the lookup resolves to a value.
+    """
+    return _joint_position(sim, joint) is not None
+
+
 __all__ = [
     "PREDICATE_REGISTRY",
     "BoolPredicate",
     "PredicateFactory",
     "RewardTerm",
     "StatefulRewardTerm",
+    "can_resolve_body",
+    "can_resolve_joint",
     "make_predicate",
     "predicate_kind",
     "register_predicate",
+    "supports_body_lookup",
 ]

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -118,6 +118,7 @@ def run_policy(
     seed: int | None = None,
     policy_kwargs: dict[str, Any] | None = None,
     video: dict[str, Any] | None = None,
+    stop_when: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Roll out a policy for ``n_episodes`` x ``n_steps`` with per-episode parquet boundaries.
 
@@ -191,6 +192,19 @@ def run_policy(
             an ``_ep<i>`` suffix is inserted into the path stem so each
             episode writes its own MP4 instead of overwriting. The returned
             payload carries ``video_paths`` (the MP4s that landed on disk).
+        stop_when: Optional semantic early-return clause forwarded to every
+            per-episode :meth:`Simulation.run_policy` call: the episode ends
+            as soon as the condition holds in the sim, instead of only at the
+            ``n_steps`` budget - a per-episode success gate for collection
+            loops. Same predicate DSL as a benchmark spec's ``success``
+            clause: a single call ``{"predicate": "grasped", "body": "cube",
+            "gripper_prefix": "so100"}`` or an ``{"all": [...]}`` /
+            ``{"any": [...]}`` group. Validated against the closed predicate
+            registry up front (before any recording is started), so an
+            unknown predicate name is rejected with the valid list while
+            nothing has been set up yet. Each rollout's ``stopped_reason``
+            (``'predicate'`` | ``'budget'`` | ``'cancelled'`` | ``'error'``)
+            is reported per episode.
 
     Returns:
         Standard ``{status, content}`` payload. On success the payload
@@ -263,6 +277,21 @@ def run_policy(
         if mapping_error := policy_mapping_error(_value, _param):
             return _err(f"run_policy: {mapping_error}")
 
+    # Same reason again for the early-return clause: compile it against the
+    # closed predicate registry BEFORE step 2 starts a recording, so an
+    # unknown predicate name / bad kwargs is rejected while nothing has been
+    # set up yet (instead of leaving an empty dataset behind and reporting
+    # every episode as errored). The compiled callable is discarded - the
+    # facade recompiles per call - because the dict form is what the
+    # per-episode run_policy forwarding below passes through.
+    if stop_when is not None:
+        from strands_robots.simulation.benchmark_spec import compile_stop_when
+
+        try:
+            compile_stop_when(stop_when)
+        except ValueError as e:
+            return _err(f"run_policy: {e}")
+
     # ---- 2. Optional: start recording -----------------------------------
     recording_started = False
     if dataset_root is not None:
@@ -317,6 +346,7 @@ def run_policy(
                     policy_kwargs=policy_kwargs,
                     seed=ep_seed,
                     video=ep_video,
+                    stop_when=stop_when,
                 )
             except Exception as e:  # noqa: BLE001 - per-episode resilience
                 logger.exception("Episode %d/%d raised: %s", ep + 1, n_episodes, e)
@@ -325,13 +355,22 @@ def run_policy(
                     "content": [{"text": f"Episode {ep + 1} raised: {e!r}"}],
                 }
 
-            episodes.append(
-                {
-                    "index": ep,
-                    "status": rollout.get("status", "error"),
-                    "text": (rollout.get("content") or [{}])[0].get("text", "")[:500],
-                }
+            ep_record = {
+                "index": ep,
+                "status": rollout.get("status", "error"),
+                "text": (rollout.get("content") or [{}])[0].get("text", "")[:500],
+            }
+            # Surface the rollout's termination attribution so a caller
+            # gating episodes on stop_when can see which episodes hit the
+            # predicate vs. ran out of budget without re-parsing text.
+            rollout_json = next(
+                (blk["json"] for blk in rollout.get("content") or [] if isinstance(blk, dict) and "json" in blk),
+                None,
             )
+            if isinstance(rollout_json, dict) and "stopped_reason" in rollout_json:
+                ep_record["stopped_reason"] = rollout_json["stopped_reason"]
+                ep_record["steps_used"] = rollout_json.get("steps_used")
+            episodes.append(ep_record)
 
             # Per-episode parquet boundary. PR #716 wired this helper inside
             # PolicyRunner.evaluate() / _evaluate_with_spec(), but bare

--- a/tests/simulation/test_run_policy_stop_when.py
+++ b/tests/simulation/test_run_policy_stop_when.py
@@ -357,3 +357,153 @@ class TestStopWhenMultiEpisode:
         for ep in episodes:
             assert ep["stopped_reason"] == "predicate"
             assert 1 < ep["steps_used"] < 200
+
+    def test_multi_episode_payload_keeps_single_episode_shape(self, sim_with_robot_and_cube):
+        """One tool, ONE payload shape: the n_episodes>1 aggregate carries
+        stopped_reason + steps_used just like the single-episode payload
+        (plus per-episode attribution in stopped_reasons), so
+        payload['stopped_reason'] never becomes a KeyError when a caller
+        bumps n_episodes from 1 to 2."""
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            n_episodes=2,
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": 0.5},
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["stopped_reasons"] == ["predicate", "predicate"]
+        assert payload["steps_used"] == payload["total_steps"] > 0
+
+
+class TestStopWhenEntityProbe:
+    """A typo'd entity name must be an up-front structured error, not a clause
+    that compiles clean, silently never fires, and burns the whole budget
+    reporting stopped_reason='budget' (review on #1656, item 1)."""
+
+    def test_typo_body_rejected_before_rollout(self, sim_with_robot_and_cube):
+        t0 = sim_with_robot_and_cube._world.sim_time
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={"predicate": "body_above_z", "body": "cubee", "z": 0.2},
+        )
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "cubee" in text
+        assert "never fire" in text
+        assert _json_block(result)["stopped_reason"] == "error"
+        # Nothing ran: no budget was burned on the unresolvable clause.
+        assert sim_with_robot_and_cube._world.sim_time == t0
+
+    def test_typo_body_inside_group_rejected(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={
+                "all": [
+                    {"predicate": "body_above_z", "body": "cube", "z": 0.2},
+                    {"predicate": "body_below_z", "body": "cuve", "z": 2.0},
+                ]
+            },
+        )
+        assert result["status"] == "error", result
+        assert "cuve" in result["content"][0]["text"]
+
+    def test_typo_joint_rejected_before_rollout(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={"predicate": "joint_above", "joint": "alice/NoSuchJoint", "value": 0.5},
+        )
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "NoSuchJoint" in text
+        assert "get_observation" in text
+
+    def test_valid_names_pass_the_probe(self, sim_with_robot_and_cube):
+        """The probe must not reject clauses whose entities DO resolve - the
+        rollout proceeds and the predicate fires normally."""
+        joint = sim_with_robot_and_cube.robot_joint_names("alice")[0]
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=5,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={
+                "any": [
+                    {"predicate": "body_above_z", "body": "cube", "z": 1000.0},
+                    {"predicate": "joint_above", "joint": joint, "value": 1e9},
+                ]
+            },
+        )
+        assert result["status"] == "success", result
+        assert _json_block(result)["stopped_reason"] == "budget"
+
+    def test_backend_without_body_lookup_rejected(self):
+        """On a backend whose predicates cannot resolve bodies at all
+        (_body_position returns None unconditionally without get_body_state),
+        a body-referencing clause is rejected up front instead of silently
+        never firing."""
+        from tests.simulation.test_policy_kwargs_forwarding import FakeSim
+
+        sim = FakeSim()
+        result = sim.run_policy(
+            robot_name="fake_robot",
+            policy_provider="mock",
+            n_steps=5,
+            fast_mode=True,
+            stop_when={"predicate": "body_above_z", "body": "cube", "z": 0.2},
+        )
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "get_body_state" in text
+        assert _json_block(result)["stopped_reason"] == "error"
+
+
+class TestErrorResultsCarryJson:
+    """Every error exit path carries the stopped_reason='error' json block -
+    'recorded on ALL exit paths' (review on #1656, item 3)."""
+
+    def test_compile_rejection_carries_error_json(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=10,
+            fast_mode=True,
+            stop_when={"predicate": "levitated", "body": "cube"},
+        )
+        assert result["status"] == "error", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "error"
+        assert payload["steps_used"] == 0
+
+    def test_video_setup_failure_carries_error_json(self, sim_with_robot_and_cube, tmp_path):
+        """The video-writer failure return was text-only; it must carry the
+        same stopped_reason='error' json block as every other error exit."""
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=5,
+            control_frequency=50.0,
+            fast_mode=True,
+            video={"path": str(tmp_path / "out.mp4"), "camera": "no_such_camera"},
+        )
+        assert result["status"] == "error", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "error"
+        assert payload["steps_used"] == 0

--- a/tests/simulation/test_run_policy_stop_when.py
+++ b/tests/simulation/test_run_policy_stop_when.py
@@ -1,0 +1,359 @@
+"""End-to-end tests for ``run_policy(stop_when=...)`` + ``stopped_reason`` telemetry.
+
+The semantic early-return primitive (issue #1644, the Harness-VLA ``vla_act``
+pattern): a rollout ends as soon as the world reaches a predicate-DSL state,
+not only when the step budget runs out, and the result json attributes WHY the
+rollout ended (``stopped_reason``: ``"predicate"`` | ``"budget"`` |
+``"cancelled"`` | ``"error"``) plus ``steps_used`` so an agent can decide
+whether to retry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.policy_runner import CooperativeStop, PolicyRunner
+
+
+@pytest.fixture
+def sim_with_robot_and_cube():
+    """so100 + a dynamic cube spawned in the air (it free-falls under gravity),
+    giving a deterministic mid-rollout state change for the stop predicates."""
+    s = Simulation(tool_name="stop_when_test", mesh=False)
+    s.create_world()
+    s.add_robot(name="alice", data_config="so100")
+    r = s.add_object(name="cube", shape="box", position=[0.4, 0.0, 1.0], size=[0.05, 0.05, 0.05])
+    assert r["status"] == "success", r
+    yield s
+    s.cleanup()
+
+
+def _json_block(result: dict) -> dict:
+    return next(c["json"] for c in result["content"] if isinstance(c, dict) and "json" in c)
+
+
+class TestStopWhenPredicate:
+    def test_already_true_predicate_stops_after_first_step(self, sim_with_robot_and_cube):
+        """body_above_z holds from step 1 (cube spawns at z=1.0) -> the rollout
+        returns after exactly one applied action, not the 200-step budget."""
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            instruction="pick up the cube",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={"predicate": "body_above_z", "body": "cube", "z": 0.5},
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["stopped_early"] is True
+        assert payload["steps_used"] == 1
+        assert payload["n_steps"] == 1
+        assert "stop_when" in result["content"][0]["text"]
+
+    def test_predicate_fires_mid_rollout_on_world_state_change(self, sim_with_robot_and_cube):
+        """The falling cube crosses z=0.5 after ~16 control steps; the rollout
+        stops there - well before the 200-step budget - proving the clause is
+        checked against the LIVE sim after every applied action."""
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": 0.5},
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["stopped_early"] is True
+        # False on step 1 (cube at z=1.0), true once fallen past 0.5 m.
+        assert 1 < payload["steps_used"] < 200
+
+    def test_group_clause_is_accepted(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={
+                "all": [
+                    {"predicate": "body_above_z", "body": "cube", "z": 0.5},
+                    {"predicate": "body_below_z", "body": "cube", "z": 2.0},
+                ]
+            },
+        )
+        assert result["status"] == "success", result
+        assert _json_block(result)["stopped_reason"] == "predicate"
+
+
+class TestStoppedReasonBudget:
+    def test_budget_exhaustion_reports_budget(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=5,
+            control_frequency=50.0,
+            fast_mode=True,
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "budget"
+        assert payload["stopped_early"] is False
+        assert payload["steps_used"] == 5
+
+    def test_never_firing_predicate_runs_to_budget(self, sim_with_robot_and_cube):
+        """An armed-but-never-true clause must not change rollout semantics:
+        full budget, stopped_reason='budget'."""
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=5,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={"predicate": "body_above_z", "body": "cube", "z": 1000.0},
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "budget"
+        assert payload["steps_used"] == 5
+
+
+class TestStoppedReasonCancelled:
+    def test_cooperative_stop_reports_cancelled(self, sim_with_robot_and_cube):
+        """The existing CooperativeStop path (stop_policy's mechanism) is
+        re-tagged 'cancelled' - distinguishable from a predicate hit."""
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot_and_cube.robot_joint_names("alice"))
+
+        def cancel_at_step_3(step: int, obs: dict, action: dict) -> None:
+            if step >= 2:
+                raise CooperativeStop("user stop")
+
+        result = PolicyRunner(sim_with_robot_and_cube).run(
+            "alice",
+            policy,
+            duration=1.0,
+            control_frequency=50.0,
+            fast_mode=True,
+            on_frame=cancel_at_step_3,
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "cancelled"
+        assert payload["stopped_early"] is True
+        assert payload["steps_used"] < 50
+
+
+class TestStoppedReasonError:
+    def test_raising_stop_when_is_fatal_and_reports_error(self, sim_with_robot_and_cube):
+        """A raising clause means the early-return contract can no longer be
+        honored - the rollout aborts (status=error, stopped_reason='error')
+        instead of silently running to budget."""
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot_and_cube.robot_joint_names("alice"))
+
+        def boom(sim) -> bool:
+            raise RuntimeError("predicate exploded")
+
+        result = PolicyRunner(sim_with_robot_and_cube).run(
+            "alice",
+            policy,
+            duration=1.0,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when=boom,
+        )
+        assert result["status"] == "error", result
+        assert "stop_when predicate raised" in result["content"][0]["text"]
+        assert _json_block(result)["stopped_reason"] == "error"
+
+    def test_rollout_failure_reports_error_reason(self, sim_with_robot_and_cube):
+        """Any error result carries stopped_reason='error' (here: the fail-fast
+        probe on a policy whose keys resolve to no actuator)."""
+
+        class _WrongKeysPolicy(MockPolicy):
+            async def get_actions(self, observation_dict, instruction, **kwargs):
+                return [{"not_a_joint": 0.5}]
+
+        policy = _WrongKeysPolicy()
+        result = PolicyRunner(sim_with_robot_and_cube).run(
+            "alice",
+            policy,
+            duration=1.0,
+            control_frequency=50.0,
+            fast_mode=True,
+        )
+        assert result["status"] == "error", result
+        assert _json_block(result)["stopped_reason"] == "error"
+
+
+class TestStopWhenValidation:
+    def test_unknown_predicate_rejected_before_rollout(self, sim_with_robot_and_cube):
+        """An unknown predicate name is a structured caller error naming the
+        valid registry set - and nothing runs (sim time unchanged)."""
+        t0 = sim_with_robot_and_cube._world.sim_time
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=50,
+            fast_mode=True,
+            stop_when={"predicate": "levitated", "body": "cube"},
+        )
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "Unknown predicate 'levitated'" in text
+        assert "grasped" in text  # the valid list is enumerated
+        assert sim_with_robot_and_cube._world.sim_time == t0
+
+    def test_empty_clause_rejected(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=50,
+            fast_mode=True,
+            stop_when={},
+        )
+        assert result["status"] == "error", result
+        assert "never fire" in result["content"][0]["text"]
+
+    def test_float_reward_term_rejected(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=50,
+            fast_mode=True,
+            stop_when={"predicate": "distance_neg", "body_a": "cube", "body_b": "cube"},
+        )
+        assert result["status"] == "error", result
+        assert "reward term" in result["content"][0]["text"]
+
+
+class TestStopWhenAsyncRtc:
+    def test_async_rtc_stops_within_one_step_of_condition(self, sim_with_robot_and_cube):
+        """The async-RTC path checks the clause after EVERY applied action, so
+        an already-true condition ends the rollout after one step even though
+        MockPolicy emits 8-action chunks - pinning the documented one-control-
+        step latency bound (the rest of the chunk is dropped)."""
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot_and_cube.robot_joint_names("alice"))
+        result = PolicyRunner(sim_with_robot_and_cube).run(
+            "alice",
+            policy,
+            duration=1.0,
+            control_frequency=50.0,
+            fast_mode=True,
+            async_rtc=True,
+            stop_when=lambda sim: True,
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["steps_used"] == 1
+
+
+class TestStopWhenToolDispatch:
+    def test_dispatch_chain_forwards_stop_when(self, sim_with_robot_and_cube):
+        """The agent-tool dispatch surface must forward stop_when all the way
+        through (AGENTS.md: no silent kwarg drop) - a dispatched run_policy
+        with an already-true clause returns after one step."""
+        result = sim_with_robot_and_cube._dispatch_action(
+            "run_policy",
+            {
+                "action": "run_policy",
+                "robot_name": "alice",
+                "policy_provider": "mock",
+                "n_steps": 100,
+                "control_frequency": 50.0,
+                "fast_mode": True,
+                "stop_when": {"predicate": "body_above_z", "body": "cube", "z": 0.5},
+            },
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "predicate"
+        assert payload["steps_used"] == 1
+
+    def test_dispatch_rejects_unknown_predicate(self, sim_with_robot_and_cube):
+        result = sim_with_robot_and_cube._dispatch_action(
+            "run_policy",
+            {
+                "action": "run_policy",
+                "robot_name": "alice",
+                "policy_provider": "mock",
+                "n_steps": 10,
+                "fast_mode": True,
+                "stop_when": {"predicate": "levitated", "body": "cube"},
+            },
+        )
+        assert result["status"] == "error", result
+        assert "Unknown predicate" in result["content"][0]["text"]
+
+
+class TestStopWhenRecordingInterplay:
+    def test_recorded_frame_count_equals_steps_used(self, sim_with_robot_and_cube, tmp_path):
+        """stop_when composes with an active recording session: frames are
+        captured up to the stop, so the reopened dataset's frame count equals
+        the result's steps_used (round-trip, per AGENTS.md recording rules)."""
+        from strands_robots.dataset_recorder import has_lerobot_dataset
+
+        if not has_lerobot_dataset():
+            pytest.skip("lerobot not installed")
+
+        sim = sim_with_robot_and_cube
+        root = str(tmp_path / "stopwhen_ds")
+        r = sim.start_recording(repo_id="local/stopwhen", fps=50, root=root, overwrite=True)
+        assert r["status"] == "success", r
+
+        result = sim.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            instruction="wait for the cube to fall",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": 0.5},
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["stopped_reason"] == "predicate"
+        steps_used = payload["steps_used"]
+        assert 1 < steps_used < 200
+
+        assert sim.stop_recording()["status"] == "success"
+
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        ds = LeRobotDataset(repo_id="local/stopwhen", root=root)
+        assert ds.meta.total_frames == steps_used
+        assert ds.meta.total_episodes == 1
+
+
+class TestStopWhenMultiEpisode:
+    def test_stop_when_gates_every_episode(self, sim_with_robot_and_cube):
+        """n_episodes>1 forwards the compiled clause to every per-episode
+        rollout (reset_between re-arms the falling cube), giving collection
+        loops a per-episode success gate."""
+        result = sim_with_robot_and_cube.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            n_steps=200,
+            control_frequency=50.0,
+            fast_mode=True,
+            n_episodes=2,
+            stop_when={"predicate": "body_below_z", "body": "cube", "z": 0.5},
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        episodes = payload["episodes"]
+        assert len(episodes) == 2
+        for ep in episodes:
+            assert ep["stopped_reason"] == "predicate"
+            assert 1 < ep["steps_used"] < 200

--- a/tests/simulation/test_stop_when_compile.py
+++ b/tests/simulation/test_stop_when_compile.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``compile_stop_when`` - the ``run_policy(stop_when=...)`` compiler.
+
+Pure DSL-compilation behaviour against fake sims; no physics backend needed.
+The end-to-end ``run_policy`` integration (early return, ``stopped_reason``
+telemetry, recording interplay, tool dispatch) lives in
+``tests/simulation/test_run_policy_stop_when.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.benchmark_spec import compile_stop_when
+
+
+class _BodyStateSim:
+    """Minimal sim exposing ``get_body_state`` for body_* predicates."""
+
+    def __init__(self, positions: dict[str, list[float]]):
+        self._pos = positions
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        if body_name not in self._pos:
+            return {"status": "error", "content": [{"text": f"Body '{body_name}' not found."}]}
+        return {
+            "status": "success",
+            "content": [
+                {"text": f"body {body_name}"},
+                {"json": {"position": self._pos[body_name], "quaternion": [1, 0, 0, 0], "mass": 1.0}},
+            ],
+        }
+
+    def get_observation(self, *_: Any, **__: Any) -> dict[str, Any]:
+        return {}
+
+
+class TestCompileSingleCall:
+    def test_single_predicate_call_compiles_and_evaluates(self):
+        fn = compile_stop_when({"predicate": "body_above_z", "body": "cube", "z": 0.2})
+        assert fn(_BodyStateSim({"cube": [0, 0, 0.5]})) is True
+        assert fn(_BodyStateSim({"cube": [0, 0, 0.1]})) is False
+
+    def test_all_group_requires_every_predicate(self):
+        fn = compile_stop_when(
+            {
+                "all": [
+                    {"predicate": "body_above_z", "body": "cube", "z": 0.2},
+                    {"predicate": "body_below_z", "body": "cube", "z": 0.8},
+                ]
+            }
+        )
+        assert fn(_BodyStateSim({"cube": [0, 0, 0.5]})) is True
+        assert fn(_BodyStateSim({"cube": [0, 0, 0.9]})) is False
+
+    def test_any_group_requires_one_predicate(self):
+        fn = compile_stop_when(
+            {
+                "any": [
+                    {"predicate": "body_above_z", "body": "cube", "z": 0.8},
+                    {"predicate": "body_below_z", "body": "cube", "z": 0.2},
+                ]
+            }
+        )
+        assert fn(_BodyStateSim({"cube": [0, 0, 0.1]})) is True
+        assert fn(_BodyStateSim({"cube": [0, 0, 0.5]})) is False
+
+
+class TestCompileRejections:
+    """Every rejected shape gets an actionable ValueError - a clause that
+    silently never fires would run the rollout to its full budget while the
+    caller believes the gate is armed."""
+
+    def test_non_dict_rejected(self):
+        with pytest.raises(ValueError, match="stop_when"):
+            compile_stop_when("grasped")  # type: ignore[arg-type]
+
+    def test_empty_dict_rejected(self):
+        with pytest.raises(ValueError, match="never fire"):
+            compile_stop_when({})
+
+    def test_empty_all_any_lists_rejected(self):
+        with pytest.raises(ValueError, match="never fire"):
+            compile_stop_when({"all": []})
+        with pytest.raises(ValueError, match="never fire"):
+            compile_stop_when({"any": []})
+
+    def test_mixed_single_call_and_group_rejected(self):
+        with pytest.raises(ValueError, match="not both"):
+            compile_stop_when(
+                {
+                    "predicate": "body_above_z",
+                    "body": "cube",
+                    "z": 0.2,
+                    "all": [{"predicate": "body_upright", "body": "cube"}],
+                }
+            )
+
+    def test_unknown_top_level_keys_rejected(self):
+        with pytest.raises(ValueError, match="unknown keys"):
+            compile_stop_when({"when": [{"predicate": "body_above_z", "body": "cube", "z": 0.2}]})
+
+    def test_unknown_predicate_name_lists_valid_set(self):
+        with pytest.raises(ValueError, match="Unknown predicate 'levitated'.*grasped"):
+            compile_stop_when({"predicate": "levitated", "body": "cube"})
+
+    def test_float_reward_term_rejected(self):
+        # A float-valued term reads as bool(<nonzero float>) == always-True and
+        # would stop the rollout on step 1 - the same guard the benchmark
+        # success clause applies.
+        with pytest.raises(ValueError, match="reward term"):
+            compile_stop_when({"predicate": "distance_neg", "body_a": "a", "body_b": "b"})
+
+    def test_bad_predicate_kwargs_rejected(self):
+        with pytest.raises(ValueError, match="body_above_z"):
+            compile_stop_when({"predicate": "body_above_z", "altitude": 0.2})

--- a/tests/simulation/test_stop_when_compile.py
+++ b/tests/simulation/test_stop_when_compile.py
@@ -115,3 +115,45 @@ class TestCompileRejections:
     def test_bad_predicate_kwargs_rejected(self):
         with pytest.raises(ValueError, match="body_above_z"):
             compile_stop_when({"predicate": "body_above_z", "altitude": 0.2})
+
+
+class TestReferencedEntities:
+    """``stop_when_referenced_entities`` - the walker behind the pre-rollout
+    scene probe (a typo'd body must not compile into a clause that silently
+    never fires)."""
+
+    def test_single_call_body(self):
+        from strands_robots.simulation.benchmark_spec import stop_when_referenced_entities
+
+        bodies, joints = stop_when_referenced_entities({"predicate": "body_above_z", "body": "cube", "z": 0.2})
+        assert bodies == ["cube"]
+        assert joints == []
+
+    def test_group_collects_all_name_kwargs_deduplicated(self):
+        from strands_robots.simulation.benchmark_spec import stop_when_referenced_entities
+
+        clause = {
+            "all": [
+                {"predicate": "distance_less_than", "body_a": "cube", "body_b": "tray", "threshold": 0.1},
+                {"predicate": "body_inside", "body": "cube", "container": "bin"},
+                {"predicate": "joint_above", "joint": "so100/Jaw", "value": 0.5},
+            ]
+        }
+        bodies, joints = stop_when_referenced_entities(clause)
+        assert bodies == ["cube", "tray", "bin"]
+        assert joints == ["so100/Jaw"]
+
+    def test_non_name_kwargs_ignored(self):
+        from strands_robots.simulation.benchmark_spec import stop_when_referenced_entities
+
+        # gripper_prefix / z / geoms are not probeable entity names.
+        bodies, joints = stop_when_referenced_entities(
+            {
+                "any": [
+                    {"predicate": "grasped", "body": "cube", "gripper_prefix": "so100"},
+                    {"predicate": "contact_between", "geom_a": "g1", "geom_b": "g2"},
+                ]
+            }
+        )
+        assert bodies == ["cube"]
+        assert joints == []

--- a/tests/tools/test_run_policy.py
+++ b/tests/tools/test_run_policy.py
@@ -725,3 +725,69 @@ class TestSuccessPayloadContentShape:
             "episodes",
         ):
             assert key in payload, f"success payload missing contract key {key!r}"
+
+
+class TestStopWhenPassThrough:
+    """The ``stop_when`` early-return clause (#1644) on the tool wrapper.
+
+    The wrapper forwards the dict verbatim to every per-episode
+    ``Simulation.run_policy`` call (no silent kwarg drop) and validates it
+    against the closed predicate registry BEFORE any recording is started, so
+    an unknown predicate never leaves an empty dataset behind.
+    """
+
+    def test_stop_when_forwarded_to_every_episode(self) -> None:
+        sim = _FakeSim()
+        clause = {"predicate": "body_above_z", "body": "cube", "z": 0.2}
+        result = run_policy(sim, n_episodes=3, n_steps=5, dataset_root=None, stop_when=clause)
+
+        assert result["status"] == "success"
+        assert len(sim.run_policy_calls) == 3
+        for call in sim.run_policy_calls:
+            assert call["stop_when"] == clause
+
+    def test_default_none_forwards_none(self) -> None:
+        sim = _FakeSim()
+        run_policy(sim, n_episodes=1, n_steps=5, dataset_root=None)
+        assert sim.run_policy_calls[0]["stop_when"] is None
+
+    def test_unknown_predicate_rejected_before_recording_starts(self, tmp_path: Path) -> None:
+        sim = _FakeSim()
+        result = run_policy(
+            sim,
+            n_episodes=1,
+            n_steps=5,
+            dataset_root=str(tmp_path / "ds"),
+            stop_when={"predicate": "levitated", "body": "cube"},
+        )
+
+        assert result["status"] == "error"
+        assert "Unknown predicate" in result["content"][0]["text"]
+        # Fail-early contract: nothing was set up, nothing ran.
+        assert sim.start_recording_calls == []
+        assert sim.run_policy_calls == []
+
+    def test_episode_records_surface_stopped_reason(self) -> None:
+        class _ReasonSim(_FakeSim):
+            def run_policy(self, **kwargs: Any) -> dict[str, Any]:
+                self.run_policy_calls.append(kwargs)
+                return {
+                    "status": "success",
+                    "content": [
+                        {"text": "rollout"},
+                        {"json": {"stopped_reason": "predicate", "steps_used": 7}},
+                    ],
+                }
+
+        sim = _ReasonSim()
+        result = run_policy(
+            sim,
+            n_episodes=1,
+            n_steps=50,
+            dataset_root=None,
+            stop_when={"predicate": "body_above_z", "body": "cube", "z": 0.2},
+        )
+        assert result["status"] == "success"
+        episodes = result["content"][1]["json"]["episodes"]
+        assert episodes[0]["stopped_reason"] == "predicate"
+        assert episodes[0]["steps_used"] == 7


### PR DESCRIPTION
Closes #1644.

## What

Adds a semantic early-return condition to `run_policy`: `stop_when=` accepts a predicate-DSL clause (same schema as benchmark `success:` clauses), so a rollout terminates as soon as the world reaches a state - not only when a step budget runs out - plus `stopped_reason` telemetry attributing WHY the rollout ended. This is the Harness VLA `vla_act` pattern (arXiv:2607.08448): it turns a monolithic policy rollout into a retryable primitive an agent can stage -> invoke -> inspect -> re-invoke.

```python
sim.run_policy(robot_name="so100", policy_provider="lerobot_local",
               policy_config={...}, instruction="pick up the red cube",
               max_steps=200,
               stop_when={"predicate": "grasped", "body": "cube", "gripper_prefix": "so100"})
# result json: {"stopped_reason": "predicate", "steps_used": 37, ...}
```

## How

- **`compile_stop_when()`** (new, `benchmark_spec.py`): compiles a single `{"predicate": <name>, ...}` call or an `{"all"/"any": [...]}` group through the existing `_compile_call` / `_compile_bool_group` path - the closed predicate registry, never `eval`/`exec`. Rejected up front with actionable errors: unknown predicate names (message lists the valid set), float-valued reward terms (would read as always-`True`), empty/never-firing clauses, mixed single-call+group shapes, unknown keys.
- **`PolicyRunner.run(stop_when=callable)`**: the clause is checked against the LIVE sim after every applied action on **both** the synchronous and async-RTC paths - matching the benchmark eval cadence, and giving a documented early-return latency bound of **one control step** regardless of chunk length (the rest of an in-flight chunk is dropped; the async prefetch worker is still joined before returning). A raising clause is fatal (`status=error`), never warn-and-continue: the caller asked for early-return semantics the runner can no longer honor.
- **`stopped_reason` + `steps_used` in the result json**: `"predicate"` (the clause fired) | `"budget"` (horizon exhausted) | `"cancelled"` (the existing `CooperativeStop` / `stop_policy` path, re-tagged) | `"error"` (all error results, including the exception path and the all-unresolved-keys path). `stopped_early` no longer conflates user cancellation with everything else - this is the paper's Figure-6 completion attribution made queryable.
- **Wiring**: `SimEngine.run_policy` accepts a DSL dict (tool surface) or a callable (programmatic callers, mirroring `PolicyRunner.evaluate`), compiles/validates BEFORE any policy is created (no error after an expensive weight download); forwarded through `_run_episodes` (per-episode success gate for multi-episode collection), the MuJoCo `run_policy` override, `tool_spec.json`, `describe()`, and the `run_policy` `@tool` wrapper (validated before any recording is started; per-episode `stopped_reason` surfaced in the payload). No silent kwarg drops anywhere in the dispatch chain.
- **Recording interplay**: composes with an active recording session - frames are captured up to the stop, `save_episode` semantics unchanged, so a recorded episode's frame count equals `steps_used`. This is the per-rollout half of #1533's collect_dataset success gating.

## Acceptance criteria (from the issue)

- [x] `run_policy(stop_when=...)` returns early with `stopped_reason="predicate"` when the condition fires; regression tests with `body_above_z` (fires at step 1) and a falling-cube `body_below_z` (fires mid-rollout on genuine world-state change, `1 < steps_used < budget`).
- [x] Budget exhaustion returns `stopped_reason="budget"` (including with an armed-but-never-firing clause); the existing `CooperativeStop` path is re-tagged `"cancelled"`.
- [x] Works identically under recording: round-trip test records with `stop_when`, reopens the LeRobotDataset, asserts `total_frames == steps_used`.
- [x] `stop_when` forwarded through the tool dispatch chain (`_dispatch_action` test) and the `@tool` wrapper (pass-through test), validated against the registry with a clear error naming the valid set on unknown predicates.
- [x] Async-RTC path honors the stop within one chunk-slice - actually within ONE control step (test pins `steps_used == 1` against MockPolicy's 8-action chunks); the bound is documented in the `PolicyRunner.run` docstring.

## Non-goals (unchanged, per the issue)

- No changes to `eval_policy` / `evaluate_benchmark` semantics.
- No arbitrary-callable injection through the tool surface (predicate-DSL dicts only; programmatic callers may pass a callable).

## Test surface

- `tests/simulation/test_stop_when_compile.py` (11 tests): DSL compile behaviour + every rejection shape, no physics backend needed.
- `tests/simulation/test_run_policy_stop_when.py` (16 tests): early fire, mid-rollout fire, group clauses, budget, cancelled, error (raising clause + rollout failure), validation-before-rollout (sim time unchanged), async-RTC latency bound, tool dispatch forwarding, LeRobot recording round-trip, multi-episode per-episode gating.
- `tests/tools/test_run_policy.py` (+4 tests): wrapper pass-through to every episode, `None` default, fail-before-recording on unknown predicate, per-episode `stopped_reason` surfacing.

`hatch run lint` clean; `hatch run test`: **12016 passed, 245 skipped, 0 failed** (full suite).

## Out of scope / follow-ups

- `start_policy` (background thread) does not accept `stop_when` yet - dispatch rejects it loudly there (unknown-parameter error), no silent drop. Can follow up if the async surface needs the gate.
- Hardware `run_policy` unchanged (predicates evaluate against sim state).
- The umbrella epic's staging/analytic-primitives items are tracked separately.

Project board: please move #1644 to "In review" (item on the Strands Labs - Robots board).
