### PR TITLE
fix(mesh): refuse a wildcard teleop source instead of following every peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a teleop receiver refuses a wildcard source instead of following every peer
+
+`InputPublisher` / `InputReceiver` interpolate `device_name` and
+`source_peer_id` into the Zenoh key expression
+`strands/{peer_id}/input/{device_name}`, and Zenoh reads `*` / `**` as
+wildcards. Nothing validated either identifier where the stream is built, so
+source scoping - the only thing making teleop point-to-point - could be
+switched off by a single argument:
+
+```python
+rx = InputReceiver(mesh, robot, source_peer_id="**")   # returned a receiver
+rx.topic          # 'strands/**/input/leader'
+# every peer publishing an input frame now reaches robot.send_action()
+```
+
+The wire `teleop_receive` command already rejected exactly those values, so the
+remote surface was stricter than the local API it delegates to
+(`HardwareRobot.start_teleop_receive` / `start_teleop_publish`, which accepted
+them too). The shared rule is now one validator,
+`strands_robots.mesh.security.validate_mesh_identifier`, called from
+`validate_command` and from both constructors; the two `HardwareRobot` entry
+points report through the tool envelope and validate before tearing down an
+existing stream, so a rejected call cannot stop a live one. Well-formed
+identifiers and their key expressions are unchanged.
+
 ### Fixed: a leader arm is refused by Robot() instead of built as a follower
 
 `so101_leader` was an alias of the `so101` registry entry, whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,68 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: a teleop receiver refuses a wildcard source instead of following every peer
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-`InputPublisher` / `InputReceiver` interpolate `device_name` and
-`source_peer_id` into the Zenoh key expression
-`strands/{peer_id}/input/{device_name}`, and Zenoh reads `*` / `**` as
-wildcards. Nothing validated either identifier where the stream is built, so
-source scoping - the only thing making teleop point-to-point - could be
-switched off by a single argument:
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
 ```python
-rx = InputReceiver(mesh, robot, source_peer_id="**")   # returned a receiver
-rx.topic          # 'strands/**/input/leader'
-# every peer publishing an input frame now reaches robot.send_action()
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
 ```
 
-The wire `teleop_receive` command already rejected exactly those values, so the
-remote surface was stricter than the local API it delegates to
-(`HardwareRobot.start_teleop_receive` / `start_teleop_publish`, which accepted
-them too). The shared rule is now one validator,
-`strands_robots.mesh.security.validate_mesh_identifier`, called from
-`validate_command` and from both constructors; the two `HardwareRobot` entry
-points report through the tool envelope and validate before tearing down an
-existing stream, so a rejected call cannot stop a live one. Well-formed
-identifiers and their key expressions are unchanged.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
+
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
+
 
 ### Fixed: the state and action sides agree on what a hardware observation is
 

--- a/changelog.d/1676-teleop-wildcard-source-scoping.md
+++ b/changelog.d/1676-teleop-wildcard-source-scoping.md
@@ -1,0 +1,24 @@
+### Fixed: a teleop receiver refuses a wildcard source instead of following every peer
+
+`InputPublisher` / `InputReceiver` interpolate `device_name` and
+`source_peer_id` into the Zenoh key expression
+`strands/{peer_id}/input/{device_name}`, and Zenoh reads `*` / `**` as
+wildcards. Nothing validated either identifier where the stream is built, so
+source scoping - the only thing making teleop point-to-point - could be
+switched off by a single argument:
+
+```python
+rx = InputReceiver(mesh, robot, source_peer_id="**")   # returned a receiver
+rx.topic          # 'strands/**/input/leader'
+# every peer publishing an input frame now reaches robot.send_action()
+```
+
+The wire `teleop_receive` command already rejected exactly those values, so the
+remote surface was stricter than the local API it delegates to
+(`HardwareRobot.start_teleop_receive` / `start_teleop_publish`, which accepted
+them too). The shared rule is now one validator,
+`strands_robots.mesh.security.validate_mesh_identifier`, called from
+`validate_command` and from both constructors; the two `HardwareRobot` entry
+points report through the tool envelope and validate before tearing down an
+existing stream, so a rejected call cannot stop a live one. Well-formed
+identifiers and their key expressions are unchanged.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -88,6 +88,14 @@ follower.stop_teleop("leader")
 
 `get_teleop_status()` on either side inspects current teleop state.
 
