### PR TITLE
fix(hardware): refuse a control-loop rate the arm cannot honor

### DIFF
--- a/changelog.d/1700-hardware-control-rate-guard.md
+++ b/changelog.d/1700-hardware-control-rate-guard.md
@@ -1,0 +1,26 @@
+### Fixed: the hardware control loop refuses a rate it cannot honor
+
+`Robot(..., mode="real", control_frequency=...)` computed the loop's per-action
+period as `1 / control_frequency` with no validation. That period is the only
+throttle between two `send_action` calls on a physical servo bus, and
+`asyncio.sleep` returns immediately from any value `<= 0`, so a rate that
+cannot be honored did not fail - it removed the throttle:
+
+- `control_frequency=-30` (period `-0.033 s`) and `control_frequency=inf`
+  (period `0.0 s`) both left the loop free-running: over one 0.4 s task they
+  applied 4784 and 7704 servo commands (about 12 kHz and 19 kHz) where the
+  requested rate allows 20, and both reported `status=completed`.
+- `control_frequency=nan` made the period `nan`, which `asyncio.sleep` refuses:
+  the task failed with `Invalid delay: NaN (not a number)` *after* the first
+  action had already been applied to the arm.
+- `control_frequency=True` silently ran a 1 Hz loop (`bool` is an `int`
+  subclass), and `0` / `"30"` surfaced a bare `ZeroDivisionError` /
+  `TypeError` from the constructor.
+
+The rate is now validated before the period is computed, and before
+`_initialize_robot` opens the serial port - so a rejected rate never reaches
+the arm. The accepted domain (any positive finite real, `bool` rejected) is the
+one the simulation already applies to the same knob in
+`SimEngine._validate_positive_frequency`, and a test asserts the two agree
+value by value, so a rollout cannot be refused for a digital twin and accepted
+for the arm it mirrors.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -53,6 +53,13 @@ robot = Robot(
 )
 ```
 
+`control_frequency` (Hz) sets the control loop's per-action period,
+`1 / control_frequency` - the only throttle between two servo commands. It must be a
+positive finite number: `0`, a negative rate, `nan` or `inf` raises `ValueError` at
+construction, before the serial port is opened, rather than leaving the loop free-running
+against the arm. This is the same domain the simulation applies to `run_policy`'s
+`control_frequency`, so a rollout rehearsed in sim is honored identically on hardware.
+
 Forwardable kwargs: `port`, `robot_ip`, `kp`, `kd`, `default_positions`, `control_dt`,
 `is_simulation`, `gravity_compensation`, `controller`, `calibration_dir`, `mock`,
 `use_degrees`, `max_relative_target`, `disable_torque_on_disconnect`.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -36,7 +36,7 @@ from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolResult, ToolSpec, ToolUse
 
 from strands_robots.teleop_mixin import TeleopMixin
-from strands_robots.utils import require_optional
+from strands_robots.utils import positive_finite_number_error, require_optional
 
 if TYPE_CHECKING:
     from lerobot.robots.config import RobotConfig
@@ -239,7 +239,12 @@ class Robot(TeleopMixin, AgentTool):
                 {"wrist": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 30}}
             action_horizon: Actions per inference step
             data_config: Data configuration (for GR00T compatibility)
-            control_frequency: Control loop frequency in Hz (default: 50Hz)
+            control_frequency: Control loop frequency in Hz (default: 50Hz).
+                Must be a positive finite number - it is the divisor of the
+                loop's per-action period (``1 / control_frequency``), the only
+                throttle between two servo commands. A ``0``, negative,
+                ``nan`` or ``inf`` rate raises ``ValueError`` here rather than
+                leaving the loop unthrottled against real hardware.
             ros2_bridge: When True, publish this robot's live observation
                 (``joint_states`` + one ``image_raw`` per camera) on a ROS 2
                 domain so external ROS 2 nodes can subscribe to the physical
@@ -283,6 +288,20 @@ class Robot(TeleopMixin, AgentTool):
         self.tool_name_str = tool_name
         self.action_horizon = action_horizon
         self.data_config = data_config
+        # ``action_sleep_time`` is ``1 / control_frequency`` and is the ONLY
+        # thing bounding how fast the task loop commands the physical servo
+        # bus: it is what ``_execute_task_async`` awaits between two
+        # ``send_action`` calls. A non-positive or non-finite rate turns that
+        # period into ``<= 0`` (``asyncio.sleep`` then returns immediately) or
+        # into ``nan`` (``asyncio.sleep`` raises mid-task, after the first
+        # action has already been applied), so the same rollout the simulation
+        # refuses outright would run here against real hardware. The identical
+        # domain is enforced on the rollout knobs of the simulation
+        # (``SimEngine._validate_positive_frequency``); validated BEFORE
+        # ``_initialize_robot`` opens the serial port, so a rejected rate never
+        # touches the arm.
+        if rate_error := positive_finite_number_error(control_frequency, "control_frequency", "Robot"):
+            raise ValueError(rate_error)
         self.control_frequency = control_frequency
         self.action_sleep_time = 1.0 / control_frequency  # Time between actions
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -299,6 +299,50 @@ def process_rss_mb() -> float | None:
         return None
 
 
+def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable positive finite number.
+
+    Shared domain for every CONTINUOUS knob that names a rate or a span of
+    time - a control-loop frequency in Hz, a rollout or teleop ``duration`` in
+    seconds. Unlike :func:`positive_whole_number_error` a fractional value is
+    perfectly usable here (``2.5`` seconds, ``62.5`` Hz), so only the sign and
+    the finiteness are constrained. It lives here rather than beside one of its
+    callers because those callers sit in different layers
+    (:mod:`strands_robots.teleop_mixin` must not depend on
+    :mod:`strands_robots.simulation`), and the accepted domain must not diverge
+    between them.
+
+    Only a positive finite value can be honored. Such a knob is always a
+    divisor (the loop period is ``1 / hz``) or a horizon (``duration *
+    frequency`` steps), so ``0`` makes the period undefined or the horizon
+    empty, a negative value inverts it, ``nan`` poisons every comparison it
+    reaches (``nan > 0`` and ``nan <= 0`` are both ``False``), and ``inf``
+    collapses the period to ``0`` - an unthrottled loop, not a fast one.
+    Accepts any real scalar (so a NumPy ``np.float32`` rate read from a config
+    array passes) and rejects ``bool`` explicitly - an ``int`` subclass whose
+    ``True`` would act as a silent ``1``.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter it came from, used in the message.
+        context: Message prefix identifying the surface that received it -
+            normally the public method name.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, numbers.Real)
+        # ``isfinite`` before the sign test: ``nan`` is never ``<= 0``, so
+        # ordering these the other way lets it through.
+        or not math.isfinite(float(value))
+        or float(value) <= 0
+    ):
+        return f"{context}: {param} must be > 0, got {value!r}."
+    return None
+
+
 def positive_whole_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive whole number.
 

--- a/tests/test_hardware_control_loop_rate_guard.py
+++ b/tests/test_hardware_control_loop_rate_guard.py
@@ -1,0 +1,247 @@
+"""Behavior tests for the hardware control loop's accepted rate domain.
+
+``strands_robots.hardware_robot.Robot`` turns ``control_frequency`` into
+``action_sleep_time = 1 / control_frequency``, and that period is the only
+throttle between two ``send_action`` calls on a physical servo bus. These
+tests pin that a rate the loop cannot honor is refused at construction:
+
+    - a ``0`` / negative / ``nan`` / ``inf`` / non-numeric rate raises
+      ``ValueError`` naming ``control_frequency``, instead of reaching the
+      division and leaving the loop unthrottled (negative / ``inf``), dying
+      mid-task after the first action was already applied (``nan``), or
+      surfacing a bare ``ZeroDivisionError`` / ``TypeError``;
+    - the refusal happens BEFORE the lerobot driver is built, so a rejected
+      rate never opens a serial port;
+    - every rate that IS accepted yields the documented period, including a
+      fractional and a NumPy-scalar rate;
+    - the accepted domain matches the simulation's rollout-frequency domain
+      (``SimEngine._validate_positive_frequency``), so the same value cannot be
+      refused for a digital twin and accepted for the arm it mirrors.
+
+No serial/USB hardware is touched: ``_initialize_robot`` is stubbed with an
+in-memory fake and the calibration migration is a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState
+from strands_robots.simulation.base import SimEngine
+
+# Rates the loop cannot honor. ``0`` makes the period undefined; a negative or
+# ``inf`` rate collapses it to a value ``asyncio.sleep`` returns from
+# immediately (an unthrottled loop); ``nan`` makes ``asyncio.sleep`` raise
+# after the first action has already been applied; the rest are not numbers a
+# period can be computed from at all.
+UNUSABLE_RATES: list[Any] = [
+    0,
+    0.0,
+    -30.0,
+    -1,
+    float("inf"),
+    float("-inf"),
+    float("nan"),
+    True,
+    "30",
+    None,
+    [50.0],
+]
+
+# Rates that are honorable: any positive finite real, fractional or NumPy.
+USABLE_RATES: list[Any] = [50.0, 30, 62.5, 0.5, 1000, np.float32(50.0), np.int64(25)]
+
+
+class _FakeArm:
+    """In-memory stand-in for a connected lerobot robot."""
+
+    def __init__(self) -> None:
+        self.name = "fake_arm"
+        self.robot_type = "fake_arm"
+        self.sent_actions: list[dict[str, Any]] = []
+        self.config = type("Cfg", (), {"cameras": {}})()
+
+    def get_observation(self) -> dict[str, Any]:
+        return {"j0.pos": 0.0}
+
+    def send_action(self, action: dict[str, Any]) -> None:
+        self.sent_actions.append(action)
+
+
+@pytest.fixture
+def hw_init(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Construct a real ``Robot.__init__`` without touching hardware.
+
+    Returns a callable taking the ``control_frequency`` under test plus a list
+    that records every ``_initialize_robot`` call, so a test can assert the
+    driver was (or was not) built.
+    """
+    built: list[Any] = []
+
+    def fake_initialize_robot(self: HwRobot, robot: Any, cameras: Any, **kwargs: Any) -> _FakeArm:
+        built.append(robot)
+        return _FakeArm()
+
+    monkeypatch.setattr(HwRobot, "_initialize_robot", fake_initialize_robot)
+    monkeypatch.setattr(HwRobot, "_migrate_legacy_calibration", lambda self: None)
+
+    def construct(**kwargs: Any) -> HwRobot:
+        return HwRobot(tool_name="test_arm", robot="fake_arm", **kwargs)
+
+    construct.built = built  # type: ignore[attr-defined]
+    return construct
+
+
+class TestUnusableRateRefused:
+    @pytest.mark.parametrize("rate", UNUSABLE_RATES, ids=repr)
+    def test_rate_the_loop_cannot_honor_raises(self, hw_init, rate):
+        """A rate with no usable period is refused, naming the parameter."""
+        with pytest.raises(ValueError, match="control_frequency"):
+            hw_init(control_frequency=rate)
+
+    @pytest.mark.parametrize("rate", UNUSABLE_RATES, ids=repr)
+    def test_refusal_precedes_driver_construction(self, hw_init, rate):
+        """A rejected rate never opens a serial port.
+
+        The guard sits ahead of ``_initialize_robot``, which is what builds the
+        lerobot driver and connects to the bus.
+        """
+        with pytest.raises(ValueError):
+            hw_init(control_frequency=rate)
+        assert hw_init.built == []
+
+    def test_message_reports_the_offending_value(self, hw_init):
+        with pytest.raises(ValueError) as excinfo:
+            hw_init(control_frequency=-30.0)
+        assert str(excinfo.value) == "Robot: control_frequency must be > 0, got -30.0."
+
+
+class TestUsableRateAccepted:
+    @pytest.mark.parametrize("rate", USABLE_RATES, ids=repr)
+    def test_accepted_rate_yields_the_documented_period(self, hw_init, rate):
+        """Every honorable rate is kept verbatim and gives period ``1 / rate``."""
+        hw = hw_init(control_frequency=rate)
+        try:
+            assert hw.control_frequency == rate
+            assert hw.action_sleep_time == pytest.approx(1.0 / float(rate))
+            assert hw_init.built == ["fake_arm"]
+        finally:
+            hw.cleanup()
+
+    def test_default_rate_is_accepted(self, hw_init):
+        hw = hw_init()
+        try:
+            assert hw.action_sleep_time == pytest.approx(0.02)
+        finally:
+            hw.cleanup()
+
+
+class TestDomainMatchesSimulation:
+    @pytest.mark.parametrize("rate", UNUSABLE_RATES + USABLE_RATES, ids=repr)
+    def test_hardware_and_simulation_agree_on_every_rate(self, hw_init, rate):
+        """One rate domain for the arm and for the digital twin that mirrors it.
+
+        ``SimEngine._validate_positive_frequency`` gates the simulation's
+        rollout rate; the hardware loop divides by the same knob for the same
+        purpose. A value accepted by one and refused by the other would mean a
+        rollout that runs on the real arm cannot be rehearsed in sim, or worse.
+        """
+        sim_refuses = SimEngine._validate_positive_frequency(rate, "run_policy") is not None
+        try:
+            hw = hw_init(control_frequency=rate)
+        except ValueError:
+            hw_refuses = True
+        else:
+            hw_refuses = False
+            hw.cleanup()
+        assert hw_refuses == sim_refuses, f"verdicts differ for control_frequency={rate!r}"
+
+
+class TestPeriodIsTheOnlyThrottle:
+    """Why the guard exists: the loop has no other rate limiter.
+
+    Pins that ``action_sleep_time`` alone bounds the command rate, so a period
+    of ``<= 0`` leaves ``_execute_task_async`` free-running against the servo
+    bus. Bounds are deliberately loose (an unthrottled loop overshoots by
+    orders of magnitude) so the assertion holds on any host.
+    """
+
+    @staticmethod
+    def _drive(period: float, duration: float = 0.2) -> int:
+        hw = HwRobot.__new__(HwRobot)
+        hw.tool_name_str = "test_arm"
+        hw.action_horizon = 1
+        hw.data_config = None
+        hw.control_frequency = 50.0
+        hw.action_sleep_time = period
+        hw._task_state = RobotTaskState()
+        hw._executor = ThreadPoolExecutor(max_workers=1)
+        hw._shutdown_event = threading.Event()
+        hw.mesh = None
+        hw.peer_id = None
+        hw.robot = _FakeArm()
+
+        class _Policy:
+            supports_rtc = False
+            execution_horizon = 1
+
+            def set_control_frequency(self, hz: float) -> None:
+                pass
+
+            def set_rtc_observed_delay(self, steps: int | None) -> None:
+                pass
+
+            async def get_actions(self, observation: Any, instruction: str) -> list[dict[str, Any]]:
+                return [{"j0.pos": 0.1}]
+
+        async def _connected() -> tuple[bool, str]:
+            return (True, "")
+
+        async def _ready() -> bool:
+            return True
+
+        def _init_policy(policy: Any) -> Any:
+            return _ready()
+
+        def _no_telemetry(observation: dict[str, Any], *, skip_images: bool = False) -> None:
+            return None
+
+        hw._connect_robot = _connected  # type: ignore[method-assign]
+        hw._initialize_policy = _init_policy  # type: ignore[method-assign]
+        hw._publish_ros_telemetry = _no_telemetry  # type: ignore[method-assign]
+        try:
+            # ``_Policy`` is a structural stub: it provides the three members the
+            # loop reads (supports_rtc / execution_horizon / get_actions) without
+            # subclassing the ABC.
+            asyncio.run(
+                hw._execute_task_async(
+                    "probe",
+                    duration=duration,
+                    policy_object=_Policy(),  # type: ignore[arg-type]
+                )
+            )
+            return len(hw.robot.sent_actions)
+        finally:
+            hw._executor.shutdown(wait=False)
+
+    def test_a_positive_period_throttles_the_loop(self):
+        """At 50 Hz a 0.2 s task applies tens of actions, not thousands."""
+        applied = self._drive(1.0 / 50.0)
+        assert 0 < applied < 200
+
+    def test_a_non_positive_period_leaves_the_loop_unthrottled(self):
+        """The pathology the guard prevents: no throttle at all.
+
+        A period of ``0`` is what ``1 / inf`` produces and what
+        ``asyncio.sleep`` returns from immediately, so the loop commands the
+        bus as fast as it can be driven.
+        """
+        applied = self._drive(0.0)
+        assert applied > 1000


### PR DESCRIPTION
## Problem

`Robot(..., mode="real", control_frequency=...)` turns the caller's rate into the task loop's per-action period and never validates it:

```python
self.control_frequency = control_frequency
self.action_sleep_time = 1.0 / control_frequency  # Time between actions
```

That period is the **only** throttle between two `send_action` calls on a physical servo bus - `_execute_task_async` awaits it after every applied action. `asyncio.sleep` returns immediately from any value `<= 0`, so a rate the loop cannot honor did not fail; it removed the throttle.

Measured over one 0.4 s task at the default `action_horizon=8`, with an in-memory stand-in for the lerobot driver counting `send_action` calls:

| `control_frequency` | period | servo commands applied | effective rate | reported |
|---|---|---|---|---|
| `50.0` (requested) | `0.02 s` | 24 | 51 Hz | `completed` |
| `-30` | `-0.033 s` | **4784** | **~12 kHz** | `completed` |
| `inf` | `0.0 s` | **7704** | **~19 kHz** | `completed` |
| `nan` | `nan` | 1, then the task died | - | `error`, `Invalid delay: NaN (not a number)` |
| `True` | `1.0 s` | 8 over 8 s | 1 Hz | `completed` |
| `0` | - | - | - | bare `ZeroDivisionError: float division by zero` |
| `"30"` | - | - | - | bare `TypeError: unsupported operand type(s) for /: 'float' and 'str'` |

Three distinct failures from one missing check: a request for a rate becomes an unbounded command rate against real servos (`-30`, `inf`); a `nan` rate reaches `asyncio.sleep` only *after* the first action has already been applied to the arm, so the refusal arrives too late to be a refusal; and `0` / `"30"` leak a bare arithmetic error out of the constructor instead of naming the parameter. `bool` is an `int` subclass, so `True` passes as a silent 1 Hz.

The simulation already refuses every one of these values for the same knob: `SimEngine._validate_positive_frequency` gates `run_policy` / `eval_policy` / `evaluate_benchmark` precisely because `control_frequency` is a divisor (`1 / control_frequency`, `duration = n_steps / control_frequency`). The surface where the consequence is physical had no such guard, so a rollout could be refused for a digital twin and accepted for the arm it mirrors.

## Change

- `strands_robots/utils.py`: `positive_finite_number_error(value, param, context)` - the shared domain for a *continuous* knob (a rate in Hz, a span in seconds), where a fractional value is legitimate so only sign and finiteness are constrained. It sits in `utils` because its callers are in layers that must not import each other, and the accepted domain must not diverge between them (the same reasoning as the neighbouring `positive_whole_number_error`).
- `strands_robots/hardware_robot.py`: the rate is validated before the period is computed, and **before `_initialize_robot` opens the serial port** - so a rejected rate never touches the arm. It raises `ValueError`, matching how this constructor already rejects an unknown/typo'd kwarg.

`positive_finite_number_error` is introduced identically (byte for byte) by #1684 for the teleop loop's `hz` / `duration`. Verified with `git merge-tree`: either merge order applies cleanly, and whichever lands second simply drops its copy in rebase.

Nothing that worked before changes: every positive finite rate - including a fractional `62.5` and a NumPy `np.float32(50.0)` / `np.int64(25)` - is kept verbatim and yields the same `1 / rate` period.

## Behaviour

![servo commands applied during one 0.4 s hardware task](https://raw.githubusercontent.com/cagataycali/robots/artifacts/hardware-control-rate-guard/control_rate_guard.png)

Cumulative `send_action` calls against wall clock for one 0.4 s task, same script on both trees (symlog y-axis so a 20-command staircase and a 7704-command wall are both readable). Left: `-30` and `inf` climb vertically past 19 kHz while reporting `completed`, and `nan` stops at a single applied action. Right: the honored 50 Hz request is unchanged and each unusable rate is refused at construction with the value it was given.

## Tests

`tests/test_hardware_control_loop_rate_guard.py` - 51 tests, no serial/USB hardware (`_initialize_robot` is stubbed with an in-memory fake):

- every unusable rate (`0`, `0.0`, `-30.0`, `-1`, `inf`, `-inf`, `nan`, `True`, `"30"`, `None`, `[50.0]`) raises `ValueError` naming `control_frequency`, and the exact message is pinned for one of them;
- **the refusal precedes driver construction** - `_initialize_robot` is never called for a rejected rate, so no port is opened;
- every usable rate (`50.0`, `30`, `62.5`, `0.5`, `1000`, `np.float32(50.0)`, `np.int64(25)`) is kept verbatim and yields period `1 / rate`;
- a **parity test** asserts the hardware verdict equals `SimEngine._validate_positive_frequency`'s verdict for all 18 probe values, so the two domains cannot drift apart again;
- two tests pin *why* the guard exists: the loop has no other rate limiter, so a positive period throttles it to tens of actions in 0.2 s while a period of `0` (what `1 / inf` produces) lets it apply thousands. Bounds are loose by orders of magnitude, so they hold on any host.

Pre-fix on `main`: **34 failed, 17 passed**, with the failure modes above (`ZeroDivisionError`, `DID NOT RAISE ValueError`, `verdicts differ for control_frequency=-30.0`, ...). Post-fix: 51 passed.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean (`Success: no issues found in 921 source files`).
- `MUJOCO_GL=egl python -m pytest tests`: **12777 passed, 253 skipped** in 429 s.
- `python scripts/assemble_changelog.py --check`: OK; fragment at `changelog.d/1700-hardware-control-rate-guard.md`.
- Docs: the accepted domain is documented on the parameter and in `docs/getting-started/robot-factory.md` under Real hardware.