### PR TITLE
fix(teleop): refuse a teleop rate or horizon the control loop cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,38 +5,68 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: the teleop loop refuses a rate or a horizon it cannot honor
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-`teleoperate(hz=..., duration=...)` reads both knobs only inside the control
-loop, which runs on a background thread, so an unusable value was reported as a
-started session and only misbehaved afterwards:
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
-- `hz=0`, a negative rate, `nan` or `inf` all left the loop period at `0`
-  (`period = 1.0 / hz if hz > 0 else 0.0`, and `1 / inf` is `0`). The loop then
-  spun as fast as the host allowed - measured at ~25 kHz against a 50 Hz
-  request - polling the leader and writing the follower on every pass, while the
-  call returned `status="success"` announcing "0Hz" / "nanHz".
-- `duration=0` was read by truthiness, so the one value that most plainly means
-  "stop now" meant "never stop"; `nan` did the same, and a negative duration
-  reported a started session whose loop had already exited with zero frames.
-- A non-numeric `hz` raised `ValueError: Unknown format code 'f' for object of
-  type 'str'` out of the success message, past the tool envelope, and a
-  non-numeric `duration` killed the loop thread while the session still reported
-  `running`.
+```python
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
+```
 
-Both are now validated at the call, before any teleoperator is connected and
-before any mesh publisher is started, so a rejected call has no side effects. The
-same rate knob reaches the mesh publish loop through `start_teleop_publish` and
-`InputPublisher`, where `1 / hz` raised (or spun) on a background thread the same
-way; both now refuse it too - the publisher at construction, so a bad rate cannot
-produce a publisher that reports `running` while publishing nothing.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
 
-The accepted domain - any positive finite real, `bool` rejected as an `int`
-subclass that would act as a silent `1` - is `positive_finite_number_error` in
-`strands_robots.utils`, now shared with the rollout knobs it duplicated
-(`run_policy(duration=...)`, `control_frequency`), so the rate contract cannot
-diverge between the surfaces that all divide by it. Error text is unchanged for
-those existing callers.
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
+
 
 ### Fixed: the state and action sides agree on what a hardware observation is
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: the teleop loop refuses a rate or a horizon it cannot honor
+
+`teleoperate(hz=..., duration=...)` reads both knobs only inside the control
+loop, which runs on a background thread, so an unusable value was reported as a
+started session and only misbehaved afterwards:
+
+- `hz=0`, a negative rate, `nan` or `inf` all left the loop period at `0`
+  (`period = 1.0 / hz if hz > 0 else 0.0`, and `1 / inf` is `0`). The loop then
+  spun as fast as the host allowed - measured at ~25 kHz against a 50 Hz
+  request - polling the leader and writing the follower on every pass, while the
+  call returned `status="success"` announcing "0Hz" / "nanHz".
+- `duration=0` was read by truthiness, so the one value that most plainly means
+  "stop now" meant "never stop"; `nan` did the same, and a negative duration
+  reported a started session whose loop had already exited with zero frames.
+- A non-numeric `hz` raised `ValueError: Unknown format code 'f' for object of
+  type 'str'` out of the success message, past the tool envelope, and a
+  non-numeric `duration` killed the loop thread while the session still reported
+  `running`.
+
+Both are now validated at the call, before any teleoperator is connected and
+before any mesh publisher is started, so a rejected call has no side effects. The
+same rate knob reaches the mesh publish loop through `start_teleop_publish` and
+`InputPublisher`, where `1 / hz` raised (or spun) on a background thread the same
+way; both now refuse it too - the publisher at construction, so a bad rate cannot
+produce a publisher that reports `running` while publishing nothing.
+
+The accepted domain - any positive finite real, `bool` rejected as an `int`
+subclass that would act as a silent `1` - is `positive_finite_number_error` in
+`strands_robots.utils`, now shared with the rollout knobs it duplicated
+(`run_policy(duration=...)`, `control_frequency`), so the rate contract cannot
+diverge between the surfaces that all divide by it. Error text is unchanged for
+those existing callers.
+
+
 ### Fixed: the mass matrix survives MuJoCo removing the legacy sparse inertia
 
 MuJoCo 3.11 removed `mjData.qM`, the legacy ancestor-walk sparse inertia buffer,

