### PR TITLE
fix(sim): a ray the caster cannot cast is refused, not reported as a miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,68 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: a ray the caster cannot cast is refused, not reported as a miss
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-`raycast` and `multi_raycast` answer clearance and obstacle questions, so "no
-intersection" is a load-bearing answer. Two inputs produced that answer without
-casting anything.
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
-`multi_raycast` validated each direction inside its cast loop and, for a
-malformed one, appended `{"distance": None, "geom_id": None, "error": ...}` and
-carried on. `distance: None` is exactly what a genuine miss reports, the overall
-`status` stayed `"success"`, and the summary folded the rejected ray into the hit
-denominator (`"Multi-ray: 4/8 hits"`), so a bearing that was never cast read as
-free space - on a fan whose bearing 3 lost a component, the obstacle 0.741 m
-ahead of it was reported as clear. The batch parameter itself was unguarded too:
-a bare string was iterated one ray per character, a non-sequence raised
-`TypeError` past the tool-error contract, and an empty batch reported `0/0 hits`.
-Every direction is now validated before any ray is cast, and a batch holding one
-it cannot cast is refused with every offending index named - matching `raycast`,
-which already refused the same directions outright.
+```python
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
+```
 
-`exclude_body` reached `mj_ray` unchecked on both methods. A fractional / string
-/ `nan` value raised `TypeError` out of the pybind11 signature, and an id outside
-`[0, model.nbody)` matched no body, so the geoms the caller asked the ray to pass
-through were silently included and could be reported as the obstacle. Both
-methods now accept only `-1` (exclude nothing) or an id the compiled model
-defines, rejecting `bool` explicitly.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
+
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
+### Fixed: Robot() forwards the base position it was given
+
+The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
+an omitted pose spawns at the origin, a NumPy pose is accepted, and a
+wrong-length / non-numeric / non-finite vector is refused with an actionable
+message. The factory read the parameter by truthiness
+(`position or [0.0, 0.0, 0.0]`), which made the wrapper both less capable and
+less safe than the method it wraps:
+
+```python
+Robot("so100", position=np.array([0.4, 0.2, 0.0]))
+# before: ValueError: truth value of an array with more than one element is ambiguous
+# after:  base at [0.4, 0.2, 0.0]   (add_robot accepted this value all along)
+
+Robot("so100", position=[])
+# before: success, base silently at [0.0, 0.0, 0.0]
+# after:  RuntimeError: add_robot: 'position' must be a 3-element vector, got 0 ([])
+```
+
+An empty vector is a caller mistake, not a request for the default, and reading
+it as "omitted" placed the robot somewhere the caller never asked for while
+reporting success - the guard that refuses it was unreachable through the
+factory. The position is now passed through verbatim, so `None` (the documented
+"spawn at the origin") stays the single source of truth for that default
+instead of a copy in the factory that can drift from the backend's.
+
 
 ### Fixed: the state and action sides agree on what a hardware observation is
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a ray the caster cannot cast is refused, not reported as a miss
+
+`raycast` and `multi_raycast` answer clearance and obstacle questions, so "no
+intersection" is a load-bearing answer. Two inputs produced that answer without
+casting anything.
+
+`multi_raycast` validated each direction inside its cast loop and, for a
+malformed one, appended `{"distance": None, "geom_id": None, "error": ...}` and
+carried on. `distance: None` is exactly what a genuine miss reports, the overall
+`status` stayed `"success"`, and the summary folded the rejected ray into the hit
+denominator (`"Multi-ray: 4/8 hits"`), so a bearing that was never cast read as
+free space - on a fan whose bearing 3 lost a component, the obstacle 0.741 m
+ahead of it was reported as clear. The batch parameter itself was unguarded too:
+a bare string was iterated one ray per character, a non-sequence raised
+`TypeError` past the tool-error contract, and an empty batch reported `0/0 hits`.
+Every direction is now validated before any ray is cast, and a batch holding one
+it cannot cast is refused with every offending index named - matching `raycast`,
+which already refused the same directions outright.
+
+`exclude_body` reached `mj_ray` unchecked on both methods. A fractional / string
+/ `nan` value raised `TypeError` out of the pybind11 signature, and an id outside
+`[0, model.nbody)` matched no body, so the geoms the caller asked the ray to pass
+through were silently included and could be reported as the obstacle. Both
+methods now accept only `-1` (exclude nothing) or an id the compiled model
+defines, rejecting `bool` explicitly.
+
+
 ### Fixed: the mass matrix survives MuJoCo removing the legacy sparse inertia
 
 MuJoCo 3.11 removed `mjData.qM`, the legacy ancestor-walk sparse inertia buffer,

