### PR TITLE
fix(sim): roll a refused robot attach back out of the scene spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,62 +5,41 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-### Fixed: a robot whose model cannot compile no longer bricks the scene
+### Fixed: a live MJPEG stream refuses options it cannot honor
 
-`add_robot` attaches the robot's subtree into the live `MjSpec` before the
-recompile that validates the result. When that recompile was refused - a robot
-model referencing a mesh file that cannot be opened attaches fine and is only
-rejected at compile time - the subtree was left in the spec. Every later scene
-mutation recompiled that same broken spec and failed too, so one unloadable
-robot bricked the whole world:
+`mjpeg_frames` is the one media entry point in `strands_robots.rendering` that
+validated nothing, while `encode_clip` beside it already refuses a frame rate it
+cannot encode at. Each of the stream's four options therefore had values that
+were accepted and then not honored:
 
 ```python
-sim.add_robot(name="badbot", urdf_path="model-with-a-missing-mesh.xml")
-# error: Failed to inject robot 'badbot' into scene.   (expected)
-
-sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
-# before: error: Failed to inject 'marker': spec recompile refused.
-# after:  success
-sim.add_camera(name="look", position=[1.5, -1.5, 1.0], target=[0, 0, 0.2])
-# before: error: Failed to inject camera 'look': spec recompile refused.
-# after:  success
-sim.add_robot(name="panda")
-# before: error: Failed to inject robot 'panda' into scene.
-# after:  success
+# documented: "target frame rate; the generator sleeps to pace emission"
+list(mjpeg_frames(render, fps=0, max_frames=6))     # 6 chunks in 0.001 s
+list(mjpeg_frames(render, fps=float("inf"), ...))   # ditto: 1 / inf is 0.0 too
+list(mjpeg_frames(render, quality=500, ...))        # encoded at 100, not 500
+list(mjpeg_frames(render, max_frames=2.7))          # 3 chunks
+list(mjpeg_frames(render, size=(0, 0)))             # bare ValueError from Pillow
 ```
 
-Nothing was wrong with any of those calls, and each failed retry left another
-orphan subtree behind, so the spec drifted further from the scene `world` still
-described. The attach is now rolled back out before the failure is reported, so
-a refused robot costs exactly the add that was refused - matching
-`add_object` and `add_camera`, which have always rolled their spec mutation
-back.
+`fps` of `0`, a negative, `nan` or `inf` all landed in a `frame_dt = 0.0`
+fallback that disabled pacing outright, so the generator emitted as fast as it
+could encode JPEGs - measured at ~16,000 chunks/s against a requested rate, the
+opposite of a rate limit. A non-numeric `fps` or `max_frames` leaked a bare
+`TypeError` from a comparison, `True` acted as a silent `1`, and Pillow quietly
+substituted any `quality` outside `[1, 95]`.
 
-The rollback reinstalls a snapshot of the spec taken before the attach. It
-cannot rebuild the scene from the registered objects/cameras/robots instead,
-because the live spec can carry mutations that registry never records - weld
-equalities from `attach_bodies`, actuators from a robot actuated for IK, bodies
-authored by `patch_scene_mjcf`, whole scenes from `replace_scene_mjcf` - and
-dropping those would turn a correctly refused add into corruption of a scene
-that was healthy before it.
+`fps` now has to be a positive finite number (deliberately wider than
+`encode_clip`'s whole-number container rate - pacing a live view is just a sleep
+interval, so `12.5` is honorable), `quality` a whole number in `[1, 95]`,
+`max_frames` a positive whole number, and `size` a `(width, height)` pair drawn
+from the shared pixel-count domain.
 