+`source_peer_id` and `device_name` are single segments of the mesh key
+expression `strands/{peer_id}/input/{device_name}`, so both must be plain
+identifiers (`[A-Za-z0-9_.-]+`, at most 128 chars). A Zenoh wildcard (`*`,
+`**`) or an embedded `/` is refused with a `ValidationError` rather than
+silently widening the stream: `source_peer_id="**"` would subscribe to
+`strands/**/input/leader` and apply joint commands from every publishing peer,
+not just the configured leader.
+
 ## Attach a mesh to a Simulation
 
 `Robot(name, mode="sim", mesh=True)` is the normal path: it resolves the

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1667,10 +1667,23 @@ class Robot(TeleopMixin, AgentTool):
             hz: Publishing frequency in Hz.
 
         Returns:
-            Status dict with topic and peer_id for the receiver to use.
+            Status dict with topic and peer_id for the receiver to use, or an
+            error dict when the mesh is inactive or ``device_name`` is not a
+            valid mesh identifier.
         """
         if not self.mesh or not self.mesh.alive:
             return {"status": "error", "content": [{"text": "Mesh not active. Cannot publish input."}]}
+
+        from strands_robots.mesh.security import ValidationError, validate_mesh_identifier
+
+        # ``device_name`` becomes a segment of the published key expression and
+        # a key in ``_input_publishers``. Validate before stopping any existing
+        # publisher for that name so a rejected call cannot tear down a live
+        # stream, and report through the tool envelope rather than raising.
+        try:
+            validate_mesh_identifier(device_name, "start_teleop_publish.device_name")
+        except ValidationError as exc:
+            return {"status": "error", "content": [{"text": str(exc)}]}
 
         from strands_robots.mesh import InputPublisher
 
@@ -1723,10 +1736,26 @@ class Robot(TeleopMixin, AgentTool):
                 Defaults to calling ``robot.send_action(action)``.
 
         Returns:
-            Status dict.
+            Status dict, or an error dict when the mesh is inactive or
+            ``source_peer_id`` / ``device_name`` is not a valid mesh
+            identifier.
         """
         if not self.mesh or not self.mesh.alive:
             return {"status": "error", "content": [{"text": "Mesh not active. Cannot receive input."}]}
+
+        from strands_robots.mesh.security import ValidationError, validate_mesh_identifier
+
+        # Both identifiers become segments of the subscribed key expression, so
+        # a Zenoh wildcard here would make this follower apply joint commands
+        # from every peer instead of the named leader. Validate before stopping
+        # any existing receiver for that key so a rejected call cannot tear
+        # down a live stream, and report through the tool envelope rather than
+        # raising past dispatch.
+        try:
+            validate_mesh_identifier(source_peer_id, "start_teleop_receive.source_peer_id")
+            validate_mesh_identifier(device_name, "start_teleop_receive.device_name")
+        except ValidationError as exc:
+            return {"status": "error", "content": [{"text": str(exc)}]}
 
         from strands_robots.mesh import InputReceiver
 

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -25,7 +25,11 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.mesh.security import ValidationError, validate_input_frame
+from strands_robots.mesh.security import (
+    ValidationError,
+    validate_input_frame,
+    validate_mesh_identifier,
+)
 
 _log_safety_event: Callable[..., None] | None
 try:  # audit is best-effort; never let an import issue break teleop apply
@@ -103,6 +107,11 @@ class InputPublisher:
 
     Runs in a background thread, polling the teleoperator and publishing
     normalized action dicts.