--- a/changelog.d/1684-teleop-rate-duration-guards.md
+++ b/changelog.d/1684-teleop-rate-duration-guards.md
@@ -1,0 +1,32 @@
+### Fixed: the teleop loop refuses a rate or a horizon it cannot honor
+
+`teleoperate(hz=..., duration=...)` reads both knobs only inside the control
+loop, which runs on a background thread, so an unusable value was reported as a
+started session and only misbehaved afterwards:
+
+- `hz=0`, a negative rate, `nan` or `inf` all left the loop period at `0`
+  (`period = 1.0 / hz if hz > 0 else 0.0`, and `1 / inf` is `0`). The loop then
+  spun as fast as the host allowed - measured at ~25 kHz against a 50 Hz
+  request - polling the leader and writing the follower on every pass, while the
+  call returned `status="success"` announcing "0Hz" / "nanHz".
+- `duration=0` was read by truthiness, so the one value that most plainly means
+  "stop now" meant "never stop"; `nan` did the same, and a negative duration
+  reported a started session whose loop had already exited with zero frames.
+- A non-numeric `hz` raised `ValueError: Unknown format code 'f' for object of
+  type 'str'` out of the success message, past the tool envelope, and a
+  non-numeric `duration` killed the loop thread while the session still reported
+  `running`.
+
+Both are now validated at the call, before any teleoperator is connected and
+before any mesh publisher is started, so a rejected call has no side effects. The
+same rate knob reaches the mesh publish loop through `start_teleop_publish` and
+`InputPublisher`, where `1 / hz` raised (or spun) on a background thread the same
+way; both now refuse it too - the publisher at construction, so a bad rate cannot
+produce a publisher that reports `running` while publishing nothing.
+
+The accepted domain - any positive finite real, `bool` rejected as an `int`
+subclass that would act as a silent `1` - is `positive_finite_number_error` in
+`strands_robots.utils`, now shared with the rollout knobs it duplicated
+(`run_policy(duration=...)`, `control_frequency`), so the rate contract cannot
+diverge between the surfaces that all divide by it. Error text is unchanged for
+those existing callers.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -36,7 +36,7 @@ from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolResult, ToolSpec, ToolUse
 
 from strands_robots.teleop_mixin import TeleopMixin
-from strands_robots.utils import require_optional
+from strands_robots.utils import positive_finite_number_error, require_optional
 
 if TYPE_CHECKING:
     from lerobot.robots.config import RobotConfig
@@ -1664,13 +1664,21 @@ class Robot(TeleopMixin, AgentTool):
                 KeyboardTeleop, Phone).
             device_name: Name for this input stream (e.g. "leader", "gamepad").
             method: Input method label ("arm", "gamepad", "keyboard", "phone").
-            hz: Publishing frequency in Hz.
+            hz: Publishing frequency in Hz. Must be a positive finite number;
+                the publish loop's period is ``1 / hz``.
 
         Returns:
-            Status dict with topic and peer_id for the receiver to use.
+            Status dict with topic and peer_id for the receiver to use, or an
+            error dict when ``hz`` is not a rate the publish loop can honor.
         """
         if not self.mesh or not self.mesh.alive:
             return {"status": "error", "content": [{"text": "Mesh not active. Cannot publish input."}]}
+
+        # Validate before stopping any publisher already registered for this
+        # device: a rejected call must not tear down a live stream.
+        error = positive_finite_number_error(hz, "hz", "start_teleop_publish")
+        if error:
+            return {"status": "error", "content": [{"text": error}]}
 
         from strands_robots.mesh import InputPublisher
 

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.mesh.security import ValidationError, validate_input_frame
+from strands_robots.utils import positive_finite_number_error
 
 _log_safety_event: Callable[..., None] | None
 try:  # audit is best-effort; never let an import issue break teleop apply
@@ -113,6 +114,28 @@ class InputPublisher:
         method: str = "arm",
         hz: float = INPUT_HZ_DEFAULT,
     ) -> None:
+        """Bind a teleoperator to a mesh topic at a fixed publish rate.
+
+        Args:
+            mesh: Live mesh used as the single publish chokepoint.
+            teleoperator: Any object exposing ``get_action() -> dict``.
+            device_name: Input-stream name; becomes the last topic segment.
+            method: Input-method label ("arm", "gamepad", "keyboard", "phone").
+            hz: Publish rate. Must be a positive finite number - the loop
+                period is ``1 / hz``, so ``0`` raises inside the background
+                thread and a negative/``nan``/``inf`` rate leaves the loop
+                unthrottled, flooding every subscribed peer.
+
+        Raises:
+            ValueError: If ``hz`` is not a positive finite number. Refusing at
+                construction is what keeps the rate a contract:
+                :meth:`_publish_loop` runs on a background thread, where the
+                same mistake would surface as a dead publisher that still
+                reports ``running``.
+        """
+        error = positive_finite_number_error(hz, "hz", "InputPublisher")
+        if error:
+            raise ValueError(error)
         self.mesh = mesh
         self.teleoperator = teleoperator
         self.device_name = device_name
@@ -192,7 +215,8 @@ class InputPublisher:
         return self.stats
 
     def _publish_loop(self) -> None:
-        period = 1.0 / self.hz
+        # ``hz`` is validated in __init__, so the division is safe.
+        period = 1.0 / float(self.hz)
         while self._running and not self._stop_event.is_set():
             loop_start = time.perf_counter()
             try:

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
+from strands_robots.utils import positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -1184,8 +1185,11 @@ class SimEngine(ABC):
         as ``np.float32(50.0)`` or ``np.int64(50)`` passes; ``bool`` is rejected
         explicitly (an ``int`` subclass, ``True`` would slip through and act as a
         silent 1 Hz) and non-finite values (``nan``/``inf``) are rejected before
-        the ``<= 0`` comparison. Returns a structured error dict to surface, or
-        ``None`` when valid.
+        the ``<= 0`` comparison. That domain is
+        :func:`~strands_robots.utils.positive_finite_number_error`, shared with
+        every other rate/duration knob (including the teleop control loop, which
+        divides by its ``hz`` the same way) so they cannot diverge. Returns a
+        structured error dict to surface, or ``None`` when valid.
 
         Args:
             control_frequency: The caller-supplied value to validate.
@@ -1194,27 +1198,9 @@ class SimEngine(ABC):
         Returns:
             An error dict naming the offending parameter, or ``None``.
         """
