### PR TITLE
fix(sim): honor the physics options a robot model declares for itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a live MJPEG stream refuses options it cannot honor
+
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
+
+```python
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
+```
+
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
+
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
 ### Fixed: Robot() forwards the base position it was given
 
 The `Robot()` factory wraps `add_robot`, which validates a base pose up front:
@@ -30,44 +66,6 @@ reporting success - the guard that refuses it was unreachable through the
 factory. The position is now passed through verbatim, so `None` (the documented
 "spawn at the origin") stays the single source of truth for that default
 instead of a copy in the factory that can drift from the backend's.
-
-
-### Fixed: a robot model's declared `<option>` reaches the simulation
-
-`<option>` is model-global, so it does not come across `spec.attach()`. Every
-solver setting a robot MJCF declared for itself was therefore discarded when the
-robot was composed into a `create_world()` scene - and the effect is physical,
-not cosmetic. A Franka Panda declares `integrator="implicitfast"`; under the
-Euler integrator the scene fell back to, its position servos diverge enough that
-a scripted top-down grasp pushes the cube away on approach and squeezes through
-it on the lift:
-
-| integrator | cube x after close | fingers after lift | cube z after lift |
-| --- | --- | --- | --- |
-| Euler (what was compiled) | 0.468 (pushed 32 mm) | 0.0000 (slipped through) | 0.0199 (never left the floor) |
-| `implicitfast` (what the model declares) | 0.502 | 0.0199 (holding) | 0.1068 |
-
-40 of the 49 locally resolvable registry robots declare an `<option>`, and
-`so100`, `so101`, `aloha`, `shadow_hand` and `robotiq_2f85` all declare
-`cone="elliptic" impratio="10"` - the standard MuJoCo recipe for a gripper that
-must hold load. `actuate_robot` already flipped the integrator to
-`implicitfast` scene-wide for the robots it actuates itself, for exactly this
-reason; a robot shipping the same declaration in its own model was not given the
-same treatment.
-
-`add_robot` now adopts the solver fields a robot model declares. Precedence: a
-field the scene already sets to a non-default value (the caller's own scene MJCF,
-or a robot attached earlier) is kept; otherwise the model's value is adopted.
-`timestep` and `gravity` stay owned by `create_world(timestep=, gravity=)`, and
-vector environment fields and flag bitfields are left to the world. Because a
-model-global field holds exactly one value, a second robot whose declaration
-disagrees is logged by field, value and robot rather than silently dropped.
-
-The declaration is read from the robot model before the spec attach that
-consumes it, but written onto the scene only once that attach has succeeded. An
-`add_robot` that reports an error therefore leaves the world's solver settings
-untouched, instead of having a robot that never entered the scene rewrite them
-with no undo path.
 
 
 ### Fixed: the state and action sides agree on what a hardware observation is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,44 @@ factory. The position is now passed through verbatim, so `None` (the documented
 instead of a copy in the factory that can drift from the backend's.
 
 
