### PR TITLE
fix(policies): an action vector shorter than the actuator list does not fabricate zero commands

### DIFF
--- a/changelog.d/1704-short-action-not-zero-filled.md
+++ b/changelog.d/1704-short-action-not-zero-filled.md
@@ -24,3 +24,21 @@ whichever consequence is in effect rather than one that was never true.
 index mapping, so the rule now lives once in
 `strands_robots.policies.align_action_values` alongside `resolve_chunk_length`,
 with a parity test pinning that the two providers agree.
+
+Omitting the actuator moves the same question to the recording path, where a
+LeRobot dataset declares one action column per actuator: `DatasetRecorder`
+defaulted a column the action dict did not carry to `0.0`, so a recorded rollout
+persisted commands that were never issued, and `replay_episode` re-issued them -
+reintroducing the travel-to-zero hazard through record then replay. Measured on
+a Panda, a rollout driving 6 of 8 actuators recorded `actuator8` (a `[0, 255]`
+tendon gripper) as `0.0` for every frame; replaying that episode drove an open
+gripper from a 0.0800 m gap to 0.0000 m.
+
+No placeholder is correct for such a column, so the frame is refused instead of
+recorded. `0.0` is a command; a joint's measured position is in different units
+from a normalized or tendon actuator's command (the Panda gripper's 0.0400 m gap
+replays as 4% open); and the command standing on the actuator cannot be read
+back, because the action-to-`ctrl` mapping is deliberately not injective. Every
+backend's recording hook now declares the action columns the driven robot owes,
+so the refusal is scoped: in a shared scene, the robots a rollout does not drive
+are still not its to report.

--- a/changelog.d/1704-short-action-not-zero-filled.md
+++ b/changelog.d/1704-short-action-not-zero-filled.md
@@ -1,0 +1,26 @@
+### Fixed: an action vector shorter than the actuator list no longer fabricates zero commands
+
+Both LeRobot providers map a policy's flat action vector onto actuator names by
+index. When the vector was shorter than the actuator list - a 6-DOF checkpoint
+pointed at a 7-actuator robot, an embodiment declaring a gripper the checkpoint
+never learned - the unmatched actuators were filled with `0.0` and sent anyway.
+
+Every action space on that path is absolute position: a LeRobot `<motor>.pos`
+follower and a MuJoCo position actuator both read `0.0` as "travel to zero", not
+as "hold". So the padding was a command. A 4-of-6 SO-arm action drove
+`wrist_roll` and `gripper` to their zero targets at servo speed, closing the
+gripper on whatever the arm was holding. The library's own diagnostic described
+the opposite outcome - "the unmatched actuator(s) are zero-filled and will not
+move" - so the documented intent was already that those actuators hold.
+
+An unmatched actuator is now omitted from the action dict, which is what makes
+it hold. Measured on two position-controlled joints parked at 0.8 rad, a
+one-value action left the unmatched joint at 0.8 rad instead of driving it to
+0.0. `pad_short_actions=True` restores the previous zero-fill for a consumer
+that needs a fixed-width action dict, and the dim-mismatch warning now reports
+whichever consequence is in effect rather than one that was never true.
+
+`LerobotLocalPolicy` and `LerobotAsyncPolicy` each carried their own copy of the
+index mapping, so the rule now lives once in
+`strands_robots.policies.align_action_values` alongside `resolve_chunk_length`,
+with a parity test pinning that the two providers agree.

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -25,6 +25,7 @@ import json
 import logging
 import re
 import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -465,6 +466,65 @@ def _prepare_create_target(dataset_dir: Path, *, overwrite: bool) -> None:
     )
 
 
+def unrecordable_action_columns_error(
+    action: Mapping[str, Any],
+    declared: Sequence[str],
+    required: Sequence[str] | None,
+) -> str | None:
+    """Reject a frame whose action omits a declared column the caller requires.
+
+    A LeRobot action column must hold the command that was issued at that step.
+    When the dataset schema declares a column the frame's action dict does not
+    carry, there is no such command, and every candidate placeholder is wrong:
+
+    * ``0.0`` is itself a command wherever the action space is absolute
+      position - a LeRobot ``<motor>.pos`` follower, a MuJoCo position actuator
+      - so the joint TRAVELS to zero at servo speed on replay rather than
+      staying where the un-commanded joint actually stayed.
+    * A joint's measured position is in different units from a normalized or
+      tendon-driven actuator's command, so substituting it moves those
+      actuators too.
+    * The command standing on the actuator cannot be read back, because the
+      action-to-``ctrl`` mapping is deliberately not injective (a normalized
+      open/close fraction and a raw tendon-unit command can share one ``ctrl``).
+
+    So the frame is refused instead of persisted, which keeps the recorded
+    action columns equal to what the policy issued and keeps ``replay_episode``
+    a faithful round trip.
+
+    ``required`` scopes the check to the columns the caller knows must come from
+    this frame - typically the action keys of the robot being driven. Columns
+    outside it (in a shared scene, the robots this rollout does not drive) are
+    not this frame's to supply and are left alone.
+
+    Args:
+        action: The frame's action dict, keyed as the dataset schema spells it.
+        declared: Action column names declared by the dataset schema.
+        required: Column names this frame must supply, or ``None`` to skip the
+            check entirely (the historical behaviour).
+
+    Returns:
+        An actionable message naming the missing columns, or ``None`` when every
+        required column is present.
+    """
+    if required is None:
+        return None
+    declared_set = set(declared)
+    missing = [key for key in required if key in declared_set and key not in action]
+    if not missing:
+        return None
+    return (
+        f"Recorded action column(s) {missing} have no value in this frame's action, so the "
+        "recording would persist a command that was never issued. No placeholder is correct: "
+        "0.0 is a 'travel to zero' command for an absolute-position actuator, a joint's measured "
+        "position is in different units from a normalized or tendon actuator's command, and the "
+        "command standing on the actuator cannot be read back (the action-to-ctrl mapping is not "
+        "injective). Record with a policy that produces a value for every declared action column "
+        "- an action vector narrower than the actuator list is reported by diagnose_action_dim - "
+        "or record a schema covering only the actuators it drives."
+    )
+
+
 class DatasetRecorder:
     """Bridge between strands-robots control loops and LeRobotDataset.
 
@@ -889,6 +949,7 @@ class DatasetRecorder:
         action: dict[str, Any],
         task: str | None = None,
         camera_keys: list[str] | None = None,
+        required_action_keys: Sequence[str] | None = None,
     ) -> None:
         """Add a single control-loop frame to the dataset.
 
@@ -900,6 +961,17 @@ class DatasetRecorder:
             action: Action dict (joint_name → float)
             task: Task description (uses default if None)
             camera_keys: Which keys in observation are camera images
