### PR TITLE
fix(mesh): refuse a teleop command a joint cannot travel that fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a live MJPEG stream refuses options it cannot honor
+
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
+
+```python
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
+```
+
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
+
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
 ### Fixed: Robot() forwards the base position it was given
 
 The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
@@ -30,48 +66,6 @@ reporting success - the guard that refuses it was unreachable through the
 factory. The position is now passed through verbatim, so `None` (the documented
 "spawn at the origin") stays the single source of truth for that default
 instead of a copy in the factory that can drift from the backend's.
-
-
-### Fixed: a teleop stream cannot command a joint faster than it can travel
-
-`InputReceiver` bounded each inbound teleop frame on four axes - who sent it,
-how fresh it is, how densely frames may arrive (`STRANDS_MESH_INPUT_MAX_HZ`)
-and how large a single value may be (`MAX_INPUT_VALUE_ABS`) - but every one of
-those judged a frame in isolation. Nothing bounded the distance between
-consecutive commands for the same joint, so a stream inside all four caps could
-still reverse a joint full-scale on every frame. Measured on a MuJoCo Panda
-follower at 50 Hz, half the permitted frame rate: 60 of 60 reversals applied,
-`rejected` and `rate_dropped` both zero, each frame commanding 90 units/s -
-roughly 14x the no-load speed of the Feetech STS3215 servos on an SO-100 class
-arm, which is the overcurrent / gear-strip trajectory the rate cap exists to
-prevent in the time domain.
-
-Frames are now also bounded on per-joint speed, via
-`security.input_frame_slew_violation` and `STRANDS_MESH_INPUT_SLEW_ABS`
-(default `8pi` units/second, above what a leader arm's own servos can produce,
-so only a synthetic stream trips it). An over-speed frame is refused and
-counted in the new `slew_rejected` stat, matching how every other guard on this
-path behaves; the commanded value is never silently altered.
-
-The baseline each command is measured against is kept *per joint* and merged on
-every apply, because the shape of the frames is the sender's choice: a stream
-that interleaves single-joint frames would otherwise erase the baseline of the
-joint it is about to reverse, so every frame would arrive with no reference and
-the bound would never fire. Measured on the same follower, that stream applied
-60 of 60 frames at 45 units/s with `slew_rejected` at zero; it is now refused.
-The baseline is pruned of entries old enough that no permissible command could
-exceed the bound from them, which cannot change a verdict and keeps a mapping
-keyed by sender-chosen joint names bounded.
-
-Because the bound is a speed measured from each joint's own last applied
-command, the allowance grows while that joint is not moving: a refused stream
-resumes on its own once the commanded pose is reachable safely, with no resync
-handshake, and a joint that pauses while others move is not over-refused when it
-starts again. The interval charged to a move is floored at the minimum
-inter-apply interval the rate cap guarantees, so a batched delivery - whose
-intermediate commands are superseded before an actuator can act on them - is not
-mistaken for a high-speed command, and the two guards compose rather than
-contradict.
 
 
 ### Fixed: the state and action sides agree on what a hardware observation is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,48 @@ factory. The position is now passed through verbatim, so `None` (the documented
 instead of a copy in the factory that can drift from the backend's.
 
 
+### Fixed: a teleop stream cannot command a joint faster than it can travel
+
+`InputReceiver` bounded each inbound teleop frame on four axes - who sent it,
+how fresh it is, how densely frames may arrive (`STRANDS_MESH_INPUT_MAX_HZ`)
+and how large a single value may be (`MAX_INPUT_VALUE_ABS`) - but every one of
+those judged a frame in isolation. Nothing bounded the distance between
+consecutive commands for the same joint, so a stream inside all four caps could
+still reverse a joint full-scale on every frame. Measured on a MuJoCo Panda
+follower at 50 Hz, half the permitted frame rate: 60 of 60 reversals applied,
+`rejected` and `rate_dropped` both zero, each frame commanding 90 units/s -
+roughly 14x the no-load speed of the Feetech STS3215 servos on an SO-100 class
+arm, which is the overcurrent / gear-strip trajectory the rate cap exists to
+prevent in the time domain.
+
+Frames are now also bounded on per-joint speed, via
+`security.input_frame_slew_violation` and `STRANDS_MESH_INPUT_SLEW_ABS`
+(default `8pi` units/second, above what a leader arm's own servos can produce,
+so only a synthetic stream trips it). An over-speed frame is refused and
+counted in the new `slew_rejected` stat, matching how every other guard on this
+path behaves; the commanded value is never silently altered.
+
+The baseline each command is measured against is kept *per joint* and merged on
+every apply, because the shape of the frames is the sender's choice: a stream
+that interleaves single-joint frames would otherwise erase the baseline of the
+joint it is about to reverse, so every frame would arrive with no reference and
+the bound would never fire. Measured on the same follower, that stream applied
+60 of 60 frames at 45 units/s with `slew_rejected` at zero; it is now refused.
+The baseline is pruned of entries old enough that no permissible command could
+exceed the bound from them, which cannot change a verdict and keeps a mapping
+keyed by sender-chosen joint names bounded.
+
+Because the bound is a speed measured from each joint's own last applied
+command, the allowance grows while that joint is not moving: a refused stream
+resumes on its own once the commanded pose is reachable safely, with no resync
+handshake, and a joint that pauses while others move is not over-refused when it
+starts again. The interval charged to a move is floored at the minimum
+inter-apply interval the rate cap guarantees, so a batched delivery - whose
+intermediate commands are superseded before an actuator can act on them - is not
+mistaken for a high-speed command, and the two guards compose rather than
+contradict.
+
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,7 @@ touches ROS 2.
 | `STRANDS_MESH_OVERRIDE_CODE` | Shared secret for e-stop resume HMAC proof; unset means no remote resume possible | unset |
 | `STRANDS_MESH_INPUT_VALUE_ABS` | Absolute value clamp for teleop joint commands (radians) | `12.566` (4pi) |
 | `STRANDS_MESH_INPUT_MAX_HZ` | Per-receiver teleop apply-rate ceiling (0 = unlimited) | `100` |
+| `STRANDS_MESH_INPUT_SLEW_ABS` | Per-joint speed bound for teleop commands, in frame units per second (widen for degree-valued or normalized actuators; cannot be disabled) | `25.133` (8pi) |
 | `STRANDS_MESH_MAX_PEERS` | Peer registry cap; evicts oldest on overflow | `1024` |
 | `STRANDS_MESH_RESUME_MAX_FAILS` | Failed resume attempts before cooldown engages | `5` |
 | `STRANDS_MESH_RESUME_BACKOFF_S` | Cooldown (seconds) after exceeding resume fail threshold | `30` |

--- a/changelog.d/1686-teleop-slew-bound.md
+++ b/changelog.d/1686-teleop-slew-bound.md
@@ -1,0 +1,40 @@
+### Fixed: a teleop stream cannot command a joint faster than it can travel
+
+`InputReceiver` bounded each inbound teleop frame on four axes - who sent it,
+how fresh it is, how densely frames may arrive (`STRANDS_MESH_INPUT_MAX_HZ`)
+and how large a single value may be (`MAX_INPUT_VALUE_ABS`) - but every one of
+those judged a frame in isolation. Nothing bounded the distance between
+consecutive commands for the same joint, so a stream inside all four caps could
+still reverse a joint full-scale on every frame. Measured on a MuJoCo Panda
+follower at 50 Hz, half the permitted frame rate: 60 of 60 reversals applied,
+`rejected` and `rate_dropped` both zero, each frame commanding 90 units/s -
+roughly 14x the no-load speed of the Feetech STS3215 servos on an SO-100 class
+arm, which is the overcurrent / gear-strip trajectory the rate cap exists to
+prevent in the time domain.
+
+Frames are now also bounded on per-joint speed, via
+`security.input_frame_slew_violation` and `STRANDS_MESH_INPUT_SLEW_ABS`
+(default `8pi` units/second, above what a leader arm's own servos can produce,
+so only a synthetic stream trips it). An over-speed frame is refused and
+counted in the new `slew_rejected` stat, matching how every other guard on this
+path behaves; the commanded value is never silently altered.
+
+The baseline each command is measured against is kept *per joint* and merged on
+every apply, because the shape of the frames is the sender's choice: a stream
+that interleaves single-joint frames would otherwise erase the baseline of the
+joint it is about to reverse, so every frame would arrive with no reference and
+the bound would never fire. Measured on the same follower, that stream applied
+60 of 60 frames at 45 units/s with `slew_rejected` at zero; it is now refused.
+The baseline is pruned of entries old enough that no permissible command could
+exceed the bound from them, which cannot change a verdict and keeps a mapping
+keyed by sender-chosen joint names bounded.
+
+Because the bound is a speed measured from each joint's own last applied
+command, the allowance grows while that joint is not moving: a refused stream
+resumes on its own once the commanded pose is reachable safely, with no resync
+handshake, and a joint that pauses while others move is not over-refused when it
+starts again. The interval charged to a move is floored at the minimum
+inter-apply interval the rate cap guarantees, so a batched delivery - whose
+intermediate commands are superseded before an actuator can act on them - is not
+mistaken for a high-speed command, and the two guards compose rather than
+contradict.

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -25,7 +25,12 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.mesh.security import ValidationError, validate_input_frame
+from strands_robots.mesh.security import (
+    ValidationError,
+    input_frame_slew_violation,
+    merge_slew_baseline,
+    validate_input_frame,
+)
 
 _log_safety_event: Callable[..., None] | None
 try:  # audit is best-effort; never let an import issue break teleop apply
