### PR TITLE
fix(hardware): SO-101 real-hardware support for camera fourcc + sim-embodiment policies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,24 +196,17 @@ lerobot-async = [
     "lerobot[async]>=0.6.0,<0.7.0",
 ]
 # MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
-# MolmoAct2Policy class ships in lerobot >= 0.6 (it landed via lerobot PR #3604
-# after the 0.5.1 PyPI release), so `strands-robots[molmoact2]` now resolves it
-# straight from PyPI through the `strands-robots[lerobot]` (>=0.6) pin -- no
-# git-source step. This extra layers the auxiliary deps MolmoAct2's
-# modeling/processor code needs on top of lerobot core -- transformers
-# (Qwen2Tokenizer + the sharded safetensors loader), peft, scipy -- mirroring
-# lerobot's own [molmoact2] extra.
+# MolmoAct2Policy ships in lerobot >= 0.6 (landed via lerobot PR #3604). Rather
+# than hand-mirror lerobot's aux-dep pins here (transformers/peft/scipy) -- which
+# silently drifts whenever lerobot bumps them -- we defer entirely to lerobot's
+# own ``[molmoact2]`` extra. That extra pulls lerobot[transformers-dep],
+# lerobot[peft-dep], lerobot[scipy-dep] at exactly the versions the MolmoAct2
+# modeling/processor code was built against, so the two stay in lock-step by
+# construction. The base ``strands-robots[lerobot]`` pin (>=0.6.0,<0.7.0) already
+# fixes the lerobot floor; ``lerobot[molmoact2]`` just adds the aux deps.
 molmoact2 = [
     "strands-robots[lerobot]",
-    # Mirror lerobot's own [molmoact2] dep pins exactly. The transformers
-    # floor MUST match lerobot[transformers-dep] (>=5.4.0,<5.6.0): MolmoAct2's
-    # modeling/processor code uses transformers 5.4+ APIs, and a looser floor
-    # (e.g. >=4.46) lets a resolver pick an incompatible transformers that
-    # imports fine -- passing the importability guard in molmoact2.build_policy
-    # -- then dead-ends deep inside lerobot model construction.
-    "transformers>=5.4.0,<5.6.0",
-    "peft>=0.18.0,<1.0.0",
-    "scipy>=1.14.0,<2.0.0",
+    "lerobot[molmoact2]>=0.6.0,<0.7.0",
 ]
 sim = [
     "robot_descriptions>=1.11.0,<2.0.0",

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -698,7 +698,7 @@ class Robot(TeleopMixin, AgentTool):
             for name, config in cameras.items():
                 cam_type = config.get("type", "opencv")
                 if cam_type == "opencv":
-                    camera_configs[name] = OpenCVCameraConfig(
+                    _cam_kwargs = dict(
                         index_or_path=config["index_or_path"],
                         fps=config.get("fps", 30),
                         width=config.get("width", 640),
@@ -706,6 +706,12 @@ class Robot(TeleopMixin, AgentTool):
                         rotation=config.get("rotation", 0),
                         color_mode=config.get("color_mode", "rgb"),
                     )
+                    # Forward fourcc (e.g. "MJPG") when provided so high-res
+                    # cameras can hit 30fps -- many UVC cams only offer 30fps
+                    # under MJPG; the YUYV default caps at ~5fps @1080p.
+                    if config.get("fourcc") is not None:
+                        _cam_kwargs["fourcc"] = config["fourcc"]
+                    camera_configs[name] = OpenCVCameraConfig(**_cam_kwargs)
                 else:
                     raise ValueError(f"Unsupported camera type: {cam_type}")
 

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -374,9 +374,39 @@ def register_pack_state_step() -> type | None:
                     missing.append(k)
 
             if present == 0:
-                # No declared state key present at all; leave obs alone so a
-                # clearer downstream error (or a state-less policy) can handle
-                # it, rather than emitting an all-zero state vector.
+                # None of the DECLARED state_keys are present. The canonical
+                # trigger is a SIM embodiment (e.g. so101: state_keys ['1'..'6'])
+                # driven from REAL hardware, whose observation carries
+                # '<motor>.pos' scalar keys instead (lerobot SOFollower). Rather
+                # than dead-end with "requires observation.state", fall back to
+                # the hardware '.pos' keys so ``embodiment="so101"`` works on the
+                # physical arm too - not only in sim.
+                #
+                # Hardware '.pos' values are ALREADY in the model's training
+                # units (so_follower MotorNormMode: arm DEGREES, gripper
+                # RANGE_0_100), so we pack them RAW and DO NOT apply the
+                # sim-radian -> model-degree conversion below (that would
+                # double-convert). Observation insertion order is lerobot motor
+                # order (shoulder_pan..gripper), which matches the positional
+                # sim state_keys, so a straight collection is index-aligned.
+                pos_keys = [
+                    k
+                    for k in observation
+                    if k.endswith(".pos")
+                    and isinstance(observation[k], (int, float, np.floating, np.ndarray))
+                    and (not isinstance(observation[k], np.ndarray) or observation[k].ndim == 0)
+                ]
+                if len(pos_keys) >= len(self.state_keys) and self.state_keys:
+                    n = len(self.state_keys)
+                    hw_vals = [float(observation[k]) for k in pos_keys[:n]]
+                    target = self.expected_dim or len(hw_vals)
+                    hw_vals = reconcile_dim(hw_vals, target, self.dim_policy, label="observation.state")
+                    out = {k: v for k, v in observation.items() if k not in pos_keys[:n]}
+                    out["observation.state"] = torch.as_tensor(hw_vals, dtype=torch.float32)
+                    return out
+                # No declared state key AND no usable '.pos' fallback; leave obs
+                # alone so a clearer downstream error (or a state-less policy)
+                # can handle it, rather than emitting an all-zero state vector.
                 return observation
 
             if missing:

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1732,6 +1732,38 @@ class LerobotLocalPolicy(Policy):
         if instruction and "task" not in observation:
             observation["task"] = instruction
 
+        # Detect REAL-hardware observations: lerobot SOFollower & friends key
+        # joint scalars as '<motor>.pos'. When a SIM embodiment (numeric/ named
+        # sim joints) is driven from hardware, the action tensor must still be
+        # emitted under these '.pos' names (and WITHOUT the sim unit conversion)
+        # so SOFollower.send_action accepts it. We capture the '.pos' order here
+        # (lerobot motor order) and thread it into _tensor_to_action_dicts. When
+        # the embodiment's own action_keys are ALREADY '.pos' (e.g. so_real /
+        # so101_follower) this is a harmless no-op override with identical keys.
+        _hw_action_keys: list[str] | None = None
+        if (
+            self._embodiment is not None
+            and self._embodiment.action_keys
+            and not any(str(k).endswith(".pos") for k in self._embodiment.action_keys)
+        ):
+            _pos = [
+                k
+                for k in observation_dict
+                if isinstance(k, str) and k.endswith(".pos") and isinstance(observation_dict[k], (int, float))
+            ]
+            # numpy scalar / 0-d support (np imported at module top)
+            if not _pos:
+                _pos = [
+                    k
+                    for k in observation_dict
+                    if isinstance(k, str)
+                    and k.endswith(".pos")
+                    and isinstance(observation_dict[k], (np.floating, np.ndarray))
+                    and (not isinstance(observation_dict[k], np.ndarray) or observation_dict[k].ndim == 0)
+                ]
+            if len(_pos) >= len(self._embodiment.action_keys):
+                _hw_action_keys = _pos[: len(self._embodiment.action_keys)]
+
         # When the processor bridge has a preprocessor, delegate normalization
         # and tokenization to it, then fix up any remaining raw arrays/tensors
         # that the pipeline did not convert (e.g. images left as HWC uint8
@@ -1812,7 +1844,7 @@ class LerobotLocalPolicy(Policy):
         if self._processor_bridge and self._processor_bridge.has_postprocessor:
             action_tensor = self._processor_bridge.postprocess(action_tensor)
 
-        return self._tensor_to_action_dicts(action_tensor)
+        return self._tensor_to_action_dicts(action_tensor, hw_action_keys=_hw_action_keys)
 
     # Observation batch building
 
@@ -2606,7 +2638,9 @@ class LerobotLocalPolicy(Policy):
             return True
         return type(policy).__name__ == "MolmoAct2Policy"
 
-    def _tensor_to_action_dicts(self, action_tensor: torch.Tensor) -> list[dict[str, Any]]:
+    def _tensor_to_action_dicts(
+        self, action_tensor: torch.Tensor, hw_action_keys: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Convert action tensor to list of robot action dicts.
 
         Maps tensor values to robot_state_keys by index. Handles:
@@ -2675,18 +2709,29 @@ class LerobotLocalPolicy(Policy):
         # arm freezes. EmbodimentMap.model_action_to_sim is a no-op when
         # action_units == "native" (the default / real-hardware path).
         emb = self._embodiment
-        convert = emb is not None and getattr(emb, "action_units", "native") != "native"
+        # HARDWARE OVERRIDE: when the caller detected real-hardware '.pos' obs
+        # keys (see get_actions), emit actions under those '.pos' names and SKIP
+        # the sim unit conversion. A SIM embodiment (e.g. so101, action_units=
+        # "degrees") would otherwise (a) key the action by numeric sim joints
+        # ('1'..'6') that the lerobot SOFollower.send_action does not accept, and
+        # (b) convert model DEGREES -> sim RADIANS, feeding ~0.003 rad to a
+        # hardware bus that expects degrees. Both are wrong on the physical arm.
+        # The '.pos' keys are already the model's native units, so pack raw.
+        if hw_action_keys:
+            out_keys = list(hw_action_keys)
+            convert = False
+        else:
+            out_keys = list(self.robot_state_keys)
+            convert = emb is not None and getattr(emb, "action_units", "native") != "native"
 
         result = []
         for action_values in actions_list:
-            vals = [
-                float(action_values[i]) if i < len(action_values) else 0.0 for i in range(len(self.robot_state_keys))
-            ]
+            vals = [float(action_values[i]) if i < len(action_values) else 0.0 for i in range(len(out_keys))]
             # `convert` already implies `emb is not None`; the explicit guard lets
             # the type checker narrow `emb` from `EmbodimentMap | None` at the call.
             if convert and emb is not None:
                 vals = emb.model_action_to_sim(vals)
-            action_dict = {key: vals[index] for index, key in enumerate(self.robot_state_keys)}
+            action_dict = {key: vals[index] for index, key in enumerate(out_keys)}
             result.append(action_dict)
 
         return result

--- a/tests/policies/lerobot_local/test_declarative_obs_image_canonicalization.py
+++ b/tests/policies/lerobot_local/test_declarative_obs_image_canonicalization.py
@@ -127,7 +127,7 @@ def test_declarative_branch_uses_source_keys_for_bare_camera():
         return False
 
     p._requires_action_chunk = _no_chunk
-    p._tensor_to_action_dicts = lambda t: [{"ok": True}]
+    p._tensor_to_action_dicts = lambda t, *a, **k: [{"ok": True}]
 
     obs = {"front": np.ones((64, 64, 3), dtype=np.uint8) * 255}
     p.get_actions_sync(obs, "pick up the cube")

--- a/tests/test_customer_workflow_regressions.py
+++ b/tests/test_customer_workflow_regressions.py
@@ -93,43 +93,43 @@ class TestMolmoact2Extra:
         joined = " ".join(extras["molmoact2"])
         # Builds on the [lerobot] extra (which carries lerobot[feetech]).
         assert "strands-robots[lerobot]" in joined
-        # The auxiliary deps MolmoAct2 modeling/processor code imports.
-        assert "transformers" in joined
-        assert "peft" in joined
-        assert "scipy" in joined
+        # The auxiliary deps MolmoAct2's modeling/processor code imports
+        # (transformers/peft/scipy) are layered via lerobot's OWN [molmoact2]
+        # extra rather than hand-mirrored here, so they stay in lock-step with
+        # lerobot instead of drifting when lerobot bumps them.
+        assert "lerobot[molmoact2]" in joined
 
     def test_molmoact2_transformers_pin_matches_lerobot(self):
-        """The transformers pin must match lerobot's [transformers-dep] floor.
+        """The transformers floor must track lerobot's [transformers-dep].
 
-        MolmoAct2's modeling/processor code uses transformers 5.4+ APIs.
-        ``molmoact2.build_policy`` guards the dep with an importability-only
-        check (``require_optional``), which a too-loose floor (e.g. the old
-        ``>=4.46``) silently defeats: a resolver can pick transformers 4.x,
-        the import succeeds, the guard passes, then model construction dead-ends
-        deep inside lerobot. The pin must therefore carry lerobot's own floor
-        (``>=5.4.0``) and an upper bound so a future incompatible major cannot
-        slip through.
+        MolmoAct2's modeling/processor code uses transformers 5.4+ APIs. Rather
+        than hand-pin transformers here (which silently drifts when lerobot bumps
+        its own floor), the [molmoact2] extra pulls ``lerobot[molmoact2]``, which
+        pulls ``lerobot[transformers-dep]`` transitively. That keeps the floor in
+        lock-step with lerobot by construction. We therefore assert the
+        DELEGATION (lerobot[molmoact2] with a lerobot floor of >=0.6.0 - the
+        release that carries MolmoAct2 + its transformers>=5.4.0 dep) rather than
+        a literal transformers pin that no longer lives in this extra.
         """
         from packaging.requirements import Requirement
-        from packaging.version import Version
 
         specs = self._extras()["molmoact2"]
-        transformers_req = next(
-            (Requirement(s) for s in specs if Requirement(s).name == "transformers"),
-            None,
+        lerobot_reqs = [
+            Requirement(sp)
+            for sp in specs
+            if Requirement(sp).name == "lerobot" and "molmoact2" in (Requirement(sp).extras or set())
+        ]
+        assert lerobot_reqs, "[molmoact2] must layer lerobot[molmoact2] (which pulls transformers>=5.4.0)"
+        spec = lerobot_reqs[0].specifier
+        # lerobot >=0.6.0 is the floor that ships MolmoAct2 + transformers>=5.4.0.
+        from packaging.version import Version
+
+        assert not spec.contains(Version("0.5.1")), (
+            f"lerobot floor too loose: {spec} admits 0.5.1, which predates MolmoAct2 and its transformers>=5.4.0 dep"
         )
-        assert transformers_req is not None, "[molmoact2] must pin transformers"
-        spec = transformers_req.specifier
-        # Floor must be at least lerobot's transformers-dep floor (5.4.0).
-        assert not spec.contains(Version("4.46")), (
-            f"transformers floor too loose: {spec} admits 4.46, which lacks the "
-            "transformers 5.4+ APIs MolmoAct2 needs (matches lerobot[transformers-dep])"
-        )
-        assert spec.contains(Version("5.4.0")), f"transformers pin {spec} must admit 5.4.0 (lerobot's molmoact2 floor)"
+        assert spec.contains(Version("0.6.0")), f"lerobot pin {spec} must admit 0.6.0 (MolmoAct2 floor)"
         # An upper bound must exist so an incompatible future major is excluded.
-        assert any(s.operator in ("<", "<=", "==", "~=") for s in spec), (
-            f"transformers pin {spec} must carry an upper bound"
-        )
+        assert any(s.operator in ("<", "<=", "==", "~=") for s in spec), f"lerobot pin {spec} must carry an upper bound"
 
     def test_molmoact2_extra_has_no_git_url(self):
         # PyPI rejects direct-reference (git+) deps in a published package's

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -44,8 +44,16 @@ def test_lerobot_extra_requires_0_6() -> None:
 
 def test_molmoact2_extra_is_pure_pypi_with_transformers_5_4_plus() -> None:
     joined = " ".join(_extras()["molmoact2"])
-    # transformers floor matches lerobot 0.6's transformers-dep (>=5.4.0), NOT 5.3.0
-    assert "transformers>=5.4.0" in joined, joined
+    # The molmoact2 extra defers to lerobot's own [molmoact2] extra for its
+    # transformers/peft/scipy floors instead of hand-mirroring them here (which
+    # silently drifts when lerobot bumps them). lerobot[molmoact2] pulls
+    # lerobot[transformers-dep] (>=5.4.0) transitively, so the >=5.4.0 guarantee
+    # is preserved by construction while staying in lock-step with lerobot.
+    assert "lerobot[molmoact2]" in joined, joined
+    # the lerobot floor is >=0.6.0 (MolmoAct2Policy landed in lerobot 0.6), so
+    # its transformers-dep (>=5.4.0) is what gets resolved - never the pre-0.6
+    # transformers==5.3.0.
+    assert ">=0.6.0" in joined, joined
     # resolves from PyPI - no git-from-source URL
     assert "git+" not in joined, f"molmoact2 extra should not need a git URL: {joined!r}"
 


### PR DESCRIPTION
## Summary

Enables **MolmoAct2** (and any `lerobot_local` policy) to run on a **physical SO-101** arm with USB cameras. Verified end-to-end on hardware: `allenai/MolmoAct2-SO100_101` loads on GPU, consumes live camera + joint state, and emits valid `.pos`/degree action chunks that drive the real arm.

Four independent fixes:

### 1. `hardware_robot.py` — forward camera `fourcc`
The camera config builder silently dropped the `fourcc` field. Many UVC cameras only offer 30fps under **MJPG**; the YUYV default caps at ~5fps at 1080p, so lerobot's `_validate_fps` raised `failed to set fps=30 (actual_fps=5.0)`. Now `fourcc` (e.g. `"MJPG"`) is passed through to `OpenCVCameraConfig` when provided.

### 2. `embodiment.py` — hardware `.pos` state fallback
`PackStateProcessorStep` looked only for the declared (sim) `state_keys`. A sim embodiment like `so101` (`state_keys=['1'..'6']`) driven from a **real** arm — whose observation carries `shoulder_pan.pos` … `gripper.pos` — found none and dead-ended with `MolmoAct2 requires observation.state`.

Now, when none of the declared keys are present, it falls back to the hardware `<motor>.pos` keys. These are already in the model's training units (SOFollower `MotorNormMode`: arm degrees, gripper `RANGE_0_100`), so they are packed **raw**, skipping the sim radian→degree conversion (which would double-convert).

### 3. `policy.py` — hardware `.pos` action keys (mirror of #2)
The action side had the symmetric gap. With a sim embodiment on hardware, actions came out keyed by numeric sim joints (`1..6`) and degree→radian converted — `SOFollower.send_action` rejects numeric keys, and ~0.003 rad is meaningless to a degrees bus.

`get_actions` now detects `.pos` observation keys and threads them into `_tensor_to_action_dicts` (new `hw_action_keys=` param), which emits the action dict under those `.pos` names and skips the sim unit conversion. When the embodiment's own `action_keys` are already `.pos` (e.g. `so_real` / `so101_follower`), it's a harmless no-op override.

### 4. `pyproject.toml` — `[molmoact2]` defers to `lerobot[molmoact2]`
Instead of hand-mirroring lerobot's `transformers`/`peft`/`scipy` pins (which silently drift when lerobot bumps them), the extra now pulls `lerobot[molmoact2]>=0.6.0,<0.7.0`, keeping the aux-dep versions in lock-step with lerobot by construction.

## Behavior / compatibility

- **Sim is unchanged.** Numeric sim `state_keys` still pack and unit-convert exactly as before; the hardware fallbacks (#2, #3) only trigger when the declared keys are **absent** from the observation.
- Checkpoints whose `action_keys` are already `.pos` (`so_real`, `so101_follower`) are unaffected (no-op override).
- Net effect: `create_policy("lerobot_local", ..., embodiment="so101")` now "just works" on a physical SO-101, not only in MuJoCo.

## Testing

- Verified on real SO-101 hardware (NVIDIA Thor, CUDA torch): MolmoAct2 loads (1295 shards), reads a live dual-camera + 6-DoF observation, and returns a 30-step action chunk keyed `shoulder_pan.pos … gripper.pos` in degrees at ~1.6 s/inference.
- State/action unit round-trip checked both directions: sim (`'1'..'6'` radians → degree-converted `observation.state`) vs hardware (`'.pos'` degrees packed raw).
- `ruff check` passes on all changed files.
