### PR TITLE
fix(sim): apply one pose-vector rule to every entry point that takes a pose

### DIFF
--- a/changelog.d/1699-pose-vector-rule-parity.md
+++ b/changelog.d/1699-pose-vector-rule-parity.md
@@ -1,0 +1,33 @@
+### Fixed: every entry point that takes a pose applies the same pose-vector rule
+
+`move_to` takes the same world-frame `[x, y, z]` and the same wxyz quaternion as
+`add_object` / `move_object` / `add_camera` / `add_robot`, but hand-rolled its
+own check instead of using the shared pose-vector guard, and the two contracts
+had drifted apart in both directions.
+
+`move_to` computed `len(position)` directly, so a value with no length raised a
+bare `TypeError` straight through the `{"status": "error"}` contract its own
+docstring promises it never breaks:
+
+```python
+sim.move_to(robot_name="panda", position=np.float64(0.4))
+# TypeError: object of type 'numpy.float64' has no len()
+```
+
+A scalar, a NumPy 0-d scalar and a generator (from `map` or a comprehension over
+an observation) all landed there, for `position` and for `orientation`. The
+scene-construction calls refuse every one of them cleanly.
+
+In the other direction, the shared guard accepted a `bool` component, because
+`float(True)` is `1.0`. `add_object(position=[True, 0, 0.3])` reported success
+and compiled the body a metre out on x; `add_camera`, `add_robot` and
+`move_object` took it too. `move_to` refused it, and so does the agent-tool
+router - the direct API was the only surface that accepted it.
+
+The guard is now `strands_robots.utils.coerce_pose_vector` (with
+`pose_vector_error` / `finite_vector_error`), promoted out of the MuJoCo facade
+because the motion primitives live in a module that facade imports, which is
+what made sharing it impossible. It refuses a `bool` where a coordinate, extent
+or colour channel belongs, matching the router, and `move_to` routes both of its
+pose parameters through it. A NumPy array pose is still accepted everywhere, and
+a supplied quaternion still constrains the IK solve.

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -56,6 +56,7 @@ import numpy as np
 
 from strands_robots.registry.robots import get_robot
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG
+from strands_robots.utils import coerce_pose_vector
 
 logger = logging.getLogger(__name__)
 
@@ -406,7 +407,12 @@ class MotionPrimitivesMixin:
             robot_name: Robot to move; defaults to the single robot in the
                 world (errors if ambiguous).
             position: World-frame target ``[x, y, z]`` in meters (required).
-            orientation: Optional target orientation quaternion ``[w, x, y, z]``.
+                Validated by the same rule the scene-construction calls use
+                (:func:`strands_robots.utils.coerce_pose_vector`): three finite
+                real components, a NumPy array accepted, a ``bool`` refused.
+            orientation: Optional target orientation quaternion ``[w, x, y, z]``,
+                validated the same way and normalized before it enters the solve
+                (a non-unit quaternion is fine; a ~zero-norm one is refused).
                 When omitted the solve is position-only - the right choice for
                 arms with fewer than 6 DOF (e.g. SO-100/SO-101), which cannot
                 realize an arbitrary full pose.
@@ -425,11 +431,18 @@ class MotionPrimitivesMixin:
         # ---- parameter validation (before touching the world) ----
         if position is None:
             return _err("move_to requires 'position' ([x, y, z] target in meters).")
-        if len(position) != 3 or not all(_is_finite_real(c) for c in position):
-            return _err("move_to: 'position' must be 3 finite numbers [x, y, z] in meters.")
+        # Same guard the scene-construction entry points use, so a pose
+        # `add_object`/`move_object` refuses is refused here too. `len()` on a
+        # value with no length (a scalar, an iterator) raises a bare TypeError,
+        # which would escape this method's documented never-raises contract.
+        position, pos_err = coerce_pose_vector("move_to", "position", position, 3)
+        if pos_err is not None:
+            return _err(pos_err)
+        assert position is not None  # non-None input yields a non-None result
+        orientation, quat_err = coerce_pose_vector("move_to", "orientation", orientation, 4)
+        if quat_err is not None:
+            return _err(quat_err)
         if orientation is not None:
-            if len(orientation) != 4 or not all(_is_finite_real(c) for c in orientation):
-                return _err("move_to: 'orientation' must be 4 finite numbers [w, x, y, z] (unit quaternion).")
             quat_norm = float(np.linalg.norm(np.asarray(orientation, dtype=np.float64)))
             if quat_norm < 1e-8:
                 return _err("move_to: 'orientation' quaternion has ~zero norm; pass a valid [w, x, y, z].")
@@ -439,7 +452,7 @@ class MotionPrimitivesMixin:
         if err is not None:
             return err
         max_steps = int(max_steps)
-        target = np.asarray([float(c) for c in position], dtype=np.float64)
+        target = np.asarray(position, dtype=np.float64)
 
         # ---- setup under the lock: guards, EE frame, IK solve ----
         with self._lock:
