### PR TITLE
fix(sim): plain-MP4 camera recorder rejects frame/pixel counts it cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: the plain-MP4 camera recorder rejects frame and pixel counts it cannot honor
+
+`start_cameras_recording` and `start_cameras_recording_synchronous` never
+validated `fps`, `width`, `height` or `max_frames_per_camera`. Each unusable
+value produced a recording that wrote no MP4 at all while both `start` and
+`stop` reported success:
+
+```python
+sim.start_cameras_recording(cameras=["wrist"], fps=0)
+# -> success: "Recording 1 camera(s) @ 0 FPS -> /tmp/..."
+sim.stop_cameras_recording()
+# -> success: frames 0, and no file on disk
+```
+
+The failures were downstream of the success return, so nothing surfaced them:
+`fps=0` killed the capture thread on its first `1 / fps`, `fps=-1`/`nan`/`inf`
+were refused by the ffmpeg writer during the flush, `fps="30"` raised a
+`TypeError` on the capture thread, `max_frames_per_camera=0` made
+`len(buffer) >= cap` true for every frame, and a non-positive `width`/`height`
+failed every render call. All nine of those inputs measured 0 frames and no MP4
+under a `status="success"` pair.
+
+These are frame counts and pixel counts, and the accepted domain for them was
+already defined for the `run_policy(video={...})` path. Both recording surfaces
+now bind that one predicate, so an unusable option is a structured error naming
+the parameter, and the two surfaces cannot drift on what a usable `fps` is.
+`width`/`height` of `None` still mean "use the camera's configured resolution".
+
+
 ### Fixed: a gripper command is honored the same way whichever name the action key spells
 
 `send_action` accepts an action key as either the actuator name (`actuator8` on

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -263,6 +263,13 @@ then only a lower bound, reported in the `unreadable_files` diagnostics.
 | `save_episode` | `[lerobot]` | Close current rollout as one episode (call once per `run_policy` for N episodes) |
 | `start_cameras_recording` / `stop_cameras_recording` | `[sim-mujoco]` alone | Plain MP4, no parquet |
 
+`fps`, `width`, `height` and `max_frames_per_camera` on the plain-MP4 recorders
+must be positive whole numbers - the same domain `run_policy(video={...})`
+enforces. An unusable value (`fps=0`, a negative frame cap) is a structured
+error naming the parameter rather than a recording that reports success and
+writes no file. Omit `width`/`height` to use each camera's configured
+resolution.
+
 ## Video codec (H.264 default, AV1 opt-in)
 
 `start_recording` (and `DatasetRecorder.create`/`resume`) default to

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -94,6 +94,62 @@ def _save_render_png(output_path: str, png_bytes: bytes) -> str:
     return str(safe)
 
 
+def _cameras_recording_option_error(
+    method: str,
+    fps: Any,
+    width: Any,
+    height: Any,
+    max_frames_per_camera: Any,
+) -> dict[str, Any] | None:
+    """Reject a plain-MP4 recording option the recorder cannot honor.
+
+    Pre-flight guard shared by both plain-MP4 entry points
+    (:meth:`RenderingMixin.start_cameras_recording` and
+    :meth:`RenderingMixin.start_cameras_recording_synchronous`). Every one of
+    these knobs is a frame count or a pixel count, so the accepted domain is the
+    shared one the ``run_policy(video=...)`` dict already enforces
+    (:func:`~strands_robots.simulation.policy_runner.positive_whole_number_error`)
+    - a single source of truth, so the two recording surfaces cannot disagree on
+    what a usable ``fps`` is.
+
+    Without this guard each unusable value produced a ``status="success"``
+    recording that wrote no MP4 at all: ``fps=0`` killed the capture thread on
+    its first ``1 / fps``, ``fps=-1`` / ``nan`` / ``inf`` were refused by the
+    ffmpeg writer at flush time, ``fps="30"`` raised a ``TypeError`` on the
+    capture thread, ``max_frames_per_camera=0`` made ``len(buffer) >= cap`` true
+    for every frame, and a non-positive ``width``/``height`` failed every render
+    call - all reported as success by both ``start`` and ``stop``.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        fps: Capture/encode frame rate.
+        width: Per-frame width, or ``None`` for the camera/renderer default.
+        height: Per-frame height, or ``None`` for the camera/renderer default.
+        max_frames_per_camera: In-memory per-camera frame cap.
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict naming the first
+        offending parameter, or ``None`` when every option is usable.
+    """
+    from strands_robots.simulation.policy_runner import positive_whole_number_error
+
+    # ``width``/``height`` are ``int | None``: ``None`` means "use the camera's
+    # configured resolution, else the renderer default", so it is skipped rather
+    # than rejected. ``fps`` and the frame cap have no such opt-out.
+    checks: tuple[tuple[str, Any], ...] = (
+        ("fps", fps),
+        ("max_frames_per_camera", max_frames_per_camera),
+        ("width", width),
+        ("height", height),
+    )
+    for param, value in checks:
+        if value is None and param in ("width", "height"):
+            continue
+        if text := positive_whole_number_error(value, param, method):
+            return {"status": "error", "content": [{"text": text}]}
+    return None
+
+
 class RenderingMixin:
     """Rendering + observation helpers mixed into ``Simulation``.
 
@@ -1742,11 +1798,17 @@ class RenderingMixin:
             output_dir: where to write ``{tag}__{cam}.mp4``. Validated against
                 ``..`` traversal / backslash / shell metacharacters / symlink;
                 set ``STRANDS_ROBOTS_VIDEO_ROOT`` to confine it to a sandbox.
-            fps: capture rate.
-            width/height: per-frame size.
+            fps: capture rate. Must be a positive whole number - the capture
+                loop's period is ``1 / fps``, so an unusable value is rejected
+                up front rather than killing the capture thread behind a
+                ``status="success"`` return.
+            width/height: per-frame size. ``None`` uses the camera's configured
+                resolution (else the renderer default); an explicit value must
+                be a positive whole number.
             name: filename tag (auto if None). Validated as a single path
                 component - separators / traversal / metacharacters rejected.
-            max_frames_per_camera: safety cap on in-memory buffers.
+            max_frames_per_camera: safety cap on in-memory buffers. Must be a
+                positive whole number; ``0``/negative would drop every frame.
         """
         import os as _os
         import tempfile as _tempfile
@@ -1756,6 +1818,14 @@ class RenderingMixin:
 
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+
+        # Reject a frame/pixel count the recorder cannot honor before any
+        # filesystem or capture-thread work: every one of these produced an
+        # empty recording that still reported success.
+        if error := _cameras_recording_option_error(
+            "start_cameras_recording", fps, width, height, max_frames_per_camera
+        ):
+            return error
 
         if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
             cur = self._cams_rec_state["name"]
@@ -2146,13 +2216,18 @@ class RenderingMixin:
                 traversal / backslash / shell metacharacters / symlink; set
                 ``STRANDS_ROBOTS_VIDEO_ROOT`` to confine it to a sandbox.
             fps: encoded MP4 frame rate (and target capture rate when
-                ``on_frame`` fires more often than ``fps``).
+                ``on_frame`` fires more often than ``fps``). Must be a positive
+                whole number - the ffmpeg writer refuses anything else, so an
+                unusable value is rejected up front instead of surfacing as an
+                empty recording that reported success.
             width, height: per-frame size; defaults to the renderer's