+### Fixed: a robot model's declared `<option>` reaches the simulation
+
+`<option>` is model-global, so it does not come across `spec.attach()`. Every
+solver setting a robot MJCF declared for itself was therefore discarded when the
+robot was composed into a `create_world()` scene - and the effect is physical,
+not cosmetic. A Franka Panda declares `integrator="implicitfast"`; under the
+Euler integrator the scene fell back to, its position servos diverge enough that
+a scripted top-down grasp pushes the cube away on approach and squeezes through
+it on the lift:
+
+| integrator | cube x after close | fingers after lift | cube z after lift |
+| --- | --- | --- | --- |
+| Euler (what was compiled) | 0.468 (pushed 32 mm) | 0.0000 (slipped through) | 0.0199 (never left the floor) |
+| `implicitfast` (what the model declares) | 0.502 | 0.0199 (holding) | 0.1068 |
+
+40 of the 49 locally resolvable registry robots declare an `<option>`, and
+`so100`, `so101`, `aloha`, `shadow_hand` and `robotiq_2f85` all declare
+`cone="elliptic" impratio="10"` - the standard MuJoCo recipe for a gripper that
+must hold load. `actuate_robot` already flipped the integrator to
+`implicitfast` scene-wide for the robots it actuates itself, for exactly this
+reason; a robot shipping the same declaration in its own model was not given the
+same treatment.
+
+`add_robot` now adopts the solver fields a robot model declares. Precedence: a
+field the scene already sets to a non-default value (the caller's own scene MJCF,
+or a robot attached earlier) is kept; otherwise the model's value is adopted.
+`timestep` and `gravity` stay owned by `create_world(timestep=, gravity=)`, and
+vector environment fields and flag bitfields are left to the world. Because a
+model-global field holds exactly one value, a second robot whose declaration
+disagrees is logged by field, value and robot rather than silently dropped.
+
+The declaration is read from the robot model before the spec attach that
+consumes it, but written onto the scene only once that attach has succeeded. An
+`add_robot` that reports an error therefore leaves the world's solver settings
+untouched, instead of having a robot that never entered the scene rewrite them
+with no undo path.
+
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/changelog.d/1687-honor-robot-declared-physics-options.md
+++ b/changelog.d/1687-honor-robot-declared-physics-options.md
@@ -1,0 +1,36 @@
+### Fixed: a robot model's declared `<option>` reaches the simulation
+
+`<option>` is model-global, so it does not come across `spec.attach()`. Every
+solver setting a robot MJCF declared for itself was therefore discarded when the
+robot was composed into a `create_world()` scene - and the effect is physical,
+not cosmetic. A Franka Panda declares `integrator="implicitfast"`; under the
+Euler integrator the scene fell back to, its position servos diverge enough that
+a scripted top-down grasp pushes the cube away on approach and squeezes through
+it on the lift:
+
+| integrator | cube x after close | fingers after lift | cube z after lift |
+| --- | --- | --- | --- |
+| Euler (what was compiled) | 0.468 (pushed 32 mm) | 0.0000 (slipped through) | 0.0199 (never left the floor) |
+| `implicitfast` (what the model declares) | 0.502 | 0.0199 (holding) | 0.1068 |
+
+40 of the 49 locally resolvable registry robots declare an `<option>`, and
+`so100`, `so101`, `aloha`, `shadow_hand` and `robotiq_2f85` all declare
+`cone="elliptic" impratio="10"` - the standard MuJoCo recipe for a gripper that
+must hold load. `actuate_robot` already flipped the integrator to
+`implicitfast` scene-wide for the robots it actuates itself, for exactly this
+reason; a robot shipping the same declaration in its own model was not given the
+same treatment.
+
+`add_robot` now adopts the solver fields a robot model declares. Precedence: a
+field the scene already sets to a non-default value (the caller's own scene MJCF,
+or a robot attached earlier) is kept; otherwise the model's value is adopted.
+`timestep` and `gravity` stay owned by `create_world(timestep=, gravity=)`, and
+vector environment fields and flag bitfields are left to the world. Because a
+model-global field holds exactly one value, a second robot whose declaration
+disagrees is logged by field, value and robot rather than silently dropped.
+
+The declaration is read from the robot model before the spec attach that
+consumes it, but written onto the scene only once that attach has succeeded. An
+`add_robot` that reports an error therefore leaves the world's solver settings
+untouched, instead of having a robot that never entered the scene rewrite them
+with no undo path.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -60,6 +60,43 @@ is an error that lists the model's available keyframes. `keyframe=None` (the
 default) keeps the zero-pose spawn. (MuJoCo backend; the Newton backend rejects
 `keyframe=` as not-yet-supported.)
 
+## Declared physics options
+
+A robot MJCF may declare the solver settings its contacts and actuators were
+tuned for. `add_robot` carries them onto the scene, because MuJoCo's `<option>`
+is model-global and does not survive the spec attach:
+
+```python
+sim.create_world()
+sim.add_robot(name="panda")          # model declares integrator="implicitfast"
+sim.mj_model.opt.integrator          # -> mjINT_IMPLICITFAST
+```
+
+This matters for manipulation. Under the default Euler integrator a Panda's
+position servos diverge enough that a top-down grasp pushes the object away and
+squeezes through it; `so100`, `so101`, `aloha`, `shadow_hand` and `robotiq_2f85`
+likewise declare `cone="elliptic" impratio="10"` so their grippers can hold load.
+
+Precedence, highest first:
+
+| Source | Wins for |
+| --- | --- |
+| `create_world(timestep=, gravity=)` | `timestep`, `gravity` - always |
+| Your own scene MJCF (`replace_scene_mjcf`) | any field it sets |
+| First robot attached that declares the field | everything else |
+
+A model-global field holds one value, so if a second robot declares a different
+value for a field already set, the existing value is kept and the discarded
+request is logged with the field, both values and the robot name. Add that robot
+first, or declare the value in your own scene MJCF, to make it win.
+
+Vector environment fields (`wind`, `magnetic`, contact overrides) and the flag
+bitfields describe the world rather than the robot and are never adopted.
+
+Adoption is committed only once the robot is actually in the scene, so an
+`add_robot` that reports an error leaves the world's solver settings exactly as
+they were - and leaves the field free for the next robot that declares it.
+
 ## Rough terrain
 
 By default `create_world()` lays down a flat ground plane. A locomotion

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -914,13 +914,175 @@ class SpecBuilder:
         for top_body in robot_spec.worldbody.bodies:
             _walk(top_body)
 