-The snapshot is a spec copy rather than a `spec.to_xml()` round trip, which
-fixes the same rollback where it already existed: for a scene holding an
-attached robot whose meshes load from files, the emitted MJCF loses the asset
-search paths those references were resolved against and re-declares the model's
-keyframes, so restoring it put an uncompilable spec back. A refused
-`patch_scene_mjcf` batch (or a failed `actuate_robot_in_scene`) therefore left
-the next unrelated mutation failing with `Error opening file 'link2.stl'`:
-
-```python
-sim.add_robot(name="panda")                       # meshes load from files
-sim.patch_scene_mjcf(ops=[..., <an op that fails>])
-# error: patch op #2 failed: ...                  (expected)
-
-sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
-# before: error: Failed to inject 'marker': spec recompile refused.
-# after:  success
-```
+The refusals are raised by the `mjpeg_frames` call itself rather than from the
+generator body. A generator function runs nothing until the consumer's first
+`next()`, by which point an HTTP handler has already committed the
+`multipart/x-mixed-replace` response headers and can only truncate the stream;
+the emission loop moved into a private helper so an unusable configuration is
+reported before any of that.
 
 ### Fixed: Robot() forwards the base position it was given
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a robot whose model cannot compile no longer bricks the scene
+
+`add_robot` attaches the robot's subtree into the live `MjSpec` before the
+recompile that validates the result. When that recompile was refused - a robot
+model referencing a mesh file that cannot be opened attaches fine and is only
+rejected at compile time - the subtree was left in the spec. Every later scene
+mutation recompiled that same broken spec and failed too, so one unloadable
+robot bricked the whole world:
+
+```python
+sim.add_robot(name="badbot", urdf_path="model-with-a-missing-mesh.xml")
+# error: Failed to inject robot 'badbot' into scene.   (expected)
+
+sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
+# before: error: Failed to inject 'marker': spec recompile refused.
+# after:  success
+sim.add_camera(name="look", position=[1.5, -1.5, 1.0], target=[0, 0, 0.2])
+# before: error: Failed to inject camera 'look': spec recompile refused.
+# after:  success
+sim.add_robot(name="panda")
+# before: error: Failed to inject robot 'panda' into scene.
+# after:  success
+```
+
+Nothing was wrong with any of those calls, and each failed retry left another
+orphan subtree behind, so the spec drifted further from the scene `world` still
+described. The attach is now rolled back out before the failure is reported, so
+a refused robot costs exactly the add that was refused - matching
+`add_object` and `add_camera`, which have always rolled their spec mutation
+back.
+
+The rollback reinstalls a snapshot of the spec taken before the attach. It
+cannot rebuild the scene from the registered objects/cameras/robots instead,
+because the live spec can carry mutations that registry never records - weld
+equalities from `attach_bodies`, actuators from a robot actuated for IK, bodies
+authored by `patch_scene_mjcf`, whole scenes from `replace_scene_mjcf` - and
+dropping those would turn a correctly refused add into corruption of a scene
+that was healthy before it.
+
+The snapshot is a spec copy rather than a `spec.to_xml()` round trip, which
+fixes the same rollback where it already existed: for a scene holding an
+attached robot whose meshes load from files, the emitted MJCF loses the asset
+search paths those references were resolved against and re-declares the model's
+keyframes, so restoring it put an uncompilable spec back. A refused
+`patch_scene_mjcf` batch (or a failed `actuate_robot_in_scene`) therefore left
+the next unrelated mutation failing with `Error opening file 'link2.stl'`:
+
+```python
+sim.add_robot(name="panda")                       # meshes load from files
+sim.patch_scene_mjcf(ops=[..., <an op that fails>])
+# error: patch op #2 failed: ...                  (expected)
+
+sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
+# before: error: Failed to inject 'marker': spec recompile refused.
+# after:  success
+```
+
 ### Fixed: Robot() forwards the base position it was given
 
 The `Robot()` factory wraps `add_robot`, which validates a base pose up front:

--- a/changelog.d/1691-robot-attach-rollback.md
+++ b/changelog.d/1691-robot-attach-rollback.md
@@ -1,0 +1,56 @@
+### Fixed: a robot whose model cannot compile no longer bricks the scene
+
+`add_robot` attaches the robot's subtree into the live `MjSpec` before the
+recompile that validates the result. When that recompile was refused - a robot
+model referencing a mesh file that cannot be opened attaches fine and is only
+rejected at compile time - the subtree was left in the spec. Every later scene
+mutation recompiled that same broken spec and failed too, so one unloadable
+robot bricked the whole world:
+
+```python
+sim.add_robot(name="badbot", urdf_path="model-with-a-missing-mesh.xml")
+# error: Failed to inject robot 'badbot' into scene.   (expected)
+
+sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
+# before: error: Failed to inject 'marker': spec recompile refused.
+# after:  success
+sim.add_camera(name="look", position=[1.5, -1.5, 1.0], target=[0, 0, 0.2])
+# before: error: Failed to inject camera 'look': spec recompile refused.
+# after:  success
+sim.add_robot(name="panda")
+# before: error: Failed to inject robot 'panda' into scene.
+# after:  success
+```
+
+Nothing was wrong with any of those calls, and each failed retry left another
+orphan subtree behind, so the spec drifted further from the scene `world` still
+described. The attach is now rolled back out before the failure is reported, so
+a refused robot costs exactly the add that was refused - matching
+`add_object` and `add_camera`, which have always rolled their spec mutation
+back.
+
+The rollback reinstalls a snapshot of the spec taken before the attach. It
+cannot rebuild the scene from the registered objects/cameras/robots instead,
+because the live spec can carry mutations that registry never records - weld
+equalities from `attach_bodies`, actuators from a robot actuated for IK, bodies
+authored by `patch_scene_mjcf`, whole scenes from `replace_scene_mjcf` - and
+dropping those would turn a correctly refused add into corruption of a scene
+that was healthy before it.
+
+The snapshot is a spec copy rather than a `spec.to_xml()` round trip, which
+fixes the same rollback where it already existed: for a scene holding an
+attached robot whose meshes load from files, the emitted MJCF loses the asset
+search paths those references were resolved against and re-declares the model's
+keyframes, so restoring it put an uncompilable spec back. A refused
+`patch_scene_mjcf` batch (or a failed `actuate_robot_in_scene`) therefore left
+the next unrelated mutation failing with `Error opening file 'link2.stl'`:
+
+```python
+sim.add_robot(name="panda")                       # meshes load from files
+sim.patch_scene_mjcf(ops=[..., <an op that fails>])
+# error: patch op #2 failed: ...                  (expected)
+
+sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
+# before: error: Failed to inject 'marker': spec recompile refused.
+# after:  success
+```

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -68,6 +68,43 @@ def _sync_cached_xml(world: SimWorld, spec: Any) -> None:
         logger.debug("spec.to_xml() failed; cached XML left stale: %s", xml_err)
 
 
