### PR TITLE
fix(sim): refuse to resume a dataset recording at a different fps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: resuming a dataset recording at a different frame rate is refused
+
+`start_recording(overwrite=False)` on an existing dataset resumes it, and
+`LeRobotDataset.resume` takes no `fps` - the dataset keeps the rate it was
+created at. The requested rate was nevertheless accepted and reported back:
+
+```python
+sim.start_recording(repo_id="local/demo", fps=30, root=root, overwrite=True)
+sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=24, control_frequency=30.0)
+sim.stop_recording()
+
+sim.start_recording(repo_id="local/demo", fps=60, root=root)   # resume
+# -> success: "Recording to LeRobotDataset: local/demo ... @ 60fps"
+sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=24, control_frequency=60.0)
+sim.stop_recording()                                            # -> success
+```
+
+Both episodes were written at 30 fps. The second was captured at 60 Hz
+(0.383 s of rollout) but timestamped across 0.767 s, so two episodes recorded at
+different cadences became indistinguishable on disk and every appended episode
+carried a wrong `dt` for training.
+
+The frame rate is now compared against the resumed dataset like the rest of the
+schema (joint columns, action columns, camera resolutions) and a mismatch is
+refused with the value that would append:
+
+```
+Cannot resume recording: the current scene does not match the existing dataset schema.
+Use overwrite=True for a fresh dataset, or restore the original scene. Differences:
+  - dataset fps differs: on-disk=30 vs requested=60 (a resumed dataset keeps its
+    on-disk rate; pass fps=30 to append at it)
+```
+
+Resuming at the dataset's own rate still appends as before. The comparison is
+shared by the MuJoCo, Newton and Isaac backends (`fps` is a required
+keyword-only argument of the schema check, so no backend can resume without it).
+
 ### Fixed: a dataset recording is refused at a frame rate it cannot be written at
 
 `start_recording` never validated `fps`. LeRobot itself only rejects `fps <= 0`,

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -65,6 +65,20 @@ When `root` already contains a LeRobotDataset (a `meta/` directory),
 LeRobotDataset, and is **not empty** is left untouched and reported as an error
 rather than clobbered - pass `overwrite=True` or choose a new/empty `root`.
 
+A resume inherits the existing dataset's schema, so `fps` must match the rate it
+was created at - a resume cannot change it. Requesting a different rate is
+refused, naming the on-disk value, rather than appending frames timestamped on
+the dataset's timebase instead of the one they were captured at:
+
+```python
+sim.start_recording(repo_id="user/my_dataset", root=root, fps=60)  # dataset is 30 fps
+# -> error: "dataset fps differs: on-disk=30 vs requested=60
+#            (a resumed dataset keeps its on-disk rate; pass fps=30 to append at it)"
+```
+
+Pass `fps=30` to append at the dataset's rate, or `overwrite=True` to record a
+fresh dataset at 60.
+
 When you drive recording through the `run_policy` tool (which owns the
 `start_recording` -> rollout -> `stop_recording` cycle), forward the same
 subset with `dataset_cameras=`:

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -153,7 +153,9 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
             task: Default task description recorded with every frame.
             fps: Recording frame rate (metadata; see pacing note above).
                 Must be a positive whole number; a rate no dataset can be
-                written at is rejected up front.
+                written at is rejected up front. When an existing dataset is
+                RESUMED (``overwrite=False``) it must equal that dataset's
+                on-disk rate, which a resume cannot change.
             root: Explicit on-disk dataset directory (overrides the repo_id
                 cache-path resolution).
             push_to_hub: Publish to the Hub at ``stop_recording``.
@@ -302,7 +304,7 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 if resume_existing:
                     logger.info("Resuming existing dataset for append: %s", dataset_dir)
                     resumed = _DatasetRecorder.resume(repo_id=repo_id, root=root, task=task, vcodec=vcodec)
