### PR TITLE
fix(lerobot_local): one shared predicate decides a hardware observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: the state and action sides agree on what a hardware observation is
+
+Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the
+local LeRobot policy. The action side (`get_actions`) ran a plain-`float` pass and
+only retried with numpy `if not _pos:`; the state side
+(`PackStateProcessorStep`) ran one combined pass. `isinstance(np.float64(1.0),
+float)` is True but `isinstance(np.float32(1.0), float)` is False, so an
+observation mixing the two matched *partially* on the first pass - non-empty, so
+the numpy retry never ran, and too short to cover the embodiment's actuators:
+
+```python
+# 3 x float + 3 x np.float32, e.g. a driver read merged with a filtered estimate
+obs = {"shoulder_pan.pos": 1.0, ..., "gripper.pos": np.float32(6.0)}
+# state side:  packs all 6 readings into observation.state RAW (already model units)
+# action side: sees no hardware keys -> emits the command under the SIM joint
+#              names ('1'..'6'), which SOFollower.send_action does not accept,
+#              with the model-degrees -> sim-radians conversion applied (1/57.3)
+```
+
+The model was conditioned on raw hardware degrees while its command was keyed and
+scaled for the sim, and nothing warned, because the state side had succeeded.
+Both sides now call one `hardware_pos_keys()` predicate. It also accepts python /
+numpy integers and 0-d tensors, and - a change on the state side - refuses
+`bool`, so a driver status flag (`is_homed.pos`) can no longer take a joint
+column and be commanded as an absolute `1.0`.
+
 ### Fixed: a leader arm is refused by Robot() instead of built as a follower
 
 `so101_leader` was an alias of the `so101` registry entry, whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,12 @@ The model was conditioned on raw hardware degrees while its command was keyed an
 scaled for the sim, and nothing warned, because the state side had succeeded.
 Both sides now call one `hardware_pos_keys()` predicate. It also accepts python /
 numpy integers and 0-d tensors, and - a change on the state side - refuses