@@ -287,7 +292,14 @@ class InputReceiver:
         self._drops = 0
         self._rejected = 0
         self._rate_dropped = 0
-        self._last_apply_mono = 0.0
+        self._slew_rejected = 0
+        self._last_rate_gate_mono = 0.0
+        # Baseline for the per-joint slew bound: for each joint, the last
+        # value actually applied and when. Updated only on a successful apply,
+        # so a refused frame never becomes the reference for the next one, and
+        # merged rather than replaced, so a frame carrying a subset of the
+        # joints cannot erase the baseline of the ones it omits.
+        self._last_applied: dict[str, tuple[float, float]] = {}
         self._start_time = 0.0
 
     def __repr__(self) -> str:
@@ -308,7 +320,9 @@ class InputReceiver:
         subscription is ``running``, ``frames_received``, ``errors``, and the
         loss/back-pressure breakdown - out-of-order ``drops``, ``rejected``
         frames (E-stop lockout, replay-freshness, or ACL checks), and
-        ``rate_dropped`` frames (shed to hold the apply-rate cap) -
+        ``rate_dropped`` frames (shed to hold the apply-rate cap), and
+        ``slew_rejected`` frames (refused for commanding a joint faster
+        than the per-joint slew bound) -
         plus the achieved ``hz_actual``.
         """
         elapsed = time.time() - self._start_time if self._start_time else 0
@@ -321,6 +335,7 @@ class InputReceiver:
             "drops": self._drops,
             "rejected": self._rejected,
             "rate_dropped": self._rate_dropped,
+            "slew_rejected": self._slew_rejected,
             "hz_actual": self._frame_count / elapsed if elapsed > 0 else 0,
         }
 
@@ -441,7 +456,7 @@ class InputReceiver:
             if max_hz > 0:
                 now_mono = time.perf_counter()
                 min_interval = 1.0 / max_hz
-                if self._last_apply_mono and (now_mono - self._last_apply_mono) < min_interval:
+                if self._last_rate_gate_mono and (now_mono - self._last_rate_gate_mono) < min_interval:
                     self._rate_dropped = getattr(self, "_rate_dropped", 0) + 1
                     if self._rate_dropped <= 5:
                         logger.warning(
@@ -450,7 +465,7 @@ class InputReceiver:
                             max_hz,
                         )
                     return
-                self._last_apply_mono = now_mono
+                self._last_rate_gate_mono = now_mono
             # B-04 / F-02: validate the teleop frame before it reaches
             # send_action(). A LAN-adjacent peer that discovers this
             # source peer_id could otherwise drive the follower's joints
@@ -469,7 +484,56 @@ class InputReceiver:
                         verr,
                     )
                 return
+            # Per-joint slew bound. The guards above bound each frame in
+            # isolation - who sent it, how fresh it is, how densely frames
+            # arrive, how large a value may be - but none bounds the distance
+            # between consecutive commands for one joint. A stream inside every
+            # one of those caps can still reverse a joint full-scale on every
+            # frame (1.8 units at 50 Hz is 90 units/s, over an order of
+            # magnitude past what the leader's own servos can travel), which is
+            # the overcurrent / gear-strip trajectory the rate cap exists to
+            # prevent in the time domain. Refuse-and-count, matching every
+            # other guard on this path: clamping toward the commanded value
+            # would silently alter an actuator command. Because the bound is a
+            # speed measured per joint from that joint's last applied value,
+            # the allowance grows while a joint is not moving, so a refused
+            # stream resumes by itself once the commanded pose is reachable
+            # safely - no resync handshake - and a joint that pauses while
+            # others move is not over-refused when it starts moving again.
+            # The baseline is per joint, and merged rather than replaced,
+            # because the frame shape is the sender's choice: a stream that
+            # interleaved single-joint frames could otherwise erase the
+            # baseline of the joint it was about to reverse, arriving with no
+            # reference every time and never tripping the bound at all.
+            # Frames can reach this point faster than real time - a batched
+            # or buffered delivery, or a legitimate burst on a network where
+            # the operator disabled the apply-rate cap. The intermediate
+            # commands of such a burst are superseded before an actuator can
+            # act on them, so the interval charged to the move is floored at
+            # the minimum inter-apply interval the rate cap guarantees; frames
+            # spaced closer than that are the rate cap's business, which lets
+            # the two guards compose instead of contradicting each other. With
+            # the cap disabled there is no guaranteed spacing, so the nominal
+            # publish period stands in.
+            apply_mono = time.perf_counter()
+            min_apply_interval = 1.0 / max_hz if max_hz > 0 else 1.0 / INPUT_HZ_DEFAULT
+            slew_reason = input_frame_slew_violation(
+                safe_action,
+                self._last_applied,
+                apply_mono,
+                min_apply_interval,
+            )
+            if slew_reason is not None:
+                self._slew_rejected += 1
+                if self._slew_rejected <= 5:
+                    logger.warning(
+                        "[mesh] input frame refused from %s: %s",
+                        self.source_peer_id,
+                        slew_reason,
+                    )
+                return
             self._apply_fn(self.robot, safe_action)
+            self._last_applied = merge_slew_baseline(self._last_applied, safe_action, apply_mono)
             self._frame_count += 1
             # M-5: sampled positive audit of the live teleop stream so a
             # successful remote actuation is not invisible to forensics.

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -54,6 +54,7 @@ import logging
 import math
 import os
 import re
+from collections.abc import Mapping
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -162,6 +163,29 @@ def _input_value_abs() -> float:
     :data:`MAX_INPUT_VALUE_ABS`). Re-reads env on every call so operators
     can tune the teleop safety envelope without a restart."""
     return _env_pos_float("STRANDS_MESH_INPUT_VALUE_ABS", DEFAULT_INPUT_VALUE_ABS)
+
+
+#: Default per-joint slew bound, in *frame units per second*: the fastest any
+#: single actuator may be commanded to travel by a teleop stream.
+#: :data:`MAX_INPUT_VALUE_ABS` bounds how far a command may reach and
+#: ``STRANDS_MESH_INPUT_MAX_HZ`` bounds how densely frames may arrive, but
+#: neither bounds the distance between consecutive commands for one joint, so a
+#: stream inside both caps can still command a full-scale reversal every frame
+#: (a 1.8-unit step at 50 Hz is 90 units/s). The default is the full
+#: :data:`MAX_INPUT_VALUE_ABS` envelope traversed once per second (2 * 4 * pi),
+#: roughly 4x the no-load speed of the Feetech STS3215 servos on an SO-100 class
+#: arm (~6.5 rad/s at 12 V): a physical leader arm cannot reach it, so only a
+#: synthetic stream trips it. Widen via ``STRANDS_MESH_INPUT_SLEW_ABS`` for
+#: degree-valued or normalized-percent actuators, whose units are larger.
+DEFAULT_INPUT_SLEW_ABS: float = 25.132741228718345  # 8 * pi units/second
+MAX_INPUT_SLEW_ABS: float = _env_pos_float("STRANDS_MESH_INPUT_SLEW_ABS", DEFAULT_INPUT_SLEW_ABS)
+
+
+def _input_slew_abs() -> float:
+    """Lazy resolver for ``STRANDS_MESH_INPUT_SLEW_ABS`` (see
+    :data:`MAX_INPUT_SLEW_ABS`). Re-reads env on every call so operators can
+    tune the teleop safety envelope without a restart."""
+    return _env_pos_float("STRANDS_MESH_INPUT_SLEW_ABS", DEFAULT_INPUT_SLEW_ABS)
 
 
 #: Charset for teleop input-frame keys (motor/joint names like
