### PR TITLE
fix(sim): start_recording rejects a dataset fps it cannot record at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a dataset recording is refused at a frame rate it cannot be written at
+
+`start_recording` never validated `fps`. LeRobot itself only rejects `fps <= 0`,
+so every other unusable rate was accepted on all three backends and cost the
+caller the episode after `status="success"` had already been returned:
+
+```python
+sim.start_recording(repo_id="local/demo", fps=2.7, root=root)
+# -> success: "Recording to LeRobotDataset: local/demo ... @ 2.7fps"
+sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=6)
+# -> error: "on_frame hook failed 5 times in a row; aborting episode"
+sim.stop_recording()
+# -> error: "failed to save the final episode (1 pending frames)"
+```
+
+A fractional or `nan` rate created the dataset and then killed the per-camera
+video encoder thread on the first frame, so the rollout aborted and the pending
+frames could never be saved. `fps=True` - an `int` subclass - silently recorded
+a 1 fps dataset, giving every frame a 1-second timestamp for anything later
+trained on it. `fps="30"`, `None` and a list dead-ended in a raw
+`TypeError: '<=' not supported between instances of 'str' and 'int'` that never
+named the parameter. Through the `run_policy` agent tool the same
+`dataset_fps=2.5` reported `1/1 episodes ok` alongside
+`parquet-truth: total_episodes=0, total_frames=0`.
+
+`fps` is a frame count, so the accepted domain is now the positive-whole-number
+one the plain-MP4 recorders and the `run_policy(video=...)` dict already share
+(`positive_whole_number_error`), checked by a single
+`dataset_recording_option_error` guard the MuJoCo, Newton and Isaac
+`start_recording` implementations all call before any recorder is created:
+
+```python
+sim.start_recording(repo_id="local/demo", fps=2.7, root=root)
+# -> error: "start_recording: fps must be a positive whole number, got 2.7."
+```
+
+The guard runs ahead of the `lerobot`-extra probe, so the same caller mistake
+reports identically regardless of which optional extras an install has. Usable
+rates are unchanged: `30`, `30.0` and a NumPy integer all still record, and a
+recorded episode reopens at the requested rate.
+
 ### Fixed: the plain-MP4 camera recorder rejects frame and pixel counts it cannot honor
 
 `start_cameras_recording` and `start_cameras_recording_synchronous` never

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -51,7 +51,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from strands_robots.simulation.recording import DatasetRecordingMixin
+from strands_robots.simulation.recording import (
+    DatasetRecordingMixin,
+    dataset_recording_option_error,
+)
 
 if TYPE_CHECKING:
     import threading
@@ -149,6 +152,8 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
             repo_id: HuggingFace dataset id (``owner/name``) or a local path.
             task: Default task description recorded with every frame.
             fps: Recording frame rate (metadata; see pacing note above).
+                Must be a positive whole number; a rate no dataset can be
+                written at is rejected up front.
             root: Explicit on-disk dataset directory (overrides the repo_id
                 cache-path resolution).
             push_to_hub: Publish to the Hub at ``stop_recording``.
@@ -181,6 +186,15 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 "status": "error",
                 "content": [{"text": "No robots in the world. Call add_robot() before start_recording()."}],
             }
