### PR TITLE
feat(sim): rotate_wrist uses the registry-first gripper classification (closes #1661)

### DIFF
--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -182,6 +182,13 @@
         "scene_xml": "scene.xml",
         "robot_descriptions_module": "panda_mj_description"
       },
+      "gripper": {
+        "actuators": [
+          "actuator8"
+        ],
+        "closed": "low",
+        "open": "high"
+      },
       "legacy_urdf": "panda/panda.urdf",
       "aliases": [
         "bimanual_panda_gripper",
@@ -235,6 +242,13 @@
       "hardware": {
         "lerobot_type": "so100_follower"
       },
+      "gripper": {
+        "actuators": [
+          "Jaw"
+        ],
+        "closed": "low",
+        "open": "high"
+      },
       "legacy_urdf": "so100/so100.urdf",
       "aliases": [
         "so100_4cam",
@@ -256,6 +270,13 @@
       },
       "hardware": {
         "lerobot_type": "so101_follower"
+      },
+      "gripper": {
+        "actuators": [
+          "6"
+        ],
+        "closed": "low",
+        "open": "high"
       },
       "aliases": [
         "robotstudio_so101",

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -54,18 +54,26 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from strands_robots.registry.robots import get_robot
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG
 
 logger = logging.getLogger(__name__)
 
 # Name hints (lowercased substring match on the namespace-stripped actuator /
-# joint name) used to resolve the gripper DOF. Matches the existing runtime
-# precedent (vera provider / cosmos3 policy use gripper|finger; SO-100/SO-101's
-# gripper joint is the "Jaw"). The registry carries no gripper metadata, so a
-# name heuristic is the only zero-config option; an unresolvable gripper
-# returns a structured error listing the actuators so the agent can fall back
-# to send_action.
+# joint name) used to resolve the gripper DOF when the robot registry carries
+# no gripper metadata for the robot's ``data_config``. Matches the existing
+# runtime precedent (vera provider / cosmos3 policy use gripper|finger;
+# SO-100's gripper joint is the "Jaw"). Registry metadata
+# (``robots.json`` -> ``<robot>.gripper``, GH #1658) is authoritative when
+# present; the heuristic is the zero-config fallback for user URDFs / injected
+# MJCF, and an unresolvable gripper returns a structured error listing the
+# actuators so the agent can fall back to send_action.
 _GRIPPER_HINTS = ("gripper", "finger", "jaw")
+
+# Valid values for the registry gripper metadata ``closed`` / ``open`` fields:
+# which ctrlrange END the state maps to. The registry integrity tests
+# shape-check the shipped robots.json against the same two values.
+_CTRLRANGE_ENDS = ("low", "high")
 
 # Wrist-yaw joint hints, most-specific first. Fallback: the last non-gripper
 # hinge joint in the robot's chain (the distal roll joint on most serial arms).
@@ -225,23 +233,108 @@ class MotionPrimitivesMixin:
             return name[len(namespace) :]
         return name or ""
 
-    def _gripper_actuator_ids(self, model: Any, robot: Any) -> set[int]:
-        """Actuator ids on *robot* classified as gripper drives by the name heuristic.
+    def _registry_gripper_metadata(self, robot: Any) -> tuple[dict[str, Any] | None, str | None]:
+        """Registry ``gripper`` block for *robot*'s ``data_config``, shape-checked.
+
+        Returns ``(metadata, None)`` when the robot's ``data_config`` resolves
+        to a registry entry with a well-formed ``gripper`` block,
+        ``(None, None)`` when there is no metadata (heuristic fallback
+        applies), and ``(None, reason)`` when a block exists but is malformed
+        (possible via the user-local registry overlay; the shipped
+        ``robots.json`` is shape-checked by tests). A malformed block is a
+        loud error, never a silent heuristic fallback - half-applying it
+        could reintroduce the silent-DOF bug this metadata exists to fix.
+        """
+        data_config = getattr(robot, "data_config", None)
+        if not data_config:
+            return None, None
+        info = get_robot(data_config)
+        if not info or "gripper" not in info:
+            return None, None
+        meta = info["gripper"]
+        actuators = meta.get("actuators") if isinstance(meta, dict) else None
+        closed_end = meta.get("closed", "low") if isinstance(meta, dict) else None
+        open_end = meta.get("open", "high") if isinstance(meta, dict) else None
+        if (
+            isinstance(actuators, list)
+            and actuators
+            and all(isinstance(a, str) and a for a in actuators)
+            and closed_end in _CTRLRANGE_ENDS
+            and open_end in _CTRLRANGE_ENDS
+            and closed_end != open_end
+        ):
+            return meta, None
+        return None, (
+            f"registry gripper metadata for data_config '{data_config}' is malformed: {meta!r}. "
+            "Expected {'actuators': [non-empty names], 'closed': 'low'|'high', "
+            "'open': 'low'|'high'} with 'closed' != 'open'. Fix the registry entry "
+            "(user overlay: user_robots.json), or drive the gripper directly with "
+            "action='send_action'."
+        )
+
+    def _resolve_gripper_actuators(
+        self, model: Any, robot: Any
+    ) -> tuple[set[int], dict[str, Any] | None, dict[str, Any] | None]:
+        """Resolve *robot*'s gripper actuator ids (registry first, heuristic fallback).
 
         The shared classification behind ``set_gripper`` (which commands these
         actuators) and ``move_to`` (which must NOT command them - the gripper
         DOF is kinematically irrelevant to the EE task, so an IK solve would
         pass whatever seed value it was given straight through, and a random
         restart seed would then servo the jaw to a random point of its range,
-        dropping a held object mid-transport). An actuator qualifies when its
-        short name, or its driven joint's short name, contains one of
-        :data:`_GRIPPER_HINTS`. Callers must hold ``self._lock``.
+        dropping a held object mid-transport). Resolution order (GH #1658):
+
+        1. Registry ``gripper`` metadata for the robot's ``data_config``,
+           when present (authoritative): an actuator qualifies when its
+           namespace-stripped name matches one of ``gripper.actuators``
+           exactly (case-insensitive). Metadata that matches NO actuator in
+           the model is a loud structured error, never a silent heuristic
+           fallback - a stale registry entry degrading to the heuristic
+           would reintroduce exactly the misclassification the metadata
+           exists to prevent.
+        2. Name heuristic (zero-config fallback for user URDFs / injected
+           MJCF): the actuator's short name, or its driven joint's short
+           name, contains one of :data:`_GRIPPER_HINTS`.
+
+        Returns ``(actuator_ids, metadata, error)``: ``metadata`` is the
+        registry block when path 1 resolved (``None`` on the heuristic path);
+        ``error`` is a structured error dict when metadata exists but is
+        unusable (malformed, or matching nothing). Callers must hold
+        ``self._lock``.
         """
         mj = self._mj
         namespace = robot.namespace or ""
         jnt_by_act = {act_id: jnt_id for jnt_id, act_id in self._joint_actuator_map(model, robot).items()}
+        act_ids = [int(a) for a in (robot.actuator_ids or [])]
+
+        meta, malformed_reason = self._registry_gripper_metadata(robot)
+        if malformed_reason is not None:
+            return set(), None, _err(f"Cannot resolve the gripper for '{robot.name}': {malformed_reason}")
+        if meta is not None:
+            wanted = {str(a).lower() for a in meta["actuators"]}
+            matched: set[int] = set()
+            short_names: list[str] = []
+            for act_id in act_ids:
+                short = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id), namespace)
+                short_names.append(short)
+                if short.lower() in wanted:
+                    matched.add(act_id)
+            if not matched:
+                return (
+                    set(),
+                    None,
+                    _err(
+                        f"Registry gripper metadata for '{robot.name}' (data_config "
+                        f"'{robot.data_config}') names actuators {meta['actuators']} but none "
+                        f"exist in the model. Model actuators: {short_names}. The registry "
+                        "entry is stale for this model; fix it, or drive the gripper "
+                        "directly with action='send_action'."
+                    ),
+                )
+            return matched, meta, None
+
         out: set[int] = set()
-        for act_id in (int(a) for a in (robot.actuator_ids or [])):
+        for act_id in act_ids:
             act_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id), namespace).lower()
             jnt_id = jnt_by_act.get(act_id)
             jnt_name = ""
@@ -249,7 +342,7 @@ class MotionPrimitivesMixin:
                 jnt_name = self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id), namespace).lower()
             if any(h in act_name or (jnt_name and h in jnt_name) for h in _GRIPPER_HINTS):
                 out.add(act_id)
-        return out
+        return out, None, None
 
     def _frame_world_pose(
         self, model: Any, data: Any, frame_name: str, frame_type: str
@@ -294,7 +387,8 @@ class MotionPrimitivesMixin:
         eef-delta policies use, so multi-robot scenes resolve the right arm.
 
         GRASP PRESERVATION (contract): gripper actuators (resolved by the same
-        name heuristic ``set_gripper`` uses) are excluded from the IK solve
+        registry-metadata-first classification ``set_gripper`` uses, see
+        :meth:`_resolve_gripper_actuators`) are excluded from the IK solve
         and its restart seeding, and are HELD at their live position for the
         whole servo descent - a closed gripper stays closed through staging
         and transport, so ``set_gripper("close") -> move_to(...)`` carries the
@@ -393,13 +487,16 @@ class MotionPrimitivesMixin:
             # its live position (not omitted: _primitive_tick writes
             # data.ctrl every tick, and an unwritten channel would let a
             # stale ctrl from another path drive it).
-            grip_acts = self._gripper_actuator_ids(model, robot)
+            grip_acts, _, grip_err = self._resolve_gripper_actuators(model, robot)
+            if grip_err is not None:
+                return grip_err
             arm_jact = {j: a for j, a in jact.items() if a not in grip_acts}
             if not arm_jact:
                 return _err(
                     f"move_to: robot '{robot_name}' has no non-gripper joint-transmission "
-                    "actuators to drive - every actuated joint matches the gripper name "
-                    f"heuristic {list(_GRIPPER_HINTS)}. Nothing can move the end-effector."
+                    "actuators to drive - every actuated joint is classified as a gripper "
+                    f"drive (registry metadata or the name heuristic {list(_GRIPPER_HINTS)}). "
+                    "Nothing can move the end-effector."
                 )
 
             try:
@@ -565,15 +662,17 @@ class MotionPrimitivesMixin:
     ) -> dict[str, Any]:
         """Drive the gripper to an open/close set-point (atomic primitive).
 
-        Resolves the gripper actuator(s) by name heuristic (actuator or driven
-        joint short-name containing ``gripper`` / ``finger`` / ``jaw`` - the
-        registry carries no gripper metadata) and commands the actuator
-        ctrlrange end-point: ``"open"`` drives to the HIGH end, ``"close"`` to
-        the LOW end. That is the convention for SO-100/SO-101 (the jaw closes
-        toward the low/negative end of its range - the sign trap documented in
-        the so101_curobo example) and for the Franka split gripper (0=closed,
-        255=open). Motion is NOT recorded into an active dataset recording
-        session (see module docstring).
+        Resolves the gripper actuator(s) via :meth:`_resolve_gripper_actuators`
+        (registry ``gripper`` metadata for the robot's ``data_config`` when
+        present, else the ``gripper`` / ``finger`` / ``jaw`` name heuristic)
+        and commands the actuator ctrlrange end-point. With no metadata,
+        ``"open"`` drives to the HIGH end and ``"close"`` to the LOW end -
+        the convention for SO-100/SO-101 (the jaw closes toward the
+        low/negative end of its range - the sign trap documented in the
+        so101_curobo example) and for the Franka split gripper (0=closed,
+        255=open). Registry metadata's ``closed``/``open`` fields override
+        that convention per robot. Motion is NOT recorded into an active
+        dataset recording session (see module docstring).
 
         Args:
             robot_name: Robot whose gripper to drive; defaults to the single
@@ -611,17 +710,32 @@ class MotionPrimitivesMixin:
             jnt_by_act = {act_id: jnt_id for jnt_id, act_id in jact.items()}
             act_ids = [int(a) for a in (robot.actuator_ids or [])]
             # Shared arm/gripper classification (also the exclusion set that
-            # keeps move_to's IK from commanding the jaw).
-            gripper_acts = sorted(self._gripper_actuator_ids(model, robot))
+            # keeps move_to's IK from commanding the jaw): registry metadata
+            # first, name heuristic as the zero-config fallback.
+            grip_set, grip_meta, grip_err = self._resolve_gripper_actuators(model, robot)
+            if grip_err is not None:
+                return grip_err
+            gripper_acts = sorted(grip_set)
             if not gripper_acts:
                 names = [
                     self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, a), namespace) for a in act_ids
                 ]
                 return _err(
-                    f"set_gripper: could not resolve a gripper actuator for '{robot_name}' - no "
-                    f"actuator/joint name contains {list(_GRIPPER_HINTS)}. Actuators: {names}. "
+                    f"set_gripper: could not resolve a gripper actuator for '{robot_name}' - the "
+                    f"registry carries no gripper metadata for this robot and no actuator/joint "
+                    f"name contains {list(_GRIPPER_HINTS)}. Actuators: {names}. "
                     "Drive it directly with action='send_action' instead."
                 )
