### PR TITLE
fix(rendering): a live MJPEG stream refuses options it cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a live MJPEG stream refuses options it cannot honor
+
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
+
+```python
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
+```
+
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
+
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
+
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
+
 ### Fixed: the state and action sides agree on what a hardware observation is
 
 Detection of `'<motor>.pos'` hardware joint readings was implemented twice in the

--- a/strands_robots/rendering/video.py
+++ b/strands_robots/rendering/video.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import io
 import logging
+import math
+import numbers
 import time
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -107,6 +109,101 @@ def encode_clip(
     return out
 
 
+# JPEG quality bounds. Pillow silently substitutes for anything outside them
+# (a quality above 100 encodes as 100, a quality below 1 encodes as 1), so an
+# out-of-range request produces a stream at a quality nobody asked for.
+_MIN_JPEG_QUALITY = 1
+_MAX_JPEG_QUALITY = 95
+
+
+def _stream_rate_error(fps: Any) -> str | None:
+    """Error text when ``fps`` is not a rate the stream can pace itself to.
+
+    The pacing loop sleeps ``1 / fps - elapsed`` between chunks, so only a
+    positive finite rate can be honored. ``0`` and any negative value both fell
+    into a ``frame_dt = 0.0`` fallback that disables pacing entirely; ``nan``
+    took the same branch (``nan > 0`` is ``False``); and ``inf`` reached it
+    through the front door, since ``1 / inf`` is also ``0.0``. In every case the
+    generator emitted as fast as it could encode - the opposite of a rate limit.
+
+    Deliberately wider than :func:`encode_clip`'s whole-number domain (see
+    :func:`~strands_robots.utils.positive_whole_number_error`): a container
+    header stores an integer frame rate, but pacing a live view is just a sleep
+    interval, so a fractional rate such as ``12.5`` is honorable here.
+
+    Args:
+        fps: The caller-supplied frame rate.
+
+    Returns:
+        An error message, or ``None`` when the rate is usable.
+    """
+    message = f"mjpeg_frames: fps must be a positive finite number, got {fps!r}."
+    if isinstance(fps, bool) or not isinstance(fps, numbers.Real):
+        return message
+    numeric = float(fps)
+    if not math.isfinite(numeric) or numeric <= 0:
+        return message
+    return None
+
+
+def _jpeg_quality_error(quality: Any) -> str | None:
+    """Error text when ``quality`` is outside the JPEG quality Pillow honors.
+
+    Only a whole number in ``[_MIN_JPEG_QUALITY, _MAX_JPEG_QUALITY]`` reaches the
+    encoder unchanged; Pillow clamps anything else, so ``quality=500`` encoded
+    identically to ``100`` and ``quality=0`` or ``-5`` identically to ``1``.
+    ``bool`` is rejected explicitly - an ``int`` subclass whose ``True`` would
+    act as a silent quality of 1.
+
+    Args:
+        quality: The caller-supplied JPEG quality.
+
+    Returns:
+        An error message, or ``None`` when the quality is usable.
+    """
+    message = (
+        f"mjpeg_frames: quality must be a whole number between {_MIN_JPEG_QUALITY} "
+        f"and {_MAX_JPEG_QUALITY}, got {quality!r}."
+    )
+    if isinstance(quality, bool) or not isinstance(quality, numbers.Real):
+        return message
+    numeric = float(quality)
+    if not math.isfinite(numeric) or numeric != int(numeric):
+        return message
+    if not _MIN_JPEG_QUALITY <= int(numeric) <= _MAX_JPEG_QUALITY:
+        return message
+    return None
+
+
+def _frame_size_error(size: Any) -> str | None:
+    """Error text when ``size`` is not a resizable ``(width, height)`` pair.
+
+    ``Image.resize`` raises straight out of the suspended generator for a
+    malformed pair (``(0, 0)`` and ``(-4, 10)`` as ``ValueError``, a 1-tuple or a
+    bare ``int`` as ``TypeError``), which surfaces mid-response rather than at
+    the call. Validate the pair up front and reuse the shared pixel-count domain
+    per component so ``size`` and the recorders' ``width``/``height`` cannot
+    diverge.
+
+    Args:
+        size: The caller-supplied ``(width, height)`` pair, or ``None``.
+
+    Returns:
+        An error message, or ``None`` when the pair is usable.
+    """
+    if size is None:
+        return None
+    message = f"mjpeg_frames: size must be a (width, height) pair of positive whole numbers, got {size!r}."
+    if isinstance(size, str | bytes | Mapping) or not (hasattr(size, "__len__") and hasattr(size, "__getitem__")):
+        return message
+    if len(size) != 2:
+        return message
+    for index, label in ((0, "size width"), (1, "size height")):
+        if text := positive_whole_number_error(size[index], label, "mjpeg_frames"):
+            return text
+    return None
+
+
 def mjpeg_frames(
     frame_fn: Callable[[], np.ndarray | None],
     fps: float = 12.0,
@@ -125,22 +222,82 @@ def mjpeg_frames(
         frame_fn: returns the current ``(H, W, 3)`` RGB frame, or ``None``
             when no frame is available yet (the generator then idles briefly
             instead of emitting a stale chunk).
-        fps: target frame rate; the generator sleeps to pace emission.
-        quality: JPEG quality (1-95).
-        size: optional ``(width, height)`` to resize frames to before
-            encoding (keeps the stream resolution stable while the source
-            camera changes).
-        max_frames: stop after this many emitted frames (``None`` = stream
-            forever until the consumer disconnects). Mostly for tests.
+        fps: target frame rate; the generator sleeps to pace emission. A
+            positive finite number of frames per second (see
+            :func:`_stream_rate_error`).
+        quality: JPEG quality, a whole number in ``[1, 95]``.
+        size: optional ``(width, height)`` of positive whole numbers to resize
+            frames to before encoding (keeps the stream resolution stable while
+            the source camera changes).
+        max_frames: stop after this many emitted frames, a positive whole number
+            (``None`` = stream forever until the consumer disconnects). Mostly
+            for tests.
         strict: when ``True``, exceptions raised by ``frame_fn`` propagate
             and terminate the stream. When ``False`` (default, the live-demo
             posture) a failed frame is logged at DEBUG and skipped so one bad
             render doesn't kill a long-lived stream.
+
+    Returns:
+        An iterator of ``multipart/x-mixed-replace`` byte chunks.
+
+    Raises:
+        ValueError: if ``fps``, ``quality``, ``size`` or ``max_frames`` names a
+            stream this generator cannot produce. Raised by this call, before
+            the first chunk exists, so a caller that has already written the
+            ``multipart`` response headers never has to abort mid-body.
+    """
+    # Validate here rather than in the generator body: a generator function
+    # runs nothing until the consumer's first ``next()``, by which point an
+    # HTTP handler has committed the response headers and can only truncate
+    # the stream. The body lives in ``_mjpeg_stream`` so these raise at the
+    # call site instead.
+    for text in (
+        _stream_rate_error(fps),
+        _jpeg_quality_error(quality),
+        _frame_size_error(size),
+        None if max_frames is None else positive_whole_number_error(max_frames, "max_frames", "mjpeg_frames"),
+    ):
+        if text:
+            raise ValueError(text)
+    return _mjpeg_stream(
+        frame_fn,
+        float(fps),
+        int(quality),
+        None if size is None else (int(size[0]), int(size[1])),
+        None if max_frames is None else int(max_frames),
+        strict,
+    )
+
+
+def _mjpeg_stream(
+    frame_fn: Callable[[], np.ndarray | None],
+    fps: float,
+    quality: int,
+    size: tuple[int, int] | None,
+    max_frames: int | None,
+    strict: bool,
+) -> Iterator[bytes]:
+    """Emit the MJPEG chunks for an already-validated stream configuration.
+
+    Separated from :func:`mjpeg_frames` only so that function can reject an
+    unusable configuration at call time; every argument here is normalised and
+    in range.
+
+    Args:
+        frame_fn: returns the current ``(H, W, 3)`` RGB frame, or ``None``.
+        fps: validated positive finite pacing rate.
+        quality: validated JPEG quality in ``[1, 95]``.
+        size: validated ``(width, height)`` pair, or ``None``.
+        max_frames: validated positive frame budget, or ``None`` for unbounded.
+        strict: whether a ``frame_fn`` failure terminates the stream.
+
+    Yields:
+        ``multipart/x-mixed-replace`` byte chunks, one per emitted frame.
     """
     from PIL import Image
 
     boundary = b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
-    frame_dt = 1.0 / float(fps) if fps > 0 else 0.0
+    frame_dt = 1.0 / fps
     emitted = 0
     try:
         while max_frames is None or emitted < max_frames:
@@ -164,7 +321,7 @@ def mjpeg_frames(
             else:
                 time.sleep(0.2)
             elapsed = time.time() - t0
-            if frame_dt and elapsed < frame_dt:
+            if elapsed < frame_dt:
                 time.sleep(frame_dt - elapsed)
     except GeneratorExit:  # client disconnected
         return

--- a/tests/rendering/test_mjpeg_stream_option_guards.py
+++ b/tests/rendering/test_mjpeg_stream_option_guards.py
@@ -1,0 +1,217 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``mjpeg_frames`` refuses a stream configuration it cannot produce.
+
+``encode_clip``, the other media entry point in
+:mod:`strands_robots.rendering.video`, validates its playback rate through the
+shared pixel/frame-count domain. ``mjpeg_frames`` validated nothing, so every
+one of its four stream options had a value that was accepted and then not
+honored:
+
+* ``fps`` of ``0``, a negative, ``nan`` or ``inf`` all disabled pacing outright
+  and the generator emitted as fast as it could encode JPEGs;
+* ``quality`` outside ``[1, 95]`` was silently substituted by Pillow;
+* a malformed ``size`` raised ``ValueError``/``TypeError`` out of ``Image.resize``;
+* ``max_frames`` of ``0`` or a negative emitted nothing, and ``2.7`` emitted 3.
+
+The refusals also have to arrive at the call, not on the consumer's first
+``next()``: the caller is an HTTP handler that has already written the
+``multipart/x-mixed-replace`` response headers by then.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import mjpeg_frames
+
+FRAME = np.zeros((8, 8, 3), dtype=np.uint8)
+
+
+def _frame() -> np.ndarray:
+    return FRAME
+
+
+class TestPacingRate:
+    """Only a positive finite ``fps`` can be slept to, so only that is accepted."""
+
+    @pytest.mark.parametrize(
+        "fps",
+        [
+            0,  # 1 / 0 is undefined; fell into the "no pacing" fallback
+            0.0,
+            -5,  # a negative period is not a rate
+            -0.5,
+            float("nan"),  # nan > 0 is False -> same fallback
+            float("inf"),  # 1 / inf is 0.0 -> same fallback via the front door
+            True,  # int subclass; would have acted as a silent 1 fps
+            "12",  # compared against 0 as a str -> bare TypeError
+            None,
+            [12],
+        ],
+    )
+    def test_a_rate_the_loop_cannot_pace_to_is_refused(self, fps: Any) -> None:
+        with pytest.raises(ValueError, match="fps must be a positive finite number"):
+            mjpeg_frames(_frame, fps=fps, max_frames=1)
+
+    def test_the_refused_rate_is_named_in_the_message(self) -> None:
+        with pytest.raises(ValueError, match=r"got 0\b"):
+            mjpeg_frames(_frame, fps=0, max_frames=1)
+
+    def test_an_unpaceable_rate_emits_no_chunk_at_all(self) -> None:
+        """The pre-fix outcome was a full-speed stream, not an empty one."""
+        with pytest.raises(ValueError):
+            list(mjpeg_frames(_frame, fps=0, max_frames=200))
+
+    def test_a_fractional_rate_is_honored(self) -> None:
+        """Wider than ``encode_clip``: pacing is a sleep, not a container header."""
+        chunks = list(mjpeg_frames(_frame, fps=12.5, max_frames=2))
+        assert len(chunks) == 2
+
+    def test_a_numpy_rate_is_honored(self) -> None:
+        # ``numbers.Real`` covers every NumPy float; the annotation says ``float``.
+        chunks = list(mjpeg_frames(_frame, fps=np.float32(500.0), max_frames=2))  # type: ignore[arg-type]
+        assert len(chunks) == 2
+
+    def test_the_accepted_rate_actually_paces_the_stream(self) -> None:
+        """The rate is a real budget: N frames take at least (N-1)/fps seconds."""
+        fps = 20.0
+        n = 4
+        started = time.monotonic()
+        chunks = list(mjpeg_frames(_frame, fps=fps, max_frames=n))
+        elapsed = time.monotonic() - started
+        assert len(chunks) == n
+        # (n - 1) intervals: the first chunk is emitted before any sleep.
+        assert elapsed >= (n - 1) / fps
+
+
+class TestJpegQuality:
+    """Pillow clamps an out-of-range quality, so the stream is not what was asked for."""
+
+    @pytest.mark.parametrize(
+        "quality",
+        [
+            0,  # encoded identically to 1
+            -5,
+            96,  # above the documented ceiling
+            100,  # accepted by Pillow; byte-identical to 500
+            500,
+            2.5,  # not a whole number
+            float("nan"),
+            True,
+            "75",  # raised "Invalid quality setting" from Pillow
+            None,
+        ],
+    )
+    def test_a_quality_pillow_would_substitute_is_refused(self, quality: Any) -> None:
+        with pytest.raises(ValueError, match="quality must be a whole number between 1 and 95"):
+            mjpeg_frames(_frame, fps=1000.0, quality=quality, max_frames=1)
+
+    @pytest.mark.parametrize("quality", [1, 75, 95, 95.0, np.int64(50)])
+    def test_a_quality_inside_the_documented_range_is_honored(self, quality: Any) -> None:
+        chunks = list(mjpeg_frames(_frame, fps=1000.0, quality=quality, max_frames=1))
+        assert len(chunks) == 1
+
+
+class TestFrameSize:
+    """A malformed resize pair is refused instead of raising out of ``Image.resize``."""
+
+    @pytest.mark.parametrize(
+        "size",
+        [
+            (16,),  # TypeError: sequence of length 2
+            (16, 12, 3),
+            (),
+            16,  # TypeError: not iterable
+            "16x12",
+            {"width": 16, "height": 12},
+        ],
+    )
+    def test_a_pair_that_is_not_two_numbers_is_refused(self, size: Any) -> None:
+        with pytest.raises(ValueError, match=r"size must be a \(width, height\) pair"):
+            mjpeg_frames(_frame, fps=1000.0, size=size, max_frames=1)
+
+    @pytest.mark.parametrize(
+        ("size", "component"),
+        [
+            ((0, 12), "size width"),
+            ((-4, 12), "size width"),
+            ((16, 0), "size height"),
+            ((16, -12), "size height"),
+            ((16.5, 12), "size width"),
+            ((16, None), "size height"),
+        ],
+    )
+    def test_a_non_pixel_component_is_refused_and_named(self, size: Any, component: str) -> None:
+        with pytest.raises(ValueError, match=f"{component} must be a positive whole number"):
+            mjpeg_frames(_frame, fps=1000.0, size=size, max_frames=1)
+
+    @pytest.mark.parametrize("size", [(16, 12), [16, 12], np.array([16, 12])])
+    def test_a_pixel_pair_is_honored_whatever_container_carries_it(self, size: Any) -> None:
+        chunks = list(mjpeg_frames(_frame, fps=1000.0, size=size, max_frames=1))
+        assert len(chunks) == 1
+
+
+class TestFrameBudget:
+    """``max_frames`` counts frames, so it shares the frame-count domain."""
+
+    @pytest.mark.parametrize(
+        "max_frames",
+        [
+            0,  # emitted nothing while reporting nothing
+            -5,
+            2.7,  # emitted 3
+            True,  # int subclass; acted as a silent 1
+            "3",
+            float("nan"),
+        ],
+    )
+    def test_a_budget_that_is_not_a_frame_count_is_refused(self, max_frames: Any) -> None:
+        with pytest.raises(ValueError, match="max_frames must be a positive whole number"):
+            mjpeg_frames(_frame, fps=1000.0, max_frames=max_frames)
+
+    @pytest.mark.parametrize("max_frames", [1, 3, np.int64(2)])
+    def test_a_frame_count_is_honored_exactly(self, max_frames: Any) -> None:
+        chunks = list(mjpeg_frames(_frame, fps=1000.0, max_frames=max_frames))
+        assert len(chunks) == int(max_frames)
+
+    def test_an_absent_budget_still_means_unbounded(self) -> None:
+        stream = mjpeg_frames(_frame, fps=1000.0)
+        assert next(stream).startswith(b"--frame")
+        stream.close()  # type: ignore[attr-defined]
+
+
+class TestRefusalArrivesAtTheCallSite:
+    """A generator body runs on the first ``next()`` - too late for an HTTP handler."""
+
+    def test_an_unusable_configuration_raises_from_the_call_itself(self) -> None:
+        with pytest.raises(ValueError, match="fps must be a positive finite number"):
+            mjpeg_frames(_frame, fps=0)  # no iteration at all
+
+    def test_a_refused_configuration_never_asks_for_a_frame(self) -> None:
+        calls = {"n": 0}
+
+        def counting_frame() -> np.ndarray:
+            calls["n"] += 1
+            return FRAME
+
+        with pytest.raises(ValueError):
+            mjpeg_frames(counting_frame, fps=1000.0, quality=500, max_frames=1)
+        assert calls["n"] == 0
+
+    def test_an_accepted_configuration_still_renders_nothing_until_iterated(self) -> None:
+        """Validation is eager; frame production stays lazy."""
+        calls = {"n": 0}
+
+        def counting_frame() -> np.ndarray:
+            calls["n"] += 1
+            return FRAME
+
+        stream = mjpeg_frames(counting_frame, fps=1000.0, max_frames=1)
+        assert calls["n"] == 0
+        assert len(list(stream)) == 1
+        assert calls["n"] == 1


### PR DESCRIPTION
## Problem

`mjpeg_frames` is the live-stream half of `strands_robots/rendering/video.py`. The other half, `encode_clip`, already refuses a frame rate it cannot encode at (via the shared pixel/frame-count domain). `mjpeg_frames` validated nothing, so each of its four stream options had values that were accepted and then not honored.

`fps` is documented as "target frame rate; the generator sleeps to pace emission", and the pacing loop read it as:

```python
frame_dt = 1.0 / float(fps) if fps > 0 else 0.0
...
if frame_dt and elapsed < frame_dt:
    time.sleep(frame_dt - elapsed)
```

The `else 0.0` turns "cannot compute a period" into "do not pace", and `if frame_dt` then skips the sleep entirely. Probed against a live 480x360 MuJoCo view (headless EGL), 30 chunks requested:

| call | before | after |
|---|---|---|
| `fps=6.0` | 30 chunks in 4.84 s (6.0/s) | 30 chunks in 4.68 s (6.2/s) |
| `fps=0` | **30 chunks in 0.147 s (197/s)** | `ValueError: fps must be a positive finite number, got 0.` |
| `fps=-5` | unpaced | refused |
| `fps=nan` | unpaced (`nan > 0` is `False`) | refused |
| `fps=inf` | unpaced (`1 / inf` is `0.0` too) | refused |
| `fps=True` | silent 1 fps | refused |
| `fps="12"` | `TypeError: '>' not supported between 'str' and 'int'` | refused with the parameter named |

`inf` is worth calling out: it passes `fps > 0` and lands in the *same* unpaced state through the front door. With a cheap frame source rather than a real render the unpaced loop measured ~16,000 chunks/s.

The other three options fail the same way:

| call | before |
|---|---|
| `quality=500` | encoded byte-identically to `100` (8745 bytes both) |
| `quality=0` / `-5` | encoded byte-identically to `1` (824 bytes) |
| `quality="75"` | `ValueError: Invalid quality setting` out of Pillow |
| `max_frames=2.7` | emitted 3 chunks |
| `max_frames=0` / `-5` | emitted nothing |
| `max_frames=True` | emitted 1 |
| `size=(0, 0)` / `(-4, 10)` | `ValueError: height and width must be > 0` out of `Image.resize` |
| `size=(16,)` / `16` | `TypeError` out of `Image.resize` |

And the refusals that *did* exist arrived in the wrong place. `mjpeg_frames` was a generator function, so its body ran nothing until the consumer's first `next()`:

```python
gen = mjpeg_frames(frame_fn, fps="12")   # returns fine
next(gen)                                # TypeError, here
```

The consumer is an HTTP handler that has already written the `multipart/x-mixed-replace` response headers by then; all it can do is truncate the body.

## Change

`strands_robots/rendering/video.py`:

- `_stream_rate_error(fps)` — a positive finite number. Deliberately **wider** than `encode_clip`'s whole-number domain: a container header stores an integer rate, but pacing a live view is only a sleep interval, so `12.5` is honorable here. `bool` rejected explicitly, `nan`/`inf` before the `<= 0` comparison.
- `_jpeg_quality_error(quality)` — a whole number in `[1, 95]`, the documented range and the range Pillow honors without substituting.
- `_frame_size_error(size)` — a 2-element `(width, height)`, each component checked with the shared `positive_whole_number_error` so `size` and the recorders' `width`/`height` cannot diverge. The failing component is named (`size width` / `size height`). Accepts any positionally indexable pair, including an `ndarray`.
- `max_frames` — `positive_whole_number_error` directly; it counts frames, which is exactly what that domain is for (its docstring already covers the recorders' in-memory frame cap, where a zero cap "drops every frame").

The emission loop moved into a private `_mjpeg_stream(...)`. `mjpeg_frames` is now an ordinary function that validates, normalises and returns that generator, so an unusable configuration is reported **by the call**, before any chunk exists. Frame production stays lazy — nothing renders until the consumer iterates. The pacing guard drops its `if frame_dt` escape hatch, since `frame_dt` can no longer be `0`.

No previously working call is refused: every value now rejected either disabled pacing, was substituted by the encoder, mis-counted frames, or raised.

## Visual artifact

Emitted-chunk timing for a live MuJoCo view (`get_frame`, 480x360, headless EGL), 30 chunks requested at 6 fps. The red trace is the pre-fix `fps=0` stream; the bottom strip is three JPEGs parsed straight back out of the multipart body, so the measured stream is a real render and not a synthetic frame source.

![mjpeg_frames pacing before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mjpeg-pacing/mjpeg_pacing.png)

## Tests

`tests/rendering/test_mjpeg_stream_option_guards.py` (58 tests, 5 classes):

- `TestPacingRate` — every unpaceable rate refused and named; a fractional and a NumPy rate accepted; and a positive pin that the accepted rate is a real budget (`N` frames take at least `(N-1)/fps` seconds).
- `TestJpegQuality` — every quality Pillow would substitute refused; `1`, `75`, `95`, `95.0`, `np.int64(50)` accepted.
- `TestFrameSize` — malformed pairs refused with the pair named, non-pixel components refused with the *component* named, and `tuple`/`list`/`ndarray` all honored.
- `TestFrameBudget` — non-count budgets refused; a count honored exactly; `None` still unbounded.
- `TestRefusalArrivesAtTheCallSite` — the refusal raises from the call, `frame_fn` is never invoked for a refused configuration, and an accepted configuration still renders nothing until iterated.

Pre-fix (`git stash` of `video.py` only, tests untouched): **45 failed, 13 passed**. Post-fix: 58 passed. Existing `tests/rendering/test_video.py` unchanged and green — its `fps=1000.0` / `size=(16, 12)` calls are all inside the accepted domain.

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`. `mypy strands_robots tests tests_integ` reports only the pre-existing `simulation/ik.py:105 Returning Any` (present on a clean tree; depends on `qpsolvers` being installed). `MUJOCO_GL=egl python -m pytest tests`: **12507 passed, 260 skipped** in 423 s.