-`bool`, so a driver status flag (`is_homed.pos`) can no longer take a joint
-column and be commanded as an absolute `1.0`.
+booleans in every flavour an observation spells them (`bool`, `np.bool_`, and 0-d
+`bool` arrays / tensors), so a driver status flag (`is_homed.pos`) can no longer
+take a joint column and be commanded as an absolute `1.0`. A flag accepted there
+does not fail loudly: both sides slice the key list to their actuator count, so
+one extra key in front renames every reading to its neighbour and drops the
+last.
 
 ### Fixed: a leader arm is refused by Robot() instead of built as a follower
 

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -157,6 +157,57 @@ def _convert_joint_vector(
     return out
 
 
+# Hardware observation detection
+
+
+def _is_joint_scalar(value: object) -> bool:
+    """Whether ``value`` is a single numeric joint reading.
+
+    Accepts python and numpy scalars plus 0-d arrays/tensors; rejects ``bool``
+    (a driver status flag is not a joint reading, and ``bool`` is an ``int``
+    subclass so the exclusion has to be explicit) and anything with more than
+    one element.
+
+    The dtype coverage is the point: ``isinstance(np.float64(1.0), float)`` is
+    True but ``isinstance(np.float32(1.0), float)`` is False, so a predicate
+    written as "plain floats, and numpy only if that found nothing" answers
+    differently for a float32 observation than for a float64 one - and
+    differently again for an observation that mixes the two.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float, np.floating, np.integer)):
+        return True
+    if isinstance(value, np.ndarray):
+        return value.ndim == 0
+    # 0-d torch tensor, without importing torch here (this module stays light).
+    return getattr(value, "ndim", None) == 0 and hasattr(value, "item")
+
+
+def hardware_pos_keys(observation: dict[str, Any]) -> list[str]:
+    """Ordered ``'<motor>.pos'`` keys of ``observation`` carrying a joint reading.
+
+    The single source of truth for "does this observation come from real
+    hardware?", shared by the state side (:class:`PackStateProcessorStep`) and
+    the action side (``LerobotLocalPolicy._hardware_action_keys``).
+
+    Both sides bind their vectors positionally, so the returned order - the
+    observation's own insertion order, i.e. lerobot motor order - is part of the
+    contract.
+
+    Args:
+        observation: A raw robot/sim observation dict.
+
+    Returns:
+        The matching keys, in observation order.
+    """
+    return [
+        key
+        for key, value in observation.items()
+        if isinstance(key, str) and key.endswith(".pos") and _is_joint_scalar(value)
+    ]
+
+
 # Action diagnostics
 
 
@@ -389,13 +440,7 @@ def register_pack_state_step() -> type | None:
                 # double-convert). Observation insertion order is lerobot motor
                 # order (shoulder_pan..gripper), which matches the positional
                 # sim state_keys, so a straight collection is index-aligned.
-                pos_keys = [
-                    k
-                    for k in observation
-                    if k.endswith(".pos")
-                    and isinstance(observation[k], (int, float, np.floating, np.ndarray))
-                    and (not isinstance(observation[k], np.ndarray) or observation[k].ndim == 0)
-                ]
+                pos_keys = hardware_pos_keys(observation)
                 if len(pos_keys) >= len(self.state_keys) and self.state_keys:
                     n = len(self.state_keys)
                     hw_vals = [float(observation[k]) for k in pos_keys[:n]]

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -160,12 +160,47 @@ def _convert_joint_vector(
 # Hardware observation detection
 
 
+def _is_boolean_flag(value: object) -> bool:
+    """Whether ``value`` carries a boolean, in any of the flavours an observation uses.
+
+    A driver status flag is not a joint reading, and the exclusion has to cover
+    every spelling of "boolean" because none of them is caught by a check for
+    another one:
+
+    ==========================  ============================================
+    ``True``                    an ``int`` subclass, so a numeric check takes it
+    ``np.bool_(True)``          NOT a ``bool`` subclass, and NOT an
+                                ``np.integer`` - it reaches a duck-typed 0-d
+                                check instead (``ndim`` is 0, ``item`` exists)
+    ``np.array(True)``          an ``ndarray`` whose ``ndim`` is 0
+    ``torch.tensor(True)``      0-d with an ``item``, dtype ``torch.bool``
+    ==========================  ============================================
+
+    So the flag test is done once here, ahead of every accept branch, rather
+    than per branch: a branch added later cannot reopen the hole.
+
+    Dtype is matched by kind rather than identity so the check does not import
+    torch (this module stays light) and covers array libraries generally. An
+    unrecognised dtype spelling therefore reads as boolean if it says "bool",
+    which is the safe direction: a wrongly-rejected reading yields a SHORT key
+    list, and a short list refuses the hardware override (see
+    ``hardware_pos_keys`` callers) instead of binding a misaligned one.
+    """
+    if isinstance(value, (bool, np.bool_)):
+        return True
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return False
+    # numpy dtypes expose ``.kind`` ('b' for boolean); torch's do not, but every
+    # dtype spelling that means boolean says so in its string form.
+    return getattr(dtype, "kind", None) == "b" or "bool" in str(dtype).lower()
+
+
 def _is_joint_scalar(value: object) -> bool:
     """Whether ``value`` is a single numeric joint reading.
 
-    Accepts python and numpy scalars plus 0-d arrays/tensors; rejects ``bool``
-    (a driver status flag is not a joint reading, and ``bool`` is an ``int``
-    subclass so the exclusion has to be explicit) and anything with more than
+    Accepts python and numpy scalars plus 0-d arrays/tensors; rejects booleans
+    in every flavour (see :func:`_is_boolean_flag`) and anything with more than
     one element.
 
     The dtype coverage is the point: ``isinstance(np.float64(1.0), float)`` is
@@ -174,7 +209,7 @@ def _is_joint_scalar(value: object) -> bool:
     differently for a float32 observation than for a float64 one - and
     differently again for an observation that mixes the two.
     """
-    if isinstance(value, bool):
+    if _is_boolean_flag(value):
         return False
     if isinstance(value, (int, float, np.floating, np.integer)):
         return True

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -21,7 +21,7 @@ import numpy as np
 import torch
 
 from .. import Policy
-from .embodiment import ZeroActionMonitor, diagnose_action_dim
+from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys
 from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
 
@@ -1707,6 +1707,42 @@ class LerobotLocalPolicy(Policy):
 
     # Inference
 
+    def _hardware_action_keys(self, observation_dict: dict[str, Any]) -> list[str] | None:
+        """Actuator names to emit actions under when a SIM embodiment is driven from hardware.
+
+        lerobot ``SOFollower`` & friends key joint scalars as ``'<motor>.pos'``.
+        When a SIM embodiment (numeric / named sim joints) is fed a hardware
+        observation, the action tensor must still be emitted under those
+        ``'.pos'`` names, and WITHOUT the sim unit conversion, for
+        ``SOFollower.send_action`` to accept it.
+
+        Detection uses the same :func:`hardware_pos_keys` predicate as the state
+        side (``PackStateProcessorStep``). The two used to be written separately
+        and could disagree: this side ran a plain-``float`` pass and only tried a
+        numpy pass ``if not _pos:``, so a PARTIALLY matching first pass poisoned
+        the retry and left the override unset, while the state side - one
+        combined pass - succeeded on the same observation. The model was then fed
+        raw hardware degrees while its action was emitted with the sim
+        radian->degree conversion applied (~57x under-scaled), and nothing
+        warned, because the state side had succeeded.
+
+        Args:
+            observation_dict: The raw observation for this step.
+
+        Returns:
+            The hardware actuator names to bind the action vector to, or ``None``
+            when this is not a hardware observation (or the embodiment already
+            declares ``'.pos'`` action keys, making the override a no-op).
+        """
+        if self._embodiment is None or not self._embodiment.action_keys:
+            return None
+        if any(str(key).endswith(".pos") for key in self._embodiment.action_keys):
+            return None
+        pos_keys = hardware_pos_keys(observation_dict)
+        if len(pos_keys) < len(self._embodiment.action_keys):
+            return None
+        return pos_keys[: len(self._embodiment.action_keys)]
+
     async def get_actions(self, observation_dict: dict[str, Any], instruction: str, **kwargs) -> list[dict[str, Any]]:
         """Get actions from policy given observation and instruction.
 
@@ -1732,37 +1768,7 @@ class LerobotLocalPolicy(Policy):
         if instruction and "task" not in observation:
             observation["task"] = instruction
 
-        # Detect REAL-hardware observations: lerobot SOFollower & friends key
-        # joint scalars as '<motor>.pos'. When a SIM embodiment (numeric/ named
-        # sim joints) is driven from hardware, the action tensor must still be
-        # emitted under these '.pos' names (and WITHOUT the sim unit conversion)
-        # so SOFollower.send_action accepts it. We capture the '.pos' order here
-        # (lerobot motor order) and thread it into _tensor_to_action_dicts. When
-        # the embodiment's own action_keys are ALREADY '.pos' (e.g. so_real /
-        # so101_follower) this is a harmless no-op override with identical keys.
-        _hw_action_keys: list[str] | None = None
-        if (
-            self._embodiment is not None
-            and self._embodiment.action_keys
-            and not any(str(k).endswith(".pos") for k in self._embodiment.action_keys)
-        ):
-            _pos = [
-                k
-                for k in observation_dict
-                if isinstance(k, str) and k.endswith(".pos") and isinstance(observation_dict[k], (int, float))
-            ]
-            # numpy scalar / 0-d support (np imported at module top)
-            if not _pos:
-                _pos = [
-                    k
-                    for k in observation_dict
-                    if isinstance(k, str)
-                    and k.endswith(".pos")
-                    and isinstance(observation_dict[k], (np.floating, np.ndarray))
-                    and (not isinstance(observation_dict[k], np.ndarray) or observation_dict[k].ndim == 0)
-                ]
-            if len(_pos) >= len(self._embodiment.action_keys):
-                _hw_action_keys = _pos[: len(self._embodiment.action_keys)]
+        _hw_action_keys = self._hardware_action_keys(observation_dict)
 
         # When the processor bridge has a preprocessor, delegate normalization
         # and tokenization to it, then fix up any remaining raw arrays/tensors

--- a/tests/policies/lerobot_local/test_hardware_pos_key_detection.py
+++ b/tests/policies/lerobot_local/test_hardware_pos_key_detection.py
@@ -52,6 +52,11 @@ def _torch_scalar(value: float):
     return torch.tensor(value)
 
 
+def _torch_bool(value: bool = True):
+    torch = pytest.importorskip("torch")
+    return torch.tensor(value, dtype=torch.bool)
+
+
 def _sim_policy(action_keys: list[str] | None = None) -> LerobotLocalPolicy:
     """A policy carrying a SIM embodiment.
 
@@ -105,6 +110,28 @@ class TestNonJointValuesAreExcluded:
     @pytest.mark.parametrize("value", [True, False])
     def test_is_joint_scalar_rejects_both_bools(self, value):
         assert _is_joint_scalar(value) is False
+
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            lambda: np.bool_(True),
+            lambda: np.bool_(False),
+            lambda: np.array(True),
+            lambda: np.array(False, dtype=bool),
+            _torch_bool,
+        ],
+        ids=["np.bool_ True", "np.bool_ False", "ndarray0d bool", "ndarray0d dtype=bool", "torch bool"],
+    )
+    def test_is_joint_scalar_rejects_every_bool_flavour(self, factory):
+        """A python ``bool`` is only one of the ways an observation says "boolean".
+
+        None of these is caught by the check for another: ``np.bool_`` is not a
+        ``bool`` subclass and not an ``np.integer``, so it reaches the duck-typed
+        0-d branch (``ndim`` is 0, ``item`` exists); a 0-d bool ``ndarray`` and a
+        0-d ``torch.bool`` tensor arrive the same way. Each one accepted is an
+        extra key in front of the real joints.
+        """
+        assert _is_joint_scalar(factory()) is False
 
     def test_a_multi_element_array_is_not_a_scalar(self):
         keys = hardware_pos_keys({"cloud.pos": np.zeros(3), "shoulder_pan.pos": 1.0})
@@ -167,6 +194,54 @@ class TestTheActionSideAgreesWithTheStateSide:
         radian->degree conversion, ~57x under-scaled, silently.
         """
         assert _sim_policy()._hardware_action_keys(_obs(_MIXED_DTYPES)) == _POS_KEYS
+
+
+class TestABooleanFlagNeverTakesAJointColumn:
+    """A flag accepted as a joint reading shifts every joint by one column.
+
+    Both sides slice ``[:len(actuators)]`` off this list, so one extra key in
+    front does not fail loudly - it renames each reading to its neighbour and
+    drops the last one. On hardware these are ABSOLUTE targets, and the flag's
+    ``1.0`` lands in joint slot 0.
+    """
+
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            lambda: True,
+            lambda: np.bool_(True),
+            lambda: np.array(True),
+            _torch_bool,
+        ],
+        ids=["python bool", "np.bool_", "ndarray0d bool", "torch bool"],
+    )
+    def test_a_leading_flag_does_not_shift_the_joints(self, factory):
+        observation = {"is_homed.pos": factory()}
+        observation.update(_obs([float(i) for i in range(1, 7)]))
+
+        assert hardware_pos_keys(observation) == _POS_KEYS
+
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            lambda: True,
+            lambda: np.bool_(True),
+            lambda: np.array(True),
+            _torch_bool,
+        ],
+        ids=["python bool", "np.bool_", "ndarray0d bool", "torch bool"],
+    )
+    def test_both_sides_still_agree_when_a_flag_is_present(self, factory):
+        """The shared predicate has to hold the invariant under a flag too.
+
+        If only one side dropped the flag, the state vector and the actuator
+        names would disagree by one column - the divergence this predicate was
+        made single-source-of-truth to prevent.
+        """
+        observation = {"is_homed.pos": factory()}
+        observation.update(_obs([float(i) for i in range(1, 7)]))
+
+        assert _sim_policy()._hardware_action_keys(observation) == hardware_pos_keys(observation)
 
 
 class TestTheOverrideStaysOffWhenItShould:

--- a/tests/policies/lerobot_local/test_hardware_pos_key_detection.py
+++ b/tests/policies/lerobot_local/test_hardware_pos_key_detection.py
@@ -49,11 +49,15 @@ def _obs(values: list) -> dict:
 
 def _torch_scalar(value: float):
     torch = pytest.importorskip("torch")
+    if not hasattr(torch.Tensor, "__torch_function__"):
+        pytest.skip("torch mock does not replicate 0-d tensor semantics")
     return torch.tensor(value)
 
 
 def _torch_bool(value: bool = True):
     torch = pytest.importorskip("torch")
+    if not hasattr(torch.Tensor, "__torch_function__"):
+        pytest.skip("torch mock does not replicate 0-d tensor semantics")
     return torch.tensor(value, dtype=torch.bool)
 
 

--- a/tests/policies/lerobot_local/test_hardware_pos_key_detection.py
+++ b/tests/policies/lerobot_local/test_hardware_pos_key_detection.py
@@ -1,0 +1,195 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""The state and action sides must agree on what a hardware observation is.
+
+Two separately-written predicates decided "does this observation carry
+``'<motor>.pos'`` hardware joint readings?":
+
+* the ACTION side (``get_actions``' hardware key override) ran a plain-``float``
+  pass and only tried a numpy pass ``if not _pos:`` - so a PARTIALLY matching
+  first pass poisoned the retry and left the override unset;
+* the STATE side (``PackStateProcessorStep``) used ONE combined pass and
+  succeeded on the same observation.
+
+When they disagreed, the model was fed raw hardware degrees while its action was
+emitted WITH the sim radian->degree conversion applied - roughly 57x
+under-scaled - and nothing warned, because the state side had succeeded.
+
+The trigger is a numpy dtype detail: ``isinstance(np.float64(1.0), float)`` is
+True but ``isinstance(np.float32(1.0), float)`` is False. So only an observation
+MIXING ``float`` with ``np.float32`` tripped it, which is why it survived
+testing.
+
+Both sides now bind to one shared :func:`hardware_pos_keys`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.lerobot_local.embodiment import (
+    EmbodimentMap,
+    _is_joint_scalar,
+    hardware_pos_keys,
+)
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+_MOTORS = ("shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper")
+_POS_KEYS = [f"{motor}.pos" for motor in _MOTORS]
+
+#: The only observation shape that tripped the split predicate: the plain-float
+#: pass matches 3 of 6 keys, so it is non-empty (no numpy retry) but too short to
+#: reach the embodiment's 6 actuators.
+_MIXED_DTYPES = [1.0, 2.0, 3.0, np.float32(4.0), np.float32(5.0), np.float32(6.0)]
+
+
+def _obs(values: list) -> dict:
+    return dict(zip(_POS_KEYS, values, strict=True))
+
+
+def _torch_scalar(value: float):
+    torch = pytest.importorskip("torch")
+    return torch.tensor(value)
+
+
+def _sim_policy(action_keys: list[str] | None = None) -> LerobotLocalPolicy:
+    """A policy carrying a SIM embodiment.
+
+    Only the hardware-key detection is exercised, and the empty checkpoint path
+    skips the model load, so construction stays offline.
+    """
+    policy = LerobotLocalPolicy(policy_type="act")
+    # so101 in sim: positional joint names, NOT '.pos' driver names.
+    keys = action_keys if action_keys is not None else [str(i) for i in range(1, 7)]
+    policy._embodiment = EmbodimentMap(name="so101", state_keys=list(keys), action_keys=list(keys))
+    return policy
+
+
+class TestEveryDtypeIsDetected:
+    def test_plain_floats(self):
+        assert hardware_pos_keys(_obs([1.0] * 6)) == _POS_KEYS
+
+    def test_numpy_float32(self):
+        assert hardware_pos_keys(_obs([np.float32(1.0)] * 6)) == _POS_KEYS
+
+    def test_numpy_float64(self):
+        assert hardware_pos_keys(_obs([np.float64(1.0)] * 6)) == _POS_KEYS
+
+    def test_python_ints(self):
+        assert hardware_pos_keys(_obs([1] * 6)) == _POS_KEYS
+
+    def test_numpy_integers(self):
+        assert hardware_pos_keys(_obs([np.int32(1)] * 6)) == _POS_KEYS
+
+    def test_zero_dim_ndarray(self):
+        assert hardware_pos_keys(_obs([np.array(1.0)] * 6)) == _POS_KEYS
+
+    def test_zero_dim_torch_tensor(self):
+        assert hardware_pos_keys(_obs([_torch_scalar(1.0)] * 6)) == _POS_KEYS
+
+    def test_mixed_float_and_float32(self):
+        assert hardware_pos_keys(_obs(_MIXED_DTYPES)) == _POS_KEYS
+
+
+class TestNonJointValuesAreExcluded:
+    def test_a_bool_is_not_a_joint_reading(self):
+        """``isinstance(True, int)`` is True, so the exclusion has to be explicit.
+
+        A driver status flag (``is_homed``, ...) must never occupy an actuator
+        column, where ``True`` would be commanded as an absolute ``1.0``.
+        """
+        keys = hardware_pos_keys({"is_homed.pos": True, "shoulder_pan.pos": 1.0})
+
+        assert keys == ["shoulder_pan.pos"]
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_is_joint_scalar_rejects_both_bools(self, value):
+        assert _is_joint_scalar(value) is False
+
+    def test_a_multi_element_array_is_not_a_scalar(self):
+        keys = hardware_pos_keys({"cloud.pos": np.zeros(3), "shoulder_pan.pos": 1.0})
+
+        assert keys == ["shoulder_pan.pos"]
+
+    def test_a_string_value_is_not_a_joint_reading(self):
+        assert hardware_pos_keys({"a.pos": "1.0"}) == []
+
+    def test_none_is_not_a_joint_reading(self):
+        assert hardware_pos_keys({"a.pos": None}) == []
+
+    def test_keys_without_the_pos_suffix_are_ignored(self):
+        keys = hardware_pos_keys({"shoulder_pan": 1.0, "shoulder_pan.pos": 1.0})
+
+        assert keys == ["shoulder_pan.pos"]
+
+    def test_a_camera_frame_is_ignored(self):
+        obs = {**_obs([1.0] * 6), "front": np.zeros((4, 4, 3), dtype=np.uint8)}
+
+        assert hardware_pos_keys(obs) == _POS_KEYS
+
+
+class TestOrderIsPreserved:
+    def test_observation_order_is_kept(self):
+        """Both sides bind positionally, so the ORDER is the contract."""
+        reversed_keys = list(reversed(_POS_KEYS))
+
+        assert hardware_pos_keys(dict.fromkeys(reversed_keys, 1.0)) == reversed_keys
+
+
+class TestTheActionSideAgreesWithTheStateSide:
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [1.0] * 6,
+            [np.float32(1.0)] * 6,
+            [np.float64(1.0)] * 6,
+            [np.array(1.0)] * 6,
+            _MIXED_DTYPES,
+        ],
+        ids=["float", "float32", "float64", "ndarray0d", "mixed"],
+    )
+    def test_the_action_side_binds_the_keys_the_state_side_packs(self, values):
+        """The invariant the split predicate violated: same obs, same answer.
+
+        ``hardware_pos_keys`` is what ``PackStateProcessorStep`` packs
+        ``observation.state`` from, so the action side returning exactly those
+        keys is what keeps the two unit systems from diverging.
+        """
+        observation = _obs(values)
+
+        assert _sim_policy()._hardware_action_keys(observation) == hardware_pos_keys(observation)
+
+    def test_mixed_dtypes_no_longer_fall_back_to_sim_action_keys(self):
+        """The regression: 3 plain floats + 3 float32 left the override unset.
+
+        The state side packed the raw hardware degrees, then the action side -
+        seeing no hardware keys - emitted the command through the sim
+        radian->degree conversion, ~57x under-scaled, silently.
+        """
+        assert _sim_policy()._hardware_action_keys(_obs(_MIXED_DTYPES)) == _POS_KEYS
+
+
+class TestTheOverrideStaysOffWhenItShould:
+    def test_no_embodiment_means_no_override(self):
+        policy = _sim_policy()
+        policy._embodiment = None
+
+        assert policy._hardware_action_keys(_obs([1.0] * 6)) is None
+
+    def test_an_embodiment_without_action_keys_means_no_override(self):
+        assert _sim_policy(action_keys=[])._hardware_action_keys(_obs([1.0] * 6)) is None
+
+    def test_a_real_hardware_embodiment_needs_no_override(self):
+        """``so101_real`` already declares '.pos' actuators - nothing to rename."""
+        assert _sim_policy(action_keys=_POS_KEYS)._hardware_action_keys(_obs([1.0] * 6)) is None
+
+    def test_a_sim_observation_is_not_mistaken_for_hardware(self):
+        sim_obs = {str(i): 0.1 for i in range(1, 7)}
+
+        assert _sim_policy()._hardware_action_keys(sim_obs) is None
+
+    def test_too_few_hardware_joints_for_the_embodiment(self):
+        """A partial hardware read must not bind a short, index-shifted action."""
+        partial = {key: 1.0 for key in _POS_KEYS[:4]}
+
+        assert _sim_policy()._hardware_action_keys(partial) is None