+        # Read the solver settings the robot model declares for itself. The read
+        # has to happen here, before ``attach`` consumes the child spec, but the
+        # scene is only written once the attach below has succeeded: everything
+        # from ``add_frame`` on can raise (``inject_robot_into_scene`` catches
+        # exactly that and reports a failed add), and the live spec outlives the
+        # failed call, so a scene mutated on the way to an error would keep
+        # solver settings for a robot that never entered the world.
+        declared_options = SpecBuilder.declared_options(robot_spec)
+
         frame = scene_spec.worldbody.add_frame(
             pos=list(robot.position),
             quat=list(robot.orientation),
         )
         scene_spec.attach(robot_spec, prefix=f"{robot.name}/", frame=frame)
 
+        SpecBuilder.adopt_declared_options(scene_spec, declared_options, robot.name)
+
         return source_joint_names
+
+    @staticmethod
+    def declared_options(robot_spec: Any) -> dict[str, Any]:
+        """Read the ``<option>`` fields a robot model declares for itself.
+
+        Call this before ``spec.attach()``, which consumes the child spec. The
+        result is a plain mapping and reading it mutates nothing, so a caller
+        can hold it across the attach and only commit it to the scene once the
+        attach has actually succeeded - see :meth:`adopt_declared_options`.
+
+        Args:
+            robot_spec: the robot's freshly loaded spec.
+
+        Returns:
+            Mapping of field name to declared value, for every field in
+            :data:`_ADOPTED_OPTION_FIELDS` this model sets away from MuJoCo's
+            default. Empty when the model declares nothing beyond the defaults.
+        """
+        mujoco = _ensure_mujoco()
+
+        defaults = mujoco.MjSpec().option
+        declared: dict[str, Any] = {}
+        for field in _ADOPTED_OPTION_FIELDS:
+            value = getattr(robot_spec.option, field)
+            # A field restating MuJoCo's default is indistinguishable from one
+            # the model does not mention, and adopting it would claim the field
+            # against the next robot for no gain.
+            if value != getattr(defaults, field):
+                declared[field] = value
+        return declared
+
+    @staticmethod
+    def adopt_declared_options(
+        scene_spec: Any,
+        declared_options: Mapping[str, Any],
+        robot_name: str,
+    ) -> dict[str, Any]:
+        """Apply a robot's declared ``<option>`` fields onto the scene.
+
+        ``<option>`` is model-global and does not survive ``spec.attach()``, so
+        without this a robot is simulated under solver settings its own model
+        rejects. See :data:`_ADOPTED_OPTION_FIELDS` for the adopted set and the
+        fields deliberately left to the world.
+
+        This writes to ``scene_spec``, so call it only once the robot is
+        actually in the scene - i.e. after a successful ``attach``. The values
+        themselves come from :meth:`declared_options`, which has to run before
+        the attach; splitting the read from the write is what keeps a failed
+        attach from leaving the scene holding this robot's settings.
+
+        Precedence, in order:
+
+        1. A field the scene already sets to a non-default value belongs to
+           whoever set it - the caller's own scene MJCF, or a robot attached
+           earlier. It is kept.
+        2. Otherwise the robot's declared value is adopted.
+
+        A model-global field holds exactly one value, so when an already-set
+        field disagrees with this robot's declaration the scene value wins and
+        the discarded request is logged by field, value and robot: the caller
+        can force the other value by declaring it in their own scene MJCF or by
+        adding that robot first.
+
+        Args:
+            scene_spec: the scene spec to mutate.
+            declared_options: this robot's declared fields, from
+                :meth:`declared_options`.
+            robot_name: robot name, used in the conflict log.
+
+        Returns:
+            Mapping of field name to the value adopted from this robot. Empty
+            when the model declared nothing, or when the scene already owned
+            every field it declared.
+        """
+        mujoco = _ensure_mujoco()
+
+        defaults = mujoco.MjSpec().option
+        adopted: dict[str, Any] = {}
+        for field, declared in declared_options.items():
+            default = getattr(defaults, field)
+            current = getattr(scene_spec.option, field)
+            if current != default:
+                if current != declared:
+                    logger.warning(
+                        "add_robot(%r): scene already sets option %s=%s, so the "
+                        "%s=%s this model declares is not applied. A model-global "
+                        "option holds one value: declare it in the scene MJCF, or "
+                        "attach this robot first, to make it win.",
+                        robot_name,
+                        field,
+                        current,
+                        field,
+                        declared,
+                    )
+                continue
+            setattr(scene_spec.option, field, declared)
+            adopted[field] = declared
+
+        if adopted:
+            logger.debug(
+                "add_robot(%r): adopted declared physics option(s) %r",
+                robot_name,
+                adopted,
+            )
+        return adopted
+
+
+# Model-global ``<option>`` fields adopted from an attached robot model.
+#
+# ``<option>`` is model-global, so it does not come across ``spec.attach()``:
+# a robot MJCF that declares the solver settings its own contacts and actuators
+# were tuned for loses them the moment it is composed into a generated scene.
+# The consequences are physical, not cosmetic - a Franka Panda declares
+# ``integrator="implicitfast"``, and under the default Euler integrator its
+# position servos diverge enough that a top-down grasp pushes the object away on
+# approach and squeezes through it on the lift. ``actuate_robot`` already flips
+# the integrator to ``implicitfast`` scene-wide for the robots it actuates
+# itself, for exactly that reason; a robot that ships the same declaration in
+# its own model deserves the same treatment.
+#
+# Excluded on purpose:
+#   * ``timestep`` / ``gravity`` - owned by ``create_world(timestep=, gravity=)``.
+#     The world always writes both, so a robot's declaration cannot be told
+#     apart from the caller's and adopting it would move the world's dt (and the
+#     rollout duration math built on it) without the caller asking.
+#   * ``wind`` / ``magnetic`` / ``o_solref`` / ``o_solimp`` / ``o_friction`` -
+#     vector-valued environment and contact-override fields that describe the
+#     world a robot is placed in, not the robot.
+#   * ``disableflags`` / ``enableflags`` / ``disableactuator`` - bitfields. One
+#     value per field is a resolvable arbitration; merging bitmasks from several
+#     models is a different decision and is not made here.
+_ADOPTED_OPTION_FIELDS: tuple[str, ...] = (
+    "integrator",
+    "cone",
+    "jacobian",
+    "solver",
+    "iterations",
+    "ls_iterations",
+    "noslip_iterations",
+    "ccd_iterations",
+    "sdf_iterations",
+    "sdf_initpoints",
+    "impratio",
+    "tolerance",
+    "ls_tolerance",
+    "noslip_tolerance",
+    "ccd_tolerance",
+    "density",
+    "viscosity",
+    "o_margin",
+)
 
 
 def _is_z0_ground_plane(geom: Any) -> bool:

--- a/tests/simulation/mujoco/test_robot_declared_physics_options.py
+++ b/tests/simulation/mujoco/test_robot_declared_physics_options.py
@@ -1,0 +1,297 @@
+"""A robot model's declared ``<option>`` must survive being added to a world.
+
+``<option>`` is model-global, so it does not come across ``spec.attach()``. A
+robot MJCF that declares the solver settings its own contacts and actuators were
+tuned for used to lose every one of them when composed into a generated scene,
+and the effect is physical: a Franka Panda declares
+``integrator="implicitfast"``, and under the Euler integrator the scene fell
+back to, its position servos diverge enough that a scripted top-down grasp
+pushes the cube 32 mm away on approach and squeezes straight through it on the
+lift instead of carrying it.
+
+These tests pin the contract on the compiled model - the only place the setting
+can be observed to take effect - rather than on the spec, and pin the precedence
+rules that decide which value a model-global field ends up holding.
+
+``integrator`` assertions deliberately use ``RK4``: ``actuate_robot`` flips the
+integrator to ``implicitfast`` scene-wide when it adds position servos to a
+model that ships none, so ``implicitfast`` alone cannot distinguish adoption
+from that unrelated path. Nothing else in the codebase selects ``RK4``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+import strands_robots as sr  # noqa: E402
+from strands_robots.simulation.models import SimRobot  # noqa: E402
+from strands_robots.simulation.mujoco.spec_builder import SpecBuilder  # noqa: E402
+
+ARM_BODY = """
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <joint name="shoulder" type="hinge" axis="0 1 0"/>
+      <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+      <body name="link" pos="0 0 0.2">
+        <joint name="elbow" type="hinge" axis="0 1 0"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_act" joint="shoulder" kp="20"/>
+    <position name="elbow_act" joint="elbow" kp="20"/>
+  </actuator>
+"""
+
+
+def _arm_mjcf(tmp_path, name: str, option: str) -> str:
+    """Write a minimal actuated 2-joint arm MJCF carrying ``option``."""
+    path = tmp_path / f"{name}.xml"
+    path.write_text(f'<mujoco model="{name}">\n  {option}\n{ARM_BODY}</mujoco>\n')
+    return str(path)
+
+
+@pytest.fixture
+def sim():
+    s = sr.Simulation(backend="mujoco", tool_name="declared_options", mesh=False)
+    yield s
+    s.destroy()
+
+
+class TestDeclaredOptionsAreCompiled:
+    """The values a robot model declares reach the compiled model."""
+
+    def test_declared_integrator_is_compiled(self, sim, tmp_path):
+        """A model that asks for RK4 is integrated with RK4."""
+        sim.create_world()
+        sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", '<option integrator="RK4"/>'))
+
+        assert sim.mj_model.opt.integrator == int(mujoco.mjtIntegrator.mjINT_RK4)
+
+    def test_declared_friction_cone_and_impratio_are_compiled(self, sim, tmp_path):
+        """The elliptic-cone/impratio recipe a load-bearing gripper needs is kept.
+
+        ``so100``, ``so101``, ``aloha``, ``shadow_hand`` and ``robotiq_2f85`` all
+        declare exactly this pair.
+        """
+        sim.create_world()
+        sim.add_robot(
+            name="arm",
+            urdf_path=_arm_mjcf(tmp_path, "arm", '<option cone="elliptic" impratio="10"/>'),
+        )
+
+        assert sim.mj_model.opt.cone == int(mujoco.mjtCone.mjCONE_ELLIPTIC)
+        assert sim.mj_model.opt.impratio == pytest.approx(10.0)
+
+    def test_declared_solver_iteration_budget_is_compiled(self, sim, tmp_path):
+        """Iteration/tolerance budgets are part of the same declaration."""
+        sim.create_world()
+        sim.add_robot(
+            name="arm",
+            urdf_path=_arm_mjcf(tmp_path, "arm", '<option solver="PGS" iterations="50" noslip_iterations="3"/>'),
+        )
+
+        assert sim.mj_model.opt.solver == int(mujoco.mjtSolver.mjSOL_PGS)
+        assert sim.mj_model.opt.iterations == 50
+        assert sim.mj_model.opt.noslip_iterations == 3
+
+    def test_model_declaring_nothing_keeps_mujoco_defaults(self, sim, tmp_path):
+        """Adoption only moves fields the model actually declares."""
+        sim.create_world()
+        sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", ""))
+
+        defaults = mujoco.MjSpec().option
+        assert sim.mj_model.opt.cone == defaults.cone
+        assert sim.mj_model.opt.impratio == pytest.approx(defaults.impratio)
+        assert sim.mj_model.opt.iterations == defaults.iterations
+
+    def test_adopted_option_survives_a_later_scene_recompile(self, sim, tmp_path):
+        """Adding an object rebuilds the scene; the declaration must not be lost."""
+        sim.create_world()
+        sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", '<option integrator="RK4"/>'))
+        sim.add_object(name="cube", shape="box", position=[0.4, 0.0, 0.05], size=[0.05, 0.05, 0.05])
+
+        assert sim.mj_model.opt.integrator == int(mujoco.mjtIntegrator.mjINT_RK4)
+
+
+class TestWorldOwnedFieldsWin:
+    """``create_world`` owns the fields it exposes; a model cannot move them."""
+
+    def test_model_declared_timestep_does_not_move_the_world_dt(self, sim, tmp_path):
+        """The world's dt is the caller's, and the rollout math is built on it."""
+        sim.create_world(timestep=0.002)
+        sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", '<option timestep="0.01"/>'))
+
+        assert sim.mj_model.opt.timestep == pytest.approx(0.002)
+
+    def test_model_declared_gravity_does_not_move_the_world_gravity(self, sim, tmp_path):
+        """Same for gravity: ``create_world(gravity=...)`` is the source of truth."""
+        sim.create_world(gravity=[0.0, 0.0, -9.81])
+        sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", '<option gravity="0 0 -1"/>'))
+
+        assert sim.mj_model.opt.gravity[2] == pytest.approx(-9.81)
+
+    def test_model_declared_wind_is_not_adopted(self, sim, tmp_path):
+        """Vector environment fields describe the world, not the robot."""
+        sim.create_world()
+        sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", '<option wind="5 0 0"/>'))
+
+        assert sim.mj_model.opt.wind[0] == pytest.approx(0.0)
+
+
+class TestConflictBetweenTwoRobots:
+    """A model-global field holds one value, so a disagreement is arbitrated."""
+
+    def test_first_declaration_wins_and_the_discarded_one_is_reported(self, sim, tmp_path, caplog):
+        """The scene value is kept and the rejected request is named in full."""
+        sim.create_world()
+        sim.add_robot(name="first", urdf_path=_arm_mjcf(tmp_path, "first", '<option integrator="RK4"/>'))
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.spec_builder"):
+            sim.add_robot(
+                name="second",
+                position=[1.0, 0.0, 0.0],
+                urdf_path=_arm_mjcf(tmp_path, "second", '<option integrator="implicitfast"/>'),
+            )
+
+        assert sim.mj_model.opt.integrator == int(mujoco.mjtIntegrator.mjINT_RK4)
+        message = caplog.text
+        assert "second" in message
+        assert "integrator" in message
+
+    def test_agreeing_declarations_are_not_reported_as_a_conflict(self, sim, tmp_path, caplog):
+        """Two robots asking for the same value is not a disagreement."""
+        sim.create_world()
+        sim.add_robot(name="first", urdf_path=_arm_mjcf(tmp_path, "first", '<option cone="elliptic"/>'))
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.spec_builder"):
+            sim.add_robot(
+                name="second",
+                position=[1.0, 0.0, 0.0],
+                urdf_path=_arm_mjcf(tmp_path, "second", '<option cone="elliptic"/>'),
+            )
+
+        assert sim.mj_model.opt.cone == int(mujoco.mjtCone.mjCONE_ELLIPTIC)
+        assert "cone" not in caplog.text
+
+    def test_two_robots_declaring_different_fields_both_apply(self, sim, tmp_path):
+        """Arbitration is per field, so disjoint declarations do not compete."""
+        sim.create_world()
+        sim.add_robot(name="first", urdf_path=_arm_mjcf(tmp_path, "first", '<option integrator="RK4"/>'))
+        sim.add_robot(
+            name="second",
+            position=[1.0, 0.0, 0.0],
+            urdf_path=_arm_mjcf(tmp_path, "second", '<option impratio="10"/>'),
+        )
+
+        assert sim.mj_model.opt.integrator == int(mujoco.mjtIntegrator.mjINT_RK4)
+        assert sim.mj_model.opt.impratio == pytest.approx(10.0)
+
+
+class TestReadingAndApplyingAreSeparate:
+    """The two halves of the adoption report exactly what they handled."""
+
+    def test_the_read_names_the_declared_fields_and_skips_world_owned_ones(self, tmp_path):
+        """Reading a model yields only the fields adoption is allowed to move."""
+        scene = mujoco.MjSpec()
+        robot = mujoco.MjSpec.from_file(_arm_mjcf(tmp_path, "arm", '<option integrator="RK4" timestep="0.01"/>'))
+
+        declared = SpecBuilder.declared_options(robot)
+
+        assert declared == {"integrator": int(mujoco.mjtIntegrator.mjINT_RK4)}
+        assert scene.option.timestep == pytest.approx(mujoco.MjSpec().option.timestep)
+
+    def test_the_read_names_nothing_for_a_model_that_declares_nothing(self, tmp_path):
+        """A model restating MuJoCo's defaults declares nothing to adopt."""
+        robot = mujoco.MjSpec.from_file(_arm_mjcf(tmp_path, "arm", ""))
+
+        assert SpecBuilder.declared_options(robot) == {}
+
+    def test_applying_reports_what_it_wrote_onto_the_scene(self, tmp_path):
+        """The write reports the subset the scene did not already own."""
+        scene = mujoco.MjSpec()
+        scene.option.cone = int(mujoco.mjtCone.mjCONE_ELLIPTIC)
+        declared = {
+            "integrator": int(mujoco.mjtIntegrator.mjINT_RK4),
+            "cone": int(mujoco.mjtCone.mjCONE_PYRAMIDAL),
+        }
+
+        adopted = SpecBuilder.adopt_declared_options(scene, declared, "arm")
+
+        assert adopted == {"integrator": int(mujoco.mjtIntegrator.mjINT_RK4)}
+        assert scene.option.cone == int(mujoco.mjtCone.mjCONE_ELLIPTIC)
+
+
+class TestAFailedAttachLeavesTheSceneAlone:
+    """A robot that never entered the world must not rewrite its physics.
+
+    ``attach_robot`` mutates the *live* spec, which outlives a failed
+    ``add_robot`` - ``inject_robot_into_scene`` catches the exception, logs it
+    and reports the add as failed, and ``Simulation.add_robot`` then rolls back
+    only its ``world.robots`` registry entry. Anything written onto the spec on
+    the way to that error has no undo path, so it is baked into ``mj_model`` by
+    the next successful scene mutation with no signal to the caller. Adoption is
+    therefore read before the attach and written only after it has succeeded.
+    """
+
+    def test_scene_options_survive_an_attach_that_raises(self, tmp_path):
+        """The declaration is dropped with the robot, not left on the scene."""
+        scene = mujoco.MjSpec()
+        robot = SimRobot(
+            name="arm",
+            urdf_path=_arm_mjcf(tmp_path, "arm", '<option integrator="RK4" impratio="10"/>'),
+            # A 3-element orientation is refused by ``worldbody.add_frame``,
+            # which runs between the read and the attach.
+            orientation=[1.0, 0.0, 0.0],
+        )
+
+        with pytest.raises(ValueError):
+            SpecBuilder.attach_robot(scene, robot, robot.urdf_path)
+
+        defaults = mujoco.MjSpec().option
+        assert scene.option.integrator == defaults.integrator
+        assert scene.option.impratio == pytest.approx(defaults.impratio)
+
+    def test_a_refused_add_robot_does_not_move_the_worlds_solver_settings(self, sim, tmp_path, monkeypatch):
+        """The compiled model keeps its settings when the add is reported failed."""
+        sim.create_world()
+        defaults = mujoco.MjSpec().option
+
+        def refuse(self, *args, **kwargs):
+            raise ValueError("attach refused")
+
+        monkeypatch.setattr(mujoco.MjSpec, "attach", refuse)
+        result = sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", '<option integrator="RK4"/>'))
+
+        assert result["status"] == "error"
+        assert "arm" not in sim._world.robots
+
+        monkeypatch.undo()
+        # The next scene mutation recompiles: a leaked adoption would surface
+        # here, attributed to a robot the world never accepted.
+        sim.add_object(name="cube", shape="box", position=[0.4, 0.0, 0.05], size=[0.05, 0.05, 0.05])
+
+        assert sim.mj_model.opt.integrator == defaults.integrator
+
+    def test_a_robot_added_after_a_refused_one_still_gets_its_declaration(self, sim, tmp_path, monkeypatch):
+        """Dropping the leak must not amount to dropping adoption itself."""
+        sim.create_world()
+
+        def refuse(self, *args, **kwargs):
+            raise ValueError("attach refused")
+
+        monkeypatch.setattr(mujoco.MjSpec, "attach", refuse)
+        sim.add_robot(name="refused", urdf_path=_arm_mjcf(tmp_path, "refused", '<option cone="elliptic"/>'))
+        monkeypatch.undo()
+
+        sim.add_robot(name="arm", urdf_path=_arm_mjcf(tmp_path, "arm", '<option integrator="RK4"/>'))
+
+        assert sim.mj_model.opt.integrator == int(mujoco.mjtIntegrator.mjINT_RK4)
+        # The refused robot's declaration is gone, so it does not out-rank a
+        # later robot asking for a different value on the same field.
+        assert sim.mj_model.opt.cone == mujoco.MjSpec().option.cone