-                native resolution.
+                native resolution. An explicit value must be a positive whole
+                number.
             name: filename tag (auto-generated UUID prefix when ``None``).
                 Validated as a single path component - separators / traversal
                 / metacharacters rejected.
-            max_frames_per_camera: safety cap on in-memory buffers.
+            max_frames_per_camera: safety cap on in-memory buffers. Must be a
+                positive whole number (``0``/negative would drop every frame).
                 Frames beyond the cap are silently dropped (status
                 visible via :meth:`get_cameras_recording_status`).
 
@@ -2174,6 +2249,14 @@ class RenderingMixin:
 
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+
+        # Reject a frame/pixel count the recorder cannot honor before any
+        # filesystem or capture-thread work: every one of these produced an
+        # empty recording that still reported success.
+        if error := _cameras_recording_option_error(
+            "start_cameras_recording_synchronous", fps, width, height, max_frames_per_camera
+        ):
+            return error
 
         if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
             cur = self._cams_rec_state["name"]

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -176,6 +176,39 @@ def _extract_frame_ndarray(render_result: dict) -> np.ndarray | None:
     return None
 
 
+def positive_whole_number_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable positive whole number.
+
+    Shared domain for every recording knob that counts frames or pixels -
+    ``fps``, ``width``, ``height`` and the in-memory frame cap. Only a positive
+    whole number can be honored: ``0`` makes the capture loop's ``1 / fps``
+    period undefined, a negative rate is rejected by the ffmpeg writer, and a
+    zero/negative frame cap drops every frame. Accepts any real scalar with an
+    integral value (so a NumPy ``np.int64`` height or a ``30.0`` computed from a
+    config float passes) and rejects ``bool`` explicitly - an ``int`` subclass
+    whose ``True`` would act as a silent 1.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter (or dict key) it came from, used in the message.
+        context: Message prefix identifying the surface that received it -
+            ``"video"`` for the :class:`VideoConfig` dict, the method name for a
+            keyword parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    message = f"{context}: {param} must be a positive whole number, got {value!r}."
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return message
+    numeric = float(value)
+    # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
+    # out of the integrality check below.
+    if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
+        return message
+    return None
+
+
 # Canonical :class:`VideoConfig` field -> the dict keys accepted for it, canonical
 # key first followed by the legacy/tool_spec aliases. Single source of truth for
 # both the schema check (``VideoConfig.validation_error``) and the value lookup