+
+        # Reject an fps no dataset can be written at before creating or
+        # resuming the recorder: an unusable rate was reported as success and
+        # then cost the caller the whole episode (see
+        # dataset_recording_option_error). Checked ahead of the lerobot-extra
+        # probe so the same caller mistake reports the same way regardless of
+        # which optional extras this install has.
+        if error := dataset_recording_option_error("start_recording", fps):
+            return error
 
         _DatasetRecorder: Any = None
         _has_lerobot = False

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -12,7 +12,10 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
-from strands_robots.simulation.recording import DatasetRecordingMixin
+from strands_robots.simulation.recording import (
+    DatasetRecordingMixin,
+    dataset_recording_option_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +79,12 @@ class RecordingMixin(DatasetRecordingMixin):
         rather than freezing on the chunk-start observation.
 
         Args:
+            fps: Dataset frame rate recorded in the LeRobot metadata. Must be a
+                positive whole number - a fractional or non-numeric rate cannot
+                be written and is rejected up front rather than aborting the
+                rollout behind a ``status="success"`` return. Set it to the
+                ``run_policy`` ``control_frequency`` so recorded timestamps
+                match the cadence frames were captured at.
             root: On-disk dataset directory (defaults to the LeRobot cache under
                 ``repo_id``). An existing EMPTY directory (e.g. from
                 ``tempfile.mkdtemp()``) is accepted and recorded into; an
@@ -111,6 +120,15 @@ class RecordingMixin(DatasetRecordingMixin):
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+
+        # Reject an fps no dataset can be written at before creating or
+        # resuming the recorder: an unusable rate was reported as success and
+        # then cost the caller the whole episode (see
+        # dataset_recording_option_error). Checked ahead of the lerobot-extra
+        # probe so the same caller mistake reports the same way regardless of
+        # which optional extras this install has.
+        if error := dataset_recording_option_error("start_recording", fps):
+            return error
 
         _DatasetRecorder: Any = None
         _has_lerobot = False

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -247,7 +247,7 @@
     },
     "fps": {
       "type": "integer",
-      "description": "Video frames per second (for run_policy record_video)"
+      "description": "Frames per second: video rate for run_policy record_video, dataset rate for start_recording. Must be a positive whole number."
     },
     "randomize_colors": {
       "type": "boolean"

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -27,7 +27,10 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.simulation.recording import DatasetRecordingMixin
+from strands_robots.simulation.recording import (
+    DatasetRecordingMixin,
+    dataset_recording_option_error,
+)
 
 if TYPE_CHECKING:
     from strands_robots.simulation.models import SimWorld
@@ -83,7 +86,8 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         Args:
             repo_id: HuggingFace dataset id (``owner/name``) or a local path.
             task: Default task description recorded with every frame.
-            fps: Recording frame rate.
+            fps: Recording frame rate. Must be a positive whole number;
+                a rate no dataset can be written at is rejected up front.
             root: Explicit on-disk dataset directory (overrides the repo_id
                 cache-path resolution).
             push_to_hub: Publish to the Hub at ``stop_recording``.
@@ -110,6 +114,15 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+
+        # Reject an fps no dataset can be written at before creating or
+        # resuming the recorder: an unusable rate was reported as success and
+        # then cost the caller the whole episode (see
+        # dataset_recording_option_error). Checked ahead of the lerobot-extra
+        # probe so the same caller mistake reports the same way regardless of
+        # which optional extras this install has.
+        if error := dataset_recording_option_error("start_recording", fps):
+            return error
 
         _DatasetRecorder: Any = None
         _has_lerobot = False

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -34,6 +34,45 @@ from typing import TYPE_CHECKING, Any
 logger = logging.getLogger(__name__)
 
 
+def dataset_recording_option_error(method: str, fps: Any) -> dict[str, Any] | None:
+    """Reject a LeRobotDataset recording option no dataset can be written at.
+
+    Pre-flight guard shared by every backend's ``start_recording`` (MuJoCo,
+    Newton, Isaac), so the three surfaces cannot disagree on what a usable
+    ``fps`` is. ``fps`` is a frame count per second, so the accepted domain is
+    the shared one the plain-MP4 recorders and the ``run_policy(video=...)``
+    dict already enforce
+    (:func:`~strands_robots.simulation.policy_runner.positive_whole_number_error`):
+    a positive whole number.
+
+    Without this guard an unusable ``fps`` was reported as ``status="success"``
+    and then cost the caller the episode: LeRobot only rejects ``fps <= 0``, so
+    a fractional ``2.7`` or a ``nan`` created the dataset, killed the video
+    encoder thread on the first frame and aborted the rollout ("on_frame hook
+    failed 5 times in a row"), after which ``stop_recording`` could not save the
+    pending frames; ``fps=True`` silently recorded a 1 fps dataset (an ``int``
+    subclass acting as a 1); and ``fps="30"`` dead-ended in a raw
+    ``TypeError: '<=' not supported between instances of 'str' and 'int'``
+    instead of naming the parameter.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        fps: Caller-supplied dataset frame rate.
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict naming ``fps``, or
+        ``None`` when the value is usable.
+    """
+    # Imported lazily: ``policy_runner`` pulls in the rollout machinery, and
+    # this module sits below it in the import graph (backends import the mixin
+    # while constructing their engine class).
+    from strands_robots.simulation.policy_runner import positive_whole_number_error
+
+    if text := positive_whole_number_error(fps, "fps", method):
+        return {"status": "error", "content": [{"text": text}]}
+    return None
+
+
 class DatasetRecordingMixin:
     """Engine-independent recording lifecycle shared by sim backends.
 

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -169,7 +169,9 @@ def run_policy(
             recording (smoke-test mode).
         dataset_repo_id: Forwarded to ``start_recording``.
         dataset_task: Task label forwarded to ``start_recording``.
-        dataset_fps: Dataset FPS forwarded to ``start_recording``.
+        dataset_fps: Dataset FPS forwarded to ``start_recording``. Must be a
+            positive whole number; an unusable rate is reported before the
+            rollout starts instead of aborting the episode mid-flight.
         dataset_cameras: Camera names to record into the dataset.
             When set, forwarded as ``start_recording(cameras=...)``
             (supported by both the MuJoCo and Newton backends) to

--- a/tests/simulation/test_dataset_recording_fps_contract.py
+++ b/tests/simulation/test_dataset_recording_fps_contract.py
@@ -1,0 +1,187 @@
+"""A dataset recording must be refused at a frame rate it cannot be written at.
+
+``start_recording`` takes an ``fps`` that becomes the LeRobotDataset's frame
+rate. LeRobot itself only rejects ``fps <= 0``, so every other unusable value
+was accepted by all three backends and cost the caller the episode *after*
+``status="success"`` had been returned:
+
+* ``fps=2.7`` (or ``nan``) created the dataset, then killed the per-camera video
+  encoder thread on the first frame; the rollout aborted with "on_frame hook
+  failed 5 times in a row" and ``stop_recording`` could not save the pending
+  frames, so the recording was lost.
+* ``fps=True`` - an ``int`` subclass - silently recorded a 1 fps dataset, giving
+  every frame a 1-second timestamp a policy would then train on.
+* ``fps="30"`` dead-ended in a raw ``TypeError: '<=' not supported between
+  instances of 'str' and 'int'`` that never named the parameter to fix.
+
+The domain is now the same positive-whole-number one the plain-MP4 recorders and
+the ``run_policy(video=...)`` dict already enforce, checked before any recorder
+is created, and shared by the MuJoCo / Newton / Isaac ``start_recording``
+implementations so the three surfaces cannot drift.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import strands_robots.simulation as simulation_pkg
+from strands_robots.simulation.recording import dataset_recording_option_error
+from strands_robots.tools.run_policy import run_policy as run_policy_tool
+
+pytest.importorskip("mujoco")
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# One actuated hinge plus a camera: enough for run_policy to drive something and
+# for the dataset schema to declare an image column, with no asset download.
+_ARM_XML = """
+<mujoco model="fps_contract_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <camera name="front" pos="0 -1 0.4" xyaxes="1 0 0 0 0.3 1"/>
+    <body name="base" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1"/>
+      <geom name="link" type="capsule" fromto="0 0 0 0.2 0 0" size="0.03"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="30"/>
+  </actuator>
+</mujoco>
+"""
+
+# Values no dataset can be recorded at. Each one previously returned
+# status="success" from start_recording (except the bare-string TypeError).
+UNUSABLE_FPS = [0, -5, 2.7, float("nan"), float("inf"), True, "30", None, [30]]
+
+
+@pytest.fixture
+def sim(tmp_path):
+    model = tmp_path / "fps_contract_arm.xml"
+    model.write_text(_ARM_XML)
+    s = Simulation(tool_name="fps_contract", mesh=False)
+    s.create_world()
+    s.add_robot("arm", urdf_path=str(model))
+    s.add_camera(name="view", position=[0.6, -0.6, 0.4], target=[0.0, 0.0, 0.1], width=64, height=64)
+    yield s
+    s.cleanup()
+
+
+class TestFpsDomain:
+    """The shared accepted domain for a dataset frame rate."""
+
+    @pytest.mark.parametrize("fps", UNUSABLE_FPS)
+    def test_unusable_rate_reports_the_parameter_and_the_method(self, fps):
+        error = dataset_recording_option_error("start_recording", fps)
+        assert error is not None
+        assert error["status"] == "error"
+        text = error["content"][0]["text"]
+        assert "start_recording" in text
+        assert "fps" in text
+        assert repr(fps) in text
+
+    @pytest.mark.parametrize("fps", [1, 30, 30.0, np.int64(60), np.float64(30.0)])
+    def test_positive_whole_rate_is_accepted(self, fps):
+        assert dataset_recording_option_error("start_recording", fps) is None
+
+
+class TestStartRecordingRefusesUnusableFps:
+    """An unusable rate must be refused before a recorder exists."""
+
+    @pytest.mark.parametrize("fps", UNUSABLE_FPS)
+    def test_no_session_is_opened_and_nothing_is_written(self, sim, tmp_path, fps):
+        root = tmp_path / "dataset"
+        result = sim.start_recording(repo_id="local/fps_contract", task="t", fps=fps, root=str(root))
+
+        assert result["status"] == "error"
+        assert "fps" in result["content"][0]["text"]
+        # No half-open session: status must still read idle, and a later
+        # stop_recording must not claim to have saved anything.
+        status = sim.get_recording_status()
+        assert "idle" in status["content"][0]["text"].lower()
+        # Nothing on disk either - the refusal precedes dataset creation.
+        assert not root.exists() or not any(root.iterdir())
+
+
+class TestStartRecordingHonorsUsableFps:
+    """A usable rate still records a complete, reopenable episode."""
+
+    def test_episode_round_trips_at_the_requested_rate(self, sim, tmp_path):
+        pytest.importorskip("lerobot")
+        root = tmp_path / "dataset"
+        started = sim.start_recording(repo_id="local/fps_contract", task="wave", fps=30, root=str(root))
+        assert started["status"] == "success", started
+
+        rollout = sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            n_steps=6,
+            control_frequency=30.0,
+        )
+        assert rollout["status"] == "success", rollout
+        stopped = sim.stop_recording()
+        assert stopped["status"] == "success", stopped
+
+        # Round-trip: the dataset reopens, carries the requested rate, and holds
+        # the frames the rollout produced (with the per-camera MP4 on disk).
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        dataset = LeRobotDataset(repo_id="local/fps_contract", root=str(root))
+        assert dataset.fps == 30
+        assert dataset.num_frames == 6
+        assert list(root.rglob("*.mp4"))
+
+
+class TestRunPolicyToolForwardsTheGuard:
+    """The agent-facing tool reports the rate before it starts a rollout."""
+
+    def test_unusable_dataset_fps_is_reported_before_the_rollout(self, sim, tmp_path):
+        root = tmp_path / "dataset"
+        result = run_policy_tool(
+            simulation=sim,
+            robot_name="arm",
+            policy_provider="mock",
+            n_steps=4,
+            control_frequency=30.0,
+            dataset_root=str(root),
+            dataset_fps=2.5,
+        )
+        assert result["status"] == "error"
+        assert "fps" in result["content"][0]["text"]
+        assert not root.exists() or not any(root.iterdir())
+
+
+def _start_recording_calls_the_shared_guard(module_path: Path) -> bool:
+    """True when the module's ``start_recording`` calls the shared fps guard.
+
+    Parsed by AST so backends whose optional dependencies (Isaac Sim, Newton)
+    are not installed are still checked.
+    """
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "start_recording":
+            return any(
+                isinstance(call.func, ast.Name) and call.func.id == "dataset_recording_option_error"
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+            )
+    return False
+
+
+@pytest.mark.parametrize("backend", ["mujoco", "newton", "isaac"])
+def test_every_backend_start_recording_shares_the_guard(backend):
+    """No backend may accept a dataset rate the others refuse."""
+    module_path = Path(simulation_pkg.__file__).parent / backend / "recording.py"
+    assert _start_recording_calls_the_shared_guard(module_path), (
+        f"{backend}/recording.py start_recording must call dataset_recording_option_error"
+    )