@@ -1182,6 +1206,148 @@ def validate_input_frame(action: Any) -> dict[str, float]:
     return out
 
 
+def input_frame_slew_violation(
+    action: dict[str, float],
+    previous: Mapping[str, tuple[float, float]],
+    now_mono: float,
+    min_interval_s: float,
+    max_slew: float | None = None,
+) -> str | None:
+    """Report why *action* commands a joint faster than the slew bound allows.
+
+    :func:`validate_input_frame` bounds each teleop frame *in isolation* - key
+    charset, finiteness, magnitude - and ``STRANDS_MESH_INPUT_MAX_HZ`` bounds how
+    densely frames may arrive. Neither bounds the distance between consecutive
+    commands for the same joint, so a stream inside both caps can still command a
+    full-scale reversal on every frame. That is the shape a replayed or synthetic
+    stream has, not one a physical leader arm can produce: the resulting
+    commanded speed exceeds the leader's own servo maximum.
+
+    The bound is a *speed*, not a per-frame step, so it is independent of the
+    publish rate and self-healing. Each joint is measured against its own last
+    applied command, so the allowance grows with the time since *that joint* last
+    moved: a stream refused because one joint jumped too far resumes on its own
+    as soon as the commanded pose is reachable at a safe speed, with no explicit
+    resync, and a joint that pauses while others move is not over-refused when it
+    starts moving again.
+
+    Args:
+        action: The sanitised frame about to be applied (post
+            :func:`validate_input_frame`).
+        previous: Per-joint baseline of the last command actually applied to the
+            robot: joint name to ``(value, applied_mono)``, as maintained by
+            :func:`merge_slew_baseline`. Per-joint entries are what make the
+            bound unbypassable by frame shape - a stream that interleaves
+            single-joint frames leaves every other joint's baseline intact
+            instead of erasing it. An empty mapping means there is no baseline
+            yet, so no speed can be computed.
+        now_mono: The monotonic instant *action* is about to be applied at, on
+            the same clock as the ``applied_mono`` stamps in *previous*.
+        min_interval_s: Floor, in seconds, on the interval charged to any one
+            joint's move: the minimum inter-apply interval the caller's rate cap
+            guarantees. Frames delivered closer together than that are shed by
+            the rate cap, and the intermediate commands of such a burst are
+            superseded before an actuator can act on them, so charging them an
+            unbounded speed would refuse a harmless batched delivery. Pass
+            ``0.0`` to charge the measured interval verbatim.
+        max_slew: Bound in frame units per second. Defaults to
+            :func:`_input_slew_abs` (``STRANDS_MESH_INPUT_SLEW_ABS``).
+
+    Returns:
+        ``None`` when every joint is within the bound, otherwise a reason naming
+        the worst-offending joint and its commanded speed. The worst offender is
+        chosen by speed, then displacement, then joint name, so the message is
+        deterministic regardless of key ordering even when several joints are
+        equally over the bound.
+    """
+    bound = _input_slew_abs() if max_slew is None else max_slew
+    if not previous:
+        return None
+
+    # (speed, displacement, interval, joint) for every joint over the bound.
+    violations: list[tuple[float, float, float, str]] = []
+    for key, value in action.items():
+        entry = previous.get(key)
+        if entry is None:
+            # A joint appearing for the first time has no prior command of its
+            # own to measure against; the magnitude bound still applies to it.
+            continue
+        prev_value, prev_mono = entry
+        delta = abs(float(value) - float(prev_value))
+        if delta == 0.0:
+            continue
+        dt_s = max(now_mono - float(prev_mono), min_interval_s)
+        speed = delta / dt_s if dt_s > 0 else math.inf
+        if speed > bound:
+            violations.append((speed, delta, dt_s, key))
+
+    if not violations:
+        return None
+    worst_speed, worst_delta, worst_dt, worst_key = max(violations, key=lambda v: (v[0], v[1], v[3]))
+    if worst_dt <= 0:
+        return (
+            f"input frame slew for {worst_key!r} out of range: moved {worst_delta:g} "
+            f"units with no elapsed time since the last applied frame "
+            f"(bound {bound:g} units/s)"
+        )
+    return (
+        f"input frame slew for {worst_key!r} out of range: {worst_speed:.1f} > {bound:g} units/s "
+        f"({worst_delta:g} units in {worst_dt:.4f}s)"
+    )
+
+
+def merge_slew_baseline(
+    previous: Mapping[str, tuple[float, float]],
+    applied: Mapping[str, float],
+    now_mono: float,
+    max_slew: float | None = None,
+    value_abs: float | None = None,
+) -> dict[str, tuple[float, float]]:
+    """Fold an applied teleop frame into the per-joint slew baseline.
+
+    The baseline :func:`input_frame_slew_violation` measures against is *merged*,
+    not replaced: a frame carrying a subset of the joints stamps only the joints
+    it commands and leaves every other joint's entry intact. Replacing it
+    wholesale would let a stream that interleaves single-joint frames erase the
+    baseline of the joint it is about to reverse, so every frame would arrive
+    with no reference and the bound would never fire.
+
+    Merging means the baseline is keyed by names the stream chooses, so it is
+    pruned to stay bounded. An entry is dropped once enough time has passed that
+    it can no longer refuse anything: the widest move any *permissible* command
+    could make from ``value`` is ``value_abs + abs(value)`` - the magnitude bound
+    caps how far a command may reach - and that displacement is within
+    ``max_slew`` once ``(value_abs + abs(value)) / max_slew`` seconds have
+    elapsed. Dropping such an entry changes no verdict, which is what makes the
+    prune safe rather than a weakening: entries only survive while they can still
+    refuse a frame, so the baseline holds at most one rate-capped window's worth
+    of joint names.
+
+    Args:
+        previous: The baseline before this apply (joint to ``(value,
+            applied_mono)``).
+        applied: The sanitised frame that was just applied to the robot.
+        now_mono: The monotonic instant *applied* was applied at.
+        max_slew: Bound in frame units per second. Defaults to
+            :func:`_input_slew_abs` (``STRANDS_MESH_INPUT_SLEW_ABS``).
+        value_abs: Magnitude envelope a command may reach. Defaults to
+            :func:`_input_value_abs` (``STRANDS_MESH_INPUT_VALUE_ABS``).
+
+    Returns:
+        The merged baseline: retained prior entries that can still refuse a
+        frame, with the applied frame's joints stamped at *now_mono*.
+    """
+    bound = _input_slew_abs() if max_slew is None else max_slew
+    envelope = _input_value_abs() if value_abs is None else value_abs
+    merged = {
+        key: entry
+        for key, entry in previous.items()
+        if now_mono - float(entry[1]) < (envelope + abs(float(entry[0]))) / bound
+    }
+    merged.update({key: (float(value), now_mono) for key, value in applied.items()})
+    return merged
+
+
 __all__ = [
     "ALLOWED_ACTIONS",
     "MAX_DURATION_S",
@@ -1189,6 +1355,7 @@ __all__ = [
     "MAX_MODEL_PATH_LEN",
     "MAX_INPUT_FRAME_KEYS",
     "MAX_INPUT_KEY_LEN",
+    "MAX_INPUT_SLEW_ABS",
     "MAX_INPUT_VALUE_ABS",
     "MAX_OVERRIDE_CODE_LEN",
     "MAX_PASSTHROUGH_LEN",
@@ -1205,6 +1372,8 @@ __all__ = [
     "is_safe_server_address",
     "validate_command",
     "validate_device_rpc",
+    "input_frame_slew_violation",
+    "merge_slew_baseline",
     "validate_input_frame",
     "MAX_DC_RPC_FUNC_LEN",
     "MAX_DC_RPC_PARAMS_BYTES",

--- a/tests/mesh/test_input_slew_bound.py
+++ b/tests/mesh/test_input_slew_bound.py
@@ -1,0 +1,567 @@
+"""Teleop input frames may not command a joint faster than it can travel.
+
+``InputReceiver._on_input`` bounds each inbound frame on four axes before it
+reaches ``send_action()``: who sent it (the subscribed key expression), how
+fresh it is, how densely frames may arrive (``STRANDS_MESH_INPUT_MAX_HZ``) and
+how large a single value may be (``MAX_INPUT_VALUE_ABS``). Each of those judges
+a frame in isolation, so a stream inside every one of them could still reverse a
+joint full-scale on every frame - a commanded speed an order of magnitude past
+what the leader's own servos can travel, which is the overcurrent / gear-strip
+trajectory the rate cap exists to prevent in the time domain.
+
+These tests pin the per-joint slew bound that closes that gap:
+:func:`~strands_robots.mesh.security.input_frame_slew_violation`, the per-joint
+baseline :func:`~strands_robots.mesh.security.merge_slew_baseline` maintains, and
+the receiver guard that applies both. They also pin the properties the design
+rests on - a physical leader arm at full speed is never refused, a refused stream
+resumes on its own without a resync handshake, and the shape of the frames cannot
+change the verdict, since the sender chooses it - plus the composition with the
+apply-rate cap that keeps a batched delivery from being mistaken for a high-speed
+command.
+
+The receiver tests drive a fake monotonic clock rather than sleeping, so the
+interval charged to each frame is exact on any host.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+
+import pytest
+
+from strands_robots.mesh import input as mesh_input
+from strands_robots.mesh import security
+from strands_robots.mesh.input import InputReceiver
+from strands_robots.mesh.security import (
+    DEFAULT_INPUT_SLEW_ABS,
+    input_frame_slew_violation,
+    merge_slew_baseline,
+)
+
+from .test_input_stream_lifecycle import _make_receiver, _RecvMesh
+
+#: A 50 Hz frame period - the rate InputPublisher streams at by default.
+FRAME_S = 1.0 / mesh_input.INPUT_HZ_DEFAULT
+
+#: Feetech STS3215 no-load speed at 12 V is ~6.5 rad/s, so a leader arm on an
+#: SO-100 class follower cannot travel more than this in one 50 Hz frame. Any
+#: bound that refuses it would refuse legitimate teleoperation.
+LEADER_MAX_STEP = 6.5 * FRAME_S
+
+
+class _Clock:
+    """A monotonic clock the test advances explicitly."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Replace the monotonic clock the receiver reads for rate and slew."""
+    c = _Clock()
+    monkeypatch.setattr(mesh_input.time, "perf_counter", c)
+    return c
+
+
+@pytest.fixture(autouse=True)
+def _default_slew_bound(monkeypatch):
+    """Pin the bound to its default so an operator env var cannot skew a test."""
+    monkeypatch.delenv("STRANDS_MESH_INPUT_SLEW_ABS", raising=False)
+
+
+def _frame(action: dict[str, float], seq: int = 0) -> dict:
+    return {"peer_id": "leader-1", "device": "leader", "t": time.time(), "seq": seq, "action": action}
+
+
+def _base(values: dict[str, float], at: float = 0.0) -> dict[str, tuple[float, float]]:
+    """A per-joint baseline whose joints were all last applied at *at*."""
+    return {key: (value, at) for key, value in values.items()}
+
+
+def _timed_receiver(clock: _Clock) -> tuple[InputReceiver, list[tuple[float, dict[str, float]]]]:
+    """A receiver that records when each frame was applied, not just what."""
+    applied: list[tuple[float, dict[str, float]]] = []
+    recv = InputReceiver(
+        # A structural stand-in for the mesh: the receiver only subscribes and
+        # reads the e-stop lockout, both of which the stub provides.
+        mesh=_RecvMesh(),  # type: ignore[arg-type]
+        robot=object(),
+        source_peer_id="leader-1",
+        apply_fn=lambda robot, action: applied.append((clock.now, dict(action))),
+    )
+    recv._running = True
+    return recv, applied
+
+
+def _max_commanded_speed(applied: list[tuple[float, dict[str, float]]]) -> float:
+    """Fastest speed any one joint was actually commanded to travel at.
+
+    Measured across the frames that reached the robot, which is the quantity the
+    bound exists to cap - independent of how the stream split joints across
+    frames.
+    """
+    previous: dict[str, tuple[float, float]] = {}
+    worst = 0.0
+    for applied_at, action in applied:
+        for key, value in action.items():
+            if key in previous:
+                prev_at, prev_value = previous[key]
+                dt = applied_at - prev_at
+                if dt > 0:
+                    worst = max(worst, abs(value - prev_value) / dt)
+            previous[key] = (applied_at, value)
+    return worst
+
+
+# --- env knob resolution -------------------------------------------------
+
+
+class TestInputSlewAbs:
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("STRANDS_MESH_INPUT_SLEW_ABS", raising=False)
+        assert security._input_slew_abs() == DEFAULT_INPUT_SLEW_ABS
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_INPUT_SLEW_ABS", "400")
+        assert security._input_slew_abs() == 400.0
+
+    def test_zero_falls_back_to_default(self, monkeypatch):
+        # Unlike the frame-rate cap, this is a safety envelope on actuator
+        # travel: it can be widened but not switched off, matching its sibling
+        # magnitude bound MAX_INPUT_VALUE_ABS.
+        monkeypatch.setenv("STRANDS_MESH_INPUT_SLEW_ABS", "0")
+        assert security._input_slew_abs() == DEFAULT_INPUT_SLEW_ABS
+
+    def test_bad_value_falls_back(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_INPUT_SLEW_ABS", "not-a-number")
+        assert security._input_slew_abs() == DEFAULT_INPUT_SLEW_ABS
+
+    def test_negative_falls_back(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_INPUT_SLEW_ABS", "-5")
+        assert security._input_slew_abs() == DEFAULT_INPUT_SLEW_ABS
+
+    def test_default_is_above_leader_servo_speed(self):
+        # The bound must sit above what the leader hardware itself can produce,
+        # or legitimate teleoperation trips it.
+        assert DEFAULT_INPUT_SLEW_ABS > 6.5
+
+
+# --- the decision function ----------------------------------------------
+
+
+class TestInputFrameSlewViolation:
+    def test_move_within_bound_allowed(self):
+        assert input_frame_slew_violation({"j0": 0.1}, _base({"j0": 0.0}), FRAME_S, 0.0) is None
+
+    def test_full_scale_reversal_refused(self):
+        reason = input_frame_slew_violation({"j0": -0.9}, _base({"j0": 0.9}), FRAME_S, 0.0)
+        assert reason is not None
+        assert "j0" in reason
+        assert "90.0" in reason  # 1.8 units in 0.02 s
+
+    def test_no_baseline_allowed(self):
+        # The first frame of a stream has nothing to measure against.
+        assert input_frame_slew_violation({"j0": 9.9}, {}, FRAME_S, 0.0) is None
+
+    def test_joint_absent_from_baseline_allowed(self):
+        # A joint appearing mid-stream has no prior command of its own; the
+        # magnitude bound still applies to it.
+        assert input_frame_slew_violation({"j1": 9.9}, _base({"j0": 0.0}), FRAME_S, 0.0) is None
+
+    def test_unchanged_pose_allowed(self):
+        assert input_frame_slew_violation({"j0": 0.9}, _base({"j0": 0.9}), 1e-9, 0.0) is None
+
+    def test_zero_interval_with_movement_refused(self):
+        reason = input_frame_slew_violation({"j0": 0.5}, _base({"j0": 0.0}), 0.0, 0.0)
+        assert reason is not None
+        assert "no elapsed time" in reason
+
+    def test_negative_interval_with_movement_refused(self):
+        assert input_frame_slew_violation({"j0": 0.5}, _base({"j0": 0.0}), -1.0, 0.0) is not None
+
+    def test_zero_interval_without_movement_allowed(self):
+        assert input_frame_slew_violation({"j0": 0.5}, _base({"j0": 0.5}), 0.0, 0.0) is None
+
+    def test_bound_is_a_speed_not_a_step(self):
+        # The same displacement is refused over one frame and allowed once
+        # enough time has passed for it to be travelled safely. This is what
+        # makes a refusal self-healing instead of a permanent stall.
+        jump = {"j0": 3.0}
+        base = _base({"j0": 0.0})
+        assert input_frame_slew_violation(jump, base, FRAME_S, 0.0) is not None
+        assert input_frame_slew_violation(jump, base, 3.0 / DEFAULT_INPUT_SLEW_ABS + 0.01, 0.0) is None
+
+    def test_each_joint_is_measured_against_its_own_last_command(self):
+        # j0 last moved a second ago, j1 a frame ago. The same displacement is
+        # reachable safely for the first and not for the second, so a shared
+        # interval could only be wrong for one of them.
+        base = {"j0": (0.0, 0.0), "j1": (0.0, 0.98)}
+        assert input_frame_slew_violation({"j0": 3.0}, base, 1.0, 0.0) is None
+        reason = input_frame_slew_violation({"j1": 3.0}, base, 1.0, 0.0)
+        assert reason is not None and "j1" in reason
+
+    def test_interval_is_floored_at_the_minimum_apply_interval(self):
+        # Two frames delivered with no time between them are the rate cap's
+        # business; the move is charged the interval the cap guarantees.
+        move, base = {"j0": 0.1}, _base({"j0": 0.0})
+        assert input_frame_slew_violation(move, base, 0.0, 0.0) is not None
+        assert input_frame_slew_violation(move, base, 0.0, FRAME_S) is None
+
+    def test_reports_worst_offender_regardless_of_key_order(self):
+        base = _base({"a": 0.0, "b": 0.0, "c": 0.0})
+        fast = {"a": 1.0, "b": 5.0, "c": 2.0}
+        reason = input_frame_slew_violation(fast, base, FRAME_S, 0.0)
+        assert reason is not None and "'b'" in reason
+        # Same frame, keys inserted in a different order -> same verdict.
+        reordered = {"c": 2.0, "b": 5.0, "a": 1.0}
+        assert input_frame_slew_violation(reordered, base, FRAME_S, 0.0) == reason
+
+    def test_equally_fast_joints_report_deterministically(self):
+        # Equal speeds are broken by joint name, so neither insertion order nor
+        # a tie can change the message.
+        base = _base({"a": 0.0, "b": 0.0})
+        forward = input_frame_slew_violation({"a": 5.0, "b": 5.0}, base, FRAME_S, 0.0)
+        backward = input_frame_slew_violation({"b": 5.0, "a": 5.0}, base, FRAME_S, 0.0)
+        assert forward is not None and forward == backward
+
+    def test_one_fast_joint_refuses_the_frame(self):
+        reason = input_frame_slew_violation({"j0": 0.01, "j1": 9.9}, _base({"j0": 0.0, "j1": 0.0}), FRAME_S, 0.0)
+        assert reason is not None and "j1" in reason
+
+    def test_explicit_bound_honoured(self):
+        # A move refused at the default bound is allowed under a wider one.
+        move, base = {"j0": 1.0}, _base({"j0": 0.0})
+        assert input_frame_slew_violation(move, base, FRAME_S, 0.0) is not None
+        assert input_frame_slew_violation(move, base, FRAME_S, 0.0, max_slew=1e6) is None
+
+    def test_env_widens_the_bound(self, monkeypatch):
+        move, base = {"j0": 1.0}, _base({"j0": 0.0})
+        assert input_frame_slew_violation(move, base, FRAME_S, 0.0) is not None
+        monkeypatch.setenv("STRANDS_MESH_INPUT_SLEW_ABS", "1000")
+        assert input_frame_slew_violation(move, base, FRAME_S, 0.0) is None
+
+    def test_reason_names_the_bound_and_the_measured_speed(self):
+        # 30 units in 1 s is 30 units/s, just over the default bound.
+        reason = input_frame_slew_violation({"j0": 30.0}, _base({"j0": 0.0}), 1.0, 0.0)
+        assert reason is not None
+        assert "30.0" in reason and f"{DEFAULT_INPUT_SLEW_ABS:g}" in reason
+        assert "1.0000s" in reason  # the offending joint's own interval
+
+    def test_leader_at_max_servo_speed_allowed(self):
+        assert input_frame_slew_violation({"j0": LEADER_MAX_STEP}, _base({"j0": 0.0}), FRAME_S, 0.0) is None
+
+    def test_non_finite_baseline_does_not_crash(self):
+        # validate_input_frame rejects non-finite values, so the guard never
+        # sees one from the wire; a direct caller must still get an answer
+        # rather than an exception.
+        assert input_frame_slew_violation({"j0": 0.0}, _base({"j0": math.inf}), FRAME_S, 0.0) is not None
+
+
+# --- the per-joint baseline ---------------------------------------------
+
+
+class TestMergeSlewBaseline:
+    def test_applied_joints_are_stamped(self):
+        merged = merge_slew_baseline({}, {"j0": 0.5}, 10.0)
+        assert merged == {"j0": (0.5, 10.0)}
+
+    def test_omitted_joints_keep_their_previous_entry(self):
+        # The bypass this closes: a frame carrying one joint must not erase the
+        # baseline of the joints it does not mention.
+        previous = {"j0": (0.9, 10.0), "j1": (0.1, 10.0)}
+        merged = merge_slew_baseline(previous, {"j1": 0.2}, 10.02)
+        assert merged["j0"] == (0.9, 10.0)
+        assert merged["j1"] == (0.2, 10.02)
+
+    def test_an_entry_that_can_still_refuse_a_frame_is_kept(self):
+        # A quarter of the way to its horizon, this entry still refuses a
+        # full-envelope command, so it must survive.
+        horizon = security.MAX_INPUT_VALUE_ABS / DEFAULT_INPUT_SLEW_ABS
+        merged = merge_slew_baseline({"j0": (0.0, 0.0)}, {"j1": 0.0}, horizon / 4)
+        assert "j0" in merged
+
+    def test_an_entry_that_can_no_longer_refuse_anything_is_dropped(self):
+        # Past its horizon the widest permissible command is reachable within
+        # the bound, so the entry cannot change a verdict and is not retained -
+        # which is what keeps a baseline keyed by sender-chosen names bounded.
+        horizon = security.MAX_INPUT_VALUE_ABS / DEFAULT_INPUT_SLEW_ABS
+        merged = merge_slew_baseline({"j0": (0.0, 0.0)}, {"j1": 0.0}, horizon + 0.01)
+        assert "j0" not in merged
+        # Dropping it changes no verdict: the move it would have been measured
+        # against is within the bound over that interval anyway.
+        widest = {"j0": security.MAX_INPUT_VALUE_ABS}
+        assert input_frame_slew_violation(widest, {"j0": (0.0, 0.0)}, horizon + 0.01, 0.0) is None
+
+    def test_a_far_baseline_is_retained_longer_than_a_near_one(self):
+        # A joint parked at the edge of the envelope can be commanded twice as
+        # far as one at the origin, so its entry stays relevant twice as long.
+        near, far = 0.0, security.MAX_INPUT_VALUE_ABS
+        at = 1.5 * security.MAX_INPUT_VALUE_ABS / DEFAULT_INPUT_SLEW_ABS
+        merged = merge_slew_baseline({"near": (near, 0.0), "far": (far, 0.0)}, {}, at)
+        assert "near" not in merged
+        assert "far" in merged
+
+    def test_explicit_bounds_honoured(self):
+        # A wider speed bound shortens the horizon; a wider envelope lengthens it.
+        previous = {"j0": (0.0, 0.0)}
+        assert merge_slew_baseline(previous, {}, 1.0, max_slew=1e6, value_abs=1.0) == {}
+        assert merge_slew_baseline(previous, {}, 1.0, max_slew=1.0, value_abs=1e6) == previous
+
+    def test_values_are_normalised_to_floats(self):
+        merged = merge_slew_baseline({}, {"j0": 1}, 10.0)
+        assert isinstance(merged["j0"][0], float)
+
+    def test_previous_is_not_mutated(self):
+        previous = {"j0": (0.9, 10.0)}
+        merge_slew_baseline(previous, {"j0": 0.1}, 10.02)
+        assert previous == {"j0": (0.9, 10.0)}
+
+
+# --- the receiver guard --------------------------------------------------
+
+
+class TestReceiverRefusesOverSpeedFrames:
+    def test_sustained_full_scale_reversals_never_move_the_joint(self, clock):
+        # The reproduction: every frame is correctly scoped, fresh, inside the
+        # 100 Hz rate cap and inside the magnitude bound, yet reverses the
+        # joint full-scale at 50 Hz.
+        recv, applied = _make_receiver()
+        for i in range(60):
+            clock.advance(FRAME_S)
+            recv._on_input(recv.topic, _frame({"j0": 0.9 if i % 2 == 0 else -0.9}, seq=i))
+
+        assert recv.stats["slew_rejected"] == 30
+        # Only the opening pose and its repeats survive, so the commanded pose
+        # never actually changes: the joint holds still instead of oscillating.
+        assert {a["j0"] for a in applied} == {0.9}
+
+    def test_first_frame_is_applied(self, clock):
+        recv, applied = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 5.0}))
+        assert applied == [{"j0": 5.0}]
+        assert recv.stats["slew_rejected"] == 0
+
+    def test_leader_at_max_servo_speed_is_never_refused(self, clock):
+        recv, applied = _make_receiver()
+        pos = 0.0
+        for i in range(60):
+            pos += LEADER_MAX_STEP
+            clock.advance(FRAME_S)
+            recv._on_input(recv.topic, _frame({"j0": pos}, seq=i))
+
+        assert recv.stats["slew_rejected"] == 0
+        assert len(applied) == 60
+
+    def test_refused_frame_never_reaches_the_robot(self, clock):
+        recv, applied = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 9.0}, seq=1))
+
+        assert applied == [{"j0": 0.0}]
+        assert recv.stats["frames_received"] == 1
+        assert recv.stats["slew_rejected"] == 1
+
+    def test_refused_frame_does_not_become_the_baseline(self, clock):
+        # Otherwise a refused excursion would silently license the next one.
+        recv, applied = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 9.0}, seq=1))  # refused
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 9.05}, seq=2))  # near the refused pose
+
+        assert recv.stats["slew_rejected"] == 2
+        assert applied == [{"j0": 0.0}]
+
+    def test_stream_resumes_without_a_resync(self, clock):
+        # The allowance grows while nothing is applied, so the follower catches
+        # up to the leader on its own once the pose is reachable safely.
+        recv, applied = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 3.0}, seq=1))
+        assert recv.stats["slew_rejected"] == 1
+
+        clock.advance(3.0 / DEFAULT_INPUT_SLEW_ABS + 0.01)
+        recv._on_input(recv.topic, _frame({"j0": 3.0}, seq=2))
+
+        assert applied == [{"j0": 0.0}, {"j0": 3.0}]
+        assert recv.stats["slew_rejected"] == 1
+
+    def test_stats_reports_slew_rejections(self, clock):
+        recv, _ = _make_receiver()
+        assert recv.stats["slew_rejected"] == 0
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 9.0}, seq=1))
+        assert recv.stats["slew_rejected"] == 1
+
+    def test_warning_is_rate_limited(self, clock, caplog):
+        recv, _ = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        # A constant far target inside the magnitude envelope, with the clock
+        # advanced little enough that the growing allowance never reaches it:
+        # 12 units over at most 0.3 s is 40 units/s, still over the bound.
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.input"):
+            for i in range(20):
+                clock.advance(0.015)
+                recv._on_input(recv.topic, _frame({"j0": 12.0}, seq=i + 1))
+
+        assert recv.stats["slew_rejected"] == 20
+        refusals = [r for r in caplog.records if "slew" in r.getMessage()]
+        assert len(refusals) == 5
+
+    def test_slew_rejection_is_counted_separately_from_other_refusals(self, clock):
+        # ``rejected`` covers the E-stop / freshness / validation refusals; a
+        # slew refusal gets its own counter, the way ``rate_dropped`` does.
+        recv, _ = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 9.0}, seq=1))
+
+        assert recv.stats["slew_rejected"] == 1
+        assert recv.stats["rejected"] == 0
+        assert recv.stats["rate_dropped"] == 0
+
+    def test_value_outside_magnitude_bound_is_still_a_validation_refusal(self, clock):
+        # The slew guard runs after validate_input_frame, so an out-of-envelope
+        # value is reported as a validation refusal rather than a slew one.
+        recv, _ = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": security.MAX_INPUT_VALUE_ABS * 10}, seq=1))
+
+        assert recv.stats["rejected"] == 1
+        assert recv.stats["slew_rejected"] == 0
+
+
+class TestSlewBoundComposesWithRateCap:
+    def test_burst_of_small_steps_is_applied_when_the_rate_cap_is_off(self, clock, monkeypatch):
+        # An operator may disable the rate cap on a trusted network, and a
+        # batched delivery then arrives with no time between frames. Those
+        # commands supersede each other before an actuator can act on them, so
+        # charging them an unbounded speed would refuse a harmless burst.
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "0")
+        recv, applied = _make_receiver()
+        for i in range(5):
+            recv._on_input(recv.topic, _frame({"j0": 0.1 * i}, seq=i))  # clock never advances
+
+        assert len(applied) == 5
+        assert recv.stats["slew_rejected"] == 0
+
+    def test_burst_of_full_scale_reversals_is_still_refused(self, clock, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "0")
+        recv, applied = _make_receiver()
+        for i in range(20):
+            recv._on_input(recv.topic, _frame({"j0": 0.9 if i % 2 == 0 else -0.9}, seq=i))
+
+        assert recv.stats["slew_rejected"] == 10
+        assert {a["j0"] for a in applied} == {0.9}
+
+    def test_frames_closer_than_the_cap_are_the_cap_s_business(self, clock, monkeypatch):
+        # With the cap on, a frame arriving inside the minimum interval is
+        # shed by the cap; the slew bound does not also charge it.
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "10")  # 100 ms minimum
+        recv, applied = _make_receiver()
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0}, seq=0))
+        clock.advance(0.001)
+        recv._on_input(recv.topic, _frame({"j0": 9.0}, seq=1))
+
+        assert recv.stats["rate_dropped"] == 1
+        assert recv.stats["slew_rejected"] == 0
+        assert applied == [{"j0": 0.0}]
+
+
+class TestFrameShapeCannotChangeTheVerdict:
+    """The sender chooses how joints are split across frames, so the bound may
+    not depend on that choice. A baseline replaced wholesale on every apply
+    would: a stream interleaving single-joint frames would leave each joint
+    absent from the baseline exactly when it is about to be reversed, so every
+    frame would arrive with no reference and none would ever be refused.
+    """
+
+    def test_interleaved_single_joint_frames_cannot_reverse_a_joint_every_frame(self, clock):
+        # Two joints, one per frame, each reversing full-scale every time it
+        # appears: every frame is correctly scoped, fresh, inside the rate cap
+        # and inside the magnitude bound, and no frame ever repeats a joint.
+        recv, applied = _timed_receiver(clock)
+        joints = ("j0", "j1")
+        for i in range(60):
+            clock.advance(FRAME_S)
+            value = 0.9 if (i // 2) % 2 == 0 else -0.9
+            recv._on_input(recv.topic, _frame({joints[i % 2]: value}, seq=i))
+
+        assert recv.stats["slew_rejected"] > 0
+        # The property the bound exists to guarantee, measured on what actually
+        # reached the robot: no joint was ever commanded past the bound.
+        assert _max_commanded_speed(applied) <= DEFAULT_INPUT_SLEW_ABS
+
+    def test_a_frame_that_omits_a_joint_does_not_clear_its_baseline(self, clock):
+        recv, applied = _timed_receiver(clock)
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.9, "j1": 0.0}, seq=0))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j1": 0.01}, seq=1))  # j0 not mentioned
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": -0.9}, seq=2))  # full-scale reversal
+
+        assert recv.stats["slew_rejected"] == 1
+        assert [action for _, action in applied] == [{"j0": 0.9, "j1": 0.0}, {"j1": 0.01}]
+
+    def test_a_flood_of_unseen_joint_names_does_not_dislodge_a_live_joint(self, clock):
+        # A frame may carry up to MAX_INPUT_FRAME_KEYS joints, so a baseline
+        # bounded by eviction could be cleared in a single frame of names the
+        # follower does not even have. Retention is by relevance, not capacity.
+        recv, applied = _timed_receiver(clock)
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.9}, seq=0))
+        clock.advance(FRAME_S)
+        flood = {f"f{n}": 0.0 for n in range(security.MAX_INPUT_FRAME_KEYS - 1)}
+        recv._on_input(recv.topic, _frame(flood, seq=1))
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": -0.9}, seq=2))
+
+        assert recv.stats["slew_rejected"] == 1
+        assert [action for _, action in applied] == [{"j0": 0.9}, flood]
+
+    def test_a_paused_joint_is_not_over_refused_when_it_moves_again(self, clock):
+        # The flip side: measuring every joint against the stream's last apply
+        # instead of its own would refuse a joint that held still while others
+        # moved, which is ordinary teleoperation, not an attack.
+        recv, applied = _timed_receiver(clock)
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 0.0, "j1": 0.0}, seq=0))
+        for i in range(15):  # 0.3 s of j1-only traffic; j0 holds still
+            clock.advance(FRAME_S)
+            recv._on_input(recv.topic, _frame({"j1": 0.01 * i}, seq=i + 1))
+
+        # j0's baseline is still there - a move too fast for the elapsed 0.32 s
+        # is still refused ...
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 12.0}, seq=100))
+        assert recv.stats["slew_rejected"] == 1
+        # ... but one reachable within the bound over that interval is applied.
+        clock.advance(FRAME_S)
+        recv._on_input(recv.topic, _frame({"j0": 6.0}, seq=101))
+        assert applied[-1][1] == {"j0": 6.0}
+        assert recv.stats["slew_rejected"] == 1
+        assert _max_commanded_speed(applied) <= DEFAULT_INPUT_SLEW_ABS


