### PR TITLE
fix(sim): a patch_scene_mjcf op key outside its vocabulary is rejected, not defaulted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a patch_scene_mjcf op key outside its vocabulary is rejected, not defaulted
+
+Every field of every structured op was read with a fallback default, and no op
+checked for keys it does not read. A key the op did not recognise therefore left
+that default in place and the patch reported success:
+
+```python
+sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0.4, 0, 0.9]}])
+# before: status=success "1 op(s) applied" - and the crate moved to [0, 0, 0]
+```
+
+`pos` defaults to the origin, `quat` to identity, `type` to `"box"` and `parent`
+to the worldbody, so the same hole covered six ops: a misspelled `pos` teleported
+a body to the world origin (or spawned it there), a misspelled `quat` reset the
+orientation to identity, `add_geom` with `shape=`/`color=` compiled a grey box
+where a coloured sphere was asked for, `add_site` with a misspelled `pos` placed
+the site at the body origin, and `add_body` with `parent_body=` re-parented the
+new body to the worldbody instead of the intended parent.
+
+Each op now declares the keys it reads, and anything else is refused with the op
+name, the unrecognised key, a close match where one exists, and the accepted
+list. The batch stays atomic, so a rejected key leaves the scene exactly as it
+was rather than half-patched.
+
+
 ### Fixed: a leader arm is refused by Robot() instead of built as a follower
 
 `so101_leader` was an alias of the `so101` registry entry, whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,69 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: a patch_scene_mjcf op key outside its vocabulary is rejected, not defaulted
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-Every field of every structured op was read with a fallback default, and no op
-checked for keys it does not read. A key the op did not recognise therefore left
-that default in place and the patch reported success:
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
 ```python
-sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0.4, 0, 0.9]}])
-# before: status=success "1 op(s) applied" - and the crate moved to [0, 0, 0]
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
 ```
 
-`pos` defaults to the origin, `quat` to identity, `type` to `"box"` and `parent`
-to the worldbody, so the same hole covered six ops: a misspelled `pos` teleported
-a body to the world origin (or spawned it there), a misspelled `quat` reset the
-orientation to identity, `add_geom` with `shape=`/`color=` compiled a grey box
-where a coloured sphere was asked for, `add_site` with a misspelled `pos` placed
-the site at the body origin, and `add_body` with `parent_body=` re-parented the
-new body to the worldbody instead of the intended parent.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
 
-Each op now declares the keys it reads, and anything else is refused with the op
-name, the unrecognised key, a close match where one exists, and the accepted
-list. The batch stays atomic, so a rejected key leaves the scene exactly as it
-was rather than half-patched.
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
+
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/changelog.d/1681-patch-op-unknown-keys.md
+++ b/changelog.d/1681-patch-op-unknown-keys.md
@@ -1,0 +1,23 @@
+### Fixed: a patch_scene_mjcf op key outside its vocabulary is rejected, not defaulted
+
+Every field of every structured op was read with a fallback default, and no op
+checked for keys it does not read. A key the op did not recognise therefore left
+that default in place and the patch reported success:
+
+```python
+sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0.4, 0, 0.9]}])
+# before: status=success "1 op(s) applied" - and the crate moved to [0, 0, 0]
+```
+
+`pos` defaults to the origin, `quat` to identity, `type` to `"box"` and `parent`
+to the worldbody, so the same hole covered six ops: a misspelled `pos` teleported
+a body to the world origin (or spawned it there), a misspelled `quat` reset the
+orientation to identity, `add_geom` with `shape=`/`color=` compiled a grey box
+where a coloured sphere was asked for, `add_site` with a misspelled `pos` placed
+the site at the body origin, and `add_body` with `parent_body=` re-parented the
+new body to the worldbody instead of the intended parent.
+
+Each op now declares the keys it reads, and anything else is refused with the op
+name, the unrecognised key, a close match where one exists, and the accepted
+list. The batch stays atomic, so a rejected key leaves the scene exactly as it
+was rather than half-patched.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -256,6 +256,36 @@ an **image texture**; the `checker` builtin reads as a literal checkerboard.
 Materials are currently supported by the MuJoCo backend; the Newton backend
 rejects a non-`None` `material` rather than silently ignoring it.
 
