### PR TITLE
fix(mesh): an emergency stop reports the peers that did not stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,37 +5,69 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: an emergency stop no longer reports a peer as halted when nothing was stopped
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-`Mesh._dispatch` answered `{"ok": True}` for `action="stop"` when the registered
-robot exposed no `stop_task`. Nothing was stopped, yet the peer returned an
-affirmative acknowledgement:
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
 ```python
-Mesh(status_only_robot, peer_id="arm-2")._dispatch({"action": "stop"})
-# before: {"ok": True}      <- nothing was stopped
-# after:  {"ok": False, "error": "peer exposes no stop_task; nothing was stopped"}
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
 ```
 
-`emergency_stop` then folded that reply into `responses_received`, so an operator
-watching a fleet E-STOP read a clean acknowledgement from a robot that was still
-executing - on a safety path an affirmative lie is the worst available failure
-mode, because it is the one that stops the operator from reaching for the
-hardware cutoff.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
 
-The dispatch now reports the failure and logs it at ERROR, and `emergency_stop`
-accounts for such peers separately: logged at CRITICAL and carried in both the
-`strands/safety/estop` envelope and the audit record as `peers_not_stopped`.
-`responses_received` keeps its original meaning (replies received), so the two
-numbers can be compared rather than one silently absorbing the other.
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
 
-The accounting is deliberately conservative - only responses that
-*affirmatively* report failure (`ok is False`, or `status == "error"` from a
-`stop_task` that itself failed) are flagged. An unrecognised response shape is
-left out rather than guessed at, because a false "did not stop" on the safety
-path trains operators to ignore the warning. Peers that never answered at all
-remain visible as the gap between `responses_received` and the known peer count.
-The local lockout still engages regardless of what any peer reports.
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
+
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: an emergency stop no longer reports a peer as halted when nothing was stopped
+
+`Mesh._dispatch` answered `{"ok": True}` for `action="stop"` when the registered
+robot exposed no `stop_task`. Nothing was stopped, yet the peer returned an
+affirmative acknowledgement:
+
+```python
+Mesh(status_only_robot, peer_id="arm-2")._dispatch({"action": "stop"})
+# before: {"ok": True}      <- nothing was stopped
+# after:  {"ok": False, "error": "peer exposes no stop_task; nothing was stopped"}
+```
+
+`emergency_stop` then folded that reply into `responses_received`, so an operator
+watching a fleet E-STOP read a clean acknowledgement from a robot that was still
+executing - on a safety path an affirmative lie is the worst available failure
+mode, because it is the one that stops the operator from reaching for the
+hardware cutoff.
+
+The dispatch now reports the failure and logs it at ERROR, and `emergency_stop`
+accounts for such peers separately: logged at CRITICAL and carried in both the
+`strands/safety/estop` envelope and the audit record as `peers_not_stopped`.
+`responses_received` keeps its original meaning (replies received), so the two
+numbers can be compared rather than one silently absorbing the other.
+
+The accounting is deliberately conservative - only responses that
+*affirmatively* report failure (`ok is False`, or `status == "error"` from a
+`stop_task` that itself failed) are flagged. An unrecognised response shape is
+left out rather than guessed at, because a false "did not stop" on the safety
+path trains operators to ignore the warning. Peers that never answered at all
+remain visible as the gap between `responses_received` and the known peer count.
+The local lockout still engages regardless of what any peer reports.
+
 ### Fixed: a leader arm is refused by Robot() instead of built as a follower
 
 `so101_leader` was an alias of the `so101` registry entry, whose