### PR DESCRIPTION
Closes #1677.

## Problem

`InputReceiver._on_input` bounds each inbound teleop frame on four axes before it reaches `send_action()`: **who** sent it (the subscribed key expression), **how fresh** it is, **how densely** frames may arrive (`STRANDS_MESH_INPUT_MAX_HZ`), and **how large** a single value may be (`MAX_INPUT_VALUE_ABS`). Every one of those judges a frame in isolation. Nothing bounded the distance between consecutive commands for the same joint, so a stream inside all four caps could still reverse a joint full-scale on every frame.

Measured on a MuJoCo Panda follower, stream correctly scoped to its configured leader, publishing at 50 Hz (half the permitted frame rate) with `+/-0.9` on every actuator:

```
frames_received  60
rejected          0
rate_dropped      0
frames sent      60

per-frame delta  1.80 units in ~0.020 s  =>  ~90 units/s
```

90 units/s is roughly **14x the no-load speed of the Feetech STS3215 servos** on an SO-100 class arm (~6.5 rad/s at 12 V). That is the overcurrent / gear-strip trajectory the rate cap already exists to prevent in the time domain - `INPUT_MAX_HZ_DEFAULT`'s own docstring says it is there because "a malicious peer can stream far faster to slam the servos (overcurrent / thermal / gear-strip)". The rate cap bounds how *dense* the stream is; nothing bounded how *far* each frame asks a joint to jump.