+
+            # Which ctrlrange END each state maps to: the registry metadata's
+            # `closed`/`open` fields when present, else the open=HIGH /
+            # close=LOW convention (correct for SO-100/SO-101 and Franka, but
+            # a convention, not a law - the metadata field exists to remove
+            # that sign trap for robots with an inverted gripper).
+            if grip_meta is not None:
+                end = grip_meta.get("open", "high") if state == "open" else grip_meta.get("closed", "low")
+            else:
+                end = "high" if state == "open" else "low"
 
             targets: dict[int, float] = {}
             for act_id in gripper_acts:
@@ -634,7 +748,7 @@ class MotionPrimitivesMixin:
                         f"({lo}, {hi}); cannot infer open/close set-points. Drive it directly "
                         "with action='send_action'."
                     )
-                targets[act_id] = hi if state == "open" else lo
+                targets[act_id] = hi if end == "high" else lo
 
         for _ in range(steps):
             with self._lock:

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -76,7 +76,9 @@ _GRIPPER_HINTS = ("gripper", "finger", "jaw")
 _CTRLRANGE_ENDS = ("low", "high")
 
 # Wrist-yaw joint hints, most-specific first. Fallback: the last non-gripper
-# hinge joint in the robot's chain (the distal roll joint on most serial arms).
+# hinge joint in the robot's chain (the distal roll joint on most serial
+# arms). "Non-gripper" is decided by the shared registry-metadata-first
+# classification (_resolve_gripper_actuators), not by _GRIPPER_HINTS alone.
 _WRIST_HINTS = ("wrist_roll", "wrist_yaw", "wrist_rotate", "wrist")
 
 # Physics substeps per control tick. Each move_to/rotate_wrist "step" (and each
