### PR TITLE
fix(rendering): encode a clip at the requested frame rate, or refuse it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,42 @@ Resuming at the dataset's own rate still appends as before. The comparison is
 shared by the MuJoCo, Newton and Isaac backends (`fps` is a required
 keyword-only argument of the schema check, so no backend can resume without it).
 
+### Fixed: a clip is encoded at the requested frame rate, or refused
+
+`encode_clip` - the shared MP4/GIF encoder behind the camera recorders and the
+render pipelines - never validated `fps`, and each container silently invented a
+different rate for the same unusable value:
+
+```python
+from strands_robots.rendering import encode_clip
+
+encode_clip(frames, "clip.gif", fps=0)   # -> clip.gif at 1 fps (clamped)
+encode_clip(frames, "clip.mp4", fps=0)   # -> clip.mp4 at 16 fps (ffmpeg default)
+encode_clip(frames, "clip.mp4", fps=-5)  # -> returns the path; no file was written
+encode_clip(frames, "clip.mp4", fps=2.7) # -> clip.mp4 at 2 fps (truncated)
+```
+
+The GIF writer clamped the rate (`duration=1000.0 / max(1, int(fps))`), so `0`
+and every negative rate became a 1 fps clip; the MP4 writer passed the value to
+ffmpeg, which substituted its own default for `0`, refused a negative rate
+without writing anything, and truncated a fractional one. `fps=True` - an `int`
+subclass - encoded at 1 fps, and `nan`/`inf`/`None`/`"20"` dead-ended in a bare
+`int()` `ValueError`/`OverflowError`/`TypeError` that never named the parameter.
+In every case the output path was returned, so a caller had no signal that the
+clip it names is mistimed or absent.
+
+`fps` is now validated against the same positive-whole-number domain the
+recorders and `run_policy(video=...)` already share (moved to
+`strands_robots.utils.positive_whole_number_error`, which both the simulation
+and rendering layers can depend on), raising `ValueError` before any encoder is
+probed. `encode_clip` additionally raises `RuntimeError` when the encoder wrote
+no clip despite accepting the frames - previously a `macro_block_size` that
+rounds the frame size to dimensions libx264 refuses also returned a path to a
+file that does not exist. The Isaac camera flush now reports such a refusal on
+its artifact line (with `flush_error`, matching the MuJoCo backend) instead of
+letting it escape `stop_cameras_recording` and instead of counting buffered
+frames as written.
+
 ### Fixed: a dataset recording is refused at a frame rate it cannot be written at
 
 `start_recording` never validated `fps`. LeRobot itself only rejects `fps <= 0`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ its artifact line (with `flush_error`, matching the MuJoCo backend) instead of
 letting it escape `stop_cameras_recording` and instead of counting buffered
 frames as written.
 
+Isaac's `start_cameras_recording` now pre-flights `fps` and
+`max_frames_per_camera` against that same domain, as the MuJoCo recorder already
+did, so a rate the flush cannot encode at is refused before a rollout's frames
+are buffered rather than after they have been captured and lost.
+
 ### Fixed: a dataset recording is refused at a frame rate it cannot be written at
 
 `start_recording` never validated `fps`. LeRobot itself only rejects `fps <= 0`,

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -278,11 +278,20 @@ then only a lower bound, reported in the `unreadable_files` diagnostics.
 | `start_cameras_recording` / `stop_cameras_recording` | `[sim-mujoco]` alone | Plain MP4, no parquet |
 
 `fps`, `width`, `height` and `max_frames_per_camera` on the plain-MP4 recorders
-must be positive whole numbers - the same domain `run_policy(video={...})`
-enforces. An unusable value (`fps=0`, a negative frame cap) is a structured
-error naming the parameter rather than a recording that reports success and
-writes no file. Omit `width`/`height` to use each camera's configured
-resolution.
+must be positive whole numbers - the same domain `run_policy(video={...})`,
+`start_recording(fps=...)` and the shared encoder
+`strands_robots.rendering.encode_clip` enforce. An unusable value (`fps=0`, a
+negative frame cap) is a structured error naming the parameter rather than a
+recording that reports success and writes no file. Omit `width`/`height` to use
+each camera's configured resolution.
+
+Encoding frames directly through `encode_clip(frames, path, fps=...)` follows the
+same rule and raises `ValueError` for a rate it cannot honor - a fractional or
+non-positive `fps` previously produced a clip at some other rate (the GIF writer
+clamped it to 1 fps, ffmpeg substituted its own default) or no file at all, with
+the output path still returned. `encode_clip` also raises `RuntimeError` when the
+encoder wrote no clip despite accepting the frames, so a returned path always
+names a clip that exists.
 
 ## Video codec (H.264 default, AV1 opt-in)
 

