### PR TITLE
fix(sim): integrate a scene object's inertia from its shape

### DIFF
--- a/changelog.d/1694-object-inertia-from-shape.md
+++ b/changelog.d/1694-object-inertia-from-shape.md
@@ -1,0 +1,26 @@
+### Fixed: a scene object's rotational inertia is integrated from its shape
+
+`add_object` declared a dynamic object's mass on the body together with a
+hard-coded inertia diagonal (`[0.001, 0.001, 0.001]`). `body_mass` was
+therefore correct and the object fell exactly as it should, so only its
+*rotational* dynamics were wrong - and wrong by orders of magnitude in a
+direction that flipped with size. For a 100 g cube the true diagonal is
+`m/6 * a**2`: at 1 cm the constant is 600x too large, at 5 cm 24x too large,
+and for a 30 cm 1 kg crate it is 15x too small. A single constant also cannot
+represent an anisotropic body at all, so every cylinder, capsule and non-cubic
+box lost the `Izz != Ixx` that decides which way it topples.
+
+The mass is now declared on the geom, so MuJoCo's compiler integrates the
+inertia tensor over the shape the caller asked for. Given the torque that
+should turn it a quarter turn in one second, a 6 cm matchstick previously
+rotated 0.6 degrees and a 40 cm plank spun 2448 degrees; both now turn 86
+degrees.
+
+Because the inertia now scales with the shape, MuJoCo's "mass and inertia of
+moving bodies must be larger than mjMINVAL" invariant becomes shape-dependent:
+a mass above `mjMINVAL` can still integrate to an inertia below it on a very
+small geom. `add_object` keeps its numeric mass pre-check (reproducing the
+per-shape bound would mean reimplementing the compiler's integration) and the
+residual case now reports the compiler's own reason, which names both mass and
+inertia, instead of the generic `"spec recompile refused."` that left the
+actionable text in the log.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -68,7 +68,7 @@ def _sync_cached_xml(world: SimWorld, spec: Any) -> None:
         logger.debug("spec.to_xml() failed; cached XML left stale: %s", xml_err)
 
 
-def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
+def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal: bool = False) -> bool:
     """Recompile ``spec`` in place, replacing ``world._model`` and ``_data``.
 
     Uses ``spec.recompile(model, data)`` which auto-preserves qpos/qvel for
@@ -78,6 +78,16 @@ def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
     Also re-discovers per-robot joint and actuator IDs (they may have shifted
     as new bodies were inserted earlier in the body tree). Returns True on
     success, False on compile failure (logged).
+
+    Args:
+        world: The scene whose model/data are replaced on success.
+        spec: The ``MjSpec`` to compile.
+        raise_on_refusal: Re-raise the compiler's exception instead of folding
+            it into a ``False`` return. A refusal message names what the
+            compiler could not honor, and a ``bool`` cannot carry it: a caller
+            that reports the reason to a user needs it, whereas a caller that
+            only rolls back does not. Off by default so existing callers keep
+            the ``bool`` contract.
     """
     mj = _ensure_mujoco()
     try:
@@ -85,6 +95,8 @@ def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
             new_model, new_data = spec.recompile(world._model, world._data)
     except (ValueError, RuntimeError) as e:
         logger.error("spec.recompile failed: %s", e)
+        if raise_on_refusal:
+            raise
         return False
 
     world._model = new_model
@@ -216,11 +228,27 @@ def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
         SpecBuilder.remove_mesh(spec, f"mesh_{obj.name}")
         raise
 