+
+    Raises:
+        ValidationError: ``device_name`` is not a valid mesh identifier
+            (see :func:`~strands_robots.mesh.security.validate_mesh_identifier`);
+            it is interpolated into the published key expression.
     """
 
     def __init__(
@@ -115,7 +124,11 @@ class InputPublisher:
     ) -> None:
         self.mesh = mesh
         self.teleoperator = teleoperator
-        self.device_name = device_name
+        # ``device_name`` is interpolated into this publisher's key expression
+        # (see ``topic``), so it carries the same identifier discipline as the
+        # wire ``teleop_receive`` surface -- a wildcard or an extra ``/``
+        # segment here publishes actuator data to a key no receiver named.
+        self.device_name = validate_mesh_identifier(device_name, "InputPublisher.device_name")
         self.method = method
         self.hz = hz
         self._running = False
@@ -264,6 +277,13 @@ class InputReceiver:
 
     Listens on ``strands/{source_peer_id}/input/{device_name}`` and calls
     ``robot.send_action(action)`` for each received frame.
+
+    Raises:
+        ValidationError: ``source_peer_id`` or ``device_name`` is not a valid
+            mesh identifier (see
+            :func:`~strands_robots.mesh.security.validate_mesh_identifier`).
+            Both are interpolated into the subscribed key expression, where a
+            Zenoh wildcard would widen this stream to every publishing peer.
     """
 
     def __init__(
@@ -276,8 +296,15 @@ class InputReceiver:
     ) -> None:
         self.mesh = mesh
         self.robot = robot
-        self.source_peer_id = source_peer_id
-        self.device_name = device_name
+        # Source scoping is the only thing that makes this a point-to-point
+        # stream: both identifiers are interpolated into the subscribed key
+        # expression (see ``topic``). Zenoh reads ``*`` / ``**`` as wildcards,
+        # so an unvalidated ``source_peer_id`` turns "follow this leader" into
+        # "apply joint commands from any peer that publishes an input frame".
+        # Same validator the wire ``teleop_receive`` path uses, so the accepted
+        # domains cannot diverge.
+        self.source_peer_id = validate_mesh_identifier(source_peer_id, "InputReceiver.source_peer_id")
+        self.device_name = validate_mesh_identifier(device_name, "InputReceiver.device_name")
         self._apply_fn = apply_fn or self._default_apply
         self._running = False
         self._sub_name: str | None = None

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -712,6 +712,53 @@ def _coerce_int(name: str, value: Any, *, lo: int, hi: int, default: int | None)
     return coerced
 
 