### PR DESCRIPTION
## Problem

Detection of `'<motor>.pos'` hardware joint readings is implemented **twice** in the local LeRobot policy, and the two implementations disagree:

| | predicate |
|---|---|
| STATE side (`PackStateProcessorStep`, `embodiment.py`) | one combined pass over `int, float, np.floating, 0-d ndarray` |
| ACTION side (`get_actions`, `policy.py`) | a plain-`float` pass, then a numpy pass **only** `if not _pos:` |

`isinstance(np.float64(1.0), float)` is True but `isinstance(np.float32(1.0), float)` is False. So an observation that **mixes** the two dtypes matches *partially* on the action side's first pass - non-empty, so the numpy retry never runs, and too short to cover the embodiment's actuators. Reproduced against `main` (`b046037`), 3 x `float` + 3 x `np.float32`, so101 sim embodiment:

```
old pass-1 matched: ['shoulder_pan.pos', 'shoulder_lift.pos', 'elbow_flex.pos']
OLD action side ->  None
OLD state side ->   ['shoulder_pan.pos', ..., 'gripper.pos']   # all 6
```

With the action-side override unset, `_tensor_to_action_dicts` takes the `else` branch and does exactly what the comment there says must not happen on hardware: it keys the command by the **sim** joint names (`'1'..'6'`, which `SOFollower.send_action` does not accept) and applies the model-degrees -> sim-radians conversion (a factor of 1/57.3). Meanwhile the state side had already packed the readings raw, so the model was conditioned in hardware units and commanded in sim units - with **no warning**, because the state side succeeded.

