### PR TITLE
fix(sim): domain randomization refuses ranges, amplitudes and seeds it cannot apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,43 @@ Use overwrite=True for a fresh dataset, or restore the original scene. Differenc
 Resuming at the dataset's own rate still appends as before. The comparison is
 shared by the MuJoCo, Newton and Isaac backends (`fps` is a required
 keyword-only argument of the schema check, so no backend can resume without it).
+### Fixed: domain randomization refuses ranges, noise amplitudes and seeds it cannot apply
+
+`randomize` writes its numeric arguments straight into the live MuJoCo model
+(`body_mass`, `body_inertia`, `geom_friction`, `geom_rgba`) and into
+`data.qpos`, and `set_obs_noise` stores a seed that is only drawn from later.
+Neither validated those values, so a range with no usable sampling interval
+either raised past the tool envelope or, worse, succeeded and left a world that
+models nothing:
+
+```python
+sim.randomize(randomize_physics=True, mass_range=(-1.0, -1.0))
+# -> success: "Physics: 3 geoms friction-scaled, 2 bodies mass-scaled"
+# body_mass is now -1 kg, so the crate FALLS UPWARD: 0.30 m -> 1.25 m in 220 steps
+
+sim.randomize(randomize_physics=True, mass_range=(0.0, 0.0))
+# -> success; the massless body then hovers, immune to gravity
+
+sim.randomize(randomize_physics=True, friction_range=(-2.0, -1.0))
+# -> success, with a negative Coulomb friction coefficient
+
+sim.randomize(mass_range=0.5)          # TypeError past the tool envelope
+sim.randomize(color_range=(0.1,))      # IndexError
+sim.randomize(randomize_positions=True, position_noise=float("nan"))  # OverflowError
+sim.set_obs_noise(joint_pos_std=0.01, seed=2.5)  # TypeError from default_rng
+```
+
+The Newton backend already refused the three shared ranges, through a private
+copy of the rule. That rule is now the shared
+`strands_robots.simulation.base.randomization_range_error`, joined by
+`finite_non_negative_error` (the sensor-noise standard deviations and
+`position_noise`) and `randomization_seed_error`, and both backends call all
+three from both `randomize` and `set_obs_noise` - so their accepted domains
+cannot diverge again. `mass_range` is additionally required to be strictly
+positive: a zero multiplier leaves a massless body that ignores gravity rather
+than a lighter one. Usable values are unaffected, including a zero lower bound
+for `friction_range` (a frictionless surface) and `color_range` (a black
+channel).
 
 ### Fixed: a dataset recording is refused at a frame rate it cannot be written at
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -132,6 +132,105 @@ def unknown_kwargs_error(method: str, kwargs: Mapping[str, Any], accepted: Seque
     }
 
 
+def randomization_range_error(value: Any, param: str, *, allow_zero: bool = True) -> str | None:
+    """Return why a ``(lo, hi)`` randomization range cannot be applied.
+
+    Domain randomization multiplies live physics constants (body mass, geom
+    friction) and re-samples colours inside a caller-supplied range. A range
+    that is not a pair of finite numbers with ``0 <= lo <= hi`` has no sampling
+    interval a backend could draw from: the sampler either raises deep inside
+    the mutation loop or, worse, succeeds and installs a physically impossible
+    constant - a negative body mass falls *upward* under gravity and a negative
+    friction coefficient is not a Coulomb model. Either way the randomized world
+    no longer models anything, so the request is refused up front.
+
+    Args:
+        value: The candidate ``(lo, hi)`` pair.
+        param: Parameter name to quote in the message (``"mass_range"``).
+        allow_zero: Whether ``lo == 0`` is meaningful for this quantity. True
+            for the ranges where zero is a real physical setting (a frictionless
+            surface, a black colour channel); pass False for a multiplicative
+            mass scale, where a zero multiplier leaves a massless body that
+            ignores gravity instead of a lighter one.
+
+    Returns:
+        ``None`` when the range is usable, otherwise the reason as a string.
+    """
+    try:
+        lo, hi = value
+        lo, hi = float(lo), float(hi)
+    except (TypeError, ValueError):
+        return f"{param} must be a (lo, hi) pair of numbers, got {value!r}"
+    if not (math.isfinite(lo) and math.isfinite(hi)):
+        return f"{param} bounds must be finite, got {value!r}"
+    if lo > hi:
+        return f"{param} lower bound {lo} exceeds upper bound {hi}"
+    if allow_zero:
+        if lo < 0:
+            return f"{param} bounds must be non-negative, got {value!r}"
+    elif lo <= 0:
+        detail = (
+            "a zero scale erases the quantity it multiplies"
+            if lo == 0
+            else "a negative scale flips the sign of the quantity it multiplies"
+        )
+        return f"{param} bounds must be positive, got {value!r} ({detail})"
+    return None
+
+
+def finite_non_negative_error(value: Any, param: str, context: str) -> str | None:
+    """Return why a magnitude parameter cannot be used as a noise/offset scale.
+
+    Shared by the sensor-noise standard deviations and the position-jitter
+    amplitude: all of them are half-widths or standard deviations, so a
+    non-numeric, non-finite or negative value describes no distribution. A
+    NaN amplitude propagates into ``qpos`` and poisons the whole physics state
+    on the next step, and a negative half-width inverts the sampling bounds.
+
+    Args:
+        value: The candidate magnitude.
+        param: Parameter name to quote in the message.
+        context: Method name to prefix the message with.
+
+    Returns:
+        ``None`` when the value is a finite non-negative number, otherwise the
+        reason as a string.
+    """
+    try:
+        fvalue = float(value)
+    except (TypeError, ValueError):
+        return f"{context}: {param} must be a number, got {value!r}"
+    if not math.isfinite(fvalue) or fvalue < 0:
+        return f"{context}: {param} must be a finite non-negative number, got {value!r}"
+    return None
+
+
+def randomization_seed_error(value: Any, context: str) -> str | None:
+    """Return why a value cannot seed a reproducible randomization stream.
+
+    The seed reaches ``numpy.random.default_rng``, which accepts only
+    non-negative integers (and a few RNG objects the ``int | None`` annotations
+    on these methods do not advertise). A float or string seed raises there -
+    on the sensor-noise path not until the first observation is drawn, long
+    after the configuring call reported success - so it is rejected at the call
+    that supplied it.
+
+    Args:
+        value: The candidate seed (``None`` selects fresh entropy).
+        context: Method name to prefix the message with.
+
+    Returns:
+        ``None`` when the seed is usable, otherwise the reason as a string.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        return f"{context}: seed must be a non-negative integer or None, got {value!r} (None draws fresh entropy)"
+    if int(value) < 0:
+        return f"{context}: seed must be a non-negative integer or None, got {value!r} (None draws fresh entropy)"
+    return None
+
+
 class SimEngine(ABC):
     """Abstract base class for simulation engines.
 

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from strands_robots.simulation.base import unknown_kwargs_error
+from strands_robots.simulation.base import (
+    finite_non_negative_error,
+    randomization_range_error,
+    randomization_seed_error,
+    unknown_kwargs_error,
+)
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
 
 logger = logging.getLogger(__name__)
