### PR TITLE
fix(sim): get_camera_params refuses an image size it cannot produce intrinsics for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: get_camera_params refuses an image size it cannot produce intrinsics for
+
+`render`, `render_depth` and `get_frame` all validate `width`/`height` through
+the same guard - positive whole numbers within the offscreen framebuffer cap.
+`get_camera_params`, which builds the pinhole `K` describing the very frame
+those three render, validated nothing and coerced with `int(...)`. Every
+dimension its siblings reject was accepted:
+
+```python
+cam = sim.get_camera_params("look", height=-48)   # returned CameraParams
+cam.K[1][1]                                       # -41.57  (fy negative: Y axis flipped)
+# unprojecting the cube-top pixel with it recovers (-1.080, 0.000, 1.709) m
+# instead of (0.000, 0.000, 0.100) m - a 1.94 m error, no error raised
+
+sim.get_camera_params("look", height=0)           # fy = 0.0 -> K singular (rank 2)
+sim.get_camera_params("look", width=2.7)          # silently truncated to 2 px
+sim.get_camera_params("look", width="640")        # string accepted by int()
+sim.get_camera_params("look", width=5000, height=5000)
+sim.render("look", width=5000, height=5000)       # status=error: exceeds the 4096 cap
+```
+
+`get_camera_params` now applies the same guard as its three siblings and raises
+`ValueError` carrying the identical message text, so the params always describe
+a frame the renderer can actually draw. The shared guard also names `bool`
+explicitly (`isinstance(True, int)` is true, so `width=True` previously reached
+MuJoCo and came back as "an integer is required").
+
 ### Fixed: a cuRobo goal embedded in the instruction survives neighbouring braces
 
 `CuroboPolicy.get_actions` reads the goal from the well-known `target_pose` /

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -37,6 +37,11 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MAX_RENDER_BYTES = 50 * 1024 * 1024  # 50 MB
 
 
+def _is_pixel_count(value: Any) -> bool:
+    """True when ``value`` is usable as a pixel dimension (an int, not a bool)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def _render_sandbox_root() -> Path:
     """Resolve the directory render() may write into (read at call time).
 
@@ -193,7 +198,11 @@ class RenderingMixin:
         """reject non-positive render dims; convert MuJoCo's framebuffer
         overflow to a plain-English message that tells the LLM the actual cap.
         """
-        if not isinstance(width, int) or not isinstance(height, int):
+        # bool is an int subclass, so `isinstance(True, int)` passes: True would
+        # be taken as a 1-pixel dimension and reach MuJoCo, which rejects it
+        # with a bare "an integer is required". A truth value is never a pixel
+        # count - name the type here instead.
+        if not _is_pixel_count(width) or not _is_pixel_count(height):
             return {
                 "status": "error",
                 "content": [
@@ -1354,13 +1363,19 @@ class RenderingMixin:
                 ``""`` / ``"default"`` / ``"free"``).
             width: image width to compute ``K`` for; ``None`` uses the
                 camera's configured resolution (the engine default for the
-                free camera).
-            height: image height to compute ``K`` for.
+                free camera). An explicit value must be a positive whole
+                number within the offscreen framebuffer cap - the same
+                dimension contract :meth:`render` and :meth:`get_frame`
+                enforce, so the params always describe a renderable frame.
+            height: image height to compute ``K`` for; same contract as
+                ``width``.
 
         Raises:
             RuntimeError: no world created.
             ValueError: the free camera is orthographic (``<visual><global
-                orthographic="true"/>``), which no pinhole ``K`` can represent.
+                orthographic="true"/>``), which no pinhole ``K`` can represent;
+                or ``width``/``height`` is not a positive whole number, or
+                exceeds the offscreen framebuffer cap.
             KeyError: unknown camera name.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
@@ -1377,8 +1392,16 @@ class RenderingMixin:
         free_camera = camera_name in (None, "", "default", "free")
         cam_cfg = None if free_camera else self._world.cameras.get(camera_name)
 
-        w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else int(width)
-        h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else int(height)
+        w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
+        h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
+        # K is only meaningful for an image the renderer can actually produce:
+        # fx/fy/cx/cy are all linear in the size, so a non-positive dimension
+        # yields a singular (h == 0) or axis-flipped (h < 0) K, and a size past
+        # the offscreen framebuffer cap describes a frame render()/get_frame()
+        # refuse to draw. Same guard, same message as those two call sites -
+        # raised here because this API reports failure by exception.
+        if err := self._validate_render_dims(w, h):
+            raise ValueError(err["content"][0]["text"])
 
         with self._lock:
             extent = float(model.stat.extent)

--- a/tests/simulation/mujoco/test_render_dimension_limits.py
+++ b/tests/simulation/mujoco/test_render_dimension_limits.py
@@ -8,10 +8,20 @@ framebuffer cap, and a non-positive byte budget. The dimension guards
 short-circuit before any GL context is created, so they are deterministic even
 on a headless host.
 