### PR DESCRIPTION
Closes #1653.

## Problem

MuJoCo's `<option>` is model-global, so it does not come across `spec.attach()`. Every solver setting a robot MJCF declares for itself is discarded the moment the robot is composed into a `create_world()` scene.

The effect is physical, not cosmetic. A Franka Panda declares `integrator="implicitfast"`. Under the Euler integrator the scene falls back to, its position servos diverge enough that a scripted top-down grasp **pushes the cube away on approach and squeezes straight through it on the lift**:

| integrator | cube x after close | fingers after lift | cube z after lift | grasp |
| --- | --- | --- | --- | --- |
| Euler (what is compiled today) | 0.468 (**pushed 32 mm**) | 0.0000 (**slipped through**) | 0.0199 (never left the floor) | fails |
| `implicitfast` (what the model declares) | 0.502 (2 mm) | 0.0199 (holding) | **0.1068** | works |
| RK4 (control) | 0.511 | 0.0000 | 0.0199 | fails |

I diffed the *compiled* Panda asset against the same robot injected by `add_robot`. Exactly one field diverges - `opt.integrator`, `implicitfast` vs `Euler`. Actuators, ctrlranges, geom friction/solref/solimp/condim, tendon, equality and contact excludes all survive the attach with zero diffs, so this single dropped attribute is the whole defect.