--- a/changelog.d/1685-raycast-refuses-uncastable-ray.md
+++ b/changelog.d/1685-raycast-refuses-uncastable-ray.md
@@ -1,0 +1,25 @@
+### Fixed: a ray the caster cannot cast is refused, not reported as a miss
+
+`raycast` and `multi_raycast` answer clearance and obstacle questions, so "no
+intersection" is a load-bearing answer. Two inputs produced that answer without
+casting anything.
+
+`multi_raycast` validated each direction inside its cast loop and, for a
+malformed one, appended `{"distance": None, "geom_id": None, "error": ...}` and
+carried on. `distance: None` is exactly what a genuine miss reports, the overall
+`status` stayed `"success"`, and the summary folded the rejected ray into the hit
+denominator (`"Multi-ray: 4/8 hits"`), so a bearing that was never cast read as
+free space - on a fan whose bearing 3 lost a component, the obstacle 0.741 m
+ahead of it was reported as clear. The batch parameter itself was unguarded too:
+a bare string was iterated one ray per character, a non-sequence raised
+`TypeError` past the tool-error contract, and an empty batch reported `0/0 hits`.
+Every direction is now validated before any ray is cast, and a batch holding one
+it cannot cast is refused with every offending index named - matching `raycast`,
+which already refused the same directions outright.
+
+`exclude_body` reached `mj_ray` unchecked on both methods. A fractional / string
+/ `nan` value raised `TypeError` out of the pybind11 signature, and an id outside
+`[0, model.nbody)` matched no body, so the geoms the caller asked the ray to pass
+through were silently included and could be reported as the obstacle. Both
+methods now accept only `-1` (exclude nothing) or an id the compiled model
+defines, rejecting `bool` explicitly.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -29,7 +29,7 @@ For walkthroughs see [Simulation overview](../simulation/overview.md).
 | `replace_scene_mjcf(xml)` | Swap entire world XML |
 | `patch_scene_mjcf(ops)` | Incremental patches, no full recompile |
 | `raycast(origin, direction, ...)` | Single ray–mesh intersection |
-| `multi_raycast(rays, ...)` | Batch ray–mesh intersections |
+| `multi_raycast(origin, directions, ...)` | Batch ray–mesh intersections from one origin; all-or-nothing, a direction it cannot cast refuses the batch |
 
 ## Robots
 

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -17,7 +17,8 @@ Exposes the deep MuJoCo C API through clean Python methods:
 
 import logging
 import math
-from typing import TYPE_CHECKING, Any
+import numbers
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -206,6 +207,118 @@ def _coerce_finite_joint_map(
             }
         out[jnt_name] = f
     return out, None
+
+
+# A ray batch is a sequence of 3-component direction vectors. Spelling it out in
+# one place keeps the batch-shape rejection and the tool_spec description in
+# agreement about what a castable batch looks like.
+_RAY_BATCH_HINT = "Pass one [dx, dy, dz] direction per ray, e.g. [[0, 0, -1], [1, 0, 0]]."
+
+
+def _coerce_ray_batch(directions: Any, method: str) -> tuple[list[Any] | None, dict[str, Any] | None]:
+    """Materialize a ray batch, refusing a value that names no castable ray.
+
+    Guards the batch parameter itself, before the per-ray direction checks. A
+    ``str`` is iterable, so ``directions="abc"`` would otherwise be read as three
+    rays - one per character - and a non-iterable raises ``TypeError`` past the
+    structured-error tool contract. An empty batch requests no ray at all, so
+    there is no cast whose result could be reported.
+
+    Args:
+        directions: The caller-supplied batch.
+        method: Calling method name, used in error text.
+
+    Returns:
+        ``(rays, None)`` with the batch materialized as a list, or
+        ``(None, error_dict)`` when it holds no castable ray.
+    """
+    if isinstance(directions, (str, bytes, bytearray)):
+        return None, {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        f"{method}: 'directions' must be a sequence of direction vectors, "
+                        f"not {type(directions).__name__} - iterating one casts a ray per "
+                        f"character. {_RAY_BATCH_HINT}"
+                    )
+                }
+            ],
+        }
+    try:
+        rays = list(directions)
+    except TypeError:
+        return None, {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        f"{method}: 'directions' must be a sequence of direction vectors, "
+                        f"got {directions!r}. {_RAY_BATCH_HINT}"
+                    )
+                }
+            ],
+        }
+    if not rays:
+        return None, {
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        f"{method}: 'directions' must hold at least one direction - "
+                        f"an empty batch casts no ray. {_RAY_BATCH_HINT}"
+                    )
+                }
+            ],
+        }
+    return rays, None
+
+
+def _coerce_excluded_body(value: Any, method: str, nbody: int) -> tuple[int | None, dict[str, Any] | None]:
+    """Coerce ``exclude_body`` to a body id ``mj_ray`` can honor.
+
+    ``mj_ray`` takes the exclusion as a C ``int`` and skips the geoms whose body
+    id equals it, so only ``-1`` (the documented "exclude nothing") or an id the
+    compiled model actually defines can be honored. A float / str / nan value
+    raises ``TypeError`` out of the pybind11 signature - past the structured-error
+    tool contract - and an id outside ``[0, nbody)`` matches no body, so the cast
+    silently includes the geoms the caller asked to skip and can report a hit on
+    the caller's own robot as an obstacle.
+
+    Accepts any real scalar with an integral value (a NumPy ``np.int64`` body id
+    read back from ``list_bodies`` passes) and rejects ``bool`` explicitly - an
+    ``int`` subclass whose ``True`` would silently exclude body 1.
+
+    Args:
+        value: The caller-supplied exclusion.
+        method: Calling method name, used in error text.
+        nbody: Body count of the compiled model (``model.nbody``).
+
+    Returns:
+        ``(body_id, None)`` on success, or ``(None, error_dict)``.
+    """
+    error = {
+        "status": "error",
+        "content": [
+            {
+                "text": (
+                    f"{method}: 'exclude_body' must be -1 (exclude nothing) or a body id "
+                    f"in [0, {nbody}), got {value!r}. Read an id from list_bodies()."
+                )
+            }
+        ],
+    }
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return None, error
+    numeric = float(value)
+    # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it out
+    # of the integrality check below.
+    if not math.isfinite(numeric) or numeric != int(numeric):
+        return None, error
+    body_id = int(numeric)
+    if body_id < -1 or body_id >= nbody:
+        return None, error
+    return body_id, None
 
 
 def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
