### PR TITLE
fix(curobo): read the embedded goal to its own closing brace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a cuRobo goal embedded in the instruction survives neighbouring braces
+
+`CuroboPolicy.get_actions` reads the goal from the well-known `target_pose` /
+`target_joints` kwargs and falls back to parsing a JSON object out of the
+natural-language instruction for LLM-driven workflows. The fallback took the
+span from the FIRST `{` to the LAST `}` in the string, so any brace elsewhere in
+the instruction swallowed the payload into an unparseable span:
+
+```python
+policy.get_actions_sync(
+    {"observation.state": [0.0] * 6},
+    'pick up the {block} and go to {"target_pose": [0.4, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]}',
+)
+# ValueError: CuroboPolicy.get_actions requires at least one of
+#   target_pose=[x,y,z,qw,qx,qy,qz] or target_joints={joint:value} ...
+```
+
+The goal was right there in the input; the span `{block} and go to {"target_pose":
+...}` simply is not JSON, so the parse returned no goal and the caller reported a
+missing one. The same happened with a brace after the payload (`... {"target_pose":
+[...]} then release the {clamp}`).
+
+Each candidate `{` is now decoded with `json.JSONDecoder.raw_decode`, which ends
+the object at its own closing brace, and the first object carrying a top-level
+goal field wins. A payload that merely nests a goal
+(`{"goal": {"target_pose": [...]}}`) is still not a goal - only top-level fields
+count, unchanged.
+
+Two side effects of the old regex are gone with it. `re.search(r"\{.*\}", ...,
+re.DOTALL)` restarted a full-length scan at every `{` when the braces never
+balanced, so a long LLM-authored instruction stalled the 50Hz caller
+(quadratic; 3.1 s for 100k unclosed braces, and `py/polynomial-redos` in code
+scanning). And an instruction that mentions a goal field whose JSON does not
+decode is now logged at WARNING instead of being indistinguishable from an
+instruction that never carried one.
+
 ### Fixed: resuming a dataset recording at a different frame rate is refused
 
 `start_recording(overwrite=False)` on an existing dataset resumes it, and

--- a/docs/policies/curobo.md
+++ b/docs/policies/curobo.md
@@ -88,7 +88,10 @@ so a goal can flow across providers without coupling to a backend:
 Pass exactly one of `target_pose` / `target_joints`. When neither is given,
 the policy makes a best-effort parse of a JSON `target_pose` / `target_joints`
 payload embedded in the instruction (for LLM-agent flows); if none is found it
-raises `ValueError`.
+raises `ValueError`. Each `{...}` object in the instruction is decoded on its
+own, so prose braces before or after the payload are harmless, and only a
+**top-level** goal field counts - a goal nested inside a wrapper object
+(`{"goal": {"target_pose": [...]}}`) is not read as a goal.
 
 ## Trajectory chunking
 

--- a/strands_robots/policies/curobo/policy.py
+++ b/strands_robots/policies/curobo/policy.py
@@ -88,6 +88,84 @@ _JOINT_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_-]*$"
 # rather than silently consuming RAM.
 _MAX_TRAJECTORY_WAYPOINTS = 100_000
 