-        # Accept any real scalar (``numbers.Real``) so a NumPy-scalar frequency
-        # (e.g. ``np.float32(50.0)`` / ``np.int64(50)`` computed from a config
-        # array or ``mj_data``) is not rejected: ``isinstance(x, (int, float))``
-        # is ``False`` for every NumPy scalar except ``np.float64``. ``bool`` is
-        # still rejected explicitly (an ``int`` subclass, ``True`` would act as a
-        # silent 1 Hz), and non-finite values (``nan``/``inf``) are rejected via
-        # ``math.isfinite`` before the ``<= 0`` comparison so a ``nan`` -- which
-        # is never ``<= 0`` -- cannot slip through into the ``1 / frequency`` and
-        # ``n_steps / frequency`` arithmetic. Mirrors the ``numbers.Real`` +
-        # finiteness contract already applied to ``add_camera(fov=...)`` and
-        # ``get_ground_height``.
-        if (
-            isinstance(control_frequency, bool)
-            or not isinstance(control_frequency, numbers.Real)
-            or not math.isfinite(float(control_frequency))
-            or float(control_frequency) <= 0
-        ):
-            return {
-                "status": "error",
-                "content": [{"text": f"{method}: control_frequency must be > 0, got {control_frequency!r}."}],
-            }
+        error = positive_finite_number_error(control_frequency, "control_frequency", method)
+        if error:
+            return {"status": "error", "content": [{"text": error}]}
         return None
 
     @staticmethod
@@ -1378,13 +1364,14 @@ class SimEngine(ABC):
         policy is created or a background thread is submitted - turns all of
         these into an actionable caller error.
 
-        The accepted domain mirrors :meth:`_validate_positive_frequency` (the
-        other knob in the same ``duration * control_frequency`` product), so
-        the two cannot diverge: any finite positive real scalar, including a
-        NumPy scalar such as ``np.float32(2.5)``; ``bool`` is rejected
-        explicitly (an ``int`` subclass, ``True`` would act as a silent 1
-        second) and ``nan``/``inf`` are rejected before the ``<= 0`` comparison
-        so a ``nan`` - which is never ``<= 0`` - cannot slip through.
+        The accepted domain is :func:`~strands_robots.utils.positive_finite_number_error`,
+        shared with :meth:`_validate_positive_frequency` (the other knob in the
+        same ``duration * control_frequency`` product) so the two cannot
+        diverge: any finite positive real scalar, including a NumPy scalar such
+        as ``np.float32(2.5)``; ``bool`` is rejected explicitly (an ``int``
+        subclass, ``True`` would act as a silent 1 second) and ``nan``/``inf``
+        are rejected before the ``<= 0`` comparison so a ``nan`` - which is
+        never ``<= 0`` - cannot slip through.
 
         Args:
             duration: The caller-supplied value to validate.