A physical leader arm cannot produce that trajectory - its own servos cap it at ~6.5 rad/s. It is the shape a replayed or synthetic stream has.

## Change

A per-joint **slew** bound, in frame units per second:

- `security.input_frame_slew_violation(action, previous, now_mono, min_interval_s, max_slew=None) -> str | None`, following the module's existing `X_error(...) -> str | None` shape. It reports the worst-offending joint rather than the first - by speed, then displacement, then joint name - so the message is deterministic regardless of key ordering.
- `security.merge_slew_baseline(previous, applied, now_mono, ...)` maintains the baseline it measures against: **per joint**, merged on every apply, so a frame carrying a subset of the joints stamps only those and retains the rest. See Round 2 below - the shape of the frames is the sender's choice, so the verdict may not depend on it.
- `STRANDS_MESH_INPUT_SLEW_ABS` / `DEFAULT_INPUT_SLEW_ABS` / `_input_slew_abs()`, mirroring the sibling magnitude bound `MAX_INPUT_VALUE_ABS` exactly - including its `_env_pos_float` posture, so the envelope can be widened but not switched off.
- An over-speed frame is **refused and counted** in a new `slew_rejected` stat, the way `rate_dropped` gets its own counter rather than folding into `rejected`.

Named "slew" rather than "rate" deliberately: `INPUT_MAX_HZ` is already a rate (frames/second), and this is units/second per joint. Slew rate is the standard control term for exactly this quantity.