-    if not _recompile_preserving_state(world, spec):
-        # Roll the just-added body (and any mesh asset) back out so the spec
-        # returns to its last good, compilable state (a worldbody body delete
-        # is safe - the attach/delete segfault only affects spec.attach()
-        # child specs).
+    # Roll the just-added body (and any mesh asset) back out so the spec
+    # returns to its last good, compilable state (a worldbody body delete is
+    # safe - the attach/delete segfault only affects spec.attach() child specs).
+    #
+    # Ask for the compiler's own reason rather than a bare False. Because the
+    # object's mass is declared on its geom, MuJoCo integrates the inertia from
+    # the shape, so its "mass and inertia of moving bodies must be larger than
+    # mjMINVAL" floor is shape-dependent: a mass above mjMINVAL can still
+    # integrate to an inertia below it on a small geom. add_object's numeric
+    # pre-check cannot express that floor without duplicating the compiler's
+    # per-shape integration, so the residual case has to arrive as the reason
+    # the compiler gives. Folded into a False it became "spec recompile
+    # refused." with the actionable text left in the log - the same dead end
+    # the unsupported-shape path was fixed to stop producing.
+    try:
+        recompiled = _recompile_preserving_state(world, spec, raise_on_refusal=True)
+    except (ValueError, RuntimeError):
+        SpecBuilder.remove_body(spec, obj.name)
+        SpecBuilder.remove_mesh(spec, f"mesh_{obj.name}")
+        raise
+    if not recompiled:
         SpecBuilder.remove_body(spec, obj.name)
         SpecBuilder.remove_mesh(spec, f"mesh_{obj.name}")
         return False

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2642,9 +2642,15 @@ class MuJoCoSimEngine(
                 return mass_err
             # MuJoCo additionally refuses to compile a moving body lighter than
             # mjMINVAL ("mass and inertia of moving bodies must be larger than
-            # mjMINVAL"), which is the last mass value that reached the generic
-            # recompile refusal. Name the floor instead, so every mass this
-            # method accepts is one the compiler accepts.
+            # mjMINVAL"). Name that floor here so the common case is rejected by
+            # parameter name rather than by a recompile. It is a necessary but
+            # not a sufficient condition: the same invariant also covers the
+            # INERTIA, which the compiler integrates from the geom's shape, so a
+            # mass above this floor can still integrate to an inertia below it
+            # on a very small geom. Reproducing that bound here would mean
+            # reimplementing MuJoCo's per-shape integration, so the residual
+            # case is reported with the compiler's own message instead (see
+            # scene_ops.inject_object_into_scene).
             minimum = float(_ensure_mujoco().mjMINVAL)
             if float(mass) < minimum:
                 return {

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -511,10 +511,11 @@ class SpecBuilder:
     def add_object(spec: Any, obj: SimObject) -> None:
         """Add a ``SimObject`` to ``spec.worldbody`` in-place.
 
-        * Dynamic objects (``is_static=False``) get a freejoint + explicit
-          inertial block (diag 0.001, user-supplied mass) matching the
-          legacy builder.
-        * Static objects skip the freejoint and inertial.
+        * Dynamic objects (``is_static=False``) get a freejoint and declare
+          ``obj.mass`` on the GEOM, so MuJoCo's compiler integrates the
+          inertia tensor from the shape the caller actually asked for.
+        * Static objects skip the freejoint and the mass declaration; their
+          compiled mass comes from the geom's default density.
         * Meshes require a matching ``spec.add_mesh(...)`` to have been
           registered (usually by :meth:`build`); this method does NOT
           register mesh assets.
@@ -548,10 +549,6 @@ class SpecBuilder:
 
             if not obj.is_static:
                 body.add_freejoint(name=f"{obj.name}_joint")
-                body.mass = float(obj.mass)
-                body.inertia = [0.001, 0.001, 0.001]
-                body.ipos = [0.0, 0.0, 0.0]
-                body.explicitinertial = True
 
             geom_kwargs: dict[str, Any] = {
                 "name": f"{obj.name}_geom",
@@ -570,6 +567,33 @@ class SpecBuilder:
 
             if material_name is not None:
                 geom_kwargs["material"] = material_name
+
+            if not obj.is_static:
+                # Declare the mass on the GEOM rather than on the body. A geom
+                # mass makes MuJoCo's compiler integrate the inertia tensor
+                # over the shape the caller asked for; a body-level explicit
+                # inertial block requires an inertia tensor to be supplied with
+                # it, and there is no tensor to invent for an arbitrary shape.
+                # The constant diagonal this replaced was wrong by orders of
+                # magnitude in BOTH directions and the direction flipped with
+                # size: for a 1 cm 100 g cube 0.001 is 600x the true value, so
+                # the cube resisted rotation like a flywheel and refused to
+                # tumble or spin out of a gripper; for a 30 cm 1 kg crate it is
+                # 15x too SMALL, so the crate spun as if hollow. Translation
+                # was unaffected (``body_mass`` was right), which is exactly
+                # what kept it silent - the object fell correctly and only its
+                # rotation was wrong.
+                #
+                # Consequence worth knowing: the compiled inertia now scales
+                # with the shape, so MuJoCo's "mass and inertia of moving
+                # bodies must be larger than mjMINVAL" floor becomes
+                # shape-dependent - a mass that clears mjMINVAL itself can
+                # still integrate to an inertia below it on a small geom.
+                # ``_validate_mass`` deliberately stays a mass-only pre-check
+                # (a fixed numeric bound cannot express a shape-dependent
+                # floor); the residual case surfaces MuJoCo's own reason, which
+                # names both mass and inertia.
+                geom_kwargs["mass"] = float(obj.mass)
 
             body.add_geom(**geom_kwargs)
         except (ValueError, RuntimeError):

--- a/tests/simulation/mujoco/test_add_object_mass_contract.py
+++ b/tests/simulation/mujoco/test_add_object_mass_contract.py
@@ -102,8 +102,31 @@ class TestAddObjectMassDomain:
         result = sim.add_object("dust", shape="box", mass=1e-16)
         assert result["status"] == "error", result
         assert "mjMINVAL" in result["content"][0]["text"]
-        # The floor itself is accepted, so the boundary is not over-tightened.
-        assert sim.add_object("speck", shape="box", mass=float(mujoco.mjMINVAL))["status"] == "success"
+        # Not over-tightened: a mass far below any physical object still
+        # compiles, because the bound that matters is on the integrated inertia.
+        assert sim.add_object("speck", shape="box", mass=1e-9)["status"] == "success"
+
+    def test_a_mass_whose_inertia_falls_under_the_floor_reports_the_compiler_reason(self, sim):
+        """The mass floor is necessary, not sufficient - and the residual says why.
+
+        MuJoCo's invariant covers the mass *and* the inertia, and the inertia is
+        integrated from the geom's shape, so a mass at ``mjMINVAL`` integrates to
+        an inertia far below it on a 5 cm cube. ``add_object``'s numeric
+        pre-check cannot express that bound without reimplementing the
+        compiler's per-shape integration, so this case has to arrive as the
+        compiler's own message rather than as the generic
+        ``"spec recompile refused."`` that left the reason in the log.
+        """
+        result = sim.add_object("speck", shape="box", mass=float(mujoco.mjMINVAL))
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "mass and inertia" in text, text
+        assert "spec recompile refused" not in text
+
+        # The refusal rolled the half-built body back out, so the scene is still
+        # usable and the name is still free.
+        assert "speck" not in sim._world.objects
+        assert sim.add_object("speck", shape="box", mass=1.0)["status"] == "success"
 
     def test_non_numeric_mass_leaves_the_scene_usable(self, sim):
         """Pre-fix this raised mid-mutation and bricked every later scene edit."""

--- a/tests/simulation/mujoco/test_object_inertia_from_shape.py
+++ b/tests/simulation/mujoco/test_object_inertia_from_shape.py
@@ -1,0 +1,223 @@
+"""A dynamic object's inertia is integrated from its shape, not a constant.
+
+``add_object`` used to declare an explicit body-level inertial block with a
+hard-coded diagonal - ``body.inertia = [0.001, 0.001, 0.001]`` - alongside the
+caller's mass. ``body_mass`` was therefore correct and the object fell exactly
+as it should, which is precisely what kept the defect silent: only the
+*rotational* dynamics were wrong, and they were wrong by orders of magnitude in
+a direction that flipped with size.
+
+For a 100 g cube the true diagonal is ``m/6 * a**2``:
+
+* 1 cm cube: ``1.67e-6`` - the constant is **600x too large**, so the cube
+  resisted rotation like a flywheel and would not tumble on impact or spin out
+  of a gripper.
+* 5 cm cube: ``4.17e-5`` - **24x too large**.
+* 30 cm 1 kg crate: ``0.015`` - the constant is **15x too small**, so the crate
+  spun up as if it were hollow.
+
+A single constant also cannot represent an anisotropic body at all: every real
+cylinder, capsule and non-cubic box has ``Izz != Ixx``, and forcing them equal
+removes the preferred spin axis that decides how an object topples.
+
+Declaring the mass on the GEOM instead lets MuJoCo's compiler integrate the
+tensor over the shape the caller actually asked for. The tests below check the
+compiled tensor against the closed-form rigid-body formulas (an oracle
+independent of the code under test) and then confirm the physical consequence:
+a torque impulse spins the body up at the rate its true inertia implies.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# The constant diagonal that used to be written for every dynamic object.
+LEGACY_CONSTANT_INERTIA = 0.001
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_object_inertia", mesh=False)
+    s.create_world()
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _compiled(sim: Simulation, name: str) -> tuple[float, np.ndarray]:
+    """Return the compiled ``(body_mass, body_inertia)`` for a named body."""
+    assert sim._world is not None and sim._world._model is not None
+    model = sim._world._model
+    body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    assert body_id >= 0, f"body {name!r} not in the compiled model"
+    return float(model.body_mass[body_id]), np.array(model.body_inertia[body_id])
+
+
+# Closed-form principal inertias for a uniform solid, in terms of the FULL
+# extents ``add_object`` documents (not MuJoCo's half-extents). Each entry is
+# (shape, size, mass, expected diagonal).
+ANALYTIC_CASES = [
+    pytest.param(
+        "box",
+        [0.01, 0.01, 0.01],
+        0.1,
+        [0.1 / 12.0 * (0.01**2 + 0.01**2)] * 3,
+        id="1cm-cube-legacy-was-600x-too-large",
+    ),
+    pytest.param(
+        "box",
+        [0.05, 0.05, 0.05],
+        0.1,
+        [0.1 / 12.0 * (0.05**2 + 0.05**2)] * 3,
+        id="5cm-cube-legacy-was-24x-too-large",
+    ),
+    pytest.param(
+        "box",
+        [0.30, 0.30, 0.30],
+        1.0,
+        [1.0 / 12.0 * (0.30**2 + 0.30**2)] * 3,
+        id="30cm-crate-legacy-was-15x-too-small",
+    ),
+    pytest.param(
+        "box",
+        [0.40, 0.10, 0.02],
+        2.0,
+        [
+            2.0 / 12.0 * (0.10**2 + 0.02**2),
+            2.0 / 12.0 * (0.40**2 + 0.02**2),
+            2.0 / 12.0 * (0.40**2 + 0.10**2),
+        ],
+        id="plank-anisotropic-no-constant-can-express-it",
+    ),
+    pytest.param(
+        "sphere",
+        [0.04, 0.04, 0.04],
+        0.2,
+        [2.0 / 5.0 * 0.2 * 0.02**2] * 3,
+        id="sphere-two-fifths-m-r-squared",
+    ),
+    pytest.param(
+        "cylinder",
+        [0.06, 0.06, 0.10],
+        0.5,
+        [
+            0.5 / 12.0 * (3.0 * 0.03**2 + 0.10**2),
+            0.5 / 12.0 * (3.0 * 0.03**2 + 0.10**2),
+            0.5 * 0.5 * 0.03**2,
+        ],
+        id="cylinder-distinct-spin-axis",
+    ),
+]
+
+
+class TestInertiaIntegratedFromTheShape:
+    @pytest.mark.parametrize(("shape", "size", "mass", "expected"), ANALYTIC_CASES)
+    def test_compiled_inertia_matches_the_closed_form_solid(self, sim, shape, size, mass, expected):
+        """The tensor is the shape's real one, and the mass is still honored."""
+        result = sim.add_object("body", shape=shape, size=size, position=[0.0, 0.0, 0.5], mass=mass)
+        assert result["status"] == "success", result
+
+        compiled_mass, inertia = _compiled(sim, "body")
+        # Translation was never broken; keep it pinned so the fix cannot trade
+        # a correct tensor for a wrong mass.
+        assert compiled_mass == pytest.approx(mass)
+        assert inertia == pytest.approx(np.array(expected), rel=1e-6)
+
+    def test_the_legacy_constant_erred_in_both_directions(self, sim):
+        """One number cannot serve a 1 cm cube and a 30 cm crate.
+
+        This is the whole reason a constant is unusable rather than merely
+        imprecise: it is too large for a small object and too small for a large
+        one, so no choice of constant is safe.
+        """
+        assert (
+            sim.add_object("pebble", shape="box", size=[0.01] * 3, position=[0, 0, 0.5], mass=0.1)["status"]
+            == "success"
+        )
+        assert (
+            sim.add_object("crate", shape="box", size=[0.30] * 3, position=[1, 0, 0.5], mass=1.0)["status"] == "success"
+        )
+
+        _, pebble = _compiled(sim, "pebble")
+        _, crate = _compiled(sim, "crate")
+
+        assert LEGACY_CONSTANT_INERTIA / pebble[0] == pytest.approx(600.0, rel=1e-3)
+        assert LEGACY_CONSTANT_INERTIA / crate[0] == pytest.approx(1.0 / 15.0, rel=1e-3)
+
+    def test_a_static_object_still_takes_its_mass_from_the_geom_density(self, sim):
+        """Static bodies are unchanged: no freejoint, no mass declaration.
+
+        ``mass`` is documented as ignored for a static body, and its compiled
+        mass comes from the geom's default density (1000 kg/m^3 x a 5 cm cube =
+        0.125 kg). Pinned so the change stays confined to dynamic objects.
+        """
+        result = sim.add_object("tile", shape="box", size=[0.05] * 3, mass=9.0, is_static=True)
+        assert result["status"] == "success", result
+        compiled_mass, _ = _compiled(sim, "tile")
+        assert compiled_mass == pytest.approx(0.125)
+
+    def test_the_inertia_survives_a_later_scene_recompile(self, sim):
+        """Every scene mutation recompiles the spec; the tensor is rebuilt from it.
+
+        The mass lives on the geom in the spec rather than in a constant
+        inertial block, so an unrelated later edit must reproduce the same
+        integrated tensor instead of reverting to a default.
+        """
+        assert (
+            sim.add_object("crate", shape="box", size=[0.05] * 3, position=[0, 0, 0.3], mass=0.1)["status"] == "success"
+        )
+        before = _compiled(sim, "crate")
+
+        assert sim.add_camera("side", position=[1.0, 0.0, 0.5], target=[0.0, 0.0, 0.1])["status"] == "success"
+        assert sim.add_object("marker", shape="sphere", size=[0.02] * 3, position=[0.4, 0, 0.1])["status"] == "success"
+
+        after = _compiled(sim, "crate")
+        assert after[0] == pytest.approx(before[0])
+        assert after[1] == pytest.approx(before[1])
+
+
+class TestInertiaChangesTheDynamics:
+    def test_a_torque_spins_the_body_up_at_the_rate_its_true_inertia_implies(self):
+        """The consequence, not just the number in the model.
+
+        With gravity off, a latched torque about z gives ``omega = tau * t / Izz``
+        for a free body. The 5 cm 100 g cube's true ``Izz`` is 24x smaller than
+        the constant that used to be compiled, so the same impulse produced a
+        24x slower spin - a cube that would not be flicked over by a nudge and
+        would not rotate in a gripper's grasp.
+        """
+        sim = Simulation(tool_name="devx_object_inertia_spin", mesh=False)
+        try:
+            sim.create_world(gravity=[0.0, 0.0, 0.0])
+            assert (
+                sim.add_object("cube", shape="box", size=[0.05] * 3, position=[0, 0, 0.5], mass=0.1)["status"]
+                == "success"
+            )
+
+            izz = _compiled(sim, "cube")[1][2]
+            torque = 1e-4
+            assert sim.apply_force("cube", torque=[0.0, 0.0, torque])["status"] == "success"
+
+            model = sim._world._model
+            assert model is not None
+            duration = 0.2
+            sim.step(int(round(duration / float(model.opt.timestep))))
+
+            state = sim.get_body_state("cube")
+            omega_z = [c["json"] for c in state["content"] if "json" in c][0]["angular_velocity"][2]
+
+            assert omega_z == pytest.approx(torque * duration / izz, rel=0.02)
+            # And the same impulse under the old constant tensor would have been
+            # a small fraction of that - the observable size of the defect.
+            legacy_omega = torque * duration / LEGACY_CONSTANT_INERTIA
+            assert omega_z > 20.0 * legacy_omega
+        finally:
+            sim.cleanup(policy_stop_timeout=0.5)


### PR DESCRIPTION
## Problem

`add_object` declared a dynamic object's mass on the body together with a hard-coded inertia diagonal:

```python
body.mass = float(obj.mass)
body.inertia = [0.001, 0.001, 0.001]
body.explicitinertial = True
```

`body_mass` was therefore correct and the object fell exactly as it should. That is precisely what kept this silent: only the **rotational** dynamics were wrong, and they were wrong by orders of magnitude in a direction that **flipped with size**. For a 100 g cube the true diagonal is `m/6 * a**2`:

| object | true `Izz` | compiled | error |
|---|---|---|---|
| 1 cm cube, 100 g | `1.67e-6` | `0.001` | **600x too large** |
| 5 cm cube, 100 g | `4.17e-5` | `0.001` | **24x too large** |
| 30 cm crate, 1 kg | `0.015` | `0.001` | **15x too small** |

So no choice of constant is safe: small objects resisted rotation like a flywheel (a cube would not tumble on impact or rotate inside a gripper's grasp), large ones spun up as if hollow. A single constant also cannot represent an anisotropic body at all, so every cylinder, capsule and non-cubic box lost the `Izz != Ixx` that decides which way it topples.

## Change

Declare the mass on the **geom**, so MuJoCo's compiler integrates the tensor over the shape the caller asked for. A body-level explicit inertial block requires a tensor to be supplied with it, and there is no tensor to invent for an arbitrary shape.

Static objects are untouched: no freejoint, no mass declaration, compiled mass still derived from the geom density (pinned).

### The mass floor becomes shape-dependent

MuJoCo's invariant covers the mass **and** the inertia, and the inertia is now integrated from the shape, so a mass above `mjMINVAL` can still integrate to an inertia below it on a very small geom. `add_object` keeps its numeric `mjMINVAL` pre-check — reproducing the per-shape bound would mean reimplementing the compiler's integration, and duplicating a compiler is how a guard drifts. The residual case instead reports the compiler's own reason, which names both mass and inertia:

```
before: Failed to inject 'speck': spec recompile refused.        # reason in the log only
after:  Failed to inject 'speck' into live scene: Error: mass and inertia of
        moving bodies must be larger than mjMINVAL ...
```

That needed `_recompile_preserving_state` to be able to carry the refusal message, which a `bool` cannot. It gained an opt-in keyword-only `raise_on_refusal` (default off, so all nine existing call sites keep the `bool` contract) and `inject_object_into_scene` rolls back and re-raises — the same rollback-then-raise the unsupported-shape path already uses for exactly this reason.

## Visual artifact

Each object is given the torque that should turn it a quarter turn in 1.0 s **at its true inertia**. Same scene, same impulse, run against both trees in MuJoCo headless (`MUJOCO_GL=egl`):

![object inertia before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/object-inertia/inertia.gif)

| object | before | after |
|---|---|---|
| 6 cm matchstick, 20 g | `Izz=0.001` (150x true), turned **0.6 deg** | `Izz=6.67e-6`, turned **86.4 deg** |
| 40 cm plank, 2 kg | `Izz=0.001` (0.035x true), spun **2448 deg** (6.8 revolutions) | `Izz=0.0283`, turned **86.4 deg** |

One scene shows the error in both directions. Frame-to-frame check: the pre-fix matchstick is effectively still (`L1(frame 0, frame 59) = 17886`, renderer-noise scale) against `1069905` after the fix; the plank's final orientation differs by `L1 = 3.99e6` between the two runs.

## Tests

New `tests/simulation/mujoco/test_object_inertia_from_shape.py` (10 tests):

- compiled tensor vs the **closed-form** rigid-body formulas for box / anisotropic plank / sphere / cylinder — an oracle independent of the code under test, so a wrong shape mapping or a transposed axis fails here rather than being absorbed by a rendered scene. Mass is asserted in the same test so a correct tensor cannot be traded for a wrong mass.
- the constant erred in **both** directions (600x / 1/15x), which is why a constant is unusable rather than merely imprecise.
- static objects still take their mass from the geom density.
- the tensor survives an unrelated later scene recompile.
- the **consequence**: a latched torque spins the body up at `tau*t/Izz`, matching the true inertia to 2% and >20x the rate the old constant gave.

`test_add_object_mass_contract.py`: one existing boundary assertion had to change. It pinned `mass=mjMINVAL` as accepted, which was only true while the inertia was faked; it now asserts a realistically small mass (1e-9 kg) is accepted, and a new test pins that the `mjMINVAL`-but-uncompilable case reports the compiler's reason and leaves the scene usable with the name free.

Pre-fix on this base: **9 failed / 13 passed**. The dynamics test reads `omega_z = 0.0200 rad/s` pre-fix vs `0.4800` after — exactly the 24x.

## Gate

`ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (the only mypy line is the pre-existing environment-dependent `simulation/ik.py:105 Returning Any` from `qpsolvers.available_solvers`, present on an unmodified tree). Full suite: **12550 passed / 260 skipped** in 425s (`MUJOCO_GL=egl python -m pytest tests`).

## Scope

Two adjacent findings measured while verifying this are deliberately **not** in this PR, each being its own root cause:

1. Every runtime property setter is undone by the next recompile — `set_body_properties(mass=5.0)` and `set_geom_properties(friction=/size=/color=)` all report success, take effect, and are silently restored to their original values by the next unrelated `add_object`. That is a write to the derived model never reaching the spec it is rebuilt from, and it needs one contract for all four fields (`SimObject` has no `friction`/live-size state), not a mass-only patch.
2. `apply_force` zeroes the whole `qfrc_applied` buffer, so latching a wrench on a second body silently cancels the first while both report success.

Both filed separately.