### PR TITLE
fix(sim): read caller-supplied vectors by membership, not truthiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,39 @@ reports identically regardless of which optional extras an install has. Usable
 rates are unchanged: `30`, `30.0` and a NumPy integer all still record, and a
 recorded episode reopens at the requested rate.
 
+### Fixed: caller-supplied vectors are read by membership, not truthiness
+
+`add_object`, `add_robot`, `add_camera`, `move_object` and `apply_force` decided
+whether a vector parameter had been supplied by testing the vector itself
+(`position or [0.0, 0.0, 0.0]`, `if position:`, `np.array(force or [0, 0, 0])`).
+Two failure modes followed from that.
+
+A NumPy vector - what pose arithmetic, an observation row or a computed wrench
+actually is - has no boolean value, so it raised a bare `ValueError` straight
+through the structured tool-result contract, on all nine affected parameters:
+
+```python
+sim.add_object(name="cube", position=base + np.array([0.1, 0.0, 0.0]))
+# -> ValueError: The truth value of an array with more than one element is ambiguous
+sim.apply_force(body_name="cube", force=np.array([8.0, 0.0, 0.0]))
+# -> same ValueError, past the {"status": ...} envelope
+```
+
+An empty vector is falsy, so it read as "omitted" and the default was applied
+under a `success` result: `add_camera(position=[])` placed the camera at the
+default `[1, 1, 1]`, and `move_object(position=[])` moved nothing while
+reporting `"'cube' moved to same"` (on a static object it reached MuJoCo's spec
+setter and raised a bare pybind `TypeError`).
+
+A vector parameter is now supplied when it is not `None`. A supplied vector is
+validated for length and finiteness and normalized to plain floats by the shared
+`_coerce_pose_vector`, so an accepted NumPy input does not outlive that boundary
+and leak `np.float64(0.05)` into status text or into the `list[float]` fields of
+`SimObject` / `SimRobot`. Omitting a vector still takes its documented default.
+`move_object` also reports the components it actually applied - an
+orientation-only move was reported as `"moved to same"` even though the rotation
+was written.
+
 ### Fixed: the plain-MP4 camera recorder rejects frame and pixel counts it cannot honor
 
 `start_cameras_recording` and `start_cameras_recording_synchronous` never

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -525,6 +525,9 @@ class PhysicsMixin:
 
         To stop the force: ``apply_force(body, force=[0, 0, 0])``.
 
+        Each vector may be a list, a tuple or a NumPy array (a computed wrench
+        is an array), and every element must be a finite real number.
+
         Args:
             body_name: Target body name.
             force: [fx, fy, fz] in world frame (Newtons).
@@ -593,11 +596,16 @@ class PhysicsMixin:
         if body_id < 0:
             return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Body", body_name)}]}
 
-        f = np.array(force or [0, 0, 0], dtype=np.float64)
-        t = np.array(torque or [0, 0, 0], dtype=np.float64)
+        # Membership, not truthiness: a vector is supplied when it is not None.
+        # ``force or [0, 0, 0]`` raised a bare "truth value of an array with more
+        # than one element is ambiguous" ValueError - through the structured
+        # tool-result contract - for a NumPy force/torque/point, which is what
+        # any computed wrench (``mass * accel``, a Jacobian row) actually is.
         # Note: explicit [0,0,0] is a valid "clear the latched force" command; we only
         # reject the case where the caller forgot both args (handled above).