This is not one unlucky robot. **40 of the 49 locally resolvable registry robots declare an `<option>`**:

| field | spread across the registry |
| --- | --- |
| `integrator` | 26 robots `implicitfast`, 1 `Euler`, 1 `RK4` |
| `cone` / `impratio` | `so100`, `so101`, `aloha`, `shadow_hand`, `robotiq_2f85`: `elliptic` + `10` |
| `solver` / `iterations` / `tolerance` | `jvrc` PGS, `rby1` CG, `aliengo`/`unitree_a1` Newton@50 |
| `noslip_iterations` | `stretch`, `stretch3`, `shadow_dexee`, `dynamixel_2r` |
| `viscosity` | `crazyflie`, `skydio_x2` (they need it to fly) |

`cone="elliptic" impratio="10"` is the standard MuJoCo recipe for a gripper that must hold load, and every one of those grippers is currently simulated without it.

The codebase already agrees with this diagnosis. `actuate_robot` flips the integrator to `implicitfast` **scene-wide** when it adds position servos itself, and says why (`scene_ops.py`): *"Euler integrator once stiff position servos are added"*. A robot that ships the same declaration in its own model was not given the same treatment.

## Change

`add_robot` adopts the solver fields a robot model declares (`SpecBuilder.adopt_declared_options`, read before `attach` consumes the child spec). Precedence:

1. A field the scene already sets to a non-default value belongs to whoever set it - the caller's own scene MJCF, or a robot attached earlier. It is kept.
2. Otherwise the model's declared value is adopted.

Deliberately left to the world, documented at the constant:

- **`timestep` / `gravity`** - owned by `create_world(timestep=, gravity=)`. The world always writes both, so a model's declaration cannot be told apart from the caller's, and adopting it would move the world's dt (and the rollout duration math built on it) without the caller asking. 11 robots declare a `timestep`; none of them get to move it.
- **`wind` / `magnetic` / `o_solref` / `o_solimp` / `o_friction`** - vector-valued environment and contact-override fields that describe the world a robot is placed in, not the robot.
- **`disableflags` / `enableflags` / `disableactuator`** - bitfields. One value per field is a resolvable arbitration; merging bitmasks from several models is a different decision and is not made here.

A model-global field holds exactly one value, so a genuine disagreement cannot be resolved by taking both. When an already-set field disagrees with a later robot's declaration, the scene value wins and the discarded request is logged with the field, both values and the robot name, plus the two ways to make it win (declare it in your own scene MJCF, or attach that robot first). Refusing the `add_robot` outright would break multi-robot scenes that work today, for a field nobody could previously set at all.

## Tests

`tests/simulation/mujoco/test_robot_declared_physics_options.py`, 17 tests, all on inline MJCF fixtures (no asset download):