@@ -99,11 +104,25 @@ class RandomizationMixin:
                                   mass so each randomized body stays physically
                                   consistent).
             randomize_positions:  Add uniform noise to dynamic-object xyz.
-            position_noise:       Max ± xyz offset in meters when randomising positions.
+            position_noise:       Max ± xyz offset in meters when randomising
+                                  positions. A finite non-negative number: a
+                                  NaN half-width writes NaN into ``qpos`` and
+                                  poisons every later step, a negative one
+                                  inverts the sampling bounds.
             color_range:          (lo, hi) for uniform RGB sampling.
             friction_range:       (lo, hi) multiplicative scale on friction[0].
             mass_range:           (lo, hi) multiplicative scale on body_mass.
-            seed:                 Optional np.random seed for reproducibility.
+                                  Each range must be a pair of finite numbers
+                                  with ``lo <= hi``, non-negative for friction
+                                  and colour and strictly positive for mass -
+                                  the domain :func:`~strands_robots.simulation.base.randomization_range_error`
+                                  defines and the Newton backend shares. A
+                                  scale a body cannot have is refused, not
+                                  installed: a negative mass falls upward and a
+                                  zero mass ignores gravity.
+            seed:                 Optional seed for a reproducible stream; a
+                                  non-negative integer, or None for fresh
+                                  entropy.
             **kwargs:             Declared only to match the ``**kwargs``-typed
                                   ``SimEngine.randomize`` signature; nothing is
                                   forwarded, so any keyword arriving here is
@@ -114,7 +133,8 @@ class RandomizationMixin:
 
         Returns:
             Status dict listing the axes applied, or an error dict when a
