### PR TITLE
chore(changelog): record entries as news fragments instead of appending to the log

### DIFF
--- a/.github/scripts/agent_api_snapshot.py
+++ b/.github/scripts/agent_api_snapshot.py
@@ -111,7 +111,7 @@ def render_markdown(breaking: list[str], info: list[str]) -> str:
     footer = (
         "> Automated static check of the AgentTool action contract. Removed or "
         + "renamed actions/parameters break agent code that calls them. If a change "
-        + "is intentional, add a `CHANGELOG.md` entry or a deprecation notice."
+        + "is intentional, add a `changelog.d/` fragment or a deprecation notice."
     )
     lines += ["", "---", footer]
     return "\n".join(lines)

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -138,7 +138,8 @@ jobs:
               "> **Note:** This is an automated static analysis check. "
               "Some flagged changes may be intentional.",
               "> Please confirm each item is expected and, if so, add a migration "
-              "note to `CHANGELOG.md` or a deprecation notice before removal.",
+              "note as a `changelog.d/` fragment (see `changelog.d/README.md`) "
+              "or a deprecation notice before removal.",
           ]
 
           body = "\n".join(lines)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,10 +80,18 @@ hatch run format            # ruff check --fix, ruff format
 
 1. Create feature branch from `main`
 2. Make changes, run `hatch run format && hatch run lint && hatch run test`