+def validate_mesh_identifier(value: Any, param: str) -> str:
+    """Validate one mesh key-expression segment and return it unchanged.
+
+    A mesh identifier is a single segment of a Zenoh key expression -- a
+    ``peer_id`` or a teleop ``device_name`` interpolated into
+    ``strands/{peer_id}/input/{device_name}`` by
+    :class:`~strands_robots.mesh.input.InputPublisher` and
+    :class:`~strands_robots.mesh.input.InputReceiver`.
+
+    Zenoh treats ``*`` and ``**`` as key-expression wildcards, so an
+    unvalidated segment silently widens a point-to-point subscription into a
+    match-any one: a receiver built with ``source_peer_id="**"`` subscribes to
+    ``strands/**/input/leader`` and applies joint commands from *every* peer on
+    the mesh, not just the configured leader. The remaining rejected shapes
+    (whitespace, NULs, C0 controls, shell metacharacters, ``/``) keep an
+    identifier from smuggling extra key segments or corrupting the log lines
+    and per-device state keys it also lands in.
+
+    Args:
+        value: Candidate identifier. Must be a non-empty ``str`` of at most
+            :data:`MAX_PEER_ID_LEN` characters matching :data:`_PEER_ID_RE`.
+        param: Dotted name of the parameter being validated, used verbatim as
+            the message prefix (e.g. ``"teleop_receive.source_peer_id"``).
+
+    Returns:
+        The validated identifier.
+
+    Raises:
+        ValidationError: The value is not a string, is empty, exceeds
+            :data:`MAX_PEER_ID_LEN`, or contains a character outside
+            :data:`_PEER_ID_RE` (wildcards included).
+    """
+    if not isinstance(value, str):
+        raise ValidationError(f"{param} must be a string (got {type(value).__name__})")
+    if not value:
+        raise ValidationError(f"{param} must be non-empty")
+    if len(value) > MAX_PEER_ID_LEN:
+        raise ValidationError(f"{param} length {len(value)} > MAX_PEER_ID_LEN ({MAX_PEER_ID_LEN}).")
+    if not _PEER_ID_RE.fullmatch(value):
+        raise ValidationError(
+            f"{param} must match [A-Za-z0-9_.-]+ "
+            "(no whitespace, NULs, control chars, shell metacharacters, "
+            "Zenoh wildcards ('*' / '**'), or '/')."
+        )
+    return value
+
+
 def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
     """Validate a mesh command and return a sanitised copy.
 
@@ -973,44 +1020,20 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
         out["steps"] = _coerce_int("steps", cmd.get("steps", 1), lo=1, hi=10_000, default=1)
 
     elif action == "teleop_receive":
-        source = cmd.get("source_peer_id", "")
-        if not isinstance(source, str) or not source:
-            raise ValidationError("teleop_receive requires non-empty source_peer_id")
-        # ``source_peer_id`` flows into ``r.start_teleop_receive(source, dev)``
-        # and into log messages, and is concatenated into device-key state. An
-        # authenticated peer publishing a ``teleop_receive`` cmd whose
-        # ``source_peer_id`` carries arbitrary unicode / control characters /
-        # NUL bytes / shell metacharacters has no business reaching downstream
-        # code, regardless of whether today's downstream consumers happen to
-        # be safe. The validator's job is to enforce the contract at the wire.
-        if len(source) > MAX_PEER_ID_LEN:
-            raise ValidationError(
-                f"teleop_receive.source_peer_id length {len(source)} > MAX_PEER_ID_LEN ({MAX_PEER_ID_LEN})."
-            )
-        if not _PEER_ID_RE.fullmatch(source):
-            raise ValidationError(
-                "teleop_receive.source_peer_id must match [A-Za-z0-9_.-]+ "
-                "(no whitespace, NULs, control chars, shell metacharacters, or '/')."
-            )
-        out["source_peer_id"] = source
+        # Both fields flow into ``r.start_teleop_receive(source, dev)``, which
+        # interpolates them into the ``strands/{peer}/input/{device}`` key
+        # expression the follower subscribes to, into log messages, and into
+        # the per-device state keys. An authenticated peer publishing a
+        # ``teleop_receive`` cmd whose identifiers carry a Zenoh wildcard or
+        # arbitrary unicode / control characters / shell metacharacters has no
+        # business reaching downstream code, regardless of whether today's
+        # downstream consumers happen to be safe. Shared with the constructors
+        # of InputReceiver / InputPublisher so the wire surface and the direct
+        # API cannot drift apart on what a valid identifier is.
+        out["source_peer_id"] = validate_mesh_identifier(cmd.get("source_peer_id", ""), "teleop_receive.source_peer_id")
         # device_name is optional and defaults to "leader" in _dispatch.
         if "device_name" in cmd:
-            device = cmd["device_name"]
-            if not isinstance(device, str):
-                raise ValidationError("teleop_receive.device_name must be a string")
-            # Same charset + length discipline for device_name -- it is
-            # concatenated into log messages and used as a key in internal
-            # state mappings (e.g. the per-device state dict).
-            if len(device) > MAX_PEER_ID_LEN:
-                raise ValidationError(
-                    f"teleop_receive.device_name length {len(device)} > MAX_PEER_ID_LEN ({MAX_PEER_ID_LEN})."
-                )
-            if not _PEER_ID_RE.fullmatch(device):
-                raise ValidationError(
-                    "teleop_receive.device_name must match [A-Za-z0-9_.-]+ "
-                    "(no whitespace, NULs, control chars, shell metacharacters, or '/')."
-                )
-            out["device_name"] = device
+            out["device_name"] = validate_mesh_identifier(cmd["device_name"], "teleop_receive.device_name")
 
     elif action == "teleop_stop":
         # device_name optional; if present, must be a string.
@@ -1206,6 +1229,7 @@ __all__ = [
     "validate_command",
     "validate_device_rpc",
     "validate_input_frame",
+    "validate_mesh_identifier",
     "MAX_DC_RPC_FUNC_LEN",
     "MAX_DC_RPC_PARAMS_BYTES",
     "LockoutError",

--- a/tests/mesh/test_teleop_identifier_source_scoping.py
+++ b/tests/mesh/test_teleop_identifier_source_scoping.py
@@ -1,0 +1,230 @@
+"""Teleop identifiers are validated wherever a stream is built, not only on the wire.
+
+``InputPublisher`` / ``InputReceiver`` interpolate ``device_name`` and
+``source_peer_id`` straight into the Zenoh key expression
+``strands/{peer_id}/input/{device_name}``. Zenoh reads ``*`` and ``**`` as
+key-expression wildcards, so an unvalidated ``source_peer_id`` converts
+"follow this one leader" into "apply joint commands from every peer that
+publishes an input frame" - the receiver hands them to
+``robot.send_action()`` with the source no longer scoped at all.
+
+The wire ``teleop_receive`` command already rejected those values through
+``validate_command``; the constructors and
+``HardwareRobot.start_teleop_publish`` / ``start_teleop_receive`` - the API the
+wire path itself delegates to, and the one a local caller uses - accepted them.
+These tests pin the shared contract: one validator
+(:func:`strands_robots.mesh.security.validate_mesh_identifier`) guards every
+surface, so the accepted domains cannot diverge.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.input import InputPublisher, InputReceiver
+from strands_robots.mesh.security import (
+    MAX_PEER_ID_LEN,
+    ValidationError,
+    validate_command,
+    validate_mesh_identifier,
+)
+
+#: Values the wire ``teleop_receive`` surface has always rejected. The
+#: wildcards are the safety-critical ones: they widen the subscription.
+BAD_IDENTIFIERS = [
+    "**",  # Zenoh "any number of segments" wildcard
+    "*",  # Zenoh single-segment wildcard
+    "leader*",  # partial wildcard still matches many keys
+    "a/b",  # extra key-expression segment
+    "evil; rm -rf /",
+    "evil$(whoami)",
+    "with space",
+    "with\nnewline",
+    "with\x00null",
+    "",
+    "a" * (MAX_PEER_ID_LEN + 1),
+]
+
+GOOD_IDENTIFIERS = ["leader", "leader-1", "peer.with.dots", "robot_99", "a"]
+
+
+class _FakeMesh:
+    """Minimal mesh: a peer_id plus a subscribe that records the key expression."""
+
+    def __init__(self, peer_id: str = "follower-1") -> None:
+        self.peer_id = peer_id
+        self.alive = True
+        self.subscribed: list[str] = []
+
+    def subscribe(self, topic: str, callback: Any = None, name: str | None = None) -> str:
+        self.subscribed.append(topic)
+        return name or topic
+
+    def unsubscribe(self, name: str) -> None:
+        return None
+
+
+class TestValidatorContract:
+    """The shared validator's accepted domain and message shape."""
+
+    @pytest.mark.parametrize("good", GOOD_IDENTIFIERS)
+    def test_clean_identifier_returned_unchanged(self, good: str) -> None:
+        assert validate_mesh_identifier(good, "p") == good
+
+    @pytest.mark.parametrize("bad", BAD_IDENTIFIERS)
+    def test_bad_identifier_rejected_and_names_the_parameter(self, bad: str) -> None:
+        with pytest.raises(ValidationError, match="InputReceiver.source_peer_id"):
+            validate_mesh_identifier(bad, "InputReceiver.source_peer_id")
+
+    def test_wildcard_rejection_message_names_wildcards(self) -> None:
+        """The message tells the caller why a wildcard is refused."""
+        with pytest.raises(ValidationError, match="Zenoh wildcards"):
+            validate_mesh_identifier("**", "p")
+
+    def test_non_string_rejected_with_type_name(self) -> None:
+        with pytest.raises(ValidationError, match="must be a string"):
+            validate_mesh_identifier(7, "p")
+
+    def test_identifier_at_length_limit_accepted(self) -> None:
+        value = "a" * MAX_PEER_ID_LEN
+        assert validate_mesh_identifier(value, "p") == value
+
+
+class TestReceiverSourceScoping:
+    """A receiver cannot be built with an identifier that widens its subscription."""
+
+    @pytest.mark.parametrize("bad", BAD_IDENTIFIERS)
+    def test_bad_source_peer_id_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError, match="InputReceiver.source_peer_id"):
+            InputReceiver(_FakeMesh(), object(), source_peer_id=bad)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad", BAD_IDENTIFIERS)
+    def test_bad_device_name_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError, match="InputReceiver.device_name"):
+            InputReceiver(_FakeMesh(), object(), source_peer_id="leader-1", device_name=bad)  # type: ignore[arg-type]
+
+    def test_wildcard_source_never_subscribes(self) -> None:
+        """Rejection happens before construction, so no wildcard key is declared."""
+        mesh = _FakeMesh()
+        with pytest.raises(ValidationError):
+            InputReceiver(mesh, object(), source_peer_id="**")  # type: ignore[arg-type]
+        assert mesh.subscribed == []
+
+    def test_clean_source_subscribes_to_the_exact_leader_key(self) -> None:
+        """The point-to-point key expression is unchanged by the guard."""
+        mesh = _FakeMesh()
+        recv = InputReceiver(mesh, object(), source_peer_id="leader-1", device_name="leader")  # type: ignore[arg-type]
+        assert recv.topic == "strands/leader-1/input/leader"
+        recv.start()
+        assert mesh.subscribed == ["strands/leader-1/input/leader"]
+        recv.stop()
+
+
+class TestPublisherDeviceName:
+    """A publisher cannot advertise actuator data on a wildcard key either."""
+
+    @pytest.mark.parametrize("bad", BAD_IDENTIFIERS)
+    def test_bad_device_name_rejected(self, bad: str) -> None:
+        with pytest.raises(ValidationError, match="InputPublisher.device_name"):
+            InputPublisher(_FakeMesh(), object(), device_name=bad)  # type: ignore[arg-type]
+
+    def test_clean_device_name_keeps_canonical_topic(self) -> None:
+        pub = InputPublisher(_FakeMesh(peer_id="leader-1"), object(), device_name="gamepad")  # type: ignore[arg-type]
+        assert pub.topic == "strands/leader-1/input/gamepad"
+
+
+class TestWireAndDirectApiAgree:
+    """Whatever the wire rejects, the API it delegates to rejects too."""
+
+    @pytest.mark.parametrize("bad", BAD_IDENTIFIERS)
+    def test_source_peer_id_domains_match(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            validate_command({"action": "teleop_receive", "source_peer_id": bad})
+        with pytest.raises(ValidationError):
+            InputReceiver(_FakeMesh(), object(), source_peer_id=bad)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("good", GOOD_IDENTIFIERS)
+    def test_accepted_shapes_match(self, good: str) -> None:
+        out = validate_command({"action": "teleop_receive", "source_peer_id": good, "device_name": good})
+        assert out["source_peer_id"] == good
+        recv = InputReceiver(_FakeMesh(), object(), source_peer_id=good, device_name=good)  # type: ignore[arg-type]
+        assert recv.source_peer_id == good
+        assert recv.device_name == good
+
+
+class _LiveStream:
+    """Stand-in for a running publisher/receiver that records being stopped."""
+
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop(self) -> dict[str, Any]:
+        self.stopped = True
+        return {}
+
+
+@pytest.fixture
+def hardware_robot() -> Any:
+    """A Robot carrying only the teleop state the guard needs (no hardware init)."""
+    from strands_robots.hardware_robot import Robot as HardwareRobot
+    from strands_robots.hardware_robot import RobotTaskState
+
+    hw = HardwareRobot.__new__(HardwareRobot)
+    hw.tool_name_str = "test_arm"
+    hw.mesh = _FakeMesh(peer_id="follower-1")
+    hw.peer_id = "follower-1"
+    hw.robot = object()
+    hw._task_state = RobotTaskState()
+    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="teleop_guard")
+    hw._shutdown_event = threading.Event()
+    return hw
+
+
+class TestHardwareRobotReportsThroughTheToolEnvelope:
+    """The agent-facing entry points reject the value without raising."""
+
+    @pytest.mark.parametrize("bad", ["**", "*", "a/b", ""])
+    def test_receive_returns_error_envelope(self, hardware_robot: Any, bad: str) -> None:
+        hw = hardware_robot
+        result = hw.start_teleop_receive(source_peer_id=bad)
+        assert result["status"] == "error"
+        assert "start_teleop_receive.source_peer_id" in result["content"][0]["text"]
+        # No receiver registered, no subscription declared.
+        assert getattr(hw, "_input_receivers", {}) == {}
+        assert hw.mesh.subscribed == []
+
+    def test_receive_rejects_wildcard_device_name(self, hardware_robot: Any) -> None:
+        hw = hardware_robot
+        result = hw.start_teleop_receive(source_peer_id="leader-1", device_name="**")
+        assert result["status"] == "error"
+        assert "start_teleop_receive.device_name" in result["content"][0]["text"]
+
+    def test_publish_returns_error_envelope(self, hardware_robot: Any) -> None:
+        hw = hardware_robot
+        result = hw.start_teleop_publish(teleoperator=object(), device_name="**")
+        assert result["status"] == "error"
+        assert "start_teleop_publish.device_name" in result["content"][0]["text"]
+        assert getattr(hw, "_input_publishers", {}) == {}
+
+    def test_rejected_receive_leaves_a_live_stream_running(self, hardware_robot: Any) -> None:
+        """Validation precedes the stop-existing-stream step, so nothing is lost."""
+        hw = hardware_robot
+        live = _LiveStream()
+        hw._input_receivers = {"leader-1/leader": live}
+        result = hw.start_teleop_receive(source_peer_id="**", device_name="leader")
+        assert result["status"] == "error"
+        assert live.stopped is False
+        assert hw._input_receivers == {"leader-1/leader": live}
+
+    def test_rejected_publish_leaves_a_live_stream_running(self, hardware_robot: Any) -> None:
+        hw = hardware_robot
+        live = _LiveStream()
+        hw._input_publishers = {"leader": live}
+        result = hw.start_teleop_publish(teleoperator=object(), device_name="a/b")
+        assert result["status"] == "error"
+        assert live.stopped is False
+        assert hw._input_publishers == {"leader": live}


