### PR TITLE
fix(sim): sim teardown releases MuJoCo whatever the mesh handle is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,35 @@ cannot diverge again. Direct joint/position/torque actuators are unchanged (the
 unit mapping applies to tendon transmissions only), and a mapped tendon command
 no longer emits a spurious "MuJoCo will clamp it" warning through the
 actuator-name spelling.
+### Fixed: sim teardown releases MuJoCo whatever the mesh handle is
+
+`Simulation.cleanup()` detaches from the peer mesh before it tears down MuJoCo,
+and a failure in that first step aborted everything after it - the compiled
+model/data, the renderers and the ThreadPoolExecutor all stayed alive:
+
+```python
+sim = Simulation(mesh=True)   # annotated `bool`, so True was the type-clean value
+sim.create_world()
+sim.cleanup()
+# -> AttributeError: 'bool' object has no attribute 'stop'
+#    sim._world still holds the live MjModel/MjData; the executor is still up.
+```
+
+`mesh=` is a hook for an already-started mesh client (the object `init_mesh`
+returns), not a boolean opt-in switch - the engine only ever calls `.stop()` on
+it. The `bool` annotation inverted that: `mesh=True` type-checked and broke
+teardown, while passing an actual client was an `arg-type` error. A truthy value
+without a callable `stop` is now rejected at construction with a message naming
+both supported ways to attach a mesh (`Robot(name, mode="sim", mesh=True)`, or
+assigning `sim.mesh` after construction), and the parameter is typed for the
+client it takes.
+
+A real client whose `stop()` raises (transport already closed, peer-registry
+error) leaked the same resources. That stop is now best-effort - logged and
+stepped over - matching the per-robot `_detach_robot_from_mesh` loop directly
+above it in `cleanup` and `HardwareRobot.cleanup`, so `cleanup()` / `destroy()` /
+`__exit__` always reach the MuJoCo teardown. The handle is cleared afterwards, so
+a second `cleanup()` never stops a client twice.
 
 ### Fixed: `add_object` rejects a mass it cannot honor, and a refused add never bricks the scene
 

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -88,6 +88,26 @@ follower.stop_teleop("leader")
 
 `get_teleop_status()` on either side inspects current teleop state.
 
+## Attach a mesh to a Simulation
+
+`Robot(name, mode="sim", mesh=True)` is the normal path: it resolves the
+`STRANDS_MESH` kill switch, starts a client, and stores it on the engine. To
+attach one to a `Simulation` you built yourself, start the client and assign it:
+
+```python
+from strands_robots.mesh import init_mesh
+from strands_robots.simulation import create_simulation
+
+sim = create_simulation("mujoco")
+sim.mesh = init_mesh(sim, peer_id="bench-sim")   # None when mesh is disabled
+```
+
+The `Simulation(mesh=...)` constructor argument takes that same started client -
+it is not a boolean opt-in switch, and a truthy value with no `.stop()` (notably
+`mesh=True`) is rejected at construction. `cleanup()` stops the client before it
+tears down MuJoCo; a stop that fails is logged and stepped over, so the world,
+renderers and executor are always released.
+
 ## Disable
 
 | Method | Scope |

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -140,6 +140,40 @@ def _jnt_qpos_width(mj: Any, jnt_type: int) -> int:
     return 1
 
 