-``render_depth`` shares the same ``_validate_render_dims`` guard as ``render``
-but through an independent call site, so it is pinned with its own parity
-suite: a refactor that drops the depth-path guard (letting a 8000x8000 depth
-request reach the offscreen framebuffer) would slip past the RGB tests alone.
+``render_depth`` and ``get_camera_params`` share the same
+``_validate_render_dims`` guard as ``render`` but through independent call
+sites, so each is pinned with its own suite plus a cross-call-site parity
+suite: a refactor that drops one of them (letting a 8000x8000 depth request
+reach the offscreen framebuffer, or building a pinhole ``K`` for a 0-pixel
+image) would slip past the RGB tests alone.
+
+``get_camera_params`` reports failure by exception rather than by an
+agent-tool dict, and its dimensions are not merely a buffer size: ``fx``,
+``fy``, ``cx`` and ``cy`` are all linear in the image size, so a 0 height
+yields a singular ``K`` (``fy == 0``, no unprojection possible) and a negative
+height yields an axis-flipped ``K`` that silently mirrors every unprojected
+point. A size past the framebuffer cap describes a frame ``render`` and
+``get_frame`` refuse to draw, breaking the symmetry those three APIs promise.
 """
 
 import pytest
@@ -106,3 +116,81 @@ class TestRenderMaxBytesCap:
         monkeypatch.setenv("STRANDS_ROBOTS_RENDER_MAX_BYTES", "0")
         with pytest.raises(ValueError, match="must be positive"):
             _max_render_bytes()
+
+
+class TestCameraParamsDimensionCaps:
+    """``get_camera_params`` must honor the same dimension contract as ``render``.
+
+    It builds intrinsics for a caller-supplied image size, so a dimension the
+    renderer cannot produce yields a ``K`` describing a frame that does not
+    exist. Failure is reported by ``ValueError`` (this API returns a
+    ``CameraParams``, not an agent-tool dict).
+    """
+
+    @pytest.mark.parametrize(
+        ("width", "height"),
+        [(0, 240), (320, 0), (-64, 240), (320, -48)],
+    )
+    def test_non_positive_dimensions_rejected(self, sim_with_world, width, height):
+        """A 0 height would give a singular K; a negative one an axis-flipped K."""
+        with pytest.raises(ValueError, match="must be > 0"):
+            sim_with_world.get_camera_params(camera_name="default", width=width, height=height)
+
+    @pytest.mark.parametrize("width", [2.7, "640", [320]])
+    def test_non_integer_dimensions_rejected(self, sim_with_world, width):
+        """A fractional/string/sequence width is refused, not silently truncated."""
+        with pytest.raises(ValueError, match="must be int"):
+            sim_with_world.get_camera_params(camera_name="default", width=width, height=240)
+
+    def test_bool_dimension_rejected_by_type(self, sim_with_world):
+        """``True`` is an int subclass but never a pixel count."""
+        with pytest.raises(ValueError, match="got bool/int"):
+            sim_with_world.get_camera_params(camera_name="default", width=True, height=240)
+
+    def test_dimensions_over_absolute_ceiling_rejected(self, sim_with_world):
+        """Params for a frame past the hard 4096 ceiling are refused."""
+        with pytest.raises(ValueError, match="absolute maximum"):
+            sim_with_world.get_camera_params(camera_name="default", width=8000, height=480)
+
+    def test_dimensions_over_model_offscreen_cap_rejected(self, sim_with_world):
+        """Past the model's offscreen framebuffer cap is refused with the cap named."""
+        cap_w = int(sim_with_world._world._model.vis.global_.offwidth)
+        with pytest.raises(ValueError, match="offscreen framebuffer cap"):
+            sim_with_world.get_camera_params(camera_name="default", width=cap_w + 1, height=48)
+
+    def test_valid_dimensions_scale_the_intrinsics(self, sim_with_world):
+        """Accepted dimensions still produce K linear in the image size."""
+        sim_with_world.add_camera("look", position=[0.6, 0.0, 0.4], target=[0.0, 0.0, 0.1], width=320, height=240)
+
+        base = sim_with_world.get_camera_params(camera_name="look")
+        assert (base.width, base.height) == (320, 240)
+
+        doubled = sim_with_world.get_camera_params(camera_name="look", width=640, height=480)
+        assert (doubled.width, doubled.height) == (640, 480)
+        assert doubled.K[1][1] == pytest.approx(2.0 * base.K[1][1])
+        assert doubled.K[0][2] == pytest.approx(2.0 * base.K[0][2])
+        assert doubled.K[1][2] == pytest.approx(2.0 * base.K[1][2])
+
+
+class TestRenderDimensionGuardParity:
+    """Every dimension ``render`` rejects, ``get_camera_params`` rejects too.
+
+    The three render-dimension call sites (``render``, ``get_frame`` /
+    ``render_depth``, ``get_camera_params``) describe the same image. An
+    accepted domain that diverges between them lets a caller hold intrinsics
+    for a frame no call can render.
+    """
+
+    @pytest.mark.parametrize(
+        ("width", "height"),
+        [(0, 240), (320, 0), (-64, 240), (320, -48), (2.7, 240), ("640", 240), (True, 240), (8000, 480)],
+    )
+    def test_render_and_camera_params_reject_identically(self, sim_with_world, width, height):
+        """Same rejection, same message text, through both call sites."""
+        rendered = sim_with_world.render(camera_name="default", width=width, height=height)
+        assert rendered["status"] == "error"
+        expected = rendered["content"][0]["text"]
+
+        with pytest.raises(ValueError) as excinfo:
+            sim_with_world.get_camera_params(camera_name="default", width=width, height=height)
+        assert str(excinfo.value) == expected