### PR DESCRIPTION
## Problem

`InputPublisher` and `InputReceiver` interpolate `device_name` and `source_peer_id` straight into the Zenoh key expression `strands/{peer_id}/input/{device_name}`. Zenoh reads `*` and `**` as key-expression wildcards, and neither identifier was validated where the stream is built - so source scoping, the only thing that makes teleop point-to-point, could be switched off by a single argument:

```python
rx = InputReceiver(mesh, robot, source_peer_id="**")   # returned a receiver
rx.topic                                              # 'strands/**/input/leader'
rx.start()                                            # subscribed to the wildcard
```

Verified live on a Zenoh session (`STRANDS_MESH_LOCAL_DEV=true`): with that receiver running, a peer named `rogue-peer-xyz` published three input frames on its own topic and all three reached `robot.send_action()`:

```
source_peer_id='**' -> topic 'strands/**/input/leader'
  applied frames from rogue peer: 3  [{'j0': 1.0}, {'j0': -1.0}]
source_peer_id='*'  -> topic 'strands/*/input/leader'
  applied frames from rogue peer: 3
source_peer_id='attacker-1' -> topic 'strands/attacker-1/input/leader'
  applied frames from rogue peer: 0      # correctly scoped
```

The existing hardening on that path (E-stop lockout gate, frame freshness, the 100 Hz apply ceiling, `validate_input_frame` key/value bounds) all still ran - every rogue frame was legitimately shaped, so nothing rejected it. Source scoping was the check that had gone missing.