+## Surgical MJCF edits
+
+`patch_scene_mjcf(ops)` applies a list of structured ops to the live spec and
+recompiles once, preserving joint state for untouched joints. Each op accepts
+only the keys it reads:
+
+| Op | Keys |
+|----|------|
+| `add_body` | `parent` (default `"world"`), `name` (required), `pos`, `quat` |
+| `add_geom` | `body` (required), `type` (default `"box"`), `size`, `rgba`, `name`, `pos`, `quat` |
+| `add_site` | `body` (default `"world"`), `name` (required), `pos`, `size`, `rgba` |
+| `set_body_pos` | `name` (required), `pos` |
+| `set_body_quat` | `name` (required), `quat` |
+| `delete_body` | `name` (required) |
+
+Any other key is rejected. Every field above has a fallback default (`pos` the
+origin, `quat` identity, `type` `"box"`, `parent` the worldbody), so a key the op
+does not read is not inert - it would leave that default in place while the patch
+reports success:
+
+```python
+sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0.4, 0, 0.9]}])
+# status=error: set_body_pos: unknown op key(s): 'position' (did you mean 'pos'?).
+#               Accepted keys: name, op, pos.
+```
+
+The batch is atomic: if any op is rejected the world is rolled back to its
+pre-patch state, so a bad key never leaves a half-applied scene. Use
+`replace_scene_mjcf(xml)` for MJCF elements this vocabulary does not cover.
+
 ## Cameras
 
 Free cameras look from `position` toward `target` (`fov=60.0`, `width=640`, `height=480`). Robot-URDF cameras (wrist, etc.) are auto-discovered on `add_robot` - no `add_camera` needed.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -27,7 +27,9 @@ the legacy API) so call sites in :mod:`simulation` don't need to change.
 
 from __future__ import annotations
 
+import difflib
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
@@ -728,17 +730,61 @@ def replace_scene_mjcf(world: SimWorld, xml: str) -> bool:
 
 # Structured-op patching of the live spec (Stage 6, part 2 - GH #125)
 