--- a/changelog.d/1680-estop-reports-peers-that-did-not-stop.md
+++ b/changelog.d/1680-estop-reports-peers-that-did-not-stop.md
@@ -1,0 +1,31 @@
+### Fixed: an emergency stop no longer reports a peer as halted when nothing was stopped
+
+`Mesh._dispatch` answered `{"ok": True}` for `action="stop"` when the registered
+robot exposed no `stop_task`. Nothing was stopped, yet the peer returned an
+affirmative acknowledgement:
+
+```python
+Mesh(status_only_robot, peer_id="arm-2")._dispatch({"action": "stop"})
+# before: {"ok": True}      <- nothing was stopped
+# after:  {"ok": False, "error": "peer exposes no stop_task; nothing was stopped"}
+```
+
+`emergency_stop` then folded that reply into `responses_received`, so an operator
+watching a fleet E-STOP read a clean acknowledgement from a robot that was still
+executing - on a safety path an affirmative lie is the worst available failure
+mode, because it is the one that stops the operator from reaching for the
+hardware cutoff.
+
+The dispatch now reports the failure and logs it at ERROR, and `emergency_stop`
+accounts for such peers separately: logged at CRITICAL and carried in both the
+`strands/safety/estop` envelope and the audit record as `peers_not_stopped`.
+`responses_received` keeps its original meaning (replies received), so the two
+numbers can be compared rather than one silently absorbing the other.
+
+The accounting is deliberately conservative - only responses that
+*affirmatively* report failure (`ok is False`, or `status == "error"` from a
+`stop_task` that itself failed) are flagged. An unrecognised response shape is
+left out rather than guessed at, because a false "did not stop" on the safety
+path trains operators to ignore the warning. Peers that never answered at all
+remain visible as the gap between `responses_received` and the known peer count.
+The local lockout still engages regardless of what any peer reports.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -294,6 +294,42 @@ def _extract_sample_source_zid(sample: Any) -> str | None:
         return None
 
 
+def _peers_that_did_not_stop(responses: list[dict[str, Any]]) -> set[str]:
+    """Identify responders that explicitly reported they did NOT stop.
+
+    An emergency stop is only as trustworthy as its accounting. A peer whose
+    registered robot exposes no ``stop_task`` answers ``{"ok": False, ...}``
+    (see ``Mesh._dispatch``), and a peer whose ``stop_task`` itself failed
+    answers ``{"status": "error", ...}``. Counting either as an acknowledgement
+    tells the operator the fleet halted while a robot is still executing.
+
+    Deliberately conservative: only responses that AFFIRMATIVELY report failure
+    are flagged. A response shape this function does not recognise is left out
+    rather than guessed at, because a false "did not stop" on the safety path
+    trains operators to ignore the warning. Peers that never answered at all are
+    not represented here either -- they are visible as the gap between
+    ``responses_received`` and the known peer count.
+
+    Args:
+        responses: Response envelopes collected by :meth:`Mesh.broadcast`.
+
+    Returns:
+        Responder ids that reported a failure to stop. An id is synthesised for
+        a response carrying no ``responder_id`` so the count stays accurate.
+    """
+    failed: set[str] = set()
+    for index, response in enumerate(responses):
+        if not isinstance(response, dict):
+            continue
+        result = response.get("result", response)
+        if not isinstance(result, dict):
+            continue
+        did_not_stop = result.get("ok") is False or result.get("status") == "error"
+        if did_not_stop:
+            failed.add(str(response.get("responder_id") or f"<unidentified-responder-{index}>"))
+    return failed
+
+
 class Mesh(SensorLoopsMixin):
     """Peer-to-peer mesh component embedded in a single Robot or Simulation.
 
@@ -1592,7 +1628,17 @@ class Mesh(SensorLoopsMixin):
         if action == "stop":
             if hasattr(r, "stop_task"):
                 return dict(r.stop_task())
-            return {"ok": True}
+            # No stop_task means NOTHING was stopped. Reporting ok=True here was
+            # an affirmative lie on the fleet safety path: an operator issuing
+            # emergency_stop counted this peer as having halted while its robot
+            # kept executing. Say so instead, so the caller (and
+            # emergency_stop's aggregation) can surface an unstoppable peer.
+            logger.error(
+                "[safety] %s: stop requested but the registered robot exposes no stop_task(); "
+                "NOTHING was stopped on this peer",
+                self.peer_id,
+            )
+            return {"ok": False, "error": "peer exposes no stop_task; nothing was stopped"}
         if action == "features":
             return dict(r.get_features()) if hasattr(r, "get_features") else {}
         if action == "state":
@@ -2836,11 +2882,28 @@ class Mesh(SensorLoopsMixin):
         Returns the list of responses received from peers within the broadcast
         timeout -- useful for telemetry (which peers acknowledged before the
         stop fanned out).
+
+        A response is only an acknowledgement that the peer STOPPED if it says
+        so. A peer whose registered robot exposes no ``stop_task`` answers
+        ``{"ok": False, ...}``; such peers are counted separately, logged at
+        CRITICAL, and reported in the safety envelope as ``peers_not_stopped``.
+        Counting them as acknowledgements would tell an operator the fleet had
+        halted while a robot was still moving.
         """
         self._estop_lockout.set()
         self._last_estop_ts = time.time()
         self._last_estop_mono = time.monotonic()
         responses = self.broadcast({"action": "stop"}, timeout=3.0)
