### PR TITLE
fix(sim): a latched external wrench belongs to the body it was applied to

### DIFF
--- a/changelog.d/1696-apply-force-per-body-latch.md
+++ b/changelog.d/1696-apply-force-per-body-latch.md
@@ -1,0 +1,27 @@
+### Fixed: a latched external wrench belongs to the body it was applied to
+
+`apply_force` latched its wrench in `qfrc_applied`, one world-wide
+generalized-force vector, and zeroed the whole buffer on every call to keep a
+repeated call from accumulating. That also revoked every wrench already latched
+on every other body: a second `apply_force` on a different body silently
+cancelled the first while both calls reported success, so a wind field, two
+thrusters, a magnetic gripper holding two parts, or a per-object disturbance
+sweep all quietly reduced to whichever body was named last.
+
+The wrench is now latched in the target body's own `xfrc_applied` row. Replacing
+one body's wrench cannot touch another's, so per-call idempotency is kept
+without revoking anyone else. No slice of `qfrc_applied` could have served the
+same purpose: a wrench on a body part way down a kinematic chain writes into its
+ancestors' degrees of freedom too, so there is no part of that buffer belonging
+to one body.
+
+Latching per body is also the more faithful reading of the documented contract
+that the wrench is "applied on every subsequent step". MuJoCo re-maps a
+Cartesian wrench through the current configuration on every step, whereas a
+generalized force frozen at call time stops describing the caller's world-frame
+wrench as soon as the body moves. Measured against the same force re-mapped
+every step, a two-hinge arm swinging under a constant 2 N load now tracks that
+reference to 0.005 rad where the frozen latch drifted 0.218 rad.
+
+`apply_force(body, force=[0, 0, 0])` still stops one body, and `reset()` still
+clears every latched wrench in the world.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -97,7 +97,7 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `set_gravity` | `gravity=[x,y,z]` or a scalar z-component |
 | `set_timestep` | `timestep` |
 | `get_contacts` / `get_contact_forces` | - |