### Why refuse rather than clamp

#1677 left this open between drop-and-count and slew-clamping. Refusing, for three reasons:

1. It matches every other guard on this path - the E-stop gate, the freshness check, the rate cap and `validate_input_frame` all drop-and-count.
2. Clamping toward the commanded value would silently alter an actuator command, which the repo's no-silent-defaults rule pushes back on.
3. **The stall objection dissolves once the bound is a speed rather than a per-frame step.** It is measured from the last frame *actually applied*, so the allowance grows linearly with the time since that apply. A stream refused because the pose jumped too far resumes on its own as soon as the commanded pose is reachable at a safe speed - no resync handshake, no explicit recovery API. Pinned by `test_stream_resumes_without_a_resync` and, at the function level, `test_bound_is_a_speed_not_a_step`.

Not auto-triggering an E-stop on a violation: a hostile peer could then induce a fleet-wide outage with one crafted frame, making the mitigation the denial of service. The count and the rate-limited warning let a supervisor escalate.

### Composition with the apply-rate cap

Frames can reach the guard faster than real time - a batched or buffered delivery, or a legitimate burst on a network where the operator disabled the rate cap (`STRANDS_MESH_INPUT_MAX_HZ=0`, documented for trusted closed networks). The intermediate commands of such a burst are superseded before an actuator can act on them, so charging them an unbounded speed would refuse a harmless delivery - and did, in an early revision of this change, which broke four existing tests including `test_rate_cap_disabled_applies_burst`.