@@ -523,7 +536,7 @@ class MotionPrimitivesMixin:
             target_pose = np.eye(4, dtype=np.float64)
             target_pose[:3, 3] = target
             if orientation is not None:
-                quat = np.asarray([float(c) for c in orientation], dtype=np.float64)
+                quat = np.asarray(orientation, dtype=np.float64)
                 quat = quat / np.linalg.norm(quat)
                 rot = np.zeros(9, dtype=np.float64)
                 self._mj.mju_quat2Mat(rot, quat)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -98,6 +98,11 @@ from strands_robots.simulation.mujoco.spec_builder import (
 from strands_robots.simulation.policy_runner import CooperativeStop
 from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_difficulty, validate_terrain
 from strands_robots.teleop_mixin import TeleopMixin
+from strands_robots.utils import (
+    coerce_pose_vector,
+    finite_vector_error,
+    pose_vector_error,
+)
 
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
@@ -174,111 +179,10 @@ def _validated_mesh_handle(mesh: Any) -> Any:
     )
 
 
-def _validate_finite_vector(method: str, param_name: str, vec: Any) -> str | None:
-    """Return an error message if any element of ``vec`` is not a finite number.
-
-    Guards the numeric vectors a scene-construction call bakes into the
-    compiled MJCF (``add_object`` color/size, ``add_camera`` position/target,
-    etc.) against the two classes the numeric-input campaign targets:
-
-    * A non-numeric or non-iterable element (e.g. ``["a", "b", "c"]`` or a
-      nested list) otherwise raises a bare ``TypeError``/``ValueError`` deep
-      inside MuJoCo's ``add_geom`` or a ``size <= 0`` comparison - escaping the
-      structured ``{"status": "error"}`` tool-result contract.
-    * A ``nan``/``inf`` component is baked verbatim into the geom/camera and
-      either poisons the physics state on the next ``mj_forward`` or aborts the
-      spec recompile with a cryptic "spec recompile refused", reporting a
-      success/garbage result instead of an actionable error.
-
-    A numpy real scalar per element is accepted (``float(np.float64(...))``
-    succeeds), matching the "accept NumPy scalar components" behaviour of the
-    other sim setters. Length is NOT checked here (size is shape-dependent, so
-    its count is checked against the shape afterwards); use
-    :func:`_validate_pose_vector` for a fixed length, or the rgba coercion in
-    :mod:`strands_robots.simulation.mujoco.physics` for a colour, whose count
-    the geom's rgba row defines. Returns ``None`` when every element is a finite
-    real number.
-    """
-    try:
-        iter(vec)
-    except TypeError:
-        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {vec!r}"
-    for _elem in vec:
-        try:
-            _f = float(_elem)
-        except (TypeError, ValueError):
-            return f"{method}: '{param_name}' elements must be numbers, got {vec!r}"
-        if not math.isfinite(_f):
-            return f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {vec!r}"
-    return None
-
-
-def _validate_pose_vector(method: str, param_name: str, vec: Any, expected_len: int) -> str | None:
-    """Return an error message if ``vec`` is not ``expected_len`` finite numbers.
-
-    Fixed-length wrapper over :func:`_validate_finite_vector` for the pose
-    vectors written straight into ``data.qpos`` (``move_object`` /
-    ``add_object`` position+orientation, ``add_camera`` position+target). A
-    wrong-length vector otherwise raises a bare ``ValueError`` inside the numpy
-    assignment - escaping the structured ``{"status": "error"}`` tool-result
-    contract - and a ``nan``/``inf`` component is propagated through the whole
-    physics state by ``mj_forward``, reporting ``success`` while silently
-    poisoning the simulation. A numpy real scalar per element is accepted.
-    Returns ``None`` when ``vec`` is acceptable.
-    """
-    try:
-        length = len(vec)
-    except TypeError:
-        return f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, got {vec!r}"
-    if length != expected_len:
-        return f"{method}: '{param_name}' must be a {expected_len}-element vector, got {length} ({vec!r})"
-    return _validate_finite_vector(method, param_name, vec)
-
-
 # Actions consumed open-loop from each policy's chunk before it is re-queried,
 # when the caller gives no per-robot override. Single-sourced so the signature
 # default and the per-robot mapping fallback cannot drift apart.
 _DEFAULT_ACTION_HORIZON = 8