+def _snapshot_spec(spec: Any, *, context: str) -> Any | None:
+    """Deep-copy ``spec`` so a refused mutation can be rolled back losslessly.
+
+    A spec mutation that is only validated by the recompile it precedes needs a
+    way back. Rebuilding the spec from the registered objects / cameras / robots
+    is not it: the live spec can carry mutations that exist ONLY on the spec and
+    are absent from that registry - weld equalities from ``attach_bodies``,
+    actuators from :func:`actuate_robot_in_scene`, bodies from
+    :func:`patch_scene_mjcf`, whole scenes from :func:`replace_scene_mjcf`. A
+    rebuild silently drops every one of them, which is why
+    :meth:`Simulation.remove_robot` refuses outright while an attachment is
+    live rather than rebuilding over it.
+
+    ``MjSpec.copy`` is used rather than a ``spec.to_xml()`` round-trip because
+    the round-trip is not faithful for a scene holding attached robots: the
+    emitted MJCF loses the asset search paths its mesh references were resolved
+    against and re-declares the attached model's keyframes, so the restored spec
+    no longer compiles ("Error opening file 'link2.stl'", "repeated name
+    'panda/home' in key") - a rollback that leaves the scene as broken as the
+    orphan it removed.
+
+    Args:
+        spec: live scene spec to snapshot.
+        context: short description of the caller, used in log messages.
+
+    Returns:
+        An independent copy of ``spec``, or ``None`` when the copy failed (the
+        reason is logged). A caller that cannot snapshot must refuse its
+        mutation rather than proceed with no way back.
+    """
+    try:
+        return spec.copy()
+    except (ValueError, RuntimeError) as e:
+        logger.error("%s: cannot snapshot the scene spec: %s", context, e)
+        return None
+
+
 def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
     """Recompile ``spec`` in place, replacing ``world._model`` and ``_data``.
 
@@ -148,10 +185,38 @@ def inject_robot_into_scene(
     Registers the robot's source joint names on ``robot.joint_names`` so
     downstream observation/policy code can resolve them via
     ``{robot.namespace}{joint_name}``.
+
+    ``spec.attach`` mutates the scene spec before the recompile that validates
+    the result, so a refused recompile - e.g. the robot model references a mesh
+    file that cannot be opened - leaves the robot's whole namespaced subtree in
+    the live spec. Every later scene mutation then recompiles that same broken
+    spec and fails too, so one unloadable robot bricked the world: subsequent
+    ``add_object`` / ``add_camera`` / ``add_robot`` calls all reported "spec
+    recompile refused" with nothing wrong with them, and each failed retry left
+    another orphan subtree behind. The attach is therefore rolled back out
+    before returning ``False``, mirroring :func:`inject_object_into_scene` and
+    :func:`inject_camera_into_scene`, so a refused robot costs exactly the add
+    that was refused.
+
+    The rollback reinstalls a snapshot taken before the attach
+    (:func:`_snapshot_spec`) rather than rebuilding the scene from ``world``: a
+    rebuild would drop the spec-only mutations the scene may already hold (weld
+    equalities, added actuators, agent-authored bodies), turning a correctly
+    refused add into corruption of a scene that was healthy before it. The
+    refused ``spec.recompile`` leaves ``world._model`` and ``_data`` untouched,
+    so putting the spec back is the whole rollback - no state restore, forward
+    pass or ID rediscovery is needed.
     """
     spec = _get_spec(world)
     if spec is None or world._model is None:
         logger.error("inject_robot: no spec or model in world")
+        return False
+
+    # Snapshot BEFORE mutating. Without a way back the add is refused here,
+    # while the scene is still exactly as it was found.
+    context = f"inject_robot {robot.name!r}"
+    backup_spec = _snapshot_spec(spec, context=context)
+    if backup_spec is None:
         return False
 
     try:
@@ -159,10 +224,22 @@ def inject_robot_into_scene(
             joint_names = SpecBuilder.attach_robot(spec, robot, robot_xml_path)
         robot.joint_names = joint_names
     except (ValueError, RuntimeError, OSError) as e:
+        # attach_robot can insert its worldbody frame before the call that
+        # raised. That leftover compiles, so it never broke the scene, but the
+        # snapshot is already in hand - restoring it costs nothing and puts
+        # every failure path on one rule: the spec is left as it was found.
         logger.error("Robot attach failed for '%s': %s", robot.name, e)
+        world._backend_state["spec"] = backup_spec
         return False
 
-    return _recompile_preserving_state(world, spec)
+    if _recompile_preserving_state(world, spec):
+        return True
+
+    # The attach landed in the spec but the model it produced was refused, so
+    # the robot's whole namespaced subtree is sitting in the live spec while the
+    # caller is about to report a failed add. Put the pre-attach spec back.
+    world._backend_state["spec"] = backup_spec
+    return False
 
 
 def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
@@ -631,11 +708,8 @@ def actuate_robot_in_scene(
     # Snapshot for atomic rollback (mirrors patch_scene_mjcf): the surgery
     # touches option/bodies/joints/actuators/geoms, too many objects to undo
     # piecewise.
-    try:
-        with filter_mujoco_attach_noise():
-            backup_xml = spec.to_xml()
-    except Exception as e:  # pragma: no cover - to_xml on a compiled spec is fine
-        logger.error("actuate_robot_in_scene: failed to snapshot spec: %s", e)
+    backup_spec = _snapshot_spec(spec, context="actuate_robot_in_scene")
+    if backup_spec is None:
         return False
 
     try:
@@ -680,13 +754,13 @@ def actuate_robot_in_scene(
             act.set_to_position(kp=float(kp), dampratio=1.0, inheritrange=jnt_range_defined)
     except (ValueError, RuntimeError, TypeError) as e:
         logger.error("actuate_robot_in_scene: spec surgery failed for '%s': %s", robot.name, e)
-        world._backend_state["spec"] = SpecBuilder.from_mjcf_string(backup_xml)
+        world._backend_state["spec"] = backup_spec
         return False
 
     if not _recompile_preserving_state(world, spec):
         # Restore the pre-surgery spec so the failed edit doesn't poison
         # later scene mutations.
-        world._backend_state["spec"] = SpecBuilder.from_mjcf_string(backup_xml)
+        world._backend_state["spec"] = backup_spec
         return False
     return True
 
@@ -900,14 +974,11 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
     if spec is None:
         raise RuntimeError("world has no spec; patch_scene_mjcf requires a compiled world")
 
-    # Apply ops on a *clone* of the spec so we can atomically reject on failure.
-    # MjSpec doesn't expose a cheap deep-copy, but round-tripping through XML
-    # is safe: it's the same canonical form used by the compiler.
-    try:
-        with filter_mujoco_attach_noise():
-            backup_xml = spec.to_xml()
-    except Exception as e:  # pragma: no cover - spec.to_xml on brand-new specs is fine
-        raise RuntimeError(f"failed to snapshot spec before patch: {e}") from e
+    # Snapshot the spec so a failed op can be atomically rejected: the batch is
+    # applied to the live spec and the snapshot put back if any op fails.
+    backup_spec = _snapshot_spec(spec, context="patch_scene_mjcf")
+    if backup_spec is None:
+        raise RuntimeError("failed to snapshot spec before patch (see logs)")
 
     applied = 0
     new_bodies: dict[str, Any] = {}
@@ -916,15 +987,7 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
             _apply_patch_op(spec, op, new_bodies)
             applied += 1
     except Exception as err:
-        # Restore from backup.
-        try:
-            restored = SpecBuilder.from_mjcf_string(backup_xml)
-            world._backend_state["spec"] = restored
-        except Exception:
-            # If even the backup round-trip fails, the world is in a bad state
-            # and the caller should rebuild. Propagate the original error
-            # either way so the user sees what went wrong.
-            pass
+        world._backend_state["spec"] = backup_spec
         raise ValueError(f"patch op #{applied + 1} failed: {err}") from err
 
     # One recompile for the whole batch - preserves qpos/qvel for unchanged joints.

--- a/tests/simulation/mujoco/test_inject_failure_cleanup.py
+++ b/tests/simulation/mujoco/test_inject_failure_cleanup.py
@@ -1,7 +1,8 @@
-"""Spec rollback when an object/camera scene injection recompile fails.
+"""Spec rollback when an object/camera/robot scene injection recompile fails.
 
-``add_object`` / ``add_camera`` mutate the live ``MjSpec`` (insert the body or
-camera) *before* the recompile that validates the result. If that recompile is
+``add_object`` / ``add_camera`` / ``add_robot`` mutate the live ``MjSpec``
+(insert the body or camera, or attach the robot's subtree) *before* the
+recompile that validates the result. If that recompile is
 refused - e.g. an object references a mesh asset that was never registered -
 the just-inserted element must be rolled back out of the spec, not merely
 popped from the Python-side ``_world`` registry. Otherwise the orphan element
@@ -13,6 +14,14 @@ The observable proof of correct rollback is that the *same name* can be added
 successfully right after a failed attempt: a leaked orphan would make the retry
 collide on the duplicate name at recompile time. These tests fail before the
 rollback fix (the retry errors with ``repeated name``) and pass after it.
+
+The robot path is the same contract with a wider blast radius: a robot's subtree
+carries its own assets, so a model whose mesh file cannot be opened attaches
+fine and is only refused at recompile. Leaving that subtree behind bricked the
+whole world - every later ``add_object`` / ``add_camera`` / ``add_robot``
+recompiled the same broken spec and reported "spec recompile refused" with
+nothing wrong with it, and each failed retry leaked another subtree. Rolling the
+attach back out is what keeps a refused robot costing exactly one refused add.
 
 ``add_object`` / ``add_camera`` also carry an ``except (ValueError,
 RuntimeError)`` around the injection call. It surfaces a raise from the
@@ -96,6 +105,183 @@ class TestAddObjectInjectionRollback:
         text = result["content"][0]["text"]
         assert "into live scene" in text
         assert "spec.recompile blew up" in text
+
+
+# A robot model whose mesh asset cannot be opened: MjSpec.from_file parses it and
+# spec.attach merges it, and only the recompile that loads the asset is refused.
+# That is the narrowest way to reach the rollback path with no asset download.
+_UNLOADABLE_MESH_MJCF = """<mujoco model="badbot">
+  <asset><mesh name="ghost" file="definitely-absent.stl"/></asset>
+  <worldbody>
+    <body name="base">
+      <joint name="j1" type="hinge" axis="0 0 1"/>
+      <geom name="g" type="mesh" mesh="ghost"/>
+    </body>
+  </worldbody>
+  <actuator><position name="a1" joint="j1"/></actuator>
+</mujoco>
+"""
+
+_VALID_MJCF = """<mujoco model="goodbot">
+  <worldbody>
+    <body name="base">
+      <joint name="j1" type="hinge" axis="0 0 1"/>
+      <geom name="g" type="box" size="0.05 0.05 0.05"/>
+    </body>
+  </worldbody>
+  <actuator><position name="a1" joint="j1"/></actuator>
+</mujoco>
+"""
+
+
+def _spec_body_names(sim) -> list[str]:
+    return [b.name for b in sim._world._backend_state["spec"].bodies]
+
+
+class TestAddRobotInjectionRollback:
+    """A robot whose attach compiles into a model MuJoCo refuses is rolled back."""
+
+    def test_refused_robot_leaves_the_scene_mutable(self, sim, tmp_path):
+        bad = tmp_path / "badbot.xml"
+        bad.write_text(_UNLOADABLE_MESH_MJCF)
+
+        refused = sim.add_robot(name="badbot", urdf_path=str(bad))
+        assert refused["status"] == "error"
+        assert "badbot" not in sim._world.robots
+
+        # Every kind of later scene mutation still compiles. Pre-fix all three
+        # failed with "spec recompile refused" / "Failed to inject robot",
+        # because they recompiled the spec the refused attach was left in.
+        assert sim.add_object(name="marker", shape="box", position=[0.3, 0.0, 0.1])["status"] == "success"
+        assert sim.add_camera(name="look", position=[1.0, -1.0, 0.8], target=[0.0, 0.0, 0.1])["status"] == "success"
+
+        good = tmp_path / "goodbot.xml"
+        good.write_text(_VALID_MJCF)
+        assert sim.add_robot(name="goodbot", urdf_path=str(good))["status"] == "success"
+
+    def test_refused_robot_name_is_reusable(self, sim, tmp_path):
+        bad = tmp_path / "badbot.xml"
+        bad.write_text(_UNLOADABLE_MESH_MJCF)
+        assert sim.add_robot(name="arm", urdf_path=str(bad))["status"] == "error"
+
+        # The rolled-back subtree freed the whole "arm/" namespace, so a
+        # corrected model under the same name compiles.
+        good = tmp_path / "goodbot.xml"
+        good.write_text(_VALID_MJCF)
+        retry = sim.add_robot(name="arm", urdf_path=str(good))
+        assert retry["status"] == "success"
+        assert "arm" in sim._world.robots
+
+    def test_refused_robot_leaves_no_orphan_in_the_live_spec(self, sim, tmp_path):
+        bad = tmp_path / "badbot.xml"
+        bad.write_text(_UNLOADABLE_MESH_MJCF)
+        before = _spec_body_names(sim)
+
+        assert sim.add_robot(name="badbot", urdf_path=str(bad))["status"] == "error"
+
+        after = _spec_body_names(sim)
+        assert not [n for n in after if n.startswith("badbot/")], f"orphan subtree left in spec: {after}"
+        # The spec is back to exactly the scene the world still describes.
+        assert after == before
+
+    def test_repeated_refusals_do_not_accumulate_orphans(self, sim, tmp_path):
+        bad = tmp_path / "badbot.xml"
+        bad.write_text(_UNLOADABLE_MESH_MJCF)
+        before = _spec_body_names(sim)
+
+        for attempt in range(3):
+            assert sim.add_robot(name=f"badbot{attempt}", urdf_path=str(bad))["status"] == "error"
+
+        assert _spec_body_names(sim) == before
+
+    def test_rollback_preserves_the_surviving_robot_pose(self, sim, tmp_path):
+        # The refused recompile never replaces world._model / _data, so putting
+        # the spec back is the whole rollback and physics state is untouched. A
+        # robot already in the scene must not be disturbed because a different
+        # robot was refused.
+        joints = sim._world.robots["so100"].joint_names
+        pose = {name: 0.15 + 0.05 * i for i, name in enumerate(joints)}
+        assert sim.set_joint_positions(positions=pose, robot_name="so100")["status"] == "success"
+        before = {name: sim.get_observation(robot_name="so100")[name] for name in joints}
+
+        bad = tmp_path / "badbot.xml"
+        bad.write_text(_UNLOADABLE_MESH_MJCF)
+        assert sim.add_robot(name="badbot", urdf_path=str(bad))["status"] == "error"
+
+        after = {name: sim.get_observation(robot_name="so100")[name] for name in joints}
+        assert after == pytest.approx(before)
+
+
+class TestRollbackKeepsSpecOnlyState:
+    """The rollback restores the scene, including state only the spec holds.
+
+    A scene's live ``MjSpec`` can carry mutations that the ``_world`` registry
+    never records: weld equalities from ``attach_bodies``, actuators from
+    ``actuate_robot_in_scene``, bodies authored by ``patch_scene_mjcf``, whole
+    scenes from ``replace_scene_mjcf``. A rollback that rebuilt the spec from
+    the registry would silently drop every one of them, turning a correctly
+    refused add into corruption of a scene that was healthy before it - which is
+    why ``remove_robot`` refuses outright while an attachment is live instead of
+    rebuilding over it. Restoring a snapshot of the spec keeps them.
+
+    The snapshot has to be a spec copy rather than a ``spec.to_xml()`` round
+    trip: the emitted MJCF loses the asset search paths the attached robot's
+    mesh references were resolved against (``meshdir``) and re-declares its
+    keyframes, so a restored round trip no longer compiles - a rollback that
+    leaves the scene as broken as the orphan it removed. The ``sim`` fixture's
+    ``so100`` is a mesh-bearing attached robot, so these tests fail against a
+    round-trip snapshot as well as against a registry rebuild.
+    """
+
+    def test_a_live_weld_survives_a_refused_robot_add(self, sim, tmp_path):
+        assert (
+            sim.add_object(name="cube", shape="box", size=[0.04, 0.04, 0.04], position=[0.2, 0.0, 0.3])["status"]
+            == "success"
+        )
+        assert sim.attach_bodies(parent="so100/Moving_Jaw", child="cube", mode="weld")["status"] == "success"
+        welds_before = sim._world._model.neq
+
+        bad = tmp_path / "badbot.xml"
+        bad.write_text(_UNLOADABLE_MESH_MJCF)
+        assert sim.add_robot(name="badbot", urdf_path=str(bad))["status"] == "error"
+
+        # The weld is still enforced by physics, and still matches what the
+        # attachment registry says is active - so detaching works. A rebuild
+        # dropped the equality while leaving the registry entry behind, which
+        # made detach_bodies fail and left "cube" unremovable.
+        assert sim._world._model.neq == welds_before
+        assert sim.detach_bodies(parent="so100/Moving_Jaw", child="cube")["status"] == "success"
+
+    def test_an_agent_authored_body_survives_a_refused_robot_add(self, sim, tmp_path):
+        assert (
+            sim.patch_scene_mjcf(ops=[{"op": "add_body", "name": "rig", "position": [0.0, 0.3, 0.5]}])["status"]
+            == "success"
+        )
+
+        bad = tmp_path / "badbot.xml"
+        bad.write_text(_UNLOADABLE_MESH_MJCF)
+        assert sim.add_robot(name="badbot", urdf_path=str(bad))["status"] == "error"
+
+        # "rig" exists only on the spec - SpecBuilder.build has no idea it was
+        # ever authored - so a registry rebuild is where it disappeared.
+        assert "rig" in _spec_body_names(sim)
+        assert sim.add_object(name="marker", shape="box", position=[0.3, 0.0, 0.1])["status"] == "success"
+
+    def test_a_refused_patch_batch_leaves_the_scene_mutable(self, sim):
+        # patch_scene_mjcf rolls its own batch back the same way. Restoring a
+        # to_xml() round trip put an uncompilable spec back on a scene holding a
+        # mesh-bearing attached robot, so the next mutation failed for a reason
+        # that had nothing to do with it.
+        result = sim.patch_scene_mjcf(
+            ops=[
+                {"op": "add_body", "name": "rig", "position": [0.0, 0.3, 0.5]},
+                {"op": "add_geom", "body": "no_such_body", "shape": "box"},
+            ]
+        )
+        assert result["status"] == "error"
+
+        assert "rig" not in _spec_body_names(sim)
+        assert sim.add_object(name="marker", shape="box", position=[0.3, 0.0, 0.1])["status"] == "success"
 
 
 class TestAddCameraInjectionRollback:


### PR DESCRIPTION
## Problem

`add_robot` attaches the robot's subtree into the live `MjSpec` **before** the recompile that validates the result. A robot model that references a mesh file which cannot be opened parses fine (`MjSpec.from_file` does not load assets), attaches fine, and is only refused at compile time - and the refused subtree was left sitting in the spec. Every later scene mutation recompiled that same broken spec and failed too, so **one unloadable robot bricked the whole world**:

```python
sim.create_world()
sim.add_object(name="crate", shape="box", position=[0.5, 0, 0.1])          # success

sim.add_robot(name="badbot", urdf_path="model-with-a-missing-mesh.xml")
# error: Failed to inject robot 'badbot' into scene.        <- expected

sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
# before: error: Failed to inject 'marker': spec recompile refused.
# after:  success

sim.add_camera(name="look", position=[1.5, -1.5, 1.0], target=[0, 0, 0.2])
# before: error: Failed to inject camera 'look': spec recompile refused.
# after:  success

sim.add_robot(name="panda")
# before: error: Failed to inject robot 'panda' into scene.
# after:  success
```

Nothing was wrong with any of those three calls. Worse, each failed retry left *another* orphan subtree behind, so the spec drifted further and further from the scene `world` still described - after the sequence above, `world.robots` was empty while the spec held `badbot/base` plus all fifteen `panda/*` bodies.

## Why this is a defect and not a design choice

The two sibling injectors already roll their spec mutation back for precisely this reason, and their docstrings say so:

> ``SpecBuilder.add_object`` mutates the spec (adds the body + geom) before the recompile that validates it. If that recompile is refused [...] the just-added body AND its mesh asset are deleted again before returning ``False`` so the spec stays compilable. **Without the rollback the orphan lingers and every later scene mutation [...] keeps failing to recompile, bricking the whole scene after one bad add.**

The robot path is the same contract with a wider blast radius (a robot brings its own assets, so it is the injector most likely to be refused at compile time), and it was the one path with no rollback. `Simulation.add_robot` did roll back its own `world.robots` entry, which is what made the divergence silent.

## Change

`inject_robot_into_scene` now rolls the attach back out before reporting the failure, so a refused robot costs exactly the add that was refused.

The rollback **reinstalls a snapshot of the spec taken before the attach**, via one new helper `_snapshot_spec(spec, *, context)`. It deliberately does *not* rebuild the scene from the registered objects/cameras/robots: the live spec can carry mutations that registry never records - weld equalities from `attach_bodies`, actuators from `actuate_robot_in_scene`, bodies from `patch_scene_mjcf`, whole scenes from `replace_scene_mjcf` - so a rebuild would turn a correctly refused add into corruption of a scene that was healthy before it. `remove_robot` already refuses outright while an attachment is live rather than rebuilding over it, for exactly that reason.

The snapshot is `MjSpec.copy()` rather than a `spec.to_xml()` round trip. **That also fixes the same rollback where it already existed.** For a scene holding an attached robot whose meshes load from files the round trip is not faithful: the emitted MJCF loses the asset search paths those mesh references were resolved against (`meshdir`) and re-declares the model's keyframes, so restoring it puts an *uncompilable* spec back - and on such a scene the snapshot often cannot be taken at all. Measured with a `panda` attached:

```python
sim.add_robot(name="panda")                          # meshes load from files
sim.patch_scene_mjcf(ops=[..., <an op that fails>])
# error: patch op #2 failed: ...                     (expected)

sim.add_object(name="marker", shape="sphere", position=[0.0, 0.5, 0.1])
# before: error: Failed to inject 'marker': spec recompile refused.
#         (log: Error opening file 'link2.stl')
# after:  success
```

`actuate_robot_in_scene` and `patch_scene_mjcf` now share that one snapshot helper, so all three rollbacks restore a spec that still compiles. Because the refused `spec.recompile` never replaces `world._model` / `_data`, putting the spec back is the whole rollback - no state snapshot, forward pass or ID rediscovery is needed, and a robot already in the scene is not disturbed because a *different* robot was refused. That is pinned.

If the snapshot cannot be taken the add is refused *before* the attach, which leaves the scene exactly as it was found - strictly better than mutating it with no way back.

## Visual artifact

A cube is welded to the `panda` hand with `attach_bodies(mode="weld")` - the grasp-assist primitive whose documented contract is that the weld "survives later scene recompiles". Then a robot whose mesh cannot be opened is added, and correctly refused. Both runs are the same script, rendered headless in MuJoCo (`MUJOCO_GL=egl`), stepping the same sim time.

![refused robot attach rollback keeps the live weld](https://raw.githubusercontent.com/cagataycali/robots/artifacts/robot-attach-rollback/artifact.gif)

Left: a rollback that rebuilds the spec from the registry drops the weld equality (`neq` 2 -> 1) while the attachment registry still lists it as active, so the carried cube falls out of the gripper onto the floor (z 0.830 m -> 0.060 m) and `detach_bodies` then fails. Right: restoring the snapshot keeps it (`neq` 2 -> 2) and the cube stays welded to the hand (z 0.830 m -> 0.846 m).

## Tests

Eight tests in `tests/simulation/mujoco/test_inject_failure_cleanup.py`, the file that already owns this contract for the object and camera paths. The fixture MJCF references a mesh file that does not exist, the narrowest way to reach the rollback with no asset download; the fixture's own `so100` is a mesh-bearing attached robot, which is what makes the snapshot-fidelity half observable.

`TestAddRobotInjectionRollback` - a refused robot leaves the scene mutable (`add_object` + `add_camera` + `add_robot` all still compile); its name is reusable; no orphan is left in the live spec; three consecutive refusals do not accumulate orphans; a robot already in the scene is undisturbed.

`TestRollbackKeepsSpecOnlyState` - a live weld survives a refused robot add and `detach_bodies` still works; a `patch_scene_mjcf`-authored body survives one; a refused `patch_scene_mjcf` batch leaves the scene mutable.

The 13 tests in that file discriminate every candidate rollback strategy:

| rollback strategy | result |
|---|---|
| none (current `main`) | **7 failed**, 6 passed |
| rebuild the spec from the `_world` registry | **3 failed**, 10 passed - exactly the three `TestRollbackKeepsSpecOnlyState` tests |
| restore a `spec.to_xml()` round trip | **5 failed**, 8 passed - on a mesh-bearing scene the snapshot cannot be taken, so it degrades to the rebuild and two of the original rollback tests regress as well |
| restore a `MjSpec.copy()` snapshot (this PR) | 13 passed |

## Gate

```
ruff check strands_robots tests tests_integ           clean
ruff format --check strands_robots tests tests_integ  916 files already formatted
mypy strands_robots tests tests_integ                 clean*
MUJOCO_GL=egl pytest tests -q                         12463 passed, 260 skipped (428s)
```

\* mypy reports one pre-existing, environment-dependent error in `strands_robots/simulation/ik.py:105` (`Returning Any` off untyped `qpsolvers.available_solvers`); it appears only where `qpsolvers` is installed, is unrelated to this change, and reproduces on a clean tree.

## Review round log

| round | finding | addressed in | pinned by |
|---|---|---|---|
| R1 | the registry rebuild destroys live-spec-only state (weld equalities, actuators, `patch_scene_mjcf` bodies) | `64d4576` | `TestRollbackKeepsSpecOnlyState` |

### Sync round: the changelog entry is now a news fragment

`main` records changelog entries as per-PR files under `changelog.d/` instead of
appending to `CHANGELOG.md`'s shared `[Unreleased]` anchor. Appending at that
anchor is what made this branch report `CONFLICTING` every time an unrelated PR
merged - on ordering alone, never on meaning - so the entry moved to
`changelog.d/1691-robot-attach-rollback.md` verbatim and `CHANGELOG.md` is no longer touched by
this PR. The conflict class is gone rather than resolved once: no other branch
writes that path.

`main` is merged in the same push. Nothing else changed - no source file, no
test, no behaviour; `python scripts/assemble_changelog.py --check` passes on the
new head.

### Sync round: `_recompile_preserving_state` gained a keyword on `main`

`main` added a `raise_on_refusal` keyword to `_recompile_preserving_state` so
`inject_object_into_scene` can surface the compiler's own reason (an object's
mass is declared on its geom, so MuJoCo's inertia floor is shape-dependent and
a bare `False` cannot carry which floor was missed). This branch inserts the
`_snapshot_spec` helper immediately above that same definition, so git saw one
conflict at that seam - two adjacent edits, not competing ones.

Both are kept. The robot-attach rollback stays on the default
`raise_on_refusal=False` bool contract deliberately: it only needs to know
*that* the recompile was refused in order to reinstall the snapshot, and the
reason is already logged. Only the object path, which reports the reason back
to a caller, opts in.

No source behaviour, test, or artifact changed in this round - the resolution is
the function signature and nothing else. Verified the two changes compose:
`tests/simulation/mujoco/test_inject_failure_cleanup.py`,
`test_object_inertia_from_shape.py` and `test_add_object_mass_contract.py`
report 33 passed on the merge result, with the only 2 failures being the
`so100` asset-download cases that fail identically on the pre-merge commit in
a sandbox with no asset fetch (`Robot model not found: so100`).