- declared `integrator` / `cone` + `impratio` / `solver` + `iterations` + `noslip_iterations` reach `mj_model.opt`
- a model declaring nothing leaves MuJoCo's defaults alone
- an adopted value survives a later scene recompile (`add_object`)
- a model-declared `timestep`, `gravity` and `wind` do **not** move the world's
- first declaration wins, the discarded one is reported by field and robot
- two robots agreeing is not logged as a conflict; two robots declaring *different* fields both apply
- the helper's return value reports exactly what it took
- a robot whose add is refused leaves the world's solver settings untouched (round 2, below)

`integrator` assertions use **RK4** on purpose: `actuate_robot` flips to `implicitfast` on an unrelated path, so `implicitfast` alone cannot distinguish adoption from that. Nothing else in the codebase selects RK4.

Pre-fix on this exact base: **9 failed, 4 passed** (the 4 that pass are the world-wins and declares-nothing cases, which were already true). Post-fix 17 passed.

## Visual artifact

Same scripted top-down Panda pick, MuJoCo headless (EGL), 40 mm 50 g cube, rendered before and after. Left slips and comes up empty; right carries the cube.

![grasp before vs after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/declared-physics-options/declared_options_grasp.gif)

Source clips: [before (Euler)](https://raw.githubusercontent.com/cagataycali/robots/artifacts/declared-physics-options/before_euler.mp4) · [after (implicitfast)](https://raw.githubusercontent.com/cagataycali/robots/artifacts/declared-physics-options/after_implicitfast.mp4)

## Gate

- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ`: clean
- `mypy strands_robots tests tests_integ`: only the pre-existing `strands_robots/simulation/ik.py:105 Returning Any` (untouched here; it surfaces only where `qpsolvers` is installed)
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **12466 passed, 260 skipped** in 428s
- Compiled-physics diff of the Panda asset vs the injected robot: option now matches, all other fields still zero diffs

Docs: new "Declared physics options" section in `docs/simulation/world-building.md` with the precedence table, plus a CHANGELOG entry.

## Round 2 - a refused add must not rewrite the world's physics (`8c0b0499`)

Review found that the adoption was written onto the **live** scene spec *before*
`scene_spec.attach(...)`, which can raise. `inject_robot_into_scene` catches that
and reports a failed add, and `Simulation.add_robot` then rolls back only its
`world.robots` registry entry - the options written into the persistent spec had
no undo path. Reproduced:

```
add_robot(name="arm", <option integrator="RK4"/>)   -> status=error, "arm" not in world.robots
add_object(name="cube", ...)                        -> status=success   (the recompile)
sim.mj_model.opt.integrator                         -> 1 (mjINT_RK4)    <- from a robot that is not in the scene
```

The leak also *claims the field*: a refused robot declaring `cone="elliptic"` made
a later, successfully added robot lose the arbitration for `cone` to a value
nobody in the world asked for. It is reachable without touching MuJoCo too -
`worldbody.add_frame` sits between the old write and the attach and refuses a
malformed pose.

**Fix - split the read from the write.** `SpecBuilder.declared_options(robot_spec)`
reads the declared fields (it has to run before attach consumes the child spec)
and mutates nothing; `SpecBuilder.adopt_declared_options(scene_spec,
declared_options, robot_name)` arbitrates against the scene and writes, and now
runs only after the attach has returned. The conflict warning moved with the
write, so a refused robot no longer reports a declaration it never competed for.
The call-site comment now states the invariant the code actually provides.

Moving the arbitration after the attach changes no outcome: `attach` does not
touch the parent's `option` - that is this PR's premise, and MuJoCo says so out
loud (`Attach conflict ... keeping parent value`, the noise
`filter_mujoco_attach_noise` suppresses). Verified directly.

Three new regression tests in `TestAFailedAttachLeavesTheSceneAlone` (attach
raises via a malformed pose; the end-to-end refused-add form above; and the
field-claiming effect, which also pins that the fix is not "stop adopting"),
plus three in `TestReadingAndApplyingAreSeparate` for the two helpers'
contracts. All 6 fail on `b4616177`, three of them on real leaked values.

No new visual artifact for this round: the change is confined to the error path
and the successful-add behaviour the artifact above demonstrates is unchanged
(the whole suite, including every adoption test, passes identically).

Known boundary, deliberately out of scope: if the attach *succeeds* and the
following recompile is refused, the attached robot's bodies stay in the spec too -
the whole composed robot, not just its options - because `inject_robot_into_scene`
has no attach rollback. That is pre-existing and not option-specific; undoing it
means removing the attached subtree and its assets, which wants its own change.

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1687-honor-robot-declared-physics-options.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.