The same values were already refused on the wire:

```
validate_command(source_peer_id='**') -> REJECTED: must match [A-Za-z0-9_.-]+ ...
validate_command(source_peer_id='*')  -> REJECTED
```

So the remote `teleop_receive` surface was stricter than the local API it delegates to. `HardwareRobot.start_teleop_receive` and `start_teleop_publish` - the methods a local caller and the mesh dispatcher both go through - performed no validation of their own.

## Change

One validator, `strands_robots.mesh.security.validate_mesh_identifier(value, param)`, is now the single definition of a mesh key-expression segment: a non-empty `str`, at most `MAX_PEER_ID_LEN` chars, matching `_PEER_ID_RE`. It rejects wildcards, embedded `/`, whitespace, NULs, C0 controls and shell metacharacters, and its message names the offending parameter and calls out wildcards explicitly.

It is called from:

- `InputReceiver.__init__` for `source_peer_id` and `device_name`, before any subscription is declared;
- `InputPublisher.__init__` for `device_name`;
- `HardwareRobot.start_teleop_receive` / `start_teleop_publish`, reported through the tool envelope (`status="error"`) rather than raised past dispatch, and evaluated **before** the stop-existing-stream step so a rejected call cannot tear down a live teleop session;
- `validate_command`, replacing two hand-duplicated copies of the same length+charset logic, so the wire surface and the direct API cannot drift apart on what a valid identifier is.