@@ -795,7 +797,9 @@ class MotionPrimitivesMixin:
         Atomic primitive: resolves the wrist-roll/yaw joint by name heuristic
         (``wrist_roll`` / ``wrist_yaw`` / ``wrist_rotate`` / ``wrist``, else
         the last non-gripper hinge joint - the distal roll joint on most serial
-        arms), commands it to ``target_yaw`` while every other arm actuator
+        arms; gripper DOFs are excluded via the shared registry-metadata-first
+        classification, :meth:`_resolve_gripper_actuators`), commands it to
+        ``target_yaw`` while every other arm actuator
         holds its current joint position, and servoes until the joint is within
         ``tol`` radians or ``max_steps`` control ticks elapse. Holding the
         other joints preserves the Cartesian EE position up to servo
@@ -815,8 +819,10 @@ class MotionPrimitivesMixin:
             ``{"status": "success", ...}`` with a json block
             ``{reached, steps, wrist_joint, target_yaw, final_yaw,
             yaw_error_rad}``; structured error (with the residual) when the
-            joint cannot be resolved, the target is out of range, or servo
-            convergence times out. Never raises.
+            joint cannot be resolved, the registry gripper metadata is
+            stale/malformed (same contract as ``set_gripper``/``move_to``),
+            the target is out of range, or servo convergence times out.
+            Never raises.
         """
         if target_yaw is None:
             return _err("rotate_wrist requires 'target_yaw' (wrist joint set-point in radians).")
@@ -853,9 +859,21 @@ class MotionPrimitivesMixin:
             def jnt_short(jnt_id: int) -> str:
                 return self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id), namespace)
 
+            # Exclude gripper DOFs via the shared registry-first classification
+            # (GH #1661, follow-up to #1658), not a raw name-hint match. On
+            # so101's shipped sim MJCF the joints are named 1..6 - no gripper
+            # hint matches, so the raw heuristic would let the last-hinge
+            # fallback below pick joint 6, which IS the jaw: rotate_wrist
+            # would open/close the gripper instead of rotating the wrist.
+            # Stale/malformed registry metadata is the same loud structured
+            # error set_gripper / move_to return, never a silent fallback.
+            grip_acts, _, grip_err = self._resolve_gripper_actuators(model, robot)
+            if grip_err is not None:
+                return grip_err
+
             hinge = int(mj.mjtJoint.mjJNT_HINGE)
             candidates = [j for j in jact if int(model.jnt_type[j]) == hinge]
-            non_gripper = [j for j in candidates if not any(h in jnt_short(j).lower() for h in _GRIPPER_HINTS)]
+            non_gripper = [j for j in candidates if jact[j] not in grip_acts]
             wrist_jnt: int | None = None
             for hint in _WRIST_HINTS:
                 matches = [j for j in non_gripper if hint in jnt_short(j).lower()]

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1774,8 +1774,9 @@ class MuJoCoSimEngine(
         )
         base["methods"]["set_gripper"] = (
             "(robot_name=None, state='open'|'close', steps=12) -> dict  # "
-            "drive the gripper actuator(s) to the open (ctrlrange HIGH) or "
-            "close (ctrlrange LOW) set-point"
+            "drive the gripper actuator(s) to the open/close set-point "
+            "(registry gripper metadata when present, else open=ctrlrange "
+            "HIGH / close=LOW)"
         )
         base["methods"]["rotate_wrist"] = (
             "(robot_name=None, target_yaw, tol=0.02, max_steps=200) -> dict  "

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -300,7 +300,7 @@
     "state": {
       "type": "string",
       "enum": ["open", "close"],
-      "description": "set_gripper set-point: 'open' drives the gripper actuator(s) to the HIGH end of ctrlrange, 'close' to the LOW end (SO-100/SO-101 jaw closes toward the low end)"
+      "description": "set_gripper set-point: 'open'/'close' drive the gripper actuator(s) to the ctrlrange end declared in the robot registry's gripper metadata when present, else the default convention: 'open' = HIGH end, 'close' = LOW end (SO-100/SO-101 jaw closes toward the low end)"
     },
     "steps": {
       "type": "integer",

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -102,6 +102,73 @@ HINT_COLLIDER_XML = ARM_XML.replace('"prim_arm"', '"hint_collider_arm"').replace
 assert HINT_COLLIDER_XML.count("finger_camera_pan") == 3  # joint def + actuator name/joint refs
 HINT_COLLIDER_XML = HINT_COLLIDER_XML.replace('"jaw"', '"Jaw"')  # joint + actuator refs; so100's metadata name
 
+# The GH #1661 regression arm: so101's shipped sim MJCF names its joints and
+# actuators "1".."6". No wrist hint matches and no gripper hint matches, so
+# the raw-heuristic fallback ("last non-gripper hinge") selected joint 6 -
+# which IS the jaw: rotate_wrist would open/close the gripper instead of
+# rotating the wrist. so101's registry gripper metadata (actuators: ["6"])
+# is what excludes the jaw from the wrist candidate set. Same servo tuning
+# as ARM_XML, one extra wrist-flex link so the DOF count matches the real
+# robot (5 arm joints + jaw).
+SO101_STYLE_XML = """
+<mujoco model="so101_style_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002" gravity="0 0 0"/>
+  <default>
+    <joint armature="0.05" damping="0.5"/>
+    <geom density="2000"/>
+  </default>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <geom type="cylinder" size="0.04 0.02"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="1" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.1" size="0.02"/>
+        <body name="link2" pos="0 0 0.1">
+          <joint name="2" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+          <geom type="capsule" fromto="0 0 0 0.1 0 0" size="0.02"/>
+          <body name="link3" pos="0.1 0 0">
+            <joint name="3" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+            <geom type="capsule" fromto="0 0 0 0.1 0 0" size="0.018"/>
+            <body name="link4" pos="0.1 0 0">
+              <joint name="4" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+              <geom type="capsule" fromto="0 0 0 0.05 0 0" size="0.016"/>
+              <body name="link5" pos="0.05 0 0">
+                <joint name="5" type="hinge" axis="1 0 0" range="-3.0 3.0"/>
+                <geom type="capsule" fromto="0 0 0 0.05 0 0" size="0.015"/>
+                <site name="ee_site" pos="0.05 0 0"/>
+                <body name="jaw_body" pos="0.05 0 0">
+                  <joint name="6" type="hinge" axis="0 0 1" range="-0.2 1.5" armature="0.01" damping="0.1"/>
+                  <geom type="box" size="0.01 0.01 0.02" contype="0" conaffinity="0"/>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="1" joint="1" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="2" joint="2" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="3" joint="3" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="4" joint="4" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="5" joint="5" kp="5" dampratio="1" ctrlrange="-3.0 3.0"/>
+    <position name="6" joint="6" kp="2" dampratio="1" ctrlrange="-0.2 1.5"/>
+  </actuator>
+</mujoco>
+"""
+
+# GH #1661's second failure mode (fallback shift): the most distal arm joint
+# is named ``finger_camera_roll`` - the raw heuristic excluded it from the
+# wrist candidate set, shifting the last-non-gripper-hinge fallback onto the
+# elbow. With so100's registry metadata (gripper = ``Jaw``) the roll joint
+# stays a candidate and the fallback picks it. No wrist hint matches (the
+# name deliberately avoids "wrist"), so the fallback path is exercised.
+FALLBACK_SHIFT_XML = ARM_XML.replace('"prim_arm"', '"fallback_shift_arm"').replace("wrist_roll", "finger_camera_roll")
+assert FALLBACK_SHIFT_XML.count("finger_camera_roll") == 3  # joint def + actuator name/joint refs
+FALLBACK_SHIFT_XML = FALLBACK_SHIFT_XML.replace('"jaw"', '"Jaw"')  # joint + actuator refs; so100's metadata name
+
 
 @pytest.fixture
 def arm_path(tmp_path):
@@ -559,6 +626,7 @@ class TestGripperRegistryMetadata:
         for action, fields in (
             ("set_gripper", {"state": "close"}),
             ("move_to", {"position": REACHABLE}),
+            ("rotate_wrist", {"target_yaw": 0.3}),
         ):
             result = _dispatch(collider_sim, action, robot_name="arm", **fields)
             assert result["status"] == "error", (action, result)
@@ -570,9 +638,13 @@ class TestGripperRegistryMetadata:
             "strands_robots.simulation.mujoco.motion_primitives.get_robot",
             lambda name: {"gripper": {"actuators": [], "closed": "low", "open": "high"}},
         )
-        result = _dispatch(collider_sim, "set_gripper", robot_name="arm", state="close")
-        assert result["status"] == "error", result
-        assert "malformed" in result["content"][0]["text"]
+        for action, fields in (
+            ("set_gripper", {"state": "close"}),
+            ("rotate_wrist", {"target_yaw": 0.3}),
+        ):
+            result = _dispatch(collider_sim, action, robot_name="arm", **fields)
+            assert result["status"] == "error", (action, result)
+            assert "malformed" in result["content"][0]["text"], (action, result)
 
     def test_no_data_config_still_uses_heuristic(self, sim):
         """Zero-config fallback pinned: a robot without a data_config resolves