-| `apply_force` | `body_name`, `force`, `torque`, `point` |
+| `apply_force` | `body_name`, `force`, `torque`, `point` - latched on that body and re-applied every step until the next `apply_force` for it, so several bodies can hold wrenches at once (`force=[0,0,0]` stops one, `reset()` stops all) |
 | `get_jacobian` | `body_name` *or* `site_name` *or* `geom_name` |
 | `get_mass_matrix` | - |
 | `inverse_dynamics` | - (compensation torques to hold the current `qpos`/`qvel`) |

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -547,12 +547,20 @@ class PhysicsMixin:
     ) -> dict[str, Any]:
         """Apply an external force and/or torque to a body (latched).
 
-        Uses mj_applyFT for precise force application at a world-frame point.
-        The force is latched in ``qfrc_applied`` and applied on every
-        subsequent ``mj_step`` until overwritten by the next ``apply_force``
-        call. Each call zeroes the buffer first (replacing, not accumulating).
+        The wrench is latched in the target body's own ``xfrc_applied`` row
+        and applied on every subsequent ``mj_step`` until the next
+        ``apply_force`` call for that body. A call replaces the wrench latched
+        on its own target rather than accumulating onto it, and leaves wrenches
+        latched on other bodies alone - so a wind field, two thrusters, or a
+        per-object disturbance sweep can hold several bodies at once.
 
-        To stop the force: ``apply_force(body, force=[0, 0, 0])``.
+        MuJoCo re-maps that Cartesian wrench into joint space on every step,
+        so a latched force keeps pointing the way the caller asked as the body
+        moves. ``force`` and ``torque`` are world-frame; a ``point`` away from
+        the body centre of mass contributes its lever-arm torque.
+
+        To stop the force on one body: ``apply_force(body, force=[0, 0, 0])``.
+        ``reset()`` clears every latched wrench in the world.
 
         Each vector may be a list, a tuple or a NumPy array (a computed wrench
         is an array), and every element must be a finite real number.
@@ -619,7 +627,7 @@ class PhysicsMixin:
                         }
 
         mj = _ensure_mujoco()
-        model, data = self._world._model, self._world._data
+        data = self._world._data
 
         body_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_BODY, body_name)
         if body_id < 0:
@@ -636,12 +644,32 @@ class PhysicsMixin:
         t = np.array([0.0, 0.0, 0.0] if torque is None else torque, dtype=np.float64)
         p = np.array(point, dtype=np.float64) if point is not None else data.xipos[body_id].copy()
 
-        # Zero the buffer first so calls are idempotent (replace, not accumulate).
-        # NOTE: MuJoCo does NOT reset qfrc_applied in mj_step - the force
-        # persists on every subsequent step until the next apply_force call.
+        # Latch the wrench in this body's own row of ``xfrc_applied``.
+        #
+        # The buffer choice is the whole per-body contract. ``qfrc_applied`` is
+        # one world-wide generalized-force vector, and a wrench on a body part
+        # way down a kinematic chain writes into its ancestors' DOFs too - so
+        # there is no slice of it that belongs to one body, and zeroing it to
+        # make a call idempotent revoked every wrench already latched on every
+        # other body. ``xfrc_applied`` is indexed by body, so replacing this
+        # body's wrench cannot touch anyone else's.
+        #
+        # It is also the more faithful latch: MuJoCo re-maps the Cartesian
+        # wrench through the current configuration on every step, whereas a
+        # generalized force frozen by mj_applyFT at call time stops describing
+        # the caller's world-frame wrench as soon as the body moves.
+        #
+        # NOTE: MuJoCo does NOT reset xfrc_applied in mj_step - the wrench
+        # persists on every subsequent step until the next apply_force call
+        # for this body (or a reset()).
         with self._lock:
-            data.qfrc_applied[:] = 0.0
-            mj.mj_applyFT(model, data, f, t, p, body_id, data.qfrc_applied)
+            # xfrc_applied's torque acts about the body centre of mass, so a
+            # force applied at an offset point contributes (point - com) x
+            # force. A caller who named no point asked for the CoM itself,
+            # where that lever arm is exactly zero.
+            com_torque = t if point is None else t + np.cross(p - data.xipos[body_id], f)
+            data.xfrc_applied[body_id, :3] = f
+            data.xfrc_applied[body_id, 3:] = com_torque
 
         return {
             "status": "success",

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2078,8 +2078,11 @@ class MuJoCoSimEngine(
         )
         base["methods"]["apply_force"] = (
             "(body_name: str, force=None, torque=None, point=None) -> dict  # "
-            "apply an external force/torque wrench to a body for the next step "
-            "(push-recovery / disturbance-rejection perturbation testing)"
+            "latch an external force/torque wrench on a body; MuJoCo re-applies "
+            "it on every subsequent step until the next apply_force for THAT "
+            "body, so several bodies can hold wrenches at once (push-recovery / "
+            "disturbance-rejection perturbation testing, wind, thrusters); "
+            "apply_force(body, force=[0,0,0]) stops one body, reset() stops all"
         )
 
         # Sim-state checkpoint + direct pose-setting surface. describe() teaches

--- a/tests/simulation/mujoco/test_apply_force_per_body_latch.py
+++ b/tests/simulation/mujoco/test_apply_force_per_body_latch.py
@@ -1,0 +1,231 @@
+"""A latched external wrench belongs to the body it was applied to.
+
+``apply_force`` latches a wrench that MuJoCo re-applies on every subsequent
+step. These tests pin who that latch belongs to: applying a wrench to one body
+must not revoke a wrench already latched on another, a second call on the same
+body must replace rather than accumulate onto it, and the latch must keep
+describing the world-frame wrench the caller asked for as the body moves.
+
+Pre-fix the wrench went into ``qfrc_applied``, one world-wide generalized-force
+vector that every call zeroed in full, so a second ``apply_force`` on a
+different body silently cancelled the first while both calls reported success.
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Two hinges in series: a wrench on ``link2`` maps onto ``link1``'s DOF as well,
+# which is why no slice of ``qfrc_applied`` can be said to belong to one body.
+ARM_XML = """
+<mujoco model="two_link">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <body name="link1" pos="0 0 0.5">
+      <joint name="j1" type="hinge" axis="0 1 0"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02" mass="0.5"/>
+      <body name="link2" pos="0.2 0 0">
+        <joint name="j2" type="hinge" axis="0 1 0"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02" mass="0.5"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _state(sim, body_name):
+    """Return the ``get_body_state`` json block for ``body_name``."""
+    result = sim.get_body_state(body_name)
+    assert result["status"] == "success", result
+    return [block["json"] for block in result["content"] if "json" in block][0]
+
+
+def _speed(sim, body_name):
+    return float(np.linalg.norm(_state(sim, body_name)["linear_velocity"]))
+
+
+@pytest.fixture
+def sim():
+    """A weightless world, so the only motion is the wrench under test."""
+    engine = Simulation(tool_name="force_latch_sim", mesh=False)
+    engine.create_world(gravity=[0.0, 0.0, 0.0])
+    yield engine
+    engine.cleanup()
+
+
+@pytest.fixture
+def two_pucks(sim):
+    """Two free bodies far enough apart that they never touch."""
+    for name, x in (("puck_a", 0.0), ("puck_b", 1.0)):
+        assert (
+            sim.add_object(name=name, shape="box", size=[0.05] * 3, position=[x, 0.0, 0.3], mass=0.1)["status"]
+            == "success"
+        )
+    return sim
+
+
+@pytest.fixture
+def arm_and_puck(sim, tmp_path):
+    """A hinge chain plus an unrelated free body."""
+    arm_file = tmp_path / "two_link.xml"
+    arm_file.write_text(ARM_XML)
+    assert sim.add_robot(name="arm", urdf_path=str(arm_file))["status"] == "success"
+    assert (
+        sim.add_object(name="puck", shape="box", size=[0.05] * 3, position=[1.0, 0.0, 0.3], mass=0.1)["status"]
+        == "success"
+    )
+    return sim
+
+
+def _hinge_angles(model, data, *joint_names):
+    """Read named hinge angles, so an unrelated body's DOFs cannot shift them."""
+    angles = []
+    for name in joint_names:
+        joint_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, name)
+        assert joint_id >= 0, f"joint {name!r} not in the compiled model"
+        angles.append(float(data.qpos[model.jnt_qposadr[joint_id]]))
+    return angles
+
+
+class TestOneLatchPerBody:
+    """A wrench latched on one body survives a wrench latched on another."""
+
+    def test_a_wrench_on_a_second_body_leaves_the_first_one_latched(self, two_pucks):
+        """Both pucks were pushed, so both must move.
+
+        Pre-fix the second call zeroed the whole buffer and ``puck_a`` stayed
+        exactly at rest while the call that requested its motion had already
+        reported success.
+        """
+        sim = two_pucks
+        assert sim.apply_force("puck_a", force=[1.0, 0.0, 0.0])["status"] == "success"
+        assert sim.apply_force("puck_b", force=[1.0, 0.0, 0.0])["status"] == "success"
+
+        sim.step(200)
+
+        assert _speed(sim, "puck_a") > 1.0, "the wrench latched on puck_a was revoked by the call targeting puck_b"
+        assert _speed(sim, "puck_b") > 1.0
+        assert _speed(sim, "puck_a") == pytest.approx(_speed(sim, "puck_b"), rel=1e-6)
+
+    def test_a_wrench_on_a_robot_link_and_on_a_free_object_coexist(self, arm_and_puck):
+        """A chain body and a free body hold their wrenches at the same time.
+
+        This is the case no per-DOF clear can express: the chain body's wrench
+        reaches its ancestors' DOFs, so there is no slice of the generalized
+        buffer that could have been cleared for it alone.
+        """
+        sim = arm_and_puck
+        assert sim.apply_force("arm/link2", force=[0.0, 0.0, -2.0])["status"] == "success"
+        assert sim.apply_force("puck", force=[1.0, 0.0, 0.0])["status"] == "success"
+
+        model, data = sim._world._model, sim._world._data
+        (joint_before,) = _hinge_angles(model, data, "arm/j1")
+        sim.step(200)
+
+        (joint_after,) = _hinge_angles(model, data, "arm/j1")
+        assert abs(joint_after - joint_before) > 0.05, "the arm never felt its latched wrench"
+        assert _speed(sim, "puck") > 1.0, "the free body never felt its latched wrench"
+
+    def test_a_second_call_on_the_same_body_replaces_its_wrench(self, two_pucks):
+        """Re-latching the same wrench is idempotent, not cumulative."""
+        sim = two_pucks
+        sim.apply_force("puck_a", force=[1.0, 0.0, 0.0])
+        sim.apply_force("puck_b", force=[1.0, 0.0, 0.0])
+        # puck_b is asked for the same wrench three times over.
+        sim.apply_force("puck_b", force=[1.0, 0.0, 0.0])
+        sim.apply_force("puck_b", force=[1.0, 0.0, 0.0])
+
+        sim.step(200)
+
+        assert _speed(sim, "puck_b") == pytest.approx(_speed(sim, "puck_a"), rel=1e-6)
+
+    def test_zeroing_one_body_leaves_the_other_pushed(self, two_pucks):
+        """A zero wrench stops its own target and only its own target."""
+        sim = two_pucks
+        sim.apply_force("puck_a", force=[1.0, 0.0, 0.0])
+        sim.apply_force("puck_b", force=[1.0, 0.0, 0.0])
+        sim.step(100)
+        a_coasting, b_accelerating = _speed(sim, "puck_a"), _speed(sim, "puck_b")
+
+        assert sim.apply_force("puck_a", force=[0.0, 0.0, 0.0])["status"] == "success"
+        sim.step(100)
+
+        assert _speed(sim, "puck_a") == pytest.approx(a_coasting, rel=1e-6), "puck_a kept accelerating after its stop"
+        assert _speed(sim, "puck_b") > b_accelerating * 1.5, "puck_b lost its wrench to the call that stopped puck_a"
+
+    def test_reset_clears_every_latched_wrench(self, two_pucks):
+        """``reset()`` is how a caller drops every wrench in the world."""
+        sim = two_pucks
+        sim.apply_force("puck_a", force=[1.0, 0.0, 0.0])
+        sim.apply_force("puck_b", force=[1.0, 0.0, 0.0])
+
+        assert sim.reset()["status"] == "success"
+        sim.step(200)
+
+        assert _speed(sim, "puck_a") == pytest.approx(0.0, abs=1e-9)
+        assert _speed(sim, "puck_b") == pytest.approx(0.0, abs=1e-9)
+
+
+class TestLatchedWrenchDirection:
+    """The latch keeps describing the wrench the caller asked for."""
+
+    def test_a_latched_force_keeps_its_world_direction_as_the_body_moves(self, arm_and_puck):
+        """A constant world-frame force stays world-frame as the arm swings.
+
+        Ground truth is the same force re-mapped through the configuration on
+        every step. A generalized force frozen at call time drifts away from it
+        by an order of magnitude more than the tolerance below once the arm has
+        turned.
+        """
+        sim = arm_and_puck
+        model, data = sim._world._model, sim._world._data
+        force = np.array([0.0, 0.0, -2.0])
+
+        truth_model = mj.MjModel.from_xml_string(ARM_XML)
+        truth_model.opt.gravity[:] = 0.0
+        truth_model.opt.timestep = model.opt.timestep
+        truth_model.opt.integrator = model.opt.integrator
+        truth_data = mj.MjData(truth_model)
+        truth_id = mj.mj_name2id(truth_model, mj.mjtObj.mjOBJ_BODY, "link2")
+        for _ in range(300):
+            truth_data.qfrc_applied[:] = 0.0
+            mj.mj_applyFT(
+                truth_model,
+                truth_data,
+                force,
+                np.zeros(3),
+                truth_data.xipos[truth_id].copy(),
+                truth_id,
+                truth_data.qfrc_applied,
+            )
+            mj.mj_step(truth_model, truth_data)
+
+        assert sim.apply_force("arm/link2", force=force)["status"] == "success"
+        sim.step(300)
+
+        assert _hinge_angles(model, data, "arm/j1", "arm/j2") == pytest.approx(
+            _hinge_angles(truth_model, truth_data, "j1", "j2"), abs=0.05
+        )
+
+    def test_a_force_at_an_offset_point_spins_a_free_body(self, two_pucks):
+        """A force off the centre of mass carries its lever-arm torque.
+
+        ``+x`` force applied above the centre of mass is a ``+y`` torque
+        (``r x F`` with ``r = +z``), so the puck must spin about ``+y`` while
+        the same force at the centre of mass leaves it unspun.
+        """
+        sim = two_pucks
+        assert sim.apply_force("puck_a", force=[2.0, 0.0, 0.0], point=[0.0, 0.0, 0.34])["status"] == "success"
+        assert sim.apply_force("puck_b", force=[2.0, 0.0, 0.0], point=[1.0, 0.0, 0.30])["status"] == "success"
+
+        sim.step(200)
+
+        assert _state(sim, "puck_a")["angular_velocity"][1] > 1.0
+        assert _state(sim, "puck_b")["angular_velocity"][1] == pytest.approx(0.0, abs=1e-6)
+        # Both were pushed with the same force, so both travel the same way.
+        assert _speed(sim, "puck_a") > 1.0
+        assert _speed(sim, "puck_b") > 1.0

