### PR TITLE
fix(mesh): a rate the environment cannot express falls back instead of removing the limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,8 +1097,10 @@ touches ROS 2.
 | `STRANDS_MESH_SUBSCRIBE_ALLOW` | Extra Zenoh key-expr patterns the `robot_mesh` `subscribe` action may target, beyond the built-in low-impact set | shared classes only |
 | `STRANDS_MESH_OVERRIDE_CODE` | Shared secret for e-stop resume HMAC proof; unset means no remote resume possible | unset |
 | `STRANDS_MESH_INPUT_VALUE_ABS` | Absolute value clamp for teleop joint commands (radians) | `12.566` (4pi) |
-| `STRANDS_MESH_INPUT_MAX_HZ` | Per-receiver teleop apply-rate ceiling (0 = unlimited) | `100` |
+| `STRANDS_MESH_INPUT_MAX_HZ` | Per-receiver teleop apply-rate ceiling (0 = unlimited). A value no rate check can be built from -- unparsable, or non-finite like `inf`/`nan` -- falls back to the default so the ceiling stays enforced | `100` |
 | `STRANDS_MESH_INPUT_SLEW_ABS` | Per-joint speed bound for teleop commands, in frame units per second (widen for degree-valued or normalized actuators; cannot be disabled) | `25.133` (8pi) |
+| `STRANDS_MESH_POSE_HZ`, `_IMU_HZ`, `_ODOM_HZ`, `_HEALTH_HZ`, `_LIDAR_SUMMARY_HZ`, `_HAND_HZ`, `_MAP_INFO_HZ` | Per-topic sensor publish rate; `0` (or any non-positive value) switches that topic off. A value the loop cannot pace itself with keeps the built-in rate | per topic: `10`/`10`/`10`/`0.5`/`5`/`50`/`0.2` |
+| `STRANDS_MESH_CAMERA_HZ` | Camera publish rate; opt-in because frames are large. Unset, non-positive, or unusable leaves camera publishing off | `0` (off) |
 | `STRANDS_MESH_MAX_PEERS` | Peer registry cap; evicts oldest on overflow | `1024` |
 | `STRANDS_MESH_RESUME_MAX_FAILS` | Failed resume attempts before cooldown engages | `5` |
 | `STRANDS_MESH_RESUME_BACKOFF_S` | Cooldown (seconds) after exceeding resume fail threshold | `30` |

--- a/changelog.d/1693-mesh-non-finite-rate-env.md
+++ b/changelog.d/1693-mesh-non-finite-rate-env.md
@@ -1,0 +1,27 @@
+### Fixed: a mesh loop rate the environment cannot express falls back instead of removing the limit
+
+Every mesh loop rate is operator-tunable through an environment variable, and
+every consumer turns that rate into a period with `1.0 / hz`. `float()` accepts
+`"inf"`, overflows `"1e999"` to `inf` and accepts `"nan"`, and neither survives
+that division: `inf` gives a zero period, so a loop that meant to wait between
+ticks never waits, and `nan` compares `False` against every bound, so a cap
+built from it never trips. `Mesh._resolve_camera_hz` already refused non-finite
+input for exactly this reason; the seven sensor publish loops and the teleop
+apply-rate ceiling, which compute the same period from the same kind of value,
+did not.
+
+`STRANDS_MESH_POSE_HZ=inf` therefore left `_pose_loop` publishing to the mesh
+as fast as the CPU allowed -- measured at roughly 400,000 samples per second
+against the 10 Hz that variable documents -- and every other sensor topic
+behaved the same way, while `nan` silently switched the topic off. More
+seriously, `STRANDS_MESH_INPUT_MAX_HZ=inf` or `=nan` silently removed the
+teleop apply-rate ceiling that exists so a peer streaming above the nominal
+publish rate cannot slam servos into overcurrent, thermal or gear damage: a
+200-frame burst was applied in full with `rate_dropped` left at 0. Only an
+explicit `0` is documented to disable a rate limit.
+
+The rule deciding which environment-held rates are usable now lives in one
+place, `strands_robots.mesh.session.hz_from_env`, which reports a value no loop
+can honor and leaves the fallback to each reader: a sensor loop keeps its
+built-in rate, the camera loop stays off, the teleop ceiling reverts to its
+default. The three readers can no longer diverge on what a rate is.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -12,7 +12,6 @@ import hashlib
 import hmac
 import json
 import logging