+# Well-known goal fields (issue #300) an LLM may pack into the natural-language
+# instruction as a JSON object. Doubles as the pre-filter for the fallback
+# parse: an instruction that mentions neither field cannot carry a goal, so no
+# JSON decode is attempted for it.
+_GOAL_PAYLOAD_KEYS = ("target_pose", "target_joints")
+
+# Cap on how many ``{`` offsets the fallback parse will try to decode. A failed
+# decode attempt costs O(len(instruction)) in the worst case, so an unbounded
+# scan over an LLM-authored string is a quadratic-time surface; the cap makes
+# the work linear in the instruction length. A goal that is not inside one of
+# the first candidate objects is reported as unparseable rather than hunted for.
+_MAX_GOAL_PAYLOAD_CANDIDATES = 32
+
+
+def _opens_a_json_object(text: str, brace: int) -> bool:
+    """True when ``text[brace]`` could start a JSON object.
+
+    A JSON object is ``{`` then whitespace then either a ``"``-quoted key or the
+    closing ``}``. Anything else (``{gripper}``, ``{{``) is prose and is not
+    worth a decode attempt.
+    """
+    probe = brace + 1
+    while probe < len(text) and text[probe] in " \t\r\n":
+        probe += 1
+    return probe < len(text) and text[probe] in '"}'
+
+
+def _find_goal_payload(instruction: str) -> dict[str, Any] | None:
+    """Return the JSON object embedded in ``instruction`` that carries a goal.
+
+    Walks the ``{`` offsets in the instruction and decodes each one with
+    :meth:`json.JSONDecoder.raw_decode`, which ends the object at its own
+    closing brace instead of assuming the payload runs to the last ``}`` in the
+    string. Instructions that mention no goal field at all are rejected without
+    a decode. A decoded object without a top-level goal field is
+    skipped whole - only a top-level ``target_pose`` / ``target_joints`` counts
+    as a goal, so a payload that merely nests one is not a goal (unchanged).
+
+    Returns ``None`` when no candidate yields such an object; when the
+    instruction does mention a goal field, that outcome is logged so a
+    malformed payload is not silently indistinguishable from no payload.
+    """
+    if not any(key in instruction for key in _GOAL_PAYLOAD_KEYS):
+        return None
+    decoder = json.JSONDecoder()
+    idx = instruction.find("{")
+    attempts = 0
+    while idx != -1 and attempts < _MAX_GOAL_PAYLOAD_CANDIDATES:
+        if not _opens_a_json_object(instruction, idx):
+            # Prose braces (``{gripper}``, ``{{``) cannot open a JSON object, so
+            # they are skipped without spending a decode attempt - the candidate
+            # budget is a backstop against a pathological string, not a limit on
+            # how much prose may precede the payload.
+            idx = instruction.find("{", idx + 1)
+            continue
+        attempts += 1
+        try:
+            payload, end = decoder.raw_decode(instruction, idx)
+        except ValueError:
+            # Not the start of a complete JSON value (prose braces, a typo in
+            # the payload). Try the next opening brace.
+            idx = instruction.find("{", idx + 1)
+            continue
+        if isinstance(payload, dict) and any(key in payload for key in _GOAL_PAYLOAD_KEYS):
+            return payload
+        # A complete value that is not a goal: resume after it rather than
+        # descending into the braces it contains.
+        idx = instruction.find("{", max(end, idx + 1))
+    logger.warning(
+        "curobo: the instruction mentions a goal field but no JSON object carrying "
+        "a top-level target_pose/target_joints could be decoded from it (%d candidate "
+        "offsets tried over %d characters). Pass the goal as target_pose= / "
+        "target_joints= kwargs instead of embedding it in the instruction text.",
+        attempts,
+        len(instruction),
+    )
+    return None
+
 
 class CuroboPolicy(Policy):
     """In-process cuRobo ``MotionPlanner`` wrapper.
@@ -911,18 +989,15 @@ class CuroboPolicy(Policy):
 
         Returns ``(None, None)`` when no goal is found - the caller will
         then raise :class:`ValueError`.
+
+        Extraction is delegated to :func:`_find_goal_payload`, which bounds the
+        object at its own closing brace; the goal survives prose that carries
+        braces of its own on either side of it.
         """
         if not instruction or not isinstance(instruction, str):
             return None, None
-        # Try to find a JSON object embedded in the instruction.
-        match = re.search(r"\{.*\}", instruction, re.DOTALL)
-        if not match:
-            return None, None
-        try:
-            payload = json.loads(match.group(0))
-        except json.JSONDecodeError:
-            return None, None
-        if not isinstance(payload, dict):
+        payload = _find_goal_payload(instruction)
+        if payload is None:
             return None, None
         target_pose = payload.get("target_pose")
         target_joints = payload.get("target_joints")