The interval charged to a move is therefore floored at the minimum inter-apply interval the rate cap guarantees. Frames spaced closer than that are the rate cap's business, so the two guards compose instead of contradicting each other. With the cap disabled the nominal publish period stands in. Pinned by `TestSlewBoundComposesWithRateCap`, including that a burst of full-scale *reversals* is still refused.

### Default value

`8pi` units/second: the full `MAX_INPUT_VALUE_ABS` (`4pi`) envelope traversed once per second, ~4x the STS3215's own no-load speed. A physical leader arm cannot reach it, so only a synthetic stream trips it - that is the property that makes the default safe to ship on by default, and it is pinned (`test_leader_at_max_servo_speed_is_never_refused`, 60/60 applied at the servo's maximum). The tradeoff is deliberate: a conservative bound that never false-positives on real hardware, rather than a tight one that would need per-robot tuning. Operators with degree-valued or normalized-percent actuators widen it, exactly as they already do for the magnitude bound.

## Tests

50 new tests in `tests/mesh/test_input_slew_bound.py`, covering env-knob resolution and fallbacks, the decision function's domain (no baseline, joint absent from the baseline, unchanged pose, zero/negative interval, per-joint intervals, the interval floor, worst-offender reporting and tie-breaking, explicit and env-set bounds), the per-joint baseline contract (`TestMergeSlewBaseline`), the receiver guard (the reproduction, first frame applied, refused frame never reaching the robot, a refused frame not becoming the next baseline, self-healing, stats, warning rate-limiting, separation from the other refusal counters, ordering after `validate_input_frame`), and frame-shape independence (`TestFrameShapeCannotChangeTheVerdict`).

The receiver tests drive a fake monotonic clock instead of sleeping, so the interval charged to each frame is exact on any host rather than depending on how fast the machine runs the loop.

Pre-fix, 13 of them fail on the reproduction alone. The clearest is `test_refused_frame_never_reaches_the_robot`:

```
AssertionError: assert [{'j0': 0.0}, {'j0': 9.0}] == [{'j0': 0.0}]
```