-import math
 import os
 import re
 import socket
@@ -31,6 +30,7 @@ from strands_robots.mesh.session import (
     STATE_HZ,
     current_session,
     get_session,
+    hz_from_env,
     prune_peers,
     put,
     release_session,
@@ -1082,21 +1082,22 @@ class Mesh(SensorLoopsMixin):
 
     # Cameras - outgoing (opt-in)
     def _resolve_camera_hz(self) -> float:
-        env = os.getenv("STRANDS_MESH_CAMERA_HZ")
-        if env is None or env.strip() == "":
+        """Resolve the camera publish rate from the environment.
+
+        Returns:
+            The ``STRANDS_MESH_CAMERA_HZ`` override when it names a rate
+            :meth:`_camera_loop` can pace itself with, and ``0.0`` -- camera
+            publishing off -- when it is unset, non-positive, or holds a value
+            no loop can honor. Frames are large, so an unusable override
+            disables the loop rather than falling back to a rate the operator
+            did not ask for.
+        """
+        hz, reason = hz_from_env("STRANDS_MESH_CAMERA_HZ")
+        if reason is not None:
+            logger.warning("%s; camera loop disabled", reason)
+            return 0.0
+        if hz is None:
             hz = CAMERA_HZ
-        else:
-            try:
-                hz = float(env)
-            except ValueError:
-                logger.warning("STRANDS_MESH_CAMERA_HZ=%r invalid; camera loop disabled", env)
-                return 0.0
-            if not math.isfinite(hz):
-                # float() accepts "inf"/"nan"/"1e999"; a non-finite rate would
-                # make _camera_loop compute period = 1.0/hz = 0.0 and busy-spin
-                # (or silently disable on nan). Treat it as invalid.
-                logger.warning("STRANDS_MESH_CAMERA_HZ=%r is not finite; camera loop disabled", env)
-                return 0.0
         return hz if hz > 0 else 0.0
 
     def _camera_loop(self, hz: float) -> None:

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -32,6 +32,7 @@ from strands_robots.mesh.security import (
     validate_input_frame,
     validate_mesh_identifier,
 )
+from strands_robots.mesh.session import hz_from_env
 
 _log_safety_event: Callable[..., None] | None
 try:  # audit is best-effort; never let an import issue break teleop apply
@@ -62,19 +63,19 @@ def _input_max_hz() -> float:
 
     Bad / missing input falls back to the default ceiling; an explicit
     non-positive value (0) disables the cap for trusted closed networks.
-    """
-    import os
+    A non-finite override falls back too: ``inf`` makes the caller's
+    ``1.0 / max_hz`` interval zero and ``nan`` makes ``max_hz > 0`` false, so
+    either one would silently switch the ceiling off -- the opposite of what an
+    operator raising a rate limit is asking for.
 
-    raw = os.getenv("STRANDS_MESH_INPUT_MAX_HZ")
-    if raw is None:
+    This resolver is evaluated per applied frame in a 50 Hz-plus loop, so an
+    unusable value is not logged here; it resolves to the default ceiling,
+    which keeps the servos protected.
+    """
+    hz, reason = hz_from_env("STRANDS_MESH_INPUT_MAX_HZ")
+    if hz is None or reason is not None or hz < 0:
         return INPUT_MAX_HZ_DEFAULT
-    try:
-        val = float(raw)
-    except (TypeError, ValueError):
-        return INPUT_MAX_HZ_DEFAULT
-    if val < 0:
-        return INPUT_MAX_HZ_DEFAULT
-    return val  # 0 => disabled
+    return hz  # 0 => disabled
 
 
 #: M-5: the teleop input path is high-rate (up to 50Hz),

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -36,6 +36,7 @@ from strands_robots.mesh.session import (
     MAP_INFO_HZ,
     ODOM_HZ,
     POSE_HZ,
+    hz_from_env,
     put,  # noqa: F401  # re-exported so test fixtures can patch.object(sensors, "put")
 )
 
@@ -43,14 +44,24 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_hz(env_name: str, default: float) -> float:
-    """Read an Hz value from environment, falling back to default."""
-    env = os.getenv(env_name)
-    if env is None or env.strip() == "":
+    """Read a publish rate (Hz) from the environment, falling back to default.
+
+    Args:
+        env_name: Environment variable holding the operator override.
+        default: Rate to use when the variable is unset or unusable.
+
+    Returns:
+        The override when it names a rate this loop can pace itself with,
+        *default* when the variable is unset or holds a value no loop can honor
+        (including a non-finite one, which would otherwise make the caller's
+        ``1.0 / hz`` period zero and busy-spin the publish loop), and ``0.0``
+        for a non-positive override, which disables the loop.
+    """
+    hz, reason = hz_from_env(env_name)
+    if reason is not None:
+        logger.warning("%s; using default %.1f", reason, default)
         return default
-    try:
-        hz = float(env)
-    except ValueError:
-        logger.warning("%s=%r invalid; using default %.1f", env_name, env, default)
+    if hz is None:
         return default
     return hz if hz > 0 else 0.0
 

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import atexit
 import json
 import logging
+import math
 import os
 import threading
 import time
@@ -113,6 +114,45 @@ HAND_HZ: float = 50.0
 
 #: Map info publishing frequency (Hz).
 MAP_INFO_HZ: float = 0.2
+
+
+def hz_from_env(name: str) -> tuple[float | None, str | None]:
+    """Read a loop rate (Hz) held in an environment variable.
+
+    Every mesh loop rate is operator-tunable through an environment variable,
+    and each reader has its own documented fallback for a value it cannot use:
+    a sensor loop keeps its built-in rate, the camera loop stays off, the
+    teleop apply ceiling reverts to its default. What they share is which
+    values are usable at all.
+    Every consumer turns the rate into a period with ``1.0 / hz``, and
+    ``float()`` accepts ``"inf"``, overflows ``"1e999"`` to ``inf`` and accepts
+    ``"nan"`` -- none of which survives that division. ``inf`` yields a zero
+    period, so a loop that meant to wait between ticks never waits; ``nan``
+    yields a period that compares ``False`` against every bound, so a cap
+    built from it never trips. Both read as "no rate limit" rather than as the
+    misconfiguration they are, which is why non-finite input is reported here
+    instead of being passed on.
+
+    Args:
+        name: Environment variable to read.
+
+    Returns:
+        ``(hz, None)`` when *name* holds a finite number, ``(None, None)`` when
+        it is unset or blank, and ``(None, reason)`` when it holds a value no
+        loop can honor. *reason* names the variable and the offending value so
+        a caller can log it alongside whichever fallback it documents; callers
+        decide the fallback, this decides only what is usable.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return None, None
+    try:
+        hz = float(raw)
+    except (TypeError, ValueError):
+        return None, f"{name}={raw!r} is not a number"
+    if not math.isfinite(hz):
+        return None, f"{name}={raw!r} is not a finite rate"
+    return hz, None
 
 
 # Backend selection helpers - when STRANDS_MESH_BACKEND is "iot" or "bridge",

--- a/tests/mesh/test_input_stream_lifecycle.py
+++ b/tests/mesh/test_input_stream_lifecycle.py
@@ -52,6 +52,20 @@ class TestInputMaxHz:
         monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "-5")
         assert mesh_input._input_max_hz() == INPUT_MAX_HZ_DEFAULT
 
+    @pytest.mark.parametrize("value", ["inf", "-inf", "nan", "1e999"])
+    def test_non_finite_falls_back(self, monkeypatch, value):
+        """A non-finite ceiling would switch the cap off, so it falls back.
+
+        ``float()`` accepts "inf"/"nan" and overflows "1e999" to inf, so these
+        reach ``_on_input`` past the unparsable-value guard. There ``inf`` makes
+        ``min_interval = 1.0 / max_hz`` zero so no frame is ever early enough to
+        drop, and ``nan`` makes ``max_hz > 0`` false so the rate block is
+        skipped entirely -- both silently disable the servo-protection ceiling.
+        Only an explicit ``0`` means "disabled".
+        """
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", value)
+        assert mesh_input._input_max_hz() == INPUT_MAX_HZ_DEFAULT
+
 
 class TestInputAuditEvery:
     def test_unset_returns_default(self, monkeypatch):
@@ -212,6 +226,22 @@ class TestReceiverBehavior:
         recv._on_input(recv.topic, {"action": {"j0": 0.2}, "seq": 1, "t": time.time()})
         assert len(applied) == 2
         assert recv._rate_dropped == 0
+
+    @pytest.mark.parametrize("value", ["inf", "nan", "1e999"])
+    def test_non_finite_rate_cap_still_drops_burst(self, monkeypatch, value):
+        """A non-finite ceiling must not let a burst through to the servos.
+
+        This is the ceiling that exists so a peer streaming far above the
+        nominal publish rate cannot slam the servos into overcurrent, thermal
+        or gear damage. Resolving it to a non-finite value silently removed it:
+        every frame of the burst was applied and ``rate_dropped`` stayed 0.
+        """
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", value)
+        recv, applied = _make_receiver()
+        for seq in range(20):
+            recv._on_input(recv.topic, {"action": {"j0": 0.1 * seq}, "seq": seq, "t": time.time()})
+        assert len(applied) == 1
+        assert recv._rate_dropped == 19
 
     def test_estop_lockout_rejects_frame(self):
         import threading

--- a/tests/mesh/test_rate_env_resolution.py
+++ b/tests/mesh/test_rate_env_resolution.py
@@ -1,0 +1,117 @@
+"""One rule decides which environment-held loop rates are usable.
+
+Every mesh loop rate is operator-tunable through an environment variable, and
+each reader has its own documented fallback for a value it cannot use: a sensor
+loop keeps its built-in rate, the camera loop stays off, the teleop apply
+ceiling reverts to its default. What none of them can use is a non-finite rate,
+because each turns the rate into a period with ``1.0 / hz``: ``inf`` makes that
+period zero, so a loop that meant to wait never waits, and ``nan`` makes it
+compare ``False`` against every bound, so a cap built from it never trips.
+``float()`` accepts ``"inf"`` and ``"nan"`` and overflows ``"1e999"`` to
+``inf``, so all three reach the readers unless something refuses them.
+
+These tests pin the shared decision in :func:`hz_from_env` and, more
+importantly, pin that all three readers agree on it -- the drift this replaces
+had the camera reader guarding non-finite input while the seven sensor loops
+and the teleop apply ceiling, which compute the same period from the same kind
+of value, did not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.mesh import input as mesh_input
+from strands_robots.mesh import sensors as mesh_sensors
+from strands_robots.mesh.input import INPUT_MAX_HZ_DEFAULT
+from strands_robots.mesh.session import hz_from_env
+
+#: Values ``float()`` accepts that no ``1.0 / hz`` consumer can honor.
+NON_FINITE = ["inf", "+inf", "-inf", "Infinity", "1e999", "nan", "NaN"]
+
+_ENV = "STRANDS_MESH_TEST_RATE_HZ"
+
+
+class TestHzFromEnv:
+    """The shared decision: usable, absent, or unusable-with-a-reason."""
+
+    def test_unset_reports_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_ENV, raising=False)
+        assert hz_from_env(_ENV) == (None, None)
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_blank_reports_absent(self, monkeypatch: pytest.MonkeyPatch, blank: str) -> None:
+        monkeypatch.setenv(_ENV, blank)
+        assert hz_from_env(_ENV) == (None, None)
+
+    @pytest.mark.parametrize(("raw", "expected"), [("20", 20.0), ("2.5", 2.5), ("0", 0.0), ("-3", -3.0)])
+    def test_finite_value_is_returned_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str, expected: float
+    ) -> None:
+        """Sign and zero are the caller's decision, not this helper's."""
+        monkeypatch.setenv(_ENV, raw)
+        assert hz_from_env(_ENV) == (expected, None)
+
+    def test_unparsable_value_reports_a_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_ENV, "not-a-number")
+        hz, reason = hz_from_env(_ENV)
+        assert hz is None
+        assert reason is not None
+        assert _ENV in reason and "not-a-number" in reason
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_non_finite_value_reports_a_reason(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv(_ENV, raw)
+        hz, reason = hz_from_env(_ENV)
+        assert hz is None
+        assert reason is not None
+        assert _ENV in reason and raw in reason
+
+
+class TestReadersAgreeOnWhatIsUsable:
+    """No reader of an environment-held rate accepts a value it cannot pace with.
+
+    Each reader keeps its own fallback, so the shared property asserted here is
+    the weaker one that actually matters: whatever comes back must be a rate the
+    ``1.0 / hz`` consumer downstream can use -- finite, and either positive or
+    the documented "off" zero.
+    """
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_sensor_loop_rate_falls_back_to_its_default(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv(_ENV, raw)
+        assert mesh_sensors._resolve_hz(_ENV, 12.5) == 12.5
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_camera_rate_stays_off(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        from strands_robots.mesh.core import Mesh
+
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_HZ", raw)
+        mesh = Mesh(object(), peer_id="rate-parity")
+        assert mesh._resolve_camera_hz() == 0.0
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_teleop_apply_ceiling_falls_back_to_its_default(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", raw)
+        assert mesh_input._input_max_hz() == INPUT_MAX_HZ_DEFAULT
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_every_reader_returns_a_rate_a_period_can_be_built_from(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str
+    ) -> None:
+        """The property the readers must share, asserted on all three at once."""
+        import math
+
+        from strands_robots.mesh.core import Mesh
+
+        monkeypatch.setenv(_ENV, raw)
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_HZ", raw)
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", raw)
+        resolved = {
+            "sensor loop": mesh_sensors._resolve_hz(_ENV, 10.0),
+            "camera loop": Mesh(object(), peer_id="rate-parity-all")._resolve_camera_hz(),
+            "teleop apply ceiling": mesh_input._input_max_hz(),
+        }
+        for reader, hz in resolved.items():
+            assert math.isfinite(hz), f"{reader} returned {hz!r} for {raw!r}"
+            assert hz >= 0.0, f"{reader} returned {hz!r} for {raw!r}"

--- a/tests/mesh/test_sensor_readers.py
+++ b/tests/mesh/test_sensor_readers.py
@@ -11,6 +11,7 @@ severity - is asserted on its outputs rather than implicitly.
 from __future__ import annotations
 
 import threading
+import time
 from typing import Any
 
 import numpy as np
@@ -73,6 +74,21 @@ def test_resolve_hz_non_positive_disables(monkeypatch: pytest.MonkeyPatch) -> No
     assert _resolve_hz("STRANDS_MESH_TEST_HZ", 5.0) == 0.0
     monkeypatch.setenv("STRANDS_MESH_TEST_HZ", "-2")
     assert _resolve_hz("STRANDS_MESH_TEST_HZ", 5.0) == 0.0
+
+
+@pytest.mark.parametrize("value", ["inf", "-inf", "nan", "1e999"])
+def test_resolve_hz_non_finite_falls_back_to_default(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """A non-finite override keeps the loop at its default rate.
+
+    ``float()`` accepts "inf"/"nan" and overflows "1e999" to inf, so these slip
+    past the unparsable-value guard. Each caller then computes
+    ``period = 1.0 / hz``: inf gives a zero period, so ``_stop_event.wait(0)``
+    returns immediately and the publish loop busy-spins; nan compares False
+    against ``hz > 0`` and silently switches the topic off. Neither is a rate an
+    operator can have meant, so the loop keeps the default it documents.
+    """
+    monkeypatch.setenv("STRANDS_MESH_TEST_HZ", value)
+    assert _resolve_hz("STRANDS_MESH_TEST_HZ", 9.0) == 9.0
 
 
 # _read_pose ----------------------------------------------------------------
@@ -407,6 +423,50 @@ def test_sensor_loop_swallows_tick_error_and_exits_cleanly(
     # Must not raise despite the reader blowing up on the only tick.
     getattr(host, loop_name)()
     assert host.published == []
+
+
+@pytest.mark.parametrize(("loop_name", "hz_env", "_reader"), _SENSOR_LOOPS)
+def test_sensor_loop_paces_itself_when_rate_env_is_non_finite(
+    monkeypatch: pytest.MonkeyPatch,
+    loop_name: str,
+    hz_env: str,
+    _reader: str,
+) -> None:
+    """A non-finite rate override must not turn the loop into a busy-spin.
+
+    ``STRANDS_MESH_*_HZ=inf`` resolves through ``float()`` to a rate whose
+    period is ``1.0 / inf == 0.0``, so ``_stop_event.wait(0.0)`` returns
+    immediately and the loop publishes to the mesh as fast as the CPU allows --
+    a flood, from one environment typo, on whichever topics the robot exposes.
+    Falling back to the documented default instead keeps the loop paced.
+
+    The bound is deliberately loose so the assertion does not depend on how
+    fast the host is: the highest default sensor rate is 50 Hz, which is a
+    handful of publishes in this window, while an unpaced loop reaches five to
+    six orders of magnitude more.
+    """
+    monkeypatch.setenv(hz_env, "inf")
+    host = _host(
+        _pose={"x": 0.0, "y": 0.0, "z": 0.0},
+        _imu={"roll": 0.0, "pitch": 0.0, "yaw": 0.0},
+        _odom={"x": 0.0, "y": 0.0},
+        _lidar_summary={"points": 1},
+        _hands={"left": {"joints": [0.0]}},
+        _map_info={"resolution": 0.05},
+    )
+    thread = threading.Thread(target=getattr(host, loop_name), daemon=True)
+    thread.start()
+    try:
+        time.sleep(0.15)
+    finally:
+        host._running = False
+        host._stop_event.set()
+        thread.join(timeout=5.0)
+    assert not thread.is_alive()
+    # A loop that published nothing would satisfy any upper bound, so pin both
+    # ends: the topic stayed live *and* it was paced.
+    assert host.published, f"{loop_name} published nothing; the bound below would be vacuous"
+    assert len(host.published) < 500, f"{loop_name} published {len(host.published)} times unpaced"
 
 
 @pytest.mark.parametrize(("loop_name", "hz_env", "reader"), _SENSOR_LOOPS)


### PR DESCRIPTION
## Problem

Every mesh loop rate is operator-tunable through an environment variable, and every consumer turns that rate into a period with `1.0 / hz`. `float()` accepts `"inf"`, overflows `"1e999"` to `inf` and accepts `"nan"`, and neither survives that division:

- `inf` gives a **zero period**, so a loop that meant to wait between ticks never waits.
- `nan` gives a period that compares `False` against every bound, so a cap built from it never trips.

Both read as "no rate limit" rather than as the misconfiguration they are. `Mesh._resolve_camera_hz` already refused non-finite input for exactly this reason, and `_zenoh_config._float_env` spells out the same argument in its docstring for the config-load path. The seven sensor publish loops (`_resolve_hz`) and the teleop apply-rate ceiling (`_input_max_hz`), which compute the same period from the same kind of value, did not.

### Measured on `main`

| variable | resolved to | observed |
|---|---|---|
| `STRANDS_MESH_POSE_HZ=inf` | `inf` | `_pose_loop` published **452,598** pose samples in 0.6 s (~750 kHz) against the 10 Hz that variable documents |
| `STRANDS_MESH_POSE_HZ=1e999` | `inf` | same |
| `STRANDS_MESH_POSE_HZ=nan` | `0.0` | topic silently switched off, no warning |
| `STRANDS_MESH_INPUT_MAX_HZ=inf` | `inf` | `min_interval = 0.0`, so no frame is ever early enough to drop: a 200-frame burst applied **200/200**, `rate_dropped=0` |
| `STRANDS_MESH_INPUT_MAX_HZ=nan` | `nan` | `max_hz > 0` is `False`, so the rate block is skipped entirely: **200/200** applied, `rate_dropped=0` |

Every sensor topic behaved like `pose` (`_imu_loop` 109,457, `_map_info_loop` 118,978, `_lidar_loop` 106,156 publishes in a 0.15 s window). The second row group matters more: `STRANDS_MESH_INPUT_MAX_HZ` is the ceiling that exists so a peer streaming above the nominal publish rate cannot slam servos into overcurrent, thermal or gear damage. Only an explicit `0` is documented to disable a rate limit.

## Change

The rule deciding which environment-held rates are usable now lives in one place, `strands_robots.mesh.session.hz_from_env`, next to the `*_HZ` constants it governs. It reports a value no loop can honor and leaves the fallback to each reader, because the readers genuinely differ there and always did:

| reader | fallback for an unusable value |
|---|---|
| `sensors._resolve_hz` | keeps the loop's built-in rate (and warns) |
| `Mesh._resolve_camera_hz` | leaves camera publishing off (frames are large; falling back to a rate nobody asked for would be worse) |
| `input._input_max_hz` | reverts to the default ceiling, so the servos stay protected |

No previously working value changes behaviour: a finite rate is returned verbatim, sign and zero stay the caller's decision, and `_resolve_camera_hz` keeps its existing outcomes exactly (its inline finite check is now the shared one). `_input_max_hz` deliberately does not log - it is evaluated per applied frame in a 50 Hz-plus loop - which is noted in its docstring.

## Evidence

![non-finite mesh rate env](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-rate-env/mesh_rate_env.png)

Left: the pose publish loop under `STRANDS_MESH_POSE_HZ=inf` - the red trace is a vertical wall (452,598 samples in 0.6 s) against the dashed 10 Hz reference the variable documents; the green trace tracks it. Right: a 200-frame burst arriving at ~1.7 kHz under `STRANDS_MESH_INPUT_MAX_HZ=inf` - before, all 200 frames reach the robot with `rate_dropped=0`; after, 12 are applied along the 100 Hz ceiling and 188 are dropped-and-counted. Both "before" traces were recorded against `upstream/main` sources.

## Tests

`tests/mesh/test_rate_env_resolution.py` (new) pins the shared decision and, more importantly, pins **parity**: a test asserts all three readers return a rate a `1.0 / hz` period can actually be built from, which is the property that drifted. Behavioural pins live in the existing homes - `tests/mesh/test_sensor_readers.py` runs each of the seven loops for 0.15 s under `=inf` and asserts the topic stayed live *and* stayed paced (both ends, so the bound cannot pass vacuously), and `tests/mesh/test_input_stream_lifecycle.py` asserts a burst is still dropped.

Against `upstream/main` sources with the tests in place: **36 failed, 10 passed** - including all seven `_*_loop` pacing pins and every receiver burst pin. After: all pass.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: no new errors (one pre-existing `simulation/ik.py:105` `no-any-return` that only appears when `qpsolvers` is installed locally).
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **12601 passed, 260 skipped** in 432 s.
- `python scripts/assemble_changelog.py --check`: OK; fragment added under `changelog.d/`.

README's mesh env table now documents the sensor rate family and `STRANDS_MESH_CAMERA_HZ`, and states the fallback on the `STRANDS_MESH_INPUT_MAX_HZ` row.

### Sync round: teleop source scoping landed on `main`

`main` gained `validate_mesh_identifier` for teleop source scoping, which
expanded the `strands_robots.mesh.security` import in
`strands_robots/mesh/input.py` that this branch also edits. git reported a
conflict on that import block alone - adjacent additions, not competing ones.

Resolved as the union of the two import lists; `validate_mesh_identifier` (6
uses, from `main`) and `hz_from_env` (2 uses, from this branch) are both live.
No source behaviour, test, or artifact changed in this round.

`pytest tests/mesh` reports the same 26 failures on the merge result as on a
clean `main` in this sandbox (all missing optional extras - `json5`, `awsiot`,
`cv2` - plus the `so100` asset download), with 2206 passed against `main`'s
2144: the delta is this branch's own tests, and no baseline test moved.

### Sync round: both rate guards are kept (commit 73a704ef)

#1684 landed on `main` and added a shared `positive_finite_number_error` guard on
the caller-supplied `InputPublisher` `hz`, placing its import at the same anchor
this branch uses for `hz_from_env`. That turned the branch `CONFLICTING` on
import ordering alone, not on meaning, so the resolution is again the union -
and the merge is a plain merge commit, no rebase or force-push, so the review
trail is intact.

The two guards are orthogonal and both are live:

| guard | value it decides | surface |
|---|---|---|
| `hz_from_env` (this branch) | operator env var `STRANDS_MESH_INPUT_MAX_HZ` | receive-side apply ceiling |
| `positive_finite_number_error` (`main`) | `hz` argument passed by the caller | publish-side rate, refused at construction |

Different values on different surfaces, and neither reads state the other
writes. They share only the observation this PR is about: a non-finite rate
divides into a zero or `nan` period and so reads as "no rate limit" rather than
as the misconfiguration it is. `main` now applies that reasoning to the
argument; this branch applies it to the environment.

**The only edit in this round is the import union.** No source, test, artifact
or changelog fragment on this branch changed.

Verified on the merge result:

* `ruff check`, `ruff format --check` and `ruff check --select I` clean on
  `strands_robots/mesh/input.py` (the isort rule confirms the two imports are in
  the right order); both names resolve at runtime.
* `tests/mesh/test_rate_env_resolution.py`,
  `tests/mesh/test_input_stream_lifecycle.py`,
  `tests/mesh/test_input_slew_bound.py` and the merged-in
  `tests/test_teleop_rate_and_duration_guards.py`: **198 passed together**, so
  both sides' pins hold at once.
* Full `tests/mesh/`: the failure set is **byte-identical** to the same run on a
  clean checkout of the new base - 84 failed / 18 errors on both, entirely
  optional-dependency gaps in this sandbox (`awsiot`, ACL config) - while passes
  go 2106 -> 2168. The +62 is this branch's own tests; no baseline test moved.

## 13. Round changelog

### Branch sync - `main` merged in, no change to this PR's own diff

The single required check was failing on a pin this PR does not touch:

```
FAILED tests/test_hardware_control_loop_rate_guard.py::TestPeriodIsTheOnlyThrottle::
  test_a_non_positive_period_leaves_the_loop_unthrottled
```

That assertion is an absolute iteration floor no GitHub runner reaches (#1707). It is
deterministic rather than flaky: re-running this branch's job at the same commit failed
identically, same assertion, same counts. The fix landed on `main` in #1709, so `main`
is merged into this branch to pick it up.

No file this PR owns changed in that merge. The ruleset dismissed the standing approval
automatically on push (`dismiss_stale_reviews_on_push`, `require_last_push_approval`),
so a re-approval is required for the merge to proceed - the diff under review is
identical to the state that was approved.