-        p = np.array(point, dtype=np.float64) if point else data.xipos[body_id].copy()
+        f = np.array([0.0, 0.0, 0.0] if force is None else force, dtype=np.float64)
+        t = np.array([0.0, 0.0, 0.0] if torque is None else torque, dtype=np.float64)
+        p = np.array(point, dtype=np.float64) if point is not None else data.xipos[body_id].copy()
 
         # Zero the buffer first so calls are idempotent (replace, not accumulate).
         # NOTE: MuJoCo does NOT reset qfrc_applied in mj_step - the force

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -240,6 +240,47 @@ def _validate_pose_vector(method: str, param_name: str, vec: Any, expected_len: 
 # default and the per-robot mapping fallback cannot drift apart.
 _DEFAULT_ACTION_HORIZON = 8
 
+
+def _coerce_pose_vector(
+    method: str, param_name: str, vec: Any, expected_len: int
+) -> tuple[list[float] | None, str | None]:
+    """Validate an optional pose vector and normalize it to plain floats.
+
+    Membership, not truthiness: a pose parameter is "supplied" when it is not
+    ``None``. Testing the vector itself (``if position:``, ``position or
+    <default>``) is wrong twice over. A NumPy array - the natural product of any
+    pose arithmetic, and what every docstring here advertises as accepted -
+    raises a bare ``ValueError: truth value of an array ... is ambiguous``
+    through the structured tool-result contract, and an empty vector reads as
+    "omitted", so the default is substituted (or the write skipped) while the
+    call reports success.
+
+    Normalizing to a ``list[float]`` keeps the accepted NumPy input from
+    outliving this boundary: the pose is stored on :class:`SimObject` /
+    :class:`SimRobot` (both annotated ``list[float]``), echoed in the status
+    text, and written into the spec, so a raw ``np.float64`` element would leak
+    ``np.float64(0.05)`` into agent-visible output.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        vec: The caller's value, or ``None`` when the parameter was omitted.
+        expected_len: Component count the target buffer defines (3 for a
+            position, 4 for a wxyz quaternion).
+
+    Returns:
+        ``(None, None)`` when ``vec`` is ``None`` (omitted - the caller applies
+        its own default), ``(floats, None)`` for an acceptable vector, or
+        ``(None, error_message)`` for a wrong length, a non-numeric element or a
+        ``nan``/``inf`` component.
+    """
+    if vec is None:
+        return None, None
+    if (err := _validate_pose_vector(method, param_name, vec, expected_len)) is not None:
+        return None, err
+    return [float(v) for v in vec], None
+
+
 _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
 
 # Tool schema is 357 lines of JSON. `tool_spec` property is on the LLM hot path
@@ -1158,12 +1199,11 @@ class MuJoCoSimEngine(
         # element raises a bare MuJoCo `add_frame(): incompatible function
         # arguments` TypeError that escapes the structured-error contract. NumPy
         # scalar components are accepted.
-        if position is not None and (e := _validate_pose_vector("add_robot", "position", position, 3)) is not None:
+        position, e = _coerce_pose_vector("add_robot", "position", position, 3)
+        if e is not None:
             return {"status": "error", "content": [{"text": e}]}
-        if (
-            orientation is not None
-            and (e := _validate_pose_vector("add_robot", "orientation", orientation, 4)) is not None
-        ):
+        orientation, e = _coerce_pose_vector("add_robot", "orientation", orientation, 4)
+        if e is not None:
             return {"status": "error", "content": [{"text": e}]}
 
         # Remember whether the caller supplied a `name` (vs an auto-derived
@@ -1252,8 +1292,12 @@ class MuJoCoSimEngine(
         robot = SimRobot(
             name=name,
             urdf_path=resolved_path,
-            position=position or [0.0, 0.0, 0.0],
-            orientation=orientation or [1.0, 0.0, 0.0, 0.0],
+            # ``is None`` means "omitted" -> the documented default. ``or`` would
+            # additionally read a NumPy pose as ambiguous (a bare ValueError) and
+            # an empty vector as omitted; _coerce_pose_vector already rejected
+            # the latter and normalized the former to plain floats.
+            position=[0.0, 0.0, 0.0] if position is None else position,
+            orientation=[1.0, 0.0, 0.0, 0.0] if orientation is None else orientation,
             data_config=data_config,
             namespace=f"{name}/",
         )
@@ -2556,12 +2600,11 @@ class MuJoCoSimEngine(
         # non-numeric element (e.g. ["a", ...]) raises a bare TypeError inside
         # MuJoCo's add_geom or the size <= 0 comparison, escaping the
         # structured-error contract. NumPy scalar components are accepted.
-        if position is not None and (e := _validate_pose_vector("add_object", "position", position, 3)) is not None:
+        position, e = _coerce_pose_vector("add_object", "position", position, 3)
+        if e is not None:
             return {"status": "error", "content": [{"text": e}]}
-        if (
-            orientation is not None
-            and (e := _validate_pose_vector("add_object", "orientation", orientation, 4)) is not None
-        ):
+        orientation, e = _coerce_pose_vector("add_object", "orientation", orientation, 4)
+        if e is not None:
             return {"status": "error", "content": [{"text": e}]}
         if size is not None and (e := _validate_finite_vector("add_object", "size", size)) is not None:
             return {"status": "error", "content": [{"text": e}]}
@@ -2626,13 +2669,20 @@ class MuJoCoSimEngine(
         obj = SimObject(
             name=name,
             shape=shape,
-            position=position or [0.0, 0.0, 0.0],
-            orientation=orientation or [1.0, 0.0, 0.0, 0.0],
+            # ``is None`` means "omitted" -> the documented default. ``or`` would
+            # additionally read a NumPy pose as ambiguous (a bare ValueError) and
+            # an empty vector as omitted; _coerce_pose_vector already rejected
+            # the latter and normalized the former to plain floats.
+            position=[0.0, 0.0, 0.0] if position is None else position,
+            orientation=[1.0, 0.0, 0.0, 0.0] if orientation is None else orientation,
             # ``size is None`` means "omitted" -> the documented 5 cm default. An
             # explicitly supplied vector is passed through verbatim: ``or`` would
             # read an empty list as omitted and substitute the default for a
-            # request _validate_size has already rejected.
-            size=[0.05, 0.05, 0.05] if size is None else list(size),
+            # request _validate_size has already rejected. Elements are floated
+            # for the same reason poses are - ``list(np.array([0.05] * 3))``
+            # keeps NumPy scalars, which leak as ``np.float64(0.05)`` into this
+            # object's status text and ``list_objects``.
+            size=[0.05, 0.05, 0.05] if size is None else [float(v) for v in size],
             # ``color is None`` means "omitted" -> the documented mid-grey
             # default. A supplied colour arrives here already coerced to 4
             # components; ``or`` would read an empty list as omitted and paint
@@ -2734,12 +2784,16 @@ class MuJoCoSimEngine(
           other joints' state), just like ``add_object`` / ``remove_object``.
 
         ``position`` must be a 3-element vector and ``orientation`` a 4-element
-        wxyz quaternion; each must contain only finite real numbers (NumPy
-        scalars accepted). A wrong-length, non-numeric, or nan/inf pose is
-        rejected up front rather than raising a bare ``ValueError`` past the
-        tool-result contract or silently writing a non-finite value into
-        ``data.qpos`` (which ``mj_forward`` would propagate through the whole
-        physics state).
+        wxyz quaternion; each must contain only finite real numbers. The vector
+        itself may be a list, a tuple or a NumPy array (pose arithmetic produces
+        arrays), and its elements may be NumPy scalars. A wrong-length,
+        non-numeric, or nan/inf pose is rejected up front rather than raising a
+        bare ``ValueError`` past the tool-result contract or silently writing a
+        non-finite value into ``data.qpos`` (which ``mj_forward`` would propagate
+        through the whole physics state). "Supplied" means "not ``None``": an
+        empty vector is a wrong-length request, not an omission, so it is
+        rejected instead of leaving the component unchanged under a success
+        result. The returned text names the components actually applied.
 
         Returns ``status="error"`` if the object is unknown, the pose is
         invalid, or the static-body recompile fails - it never reports success
@@ -2760,9 +2814,11 @@ class MuJoCoSimEngine(
         # mj_forward silently poisons the whole physics state. Only validate a
         # component that is actually supplied (None leaves it unchanged; the
         # move logic below treats a falsy value as "no change").
-        if position and (perr := _validate_pose_vector("move_object", "position", position, 3)) is not None:
+        position, perr = _coerce_pose_vector("move_object", "position", position, 3)
+        if perr is not None:
             return {"status": "error", "content": [{"text": perr}]}
-        if orientation and (oerr := _validate_pose_vector("move_object", "orientation", orientation, 4)) is not None:
+        orientation, oerr = _coerce_pose_vector("move_object", "orientation", orientation, 4)
+        if oerr is not None:
             return {"status": "error", "content": [{"text": oerr}]}
 
         mj = self._mj
@@ -2780,11 +2836,11 @@ class MuJoCoSimEngine(
                 # through data.qpos + a forward pass (no recompile).
                 qpos_addr = model.jnt_qposadr[jnt_id]
                 moved = False
-                if position:
+                if position is not None:
                     data.qpos[qpos_addr : qpos_addr + 3] = position
                     self._world.objects[name].position = position
                     moved = True
-                if orientation:
+                if orientation is not None:
                     data.qpos[qpos_addr + 3 : qpos_addr + 7] = orientation
                     self._world.objects[name].orientation = orientation
                     moved = True
@@ -2818,7 +2874,16 @@ class MuJoCoSimEngine(
                 if orientation is not None:
                     self._world.objects[name].orientation = orientation
 
-        return {"status": "success", "content": [{"text": f"'{name}' moved to {position or 'same'}"}]}
+        # Report what was actually applied. ``position or 'same'`` claimed
+        # "moved to same" for an orientation-only move (which DID change the
+        # pose) and raised on a NumPy position.
+        applied = [
+            f"{label} {vec}" for label, vec in (("position", position), ("orientation", orientation)) if vec is not None
+        ]
+        return {
+            "status": "success",
+            "content": [{"text": f"'{name}' moved to {', '.join(applied) if applied else 'same'}"}],
+        }
 
     def list_objects(self) -> dict[str, Any]:
         """List every object in the scene with its shape, position, and mass.
@@ -2885,7 +2950,10 @@ class MuJoCoSimEngine(
         ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
 
         Validation: ``position`` and ``target`` must each be 3 finite numbers
-        (NumPy scalars accepted); ``fov`` must be a finite angle in ``(0, 180)``
+        (a list, tuple or NumPy array; NumPy scalar elements accepted). Omit a
+        vector to take its default - an empty vector is a wrong-length request
+        and is rejected rather than silently placing the camera at the default
+        pose. ``fov`` must be a finite angle in ``(0, 180)``
         degrees; and ``width``/``height`` must be positive ints within the
         offscreen framebuffer cap (same bounds ``render`` enforces). Invalid
         values are rejected here at config time with an actionable error rather
@@ -2898,9 +2966,19 @@ class MuJoCoSimEngine(
         if err := self._require_no_running_policy("add_camera"):
             return err
 
-        # validate position / target shape before we bake them into XML.
-        pos = position or [1.0, 1.0, 1.0]
-        tgt = target or [0.0, 0.0, 0.0]
+        # Validate position / target shape before we bake them into XML.
+        # Membership, not truthiness: ``position or <default>`` raised a bare
+        # ValueError on a NumPy pose (what the docstring above advertises as
+        # accepted) and read an empty vector as "omitted", quietly placing the
+        # camera at the default [1, 1, 1] under a success result.
+        position, _perr = _coerce_pose_vector("add_camera", "position", position, 3)
+        if _perr is not None:
+            return {"status": "error", "content": [{"text": _perr}]}
+        target, _terr = _coerce_pose_vector("add_camera", "target", target, 3)
+        if _terr is not None:
+            return {"status": "error", "content": [{"text": _terr}]}
+        pos = [1.0, 1.0, 1.0] if position is None else position
+        tgt = [0.0, 0.0, 0.0] if target is None else target
         for _lbl, _vec in (("position", pos), ("target", tgt)):
             # Validate shape AND finiteness up front. The degenerate-orientation
             # check below does ``abs(pos[i] - tgt[i])`` element-wise, so a

--- a/tests/simulation/mujoco/test_vector_params_read_by_membership.py
+++ b/tests/simulation/mujoco/test_vector_params_read_by_membership.py
@@ -1,0 +1,210 @@
+"""Regression tests: caller-supplied vectors are read by membership, not truthiness.
+
+Every pose/wrench parameter in the MuJoCo scene API is optional, and the engine
+has to decide whether the caller supplied one. Deciding that by testing the
+vector itself (``if position:``, ``position or <default>``) is wrong twice over:
+
+* A NumPy array has no boolean value, so ``position or <default>`` raises a bare
+  ``ValueError: The truth value of an array with more than one element is
+  ambiguous`` straight through the ``{"status": ...}`` tool-result contract - and
+  an array is exactly what pose arithmetic (``base + offset``), an observation
+  row or a computed wrench (``mass * accel``) produces.
+* An empty vector is falsy, so it reads as "omitted": the default is substituted
+  (``add_camera`` placed the camera at ``[1, 1, 1]``) or the write is skipped
+  (``move_object`` moved nothing), and the call still reports success. On a
+  static object the empty vector reached MuJoCo's spec setter and raised a bare
+  pybind ``TypeError``.
+
+The contract these pin: a vector parameter is supplied when it is not ``None``;
+a supplied vector is validated for length/finiteness and normalized to plain
+floats; and the status text reports what was actually applied.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+def _text(result):
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _camera_position(sim, camera_name):
+    """Return the camera's world position from its reported extrinsics."""
+    params = sim.get_camera_params(camera_name=camera_name)
+    return [float(v) for v in params.T_world_cam[:3, 3]]
+
+
+def _position_of(sim, body):
+    result = sim.get_body_state(body)
+    assert result["status"] == "success", result
+    payload = [block["json"] for block in result["content"] if "json" in block][0]
+    return payload["position"]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_vector_membership_sim", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+class TestNumpyVectorsAreAccepted:
+    """A NumPy vector is honored, not raised past the tool-result contract."""
+
+    def test_add_object_accepts_numpy_pose_and_normalizes_it(self, sim):
+        """``add_object`` places the object at the NumPy pose it was given.
+
+        The status text and the stored object echo plain floats: a NumPy element
+        surviving this boundary renders as ``np.float64(0.05)`` in agent-visible
+        output and contradicts ``SimObject``'s ``list[float]`` annotation.
+        """
+        base = np.array([0.2, 0.1, 0.05])
+        result = sim.add_object(
+            name="cube",
+            shape="box",
+            size=np.array([0.05, 0.05, 0.05]),
+            position=base + np.array([0.1, 0.0, 0.0]),
+            orientation=np.array([1.0, 0.0, 0.0, 0.0]),
+        )
+        assert result["status"] == "success", result
+        assert _position_of(sim, "cube") == pytest.approx([0.3, 0.1, 0.05], abs=1e-6)
+        assert "np.float64" not in _text(result)
+        assert "np.float64" not in _text(sim.list_objects())
+
+    def test_add_camera_accepts_numpy_pose_and_looks_where_asked(self, sim):
+        """``add_camera`` honors a NumPy position/target instead of raising.
+
+        Pinned on the rendered camera's reported pose, not on the call status:
+        the pre-fix ``position or <default>`` failure mode for a wrong-typed
+        vector was a silent fallback to ``[1, 1, 1]``.
+        """
+        result = sim.add_camera(
+            name="look",
+            position=np.array([0.9, 0.0, 0.55]),
+            target=np.array([0.3, 0.0, 0.1]),
+        )
+        assert result["status"] == "success", result
+        assert _camera_position(sim, "look") == pytest.approx([0.9, 0.0, 0.55], abs=1e-6)
+
+    def test_add_robot_accepts_numpy_position(self, sim):
+        """``add_robot`` honors a NumPy base position instead of raising."""
+        result = sim.add_robot(name="panda", position=np.array([0.0, 0.15, 0.0]))
+        assert result["status"] == "success", result
+        assert sim._world.robots["panda"].position == pytest.approx([0.0, 0.15, 0.0], abs=1e-6)
+
+    def test_move_object_accepts_numpy_pose(self, sim):
+        """``move_object`` moves the body to the NumPy pose it was given."""
+        sim.add_object(name="cube", shape="box", size=[0.05, 0.05, 0.05], position=[0.4, 0.0, 0.05])
+        result = sim.move_object(name="cube", position=np.array([0.1, 0.2, 0.3]))
+        assert result["status"] == "success", result
+        assert _position_of(sim, "cube") == pytest.approx([0.1, 0.2, 0.3], abs=1e-6)
+        assert "np.float64" not in _text(result)
+
+    def test_move_object_accepts_numpy_pose_on_static_object(self, sim):
+        """The static (spec-recompile) path honors a NumPy pose too."""
+        sim.add_object(name="fixture", shape="box", size=[0.05, 0.05, 0.05], position=[-0.4, 0.0, 0.05], is_static=True)
+        result = sim.move_object(name="fixture", position=np.array([-0.2, 0.1, 0.05]))
+        assert result["status"] == "success", result
+        assert _position_of(sim, "fixture") == pytest.approx([-0.2, 0.1, 0.05], abs=1e-6)
+
+    def test_apply_force_accepts_numpy_wrench(self, sim):
+        """``apply_force`` accepts a NumPy force/torque/point and moves the body.
+
+        A computed wrench is an array; assert the body actually accelerated
+        along it so the force reached ``qfrc_applied`` rather than being
+        reported as applied.
+        """
+        sim.add_object(name="puck", shape="box", size=[0.05, 0.05, 0.05], position=[0.0, 0.0, 0.05])
+        result = sim.apply_force(
+            body_name="puck",
+            force=np.array([8.0, 0.0, 0.0]),
+            torque=np.array([0.0, 0.0, 0.0]),
+            point=np.array([0.0, 0.0, 0.05]),
+        )
+        assert result["status"] == "success", result
+        sim.step(50)
+        assert _position_of(sim, "puck")[0] > 0.02, "NumPy force should have pushed the puck along +x"
+
+
+class TestEmptyVectorIsRejectedNotTreatedAsOmitted:
+    """An empty vector is a wrong-length request, never an omission."""
+
+    def test_add_camera_rejects_empty_position(self, sim):
+        """An empty position errors instead of placing the camera at the default."""
+        result = sim.add_camera(name="cam", position=[], target=[0.0, 0.0, 0.1])
+        assert result["status"] == "error", result
+        assert "'position' must be a 3-element vector" in _text(result)
+        assert "cam" not in sim.list_cameras()
+
+    def test_add_camera_rejects_empty_target(self, sim):
+        """An empty target errors instead of aiming at the default origin."""
+        result = sim.add_camera(name="cam", position=[1.0, 0.0, 0.5], target=[])
+        assert result["status"] == "error", result
+        assert "'target' must be a 3-element vector" in _text(result)
+
+    def test_move_object_rejects_empty_position(self, sim):
+        """An empty position errors and the object stays where it was."""
+        sim.add_object(name="cube", shape="box", size=[0.05, 0.05, 0.05], position=[0.4, 0.0, 0.05])
+        result = sim.move_object(name="cube", position=[])
+        assert result["status"] == "error", result
+        assert "'position' must be a 3-element vector" in _text(result)
+        assert _position_of(sim, "cube") == pytest.approx([0.4, 0.0, 0.05], abs=1e-6)
+
+    def test_move_object_rejects_empty_orientation(self, sim):
+        """An empty orientation errors rather than reporting a move."""
+        sim.add_object(name="cube", shape="box", size=[0.05, 0.05, 0.05], position=[0.4, 0.0, 0.05])
+        result = sim.move_object(name="cube", orientation=())
+        assert result["status"] == "error", result
+        assert "'orientation' must be a 4-element vector" in _text(result)
+
+    def test_move_object_rejects_empty_position_on_static_object(self, sim):
+        """The static path reports a structured error, not a bare pybind TypeError."""
+        sim.add_object(name="fixture", shape="box", size=[0.05, 0.05, 0.05], position=[-0.4, 0.0, 0.05], is_static=True)
+        result = sim.move_object(name="fixture", position=[])
+        assert result["status"] == "error", result
+        assert "'position' must be a 3-element vector" in _text(result)
+        assert _position_of(sim, "fixture") == pytest.approx([-0.4, 0.0, 0.05], abs=1e-6)
+
+    def test_omitted_vectors_still_take_their_documented_defaults(self, sim):
+        """Omission (``None``) keeps working: the documented defaults apply."""
+        assert sim.add_object(name="cube", shape="box", size=[0.05, 0.05, 0.05])["status"] == "success"
+        assert _position_of(sim, "cube") == pytest.approx([0.0, 0.0, 0.0], abs=1e-6)
+        assert sim.add_camera(name="cam")["status"] == "success"
+        assert _camera_position(sim, "cam") == pytest.approx([1.0, 1.0, 1.0], abs=1e-6)
+
+
+class TestMoveObjectReportsWhatItApplied:
+    """The success text names the components actually written."""
+
+    def test_orientation_only_move_is_not_reported_as_unchanged(self, sim):
+        """An orientation-only move names the orientation, not ``same``.
+
+        The rotation IS applied on this path, so reporting "moved to same"
+        (what ``position or 'same'`` produced) contradicts the state.
+        """
+        sim.add_object(name="cube", shape="box", size=[0.05, 0.05, 0.05], position=[0.4, 0.0, 0.05])
+        result = sim.move_object(name="cube", orientation=[0.7071, 0.0, 0.0, 0.7071])
+        assert result["status"] == "success", result
+        text = _text(result)
+        assert "orientation" in text
+        assert "same" not in text
+
+    def test_both_components_are_reported(self, sim):
+        """A full pose move names both components."""
+        sim.add_object(name="cube", shape="box", size=[0.05, 0.05, 0.05], position=[0.4, 0.0, 0.05])
+        result = sim.move_object(name="cube", position=[0.1, 0.0, 0.2], orientation=[1.0, 0.0, 0.0, 0.0])
+        assert result["status"] == "success", result
+        text = _text(result)
+        assert "position" in text and "orientation" in text
+
+    def test_no_components_reports_unchanged(self, sim):
+        """Omitting both components is a documented no-op reported as ``same``."""
+        sim.add_object(name="cube", shape="box", size=[0.05, 0.05, 0.05], position=[0.4, 0.0, 0.05])
+        result = sim.move_object(name="cube")
+        assert result["status"] == "success", result
+        assert "same" in _text(result)


### PR DESCRIPTION
## Problem

Five MuJoCo scene methods decided whether an optional vector parameter had been supplied by testing **the vector itself** rather than by testing for `None`:

```python
# simulation.py
position=position or [0.0, 0.0, 0.0]      # add_robot, add_object
pos = position or [1.0, 1.0, 1.0]          # add_camera
if position:  ...                          # move_object write path
f"'{name}' moved to {position or 'same'}"  # move_object status text
# physics.py
f = np.array(force or [0, 0, 0], ...)      # apply_force (force / torque / point)
```

Two distinct defects follow from that, on nine parameters.

**1. A NumPy vector raises past the tool-result contract.** An array has no boolean value, so the `or` raises before anything is applied - and an array is exactly what pose arithmetic, an observation row or a computed wrench produces. This happens even though the docstrings advertise NumPy input (`add_camera`: "must each be 3 finite numbers (NumPy scalars accepted)").

```python
sim.add_object(name="cube", position=base + np.array([0.1, 0.0, 0.0]))
# ValueError: The truth value of an array with more than one element is ambiguous
sim.apply_force(body_name="cube", force=np.array([8.0, 0.0, 0.0]))
# same ValueError - past the {"status": ...} envelope
```

Measured on `main` (`add_object` position + orientation, `add_robot` position, `add_camera` position + target, `move_object` position + orientation, `apply_force` force/torque/point): every one raises `ValueError`.

**2. An empty vector reads as "omitted", so the default is applied under `success`.**

```python
sim.add_camera(name="cam", position=[], target=[0, 0, 0.1])
# success: "Camera 'cam' added at [1.0, 1.0, 1.0]"   <- the default pose
sim.move_object(name="cube", position=[])
# success: "'cube' moved to same"                     <- nothing written
sim.move_object(name="static_fixture", position=[])
# TypeError: (): incompatible function arguments ... Invoked with: <MjsBody>, []
```

The empty vector is a wrong-length request that the sibling entry points already reject (`add_object(position=[])` errors with `'position' must be a 3-element vector, got 0`), so the accepted domain diverged between methods writing the same buffers.

**3. `move_object` misreported what it applied.** `position or 'same'` printed `"moved to same"` for an orientation-only move even though the rotation *was* written.

## Change

A vector parameter is supplied when it is **not `None`**. One shared helper is the single source of that decision:

```python
def _coerce_pose_vector(method, param_name, vec, expected_len) -> tuple[list[float] | None, str | None]:
    if vec is None:
        return None, None                       # omitted -> caller applies its default
    if (err := _validate_pose_vector(method, param_name, vec, expected_len)) is not None:
        return None, err                        # wrong length / non-numeric / nan-inf
    return [float(v) for v in vec], None        # accepted, normalized
```

- `add_object`, `add_robot`, `add_camera`, `move_object` route their pose/target vectors through it; defaults are selected with `is None`.
- `apply_force` selects its zero-wrench and CoM defaults with `is None` (its own length/finiteness loop already accepted NumPy, only the `or` did not).
- **Normalization** keeps an accepted NumPy input from outliving the boundary: the pose is stored on `SimObject` / `SimRobot` (both annotated `list[float]`), echoed in the status text, and written into the spec, so a raw element leaked as `np.float64(0.05)` into agent-visible output (`add_object(size=np.array([0.05] * 3))` printed `size=[np.float64(0.05), np.float64(0.05), np.float64(0.05)]`; `size` is floated for the same reason).
- `move_object` now names the components it actually wrote; omitting both remains the documented no-op reported as `same`.
- Error text is unchanged (`_validate_pose_vector` still produces it), so existing message pins hold.

## Verification

15 tests in `tests/simulation/mujoco/test_vector_params_read_by_membership.py`, asserting observable state (the body position after the call, the camera's reported extrinsics, the puck actually accelerating along a NumPy force) rather than the status string alone. **13 of the 15 fail on pre-fix code**; the 2 that pass are the deliberate controls - omitted vectors still take their defaults, and a no-component `move_object` still reports `same`.

```
# pre-fix (source stashed, tests kept)
13 failed, 2 passed
# post-fix
15 passed
```

Full local gate on this branch: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean, and `MUJOCO_GL=egl python -m pytest tests` -> **12198 passed, 260 skipped** (12183 before these 15 tests).

## Rollout in MuJoCo sim (headless)

The same 5-call script run against both trees: three cubes placed at `base + np.array([0, i * 0.12, 0])`, a Panda at a NumPy base position, and a look-at camera built from NumPy `position`/`target`. Before, every call raises and the scene is empty, so the render falls back to the default camera; after, the scene is built and rendered from the camera that was actually requested.

![numpy pose scene, before vs after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vector-membership/vector_membership.png)

| | before | after |
|---|---|---|
| `add_object(position=base + np.array(...))` x3 | `ValueError` | success |
| `add_robot(position=np.array(...))` | `ValueError` | success |
| `add_camera(position=np.array(...), target=np.array(...))` | `ValueError` | success, `[1.05, -0.75, 0.62]` |
| objects in scene / camera rendered | 0 / `default` | 3 + panda / `look` |

L1 between the two panels: 4.74e7.

## §13 Changelog

**Rebase onto current `main`** - rebased onto `main` after the sibling `start_recording` fps-guard fix merged. The only conflict was in `CHANGELOG.md`: both changes add a `### Fixed:` block under `[Unreleased]`. Resolved by keeping both entries in order (the merged fps-guard entry first, this one second) with the required blank line between headings. No code, test, or behavioural change - the reviewed diff on the three source/test files is byte-identical to the approved revision; `py_compile` clean and `git diff --stat` confirms the 4-file scope is unchanged. The prior approval was auto-dismissed by the rebase force-update; re-review is on the same content plus the changelog merge.