### PR TITLE
fix(registry): a leader arm is a teleoperator, not a follower robot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a leader arm is refused by Robot() instead of built as a follower
+
+`so101_leader` was an alias of the `so101` registry entry, whose
+`hardware.lerobot_type` is `so101_follower`. Naming the leader therefore built a
+follower driver on the leader's own motor bus:
+
+```python
+Robot("so101_leader", mode="real", port="/dev/ttyACM1")
+# before: HardwareRobot(tool_name="so101", robot="so101_follower", port="/dev/ttyACM1")
+```
+
+That torque-enables the arm the operator is holding and drives it as a rigid
+position servo against the hand on it - and the resulting tool answered to
+`so101`, so nothing in the session named the swap. The alias is gone, and
+`Robot()` now refuses every `*_leader` name with a `ValueError` naming the
+teleoperator route (`Teleoperator(...)` + `attach_teleop(...)`) rather than the
+generic registry listing, which would have invited a retry with the follower
+name on the same port. `so101_follower` / `so101_dualcam` / `so101_tricam` and
+every other alias resolve as before.
+
 ### Fixed: get_camera_params refuses an image size it cannot produce intrinsics for
 
 `render`, `render_depth` and `get_frame` all validate `width`/`height` through

--- a/docs/hardware/teleoperation.md
+++ b/docs/hardware/teleoperation.md
@@ -38,6 +38,20 @@ leader = Teleoperator("so101_leader", port="/dev/ttyACM1", id="leader")
 that teleoperator's config (`port`, `id`, `left_port`, …) and validated -
 unknown kwargs raise immediately so typos surface fast.
 
+### A leader arm is a teleoperator, not a `Robot`
+
+A leader carries the same servo bus as the follower it drives, so its name reads
+like a robot name - but `Robot()` builds a *follower* driver, which would
+torque-enable the arm you are holding. `Robot()` refuses every `*_leader` name
+and points here:
+
+```python
+Robot("so101_leader", mode="real", port="/dev/ttyACM1")
+# ValueError: 'so101_leader' is a teleoperator (leader) device, not a robot.
+#   Build it with ``Teleoperator('so101_leader', port=...)`` and attach it to
+#   the follower it drives ...
+```
+
 ### Available teleoperators
 
 | Teleoperator | Emits (action keys) |

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -282,7 +282,6 @@
         "robotstudio_so101",
         "so101_dualcam",
         "so101_follower",
-        "so101_leader",
         "so101_tricam"
       ]
     },

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -131,6 +131,20 @@ def _validate_known_robot(canonical: str, original: str, urdf_path: str | None) 
         and not (has_sim(canonical) or has_hardware(canonical))
         and not is_discoverable(canonical)
     ):