### PR DESCRIPTION
## Problem

`start_recording` never validated `fps`. LeRobot itself only rejects `fps <= 0`, so every other unusable rate was accepted on all three backends and cost the caller the episode **after** `status="success"` had already been returned:

```python
sim.start_recording(repo_id="local/demo", fps=2.7, root=root, cameras=["view"])
# -> success: "Recording to LeRobotDataset: local/demo ... @ 2.7fps"
sim.run_policy(robot_name="panda", policy_provider="mock", n_steps=60)
# -> error: "on_frame hook failed 5 times in a row; aborting episode"
sim.stop_recording()
# -> error: "failed to save the final episode (1 pending frames)"
# on disk: 0 MP4 files, 0 episodes
```

The failure is entirely downstream of the success return: a fractional (or `nan`/`inf`) rate creates the dataset, then kills the per-camera video encoder thread on the first frame, so the rollout aborts and the pending frames can never be saved. Two more shapes of the same gap:

| `fps` | Before | Cost |
|---|---|---|
| `2.7`, `nan`, `inf` | `success`, then rollout aborts | episode lost, no MP4 |
| `True` (an `int` subclass) | `success` @ 1 fps | frames silently timestamped 1 s apart |
| `"30"`, `None`, `[30]` | `Dataset init failed: '<=' not supported between instances of 'str' and 'int'` | dead-end message, never names `fps` |