A mixed-dtype observation is not exotic: any path that merges a driver read (python `float`) with a numpy-computed estimate produces one. It survived testing because a uniformly-`float32` or uniformly-`float64` observation works on both sides.

## Change

One predicate, `hardware_pos_keys(observation)` in `embodiment.py`, is now the single source of truth, called by both sides:

- **`embodiment.py`**: adds `_is_boolean_flag` + `_is_joint_scalar` + `hardware_pos_keys`; `PackStateProcessorStep` calls it instead of its inline comprehension.
- **`policy.py`**: the inline two-pass block in `get_actions` becomes `_hardware_action_keys()`, which calls the shared predicate. Extracting the branch is what makes the binding assertable without a checkpoint (`get_actions` needs a loaded model; the seam does not).

Two deliberate behaviour changes beyond de-duplication, both toward the stricter side:

- **Booleans are refused, in every flavour an observation spells them** (`bool`, `np.bool_`, 0-d `bool` ndarray, 0-d `torch.bool`). `bool` is an `int` subclass, so the old state-side predicate accepted `True` and let a driver status flag (`is_homed.pos`) take a joint column, where `1.0` is an **absolute** target. This matches the contract `tests/policies/lerobot_local/test_bool_observation_not_read_as_joint.py` already pins for the generic state path.
- python/numpy integers and 0-d tensors are accepted (the state side rejected `np.int32`, the action side rejected it too unless it was the only shape present).