@@ -760,7 +873,11 @@ class PhysicsMixin:
         Args:
             origin: [x, y, z] ray start point in world frame.
             direction: [dx, dy, dz] ray direction (auto-normalized).
-            exclude_body: Body ID to exclude from intersection (-1 = none).
+            exclude_body: Body ID whose geoms the ray passes through (``-1`` =
+                exclude nothing). Any other value must be a body id the compiled
+                model defines - an id outside ``[0, model.nbody)`` matches no
+                body, so the geoms the caller asked to skip would be included
+                and could be reported as the obstacle.
             include_static: Whether to include static geoms.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
@@ -800,6 +917,13 @@ class PhysicsMixin:
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
 
+        # ``exclude_body`` reaches mj_ray as a C int. A non-integral value raises
+        # TypeError out of the pybind11 signature (past the tool contract) and an
+        # out-of-range id matches no body, so the exclusion silently does nothing.
+        exclusion, err = _coerce_excluded_body(exclude_body, "raycast", int(model.nbody))
+        if err is not None:
+            return err
+
         pnt = np.array(origin_f, dtype=np.float64)
         vec = np.array(direction_f, dtype=np.float64)
         # Normalize direction
@@ -829,7 +953,7 @@ class PhysicsMixin:
                 vec,
                 None,  # geom group filter (None = all)
                 1 if include_static else 0,
-                exclude_body,
+                exclusion,
                 geomid,
             )
             hit = dist >= 0
@@ -1810,15 +1934,37 @@ class PhysicsMixin:
         are refreshed once (``mj_kinematics``) and the whole batch is cast under
         the sim lock, so every ray samples one consistent, current snapshot of
         the scene (see ``raycast``).
-        Returns array of distances and hit geoms.
+
+        The batch is all-or-nothing: every direction is validated before any ray
+        is cast, and a direction that cannot be cast (wrong component count,
+        non-numeric, nan/inf, zero-length) refuses the whole call, naming every
+        offending index. Casting the rest and reporting ``distance: None`` for
+        the rejected ones - the previous behavior - makes a ray that was never
+        cast indistinguishable from a ray that found nothing, i.e. free space,
+        which is the dangerous reading for the clearance and obstacle checks this
+        method exists to serve. It matches ``raycast``, which refuses the same
+        directions outright, so a caller does not get two contracts for one
+        malformed vector.
+
+        Args:
+            origin: [x, y, z] ray start point in world frame.
+            directions: One [dx, dy, dz] direction per ray, each auto-normalized.
+                Must be a non-empty sequence of 3-component vectors (a bare
+                string is refused rather than read as one ray per character).
+            exclude_body: Body ID whose geoms every ray passes through (``-1`` =
+                exclude nothing); see :meth:`raycast`.
+
+        Returns:
+            Standard status dict. On success the ``{"json": ...}`` block carries
+            ``rays`` - one ``{"distance", "geom_id"}`` entry per direction, in
+            order, with ``distance`` ``None`` for a genuine miss - plus ``hits``.
+            On rejection it carries ``invalid_directions``, one
+            ``{"index", "error"}`` entry per direction that cannot be cast.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
-        mj = _ensure_mujoco()
-        model, data = self._world._model, self._world._data
-
-        # validate origin shape; per-ray zero-direction guard (avoid mj_ray abort)
+        # validate origin shape
         try:
             if len(origin) != 3:
                 return {
@@ -1834,6 +1980,56 @@ class PhysicsMixin:
         if err is not None:
             return err
 
+        rays, batch_err = _coerce_ray_batch(directions, "multi_raycast")
+        if rays is None:
+            return cast("dict[str, Any]", batch_err)
+
+        mj = _ensure_mujoco()
+        model, data = self._world._model, self._world._data
+
+        exclusion, err = _coerce_excluded_body(exclude_body, "multi_raycast", int(model.nbody))
+        if err is not None:
+            return err
+
+        # Validate and normalize EVERY direction before casting anything, so a
+        # batch that cannot be cast in full is refused rather than half-cast. The
+        # loop collects all offending indices instead of returning on the first,
+        # so one round-trip is enough to fix a whole malformed fan.
+        vectors: list[np.ndarray] = []
+        invalid: list[dict[str, Any]] = []
+        for idx, d in enumerate(rays):
+            param = f"directions[{idx}]"
+            floats, d_err = _coerce_finite_vector(d, param, "multi_raycast", accepted_lengths=(3,), layout="dx, dy, dz")
+            if d_err is not None:
+                invalid.append({"index": idx, "error": d_err["content"][0]["text"]})
+                continue
+            vec = np.array(floats, dtype=np.float64)
+            norm = float(np.linalg.norm(vec))
+            if norm < 1e-10:
+                invalid.append(
+                    {
+                        "index": idx,
+                        "error": (f"multi_raycast: '{param}' is zero-length - supply a non-zero direction."),
+                    }
+                )
+                continue
+            vectors.append(vec / norm)
+
+        if invalid:
+            detail = "; ".join(f"[{entry['index']}] {entry['error']}" for entry in invalid)
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"multi_raycast: {len(invalid)} of {len(rays)} direction(s) cannot be "
+                            f"cast, so no ray was cast (a rejected ray is not a miss): {detail}"
+                        )
+                    },
+                    {"json": {"invalid_directions": invalid}},
+                ],
+            }
+
         pnt = np.array(origin_f, dtype=np.float64)
         results: list[dict[str, Any]] = []
 