--- a/strands_robots/rendering/video.py
+++ b/strands_robots/rendering/video.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import require_optional
+from strands_robots.utils import positive_whole_number_error, require_optional
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,9 @@ def encode_clip(
             share one shape.
         path: output file path; the extension selects the container
             (``.gif`` -> GIF, anything else -> MP4 via ffmpeg).
-        fps: playback frame rate.
+        fps: playback frame rate, a positive whole number of frames per
+            second (the shared media domain - see
+            :func:`~strands_robots.utils.positive_whole_number_error`).
         quality: imageio/ffmpeg quality knob (0-10, higher is better).
             Ignored for GIF.
         macro_block_size: libx264 macro-block rounding; ``1`` preserves the
@@ -56,9 +58,18 @@ def encode_clip(
     Raises:
         ImportError: if ``imageio`` (and, for MP4, ``imageio-ffmpeg``) is not
             installed.
-        ValueError: if ``frames`` is empty -- an empty clip write would
-            silently produce a corrupt/zero-length artifact.
+        ValueError: if ``frames`` is empty, or if ``fps`` is not a positive
+            whole number -- either would silently produce a corrupt or
+            wrongly-timed artifact rather than the requested clip.
+        RuntimeError: if the encoder wrote no clip despite accepting the
+            frames (for example a ``macro_block_size`` that rounds the frame
+            size to dimensions libx264 refuses), so the returned path always
+            names a clip that exists.
     """
+    # Guard the caller's parameters before probing the optional encoder, so
+    # the same mistake reports identically whether or not imageio is installed.
+    if text := positive_whole_number_error(fps, "fps", "encode_clip"):
+        raise ValueError(text)
     require_optional(
         "imageio",
         pip_install="imageio imageio-ffmpeg",
@@ -75,14 +86,24 @@ def encode_clip(
         out.parent.mkdir(parents=True, exist_ok=True)
     if out.suffix.lower() == ".gif":
         # Pillow's GIF writer takes per-frame duration (ms), not fps.
-        imageio.mimsave(str(out), frame_list, duration=1000.0 / max(1, int(fps)))
-        return out
-    writer = imageio.get_writer(str(out), fps=int(fps), quality=quality, macro_block_size=macro_block_size)
-    try:
-        for frame in frame_list:
-            writer.append_data(frame)
-    finally:
-        writer.close()
+        imageio.mimsave(str(out), frame_list, duration=1000.0 / int(fps))
+    else:
+        writer = imageio.get_writer(str(out), fps=int(fps), quality=quality, macro_block_size=macro_block_size)
+        try:
+            for frame in frame_list:
+                writer.append_data(frame)
+        finally:
+            writer.close()
+    # The ffmpeg writer reports a refused encode on its own stderr and closes
+    # without writing anything, so without this check the caller is handed a
+    # path to a clip that does not exist.
+    if not out.exists() or out.stat().st_size == 0:
+        raise RuntimeError(
+            f"encode_clip: the encoder wrote no clip to {out} for {len(frame_list)} "
+            f"frames of shape {frame_list[0].shape} at {int(fps)}fps (quality={quality}, "
+            f"macro_block_size={macro_block_size}); see the encoder output above for the "
+            "refusal reason."
+        )
     return out
 
 

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -3325,32 +3325,45 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             errors = state["errors"][cam]
             frames_written = 0
             size_kb = 0.0
+            flush_error = None
             if frames_buffer:
                 # Shared encoder (strands_robots.rendering.video, issue #1537);
                 # same imageio/libx264 invocation as the previous inline writer.
                 try:
                     encode_clip(frames_buffer, path, fps=state["fps"])
+                    frames_written = len(frames_buffer)
                 except ImportError:
                     return {
                         "status": "error",
                         "content": [{"text": "imageio not installed. pip install imageio imageio-ffmpeg"}],
                     }
-                frames_written = len(frames_buffer)
+                except RuntimeError as e:
+                    # ``encode_clip`` refused to hand back a clip it never
+                    # wrote. Report the reason on the artifact line (this
+                    # method's contract is best-effort and never-raise) and
+                    # keep ``frames_written`` at 0 rather than claiming frames
+                    # that reached no file.
+                    flush_error = f"{type(e).__name__}: {e}"
+                    logger.warning("camera recorder flush failed for %r -> %s: %s", cam, path, flush_error)
                 if _os.path.exists(path):
                     size_kb = _os.path.getsize(path) / 1024
-            lines.append(
+            line = (
                 f"   {cam:20s} {frames_written:>5d} frames  {size_kb:>7.1f} KB  "
                 f"({errors} errors)  -> {_os.path.basename(path)}"
             )
-            artifacts.append(
-                {
-                    "camera": cam,
-                    "path": path,
-                    "frames": frames_written,
-                    "errors": errors,
-                    "size_kb": size_kb,
-                }
-            )
+            if flush_error:
+                line += f"  [flush failed: {flush_error}]"
+            lines.append(line)
+            artifact = {
+                "camera": cam,
+                "path": path,
+                "frames": frames_written,
+                "errors": errors,
+                "size_kb": size_kb,
+            }
+            if flush_error:
+                artifact["flush_error"] = flush_error
+            artifacts.append(artifact)
 
         return {
             "status": "success",

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -36,6 +36,7 @@ import numpy as np
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.config import IsaacConfig
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
+from strands_robots.utils import positive_whole_number_error
 
 if TYPE_CHECKING:
     from strands_robots.rendering import CameraParams
@@ -401,6 +402,47 @@ class _RobotState:
         # ``/World/Robots/arm`` being requested). Used by
         # ``gripper_frame_pose`` to walk the actual robot subtree.
         self.actual_prim_path = actual_prim_path or prim_path
+
+
+def _cameras_recording_option_error(
+    method: str,
+    fps: Any,
+    max_frames_per_camera: Any,
+) -> dict[str, Any] | None:
+    """Reject a rollout-video option the Isaac recorder cannot honor.
+
+    Pre-flight guard for :meth:`IsaacSimulation.start_cameras_recording`,
+    mirroring the MuJoCo backend's guard of the same name
+    (:func:`strands_robots.simulation.mujoco.rendering._cameras_recording_option_error`)
+    against the one shared domain
+    (:func:`~strands_robots.utils.positive_whole_number_error`), so the two
+    recording surfaces cannot disagree on what a usable ``fps`` is. Isaac takes
+    no ``width``/``height`` here - each camera carries its own resolution from
+    :meth:`IsaacSimulation.add_camera` - so only the two frame counts are
+    checked.
+
+    Refusing at ``start`` is what keeps the flush honest: ``fps`` is stored in
+    the recording state and handed to
+    :func:`~strands_robots.rendering.encode_clip` by
+    :meth:`IsaacSimulation.stop_cameras_recording`, which refuses a rate it
+    cannot encode at. Validating only at flush time would surface the mistake
+    after a whole rollout's frames had been buffered, and
+    ``max_frames_per_camera=0`` would drop every frame while both calls still
+    reported success.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        fps: Encoded MP4 frame rate.
+        max_frames_per_camera: In-memory per-camera frame cap.
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict naming the first
+        offending parameter, or ``None`` when both options are usable.
+    """
+    for param, value in (("fps", fps), ("max_frames_per_camera", max_frames_per_camera)):
+        if text := positive_whole_number_error(value, param, method):
+            return {"status": "error", "content": [{"text": text}]}
+    return None
 
 
 class _CameraState:
@@ -3162,12 +3204,15 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             Directory for the ``{name}__{camera}.mp4`` files. Defaults to
             ``$TMPDIR/strands_robots/recordings``.
         fps : int
-            Encoded MP4 frame rate. Default 30.
+            Encoded MP4 frame rate. Default 30. Must be a positive whole
+            number - the rate the flush encodes at, refused here rather
+            than after a rollout's frames have been buffered.
         name : str
             Filename tag. Auto-generated (``rec_<uuid>``) when ``None``.
         max_frames_per_camera : int
             Safety cap on in-memory buffers. Frames beyond the cap are
-            silently dropped. Default 3000.
+            silently dropped. Default 3000. Must be a positive whole
+            number; a cap below 1 drops every frame.
 
         Returns
         -------
@@ -3176,13 +3221,22 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             {"json": {"on_frame": <callable>, "cameras": [...],
             "output_dir": ..., "name": ...}}]}``. The ``on_frame`` closure
             isn't JSON-serializable; Python callers unpack it from the
-            json block. On error (no world, already recording, unknown
-            cameras, none to record): ``{"status": "error", ...}``.
+            json block. On error (unusable ``fps`` or
+            ``max_frames_per_camera``, no world, already recording,
+            unknown cameras, none to record):
+            ``{"status": "error", ...}``.
         """
         import os as _os
         import tempfile as _tempfile
         import time as _time
         import uuid as _uuid
+
+        # Refuse a frame count the recorder cannot honor before any filesystem
+        # or buffer work: ``fps`` reaches ``encode_clip`` at flush time, which
+        # refuses a rate it cannot encode at, and a non-positive frame cap
+        # drops every captured frame.
+        if error := _cameras_recording_option_error("start_cameras_recording", fps, max_frames_per_camera):
+            return error
 
         with self._lock:
             if not self._world_created:
@@ -3337,12 +3391,16 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                         "status": "error",
                         "content": [{"text": "imageio not installed. pip install imageio imageio-ffmpeg"}],
                     }
-                except RuntimeError as e:
-                    # ``encode_clip`` refused to hand back a clip it never
-                    # wrote. Report the reason on the artifact line (this
-                    # method's contract is best-effort and never-raise) and
-                    # keep ``frames_written`` at 0 rather than claiming frames
-                    # that reached no file.
+                except (RuntimeError, ValueError) as e:
+                    # ``encode_clip`` refused the clip: ``RuntimeError`` when it
+                    # wrote no file, ``ValueError`` when it will not encode at
+                    # the requested rate. ``start_cameras_recording`` pre-flights
+                    # that rate, so the second is unreachable through the tool
+                    # pair; it is caught anyway because this method's contract is
+                    # best-effort and never-raise, and the flush is the last
+                    # chance to hand back the buffered frames' fate. Report the
+                    # reason on the artifact line and keep ``frames_written`` at
+                    # 0 rather than claiming frames that reached no file.
                     flush_error = f"{type(e).__name__}: {e}"
                     logger.warning("camera recorder flush failed for %r -> %s: %s", cam, path, flush_error)
                 if _os.path.exists(path):

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -108,7 +108,7 @@ def _cameras_recording_option_error(
     :meth:`RenderingMixin.start_cameras_recording_synchronous`). Every one of
     these knobs is a frame count or a pixel count, so the accepted domain is the
     shared one the ``run_policy(video=...)`` dict already enforces
-    (:func:`~strands_robots.simulation.policy_runner.positive_whole_number_error`)
+    (:func:`~strands_robots.utils.positive_whole_number_error`)
     - a single source of truth, so the two recording surfaces cannot disagree on
     what a usable ``fps`` is.
 
@@ -131,7 +131,7 @@ def _cameras_recording_option_error(
         A structured ``{"status": "error", ...}`` dict naming the first
         offending parameter, or ``None`` when every option is usable.
     """
-    from strands_robots.simulation.policy_runner import positive_whole_number_error
+    from strands_robots.utils import positive_whole_number_error
 
     # ``width``/``height`` are ``int | None``: ``None`` means "use the camera's
     # configured resolution, else the renderer default", so it is skipped rather

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -46,7 +46,7 @@ import numpy as np
 
 from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.policies.base import resolve_chunk_length
-from strands_robots.utils import process_rss_mb, require_optional
+from strands_robots.utils import positive_whole_number_error, process_rss_mb, require_optional
 
 if TYPE_CHECKING:
     from strands_robots.policies.base import Policy
@@ -173,39 +173,6 @@ def _extract_frame_ndarray(render_result: dict) -> np.ndarray | None:
             return np.asarray(Image.open(io.BytesIO(png_bytes)).convert("RGB"))
         except Exception:
             return None
-    return None
-
-
-def positive_whole_number_error(value: Any, param: str, context: str) -> str | None:
-    """Error text when ``value`` is not a usable positive whole number.
-
-    Shared domain for every recording knob that counts frames or pixels -
-    ``fps``, ``width``, ``height`` and the in-memory frame cap. Only a positive
-    whole number can be honored: ``0`` makes the capture loop's ``1 / fps``
-    period undefined, a negative rate is rejected by the ffmpeg writer, and a
-    zero/negative frame cap drops every frame. Accepts any real scalar with an
-    integral value (so a NumPy ``np.int64`` height or a ``30.0`` computed from a
-    config float passes) and rejects ``bool`` explicitly - an ``int`` subclass
-    whose ``True`` would act as a silent 1.
-
-    Args:
-        value: The caller-supplied value.
-        param: The parameter (or dict key) it came from, used in the message.
-        context: Message prefix identifying the surface that received it -
-            ``"video"`` for the :class:`VideoConfig` dict, the method name for a
-            keyword parameter.
-
-    Returns:
-        An error message, or ``None`` when the value is usable.
-    """
-    message = f"{context}: {param} must be a positive whole number, got {value!r}."
-    if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        return message
-    numeric = float(value)
-    # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
-    # out of the integrality check below.
-    if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
-        return message
     return None
 
 

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -31,6 +31,8 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.utils import positive_whole_number_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,7 +44,7 @@ def dataset_recording_option_error(method: str, fps: Any) -> dict[str, Any] | No
     ``fps`` is. ``fps`` is a frame count per second, so the accepted domain is
     the shared one the plain-MP4 recorders and the ``run_policy(video=...)``
     dict already enforce
-    (:func:`~strands_robots.simulation.policy_runner.positive_whole_number_error`):
+    (:func:`~strands_robots.utils.positive_whole_number_error`):
     a positive whole number.
 
     Without this guard an unusable ``fps`` was reported as ``status="success"``
@@ -63,11 +65,6 @@ def dataset_recording_option_error(method: str, fps: Any) -> dict[str, Any] | No
         A structured ``{"status": "error", ...}`` dict naming ``fps``, or
         ``None`` when the value is usable.
     """
-    # Imported lazily: ``policy_runner`` pulls in the rollout machinery, and
-    # this module sits below it in the import graph (backends import the mixin
-    # while constructing their engine class).
-    from strands_robots.simulation.policy_runner import positive_whole_number_error
-
     if text := positive_whole_number_error(fps, "fps", method):
         return {"status": "error", "content": [{"text": text}]}
     return None

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2,8 +2,11 @@
 
 import importlib
 import logging
+import math
+import numbers
 import os
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -294,3 +297,41 @@ def process_rss_mb() -> float | None:
         return float(maxrss) / divisor
     except (ImportError, ValueError, OSError):
         return None
+
+
+def positive_whole_number_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable positive whole number.
+
+    Shared domain for every media knob that counts frames or pixels - the
+    recorders' ``fps``, ``width``, ``height`` and in-memory frame cap, the
+    ``run_policy(video=...)`` dict fields, and the
+    :func:`~strands_robots.rendering.encode_clip` playback rate. It lives here
+    rather than beside one of its callers because those callers sit in different
+    layers (:mod:`strands_robots.rendering` must not depend on
+    :mod:`strands_robots.simulation`), and the accepted domain must not diverge
+    between them. Only a positive whole number can be honored: ``0`` makes the capture loop's ``1 / fps``
+    period undefined, a negative rate is rejected by the ffmpeg writer, and a
+    zero/negative frame cap drops every frame. Accepts any real scalar with an
+    integral value (so a NumPy ``np.int64`` height or a ``30.0`` computed from a
+    config float passes) and rejects ``bool`` explicitly - an ``int`` subclass
+    whose ``True`` would act as a silent 1.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter (or dict key) it came from, used in the message.
+        context: Message prefix identifying the surface that received it -
+            ``"video"`` for the :class:`VideoConfig` dict, the method name for a
+            keyword parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    message = f"{context}: {param} must be a positive whole number, got {value!r}."
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return message
+    numeric = float(value)
+    # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
+    # out of the integrality check below.
+    if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
+        return message
+    return None

--- a/tests/rendering/test_encode_clip_option_guards.py
+++ b/tests/rendering/test_encode_clip_option_guards.py
@@ -1,0 +1,111 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``encode_clip`` only accepts clip options it can actually encode.
+
+``fps`` is the clip's timebase, so a value the encoders cannot honor has no
+usable interpretation: the GIF writer used to clamp it
+(``duration=1000.0 / max(1, int(fps))``, turning ``0`` or ``-5`` into a 1 fps
+clip), the MP4 writer let ffmpeg substitute its own default rate for ``0`` and
+refused a negative rate without writing a file at all - and in every one of
+those cases ``encode_clip`` still returned the output path. These tests pin the
+contract that the returned path names a clip that exists and plays at the
+requested rate, on both containers.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import encode_clip
+from strands_robots.simulation.recording import dataset_recording_option_error
+from strands_robots.utils import positive_whole_number_error
+
+# Values no encoder can turn into a frame rate: zero and negative rates, a
+# fractional rate, non-finite floats, a numeric string, ``True`` (an ``int``
+# subclass that would silently act as 1 fps) and a missing value.
+UNUSABLE_FPS = [0, -5, 2.7, math.nan, math.inf, "20", True, None]
+
+
+def _frames(n: int = 6, w: int = 48, h: int = 32) -> list[np.ndarray]:
+    """``n`` distinct RGB frames of one shape (a gradient, so decode is visible)."""
+    return [np.full((h, w, 3), (i * 20) % 256, dtype=np.uint8) for i in range(n)]
+
+
+@pytest.mark.parametrize("suffix", [".gif", ".mp4"])
+@pytest.mark.parametrize("fps", UNUSABLE_FPS)
+def test_unusable_fps_is_refused_before_any_file_is_written(tmp_path, suffix, fps) -> None:
+    """Every container refuses the same unusable rates, naming fps and the value."""
+    out = tmp_path / f"clip{suffix}"
+    with pytest.raises(ValueError, match="fps must be a positive whole number"):
+        encode_clip(_frames(), out, fps=fps)
+    assert not out.exists(), f"encode_clip({fps!r}) left a file behind at {out}"
+
+
+@pytest.mark.parametrize("fps", [1, 25, 30.0, np.int64(24)])
+def test_usable_fps_encodes_a_gif_at_the_requested_rate(tmp_path, fps) -> None:
+    """A whole-number rate (including a float or NumPy integer) sets the GIF timing."""
+    pytest.importorskip("imageio.v2")
+    pil_image = pytest.importorskip("PIL.Image")
+    out = encode_clip(_frames(), tmp_path / "clip.gif", fps=fps)
+    with pil_image.open(out) as im:
+        assert im.n_frames == 6
+        # Pillow stores per-frame duration in milliseconds, and the GIF
+        # format quantizes it to centiseconds - hence the 10 ms tolerance.
+        assert im.info["duration"] == pytest.approx(1000.0 / int(fps), abs=10.0)
+
+
+def test_mp4_is_encoded_at_the_requested_rate(tmp_path) -> None:
+    """The MP4's own metadata reports the requested rate, not an ffmpeg default."""
+    pytest.importorskip("imageio.v2")
+    pytest.importorskip("imageio_ffmpeg")
+    imageio_v3 = pytest.importorskip("imageio.v3")
+    out = encode_clip(_frames(n=12), tmp_path / "clip.mp4", fps=3)
+    assert out.stat().st_size > 0
+    assert float(imageio_v3.immeta(out, plugin="pyav")["fps"]) == pytest.approx(3.0)
+
+
+def test_encoder_refusal_raises_instead_of_returning_a_path_to_nothing(tmp_path) -> None:
+    """A frame size the codec refuses is reported, not returned as a written clip.
+
+    ``macro_block_size=7`` rounds a 48x32 frame up to 49x35, which libx264
+    refuses; the writer then closes having written nothing. The failure has to
+    reach the caller, because the return value is the caller's only handle on
+    the artifact.
+    """
+    pytest.importorskip("imageio.v2")
+    pytest.importorskip("imageio_ffmpeg")
+    out = tmp_path / "refused.mp4"
+    with pytest.raises(RuntimeError, match="wrote no clip"):
+        encode_clip(_frames(), out, fps=20, macro_block_size=7)
+    assert not out.exists() or out.stat().st_size == 0
+
+
+def test_fps_is_refused_before_the_optional_encoder_is_probed(tmp_path, monkeypatch) -> None:
+    """The parameter guard runs first, so the error is the same on any install.
+
+    Without imageio present the caller would otherwise be told to install an
+    extra when the real problem is the value they passed.
+    """
+
+    def _no_imageio(*args, **kwargs):
+        raise ImportError("imageio is not installed")
+
+    monkeypatch.setattr("strands_robots.rendering.video.require_optional", _no_imageio)
+    with pytest.raises(ValueError, match="fps must be a positive whole number"):
+        encode_clip(_frames(), tmp_path / "clip.mp4", fps=0)
+
+
+@pytest.mark.parametrize("fps", UNUSABLE_FPS)
+def test_one_frame_rate_domain_across_the_media_surfaces(fps) -> None:
+    """encode_clip, the recorders and the run_policy video dict share one domain.
+
+    A rate rejected when recording a dataset cannot be accepted when encoding
+    the clip of that same rollout, so both surfaces resolve the value through
+    the same helper and only the message prefix differs.
+    """
+    text = positive_whole_number_error(fps, "fps", "encode_clip")
+    assert text == f"encode_clip: fps must be a positive whole number, got {fps!r}."
+    assert dataset_recording_option_error("start_recording", fps) is not None

--- a/tests/simulation/isaac/test_cameras_recording_preflight_guards.py
+++ b/tests/simulation/isaac/test_cameras_recording_preflight_guards.py
@@ -1,0 +1,159 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Isaac's rollout-video recorder refuses a rate it cannot encode at.
+
+``IsaacSimulation.start_cameras_recording`` stores ``fps`` in the recording
+state and ``stop_cameras_recording`` hands it to
+:func:`strands_robots.rendering.encode_clip`, which refuses a rate it cannot
+honor rather than inventing one. Without a pre-flight the mistake surfaced only
+at flush time - after a whole rollout's frames had been buffered - as a
+``ValueError`` escaping ``stop_cameras_recording``, an agent-facing tool whose
+flush contract is best-effort and never-raise, with the recording state already
+cleared so every buffered frame was lost with no structured response.
+
+So ``fps`` (and the in-memory frame cap, whose sub-1 values drop every captured
+frame) is checked at ``start`` against the same domain the MuJoCo recorder uses,
+and the flush reports a refusal on its artifact line either way.
+
+The engine is a skeleton ``IsaacSimulation`` built with ``__new__`` (the fixture
+shape ``test_dataset_recording.py`` uses) so the recording lifecycle runs
+without the Isaac Sim Kit runtime.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import (
+    IsaacSimulation,
+    _CameraState,
+)
+
+# Every value the shared positive-whole-number domain refuses: zero and
+# negative rates, a fractional rate, non-finite floats, a string that looks
+# like a number, ``True`` (an ``int`` subclass that would act as a silent 1),
+# and ``None``.
+_UNUSABLE = [0, -5, 2.7, float("nan"), float("inf"), "30", True, None]
+
+
+class _FakeCameraHandle:
+    """Stub RTX camera handle: ``get_rgba()`` returns a fixed RGBA buffer."""
+
+    def __init__(self, rgba: np.ndarray) -> None:
+        self.rgba = rgba
+
+    def get_rgba(self) -> np.ndarray:
+        return self.rgba
+
+
+def _camera(name: str, width: int = 64, height: int = 48) -> _CameraState:
+    cam = _CameraState(name=name, prim_path=f"/World/Cameras/{name}", width=width, height=height)
+    cam.handle = _FakeCameraHandle(np.zeros((height, width, 4), dtype=np.uint8))
+    return cam
+
+
+def _make_engine() -> IsaacSimulation:
+    """Skeleton IsaacSimulation with one camera and no Kit runtime."""
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig()
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {}
+    engine._cameras = {"front": _camera("front")}
+    engine._objects = {}
+    engine._prim_registry = []
+    engine._cams_rec_state = None
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._main_tid = threading.get_ident()
+    return engine
+
+
+@pytest.mark.parametrize("fps", _UNUSABLE)
+def test_start_cameras_recording_refuses_an_unusable_fps(fps: object, tmp_path) -> None:
+    """An fps the encoder cannot honor is refused before any frame is buffered."""
+    engine = _make_engine()
+
+    result = engine.start_cameras_recording(output_dir=str(tmp_path), fps=fps)  # type: ignore[arg-type]
+
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "fps" in text and repr(fps) in text
+    # No recording started, so no rollout's frames are buffered against a rate
+    # the flush would refuse.
+    assert engine._cams_rec_state is None
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("cap", _UNUSABLE)
+def test_start_cameras_recording_refuses_an_unusable_frame_cap(cap: object, tmp_path) -> None:
+    """A frame cap below 1 drops every frame, so it is refused up front."""
+    engine = _make_engine()
+
+    result = engine.start_cameras_recording(output_dir=str(tmp_path), max_frames_per_camera=cap)  # type: ignore[arg-type]
+
+    assert result["status"] == "error"
+    assert "max_frames_per_camera" in result["content"][0]["text"]
+    assert engine._cams_rec_state is None
+
+
+def test_start_cameras_recording_accepts_a_usable_rate(tmp_path) -> None:
+    """The guard admits the rates the encoder honors, including a real-valued one."""
+    engine = _make_engine()
+
+    result = engine.start_cameras_recording(output_dir=str(tmp_path), fps=np.int64(24), max_frames_per_camera=30.0)  # type: ignore[arg-type]
+
+    assert result["status"] == "success"
+    assert engine._cams_rec_state is not None
+    assert callable(result["content"][0]["json"]["on_frame"])
+
+
+def test_isaac_refuses_the_same_rate_as_the_mujoco_recorder() -> None:
+    """One domain across the two recording surfaces, only the prefix differs."""
+    from strands_robots.simulation.isaac.simulation import _cameras_recording_option_error as isaac_error
+    from strands_robots.simulation.mujoco.rendering import _cameras_recording_option_error as mujoco_error
+
+    for fps in _UNUSABLE:
+        assert isaac_error("start_cameras_recording", fps, 3000) is not None
+        assert mujoco_error("start_cameras_recording", fps, None, None, 3000) is not None
+    assert isaac_error("start_cameras_recording", 30, 3000) is None
+    assert mujoco_error("start_cameras_recording", 30, None, None, 3000) is None
+
+
+def test_stop_cameras_recording_reports_a_refused_rate_instead_of_raising(tmp_path) -> None:
+    """A rate that reaches the flush is reported, never raised past the tool.
+
+    The pre-flight above makes this unreachable through the public pair, but the
+    flush is the last chance to hand back the buffered frames' fate: its
+    documented contract is best-effort and never-raise, so a state carrying a
+    rate ``encode_clip`` refuses has to come back as a structured response.
+    """
+    engine = _make_engine()
+    path = str(tmp_path / "rec__front.mp4")
+    engine._cams_rec_state = {
+        "running": True,
+        "name": "rec",
+        "cameras": ["front"],
+        "fps": 0,
+        "buffers": {"front": [np.zeros((48, 64, 3), dtype=np.uint8)] * 4},
+        "paths": {"front": path},
+        "errors": {"front": 0},
+        "output_dir": str(tmp_path),
+        "started_at": 0.0,
+        "max_frames": 3000,
+    }
+
+    result = engine.stop_cameras_recording()
+
+    assert result["status"] == "success"
+    artifact = result["content"][1]["json"]["artifacts"][0]
+    assert "ValueError" in artifact["flush_error"]
+    assert "fps" in artifact["flush_error"]
+    # Frames that reached no file are not counted as written.
+    assert artifact["frames"] == 0
+    assert engine._cams_rec_state is None

--- a/tests/simulation/mujoco/test_cameras_recording_preflight_guards.py
+++ b/tests/simulation/mujoco/test_cameras_recording_preflight_guards.py
@@ -216,20 +216,22 @@ class TestSharedPositiveWholeNumberDomain:
     # that is a real supplied number is rejected identically by both.
     @pytest.mark.parametrize("bad", [0, -1, 2.5, float("nan"), float("inf"), "30", True])
     def test_video_config_and_recorder_agree_on_rejection(self, bad):
-        from strands_robots.simulation.policy_runner import VideoConfig, positive_whole_number_error
+        from strands_robots.simulation.policy_runner import VideoConfig
+        from strands_robots.utils import positive_whole_number_error
 
         assert positive_whole_number_error(bad, "fps", "start_cameras_recording") is not None
         assert VideoConfig.validation_error({"path": "/tmp/a.mp4", "fps": bad}) is not None
 
     @pytest.mark.parametrize("good", [1, 30, 30.0])
     def test_video_config_and_recorder_agree_on_acceptance(self, good):
-        from strands_robots.simulation.policy_runner import VideoConfig, positive_whole_number_error
+        from strands_robots.simulation.policy_runner import VideoConfig
+        from strands_robots.utils import positive_whole_number_error
 
         assert positive_whole_number_error(good, "fps", "start_cameras_recording") is None
         assert VideoConfig.validation_error({"path": "/tmp/a.mp4", "fps": good}) is None
 
     def test_error_text_names_the_receiving_surface(self):
-        from strands_robots.simulation.policy_runner import positive_whole_number_error
+        from strands_robots.utils import positive_whole_number_error
 
         assert positive_whole_number_error(0, "fps", "video") == "video: fps must be a positive whole number, got 0."
         assert (

--- a/tests/simulation/test_camera_flush_encoder_refusal.py
+++ b/tests/simulation/test_camera_flush_encoder_refusal.py
@@ -2,19 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """A refused encode is reported by the camera flush, never raised past it.
 
-:func:`strands_robots.rendering.encode_clip` raises ``RuntimeError`` when the
-encoder accepted the frames but wrote no clip (for example a frame size libx264
-refuses), because the returned path is the caller's only handle on the
-artifact. ``stop_cameras_recording`` is an agent-facing tool whose flush
-contract is best-effort and never-raise, so every backend that flushes buffered
-camera frames through ``encode_clip`` has to turn that refusal into a reported
-artifact error rather than letting it escape the tool envelope.
+:func:`strands_robots.rendering.encode_clip` refuses to hand back a clip it
+cannot stand behind - ``RuntimeError`` when the encoder accepted the frames but
+wrote no file (for example a frame size libx264 refuses), ``ValueError`` when it
+will not encode at the requested rate - because the returned path is the
+caller's only handle on the artifact. ``stop_cameras_recording`` is an
+agent-facing tool whose flush contract is best-effort and never-raise, so every
+backend that flushes buffered camera frames through ``encode_clip`` has to turn
+*both* refusals into a reported artifact error rather than letting one escape
+the tool envelope - the more so because the flush runs after the recording state
+is cleared, so an escape loses every buffered frame with no structured response.
 
-The MuJoCo backend already wrapped the call in a best-effort handler; the Isaac
-backend handled only ``ImportError``, so a refused encode would have propagated
-out of the tool *and* the artifact line still claimed every buffered frame as
-written. Checked by AST because the Isaac backend cannot be imported without the
-Omniverse runtime.
+This is a cross-backend structural guard: it asserts the property holds for
+every module that flushes, so a new backend cannot add an unguarded flush. The
+per-backend behavioural coverage lives next to each backend
+(``tests/simulation/isaac/test_cameras_recording_preflight_guards.py``,
+``tests/simulation/mujoco/test_recording_backends.py``); this one is by AST so
+it stays honest about backends whose flush path a unit test cannot reach.
 """
 
 from __future__ import annotations
@@ -43,8 +47,15 @@ def _functions_calling_encode_clip(tree: ast.AST) -> list[ast.FunctionDef]:
     return found
 
 
-def _catches_runtime_error(func: ast.FunctionDef) -> bool:
-    """True if some ``try`` in the function handles ``RuntimeError``."""
+# Every exception ``encode_clip`` raises to refuse a clip, and the broader
+# handlers that also contain them.
+_REFUSALS = ("RuntimeError", "ValueError")
+_CATCH_ALL = {"BaseException", "Exception"}
+
+
+def _handled_refusals(func: ast.FunctionDef) -> set[str]:
+    """The ``encode_clip`` refusals some ``try`` in the function handles."""
+    handled: set[str] = set()
     for node in ast.walk(func):
         if not isinstance(node, ast.Try):
             continue
@@ -54,13 +65,14 @@ def _catches_runtime_error(func: ast.FunctionDef) -> bool:
                 names = [handler.type.id]
             elif isinstance(handler.type, ast.Tuple):
                 names = [e.id for e in handler.type.elts if isinstance(e, ast.Name)]
-            if {"RuntimeError", "BaseException", "Exception"} & set(names):
-                return True
-    return False
+            if _CATCH_ALL & set(names):
+                return set(_REFUSALS)
+            handled |= set(names) & set(_REFUSALS)
+    return handled
 
 
 def test_every_camera_flush_handles_an_encoder_refusal() -> None:
-    """No backend lets encode_clip's refusal escape stop_cameras_recording."""
+    """No backend lets either encode_clip refusal escape stop_cameras_recording."""
     checked = 0
     for relative in _FLUSH_MODULES:
         module_path = _PACKAGE_DIR / relative
@@ -68,8 +80,9 @@ def test_every_camera_flush_handles_an_encoder_refusal() -> None:
         functions = _functions_calling_encode_clip(ast.parse(module_path.read_text(encoding="utf-8")))
         assert functions, f"{relative} no longer flushes through encode_clip; update this guard"
         for func in functions:
-            assert _catches_runtime_error(func), (
-                f"{relative}::{func.name} calls encode_clip without handling a RuntimeError, "
+            missing = set(_REFUSALS) - _handled_refusals(func)
+            assert not missing, (
+                f"{relative}::{func.name} calls encode_clip without handling {sorted(missing)}, "
                 "so a refused encode would raise past the tool envelope"
             )
             checked += 1

--- a/tests/simulation/test_camera_flush_encoder_refusal.py
+++ b/tests/simulation/test_camera_flush_encoder_refusal.py
@@ -1,0 +1,76 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A refused encode is reported by the camera flush, never raised past it.
+
+:func:`strands_robots.rendering.encode_clip` raises ``RuntimeError`` when the
+encoder accepted the frames but wrote no clip (for example a frame size libx264
+refuses), because the returned path is the caller's only handle on the
+artifact. ``stop_cameras_recording`` is an agent-facing tool whose flush
+contract is best-effort and never-raise, so every backend that flushes buffered
+camera frames through ``encode_clip`` has to turn that refusal into a reported
+artifact error rather than letting it escape the tool envelope.
+
+The MuJoCo backend already wrapped the call in a best-effort handler; the Isaac
+backend handled only ``ImportError``, so a refused encode would have propagated
+out of the tool *and* the artifact line still claimed every buffered frame as
+written. Checked by AST because the Isaac backend cannot be imported without the
+Omniverse runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.simulation as simulation_pkg
+
+_PACKAGE_DIR = Path(simulation_pkg.__file__).parent
+
+# Backend module -> the modules that flush buffered camera frames to disk.
+_FLUSH_MODULES = ["mujoco/rendering.py", "isaac/simulation.py"]
+
+
+def _functions_calling_encode_clip(tree: ast.AST) -> list[ast.FunctionDef]:
+    """Every function definition whose body calls ``encode_clip``."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for call in ast.walk(node):
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == "encode_clip":
+                found.append(node)
+                break
+    return found
+
+
+def _catches_runtime_error(func: ast.FunctionDef) -> bool:
+    """True if some ``try`` in the function handles ``RuntimeError``."""
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Try):
+            continue
+        for handler in node.handlers:
+            names = []
+            if isinstance(handler.type, ast.Name):
+                names = [handler.type.id]
+            elif isinstance(handler.type, ast.Tuple):
+                names = [e.id for e in handler.type.elts if isinstance(e, ast.Name)]
+            if {"RuntimeError", "BaseException", "Exception"} & set(names):
+                return True
+    return False
+
+
+def test_every_camera_flush_handles_an_encoder_refusal() -> None:
+    """No backend lets encode_clip's refusal escape stop_cameras_recording."""
+    checked = 0
+    for relative in _FLUSH_MODULES:
+        module_path = _PACKAGE_DIR / relative
+        assert module_path.exists(), f"{relative} moved; update this guard"
+        functions = _functions_calling_encode_clip(ast.parse(module_path.read_text(encoding="utf-8")))
+        assert functions, f"{relative} no longer flushes through encode_clip; update this guard"
+        for func in functions:
+            assert _catches_runtime_error(func), (
+                f"{relative}::{func.name} calls encode_clip without handling a RuntimeError, "
+                "so a refused encode would raise past the tool envelope"
+            )
+            checked += 1
+    assert checked >= len(_FLUSH_MODULES)


### PR DESCRIPTION
## Problem

`encode_clip` (`strands_robots/rendering/video.py`) is the shared MP4/GIF encoder behind the plain-MP4 camera recorders and the render pipelines. It never validated `fps`, and the two containers invented a *different* rate for the same unusable value - while both still returned the output path, the caller's only handle on the artifact:

```python
from strands_robots.rendering import encode_clip

encode_clip(frames, "clip.gif", fps=0)    # -> returns the path; clip plays at 1 fps
encode_clip(frames, "clip.mp4", fps=0)    # -> returns the path; clip plays at 16 fps
encode_clip(frames, "clip.mp4", fps=-5)   # -> returns the path; no file was written
encode_clip(frames, "clip.mp4", fps=2.7)  # -> returns the path; clip plays at 2 fps
```

The GIF branch clamped the rate - `duration=1000.0 / max(1, int(fps))` - so `0` and every negative rate became a 1 fps clip. The MP4 branch handed the value to ffmpeg, which substituted its own default (`16`) for `0`, truncated a fractional rate, and refused a negative one: on a small frame it wrote no file at all and `encode_clip` still returned the path, on a 400x300 clip it dead-ended in a bare `OSError: Broken pipe` carrying the raw ffmpeg command line. `fps=True` - an `int` subclass - encoded at 1 fps, and `nan`/`inf`/`None`/`"20"` surfaced as a bare `int()` `ValueError`/`OverflowError`/`TypeError` that never named the parameter to fix.

A clamp is not a safety net here: it converts a request the encoder cannot honor into a plausible-but-wrong clip. A rollout encoded at a tenth of its real rate looks like a slow robot, and anything that times events off the clip (a reviewer, a VLM watching the episode) reads the wrong dynamics.

The same `fps` was already validated on every neighbouring surface - `run_policy(video={"fps": ...})`, `start_cameras_recording(fps=...)`, `start_recording(fps=...)` - all through one positive-whole-number domain. The encoder those recorders flush *through* was the one surface left out.

## Change

- `encode_clip` validates `fps` against that shared domain and raises `ValueError` naming the parameter and the value. The guard runs **before** the optional-encoder probe, so the same mistake reports identically whether or not `imageio` is installed (the order the recorder guards use).
- The `max(1, int(fps))` clamp is gone; both containers now encode at the requested rate or refuse.
- The shared helper `positive_whole_number_error` moves to `strands_robots/utils.py`, the module both the simulation and rendering layers already depend on. `strands_robots.rendering` must not import `strands_robots.simulation`, and the accepted domain must not diverge between them; this also lets the recording mixin drop the lazy import it needed to reach the helper.
- `encode_clip` raises `RuntimeError` when the encoder accepted the frames but wrote no clip, so a returned path always names a file that exists. A `macro_block_size` that rounds the frame size to dimensions libx264 refuses (e.g. `7` on a 48x32 frame -> 49x35) previously also returned a path to nothing.
- The Isaac camera flush handled only `ImportError` around `encode_clip`, so that new `RuntimeError` would have escaped the `stop_cameras_recording` tool envelope - and its artifact line counted every buffered frame as written regardless. It now reports the refusal as `flush_error` on the artifact line, matching the MuJoCo backend's best-effort flush.

`quality` is left alone: imageio already rejects out-of-range values.

## Rollout in MuJoCo sim (headless)

48 frames of a Panda rollout, one `encode_clip` call per side. Left is the GIF that `fps=0` really produced before this change (Pillow stored 1000 ms per frame, so the clip advances one rendered frame per second of playback); right is the honored `fps=24` clip. Same frames, same call, same source rollout.

![encode_clip fps timing](https://raw.githubusercontent.com/cagataycali/robots/artifacts/encode-clip-fps/encode_clip_fps.gif)

[The 24 fps MP4 the fixed path writes](https://raw.githubusercontent.com/cagataycali/robots/artifacts/encode-clip-fps/encode_clip_fps24.mp4)

Measured on the same 48 frames (effective rate read back out of each artifact's own metadata):

| call | before | after |
|---|---|---|
| `fps=0` -> `.gif` | path returned, 1453 KB, plays at **1.0 fps** | `ValueError: encode_clip: fps must be a positive whole number, got 0.` |
| `fps=0` -> `.mp4` | path returned, 207 KB, plays at **16.0 fps** | same `ValueError` |
| `fps=-5` -> `.mp4` | `OSError: Broken pipe` + raw ffmpeg command line, **no file** | `ValueError: ... got -5.` |
| `fps=2.7` -> `.mp4` | path returned, plays at **2.0 fps** | `ValueError: ... got 2.7.` |
| `fps=24` -> `.mp4` | 24.0 fps | 24.0 fps (unchanged) |
| `macro_block_size=7` -> `.mp4` | path returned, **no file** | `RuntimeError: encode_clip: the encoder wrote no clip to ...` |

## Tests

`tests/rendering/test_encode_clip_option_guards.py` (new):

- every unusable rate (`0`, `-5`, `2.7`, `nan`, `inf`, `"20"`, `True`, `None`) refused on **both** containers, naming `fps`, leaving no file behind;
- usable rates (`1`, `25`, `30.0`, `np.int64(24)`) encode a GIF whose stored per-frame duration matches the request;
- the MP4's own metadata reports the requested rate rather than an ffmpeg default;
- a codec-refused frame size raises instead of returning a path to nothing;
- the guard precedes the `imageio` probe;
- one domain across the media surfaces: a rate refused by `encode_clip` is refused by the dataset recorder, only the message prefix differs.

`tests/simulation/test_camera_flush_encoder_refusal.py` (new): every backend that flushes buffered camera frames through `encode_clip` handles the refusal, so it cannot escape `stop_cameras_recording`. Checked by AST because the Isaac backend needs the Omniverse runtime to import.

Pre-fix / post-fix on this branch's base: **19 failed, 13 passed** before the source change (including the Isaac flush pin), **32 passed** after.

## Validation

- `ruff check strands_robots tests tests_integ` clean; `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean.
- `MUJOCO_GL=egl python -m pytest tests -q`: **12277 passed, 260 skipped** (424s).
- `docs/recording.md` documents the encoder's rate rule alongside the recorder options; CHANGELOG entry added.

## Changelog

- **rebase onto main**: rebased onto the merged #1668 to resolve a CHANGELOG conflict (both PRs added an `[Unreleased]` entry). Both entries are kept in order; the only rebase edit was the CHANGELOG merge. `recording.py` auto-merged cleanly - #1668 keeps its resume-fps guard, this PR relocates `positive_whole_number_error` to `strands_robots/utils.py` and updates the docstring cross-reference. No source behaviour changed by the rebase; all five touched Python modules compile.

- **round 2 - Isaac pre-flights the rate the flush encodes at** (`47fbc55`): review feedback showed the new `ValueError` was reachable through `stop_cameras_recording`. Isaac's `start_cameras_recording` never validated `fps` (unlike MuJoCo), so it stored the raw value in the recording state and the flush handed it to `encode_clip`; the handler caught only `ImportError`/`RuntimeError`, so the refusal escaped the tool *after* `_cams_rec_state` was cleared and every buffered frame was lost with no structured response. Fixed at the start, where the frames are still recoverable: a module-level `_cameras_recording_option_error(method, fps, max_frames_per_camera)` - same name, same structured-error shape and same `positive_whole_number_error` domain as the MuJoCo guard - refuses `fps` and the frame cap before the lock. The flush clause is now `except (RuntimeError, ValueError)` as defence in depth on its never-raise contract. The PR description's claim that `start_cameras_recording(fps=...)` already validated the rate held for MuJoCo only; it now holds for both.

  The escape path is pinned **behaviourally**, not structurally: `strands_robots.simulation.isaac.simulation` imports without the Omniverse runtime (`isaacsim` is lazy), so `tests/simulation/isaac/test_cameras_recording_preflight_guards.py` drives the real `start`/`stop` pair off a `__new__` skeleton - the fixture shape `test_dataset_recording.py` already uses. Every unusable value (`0`, `-5`, `2.7`, `nan`, `inf`, `"30"`, `True`, `None`) is refused with no state and no file left behind, `np.int64(24)` / `30.0` still start, both backends refuse the same domain, and a state carrying a refused rate returns `flush_error` with `frames=0` instead of raising. The cross-backend AST guard is kept for the property a unit test cannot assert - that no *future* backend adds an unguarded flush - and now requires both refusals. Pre-fix on this head: 19 failed, 1 passed; post-fix: 53 passed.
- **round 2 - stale cross-reference** (`9d92a37`): this PR moved `positive_whole_number_error` to `strands_robots.utils`, but the MuJoCo guard still imported it through `policy_runner`'s namespace and its docstring named a function that module no longer defines. Both now name `strands_robots.utils`. No behaviour change - the indirection resolved to the same object.