@@ -1394,16 +1381,9 @@ class SimEngine(ABC):
             An error dict naming the offending parameter, or ``None`` when the
             value is valid.
         """
-        if (
-            isinstance(duration, bool)
-            or not isinstance(duration, numbers.Real)
-            or not math.isfinite(float(duration))
-            or float(duration) <= 0
-        ):
-            return {
-                "status": "error",
-                "content": [{"text": f"{method}: duration must be > 0, got {duration!r}."}],
-            }
+        error = positive_finite_number_error(duration, "duration", method)
+        if error:
+            return {"status": "error", "content": [{"text": error}]}
         return None
 
     @staticmethod

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -32,6 +32,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from strands_robots.utils import positive_finite_number_error
+
 logger = logging.getLogger(__name__)
 
 # Default local control loop frequency (Hz). Matches InputPublisher.
@@ -266,7 +268,8 @@ class TeleopMixin:
             robot_name: Target robot for ``send_action``. ``None`` -> the
                 host's default (single hardware robot, or first sim robot).
                 In a multi-robot sim, name the specific robot.
-            hz: Local control-loop frequency.
+            hz: Local control-loop frequency. Must be a positive finite
+                number - the loop period is ``1 / hz``.
             publish: Also publish each selected device to the mesh via the
                 host's ``start_teleop_publish`` so remote peers can follow.
                 Requires the host to expose ``start_teleop_publish`` and a
@@ -275,14 +278,30 @@ class TeleopMixin:
                 ``duration`` elapses or KeyboardInterrupt). When ``False``
                 (default) the loop runs in a managed background thread and the
                 call returns immediately with a handle/status.
-            duration: Stop automatically after N seconds. ``None`` = run until
+            duration: Stop automatically after N seconds. Must be a positive
+                finite number when given; ``None`` = run until
                 ``stop_teleoperate()`` (background) / Ctrl+C (block).
 
         Returns:
             Status dict. Background mode returns immediately; ``block=True``
-            returns after the loop ends with frame/error stats.
+            returns after the loop ends with frame/error stats. An ``hz`` or
+            ``duration`` the loop cannot honor is refused here rather than
+            reported as a started session.
         """
         self._ensure_teleop_state()
+
+        # Validate the loop knobs BEFORE anything is connected or published:
+        # both are consumed only inside the loop (``1 / hz`` for the period,
+        # ``start + duration`` for the deadline), so an unusable value used to
+        # be reported as a started session and only misbehave on the background
+        # thread - see the module docstring's rate/duration contract.
+        for value, param in ((hz, "hz"), (duration, "duration")):
+            if param == "duration" and value is None:
+                # Documented: run until stop_teleoperate() / Ctrl+C.
+                continue
+            error = positive_finite_number_error(value, param, "teleoperate")
+            if error:
+                return {"status": "error", "content": [{"text": error}]}
 
         if not self._teleops:
             return {
@@ -461,8 +480,11 @@ class TeleopMixin:
         hz: float,
         duration: float | None,
     ) -> None:
-        period = 1.0 / hz if hz > 0 else 0.0
-        deadline = (self._teleop_start_time + duration) if duration else None
+        # ``hz`` and ``duration`` are validated in :meth:`teleoperate` (the only
+        # caller), so the division is safe. ``duration`` is read by membership,
+        # not truthiness: a falsy-but-supplied value must not read as "absent".
+        period = 1.0 / float(hz)
+        deadline = (self._teleop_start_time + duration) if duration is not None else None
         warned_conflicts: set[str] = set()
 
         while self._teleop_running and not self._teleop_stop_event.is_set():

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -299,6 +299,50 @@ def process_rss_mb() -> float | None:
         return None
 
 