--- a/tests/policies/curobo/test_instruction_goal_extraction.py
+++ b/tests/policies/curobo/test_instruction_goal_extraction.py
@@ -1,0 +1,142 @@
+"""Pin the JSON-in-instruction goal extraction of :class:`CuroboPolicy`.
+
+``Robot.start_task(..., policy_provider="curobo")`` lets an LLM pack the
+issue-#300 goal fields into the natural-language instruction, and
+``CuroboPolicy._parse_target`` is what recovers them. The extraction used to
+take the span from the FIRST ``{`` to the LAST ``}`` in the string, which
+
+* dropped a valid goal whenever the instruction carried a brace of its own on
+  either side of the payload - the span then covered prose and failed to
+  decode, so ``get_actions`` raised "requires at least one of target_pose=..."
+  about a goal that was right there in its input; and
+* scanned the instruction quadratically when the braces never balance, so a
+  long LLM-authored string could stall the 50Hz caller for seconds
+  (``py/polynomial-redos``).
+
+The extraction now decodes each candidate object at its own closing brace.
+These tests fail on the pre-fix source.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+from strands_robots.policies.curobo import CuroboPolicy
+from tests.policies.curobo.test_policy import _StubMotionGen
+
+
+class TestGoalSurvivesNeighbouringBraces:
+    """A goal payload is found even when the prose around it carries braces."""
+
+    def test_brace_in_prose_before_the_goal(self) -> None:
+        tp, tj = CuroboPolicy._parse_target('close the {gripper} then move {"target_joints": {"j1": 0.5}}')
+        assert tp is None
+        assert tj == {"j1": 0.5}
+
+    def test_brace_in_prose_after_the_goal(self) -> None:
+        tp, tj = CuroboPolicy._parse_target(
+            '{"target_pose": [0.4, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]} then release the {clamp}'
+        )
+        assert tp == [0.4, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]
+        assert tj is None
+
+    def test_braces_on_both_sides_of_the_goal(self) -> None:
+        tp, tj = CuroboPolicy._parse_target('from {home} go to {"target_joints": {"j0": -0.25}} at {slow} speed')
+        assert tp is None
+        assert tj == {"j0": -0.25}
+
+    def test_first_goal_carrying_object_wins(self) -> None:
+        """Objects are scanned left to right; the first one with a goal field is
+        the goal, so a leading non-goal object does not mask it."""
+        tp, _tj = CuroboPolicy._parse_target(
+            '{"note": "warm up"} {"target_pose": [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]} '
+            '{"target_pose": [9.0, 9.0, 9.0, 1.0, 0.0, 0.0, 0.0]}'
+        )
+        assert tp == [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+
+    def test_goal_field_named_in_the_prose_does_not_hide_the_payload(self) -> None:
+        """The field name appearing as prose ahead of the payload must not be
+        mistaken for the payload's position - the object still opens later."""
+        tp, tj = CuroboPolicy._parse_target(
+            'set target_pose from the {chart}: {"target_pose": [0.1, 0.2, 0.3, 1.0, 0.0, 0.0, 0.0]}'
+        )
+        assert tp == [0.1, 0.2, 0.3, 1.0, 0.0, 0.0, 0.0]
+        assert tj is None
+
+    def test_goal_after_braces_reaches_the_planner(self) -> None:
+        """End to end: the recovered goal drives a plan instead of raising."""
+        stub = _StubMotionGen(ndof=6, horizon=5)
+        policy = CuroboPolicy(motion_gen=stub, action_horizon=4)
+        actions = asyncio.run(
+            policy.get_actions(
+                {"observation.state": [0.0] * 6},
+                'pick up the {block} and go to {"target_pose": [0.4, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]}',
+            )
+        )
+        assert actions
+        assert stub.plan_calls and stub.plan_calls[0][0] == "plan_single"
+
+
+class TestGoalExtractionContractUnchanged:
+    """Cases whose outcome the wider scan must not change."""
+
+    def test_goal_nested_in_a_wrapper_object_is_not_a_goal(self) -> None:
+        """Only a TOP-LEVEL goal field counts. A decoded object without one is
+        skipped whole rather than descended into, so ``{"goal": {...}}`` stays
+        unparsed exactly as before - honouring it would be a new feature, not a
+        fix."""
+        assert CuroboPolicy._parse_target('{"goal": {"target_pose": [1, 2, 3, 1, 0, 0, 0]}}') == (None, None)
+
+    def test_malformed_payload_degrades_to_no_goal(self) -> None:
+        assert CuroboPolicy._parse_target("do this {target_pose: not, json}") == (None, None)
+
+    def test_object_without_goal_fields_is_not_a_goal(self) -> None:
+        assert CuroboPolicy._parse_target('noise {"unrelated": 1} tail') == (None, None)
+
+
+class TestUnparseablePayloadIsReported:
+    """A mentioned-but-unrecoverable goal is logged, not silently dropped."""
+
+    def test_warns_when_a_mentioned_goal_cannot_be_decoded(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.policies.curobo.policy"):
+            assert CuroboPolicy._parse_target('go to {"target_pose": [1, 2,,]}') == (None, None)
+        assert any("no JSON object carrying" in r.getMessage() for r in caplog.records)
+
+    def test_no_warning_when_no_goal_field_is_mentioned(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A plain instruction is the normal kwargs-driven path - it must not
+        log about a goal the caller never claimed to embed."""
+        with caplog.at_level(logging.WARNING, logger="strands_robots.policies.curobo.policy"):
+            assert CuroboPolicy._parse_target("move the gripper down slowly") == (None, None)
+        assert caplog.records == []
+
+
+class TestExtractionIsBounded:
+    """The scan is bounded, so an unbalanced instruction cannot stall the loop."""
+
+    def test_unbalanced_braces_return_quickly(self) -> None:
+        # 100k unclosed braces followed by the goal field name. The pre-fix
+        # ``re.search(r"\{.*\}", ..., re.DOTALL)`` restarts a full-length scan
+        # at every one of them (measured 3.1 s); the bounded decode scan
+        # returns in well under a millisecond.
+        instruction = "{" * 100_000 + '"target_pose"'
+        started = time.perf_counter()
+        assert CuroboPolicy._parse_target(instruction) == (None, None)
+        assert time.perf_counter() - started < 1.0
+
+    def test_prose_braces_do_not_consume_the_candidate_budget(self) -> None:
+        """A brace that cannot open a JSON object is skipped without spending a
+        decode attempt, so the bound is a backstop against a pathological string
+        rather than a limit on how much braced prose may precede the goal."""
+        instruction = "{step} " * 200 + '{"target_pose": [0.1, 0.2, 0.3, 1.0, 0.0, 0.0, 0.0]}'
+        tp, _tj = CuroboPolicy._parse_target(instruction)
+        assert tp == [0.1, 0.2, 0.3, 1.0, 0.0, 0.0, 0.0]
+
+    def test_long_instruction_with_no_braces_is_not_scanned(self) -> None:
+        instruction = "move the arm slowly " * 20_000
+        started = time.perf_counter()
+        assert CuroboPolicy._parse_target(instruction) == (None, None)
+        assert time.perf_counter() - started < 1.0


### PR DESCRIPTION
## Summary

`CuroboPolicy.get_actions` reads its goal from the issue-#300 kwargs (`target_pose` / `target_joints`) and, for LLM-driven flows, falls back to parsing a JSON goal out of the natural-language instruction. The fallback took the span from the **first** `{` to the **last** `}` in the string, so a brace anywhere else in the instruction swallowed the payload into a span that is not JSON:

```python
policy.get_actions_sync(
    {"observation.state": [0.0] * 6},
    'pick up the {block} and go to {"target_pose": [0.4, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]}',
)
# ValueError: CuroboPolicy.get_actions requires at least one of
#   target_pose=[x,y,z,qw,qx,qy,qz] or target_joints={joint:value} ...
```

The goal is right there in the input. The span `{block} and go to {"target_pose": ...}` simply is not JSON, so `_parse_target` returned no goal and the caller reported a missing one. A brace *after* the payload did the same (`{"target_pose": [...]} then release the {clamp}`), as did any instruction that framed the payload with braced prose on both sides.

## The fix

Each candidate `{` is decoded with `json.JSONDecoder.raw_decode`, which ends the object at **its own** closing brace, and the first object carrying a top-level goal field wins.

Two properties keep the scan cheap and predictable:

- A brace that cannot open a JSON object (`{gripper}`, `{{`) is skipped in O(1) without spending a decode attempt, so braced prose before the payload does not eat into the budget (200 `{step}` tokens ahead of the goal still resolve).
- Decode attempts are capped (`_MAX_GOAL_PAYLOAD_CANDIDATES = 32`), which bounds the total work at O(len(instruction)). The old `re.search(r"\{.*\}", ..., re.DOTALL)` restarted a full-length scan at every `{` when the braces never balanced: 100k unclosed braces took **3.1 s** on this machine (and is `py/polynomial-redos` #709 in code scanning, on an LLM-supplied string reaching a 50 Hz caller). The same input now returns in ~0.2 ms.

An instruction that *names* a goal field but carries no decodable object is logged at WARNING pointing at the kwargs, instead of being indistinguishable from an instruction that never carried a goal. The message contains no instruction text (candidate count and length only), so it does not open a log-injection surface.

## Explicitly unchanged

- Only a **top-level** goal field counts: `{"goal": {"target_pose": [...]}}` is still not a goal. A decoded object without a goal field is skipped *whole* rather than descended into, so honouring a wrapper object stays a feature request, not a side effect of this fix.
- Malformed payloads (`{target_pose: not, json}`), objects without goal fields (`{"unrelated": 1}`), wrongly-typed fields (`"target_pose": "not-a-list"`), empty / non-`str` instructions: all behave exactly as before. The existing `_parse_target` tests in `tests/policies/curobo/test_policy.py` pass unmodified.

## Tests

`tests/policies/curobo/test_instruction_goal_extraction.py` (14 tests) pins:

- the recovered goal for a brace before, after, and on both sides of the payload, plus the goal-field name appearing as prose ahead of the payload;
- the end-to-end path: the recovered goal reaches `plan_single` on the stub planner instead of raising;
- first-goal-carrying-object-wins ordering;
- the unchanged cases above (wrapper-nested goal, malformed payload, non-goal object);
- the WARNING on a mentioned-but-undecodable goal, and its absence on a plain instruction;
- the scan bound (100k unbalanced braces under a 1 s budget; the pre-fix source takes 3.1 s).

9 of the 14 fail on the pre-fix source; the 5 that pass are the unchanged-contract ones, by design.

## Validation

- `ruff check`, `ruff format --check`, `mypy` clean on the touched files.
- `pytest tests/policies/curobo` : 107 passed (2 pre-existing failures in this sandbox come from the torch mock lacking `arange` and reproduce unchanged on `main`).
- CHANGELOG entry added for the behavioural change; `docs/policies/curobo.md` states the extraction contract (per-object decode, top-level fields only).
