### PR TITLE
security(lerobot_train): gate pretrained_path through HIL

### DIFF
--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -636,6 +636,11 @@ def lerobot_train(
                 if gate_err:
                     return gate_err
 
+            if pretrained_path:
+                gate_err = _gate_extra_flags({"policy.pretrained_path": pretrained_path}, tool_context)
+                if gate_err:
+                    return gate_err
+
             try:
                 cmd = build_train_command(
                     dataset_root=dataset_root,

--- a/tests/test_lerobot_train_blocklist.py
+++ b/tests/test_lerobot_train_blocklist.py
@@ -187,3 +187,30 @@ class TestGateExtraFlags:
     @pytest.mark.parametrize("response", ["n", "no", "nope", "", 42, None])
     def test_approve_response_negative(self, response):
         assert _approve_response(response) is False
+
+
+class TestPretrainedPathGate:
+    """Pin: the pretrained_path named parameter is gated identically to extra_flags."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic_env(self, monkeypatch):
+        monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
+        monkeypatch.delenv("STRANDS_TRAIN_EXTRA_FLAGS_ALLOW", raising=False)
+
+    def test_pretrained_path_blocked_without_approval(self):
+        """The named parameter hits the same gate as extra_flags={'policy.pretrained_path': ...}."""
+        result = _gate_extra_flags({"policy.pretrained_path": "evil/model"}, None)
+        assert result is not None
+        assert result["status"] == "error"
+
+    def test_pretrained_path_allowed_via_allowlist(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_TRAIN_EXTRA_FLAGS_ALLOW", "policy.pretrained_path")
+        result = _gate_extra_flags({"policy.pretrained_path": "trusted/model"}, None)
+        assert result is None
+
+    def test_pretrained_path_approved_via_interrupt(self):
+        ctx = MagicMock()
+        ctx.interrupt.return_value = "y"
+        result = _gate_extra_flags({"policy.pretrained_path": "org/model"}, ctx)
+        assert result is None
+        ctx.interrupt.assert_called_once()


### PR DESCRIPTION
The named `pretrained_path` parameter bypasses `_gate_extra_flags` (which only covers the `extra_flags` dict) and reaches `--policy.pretrained_path` ungated. A prompt-injected agent can supply a malicious model path without operator approval.

Fix: route it through the same `_gate_extra_flags` call. Same interrupt, same allowlist, same bypass — no new mechanisms.

```diff
+            if pretrained_path:
+                gate_err = _gate_extra_flags({"policy.pretrained_path": pretrained_path}, tool_context)
+                if gate_err:
+                    return gate_err
```

Tests: `TestPretrainedPathGate` pins blocked/allowlist/interrupt paths.