-# Supported ops for patch_scene_mjcf. Kept narrow on purpose - adding unchecked
-# attribute setters would make the tool an arbitrary-code hole. Agents that
-# need exotic MJCF should go through replace_scene_mjcf with a full XML.
-_PATCH_OPS = {
-    "add_body",
-    "add_geom",
-    "add_site",
-    "set_body_pos",
-    "set_body_quat",
-    "delete_body",
+# Supported ops for patch_scene_mjcf, each mapped to the complete set of keys
+# that op reads. Kept narrow on purpose - adding unchecked attribute setters
+# would make the tool an arbitrary-code hole. Agents that need exotic MJCF
+# should go through replace_scene_mjcf with a full XML.
+#
+# This mapping is the single source of truth for the op vocabulary: it names
+# the supported ops AND, per op, every key that reaches MuJoCo. Any other key
+# is refused, because each field below is read with a fallback default - a
+# misspelled key would otherwise apply that default and report success, so
+# ``{"op": "set_body_pos", "name": "crate", "position": [...]}`` would move the
+# body to the origin rather than to the requested pose.
+_PATCH_OP_KEYS: dict[str, frozenset[str]] = {
+    "add_body": frozenset({"op", "parent", "name", "pos", "quat"}),
+    "add_geom": frozenset({"op", "body", "type", "size", "rgba", "name", "pos", "quat"}),
+    "add_site": frozenset({"op", "body", "name", "pos", "size", "rgba"}),
+    "set_body_pos": frozenset({"op", "name", "pos"}),
+    "set_body_quat": frozenset({"op", "name", "quat"}),
+    "delete_body": frozenset({"op", "name"}),
 }
+
+
+def _unknown_op_keys_error(kind: str, op: Mapping[str, Any]) -> str | None:
+    """Reject keys a patch op does not read, before its defaults are applied.
+
+    Every field of every op is read with a fallback default (``pos`` defaults
+    to the origin, ``quat`` to identity, ``type`` to ``"box"``, ``parent`` to
+    ``"world"``), so an unrecognised key is not an inert extra: the op runs
+    with that default and reports success. A misspelled ``pos`` silently moves
+    a body to the world origin, a misspelled ``parent`` re-parents it to the
+    worldbody, and a misspelled ``type`` compiles a box where a sphere was
+    asked for.
+
+    Args:
+        kind: The op name, already known to be in :data:`_PATCH_OP_KEYS`.
+        op: The caller-supplied op dict.
+
+    Returns:
+        An error message naming the unknown key(s), a close-match suggestion
+        where one exists, and the keys this op accepts - or ``None`` when
+        every key is honored.
+    """
+    accepted = _PATCH_OP_KEYS[kind]
+    unknown = [key for key in op if key not in accepted]
+    if not unknown:
+        return None
+    known = sorted(accepted)
+    # Suggest field names only. "op" selects the op and is already validated
+    # above, so it is never what a misspelled field meant - offering it turns a
+    # real MJCF attribute like "group" into a nonsense hint.
+    candidates = [key for key in known if key != "op"]
+    described = []
+    for key in sorted(unknown, key=str):
+        close = difflib.get_close_matches(str(key).lower(), candidates, n=1, cutoff=0.5)
+        described.append(f"{key!r}" + (f" (did you mean {close[0]!r}?)" if close else ""))
+    return f"{kind}: unknown op key(s): {', '.join(described)}. Accepted keys: {', '.join(known)}."
 
 
 def _find_body(spec: Any, name: str, new_bodies: dict[str, Any]) -> Any:
@@ -778,8 +824,10 @@ def _apply_patch_op(spec: Any, op: dict[str, Any], new_bodies: dict[str, Any]) -
         raise ValueError(f"each op must be a dict, got {type(op).__name__}")
 
     kind = op.get("op")
-    if kind not in _PATCH_OPS:
-        raise ValueError(f"unknown op '{kind}'. Supported: {sorted(_PATCH_OPS)}")
+    if kind not in _PATCH_OP_KEYS:
+        raise ValueError(f"unknown op '{kind}'. Supported: {sorted(_PATCH_OP_KEYS)}")
+    if err := _unknown_op_keys_error(str(kind), op):
+        raise ValueError(err)
 
     if kind == "add_body":
         parent = op.get("parent", "world")
@@ -883,6 +931,10 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
         {"op": "add_geom", "body": "foo", "type": "sphere", "size": [0.1]}
         {"op": "set_body_pos", "name": "foo", "pos": [1,0,1]}
         {"op": "delete_body", "name": "foo"}
+
+    Each op accepts exactly the keys listed for it in :data:`_PATCH_OP_KEYS`;
+    anything else is rejected, because an unread key would leave the op running
+    on its fallback default (see :func:`_unknown_op_keys_error`).
 
     The list is applied atomically: if any op raises, the whole patch is
     rejected and the world is left in its original state. After all ops

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -841,6 +841,24 @@ class MuJoCoSimEngine(
             {"op": "set_body_quat", "name": "foo",     "quat": [1,0,0,0]}
             {"op": "delete_body",   "name": "foo"}
 
+        Each op accepts only the keys it reads, and every other key is
+        refused::
+
+            add_body       op, parent, name, pos, quat
+            add_geom       op, body, type, size, rgba, name, pos, quat
+            add_site       op, body, name, pos, size, rgba
+            set_body_pos   op, name, pos
+            set_body_quat  op, name, quat
+            delete_body    op, name
+
+        Rejecting the rest is not pedantry: every field has a fallback default
+        (``pos`` the origin, ``quat`` identity, ``type`` ``"box"``, ``parent``
+        the worldbody), so a misspelled key would apply that default and report
+        success - ``{"op": "set_body_pos", "name": "crate", "position": [...]}``
+        would move the body to the origin instead of to the requested pose. The
+        error names the op, the unrecognised key, a close match where one
+        exists, and the keys that op accepts.
+
         The whole batch is applied, then the spec is recompiled once. If any
         op fails, the batch is rejected and the world is rolled back to its
         pre-patch state (from an XML snapshot). Use this for fast iterative

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -449,7 +449,7 @@
     },
     "ops": {
       "type": "array",
-      "description": "List of structured MJCF edit ops for action='patch_scene_mjcf'. Each op is a dict like {'op': 'add_body', 'parent': 'world', 'name': 'foo', 'pos': [0,0,1]}, {'op': 'add_geom', 'body': 'foo', 'type': 'sphere', 'size': [0.1]}, {'op': 'add_site', 'body': 'foo', 'name': 'tip', 'pos': [0,0,0.2]}, {'op': 'set_body_pos', 'name': 'foo', 'pos': [1,0,1]}, {'op': 'set_body_quat', 'name': 'foo', 'quat': [1,0,0,0]}, or {'op': 'delete_body', 'name': 'foo'}. Applied atomically: if any op fails, the whole batch is rolled back.",
+      "description": "List of structured MJCF edit ops for action='patch_scene_mjcf'. Each op is a dict like {'op': 'add_body', 'parent': 'world', 'name': 'foo', 'pos': [0,0,1]}, {'op': 'add_geom', 'body': 'foo', 'type': 'sphere', 'size': [0.1]}, {'op': 'add_site', 'body': 'foo', 'name': 'tip', 'pos': [0,0,0.2]}, {'op': 'set_body_pos', 'name': 'foo', 'pos': [1,0,1]}, {'op': 'set_body_quat', 'name': 'foo', 'quat': [1,0,0,0]}, or {'op': 'delete_body', 'name': 'foo'}. Each op accepts only the keys it reads (add_body: parent, name, pos, quat; add_geom: body, type, size, rgba, name, pos, quat; add_site: body, name, pos, size, rgba; set_body_pos: name, pos; set_body_quat: name, quat; delete_body: name) - any other key is rejected, since an unread key would leave the op running on its default (a misspelled 'pos' would move the body to the origin). Applied atomically: if any op fails, the whole batch is rolled back.",
       "items": {
         "type": "object"
       }

--- a/tests/simulation/mujoco/test_patch_scene_mjcf_unknown_op_keys.py
+++ b/tests/simulation/mujoco/test_patch_scene_mjcf_unknown_op_keys.py
@@ -1,0 +1,257 @@
+"""``patch_scene_mjcf`` refuses op keys it does not read.
+
+Every field of every structured op is read with a fallback default (``pos``
+defaults to the origin, ``quat`` to identity, ``type`` to ``"box"``, ``parent``
+to ``"world"``), so a key outside an op's vocabulary is not an inert extra: the
+op runs with that default and reports success. A misspelled ``pos`` moved a body
+to the world origin, a misspelled ``parent`` re-parented it to the worldbody,
+and a misspelled ``type`` compiled a box where a sphere was requested - each
+reported ``status="success"`` with an "op(s) applied" count.
+
+These tests pin the corrected contract: an unrecognised key is refused, the
+message names the op, the key and the keys that op accepts, and - because the
+batch is atomic - the scene is left exactly as it was.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.scene_ops import (  # noqa: E402
+    _PATCH_OP_KEYS,
+    _unknown_op_keys_error,
+)
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_patch_keys", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+CRATE_POS = [0.4, 0.0, 0.5]
+
+
+def _seeded_world(sim: Simulation) -> None:
+    """Compile a world holding one named body ``crate`` at :data:`CRATE_POS`."""
+    sim.create_world()
+    result = sim.patch_scene_mjcf(
+        [
+            {"op": "add_body", "parent": "world", "name": "crate", "pos": CRATE_POS},
+            {"op": "add_geom", "body": "crate", "type": "box", "size": [0.2, 0.2, 0.2]},
+        ]
+    )
+    assert result["status"] == "success"
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _body_pos(sim: Simulation, name: str) -> list[float]:
+    mj = sim._mj
+    assert sim._world is not None and sim._world._model is not None
+    body_id = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, name)
+    assert body_id >= 0, f"body {name!r} missing"
+    return [float(v) for v in sim._world._model.body_pos[body_id]]
+
+
+def _body_names(sim: Simulation) -> list[str]:
+    mj = sim._mj
+    assert sim._world is not None and sim._world._model is not None
+    model = sim._world._model
+    return [mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i) for i in range(model.nbody)]
+
+
+class TestAMisspelledFieldDoesNotApplyItsDefault:
+    """The silent-default cases: each of these used to report success."""
+
+    def test_set_body_pos_with_position_key_does_not_move_the_body(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        result = sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0.4, 0.0, 0.9]}])
+
+        assert result["status"] == "error"
+        assert "'position'" in _text(result)
+        # Pre-fix this reported "1 op(s) applied" and left the crate at the origin.
+        assert _body_pos(sim, "crate") == CRATE_POS
+
+    def test_set_body_quat_with_quaternion_key_does_not_reset_orientation(self, sim: Simulation) -> None:
+        sim.create_world()
+        assert (
+            sim.patch_scene_mjcf(
+                [{"op": "add_body", "name": "crate", "pos": CRATE_POS, "quat": [0.7071, 0.0, 0.7071, 0.0]}]
+            )["status"]
+            == "success"
+        )
+        mj = sim._mj
+        assert sim._world is not None and sim._world._model is not None
+        body_id = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, "crate")
+        before = [float(v) for v in sim._world._model.body_quat[body_id]]
+
+        result = sim.patch_scene_mjcf([{"op": "set_body_quat", "name": "crate", "quaternion": [1.0, 0.0, 0.0, 0.0]}])
+
+        assert result["status"] == "error"
+        assert "'quaternion'" in _text(result)
+        after = [float(v) for v in sim._world._model.body_quat[body_id]]
+        assert after == pytest.approx(before)
+
+    def test_add_geom_with_shape_key_does_not_compile_the_default_box(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+        assert sim._world is not None and sim._world._model is not None
+        geoms_before = sim._world._model.ngeom
+
+        result = sim.patch_scene_mjcf([{"op": "add_geom", "body": "crate", "shape": "sphere", "size": [0.2, 0.2, 0.2]}])
+
+        assert result["status"] == "error"
+        assert "'shape'" in _text(result)
+        assert sim._world._model.ngeom == geoms_before
+
+    def test_add_body_with_misspelled_pos_does_not_spawn_at_the_origin(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        result = sim.patch_scene_mjcf([{"op": "add_body", "name": "widget", "postion": [1.0, 1.0, 1.0]}])
+
+        assert result["status"] == "error"
+        assert "'postion'" in _text(result)
+        assert "widget" not in _body_names(sim)
+
+    def test_add_body_with_misspelled_parent_does_not_reparent_to_world(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        result = sim.patch_scene_mjcf([{"op": "add_body", "name": "child", "parent_body": "crate"}])
+
+        assert result["status"] == "error"
+        assert "'parent_body'" in _text(result)
+        assert "child" not in _body_names(sim)
+
+    def test_add_site_with_misspelled_pos_does_not_place_it_at_the_body_origin(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+        assert sim._world is not None and sim._world._model is not None
+        sites_before = sim._world._model.nsite
+
+        result = sim.patch_scene_mjcf([{"op": "add_site", "body": "crate", "name": "tip", "location": [0, 0, 0.3]}])
+
+        assert result["status"] == "error"
+        assert "'location'" in _text(result)
+        assert sim._world._model.nsite == sites_before
+
+    def test_delete_body_keyed_by_body_does_not_silently_target_nothing(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        result = sim.patch_scene_mjcf([{"op": "delete_body", "body": "crate"}])
+
+        assert result["status"] == "error"
+        assert "crate" in _body_names(sim)
+
+
+class TestTheRejectionIsActionable:
+    def test_message_names_the_op_the_key_and_the_accepted_keys(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        text = _text(sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0, 0, 1]}]))
+
+        assert "set_body_pos" in text
+        assert "'position' (did you mean 'pos'?)" in text
+        assert "Accepted keys: name, op, pos." in text
+
+    def test_an_unrelated_key_gets_the_accepted_list_without_a_bogus_suggestion(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        # "group" is a real MJCF site attribute this op vocabulary does not
+        # cover: it must be refused, but nothing here is a plausible typo of it.
+        text = _text(sim.patch_scene_mjcf([{"op": "add_site", "body": "crate", "name": "tip", "group": 2}]))
+
+        assert "'group'" in text
+        assert "did you mean" not in text
+        assert "Accepted keys: body, name, op, pos, rgba, size." in text
+
+    def test_every_unknown_key_in_one_op_is_reported_together(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        text = _text(
+            sim.patch_scene_mjcf(
+                [{"op": "add_geom", "body": "crate", "shape": "sphere", "color": [0, 0, 1, 1], "size": [0.1] * 3}]
+            )
+        )
+
+        assert "'color'" in text and "'shape'" in text
+
+    def test_a_bad_key_late_in_a_batch_rolls_the_whole_batch_back(self, sim: Simulation) -> None:
+        _seeded_world(sim)
+
+        result = sim.patch_scene_mjcf(
+            [
+                {"op": "set_body_pos", "name": "crate", "pos": [0.1, 0.1, 0.1]},
+                {"op": "add_body", "name": "widget", "postion": [1, 1, 1]},
+            ]
+        )
+
+        assert result["status"] == "error"
+        assert "patch op #2 failed" in _text(result)
+        assert _body_pos(sim, "crate") == CRATE_POS
+        assert "widget" not in _body_names(sim)
+
+
+class TestTheDocumentedVocabularyIsAccepted:
+    def test_an_op_using_every_key_it_documents_is_applied(self, sim: Simulation) -> None:
+        sim.create_world()
+
+        result = sim.patch_scene_mjcf(
+            [
+                {"op": "add_body", "parent": "world", "name": "crate", "pos": CRATE_POS, "quat": [1, 0, 0, 0]},
+                {
+                    "op": "add_geom",
+                    "body": "crate",
+                    "type": "box",
+                    "size": [0.2, 0.2, 0.2],
+                    "rgba": [0.9, 0.2, 0.1, 1.0],
+                    "name": "crate_geom",
+                    "pos": [0, 0, 0],
+                    "quat": [1, 0, 0, 0],
+                },
+                {
+                    "op": "add_site",
+                    "body": "crate",
+                    "name": "tip",
+                    "pos": [0, 0, 0.2],
+                    "size": [0.01],
+                    "rgba": [0, 1, 0, 1],
+                },
+                {"op": "set_body_quat", "name": "crate", "quat": [1, 0, 0, 0]},
+                {"op": "set_body_pos", "name": "crate", "pos": CRATE_POS},
+                {"op": "delete_body", "name": "crate"},
+            ]
+        )
+
+        assert result["status"] == "success"
+        assert "6 op(s) applied" in _text(result)
+
+    @pytest.mark.parametrize("kind", sorted(_PATCH_OP_KEYS))
+    def test_the_op_key_itself_is_part_of_every_vocabulary(self, kind: str) -> None:
+        # Guards against an entry that forgets "op" and so rejects every call.
+        assert "op" in _PATCH_OP_KEYS[kind]
+        assert _unknown_op_keys_error(kind, {"op": kind}) is None
+
+
+class TestTheKeyCheckIsIndependentOfValueValidation:
+    def test_a_non_string_key_is_refused(self) -> None:
+        # A JSON-shaped op reaching the tool can carry a non-string key; it must
+        # be reported like any other unknown key rather than crashing the lookup.
+        op: dict[Any, Any] = {"op": "set_body_pos", 3: [0, 0, 1]}
+
+        message = _unknown_op_keys_error("set_body_pos", op)
+
+        assert message is not None
+        assert "3" in message
+
+    def test_a_fully_documented_op_passes_the_key_check(self) -> None:
+        assert _unknown_op_keys_error("add_geom", {"op": "add_geom", "body": "b", "type": "sphere"}) is None


### PR DESCRIPTION
## Problem

Every field of every `patch_scene_mjcf` structured op is read with a fallback default, and no op checked for keys it does not read. A key outside an op's vocabulary was therefore not an inert extra: the op ran with that default and reported success.

```python
sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0.4, 0, 0.9]}])
# status=success  "1 op(s) applied"
# crate body_pos -> [0.0, 0.0, 0.0]   (it was at [0.4, 0.0, 0.5])
```

`pos` defaults to the origin, `quat` to identity, `type` to `"box"` and `parent` to the worldbody, so one missing check covered six ops. All of these returned `status="success"` with an "op(s) applied" count on `main`:

| Call | Reported | Actually compiled |
|---|---|---|
| `set_body_pos(name="crate", position=[...])` | success | body moved to the world origin |
| `set_body_quat(name="crate", quaternion=[...])` | success | orientation reset to identity |
| `add_body(name="widget", postion=[1,1,1])` | success | body spawned at the origin |
| `add_body(name="child", parent_body="crate")` | success | re-parented to the worldbody |
| `add_geom(body=..., shape="sphere", color=[0,0,1,1])` | success | default grey **box** |
| `add_site(body=..., name="tip", location=[0,0,0.3])` | success | site at the body origin |

The `set_body_pos` case is the worst of the set: it is silently destructive. A scene that was assembled correctly gets one body teleported into the world origin - typically inside the robot base or the table it was standing on - and nothing in the session names it. The `parent_body` case silently changes the kinematic tree, so a body meant to ride with a link stays fixed in the world.

This is the same shape already fixed for `add_object(material=...)` (unknown material keys) and `run_policy(video=...)` (unknown video keys); the op-dict vocabulary was the remaining dict-shaped parameter reading its fields with bare `.get()`.

## Change

`_PATCH_OP_KEYS` maps each op to the complete set of keys that op reads, and is now the single source of truth for the vocabulary - it replaces the `_PATCH_OPS` name-only set, so the supported ops and their accepted keys cannot drift apart:

```
add_body       op, parent, name, pos, quat
add_geom       op, body, type, size, rgba, name, pos, quat
add_site       op, body, name, pos, size, rgba
set_body_pos   op, name, pos
set_body_quat  op, name, quat
delete_body    op, name
```

Any other key is refused before the op runs:

```
set_body_pos: unknown op key(s): 'position' (did you mean 'pos'?). Accepted keys: name, op, pos.
add_geom: unknown op key(s): 'color', 'shape'. Accepted keys: body, name, op, pos, quat, rgba, size, type.
```

Suggestions come from `difflib` at cutoff 0.5, which catches the realistic near-misses (`position`/`postion` -> `pos`, `quaternion` -> `quat`, `parent_body` -> `parent`, `sizes` -> `size`). `op` is excluded from the suggestion candidates - it selects the op and is already validated one line above, so offering it would turn a real MJCF attribute like `group` into a nonsense hint; an unrelated key gets the accepted list and no suggestion. Every unknown key in an op is reported together rather than one per round-trip.

The rejection rides the existing atomic-batch path, so a bad key in op #2 rolls op #1 back too - the scene is left exactly as it was rather than half-patched.

## Visual artifact

One script, three calls, run against both trees: build a crate on a pedestal, ask to raise the crate (spelling `pos` as `position`), then add a blue sphere marker above it (spelling `type`/`rgba` as `shape`/`color`). Headless MuJoCo render (`MUJOCO_GL=egl`), same camera.

![patch_scene_mjcf unknown op keys](https://raw.githubusercontent.com/cagataycali/robots/artifacts/patch-op-keys/patch_op_keys.png)

| | before | after |
|---|---|---|
| `set_body_pos ... position=[0,0,0.62]` | `status=success` | `status=error` naming `'position'` |
| `add_geom ... shape=sphere color=blue` | `status=success` | `status=error` naming `'color'`, `'shape'` |
| crate `body_pos` z (asked for 0.62) | **0.00 m** - sunk to the origin, inside the pedestal | 0.32 m, unchanged |
| marker geom compiled | grey **box** | none - the patch was refused |

The left panel is what three "successful" patches produce: the crate has vanished into the pedestal and the marker is a grey box in the wrong shape. L1 between panels 9.5e5.

## Tests

`tests/simulation/mujoco/test_patch_scene_mjcf_unknown_op_keys.py` - 20 tests over three groups: the six silent-default cases (each asserts the scene is unchanged, not just that the status flipped), the message contract (op named, close match present, accepted list, unrelated key gets no suggestion, all unknown keys reported together, late-op rejection rolls the batch back), and the positive contract (an op using every key it documents is applied; every vocabulary entry contains `op`).

**10 of 12 behavioural tests fail on pre-fix code** (the two that pass are `delete_body`, which already required `name`, and the all-documented-keys happy path):

```
FAILED ...::test_set_body_pos_with_position_key_does_not_move_the_body - assert 'success' == 'error'
FAILED ...::test_add_body_with_misspelled_parent_does_not_reparent_to_world - assert 'success' == 'error'
FAILED ...::test_message_names_the_op_the_key_and_the_accepted_keys
  - assert 'set_body_pos' in 'Patched scene: 1 op(s) applied ...'
10 failed, 2 passed
```

## Gate

`ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean. Full suite `MUJOCO_GL=egl pytest tests`: **12423 passed / 260 skipped** in 429s. Two failures in `test_physics.py::TestFullMassMatrixSignatureDrift` are pre-existing and environment-only - reproduced on a clean tree at this base; the local mujoco is 3.11, which renamed `MjData.qM` to `MjData.M`, and those tests reference the old attribute.

## Docs

`docs/simulation/world-building.md` gains a "Surgical MJCF edits" section with the per-op key table and the rejection rationale; the `Simulation.patch_scene_mjcf` docstring and the `ops` `tool_spec.json` description carry the same vocabulary, so an agent reading either surface sees the accepted keys before it guesses.

---

**Synced with `main`** — mechanical merge only. `main` picked up the MuJoCo 3.11 mass-matrix fix (#1682), which every open branch needed to get a green `Test and Lint` run; the only conflict was CHANGELOG entry ordering under `[Unreleased]`, resolved by keeping both entries. The change under review is byte-identical; the sync commit dismissed the prior approval, so this needs a re-approval rather than a fresh review. CI is green on the synced head.

### Round 1 - merged main to clear the CHANGELOG append conflict (commit a99c86d)

`main` advanced to `44d4f6b` (#1675) while this PR sat approved, which turned it
CONFLICTING. The only conflicting file was `CHANGELOG.md`: this branch appends an
entry at the top of `## [Unreleased]` and #1675's entry anchors at the identical
position, so the two collide on ordering alone, not on meaning.

Resolved by merging `main` in as a plain merge commit (no rebase, no force-push, so
the review trail is intact) and taking `CHANGELOG.md` as a union - both entries
kept, this branch's first. Verified: no conflict markers remain, the `###` heading
count is exactly base + this branch + #1675, and diffing the pre-merge head against
the post-merge head shows only `CHANGELOG.md` plus the three files #1675 itself
changed. No file belonging to this PR moved.

Note: the push auto-dismissed the prior approval (the repo dismisses stale reviews
on push). The only diff since approval is this merge commit.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1681-patch-op-unknown-keys.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

The push dismissed the prior approval. The reviewed diff is otherwise byte-identical: the delta is the fragment move plus the merge.