@@ -580,6 +652,73 @@ class TestGripperRegistryMetadata:
         result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=5)
         assert result["status"] == "success", result
         assert _json_block(result)["actuators"] == ["jaw"]
+
+
+class TestRotateWristRegistryMetadata:
+    """rotate_wrist excludes gripper DOFs via the shared registry-first
+    classification (GH #1661, follow-up to #1658).
+
+    Both heuristic failure modes from #1658 applied to rotate_wrist's joint
+    selection, and one was live on a shipped model: so101's sim MJCF names
+    its joints ``1``..``6`` - no wrist hint matches, no gripper hint matches,
+    so the last-non-gripper-hinge fallback selected joint ``6``, the JAW.
+    rotate_wrist on so101 would open/close the gripper instead of rotating
+    the wrist. These tests use the REAL shipped registry entries (so101:
+    ``actuators: ["6"]``; so100: ``actuators: ["Jaw"]``) against inline
+    arms - no asset downloads.
+    """
+
+    @pytest.fixture
+    def so101_sim(self, tmp_path):
+        path = tmp_path / "so101_style_arm.xml"
+        path.write_text(SO101_STYLE_XML)
+        s = Simulation(tool_name="test_rotate_wrist_metadata", mesh=False)
+        assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+        assert s.add_robot("arm", urdf_path=str(path), data_config="so101")["status"] == "success"
+        yield s
+        s.cleanup(policy_stop_timeout=2.0)
+
+    def test_jaw_is_never_selected_as_wrist_on_so101_style_model(self, so101_sim):
+        """The issue's acceptance test: joints named 1..6 + so101 registry
+        metadata - the jaw (joint 6) is excluded, the fallback picks the
+        distal arm roll joint (5), and the jaw does not move."""
+        result = _dispatch(so101_sim, "rotate_wrist", robot_name="arm", target_yaw=0.5)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["wrist_joint"] == "5", payload
+        assert payload["reached"] is True
+        state = _json_block(so101_sim.get_robot_state("arm"))["state"]
+        assert float(state["5"]["position"]) == pytest.approx(0.5, abs=0.05)
+        assert abs(float(state["6"]["position"])) < 0.05, "rotate_wrist moved the jaw"
+
+    def test_hint_colliding_distal_joint_stays_a_wrist_candidate(self, tmp_path):
+        """The fallback-shift failure mode: the most distal arm joint is named
+        ``finger_camera_roll``. The raw heuristic excluded it (finger hint)
+        and the fallback shifted onto the elbow; with so100's metadata
+        (gripper = Jaw) the roll joint stays a candidate and is picked."""
+        path = tmp_path / "fallback_shift_arm.xml"
+        path.write_text(FALLBACK_SHIFT_XML)
+        s = Simulation(tool_name="test_rotate_wrist_fallback_shift", mesh=False)
+        try:
+            assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+            assert s.add_robot("arm", urdf_path=str(path), data_config="so100")["status"] == "success"
+            result = _dispatch(s, "rotate_wrist", robot_name="arm", target_yaw=0.5)
+            assert result["status"] == "success", result
+            payload = _json_block(result)
+            assert payload["wrist_joint"] == "finger_camera_roll", payload
+            assert payload["reached"] is True
+            state = _json_block(s.get_robot_state("arm"))["state"]
+            assert abs(float(state["elbow"]["position"])) < 0.05, "fallback shifted onto the elbow"
+            assert abs(float(state["Jaw"]["position"])) < 0.05, "rotate_wrist moved the jaw"
+        finally:
+            s.cleanup(policy_stop_timeout=2.0)
+
+    def test_no_metadata_heuristic_unchanged(self, sim):
+        """Zero-config fallback pinned: without registry metadata the wrist
+        hint match resolves ``wrist_roll`` exactly as before this change."""
+        result = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=0.4)
+        assert result["status"] == "success", result
+        assert _json_block(result)["wrist_joint"] == "wrist_roll"
 
 
 class TestRecordingInterplay:

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -91,6 +91,17 @@ ARM_XML = """
 REACHABLE = [0.2, 0.1, 0.2]
 UNREACHABLE = [1.5, 0.0, 0.2]  # inside the sanity box, outside the workspace
 
+# The GH #1658 regression arm: same kinematics as ARM_XML, but the BASE pan
+# actuator is named ``finger_camera_pan`` (contains the "finger" hint - the
+# name heuristic misclassifies it as a gripper drive) and the real gripper
+# matches the shipped so100 registry entry (actuator ``Jaw``). REACHABLE has a
+# nonzero y component, so the EE target is only reachable when the pan DOF is
+# available to the IK solve: with the heuristic in charge, move_to holds the
+# pan at 0 and the target is unreachable.
+HINT_COLLIDER_XML = ARM_XML.replace('"prim_arm"', '"hint_collider_arm"').replace("shoulder_pan", "finger_camera_pan")
+assert HINT_COLLIDER_XML.count("finger_camera_pan") == 3  # joint def + actuator name/joint refs
+HINT_COLLIDER_XML = HINT_COLLIDER_XML.replace('"jaw"', '"Jaw"')  # joint + actuator refs; so100's metadata name
+
 
 @pytest.fixture
 def arm_path(tmp_path):
@@ -450,6 +461,125 @@ class TestRotateWrist:
         result = _dispatch(sim, "rotate_wrist", robot_name="arm")
         assert result["status"] == "error"
         assert "target_yaw" in result["content"][0]["text"]
+
+
+class TestGripperRegistryMetadata:
+    """Registry gripper metadata beats the name heuristic (GH #1658).
+
+    The heuristic's inverse failure mode is silent: an ARM actuator whose
+    name happens to contain a hint (here ``finger_camera_pan``, the base pan
+    joint) would be classified as a gripper - ``set_gripper`` would command
+    it and ``move_to`` would exclude it from IK and hold it, quietly
+    reducing the arm's usable DOF. Registry metadata for the robot's
+    ``data_config`` is authoritative: only the named actuators are gripper
+    drives. These tests use the REAL shipped ``so100`` registry entry
+    (``actuators: ["Jaw"]``) against an inline arm - no asset downloads.
+    """
+
+    @pytest.fixture
+    def collider_sim(self, tmp_path):
+        path = tmp_path / "hint_collider_arm.xml"
+        path.write_text(HINT_COLLIDER_XML)
+        s = Simulation(tool_name="test_gripper_metadata", mesh=False)
+        assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+        assert s.add_robot("arm", urdf_path=str(path), data_config="so100")["status"] == "success"
+        yield s
+        s.cleanup(policy_stop_timeout=2.0)
+
+    def test_set_gripper_commands_only_metadata_actuators(self, collider_sim):
+        """Regression (the issue's acceptance test): with metadata present,
+        set_gripper commands ONLY the named actuator - the hint-colliding
+        arm actuator is not driven. Pre-#1658 the heuristic classified
+        ``finger_camera_pan`` as a gripper drive and slewed the whole base."""
+        result = _dispatch(collider_sim, "set_gripper", robot_name="arm", state="close", steps=20)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["actuators"] == ["Jaw"], payload
+        assert "finger_camera_pan" not in payload["targets"]
+
+    def test_move_to_keeps_hint_colliding_arm_dof_in_ik(self, collider_sim):
+        """The off-axis target NEEDS the base pan DOF. Pre-#1658 the heuristic
+        excluded ``finger_camera_pan`` from the IK solve and held it, so the
+        target was unreachable; metadata keeps the DOF usable while the real
+        gripper stays held (grasp preservation intact)."""
+        pytest.importorskip("mink")
+        r = _dispatch(collider_sim, "set_gripper", robot_name="arm", state="close", steps=30)
+        assert r["status"] == "success", r
+        jaw_before = _json_block(r)["gripper_joint_positions"]["Jaw"]
+
+        result = _dispatch(collider_sim, "move_to", robot_name="arm", position=REACHABLE, tol=0.03, max_steps=400)
+        assert result["status"] == "success", result
+        assert _json_block(result)["reached"] is True
+
+        state = _json_block(collider_sim.get_robot_state("arm"))["state"]
+        jaw_after = float(state["Jaw"]["position"])
+        assert abs(jaw_after - jaw_before) < 0.05, f"move_to moved the gripper: {jaw_before:.3f} -> {jaw_after:.3f}"
+        assert abs(float(state["finger_camera_pan"]["position"])) > 0.05, (
+            "the hint-colliding base pan joint never moved - it was excluded from IK"
+        )
+
+    def test_alias_data_config_resolves_metadata(self, tmp_path):
+        """data_config aliases (e.g. multi-cam configs) resolve to the canonical
+        registry entry - so100_dualcam must not silently lose the metadata."""
+        path = tmp_path / "hint_collider_arm.xml"
+        path.write_text(HINT_COLLIDER_XML)
+        s = Simulation(tool_name="test_gripper_metadata_alias", mesh=False)
+        try:
+            assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+            assert s.add_robot("arm", urdf_path=str(path), data_config="so100_dualcam")["status"] == "success"
+            result = _dispatch(s, "set_gripper", robot_name="arm", state="open", steps=5)
+            assert result["status"] == "success", result
+            assert _json_block(result)["actuators"] == ["Jaw"]
+        finally:
+            s.cleanup(policy_stop_timeout=2.0)
+
+    def test_set_gripper_honors_inverted_open_close_convention(self, collider_sim, monkeypatch):
+        """The metadata ``closed``/``open`` fields override the open=HIGH /
+        close=LOW convention (the SO-101-style sign trap): closed=high means
+        'close' targets the HIGH ctrlrange end."""
+        monkeypatch.setattr(
+            "strands_robots.simulation.mujoco.motion_primitives.get_robot",
+            lambda name: {"gripper": {"actuators": ["Jaw"], "closed": "high", "open": "low"}},
+        )
+        result = _dispatch(collider_sim, "set_gripper", robot_name="arm", state="close", steps=5)
+        assert result["status"] == "success", result
+        assert _json_block(result)["targets"]["Jaw"] == pytest.approx(1.5)  # HIGH end
+        result = _dispatch(collider_sim, "set_gripper", robot_name="arm", state="open", steps=5)
+        assert result["status"] == "success", result
+        assert _json_block(result)["targets"]["Jaw"] == pytest.approx(-0.2)  # LOW end
+
+    def test_stale_metadata_is_a_loud_error_not_a_heuristic_fallback(self, collider_sim, monkeypatch):
+        """Metadata naming actuators absent from the model errors with the
+        model's actual actuator list - silently degrading to the heuristic
+        would reintroduce the misclassification the metadata prevents."""
+        monkeypatch.setattr(
+            "strands_robots.simulation.mujoco.motion_primitives.get_robot",
+            lambda name: {"gripper": {"actuators": ["no_such_actuator"], "closed": "low", "open": "high"}},
+        )
+        for action, fields in (
+            ("set_gripper", {"state": "close"}),
+            ("move_to", {"position": REACHABLE}),
+        ):
+            result = _dispatch(collider_sim, action, robot_name="arm", **fields)
+            assert result["status"] == "error", (action, result)
+            text = result["content"][0]["text"]
+            assert "no_such_actuator" in text and "Jaw" in text, (action, text)
+
+    def test_malformed_metadata_is_a_loud_error(self, collider_sim, monkeypatch):
+        monkeypatch.setattr(
+            "strands_robots.simulation.mujoco.motion_primitives.get_robot",
+            lambda name: {"gripper": {"actuators": [], "closed": "low", "open": "high"}},
+        )
+        result = _dispatch(collider_sim, "set_gripper", robot_name="arm", state="close")
+        assert result["status"] == "error", result
+        assert "malformed" in result["content"][0]["text"]
+
+    def test_no_data_config_still_uses_heuristic(self, sim):
+        """Zero-config fallback pinned: a robot without a data_config resolves
+        the jaw by name hints exactly as before this feature."""
+        result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=5)
+        assert result["status"] == "success", result
+        assert _json_block(result)["actuators"] == ["jaw"]
 
 
 class TestRecordingInterplay:

--- a/tests/test_registry_integrity.py
+++ b/tests/test_registry_integrity.py
@@ -193,3 +193,72 @@ def test_rebot_b601_family_is_drivable_real(registry: dict) -> None:
         assert resolve_name(canonical) == canonical
         assert resolve_name(lerobot_type) == canonical
         assert get_hardware_type(canonical) == lerobot_type
+
+
+# Valid values for gripper.closed / gripper.open: which ctrlrange END the
+# state maps to. Kept in sync with
+# strands_robots/simulation/mujoco/motion_primitives.py::_CTRLRANGE_ENDS.
+_GRIPPER_ENDS = {"low", "high"}
+
+
+def test_gripper_metadata_shape(registry: dict) -> None:
+    """Optional ``gripper`` blocks are shape-checked when present (GH #1658).
+
+    The motion primitives treat this metadata as AUTHORITATIVE over the
+    gripper name heuristic, so a malformed block would either brick
+    ``set_gripper``/``move_to`` for that robot or silently misclassify an
+    arm DOF as a gripper. Shape contract::
+
+        "gripper": {
+            "actuators": ["<actuator short name>", ...],   # non-empty
+            "closed": "low" | "high",                       # ctrlrange end
+            "open":   "low" | "high"                        # must differ
+        }
+
+    Actuator names are the namespace-stripped names in the robot's SHIPPED
+    sim MJCF (``asset.model_xml``), matched case-insensitively at runtime.
+    """
+    problems: list[str] = []
+    for name, info in registry.items():
+        gripper = info.get("gripper")
+        if gripper is None:
+            continue
+        if not isinstance(gripper, dict):
+            problems.append(f"{name}.gripper must be a dict, got {type(gripper).__name__}")
+            continue
+        unknown = set(gripper) - {"actuators", "closed", "open"}
+        if unknown:
+            problems.append(f"{name}.gripper has unknown keys: {sorted(unknown)}")
+        actuators = gripper.get("actuators")
+        if not (isinstance(actuators, list) and actuators and all(isinstance(a, str) and a.strip() for a in actuators)):
+            problems.append(f"{name}.gripper.actuators must be a non-empty list of non-empty strings: {actuators!r}")
+        closed = gripper.get("closed", "low")
+        opened = gripper.get("open", "high")
+        if closed not in _GRIPPER_ENDS:
+            problems.append(f"{name}.gripper.closed must be one of {sorted(_GRIPPER_ENDS)}: {closed!r}")
+        if opened not in _GRIPPER_ENDS:
+            problems.append(f"{name}.gripper.open must be one of {sorted(_GRIPPER_ENDS)}: {opened!r}")
+        if closed in _GRIPPER_ENDS and opened in _GRIPPER_ENDS and closed == opened:
+            problems.append(f"{name}.gripper: 'closed' and 'open' must map to different ctrlrange ends")
+    assert not problems, "Malformed gripper metadata:\n  " + "\n  ".join(problems)
+
+
+def test_shipped_gripper_metadata_entries(registry: dict) -> None:
+    """Pin the gripper metadata for the robots we ship policy configs for.
+
+    The actuator names were verified against each robot's shipped sim model
+    (``asset.model_xml``); losing an entry silently demotes that robot to the
+    name heuristic, which FAILS for so101 (actuators named ``1``..``6``) and
+    panda (tendon-driven ``actuator8``) - their grippers would become
+    undrivable through ``set_gripper``.
+    """
+    expected = {
+        "so100": ["Jaw"],  # trs_so_arm100/so_arm100.xml
+        "so101": ["6"],  # robotstudio so101_new_calib.xml (actuators named 1..6)
+        "panda": ["actuator8"],  # franka_emika_panda/panda.xml (tendon 'split', 0=closed 255=open)
+    }
+    for name, actuators in expected.items():
+        gripper = registry[name].get("gripper")
+        assert gripper is not None, f"{name} lost its registry gripper metadata"
+        assert gripper["actuators"] == actuators, f"{name}.gripper.actuators changed: {gripper['actuators']}"
+        assert gripper["closed"] == "low" and gripper["open"] == "high", name


### PR DESCRIPTION
Closes #1661. Follow-up to #1658 / PR #1660.

> **Stacked on #1660** (`feat/registry-gripper-metadata`): this branch contains #1660's commit because `_resolve_gripper_actuators()` lands there. Merge #1660 first; after that this PR's diff reduces to the single `rotate_wrist` commit (`99c1a574`). Happy to rebase onto `main` once #1660 merges if preferred.

## What changed

`rotate_wrist` was deliberately left out of #1660's scope: it still filtered gripper joints out of its wrist-candidate set with the raw `_GRIPPER_HINTS` substring match on joint names. Both heuristic failure modes from #1658 applied to that selection, and one was live on a shipped model:

- **so101's shipped sim MJCF names its joints `1`..`6`.** No wrist hint matches, no gripper hint matches, so the last-non-gripper-hinge fallback selected joint `6` - which IS the jaw. `rotate_wrist` on so101 would open/close the gripper instead of rotating the wrist.
- **A hint-colliding arm joint name** (e.g. a distal `finger_camera_roll`) was excluded from the wrist candidate set, shifting the fallback onto a more proximal joint (the elbow).

Now `rotate_wrist` excludes gripper DOFs via the shared `_resolve_gripper_actuators()` (registry `gripper` metadata first, name hints as the zero-config fallback), exactly like `set_gripper` and `move_to`.

**Error contract**: same as `set_gripper`/`move_to` - stale metadata (names no actuator in the model) and malformed metadata are loud structured errors, never a silent heuristic fallback.

Diff over #1660 is small: `motion_primitives.py` +20/-2 (one classification call replacing the inline hint filter, plus docstrings), the rest is tests.

## Test surface

All in `tests/simulation/mujoco/test_motion_primitives.py`:

- `TestRotateWristRegistryMetadata::test_jaw_is_never_selected_as_wrist_on_so101_style_model` - the issue's acceptance test: an inline arm with joints/actuators named `1`..`6` + the REAL shipped `so101` registry entry (`actuators: ["6"]`). Pins that the fallback picks joint `5`, reaches the set-point, and the jaw does not move. Fails on pre-fix code (pre-fix selects joint `6`).
- `TestRotateWristRegistryMetadata::test_hint_colliding_distal_joint_stays_a_wrist_candidate` - fallback-shift regression: a most-distal `finger_camera_roll` joint stays a candidate under so100 metadata and is picked; elbow and jaw hold position. Fails on pre-fix code (pre-fix picks the elbow).
- `test_stale_metadata_is_a_loud_error_not_a_heuristic_fallback` and `test_malformed_metadata_is_a_loud_error` now cover `rotate_wrist` alongside `set_gripper`/`move_to`.
- `TestRotateWristRegistryMetadata::test_no_metadata_heuristic_unchanged` - zero-config pin: without registry metadata the wrist hint match resolves `wrist_roll` exactly as before.

## Acceptance criteria from #1661

- [x] `rotate_wrist` excludes gripper DOFs via the shared `_resolve_gripper_actuators()` (registry metadata first, hints fallback) instead of raw `_GRIPPER_HINTS` joint-name matching
- [x] Error contract decided: same loud structured error as `set_gripper`/`move_to` on stale/malformed metadata (pinned by tests)
- [x] Regression test on the so101-style model (joints named `1..6` + registry metadata) pinning that the jaw is never selected as the wrist
- [ ] Optional `wrist` registry field - **out of scope** (the issue marks it a separate decision; the last-non-gripper-hinge fallback is sufficient once the gripper exclusion is metadata-aware, as the so101 test shows). Can file a follow-up issue if the hint list misses again.

## Validation

- `hatch run lint` - clean (ruff check, ruff format, mypy: no issues in 896 files)
- `hatch run test` with `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl` - **12062 passed, 245 skipped, 0 failed**
- Environmental note: without EGL env vars the suite SIGABRTs inside MuJoCo's classic GL renderer init (`mujoco/rendering/classic/renderer.py` `__init__`) on headless render tests - pre-existing on this dev box (reproduced on the base branch), not introduced here.

## Project board

Issue #1661 should move to "In review" on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2).