Well-formed identifiers and the key expressions they build are unchanged (`strands/leader-1/input/leader` still exactly that), and the pre-existing wire messages keep their `must match` / `MAX_PEER_ID_LEN` wording.

## Visual artifact

A MuJoCo follower (Panda) with a mesh receiver built the two ways, headless (`MUJOCO_GL=egl`). A peer named `rogue-attacker-9k` - which nobody configured as this follower's leader - ramps all seven joints toward a pose at the nominal 50 Hz publish rate. Left: before, the wildcard receiver accepts all 60 frames and the arm sweeps to the rogue pose. Right: after, the same constructor call is refused, no subscription exists, and the arm stays at rest under the identical traffic.

![teleop wildcard source scoping](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-wildcard-source/teleop_wildcard_source.gif)

| | before | after |
|---|---|---|
| `InputReceiver(source_peer_id="**")` | returned a receiver, subscribed `strands/**/input/leader` | `ValidationError` |
| rogue-peer frames applied | 60 | 0 |
| `joint1` travel | 0.004 -> 1.386 rad (79 deg) | 0.009 rad range (gravity settle only) |

L1 between the final frames: 2.71e6.

## Tests

`tests/mesh/test_teleop_identifier_source_scoping.py` (79 cases):

- the validator's accepted domain, its `MAX_PEER_ID_LEN` boundary, and that a wildcard rejection names wildcards;
- every bad identifier refused by `InputReceiver` (both fields) and `InputPublisher`, plus proof no subscription is declared on the rejected path;
- clean identifiers still build the exact point-to-point key expression;
- both `HardwareRobot` entry points return the error envelope, register nothing, and leave an already-running stream alone;
- a parity class asserting the wire path and the constructors accept and reject the same values.