+def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable positive finite number.
+
+    Shared domain for every CONTINUOUS knob that names a rate or a span of
+    time - a control-loop frequency in Hz, a rollout or teleop ``duration`` in
+    seconds. Unlike :func:`positive_whole_number_error` a fractional value is
+    perfectly usable here (``2.5`` seconds, ``62.5`` Hz), so only the sign and
+    the finiteness are constrained. It lives here rather than beside one of its
+    callers because those callers sit in different layers
+    (:mod:`strands_robots.teleop_mixin` must not depend on
+    :mod:`strands_robots.simulation`), and the accepted domain must not diverge
+    between them.
+
+    Only a positive finite value can be honored. Such a knob is always a
+    divisor (the loop period is ``1 / hz``) or a horizon (``duration *
+    frequency`` steps), so ``0`` makes the period undefined or the horizon
+    empty, a negative value inverts it, ``nan`` poisons every comparison it
+    reaches (``nan > 0`` and ``nan <= 0`` are both ``False``), and ``inf``
+    collapses the period to ``0`` - an unthrottled loop, not a fast one.
+    Accepts any real scalar (so a NumPy ``np.float32`` rate read from a config
+    array passes) and rejects ``bool`` explicitly - an ``int`` subclass whose
+    ``True`` would act as a silent ``1``.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter it came from, used in the message.
+        context: Message prefix identifying the surface that received it -
+            normally the public method name.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, numbers.Real)
+        # ``isfinite`` before the sign test: ``nan`` is never ``<= 0``, so
+        # ordering these the other way lets it through.
+        or not math.isfinite(float(value))
+        or float(value) <= 0
+    ):
+        return f"{context}: {param} must be > 0, got {value!r}."
+    return None
+
+
 def positive_whole_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive whole number.
 