+            required_action_keys: Action column names this frame must
+                supply a value for - typically the action keys of the robot
+                being driven. A declared column in this set that ``action``
+                omits raises ``ValueError`` rather than being written as a
+                fabricated command; see
+                :func:`unrecordable_action_columns_error`. ``None`` skips
+                the check.
+
+        Raises:
+            ValueError: A column in ``required_action_keys`` is declared by
+                the dataset schema but absent from ``action``.
         """
         if self._closed:
             return
@@ -952,15 +1024,26 @@ class DatasetRecorder:
                 frame["observation.state"] = np.array(state_vals, dtype=np.float32)
 
         # Action → flattened vector
-        # Use feature schema ordering for actions too.
+        # Use feature schema ordering for actions too. Resolved before the
+        # `if action:` guard so a frame carrying NO action for a column the
+        # caller requires is refused rather than silently skipped. The sorted()
+        # fallback still only runs for a non-empty action, so an observation-only
+        # frame cannot cache an empty key list for the rest of the episode.
+        if self._cached_action_keys is None:
+            feat = self.dataset.features.get("action", {})
+            action_names = feat.get("names", []) if isinstance(feat, dict) else getattr(feat, "names", [])
+            if action_names:
+                self._cached_action_keys = list(action_names)
+            elif action:
+                self._cached_action_keys = sorted(action.keys())
+
+        gap = unrecordable_action_columns_error(action, self._cached_action_keys or [], required_action_keys)
+        if gap is not None:
+            raise ValueError(gap)
+
         if action:
             action_vals = []
-            if self._cached_action_keys is None:
-                feat = self.dataset.features.get("action", {})
-                action_names = feat.get("names", []) if isinstance(feat, dict) else getattr(feat, "names", [])
-                self._cached_action_keys = action_names if action_names else sorted(action.keys())
-
-            for k in self._cached_action_keys:
+            for k in self._cached_action_keys or []:
                 v = action.get(k)
                 if v is None:
                     action_vals.append(0.0)

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -36,7 +36,12 @@ Usage::
 
 from typing import TYPE_CHECKING
 
-from strands_robots.policies.base import ChunkedPolicy, Policy, resolve_chunk_length
+from strands_robots.policies.base import (
+    ChunkedPolicy,
+    Policy,
+    align_action_values,
+    resolve_chunk_length,
+)
 
 # Cosmos3Policy is import-safe: it depends only on numpy. The WebSocket
 # client uses a self-contained msgpack+websockets transport (no
@@ -63,6 +68,7 @@ __all__ = [
     "Policy",
     "ChunkedPolicy",
     "resolve_chunk_length",
+    "align_action_values",
     "MockPolicy",
     "Cosmos3Policy",
     "CompositePolicy",

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -24,7 +24,10 @@ non-VLA reference implementation.
 import asyncio
 import concurrent.futures
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
 
 
 class Policy(ABC):
@@ -371,6 +374,57 @@ class ChunkedPolicy(Protocol):
 
     actions_per_step: int
     supports_rtc: bool
+
+
+def align_action_values(
+    values: Sequence[float] | np.ndarray,
+    action_keys: Sequence[str],
+    *,
+    pad_short: bool = False,
+) -> tuple[list[float], list[str]]:
+    """Pair a model's ordered action vector with the actuator keys it drives.
+
+    Every provider maps a policy's flat action vector onto actuator names BY
+    INDEX, and the two lengths are not guaranteed to agree: a checkpoint trained
+    for a 6-DOF arm can be pointed at a 7-actuator robot, or an embodiment can
+    declare a gripper the checkpoint never learned. This centralizes the single
+    rule for that mismatch so providers cannot drift.
+
+    * **More values than keys** - the trailing values are dropped. There is no
+      actuator to receive them.
+    * **Fewer values than keys** (the default) - only the leading keys the model
+      actually produced a value for are returned. The unmatched actuators are
+      left out of the action dict entirely, so they receive no command and hold
+      their current position.
+    * **Fewer values than keys with ``pad_short=True``** - the unmatched keys are
+      returned carrying ``0.0``. That is a COMMAND, not an omission: where the
+      action space is absolute position - a LeRobot ``<motor>.pos`` follower, a
+      MuJoCo position actuator - ``0.0`` means "travel to zero", so those
+      actuators MOVE, at whatever rate the servo will do it. Opt in only when
+      the consumer needs a fixed-width action dict and zero is a meaningful
+      target for every key it pads.
+
+    Args:
+        values: The model's per-step action vector. Any sized, indexable
+            numeric sequence - a list or a 1-D array, as the two providers hand
+            over a NumPy row; entries are coerced with ``float``.
+        action_keys: Ordered actuator keys the vector maps onto, index 0 first.
+        pad_short: Emit ``0.0`` for keys past the end of ``values`` instead of
+            omitting them. See the note above before enabling this.
+
+    Returns:
+        ``(values, keys)``, equal length and aligned 1:1 by index - ready to zip
+        into an action dict after any unit conversion has been applied to the
+        values.
+    """
+    keys = list(action_keys)
+    aligned = [float(values[index]) for index in range(min(len(values), len(keys)))]
+    if len(aligned) < len(keys):
+        if pad_short:
+            aligned.extend(0.0 for _ in range(len(keys) - len(aligned)))
+        else:
+            keys = keys[: len(aligned)]
+    return aligned, keys
 
 
 def resolve_chunk_length(policy: "Policy", action_horizon: int) -> int:

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -57,7 +57,7 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.policies.base import Policy
+from strands_robots.policies.base import Policy, align_action_values
 from strands_robots.utils import require_optional
 
 logger = logging.getLogger(__name__)
@@ -167,6 +167,7 @@ class LerobotAsyncPolicy(Policy):
         connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
         request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
         rename_map: dict[str, str] | None = None,
+        pad_short_actions: bool = False,
         **ignored_kwargs: Any,
     ) -> None:
         address = server_address or f"{host}:{port}"
@@ -202,6 +203,11 @@ class LerobotAsyncPolicy(Policy):
                 f"key to the model's expected feature key, got {type(rename_map).__name__}."
             )
         self.rename_map: dict[str, str] = dict(rename_map) if rename_map else {}
+        # A server chunk narrower than robot_state_keys leaves the trailing
+        # actuators unmatched. False (the default) omits them so they hold
+        # position; True commands them 0.0, which is an absolute target on a
+        # <motor>.pos follower. See align_action_values.
+        self.pad_short_actions = bool(pad_short_actions)
 
         if ignored_kwargs:
             logger.warning(
@@ -416,7 +422,10 @@ class LerobotAsyncPolicy(Policy):
         Each ``TimedAction.action`` is a 1D tensor over the policy's action
         dimensions; values are mapped to :attr:`robot_state_keys` by index and
         the chunk is capped at :attr:`execution_horizon` (the re-query interval
-        the consumer drives).
+        the consumer drives). A chunk narrower than ``robot_state_keys`` leaves
+        the trailing actuators without a command (they hold) unless
+        ``pad_short_actions`` is set - see
+        :func:`~strands_robots.policies.base.align_action_values`.
         """
         if not self.robot_state_keys:
             raise RuntimeError(
@@ -427,9 +436,8 @@ class LerobotAsyncPolicy(Policy):
         for timed_action in chunk[: self.execution_horizon]:
             action = timed_action.get_action() if hasattr(timed_action, "get_action") else timed_action.action
             values = np.asarray(action.detach().cpu().numpy() if hasattr(action, "detach") else action).flatten()
-            result.append(
-                {key: (float(values[i]) if i < len(values) else 0.0) for i, key in enumerate(self.robot_state_keys)}
-            )
+            aligned, keys = align_action_values(values, self.robot_state_keys, pad_short=self.pad_short_actions)
+            result.append(dict(zip(keys, aligned, strict=True)))
         if not result:
             raise RuntimeError("lerobot_async: server returned an empty action chunk.")
         return result

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -246,22 +246,32 @@ def hardware_pos_keys(observation: dict[str, Any]) -> list[str]:
 # Action diagnostics
 
 
-def diagnose_action_dim(n_action_values: int, n_action_keys: int, *, name: str = "") -> str | None:
+def diagnose_action_dim(
+    n_action_values: int, n_action_keys: int, *, name: str = "", pad_short: bool = False
+) -> str | None:
     """Return a warning message when a model action vector mis-matches the
     embodiment's declared actuator count, else ``None``.
 
     The local policy maps a model's action tensor onto robot actuators by index
     (``LerobotLocalPolicy._tensor_to_action_dicts``). When the model emits FEWER
     values than the embodiment declares actuator keys, the unmatched actuators
-    are zero-filled -- which silently freezes those joints and looks exactly like
-    "the policy runs but the robot does not move". When it emits MORE, the extra
-    trailing values are dropped. Either case is almost always an
-    embodiment/checkpoint mismatch the operator wants surfaced, not swallowed.
+    get no value from the model, and when it emits MORE the extra trailing values
+    are dropped. Either case is almost always an embodiment/checkpoint mismatch
+    the operator wants surfaced, not swallowed.
+
+    What happens to those unmatched actuators is the caller's choice, so the
+    message has to report the behaviour actually in effect: by default they are
+    omitted from the action dict and hold position, while
+    ``pad_short_actions=True`` sends them an explicit ``0.0``, which on an
+    absolute-position action space travels them to zero.
 
     Args:
         n_action_values: Length of the model's per-step action vector.
         n_action_keys: Number of declared actuator keys (``robot_state_keys``).
         name: Embodiment name for the message (optional).
+        pad_short: Whether the caller pads the unmatched actuators with ``0.0``
+            (see :func:`strands_robots.policies.base.align_action_values`).
+            Selects which consequence the message describes.
 
     Returns:
         A human-readable warning string, or ``None`` when the dims match.
@@ -271,11 +281,17 @@ def diagnose_action_dim(n_action_values: int, n_action_keys: int, *, name: str =
     label = f" '{name}'" if name else ""
     if n_action_values < n_action_keys:
         missing = n_action_keys - n_action_values
+        consequence = (
+            f"the {missing} unmatched actuator(s) are commanded to 0.0 "
+            f"(pad_short_actions=True), which on an absolute-position action space travels "
+            f"them to zero rather than holding them"
+            if pad_short
+            else f"the {missing} unmatched actuator(s) receive no command and hold their current position"
+        )
         return (
             f"Policy action dim {n_action_values} < embodiment{label} actuator count "
-            f"{n_action_keys}: the {missing} unmatched actuator(s) are zero-filled and will "
-            f"not move. Check the embodiment's action_keys order/count against the "
-            f"checkpoint's action dimension."
+            f"{n_action_keys}: {consequence}. Check the embodiment's action_keys "
+            f"order/count against the checkpoint's action dimension."
         )
     extra = n_action_values - n_action_keys
     return (

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -20,7 +20,7 @@ from typing import Any
 import numpy as np
 import torch
 
-from .. import Policy
+from .. import Policy, align_action_values
 from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys
 from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
@@ -226,6 +226,15 @@ class LerobotLocalPolicy(Policy):
             fallback) if any camera name cannot be matched to a declared
             policy image key by exact name and no ``camera_key_map`` covers
             it. Defaults to False (positional fallback).
+        pad_short_actions: When the model emits FEWER action values than the
+            robot declares actuator keys, command the unmatched actuators to
+            ``0.0`` instead of omitting them. Defaults to False: an omitted
+            actuator holds its position, whereas ``0.0`` is an absolute target
+            on a LeRobot ``<motor>.pos`` follower or a MuJoCo position
+            actuator, so padding TRAVELS those joints to zero. Enable only when
+            the consumer needs a fixed-width action dict and zero is a
+            meaningful target for every key it pads. Either way the dim
+            mismatch itself is reported once via ``diagnose_action_dim``.
     """
 
     def __init__(
@@ -249,6 +258,7 @@ class LerobotLocalPolicy(Policy):
         camera_key_map: dict[str, str] | None = None,
         obs_rename_override: dict[str, str | None] | None = None,
         strict_keys: bool = False,
+        pad_short_actions: bool = False,
         cache_model: bool = True,
         revision: str | None = None,
         **kwargs,
@@ -298,6 +308,11 @@ class LerobotLocalPolicy(Policy):
         # camera_key_map covers them). Defaults to False (positional fallback
         # with a warning), preserving zero-config ergonomics.
         self.strict_keys = strict_keys
+        # When the model emits fewer action values than the robot declares
+        # actuator keys, False (the default) omits the unmatched actuators so
+        # they hold position; True commands them 0.0, which on an absolute-
+        # position action space travels them to zero. See align_action_values.
+        self.pad_short_actions = bool(pad_short_actions)
         # Routing-degradation telemetry. The heuristic (non-declarative)
         # remap path can keep a run alive while silently producing
         # meaningless inputs - a camera routed to an arbitrary model image
@@ -2698,7 +2713,9 @@ class LerobotLocalPolicy(Policy):
         emb_name = self._embodiment.name if self._embodiment is not None else ""
         n_values = len(actions_list[0]) if actions_list else 0
         if not self._action_dim_warned:
-            dim_msg = diagnose_action_dim(n_values, len(self.robot_state_keys), name=emb_name)
+            dim_msg = diagnose_action_dim(
+                n_values, len(self.robot_state_keys), name=emb_name, pad_short=self.pad_short_actions
+            )
             if dim_msg:
                 logger.warning("lerobot_local: %s", dim_msg)
                 self._action_dim_warned = True
@@ -2732,12 +2749,15 @@ class LerobotLocalPolicy(Policy):
 
         result = []
         for action_values in actions_list:
-            vals = [float(action_values[i]) if i < len(action_values) else 0.0 for i in range(len(out_keys))]
+            # Align the model's vector with the actuator keys BEFORE any unit
+            # conversion, so a short vector converts only the columns the model
+            # actually produced (the embodiment's gripper column is positional).
+            vals, keys = align_action_values(action_values, out_keys, pad_short=self.pad_short_actions)
             # `convert` already implies `emb is not None`; the explicit guard lets
             # the type checker narrow `emb` from `EmbodimentMap | None` at the call.
             if convert and emb is not None:
                 vals = emb.model_action_to_sim(vals)
-            action_dict = {key: vals[index] for index, key in enumerate(out_keys)}
+            action_dict = dict(zip(keys, vals, strict=True))
             result.append(action_dict)
 
         return result

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -466,6 +466,29 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         robot.policy_steps = 0
         multi_robot = len(self._robots) > 1
 
+        # Action columns this rollout is responsible for: the driven robot's own
+        # actuators. A declared column the policy never produced cannot be written
+        # as a placeholder without persisting a command nobody issued, so
+        # ``add_frame`` refuses it.
+        #
+        # Resolved on the first recorded frame and cached, rather than up front:
+        # ``robot_action_keys`` is explicitly best-effort for the runner's
+        # fail-fast probe (a backend quirk or a mid-rollout teardown may make it
+        # raise, and that must not mask the primary "robot has not moved" signal),
+        # so the hook must not call it for a rollout that is not recording. Where a
+        # recording IS attached the keys are load-bearing - without them the frame
+        # cannot be checked - so a raise there correctly fails the recording.
+        action_key_cache: dict[bool, list[str]] = {}
+
+        def _required_action_keys(prefixed: bool) -> list[str]:
+            """Action columns this frame owes the recorder, resolved once."""
+            cached = action_key_cache.get(prefixed)
+            if cached is None:
+                keys = self.robot_action_keys(robot_name)
+                cached = [f"{robot_name}__{key}" for key in keys] if prefixed else list(keys)
+                action_key_cache[prefixed] = cached
+            return cached
+
         def _hook(step: int, observation: dict[str, Any], action: dict[str, Any]) -> None:
             robot.policy_steps = step + 1
             if not state.get("recording", False):
@@ -505,10 +528,20 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 obs = {f"{robot_name}__{k}": v for k, v in scalars.items()}
                 obs.update(images)
                 act = {f"{robot_name}__{k}": v for k, v in action.items()}
-                rec.add_frame(observation=obs, action=act, task=instruction)
+                rec.add_frame(
+                    observation=obs,
+                    action=act,
+                    task=instruction,
+                    required_action_keys=_required_action_keys(True),
+                )
             else:
                 obs = dict(scalars)
                 obs.update(images)
-                rec.add_frame(observation=obs, action=action, task=instruction)
+                rec.add_frame(
+                    observation=obs,
+                    action=action,
+                    task=instruction,
+                    required_action_keys=_required_action_keys(False),
+                )
 
         return _hook

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3906,6 +3906,29 @@ class MuJoCoSimEngine(
 
         lock = self._lock
 
+        # Action columns this rollout is responsible for: the driven robot's own
+        # actuators. A declared column the policy never produced cannot be written
+        # as a placeholder without persisting a command nobody issued, so
+        # ``add_frame`` refuses it.
+        #
+        # Resolved on the first recorded frame and cached, rather than up front:
+        # ``robot_action_keys`` is explicitly best-effort for the runner's
+        # fail-fast probe (a backend quirk or a mid-rollout teardown may make it
+        # raise, and that must not mask the primary "robot has not moved" signal),
+        # so the hook must not call it for a rollout that is not recording. Where a
+        # recording IS attached the keys are load-bearing - without them the frame
+        # cannot be checked - so a raise there correctly fails the recording.
+        action_key_cache: dict[bool, list[str]] = {}
+
+        def _required_action_keys(prefixed: bool) -> list[str]:
+            """Action columns this frame owes the recorder, resolved once."""
+            cached = action_key_cache.get(prefixed)
+            if cached is None:
+                keys = self.robot_action_keys(robot_name)
+                cached = [f"{robot_name}__{key}" for key in keys] if prefixed else list(keys)
+                action_key_cache[prefixed] = cached
+            return cached
+
         def _hook(step: int, observation: dict[str, Any], action: dict[str, Any]) -> None:
             # Cooperative cancellation: stop_policy flips this flag.
             if not robot.policy_running:
@@ -3949,9 +3972,19 @@ class MuJoCoSimEngine(
                                 for k, v in observation.items()
                             }
                             act_keyed = {f"{robot_name}__{k}": v for k, v in action.items()}
-                            rec.add_frame(observation=obs_keyed, action=act_keyed, task=instruction)
+                            rec.add_frame(
+                                observation=obs_keyed,
+                                action=act_keyed,
+                                task=instruction,
+                                required_action_keys=_required_action_keys(True),
+                            )
                         else:
-                            rec.add_frame(observation=observation, action=action, task=instruction)
+                            rec.add_frame(
+                                observation=observation,
+                                action=action,
+                                task=instruction,
+                                required_action_keys=_required_action_keys(False),
+                            )
 
         return _hook
 
@@ -4225,6 +4258,15 @@ class MuJoCoSimEngine(
         multi_robot = len(self._world.robots) > 1
         recorder = self._world._backend_state.get("dataset_recorder")
         recording = bool(self._world._backend_state.get("recording", False)) and recorder is not None
+        # Every robot driven here contributes to the one merged frame, so the
+        # merged action owes a value for each of their actuators. Resolved once
+        # rather than per frame, and only when a recorder will consume it (see the
+        # note on ``robot_action_keys`` being best-effort in _make_run_policy_hook).
+        merged_required_action_keys = (
+            [f"{rname}__{key}" if multi_robot else key for rname in policies for key in self.robot_action_keys(rname)]
+            if recording
+            else []
+        )
 
         # Whether ANY policy needs images (renders are expensive; skip if none
         # need them AND we're not recording - recording always needs frames).
@@ -4358,7 +4400,12 @@ class MuJoCoSimEngine(
                     # and 3, and merged_obs/merged_act are plain copies, so holding
                     # the physics lock across frame writeout would needlessly starve
                     # other lock holders (viewer sync, concurrent tool reads).
-                    recorder.add_frame(observation=merged_obs, action=merged_act, task=task)
+                    recorder.add_frame(
+                        observation=merged_obs,
+                        action=merged_act,
+                        task=task,
+                        required_action_keys=merged_required_action_keys,
+                    )
 
                 step_count += 1
                 for rname in policies:

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -57,6 +57,10 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         def render(self, camera_name: str = ..., width: int | None = ..., height: int | None = ...) -> dict[str, Any]:
             """Type-only stub for the engine-provided render method."""
 
+        def robot_action_keys(self, robot_name: str) -> list[str]:
+            """Type-only stub for the engine-provided action-key accessor."""
+            return []
+
     def start_recording(
         self,
         repo_id: str = "local/sim_recording",
@@ -361,6 +365,29 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         robot.policy_steps = 0
         multi_robot = len(world.robots) > 1
 
+        # Action columns this rollout is responsible for: the driven robot's own
+        # actuators. A declared column the policy never produced cannot be written
+        # as a placeholder without persisting a command nobody issued, so
+        # ``add_frame`` refuses it.
+        #
+        # Resolved on the first recorded frame and cached, rather than up front:
+        # ``robot_action_keys`` is explicitly best-effort for the runner's
+        # fail-fast probe (a backend quirk or a mid-rollout teardown may make it
+        # raise, and that must not mask the primary "robot has not moved" signal),
+        # so the hook must not call it for a rollout that is not recording. Where a
+        # recording IS attached the keys are load-bearing - without them the frame
+        # cannot be checked - so a raise there correctly fails the recording.
+        action_key_cache: dict[bool, list[str]] = {}
+
+        def _required_action_keys(prefixed: bool) -> list[str]:
+            """Action columns this frame owes the recorder, resolved once."""
+            cached = action_key_cache.get(prefixed)
+            if cached is None:
+                keys = self.robot_action_keys(robot_name)
+                cached = [f"{robot_name}__{key}" for key in keys] if prefixed else list(keys)
+                action_key_cache[prefixed] = cached
+            return cached
+
         def _hook(step: int, observation: dict[str, Any], action: dict[str, Any]) -> None:
             robot.policy_steps = step + 1
             if not world._backend_state.get("recording", False):
@@ -381,8 +408,18 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
 
                 obs = {(k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v for k, v in obs.items()}
                 act = {f"{robot_name}__{k}": v for k, v in action.items()}
-                rec.add_frame(observation=obs, action=act, task=instruction)
+                rec.add_frame(
+                    observation=obs,
+                    action=act,
+                    task=instruction,
+                    required_action_keys=_required_action_keys(True),
+                )
             else:
-                rec.add_frame(observation=obs, action=action, task=instruction)
+                rec.add_frame(
+                    observation=obs,
+                    action=action,
+                    task=instruction,
+                    required_action_keys=_required_action_keys(False),
+                )
 
         return _hook

--- a/tests/policies/lerobot_local/test_action_diagnostics.py
+++ b/tests/policies/lerobot_local/test_action_diagnostics.py
@@ -2,7 +2,7 @@
 
 A VLA (e.g. MolmoAct2 on SO-101) can step every control tick yet leave the arm
 motionless when its action vector mis-matches the embodiment's actuator count
-(unmatched actuators are zero-filled) or when it keeps emitting near-zero
+(unmatched actuators get no command) or when it keeps emitting near-zero
 actions (a broken obs/rename pipeline starves the model). These were silent.
 This pins the surfaced diagnostics: a one-shot action-dim warning, a
 consecutive near-zero-action warning, and an end-to-end MuJoCo check that a
@@ -33,12 +33,21 @@ def test_diagnose_action_dim_match_is_silent():
     assert diagnose_action_dim(6, 6, name="so101") is None
 
 
-def test_diagnose_action_dim_fewer_values_flags_zero_fill():
+def test_diagnose_action_dim_fewer_values_names_the_unmatched_actuators():
+    """The message reports the consequence actually in effect.
+
+    It used to claim the unmatched actuators were "zero-filled and will not
+    move". They are now omitted from the action dict, so they really do hold;
+    the zero-fill only happens under ``pad_short_actions=True``, where it is a
+    command that travels them to zero. See
+    ``tests/policies/test_short_action_holds_unmatched_actuators.py``.
+    """
     msg = diagnose_action_dim(4, 6, name="so101")
     assert msg is not None
-    assert "zero-filled" in msg
+    assert "receive no command" in msg
+    assert "hold their current position" in msg
     assert "so101" in msg
-    # names the count of frozen actuators
+    # names the count of unmatched actuators
     assert "2" in msg
 
 
@@ -92,10 +101,12 @@ def test_tensor_to_action_dicts_warns_on_dim_mismatch(caplog):
     policy.set_robot_state_keys(["1", "2", "3", "4", "5", "6"])
     with caplog.at_level(logging.WARNING):
         result = policy._tensor_to_action_dicts(torch.zeros(4))
-    # unmatched actuators are still returned (zero-filled), but now flagged
-    assert set(result[0].keys()) == {"1", "2", "3", "4", "5", "6"}
-    assert result[0]["5"] == 0.0 and result[0]["6"] == 0.0
-    assert any("action dim 4" in r.message and "zero-filled" in r.message for r in caplog.records)
+    # The unmatched actuators are left out of the action dict (a fabricated 0.0
+    # would be an absolute-position command, not an omission) and the mismatch
+    # is flagged.
+    assert set(result[0].keys()) == {"1", "2", "3", "4"}
+    assert "5" not in result[0] and "6" not in result[0]
+    assert any("action dim 4" in r.message and "hold their current position" in r.message for r in caplog.records)
 
 
 def test_tensor_to_action_dicts_dim_warning_is_one_shot(caplog):

--- a/tests/policies/test_short_action_holds_unmatched_actuators.py
+++ b/tests/policies/test_short_action_holds_unmatched_actuators.py
@@ -1,0 +1,332 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A model action vector shorter than the robot's actuator list must not fabricate commands.
+
+Both LeRobot providers map a policy's flat action vector onto actuator names BY
+INDEX. When the vector is shorter than the actuator list -- a 6-DOF checkpoint
+pointed at a 7-actuator robot, an embodiment declaring a gripper the checkpoint
+never learned -- the unmatched actuators have no value from the model.
+
+They used to be filled with ``0.0`` and sent anyway. That is not a no-op: every
+action space involved here is ABSOLUTE POSITION (a LeRobot ``<motor>.pos``
+follower, a MuJoCo position actuator), so ``0.0`` means "travel to zero" and the
+unmatched joints move -- a real follower drives them there at servo speed, and a
+gripper column padded to ``0.0`` closes. The library's own diagnostic described
+the opposite ("zero-filled and will not move"), so the documented intent was
+already "these actuators hold".
+
+These tests pin the corrected contract: an actuator the model said nothing about
+is omitted from the action dict, so it holds position. ``pad_short_actions=True``
+restores the padding for a consumer that needs a fixed-width dict, and the
+diagnostic then reports the consequence that is actually in effect.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pytest
+import torch  # real or conftest mock - both work
+
+from strands_robots.policies import align_action_values, create_policy
+from strands_robots.policies.lerobot_async import LerobotAsyncPolicy
+from strands_robots.policies.lerobot_local.embodiment import EmbodimentMap, diagnose_action_dim
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+SIX_KEYS = [
+    "shoulder_pan.pos",
+    "shoulder_lift.pos",
+    "elbow_flex.pos",
+    "wrist_flex.pos",
+    "wrist_roll.pos",
+    "gripper.pos",
+]
+
+# A two-link arm with damped, range-limited joints driven by position actuators.
+# Written inline so the test needs no asset download: the point is only that the
+# action space is absolute joint position, which is what makes a padded 0.0 a
+# command rather than an omission.
+ARM_MJCF = """
+<mujoco model="two_link">
+  <compiler angle="radian"/>
+  <default>
+    <joint type="hinge" axis="0 0 1" damping="4" range="-1.5 1.5" limited="true"/>
+    <geom type="capsule" size="0.02"/>
+  </default>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <joint name="shoulder"/>
+      <geom fromto="0 0 0 0.2 0 0"/>
+      <body name="link2" pos="0.2 0 0">
+        <joint name="elbow"/>
+        <geom fromto="0 0 0 0.2 0 0"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a_shoulder" joint="shoulder" kp="30" ctrlrange="-1.5 1.5"/>
+    <position name="a_elbow" joint="elbow" kp="30" ctrlrange="-1.5 1.5"/>
+  </actuator>
+</mujoco>
+"""
+
+
+# -- The shared rule ----------------------------------------------------------
+
+
+class TestAlignActionValues:
+    """One rule both providers apply, so their contracts cannot drift apart."""
+
+    def test_short_vector_returns_only_the_keys_the_model_produced(self):
+        values, keys = align_action_values([1.0, 2.0], ["a", "b", "c"])
+        assert values == [1.0, 2.0]
+        assert keys == ["a", "b"]  # "c" is omitted, not zeroed
+
+    def test_short_vector_pads_with_zero_only_when_asked(self):
+        values, keys = align_action_values([1.0, 2.0], ["a", "b", "c"], pad_short=True)
+        assert values == [1.0, 2.0, 0.0]
+        assert keys == ["a", "b", "c"]
+
+    def test_exact_length_maps_every_key(self):
+        values, keys = align_action_values([1.0, 2.0, 3.0], ["a", "b", "c"])
+        assert values == [1.0, 2.0, 3.0]
+        assert keys == ["a", "b", "c"]
+
+    def test_long_vector_drops_the_values_with_no_actuator(self):
+        # Padding is irrelevant here: there is no actuator to receive index 3.
+        for pad in (False, True):
+            values, keys = align_action_values([1.0, 2.0, 3.0, 4.0], ["a", "b", "c"], pad_short=pad)
+            assert values == [1.0, 2.0, 3.0]
+            assert keys == ["a", "b", "c"]
+
+    def test_empty_vector_commands_nothing(self):
+        assert align_action_values([], ["a", "b"]) == ([], [])
+
+    def test_numpy_values_are_coerced_to_float(self):
+        values, _ = align_action_values(np.array([1.5, -2.5], dtype=np.float32), ["a", "b"])
+        assert values == [1.5, -2.5]
+        assert all(type(v) is float for v in values)
+
+    def test_returned_pair_is_always_zippable(self):
+        # The caller zips these strict=True after unit conversion; equal length
+        # is the invariant that makes that safe for every input shape.
+        for n_values in range(0, 6):
+            values, keys = align_action_values([0.0] * n_values, ["a", "b", "c"])
+            assert len(values) == len(keys)
+
+
+# -- lerobot_local ------------------------------------------------------------
+
+
+class TestLocalPolicyShortAction:
+    def test_unmatched_actuators_are_absent_from_the_action_dict(self):
+        policy = LerobotLocalPolicy()
+        policy.set_robot_state_keys(SIX_KEYS)
+        action = policy._tensor_to_action_dicts(torch.tensor([12.0, -30.0, 45.0, 5.0]))[0]
+        assert list(action) == SIX_KEYS[:4]
+        # The gripper is the dangerous one: padded to 0.0 it closes on whatever
+        # the arm is holding. Absent, it keeps its current opening.
+        assert "gripper.pos" not in action
+        assert "wrist_roll.pos" not in action
+
+    def test_pad_short_actions_restores_the_zero_fill(self):
+        policy = LerobotLocalPolicy(pad_short_actions=True)
+        policy.set_robot_state_keys(SIX_KEYS)
+        action = policy._tensor_to_action_dicts(torch.tensor([12.0, -30.0, 45.0, 5.0]))[0]
+        assert list(action) == SIX_KEYS
+        assert action["wrist_roll.pos"] == 0.0
+        assert action["gripper.pos"] == 0.0
+
+    def test_default_is_not_to_pad(self):
+        assert LerobotLocalPolicy().pad_short_actions is False
+
+    def test_hardware_pos_key_override_omits_unmatched_actuators_too(self):
+        # The '.pos' path is where a fabricated 0.0 reaches a physical bus as an
+        # absolute Goal_Position, so it must not pad either.
+        policy = LerobotLocalPolicy()
+        policy.set_robot_state_keys(SIX_KEYS)
+        action = policy._tensor_to_action_dicts(
+            torch.tensor([12.0, -30.0]),
+            hw_action_keys=["shoulder_pan.pos", "shoulder_lift.pos", "elbow_flex.pos"],
+        )[0]
+        assert action == {"shoulder_pan.pos": 12.0, "shoulder_lift.pos": -30.0}
+
+    def test_unit_conversion_applies_to_the_emitted_columns_only(self):
+        # A degrees embodiment converts model degrees -> sim radians positionally.
+        # The conversion must run on the aligned prefix so column N keeps its own
+        # scaling instead of being shifted by a fabricated tail.
+        policy = LerobotLocalPolicy()
+        policy.set_robot_state_keys(["j1", "j2", "j3"])
+        policy._embodiment = EmbodimentMap(
+            name="degrees_short",
+            state_keys=["j1", "j2", "j3"],
+            action_keys=["j1", "j2", "j3"],
+            action_units="degrees",
+        )
+        action = policy._tensor_to_action_dicts(torch.tensor([90.0, 180.0]))[0]
+        assert list(action) == ["j1", "j2"]
+        assert action["j1"] == pytest.approx(np.pi / 2, rel=1e-6)
+        assert action["j2"] == pytest.approx(np.pi, rel=1e-6)
+
+    def test_exact_and_long_vectors_are_unchanged(self):
+        policy = LerobotLocalPolicy()
+        policy.set_robot_state_keys(["a", "b", "c"])
+        assert policy._tensor_to_action_dicts(torch.tensor([1.0, 2.0, 3.0]))[0] == {
+            "a": 1.0,
+            "b": 2.0,
+            "c": 3.0,
+        }
+        assert policy._tensor_to_action_dicts(torch.tensor([1.0, 2.0, 3.0, 4.0]))[0] == {
+            "a": 1.0,
+            "b": 2.0,
+            "c": 3.0,
+        }
+
+
+# -- lerobot_async ------------------------------------------------------------
+
+
+class _TimedAction:
+    """Minimal stand-in for lerobot's ``TimedAction`` (only ``.action`` is read)."""
+
+    def __init__(self, values: list[float]) -> None:
+        self.action = np.asarray(values, dtype=np.float32)
+
+
+def _async_policy(**kwargs: Any) -> LerobotAsyncPolicy:
+    policy = create_policy(
+        "lerobot_async",
+        server_address="h:1",
+        policy_type="act",
+        pretrained_name_or_path="x/y",
+        **kwargs,
+    )
+    assert isinstance(policy, LerobotAsyncPolicy)
+    policy.set_robot_state_keys(SIX_KEYS)
+    return policy
+
+
+class TestAsyncPolicyShortChunk:
+    def test_short_server_chunk_omits_unmatched_actuators(self):
+        policy = _async_policy()
+        action = policy._chunk_to_action_dicts([_TimedAction([1.0, 2.0, 3.0])])[0]
+        assert list(action) == SIX_KEYS[:3]
+        assert "gripper.pos" not in action
+
+    def test_pad_short_actions_restores_the_zero_fill(self):
+        policy = _async_policy(pad_short_actions=True)
+        action = policy._chunk_to_action_dicts([_TimedAction([1.0, 2.0, 3.0])])[0]
+        assert list(action) == SIX_KEYS
+        assert action["gripper.pos"] == 0.0
+
+    def test_default_is_not_to_pad(self):
+        assert _async_policy().pad_short_actions is False
+
+    def test_pad_short_actions_is_a_declared_kwarg_not_an_ignored_one(self, caplog):
+        # The client warns about kwargs it drops; this one must be honored, so it
+        # must not show up in that warning.
+        with caplog.at_level(logging.WARNING):
+            policy = _async_policy(pad_short_actions=True)
+        assert policy.pad_short_actions is True
+        assert "pad_short_actions" not in caplog.text
+
+
+def test_both_providers_apply_the_same_rule():
+    """The shared helper exists so these two cannot drift apart again."""
+    values = [1.0, 2.0, 3.0, 4.0]
+    for pad in (False, True):
+        local = LerobotLocalPolicy(pad_short_actions=pad)
+        local.set_robot_state_keys(SIX_KEYS)
+        remote = _async_policy(pad_short_actions=pad)
+        assert (
+            local._tensor_to_action_dicts(torch.tensor(values))[0]
+            == remote._chunk_to_action_dicts([_TimedAction(values)])[0]
+        )
+
+
+# -- The diagnostic must describe what actually happens -----------------------
+
+
+class TestDimMismatchDiagnostic:
+    def test_default_reports_that_the_actuators_hold(self):
+        msg = diagnose_action_dim(4, 6, name="so101")
+        assert msg is not None
+        assert "receive no command" in msg
+        assert "hold their current position" in msg
+        # The old message claimed a zero-fill that no longer happens.
+        assert "zero-filled" not in msg
+        assert "so101" in msg
+        assert "2" in msg  # names the count of unmatched actuators
+
+    def test_pad_short_reports_the_zero_command_and_its_consequence(self):
+        msg = diagnose_action_dim(4, 6, pad_short=True)
+        assert msg is not None
+        assert "commanded to 0.0" in msg
+        assert "pad_short_actions=True" in msg
+        assert "travels" in msg
+
+    def test_matching_dims_stay_silent_either_way(self):
+        assert diagnose_action_dim(6, 6) is None
+        assert diagnose_action_dim(6, 6, pad_short=True) is None
+
+    def test_more_values_than_keys_still_flags_the_drop(self):
+        for pad in (False, True):
+            msg = diagnose_action_dim(8, 6, pad_short=pad)
+            assert msg is not None
+            assert "dropped" in msg
+
+    def test_warning_logged_by_the_policy_matches_its_own_behaviour(self, caplog):
+        policy = LerobotLocalPolicy()
+        policy.set_robot_state_keys(SIX_KEYS)
+        with caplog.at_level(logging.WARNING):
+            action = policy._tensor_to_action_dicts(torch.zeros(4))
+        assert "gripper.pos" not in action[0]
+        assert any("action dim 4" in r.message and "hold their current position" in r.message for r in caplog.records)
+
+
+# -- End to end in sim: absolute-position actuators ---------------------------
+
+
+@pytest.mark.parametrize("pad_short", [False, True])
+def test_omitted_actuator_holds_while_a_padded_one_travels_to_zero(tmp_path, pad_short):
+    """The whole point, measured on a real position-controlled joint.
+
+    Both actuators are parked at 0.8 rad. The policy then emits a ONE-value
+    action, leaving ``a_elbow`` unmatched. Omitted, the elbow holds 0.8. Padded,
+    it is commanded to 0.0 and travels there -- which is what a real follower
+    does to an unmatched joint, at servo speed.
+    """
+    from strands_robots import Simulation
+
+    mjcf = tmp_path / "two_link.xml"
+    mjcf.write_text(ARM_MJCF)
+
+    sim = Simulation(backend="mujoco", tool_name="short_action_sim", mesh=False)
+    try:
+        sim.create_world()
+        assert sim.add_robot(name="arm", urdf_path=str(mjcf))["status"] == "success"
+        action_keys = sim.robot_action_keys(robot_name="arm")
+        assert action_keys == ["a_shoulder", "a_elbow"]
+
+        def elbow() -> float:
+            return float(sim.get_observation(robot_name="arm")["elbow"])
+
+        # Park both joints at 0.8 rad.
+        sim.send_action({key: 0.8 for key in action_keys}, robot_name="arm", n_substeps=500)
+        assert elbow() == pytest.approx(0.8, abs=0.01)
+
+        policy = LerobotLocalPolicy(pad_short_actions=pad_short)
+        policy.set_robot_state_keys(action_keys)
+        action = policy._tensor_to_action_dicts(torch.tensor([0.2]))[0]
+        sim.send_action(action, robot_name="arm", n_substeps=500)
+
+        if pad_short:
+            assert "a_elbow" in action
+            assert elbow() == pytest.approx(0.0, abs=0.01)  # travelled to zero
+        else:
+            assert "a_elbow" not in action
+            assert elbow() == pytest.approx(0.8, abs=0.01)  # held position
+    finally:
+        sim.cleanup()

--- a/tests/simulation/test_policy_runner_chunk_obs_alignment.py
+++ b/tests/simulation/test_policy_runner_chunk_obs_alignment.py
@@ -37,7 +37,8 @@ class _CapturingRecorder:
     """Stub recorder that records the observation handed to each ``add_frame``.
 
     Mirrors only the surface the MuJoCo ``on_frame`` recording hook touches:
-    ``add_frame(observation=, action=, task=)``. The hook forwards the raw sim
+    ``add_frame(observation=, action=, task=, required_action_keys=)``. The hook
+    forwards the raw sim
     observation (per-joint scalar keys such as ``Rotation`` / ``Pitch`` plus
     their ``.vel`` companions - the real ``DatasetRecorder`` packs these into
     ``observation.state``). We snapshot the scalar proprioceptive vector per
@@ -48,6 +49,7 @@ class _CapturingRecorder:
     def __init__(self) -> None:
         self.states: list[np.ndarray] = []
         self.actions: list[dict[str, Any]] = []
+        self.required_action_keys: list[list[str]] = []
         self.episode_frame_count = 0
         self.frame_count = 0
 
@@ -59,9 +61,16 @@ class _CapturingRecorder:
         )
         return np.array([v for _, v in items], dtype=float)
 
-    def add_frame(self, observation: dict[str, Any], action: dict[str, Any], task: str = "") -> None:
+    def add_frame(
+        self,
+        observation: dict[str, Any],
+        action: dict[str, Any],
+        task: str = "",
+        required_action_keys: list[str] | None = None,
+    ) -> None:
         self.states.append(self._scalar_state(observation))
         self.actions.append(dict(action))
+        self.required_action_keys.append(list(required_action_keys or []))
         self.episode_frame_count += 1
         self.frame_count += 1
 
@@ -132,3 +141,30 @@ def test_recorded_state_advances_within_a_single_chunk(async_rtc: bool) -> None:
         )
     finally:
         sim.cleanup()
+
+
+def test_the_recording_hook_declares_the_driven_robots_action_columns() -> None:
+    """The hook must tell the recorder which columns this rollout owes it.
+
+    Without that scope the recorder cannot tell a column the policy chose not to
+    command from one it commanded to zero, and fills the former with ``0.0`` - a
+    travel-to-zero command on an absolute-position actuator, persisted as though
+    the policy had issued it.
+    """
+    sim, rec = _make_recording_sim()
+    try:
+        expected = sim.robot_action_keys(robot_name="arm")
+        assert expected, "fixture robot must expose action keys"
+        result = sim.run_policy(
+            robot_name="arm",
+            policy_object=MockPolicy(),
+            instruction="t",
+            n_steps=3,
+            control_frequency=50.0,
+        )
+        assert result["status"] == "success"
+    finally:
+        sim.cleanup()
+
+    assert rec.required_action_keys, "no frame was recorded"
+    assert all(keys == expected for keys in rec.required_action_keys)

--- a/tests/test_recorded_action_columns_not_fabricated.py
+++ b/tests/test_recorded_action_columns_not_fabricated.py
@@ -1,0 +1,367 @@
+"""A recorded action column holds a command that was issued, or the frame is refused.
+
+``DatasetRecorder.add_frame`` writes one value per declared action column. When
+the frame's action dict does not carry a declared column, there is no command to
+record, and every candidate placeholder misrepresents what happened:
+
+* ``0.0`` is itself a command on an absolute-position action space, so
+  :meth:`replay_episode` drives that joint to zero at servo speed.
+* A joint's measured position is in different units from a normalized or
+  tendon-driven actuator's command.
+* The command standing on the actuator cannot be read back - the
+  action-to-``ctrl`` map is deliberately not injective.
+
+So the frame is refused. These tests pin the refusal, the scoping that keeps a
+shared-scene recording working, and that no episode survives a refused rollout
+for :meth:`replay_episode` to re-issue.
+"""
+
+import ast
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from strands_robots.dataset_recorder import DatasetRecorder, unrecordable_action_columns_error
+from strands_robots.policies import Policy
+
+from .test_dataset_recorder import _CapturingDataset, _state_action_features
+
+DECLARED = ["a_shoulder", "a_elbow", "a_grip"]
+
+
+class TestUnrecordableActionColumnsError:
+    """The rule itself, independent of any dataset."""
+
+    def test_no_required_columns_declared_skips_the_check(self):
+        """``None`` is the historical contract: the caller makes no claim."""
+        assert unrecordable_action_columns_error({}, DECLARED, None) is None
+
+    def test_every_required_column_present_is_accepted(self):
+        action = dict.fromkeys(DECLARED, 0.3)
+        assert unrecordable_action_columns_error(action, DECLARED, DECLARED) is None
+
+    def test_a_missing_required_column_is_named(self):
+        action = {"a_shoulder": 0.3}
+        msg = unrecordable_action_columns_error(action, DECLARED, DECLARED)
+        assert msg is not None
+        assert "'a_elbow'" in msg and "'a_grip'" in msg
+        assert "a_shoulder" not in msg
+
+    def test_a_declared_column_outside_the_required_set_is_not_this_frames_job(self):
+        """A shared scene declares columns for robots this rollout does not drive."""
+        declared = [*DECLARED, "bob__a_shoulder"]
+        action = dict.fromkeys(DECLARED, 0.3)
+        assert unrecordable_action_columns_error(action, declared, DECLARED) is None
+
+    def test_a_required_column_the_schema_never_declared_is_not_a_recorded_column(self):
+        action = dict.fromkeys(DECLARED, 0.3)
+        required = [*DECLARED, "a_phantom"]
+        assert unrecordable_action_columns_error(action, DECLARED, required) is None
+
+    def test_an_action_carrying_nothing_at_all_is_refused(self):
+        msg = unrecordable_action_columns_error({}, DECLARED, DECLARED)
+        assert msg is not None
+        assert all(f"'{key}'" in msg for key in DECLARED)
+
+    def test_the_message_explains_why_no_placeholder_is_correct_and_what_to_do(self):
+        msg = unrecordable_action_columns_error({}, DECLARED, DECLARED)
+        assert msg is not None
+        # names the hazard, not just the symptom
+        assert "travel to zero" in msg
+        # and the two reasons a substitute cannot be synthesized
+        assert "different units" in msg
+        assert "not " in msg and "injective" in msg
+        # and the remedy, pointing at the existing width diagnostic
+        assert "diagnose_action_dim" in msg
+
+    def test_the_reported_order_follows_the_declared_schema(self):
+        msg = unrecordable_action_columns_error({}, DECLARED, DECLARED)
+        assert msg is not None
+        assert msg.index("'a_shoulder'") < msg.index("'a_elbow'") < msg.index("'a_grip'")
+
+
+class TestAddFrameRefusesToFabricateAColumn:
+    """The guard where the fabrication used to happen."""
+
+    def _recorder(self):
+        ds = _CapturingDataset(_state_action_features(["shoulder", "elbow", "grip"], DECLARED))
+        return DatasetRecorder(dataset=ds, task="t"), ds
+
+    def test_a_missing_required_column_raises(self):
+        rec, _ds = self._recorder()
+        with pytest.raises(ValueError, match="a_grip"):
+            rec.add_frame(
+                observation={"shoulder": 0.1, "elbow": 0.2, "grip": 0.3},
+                action={"a_shoulder": 0.1, "a_elbow": 0.2},
+                required_action_keys=DECLARED,
+            )
+
+    def test_nothing_is_written_for_a_refused_frame(self):
+        """The refusal must not leave a half-built frame in the episode buffer."""
+        rec, ds = self._recorder()
+        with pytest.raises(ValueError):
+            rec.add_frame(
+                observation={"shoulder": 0.1, "elbow": 0.2, "grip": 0.3},
+                action={"a_shoulder": 0.1},
+                required_action_keys=DECLARED,
+            )
+        assert ds.frames == []
+
+    def test_a_complete_frame_records_exactly_what_was_commanded(self):
+        rec, ds = self._recorder()
+        rec.add_frame(
+            observation={"shoulder": 0.1, "elbow": 0.2, "grip": 0.3},
+            action={"a_shoulder": 0.4, "a_elbow": 0.5, "a_grip": 0.6},
+            required_action_keys=DECLARED,
+        )
+        assert len(ds.frames) == 1
+        np.testing.assert_allclose(ds.frames[0]["action"], [0.4, 0.5, 0.6], atol=1e-6)
+
+    def test_the_default_still_fills_unmatched_columns(self):
+        """Unchanged for callers that make no claim - e.g. a shared-scene recording.
+
+        This is the behaviour the ``required_action_keys`` scoping deliberately
+        preserves: a rollout driving one robot in a two-robot scene supplies only
+        its own columns, and the robots it does not drive are not its to report.
+        """
+        rec, ds = self._recorder()
+        rec.add_frame(
+            observation={"shoulder": 0.1, "elbow": 0.2, "grip": 0.3},
+            action={"a_shoulder": 0.4},
+        )
+        np.testing.assert_allclose(ds.frames[0]["action"], [0.4, 0.0, 0.0], atol=1e-6)
+
+    def test_an_actionless_frame_does_not_poison_the_declared_column_cache(self):
+        """The declared columns are resolved from the schema, not from frame one.
+
+        The guard has to run before the ``if action:`` branch so an empty action
+        is refused too; that must not let the first frame cache an empty column
+        list and silently drop every later action.
+        """
+        rec, ds = self._recorder()
+        rec.add_frame(observation={"shoulder": 0.1, "elbow": 0.2, "grip": 0.3}, action={})
+        rec.add_frame(
+            observation={"shoulder": 0.1, "elbow": 0.2, "grip": 0.3},
+            action={"a_shoulder": 0.4, "a_elbow": 0.5, "a_grip": 0.6},
+            required_action_keys=DECLARED,
+        )
+        np.testing.assert_allclose(ds.frames[-1]["action"], [0.4, 0.5, 0.6], atol=1e-6)
+
+
+class TestEveryRecordingHookDeclaresItsActionColumns:
+    """No backend may forward a policy's action without scoping the columns.
+
+    Read statically so the check covers the Isaac Sim and Newton backends, whose
+    runtimes are not installed here. A backend that stops passing
+    ``required_action_keys`` silently returns to fabricating the columns its
+    policy did not produce.
+    """
+
+    HOOK_MODULES = [
+        "strands_robots/simulation/mujoco/simulation.py",
+        "strands_robots/simulation/isaac/recording.py",
+        "strands_robots/simulation/newton/recording.py",
+    ]
+
+    @pytest.mark.parametrize("module_path", HOOK_MODULES)
+    def test_every_add_frame_call_scopes_its_action_columns(self, module_path):
+        source = (Path(__file__).resolve().parents[1] / module_path).read_text()
+        tree = ast.parse(source)
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_frame"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in {"rec", "recorder"}
+        ]
+        assert calls, f"{module_path}: no recorder.add_frame call found"
+        for call in calls:
+            keywords = {kw.arg for kw in call.keywords}
+            assert "required_action_keys" in keywords, (
+                f"{module_path}:{call.lineno} calls add_frame without required_action_keys, "
+                "so a policy that omits an actuator would have that column fabricated."
+            )
+
+
+# -- End to end in sim: the record -> replay round trip ------------------------
+
+_ARM_MJCF = """
+<mujoco model="two_link">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <body name="upper" pos="0 0 0.5">
+      <joint name="shoulder" type="hinge" axis="0 1 0" range="-1.5 1.5" damping="4"/>
+      <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.03"/>
+      <body name="lower" pos="0 0 0.2">
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-1.5 1.5" damping="4"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.025"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a_shoulder" joint="shoulder" kp="50"/>
+    <position name="a_elbow" joint="elbow" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _episode_parquets(root):
+    """Recorded frame parquets only - LeRobot also writes meta/ parquets."""
+    return sorted(path for path in root.rglob("*.parquet") if "data" in path.parts)
+
+
+def _arm_sim(tmp_path, tool_name):
+    from strands_robots import Simulation
+
+    mjcf = tmp_path / "two_link.xml"
+    mjcf.write_text(_ARM_MJCF)
+    sim = Simulation(backend="mujoco", tool_name=tool_name, mesh=False)
+    sim.create_world()
+    assert sim.add_robot(name="arm", urdf_path=str(mjcf))["status"] == "success"
+    assert sim.robot_action_keys(robot_name="arm") == ["a_shoulder", "a_elbow"]
+    return sim
+
+
+class _PartialPolicy(Policy):
+    """A policy driving only the leading actuators, as a narrow checkpoint does."""
+
+    def __init__(self, driven):
+        self._driven = driven
+        self.keys: list[str] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "partial"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, keys) -> None:
+        self.keys = list(keys)
+
+    async def get_actions(self, observation_dict, instruction, **kwargs):
+        return [dict.fromkeys(self.keys[: self._driven], 0.4) for _ in range(8)]
+
+
+def test_a_short_action_rollout_records_no_episode_to_replay(tmp_path):
+    """The round-trip hazard, closed at its source.
+
+    A recorded ``0.0`` for an actuator the policy never commanded is
+    indistinguishable from a real command, and :meth:`replay_episode` re-issues
+    it - driving that joint to zero at servo speed. The rollout is refused
+    instead, so no episode reaches disk for a replay to re-issue.
+    """
+    pytest.importorskip("mujoco")
+    pytest.importorskip("lerobot")
+
+    sim = _arm_sim(tmp_path, "refuse_sim")
+    try:
+        started = sim.start_recording(repo_id="local/short_action_refused", task="t", fps=30, root=str(tmp_path / "ds"))
+        assert started["status"] == "success"
+        result = sim.run_policy(
+            robot_name="arm",
+            policy_object=_PartialPolicy(driven=1),
+            instruction="t",
+            n_steps=10,
+            control_frequency=30.0,
+        )
+        assert result["status"] == "error"
+        text = str(result)
+        assert "a_elbow" in text
+        assert "never issued" in text
+        sim.stop_recording()
+    finally:
+        sim.cleanup()
+
+    assert _episode_parquets(tmp_path / "ds") == [], "a refused rollout must not leave an episode on disk"
+
+
+def test_a_complete_rollout_records_the_commands_that_were_issued(tmp_path):
+    """The counterpart: a policy covering every actuator still records normally.
+
+    Pins that the guard rejects only frames it cannot record faithfully - the
+    recorded action column equals the command the policy actually issued, which
+    is what makes replaying the episode reproduce the rollout.
+    """
+    pytest.importorskip("mujoco")
+    pytest.importorskip("lerobot")
+    pd = pytest.importorskip("pandas")
+
+    sim = _arm_sim(tmp_path, "record_sim")
+    try:
+        assert (
+            sim.start_recording(repo_id="local/full_action_ok", task="t", fps=30, root=str(tmp_path / "ds"))["status"]
+            == "success"
+        )
+        result = sim.run_policy(
+            robot_name="arm",
+            policy_object=_PartialPolicy(driven=2),
+            instruction="t",
+            n_steps=10,
+            control_frequency=30.0,
+        )
+        assert result["status"] == "success"
+        assert sim.stop_recording()["status"] == "success"
+    finally:
+        sim.cleanup()
+
+    parquets = _episode_parquets(tmp_path / "ds")
+    assert parquets, "a complete rollout must record an episode"
+    actions = np.stack(pd.concat([pd.read_parquet(p) for p in parquets])["action"].to_numpy())
+    assert actions.shape[1] == 2
+    # Both columns carry the issued command, not a fabricated placeholder.
+    np.testing.assert_allclose(actions, 0.4, atol=1e-5)
+
+
+def test_a_recording_never_falls_back_to_fabricating_when_the_columns_are_unknown(tmp_path, monkeypatch):
+    """The scope is load-bearing for a recording, not best-effort.
+
+    ``robot_action_keys`` is deliberately best-effort for the runner's fail-fast
+    probe - see ``test_policy_runner_action_keys_probe_failsoft`` - which is why
+    the recording hook resolves it lazily and only when a recorder is attached.
+    But a recording cannot proceed without it: not knowing which columns the
+    rollout owes is not a licence to fill them in. The rollout must fail rather
+    than persist a frame it could not check.
+    """
+    pytest.importorskip("mujoco")
+
+    class _Recorder:
+        def __init__(self):
+            self.frames = 0
+
+        def add_frame(self, observation, action, task="", required_action_keys=None):
+            self.frames += 1
+
+        def save_episode(self):
+            return {"status": "success"}
+
+    sim = _arm_sim(tmp_path, "unknown_cols_sim")
+    rec = _Recorder()
+    try:
+        assert sim._world is not None
+        sim._world._backend_state["recording"] = True
+        sim._world._backend_state["trajectory"] = []
+        sim._world._backend_state["dataset_recorder"] = rec
+
+        def _boom(robot_name: str) -> list[str]:
+            raise RuntimeError("action keys unavailable")
+
+        monkeypatch.setattr(sim, "robot_action_keys", _boom)
+        result = sim.run_policy(
+            robot_name="arm",
+            policy_object=_PartialPolicy(driven=2),
+            instruction="t",
+            n_steps=6,
+            control_frequency=50.0,
+        )
+        assert result["status"] == "error"
+    finally:
+        sim.cleanup()
+
+    assert rec.frames == 0, "no frame may be recorded when the owed columns are unknown"


### PR DESCRIPTION
## Problem

Both LeRobot providers map a policy's flat action vector onto actuator names **by index**. The two lengths are not guaranteed to agree: a 6-DOF checkpoint can be pointed at a 7-actuator robot, or an embodiment can declare a gripper the checkpoint never learned.

When the vector was **shorter**, the unmatched actuators were filled with `0.0` and sent anyway:

```python
vals = [float(action_values[i]) if i < len(action_values) else 0.0 for i in range(len(out_keys))]
```

Every action space on that path is **absolute position**. A LeRobot `<motor>.pos` follower and a MuJoCo position actuator both read `0.0` as "travel to zero", not "hold". So the padding was a *command*. A 4-of-6 SO-arm action:

```
lerobot_local: Policy action dim 4 < embodiment actuator count 6: the 2 unmatched
actuator(s) are zero-filled and will not move.
-> {'shoulder_pan.pos': 12.0, 'shoulder_lift.pos': -30.0, 'elbow_flex.pos': 45.0,
    'wrist_flex.pos': 5.0, 'wrist_roll.pos': 0.0, 'gripper.pos': 0.0}
```

`wrist_roll` and `gripper` are driven to their zero targets at servo speed -- the gripper closing on whatever the arm is holding.

The strongest evidence that this was never the intent is `diagnose_action_dim`'s own message, quoted above: it promised the unmatched actuators **"are zero-filled and will not move"**. Zero-filling does not freeze a joint on an absolute-position bus; it commands it to zero. The documented contract was already "these actuators hold" -- only the code disagreed.

`lerobot_async._chunk_to_action_dicts` carried its own copy of the same expression, so a server chunk narrower than `robot_state_keys` had the identical effect.

## Change

An actuator the model said nothing about is **omitted from the action dict**, which is what makes it hold. `send_action` accepts a partial dict on both backends (MuJoCo leaves the unlisted actuators' `ctrl` untouched; a `<motor>.pos` follower writes only the motors named), and `DatasetRecorder` builds its action columns from the declared schema, so recorded width is unaffected.

`pad_short_actions=True` restores the previous zero-fill for a consumer that needs a fixed-width dict, documented at the opt-in site as travelling those joints to zero. `diagnose_action_dim` gained a matching `pad_short` argument so the warning reports whichever consequence is actually in effect instead of one that was never true.

The index mapping was duplicated across the two providers, so the rule now lives once in `strands_robots.policies.align_action_values`, beside `resolve_chunk_length` and for the same stated reason -- each consumer inlined the same expression and they drifted. A parity test pins that the two providers agree for every input shape.

A vector **longer** than the actuator list is unchanged: the trailing values are dropped, because there is no actuator to receive them.

## Visual artifact -- MuJoCo sim, headless (`MUJOCO_GL=egl`)

A Panda is posed with the wrist bent and the gripper wide open, then a policy emits **five of the robot's eight** action values, leaving `actuator6`, `actuator7` and `actuator8` (the gripper) unmatched. Nothing the model produced mentions them. All three zero targets are inside their `ctrlrange`, so nothing here is a clamp artifact.

![short action vector: padded to zero vs omitted](https://raw.githubusercontent.com/cagataycali/robots/artifacts/short-action-zero-fill/short_action.gif)

| | gripper gap | joint6 | joint7 |
|---|---|---|---|
| before -- padded to `0.0` | 0.0800 -> **0.0000 m** (slams shut) | 1.794 -> 0.193 | 0.997 -> 0.001 |
| after -- omitted | 0.0800 -> **0.0800 m** (holds) | 1.794 -> 1.794 | 0.997 -> 0.996 |

The left panel was rendered with the source reverted to `main`. Over the 60 control steps the before panel changes 17.5% of its pixels and the after panel 6.2% (silhouette antialiasing at this magnification -- the joint values above are the measurement).

## Tests

`tests/policies/test_short_action_holds_unmatched_actuators.py` (25 tests): the shared rule for every length and both flag values; `lerobot_local` on the sim-key and hardware `.pos` paths; unit conversion applying to the emitted columns only; `lerobot_async` short chunks; `pad_short_actions` being a declared kwarg rather than one the async client warns it is dropping; provider parity; the diagnostic describing its own behaviour; and an end-to-end MuJoCo case on two position actuators parked at 0.8 rad, where the unmatched joint holds 0.8 rad instead of travelling to 0.0. The MJCF is inline, so it needs no asset download.

Pre-fix, against `196c667f` with only the source reverted: **15 failed, 17 passed** -- including `assert 'a_elbow' not in {'a_shoulder': 0.2, 'a_elbow': 0.0}` from the sim case. (The `pad_short=True` parametrization passes pre-fix by construction: padding is what `main` always did.)

Two existing tests in `tests/policies/lerobot_local/test_action_diagnostics.py` pinned the incorrect claim (`assert "zero-filled" in msg`, and an assertion that all six keys come back with `result[0]["5"] == 0.0`). They are updated to the corrected contract with the reason in their docstrings rather than shimming the code to keep them green.

## Gate

`ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean (`Success: no issues found in 921 source files`). Full suite `MUJOCO_GL=egl python -m pytest tests`: **12751 passed, 253 skipped** in 435s (12726 on `196c667f` before this PR's 25 new tests).

---

## §13 Review Rounds

### Round 1 -- exploratory, superseded

Four commits explored this thread and were reverted: a blanket refusal in
`DatasetRecorder.add_frame` (`e79beba`, reverted by `3157b3d`) and a `data.ctrl`
readback fill in the MuJoCo hooks (`138dd80`, reverted by `e275b46`). Both
reverts were correct and their reasoning stands:

- the **readback** returns ctrl units, so a Panda-class gripper column would mix
  a logical `0..1` fraction with `255.0`; it also read `data.ctrl` outside
  `self._lock` at the frame-writeout block whose lock-free-ness is justified by
  "does not touch MuJoCo model/data", resolved keys by actuator name only with a
  silent fallback to `0.0`, and was MuJoCo-only.
- the **blanket refusal** has a false positive: every backend hook calls
  `add_frame` once per robot with only that robot's prefixed keys while
  `start_recording` declares all robots' columns, so a two-robot scene
  legitimately produces a half-width action dict every frame
  (`tests/simulation/isaac/test_dataset_recording.py::test_multi_robot_namespaced_schema`).

### Round 2 (`c28cb6c`) -- fixed, scoped by the producer

The round-1 analysis identified the right seam and #1715 named it: the recorder
cannot distinguish "deliberately uncommanded so it holds" from "one robot's slice
of a shared schema", but **the producer knows both**. That is now implemented
here, so this PR no longer leaves a reachable path to the hazard it removes.

`add_frame` takes `required_action_keys=` -- the columns this frame is answerable
for -- and refuses a declared column in that set which the action dict does not
carry. Every backend's recording hook passes the driven robot's action keys, so
the multi-robot pattern is untouched and `test_multi_robot_namespaced_schema`
passes unchanged. An AST parity test pins that no hook may forward an action
without scoping it; it caught a fourth call site in `run_multi_policy`'s merged
frame.

**Refusing rather than substituting was measured**, not assumed. On the Panda
tendon gripper:

| candidate placeholder | replayed as | outcome |
|---|---|---|
| `0.0` (the behaviour on main) | `ctrl 0` of `[0, 255]` | gripper **fully closed** |
| the joint's measured position, `0.03999 m` | `ctrl 10.197` of `[0, 255]` | **4.0% open** -- still closes |
| the standing command, read back from `data.ctrl` | ambiguous | `_scale_ctrl_for_actuator` is non-injective: action `0.5` and action `127.5` both map to `ctrl 127.500` |

Reproduced end to end before fixing: a rollout driving 6 of 8 actuators recorded
`actuator8` as `0.0` for all 30 frames, and replaying it drove an open gripper
from a **0.0800 m gap to 0.0000 m** while reporting `success`.

`robot_action_keys` is resolved lazily and only when a recorder is attached,
because it is best-effort for the runner's fail-fast probe (an eager call breaks
`test_policy_runner_action_keys_probe_failsoft`). Where a recording *is* attached
the columns are load-bearing, so a raise fails the recording instead of silently
falling back to filling them in.

![recorded action columns](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recorded-action-columns/recorded_action_columns.png)

**Pre-fix**: against the reviewed state the new tests are **8 failed, 2 passed**,
including `test_a_short_action_rollout_records_no_episode_to_replay` failing as
`assert 'success' == 'error'`. The 2 passing pre-fix are the preserved-default
and complete-rollout cases, which keep the contract symmetric.

**Still open, deliberately.** Those other robots' columns are filled with `0.0`
on every multi-robot recording that exists today, with no narrow policy involved.
That is older and wider than this PR's path and needs the frame-contract decision
(one merged frame per step vs per-robot schemas), so #1715 stays open for it and
`test_the_default_still_fills_unmatched_columns` pins the unchanged default rather
than quietly changing it.

**Gate** (Thor, aarch64, `MUJOCO_GL=egl`, rebased onto `f915612f`):

```
ruff check strands_robots tests tests_integ           All checks passed!
ruff format --check strands_robots tests tests_integ  940 files already formatted
mypy strands_robots tests tests_integ                 Success: no issues found in 937 source files
pytest tests -q --no-cov                              13165 passed, 253 skipped in 427.90s
python scripts/assemble_changelog.py --check          changelog fragments OK
```