The returned order is the observation's own insertion order (lerobot motor order); both sides bind positionally, so the order is part of the contract and is pinned.

## Tests

`tests/policies/lerobot_local/test_hardware_pos_key_detection.py` (41 tests):

- **dtype matrix** - `float`, `np.float32`, `np.float64`, `int`, `np.int32`, 0-d `ndarray`, 0-d torch tensor, and the **mixed** `float` + `float32` case that is the regression.
- **exclusions** - booleans in all four flavours (both values), multi-element array, `str`, `None`, keys without the `.pos` suffix, camera frames.
- **a boolean flag never takes a joint column** - at the predicate and on a full six-joint arm observation, for each flavour.
- **order preserved** - a reversed-order observation round-trips.
- **the two sides agree** - `policy._hardware_action_keys(obs) == hardware_pos_keys(obs)` across the dtype matrix and under a leading flag, i.e. the action side binds exactly the keys the state side packs from. Plus the direct pin: mixed dtypes no longer fall back to sim action keys.
- **the override stays off when it should** - no embodiment, no `action_keys`, an embodiment that already declares `.pos` actuators, a pure-sim observation, and a partial hardware read (4 of 6 joints) must not bind a short, index-shifted action.

## Validation

- `ruff check` + `ruff format --check` clean on the touched files (ruff 0.15.22, the pinned range).
- `mypy` reports nothing on the touched files.
- `pytest tests/policies/lerobot_local`: **489 passed**, 56 skipped.
- `pytest tests/policies`: **1300 passed**, 76 skipped. The 5 failures in that run are a missing optional dep in the local env (`mujoco`) and reproduce unchanged on `main`.
- CHANGELOG entry added under `[Unreleased]` for the behaviour change.