@@ -257,13 +290,13 @@ class VideoConfig:
 
     @staticmethod
     def _positive_int_error(value: Any, key: str) -> str | None:
-        """Error text when ``value`` is not a usable positive whole number.
+        """Error text when a ``video`` dict value is not a positive whole number.
 
-        ``fps`` / ``width`` / ``height`` are frame counts and pixel counts:
-        only a positive whole number can be honored. Accepts any real scalar
-        with an integral value (so a NumPy ``np.int64`` height or a ``30.0``
-        computed from a config float passes) and rejects ``bool`` explicitly -
-        an ``int`` subclass whose ``True`` would act as a silent 1.
+        Thin binding of the shared frame/pixel-count domain
+        (:func:`positive_whole_number_error`) to the ``video:`` message prefix,
+        so this dict schema and the plain-MP4 recorder's keyword parameters
+        cannot drift apart on what counts as a usable ``fps`` / ``width`` /
+        ``height``.
 
         Args:
             value: The caller-supplied value.
@@ -272,15 +305,7 @@ class VideoConfig:
         Returns:
             An error message, or ``None`` when the value is usable.
         """
-        message = f"video: {key} must be a positive whole number, got {value!r}."
-        if isinstance(value, bool) or not isinstance(value, numbers.Real):
-            return message
-        numeric = float(value)
-        # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
-        # out of the integrality check below.
-        if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
-            return message
-        return None
+        return positive_whole_number_error(value, key, "video")
 
     @classmethod
     def validation_error(cls, d: Any) -> str | None:

--- a/tests/simulation/mujoco/test_cameras_recording_preflight_guards.py
+++ b/tests/simulation/mujoco/test_cameras_recording_preflight_guards.py
@@ -12,7 +12,11 @@ capture thread:
   MP4 files, and
 * an ``output_dir`` that fails path validation (traversal / metacharacters) is
   rejected with a ``"cameras_recording: ..."`` error instead of being passed
-  through to ``os.makedirs``.
+  through to ``os.makedirs``, and
+* every frame/pixel-count option (``fps``, ``width``, ``height``,
+  ``max_frames_per_camera``) must be a positive whole number, since each
+  unusable value produced an empty recording that both ``start`` and ``stop``
+  reported as ``status="success"``.
 
 These are LLM-facing tool contracts, so the guards return the structured
 ``{"status": "error", ...}`` shape rather than raising. Pinned here so a
@@ -25,6 +29,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import time
 
 import pytest
 
@@ -109,3 +114,125 @@ class TestOutputDirValidation:
         assert "output_dir" in text
         # Rejected at the pre-flight stage: no synchronous session started.
         assert sim.get_cameras_recording_status()["status"] == "success"
+
+
+class TestRecordingOptionValidation:
+    """Frame/pixel-count options must be positive whole numbers on both entry points.
+
+    Each of these values makes a recording impossible, and each one used to be
+    accepted: ``fps=0`` killed the capture thread on its first ``1 / fps``,
+    ``fps=-1``/``nan``/``inf`` were refused by the ffmpeg writer at flush time,
+    ``fps="30"`` raised a ``TypeError`` on the capture thread, and a
+    non-positive ``max_frames_per_camera``/``width``/``height`` dropped or
+    failed every frame. In every case ``start_cameras_recording`` returned
+    ``status="success"`` (announcing e.g. "Recording 1 camera(s) @ 0 FPS") and
+    ``stop_cameras_recording`` also returned success with ``frames: 0`` and no
+    MP4 on disk - so a caller had no signal that the recording never happened.
+    """
+
+    _BAD_VALUES = [0, -1, 2.5, float("nan"), float("inf"), "30", True, None]
+
+    @pytest.fixture
+    def cam_sim(self, sim):
+        sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+        return sim
+
+    @staticmethod
+    def _assert_rejected(result, method, param):
+        """The result is a structured error naming the method and the parameter."""
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith(f"{method}: {param} must be a positive whole number"), text
+
+    @pytest.mark.parametrize("bad", _BAD_VALUES)
+    def test_daemon_recorder_rejects_unusable_fps(self, cam_sim, bad, tmp_path):
+        result = cam_sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), fps=bad)
+        self._assert_rejected(result, "start_cameras_recording", "fps")
+        # Rejected before any thread/state registration: nothing is recording.
+        assert "No active camera recording" in cam_sim.get_cameras_recording_status()["content"][0]["text"]
+
+    @pytest.mark.parametrize("bad", _BAD_VALUES)
+    def test_synchronous_recorder_rejects_unusable_fps(self, cam_sim, bad, tmp_path):
+        result = cam_sim.start_cameras_recording_synchronous(cameras=["cam_a"], output_dir=str(tmp_path), fps=bad)
+        self._assert_rejected(result, "start_cameras_recording_synchronous", "fps")
+
+    @pytest.mark.parametrize("bad", [0, -5, 1.5, None])
+    def test_daemon_recorder_rejects_unusable_frame_cap(self, cam_sim, bad, tmp_path):
+        result = cam_sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), max_frames_per_camera=bad)
+        self._assert_rejected(result, "start_cameras_recording", "max_frames_per_camera")
+
+    @pytest.mark.parametrize("param", ["width", "height"])
+    @pytest.mark.parametrize("bad", [0, -64, 12.5])
+    def test_daemon_recorder_rejects_unusable_frame_size(self, cam_sim, param, bad, tmp_path):
+        result = cam_sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), **{param: bad})
+        self._assert_rejected(result, "start_cameras_recording", param)
+
+    def test_omitted_frame_size_is_accepted(self, cam_sim, tmp_path):
+        """``width``/``height`` of ``None`` means "camera default", not an error."""
+        result = cam_sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), width=None, height=None)
+        assert result["status"] == "success"
+        cam_sim.stop_cameras_recording()
+
+    def test_integral_float_and_numpy_options_are_accepted(self, cam_sim, tmp_path):
+        """A ``30.0``/``np.int64`` option is usable and must not be rejected."""
+        import numpy as np
+
+        result = cam_sim.start_cameras_recording(
+            cameras=["cam_a"],
+            output_dir=str(tmp_path),
+            fps=30.0,
+            width=np.int64(64),
+            height=np.int64(48),
+            max_frames_per_camera=np.int64(10),
+        )
+        assert result["status"] == "success"
+        cam_sim.stop_cameras_recording()
+
+    def test_valid_options_still_write_an_mp4(self, cam_sim, tmp_path):
+        """Round trip: the guard does not disturb a recording it should allow."""
+        started = cam_sim.start_cameras_recording(
+            cameras=["cam_a"], output_dir=str(tmp_path), name="roundtrip", fps=10, width=64, height=48
+        )
+        assert started["status"] == "success"
+        time.sleep(0.6)
+        stopped = cam_sim.stop_cameras_recording()
+        assert stopped["status"] == "success"
+        mp4 = tmp_path / "roundtrip__cam_a.mp4"
+        assert mp4.exists() and mp4.stat().st_size > 0
+
+
+class TestSharedPositiveWholeNumberDomain:
+    """The recorder and ``run_policy(video=...)`` share one accepted domain.
+
+    ``video={"fps": 0}`` has been rejected since the video-config schema landed;
+    the plain-MP4 recorder accepted the same value. Both now bind the same
+    predicate, so the two surfaces cannot drift on what a usable frame or pixel
+    count is.
+    """
+
+    # ``None`` is deliberately absent: in the ``video`` dict it means "key not
+    # supplied" (``_pick`` falls back to the field default), while on the
+    # recorder it is an explicit argument with no such fallback. Every value
+    # that is a real supplied number is rejected identically by both.
+    @pytest.mark.parametrize("bad", [0, -1, 2.5, float("nan"), float("inf"), "30", True])
+    def test_video_config_and_recorder_agree_on_rejection(self, bad):
+        from strands_robots.simulation.policy_runner import VideoConfig, positive_whole_number_error
+
+        assert positive_whole_number_error(bad, "fps", "start_cameras_recording") is not None
+        assert VideoConfig.validation_error({"path": "/tmp/a.mp4", "fps": bad}) is not None
+
+    @pytest.mark.parametrize("good", [1, 30, 30.0])
+    def test_video_config_and_recorder_agree_on_acceptance(self, good):
+        from strands_robots.simulation.policy_runner import VideoConfig, positive_whole_number_error
+
+        assert positive_whole_number_error(good, "fps", "start_cameras_recording") is None
+        assert VideoConfig.validation_error({"path": "/tmp/a.mp4", "fps": good}) is None
+
+    def test_error_text_names_the_receiving_surface(self):
+        from strands_robots.simulation.policy_runner import positive_whole_number_error
+
+        assert positive_whole_number_error(0, "fps", "video") == "video: fps must be a positive whole number, got 0."
+        assert (
+            positive_whole_number_error(0, "fps", "start_cameras_recording")
+            == "start_cameras_recording: fps must be a positive whole number, got 0."
+        )


### PR DESCRIPTION
## Problem

`start_cameras_recording` and `start_cameras_recording_synchronous` (the `[sim-mujoco]`-only plain-MP4 recorders) never validated `fps`, `width`, `height` or `max_frames_per_camera`. Every unusable value produced a recording that wrote **no MP4 at all**, while both `start` **and** `stop` reported success:

```python
sim.start_cameras_recording(cameras=["scene"], output_dir=d, fps=0)
# -> {"status": "success"}  "Recording 1 camera(s) @ 0 FPS -> /tmp/..."
sim.stop_cameras_recording()
# -> {"status": "success"}  frames: 0   ... and no file on disk
```

Every failure happened *downstream of the success return*, so nothing surfaced it:

| input | what actually happened | `start` | `stop` | frames | MP4 |
|---|---|---|---|---|---|
| `fps=0` | capture thread died on its first `interval = 1.0 / fps` (`ZeroDivisionError`) | success | success | 0 | absent |
| `fps=-1` | ffmpeg refused `-r -1.00`, flush hit a broken pipe | success | success | 0 | absent |
| `fps=nan` | flush: `cannot convert float NaN to integer` | success | success | 0 | absent |
| `fps=inf` | flush: `OverflowError` | success | success | 0 | absent |
| `fps="30"` | capture thread died (`TypeError: / 'float' and 'str'`) | success | success | 0 | absent |
| `max_frames_per_camera=0` / `-5` | `len(buffer) >= cap` true for every frame | success | success | 0 | absent |
| `width=0` / `-64` | every `render()` call failed | success | success | 0 | absent |

The exceptions on the capture thread are raised *after* `state["ready"].set()` unblocks the caller, and the flush failures are absorbed into the best-effort per-camera error path, so the caller's only two return values both said success.

The values are frame counts and pixel counts, and the accepted domain for exactly these knobs was already defined for the other MP4 path: `run_policy(video={"fps": 0})` has been rejected since the video-config schema landed. The two recording surfaces simply disagreed.

## Change

- Promote the frame/pixel-count domain that `VideoConfig` already enforced into a shared `positive_whole_number_error(value, param, context)` in `simulation/policy_runner.py`. `VideoConfig._positive_int_error` becomes a thin binding of it with the `video:` prefix, so its messages are byte-identical to before and the two surfaces cannot drift on what a usable `fps` is.
- Add a pre-flight guard, `_cameras_recording_option_error`, shared by both plain-MP4 entry points. It runs immediately after the no-world check, before any `os.makedirs`, state registration or capture thread, and returns the structured tool-error envelope naming the offending parameter:

```
start_cameras_recording: fps must be a positive whole number, got 0.
start_cameras_recording_synchronous: max_frames_per_camera must be a positive whole number, got -5.
```

- `width`/`height` of `None` keep their meaning ("use the camera's configured resolution, else the renderer default") and are skipped, not rejected. `fps` and the frame cap have no such opt-out. A `30.0` or an `np.int64(48)` is accepted; `True` is rejected explicitly (an `int` subclass that would act as a silent 1).

One deliberate asymmetry, documented at the parity test: `fps=None` is valid in the `video` dict (membership semantics - the key is absent, the field default applies) but invalid as an explicit recorder keyword, which has no such fallback.

## Visual artifact

Same call, before and after. The left panel is the pre-fix run (source reverted); the right panel is the frame decoded out of the MP4 the honored `fps=20` call actually produced.

![before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cameras-recording-option-guard/cameras_recording_fps_guard.png)

The honored recording, decoded back from disk (11 frames, 39 KB):

![honored recording](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cameras-recording-option-guard/honored_recording.gif)

## Tests

37 new/changed cases in `tests/simulation/mujoco/test_cameras_recording_preflight_guards.py` (the existing home for this recorder's pre-flight contracts):

- `fps` rejected on **both** entry points for `0`, `-1`, `2.5`, `nan`, `inf`, `"30"`, `True`, `None`, with the error naming the method and the parameter, and `get_cameras_recording_status()` confirming no session was registered.
- `max_frames_per_camera` and an explicit `width`/`height` rejected for the same class of values.
- Positive cases pinned so the guard cannot over-reject: omitted `width`/`height`, a `30.0` fps, `np.int64` sizes, and a full round trip (`start` -> sleep -> `stop`) that asserts the MP4 exists and is non-empty.
- A parity class asserting the recorder and `VideoConfig.validation_error` accept and reject the same values, plus the exact message text for both prefixes.

Pre-fix on this base: **37 failed, 6 passed** (26 behavioural rejections plus 11 on the shared predicate). Post-fix: 43 passed.

Full local gate: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean, and `MUJOCO_GL=egl pytest tests` -> **12183 passed, 260 skipped** (415s).

## Docs

`docs/recording.md` states the accepted domain next to the plain-MP4 recorder row; both method docstrings state it per parameter, including that `None` width/height means "camera default".