--- a/tests/simulation/mujoco/test_concurrency.py
+++ b/tests/simulation/mujoco/test_concurrency.py
@@ -142,8 +142,8 @@ class TestApplyForceLatchedBehavior:
     def test_force_persists_across_multiple_steps(self, sim_with_robot):
         """Apply lateral force to a body, step 50 times, verify body moved.
 
-        This validates the docstring contract: force is latched in
-        qfrc_applied and applied on every subsequent step.
+        This validates the docstring contract: the wrench is latched on the
+        body and applied on every subsequent step.
 
         NOTE: We use an X-force (lateral) because a Z-force along the
         kinematic chain of hinge joints produces zero generalized torque
@@ -177,17 +177,26 @@ class TestApplyForceLatchedBehavior:
         )
 
     def test_zero_force_stops_effect(self, sim_with_robot):
-        """Apply force, then zero it, verify force buffer is cleared."""
+        """Apply force, then zero it, verify the latched wrench is cleared.
+
+        The wrench is latched in the target body's own ``xfrc_applied`` row, so
+        after zeroing it no body in the world is left holding an external
+        wrench.
+        """
         sim = sim_with_robot
+        model, data = sim._world._model, sim._world._data
+        body_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "arm1/link2")
+        if body_id < 0:
+            body_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "link2")
+        assert body_id >= 0
 
-        # Apply lateral (X) force - produces non-zero generalized torques
+        # Apply lateral (X) force - it is latched on link2 and nowhere else
         sim.apply_force("link2", force=[50.0, 0, 0])
-        assert np.any(sim._world._data.qfrc_applied != 0), "X-force on link2 should produce non-zero generalized forces"
+        assert np.any(data.xfrc_applied[body_id] != 0), "X-force on link2 should be latched on link2"
 
-        # Zero it - apply_force zeros buffer first, then applies zero force
+        # Zero it - this body's latched wrench is replaced by nothing
         sim.apply_force("link2", force=[0, 0, 0])
-        # After zeroing + applying zero force/torque, buffer should be all zeros
-        assert np.allclose(sim._world._data.qfrc_applied, 0.0)
+        assert np.allclose(data.xfrc_applied, 0.0)
 
 
 class TestThreadSafety:

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -232,8 +232,8 @@ class TestApplyForceValidation:
     @pytest.mark.parametrize(
         "kwargs",
         [
-            # nan/inf pass the length check and, pre-fix, are silently applied to
-            # qfrc_applied - poisoning every subsequent mj_step.
+            # nan/inf pass the length check and, pre-fix, were silently latched
+            # on the body - poisoning every subsequent mj_step.
             {"force": [float("nan"), 0.0, 0.0]},
             {"force": [float("inf"), 0.0, 0.0]},
             {"torque": [0.0, float("-inf"), 0.0]},

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -239,12 +239,19 @@ class TestExternalForces:
         assert result["status"] == "error"
 
     def test_force_changes_acceleration(self, sim):
-        # Get initial state
+        """A latched force accelerates the body it names.
+
+        Asserts the motion rather than a physics buffer: which buffer carries
+        the latch is an implementation choice, whereas a 100 N upward force on
+        a 1 kg box under gravity has to lift it.
+        """
         data = sim._world._data
-        old_qfrc = data.qfrc_applied.copy()
-        sim.apply_force(body_name="box1", force=[0, 0, 100])
-        # qfrc_applied should change
-        assert not np.array_equal(old_qfrc, data.qfrc_applied)
+        z_before = float(data.qpos[2])
+
+        assert sim.apply_force(body_name="box1", force=[0, 0, 100])["status"] == "success"
+        sim.step(50)
+
+        assert float(data.qpos[2]) > z_before, "box1 did not rise under a 100 N upward force"
 
 
 class TestMassMatrix:

--- a/tests/simulation/mujoco/test_vector_params_read_by_membership.py
+++ b/tests/simulation/mujoco/test_vector_params_read_by_membership.py
@@ -116,7 +116,7 @@ class TestNumpyVectorsAreAccepted:
         """``apply_force`` accepts a NumPy force/torque/point and moves the body.
 
         A computed wrench is an array; assert the body actually accelerated
