### PR TITLE
fix(rendering): HybridCompositor refuses render options it cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: HybridCompositor refuses render options it cannot honor
+
+Every option the hybrid compositor takes was coerced rather than checked, so a
+value with no usable interpretation still returned a frame - just not the one
+the caller asked for. `depth_epsilon` (the "this pixel has no geometry" depth
+threshold) was stored with a bare `float(...)`:
+
+```python
+frame = HybridCompositor(sim, depth_epsilon=float("nan")).render("look")
+frame.foreground_mask.mean()   # 0.0000 - the whole robot is gone
+```
+
+`fg_depth > nan` is false for every pixel, so the entire simulation foreground
+read as empty and the composite was the background alone, with no diagnostic.
+`inf` did the same; a negative threshold did the opposite, admitting the no-hit
+pixels (Isaac's RTX annotator reports them as `0`) that the parameter exists to
+exclude, painting simulation sky over the background.
+
+`feather_pixels` was clamped with `max(0, int(value))`, so `-5` and `2.7`
+silently became `0` and `2` - the first disabling the seam blend the parameter
+exists to apply. And `render(width=..., height=...)` read its size with
+`width or self.default_width`, so a supplied `0` read as "not supplied" and the
+frame came back at the default size, even though that same `0` is refused when
+it reaches `get_camera_params` as `default_width`.
+
+All four options are now validated where they are supplied - pixel counts
+through the shared `positive_whole_number_error` domain, `depth_epsilon` as a
+finite distance in meters `>= 0` (`0` remains valid: "only an exactly-zero
+depth is no geometry"), and the render size read by membership rather than
+truthiness - so a `default_width` mistake names `default_width` instead of
+surfacing later as a render error. Integral options are normalized to plain
+`int`, so a `np.int64` size no longer leaks into the requested camera size.
+
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,38 +5,67 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: HybridCompositor refuses render options it cannot honor
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-Every option the hybrid compositor takes was coerced rather than checked, so a
-value with no usable interpretation still returned a frame - just not the one
-the caller asked for. `depth_epsilon` (the "this pixel has no geometry" depth
-threshold) was stored with a bare `float(...)`:
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
 ```python
-frame = HybridCompositor(sim, depth_epsilon=float("nan")).render("look")
-frame.foreground_mask.mean()   # 0.0000 - the whole robot is gone
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
 ```
 
-`fg_depth > nan` is false for every pixel, so the entire simulation foreground
-read as empty and the composite was the background alone, with no diagnostic.
-`inf` did the same; a negative threshold did the opposite, admitting the no-hit
-pixels (Isaac's RTX annotator reports them as `0`) that the parameter exists to
-exclude, painting simulation sky over the background.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
 
-`feather_pixels` was clamped with `max(0, int(value))`, so `-5` and `2.7`
-silently became `0` and `2` - the first disabling the seam blend the parameter
-exists to apply. And `render(width=..., height=...)` read its size with
-`width or self.default_width`, so a supplied `0` read as "not supplied" and the
-frame came back at the default size, even though that same `0` is refused when
-it reaches `get_camera_params` as `default_width`.
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
 
-All four options are now validated where they are supplied - pixel counts
-through the shared `positive_whole_number_error` domain, `depth_epsilon` as a
-finite distance in meters `>= 0` (`0` remains valid: "only an exactly-zero
-depth is no geometry"), and the render size read by membership rather than
-truthiness - so a `default_width` mistake names `default_width` instead of
-surfacing later as a render error. Integral options are normalized to plain
-`int`, so a `np.int64` size no longer leaks into the requested camera size.
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
 
 
 ### Fixed: the state and action sides agree on what a hardware observation is

--- a/changelog.d/1679-compositor-option-guards.md
+++ b/changelog.d/1679-compositor-option-guards.md
@@ -1,0 +1,32 @@
+### Fixed: HybridCompositor refuses render options it cannot honor
+
+Every option the hybrid compositor takes was coerced rather than checked, so a
+value with no usable interpretation still returned a frame - just not the one
+the caller asked for. `depth_epsilon` (the "this pixel has no geometry" depth
+threshold) was stored with a bare `float(...)`:
+
+```python
+frame = HybridCompositor(sim, depth_epsilon=float("nan")).render("look")
+frame.foreground_mask.mean()   # 0.0000 - the whole robot is gone
+```
+
+`fg_depth > nan` is false for every pixel, so the entire simulation foreground
+read as empty and the composite was the background alone, with no diagnostic.
+`inf` did the same; a negative threshold did the opposite, admitting the no-hit
+pixels (Isaac's RTX annotator reports them as `0`) that the parameter exists to
+exclude, painting simulation sky over the background.
+
+`feather_pixels` was clamped with `max(0, int(value))`, so `-5` and `2.7`
+silently became `0` and `2` - the first disabling the seam blend the parameter
+exists to apply. And `render(width=..., height=...)` read its size with
+`width or self.default_width`, so a supplied `0` read as "not supplied" and the
+frame came back at the default size, even though that same `0` is refused when
+it reaches `get_camera_params` as `default_width`.
+
+All four options are now validated where they are supplied - pixel counts
+through the shared `positive_whole_number_error` domain, `depth_epsilon` as a
+finite distance in meters `>= 0` (`0` remains valid: "only an exactly-zero
+depth is no geometry"), and the render size read by membership rather than
+truthiness - so a `default_width` mistake names `default_width` instead of
+surfacing later as a render error. Integral options are normalized to plain
+`int`, so a `np.int64` size no longer leaks into the requested camera size.

--- a/strands_robots/rendering/compositor.py
+++ b/strands_robots/rendering/compositor.py
@@ -45,15 +45,81 @@ single-render-thread wrapper).
 from __future__ import annotations
 
 import logging
+import math
+import numbers
 from dataclasses import dataclass
 from typing import Any, Protocol
 
 import numpy as np
 
+from ..utils import positive_whole_number_error
 from .backgrounds import BackgroundRenderer, PanoramaBackground
 from .camera import CameraParams
 
 logger = logging.getLogger(__name__)
+
+
+def _feather_pixels_error(value: Any) -> str | None:
+    """Error text when ``value`` is not a usable feather radius.
+
+    A feather radius is a whole number of pixels, with ``0`` meaning "no
+    blend". Nothing else can be honored: :func:`feather_mask` builds a
+    ``2 * radius + 1`` box kernel, so a fractional or non-finite radius has no
+    kernel and a negative one has no edge to soften. Those values used to be
+    coerced with ``max(0, int(value))``, which turned every one of them into
+    ``0`` - silently disabling the very seam blend the caller asked for.
+    ``bool`` is rejected explicitly: it is an ``int`` subclass whose ``True``
+    would act as a 1-pixel radius.
+
+    Args:
+        value: The caller-supplied radius.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    message = f"HybridCompositor: feather_pixels must be a whole number of pixels >= 0, got {value!r}."
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return message
+    numeric = float(value)
+    # ``isfinite`` first: ``int(nan)`` raises, so short-circuit before the
+    # integrality check below.
+    if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 0:
+        return message
+    return None
+
+
+def _depth_epsilon_error(value: Any) -> str | None:
+    """Error text when ``value`` is not a usable no-geometry depth threshold.
+
+    The threshold is compared against the foreground depth buffer
+    (``fg_depth > depth_epsilon`` selects "the simulation saw geometry here"),
+    so only a finite, non-negative distance in meters can be honored:
+
+    * ``nan`` makes that comparison ``False`` for every pixel, so the whole
+      simulation foreground reads as empty and the composite is the background
+      alone - the robot silently disappears from the frame.
+    * ``inf`` discards every pixel for the same reason.
+    * a negative threshold admits the no-hit pixels the parameter exists to
+      exclude (Isaac's RTX annotator reports them as ``0``), painting
+      simulation sky over the background.
+
+    ``0`` is a legitimate setting: it means "only an exactly-zero depth counts
+    as no geometry". ``bool`` is rejected explicitly - a truth value is not a
+    distance, and ``True`` would act as a 1 m threshold.
+
+    Args:
+        value: The caller-supplied threshold, in meters.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    message = f"HybridCompositor: depth_epsilon must be a finite distance in meters >= 0, got {value!r}."
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return message
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0.0:
+        return message
+    return None
 
 
 class FrameSource(Protocol):
@@ -106,16 +172,29 @@ class HybridCompositor:
             (e.g. ``strands_robots.simulation.Simulation``).
         background: any :class:`BackgroundRenderer`. Defaults to a procedural
             panorama so hybrid rendering works out of the box with zero ML deps.
-        default_width: image width if not overridden per call. ``None`` defers
-            to the engine's per-camera configuration.
-        default_height: image height if not overridden per call.
+        default_width: image width if not overridden per call, a positive
+            whole number of pixels (the shared media domain - see
+            :func:`~strands_robots.utils.positive_whole_number_error`).
+            ``None`` defers to the engine's per-camera configuration.
+        default_height: image height if not overridden per call, same domain.
         feather_pixels: width (in pixels) of a soft edge blend between
             foreground and background to hide the offscreen-renderer's
-            anti-aliasing seam. ``0`` disables feathering. Default ``1``.
+            anti-aliasing seam. A whole number of pixels; ``0`` disables
+            feathering. Default ``1``.
         depth_epsilon: foreground depth at or below this (meters) is treated
             as "no geometry" -- those pixels show the background. Isaac's RTX
             depth annotator reports no-hit pixels as ``0`` (or non-finite);
             MuJoCo pins them to the far clip. Both extremes read as background.
+            A finite distance in meters, ``>= 0``.
+
+    Raises:
+        ValueError: if any option cannot be honored -- a ``feather_pixels``
+            that is not a whole pixel count ``>= 0``, a ``depth_epsilon`` that
+            is not a finite distance ``>= 0`` (a non-finite threshold discards
+            the entire foreground, so the robot would vanish from the frame),
+            or a ``default_width`` / ``default_height`` that is not a positive
+            whole number. Every one of these was previously coerced or clamped
+            into a plausible-but-different render.
 
     Example:
 
@@ -140,11 +219,23 @@ class HybridCompositor:
         feather_pixels: int = 1,
         depth_epsilon: float = 1e-4,
     ) -> None:
+        if text := _feather_pixels_error(feather_pixels):
+            raise ValueError(text)
+        if text := _depth_epsilon_error(depth_epsilon):
+            raise ValueError(text)
+        for label, size in (("default_width", default_width), ("default_height", default_height)):
+            # ``None`` means "defer to the engine"; any supplied size must be a
+            # size the engine can render, checked here rather than at the first
+            # render so the error names the constructor argument.
+            if size is not None and (size_text := positive_whole_number_error(size, label, "HybridCompositor")):
+                raise ValueError(size_text)
         self.sim = sim
         self.background: BackgroundRenderer = background or PanoramaBackground()
-        self.default_width = default_width
-        self.default_height = default_height
-        self.feather_pixels = max(0, int(feather_pixels))
+        # Normalize to plain ints/floats: these flow into the requested camera
+        # size and into status/cache keys, so a np.int64 must not leak through.
+        self.default_width = None if default_width is None else int(default_width)
+        self.default_height = None if default_height is None else int(default_height)
+        self.feather_pixels = int(feather_pixels)
         self.depth_epsilon = float(depth_epsilon)
         # Cache of background renders keyed by (camera_name, W, H, background
         # name) + a rounded hash of the camera pose/intrinsics. The background
@@ -163,15 +254,36 @@ class HybridCompositor:
     ) -> CompositeFrame:
         """Render one depth-composited frame of the current sim state.
 
+        Args:
+            camera_name: the camera to render, as named to the engine.
+            width: image width in pixels, a positive whole number. ``None``
+                falls back to ``default_width``, then to the engine's own
+                per-camera configuration.
+            height: image height in pixels, same domain.
+
+        Returns:
+            The composited :class:`CompositeFrame`.
+
         Raises:
+            ValueError: if ``width`` or ``height`` is supplied but is not a
+                positive whole number of pixels.
             RuntimeError: if the backend's ``get_frame`` returns no depth
                 buffer (e.g. the Newton backend, which renders RGB only) --
                 compositing without depth would silently paint the background
                 over/under the wrong pixels, and silent wrong output is
                 forbidden. Use a depth-capable backend (MuJoCo, Isaac).
         """
+        for label, size in (("width", width), ("height", height)):
+            if size is not None and (text := positive_whole_number_error(size, label, "HybridCompositor.render")):
+                raise ValueError(text)
+        # Read the requested size by membership, not truthiness: ``width or
+        # self.default_width`` read a supplied ``0`` as "not supplied" and fell
+        # back to the default size, so a size no engine can render returned a
+        # frame at a different one.
         cam = self.sim.get_camera_params(
-            camera_name, width=width or self.default_width, height=height or self.default_height
+            camera_name,
+            width=self.default_width if width is None else int(width),
+            height=self.default_height if height is None else int(height),
         )
         fg_rgb, fg_depth = self.sim.get_frame(camera_name, width=cam.width, height=cam.height)
         if fg_depth is None:

--- a/tests/rendering/test_compositor_option_guards.py
+++ b/tests/rendering/test_compositor_option_guards.py
@@ -1,0 +1,158 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``HybridCompositor`` only accepts render options it can actually honor.
+
+Every option the compositor takes used to be coerced rather than checked, so a
+value with no usable interpretation still returned a frame - just a different
+one than the caller asked for:
+
+* ``depth_epsilon`` was stored with a bare ``float(...)``. A non-finite
+  threshold makes ``fg_depth > depth_epsilon`` false for every pixel, so the
+  entire simulation foreground reads as empty and the composite is the
+  background alone: the robot silently disappears. A negative threshold does
+  the opposite, admitting the no-hit pixels (Isaac reports them as ``0``) that
+  ``test_isaac_style_zero_and_inf_depth_reads_as_background`` pins as
+  background.
+* ``feather_pixels`` was clamped with ``max(0, int(value))``, so ``-5`` became
+  ``0`` - silently disabling the seam blend the parameter exists to apply.
+* ``width`` / ``height`` were read with ``width or self.default_width``, so a
+  supplied ``0`` read as "not supplied" and the frame came back at the default
+  size - even though the same ``0`` is refused by the backend's
+  ``get_camera_params`` when it arrives as ``default_width``.
+
+The compositor is pure numpy over the structural ``FrameSource`` protocol, so
+these guards are pinned against a fake frame source with no GL / sim deps.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import HybridCompositor
+
+from .test_compositor import ZFAR, FakeBackground, FakeSim, _square_depth
+
+# Thresholds that are not a finite, non-negative distance in meters: the two
+# non-finite floats that discard every foreground pixel, a negative distance, a
+# numeric string, ``True`` (an ``int`` subclass that would act as a 1 m
+# threshold) and a missing value.
+UNUSABLE_DEPTH_EPSILON = [math.nan, math.inf, -math.inf, -1.0, "1e-4", True, None]
+
+# Radii that are not a whole pixel count >= 0.
+UNUSABLE_FEATHER_PIXELS = [-1, -5, 2.7, math.nan, math.inf, True, "3", None]
+
+# Sizes no engine can render, including the ``0`` that truthiness read as absent.
+UNUSABLE_SIZES = [0, -64, 2.5, math.nan, True, "64", []]
+
+
+def _compositor(**kwargs) -> HybridCompositor:
+    """A compositor over the fake square-geometry frame source."""
+    return HybridCompositor(FakeSim(_square_depth()), background=FakeBackground(), **kwargs)
+
+
+@pytest.mark.parametrize("depth_epsilon", UNUSABLE_DEPTH_EPSILON)
+def test_unusable_depth_epsilon_is_refused_instead_of_discarding_the_foreground(depth_epsilon) -> None:
+    """A threshold that cannot select geometry is refused, naming it and the value.
+
+    The default threshold composites real geometry, so silently accepting one of
+    these would have returned a frame with nothing simulated in it.
+    """
+    honored = _compositor(feather_pixels=0).render("cam")
+    assert honored.foreground_mask.any(), "fixture must show foreground under the default threshold"
+
+    with pytest.raises(ValueError, match="depth_epsilon"):
+        _compositor(depth_epsilon=depth_epsilon)
+
+
+def test_zero_depth_epsilon_is_accepted_as_the_exactly_zero_convention() -> None:
+    """``0`` means "only an exactly-zero depth is no geometry" - a real setting."""
+    frame = _compositor(depth_epsilon=0.0, feather_pixels=0).render("cam")
+    assert frame.foreground_mask[5, 7]
+
+
+@pytest.mark.parametrize("feather_pixels", UNUSABLE_FEATHER_PIXELS)
+def test_unusable_feather_pixels_is_refused_instead_of_clamped_to_off(feather_pixels) -> None:
+    """A radius with no box kernel is refused rather than silently becoming ``0``.
+
+    Feathering is observable in the output, so the clamp turned "blend the seam"
+    into "do not blend it" with no diagnostic.
+    """
+    hard = _compositor(feather_pixels=0).render("cam")
+    soft = _compositor(feather_pixels=2).render("cam")
+    assert not np.array_equal(hard.rgb, soft.rgb), "feathering must be observable for the clamp to matter"
+
+    with pytest.raises(ValueError, match="feather_pixels"):
+        _compositor(feather_pixels=feather_pixels)
+
+
+@pytest.mark.parametrize("size", UNUSABLE_SIZES)
+def test_unusable_render_size_is_refused_rather_than_read_as_absent(size) -> None:
+    """``render(width=0)`` is refused, not silently replaced by the default size."""
+    comp = _compositor(default_width=32, default_height=24, feather_pixels=0)
+    with pytest.raises(ValueError, match="HybridCompositor.render: width"):
+        comp.render("cam", width=size)
+    with pytest.raises(ValueError, match="HybridCompositor.render: height"):
+        comp.render("cam", height=size)
+
+
+@pytest.mark.parametrize("size", UNUSABLE_SIZES)
+def test_unusable_default_size_is_refused_by_the_constructor_that_took_it(size) -> None:
+    """A bad default size names the constructor argument, not a later render call."""
+    with pytest.raises(ValueError, match="HybridCompositor: default_width"):
+        _compositor(default_width=size)
+    with pytest.raises(ValueError, match="HybridCompositor: default_height"):
+        _compositor(default_height=size)
+
+
+def test_requested_size_reaches_the_frame_source_and_defaults_when_absent() -> None:
+    """The size the engine is asked for is the caller's, or the stored default."""
+
+    class RecordingSim(FakeSim):
+        def __init__(self, depth):
+            super().__init__(depth)
+            self.requested: list[tuple[int | None, int | None]] = []
+
+        def get_camera_params(self, camera_name="default", width=None, height=None):
+            self.requested.append((width, height))
+            return super().get_camera_params(camera_name, width=width, height=height)
+
+    sim = RecordingSim(_square_depth())
+    comp = HybridCompositor(sim, background=FakeBackground(), default_width=32, default_height=24, feather_pixels=0)
+    comp.render("cam")
+    comp.render("cam", width=8, height=6)
+    assert sim.requested == [(32, 24), (8, 6)]
+
+
+def test_integral_options_are_normalized_to_plain_python_numbers() -> None:
+    """A NumPy size or an integral float is stored as ``int`` before it is used."""
+    comp = _compositor(default_width=np.int64(32), default_height=24.0, feather_pixels=2.0)
+    assert (comp.default_width, comp.default_height, comp.feather_pixels) == (32, 24, 2)
+    assert all(type(v) is int for v in (comp.default_width, comp.default_height, comp.feather_pixels))
+    assert comp.render("cam").camera.width == 32
+
+
+def test_a_negative_threshold_would_have_admitted_isaac_no_hit_pixels() -> None:
+    """The refused negative threshold is the one that breaks the no-hit convention.
+
+    A ``0`` depth is Isaac's "ray hit nothing"; under the default threshold it
+    reads as background (as its own test pins). Only a negative threshold puts
+    it above the bar, painting simulation sky over the photoreal background.
+    """
+    depth = _square_depth()
+    depth[0, 0] = 0.0
+    comp = HybridCompositor(FakeSim(depth), background=FakeBackground(), feather_pixels=0)
+    assert not comp.render("cam").foreground_mask[0, 0]
+    assert 0.0 > -1.0, "the arithmetic the refused threshold would have inverted"
+    with pytest.raises(ValueError, match="depth_epsilon"):
+        HybridCompositor(FakeSim(depth), background=FakeBackground(), depth_epsilon=-1.0)
+
+
+def test_a_far_clip_depth_still_reads_as_background_under_a_valid_threshold() -> None:
+    """Sanity: the accepted domain does not change MuJoCo's zfar sky convention."""
+    depth = _square_depth()
+    assert depth[0, 0] == pytest.approx(ZFAR)
+    frame = _compositor(depth_epsilon=1e-3, feather_pixels=0).render("cam")
+    assert not frame.foreground_mask[0, 0]


### PR DESCRIPTION
## Problem

Every option `HybridCompositor` takes was coerced rather than checked, so a value with no usable interpretation still returned a frame - just not the one the caller asked for.

`depth_epsilon` is the "this pixel has no geometry" depth threshold, stored with a bare `float(...)`. It is compared as `fg_depth > depth_epsilon`, so a non-finite threshold is false for **every** pixel: the entire simulation foreground reads as empty and the composite is the background alone.

```python
frame = HybridCompositor(sim, depth_epsilon=float("nan")).render("look")
frame.rgb.shape                # (480, 640, 3)  - a frame came back
frame.foreground_mask.mean()   # 0.0000         - with no robot in it
```

`inf` does the same. A **negative** threshold does the opposite: it admits the no-hit pixels the parameter exists to exclude (Isaac's RTX annotator reports them as `0`, which `test_isaac_style_zero_and_inf_depth_reads_as_background` pins as background), painting simulation sky over the photoreal backdrop.

That is the failure mode `render`'s own docstring already refuses for a missing depth buffer - "compositing without depth would silently paint the background over/under the wrong pixels, and silent wrong output is forbidden" - reachable through a caller option instead of a backend.

Two more options in the same class:

| call | before | after |
|---|---|---|
| `depth_epsilon=nan` / `inf` | frame returned, `foreground_mask` 0.0000 | `ValueError` naming `depth_epsilon` |
| `depth_epsilon=-1.0` | a `0`-depth no-hit pixel counts as geometry | refused |
| `feather_pixels=-5` | clamped to `0` - seam blend silently off | refused |
| `feather_pixels=2.7` | truncated to `2` | refused |
| `render(width=0)` | success at the default size | refused |
| `default_width=0` | `render: width and height must be > 0` at first render | `HybridCompositor: default_width must be a positive whole number` |

`feather_pixels` was clamped with `max(0, int(value))`, which turns every unusable radius into `0` - disabling the very blend the parameter exists to apply. `render` read its size with `width or self.default_width`, so a supplied `0` read as "not supplied": the same `0` that **is** refused once it arrives at `get_camera_params` as `default_width` was silently replaced by the default size when it arrived as `width`. Same parameter, same value, two contradictory outcomes.

## Change

All four options are validated where they are supplied, mirroring `encode_clip`'s guard-before-work shape:

- `default_width` / `default_height` / `render(width=, height=)` go through the shared `positive_whole_number_error` domain - the helper whose own docstring already names width and height as its callers - so the compositor and the recorders accept the same pixel counts. Checking the constructor arguments in the constructor means a `default_width` mistake names `default_width`, instead of surfacing later as a render error about `width`.
- `depth_epsilon` must be a finite distance in meters `>= 0`. `0` stays valid and keeps its meaning ("only an exactly-zero depth is no geometry"); `bool` is refused, since a truth value is not a distance.
- `feather_pixels` must be a whole pixel count `>= 0`, no clamp. `0` still disables feathering, as the examples' wrappers document.
- The render size is read by membership (`width is None`) rather than truthiness, so a supplied `0` reaches the guard.
- Integral options normalize to plain `int`, so a `np.int64` size cannot leak into the requested camera size or the background cache key.

The guards live in the compositor rather than relying on the backend's, because `FrameSource` is a structural protocol - a frame source is not required to validate anything, and the caller called the compositor.

## Visual artifact

MuJoCo Panda foreground composited over the procedural panorama background, rendered headless (EGL). Left: the frame the `nan` threshold returned - `foreground_mask` covers 0.0000 of it, so the composite is the background alone and the robot is simply absent. Right: the threshold is now refused, and a valid one composites 0.7739 of the frame. L1 between panels 4.17e7.

![depth_epsilon before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/compositor-option-guards/compositor_depth_epsilon.png)

## Tests

`tests/rendering/test_compositor_option_guards.py` - 34 tests against the existing fake frame source (pure numpy, no GL or sim deps), covering each option's unusable values plus the values that must stay accepted (`depth_epsilon=0`, `feather_pixels=0`, an integral float, a `np.int64` size). Two behavioural pins make the silence visible: the fixture composites real geometry under the default threshold, and `feather_pixels=0` vs `2` produce different pixels, so the clamp really did change the output.

**31 of 34 fail on `main`** (`DID NOT RAISE ValueError`; the 3 that pass are the values already honored). Full suite after: **12439 passed, 260 skipped**. `ruff check`, `ruff format --check` and `mypy strands_robots tests tests_integ` clean.

Same class of fix as #1669 (`encode_clip` fps), #1673 (`get_camera_params` size) and #1665 (vectors read by membership, not truthiness) - the rendering options that were still coerced.

---

**Synced with `main`** — mechanical merge only. `main` picked up the MuJoCo 3.11 mass-matrix fix (#1682), which every open branch needed to get a green `Test and Lint` run; the only conflict was CHANGELOG entry ordering under `[Unreleased]`, resolved by keeping both entries. The change under review is byte-identical; the sync commit dismissed the prior approval, so this needs a re-approval rather than a fresh review. CI is green on the synced head.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1679-compositor-option-guards.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

The push dismissed the prior approval. The reviewed diff is otherwise byte-identical: the delta is the fragment move plus the merge.