This is a slice extracted from the consolidated local-work branch so it can be reviewed on its own; the shared-predicate change stands alone and needs nothing else from that branch.

---

## §13 Round changelog

| Round | Concern | Fix commit | Pin test path |
|---|---|---|---|
| 1 | Initial: shared predicate, mixed-dtype fix | `aed207b8` | `tests/policies/lerobot_local/test_hardware_pos_key_detection.py` |
| 2 | `np.bool_` / 0-d bool ndarray / torch.bool fall through | `a3ab846b` | same file, 13 added bool-flavour tests |
| 3 | torch 0-d tests fail under torch_mock (CI without real torch) | `b4e9ecb1` | same file, `_torch_scalar`/`_torch_bool` skip on mock |

### Round 3 (`b4e9ecb1`) - torch 0-d tests skip cleanly under the test mock

The `tests/mocks/torch_mock.py` conftest installs a `MockTensor` that stores a scalar as `np.array([value])` (ndim=1), not as a 0-d tensor (ndim=0). The round-2 torch tests call `torch.tensor(1.0)` through `_torch_scalar`, which returns the mock, and `_is_joint_scalar`'s duck-typed branch checks `ndim == 0` - so the test sees an empty key list and fails rather than being skipped.

`pytest.importorskip("torch")` does not help because the mock installs a `torch` module in `sys.modules` before the test session starts.

