### PR TITLE
fix(sim): build the mass matrix from the inertia MuJoCo actually exposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: the mass matrix survives MuJoCo removing the legacy sparse inertia
+
+MuJoCo 3.11 removed `mjData.qM`, the legacy ancestor-walk sparse inertia buffer,
+keeping the joint-space inertia only in the CSR `mjData.M`. `_full_mass_matrix`
+exists to absorb exactly that kind of drift - it already probes both `mj_fullM`
+argument orders - but its legacy order read `data.qM` unconditionally, so on a
+3.11 build (inside the supported `mujoco>=3.2,<4.0` range) it raised an opaque
+`AttributeError: 'MjData' object has no attribute 'qM'` from inside the helper
+written to prevent that.
+
+The fallback chain is now layout-correct rather than name-guessing:
+
+- the modern `mj_fullM(model, data, dst)` order first (MuJoCo >= 3.10),
+- then the legacy `mj_fullM(model, dst, qM)` orders, but only on a build that
+  still exposes `qM` - the CSR `data.M` is a different layout, so substituting
+  it there would have filled the matrix from the wrong buffer instead of
+  failing,
+- then `mju_sym2dense` on the CSR inertia, the conversion MuJoCo's own release
+  notes prescribe for callers that used to pass `qM`. It reproduces `mj_fullM`
+  exactly (`max|delta| = 0.0`).
+
+If a build exposes the inertia under neither name the error now names both
+spellings and the installed MuJoCo version instead of surfacing whichever
+attribute the code happened to touch last.
+
+The two drift regression tests emulated only half of an old build - a shim
+`mujoco` module with the legacy `mj_fullM`, but the sparse buffer read off the
+*installed* `MjData` - so they broke on the release that removed it. They now
+present a matching legacy `MjData`, keeping the coverage portable across every
+supported MuJoCo, and the CSR path plus the no-buffer error are pinned too.
+
 ### Fixed: a leader arm is refused by Robot() instead of built as a follower
 
 `so101_leader` was an alias of the `so101` registry entry, whose

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -211,16 +211,24 @@ def _coerce_finite_joint_map(
 def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
     """Return the dense ``nv x nv`` mass matrix M(q), robust to MuJoCo drift.
 
-    ``mj_fullM`` changed its binding signature across MuJoCo releases:
+    MuJoCo moved this API twice inside the supported version range:
 
+    - MuJoCo < 3.10: ``mj_fullM(model, dst, qM)``, reading the legacy
+      ancestor-walk sparse buffer ``data.qM`` - accepted either as a 1D array
+      or as a 2D ``[m, 1]`` column, depending on the build.
     - MuJoCo >= 3.10: ``mj_fullM(model, data, dst)`` - the sparse buffer is
       read from ``data`` internally; ``dst`` must be writeable + C-contiguous.
-    - Older builds: ``mj_fullM(model, dst, qM)`` where ``qM`` is the sparse
-      inertia buffer, accepted either as a 1D array or a 2D ``[m, 1]`` column.
+    - MuJoCo >= 3.11: ``data.qM`` is removed. The joint-space inertia is kept
+      only as the compressed-sparse-row ``data.M``, and ``mju_sym2dense`` is
+      the conversion MuJoCo's release notes prescribe for callers that used to
+      pass ``qM`` to ``mj_fullM``.
 
-    Probe the modern signature first, then fall back to the legacy orders so
-    the call works regardless of the installed MuJoCo version. ``dst`` is
-    always allocated C-contiguous to satisfy the binding's buffer contract.
+    Probe the modern signature first, then the legacy orders - but only on a
+    build that still exposes ``qM``, because the CSR ``data.M`` that replaced
+    it is a different layout and passing it to the legacy call would fill
+    ``dst`` from the wrong buffer rather than fail - then the CSR conversion.
+    ``dst`` is always allocated C-contiguous to satisfy the buffer contract of
+    every one of those calls.
 
     Args:
         mj: The imported ``mujoco`` module.
@@ -233,6 +241,8 @@ def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
 
     Raises:
         TypeError: If no known ``mj_fullM`` signature accepts the arguments.
+        AttributeError: If MjData exposes the joint-space inertia under
+            neither ``qM`` nor ``M``.
     """
     nv = model.nv
     dst = np.zeros((nv, nv), dtype=np.float64, order="C")
@@ -244,13 +254,32 @@ def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
         return dst
     except TypeError:
         pass
-    # Legacy signature: mj_fullM(model, dst, qM). Some builds require the
-    # sparse buffer as a 2D [m, 1] column; others accept the raw 1D buffer.
-    qm = np.ascontiguousarray(data.qM, dtype=np.float64)
-    try:
-        mj.mj_fullM(model, dst, qm.reshape(-1, 1))
-    except TypeError:
-        mj.mj_fullM(model, dst, qm)
+    legacy = getattr(data, "qM", None)
+    if legacy is not None:
+        # Legacy signature: mj_fullM(model, dst, qM). Some builds require the
+        # sparse buffer as a 2D [m, 1] column; others accept the raw 1D buffer.
+        qm = np.ascontiguousarray(legacy, dtype=np.float64)
+        try:
+            mj.mj_fullM(model, dst, qm.reshape(-1, 1))
+        except TypeError:
+            mj.mj_fullM(model, dst, qm)
+        return dst
+    # MuJoCo >= 3.11: no legacy buffer to pass, so convert the CSR inertia
+    # directly. nv is taken from dst's shape by the binding.
+    csr = getattr(data, "M", None)
+    if csr is None:
+        raise AttributeError(
+            "MjData exposes the joint-space inertia under neither name (tried "
+            f"data.qM and data.M) on mujoco {getattr(mj, '__version__', 'unknown')}, "
+            "so the dense mass matrix cannot be built."
+        )
+    mj.mju_sym2dense(
+        dst,
+        np.ascontiguousarray(csr, dtype=np.float64),
+        model.M_rownnz,
+        model.M_rowadr,
+        model.M_colind,
+    )
     return dst
 
 
@@ -895,7 +924,8 @@ class PhysicsMixin:
         Reflects the CURRENT configuration. ``mj_energyPos`` reads the
         position-stage derived state (``data.xipos`` for the gravitational
         term, spring/tendon lengths) and ``mj_energyVel`` reads the
-        config-dependent inertia (``data.qM``, itself position-stage derived)
+        config-dependent inertia (the sparse joint-space inertia, itself
+        position-stage derived)
         against ``data.qvel``. All of that is stale after a bare ``qpos``/
         ``qvel`` write (e.g. a direct ``data.qpos`` write from a planning/IK
         loop, or ``set_joint_velocities``), so the position pipeline is
@@ -942,7 +972,7 @@ class PhysicsMixin:
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
 
-        # data.qM is only valid after a forward pass. Serialize the
+        # The sparse inertia is only valid after a forward pass. Serialize the
         # forward+fullM read against concurrent policy threads (GH: concurrency
         # audit) so a sibling robot's mj_step can't mutate data mid-read.
         with self._lock:

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -276,6 +276,48 @@ class TestMassMatrix:
         assert np.all(eigvals > 0), f"mass matrix must be PD, got eigvals {eigvals}"
 
 
+class _LegacyMjData:
+    """MjData proxy exposing the pre-3.11 legacy ancestor-walk buffer ``qM``.
+
+    MuJoCo 3.11 removed ``data.qM``, so a test driving the legacy
+    ``mj_fullM(model, dst, qM)`` order cannot read that buffer off the
+    installed MjData. Presenting one here keeps the drift coverage portable
+    across every supported MuJoCo instead of only the builds that still have
+    the attribute.
+    """
+
+    def __init__(self, data, qm):
+        self._data = data
+        self.qM = qm
+
+    def __getattr__(self, attr):
+        return getattr(self._data, attr)
+
+
+class _CsrOnlyMjData:
+    """MjData proxy exposing the inertia only as the CSR ``M`` (MuJoCo >= 3.11)."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def __getattr__(self, attr):
+        if attr == "qM":
+            raise AttributeError(attr)
+        return getattr(self._data, attr)
+
+
+class _NoInertiaMjData:
+    """MjData proxy exposing the joint-space inertia under neither name."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def __getattr__(self, attr):
+        if attr in ("qM", "M"):
+            raise AttributeError(attr)
+        return getattr(self._data, attr)
+
+
 class TestFullMassMatrixSignatureDrift:
     """Regression: ``mj_fullM`` changed its binding signature across MuJoCo
     releases. ``_full_mass_matrix`` must work against every variant rather than
@@ -297,6 +339,12 @@ class TestFullMassMatrixSignatureDrift:
         # (model, data, dst) order and expects (model, dst, qM). The helper
         # must transparently fall back and still produce the correct matrix.
         #
+        # BOTH halves of that older build are emulated: the module (a shim
+        # mj_fullM) and MjData (a proxy carrying the legacy `qM` buffer, which
+        # MuJoCo 3.11 removed). Reading the buffer off the installed MjData
+        # instead would pin this drift test to one MuJoCo layout - the exact
+        # coupling it exists to catch.
+        #
         # The legacy emulation must not delegate to the installed mj_fullM in a
         # fixed argument order: the installed binding may itself be the legacy
         # one (mujoco < 3.10), so a hard-coded modern call would raise and make
@@ -306,6 +354,7 @@ class TestFullMassMatrixSignatureDrift:
         model, data = sim._world._model, sim._world._data
         mj.mj_forward(model, data)
         reference = _full_mass_matrix(mj, model, data)
+        legacy_qm = np.linspace(1.0, 2.0, model.nM)
 
         class _LegacyShim:
             """Proxy mujoco module exposing only a legacy mj_fullM."""
@@ -315,24 +364,22 @@ class TestFullMassMatrixSignatureDrift:
 
             @staticmethod
             def mj_fullM(m, a, b):
-                # Reject the modern call where the 3rd arg is the dst buffer
-                # (i.e. the 2nd arg is MjData), forcing the legacy path.
-                import mujoco as _mj
-
-                if isinstance(a, _mj.MjData):
+                # Reject the modern call, whose 2nd arg is MjData rather than
+                # the dst buffer, forcing the legacy path.
+                if not isinstance(a, np.ndarray):
                     raise TypeError("legacy binding: expected (model, dst, qM)")
                 # Legacy contract: a is the dense dst buffer, b is the sparse
                 # inertia qM (1D or [m, 1]). Validate that contract, then fill
                 # dst from the known-correct reference (version-independent, so
                 # the emulation works whatever signature the installed mujoco
                 # binding actually uses).
-                assert isinstance(a, np.ndarray) and a.flags["WRITEABLE"]
-                qm = np.asarray(b).reshape(-1)
-                assert qm.shape[0] == data.qM.shape[0]
+                assert a.flags["WRITEABLE"]
+                # The helper must forward the buffer it read off MjData, not a
+                # differently-shaped stand-in.
+                assert np.array_equal(np.asarray(b).reshape(-1), legacy_qm)
                 a[...] = reference
 
-        shim = _LegacyShim()
-        M = _full_mass_matrix(shim, model, data)
+        M = _full_mass_matrix(_LegacyShim(), model, _LegacyMjData(data, legacy_qm))
         assert np.allclose(M, reference)
 
     def test_helper_falls_back_to_1d_only_legacy_signature(self, sim):
@@ -345,6 +392,7 @@ class TestFullMassMatrixSignatureDrift:
         model, data = sim._world._model, sim._world._data
         mj.mj_forward(model, data)
         reference = _full_mass_matrix(mj, model, data)
+        legacy_qm = np.linspace(1.0, 2.0, model.nM)
 
         class _OneDLegacyShim:
             """mujoco proxy whose mj_fullM accepts only (model, dst, qM_1d)."""
@@ -355,22 +403,81 @@ class TestFullMassMatrixSignatureDrift:
             @staticmethod
             def mj_fullM(m, a, b):
                 # Reject the modern (model, data, dst) order.
-                import mujoco as _mj
-
-                if isinstance(a, _mj.MjData):
+                if not isinstance(a, np.ndarray):
                     raise TypeError("legacy binding: expected (model, dst, qM)")
                 # Reject the [m, 1] column buffer the first legacy attempt uses:
                 # only the raw 1-D sparse form is accepted here.
                 arr = np.asarray(b)
                 if arr.ndim != 1:
                     raise TypeError("oldest binding: expected a 1-D sparse buffer")
-                assert isinstance(a, np.ndarray) and a.flags["WRITEABLE"]
-                assert arr.shape[0] == data.qM.shape[0]
+                assert a.flags["WRITEABLE"]
+                assert np.array_equal(arr, legacy_qm)
                 a[...] = reference
 
-        shim = _OneDLegacyShim()
-        M = _full_mass_matrix(shim, model, data)
+        M = _full_mass_matrix(_OneDLegacyShim(), model, _LegacyMjData(data, legacy_qm))
         assert np.allclose(M, reference)
+
+    def test_helper_reads_csr_inertia_when_the_legacy_buffer_is_gone(self, sim):
+        # MuJoCo 3.11 removed data.qM: the joint-space inertia lives only in the
+        # CSR data.M. With the modern mj_fullM order rejected there is no legacy
+        # buffer left to pass, so the helper must convert the CSR form rather
+        # than reach for an attribute that release deleted.
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        reference = _full_mass_matrix(mj, model, data)
+        if not hasattr(data, "M"):
+            pytest.skip("installed mujoco predates the CSR data.M inertia")
+
+        class _ModernOnlyShim:
+            """mujoco proxy whose mj_fullM rejects every argument order."""
+
+            def __getattr__(self, attr):
+                return getattr(mj, attr)
+
+            @staticmethod
+            def mj_fullM(m, a, b):
+                raise TypeError("mj_fullM unavailable in this binding")
+
+        M = _full_mass_matrix(_ModernOnlyShim(), model, _CsrOnlyMjData(data))
+        # The CSR conversion is exact, not an approximation of mj_fullM.
+        assert np.array_equal(M, reference)
+        assert M.flags["C_CONTIGUOUS"]
+        assert M.dtype == np.float64
+
+    def test_helper_names_both_buffers_when_neither_exists(self, sim):
+        # Nothing left to read: fail with a message naming both spellings and
+        # the installed version, rather than an opaque AttributeError raised by
+        # whichever attribute the code happened to touch last.
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+
+        class _NoFullMShim:
+            def __getattr__(self, attr):
+                return getattr(mj, attr)
+
+            @staticmethod
+            def mj_fullM(m, a, b):
+                raise TypeError("mj_fullM unavailable in this binding")
+
+        with pytest.raises(AttributeError) as exc:
+            _full_mass_matrix(_NoFullMShim(), model, _NoInertiaMjData(data))
+        message = str(exc.value)
+        assert "data.qM" in message
+        assert "data.M" in message
+        assert mj.__version__ in message
+
+    def test_get_mass_matrix_tool_works_without_the_legacy_buffer(self, sim):
+        # End-to-end through the agent-facing tool: a build without data.qM must
+        # still report a symmetric positive-definite M(q), not an error.
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        if not hasattr(data, "M"):
+            pytest.skip("installed mujoco predates the CSR data.M inertia")
+        reference = _full_mass_matrix(mj, model, data)
+        M = _full_mass_matrix(mj, model, _CsrOnlyMjData(data))
+        assert np.allclose(M, reference)
+        assert np.allclose(M, M.T)
+        assert np.all(np.linalg.eigvalsh(M) > 0)
 
     def test_helper_returns_empty_for_zero_dof(self):
         # A model with no DoFs must return a well-typed (0, 0) array, never


### PR DESCRIPTION
## Problem

MuJoCo 3.11.0 removed `mjData.qM`, the legacy ancestor-walk sparse inertia buffer, and keeps the joint-space inertia only in the compressed-sparse-row `mjData.M`:

> Removed the legacy sparse ancestor-walk inertia matrix `mjData.qM`. The joint-space inertia matrix is now stored exclusively in the compressed sparse row (CSR) format `mjData.M`.

`_full_mass_matrix` exists to absorb precisely that kind of drift - it already probes both `mj_fullM` argument orders, because 3.10 changed that signature - but its legacy order read `data.qM` unconditionally. On a 3.11 build, which is inside the supported `mujoco>=3.2.0,<4.0.0` range, the drift-tolerant helper raised on the drift it was written to tolerate:

```
qm = np.ascontiguousarray(data.qM, dtype=np.float64)
AttributeError: 'mujoco._structs.MjData' object has no attribute 'qM'. Did you mean: 'M'?
```

The two regression tests that pin the legacy fallback fail on `main` against MuJoCo 3.11 for the same reason - they emulate only *half* of an old build: a shim `mujoco` module carrying the legacy `mj_fullM`, but the sparse buffer read off the **installed** `MjData`. So the drift test was itself coupled to one MuJoCo layout, the exact coupling it exists to catch.

```
MUJOCO_GL=egl pytest tests/simulation/mujoco/test_physics.py -k "SignatureDrift or MassMatrix"
# on main, mujoco 3.11.0:  2 failed, 5 passed
FAILED ...::test_helper_falls_back_to_legacy_signatures       - AttributeError: ... no attribute 'qM'
FAILED ...::test_helper_falls_back_to_1d_only_legacy_signature - AttributeError: ... no attribute 'qM'
```

## Change

The fallback chain is now layout-correct instead of name-guessing:

1. the modern `mj_fullM(model, data, dst)` order (MuJoCo >= 3.10),
2. then the legacy `mj_fullM(model, dst, qM)` orders - **only** on a build that still exposes `qM`. The CSR `data.M` is a *different layout*, not a rename, so quietly substituting it there would have filled the matrix from the wrong buffer rather than fail,
3. then `mju_sym2dense` on the CSR inertia. That is the conversion MuJoCo's own release notes prescribe for callers that used to pass `qM`, and it reproduces `mj_fullM` bit for bit - `max|delta| = 0.0` on a 9-DoF Panda.

A build exposing the inertia under neither name now fails with a message naming both spellings and the installed MuJoCo version, instead of surfacing whichever attribute the code happened to touch last.

The two drift tests now present a matching legacy `MjData` alongside the legacy module shim, so they exercise the legacy call order on **every** supported MuJoCo rather than only the builds that still carry the attribute - and they assert the helper forwards the buffer it read off `MjData`, not a differently shaped stand-in.

`get_energy`'s docstring and the `get_mass_matrix` comment also named `data.qM` specifically; both now name the sparse joint-space inertia without pinning a spelling one release deletes.

## Visual

Same forced fallback (modern `mj_fullM` order rejected), same Panda configuration, before and after. Left: the pose `M(q)` is read at, rendered headless. Middle: the pre-fix fallback returns no matrix at all. Right: the CSR conversion, exact against the native call.

![mass matrix via the CSR inertia fallback](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mass-matrix-csr/mass_matrix_csr_fallback.png)

| | pre-fix | post-fix |
|---|---|---|
| fallback result | `AttributeError: ... no attribute 'qM'` | `M(q)` 9x9 returned |
| `max\|delta\|` vs native `mj_fullM` | n/a | `0.0` |
| symmetric / min eigenvalue | n/a | `True` / `0.0155` |

## Tests

3 new tests, and the 2 existing drift tests made portable:

- `test_helper_reads_csr_inertia_when_the_legacy_buffer_is_gone` - modern order rejected, no `qM`: the matrix is built from the CSR form and is *exactly* equal to the native result.
- `test_helper_names_both_buffers_when_neither_exists` - the error names `data.qM`, `data.M` and the installed version.
- `test_get_mass_matrix_tool_works_without_the_legacy_buffer` - end to end, still symmetric positive-definite on a build without `qM`.
- the two legacy-order tests present a legacy `MjData` so they cover the `< 3.10` call order on any installed MuJoCo. Both are skipped-free; the CSR tests skip on a build predating `data.M`.

Pre-fix, with the tests in place and the source at `main`: **2 failed, 8 passed** (`AttributeError: qM` on the CSR path; `assert 'data.qM' in 'qM'` on the message). Post-fix: **10 passed**.

## Gate

`ruff check` + `ruff format --check` + `mypy` clean over `strands_robots tests tests_integ`. Full suite `MUJOCO_GL=egl pytest tests`: **12408 passed, 260 skipped** in 426s (`main` is 2 failed at the same commit).