-3. All tests must pass, lint must be clean
-4. Open PR from your fork, address all review comments
-5. Track follow-up items as issues on the [project board](https://github.com/orgs/strands-labs/projects/2)
-6. Squash merge into `main`
+3. Record the change as a news fragment: `changelog.d/<pr-number>-<slug>.md`
+   (see [`changelog.d/README.md`](changelog.d/README.md)). **Never append to
+   `## [Unreleased]` in `CHANGELOG.md` directly** - every branch inserts at the
+   same anchor, so two PRs open at once conflict on ordering alone, and because
+   stale approvals are dismissed on push each resolution costs a re-approval
+   round that reviews no changed behaviour. A fragment is its own file, so there
+   is nothing to conflict on. `CHANGELOG.md` is assembled from the accumulated
+   fragments when a tag is cut (`python scripts/assemble_changelog.py --apply`).
+4. All tests must pass, lint must be clean
+5. Open PR from your fork, address all review comments
+6. Track follow-up items as issues on the [project board](https://github.com/orgs/strands-labs/projects/2)
+7. Squash merge into `main`
 
 
 ## Registry conventions (strands_robots/registry/robots.json)

--- a/changelog.d/1689-changelog-news-fragments.md
+++ b/changelog.d/1689-changelog-news-fragments.md
@@ -1,0 +1,25 @@
+### Quality: changelog entries are recorded as news fragments
+
+A behavioural change now records its changelog entry as its own file under
+`changelog.d/` (`<pr-number>-<slug>.md`) instead of appending to the
+`## [Unreleased]` section of `CHANGELOG.md`. `scripts/assemble_changelog.py`
+folds the accumulated fragments into the log when a tag is cut.
+
+Appending to `[Unreleased]` put every branch at the same insertion anchor, so
+any two pull requests open at once conflicted the moment either one merged - on
+ordering alone, never on meaning. One merge to `main` was observed turning five
+already-approved PRs `CONFLICTING`, with `CHANGELOG.md` the only conflicting
+file in all five; because stale approvals are dismissed on push, each resolution
+cost a re-approval round that reviewed no changed behaviour, and the cost scaled
+with the number of open PRs.
+
+A `CHANGELOG.md merge=union` attribute does not address this: local git honors
+the driver, but GitHub's mergeability computation does not apply merge drivers,
+so the pull request still reports as conflicting and the resolving push still
+dismisses the approval. A fragment is its own path, so no two pull requests
+touch the same file and there is nothing for a merge to reconcile.
+
+`CHANGELOG.md` remains the human-facing log and is still edited directly for
+release bookkeeping. Assembly refuses wholesale if any pending fragment is
+malformed or misnamed, so a fragment cannot be silently dropped, nor deleted
+without its content landing in the log.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,69 @@
+# changelog.d - news fragments
+
+One file per change. `CHANGELOG.md` is assembled from these at release time.
+
+## Why not edit CHANGELOG.md directly
+
+Every PR that appended straight to `## [Unreleased]` inserted at the *same
+anchor*, so any two PRs open at once conflicted the moment either one merged --
+on ordering alone, never on meaning. Because stale approvals are dismissed on
+push, clearing that conflict cost a full re-approval round per affected PR, and
+the cost grew with the number of open PRs. A fragment removes the conflict
+class outright: no two PRs touch the same path, so there is nothing to
+reconcile.
+
+`CHANGELOG.md` stays the human-facing log and is still edited directly for
+release bookkeeping (collapsing `[Unreleased]` into a dated section). It is
+fragments, not the log, that behavioural PRs write to.
+
+## Adding a fragment
+
+Create `changelog.d/<number>-<slug>.md`, where `<number>` is your PR (or issue)
+number and `<slug>` is a short lowercase description:
+
+```
+changelog.d/1692-teleop-slew-bound.md
+```
+
+The content is exactly what would have gone into `CHANGELOG.md` -- a
+`### <Category>: <summary>` heading followed by the prose body:
+
+```markdown
+### Fixed: a teleop command a joint cannot travel that fast is refused
+
+`RobotMesh.apply_input_frame` bounded frame rate and value magnitude but not
+rate of change, so a replayed stream could command a full-scale reversal
+every frame ...
+```
+
+Rules, all enforced by `tests/test_changelog_fragments.py`:
+
+- Opens with a level-3 entry heading, in the style of the entries already in the
+  log (`Fixed`, `Added`, `Docs`, `Security`, ...). The category wording is yours
+  -- only the structure is checked, so this convention does not narrow what the
+  log may say.
+- Exactly one `### ` entry per file -- split two changes into two files.
+- No level-2 (`## `) heading: that would forge a version section and break the
+  structural contract in `tests/test_changelog_format.py`.
+- Nothing else lives in this directory. A stray or misnamed file is a hard
+  error, not a skipped one, so an entry can never be silently dropped.
+
+Validate locally with:
+
+```bash
+python scripts/assemble_changelog.py --check    # names + headings
+python scripts/assemble_changelog.py --print    # preview the assembled section
+```
+
+## Releasing
+
+Fold the accumulated fragments into the log, then collapse `[Unreleased]` into
+the dated section for the tag:
+
+```bash
+python scripts/assemble_changelog.py --apply    # writes CHANGELOG.md, removes fragments
+```
+
+`--apply` validates everything first and refuses wholesale on any problem, so a
+malformed fragment cannot leave the log half-written or a fragment deleted
+without its content landing.

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Assemble ``changelog.d/`` news fragments into ``CHANGELOG.md``.
+
+Why this exists
+---------------
+Every behavioural PR used to append its entry directly to the top of the
+``## [Unreleased]`` section of ``CHANGELOG.md``. Because every branch inserts at
+the *same anchor*, any two PRs open at once are guaranteed to conflict the
+moment either one merges -- on ordering alone, never on meaning. The repository
+dismisses stale approvals on push, so clearing a conflict that is purely an
+append-ordering artifact costs a re-approval round on every affected PR, and the
+cost scales as O(open PRs). One recorded instance: a single merge to ``main``
+turned five already-approved PRs ``CONFLICTING``, with ``CHANGELOG.md`` as the
+only conflicting file in all five.
+
+A ``merge=union`` attribute does not fix that: it removes the manual resolution
+step, but GitHub's mergeability computation does not apply merge drivers, so the
+PR still reports ``CONFLICTING``, the merge button stays disabled, and the
+resolving push still dismisses the approval.
+
+A news fragment makes the conflict *structurally impossible*: each PR adds its
+own file under ``changelog.d/``, so no two PRs ever touch the same path and
+there is nothing for a merge to reconcile. This script is the release-time
+assembly step that pays for that: it validates every accumulated fragment and
+folds them into the ``[Unreleased]`` section of ``CHANGELOG.md``.
+
+Fragment contract
+-----------------
+- Path: ``changelog.d/<number>-<slug>.md``, where ``<number>`` is the PR (or
+  issue) number and ``<slug>`` is lowercase ``a-z0-9`` words joined by ``-``.
+- Content: exactly the Markdown that would have been pasted into
+  ``CHANGELOG.md`` -- one ``### <Category>: <summary>`` heading followed by the
+  prose body, in the style of the entries already in the log.
+- A fragment may not contain a level-2 (``## ``) heading: that would forge a
+  version section and break the structural contract pinned by
+  ``tests/test_changelog_format.py``.
+
+Anything else in ``changelog.d/`` (a stray ``.txt``, a misnamed ``.md``) is a
+hard error rather than a skipped file -- a fragment that is silently ignored is
+a behavioural change that never reaches the log.
+
+Usage
+-----
+``--check``   validate the fragments and exit non-zero on any problem
+              (safe to run in CI; writes nothing).
+``--print``   write the assembled ``[Unreleased]`` body to stdout.
+``--apply``   fold the fragments into ``CHANGELOG.md`` and delete the consumed
+              files. Refuses wholesale if *any* fragment is invalid, leaving
+              both the log and the fragments untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FRAGMENT_DIR = _REPO_ROOT / "changelog.d"
+DEFAULT_CHANGELOG = _REPO_ROOT / "CHANGELOG.md"
+
+#: Files in the fragment directory that are documentation, not fragments.
+RESERVED_NAMES = frozenset({"README.md"})
+
+FRAGMENT_NAME = re.compile(r"^(?P<number>\d+)-[a-z0-9]+(?:-[a-z0-9]+)*\.md$")
+#: A fragment opens with the same level-3 entry heading the log already uses
+#: (``### Fixed: ...``, ``### Added: ...``, ``### Docs: ...``). The wording is
+#: not policed here: the log carries a dozen categories in practice, and this
+#: script guards structure, not taxonomy.
+FRAGMENT_HEADING = re.compile(r"^### \S")
+UNRELEASED_HEADING = "## [Unreleased]"
+
+#: Two blank lines separate sibling entries inside a section, matching the
+#: existing hand-written layout of CHANGELOG.md.
+ENTRY_SEPARATOR = "\n\n\n"
+
+
+@dataclass(frozen=True)
+class Fragment:
+    """One accumulated changelog entry, read from ``changelog.d/``."""
+
+    path: Path
+    number: int
+    body: str
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+
+def collect_fragments(directory: Path = DEFAULT_FRAGMENT_DIR) -> list[Fragment]:
+    """Read every fragment in ``directory``, newest number first.
+
+    Ordering is by descending number then by name, so the assembled section
+    reads newest-first like the rest of the log and is byte-identical across
+    runs and machines (``Path.iterdir`` order is not guaranteed).
+
+    Raises:
+        ValueError: if the directory holds a file that is neither a reserved
+            documentation file nor a validly named fragment.
+    """
+    if not directory.is_dir():
+        return []
+
+    fragments: list[Fragment] = []
+    for path in sorted(directory.iterdir()):
+        if path.name in RESERVED_NAMES or path.name.startswith("."):
+            continue
+        if not path.is_file():
+            raise ValueError(f"{path}: fragment directory must hold files only")
+        match = FRAGMENT_NAME.match(path.name)
+        if match is None:
+            raise ValueError(
+                f"{path.name}: not a valid fragment name - expected "
+                "'<number>-<slug>.md' (lowercase slug, words joined by '-')"
+            )
+        fragments.append(
+            Fragment(
+                path=path,
+                number=int(match.group("number")),
+                body=path.read_text(encoding="utf-8"),
+            )
+        )
+
+    fragments.sort(key=lambda fragment: (-fragment.number, fragment.name))
+    return fragments
+
+
+def validate_fragment(fragment: Fragment) -> list[str]:
+    """Return every contract violation in one fragment (empty list if valid)."""
+    problems: list[str] = []
+    lines = fragment.body.splitlines()
+    stripped = [line for line in lines if line.strip()]
+
+    if not stripped:
+        problems.append(f"{fragment.name}: fragment is empty")
+        return problems
+
+    if not FRAGMENT_HEADING.match(stripped[0]):
+        problems.append(
+            f"{fragment.name}: first line must be a level-3 entry heading "
+            f"('### <Category>: <summary>'), got {stripped[0]!r}"
+        )
+
+    for line in lines:
+        if line.startswith("## "):
+            problems.append(
+                f"{fragment.name}: fragment may not contain a level-2 heading "
+                f"({line!r}) - that would forge a version section"
+            )
+            break
+
+    if sum(1 for line in lines if line.startswith("### ")) > 1:
+        problems.append(
+            f"{fragment.name}: fragment must hold exactly one '### ' entry - split multiple entries into one file each"
+        )
+
+    return problems
+
+
+def validate_fragments(directory: Path = DEFAULT_FRAGMENT_DIR) -> list[str]:
+    """Return every contract violation across the fragment directory."""
+    try:
+        fragments = collect_fragments(directory)
+    except ValueError as exc:
+        return [str(exc)]
+
+    problems: list[str] = []
+    for fragment in fragments:
+        problems.extend(validate_fragment(fragment))
+    return problems
+
+
+def render(fragments: list[Fragment]) -> str:
+    """Render fragments as the body of an ``[Unreleased]`` section."""
+    return ENTRY_SEPARATOR.join(fragment.body.strip("\n") for fragment in fragments)
+
+
+def insert_into_changelog(changelog_text: str, rendered: str) -> str:
+    """Return ``changelog_text`` with ``rendered`` at the top of ``[Unreleased]``.
+
+    Raises:
+        ValueError: if the log has no ``## [Unreleased]`` heading to insert
+            under, or more than one.
+    """
+    if not rendered:
+        return changelog_text
+
+    lines = changelog_text.splitlines()
+    anchors = [i for i, line in enumerate(lines) if line.strip() == UNRELEASED_HEADING]
+    if len(anchors) != 1:
+        raise ValueError(f"CHANGELOG.md must hold exactly one '{UNRELEASED_HEADING}' heading, found {len(anchors)}")
+
+    anchor = anchors[0]
+    tail = lines[anchor + 1 :]
+    # Drop the blank line(s) the heading is followed by; they are re-emitted
+    # below so the seam has the same shape whether or not the section was empty.
+    while tail and not tail[0].strip():
+        tail.pop(0)
+
+    head = "\n".join(lines[: anchor + 1])
+    body = rendered.strip("\n")
+    rest = "\n".join(tail).strip("\n")
+
+    assembled = f"{head}\n\n{body}"
+    if rest:
+        assembled = f"{assembled}{ENTRY_SEPARATOR}{rest}"
+    return assembled + "\n"
+
+
+def apply(
+    directory: Path = DEFAULT_FRAGMENT_DIR,
+    changelog: Path = DEFAULT_CHANGELOG,
+) -> list[Fragment]:
+    """Fold fragments into ``changelog`` and delete the consumed files.
+
+    Validation runs first and refuses the whole operation on any problem, so a
+    malformed fragment can never leave the log half-written or a fragment
+    deleted without its content landing.
+
+    Returns:
+        The fragments that were consumed (empty if there were none).
+
+    Raises:
+        ValueError: if any fragment is invalid or the log has no single
+            ``[Unreleased]`` anchor. Nothing is written in that case.
+    """
+    problems = validate_fragments(directory)
+    if problems:
+        raise ValueError("refusing to assemble - invalid fragment(s):\n  " + "\n  ".join(problems))
+
+    fragments = collect_fragments(directory)
+    if not fragments:
+        return []
+
+    # Compute the new text before touching the filesystem: a bad anchor must
+    # not cost a deleted fragment.
+    updated = insert_into_changelog(changelog.read_text(encoding="utf-8"), render(fragments))
+
+    changelog.write_text(updated, encoding="utf-8")
+    for fragment in fragments:
+        fragment.path.unlink()
+    return fragments
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="validate fragments, write nothing")
+    mode.add_argument("--print", dest="print_only", action="store_true", help="print the assembled section")
+    mode.add_argument("--apply", action="store_true", help="fold fragments into CHANGELOG.md and delete them")
+    parser.add_argument("--fragment-dir", type=Path, default=DEFAULT_FRAGMENT_DIR)
+    parser.add_argument("--changelog", type=Path, default=DEFAULT_CHANGELOG)
+    args = parser.parse_args(argv)
+
+    problems = validate_fragments(args.fragment_dir)
+    if problems:
+        print("invalid changelog fragment(s):", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+
+    fragments = collect_fragments(args.fragment_dir)
+
+    if args.check:
+        print(f"changelog fragments OK ({len(fragments)} pending)")
+        return 0
+
+    if args.print_only:
+        print(render(fragments))
+        return 0
+
+    consumed = apply(args.fragment_dir, args.changelog)
+    if not consumed:
+        print("no changelog fragments to assemble")
+        return 0
+    print(f"assembled {len(consumed)} fragment(s) into {args.changelog.name}:")
+    for fragment in consumed:
+        print(f"  {fragment.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_changelog_fragments.py
+++ b/tests/test_changelog_fragments.py
@@ -1,0 +1,298 @@
+"""Contract pins for the ``changelog.d/`` news-fragment convention.
+
+A behavioural PR records its entry as a file under ``changelog.d/`` instead of
+appending to ``## [Unreleased]`` in ``CHANGELOG.md``. That is what keeps two
+concurrently open PRs from conflicting on the changelog: they never touch the
+same path. ``scripts/assemble_changelog.py`` folds the accumulated fragments
+into the log at release time.
+
+These checks pin the two halves of that trade:
+
+- the convention is *declared* (``changelog.d/README.md`` exists and documents
+  it), so a future directory cleanup cannot quietly drop the policy while
+  leaving the tooling in place;
+- assembly is *lossless and fail-safe* -- fragments are ordered
+  deterministically, every body lands exactly once, a malformed or misnamed
+  fragment is refused rather than skipped, and a refusal writes nothing and
+  deletes nothing.
+
+The last point is the one that matters most: a fragment that is silently
+ignored is a behavioural change that never reaches the log, and a half-applied
+assembly can delete a fragment whose content never landed.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "assemble_changelog.py"
+_FRAGMENT_DIR = _REPO_ROOT / "changelog.d"
+_CHANGELOG = _REPO_ROOT / "CHANGELOG.md"
+
+_VERSION_HEADING = re.compile(r"^## \[(?P<ver>\d+\.\d+\.\d+)\] - (?P<date>\d{4}-\d{2}-\d{2})\s*$")
+
+
+def _load_module():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location("assemble_changelog", _SCRIPT_PATH)
+    assert spec and spec.loader, f"cannot load {_SCRIPT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["assemble_changelog"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+assemble = _load_module()
+
+_MINIMAL_LOG = """# CHANGELOG
+
+## [Unreleased]
+
+### Fixed: an entry that was already in the log
+
+Body of the pre-existing entry.
+
+
+## [0.4.1] - 2026-01-02
+
+### Fixed: something released
+
+Released body.
+"""
+
+
+def _fragment(directory: Path, name: str, text: str) -> Path:
+    path = directory / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> tuple[Path, Path]:
+    """A fragment directory plus a changelog, isolated from the repo copy."""
+    fragment_dir = tmp_path / "changelog.d"
+    fragment_dir.mkdir()
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_MINIMAL_LOG, encoding="utf-8")
+    return fragment_dir, changelog
+
+
+# --- the convention is declared -------------------------------------------------
+
+
+def test_fragment_directory_documents_the_convention() -> None:
+    """The policy lives in the repo, not only in reviewers' heads."""
+    readme = _FRAGMENT_DIR / "README.md"
+    assert readme.is_file(), "changelog.d/README.md must document the fragment convention"
+    text = readme.read_text(encoding="utf-8")
+    assert "<number>-<slug>.md" in text, "README must state the fragment naming contract"
+    assert "assemble_changelog.py" in text, "README must point at the assembly step"
+
+
+def test_repository_fragments_are_valid() -> None:
+    """Pending fragments are checked at PR time, not at release time."""
+    assert assemble.validate_fragments(_FRAGMENT_DIR) == []
+
+
+# --- ordering and losslessness --------------------------------------------------
+
+
+def test_fragments_are_ordered_newest_first_and_deterministically(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, _ = workspace
+    _fragment(fragment_dir, "9-old.md", "### Fixed: old\n\nOld body.\n")
+    _fragment(fragment_dir, "1200-new.md", "### Added: new\n\nNew body.\n")
+    _fragment(fragment_dir, "100-middle.md", "### Changed: middle\n\nMiddle body.\n")
+
+    names = [fragment.name for fragment in assemble.collect_fragments(fragment_dir)]
+    assert names == ["1200-new.md", "100-middle.md", "9-old.md"], "numeric descending, not lexicographic"
+
+
+def test_render_keeps_every_body_exactly_once(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, _ = workspace
+    _fragment(fragment_dir, "10-one.md", "### Fixed: one\n\nFirst body.\n")
+    _fragment(fragment_dir, "11-two.md", "### Added: two\n\nSecond body.\n")
+
+    rendered = assemble.render(assemble.collect_fragments(fragment_dir))
+    assert rendered.count("First body.") == 1
+    assert rendered.count("Second body.") == 1
+    assert rendered.count("### ") == 2
+
+
+def test_readme_is_not_treated_as_a_fragment(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, _ = workspace
+    _fragment(fragment_dir, "README.md", "# changelog.d\n\nHow to add a fragment.\n")
+    assert assemble.collect_fragments(fragment_dir) == []
+    assert assemble.validate_fragments(fragment_dir) == []
+
+
+# --- apply: the happy path ------------------------------------------------------
+
+
+def test_apply_folds_fragments_in_and_consumes_them(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, changelog = workspace
+    first = _fragment(fragment_dir, "20-newer.md", "### Fixed: newer thing\n\nNewer body.\n")
+    second = _fragment(fragment_dir, "15-older.md", "### Added: older thing\n\nOlder body.\n")
+
+    consumed = assemble.apply(fragment_dir, changelog)
+
+    assert [fragment.name for fragment in consumed] == ["20-newer.md", "15-older.md"]
+    assert not first.exists() and not second.exists(), "consumed fragments must be removed"
+
+    text = changelog.read_text(encoding="utf-8")
+    assert "Newer body." in text and "Older body." in text
+    assert "an entry that was already in the log" in text, "pre-existing entries must survive"
+    assert text.index("Newer body.") < text.index("Older body.") < text.index("Body of the pre-existing entry.")
+    assert text.index("## [Unreleased]") < text.index("Newer body.")
+    assert text.endswith("\n")
+
+
+def test_apply_with_no_fragments_leaves_the_log_byte_identical(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, changelog = workspace
+    before = changelog.read_text(encoding="utf-8")
+    assert assemble.apply(fragment_dir, changelog) == []
+    assert changelog.read_text(encoding="utf-8") == before
+
+
+def test_apply_into_an_empty_unreleased_section(tmp_path: Path) -> None:
+    """The seam has the same shape whether or not the section already had entries."""
+    fragment_dir = tmp_path / "changelog.d"
+    fragment_dir.mkdir()
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# CHANGELOG\n\n## [Unreleased]\n\n## [0.4.1] - 2026-01-02\n\nBody.\n", encoding="utf-8")
+    _fragment(fragment_dir, "30-first.md", "### Fixed: the first entry\n\nFirst body.\n")
+
+    assemble.apply(fragment_dir, changelog)
+    text = changelog.read_text(encoding="utf-8")
+
+    assert "## [Unreleased]\n\n### Fixed: the first entry" in text
+    assert text.count("## [Unreleased]") == 1
+
+
+def test_assembled_log_still_satisfies_the_structural_contract(tmp_path: Path) -> None:
+    """Assembly must not disturb what tests/test_changelog_format.py pins."""
+    fragment_dir = tmp_path / "changelog.d"
+    fragment_dir.mkdir()
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_CHANGELOG.read_text(encoding="utf-8"), encoding="utf-8")
+    _fragment(fragment_dir, "40-structural.md", "### Fixed: a freshly assembled entry\n\nBody.\n")
+
+    assemble.apply(fragment_dir, changelog)
+
+    h2 = [line for line in changelog.read_text(encoding="utf-8").splitlines() if line.startswith("## ")]
+    assert h2[0].strip() == "## [Unreleased]"
+    assert sum(1 for line in h2 if line.strip() == "## [Unreleased]") == 1
+
+    versions = []
+    for line in h2[1:]:
+        match = _VERSION_HEADING.match(line)
+        assert match, f"assembly forged a malformed version heading: {line!r}"
+        _dt.date.fromisoformat(match.group("date"))
+        versions.append(tuple(int(part) for part in match.group("ver").split(".")))
+    assert versions == sorted(versions, reverse=True)
+
+
+# --- refusals: nothing written, nothing deleted ---------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "text", "expected"),
+    [
+        ("50-empty.md", "\n\n", "empty"),
+        ("51-no-heading.md", "Just prose, no heading.\n", "level-3 entry heading"),
+        ("52-deeper-heading-first.md", "#### Fixed: too deep\n\nBody.\n", "level-3 entry heading"),
+        ("54-two-entries.md", "### Fixed: one\n\nA.\n\n### Added: two\n\nB.\n", "exactly one"),
+        ("55-version-heading.md", "### Fixed: one\n\n## [9.9.9] - 2026-01-01\n\nA.\n", "level-2 heading"),
+    ],
+)
+def test_invalid_fragment_is_reported(workspace: tuple[Path, Path], name: str, text: str, expected: str) -> None:
+    fragment_dir, _ = workspace
+    _fragment(fragment_dir, name, text)
+    problems = assemble.validate_fragments(fragment_dir)
+    assert problems, f"{name} must be refused"
+    assert any(expected in problem for problem in problems), problems
+
+
+@pytest.mark.parametrize("category", ["Fixed", "Added", "Docs", "Quality", "Security", "Internal Refactor"])
+def test_the_categories_already_in_the_log_are_accepted(workspace: tuple[Path, Path], category: str) -> None:
+    """Structure is policed, taxonomy is not.
+
+    ``CHANGELOG.md`` carries a dozen entry categories in practice (``Docs``,
+    ``Quality``, ``Internal Refactor``, ...). A fragment validator that accepted
+    only the Keep a Changelog six would legislate a new content policy, and
+    would refuse entries in the style the log already uses.
+    """
+    fragment_dir, _ = workspace
+    _fragment(fragment_dir, "56-category.md", f"### {category}: a summary\n\nBody.\n")
+    assert assemble.validate_fragments(fragment_dir) == []
+
+
+def test_misnamed_fragment_is_an_error_not_a_skip(workspace: tuple[Path, Path]) -> None:
+    """A file that does not match the naming contract must never be ignored."""
+    fragment_dir, _ = workspace
+    _fragment(fragment_dir, "no-leading-number.md", "### Fixed: something\n\nBody.\n")
+    problems = assemble.validate_fragments(fragment_dir)
+    assert any("not a valid fragment name" in problem for problem in problems), problems
+
+
+def test_stray_non_markdown_file_is_an_error_not_a_skip(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, _ = workspace
+    _fragment(fragment_dir, "60-notes.txt", "### Fixed: something\n\nBody.\n")
+    problems = assemble.validate_fragments(fragment_dir)
+    assert any("not a valid fragment name" in problem for problem in problems), problems
+
+
+def test_apply_refuses_invalid_fragment_without_touching_anything(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, changelog = workspace
+    good = _fragment(fragment_dir, "70-good.md", "### Fixed: a good entry\n\nGood body.\n")
+    bad = _fragment(fragment_dir, "71-bad.md", "no heading at all\n")
+    before = changelog.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="refusing to assemble"):
+        assemble.apply(fragment_dir, changelog)
+
+    assert changelog.read_text(encoding="utf-8") == before, "a refusal must not write the log"
+    assert good.exists() and bad.exists(), "a refusal must not delete fragments"
+
+
+def test_apply_refuses_a_log_without_an_unreleased_anchor(tmp_path: Path) -> None:
+    fragment_dir = tmp_path / "changelog.d"
+    fragment_dir.mkdir()
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# CHANGELOG\n\n## [0.4.1] - 2026-01-02\n\nBody.\n", encoding="utf-8")
+    pending = _fragment(fragment_dir, "80-pending.md", "### Fixed: pending\n\nBody.\n")
+    before = changelog.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="exactly one"):
+        assemble.apply(fragment_dir, changelog)
+
+    assert changelog.read_text(encoding="utf-8") == before
+    assert pending.exists(), "the fragment must survive a failed assembly"
+
+
+# --- CLI ------------------------------------------------------------------------
+
+
+def test_check_mode_reports_and_writes_nothing(workspace: tuple[Path, Path], capsys: pytest.CaptureFixture) -> None:
+    fragment_dir, changelog = workspace
+    kept = _fragment(fragment_dir, "90-kept.md", "### Fixed: kept\n\nBody.\n")
+    before = changelog.read_text(encoding="utf-8")
+
+    code = assemble.main(["--check", "--fragment-dir", str(fragment_dir), "--changelog", str(changelog)])
+
+    assert code == 0
+    assert "1 pending" in capsys.readouterr().out
+    assert kept.exists()
+    assert changelog.read_text(encoding="utf-8") == before
+
+
+def test_check_mode_exits_non_zero_on_an_invalid_fragment(workspace: tuple[Path, Path]) -> None:
+    fragment_dir, changelog = workspace
+    _fragment(fragment_dir, "91-bad.md", "no heading\n")
+    code = assemble.main(["--check", "--fragment-dir", str(fragment_dir), "--changelog", str(changelog)])
+    assert code == 1


### PR DESCRIPTION
## Problem

Every behavioural PR appends its entry at the top of `## [Unreleased]` in `CHANGELOG.md`. Because every branch inserts at the **same anchor**, any two PRs open at once are guaranteed to conflict the moment either one merges - on ordering alone, never on meaning. Stale approvals are dismissed on push, so clearing that conflict costs a re-approval round per affected PR that reviews no changed behaviour, and the cost scales as O(open PRs).

Measured on this repository, not hypothetical. At the time of writing, **9 of the 10 approved open PRs are `CONFLICTING`, and `CHANGELOG.md` is the only conflicting file in every one of them**:

```
$ for b in <the nine approved branches>; do git merge-tree --write-tree --name-only main $b; done
CHANGELOG.md   CONFLICT (content): Merge conflict in CHANGELOG.md      # x9, nothing else
```

Not one source or test file conflicts. An earlier pass resolved five of these by hand; the next merge to `main` re-created the situation for whatever was open at the time.

Fixes #1689.

## Why not `merge=union`

Measured and ruled out as a standalone fix (recorded in #1689): local git honors the driver (`git merge`, `git rebase`, `git merge-tree` all clean), but GitHub's mergeability computation does not apply merge drivers. The PR still reports `CONFLICTING`, the merge button stays disabled, and the resolving push still dismisses the approval - all three of the costs above survive.

## Approach

A news fragment makes the conflict **structurally impossible** rather than automatically resolvable: each PR adds its own `changelog.d/<number>-<slug>.md`, so no two PRs touch the same path and there is nothing for a merge to reconcile.

| file | lines | what it is |
|---|---|---|
| `changelog.d/README.md` | +69 | the contributor-facing convention and the reason for it |
| `scripts/assemble_changelog.py` | +286 | `--check` / `--print` / `--apply` assembly, the release-time step that pays for the convention |
| `tests/test_changelog_fragments.py` | +298 | 30 pins: ordering, losslessness, refusals, CLI |
| `AGENTS.md` | +16/-4 | one PR Workflow step (acceptance item 3 of #1689) |
| `changelog.d/1689-...md` | +25 | this change's own entry, recorded as a fragment |
| `.github/` advisories | +3/-2 | second commit: the two automated bot messages that say "add a `CHANGELOG.md` entry" now point at `changelog.d/` |

`CHANGELOG.md` is **not touched by this PR**. It remains the human-facing log and is still edited directly for release bookkeeping (collapsing `[Unreleased]` into a dated section).

## Evidence

**1. Assembly is provably additive.** `--apply` on a copy of the real log, diffed against `main`:

```
removed lines: 0
added lines:  27      (inserted at 7a8, i.e. directly under '## [Unreleased]')
```

**2. This PR is itself immune to the problem it fixes.** Simulating the next squash-merge to `main` (one entry prepended to `[Unreleased]`), then merge-testing both this branch and an approved CHANGELOG-editing branch against it:

| branch | after the next merge to `main` |
|---|---|
| this one (fragment only, no `CHANGELOG.md` edit) | **CLEAN** (`merge-tree` rc=0) |
| an approved PR that appends to `[Unreleased]` | CONFLICT (`merge-tree` rc=1) |

**3. Refusals are fail-safe.** Validation runs before any write, so a malformed fragment can neither leave the log half-written nor be deleted without its content landing. Pinned by `test_apply_refuses_invalid_fragment_without_touching_anything` and `test_apply_refuses_a_log_without_an_unreleased_anchor` (both assert the log is byte-identical and every fragment still on disk after the refusal) - the "clean up on failure" contract from AGENTS.md > Review Learnings (#85).

**4. A dropped entry is impossible.** A stray (`60-notes.txt`) or misnamed (`no-leading-number.md`) file in `changelog.d/` is a hard error, not a skipped file, so an entry cannot silently fail to reach the log.

**5. Structure is policed, taxonomy is not.** The log carries thirteen entry categories in practice (`Fixed` x128, `Added` x64, `Docs` x8, `Feature` x5, `Quality`, `Internal Refactor`, ...). An early draft of the validator enforced the Keep a Changelog six; that would have legislated a new content policy on top of a tooling change and refused entries in the style the log already uses. It now checks only that a fragment opens with one `### ` entry and contains no `## ` heading (which would forge a version section and break `tests/test_changelog_format.py`). `test_the_categories_already_in_the_log_are_accepted` pins that against re-tightening.

**6. Local verification.**

```
pytest tests/test_changelog_fragments.py tests/test_changelog_format.py   30 passed
ruff check / ruff format --check                                          clean
mypy tests/test_changelog_fragments.py                                    clean
grep -nP '[^\x00-\x7F]' <new files>                                       no non-ASCII
yaml.safe_load(breaking-change-check.yml)                                 parses
```

## Scope notes

- **No CI workflow change beyond two advisory strings.** Fragment validation runs in CI through `test_repository_fragments_are_valid`, which fails the normal test job on a malformed pending fragment. No new job, no new required check; the breaking-change workflow stays informational.
- **The 9 conflicting PRs are not touched here.** They still each need one conflict resolution to land; this change is what stops the tenth, eleventh and twelfth from happening.
- **`merge=union` is not added.** It is orthogonal quality-of-life, and adding it alongside this would blur what is being decided. Happy to add it as a follow-up if wanted.
- **The decision this asks for:** #1689's first acceptance item is "a recorded decision on which option to take". This PR is that proposal, implemented so the trade is concrete rather than abstract - a release-time assembly step and a contributor-facing convention change, in exchange for removing the conflict class. If the convention change is unwanted, closing this is cheap and nothing in the package changes either way.

## §13 Changelog

- **Round 1** - initial submission. Two commits, both pre-review: the fragment convention + tooling + pins, then the `.github/` advisory text that would otherwise have gone stale the moment this lands.
