### PR TITLE
fix(deps): the sim extra declares the IK solver its move_to primitive needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,69 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: the sim extra declares the IK solver its move_to primitive needs
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-`move_to` - the Cartesian transport primitive in the MuJoCo backend's
-agent-callable action enum - solves inverse kinematics through
-`MinkIKBridge`, i.e. through `mink` + `qpsolvers`. No extra declared either
-package, so on the advertised install the action was a dead end:
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
 ```python
-Robot("panda", mode="sim").move_to(position=[0.4, 0.0, 0.4])
-# pip install "strands-robots[all]"
-# {"status": "error"}  move_to: IK bridge unavailable: ... No module named 'mink'
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
 ```
 
-The library documented the gap rather than closing it: the install hint read
-`uv pip install 'strands-robots[sim-mujoco]' mink` - an extra plus a package
-name no extra provides - and the dev environment installed `mink` by hand, which
-is why every IK test passed in CI while the action could not run for a user.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
 
-`[sim-mujoco]` now declares `mink` and `qpsolvers`, so `[sim-mujoco]` and
-`[all]` can run `move_to`; the dev env drops its hand-installed copies and gets
-them through `features = ["all"]` like every other dependency; and the four IK
-install hints name only extras, matching the `cosmos3-sim` hint that was already
-self-sufficient. `mink` brings its own QP backend (`qpsolvers[daqp]`, the
-bridge's first preference), so no additional solver has to be chosen.
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
+
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: the sim extra declares the IK solver its move_to primitive needs
+
+`move_to` - the Cartesian transport primitive in the MuJoCo backend's
+agent-callable action enum - solves inverse kinematics through
+`MinkIKBridge`, i.e. through `mink` + `qpsolvers`. No extra declared either
+package, so on the advertised install the action was a dead end:
+
+```python
+Robot("panda", mode="sim").move_to(position=[0.4, 0.0, 0.4])
+# pip install "strands-robots[all]"
+# {"status": "error"}  move_to: IK bridge unavailable: ... No module named 'mink'
+```
+
+The library documented the gap rather than closing it: the install hint read
+`uv pip install 'strands-robots[sim-mujoco]' mink` - an extra plus a package
+name no extra provides - and the dev environment installed `mink` by hand, which
+is why every IK test passed in CI while the action could not run for a user.
+
+`[sim-mujoco]` now declares `mink` and `qpsolvers`, so `[sim-mujoco]` and
+`[all]` can run `move_to`; the dev env drops its hand-installed copies and gets
+them through `features = ["all"]` like every other dependency; and the four IK
+install hints name only extras, matching the `cosmos3-sim` hint that was already
+self-sufficient. `mink` brings its own QP backend (`qpsolvers[daqp]`, the
+bridge's first preference), so no additional solver has to be chosen.
 ### Fixed: the mass matrix survives MuJoCo removing the legacy sparse inertia
 
 MuJoCo 3.11 removed `mjData.qM`, the legacy ancestor-walk sparse inertia buffer,

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ extras you need:
 
 | Extra | Installs | Use for |
 |-------|----------|---------|
-| `sim-mujoco` | MuJoCo, robot_descriptions, imageio | Simulation (recommended starting point) |
+| `sim-mujoco` | MuJoCo, robot_descriptions, imageio, mink + qpsolvers | Simulation (recommended starting point). mink/qpsolvers are the differential-IK solver behind the `move_to` Cartesian transport primitive. |
 | `sim-newton` | Newton, Warp, MuJoCo-Warp, trimesh | GPU-native simulation (NVIDIA GPU; batched envs, headless ray-traced render) |
 | `sim-isaac` | usd-core, imageio (Isaac Sim installed out-of-band) | NVIDIA Isaac Sim backend - photorealistic RTX rendering, synthetic data, GPU-batched sensors, USD-native scenes. Isaac Sim itself is **not** pip-installable; install it via the Omniverse Launcher, Isaac Lab, or the NGC docker image. This extra pulls only the pip-installable Python helpers. (NVIDIA RTX GPU; GPU-only, not in `[all]`.) |
 | `sim-gs` | gsplat, plyfile, torch | 3D Gaussian Splatting hybrid rendering (`strands_robots.rendering`): composite any sim backend's robot over a captured photoreal 3DGS scene. `gsplat` ships as a source dist that JIT-compiles CUDA kernels via `nvcc` on first use - probe with `strands_robots.rendering.gsplat_rasterizer_available()`; the zero-GPU `PanoramaBackground` works without this extra. (CUDA GPU; GPU-only, not in `[all]`.) |

--- a/changelog.d/1683-declare-ik-solver-in-sim-extra.md
+++ b/changelog.d/1683-declare-ik-solver-in-sim-extra.md
@@ -1,0 +1,24 @@
+### Fixed: the sim extra declares the IK solver its move_to primitive needs
+
+`move_to` - the Cartesian transport primitive in the MuJoCo backend's
+agent-callable action enum - solves inverse kinematics through
+`MinkIKBridge`, i.e. through `mink` + `qpsolvers`. No extra declared either
+package, so on the advertised install the action was a dead end:
+
+```python
+Robot("panda", mode="sim").move_to(position=[0.4, 0.0, 0.4])
+# pip install "strands-robots[all]"
+# {"status": "error"}  move_to: IK bridge unavailable: ... No module named 'mink'
+```
+
+The library documented the gap rather than closing it: the install hint read
+`uv pip install 'strands-robots[sim-mujoco]' mink` - an extra plus a package
+name no extra provides - and the dev environment installed `mink` by hand, which
+is why every IK test passed in CI while the action could not run for a user.
+
+`[sim-mujoco]` now declares `mink` and `qpsolvers`, so `[sim-mujoco]` and
+`[all]` can run `move_to`; the dev env drops its hand-installed copies and gets
+them through `features = ["all"]` like every other dependency; and the four IK
+install hints name only extras, matching the `cosmos3-sim` hint that was already
+self-sufficient. `mink` brings its own QP backend (`qpsolvers[daqp]`, the
+bridge's first preference), so no additional solver has to be chosen.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ graph TB
 
 | Extra | Pulls in | When |
 |-------|----------|------|
-| `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg` | `Robot(mode="sim")` |
+| `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg`, `mink`, `qpsolvers` | `Robot(mode="sim")`; `mink`/`qpsolvers` solve IK for the `move_to` primitive |
 | `[lerobot]` | `lerobot>=0.6.0,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` ZMQ |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | `ModuleNotFoundError: mujoco` | Missing `[sim-mujoco]` | `uv pip install "strands-robots[sim-mujoco]"` |
+| `move_to: IK bridge unavailable: ... No module named 'mink'` | Missing `[sim-mujoco]` (the extra declares the IK solver) | `uv pip install "strands-robots[sim-mujoco]"` |
 | `ModuleNotFoundError: lerobot` | Missing `[lerobot]` | `uv pip install "strands-robots[lerobot]"` |
 | `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.0,<0.7.0`) |
 | `ImportError: cannot import name 'MolmoAct2Policy'` | `lerobot < 0.6` (`MolmoAct2Policy` ships in lerobot >= 0.6) | `uv pip install "strands-robots[molmoact2]"` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,15 @@ sim-mujoco = [
     "mujoco>=3.2.0,<4.0.0",
     "imageio>=2.28.0,<3.0.0",
     "imageio-ffmpeg>=0.4.0,<1.0.0",
+    # Differential-IK solver stack. `move_to`, the Cartesian transport
+    # primitive in this backend's agent-callable action enum, solves IK on the
+    # same mujoco.MjModel via strands_robots.simulation.ik.MinkIKBridge, so the
+    # solver is part of what this extra ships rather than an add-on the caller
+    # has to name themselves. `mink` pulls a QP backend of its own
+    # (qpsolvers[daqp], the bridge's first preference); `qpsolvers` is declared
+    # here too because simulation/ik.py imports it directly.
+    "mink>=0.0.4",
+    "qpsolvers>=4.0.0",
 ]
 # Newton GPU-native backend (newton-physics/newton on NVIDIA Warp +
 # MuJoCo-Warp). GPU-batched parallel envs, headless ray-traced rendering, and
@@ -420,12 +429,6 @@ dependencies = [
     "requests>=2.28.0,<3.0.0",
     "msgpack>=1.0.0,<2.0.0",
     "pyzmq>=27.0.0,<28.0.0",
-    # mink (differential IK) for the Cosmos 3 sim-loop bridge regression test
-    # (tests/policies/cosmos3/test_sim_ik.py); the cosmos3-sim extra is not in
-    # `features=all`, so pull it into the dev env explicitly. mujoco comes from
-    # sim-mujoco (already in `all`).
-    "mink>=0.0.4",
-    "qpsolvers[quadprog]>=4.0.0",
 ]
 
 # ---------------------------------------------------------------------------

--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -39,7 +39,7 @@ def _install_hint() -> str:
     return (
         "The VERA eef-delta IK-to-MuJoCo bridge needs 'mink' + 'mujoco', which "
         "were not importable. Install the sim extra:\n"
-        "  uv pip install 'strands-robots[sim-mujoco]' mink\n"
+        "  uv pip install 'strands-robots[sim-mujoco]'\n"
         "This turns VERA's end-effector delta chunk (mimicgen/droid) into joint "
         "targets the MuJoCo arm can track. For joint_position embodiments "
         "(allegro) no IK is needed - the action maps directly to joints."
@@ -48,8 +48,8 @@ def _install_hint() -> str:
 
 _NO_BACKEND_MSG = (
     "No qpsolvers backend is installed; the VERA IK bridge needs one "
-    "(e.g. 'daqp' or 'quadprog'). Install: "
-    "uv pip install 'strands-robots[sim-mujoco]' 'qpsolvers[quadprog]'."
+    "(e.g. 'daqp' or 'quadprog'). Install the sim extra: "
+    "uv pip install 'strands-robots[sim-mujoco]'."
 )
 
 

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -43,15 +43,16 @@ _PREFERRED_QP_SOLVERS = ("daqp", "quadprog", "osqp", "proxqp", "cvxopt", "scs")
 _DEFAULT_INSTALL_HINT = (
     "The mink IK bridge needs 'mink' + 'mujoco' + a qpsolvers backend, which "
     "were not importable. Install the sim extra:\n"
-    "  uv pip install 'strands-robots[sim-mujoco]' mink\n"
-    "This pulls mink (differential IK on the MuJoCo model) and mujoco, turning "
-    "Cartesian end-effector targets into joint configurations the arm can track."
+    "  uv pip install 'strands-robots[sim-mujoco]'\n"
+    "This pulls mink (differential IK on the MuJoCo model), mujoco and a QP "
+    "backend, turning Cartesian end-effector targets into joint configurations "
+    "the arm can track."
 )
 
 _DEFAULT_NO_BACKEND_MSG = (
     "No qpsolvers backend is installed; the mink IK bridge needs one "
-    "(e.g. 'daqp' or 'quadprog'). Install: "
-    "uv pip install 'strands-robots[sim-mujoco]' 'qpsolvers[quadprog]'."
+    "(e.g. 'daqp' or 'quadprog'). Install the sim extra: "
+    "uv pip install 'strands-robots[sim-mujoco]'."
 )
 
 

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -346,3 +346,127 @@ def test_vera_sim_is_forked_away_from_lerobot06_extras():
             f"its gymnasium 0.29 pin cannot drag the lock below lerobot 0.6; "
             f"forked pairs found: {sorted(forked)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# The IK solver stack must be declared by the extra that ships `move_to`.
+#
+# `move_to` is a Cartesian transport primitive in the MuJoCo backend's
+# agent-callable action enum, and it solves inverse kinematics through
+# `strands_robots.simulation.ik.MinkIKBridge`, i.e. through `mink` +
+# `qpsolvers`. Neither was declared by any extra reachable from `[all]`, so on
+# a `pip install "strands-robots[all]"` the action returned
+# `IK bridge unavailable: ... No module named 'mink'` -- and the only reason CI
+# did not see it was that the dev environment installed `mink` by hand. These
+# guards pin the two halves of that: the extra declares the solver, and the dev
+# env does not compensate for an undeclared dependency (which is what let the
+# gap stay invisible while every IK test passed).
+_SELF_NAME = "strands-robots"
+_IK_SOLVER_PACKAGES = ("mink", "qpsolvers")
+
+
+def _extra_closure(extra: str) -> set[str]:
+    """Canonical names an extra pulls in, following ``strands-robots[...]`` self-references.
+
+    Args:
+        extra: Name of the extra in ``[project.optional-dependencies]``.
+
+    Returns:
+        The set of distribution names reachable from *extra*, lower-cased.
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    extras = data["project"]["optional-dependencies"]
+    seen: set[str] = set()
+    names: set[str] = set()
+    pending = [extra]
+    while pending:
+        current = pending.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        assert current in extras, f"unknown extra {current!r}"
+        for spec in extras[current]:
+            req = Requirement(spec)
+            if req.name.lower() == _SELF_NAME:
+                pending.extend(req.extras)
+                continue
+            names.add(req.name.lower())
+    return names
+
+
+def test_sim_mujoco_extra_declares_the_ik_solver_stack() -> None:
+    """``[sim-mujoco]`` must declare the solver its ``move_to`` primitive needs.
+
+    The extra ships the MuJoCo backend, whose action enum includes ``move_to``;
+    that action is a dead end unless the same extra also brings the IK solver.
+    """
+    closure = _extra_closure("sim-mujoco")
+    missing = [pkg for pkg in _IK_SOLVER_PACKAGES if pkg not in closure]
+    assert not missing, (
+        f"[sim-mujoco] ships the move_to primitive but does not declare {missing}; "
+        f"move_to then returns 'IK bridge unavailable'. Declared: {sorted(closure)}"
+    )
+
+
+def test_all_extra_can_run_the_move_to_primitive() -> None:
+    """``[all]`` must be able to honor every action the backends it installs advertise."""
+    closure = _extra_closure("all")
+    missing = [pkg for pkg in _IK_SOLVER_PACKAGES if pkg not in closure]
+    assert not missing, (
+        f"pip install 'strands-robots[all]' advertises move_to but does not install {missing}, so the action cannot run"
+    )
+
+
+def test_dev_env_does_not_install_undeclared_ik_dependencies() -> None:
+    """The dev env must not hand-install the IK stack the extras are meant to declare.
+
+    A test environment that adds a dependency no extra provides makes the IK
+    paths green in CI while they are unreachable for users; the solver has to
+    arrive through ``features = ["all"]`` like every other dependency.
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    env = data["tool"]["hatch"]["envs"]["default"]
+    assert env["features"] == ["all"], "the dev env must install the package via features"
+    offenders = [spec for spec in env.get("dependencies", []) if Requirement(spec).name.lower() in _IK_SOLVER_PACKAGES]
+    assert not offenders, (
+        f"the dev env pins {offenders} directly; declare them in the extra that "
+        f"needs them instead so a user install matches CI"
+    )
+
+
+def test_ik_install_hints_name_only_declared_extras() -> None:
+    """Every IK install hint must be a command of extras, not extras plus loose packages.
+
+    A hint reading ``uv pip install 'strands-robots[sim-mujoco]' mink`` documents
+    a dependency the extra does not declare. Each hint's install command must
+    consist solely of ``strands-robots[...]`` specs whose closure provides the
+    solver, so following it is sufficient.
+    """
+    from strands_robots.policies.cosmos3 import sim_ik as cosmos3_sim_ik
+    from strands_robots.policies.vera import sim_ik as vera_sim_ik
+    from strands_robots.simulation import ik as shared_ik
+
+    hints = {
+        "shared install": shared_ik._DEFAULT_INSTALL_HINT,
+        "shared no-backend": shared_ik._DEFAULT_NO_BACKEND_MSG,
+        "vera install": vera_sim_ik._install_hint(),
+        "vera no-backend": vera_sim_ik._NO_BACKEND_MSG,
+        "cosmos3 install": cosmos3_sim_ik._install_hint(),
+        "cosmos3 no-backend": cosmos3_sim_ik._NO_BACKEND_MSG,
+    }
+    for label, hint in hints.items():
+        commands = [line.split("uv pip install", 1)[1] for line in hint.splitlines() if "uv pip install" in line]
+        assert commands, f"{label} hint has no install command: {hint!r}"
+        for command in commands:
+            specs = [token.strip("'\".") for token in command.split() if token.strip("'\". ")]
+            assert specs, f"{label} hint has an empty install command"
+            for spec in specs:
+                req = Requirement(spec)
+                assert req.name.lower() == _SELF_NAME, (
+                    f"{label} hint tells the user to install {spec!r} alongside the "
+                    f"extra, i.e. a dependency no extra declares: {command.strip()!r}"
+                )
+                for name in req.extras:
+                    closure = _extra_closure(name)
+                    missing = [pkg for pkg in _IK_SOLVER_PACKAGES if pkg not in closure]
+                    assert not missing, f"{label} hint points at [{name}], which does not provide {missing}"


### PR DESCRIPTION
## Problem

`move_to` is the Cartesian transport primitive in the MuJoCo backend's agent-callable action enum. It solves inverse kinematics through `strands_robots.simulation.ik.MinkIKBridge`, i.e. through `mink` + `qpsolvers`. **No extra declared either package**, so on the advertised install the action was a dead end:

```python
# pip install "strands-robots[all]"
sim.move_to(robot_name="panda", position=[0.35, 0.20, 0.45], tol=0.02, max_steps=600)
# {"status": "error"}
# move_to: IK bridge unavailable: The mink IK bridge needs 'mink' + 'mujoco' +
# a qpsolvers backend, which were not importable. ...
```

The transitive closure of the extras confirms it - neither `[sim-mujoco]` (which ships the backend and the action) nor `[all]` names the solver:

```
[sim-mujoco] -> imageio, imageio-ffmpeg, mujoco, robot_descriptions
```

Two things kept this invisible:

1. **The install hint documented the gap instead of closing it.** It read `uv pip install 'strands-robots[sim-mujoco]' mink` - an extra *plus a package name no extra provides*. Same shape in the no-backend message (`'strands-robots[sim-mujoco]' 'qpsolvers[quadprog]'`) and in the VERA bridge's two hints. The `cosmos3` hint is the sibling that already does it right: `uv pip install strands-robots[cosmos3-sim]`, an extra that genuinely declares the stack.
2. **The dev environment installed `mink` by hand**, with a comment saying so:

   ```toml
   # mink (differential IK) for the Cosmos 3 sim-loop bridge regression test
   # ...; the cosmos3-sim extra is not in `features=all`, so pull it into the
   # dev env explicitly.
   "mink>=0.0.4",
   "qpsolvers[quadprog]>=4.0.0",
   ```

   So every IK test passed in CI in an environment no documented install reproduces, while the action could not run for a user.

## Change

`[sim-mujoco]` declares `mink` and `qpsolvers`, so `[sim-mujoco]` and `[all]` can run `move_to`. `mink` brings its own QP backend (`qpsolvers[daqp]` - already the bridge's first preference in `_PREFERRED_QP_SOLVERS`), so no solver has to be chosen and no extra compiled dependency is imposed beyond what `mink` itself requires. `qpsolvers` is named directly because `simulation/ik.py` imports it rather than relying on a transitive dependency.

The dev env drops its hand-installed copies and receives them through `features = ["all"]` like every other dependency, so CI and a user install now resolve the same set. The four IK install hints name only extras.

Docs updated in the same change: the extras tables in `README.md` and `docs/architecture.md`, and a `docs/troubleshooting.md` row mapping the `IK bridge unavailable` symptom to the extra.

## Visual

Same call, same scene, headless MuJoCo. Left: the arm on `pip install "strands-robots[all]"` before this change - the action returns an error and nothing moves. Right: the same install after it. The crosshair is the world target forward-projected through `get_camera_params`.

![move_to on the advertised install, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/move-to-ik-extra/move_to_ik_extra.png)

| | before | after |
|---|---|---|
| `status` | `error` (IK bridge unavailable) | `success` |
| `reached` / `steps` | n/a | `True` / `162` |
| `position_error_m` | n/a | `0.0199` (tol `0.02`) |
| `ik_residual_m` | n/a | `0.0005` |
| frame-to-frame L1 | `77` (renderer noise; the arm never moved) | `7.37e6` |

## Tests

Four guards in `tests/test_dependency_audit.py`, over a helper that resolves an extra's closure through `strands-robots[...]` self-references:

- `test_sim_mujoco_extra_declares_the_ik_solver_stack` - the extra that ships `move_to` declares its solver.
- `test_all_extra_can_run_the_move_to_primitive` - `[all]` can honor the action it advertises.
- `test_dev_env_does_not_install_undeclared_ik_dependencies` - the dev env must not compensate for an undeclared dependency; this is the guard that would have caught the gap, since compensating there is exactly what made CI green while users were broken.
- `test_ik_install_hints_name_only_declared_extras` - every IK hint's install command consists solely of `strands-robots[...]` specs whose closure provides the solver, so following it is sufficient. Covers all six hint strings (shared, VERA, cosmos3).

Pre-fix, with the tests in place and `pyproject.toml` + `strands_robots/` at `87a38821`: **4 failed, 18 passed**.

```
test_sim_mujoco_extra_declares_the_ik_solver_stack   - [sim-mujoco] ships the move_to primitive but does not declare ['mink', 'qpsolvers']
test_all_extra_can_run_the_move_to_primitive         - [all] advertises move_to but does not install ['mink', 'qpsolvers']
test_dev_env_does_not_install_undeclared_ik_deps     - the dev env pins ['mink>=0.0.4', 'qpsolvers[quadprog]>=4.0.0'] directly
test_ik_install_hints_name_only_declared_extras      - shared install hint points at [sim-mujoco], which does not provide ['mink', 'qpsolvers']
```

Post-fix: **22 passed**. The existing IK hint pins (`"sim-mujoco" in hint`, `"mink" in hint`) still hold.

## Gate

`ruff check` + `ruff format --check` + `mypy` clean over `strands_robots tests tests_integ`. Full suite `MUJOCO_GL=egl pytest tests`: **12430 passed, 253 skipped** in 412s on `87a38821`, no failures. Installing the stack the extra now declares also lets 7 previously-skipped `importorskip("mink")` IK tests execute locally.

### Round 1 - merged main to clear the CHANGELOG append conflict (commit e1a80e5)

`main` advanced to `44d4f6b` (#1675) while this PR sat approved, which turned it
CONFLICTING. The only conflicting file was `CHANGELOG.md`: this branch appends an
entry at the top of `## [Unreleased]` and #1675's entry anchors at the identical
position, so the two collide on ordering alone, not on meaning.

Resolved by merging `main` in as a plain merge commit (no rebase, no force-push, so
the review trail is intact) and taking `CHANGELOG.md` as a union - both entries
kept, this branch's first. Verified: no conflict markers remain, the `###` heading
count is exactly base + this branch + #1675, and diffing the pre-merge head against
the post-merge head shows only `CHANGELOG.md` plus the three files #1675 itself
changed. No file belonging to this PR moved.

Note: the push auto-dismissed the prior approval (the repo dismisses stale reviews
on push). The only diff since approval is this merge commit.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1683-declare-ik-solver-in-sim-extra.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

The push dismissed the prior approval. The reviewed diff is otherwise byte-identical: the delta is the fragment move plus the merge.