+def _validated_mesh_handle(mesh: Any) -> Any:
+    """Normalize the constructor ``mesh`` argument to a stoppable client or None.
+
+    ``mesh`` is a hook for an already-started mesh client (see
+    :func:`strands_robots.mesh.init_mesh`), not a boolean opt-in switch: the
+    engine only ever calls ``.stop()`` on it during teardown. A truthy value
+    without a callable ``stop`` cannot be honored - ``cleanup()`` would abort
+    on it and leave the MuJoCo world, renderers, and the executor alive - so
+    it is rejected at construction, where the caller can still fix the call.
+
+    Args:
+        mesh: The raw constructor argument. Falsy (``None`` / ``False``) means
+            "standalone, never joined a mesh".
+
+    Returns:
+        ``None`` for a falsy value, otherwise ``mesh`` unchanged.
+
+    Raises:
+        TypeError: If ``mesh`` is truthy but exposes no callable ``stop``. The
+            message names the two supported ways to attach a mesh.
+    """
+    if not mesh:
+        return None
+    if callable(getattr(mesh, "stop", None)):
+        return mesh
+    raise TypeError(
+        f"mesh={mesh!r} is not a mesh client: mesh= takes an already-started client "
+        f"exposing .stop() (got {type(mesh).__name__}), because the engine only stops it "
+        "during teardown. To join a mesh use Robot(name, mode='sim', mesh=True), which "
+        "resolves the STRANDS_MESH kill switch and attaches a client; or attach one "
+        "yourself after construction: sim.mesh = init_mesh(sim, peer_id=...)."
+    )
+
+
 def _validate_finite_vector(method: str, param_name: str, vec: Any) -> str | None:
     """Return an error message if any element of ``vec`` is not a finite number.
 
@@ -240,7 +274,7 @@ class MuJoCoSimEngine(
         default_timestep: float = 0.002,
         default_width: int = 640,
         default_height: int = 480,
-        mesh: bool = False,
+        mesh: Any = None,
         peer_id: str | None = None,
         ros2_bridge: bool = False,
         ros2_domain: int = 0,
@@ -256,13 +290,19 @@ class MuJoCoSimEngine(
             default_width: Default render width (pixels) used when a
                 caller does not pass explicit dimensions to ``render``.
             default_height: Default render height (pixels).
-            mesh: Optional mesh-networking hook. Falsy (default) keeps
-                the Simulation standalone - all mesh code paths are
-                no-ops. When set to a live mesh-client object exposing
-                ``.stop()``, ``cleanup()`` will detach this Simulation
-                from the peer network before tearing down the MuJoCo
-                world. The attribute is plain (not a property), so
-                consumers may attach a client after construction.
+            mesh: Optional mesh-networking hook: an already-started mesh
+                client exposing ``.stop()`` (see
+                :func:`strands_robots.mesh.init_mesh`), which ``cleanup()``
+                stops to detach this Simulation from the peer network before
+                tearing down the MuJoCo world. Falsy (``None``, the default)
+                keeps the Simulation standalone - all mesh code paths are
+                no-ops. A truthy value that is not stoppable (notably
+                ``mesh=True``) is rejected with a ``TypeError``: it is not a
+                boolean opt-in switch, and the engine has nothing to stop.
+                To join a mesh, use ``Robot(name, mode="sim", mesh=True)``,
+                which resolves the ``STRANDS_MESH`` kill switch and attaches a
+                client. The attribute is plain (not a property), so consumers
+                may also attach a client after construction.
             peer_id: Stable identifier the mesh transport uses to
                 address this Simulation. Opaque to MuJoCo itself; only
                 consulted when ``mesh`` is truthy.
@@ -291,7 +331,7 @@ class MuJoCoSimEngine(
         # downstream code can swap in a real mesh client after
         # construction without a setter dance. See the ``mesh`` /
         # ``peer_id`` docstring entries above for the contract.
-        self.mesh: Any = mesh if mesh else None
+        self.mesh: Any = _validated_mesh_handle(mesh)
         self.peer_id: str | None = peer_id
 
         # Additive sensor-noise config + reproducible RNG (set_obs_noise).
@@ -4621,7 +4661,20 @@ class MuJoCoSimEngine(
             for r in list(self._world.robots.values()):
                 self._detach_robot_from_mesh(r)
         if self.mesh:
-            self.mesh.stop()
+            # Best-effort, mirroring the per-robot ``_detach_robot_from_mesh``
+            # loop above: a mesh client that fails to stop (transport already
+            # closed, peer registry error) must not abort the teardown of the
+            # MuJoCo world, renderers, and the executor below.
+            try:
+                self.mesh.stop()
+            except Exception as exc:  # noqa: BLE001 - teardown continues regardless
+                logger.warning(
+                    "cleanup: failed to stop mesh client (peer_id=%s): %s",
+                    self.peer_id or "?",
+                    exc,
+                )
+            finally:
+                self.mesh = None
 
         timeout = policy_stop_timeout if policy_stop_timeout is not None else self._DEFAULT_POLICY_STOP_TIMEOUT
 

--- a/tests/simulation/mujoco/test_mesh_handle_teardown.py
+++ b/tests/simulation/mujoco/test_mesh_handle_teardown.py
@@ -1,0 +1,162 @@
+"""Teardown always releases the MuJoCo world, whatever the mesh handle is.
+
+``MuJoCoSimEngine.cleanup`` detaches the Simulation from its peer network
+before it tears down MuJoCo: it calls ``self.mesh.stop()`` first, then stops
+live policies, nulls the world, frees renderers, and shuts down the executor.
+The mesh hook is an enrichment, but a failure in it used to abort that whole
+sequence:
+
+* ``Simulation(mesh=True)`` constructed happily - the parameter was annotated
+  ``bool``, so ``True`` was the type-clean spelling - and stored the bool as the
+  mesh handle. ``cleanup()`` / ``destroy()`` / ``__exit__`` then raised
+  ``AttributeError: 'bool' object has no attribute 'stop'`` *before* any MuJoCo
+  teardown ran, leaving the compiled model/data and a live ThreadPoolExecutor
+  behind on every session. The annotation also made the documented usage (an
+  actual mesh client) an ``arg-type`` error, so the only mypy-clean value was
+  the one that broke teardown.
+* A real client whose ``stop()`` raises (transport already closed, peer-registry
+  error) leaked the same resources, even though the per-robot
+  ``_detach_robot_from_mesh`` loop immediately above it in ``cleanup`` is
+  already no-raise, and ``HardwareRobot.cleanup`` guards its own mesh stop.
+
+Now a truthy handle without a callable ``stop`` is rejected at construction -
+where the caller can still fix the call - and a stop that fails is logged and
+stepped over so the MuJoCo teardown below it always runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+class _StoppableMesh:
+    """Minimal stand-in for a started mesh client: it can be stopped."""
+
+    def __init__(self) -> None:
+        self.stop_calls = 0
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+
+class _FailingMesh:
+    """A started client whose transport is already gone, so ``stop`` raises."""
+
+    def __init__(self) -> None:
+        self.stop_calls = 0
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+        raise RuntimeError("zenoh session already closed")
+
+
+def _torn_down(sim: Simulation) -> bool:
+    """True when the MuJoCo world is gone and the executor takes no more work.
+
+    The executor is probed behaviourally: a shut-down ``ThreadPoolExecutor``
+    refuses ``submit`` with ``RuntimeError``, while a leaked one accepts it (and
+    the accepted task is cancelled again so the probe leaves no worker behind).
+    """
+    if sim._world is not None:
+        return False
+    try:
+        sim._executor.submit(lambda: None).cancel()
+    except RuntimeError:
+        return True
+    return False
+
+
+class TestNonStoppableHandleRejected:
+    """A handle the engine cannot stop is refused at construction."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [True, 1, "zenoh", {"peer_id": "sim-1"}, object()],
+        ids=["bool", "int", "str", "dict", "object"],
+    )
+    def test_a_handle_without_stop_is_rejected(self, value):
+        with pytest.raises(TypeError, match=r"not a mesh client"):
+            Simulation(tool_name="mesh_reject", mesh=value)
+
+    def test_the_rejection_names_both_supported_ways_to_attach_a_mesh(self):
+        with pytest.raises(TypeError) as excinfo:
+            Simulation(tool_name="mesh_reject_msg", mesh=True)
+        msg = str(excinfo.value)
+        assert ".stop()" in msg, "must say what the parameter actually takes"
+        assert "mode='sim', mesh=True" in msg, "must point at the Robot factory"
+        assert "sim.mesh = init_mesh" in msg, "must point at post-construction attach"
+        assert "bool" in msg, "must name the type it was handed"
+
+    @pytest.mark.parametrize("value", [None, False, 0], ids=["none", "false", "zero"])
+    def test_a_falsy_handle_keeps_the_simulation_standalone(self, value):
+        sim = Simulation(tool_name="mesh_falsy", mesh=value)
+        try:
+            assert sim.mesh is None, "falsy means 'never joined a mesh'"
+        finally:
+            sim.cleanup(policy_stop_timeout=0.5)
+        assert _torn_down(sim)
+
+
+class TestStoppableHandleHonored:
+    """A real client is stored, stopped once, and never stopped twice."""
+
+    def test_client_is_stopped_and_cleared_by_cleanup(self):
+        client = _StoppableMesh()
+        sim = Simulation(tool_name="mesh_client", mesh=client)
+        assert sim.mesh is client, "a stoppable handle is stored as given"
+        sim.create_world()
+        sim.cleanup(policy_stop_timeout=0.5)
+        assert client.stop_calls == 1
+        assert sim.mesh is None, "cleanup clears the handle so it cannot be stopped twice"
+        assert _torn_down(sim)
+
+    def test_second_cleanup_does_not_stop_the_client_again(self):
+        client = _StoppableMesh()
+        sim = Simulation(tool_name="mesh_client_idem", mesh=client)
+        sim.create_world()
+        sim.cleanup(policy_stop_timeout=0.5)
+        sim.cleanup(policy_stop_timeout=0.5)
+        assert client.stop_calls == 1
+
+
+class TestFailingStopDoesNotLeakTheWorld:
+    """A mesh stop that raises must not abort the MuJoCo teardown."""
+
+    def test_cleanup_completes_and_releases_the_world(self, caplog):
+        client = _FailingMesh()
+        sim = Simulation(tool_name="mesh_stop_raises", mesh=client)
+        sim.create_world()
+        sim.add_object(name="cube", shape="box", size=[0.1, 0.1, 0.1], position=[0, 0, 0.05])
+        with caplog.at_level("WARNING"):
+            sim.cleanup(policy_stop_timeout=0.5)
+        assert client.stop_calls == 1
+        assert _torn_down(sim), "world and executor must be released despite the mesh failure"
+        assert any("failed to stop mesh client" in r.message.lower() for r in caplog.records), (
+            "the swallowed failure must still be reported"
+        )
+
+    def test_the_released_world_is_no_longer_usable(self):
+        sim = Simulation(tool_name="mesh_stop_raises_render", mesh=_FailingMesh())
+        sim.create_world()
+        sim.cleanup(policy_stop_timeout=0.5)
+        result = sim.render()
+        assert result["status"] == "error"
+        assert "No world" in result["content"][0]["text"], "a world that survived cleanup would still render a frame"
+
+    def test_context_manager_exit_completes(self):
+        client = _FailingMesh()
+        with Simulation(tool_name="mesh_stop_raises_ctx", mesh=client) as sim:
+            sim.create_world()
+        assert client.stop_calls == 1
+        assert _torn_down(sim), "__exit__ must not propagate a mesh-stop failure"
+
+    def test_destroy_completes(self):
+        client = _FailingMesh()
+        sim = Simulation(tool_name="mesh_stop_raises_destroy", mesh=client)
+        sim.create_world()
+        sim.destroy()
+        assert _torn_down(sim)


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.cleanup()` detaches from the peer mesh before it tears down MuJoCo: it stops `self.mesh`, then stops live policies, nulls the world, frees renderers and shuts down the executor. A failure in that first step aborted everything after it.

**1. `mesh=True` was the type-clean spelling, and it broke teardown.**

```python
sim = Simulation(mesh=True)      # parameter was annotated `bool`
sim.create_world()
sim.cleanup()
# AttributeError: 'bool' object has no attribute 'stop'
#   sim._world still holds the live MjModel/MjData
#   sim._executor still accepts work
```

`destroy()` and `__exit__` take the same path, so a `with Simulation(mesh=True) as sim:` block leaked a MuJoCo world plus a ThreadPoolExecutor on every session. `mesh=` is a hook for an already-started mesh client (the object `init_mesh` returns) - the engine only ever calls `.stop()` on it - so the `bool` annotation documented the opposite of the contract in the docstring right below it. It also inverted mypy:

```
# before
$ mypy demo.py    # sim.mesh = init_mesh(...) passed to the constructor
demo.py:7: error: Argument "mesh" to "MuJoCoSimEngine" has incompatible type "Mesh | None"; expected "bool"  [arg-type]

# after
Success: no issues found in 1 source file
```

The only mypy-clean value was the one that broke teardown; the documented one was an error.

**2. A real client whose `stop()` raises leaked the same resources.** A closed transport or a peer-registry error propagated out of `cleanup()` before any MuJoCo teardown - even though the per-robot `_detach_robot_from_mesh` loop *immediately above it in the same method* is already no-raise, and `HardwareRobot.cleanup` guards its own mesh stop the same way.

## Change

- `mesh=` is typed for the client it takes, and a truthy value with no callable `stop` is rejected at construction, where the caller can still fix the call. The message names both supported ways to attach a mesh:

```
mesh=True is not a mesh client: mesh= takes an already-started client exposing .stop()
(got bool), because the engine only stops it during teardown. To join a mesh use
Robot(name, mode='sim', mesh=True), which resolves the STRANDS_MESH kill switch and
attaches a client; or attach one yourself after construction:
sim.mesh = init_mesh(sim, peer_id=...).
```

  Rejecting rather than honoring `True` keeps mesh policy in one place: `Robot(..., mesh=True)` resolves the `STRANDS_MESH` kill switch and best-effort attaches a client, and `init_mesh` enforces the ACL posture. A constructor that quietly joined a network would duplicate that.
- The sim-level mesh stop is now best-effort (logged, then stepped over, handle cleared) exactly like the per-robot loop above it, so `cleanup()` / `destroy()` / `__exit__` always reach the MuJoCo teardown. Clearing the handle also makes a second `cleanup()` a no-op instead of a second `stop()`.
- Falsy (`None`, the default) is unchanged: standalone sim, every mesh path a no-op.

## Verification

Same call on both sides - a client whose `stop()` raises, then `render()` after `cleanup()`:

![cleanup with a failing mesh stop](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-teardown/mesh_teardown.png)

| after `cleanup()` | before | with this change |
|---|---|---|
| `cleanup()` | raised `RuntimeError: zenoh session already closed` | returned (failure logged) |
| world | alive | released |
| executor | still accepts work | refuses new work |
| `render()` | `status=success`, `640x480 from 'look' at t=0.400s` | `status=error`, `No world. Call create_world (or load_scene) first.` |

The left panel is a real frame rendered *after* `cleanup()` on the pre-change code - the world outlived its own teardown.

`tests/simulation/mujoco/test_mesh_handle_teardown.py` (15 tests) pins the rejection, the falsy pass-through, single-stop-then-clear, and that the world/executor are released when the stop raises (probed behaviourally: a shut-down executor refuses `submit`). On the pre-change engine: **12 failed, 3 passed**; after: **15 passed**.

Gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; full suite `MUJOCO_GL=egl pytest tests` **12014 passed, 254 skipped** (11999 before these tests).

Docs: constructor docstring rewritten to the actual contract, a "Attach a mesh to a Simulation" section added to `docs/mesh.md`, CHANGELOG entry under Unreleased.

---

### Round 2 - rebase only (no behavioural change)

Rebased onto `main` after #1652 merged. The only conflict was in `CHANGELOG.md` (both PRs add an Unreleased entry); both entries are kept, #1652's first. `simulation.py` auto-merged cleanly - the two changes are disjoint (#1652 is `send_action` gripper scaling, this is mesh-handle teardown). No source diff versus the reviewed head. Re-approval (not full re-review) is all that is needed.