Fix: detect the mock by probing for `torch.Tensor.__torch_function__` (present on real PyTorch, absent on `MockTensor`) and `pytest.skip` when the mock is active. The 4 torch-dependent tests now skip cleanly in CI without real torch; they still run and pass in an environment that has torch installed.

### Round 2 (`a3ab846b`) - a boolean is not a joint reading, in any flavour

Addresses the review's `[MUST FIX]` on the bool exclusion. The exclusion only covered python `bool`; `np.bool_` is not a `bool` subclass and not an `np.integer`, so it fell through to the duck-typed 0-d branch and was accepted as a joint reading.

One `_is_boolean_flag` guard ahead of every accept branch rather than three per-branch conditions, so a branch added later cannot reopen the hole. Dtype is matched by kind rather than identity to avoid importing torch here.

Pinned by 13 tests (28 -> 41) over all four flavours. 11 of 13 fail without the fix.

### Round 1 (`aed207b8`)

Initial submission: the shared `hardware_pos_keys` predicate replacing the two divergent implementations, with the mixed-dtype regression pinned.

---

**Synced with `main`** — mechanical merge only. `main` picked up the MuJoCo 3.11 mass-matrix fix (#1682), which every open branch needed to get a green `Test and Lint` run; the only conflict was CHANGELOG entry ordering under `[Unreleased]`, resolved by keeping both entries. The change under review is byte-identical. CI is green on the synced head.