the 9-unit jump was applied. The rest fail on `KeyError: 'slew_rejected'` - the counter did not exist. All 35 pass after.

## Rollout in MuJoCo sim (headless)

The same rogue stream against both trees - correctly scoped, fresh, inside the rate cap and inside the magnitude bound - on a Panda follower. The stream opens at the follower's own home pose, so the first frame (which has no baseline) commands no movement; every frame after it is a full-scale reversal.

![teleop slew bound](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-slew/teleop_slew.gif)

| | before (main) | after |
|---|---|---|
| frames applied | 60 / 60 | 31 / 60 |
| `slew_rejected` | no such guard | 29 |
| joint direction reversals | **265** | **10** (one settling move) |
| frame-to-frame image motion, late in the run | ~3.8e4 sustained | 2.4e3 (settled) |

Direction reversals are the quantity that strips gears - each one forces the servo to brake and re-accelerate against its own inertia - counted as sign flips of joint velocity outside a deadband. Peak velocity remains non-zero after the fix because one single 0.9-unit step *is* within the bound and is correctly applied; what the bound removes is the sustained reversal, not one legitimate move.

## Scope

The local teleop path (`attach_teleop`, a physically attached leader arm) is untouched: its commands are bounded by the leader's own mechanics, so there is no synthetic-stream case to guard. `InputReceiver` is the only network apply path (`hardware_robot.start_teleop_receive`).

`_last_apply_mono` is renamed `_last_rate_gate_mono` in the same change: it records the last frame that *passed the rate gate*, which is a different instant from the last frame *applied*, and the slew baseline needs the latter. Keeping two near-identical names for two different instants would be indistinguishable to a future reader. Private, no external callers.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: only the pre-existing `simulation/ik.py:105 Returning Any` (present on a clean tree wherever `qpsolvers` is installed; not in a file this PR touches).
- `MUJOCO_GL=egl python -m pytest tests`: **12499 passed, 260 skipped** in 432 s. Includes the four tests an earlier revision broke, which is what surfaced the burst-composition requirement above.

## Round 2: the verdict may not depend on the shape of the frames

Review caught a bypass in the guard this PR ships, and it is the sharper version of the same defect: the baseline was replaced wholesale on every apply (`self._last_applied_action = safe_action`), and `input_frame_slew_violation` skips a joint absent from the baseline. Since `validate_input_frame` does not require a full joint set, a stream that interleaves single-joint frames leaves each joint absent from the baseline exactly when it is about to be reversed. Every frame arrives with no reference; the bound never fires. Frame shape is the sender's choice, so this costs the adversary in the threat model nothing.

Reproduced on the same Panda follower at 50 Hz, `j0`/`j1` one joint per frame, each reversing full-scale every time it appears:

![interleaved bypass](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-slew-interleaved/interleaved_bypass.gif)

| | before this round | after |
|---|---|---|
| frames applied | 60 / 60 | 30 / 60 |
| `slew_rejected` | **0** (guard never fired) | **30** |
| peak commanded speed | **45.0 units/s** (bound 25.13) | 0.0 units/s |
| joint direction reversals | **128** | 14 (one settling move) |
| frame-to-frame image motion, late in the run | 1.14e5 sustained | 2.49e4 (settled) |

45 units/s is ~7x the STS3215 no-load speed - the same overcurrent trajectory, reached through a differently shaped stream.

### Change

The baseline is now per joint and merged, never replaced: `_last_applied` maps each joint to `(value, applied_mono)`, `merge_slew_baseline` stamps only the joints an applied frame carried and retains the entries it omitted, and each joint's speed is measured against **its own** last-applied instant (`dt = max(now_mono - prev_mono, min_interval_s)`, so the rate-cap floor is applied per joint).

Per-joint timestamps rather than one shared instant, because the shared instant has the opposite failure: a joint that holds still while others move would be charged the *stream's* last apply and refused for an ordinary move. Both halves are pinned - after 0.32 s of `j1`-only traffic, a `j0` move too fast for that interval is still refused, and one reachable within the bound is applied.

### Keeping a sender-keyed mapping bounded

Merging makes the baseline keyed by names the stream chooses, so it could grow without bound - a memory-exhaustion vector, and a new one, since replacing it wholesale had capped it at `MAX_INPUT_FRAME_KEYS`.

It is **not** bounded by capacity with oldest-first eviction, which would be the same bypass a third time: one frame may legitimately carry `MAX_INPUT_FRAME_KEYS` joints, so a single frame of names the follower does not even have would evict the baseline of the joint about to be reversed.

It is bounded by *relevance*. An entry is dropped once `(value_abs + abs(value)) / max_slew` seconds have elapsed - the point past which the widest command the magnitude bound permits is reachable from that value within the speed bound. Such an entry cannot change any verdict, so the prune is provably not a weakening, and entries survive only while they can still refuse a frame, which caps the mapping at one rate-capped window's worth of names. `test_an_entry_that_can_no_longer_refuse_anything_is_dropped` asserts the drop *and* the verdict-neutrality; `test_a_flood_of_unseen_joint_names_does_not_dislodge_a_live_joint` pins the security property at the receiver.

### Tests

`TestFrameShapeCannotChangeTheVerdict` (4) - the interleaved stream, the minimal three-frame omit case, the flood, and the paused-joint flip side - plus `TestMergeSlewBaseline` (8) and two additions to the decision-function class. All four receiver-level tests fail on the previous head with `slew_rejected == 0`:

```
FAILED test_interleaved_single_joint_frames_cannot_reverse_a_joint_every_frame - assert 0 > 0
FAILED test_a_frame_that_omits_a_joint_does_not_clear_its_baseline           - assert 0 == 1
FAILED test_a_flood_of_unseen_joint_names_does_not_dislodge_a_live_joint     - assert 0 == 1
FAILED test_a_paused_joint_is_not_over_refused_when_it_moves_again           - assert 0 == 1
```

Rebased onto `44d4f6b8`; the only overlap with the new base was the changelog.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1686-teleop-slew-bound.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

### Landing note: overlaps #1676 and #1684 on one import block

This branch is `MERGEABLE` against `main` today, but `strands_robots/mesh/input.py`
is also touched by the two sibling teleop PRs, so whichever lands first turns the
others `CONFLICTING`. Recording the resolution here so it does not have to be
rediscovered at merge time, and so it can be applied in the merge UI rather than by
pushing a merge commit (which would dismiss a standing approval for a change that
reviews no new behaviour).

The overlap is the `strands_robots.mesh.security` import block **only** - three
branches each add names to it:

* this branch: `input_frame_slew_violation`, `merge_slew_baseline`
* #1676: `validate_mesh_identifier`
* #1684: `positive_finite_number_error` (from `strands_robots.utils`)

The resolution is the union of all names. The three guards are orthogonal - *who*
sent the frame (#1676), *how fast* the publish loop runs (#1684), and *how far* a
joint may travel per unit time (this branch) - and none reads state another writes,
so no ordering question arises beyond the import list itself.

Verified locally by stacking `main` + #1676 + #1684 + this branch with that union
resolution: `tests/mesh/test_teleop_identifier_source_scoping.py`,
`tests/test_teleop_rate_and_duration_guards.py` and
`tests/mesh/test_input_slew_bound.py` are **195 passed**, and the full `tests/mesh/`
failure set is byte-identical to the same run on `main` (the residue is
optional-dependency gaps in the sandbox, not the stack). The stacked tree adds
+129 passing tests over `main` with zero new failures. No behaviour change on this
branch; description only.

### Sync round: teleop source scoping landed on `main`

`main` gained `validate_mesh_identifier` for teleop source scoping, which
expanded the `strands_robots.mesh.security` import in
`strands_robots/mesh/input.py` that this branch also edits. git reported a
conflict on that import block alone - adjacent additions, not competing ones.

Resolved as the union of the two import lists, in the sorted order ruff/isort
expects: `input_frame_slew_violation` and `merge_slew_baseline` from this
branch, `validate_mesh_identifier` from `main`. All three are used. No source
behaviour, test, or artifact changed in this round.

`pytest tests/mesh` reports the same 26 failures on the merge result as on a
clean `main` in this sandbox (missing optional extras plus the `so100` asset
download), with 2194 passed against `main`'s 2144.
