### PR TITLE
docs(examples): use sync_dataset_to_bucket() in the data-loop example bucket step

### DIFF
--- a/examples/06_agent_collect_and_stream.py
+++ b/examples/06_agent_collect_and_stream.py
@@ -60,7 +60,21 @@ for i, frame in enumerate(reader):
     if i >= 2:
         break
 
-# 3. (Optional) Dump to a mutable HF Storage Bucket during collection —
-#    Xet-deduped, overwrite-in-place (Phase 1/2). One kwarg on stop_recording:
-#    sim.stop_recording(bucket="your-org/robot-fave")
-print("\nDone. To dump to an HF Storage Bucket: stop_recording(bucket='org/name')")
+# 3. (Optional) Sync the finished dataset into a mutable HF Storage Bucket for
+#    collection — Xet-deduped, overwrite-in-place (Phase 1/2). Use the
+#    lifecycle-independent helper, which syncs an on-disk dataset without a live
+#    recording session (needs `hf auth login` + huggingface_hub >= 1.0). Set
+#    STRANDS_DEMO_BUCKET="your-org/robot-fave" to run it; it stays a no-op
+#    otherwise so the default path needs no Hub credentials.
+bucket = os.environ.get("STRANDS_DEMO_BUCKET")
+if bucket:
+    from strands_robots import sync_dataset_to_bucket
+
+    result = sync_dataset_to_bucket(DATASET_ROOT, bucket)
+    if result.get("status") == "success":
+        print(f"\nSynced to bucket: {result['bucket_uri']}")
+    else:
+        # Surface the failure instead of reporting a sync that did not happen.
+        raise RuntimeError(f"bucket sync failed: {result.get('message')}")
+else:
+    print("\nDone. Set STRANDS_DEMO_BUCKET=org/name to sync this dataset to an HF Storage Bucket.")


### PR DESCRIPTION
The optional bucket step in `examples/06_agent_collect_and_stream.py` described `stop_recording(bucket=...)` in a comment and a print string. By that point in the example the recording is already stopped, so that call would hit the idle early-return in `stop_recording` and sync nothing - the same silent-no-op pattern (C1) called out in the storage-buckets blog review.

## Change

Replace the dead comment/print with the lifecycle-independent `sync_dataset_to_bucket(root, bucket)` helper (added in #1515), which syncs an on-disk dataset without a live recording session:

- gated on `STRANDS_DEMO_BUCKET` so the default path stays credential-free (the example still runs end-to-end with no Hub access);
- checks the returned status and raises on failure instead of printing a sync that did not happen.

## Verification

- Confirmed the helper imports from `strands_robots`, the no-op branch (bucket unset) is taken by default, and a bad root returns `{"status": "error", "message": ...}` (so the `raise` path is correct), all on CPU with no credentials.
- ruff check + format clean on the changed file.

Notebook `05_streaming_data_loop.ipynb` cell 7 already uses a status-gated `sync_to_bucket` via `DatasetRecorder.resume`, so no notebook change is needed; this brings the agent-driven example to the same correct pattern.