-                    self._verify_resume_schema(resumed, joint_names, camera_keys, camera_dims, action_names)
+                    self._verify_resume_schema(resumed, joint_names, camera_keys, camera_dims, action_names, fps=fps)
                     state["dataset_recorder"] = resumed
                 else:
                     state["dataset_recorder"] = _DatasetRecorder.create(

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -84,7 +84,11 @@ class RecordingMixin(DatasetRecordingMixin):
                 be written and is rejected up front rather than aborting the
                 rollout behind a ``status="success"`` return. Set it to the
                 ``run_policy`` ``control_frequency`` so recorded timestamps
-                match the cadence frames were captured at.
+                match the cadence frames were captured at. When an existing
+                dataset is RESUMED (``overwrite=False``), it must equal that
+                dataset's on-disk rate: a resumed dataset keeps the rate it was
+                created at, so a differing request is refused with the on-disk
+                value rather than silently appending frames on a wrong timebase.
             root: On-disk dataset directory (defaults to the LeRobot cache under
                 ``repo_id``). An existing EMPTY directory (e.g. from
                 ``tempfile.mkdtemp()``) is accepted and recorded into; an
@@ -363,7 +367,7 @@ class RecordingMixin(DatasetRecordingMixin):
                 # a camera resolution between episodes would otherwise yield a
                 # cryptic per-feature shape error on the next add_frame. Compare
                 # up front and raise a clear schema-diff instead.
-                self._verify_resume_schema(resumed, state_names_full, camera_keys, camera_dims, action_names)
+                self._verify_resume_schema(resumed, state_names_full, camera_keys, camera_dims, action_names, fps=fps)
                 self._world._backend_state["dataset_recorder"] = resumed
             else:
                 self._world._backend_state["dataset_recorder"] = _DatasetRecorder.create(

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -87,7 +87,9 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             repo_id: HuggingFace dataset id (``owner/name``) or a local path.
             task: Default task description recorded with every frame.
             fps: Recording frame rate. Must be a positive whole number;
-                a rate no dataset can be written at is rejected up front.
+                a rate no dataset can be written at is rejected up front. When
+                an existing dataset is RESUMED (``overwrite=False``) it must
+                equal that dataset's on-disk rate, which a resume cannot change.
             root: Explicit on-disk dataset directory (overrides the repo_id
                 cache-path resolution).
             push_to_hub: Publish to the Hub at ``stop_recording``.
@@ -251,7 +253,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             if resume_existing:
                 logger.info("Resuming existing dataset for append: %s", dataset_dir)
                 resumed = _DatasetRecorder.resume(repo_id=repo_id, root=root, task=task, vcodec=vcodec)
-                self._verify_resume_schema(resumed, state_names_full, camera_keys, camera_dims)
+                self._verify_resume_schema(resumed, state_names_full, camera_keys, camera_dims, fps=fps)
                 world._backend_state["dataset_recorder"] = resumed
             else:
                 world._backend_state["dataset_recorder"] = _DatasetRecorder.create(

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -73,6 +73,51 @@ def dataset_recording_option_error(method: str, fps: Any) -> dict[str, Any] | No
     return None
 
 
+def _resumed_dataset_fps(recorder: Any) -> int | None:
+    """Read the on-disk frame rate of a resumed dataset, or None if unavailable.
+
+    ``LeRobotDataset`` exposes ``fps`` directly and via ``meta.fps``; both are
+    probed so a layout that only carries the metadata object still compares.
+
+    Only a positive WHOLE rate is reported. A dataset whose on-disk rate is
+    fractional cannot be appended to at any rate ``start_recording`` accepts
+    (it requires a positive whole number), so there is no value to advise the
+    caller to pass and the comparison is skipped rather than dead-ending a
+    resume - matching the best-effort posture of the rest of the schema check.
+
+    Args:
+        recorder: The resumed ``DatasetRecorder``.
+
+    Returns:
+        The dataset frame rate as an int, or ``None`` when the dataset does not
+        report a usable whole rate (an unexpected LeRobot layout must not block
+        a valid resume).
+    """
+    dataset = getattr(recorder, "dataset", None)
+    for value in (getattr(dataset, "fps", None), getattr(getattr(dataset, "meta", None), "fps", None)):
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            continue
+        if value > 0 and float(value).is_integer():
+            return int(value)
+    return None
+
+
+def _resume_schema_error(diffs: list[str]) -> str:
+    """Format the resume-refusal message from the collected schema differences.
+
+    Args:
+        diffs: One human-readable line per divergence found.
+
+    Returns:
+        The full error message, listing every difference.
+    """
+    return (
+        "Cannot resume recording: the current scene does not match the existing dataset schema. "
+        "Use overwrite=True for a fresh dataset, or restore the original scene. Differences:\n  - "
+        + "\n  - ".join(diffs)
+    )
+
+
 class DatasetRecordingMixin:
     """Engine-independent recording lifecycle shared by sim backends.
 
@@ -690,6 +735,8 @@ class DatasetRecordingMixin:
         camera_keys: list[str],
         camera_dims: dict[str, tuple[int, int]],
         action_names: list[str] | None = None,
+        *,
+        fps: int,
     ) -> None:
         """Verify the live scene matches the resumed dataset's on-disk schema.
 
@@ -699,10 +746,19 @@ class DatasetRecordingMixin:
         mismatch would only surface as a cryptic per-feature shape error on the
         next ``add_frame``. Compare here and raise a clear schema diff instead.
 
-        Compares the expected ``observation.state`` joint names and each
-        ``observation.images.*`` camera (presence + height/width). Best-effort:
-        if the dataset does not expose ``features`` we skip silently rather than
-        block a valid resume on an unexpected LeRobot layout.
+        Compares the expected ``observation.state`` joint names, each
+        ``observation.images.*`` camera (presence + height/width), and the
+        dataset frame rate. Best-effort: if the dataset does not expose
+        ``features`` / ``fps`` we skip that comparison rather than block a valid
+        resume on an unexpected LeRobot layout.
+
+        ``fps`` is checked here because a resumed dataset keeps the rate it was
+        created at - ``LeRobotDataset.resume`` takes no ``fps`` - so a differing
+        request cannot be honored. Appending anyway timestamps the new frames at
+        the on-disk rate while they were captured at the requested one, which
+        writes a wrong timebase into the dataset: episodes recorded at different
+        cadences become indistinguishable, and a policy trained on them reads
+        the wrong dt (and so the wrong velocities) for every appended episode.
 
         Args:
             recorder: The resumed DatasetRecorder.
@@ -715,15 +771,30 @@ class DatasetRecordingMixin:
             action_names: Action-column names the current scene will emit
                 (actuator keys; namespaced for multi-robot scenes). When None
                 the action feature is not compared.
+            fps: Frame rate the caller asked to record at. Must equal the
+                resumed dataset's on-disk rate; keyword-only and required so no
+                backend can resume without comparing it.
 
         Raises:
             ValueError: If the live scene schema diverges from the on-disk one.
         """
+        diffs: list[str] = []
+
+        # Frame rate first: it is carried by the dataset metadata rather than
+        # the feature dict, so it is comparable even on a LeRobot layout whose
+        # ``features`` mapping is missing (the early return below).
+        disk_fps = _resumed_dataset_fps(recorder)
+        if disk_fps is not None and disk_fps != int(fps):
+            diffs.append(
+                f"dataset fps differs: on-disk={disk_fps} vs requested={int(fps)} "
+                f"(a resumed dataset keeps its on-disk rate; pass fps={disk_fps} to append at it)"
+            )
+
         features = getattr(getattr(recorder, "dataset", None), "features", None)
         if not isinstance(features, dict):
+            if diffs:
+                raise ValueError(_resume_schema_error(diffs))
             return
-
-        diffs: list[str] = []
 
         state = features.get("observation.state")
         if isinstance(state, dict):
@@ -759,8 +830,4 @@ class DatasetRecordingMixin:
             diffs.append(f"camera '{cam}' is in the on-disk schema but not in the current scene")
 
         if diffs:
-            raise ValueError(
-                "Cannot resume recording: the current scene does not match the existing dataset schema. "
-                "Use overwrite=True for a fresh dataset, or restore the original scene. Differences:\n  - "
-                + "\n  - ".join(diffs)
-            )
+            raise ValueError(_resume_schema_error(diffs))

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -221,6 +221,63 @@ def test_b12_multi_episode_resume_appends(sim_with_two_robots, tmp_path):
     assert ds.meta.total_episodes == 2, f"expected 2 episodes, got {ds.meta.total_episodes}"
 
 
+def test_resume_at_a_different_fps_is_refused_and_leaves_the_dataset_intact(sim_with_two_robots, tmp_path):
+    """Appending to an existing dataset at a different ``fps`` is rejected.
+
+    A resumed dataset keeps the rate it was created at (``LeRobotDataset.resume``
+    takes no ``fps``), so a differing request cannot be honored. Pre-fix the
+    second ``start_recording`` returned ``status="success"`` and reported the
+    requested rate while every appended frame was timestamped at the on-disk one
+    - two episodes captured at different cadences became indistinguishable on
+    disk. The refusal must also leave the existing dataset untouched.
+    """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_two_robots
+    root = str(tmp_path / "fpsmix")
+
+    r = sim.start_recording(repo_id="local/fpsmix", fps=20, root=root, overwrite=True)
+    assert r["status"] == "success", r
+    sim.run_policy(
+        robot_name="alpha",
+        policy_provider="mock",
+        instruction="ep0",
+        duration=0.3,
+        control_frequency=20.0,
+        fast_mode=True,
+    )
+    assert sim.stop_recording()["status"] == "success"
+
+    r = sim.start_recording(repo_id="local/fpsmix", fps=40, root=root, overwrite=False)
+    assert r["status"] == "error", f"resume at a different fps must be refused: {r}"
+    text = r["content"][0]["text"]
+    assert "fps" in text and "on-disk=20" in text and "requested=40" in text, text
+
+    # The dataset the caller already recorded is intact and still at its rate.
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    ds = LeRobotDataset(repo_id="local/fpsmix", root=root)
+    assert ds.meta.fps == 20
+    assert ds.meta.total_episodes == 1
+
+    # The same rate still appends, so the guard only rejects the unhonorable case.
+    r = sim.start_recording(repo_id="local/fpsmix", fps=20, root=root, overwrite=False)
+    assert r["status"] == "success", r
+    sim.run_policy(
+        robot_name="alpha",
+        policy_provider="mock",
+        instruction="ep1",
+        duration=0.3,
+        control_frequency=20.0,
+        fast_mode=True,
+    )
+    assert sim.stop_recording()["status"] == "success"
+    assert LeRobotDataset(repo_id="local/fpsmix", root=root).meta.total_episodes == 2
+
+
 def test_b4_synchronized_multi_robot_recording(sim_with_two_robots, tmp_path):
     """B4 fix: run_multi_policy drives BOTH robots in one synchronized loop and
     records them into ONE merged frame per timestep - so every frame co-observes

--- a/tests/simulation/mujoco/test_resume_schema.py
+++ b/tests/simulation/mujoco/test_resume_schema.py
@@ -5,6 +5,10 @@ instance state), so these tests bind it to a dummy ``self`` and run without
 mujoco or lerobot installed. They pin the #366 follow-up: resume() must reject a
 scene whose schema diverges from the existing on-disk dataset rather than
 deferring to a cryptic per-feature shape error on the next add_frame.
+
+The dataset frame rate is part of that schema: a resume cannot change it, so a
+differing ``fps`` must be refused rather than silently appending frames on the
+dataset's timebase instead of the requested one.
 """
 
 import pytest
@@ -15,8 +19,23 @@ verify = RecordingMixin._verify_resume_schema
 
 
 class _FakeRecorder:
-    def __init__(self, features):
-        self.dataset = type("_DS", (), {"features": features})()
+    def __init__(self, features, fps=None, meta_fps=None):
+        """Fake resumed recorder.
+
+        Args:
+            features: On-disk feature dict, or None to omit ``features``
+                entirely (an unexpected LeRobot layout).
+            fps: Value for the dataset's ``fps`` attribute, omitted when None.
+            meta_fps: Value for ``dataset.meta.fps``, omitted when None.
+        """
+        attrs = {}
+        if features is not None:
+            attrs["features"] = features
+        if fps is not None:
+            attrs["fps"] = fps
+        if meta_fps is not None:
+            attrs["meta"] = type("_Meta", (), {"fps": meta_fps})()
+        self.dataset = type("_DS", (), attrs)()
 
 
 def _features(joint_names, cams, actions=None):
@@ -39,43 +58,43 @@ def _features(joint_names, cams, actions=None):
 def test_resume_schema_matching_scene_passes():
     rec = _FakeRecorder(_features(["shoulder_pan", "elbow"], {"front": (480, 640)}))
     # No raise -> schema matches.
-    verify(None, rec, ["shoulder_pan", "elbow"], ["front"], {"front": (480, 640)})
+    verify(None, rec, ["shoulder_pan", "elbow"], ["front"], {"front": (480, 640)}, fps=30)
 
 
 def test_resume_schema_extra_joint_raises():
     rec = _FakeRecorder(_features(["shoulder_pan"], {}))
     with pytest.raises(ValueError, match="observation.state joints differ"):
-        verify(None, rec, ["shoulder_pan", "elbow"], [], {})
+        verify(None, rec, ["shoulder_pan", "elbow"], [], {}, fps=30)
 
 
 def test_resume_schema_camera_resolution_mismatch_raises():
     rec = _FakeRecorder(_features(["j"], {"front": (480, 640)}))
     with pytest.raises(ValueError, match="resolution differs"):
-        verify(None, rec, ["j"], ["front"], {"front": (256, 256)})
+        verify(None, rec, ["j"], ["front"], {"front": (256, 256)}, fps=30)
 
 
 def test_resume_schema_new_camera_in_scene_raises():
     rec = _FakeRecorder(_features(["j"], {"front": (480, 640)}))
     with pytest.raises(ValueError, match="not in the on-disk schema"):
-        verify(None, rec, ["j"], ["front", "wrist"], {"front": (480, 640), "wrist": (480, 640)})
+        verify(None, rec, ["j"], ["front", "wrist"], {"front": (480, 640), "wrist": (480, 640)}, fps=30)
 
 
 def test_resume_schema_dropped_camera_raises():
     rec = _FakeRecorder(_features(["j"], {"front": (480, 640), "wrist": (480, 640)}))
     with pytest.raises(ValueError, match="not in the current scene"):
-        verify(None, rec, ["j"], ["front"], {"front": (480, 640)})
+        verify(None, rec, ["j"], ["front"], {"front": (480, 640)}, fps=30)
 
 
 def test_resume_schema_no_features_skips_silently():
     """An unexpected LeRobot layout (no .features) must not block a valid resume."""
     rec = type("_R", (), {"dataset": type("_DS", (), {})()})()
-    verify(None, rec, ["j"], [], {})  # no raise
+    verify(None, rec, ["j"], [], {}, fps=30)  # no raise
 
 
 def test_resume_schema_error_message_is_ascii():
     rec = _FakeRecorder(_features(["shoulder_pan"], {}))
     with pytest.raises(ValueError) as exc:
-        verify(None, rec, ["shoulder_pan", "elbow"], [], {})
+        verify(None, rec, ["shoulder_pan", "elbow"], [], {}, fps=30)
     str(exc.value).encode("ascii")  # raises if any non-ASCII glyph leaked
 
 
@@ -89,11 +108,89 @@ def test_resume_schema_action_columns_mismatch_raises():
     """
     rec = _FakeRecorder(_features(["j"], {}, actions=["shoulder_pan", "elbow"]))
     with pytest.raises(ValueError, match="action columns differ"):
-        verify(None, rec, ["j"], [], {}, action_names=["shoulder_pan", "wrist"])
+        verify(None, rec, ["j"], [], {}, action_names=["shoulder_pan", "wrist"], fps=30)
 
 
 def test_resume_schema_matching_action_columns_passes():
     """Matching action columns must not raise when action_names is supplied."""
     rec = _FakeRecorder(_features(["j"], {}, actions=["shoulder_pan", "elbow"]))
     # No raise -> the action feature matches the scene's actuator columns.
-    verify(None, rec, ["j"], [], {}, action_names=["shoulder_pan", "elbow"])
+    verify(None, rec, ["j"], [], {}, action_names=["shoulder_pan", "elbow"], fps=30)
+
+
+def test_resume_schema_fps_mismatch_raises():
+    """A resume at a rate the dataset cannot be re-created at is refused.
+
+    ``LeRobotDataset.resume`` takes no ``fps``, so the dataset keeps the rate it
+    was created at. Appending anyway timestamps the new frames at the on-disk
+    rate although they were captured at the requested one, silently writing a
+    wrong timebase into the dataset.
+    """
+    rec = _FakeRecorder(_features(["j"], {}), fps=30)
+    with pytest.raises(ValueError, match="dataset fps differs: on-disk=30 vs requested=60"):
+        verify(None, rec, ["j"], [], {}, fps=60)
+
+
+def test_resume_schema_fps_error_names_the_rate_to_pass():
+    """The refusal is actionable: it names the value that would append."""
+    rec = _FakeRecorder(_features(["j"], {}), fps=30)
+    with pytest.raises(ValueError, match=r"pass fps=30 to append at it"):
+        verify(None, rec, ["j"], [], {}, fps=60)
+
+
+def test_resume_schema_matching_fps_passes():
+    rec = _FakeRecorder(_features(["j"], {}), fps=30)
+    verify(None, rec, ["j"], [], {}, fps=30)  # no raise
+
+
+def test_resume_schema_fps_read_from_dataset_metadata():
+    """The rate is also honored when only ``dataset.meta.fps`` is exposed."""
+    rec = _FakeRecorder(_features(["j"], {}), meta_fps=25)
+    with pytest.raises(ValueError, match="on-disk=25 vs requested=30"):
+        verify(None, rec, ["j"], [], {}, fps=30)
+
+
+def test_resume_schema_fps_mismatch_raises_without_a_feature_dict():
+    """The rate is metadata, so it is compared even with no ``features`` map.
+
+    A LeRobot layout that does not expose ``features`` skips the joint/camera
+    comparison, but the frame rate still comes from the dataset metadata and a
+    mismatch there is enough to lose the timebase.
+    """
+    rec = _FakeRecorder(None, fps=30)
+    with pytest.raises(ValueError, match="dataset fps differs"):
+        verify(None, rec, ["j"], [], {}, fps=60)
+
+
+def test_resume_schema_missing_fps_does_not_block_resume():
+    """No reported rate -> no comparison, same best-effort posture as features."""
+    rec = _FakeRecorder(_features(["j"], {}))
+    verify(None, rec, ["j"], [], {}, fps=60)  # no raise
+
+
+def test_resume_schema_fractional_disk_fps_does_not_block_resume():
+    """A fractional on-disk rate has no whole-number equivalent to advise.
+
+    ``start_recording`` only accepts a positive whole ``fps``, so there is no
+    value the caller could pass to match a 29.97 fps dataset; refusing would
+    dead-end the resume, so the comparison is skipped instead.
+    """
+    rec = _FakeRecorder(_features(["j"], {}), fps=29.97)
+    verify(None, rec, ["j"], [], {}, fps=30)  # no raise
+
+
+def test_resume_schema_boolean_disk_fps_is_not_read_as_a_rate():
+    """``True`` is an int subclass but not a frame rate; it must not compare."""
+    rec = _FakeRecorder(_features(["j"], {}), fps=True)
+    verify(None, rec, ["j"], [], {}, fps=30)  # no raise
+
+
+def test_resume_schema_reports_fps_and_scene_diffs_together():
+    """Every divergence is listed in one refusal, not just the first found."""
+    rec = _FakeRecorder(_features(["shoulder_pan"], {}), fps=30)
+    with pytest.raises(ValueError) as exc:
+        verify(None, rec, ["shoulder_pan", "elbow"], [], {}, fps=60)
+    message = str(exc.value)
+    assert "dataset fps differs" in message
+    assert "observation.state joints differ" in message
+    message.encode("ascii")  # raises if any non-ASCII glyph leaked


### PR DESCRIPTION
## Problem

`start_recording(overwrite=False)` on an existing dataset **resumes** it, and `LeRobotDataset.resume` takes no `fps` - a resumed dataset keeps the rate it was created at. The requested rate was accepted anyway, echoed back in the success text, and then silently discarded:

```python
sim.start_recording(repo_id="local/demo", fps=30, root=root, overwrite=True)
sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=24, control_frequency=30.0)
sim.stop_recording()                        # episode 0, 30 Hz

sim.start_recording(repo_id="local/demo", fps=60, root=root)   # resume
# -> success: "Recording to LeRobotDataset: local/demo | 2 joints, 2 cameras @ 60fps"
sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=24, control_frequency=60.0)
sim.stop_recording()                        # -> success
```

Both episodes landed at 30 fps (`meta/info.json: "fps": 30`). Episode 1 was captured at 60 Hz - 0.383 s of rollout - but timestamped across 0.767 s, so:

* two episodes recorded at different cadences are **indistinguishable on disk** (identical timestamp columns, identical MP4 rate),
* every appended episode carries a wrong `dt`, and so wrong velocities, for anything trained on it,
* the caller was told the rate they asked for was in effect.

Everything *else* about a resume is already validated: `_verify_resume_schema` refuses a resume whose joint columns, action columns or camera resolutions diverge from the on-disk dataset, pointing at `overwrite=True`. The frame rate is metadata a resume cannot change either, and it was the one field left out.

## Change

`fps` joins the resume schema comparison. A mismatch is refused, naming the value that *would* append:

```
Cannot resume recording: the current scene does not match the existing dataset schema.
Use overwrite=True for a fresh dataset, or restore the original scene. Differences:
  - dataset fps differs: on-disk=30 vs requested=60 (a resumed dataset keeps its
    on-disk rate; pass fps=30 to append at it)
```

* `fps` is a **required keyword-only** argument of `_verify_resume_schema`, so no backend can resume without comparing it; the MuJoCo, Newton and Isaac `start_recording` call sites all pass it and the type checker enforces that.
* The rate is read from the dataset metadata (`dataset.fps`, falling back to `dataset.meta.fps`), so it is compared even on a LeRobot layout that does not expose a `features` map - the existing early return skipped everything in that case.
* Best-effort where there is nothing actionable to say: an unreported rate, or a fractional on-disk rate (no whole-number value exists for the caller to pass, since `start_recording` requires one), skips the comparison instead of dead-ending a valid resume. Documented on the reader helper.
* Resuming at the dataset's own rate appends exactly as before.
* The refusal collects alongside the other diffs, so a scene that changed both its schema and its rate reports both in one message.

## Visual artifact

Same two-session recording script run against both trees: create at `fps=30`/30 Hz, then append a 60 Hz episode requesting `fps=60`. Top strip is the appended episode decoded back out of the dataset's MP4; bottom plot is the recorded timestamp column against the cadence the frames were actually captured at.

![resume fps timebase](https://raw.githubusercontent.com/cagataycali/robots/artifacts/resume-fps/resume_fps.png)

| | before | after |
| --- | --- | --- |
| `start_recording(fps=60, overwrite=False)` | `success`, reports "@ 60fps" | `error`, names on-disk=30 |
| appended episode, real capture time | 0.3833 s (24 frames @ 60 Hz) | 0.7667 s (24 frames @ 30 Hz) |
| appended episode, recorded timespan | 0.7667 s (**2.0x too slow**) | 0.7667 s (matches) |
| dataset after the call | 2 episodes, mixed cadence, both labelled 30 fps | 1 episode, untouched, still 30 fps |

Round-trip of the honored path (`fps=30` resume -> rollout -> `stop_recording` -> reopen): dataset reports `meta.fps == 30`, `total_episodes == 2`, and the appended episode's MP4 decodes to 24 frames:

![appended episode](https://raw.githubusercontent.com/cagataycali/robots/artifacts/resume-fps/appended_episode.gif)

## Tests

`tests/simulation/mujoco/test_resume_schema.py` (+9): mismatch refused, message names the rate to pass, matching rate passes, rate read from `dataset.meta.fps`, mismatch reported with no `features` map, missing/fractional/boolean on-disk rate does not block a resume, and fps + joint diffs reported together.

`tests/simulation/mujoco/test_recording_paths.py` (+1): end-to-end through the public facade - a `fps=40` resume of a 20 fps dataset is refused, the existing dataset is left intact (`meta.fps == 20`, 1 episode), and a `fps=20` resume still appends to 2 episodes.

Pre-fix on this branch's base, the new pins fail (`19 failed`), the integration one on the exact defect:

```
AssertionError: resume at a different fps must be refused: {'status': 'success', 'content':
  [{'text': 'Recording to LeRobotDataset: local/fpsmix\n6 joints, 1 cameras @ 40fps ...'}]}
```

Local gate: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` clean; full suite `12255 passed, 260 skipped` (headless MuJoCo, `MUJOCO_GL=egl`).

## Docs

`docs/recording.md` resume section states the constraint with the error and both remedies; the `fps` docstring in all three backends' `start_recording` notes that a resume must match the on-disk rate; `CHANGELOG.md` under `[Unreleased]`.