Through the `run_policy` agent tool the same mistake is quieter still - `dataset_fps=2.5` reported `run_policy: 1/1 episodes ok` right next to `parquet-truth: total_episodes=0, total_frames=0`.

## Change

`fps` is a frame count, so the accepted domain is the positive-whole-number one the plain-MP4 recorders and the `run_policy(video=...)` dict already enforce (`positive_whole_number_error`). One new `dataset_recording_option_error` guard applies it, and the MuJoCo, Newton and Isaac `start_recording` implementations all call it before any recorder is created, so the three surfaces cannot disagree on what a usable rate is:

```python
sim.start_recording(repo_id="local/demo", fps=2.7, root=root)
# -> error: "start_recording: fps must be a positive whole number, got 2.7."
```

The guard runs ahead of the `lerobot`-extra probe, so the same caller mistake reports identically regardless of which optional extras an install has (and the contract is testable on a minimal install). Usable rates are untouched: `30`, `30.0` and a NumPy integer all still record, and the resulting episode reopens at the requested rate.

Also documented: `fps` had no `Args` entry at all on the MuJoCo `start_recording`; the shared `fps` tool-spec property described only the `run_policy` video path.

## Verification

MuJoCo sim, headless. Left panel is the pre-fix run (source reverted), right panel is a frame decoded back **out of the MP4 the honored call produced**:

![fps guard before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/start-recording-fps/fps_guard.png)

The recorded MP4 itself, decoded back and replayed - the recording contains the rollout it claims to:

![recorded episode](https://raw.githubusercontent.com/cagataycali/robots/artifacts/start-recording-fps/recorded_30fps.gif)

| | before (`fps=2.7`) | after |
|---|---|---|
| `start_recording` | `success` @ 2.7fps | `error` naming `fps` |
| `run_policy` | `error` on_frame hook failed 5x | n/a (refused up front) |
| `stop_recording` | `error`, 1 frame unsaved | `success`, 60 frames / 1 episode at `fps=30` |
| MP4 on disk | 0 files | 1 file, 184 KB, 60 frames decoded |
| dataset reopened | - | `fps=30`, `num_frames=60` |

## Tests

`tests/simulation/test_dataset_recording_fps_contract.py` - 28 tests: the 9-value rejected domain and the 5-value accepted domain, refusal leaving no session and nothing on disk, the honored round-trip (record -> stop -> reopen the dataset -> assert `fps`/`num_frames` and the MP4), the `run_policy` tool path, and an AST parity check that every backend's `start_recording` calls the shared guard (so a backend cannot drift, and the check runs without Isaac Sim or Newton installed).

11 of them fail on the pre-fix source (`git stash` of `strands_robots/` only): `11 failed, 3 passed` - the three that pass are `fps=0`/`-5`, which LeRobot's own `fps <= 0` guard already caught, plus the honored round-trip.

Local gate: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` clean; full suite `12211 passed, 260 skipped` (414 s).