@@ -1842,38 +2038,9 @@ class PhysicsMixin:
         # all rays sample one consistent snapshot of the scene.
         with self._lock:
             mj.mj_kinematics(model, data)
-            for idx, d in enumerate(directions):
-                try:
-                    if len(d) != 3:
-                        results.append(
-                            {
-                                "distance": None,
-                                "geom_id": None,
-                                "error": f"ray[{idx}]: direction must have 3 elements, got {len(d)}",
-                            }
-                        )
-                        continue
-                except TypeError:
-                    results.append(
-                        {
-                            "distance": None,
-                            "geom_id": None,
-                            "error": f"ray[{idx}]: direction must be a list of 3 numbers",
-                        }
-                    )
-                    continue
-                d_floats, d_err = _coerce_finite_vector(d, "direction", f"ray[{idx}]")
-                if d_err is not None:
-                    results.append({"distance": None, "geom_id": None, "error": d_err["content"][0]["text"]})
-                    continue
-                vec = np.array(d_floats, dtype=np.float64)
-                norm = np.linalg.norm(vec)
-                if norm < 1e-10:
-                    results.append({"distance": None, "geom_id": None, "error": f"ray[{idx}]: zero-length direction"})
-                    continue
-                vec /= norm
+            for vec in vectors:
                 geomid = np.array([-1], dtype=np.int32)
-                dist = mj.mj_ray(model, data, pnt, vec, None, 1, exclude_body, geomid)
+                dist = mj.mj_ray(model, data, pnt, vec, None, 1, exclusion, geomid)
                 results.append(
                     {
                         "distance": float(dist) if dist >= 0 else None,
@@ -1885,8 +2052,8 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"Multi-ray: {hit_count}/{len(directions)} hits from {origin}"},
-                {"json": {"rays": results}},
+                {"text": f"Multi-ray: {hit_count}/{len(results)} hits from {origin}"},
+                {"json": {"rays": results, "hits": hit_count}},
             ],
         }
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2039,7 +2039,9 @@ class MuJoCoSimEngine(
         )
         base["methods"]["multi_raycast"] = (
             "(origin: list[float], directions: list[list[float]], "
-            "exclude_body=-1) -> dict  # batch raycast from one origin (e.g. a lidar fan)"
+            "exclude_body=-1) -> dict  # batch raycast from one origin (e.g. a lidar fan); "
+            "all-or-nothing - a direction it cannot cast refuses the batch instead of "
+            "reporting that bearing as a miss"
         )
 
         # Physics-tuning / domain-perturbation WRITE surface -- the complement

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -396,11 +396,11 @@
           "type": "number"
         }
       },