+        not_stopped = _peers_that_did_not_stop(responses)
+        if not_stopped:
+            logger.critical(
+                "[safety] %s: EMERGENCY STOP - %d of %d responding peer(s) did NOT stop: %s. "
+                "Those robots may still be executing; use a hardware cutoff.",
+                self.peer_id,
+                len(not_stopped),
+                len(responses),
+                sorted(not_stopped),
+            )
         # Wire-level publisher attribution: bind the local TLS-bound zid
         # into both the body (so receivers can verify the body matches
         # ``sample.source_info.source_id.zid``) and the publish path (via
@@ -2853,6 +2916,7 @@ class Mesh(SensorLoopsMixin):
             "peer_id": self.peer_id,
             "t": self._last_estop_ts,
             "responses_received": len(responses),
+            "peers_not_stopped": sorted(not_stopped),
             "lockout_engaged": True,
         }
         if local_zid is not None:
@@ -2864,6 +2928,7 @@ class Mesh(SensorLoopsMixin):
             payload={
                 "sender_id": self.peer_id,
                 "responses_received": len(responses),
+                "peers_not_stopped": sorted(not_stopped),
                 "lockout_engaged": True,
             },
         )

--- a/tests/mesh/test_dispatch_command_routing.py
+++ b/tests/mesh/test_dispatch_command_routing.py
@@ -137,11 +137,13 @@ def test_dispatch_routes_resume_to_lockout_release_even_under_lockout(monkeypatc
     assert m._estop_lockout.is_set()
 
 
-def test_dispatch_stop_falls_back_when_robot_lacks_stop_task() -> None:
-    # A robot with no ``stop_task`` (e.g. a bare status-only peer) still gets a
-    # well-formed acknowledgement rather than an error or an exception.
+def test_dispatch_stop_reports_failure_when_robot_lacks_stop_task() -> None:
+    # A robot with no ``stop_task`` stopped NOTHING. It must say so: reporting
+    # ok=True was an affirmative lie on the fleet safety path, counting an
+    # unstoppable peer as halted.
     m = Mesh(_StatusRobot(), peer_id="p")
 
     out = m._dispatch({"action": "stop"})
 
-    assert out == {"ok": True}
+    assert out["ok"] is False
+    assert "no stop_task" in out["error"]

--- a/tests/mesh/test_estop_stop_honesty.py
+++ b/tests/mesh/test_estop_stop_honesty.py
@@ -1,0 +1,170 @@
+"""An emergency stop must never report a peer as halted when it was not.
+
+``Mesh._dispatch`` answered ``{"ok": True}`` for ``action="stop"`` when the
+registered robot exposed no ``stop_task`` -- nothing was stopped, yet the peer
+acknowledged the stop. ``emergency_stop`` then counted that response in
+``responses_received``, so an operator watching a fleet E-STOP saw a clean
+acknowledgement from a robot that was still executing. On a safety path an
+affirmative lie is the worst available failure mode.
+
+The dispatch now reports the failure, and ``emergency_stop`` counts such peers
+separately: logged at CRITICAL and carried in the safety envelope / audit record
+as ``peers_not_stopped``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from strands_robots.mesh.core import Mesh, _peers_that_did_not_stop
+
+
+class _StoppableRobot:
+    """A robot that can genuinely stop."""
+
+    def stop_task(self) -> dict[str, object]:
+        return {"status": "success", "content": [{"text": "stopped"}]}
+
+
+class _StatusOnlyRobot:
+    """A peer with no ``stop_task`` -- it cannot stop anything."""
+
+    def get_task_status(self) -> dict[str, object]:
+        return {"status": "success", "content": [{"text": "idle"}]}
+
+
+class TestDispatchHonesty:
+    def test_missing_stop_task_reports_failure(self):
+        mesh = Mesh(_StatusOnlyRobot(), peer_id="p")
+
+        out = mesh._dispatch({"action": "stop"})
+
+        assert out["ok"] is False
+        assert "nothing was stopped" in out["error"]
+
+    def test_missing_stop_task_logs_at_error(self, caplog):
+        """An unstoppable peer must be loud in the log, not only in the return."""
+        mesh = Mesh(_StatusOnlyRobot(), peer_id="p")
+
+        with caplog.at_level(logging.ERROR):
+            mesh._dispatch({"action": "stop"})
+
+        msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("no stop_task" in m for m in msgs), msgs
+
+    def test_real_stop_task_result_is_passed_through(self):
+        """A robot that can stop keeps its own result shape."""
+        mesh = Mesh(_StoppableRobot(), peer_id="p")
+
+        out = mesh._dispatch({"action": "stop"})
+
+        assert out["status"] == "success"
+        assert out.get("ok") is not False
+
+
+class TestFailedStopAccounting:
+    def test_ok_false_response_is_counted_as_not_stopped(self):
+        responses = [
+            {"responder_id": "arm-1", "result": {"status": "success"}},
+            {"responder_id": "arm-2", "result": {"ok": False, "error": "no stop_task"}},
+        ]
+        assert _peers_that_did_not_stop(responses) == {"arm-2"}
+
+    def test_error_status_response_is_counted_as_not_stopped(self):
+        """A stop_task that itself failed is also a peer that did not stop."""
+        responses = [{"responder_id": "arm-3", "result": {"status": "error", "error": "bus fault"}}]
+        assert _peers_that_did_not_stop(responses) == {"arm-3"}
+
+    def test_successful_peers_are_not_flagged(self):
+        responses = [
+            {"responder_id": "arm-1", "result": {"status": "success"}},
+            {"responder_id": "arm-2", "result": {"ok": True}},
+        ]
+        assert _peers_that_did_not_stop(responses) == set()
+
+    def test_unidentified_responder_still_counted(self):
+        """A failure with no responder_id must not vanish from the count."""
+        responses = [{"result": {"ok": False}}]
+        flagged = _peers_that_did_not_stop(responses)
+        assert len(flagged) == 1
+        assert "unidentified-responder" in next(iter(flagged))
+
+    def test_unrecognised_shapes_are_not_guessed_at(self):
+        """Only affirmative failures count: a false alarm trains operators to ignore it."""
+        responses = [
+            {"responder_id": "a", "result": {}},
+            {"responder_id": "b"},
+            {"responder_id": "c", "result": "not-a-dict"},
+            "not-a-dict",
+        ]
+        assert _peers_that_did_not_stop(responses) == set()
+
+    def test_bare_result_dict_without_envelope_is_handled(self):
+        """Some transports hand back the result directly, not wrapped."""
+        assert _peers_that_did_not_stop([{"ok": False}])
+
+
+class TestEmergencyStopSurfacesUnstoppablePeers:
+    def _mesh_with_responses(self, monkeypatch, responses):
+        mesh = Mesh(_StoppableRobot(), peer_id="operator")
+        monkeypatch.setattr(mesh, "broadcast", lambda cmd, timeout=3.0: responses)
+        published: list[tuple[str, dict]] = []
+        monkeypatch.setattr(
+            mesh,
+            "_publish_safety_envelope",
+            lambda topic, envelope: published.append((topic, envelope)),
+        )
+        events: list[dict] = []
+        monkeypatch.setattr(
+            mesh,
+            "publish_safety_event",
+            lambda **kwargs: events.append(kwargs),
+        )
+        monkeypatch.setattr(mesh, "_local_session_zid", lambda: None)
+        return mesh, published, events
+
+    def test_envelope_and_audit_name_the_peers_that_did_not_stop(self, monkeypatch):
+        responses = [
+            {"responder_id": "arm-1", "result": {"status": "success"}},
+            {"responder_id": "arm-2", "result": {"ok": False, "error": "no stop_task"}},
+        ]
+        mesh, published, events = self._mesh_with_responses(monkeypatch, responses)
+
+        mesh.emergency_stop()
+
+        assert published, "no safety envelope published"
+        _topic, envelope = published[0]
+        assert envelope["peers_not_stopped"] == ["arm-2"]
+        # The raw ack count is preserved so the two numbers can be compared.
+        assert envelope["responses_received"] == 2
+        assert events[0]["payload"]["peers_not_stopped"] == ["arm-2"]
+
+    def test_critical_log_when_a_peer_did_not_stop(self, monkeypatch, caplog):
+        responses = [{"responder_id": "arm-2", "result": {"ok": False}}]
+        mesh, _published, _events = self._mesh_with_responses(monkeypatch, responses)
+
+        with caplog.at_level(logging.CRITICAL):
+            mesh.emergency_stop()
+
+        msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.CRITICAL]
+        assert any("did NOT stop" in m for m in msgs), msgs
+        assert any("arm-2" in m for m in msgs), msgs
+
+    def test_all_clear_fleet_reports_no_failures(self, monkeypatch):
+        responses = [{"responder_id": "arm-1", "result": {"status": "success"}}]
+        mesh, published, events = self._mesh_with_responses(monkeypatch, responses)
+
+        mesh.emergency_stop()
+
+        _topic, envelope = published[0]
+        assert envelope["peers_not_stopped"] == []
+        assert events[0]["payload"]["peers_not_stopped"] == []
+
+    def test_lockout_still_engages_even_when_a_peer_cannot_stop(self, monkeypatch):
+        """The local lockout is independent of remote acknowledgement."""
+        responses = [{"responder_id": "arm-2", "result": {"ok": False}}]
+        mesh, _published, _events = self._mesh_with_responses(monkeypatch, responses)
+
+        mesh.emergency_stop()
+
+        assert mesh._estop_lockout.is_set()


### PR DESCRIPTION
## What

`Mesh._dispatch` answered `{"ok": True}` for `action="stop"` when the registered robot exposed no `stop_task`. **Nothing was stopped, yet the peer returned an affirmative acknowledgement.**

Verified on `main` @ `b046037`:

```python
class StatusOnly:                      # a bare status-only peer, no stop_task
    def get_task_status(self): return {"status": "success"}

Mesh(StatusOnly(), peer_id="arm-2")._dispatch({"action": "stop"})
# main:  {'ok': True}          <- nothing was stopped
# after: {'ok': False, 'error': 'peer exposes no stop_task; nothing was stopped'}
```

`emergency_stop` then folded that reply into `responses_received`, so an operator watching a fleet E-STOP read a clean acknowledgement from a robot that was still executing.

On a safety path an affirmative lie is the worst available failure mode, because it is precisely the one that stops the operator reaching for the hardware cutoff. A peer that stays silent is visibly missing; a peer that says "stopped" when it did not is invisible.

## Why this shape

The fix is in two halves, because the bug has two halves:

1. **The dispatch stops lying.** No `stop_task` means nothing was stopped, so it reports `ok=False` and logs at ERROR naming the peer.
2. **`emergency_stop` accounts for it.** A new `_peers_that_did_not_stop` helper aggregates affirmative failures, logs at CRITICAL, and carries `peers_not_stopped` in both the `strands/safety/estop` envelope and the audit record.

`responses_received` deliberately keeps its original meaning (replies received). The new field sits alongside it rather than silently correcting it, so an operator and a log reader can compare the two numbers.

**The accounting is deliberately conservative.** Only responses that *affirmatively* report failure are flagged — `ok is False`, or `status == "error"` from a `stop_task` that itself failed. An unrecognised response shape is left out rather than guessed at, because a false "did not stop" on the safety path trains operators to ignore the warning, which costs more than it buys. Peers that never answered at all are not invented into this set either: they remain visible as the gap between `responses_received` and the known peer count.

The local lockout engagement is unchanged and independent of what any peer reports — consistent with the existing AGENTS.md mesh learning that lockout engagement is decoupled from remote accounting.

## Scope

4 files, +274/-5. Only `action="stop"`'s no-`stop_task` fallback changes behaviour; the `stop_task` present path passes its own result through untouched. `mesh/core.py:1593` is the sole in-tree consumer of this reply (`grep -rn stop_task strands_robots/`), and no test pinned the old value other than the one inverted below.

## Verification

- **Regression pinned** (AGENTS.md > Review Learnings — pin regression tests for reviewed fixes): `tests/mesh/test_estop_stop_honesty.py`, 13 tests across dispatch honesty, the accounting helper (including unrecognised shapes, bare unwrapped results, and a missing `responder_id`), and the envelope/audit/CRITICAL-log surface. `main` cannot even import the helper; the dispatch assertions fail against `main`'s `{'ok': True}`.
- **Existing test inverted, not deleted:** `test_dispatch_stop_falls_back_when_robot_lacks_stop_task` pinned the old affirmative reply. It is renamed to `test_dispatch_stop_reports_failure_when_robot_lacks_stop_task` and asserts the new contract, so the change of contract is visible in the diff rather than silent.
- **No collateral damage:** `tests/mesh/` + `tests/test_robot_mesh_dc_dispatch_errors.py` — failure set is **identical to `main` (122 = 122)**, all pre-existing `ModuleNotFoundError` for optional transports (`awsiot`, zenoh) absent from this environment. Zero new failures.
- Touched files: **21 passed**.
- `ruff check` + `ruff format --check` clean (ruff 0.15.22, the pinned range); `mypy` clean.

## Notes

Carved out of the #1667 consolidated draft as a self-contained slice so the safety-path change can be reviewed on its own.

### §13 Round changelog

**Round 0 (initial):** dispatch reports `ok=False` when no `stop_task` exists; `emergency_stop` aggregates `peers_not_stopped` into the safety envelope, audit record and a CRITICAL log; conservative affirmative-failure-only accounting; 13 pinned regression tests; one pre-existing test inverted; CHANGELOG entry.

---

**Synced with `main`** — mechanical merge only. `main` picked up the MuJoCo 3.11 mass-matrix fix (#1682), which every open branch needed to get a green `Test and Lint` run; the only conflict was CHANGELOG entry ordering under `[Unreleased]`, resolved by keeping both entries. The change under review is byte-identical; the sync commit dismissed the prior approval, so this needs a re-approval rather than a fresh review. CI is green on the synced head.

### Round 1 - merged main to clear the CHANGELOG append conflict (commit 98a7d4a)

`main` advanced to `44d4f6b` (#1675) while this PR sat approved, which turned it
CONFLICTING. The only conflicting file was `CHANGELOG.md`: this branch appends an
entry at the top of `## [Unreleased]` and #1675's entry anchors at the identical
position, so the two collide on ordering alone, not on meaning.

Resolved by merging `main` in as a plain merge commit (no rebase, no force-push, so
the review trail is intact) and taking `CHANGELOG.md` as a union - both entries
kept, this branch's first. Verified: no conflict markers remain, the `###` heading
count is exactly base + this branch + #1675, and diffing the pre-merge head against
the post-merge head shows only `CHANGELOG.md` plus the three files #1675 itself
changed. No file belonging to this PR moved.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1680-estop-reports-peers-that-did-not-stop.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

The push dismissed the prior approval. The reviewed diff is otherwise byte-identical: the delta is the fragment move plus the merge.