-            keyword is unknown, no world exists, or a policy is running.
+            keyword is unknown, a range/noise/seed value cannot be applied, no
+            world exists, or a policy is running.
         """
         if err := unknown_kwargs_error("randomize", kwargs, _RANDOMIZE_PARAMS):
             return err
@@ -123,6 +143,26 @@ class RandomizationMixin:
         # domain randomization mutates model arrays; a running policy racing with it is UB
         if err := self._require_no_running_policy("randomize"):
             return err
+        # Every numeric knob below is written straight into the live model (or
+        # into ``data.qpos``), so a value with no valid sampling interval either
+        # raises deep inside the mutation loop - past the tool envelope - or
+        # succeeds and leaves an unphysical world reporting success. Reject at
+        # the call instead, with the same accepted domain the Newton backend
+        # already enforces for the three ranges it shares.
+        for label, rng_range, allow_zero in (
+            # A zero MASS multiplier is not a lighter body, it is a massless one
+            # that ignores gravity; zero friction and zero colour are both real
+            # physical settings.
+            ("mass_range", mass_range, False),
+            ("friction_range", friction_range, True),
+            ("color_range", color_range, True),
+        ):
+            if msg := randomization_range_error(rng_range, label, allow_zero=allow_zero):
+                return {"status": "error", "content": [{"text": msg}]}
+        if msg := finite_non_negative_error(position_noise, "position_noise", "randomize"):
+            return {"status": "error", "content": [{"text": msg}]}
+        if msg := randomization_seed_error(seed, "randomize"):
+            return {"status": "error", "content": [{"text": msg}]}
 
         rng = np.random.default_rng(seed)
         mj = _ensure_mujoco()
@@ -247,7 +287,10 @@ class RandomizationMixin:
                 and the ``velocity`` field in ``get_robot_state``.
             camera_jitter_px: Max integer pixel shift applied to rendered
                 frames (uniform in ``[-px, px]`` per axis).
-            seed: Optional seed for a reproducible noise stream.
+            seed: Optional seed for a reproducible noise stream; a non-negative
+                integer, or None for fresh entropy. Validated here rather than
+                where the stream is first drawn, so an unusable seed is reported
+                by the call that supplied it.
             **kwargs: Declared only to match the ``**kwargs``-typed
                 ``SimEngine.set_obs_noise`` signature; nothing is forwarded, so
                 any keyword arriving here is rejected with an error naming the
@@ -265,20 +308,13 @@ class RandomizationMixin:
             ("joint_vel_std", joint_vel_std),
             ("camera_jitter_px", camera_jitter_px),
         ):
-            try:
-                fvalue = float(value)
-            except (TypeError, ValueError):
-                return {
-                    "status": "error",
-                    "content": [{"text": f"set_obs_noise: {label} must be a number, got {value!r}"}],
-                }
-            if not np.isfinite(fvalue) or fvalue < 0:
-                return {
-                    "status": "error",
-                    "content": [
-                        {"text": f"set_obs_noise: {label} must be a finite non-negative number, got {value!r}"}
-                    ],
-                }
+            if msg := finite_non_negative_error(value, label, "set_obs_noise"):
+                return {"status": "error", "content": [{"text": msg}]}
+        # The seed only reaches ``default_rng`` here; an unusable one would
+        # otherwise raise on the first observation drawn, long after this call
+        # reported the noise configured.
+        if msg := randomization_seed_error(seed, "set_obs_noise"):
+            return {"status": "error", "content": [{"text": msg}]}
 
         with self._lock:
             self._obs_noise = {

--- a/strands_robots/simulation/newton/randomization.py
+++ b/strands_robots/simulation/newton/randomization.py
@@ -30,7 +30,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from strands_robots.simulation.base import unknown_kwargs_error
+from strands_robots.simulation.base import (
+    finite_non_negative_error,
+    randomization_range_error,
+    randomization_seed_error,
+    unknown_kwargs_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,10 +127,13 @@ class DomainRandomizationMixin:
             randomize_colors: Resample per-shape RGB.
             randomize_lighting: Jitter the directional-light orientation.
             randomize_physics: Scale per-body mass and per-shape friction.
-            mass_range: ``(lo, hi)`` multiplicative scale on body mass.
+            mass_range: ``(lo, hi)`` multiplicative scale on body mass. Must
+                be strictly positive: a zero multiplier leaves a massless body
+                that ignores gravity rather than a lighter one.
             friction_range: ``(lo, hi)`` multiplicative scale on shape friction.
             color_range: ``(lo, hi)`` for uniform RGB sampling.
-            seed: Optional seed for reproducible randomization.
+            seed: Optional seed for reproducible randomization; a non-negative
+                integer, or None for fresh entropy.
             **kwargs: Tolerated for MuJoCo-signature parity: ``randomize_positions``
                 and ``position_noise`` are accepted keywords, and a truthy
                 ``randomize_positions`` returns an error (Newton does not yet
@@ -156,14 +164,21 @@ class DomainRandomizationMixin:
                     }
                 ],
             }
-        for label, rng_range in (
-            ("mass_range", mass_range),
-            ("friction_range", friction_range),
-            ("color_range", color_range),
+        for label, rng_range, allow_zero in (
+            # A zero MASS multiplier is not a lighter body, it is a massless one
+            # that ignores gravity; zero friction and zero colour are both real
+            # physical settings.
+            ("mass_range", mass_range, False),
+            ("friction_range", friction_range, True),
+            ("color_range", color_range, True),
         ):
-            err = _validate_range(label, rng_range)
-            if err is not None:
-                return {"status": "error", "content": [{"text": err}]}
+            if msg := randomization_range_error(rng_range, label, allow_zero=allow_zero):
+                return {"status": "error", "content": [{"text": msg}]}
+        # The seed is stored now and only reaches ``default_rng`` inside
+        # ``_rebuild``, so an unusable one would otherwise raise after this call
+        # already reported the randomization applied.
+        if msg := randomization_seed_error(seed, "randomize"):
+            return {"status": "error", "content": [{"text": msg}]}
 
         with self._lock:
             self._dr = {
@@ -287,7 +302,8 @@ class DomainRandomizationMixin:
                 velocities in ``get_robot_state``.
             camera_jitter_px: Max integer pixel shift applied to rendered
                 frames (uniform in ``[-px, px]`` per axis).
-            seed: Optional seed for a reproducible noise stream.
+            seed: Optional seed for a reproducible noise stream; a non-negative
+                integer, or None for fresh entropy.
             **kwargs: Declared only to match the ``**kwargs``-typed
                 ``SimEngine.set_obs_noise`` signature; nothing is forwarded, so
                 any keyword arriving here is rejected with an error naming the
@@ -305,20 +321,13 @@ class DomainRandomizationMixin:
             ("joint_vel_std", joint_vel_std),
             ("camera_jitter_px", camera_jitter_px),
         ):
-            try:
-                fvalue = float(value)
-            except (TypeError, ValueError):
-                return {
-                    "status": "error",
-                    "content": [{"text": f"set_obs_noise: {label} must be a number, got {value!r}"}],
-                }
-            if not np.isfinite(fvalue) or fvalue < 0:
-                return {
-                    "status": "error",
-                    "content": [
-                        {"text": f"set_obs_noise: {label} must be a finite non-negative number, got {value!r}"}
-                    ],
-                }
+            if msg := finite_non_negative_error(value, label, "set_obs_noise"):
+                return {"status": "error", "content": [{"text": msg}]}
+        # See the note in ``randomize``: the seed only reaches ``default_rng``
+        # below, and on the noise path an unusable one would raise on the first
+        # observation drawn rather than at this call.
+        if msg := randomization_seed_error(seed, "set_obs_noise"):
+            return {"status": "error", "content": [{"text": msg}]}
 
         with self._lock:
             self._obs_noise = {
@@ -406,27 +415,3 @@ class DomainRandomizationMixin:
         dy = int(rng.integers(-max_shift, max_shift + 1))
         dx = int(rng.integers(-max_shift, max_shift + 1))
         return np.roll(frame, shift=(dy, dx), axis=(0, 1))
-
-
-def _validate_range(label: str, rng_range: Any) -> str | None:
-    """Validate a ``(lo, hi)`` randomization range.
-
-    Args:
-        label: Parameter name for the error message.
-        rng_range: The candidate ``(lo, hi)`` pair.
-
-    Returns:
-        ``None`` when valid, otherwise an error message string.
-    """
-    try:
-        lo, hi = rng_range
-        lo, hi = float(lo), float(hi)
-    except (TypeError, ValueError):
-        return f"{label} must be a (lo, hi) pair of numbers, got {rng_range!r}"
-    if not (np.isfinite(lo) and np.isfinite(hi)):
-        return f"{label} bounds must be finite, got {rng_range!r}"
-    if lo > hi:
-        return f"{label} lower bound {lo} exceeds upper bound {hi}"
-    if lo < 0:
-        return f"{label} bounds must be non-negative, got {rng_range!r}"
-    return None

--- a/tests/simulation/mujoco/test_randomization_option_guards.py
+++ b/tests/simulation/mujoco/test_randomization_option_guards.py
@@ -1,0 +1,277 @@
+"""Domain randomization refuses ranges, noise amplitudes and seeds it cannot apply.
+
+``randomize`` writes its numeric arguments straight into the live ``mjModel``
+(``body_mass``, ``body_inertia``, ``geom_friction``, ``geom_rgba``) and into
+``data.qpos``, and ``set_obs_noise`` stores a seed that is only drawn from later.
+Neither validated any of those values, so a value with no valid sampling
+interval had two ways to go wrong:
+
+* it raised deep inside the mutation loop - ``TypeError``/``IndexError``/
+  ``OverflowError`` past the tool envelope these methods are dispatched behind
+  (a scalar or 3-element ``mass_range``, a 1-element ``color_range``, a NaN
+  ``position_noise``, a float ``seed``); or
+* it succeeded and left a world that models nothing: ``mass_range=(-1, -1)``
+  installed a NEGATIVE body mass, so the object fell *upward* (0.30 m -> 2.07 m
+  in 300 steps) while the call reported "Physics: N bodies mass-scaled";
+  ``mass_range=(0, 0)`` left a massless body frozen in mid-air; and
+  ``friction_range=(-2, -2)`` installed a negative Coulomb coefficient.
+
+The Newton backend already refused the three shared ranges through its own
+private copy of the rule. These tests pin the promoted, shared contract
+(:func:`~strands_robots.simulation.base.randomization_range_error`,
+:func:`~strands_robots.simulation.base.finite_non_negative_error`,
+:func:`~strands_robots.simulation.base.randomization_seed_error`) on the MuJoCo
+backend, and pin that both backends call it so the accepted domains cannot
+diverge again.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+import strands_robots.simulation as simulation_pkg  # noqa: E402
+from strands_robots.simulation.base import (  # noqa: E402
+    finite_non_negative_error,
+    randomization_range_error,
+    randomization_seed_error,
+)
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+CUBE_Z = 0.30
+
+
+@pytest.fixture
+def sim():
+    """A world holding one dynamic 1 kg cube hovering at 0.30 m."""
+    s = Simulation(tool_name="test_randomization_guards", mesh=False)
+    assert s.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+    assert (
+        s.add_object(name="cube", shape="box", size=[0.06, 0.06, 0.06], position=[0.0, 0.0, CUBE_Z], mass=1.0)["status"]
+        == "success"
+    )
+    yield s
+    s.cleanup()
+
+
+def _err_text(result: dict) -> str:
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _cube_z(sim: Simulation) -> float:
+    body = sim.get_body_state("cube")
+    payload = next(block["json"] for block in body["content"] if "json" in block)
+    return float(payload["position"][2])
+
+
+def _cube_mass(sim: Simulation) -> float:
+    assert sim._world is not None and sim._world._model is not None
+    model = sim._world._model
+    return float(model.body_mass[mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "cube")])
+
+
+class TestRangeGuardHelper:
+    """The promoted range rule: a finite, ordered, physically usable interval."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [0.5, (0.5,), (0.5, 2.0, 3.0), "ab", None, {"lo": 0.5}],
+        ids=["scalar", "one-element", "three-element", "two-char-string", "none", "mapping"],
+    )
+    def test_rejects_anything_that_is_not_a_numeric_pair(self, value):
+        msg = randomization_range_error(value, "mass_range")
+        assert msg is not None and "must be a (lo, hi) pair of numbers" in msg
+
+    @pytest.mark.parametrize("value", [(float("nan"), 1.0), (0.5, float("inf")), (-float("inf"), 1.0)])
+    def test_rejects_non_finite_bounds(self, value):
+        assert "bounds must be finite" in (randomization_range_error(value, "mass_range") or "")
+
+    def test_rejects_inverted_bounds(self):
+        assert "exceeds upper bound" in (randomization_range_error((2.0, 0.5), "friction_range") or "")
+
+    def test_zero_is_a_real_setting_for_friction_and_colour(self):
+        assert randomization_range_error((0.0, 1.5), "friction_range") is None
+        assert randomization_range_error((0.0, 1.0), "color_range") is None
+
+    def test_zero_and_negative_mass_scales_are_both_refused_with_distinct_reasons(self):
+        zero = randomization_range_error((0.0, 0.0), "mass_range", allow_zero=False)
+        negative = randomization_range_error((-1.0, -0.5), "mass_range", allow_zero=False)
+        assert zero is not None and "must be positive" in zero and "erases" in zero
+        assert negative is not None and "must be positive" in negative and "flips the sign" in negative
+
+    def test_accepts_an_ordered_positive_pair(self):
+        assert randomization_range_error((0.5, 2.0), "mass_range", allow_zero=False) is None
+
+
+class TestMagnitudeAndSeedGuardHelpers:
+    """Noise amplitudes describe a distribution; seeds must reach ``default_rng``."""
+
+    @pytest.mark.parametrize("value", ["x", None, [0.1]])
+    def test_non_numeric_amplitude_is_rejected(self, value):
+        msg = finite_non_negative_error(value, "position_noise", "randomize")
+        assert msg is not None and msg.startswith("randomize: position_noise must be a number")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.5])
+    def test_non_finite_or_negative_amplitude_is_rejected(self, value):
+        msg = finite_non_negative_error(value, "position_noise", "randomize")
+        assert msg is not None and "finite non-negative number" in msg
+
+    def test_zero_amplitude_is_a_valid_no_op(self):
+        assert finite_non_negative_error(0.0, "position_noise", "randomize") is None
+
+    @pytest.mark.parametrize("value", [2.5, "abc", True, -1, [1, 2]], ids=["float", "str", "bool", "negative", "list"])
+    def test_seed_outside_the_annotated_domain_is_rejected(self, value):
+        msg = randomization_seed_error(value, "randomize")
+        assert msg is not None and msg.startswith("randomize: seed must be a non-negative integer or None")
+
+    @pytest.mark.parametrize("value", [None, 0, 7, np.int64(3)])
+    def test_seed_inside_the_annotated_domain_is_accepted(self, value):
+        assert randomization_seed_error(value, "set_obs_noise") is None
+        assert np.random.default_rng(value) is not None
+
+
+class TestRandomizeRefusesUnusablePhysics:
+    """A scale a body cannot have is refused, not installed."""
+
+    def test_negative_mass_scale_is_refused_and_the_cube_still_falls(self, sim):
+        """Pre-fix: status=success, mass -1 kg, cube RISES 0.30 -> 2.07 m."""
+        result = sim.randomize(
+            randomize_colors=False, randomize_lighting=False, randomize_physics=True, mass_range=(-1.0, -1.0)
+        )
+        assert result["status"] == "error"
+        assert "mass_range" in _err_text(result)
+        assert _cube_mass(sim) == pytest.approx(1.0)
+        sim.step(300)
+        assert _cube_z(sim) < 0.1, "a refused randomization must leave gravity working"
+
+    def test_zero_mass_scale_is_refused_and_the_cube_is_not_frozen(self, sim):
+        """Pre-fix: status=success, mass 0, cube hovered at 0.30 m forever."""
+        result = sim.randomize(
+            randomize_colors=False, randomize_lighting=False, randomize_physics=True, mass_range=(0.0, 0.0)
+        )
+        assert result["status"] == "error"
+        assert _cube_mass(sim) == pytest.approx(1.0)
+        sim.step(300)
+        assert _cube_z(sim) < 0.1
+
+    def test_negative_friction_scale_is_refused_and_friction_stays_coulomb(self, sim):
+        """Pre-fix: status=success with geom_friction[:, 0] == -1.54."""
+        assert sim._world is not None and sim._world._model is not None
+        before = np.array(sim._world._model.geom_friction[:, 0], copy=True)
+        result = sim.randomize(
+            randomize_colors=False, randomize_lighting=False, randomize_physics=True, friction_range=(-2.0, -1.0)
+        )
+        assert result["status"] == "error"
+        assert "friction_range" in _err_text(result)
+        assert np.array_equal(sim._world._model.geom_friction[:, 0], before)
+        assert (sim._world._model.geom_friction[:, 0] >= 0).all()
+
+    @pytest.mark.parametrize(
+        ("param", "value"),
+        [
+            ("mass_range", 0.5),
+            ("mass_range", (0.5, 2.0, 3.0)),
+            ("mass_range", (float("nan"), float("nan"))),
+            ("friction_range", (0.5,)),
+            ("color_range", (0.1,)),
+            ("color_range", "ab"),
+        ],
+        ids=["mass-scalar", "mass-triple", "mass-nan", "friction-single", "color-single", "color-string"],
+    )
+    def test_malformed_range_returns_the_tool_envelope_instead_of_raising(self, sim, param, value):
+        """Pre-fix these escaped as TypeError / IndexError / OverflowError."""
+        result = sim.randomize(
+            randomize_colors=True, randomize_lighting=False, randomize_physics=True, **{param: value}
+        )
+        assert result["status"] == "error"
+        assert param in _err_text(result)
+
+    @pytest.mark.parametrize("value", [float("nan"), -0.5, "x"], ids=["nan", "negative", "string"])
+    def test_unusable_position_noise_is_refused_and_qpos_stays_finite(self, sim, value):
+        """Pre-fix a NaN half-width raised, and would have written NaN into qpos."""
+        result = sim.randomize(
+            randomize_colors=False, randomize_lighting=False, randomize_positions=True, position_noise=value
+        )
+        assert result["status"] == "error"
+        assert "position_noise" in _err_text(result)
+        assert sim._world is not None and sim._world._data is not None
+        assert np.isfinite(sim._world._data.qpos).all()
+
+    @pytest.mark.parametrize("value", [2.5, "abc", -1], ids=["float", "string", "negative"])
+    def test_unusable_seed_is_refused_by_both_randomization_entry_points(self, sim, value):
+        """Pre-fix ``default_rng`` raised TypeError/ValueError past the envelope."""
+        randomize_result = sim.randomize(seed=value)
+        noise_result = sim.set_obs_noise(joint_pos_std=0.01, seed=value)
+        assert randomize_result["status"] == "error"
+        assert noise_result["status"] == "error"
+        assert _err_text(randomize_result).startswith("randomize: seed")
+        assert _err_text(noise_result).startswith("set_obs_noise: seed")
+
+    def test_usable_values_are_still_applied(self, sim):
+        """The happy path: every axis on, zero friction/colour lower bounds, seeded."""
+        result = sim.randomize(
+            randomize_colors=True,
+            randomize_lighting=True,
+            randomize_physics=True,
+            randomize_positions=True,
+            position_noise=0.01,
+            color_range=(0.0, 1.0),
+            friction_range=(0.0, 1.5),
+            mass_range=(0.5, 2.0),
+            seed=7,
+        )
+        assert result["status"] == "success"
+        assert 0.5 <= _cube_mass(sim) <= 2.0
+        assert sim.set_obs_noise(joint_pos_std=0.01, camera_jitter_px=1, seed=0)["status"] == "success"
+
+
+class TestBackendGuardParity:
+    """Every backend with a randomization mixin routes through the shared guards.
+
+    AST-based so it runs with Newton/Isaac uninstalled: a backend that stops
+    calling a guard (or a new backend that never starts) fails here rather than
+    silently re-acquiring its own accepted domain.
+    """
+
+    _GUARD_NAMES = {"randomization_range_error", "finite_non_negative_error", "randomization_seed_error"}
+
+    @staticmethod
+    def _called_guards(module_path: Path, method: str) -> set[str]:
+        tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == method:
+                return {
+                    call.func.id
+                    for call in ast.walk(node)
+                    if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                }
+        raise AssertionError(f"{module_path.name} defines no {method}()")
+
+    @staticmethod
+    def _modules() -> list[Path]:
+        package_dir = Path(simulation_pkg.__file__).parent
+        found = sorted(package_dir.glob("*/randomization.py"))
+        assert {p.parent.name for p in found} >= {"mujoco", "newton"}, found
+        return found
+
+    def test_every_backend_randomize_validates_its_ranges_and_seed(self):
+        for module_path in self._modules():
+            called = self._called_guards(module_path, "randomize")
+            assert "randomization_range_error" in called, module_path
+            assert "randomization_seed_error" in called, module_path
+
+    def test_every_backend_set_obs_noise_validates_amplitudes_and_seed(self):
+        for module_path in self._modules():
+            called = self._called_guards(module_path, "set_obs_noise")
+            assert "finite_non_negative_error" in called, module_path
+            assert "randomization_seed_error" in called, module_path
+
+    def test_no_backend_keeps_a_private_copy_of_the_range_rule(self):
+        for module_path in self._modules():
+            source = module_path.read_text(encoding="utf-8")
+            assert "def _validate_range(" not in source, module_path

--- a/tests/simulation/newton/test_domain_randomization.py
+++ b/tests/simulation/newton/test_domain_randomization.py
@@ -24,11 +24,11 @@ import threading
 import numpy as np
 import pytest
 
+from strands_robots.simulation.base import randomization_range_error
 from strands_robots.simulation.newton.randomization import (
     _OBS_NOISE_PARAMS,
     _RANDOMIZE_PARAMS,
     DomainRandomizationMixin,
-    _validate_range,
 )
 
 _HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
@@ -101,21 +101,21 @@ class TestUnknownParamsRejected:
 
 class TestValidateRange:
     def test_accepts_ordered_non_negative_pair(self):
-        assert _validate_range("mass_range", (0.5, 2.0)) is None
+        assert randomization_range_error((0.5, 2.0), "mass_range") is None
 
     def test_rejects_inverted_bounds(self):
-        msg = _validate_range("mass_range", (2.0, 0.5))
+        msg = randomization_range_error((2.0, 0.5), "mass_range")
         assert msg is not None and "exceeds upper bound" in msg
 
     def test_rejects_negative_bound(self):
-        msg = _validate_range("friction_range", (-0.1, 1.0))
+        msg = randomization_range_error((-0.1, 1.0), "friction_range")
         assert msg is not None and "non-negative" in msg
 
     def test_rejects_non_numeric(self):
-        assert _validate_range("color_range", "nope") is not None
+        assert randomization_range_error("nope", "color_range") is not None
 
     def test_rejects_non_finite(self):
-        assert _validate_range("mass_range", (0.0, float("inf"))) is not None
+        assert randomization_range_error((0.0, float("inf")), "mass_range") is not None
 
 
 class TestSetObsNoiseValidation:


### PR DESCRIPTION
## Problem

`randomize` writes its numeric arguments straight into the live MuJoCo model (`body_mass`, `body_inertia`, `geom_friction`, `geom_rgba`) and into `data.qpos`, and `set_obs_noise` stores a seed that is only drawn from later. Neither validated any of those values. A value with no usable sampling interval therefore went wrong in one of two ways.

**It succeeded and left a world that models nothing.**

```python
sim.randomize(randomize_physics=True, mass_range=(-1.0, -1.0))
# -> success: "Physics: 3 geoms friction-scaled, 2 bodies mass-scaled"
# body_mass is now -1 kg, so a released crate FALLS UPWARD: 0.30 m -> 1.25 m in 220 steps

sim.randomize(randomize_physics=True, mass_range=(0.0, 0.0))
# -> success; the massless body then hovers, immune to gravity (still 0.300 m after 300 steps)

sim.randomize(randomize_physics=True, friction_range=(-2.0, -1.0))
# -> success, with geom_friction[:, 0] == -1.54 - not a Coulomb model
```

**Or it raised past the tool envelope these methods are dispatched behind.**

```python
sim.randomize(mass_range=0.5)                     # TypeError: argument after * must be an iterable
sim.randomize(mass_range=(0.5, 2.0, 3.0))         # TypeError: expected a sequence of integers ... got '3.0'
sim.randomize(color_range=(0.1,))                 # IndexError: tuple index out of range
sim.randomize(color_range="ab")                   # ValueError: could not convert string to float: 'a'
sim.randomize(randomize_positions=True, position_noise=float("nan"))  # OverflowError
sim.randomize(seed=2.5)                           # TypeError: SeedSequence expects int ...
sim.set_obs_noise(joint_pos_std=0.01, seed=2.5)   # same, and only on the first observation drawn
```

Probing all fourteen cases on `main`: 9 raised, 5 returned `status="success"` having installed an unphysical constant.

The Newton backend already refused the three shared ranges - pair-shaped, finite, ordered, non-negative - through a private copy of the rule in its own randomization module. MuJoCo, the default backend, enforced none of it. `set_obs_noise` in both backends validated its standard deviations (finite, non-negative) but not the seed sitting next to them in the same signature, and MuJoCo's `position_noise` - the amplitude for the one axis Newton does not support - was unvalidated everywhere.

## Change

Promote the range rule out of the Newton backend into `strands_robots.simulation.base` as `randomization_range_error`, add two siblings, and call all three from both `randomize` and `set_obs_noise` on both backends:

| helper | covers | accepted domain |
|---|---|---|
| `randomization_range_error(value, param, *, allow_zero=True)` | `mass_range`, `friction_range`, `color_range` | a pair of finite numbers with `lo <= hi`; `lo >= 0`, or `lo > 0` for a mass scale |
| `finite_non_negative_error(value, param, context)` | `joint_pos_std`, `joint_vel_std`, `camera_jitter_px`, `position_noise` | a finite non-negative number |
| `randomization_seed_error(value, context)` | `seed` on all four entry points | a non-negative integer, or `None` for fresh entropy - the `int \| None` the signatures already advertise |

Message text for the ranges is preserved verbatim from the Newton implementation, so every existing pin holds. Newton's private `_validate_range` is deleted rather than kept alongside the shared one.

`mass_range` is the one place the shared rule is tightened: it must be strictly positive. A zero multiplier does not produce a lighter body, it produces a massless one that ignores gravity, so `allow_zero=False` is passed for mass while zero stays valid for friction (a frictionless surface) and colour (a black channel). The two rejections carry distinct reasons - "a zero scale erases the quantity it multiplies" vs "a negative scale flips the sign of the quantity it multiplies".

The seed is validated at the call that supplies it, not where the stream is first drawn. On the sensor-noise path that difference is the whole point: an unusable seed otherwise raises on the first observation, long after `set_obs_noise` reported the noise configured. Same for Newton's `randomize`, where the seed is stored and only reaches `default_rng` inside `_rebuild`.

Usable values are unaffected: every axis on, with `color_range=(0.0, 1.0)`, `friction_range=(0.0, 1.5)`, `mass_range=(0.5, 2.0)` and `seed=7`, still succeeds and still scales the body mass into `[0.5, 2.0]`.

## Sim evidence

Same call, before and after, in headless MuJoCo: a 1 kg crate released from 0.30 m under gravity `-9.81 m/s^2`.

![randomize mass_range guard](https://raw.githubusercontent.com/cagataycali/robots/artifacts/randomization-guards/randomize_mass_scale.gif)

| | before | after |
|---|---|---|
| `randomize(mass_range=(-1.0, -1.0))` | `status=success`, "2 bodies mass-scaled" | `status=error`, "mass_range bounds must be positive" |
| `body_mass` | `-1.0 kg` | `+1.0 kg` (untouched) |
| crate after 220 steps | rises to `z = 1.25 m` | falls, rests at `z = 0.125 m` |

L1 between the two final frames is 6.47e5; each panel's own start-to-end L1 is 6.78e5 / 4.16e5, so both worlds really are moving - in opposite directions. The before panel was generated with the guards stashed.

## Tests

`tests/simulation/mujoco/test_randomization_option_guards.py`, 48 tests:

- the shared helpers' accepted domains, including that zero is a real setting for friction and colour but not for a mass scale, and that the two mass rejections give distinct reasons;
- behavioural pins on the physics: a refused negative mass scale leaves `body_mass` at 1.0 and the crate still falls (`z < 0.1` after 300 steps); a refused zero mass scale does not freeze it; a refused negative friction scale leaves `geom_friction` byte-identical and non-negative;
- every malformed range shape returns the tool envelope instead of raising, and an unusable `position_noise` leaves `qpos` finite;
- an unusable seed is refused by `randomize` *and* `set_obs_noise`, each naming its own method;
- the happy path still applies every axis;
- an AST parity check that both backends' `randomize`/`set_obs_noise` call the shared guards and that no backend keeps a private copy of the range rule - it runs with Newton uninstalled, so a future backend cannot quietly re-acquire its own domain.

Pre-fix on this base, with the helper unit tests removed so the module still imports: **18 failed, 1 passed** (the survivor is the happy path). Failures are exactly the raises quoted above plus `assert 'success' == 'error'` for the three unphysical-but-successful cases.

Gate: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean, full suite `MUJOCO_GL=egl pytest tests` **12293 passed, 260 skipped**.

Docs: CHANGELOG entry under Unreleased; `randomize` / `set_obs_noise` docstrings on both backends now state each parameter's accepted domain and why.

## Changelog

- **rebase onto main** (`7956c02`): the branch went `CONFLICTING` when #1668 landed - both PRs add a `### Fixed:` section at the same `[Unreleased]` anchor in `CHANGELOG.md`. Rebased onto `f626a64`; both entries are kept, the landed one first. `CHANGELOG.md` was the only conflicted file and the only file the rebase edited - the non-CHANGELOG diff against the new base is byte-identical to the diff against the old one, so no source behaviour changed. Approved with no open threads at the time of the rebase.