--- a/tests/test_teleop_rate_and_duration_guards.py
+++ b/tests/test_teleop_rate_and_duration_guards.py
@@ -1,0 +1,164 @@
+"""The teleop loop refuses a rate or a horizon it cannot honor.
+
+``teleoperate(hz=..., duration=...)`` consumes both knobs only inside the
+control loop - ``1 / hz`` is the period, ``start + duration`` the deadline - and
+that loop runs on a background thread. An unusable value therefore never failed
+where the caller could see it:
+
+* ``hz=0`` / ``-10`` / ``nan`` / ``inf`` left the period at ``0`` and spun the
+  loop as fast as the host allowed, polling the leader (and, on a hardware
+  ``Robot``, writing the servo bus) thousands of times per second while the call
+  reported ``status="success"`` at "0Hz" / "nanHz".
+* ``duration=0`` was read by truthiness, so the one value that most obviously
+  means "stop now" meant "never stop".
+* a non-numeric ``hz`` / ``duration`` raised on the loop thread, leaving a
+  started-and-dead session behind.
+
+The same rate knob reaches the mesh publish loop through
+``Robot.start_teleop_publish`` and :class:`InputPublisher`, so all three entry
+points share one domain: :func:`strands_robots.utils.positive_finite_number_error`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.mesh.input import InputPublisher
+from strands_robots.simulation.base import SimEngine
+from strands_robots.utils import positive_finite_number_error
+from tests.test_teleop import FakeHost, FakePublishHost, FakeTeleop, _spin_until
+
+#: Values no rate or time span can be built from. ``True`` is included because
+#: it is an ``int`` subclass that would otherwise act as a silent 1.
+UNUSABLE = [0, 0.0, -1, -10.5, float("nan"), float("inf"), float("-inf"), "30", None, [50], True]
+
+
+def _attached(host: FakeHost) -> FakeTeleop:
+    dev = FakeTeleop({"a.pos": 1.0})
+    host.attach_teleop(dev, name="lead")
+    return dev
+
+
+class TestTeleoperateRefusesAnUnusableRate:
+    """``hz`` is refused at the call, before any hardware is touched."""
+
+    @pytest.mark.parametrize("hz", UNUSABLE)
+    def test_unusable_hz_is_refused(self, hz):
+        host = FakeHost()
+        _attached(host)
+        res = host.teleoperate(hz=hz)
+        assert res["status"] == "error"
+        assert "hz must be > 0" in res["content"][0]["text"]
+        assert repr(hz) in res["content"][0]["text"]
+
+    @pytest.mark.parametrize("hz", UNUSABLE)
+    def test_a_refused_rate_starts_no_loop_and_touches_no_device(self, hz):
+        """The guard runs before connect(), so a rejection has no side effects."""
+        host = FakeHost()
+        dev = _attached(host)
+        host.teleoperate(hz=hz)
+        assert dev.connect_calls == 0
+        assert dev.get_action_calls == 0
+        assert dev.is_connected is False
+        assert host.sent == []
+        assert host.get_teleoperate_status()["content"][1]["json"]["running"] is False
+
+    @pytest.mark.parametrize("hz", [1, 50.0, 62.5, np.float32(200.0), np.int64(30)])
+    def test_a_usable_rate_still_runs(self, hz):
+        host = FakeHost()
+        dev = _attached(host)
+        res = host.teleoperate(hz=hz)
+        try:
+            assert res["status"] == "success"
+            assert _spin_until(lambda: dev.get_action_calls > 0)
+        finally:
+            host.stop_teleoperate()
+
+
+class TestTeleoperateRefusesAnUnusableDuration:
+    """``duration`` is refused unless it is omitted, which means "run on"."""
+
+    # ``None`` is dropped: for ``duration`` it is the documented "run until
+    # stopped", not a mistake.
+    @pytest.mark.parametrize("duration", [v for v in UNUSABLE if v is not None])
+    def test_unusable_duration_is_refused(self, duration):
+        host = FakeHost()
+        _attached(host)
+        res = host.teleoperate(duration=duration)
+        assert res["status"] == "error"
+        assert "duration must be > 0" in res["content"][0]["text"]
+
+    def test_zero_duration_is_refused_not_read_as_absent(self):
+        """``duration=0`` used to be falsy, so it meant "run forever"."""
+        host = FakeHost()
+        dev = _attached(host)
+        res = host.teleoperate(duration=0.0)
+        assert res["status"] == "error"
+        assert "duration must be > 0" in res["content"][0]["text"]
+        assert dev.connect_calls == 0
+
+    def test_duration_none_still_runs_until_stopped(self):
+        host = FakeHost()
+        dev = _attached(host)
+        res = host.teleoperate(hz=200, duration=None)
+        try:
+            assert res["status"] == "success"
+            assert _spin_until(lambda: dev.get_action_calls > 2)
+        finally:
+            host.stop_teleoperate()
+
+    def test_a_usable_duration_stops_the_loop_on_its_own(self):
+        host = FakeHost()
+        dev = _attached(host)
+        res = host.teleoperate(hz=200, duration=0.05, block=True)
+        assert res["status"] == "success"
+        assert dev.get_action_calls >= 1
+        assert host.get_teleoperate_status()["content"][1]["json"]["running"] is False
+
+
+class TestARefusedRateNeverReachesTheMeshPublisher:
+    """``publish=True`` forwards ``hz`` on, so the guard must precede it."""
+
+    def test_refused_rate_starts_no_publisher(self):
+        host = FakePublishHost()
+        dev = _attached(host)
+        res = host.teleoperate(hz=0, publish=True)
+        assert res["status"] == "error"
+        assert host.publish_calls == []
+        assert dev.is_connected is False
+
+    @pytest.mark.parametrize("hz", [0, -5, float("nan"), float("inf"), "30", True, None])
+    def test_input_publisher_refuses_it_at_construction(self, hz):
+        """The publish loop divides by hz on a background thread."""
+        with pytest.raises(ValueError, match="hz must be > 0"):
+            InputPublisher(mesh=object(), teleoperator=object(), hz=hz)
+
+    def test_input_publisher_accepts_a_usable_rate(self):
+        pub = InputPublisher(mesh=object(), teleoperator=object(), hz=np.float32(12.5))
+        assert float(pub.hz) == pytest.approx(12.5)
+
+
+class TestOneDomainForEveryRateAndDurationKnob:
+    """The shared helper and the sim's rollout knobs cannot diverge."""
+
+    @pytest.mark.parametrize("value", UNUSABLE + [1, 50.0, 62.5, np.float32(2.5)])
+    def test_the_sim_rollout_knobs_agree_with_the_shared_domain(self, value):
+        shared_rejects = positive_finite_number_error(value, "x", "m") is not None
+        assert (SimEngine._validate_duration(value, "run_policy") is not None) is shared_rejects
+        assert (SimEngine._validate_positive_frequency(value, "run_policy") is not None) is shared_rejects
+
+    def test_the_sim_rollout_messages_are_unchanged(self):
+        """Callers (and tests) pin this exact text."""
+        assert SimEngine._validate_duration(0, "run_policy")["content"][0]["text"] == (
+            "run_policy: duration must be > 0, got 0."
+        )
+        assert SimEngine._validate_positive_frequency(math.nan, "eval_policy")["content"][0]["text"] == (
+            "eval_policy: control_frequency must be > 0, got nan."
+        )
+
+    def test_a_numpy_rate_is_usable_but_a_bool_is_not(self):
+        assert positive_finite_number_error(np.float32(50.0), "hz", "teleoperate") is None
+        assert positive_finite_number_error(True, "hz", "teleoperate") == ("teleoperate: hz must be > 0, got True.")


### PR DESCRIPTION
## Problem

`teleoperate(hz=..., duration=...)` reads both knobs **only inside the control loop**, and that loop runs on a background thread. Nothing validated them at the call, so an unusable value was reported as a started session and only misbehaved afterwards.

