### PR TITLE
fix(robot): Robot() forwards the base position it was given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
+
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -241,7 +241,12 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
             via the simulation tool (``add_camera`` action). They cannot
             be passed to the factory yet.
 
-        position: Robot position in sim world [x, y, z].
+        position: Robot base position in the sim world, ``[x, y, z]``. Passed
+            through to the backend's ``add_robot`` verbatim, so the backend's
+            contract governs: omitting it spawns at the origin, and a
+            wrong-length, non-numeric or non-finite vector is refused with an
+            actionable message (surfaced here as ``RuntimeError``) instead of
+            being replaced by the origin.
         data_config: Data configuration name for observation/action schema.
                      Defaults to the canonical robot name. For multi-camera
                      setups, specify explicitly: ``data_config="so100_dualcam"``.
@@ -338,11 +343,23 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
                 msg = content[0].get("text", str(result)) if content else str(result)
                 raise RuntimeError(f"Failed to create sim world for {canonical!r}: {msg}")
 
+            # Forward ``position`` exactly as the caller wrote it. Reading it
+            # by truthiness (``position or [0.0, 0.0, 0.0]``) broke the
+            # parameter twice over: a NumPy pose - what any pose arithmetic
+            # produces, and a value ``add_robot`` itself accepts - raised a bare
+            # ``ValueError: truth value of an array ... is ambiguous`` out of the
+            # factory, and an empty vector read as "omitted", so the origin was
+            # substituted for a caller mistake that ``add_robot`` refuses with an
+            # actionable message. Membership (``is not None``) is the only
+            # correct supplied-test for a vector, and here even that is
+            # unnecessary: ``position=None`` is what ``add_robot`` already
+            # documents as "spawn at the origin", so passing it through keeps ONE
+            # source of truth for that default instead of a copy that can drift.
             result = sim.add_robot(
                 name=name,
                 urdf_path=urdf_path,
                 data_config=data_config or canonical,
-                position=position or [0.0, 0.0, 0.0],
+                position=position,
             )
             if result.get("status") == "error":
                 content = result.get("content", [])

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -273,6 +273,115 @@ class TestRobotFactory:
         assert callable(lr)
 
 
+class TestFactoryForwardsPosition:
+    """``Robot(position=...)`` reaches the backend exactly as the caller wrote it.
+
+    The factory is a thin wrapper over ``add_robot``, which validates a base
+    pose up front: a wrong-length, non-numeric or non-finite vector is refused
+    with an actionable message, an omitted pose spawns at the origin, and a
+    NumPy pose is accepted. Reading the parameter by truthiness in the factory
+    made the wrapper both less capable and less safe than the method it wraps -
+    an empty vector read as "omitted" so the origin was substituted for a caller
+    mistake ``add_robot`` refuses, and a NumPy pose raised a bare
+    ``ValueError: truth value of an array ... is ambiguous``.
+    """
+
+    MJCF = """<mujoco model="test_arm">
+      <worldbody>
+        <light pos="0 0 3"/>
+        <geom type="plane" size="1 1 0.1"/>
+        <body name="link0" pos="0 0 0.1">
+          <joint name="joint0" type="hinge" axis="0 0 1"/>
+          <geom type="capsule" size="0.02" fromto="0 0 0  0 0 0.2"/>
+        </body>
+      </worldbody>
+      <actuator><motor joint="joint0" ctrlrange="-1 1"/></actuator>
+    </mujoco>"""
+
+    @classmethod
+    def _model(cls, tmp_path):
+        """Write the minimal inline arm so no downloaded asset is needed."""
+        path = tmp_path / "test_arm.xml"
+        path.write_text(cls.MJCF)
+        return str(path)
+
+    def _spawned_position(self, tmp_path, **kwargs):
+        """Return the base position the factory actually gave the backend."""
+        sim = Robot("so100", mode="sim", urdf_path=self._model(tmp_path), mesh=False, **kwargs)
+        try:
+            return list(sim._world.robots["so100"].position)
+        finally:
+            sim.destroy()
+
+    def test_omitted_position_spawns_at_the_origin(self, tmp_path):
+        """The documented default survives: no position means the origin."""
+        pytest.importorskip("mujoco")
+        assert self._spawned_position(tmp_path) == [0.0, 0.0, 0.0]
+
+    def test_list_position_is_forwarded_unchanged(self, tmp_path):
+        pytest.importorskip("mujoco")
+        assert self._spawned_position(tmp_path, position=[0.4, 0.2, 0.1]) == [0.4, 0.2, 0.1]
+
+    def test_numpy_position_is_forwarded_unchanged(self, tmp_path):
+        """A pose computed with NumPy is what pose arithmetic produces, and
+        ``add_robot`` accepts it; the factory must not reject it."""
+        pytest.importorskip("mujoco")
+        np = pytest.importorskip("numpy")
+        assert self._spawned_position(tmp_path, position=np.array([0.4, 0.2, 0.1])) == [0.4, 0.2, 0.1]
+
+    def test_empty_position_is_refused_not_replaced_by_the_origin(self, tmp_path):
+        """An empty vector is a caller mistake, not a request for the default.
+
+        Substituting the origin would place the robot somewhere the caller never
+        asked for while reporting success.
+        """
+        pytest.importorskip("mujoco")
+        with pytest.raises(RuntimeError, match="3-element vector"):
+            Robot("so100", mode="sim", urdf_path=self._model(tmp_path), mesh=False, position=[])
+
+    def test_non_finite_position_is_refused(self, tmp_path):
+        """nan/inf would propagate through the whole physics state."""
+        pytest.importorskip("mujoco")
+        with pytest.raises(RuntimeError, match="finite numbers"):
+            Robot(
+                "so100",
+                mode="sim",
+                urdf_path=self._model(tmp_path),
+                mesh=False,
+                position=[float("nan"), 0.0, 0.0],
+            )
+
+    def test_factory_and_add_robot_agree_on_every_position(self, tmp_path):
+        """Parity: the wrapper accepts a pose if and only if the backend does.
+
+        Any value where the two verdicts differ is a pose the caller can only
+        express through one of the two entry points.
+        """
+        pytest.importorskip("mujoco")
+        np = pytest.importorskip("numpy")
+        from strands_robots import Simulation
+
+        model = self._model(tmp_path)
+        cases = [[], [0.5], [0.4, 0.2, 0.1], [float("inf"), 0.0, 0.0], np.array([0.4, 0.2, 0.1])]
+
+        for position in cases:
+            sim = Simulation(tool_name="parity", mesh=False)
+            try:
+                sim.create_world()
+                backend_accepts = sim.add_robot(name="so100", urdf_path=model, position=position)["status"] != "error"
+            finally:
+                sim.destroy()
+
+            try:
+                factory = Robot("so100", mode="sim", urdf_path=model, mesh=False, position=position)
+                factory.destroy()
+                factory_accepts = True
+            except RuntimeError:
+                factory_accepts = False
+
+            assert factory_accepts is backend_accepts, f"verdicts differ for position={position!r}"
+
+
 class TestRobotRealMode:
     """Tests for mode='real' path (mocked - no physical hardware)."""
 