-      "description": "Multiple ray directions for multi_raycast"
+      "description": "Multiple ray directions for multi_raycast - one [dx, dy, dz] per ray, at least one. The batch is all-or-nothing: a direction that cannot be cast refuses it, so a rejected ray is never reported as a miss"
     },
     "exclude_body": {
       "type": "integer",
-      "description": "Body ID to exclude from raycast (-1=none)"
+      "description": "Body ID whose geoms a ray passes through (-1 = exclude nothing); any other value must be a body id the model defines - read one from list_bodies"
     },
     "include_static": {
       "type": "boolean",

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -118,18 +118,21 @@ class TestRaycastValidation:
         res = sim_with_robot.raycast(origin=[0, 0, 5], direction=[0, 0, -1])
         assert res["status"] == "success"
 
-    def test_multi_raycast_zero_direction_isolates_error(self, sim_with_robot):
-        """A zero-length direction in one ray must not abort the whole batch."""
+    def test_multi_raycast_zero_direction_refuses_the_batch(self, sim_with_robot):
+        """A zero-length direction refuses the batch instead of half-casting it.
+
+        Reporting the other two rays under ``status: "success"`` gave ray[1] the
+        same ``distance: None`` a genuine miss carries, so the bearing that was
+        never cast read as clear.
+        """
         res = sim_with_robot.multi_raycast(
             origin=[0, 0, 5],
             directions=[[0, 0, -1], [0, 0, 0], [1, 0, -1]],
         )
-        assert res["status"] == "success"
-        # The JSON payload should show error on ray[1] only
-        rays = res["content"][1]["json"]["rays"]
-        assert len(rays) == 3
-        assert rays[1].get("error") is not None
-        assert "zero-length" in rays[1]["error"]
+        assert res["status"] == "error"
+        invalid = res["content"][1]["json"]["invalid_directions"]
+        assert [entry["index"] for entry in invalid] == [1]
+        assert "zero-length" in invalid[0]["error"]
 
     @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
     def test_nonfinite_direction_errors(self, sim_with_robot, bad):
@@ -170,21 +173,17 @@ class TestRaycastValidation:
         assert res["status"] == "error"
         assert "finite" in res["content"][0]["text"].lower()
 
-    def test_multi_raycast_nonfinite_direction_isolates_error(self, sim_with_robot):
-        """A nan direction in one ray must be reported per-ray, not abort the
-        batch or silently pass a poisoned vector to mj_ray."""
+    def test_multi_raycast_nonfinite_direction_refuses_the_batch(self, sim_with_robot):
+        """A nan direction refuses the batch, naming its index, and never reaches
+        mj_ray as a poisoned vector."""
         res = sim_with_robot.multi_raycast(
             origin=[0, 0, 5],
             directions=[[0, 0, -1], [float("nan"), 0.0, 0.0], [1, 0, -1]],
         )
-        assert res["status"] == "success"
-        rays = res["content"][1]["json"]["rays"]
-        assert len(rays) == 3
-        assert rays[1].get("error") is not None
-        assert "finite" in rays[1]["error"].lower()
-        # Valid rays around the bad one are unaffected.
-        assert rays[0].get("error") is None
-        assert rays[2].get("error") is None
+        assert res["status"] == "error"
+        invalid = res["content"][1]["json"]["invalid_directions"]
+        assert [entry["index"] for entry in invalid] == [1]
+        assert "finite" in invalid[0]["error"].lower()
 
 
 class TestApplyForceValidation:

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -1234,10 +1234,13 @@ class TestDirectJointControlListForm:
 
 
 class TestMultiRaycast:
-    """Batch raycasting: origin validation plus per-ray fail-soft contract.
+    """Batch raycasting: origin validation plus the all-or-nothing batch contract.
 
-    A single malformed ray must not abort the whole batch; it produces a
-    per-ray error entry while valid rays still resolve.
+    A single malformed direction refuses the whole batch, naming its index. The
+    batch previously cast the remaining rays and reported ``distance: None`` for
+    the malformed one, which is exactly what a genuine miss reports - so a ray
+    that was never cast read as free space in the very clearance checks this
+    method serves.
     """
 
     def test_multi_raycast_origin_wrong_length(self, sim):
@@ -1250,23 +1253,25 @@ class TestMultiRaycast:
         assert result["status"] == "error"
         assert "list of 3 numbers" in result["content"][0]["text"]
 
-    def test_multi_raycast_per_ray_bad_direction_length(self, sim):
+    def test_multi_raycast_bad_direction_length_refuses_the_batch(self, sim):
+        """A 2-component direction refuses the batch and names its index."""
         result = sim.multi_raycast(origin=[0, 0, 2], directions=[[0, 0, -1], [0, 1]])
-        assert result["status"] == "success"
-        rays = _extract_json_block(result, 1)["rays"]
-        assert "must have 3 elements" in rays[1]["error"]
+        assert result["status"] == "error"
+        invalid = _extract_json_block(result, 1)["invalid_directions"]
+        assert [entry["index"] for entry in invalid] == [1]
+        assert "must have exactly 3 component" in invalid[0]["error"]
 
-    def test_multi_raycast_per_ray_zero_direction(self, sim):
+    def test_multi_raycast_zero_direction_refuses_the_batch(self, sim):
         result = sim.multi_raycast(origin=[0, 0, 2], directions=[[0, 0, 0]])
-        assert result["status"] == "success"
-        rays = _extract_json_block(result, 1)["rays"]
-        assert "zero-length" in rays[0]["error"]
+        assert result["status"] == "error"
+        invalid = _extract_json_block(result, 1)["invalid_directions"]
+        assert "zero-length" in invalid[0]["error"]
 
-    def test_multi_raycast_per_ray_direction_not_iterable(self, sim):
+    def test_multi_raycast_direction_not_iterable_refuses_the_batch(self, sim):
         result = sim.multi_raycast(origin=[0, 0, 2], directions=[7])
-        assert result["status"] == "success"
-        rays = _extract_json_block(result, 1)["rays"]
-        assert "list of 3 numbers" in rays[0]["error"]
+        assert result["status"] == "error"
+        invalid = _extract_json_block(result, 1)["invalid_directions"]
+        assert "must be a sequence of numbers" in invalid[0]["error"]
 
     def test_multi_raycast_hit_from_above(self, sim):
         # Cast straight down from above the ground plane: expect a hit.

--- a/tests/simulation/mujoco/test_raycast_uncastable_ray_refused.py
+++ b/tests/simulation/mujoco/test_raycast_uncastable_ray_refused.py
@@ -1,0 +1,173 @@
+"""A ray the caster cannot cast is refused, never reported as a miss.
+
+``raycast`` and ``multi_raycast`` exist to answer clearance and obstacle
+questions, so "no intersection" is a load-bearing answer. Two inputs used to
+produce that answer without casting anything:
+
+* ``multi_raycast`` validated each direction INSIDE the cast loop and, for a
+  malformed one, appended ``{"distance": None, "geom_id": None, "error": ...}``
+  and continued. ``distance: None`` is exactly what a genuine miss reports, the
+  overall ``status`` stayed ``"success"``, and the summary text folded the
+  rejected ray into the hit denominator (``"1/2 hits"``), so a bearing that was
+  never cast read as free space. The batch parameter itself was unguarded too: a
+  bare string was iterated one ray per character, a non-sequence raised
+  ``TypeError`` past the tool contract, and an empty batch reported ``0/0 hits``.
+* ``exclude_body`` reached ``mj_ray`` unchecked on both methods. A float / str /
+  ``nan`` raised ``TypeError`` out of the pybind11 signature, and an id outside
+  ``[0, model.nbody)`` matched no body - so the geoms the caller asked the ray to
+  pass through were included and could be reported as the obstacle.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Directions that name no castable ray. Each must be refused identically by the
+# single-ray and the batch entry point - a caller must not get two contracts for
+# one malformed vector.
+UNCASTABLE_DIRECTIONS = [
+    pytest.param([0.0, 1.0], id="two-components"),
+    pytest.param([0.0, 0.0, -1.0, 0.0], id="four-components"),
+    pytest.param([], id="empty"),
+    pytest.param([0.0, 0.0, 0.0], id="zero-length"),
+    pytest.param([float("nan"), 0.0, 0.0], id="nan"),
+    pytest.param([float("inf"), 0.0, 0.0], id="inf"),
+    pytest.param(["x", 0.0, 0.0], id="non-numeric"),
+    pytest.param(7, id="not-a-sequence"),
+]
+
+# Exclusions mj_ray cannot honor: it takes a C int and skips the geoms whose body
+# id equals it, so only -1 or an id the compiled model defines means anything.
+UNHONORABLE_EXCLUSIONS = [
+    pytest.param(-5, id="negative-but-not-minus-one"),
+    pytest.param(999, id="beyond-nbody"),
+    pytest.param(2.7, id="fractional"),
+    pytest.param("1", id="string"),
+    pytest.param(True, id="bool"),
+    pytest.param(float("nan"), id="nan"),
+]
+
+
+@pytest.fixture
+def sim():
+    """A world holding exactly two bodies: ``world`` (id 0) and ``cube`` (id 1).
+
+    The cube sits under the origin so a downward ray hits it, and the ground
+    plane sits below the cube so excluding the cube's body still yields a hit -
+    which is what makes the exclusion observable rather than just accepted.
+    """
+    engine = Simulation()
+    engine.create_world()
+    assert (
+        engine.add_object(name="cube", shape="box", size=[0.2, 0.2, 0.2], position=[0, 0, 0.1])["status"] == "success"
+    )
+    yield engine
+    engine.destroy()
+
+
+def _json(result):
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+def _text(result):
+    return result["content"][0]["text"]
+
+
+class TestBatchNamesNoCastableRay:
+    """The ``directions`` parameter itself must name at least one castable ray."""
+
+    def test_string_is_not_a_ray_per_character(self, sim):
+        result = sim.multi_raycast(origin=[0, 0, 1.0], directions="abc")
+        assert result["status"] == "error"
+        assert "character" in _text(result)
+
+    def test_non_sequence_errors_instead_of_raising(self, sim):
+        result = sim.multi_raycast(origin=[0, 0, 1.0], directions=5)
+        assert result["status"] == "error"
+        assert "sequence of direction vectors" in _text(result)
+
+    def test_empty_batch_is_refused(self, sim):
+        result = sim.multi_raycast(origin=[0, 0, 1.0], directions=[])
+        assert result["status"] == "error"
+        assert "at least one direction" in _text(result)
+
+
+class TestUncastableDirectionRefusesTheBatch:
+    """A malformed direction must not be reported as a bearing with no hit."""
+
+    @pytest.mark.parametrize("direction", UNCASTABLE_DIRECTIONS)
+    def test_single_and_batch_agree_on_an_uncastable_direction(self, sim, direction):
+        single = sim.raycast(origin=[0, 0, 1.0], direction=direction)
+        batch = sim.multi_raycast(origin=[0, 0, 1.0], directions=[direction])
+        assert single["status"] == "error"
+        assert batch["status"] == "error"
+
+    def test_one_bad_direction_casts_no_ray_at_all(self, sim):
+        """The valid rays are not cast, so no partial sweep can be mistaken for a full one."""
+        result = sim.multi_raycast(
+            origin=[0, 0, 1.0],
+            directions=[[0, 0, -1], [0, 0, 0], [1, 0, 0]],
+        )
+        assert result["status"] == "error"
+        payload = _json(result)
+        assert "rays" not in payload
+        assert [entry["index"] for entry in payload["invalid_directions"]] == [1]
+
+    def test_every_offending_index_is_named(self, sim):
+        """One round-trip is enough to fix a whole malformed fan."""
+        result = sim.multi_raycast(
+            origin=[0, 0, 1.0],
+            directions=[[0, 0, -1], [0, 1], [1, 0, 0], [float("nan"), 0, 0]],
+        )
+        assert result["status"] == "error"
+        assert [entry["index"] for entry in _json(result)["invalid_directions"]] == [1, 3]
+        assert "2 of 4" in _text(result)
+
+
+class TestExcludedBodyDomain:
+    """``exclude_body`` must name a body the model defines, or nothing (-1)."""
+
+    @pytest.mark.parametrize("method", ["raycast", "multi_raycast"])
+    @pytest.mark.parametrize("exclusion", UNHONORABLE_EXCLUSIONS)
+    def test_unhonorable_exclusion_is_refused(self, sim, method, exclusion):
+        if method == "raycast":
+            result = sim.raycast(origin=[0, 0, 1.0], direction=[0, 0, -1], exclude_body=exclusion)
+        else:
+            result = sim.multi_raycast(origin=[0, 0, 1.0], directions=[[0, 0, -1]], exclude_body=exclusion)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "exclude_body" in text
+        # The world holds world(0) + cube(1), so the honorable ids are -1, 0, 1.
+        assert "[0, 2)" in text
+
+    @pytest.mark.parametrize("exclusion", [-1, 0, 1, np.int64(1), 1.0])
+    def test_honorable_exclusion_is_accepted(self, sim, exclusion):
+        result = sim.raycast(origin=[0, 0, 1.0], direction=[0, 0, -1], exclude_body=exclusion)
+        assert result["status"] == "success"
+
+    def test_exclusion_is_actually_applied(self, sim):
+        """Excluding the cube's body lets the ray through to the ground below it."""
+        included = _json(sim.raycast(origin=[0, 0, 1.0], direction=[0, 0, -1]))
+        excluded = _json(sim.raycast(origin=[0, 0, 1.0], direction=[0, 0, -1], exclude_body=1))
+        assert included["geom_name"] == "cube_geom"
+        assert excluded["geom_name"] == "ground"
+        assert excluded["distance"] > included["distance"]
+
+
+class TestCastableBatchStillResolves:
+    def test_hits_and_misses_are_reported_in_order(self, sim):
+        result = sim.multi_raycast(origin=[0, 0, 1.0], directions=[[0, 0, -1], [0, 0, 1]])
+        assert result["status"] == "success"
+        payload = _json(result)
+        assert payload["hits"] == 1
+        assert payload["rays"][0]["distance"] == pytest.approx(0.8, abs=1e-6)
+        assert payload["rays"][1]["distance"] is None
+        assert "1/2 hits" in _text(result)
+
+    def test_numpy_direction_array_is_accepted(self, sim):
+        result = sim.multi_raycast(origin=[0, 0, 1.0], directions=np.array([[0.0, 0.0, -1.0]]))
+        assert result["status"] == "success"
+        assert _json(result)["hits"] == 1


### PR DESCRIPTION
`raycast` and `multi_raycast` answer clearance and obstacle questions, so "no intersection" is a load-bearing answer. Two inputs produced that answer without casting anything.

## The malformed ray that reads as free space

`multi_raycast` validated each direction INSIDE its cast loop and, for a malformed one, appended `{"distance": None, "geom_id": None, "error": ...}` and continued. `distance: None` is exactly what a genuine miss reports, the overall `status` stayed `"success"`, and the summary text folded the rejected ray into the hit denominator - so the bearing that was never cast was indistinguishable from a bearing that saw nothing.

An 8-ray fan in front of a box, where bearing 3's direction lost a component (`[1.0, -0.15]` instead of `[1.0, 0.0, -0.15]` - a plausible slice/zip typo):

| | before | after | after, caller fixed bearing 3 |
|---|---|---|---|
| `status` | `success` | `error` | `success` |
| summary | `Multi-ray: 4/8 hits` | `1 of 8 direction(s) cannot be cast, so no ray was cast ... [3]` | `Multi-ray: 5/8 hits` |
| bearing 3 | `distance: None` | not cast | `distance: 0.741 m` |
| rays cast | 7 of 8 | 0 | 8 |

Bearing 3's real reading is an obstacle **0.741 m** ahead. The previous code returned `None` for it, byte-identical to bearings 5-7 which genuinely see nothing.

![multi_raycast rejected ray](https://raw.githubusercontent.com/cagataycali/robots/artifacts/multi-raycast-rejected-ray/multi_raycast_rejected_ray.png)

Rollout in MuJoCo sim (headless, `MUJOCO_GL=egl`). Green = ray cast and hit (circle at the hit point), grey dotted = cast and missed, red dotted = never cast but reported as a miss. Bearings are projected through `get_camera_params` so the overlay is the sim's own geometry, not a sketch. Panel 1 was generated with the pre-fix source in place.

### Change

Every direction is validated **before any ray is cast**, and a batch holding one that cannot be cast is refused with **every** offending index named, so one round-trip fixes a whole malformed fan. This matches the sibling `raycast`, which already refused the same directions (wrong component count, non-numeric, nan/inf, zero-length) outright - a caller no longer gets two contracts for one malformed vector. All-or-nothing also means no partial sweep can be mistaken for a full one; the same rule `set_joint_positions` and `send_action` apply to a name map they cannot fully resolve.

The batch parameter itself was unguarded: `directions="abc"` was iterated one ray per character (`0/3 hits`), a non-sequence raised `TypeError` past the tool-error contract, and `directions=[]` reported `0/0 hits`. All three are refused now, with the string case naming why.

## exclude_body

`exclude_body` reached `mj_ray` unchecked on both methods. It is a C `int` that skips the geoms whose body id equals it, so only `-1` (the documented "exclude nothing") or an id the compiled model defines can be honored:

| value | before | after |
|---|---|---|
| `2.7` / `"1"` / `nan` | bare `TypeError` from the pybind11 signature, past the tool-error contract | refused, naming the accepted range |
| `-5` / `10**9` | `success` - matched no body, so the geoms the caller asked the ray to pass through were included and could be reported as the obstacle | refused |
| `True` | `success` - silently excluded body 1 | refused (`bool` is an `int` subclass) |
| `-1`, a real id, `np.int64(1)`, `1.0` | accepted | accepted |

## Tests

New `tests/simulation/mujoco/test_raycast_uncastable_ray_refused.py`, 33 tests: the batch-shape rejections; a parity test asserting `raycast(direction=d)` and `multi_raycast(directions=[d])` reach the same verdict for all eight uncastable directions; proof that one bad direction casts **no** ray (`"rays" not in payload`); every offending index named; the `exclude_body` domain on both methods, including a behavioural check that a valid exclusion actually lets the ray through to the ground below the cube. Pre-fix on this base: **28 failed, 5 passed**.

Five existing pins asserted the old fail-soft contract (`status == "success"` with the rejection buried in `rays[i]["error"]`). They are renamed to the corrected contract with the reason in their docstrings rather than shimmed around - fail-soft is only safe when the failure is visible, and it was reported only inside a nested field while the status and the summary both said success.

Docs: `docs/simulation/overview.md` also had the wrong parameter name for this method (`multi_raycast(rays, ...)`); it is `directions`. `tool_spec.json` descriptions and `describe()` now state the accepted domain of both knobs.

## Gate (local, on this branch)

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean
- `mypy strands_robots tests tests_integ`: clean apart from a pre-existing `simulation/ik.py:105 Returning Any` that only appears where `qpsolvers` is installed (reproduces on a clean `upstream/main` tree)
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **12441 passed, 260 skipped** (424s), including the 33 new tests

### Round 1 - merged main to clear the CHANGELOG append conflict (commit f9a70d9)

`main` advanced to `44d4f6b` (#1675) while this PR sat approved, which turned it
CONFLICTING. The only conflicting file was `CHANGELOG.md`: this branch appends an
entry at the top of `## [Unreleased]` and #1675's entry anchors at the identical
position, so the two collide on ordering alone, not on meaning.

Resolved by merging `main` in as a plain merge commit (no rebase, no force-push, so
the review trail is intact) and taking `CHANGELOG.md` as a union - both entries
kept, this branch's first. Verified: no conflict markers remain, the `###` heading
count is exactly base + this branch + #1675, and diffing the pre-merge head against
the post-merge head shows only `CHANGELOG.md` plus the three files #1675 itself
changed. No file belonging to this PR moved.

Note: the push auto-dismissed the prior approval (the repo dismisses stale reviews
on push). The only diff since approval is this merge commit.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1685-raycast-refuses-uncastable-ray.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

The push dismissed the prior approval. The reviewed diff is otherwise byte-identical: the delta is the fragment move plus the merge.