-        along it so the force reached ``qfrc_applied`` rather than being
+        along it so the force reached the physics buffer rather than being
         reported as applied.
         """
         sim.add_object(name="puck", shape="box", size=[0.05, 0.05, 0.05], position=[0.0, 0.0, 0.05])


### PR DESCRIPTION
Closes #1696.

## Problem

`apply_force` latched its wrench in `qfrc_applied` and zeroed the **whole** buffer on every call so a repeated call would replace rather than accumulate:

```python
data.qfrc_applied[:] = 0.0
mj.mj_applyFT(model, data, f, t, p, body_id, data.qfrc_applied)
```

`qfrc_applied` is one world-wide generalized-force vector, so that also revoked every wrench already latched on every **other** body. A second `apply_force` on a different body silently cancelled the first, and both calls reported success:

```python
sim.create_world(gravity=[0, 0, 0])
sim.add_object(name="a", shape="box", size=[0.05] * 3, position=[0.0, 0, 0.3], mass=0.1)
sim.add_object(name="b", shape="box", size=[0.05] * 3, position=[0.3, 0, 0.3], mass=0.1)

sim.apply_force("a", force=[1.0, 0, 0])   # -> success
sim.apply_force("b", force=[1.0, 0, 0])   # -> success
sim.step(200)
```

```
a: linear_velocity = [0.0, 0.0, 0.0]      # never moved
b: linear_velocity = [4.0, 0.0, 0.0]
```

Per-call idempotency is the right contract *for one body* -- calling `apply_force("a", force=F)` twice should leave one `F`. Achieving it by clearing the world additionally revokes a request that was already accepted and documented as latched, which makes a multi-body wrench unexpressible through this API with no error to say so: a wind field, two thrusters, a magnetic gripper holding two parts, or a per-object disturbance sweep all reduce to whichever body was named last.

## Change

The wrench is latched in the target body's own `xfrc_applied` row, so replacing one body's wrench cannot touch another's and idempotency is kept without revoking anyone else.

**No slice of `qfrc_applied` could have served the same purpose.** A wrench on a body part way down a kinematic chain writes into its ancestors' DOFs, so no part of that buffer belongs to one body. On a two-hinge arm, a force on `link2` lands on both DOFs:

```
nv = 2   link1 dofadr/num: 0 1   link2 dofadr/num: 1 1
qfrc_applied after a wrench on link2: [0.3, 0.1]   # link1's DOF too
```

Clearing only `link2`'s own DOF would leave a residue; clearing the DOF its wrench actually reached would erase a wrench latched on `link1`.

Latching per body is also the more faithful reading of the documented contract that the wrench is "applied on every subsequent `mj_step`". MuJoCo re-maps a Cartesian wrench through the current configuration on every step, whereas a generalized force frozen by `mj_applyFT` at call time stops describing the caller's world-frame wrench as soon as the body moves. Measured against ground truth -- the same force re-mapped every step -- for a two-hinge arm under a constant 2 N load over 300 steps:

| latch | final `qpos` | error vs ground truth |
|---|---|---|
| ground truth (re-mapped every step) | `[1.8236, -0.1505]` | - |
| `xfrc_applied` (this PR) | `[1.8189, -0.1473]` | **0.005 rad** |
| `qfrc_applied` frozen at call time (before) | `[2.0416, -0.1252]` | 0.218 rad |

`reset()` and `save_state`/`load_state` handle `xfrc_applied` natively (`mj_resetData` zeroes it; `mjSTATE_INTEGRATION` round-trips it), so the change needs no bookkeeping of its own -- verified in both directions.

Behaviour that is unchanged: `apply_force(body, force=[0, 0, 0])` still stops that one body, `reset()` still clears every latched wrench in the world, and a force at a `point` away from the centre of mass still carries its lever-arm torque (`xfrc_applied`'s torque acts about the CoM, so the offset contributes `(point - com) x force`; verified identical to `mj_applyFT` in all six components over 200 steps).

## Visual

Two identical 0.4 kg crates in a weightless world, each given the same 1.6 N `+x` thrust by one `apply_force` call. Grey posts mark the start line. Rendered in MuJoCo headless.

![two thrusters, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/apply-force-per-body-latch/apply_force_per_body_latch.gif)

| | `apply_force('crate_a')` | `apply_force('crate_b')` | crate_a travelled | crate_b travelled |
|---|---|---|---|---|
| before | success | success | **0.000 m** | 0.752 m |
| after | success | success | 0.752 m | 0.752 m |

Before, `crate_a` never leaves its start post -- pixel centroid 182.8 on the first frame and 182.8 on the last -- although the call that asked for its thrust returned success. After, both crates travel the same 0.752 m. Final-frame still: [apply_force_per_body_latch.png](https://raw.githubusercontent.com/cagataycali/robots/artifacts/apply-force-per-body-latch/apply_force_per_body_latch.png)

## Tests

`tests/simulation/mujoco/test_apply_force_per_body_latch.py`, 7 tests: a wrench on a second body leaves the first latched; a wrench on a robot link and on a free object coexist (the case no per-DOF clear can express); a second call on the same body replaces rather than accumulates; zeroing one body leaves the other pushed; `reset()` clears every wrench; a latched force keeps its world direction as the body moves (pinned against ground truth re-mapped every step); a force at an offset point spins a free body while the same force at the CoM does not.

Pre-fix on this base: **6 failed, 1 passed** (the passing one is `reset()`, which cleared the old buffer too).

Two existing tests asserted on `qfrc_applied` directly. `test_force_changes_acceleration` now asserts the motion instead of a buffer -- which buffer carries the latch is an implementation choice, but a 100 N upward force on a 1 kg box has to lift it. `test_zero_force_stops_effect` is explicitly a buffer test ("verify the latched wrench is cleared") and now checks that no body in the world is left holding a wrench. Two stale references to `qfrc_applied` in unrelated test prose were corrected in the same change.

## Docs

`describe()`'s `apply_force` entry said the wrench applies "for the next step" and said nothing about who the latch belongs to; it now states that MuJoCo re-applies it every step until the next `apply_force` for *that* body, that several bodies can hold wrenches at once, and how to stop one or all. The `docs/simulation/overview.md` physics table row says the same.

## Gate

`ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`. Full suite `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **12566 passed, 260 skipped** in 406s on `4536ad2a`. `mypy` reports only a pre-existing `simulation/ik.py:106 Returning Any` that depends on `qpsolvers` being installed locally and does not reproduce in CI.