Pre-fix (source stashed, the new-symbol import and its unit class removed so the module still collects): **53 failed, 7 passed**. Post-fix: **79 passed**.

## Gate

```
ruff check strands_robots tests tests_integ          # All checks passed!
ruff format --check strands_robots tests tests_integ # clean
mypy strands_robots tests tests_integ               # clean apart from the
    # pre-existing environment-only simulation/ik.py:105 qpsolvers no-any-return
MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly
    # 12484 passed, 260 skipped in 434s
```

Docs: `docs/mesh.md` teleop section states the identifier shape and why a wildcard is refused; `CHANGELOG.md` entry added.

---

## Round changelog

**Round 1 - sync with `main`.** Mechanical merge only. `main` picked up the MuJoCo 3.11 mass-matrix fix (#1682), which every open branch needed to get a green `Test and Lint` run; the only conflict was CHANGELOG entry ordering under `[Unreleased]`, resolved by keeping both entries. The change under review is byte-identical.

**Round 2 - sync with `main` again (`ca50605`).** No review feedback addressed in this round; nothing in the change under review moved. `main` advanced to `44d4f6b` (#1675, #1682) and this branch went `CONFLICTING` on `CHANGELOG.md` alone - again purely entry ordering under `[Unreleased]`, resolved by keeping both entries in newest-merged-first order. Verified the code side is untouched: `git diff origin/main...HEAD` is the same 5 non-changelog files at +385/-42, and `tests/mesh/test_teleop_identifier_source_scoping.py` is 79 passed with `ruff check` / `ruff format --check` clean.

Note the branch update dismissed the prior approval (`APPROVED` -> `REVIEW_REQUIRED`), so this needs a re-approval rather than a fresh review - the reviewed diff has not changed since the approval.

This PR is one of six that were simultaneously approved, green, and blocked only by this changelog conflict. Filed #1688 for the root cause: every entry lands at the same `## [Unreleased]` anchor, so each merge conflicts every other open PR and each resolution dismisses that PR's approval. 12 of the 13 active PRs touch the file. Per the interim mitigation recorded there, the other five are deliberately left `CONFLICTING` rather than batch-rebased, since rebasing them now would dismiss five approvals at once.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1676-teleop-wildcard-source-scoping.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

The push dismissed the prior approval. The reviewed diff is otherwise byte-identical: the delta is the fragment move plus the merge.