### PR DESCRIPTION
## Problem

`render`, `render_depth` and `get_frame` all validate `width`/`height` through the same guard (`_validate_render_dims`): a positive whole number within the offscreen framebuffer cap. `get_camera_params` - which builds the pinhole `K` describing the very frame those three render - validated nothing and coerced with `int(...)`, so **every dimension its three siblings reject was accepted**.

Its dimensions are not merely a buffer size: `fx`, `fy`, `cx`, `cy` are all linear in the image size, so a bad size does not fail, it silently produces geometry.

```python
sim.add_camera("look", position=[0.55, 0.0, 0.42], target=[0.0, 0.0, 0.05], width=320, height=240)

cam = sim.get_camera_params("look", height=-48)   # returned CameraParams
cam.K[1][1]                                      # -41.57 -> fy negative, Y axis flipped
# unprojecting the cube-top pixel (160,106) at depth 0.633 m with it recovers
#   (-1.080, 0.000, 1.709) m  instead of  (0.000, 0.000, 0.100) m  ->  1.94 m error

sim.get_camera_params("look", height=0)          # fy = 0.0  ->  K singular (rank 2)
sim.get_camera_params("look", width=2.7)         # silently truncated to 2 px
sim.get_camera_params("look", width="640")       # string accepted by int()
sim.get_camera_params("look", width=5000, height=5000)   # intrinsics returned
sim.render("look", width=5000, height=5000)      # status=error: exceeds the 4096x4096 cap
```

The last pair is the contract break: the abstract `SimEngine.get_camera_params` already documents `ValueError` for "a resolution the backend cannot honor", and the MuJoCo docstring promises the params describe "the same view `get_frame` and `render` produce". A caller holding `K` for 5000x5000 holds intrinsics for a frame no call in the library will draw.

Related: `isinstance(True, int)` is true, so `width=True` passed the shared type check, reached MuJoCo, and came back as a bare `an integer is required`.

## Change

`get_camera_params` resolves `width`/`height` by membership (`is None`) without coercion, then applies the same `_validate_render_dims` guard as its siblings and raises `ValueError` carrying the **identical message text** (the pattern `get_frame` already uses, since this API reports failure by exception rather than an agent-tool dict). The shared guard now names `bool` explicitly via a small `_is_pixel_count` helper - a truth value is never a pixel count.

Behaviour after the change, all four call sites agreeing:

| argument | `render` | `get_frame` | `get_camera_params` |
|---|---|---|---|
| `height=0` | error: must be > 0 | ValueError | ValueError (was: `fy=0`, singular K) |
| `height=-48` | error: must be > 0 | ValueError | ValueError (was: `fy=-41.57`) |
| `width=2.7` | error: must be int | ValueError | ValueError (was: 2 px) |
| `width="640"` | error: must be int | ValueError | ValueError (was: 640) |
| `width=True` | error: got bool/int | ValueError | ValueError (was: 1 px) |
| `5000x5000` | error: exceeds 4096 cap | ValueError | ValueError (was: K returned) |
| omitted / valid | unchanged | unchanged | unchanged |

## Verification

MuJoCo sim, headless (`MUJOCO_GL=egl`). A cube is placed at a known pose, the sampled pixel is chosen by forward-projecting the true world point through the honored intrinsics (so the pixel choice cannot mask a bug in the code under test), and the depth buffer plus that pixel are unprojected with whatever `K` the call returns.

![get_camera_params dimension guard](https://raw.githubusercontent.com/cagataycali/robots/artifacts/camera-params-dims/camera_params_dims.png)

Left: pre-change, `height=-48` returns intrinsics and the cube-top pixel recovers a point 1.94 m away - 1.7 m up in the air, reprojecting to `v = -530 px`, i.e. 530 px above the top of a 240 px frame. Right: post-change the call raises, while the honored call still recovers the point to 0.23 cm.

## Tests

`tests/simulation/mujoco/test_render_dimension_limits.py` (the existing home for this guard, which already pins the `render` / `render_depth` call sites) gains:

* `TestCameraParamsDimensionCaps` - non-positive (both axes), non-integer, `bool`, over the absolute 4096 ceiling, over the model's offscreen cap, plus a happy path asserting `K` stays linear in the accepted size.
* `TestRenderDimensionGuardParity` - parametrized over all eight rejected values, asserting `render` errors and `get_camera_params` raises with the **same message string**, so the accepted domains cannot drift apart again.

Pre-change: `18 failed, 10 passed`. Post-change: `28 passed`.

Full local gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; `MUJOCO_GL=egl pytest tests` -> **12336 passed, 260 skipped** (18 new).

<sub>This change was prepared by an AI agent (strands-robots autonomous contributor). Review for accuracy.</sub>