-
-
-def _coerce_pose_vector(
-    method: str, param_name: str, vec: Any, expected_len: int
-) -> tuple[list[float] | None, str | None]:
-    """Validate an optional pose vector and normalize it to plain floats.
-
-    Membership, not truthiness: a pose parameter is "supplied" when it is not
-    ``None``. Testing the vector itself (``if position:``, ``position or
-    <default>``) is wrong twice over. A NumPy array - the natural product of any
-    pose arithmetic, and what every docstring here advertises as accepted -
-    raises a bare ``ValueError: truth value of an array ... is ambiguous``
-    through the structured tool-result contract, and an empty vector reads as
-    "omitted", so the default is substituted (or the write skipped) while the
-    call reports success.
-
-    Normalizing to a ``list[float]`` keeps the accepted NumPy input from
-    outliving this boundary: the pose is stored on :class:`SimObject` /
-    :class:`SimRobot` (both annotated ``list[float]``), echoed in the status
-    text, and written into the spec, so a raw ``np.float64`` element would leak
-    ``np.float64(0.05)`` into agent-visible output.
-
-    Args:
-        method: Calling method name, used in error text.
-        param_name: Parameter name, used in error text.
-        vec: The caller's value, or ``None`` when the parameter was omitted.
-        expected_len: Component count the target buffer defines (3 for a
-            position, 4 for a wxyz quaternion).
-
-    Returns:
-        ``(None, None)`` when ``vec`` is ``None`` (omitted - the caller applies
-        its own default), ``(floats, None)`` for an acceptable vector, or
-        ``(None, error_message)`` for a wrong length, a non-numeric element or a
-        ``nan``/``inf`` component.
-    """
-    if vec is None:
-        return None, None
-    if (err := _validate_pose_vector(method, param_name, vec, expected_len)) is not None:
-        return None, err
-    return [float(v) for v in vec], None
 
 
 _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