Every row below was measured on a MuJoCo sim host with a stub leader (`TeleopMixin` is shared by the hardware `Robot` and the simulation, so the same call drives real servos):

| call | returned | leader polls in 0.4 s | what actually happened |
|---|---|---|---|
| `hz=50` | success `@ 50Hz` | 20 | 50.0 Hz, correct |
| `hz=0` | **success** `@ 0Hz` | **9942** | **~25 kHz busy loop** |
| `hz=-10` | **success** `@ -10Hz` | 9767 | ~24 kHz busy loop |
| `hz=nan` | **success** `@ nanHz` | 10132 | ~25 kHz busy loop |
| `hz=inf` | **success** `@ infHz` | 10034 | ~25 kHz busy loop |
| `hz="30"` | **`ValueError: Unknown format code 'f' for object of type 'str'`** | 0 | raised past the tool envelope; loop thread also died on `TypeError` |
| `duration=0` | success | 20 | **ran forever** |
| `duration=-1` | **success** `started` | 0 | loop had already exited |
| `duration=nan` | success | 20 | ran forever |
| `duration="5"` | **success** `started` | 0 | loop thread dead, session still `running=True` |

The causes are two lines:

```python
period = 1.0 / hz if hz > 0 else 0.0
deadline = (self._teleop_start_time + duration) if duration else None
```

* The `else 0.0` fallback turns "I cannot compute a period" into "do not throttle". `inf` reaches the same place through the front door, because `1 / inf` is `0`. On a hardware `Robot` that is a servo-bus flood at ~500x the requested rate, reported as a successful 0 Hz session.
* `duration` is read by **truthiness**, so `0` - the value that most plainly means *stop now* - reads as "absent" and means *never stop*, the exact opposite of the documented "Stop automatically after N seconds".

## Change

Both knobs are validated at the public call, **before any teleoperator is connected and before any mesh publisher is started**, so a rejected call leaves no half-open hardware and no live stream torn down (same guard placement as the rollout entry points). `_teleop_loop` then divides unconditionally and reads `duration is not None`.

The same rate knob reaches the **mesh publish loop** through `Robot.start_teleop_publish` -> `InputPublisher`, where `period = 1.0 / self.hz` raised `ZeroDivisionError` on a background thread for `hz=0` and left the loop unthrottled for a negative/`nan` rate - flooding every subscribed peer while `stats` reported `running`. Both refuse it too; the publisher at construction, which is where `InputReceiver` already refuses a malformed peer id.

The accepted domain is one function, `positive_finite_number_error` in `strands_robots.utils`: any positive finite real (so a NumPy `np.float32` rate passes), `bool` rejected as an `int` subclass that would act as a silent `1`, and `nan`/`inf` rejected before the sign test. `SimEngine._validate_duration` and `_validate_positive_frequency` already contained that predicate twice; they now delegate to it, so the rate contract cannot diverge between the surfaces that all divide by it. **Their error text is byte-identical** (`run_policy: duration must be > 0, got 0.`), pinned by a test.

`hz` and `duration` are keyword-only Python parameters, not agent-tool fields, so no `tool_spec.json` change is needed.

## Sim artifact

The leader's pose is indexed by **poll**, not by clock, so how far the arm travels in a fixed 0.4 s window *is* the loop rate the mixin honored. Same window, same ramp (1000 polls end to end), rendered headless in MuJoCo:

![teleop rate guard](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-rate-guard/teleop_rate_guard.png)

Left is the contract (`hz=50`: 20 polls, 2 % of the ramp - the arm creeps as commanded). Middle is `hz=0` accepted before this change: 9942 polls, **24 855 Hz**, the ramp fully traversed - the arm is thrown to its sweep limit inside 0.4 s while the call reports success at "0Hz". Right is `hz=0` after: refused, loop never started, device left unconnected. `L1(middle, right) = 5.67e6`.

## Tests

New `tests/test_teleop_rate_and_duration_guards.py` (66 tests), reusing the existing `FakeTeleop`/`FakeHost`/`FakePublishHost` fixtures:

* every unusable `hz` and `duration` refused, message naming the parameter and the value;
* a refused call performs **no** `connect()`, sends nothing, starts no publisher, and leaves `running=False` - the guard-placement contract;
* `hz=0` refused before `start_teleop_publish` is reached, and `InputPublisher(hz=...)` refused at construction;
* usable values still work: `62.5`, `np.float32(200.0)`, `np.int64(30)`, `duration=0.05` stopping the loop on its own, `duration=None` still meaning "run until stopped";
* a parity test asserting `_validate_duration` / `_validate_positive_frequency` return the same verdict as the shared helper across the whole probe set, plus the exact-message pins that protect the dedupe.