+        # A leader arm is an input device, not a robot: it carries the same
+        # servo bus and USB-serial shape as its follower, so "so101_leader"
+        # reads as a plausible Robot() name. Answering it with the generic
+        # registry listing invites the caller to retry with the follower name
+        # on the leader's port - the exact mistake that torque-enables the arm
+        # a human is holding. Name the teleoperator entry point instead.
+        if canonical.endswith("_leader"):
+            raise ValueError(
+                f"{original!r} is a teleoperator (leader) device, not a robot. "
+                f"Build it with ``Teleoperator({canonical!r}, port=...)`` and attach it to the "
+                f"follower it drives: ``Robot('<follower>', mode='real', port=...)"
+                f".attach_teleop({canonical!r}, port=...)``. Passing a leader to ``Robot()`` would "
+                "drive the arm a human is holding as a position servo."
+            )
         raise ValueError(
             f"Unknown robot {original!r} (resolved to {canonical!r}). "
             "Pass a registered name (see ``list_robots()``), one of the "

--- a/tests/test_leader_arm_is_not_a_robot.py
+++ b/tests/test_leader_arm_is_not_a_robot.py
@@ -1,0 +1,116 @@
+"""A leader arm is a teleoperator, not a robot.
+
+``so101_leader`` was an alias of the ``so101`` registry entry, whose
+``hardware.lerobot_type`` is ``so101_follower``. So
+``Robot("so101_leader", mode="real", port=<leader port>)`` built an
+SO101Follower driver on the leader's motor bus - torque-enabling the arm a
+human is holding and turning it into a rigid position servo. These tests pin
+the refusal and the registry invariant behind it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.hardware_robot as hardware_robot
+import strands_robots.robot as robot_module
+from strands_robots import Robot
+from strands_robots.registry import get_hardware_type, get_robot, resolve_name
+
+REGISTRY_PATH = Path(__file__).parent.parent / "strands_robots" / "registry" / "robots.json"
+
+
+@pytest.fixture(scope="module")
+def registry() -> dict[str, Any]:
+    """Load the shipped robot registry once per module."""
+    with open(REGISTRY_PATH) as f:
+        data = json.load(f)
+    entries: dict[str, Any] = data.get("robots", data)
+    return entries
+
+
+def test_no_leader_name_resolves_to_a_follower_entry(registry: dict[str, Any]) -> None:
+    """Registry invariant: a ``*_leader`` name never names a follower robot.
+
+    Generalises the ``so101_leader`` regression to the whole file - a leader
+    name may only appear as a key or alias of an entry that is itself that
+    leader device (``hardware.lerobot_type`` matching), never of the follower
+    it drives.
+    """
+    offenders = []
+    for name, info in registry.items():
+        lerobot_type = (info.get("hardware") or {}).get("lerobot_type")
+        for candidate in (name, *info.get("aliases", [])):
+            if candidate.endswith("_leader") and candidate != lerobot_type:
+                offenders.append(f"{candidate!r} -> entry {name!r} (lerobot_type={lerobot_type!r})")
+    assert not offenders, "leader names resolving to a non-leader entry: " + "; ".join(offenders)
+
+
+def test_so101_leader_does_not_resolve_to_the_follower() -> None:
+    """The leader name must not carry the follower's hardware type."""
+    assert resolve_name("so101_leader") == "so101_leader"
+    assert get_robot("so101_leader") is None
+    assert get_hardware_type("so101_leader") is None
+
+
+def test_real_mode_refuses_a_leader_before_touching_hardware(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The refusal lands before any driver is constructed on the leader's port."""
+    constructed: list[dict[str, Any]] = []
+
+    class _Recorder:
+        def __init__(self, **kwargs: Any) -> None:
+            constructed.append(kwargs)
+
+    monkeypatch.setattr(hardware_robot, "Robot", _Recorder)
+
+    with pytest.raises(ValueError, match="teleoperator"):
+        Robot("so101_leader", mode="real", port="/dev/ttyACM1")
+
+    assert constructed == []
+
+
+def test_the_refusal_names_the_teleoperator_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The message points at ``Teleoperator``/``attach_teleop``, not the follower.
+
+    Answering with the follower name would invite the caller to retry
+    ``Robot("so101", mode="real", port=<leader port>)`` - the same hazard by
+    another spelling.
+    """
+    monkeypatch.setattr(hardware_robot, "Robot", lambda **kwargs: pytest.fail("built a driver for a leader"))
+
+    with pytest.raises(ValueError) as excinfo:
+        Robot("so101_leader", mode="real", port="/dev/ttyACM1")
+
+    message = str(excinfo.value)
+    assert "Teleoperator('so101_leader', port=...)" in message
+    assert "attach_teleop('so101_leader', port=...)" in message
+    assert "so101_follower" not in message
+
+
+@pytest.mark.parametrize("mode", ["sim", "real", "auto"])
+@pytest.mark.parametrize("name", ["so101_leader", "SO101-Leader", "so100_leader", "koch_leader"])
+def test_a_leader_is_refused_in_every_mode(mode: str, name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No mode accepts a leader - sim would silently hand back the follower."""
+    monkeypatch.setattr(hardware_robot, "Robot", lambda **kwargs: pytest.fail("built a driver for a leader"))
+
+    with pytest.raises(ValueError, match="is a teleoperator .leader. device, not a robot"):
+        Robot(name, mode=mode, port="/dev/ttyACM1")
+
+
+def test_follower_names_still_resolve() -> None:
+    """The follower aliases this fix did not touch keep resolving."""
+    assert resolve_name("so101_follower") == "so101"
+    assert resolve_name("so101_dualcam") == "so101"
+    assert get_hardware_type("so101") == "so101_follower"
+
+
+def test_an_unknown_non_leader_name_keeps_the_registry_listing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The leader branch must not hijack the generic unknown-robot error."""
+    monkeypatch.setattr(robot_module, "is_discoverable", lambda name: False)
+
+    with pytest.raises(ValueError, match="Unknown robot 'so101_leaderr'"):
+        Robot("so101_leaderr", mode="sim")


### PR DESCRIPTION
## Problem

`so101_leader` was an alias of the `so101` registry entry (`strands_robots/registry/robots.json`), whose `hardware.lerobot_type` is `so101_follower`. Naming the leader therefore built a **follower** driver bound to the leader's own motor bus:

```python
Robot("so101_leader", mode="real", port="/dev/ttyACM1")
# HardwareRobot(tool_name="so101", robot="so101_follower", port="/dev/ttyACM1")
```

An SO-101 leader is the arm a human holds; a follower driver torque-enables those same servos and holds them at commanded `Goal_Position`, so the device stops back-driving and starts pushing against the hand on it. The tool that came back answered to `so101` - not `so101_leader` - so nothing in the session named the swap, and in `mode="sim"` the same call silently handed back the follower model.

Evidence the alias was accidental rather than intended:

- `so100` does not carry a `so100_leader` alias - the leader/follower confusion exists on `so101` only.
- `docs/robots/arms.md` already documents the `so101` aliases as `robotstudio_so101`, `so101_dualcam`, `so101_follower` - the leader was never in the documented set.
- Leader devices are resolved through the `Teleoperator()` factory (LeRobot's `TeleoperatorConfig` choice registry). Nothing in the codebase reads a leader name out of the robot registry: `resolve_name` / `get_robot` are not called from `teleop_mixin`, `teleoperator`, or `hardware_robot`.

## Change

- `strands_robots/registry/robots.json`: drop `so101_leader` from the `so101` aliases. It is the only leader name anywhere in the registry (or in any shipped JSON/YAML/TOML).
- `strands_robots/robot.py`: the unknown-name branch of `_validate_known_robot` answers a `*_leader` name with a `ValueError` naming the teleoperator route instead of the generic registry listing:

```text
'so101_leader' is a teleoperator (leader) device, not a robot. Build it with
``Teleoperator('so101_leader', port=...)`` and attach it to the follower it drives:
``Robot('<follower>', mode='real', port=...).attach_teleop('so101_leader', port=...)``.
Passing a leader to ``Robot()`` would drive the arm a human is holding as a position servo.
```

  The generic message ("Pass a registered name, see `list_robots()`") would have pointed the caller at `so101` - i.e. invited a retry with the follower name on the leader's port, the same hazard by another spelling. The message deliberately does not name `so101_follower`.

  The branch is scoped to names that are **not** registered, so a future entry that genuinely *is* a leader device (`hardware.lerobot_type == "<name>_leader"`) is unaffected. The refusal covers every mode - validation runs before mode resolution, backend import and hardware construction - and normalises first, so `"SO101-Leader"` is refused too. Names that were already unknown (`so100_leader`, `koch_leader`, ...) now get the same actionable message instead of the registry listing.

## Tests

`tests/test_leader_arm_is_not_a_robot.py` (new, 18 cases):

- registry invariant across the whole file, not just `so101`: no key or alias ending in `_leader` may belong to an entry whose `hardware.lerobot_type` is something else;
- `resolve_name("so101_leader")` no longer collapses to `so101`, and `get_hardware_type("so101_leader")` is `None`;
- the refusal lands *before* any driver is constructed - `hardware_robot.Robot` is patched with a recorder and must stay untouched;
- the message names `Teleoperator('so101_leader', port=...)` and `attach_teleop('so101_leader', port=...)` and does not name the follower type;
- every mode (`sim`, `real`, `auto`) refuses every spelling (`so101_leader`, `SO101-Leader`, `so100_leader`, `koch_leader`);
- the aliases this fix did not touch still resolve (`so101_follower`, `so101_dualcam` -> `so101`, `get_hardware_type("so101") == "so101_follower"`);
- an unknown non-leader name (`so101_leaderr`) keeps the generic registry listing, so the new branch cannot hijack it.

Pre-fix on this branch's base: 16 failed, 2 passed. Post-fix: 18 passed.

## Validation

- `ruff check strands_robots tests` clean; `ruff format --check` clean; `mypy` clean on both touched Python files.
- `tests/test_leader_arm_is_not_a_robot.py tests/test_registry.py tests/test_registry_integrity.py tests/test_changelog_format.py tests/registry`: 638 passed, 11 skipped.
- Whole `tests/` tree run head-vs-base in the same environment: identical results (263 failed / 1067 passed / 130 errors both ways - all from optional deps absent in this sandbox: torch, mujoco, lerobot, msgpack, device_connect_edge). No behavioural delta outside the new file.
- `docs/hardware/teleoperation.md` gains a short "A leader arm is a teleoperator, not a `Robot`" note next to the factory it points at; CHANGELOG entry added.

## Changelog

- round 1: initial submission.