@@ -1199,10 +1103,10 @@ class MuJoCoSimEngine(
         # element raises a bare MuJoCo `add_frame(): incompatible function
         # arguments` TypeError that escapes the structured-error contract. NumPy
         # scalar components are accepted.
-        position, e = _coerce_pose_vector("add_robot", "position", position, 3)
+        position, e = coerce_pose_vector("add_robot", "position", position, 3)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
-        orientation, e = _coerce_pose_vector("add_robot", "orientation", orientation, 4)
+        orientation, e = coerce_pose_vector("add_robot", "orientation", orientation, 4)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
 
@@ -1294,7 +1198,7 @@ class MuJoCoSimEngine(
             urdf_path=resolved_path,
             # ``is None`` means "omitted" -> the documented default. ``or`` would
             # additionally read a NumPy pose as ambiguous (a bare ValueError) and
-            # an empty vector as omitted; _coerce_pose_vector already rejected
+            # an empty vector as omitted; coerce_pose_vector already rejected
             # the latter and normalized the former to plain floats.
             position=[0.0, 0.0, 0.0] if position is None else position,
             orientation=[1.0, 0.0, 0.0, 0.0] if orientation is None else orientation,
@@ -2600,13 +2504,13 @@ class MuJoCoSimEngine(
         # non-numeric element (e.g. ["a", ...]) raises a bare TypeError inside
         # MuJoCo's add_geom or the size <= 0 comparison, escaping the
         # structured-error contract. NumPy scalar components are accepted.
-        position, e = _coerce_pose_vector("add_object", "position", position, 3)
+        position, e = coerce_pose_vector("add_object", "position", position, 3)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
-        orientation, e = _coerce_pose_vector("add_object", "orientation", orientation, 4)
+        orientation, e = coerce_pose_vector("add_object", "orientation", orientation, 4)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
-        if size is not None and (e := _validate_finite_vector("add_object", "size", size)) is not None:
+        if size is not None and (e := finite_vector_error("add_object", "size", size)) is not None:
             return {"status": "error", "content": [{"text": e}]}
 
         # 'color' targets the geom's 4-component rgba row, so its component
@@ -2677,7 +2581,7 @@ class MuJoCoSimEngine(
             shape=shape,
             # ``is None`` means "omitted" -> the documented default. ``or`` would
             # additionally read a NumPy pose as ambiguous (a bare ValueError) and
-            # an empty vector as omitted; _coerce_pose_vector already rejected
+            # an empty vector as omitted; coerce_pose_vector already rejected
             # the latter and normalized the former to plain floats.
             position=[0.0, 0.0, 0.0] if position is None else position,
             orientation=[1.0, 0.0, 0.0, 0.0] if orientation is None else orientation,
@@ -2820,10 +2724,10 @@ class MuJoCoSimEngine(
         # mj_forward silently poisons the whole physics state. Only validate a
         # component that is actually supplied (None leaves it unchanged; the
         # move logic below treats a falsy value as "no change").
-        position, perr = _coerce_pose_vector("move_object", "position", position, 3)
+        position, perr = coerce_pose_vector("move_object", "position", position, 3)
         if perr is not None:
             return {"status": "error", "content": [{"text": perr}]}
-        orientation, oerr = _coerce_pose_vector("move_object", "orientation", orientation, 4)
+        orientation, oerr = coerce_pose_vector("move_object", "orientation", orientation, 4)
         if oerr is not None:
             return {"status": "error", "content": [{"text": oerr}]}
 
@@ -2977,10 +2881,10 @@ class MuJoCoSimEngine(
         # ValueError on a NumPy pose (what the docstring above advertises as
         # accepted) and read an empty vector as "omitted", quietly placing the
         # camera at the default [1, 1, 1] under a success result.
-        position, _perr = _coerce_pose_vector("add_camera", "position", position, 3)
+        position, _perr = coerce_pose_vector("add_camera", "position", position, 3)
         if _perr is not None:
             return {"status": "error", "content": [{"text": _perr}]}
-        target, _terr = _coerce_pose_vector("add_camera", "target", target, 3)
+        target, _terr = coerce_pose_vector("add_camera", "target", target, 3)
         if _terr is not None:
             return {"status": "error", "content": [{"text": _terr}]}
         pos = [1.0, 1.0, 1.0] if position is None else position
@@ -2992,7 +2896,7 @@ class MuJoCoSimEngine(
             # TypeError there, and a nan/inf slips silently into the camera's
             # baked xyaxes (fwd /= flen divides by nan -> a degenerate camera
             # that renders garbage while reporting success). NumPy scalars ok.
-            if (e := _validate_pose_vector("add_camera", _lbl, _vec, 3)) is not None:
+            if (e := pose_vector_error("add_camera", _lbl, _vec, 3)) is not None:
                 return {"status": "error", "content": [{"text": e}]}
         # Degenerate orientation: position == target means no well-defined look direction.
         if all(abs(pos[i] - tgt[i]) < 1e-9 for i in range(3)):

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -335,3 +335,116 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
         return message
     return None
+
+
+def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
+    """Return an error message if any element of ``vec`` is not a finite number.
+
+    Guards the numeric vectors a scene-construction call bakes into the
+    compiled MJCF (``add_object`` color/size, ``add_camera`` position/target,
+    etc.) against the two classes the numeric-input campaign targets:
+
+    * A non-numeric or non-iterable element (e.g. ``["a", "b", "c"]`` or a
+      nested list) otherwise raises a bare ``TypeError``/``ValueError`` deep
+      inside MuJoCo's ``add_geom`` or a ``size <= 0`` comparison - escaping the
+      structured ``{"status": "error"}`` tool-result contract.
+    * A ``nan``/``inf`` component is baked verbatim into the geom/camera and
+      either poisons the physics state on the next ``mj_forward`` or aborts the
+      spec recompile with a cryptic "spec recompile refused", reporting a
+      success/garbage result instead of an actionable error.
+
+    A numpy real scalar per element is accepted (``np.float64`` and friends are
+    registered as ``numbers.Real``), matching the "accept NumPy scalar
+    components" behaviour of the other sim setters; a ``bool`` is refused
+    because ``float(True)`` would silently write ``1.0`` where a coordinate,
+    extent or colour channel belongs. Length is NOT checked here (size is shape-dependent, so
+    its count is checked against the shape afterwards); use
+    :func:`pose_vector_error` for a fixed length, or the rgba coercion in
+    :mod:`strands_robots.simulation.mujoco.physics` for a colour, whose count
+    the geom's rgba row defines. Returns ``None`` when every element is a finite
+    real number.
+    """
+    try:
+        iter(vec)
+    except TypeError:
+        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {vec!r}"
+    for _elem in vec:
+        # ``numbers.Real`` accepts a numpy scalar (``np.float32`` / ``np.int64``
+        # are registered) and rejects a string, ``None`` or a nested list.
+        # ``bool`` is an ``int`` subclass, so it would otherwise pass as a
+        # silent ``1.0`` - a ``True`` coordinate placing a body 1 m out. The
+        # agent-tool router already refuses a bool component, so refusing it
+        # here keeps the direct API and the tool surface in step.
+        if isinstance(_elem, bool) or not isinstance(_elem, numbers.Real):
+            return f"{method}: '{param_name}' elements must be numbers, got {vec!r}"
+        if not math.isfinite(float(_elem)):
+            return f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {vec!r}"
+    return None
+
+
+def pose_vector_error(method: str, param_name: str, vec: Any, expected_len: int) -> str | None:
+    """Return an error message if ``vec`` is not ``expected_len`` finite numbers.
+
+    Fixed-length wrapper over :func:`finite_vector_error` for the pose
+    vectors written straight into ``data.qpos`` (``move_object`` /
+    ``add_object`` position+orientation, ``add_camera`` position+target). A
+    wrong-length vector otherwise raises a bare ``ValueError`` inside the numpy
+    assignment - escaping the structured ``{"status": "error"}`` tool-result
+    contract - and a ``nan``/``inf`` component is propagated through the whole
+    physics state by ``mj_forward``, reporting ``success`` while silently
+    poisoning the simulation. A numpy real scalar per element is accepted.
+
+    It lives here rather than beside one of its callers because those callers
+    sit in different layers: the scene-construction facade builds a pose before
+    the model is compiled, while the motion primitives take one against a live
+    model, and their accepted domain must not diverge - a pose either backend
+    entry point refuses must be refused by the other. Returns ``None`` when
+    ``vec`` is acceptable.
+    """
+    try:
+        length = len(vec)
+    except TypeError:
+        return f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, got {vec!r}"
+    if length != expected_len:
+        return f"{method}: '{param_name}' must be a {expected_len}-element vector, got {length} ({vec!r})"
+    return finite_vector_error(method, param_name, vec)
+
+
+def coerce_pose_vector(
+    method: str, param_name: str, vec: Any, expected_len: int
+) -> tuple[list[float] | None, str | None]:
+    """Validate an optional pose vector and normalize it to plain floats.
+
+    Membership, not truthiness: a pose parameter is "supplied" when it is not
+    ``None``. Testing the vector itself (``if position:``, ``position or
+    <default>``) is wrong twice over. A NumPy array - the natural product of any
+    pose arithmetic, and what every docstring here advertises as accepted -
+    raises a bare ``ValueError: truth value of an array ... is ambiguous``
+    through the structured tool-result contract, and an empty vector reads as
+    "omitted", so the default is substituted (or the write skipped) while the
+    call reports success.
+
+    Normalizing to a ``list[float]`` keeps the accepted NumPy input from
+    outliving this boundary: the pose is stored on :class:`SimObject` /
+    :class:`SimRobot` (both annotated ``list[float]``), echoed in the status
+    text, and written into the spec, so a raw ``np.float64`` element would leak
+    ``np.float64(0.05)`` into agent-visible output.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        vec: The caller's value, or ``None`` when the parameter was omitted.
+        expected_len: Component count the target buffer defines (3 for a
+            position, 4 for a wxyz quaternion).
+
+    Returns:
+        ``(None, None)`` when ``vec`` is ``None`` (omitted - the caller applies
+        its own default), ``(floats, None)`` for an acceptable vector, or
+        ``(None, error_message)`` for a wrong length, a non-numeric element or a
+        ``nan``/``inf`` component.
+    """
+    if vec is None:
+        return None, None
+    if (err := pose_vector_error(method, param_name, vec, expected_len)) is not None:
+        return None, err
+    return [float(v) for v in vec], None

--- a/tests/simulation/mujoco/test_pose_vector_rule_parity.py
+++ b/tests/simulation/mujoco/test_pose_vector_rule_parity.py
@@ -1,0 +1,186 @@
+"""One pose-vector rule for every entry point that takes a pose.
+
+``add_object`` / ``move_object`` / ``add_camera`` / ``add_robot`` route their
+position/orientation/target through the shared pose-vector guard. ``move_to``
+- the motion primitive that takes the same ``[x, y, z]`` and the same wxyz
+quaternion - hand-rolled its own check, and the two contracts had drifted apart
+in both directions:
+
+* ``move_to`` computed ``len(position)`` directly, so a value with no length
+  (a scalar, a NumPy 0-d scalar, a generator from ``map``/a comprehension)
+  raised a bare ``TypeError: object of type 'float' has no len()`` straight
+  through the ``{"status": "error"}`` contract its own docstring promises it
+  never breaks. The scene calls refuse the same value cleanly.
+* The scene calls accepted a ``bool`` component, because ``float(True)`` is
+  ``1.0``: ``add_object(position=[True, 0, 0.3])`` reported success and placed
+  the body a metre out on x. ``move_to`` refused it, and so does the agent-tool
+  router - so the direct API was the only surface that took it.
+
+These pin the unified contract: every entry point refuses a pose it cannot
+read, refuses a ``bool`` where a coordinate belongs, accepts a NumPy array, and
+- for ``move_to`` - an orientation that is supplied genuinely constrains the IK
+solve rather than being validated and dropped.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_motion_primitives import ARM_XML, REACHABLE  # noqa: E402
+
+# Values with no length. Each one raised ``TypeError`` out of ``move_to``'s
+# ``len(position)`` before the shared guard was applied; the scene entry points
+# have always refused them.
+UNREADABLE_POSES = [
+    pytest.param(0.5, id="python-scalar"),
+    pytest.param(3, id="python-int"),
+    pytest.param(np.float64(1.0), id="numpy-scalar"),
+    pytest.param((component for component in (0.2, 0.1, 0.2)), id="generator"),
+]
+
+
+def _text(result):
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _json(result):
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+@pytest.fixture
+def arm_path(tmp_path):
+    path = tmp_path / "pose_rule_arm.xml"
+    path.write_text(ARM_XML)
+    return str(path)
+
+
+@pytest.fixture
+def sim(arm_path):
+    s = Simulation(tool_name="test_pose_vector_rule_parity", mesh=False)
+    assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+    assert s.add_robot("arm", urdf_path=arm_path)["status"] == "success"
+    assert s.add_object(name="crate", shape="box", size=[0.05] * 3, position=[0.0, 0.0, 0.3])["status"] == "success"
+    yield s
+    s.cleanup(policy_stop_timeout=2.0)
+
+
+class TestMoveToRefusesAPoseItCannotRead:
+    """A pose with no length is a structured error, never a raise."""
+
+    @pytest.mark.parametrize("bad", UNREADABLE_POSES)
+    def test_position_without_a_length_is_refused(self, sim, bad):
+        result = sim.move_to(robot_name="arm", position=bad, max_steps=2)
+        assert result["status"] == "error"
+        assert "move_to" in _text(result) and "position" in _text(result)
+
+    @pytest.mark.parametrize("bad", UNREADABLE_POSES)
+    def test_orientation_without_a_length_is_refused(self, sim, bad):
+        result = sim.move_to(robot_name="arm", position=REACHABLE, orientation=bad, max_steps=2)
+        assert result["status"] == "error"
+        assert "move_to" in _text(result) and "orientation" in _text(result)
+
+    def test_wrong_component_count_names_the_count(self, sim):
+        result = sim.move_to(robot_name="arm", position=[0.2, 0.1], max_steps=2)
+        assert result["status"] == "error"
+        assert "3-element" in _text(result)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_non_finite_component_is_refused(self, sim, bad):
+        result = sim.move_to(robot_name="arm", position=[0.2, bad, 0.2], max_steps=2)
+        assert result["status"] == "error"
+        assert "finite" in _text(result)
+
+
+class TestVerdictsMatchAcrossEntryPoints:
+    """``move_to`` and the scene calls accept and refuse the same poses."""
+
+    # Factories, not values: a generator is consumed by whichever entry point
+    # reads it first, so each side of the comparison needs its own.
+    @pytest.mark.parametrize(
+        "make_pose",
+        [
+            pytest.param(lambda: 0.5, id="python-scalar"),
+            pytest.param(lambda: np.float64(1.0), id="numpy-scalar"),
+            pytest.param(lambda: (c for c in (0.2, 0.1, 0.2)), id="generator"),
+            pytest.param(lambda: [0.2, 0.1], id="too-short"),
+            pytest.param(lambda: [0.2, float("nan"), 0.2], id="nan-component"),
+            pytest.param(lambda: [True, 0.1, 0.2], id="bool-component"),
+        ],
+    )
+    def test_a_pose_one_entry_point_refuses_is_refused_by_the_other(self, sim, make_pose):
+        primitive = sim.move_to(robot_name="arm", position=make_pose(), max_steps=2)
+        scene = sim.move_object(name="crate", position=make_pose())
+        assert primitive["status"] == scene["status"] == "error", (
+            f"verdicts differ: move_to={primitive['status']}, move_object={scene['status']}"
+        )
+
+    def test_a_numpy_array_pose_is_accepted_by_both(self, sim):
+        pose = np.array([0.2, 0.1, 0.2])
+        assert sim.move_object(name="crate", position=pose)["status"] == "success"
+        assert sim.move_to(robot_name="arm", position=pose, tol=0.02, max_steps=400)["status"] == "success"
+
+
+class TestBoolIsNotACoordinate:
+    """``float(True) == 1.0``, so a bool component silently placed a body 1 m out."""
+
+    def test_add_object_refuses_a_bool_component(self, sim):
+        result = sim.add_object(name="flagged", shape="box", size=[0.05] * 3, position=[True, 0.0, 0.3])
+        assert result["status"] == "error"
+        assert "elements must be numbers" in _text(result)
+        assert "flagged" not in _text(sim.list_objects())
+
+    def test_move_object_refuses_a_bool_and_leaves_the_pose_alone(self, sim):
+        before = _json(sim.get_body_state("crate"))["position"]
+        assert sim.move_object(name="crate", position=[True, 0.0, 0.3])["status"] == "error"
+        assert _json(sim.get_body_state("crate"))["position"] == pytest.approx(before)
+
+    def test_add_camera_refuses_a_bool_component(self, sim):
+        assert sim.add_camera(name="cam", position=[True, 1.0, 1.0], target=[0, 0, 0])["status"] == "error"
+
+    def test_add_robot_refuses_a_bool_component(self, sim, arm_path):
+        assert sim.add_robot("second", urdf_path=arm_path, position=[True, 0.0, 0.0])["status"] == "error"
+
+    def test_move_to_refuses_a_bool_component(self, sim):
+        assert sim.move_to(robot_name="arm", position=[True, 0.0, 0.3], max_steps=2)["status"] == "error"
+
+    def test_the_agent_tool_router_and_the_direct_call_agree(self, sim):
+        fields = {"action": "move_object", "name": "crate", "position": [True, 0.0, 0.3]}
+        routed = sim._dispatch_action("move_object", fields)
+        direct = sim.move_object(name="crate", position=[True, 0.0, 0.3])
+        assert routed["status"] == direct["status"] == "error"
+
+
+class TestOrientationEntersTheSolve:
+    """A supplied quaternion constrains IK; it is normalized, not just checked."""
+
+    def test_a_non_unit_quaternion_is_normalized(self, sim):
+        pytest.importorskip("mink")
+        unit = sim.move_to(robot_name="arm", position=REACHABLE, orientation=[0.0, 1.0, 0.0, 0.0], max_steps=2)
+        scaled = sim.move_to(robot_name="arm", position=REACHABLE, orientation=[0.0, 2.0, 0.0, 0.0], max_steps=2)
+        assert _json(unit)["ik_residual_m"] == pytest.approx(_json(scaled)["ik_residual_m"], abs=1e-9)
+
+    def test_a_different_quaternion_changes_the_solve(self, sim):
+        pytest.importorskip("mink")
+        flipped = sim.move_to(robot_name="arm", position=REACHABLE, orientation=[0.0, 1.0, 0.0, 0.0], max_steps=2)
+        quarter = sim.move_to(robot_name="arm", position=REACHABLE, orientation=[0.7071, 0.0, 0.7071, 0.0], max_steps=2)
+        assert _json(flipped)["ik_residual_m"] != pytest.approx(_json(quarter)["ik_residual_m"], abs=1e-4)
+
+    def test_position_only_reaches_a_target_the_full_pose_cannot(self, sim):
+        pytest.importorskip("mink")
+        # The fixture arm has 4 arm DOF, so an arbitrary full pose is not
+        # realizable - the residual proves the orientation is a real constraint
+        # rather than a validated-then-discarded parameter.
+        assert sim.move_to(robot_name="arm", position=REACHABLE, tol=0.02, max_steps=400)["status"] == "success"
+        constrained = sim.move_to(
+            robot_name="arm", position=REACHABLE, orientation=[0.0, 1.0, 0.0, 0.0], tol=0.02, max_steps=400
+        )
+        assert constrained["status"] == "error"
+        assert _json(constrained)["ik_residual_m"] > 0.02
+
+    def test_a_zero_norm_quaternion_is_refused(self, sim):
+        result = sim.move_to(robot_name="arm", position=REACHABLE, orientation=[0.0, 0.0, 0.0, 0.0], max_steps=2)
+        assert result["status"] == "error"
+        assert "zero norm" in _text(result)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,14 @@
 """Tests for strands_robots.utils - require_optional lazy import helper."""
 
+import numpy as np
 import pytest
 
-from strands_robots.utils import process_rss_mb, require_optional, require_optionals
+from strands_robots.utils import (
+    coerce_pose_vector,
+    process_rss_mb,
+    require_optional,
+    require_optionals,
+)
 
 
 class TestRequireOptional:
@@ -356,3 +362,28 @@ class TestProcessRssMb:
         monkeypatch.setitem(sys.modules, "resource", None)
 
         assert process_rss_mb() is None
+
+
+class TestPoseVectorDomain:
+    """Accepted domain of the shared pose-vector guard.
+
+    Promoted out of the MuJoCo facade so the scene-construction calls and the
+    motion primitives (which live in a module the facade imports) cannot hold
+    different opinions about the same ``[x, y, z]``.
+    """
+
+    def test_an_omitted_vector_is_not_an_error(self):
+        assert coerce_pose_vector("m", "position", None, 3) == (None, None)
+
+    def test_numpy_components_are_normalized_to_plain_floats(self):
+        values, error = coerce_pose_vector("m", "position", np.array([0.1, 0.2, 0.3]), 3)
+        assert error is None
+        assert all(type(v) is float for v in values)
+
+    @pytest.mark.parametrize(
+        "bad", [0.5, np.float64(1.0), [0.1, 0.2], [0.1, "b", 0.3], [0.1, float("nan"), 0.3], [True, 0.2, 0.3]]
+    )
+    def test_a_vector_that_cannot_be_honored_returns_a_message(self, bad):
+        values, error = coerce_pose_vector("m", "position", bad, 3)
+        assert values is None
+        assert error and error.startswith("m: 'position'")


### PR DESCRIPTION
## Problem

`move_to` takes the same world-frame `[x, y, z]` and the same wxyz quaternion as `add_object` / `move_object` / `add_camera` / `add_robot`, but hand-rolled its own check instead of using the shared pose-vector guard. The two contracts had drifted apart **in both directions**.

**`move_to` raised where the scene calls refuse.** It computed `len(position)` directly, so a value with no length escaped the `{"status": "error"}` contract its own docstring promises it never breaks ("Never raises."):

```python
sim.move_to(robot_name="panda", position=np.float64(0.4))
# TypeError: object of type 'numpy.float64' has no len()
```

A Python scalar, a NumPy 0-d scalar and a generator (from `map`, or a comprehension over an observation row) all landed there, for `position` **and** for `orientation`. `move_object` refuses every one of them cleanly.

**The scene calls accepted a `bool` where `move_to` and the router refuse it.** `float(True)` is `1.0`, so the shared guard let a bool through:

```python
sim.add_object(name="crate", shape="box", size=[0.12]*3, position=[STAGED, 0.0, 0.30])
# {"status": "success"}  'crate' added: box at [1.0, 0.0, 0.3]
```

The body compiled a **metre out on x**. `add_camera`, `add_robot` and `move_object` took it too. `move_to` refused it, and so does the agent-tool router (`_VECTOR_PARAM_LENGTHS` rejects a bool component explicitly) — so the direct API was the only surface that accepted it.

## Change

The guard moves to `strands_robots.utils` as `coerce_pose_vector` / `pose_vector_error` / `finite_vector_error`. That is what made sharing it impossible before: it lived in `simulation/mujoco/simulation.py`, which *imports* the module the motion primitives live in, so `motion_primitives.py` could not reach it. `utils` is where the sibling scalar option-domain guards (`positive_whole_number_error`, `positive_finite_number_error`) already live for exactly this reason — their docstring states it: callers in different layers must not hold different opinions about the same value.

- `finite_vector_error` refuses a `bool` component (`isinstance(_elem, bool) or not isinstance(_elem, numbers.Real)`), matching the router. `numbers.Real` still accepts a NumPy scalar, and `np.bool_` is refused because it is not `Real` — the same predicate the router uses.
- `move_to` routes both `position` and `orientation` through `coerce_pose_vector`, and the coerced plain-float vectors replace the two redundant `[float(c) for c in ...]` re-coercions downstream.
- Message text is byte-identical to before the move, so every existing pin holds.
- The quaternion zero-norm check stays where it was (it is a `move_to`-specific concern, not part of the pose-vector rule).

Out of scope, stated for the reviewer: `mujoco/physics.py::_coerce_finite_vector` is a *different* contract (`accepted_lengths` tuple + `layout` string, for live-geom buffers whose component count comes from the compiled `geom_type`). It is not folded in here.

## Visual artifact

One scene, four real calls, run against `main` and against this branch (MuJoCo headless, `MUJOCO_GL=egl`). A staging flag spliced into the coordinate list, and a target reduced to a single coordinate by a mis-indexed observation:

![pose-vector rule parity](https://raw.githubusercontent.com/cagataycali/robots/artifacts/pose-vector-rule/pose-vector-rule.png)

| call | before | after |
|---|---|---|
| `add_object(position=[STAGED, 0.0, 0.30])` | `success` — compiled at **x = 1.00 m** | `error` — `'position' elements must be numbers` |
| `add_object(position=[0.0, 0.0, 0.30])` (reference) | `success` | `success` |
| `add_robot("panda")` | `success` | `success` |
| `move_to(position=np.float64(0.4))` | **`TypeError: object of type 'numpy.float64' has no len()`** | `error` — `'position' must be a list/tuple of 3 numbers` |

In the left panel the orange crate sits a metre from where the caller asked and the run then died on an uncaught `TypeError`; in the right panel neither bad call built anything and the scene contains only the reference crate. `L1(before, after)` over the two renders is `6.09e5`.

## Tests

`tests/simulation/mujoco/test_pose_vector_rule_parity.py` (new, inline MJCF arm — no asset download) plus a `coerce_pose_vector` domain class in `tests/test_utils.py`:

- every unreadable pose (scalar / int / NumPy scalar / generator) is a structured error for `position` and for `orientation`;
- **verdict parity**: for each malformed pose, `move_to` and `move_object` reach the same verdict — value *factories*, not values, because a generator is consumed by whichever side reads it first;
- a `bool` component is refused by `add_object`, `move_object`, `add_camera`, `add_robot` and `move_to`, the object is not created, an existing pose is left untouched, and the router and the direct call agree;
- a NumPy array pose is still accepted by both;
- the orientation genuinely enters the solve: a non-unit quaternion yields an IK residual identical to its normalized form, a different quaternion yields a different residual, and a full pose the 4-DOF fixture cannot realize returns the structured residual error while the position-only solve succeeds. This path had **no** coverage before.

Pre-fix, against `upstream/main` source: **18 failed, 10 passed** — the failures are the literal `TypeError: object of type 'float' has no len()` for the unreadable poses, and `assert 'success' == 'error'` for each bool entry point.

## Gate (local, on `196c667f`)

```
ruff check strands_robots tests tests_integ      All checks passed!
ruff format --check strands_robots tests tests_integ  924 files already formatted
mypy strands_robots tests tests_integ            Success: no issues found in 921 source files
MUJOCO_GL=egl pytest tests                       12762 passed, 253 skipped in 480s
```

Coverage: total 93.65% -> 93.67%; `simulation/mujoco/motion_primitives.py` **88% -> 91%** (46 -> 35 uncovered lines, the pose-validation and orientation-solve branches); `utils.py` 100%.

Changelog: `changelog.d/1699-pose-vector-rule-parity.md`.