**Pre-fix: 41 failed, 8 passed** (source stashed, tests unchanged). The pre-fix run also took **106 s** versus 0.5 s after - the spinning loops are visible in the wall clock.

## Gate

* `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean.
* `mypy strands_robots tests tests_integ`: one error, `simulation/ik.py:105 Returning Any` off untyped `qpsolvers.available_solvers`. Pre-existing and environment-dependent - reproduced on a clean checkout of this base with the source stashed.
* `MUJOCO_GL=egl pytest tests`: **12474 passed, 260 skipped** in 434 s.

### Round 1 - merged main to clear the CHANGELOG append conflict (commit 8dbf156)

`main` advanced to `44d4f6b` (#1675) while this PR sat approved, which turned it
CONFLICTING. The only conflicting file was `CHANGELOG.md`: this branch appends an
entry at the top of `## [Unreleased]` and #1675's entry anchors at the identical
position, so the two collide on ordering alone, not on meaning.

Resolved by merging `main` in as a plain merge commit (no rebase, no force-push, so
the review trail is intact) and taking `CHANGELOG.md` as a union - both entries
kept, this branch's first. Verified: no conflict markers remain, the `###` heading
count is exactly base + this branch + #1675, and diffing the pre-merge head against
the post-merge head shows only `CHANGELOG.md` plus the three files #1675 itself
changed. No file belonging to this PR moved.

Note: the push auto-dismissed the prior approval (the repo dismisses stale reviews
on push). The only diff since approval is this merge commit.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1684-teleop-rate-duration-guards.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

The push dismissed the prior approval. The reviewed diff is otherwise byte-identical: the delta is the fragment move plus the merge.

### Landing note: overlaps #1676 on two files, resolution is a verified union

This branch is `MERGEABLE` against `main` today, but it shares two files with the
sibling teleop PRs, so whichever of them lands first turns the others
`CONFLICTING`. Recording the resolution here so it does not have to be
rediscovered at merge time, and so it can be applied in the merge UI rather than
by pushing a merge commit (which would dismiss a standing approval for a change
that reviews no new behaviour).

Overlap with #1676 (`fix/teleop-wildcard-source-scoping`):

* `strands_robots/mesh/input.py` - the `strands_robots.mesh.security` import block only.
* `strands_robots/hardware_robot.py` - the `start_teleop_publish` docstring `Returns:` clause and the guard prologue.

Both are **purely additive and orthogonal**: #1676 validates *who* (`device_name`
as a mesh identifier), this branch validates *how fast* (`hz` as a positive finite
rate). Neither guard reads state the other writes, and both must run before the
existing publisher is torn down, so the resolution is the union - keep both import
names, keep both guards, identifier first then rate, and state all three refusal
conditions in the docstring.

Verified locally by stacking `main` + #1676 + this branch + #1686 with that union
resolution: `tests/mesh/test_teleop_identifier_source_scoping.py`,
`tests/test_teleop_rate_and_duration_guards.py` and
`tests/mesh/test_input_slew_bound.py` are **195 passed**, and the full
`tests/mesh/` failure set is byte-identical to the same run on `main` (the
residue is optional-dependency gaps in the sandbox, not the stack). No behaviour
change on this branch; description only.

### Sync round: both sides guard the same pre-teardown window

`main` added a `validate_mesh_identifier` check on `device_name` to
`start_teleop_publish`, in the same place this branch adds its
`positive_finite_number_error` check on `hz`. Both exist for the same stated
reason - the call must be refused *before*
`_input_publishers[device_name].stop()` tears down a publisher already
registered under that name, because a rejected call must not stop a live
stream. So this is a union, not a choice, and both guards are kept.

`device_name` is validated first, so a call that is wrong in both respects
names the key it could not resolve before commenting on the rate. The `Returns`
clause now lists all three refusal reasons (inactive mesh, invalid identifier,
unhonorable rate) and the two separate comments are folded into one that
explains why both checks sit above the teardown. The `mesh/input.py` hunk is
the same import union as the sibling branches.

No behaviour was dropped from either side, and no test or artifact changed.
Verified the two guards compose rather than shadow each other:
`tests/test_teleop_rate_and_duration_guards.py` (this branch) plus
`tests/mesh/test_teleop_identifier_source_scoping.py` (`main`) report **145
passed together** on the merge result.