### PR DESCRIPTION
## Problem

`Robot()` is a thin factory over `add_robot`, which validates a base pose up front: an omitted pose spawns at the origin, a NumPy pose is accepted, and a wrong-length / non-numeric / non-finite vector is refused with an actionable message. The factory decided whether the caller supplied a position by testing the vector itself:

```python
# strands_robots/robot.py
position=position or [0.0, 0.0, 0.0],
```

That made the wrapper both less capable and less safe than the method it wraps.

| `position=` | `sim.add_robot(...)` | `Robot(...)` before | `Robot(...)` after |
|---|---|---|---|
| omitted | success, base `[0.0, 0.0, 0.0]` | success, base `[0.0, 0.0, 0.0]` | unchanged |
| `np.array([0.4, 0.2, 0.0])` | success, base `[0.4, 0.2, 0.0]` | **`ValueError: truth value of an array with more than one element is ambiguous`** | success, base `[0.4, 0.2, 0.0]` |
| `[]` | error: `'position' must be a 3-element vector, got 0 ([])` | **success, base silently `[0.0, 0.0, 0.0]`** | `RuntimeError` carrying that message |
| `[0.5]` | error: 3-element | error (3-element) | unchanged |
| `[nan, 0, 0]` | error: finite numbers | error (finite) | unchanged |

Two distinct failures from the one read:

- **A NumPy pose is rejected by the wrapper and accepted by the wrapped method.** A pose is normally the product of arithmetic (`base + offset`), so an `ndarray` is the natural value to pass; the bare ambiguous-truth `ValueError` comes out of the factory before `add_robot` is ever reached.
- **An empty vector reads as "omitted", so the origin is substituted.** That is a caller mistake, not a request for the default, and `add_robot` refuses it precisely so a robot is never placed somewhere nobody asked for while the call reports success. Routing through the factory made that guard unreachable.

## Change

Forward `position` verbatim. `None` is already what `add_robot` documents as "spawn at the origin", so the factory's duplicate `[0.0, 0.0, 0.0]` default is deleted rather than moved behind an `is not None` test - one source of truth for that default instead of a copy that can drift from the backend's. The `position` docstring now states that the backend's contract governs and that an unusable vector surfaces as `RuntimeError`.

## Visual artifact

Same two calls run against both trees (MuJoCo, headless `egl`). The green pad marks the requested base position `[0.4, 0.2, 0.0]`; before, the only world the factory would build was the one it invented at the origin.

![Robot() base position before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/factory-position/factory_position.png)

L1 between panels 1.58e6 - the arm is genuinely in a different place, not a caption change.

## Tests

`TestFactoryForwardsPosition` in `tests/test_robot_factory.py` (6 tests, minimal inline MJCF so no asset download): the omitted-pose default, a list pose, a NumPy pose, the empty vector, a non-finite vector, and a parity test asserting the factory accepts a pose **if and only if** `add_robot` does - any value where the two verdicts differ is a pose expressible through only one of the two entry points.

Pre-fix (source reverted, tests kept): **3 failed, 3 passed**

```
FAILED test_numpy_position_is_forwarded_unchanged - ValueError: The truth value of an array with more than one element is ambiguous
FAILED test_empty_position_is_refused_not_replaced_by_the_origin - Failed: DID NOT RAISE RuntimeError
FAILED test_factory_and_add_robot_agree_on_every_position - verdicts differ for position=[]
```

Post-fix: 6 passed.

## Gate

`ruff check` + `ruff format --check` + `mypy` clean on `strands_robots tests tests_integ`; full suite `MUJOCO_GL=egl pytest tests` **12411 passed / 260 skipped** (424s). Branched off `b046037c`.

---

**Synced with `main`** — mechanical merge only. `main` picked up the MuJoCo 3.11 mass-matrix fix (#1682), which every open branch needed to get a green `Test and Lint` run; the only conflict was CHANGELOG entry ordering under `[Unreleased]`, resolved by keeping both entries. The change under review is byte-identical; the sync commit dismissed the prior approval, so this needs a re-approval rather than a fresh review. CI is green on the synced head.