### PR TITLE
fix(hardware): refuse a per-camera option that cannot be honored

### DIFF
--- a/changelog.d/1705-camera-options-fields-driven.md
+++ b/changelog.d/1705-camera-options-fields-driven.md
@@ -1,0 +1,25 @@
+### Fixed: a per-camera option that cannot be honored is refused, and every declared field is reachable
+
+`Robot(..., cameras={"front": {...}})` read each camera's dict key by key
+against a hand-picked list of six options. Two consequences, both silent:
+
+- `warmup_s` and `backend` were **unreachable**. lerobot's
+  `OpenCVCameraConfig` declares nine fields; the builder read six, so no
+  caller could set the connect-time warmup or select an OpenCV backend
+  (`cv2.CAP_V4L2`) at all -- the value was accepted and the default compiled.
+- Any other key was **discarded**. `heigth=1080` (or `fourc="MJPG"`, or the
+  `serial` key the documentation itself advertised) returned a working config
+  streaming at the 640x480 default, with no signal that the option had been
+  dropped.
+
+The accepted vocabulary is now derived from
+`dataclasses.fields(OpenCVCameraConfig)`, so every declared field -- including
+fields future lerobot releases add -- is reachable, and an unknown key raises
+`ValueError` naming the camera, the unknown option and the closest declared
+field, per AGENTS.md > Review Learnings (#86). Three dead-end errors on the same
+read path are also resolved: an omitted `index_or_path` reported `KeyError:
+'index_or_path'`, a non-mapping camera entry reported `AttributeError: 'str'
+object has no attribute 'get'`, and a value lerobot's own validation refuses
+(e.g. a 3-character `fourcc`) raised without naming which camera it came from.
+
+The documented `fps=30`/`width=640`/`height=480` defaults are unchanged.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -35,7 +35,7 @@ robot.cleanup()
 |-------|------|
 | `tool_name` | Tool identifier for the agent. |
 | `robot` | LeRobot `Robot` instance, `RobotConfig`, or string (e.g. `"so100"`). |
-| `cameras` | `{name: config_dict}`. Config keys: `type`, `index_or_path`, `fps`, `width`, `height`, `serial`. |
+| `cameras` | `{name: config_dict}`. Config keys are `type` (backend selector, `opencv`) plus the fields of lerobot's `OpenCVCameraConfig`: `index_or_path` (required), `fps`, `width`, `height`, `color_mode`, `rotation`, `warmup_s`, `fourcc`, `backend`. An unknown key raises `ValueError`. |
 | `action_horizon` | Actions per inference step (default 8; must be a positive integer). |
 | `data_config` | GR00T data_config name. |
 | `control_frequency` | Control loop Hz (default 50). |

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import difflib
 import functools
 import importlib
 import logging
@@ -24,7 +25,7 @@ import pkgutil
 import shutil
 import threading
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
@@ -96,6 +97,111 @@ _FORWARDABLE_KWARGS = (
     "max_relative_target",
     "disable_torque_on_disconnect",
 )
+
+
+# ---------------------------------------------------------------------------
+# Per-camera config construction.
+# ---------------------------------------------------------------------------
+#
+# ``Robot(..., cameras={"front": {...}})`` describes each camera with a
+# free-form dict whose keys are the fields of lerobot's camera config
+# dataclass. The accepted vocabulary is therefore derived from
+# ``dataclasses.fields()`` rather than hand-picked: a hand-picked list leaves
+# every field it forgets unreachable (no caller can set it at all) and silently
+# discards every key it does not recognise, so a typo like ``heigth=1080``
+# reports success having configured the default resolution.
+#
+# ``strands_robots`` supplies its own defaults for the three fields lerobot
+# leaves as ``None`` (meaning "whatever the device negotiates") so an
+# unconfigured camera has a predictable, documented stream. Every other field
+# keeps lerobot's own default.
+#
+# Invariant: every key here must be a field lerobot still declares. If one is
+# renamed upstream the stale key reaches ``OpenCVCameraConfig(**options)`` and
+# fails loudly for every camera rather than being silently dropped -- and the
+# test suite asserts the containment directly, so the drift is caught before a
+# release rather than at an operator's ``Robot()`` call.
+_OPENCV_CAMERA_DEFAULTS: dict[str, Any] = {"fps": 30, "width": 640, "height": 480}
+
+# ``type`` selects which camera backend to build. It is consumed by the
+# dispatch below, not forwarded to the config dataclass.
+_CAMERA_TYPE_KEY = "type"
+
+
+def _build_camera_config(camera_name: str, config: Any) -> Any:
+    """Build the lerobot camera config for one entry of a ``cameras`` dict.
+
+    Args:
+        camera_name: The key this camera was registered under. Named in every
+            error so a multi-camera rig reports which entry is at fault.
+        config: The per-camera options. Accepted keys are the declared fields
+            of lerobot's ``OpenCVCameraConfig`` plus ``type``, which selects
+            the camera backend (``opencv`` is the only one implemented).
+
+    Returns:
+        The constructed ``OpenCVCameraConfig``.
+
+    Raises:
+        ValueError: If ``config`` is not a mapping, names an unimplemented
+            camera ``type``, carries a key that is not a declared field, omits
+            a field that has no default, or holds a value lerobot's own config
+            validation refuses. An unknown key is refused rather than dropped
+            per AGENTS.md > Review Learnings (#86): a silently discarded option
+            reports success while the camera streams at the default.
+    """
+    from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
+
+    if not isinstance(config, Mapping):
+        raise ValueError(
+            f"Camera {camera_name!r} config must be a mapping of option name to value, "
+            f"got {type(config).__name__}: {config!r}."
+        )
+
+    cam_type = config.get(_CAMERA_TYPE_KEY, "opencv")
+    if cam_type != "opencv":
+        raise ValueError(f"Unsupported camera type: {cam_type}")
+
+    fields = {f.name: f for f in dataclasses.fields(OpenCVCameraConfig)}
+    accepted = sorted(set(fields) | {_CAMERA_TYPE_KEY})
+
+    unknown = sorted(set(config) - set(fields) - {_CAMERA_TYPE_KEY}, key=repr)
+    if unknown:
+        hints = []
+        for key in unknown:
+            close = difflib.get_close_matches(str(key), accepted, n=1, cutoff=0.7)
+            if close:
+                hints.append(f"{key!r} -> {close[0]!r}")
+        hint = f" Did you mean: {', '.join(hints)}?" if hints else ""
+        raise ValueError(
+            f"Unknown option(s) for camera {camera_name!r}: {unknown}.{hint} "
+            f"OpenCVCameraConfig accepts: {accepted} (where {_CAMERA_TYPE_KEY!r} selects "
+            f"the camera backend). (If this is a typo, fix it.)"
+        )
+
+    missing = sorted(
+        name
+        for name, field in fields.items()
+        if name not in config
+        and name not in _OPENCV_CAMERA_DEFAULTS
+        and field.default is dataclasses.MISSING
+        and field.default_factory is dataclasses.MISSING
+    )
+    if missing:
+        raise ValueError(
+            f"Camera {camera_name!r} is missing required option(s): {missing}. OpenCVCameraConfig accepts: {accepted}."
+        )
+
+    # strands defaults first so an explicitly configured value always wins.
+    options = {**_OPENCV_CAMERA_DEFAULTS, **{name: config[name] for name in fields if name in config}}
+    try:
+        return OpenCVCameraConfig(**options)
+    except (TypeError, ValueError) as exc:
+        # Names the camera, which lerobot's own message cannot: its
+        # ``__post_init__`` validation (e.g. a 3-character ``fourcc``) raises
+        # with no idea which entry of the ``cameras`` dict it came from.
+        raise ValueError(
+            f"Failed to construct OpenCVCameraConfig for camera {camera_name!r}: {exc}. Options: {options}"
+        ) from exc
 
 
 @functools.cache
@@ -703,36 +809,22 @@ class Robot(TeleopMixin, AgentTool):
         typos like ``prot=`` (instead of ``port=``) at config-build time
         rather than as a delayed connection failure with no kwarg in
         sight.
+
+        Each entry of ``cameras`` follows the same contract, resolved against
+        the fields of lerobot's ``OpenCVCameraConfig`` -- see
+        :func:`_build_camera_config`.
         """
         # ``lerobot`` is already a hard dep at this point (``_initialize_robot``
         # imports it eagerly). Importing the camera + config modules here is
         # cheap and the only reason it isn't at module top is that some
         # downstream packagers tree-shake unused submodules.
-        from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
         from lerobot.robots.config import RobotConfig
 
         # Convert cameras to lerobot format.
         camera_configs: dict[str, Any] = {}
         if cameras:
             for name, config in cameras.items():
-                cam_type = config.get("type", "opencv")
-                if cam_type == "opencv":
-                    _cam_kwargs = dict(
-                        index_or_path=config["index_or_path"],
-                        fps=config.get("fps", 30),
-                        width=config.get("width", 640),
-                        height=config.get("height", 480),
-                        rotation=config.get("rotation", 0),
-                        color_mode=config.get("color_mode", "rgb"),
-                    )
-                    # Forward fourcc (e.g. "MJPG") when provided so high-res
-                    # cameras can hit 30fps -- many UVC cams only offer 30fps
-                    # under MJPG; the YUYV default caps at ~5fps @1080p.
-                    if config.get("fourcc") is not None:
-                        _cam_kwargs["fourcc"] = config["fourcc"]
-                    camera_configs[name] = OpenCVCameraConfig(**_cam_kwargs)
-                else:
-                    raise ValueError(f"Unsupported camera type: {cam_type}")
+                camera_configs[name] = _build_camera_config(name, config)
 
         # Trigger lerobot's lazy registration. Each robot driver registers
         # its config via @RobotConfig.register_subclass at module-import

--- a/tests/test_hardware_robot_camera_config.py
+++ b/tests/test_hardware_robot_camera_config.py
@@ -1,0 +1,192 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Behavior tests for per-camera config construction on the hardware ``Robot``.
+
+``Robot(..., cameras={"front": {...}})`` describes each camera with a free-form
+dict. Those keys are the fields of lerobot's ``OpenCVCameraConfig``, so the
+accepted vocabulary must be *derived* from the dataclass rather than
+hand-picked. A hand-picked list has two silent failure modes, both pinned here:
+
+    - every field it forgets is **unreachable** -- no caller can set it at all,
+      so the camera streams at the default with no signal (``warmup_s`` and
+      ``backend`` were both unreachable);
+    - every key it does not recognise is **discarded** -- so ``heigth=1080``
+      reported success having configured 480p (AGENTS.md > Review Learnings
+      (#86) > "Reject silently-dropped kwargs").
+
+The reachability test is deliberately written against
+``dataclasses.fields(OpenCVCameraConfig)`` rather than a fixed list of field
+names, so a field lerobot adds in a future release fails this test until it is
+verified reachable, instead of quietly joining the unreachable set.
+
+No serial/USB hardware is touched: only config dataclasses are constructed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+pytest.importorskip("lerobot")
+
+from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
+
+from strands_robots.hardware_robot import _OPENCV_CAMERA_DEFAULTS, _build_camera_config
+
+from .test_hardware_robot_config import _make_robot
+
+# A non-default, valid value for every field an operator can configure.
+# ``index_or_path`` is the one required field and is supplied separately.
+#
+# Keyed by field name so the coverage assertion below is exact: this map must
+# name every declared field, which is what makes "a new lerobot field is
+# reachable" a test failure rather than a silent regression.
+_PROBE_VALUES: dict[str, object] = {
+    "index_or_path": 1,
+    "fps": 15,
+    "width": 800,
+    "height": 600,
+    "color_mode": "bgr",
+    "rotation": 90,
+    "warmup_s": 5,
+    "fourcc": "MJPG",
+    "backend": 200,  # cv2.CAP_V4L2
+}
+
+
+def _declared_fields() -> dict[str, dataclasses.Field]:
+    return {f.name: f for f in dataclasses.fields(OpenCVCameraConfig)}
+
+
+class TestFieldReachability:
+    def test_probe_values_cover_every_declared_field(self):
+        """The probe map must name every field, so new lerobot fields surface.
+
+        Without this, a field added by a lerobot release would simply be absent
+        from the reachability test below and could go unreachable unnoticed --
+        exactly how ``warmup_s`` and ``backend`` were lost.
+        """
+        assert set(_PROBE_VALUES) == set(_declared_fields())
+
+    @pytest.mark.parametrize("field_name", sorted(_PROBE_VALUES))
+    def test_declared_field_is_reachable_from_a_camera_dict(self, field_name: str):
+        """Every declared field can be set through the per-camera dict.
+
+        Pre-fix the builder hand-picked six of the nine fields, so ``warmup_s``
+        and ``backend`` could not be configured at all: the value was accepted
+        and the config carried the default.
+        """
+        probe = _PROBE_VALUES[field_name]
+        cfg = _build_camera_config("front", {"index_or_path": 0, field_name: probe})
+
+        stored = getattr(cfg, field_name)
+        # ``color_mode`` / ``rotation`` / ``backend`` are coerced to enums by
+        # lerobot's ``__post_init__``; compare on the underlying value.
+        assert getattr(stored, "value", stored) == probe
+
+    def test_strands_defaults_apply_and_explicit_values_win(self):
+        """The documented 30fps/640x480 defaults survive the fields-driven build.
+
+        lerobot leaves ``fps``/``width``/``height`` as ``None`` ("negotiate with
+        the device"); strands_robots pins them so an unconfigured camera has a
+        predictable stream. That contract is behaviour, not an implementation
+        detail of the old hand-picked list.
+        """
+        default = _build_camera_config("front", {"index_or_path": 0})
+        assert (default.fps, default.width, default.height) == (30, 640, 480)
+
+        explicit = _build_camera_config("front", {"index_or_path": 0, "fps": 60, "width": 1280, "height": 720})
+        assert (explicit.fps, explicit.width, explicit.height) == (60, 1280, 720)
+
+    def test_strands_defaults_are_declared_fields(self):
+        """A strands default must name a field lerobot still declares.
+
+        If lerobot renames one of these, forwarding the stale key would fail at
+        construction time for every camera. Catch the drift here instead.
+        """
+        assert set(_OPENCV_CAMERA_DEFAULTS) <= set(_declared_fields())
+
+
+class TestUnknownOptionsRefused:
+    def test_typo_is_refused_with_the_closest_field_named(self):
+        """A misspelled option raises instead of configuring the default.
+
+        Pre-fix ``heigth=1080`` returned a config at 480p with status success.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _build_camera_config("front", {"index_or_path": 0, "heigth": 1080})
+
+        message = str(excinfo.value)
+        assert "heigth" in message
+        assert "'height'" in message  # the suggestion
+        assert "'front'" in message  # which camera is at fault
+
+    def test_unrecognisable_option_lists_the_accepted_fields(self):
+        """An option with no close match still reports the accepted vocabulary."""
+        with pytest.raises(ValueError) as excinfo:
+            _build_camera_config("front", {"index_or_path": 0, "resolution": [1920, 1080]})
+
+        message = str(excinfo.value)
+        assert "resolution" in message
+        for name in _declared_fields():
+            assert name in message
+
+    def test_missing_required_option_names_it(self):
+        """An omitted required field reports the option, not a bare ``KeyError``.
+
+        Pre-fix this raised ``KeyError: 'index_or_path'`` out of the builder,
+        naming neither the camera nor what was required of it.
+        """
+        with pytest.raises(ValueError, match=r"'front' is missing required option\(s\): \['index_or_path'\]"):
+            _build_camera_config("front", {"type": "opencv"})
+
+    def test_non_mapping_camera_config_is_refused(self):
+        """A camera entry that is not a mapping reports what was passed.
+
+        Pre-fix this raised ``AttributeError: 'str' object has no attribute
+        'get'`` from the first ``config.get(...)``.
+        """
+        with pytest.raises(ValueError, match=r"Camera 'front' config must be a mapping"):
+            _build_camera_config("front", "video0")
+
+    def test_value_rejected_by_lerobot_names_the_camera(self):
+        """lerobot's own option validation is reported against the camera name.
+
+        ``fourcc`` must be a 4-character code; lerobot raises with no idea which
+        entry of a multi-camera ``cameras`` dict it came from.
+        """
+        with pytest.raises(ValueError, match=r"for camera 'wrist'"):
+            _build_camera_config("wrist", {"index_or_path": 0, "fourcc": "MJP"})
+
+
+class TestWiredIntoCreateMinimalConfig:
+    """The contract holds through the public ``cameras=`` entry point.
+
+    The tests above exercise the builder directly; these pin that
+    ``_create_minimal_config`` actually routes through it, so the guard cannot
+    be bypassed by the surface an operator/agent really calls.
+    """
+
+    def test_previously_unreachable_fields_reach_the_robot_config(self):
+        hw = _make_robot()
+        cfg = hw._create_minimal_config(
+            "so101_follower",
+            {"front": {"type": "opencv", "index_or_path": 0, "warmup_s": 4, "backend": 200}},
+            port="/dev/ttyACM0",
+        )
+        cam = cfg.cameras["front"]
+        assert cam.warmup_s == 4
+        assert cam.backend.value == 200
+
+    def test_typo_in_one_camera_of_several_is_refused(self):
+        hw = _make_robot()
+        with pytest.raises(ValueError, match=r"Unknown option\(s\) for camera 'wrist'.*fourc"):
+            hw._create_minimal_config(
+                "so101_follower",
+                {
+                    "front": {"type": "opencv", "index_or_path": 0},
+                    "wrist": {"type": "opencv", "index_or_path": 1, "fourc": "MJPG"},
+                },
+                port="/dev/ttyACM0",
+            )


### PR DESCRIPTION
## Problem

`Robot(..., cameras={"front": {...}})` describes each camera with a free-form dict. `_create_minimal_config` read that dict key by key against a hand-picked list of six options, and lerobot's `OpenCVCameraConfig` declares **nine** fields. One hand-picked list, two silent failures:

**`warmup_s` and `backend` were unreachable.** Not "dropped when unsupported" - there was no way for any caller to set the connect-time warmup or select an OpenCV backend (`cv2.CAP_V4L2`) at all. The value was accepted and the default compiled.

**Every other key was discarded.** `heigth=1080` returned a working config streaming at the 640x480 default, with no signal. So did `fourc="MJPG"` - and so did `serial`, a key `docs/hardware/robot-control.md` itself advertised and which has never been a field of `OpenCVCameraConfig`.

Measured on a real UVC camera (`/dev/video2`, Jetson AGX Thor), driving the public `cameras=` entry point:

| Call | Before | After |
|---|---|---|
| `{..., "backend": 200, "warmup_s": 3}` | success; `backend=ANY`, `warmup_s=1`, connect took **1.54 s** | success; `backend=V4L2`, `warmup_s=3`, connect took **3.53 s** |
| `{"width": 640, "heigth": 1080}` | success; `height=480`, streaming 640x480 | `ValueError: Unknown option(s) for camera 'front': ['heigth']. Did you mean: 'heigth' -> 'height'?` |

The connect wall clock is the proof that `warmup_s` is genuinely honored now rather than merely stored: 1.54 s (the 1 s default) before, 3.53 s (the requested 3 s) after.

Three dead-end errors live on the same read path. An omitted `index_or_path` raised `KeyError: 'index_or_path'` from `config["index_or_path"]`, naming neither the camera nor what was required. A non-mapping camera entry raised `AttributeError: 'str' object has no attribute 'get'` from the first `config.get(...)`. And a value lerobot's own `__post_init__` refuses (e.g. a 3-character `fourcc`) raised with no indication which entry of a multi-camera dict produced it.

## Change

The accepted vocabulary is derived from `dataclasses.fields(OpenCVCameraConfig)` rather than hand-picked, in one `_build_camera_config(camera_name, config)`:

- every declared field is reachable, **including fields future lerobot releases add** - the list cannot fall behind the dataclass again;
- an unknown key raises `ValueError` naming the camera, the unknown option, the closest declared field (difflib, cutoff 0.7) and the full accepted set, per AGENTS.md > Review Learnings (#86) - the same contract the robot-level kwargs already had;
- `type` stays accepted as the backend selector and is not forwarded to the dataclass; the `Unsupported camera type: <t>` message is unchanged;
- a missing required field, a non-mapping entry, and a value lerobot refuses each report against the camera name instead of a bare `KeyError` / `AttributeError` / anonymous `ValueError`.

The documented `fps=30` / `width=640` / `height=480` defaults are unchanged - lerobot leaves those three as `None` ("negotiate with the device") and `strands_robots` pins them so an unconfigured camera has a predictable stream. `rotation=0` and `color_mode="rgb"` were dropped from the explicit map because they already *are* the dataclass defaults (`Cv2Rotation(0) is NO_ROTATION`, `ColorMode("rgb") is RGB`), so removing them changes nothing.

`_OPENCV_CAMERA_DEFAULTS` must name fields lerobot still declares; that containment is asserted directly, so an upstream rename is caught before a release rather than at an operator's `Robot()` call.

## Cutoff calibration

Measured before picking 0.7, over realistic typos vs unrelated keys:

| cutoff | typos matched | false positives |
|---|---|---|
| 0.4 | 10/10 | 3 (`resolution`->`rotation`, `exposure`->`fourcc`, `gain`->`rotation`) |
| 0.5 | 10/10 | 2 |
| 0.6 | 9/10 | 1 (`resolution`->`rotation`) |
| **0.7** | **9/10** | **0** |

At 0.7 every realistic misspelling (`heigth`, `fourc`, `wdith`, `colour_mode`, `rotaton`, `warmup`, `backends`) still gets its suggestion and no unrelated key gets a misleading one; the one miss (`index` for `index_or_path`) is a different word, and the message lists the accepted set regardless.

## Tests

`tests/test_hardware_robot_camera_config.py`, 19 tests. The reachability test is written against `dataclasses.fields(OpenCVCameraConfig)` and paired with `test_probe_values_cover_every_declared_field`, so a field a future lerobot release adds **fails this test** until it is verified reachable, instead of quietly joining the unreachable set - that is the guard that would have caught `warmup_s` and `backend`. A second class pins the contract through `_create_minimal_config` itself, so the guard cannot be bypassed by the surface an operator or agent actually calls.

Pre-fix proof, same contracts expressed only through the public entry point so they collect against `main`:

```
upstream/main:  7 failed, 9 passed
  [backend]  AssertionError: assert 0 == 200
  [warmup_s] AssertionError: assert 1 == 5
  typo refused              -> DID NOT RAISE ValueError
  unknown option refused    -> DID NOT RAISE ValueError
  missing required option   -> KeyError: 'index_or_path'
  non-mapping entry         -> AttributeError: 'str' object has no attribute 'get'
  lerobot error names camera-> "`fourcc` must be a 4-character string..." (no camera named)
this PR:       16 passed
```

## Artifact

Real UVC camera on Jetson AGX Thor; the frames are live captures through the config each tree built, and the pre-fix panels were generated with the source reverted.

![camera options honored](https://raw.githubusercontent.com/cagataycali/robots/artifacts/camera-options/camera_options.png)

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean (`Success: no issues found in 925 source files`).
- Full suite, CI's fixed order: **12859 passed, 253 skipped** (411 s).
- Randomized order: `pytest-randomly` is not in the dev environment, so nothing configures randomization. Running the 653 test modules in a seeded shuffled file order gives **45 failures on this branch and 46 on pure `main` at the same commit with the same ordering** - the suite is order-sensitive today through shared global state (user registry `already in user registry`, tool-module attributes, mesh singletons) in `tests/registry/`, `tests/mesh/`, `tests/test_tool_result_contract.py`, `tests/tools/`. No failure is in a module this PR touches, and none is in either camera-config module. Happy to file that separately; it is pre-existing and orthogonal.

## Scope

Per-camera option rejection only. The half-open-port cleanup already landed (`_rollback_half_open_connect`), and per-task policy reset is a separate contract that has not been triaged against `main` here.

## 13. Round changelog

### Branch sync - `main` merged in, no change to this PR's own diff

The single required check was failing on a pin this PR does not touch:

```
FAILED tests/test_hardware_control_loop_rate_guard.py::TestPeriodIsTheOnlyThrottle::
  test_a_non_positive_period_leaves_the_loop_unthrottled
```

That assertion is an absolute iteration floor no GitHub runner reaches (#1707). It is
deterministic rather than flaky: re-running this branch's job at the same commit failed
identically, same assertion, same counts. The fix landed on `main` in #1709, so `main`
is merged into this branch to pick it up.

No file this PR owns changed in that merge. The ruleset dismissed the standing approval
automatically on push (`dismiss_stale_reviews_on_push`, `require_last_push_approval`),
so a re-approval is required for the merge to proceed - the diff under review is
identical to the state that was approved.
