### PR TITLE
fix(tools): pose_tool emergency_stop de-energizes the arm instead of reporting that it did

### DIFF
--- a/changelog.d/1706-pose-tool-emergency-stop.md
+++ b/changelog.d/1706-pose-tool-emergency-stop.md
@@ -1,0 +1,25 @@
+### Fixed: pose_tool emergency_stop de-energizes the arm instead of reporting that it did
+
+`pose_tool(action="emergency_stop")` returned
+`{"status": "success", "text": "Emergency stop executed (torque disabled)"}`
+while executing no code at all:
+
+```python
+if action == "emergency_stop":
+    # This would require torque disable in real implementation
+    return {"status": "success", "content": [{"text": "Emergency stop executed (torque disabled)"}]}
+```
+
+The bus was never opened and no packet was ever written, for any port,
+connected or not. An operator or agent that reached for the one action meant to
+stop a moving arm was told the arm had been released when nothing had happened
+to it.
+
+The handler now connects and writes `Torque_Enable = 0` (address 40 on the
+Feetech STS/SMS control table) to every configured motor via the new
+`MotorController.disable_torque()`, which attempts every motor even after one
+fails and returns the ones still driven. An unreachable bus or any failed write
+is reported as `status="error"` naming the joints that are still energized and
+pointing at the hardware cutoff. The success text now also states that the arm
+goes limp and drops what it is holding, which is what de-energizing means and
+is not what "stopped" implies.

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -233,6 +233,40 @@ class MotorController:
             logger.error(f"Failed to move motor {motor_name}: {e}")
             return False
 
+    def disable_torque(self) -> list[str]:
+        """De-energize every configured motor, returning the ones that failed.
+
+        Writes ``Torque_Enable = 0`` to each motor. That register is address 40
+        (1 byte) on the Feetech STS/SMS control table -- the authority is
+        ``lerobot.motors.feetech.tables``, the same table that gives
+        ``Goal_Position`` address 42 used by :meth:`move_motor`.
+
+        Every motor is attempted even after one fails: a stop that gave up on
+        the remaining joints would be worse than no stop at all, because the
+        caller would be told the whole arm was released when part of it is
+        still driven.
+
+        Returns:
+            Names of the motors whose write failed, empty when all succeeded. A
+            non-empty list means the arm is NOT fully de-energized.
+        """
+        if not self.serial_conn or not self.serial_conn.is_open:
+            return list(self.motor_configs)
+
+        failed: list[str] = []
+        for motor_name, config in self.motor_configs.items():
+            try:
+                # INST_WRITE (0x03), Torque_Enable address (0x28), value 0.
+                packet = self.build_feetech_packet(config["id"], 0x03, [0x28, 0x00])
+                self.serial_conn.write(packet)
+            except OSError as e:
+                # Narrow to the transport: ``serial.SerialException`` subclasses
+                # ``OSError``. Record and continue so the remaining motors are
+                # still attempted, then report which ones are still driven.
+                logger.error(f"Failed to disable torque on {motor_name}: {e}")
+                failed.append(motor_name)
+        return failed
+
     def read_motor_position(self, motor_name: str) -> float | None:
         """Read current motor position in degrees."""
         if not self.serial_conn or not self.serial_conn.is_open:
@@ -346,7 +380,10 @@ def pose_tool(
 
         System:
         - "connect": Test robot connection
-        - "emergency_stop": Stop all motor movement
+        - "emergency_stop": De-energize every motor (Torque_Enable=0). The arm
+          goes LIMP and falls under gravity -- it does not hold position, so
+          anything it is grasping is dropped. Reports an error when any motor
+          could not be released.
         - "reset_to_home": Move to safe home position
 
     Args:
@@ -660,8 +697,55 @@ def pose_tool(
                 controller.disconnect()
 
         if action == "emergency_stop":
-            # This would require torque disable in real implementation
-            return {"status": "success", "content": [{"text": "Emergency stop executed (torque disabled)"}]}
+            # This handler used to return "Emergency stop executed (torque
+            # disabled)" while executing no code at all. A fabricated
+            # confirmation is the worst possible failure on a safety path: an
+            # operator or agent reading success believes a moving arm has been
+            # released, and the one action they would reach for in an emergency
+            # is the one that never did anything.
+            connected, connect_error = controller.connect()
+            if not connected:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"EMERGENCY STOP FAILED - the arm was NOT de-energized: {connect_error}. "
+                                "Use the hardware power cutoff."
+                            )
+                        }
+                    ],
+                }
+            try:
+                failed = controller.disable_torque()
+            finally:
+                controller.disconnect()
+
+            if failed:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "EMERGENCY STOP INCOMPLETE - torque is still enabled on: "
+                                f"{', '.join(failed)}. Those joints are still driven; use the "
+                                "hardware power cutoff."
+                            )
+                        }
+                    ],
+                }
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            "Emergency stop executed - torque disabled on "
+                            f"{len(controller.motor_configs)} motors. The arm is limp and will "
+                            "fall under gravity; anything held has been dropped."
+                        )
+                    }
+                ],
+            }
 
         else:
             return {

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared serial-layer doubles for the ``pose_tool`` test modules.
+
+These live in a conftest rather than in one test module because two modules
+now need them, and importing a fixture across test modules re-binds the name
+in the importing module (ruff F811) as well as making the owning module an
+implicit dependency of the other.
+
+``pose_tool``'s ``port`` defaults to ``/dev/ttyACM0`` and several actions --
+``emergency_stop`` above all -- write to the bus, so every test that reaches
+the motor path must both take ``fake_serial`` and pass an explicit fake
+``port``. Otherwise the suite drives whatever arm is plugged into the machine
+running it.
+"""
+
+from __future__ import annotations
+
+import pytest
+import serial
+
+
+class FakeSerial:
+    """Minimal stand-in for ``serial.Serial`` recording writes and serving reads."""
+
+    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self.writes: list[bytes] = []
+        self._read_queue: list[bytes] = []
+        self.is_open = True
+
+    def queue_read(self, data: bytes) -> None:
+        self._read_queue.append(data)
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        if self._read_queue:
+            return self._read_queue.pop(0)
+        return b""
+
+    def close(self) -> None:
+        self.is_open = False
+
+
+@pytest.fixture
+def fake_serial(monkeypatch):
+    """Patch ``serial.Serial`` to return a single shared FakeSerial instance."""
+    instances: list[FakeSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> FakeSerial:
+        fs = FakeSerial(port, baudrate, timeout)
+        instances.append(fs)
+        return fs
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return instances
+
+
+@pytest.fixture
+def cwd_tmp(tmp_path, monkeypatch):
+    """Run with cwd in a temp dir so PoseManager persists under tmp."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path

--- a/tests/tools/test_pose_tool.py
+++ b/tests/tools/test_pose_tool.py
@@ -33,6 +33,8 @@ from strands_robots.tools.pose_tool import (
 )
 from tests.tool_result_contract import tool_json
 
+from .conftest import FakeSerial
+
 
 def _texts(result: dict[str, Any]) -> str:
     """Concatenate all content ``text`` fields from a tool result."""
@@ -48,51 +50,6 @@ def _assert_ascii(result: dict[str, Any]) -> None:
 # --------------------------------------------------------------------------- #
 # Fake serial layer
 # --------------------------------------------------------------------------- #
-class FakeSerial:
-    """Minimal stand-in for ``serial.Serial`` recording writes and serving reads."""
-
-    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
-        self.port = port
-        self.baudrate = baudrate
-        self.timeout = timeout
-        self.writes: list[bytes] = []
-        self._read_queue: list[bytes] = []
-        self.is_open = True
-
-    def queue_read(self, data: bytes) -> None:
-        self._read_queue.append(data)
-
-    def write(self, data: bytes) -> None:
-        self.writes.append(bytes(data))
-
-    def read(self, n: int = 1) -> bytes:
-        if self._read_queue:
-            return self._read_queue.pop(0)
-        return b""
-
-    def close(self) -> None:
-        self.is_open = False
-
-
-@pytest.fixture
-def fake_serial(monkeypatch):
-    """Patch ``serial.Serial`` to return a single shared FakeSerial instance."""
-    instances: list[FakeSerial] = []
-
-    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> FakeSerial:
-        fs = FakeSerial(port, baudrate, timeout)
-        instances.append(fs)
-        return fs
-
-    monkeypatch.setattr(serial, "Serial", _ctor)
-    return instances
-
-
-@pytest.fixture
-def cwd_tmp(tmp_path, monkeypatch):
-    """Run with cwd in a temp dir so PoseManager persists under tmp."""
-    monkeypatch.chdir(tmp_path)
-    return tmp_path
 
 
 # --------------------------------------------------------------------------- #
@@ -329,8 +286,12 @@ def test_pose_tool_move_motor_success_is_ascii(cwd_tmp, fake_serial) -> None:
     _assert_ascii(result)
 
 
-def test_pose_tool_emergency_stop_is_ascii(cwd_tmp) -> None:
-    result = pose_tool(action="emergency_stop", robot_id="hw_arm")
+def test_pose_tool_emergency_stop_is_ascii(cwd_tmp, fake_serial) -> None:
+    # An explicit fake port is mandatory here: ``port`` defaults to
+    # "/dev/ttyACM0" and ``emergency_stop`` now really opens the bus and writes
+    # Torque_Enable=0, so a portless call would de-energize whatever arm is
+    # plugged into the machine running the suite.
+    result = pose_tool(action="emergency_stop", robot_id="hw_arm", port="/dev/ttyTEST")
     assert result["status"] == "success"
     _assert_ascii(result)
 

--- a/tests/tools/test_pose_tool_emergency_stop.py
+++ b/tests/tools/test_pose_tool_emergency_stop.py
@@ -1,0 +1,194 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``pose_tool(action="emergency_stop")`` must de-energize the arm, or say it did not.
+
+The handler used to be::
+
+    if action == "emergency_stop":
+        # This would require torque disable in real implementation
+        return {"status": "success", "content": [{"text": "Emergency stop executed (torque disabled)"}]}
+
+No code ran. It reported success unconditionally, for every port, connected or
+not -- a fabricated safety confirmation on the one action an operator or agent
+reaches for when an arm is moving and must stop. The tests here assert against
+the BYTES that reach the bus rather than the status text, because the status
+text was exactly what was already correct.
+
+``Torque_Enable`` is address 40 (``0x28``, 1 byte) on the Feetech STS/SMS
+control table, per ``lerobot.motors.feetech.tables``.
+
+No real serial port is opened: ``serial.Serial`` is replaced by the recording
+``FakeSerial`` from the sibling module, and every call passes an explicit fake
+``port`` -- ``pose_tool``'s ``port`` defaults to ``/dev/ttyACM0``, so a portless
+call would reach a real arm plugged into the machine running the suite.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import serial
+
+from strands_robots.tools.pose_tool import MotorController, pose_tool
+
+from .conftest import FakeSerial
+
+_PORT = "/dev/ttyTEST"
+_TORQUE_ENABLE_ADDR = 0x28
+_MOTOR_IDS = {"shoulder_pan": 1, "shoulder_lift": 2, "elbow_flex": 3, "wrist_flex": 4, "wrist_roll": 5, "gripper": 6}
+
+
+def _torque_writes(writes: list[bytes]) -> list[int]:
+    """Motor ids that received a ``Torque_Enable = 0`` write, in order."""
+    return [
+        w[2]
+        for w in writes
+        if len(w) >= 7 and w[:2] == b"\xff\xff" and w[4] == 0x03 and w[5] == _TORQUE_ENABLE_ADDR and w[6] == 0x00
+    ]
+
+
+class TestEmergencyStopReachesTheBus:
+    def test_every_motor_is_de_energized(self, cwd_tmp, fake_serial):
+        """The call writes Torque_Enable=0 to all six motors.
+
+        Pre-fix ``fake_serial`` recorded zero writes and the port was never even
+        opened, while the tool reported success.
+        """
+        result = pose_tool(action="emergency_stop", robot_id="arm", port=_PORT)
+
+        assert result["status"] == "success"
+        assert len(fake_serial) == 1, "the bus must actually be opened"
+        assert _torque_writes(fake_serial[0].writes) == list(_MOTOR_IDS.values())
+
+    def test_packets_are_well_formed_feetech_writes(self, cwd_tmp, fake_serial):
+        """Each packet is a checksummed INST_WRITE of 0 to address 40."""
+        pose_tool(action="emergency_stop", robot_id="arm", port=_PORT)
+
+        writes = fake_serial[0].writes
+        assert len(writes) == len(_MOTOR_IDS)
+        for motor_id, packet in zip(_MOTOR_IDS.values(), writes, strict=True):
+            body = [motor_id, 4, 0x03, _TORQUE_ENABLE_ADDR, 0x00]
+            assert packet == bytes([0xFF, 0xFF, *body, ~sum(body) & 0xFF])
+
+    def test_the_port_is_released(self, cwd_tmp, fake_serial):
+        """A stop must not leave the bus held open against the next attempt."""
+        pose_tool(action="emergency_stop", robot_id="arm", port=_PORT)
+
+        assert fake_serial[0].is_open is False
+
+    def test_success_text_warns_the_arm_goes_limp(self, cwd_tmp, fake_serial):
+        """De-energizing drops whatever is held; the report must say so.
+
+        An operator who reads "stopped" and expects the arm to hold position
+        gets a falling arm and a dropped payload.
+        """
+        result = pose_tool(action="emergency_stop", robot_id="arm", port=_PORT)
+
+        text = " ".join(c["text"] for c in result["content"] if "text" in c).lower()
+        assert "limp" in text
+        assert "fall" in text
+
+
+class TestEmergencyStopReportsFailure:
+    def test_unreachable_bus_is_not_reported_as_a_stop(self, cwd_tmp, monkeypatch):
+        """A port that cannot be opened must report the arm was NOT released.
+
+        Pre-fix this returned success -- the arm could be unplugged, powered
+        down, or held by another process and the tool still said it had stopped.
+        """
+
+        def _boom(port, baudrate, timeout=1.0):
+            raise serial.SerialException("could not open port")
+
+        monkeypatch.setattr(serial, "Serial", _boom)
+
+        result = pose_tool(action="emergency_stop", robot_id="arm", port=_PORT)
+
+        assert result["status"] == "error"
+        text = " ".join(c["text"] for c in result["content"] if "text" in c)
+        assert "NOT de-energized" in text
+
+    def test_a_failed_write_names_the_joints_still_driven(self, cwd_tmp, fake_serial, monkeypatch):
+        """A motor whose write fails is named, and the rest are still attempted.
+
+        Giving up at the first failure would leave later joints driven while
+        reporting nothing about them.
+        """
+        controller = MotorController(_PORT)
+        connected, _ = controller.connect()
+        assert connected
+
+        failing = {"elbow_flex", "gripper"}
+        real_write = controller.serial_conn.write
+        ids_to_names = {v: k for k, v in _MOTOR_IDS.items()}
+
+        def _write(data: bytes) -> None:
+            if ids_to_names.get(data[2]) in failing:
+                raise serial.SerialException("bus write failed")
+            real_write(data)
+
+        monkeypatch.setattr(controller.serial_conn, "write", _write)
+
+        failed = controller.disable_torque()
+
+        assert sorted(failed) == sorted(failing)
+        # The four healthy joints were still released.
+        assert _torque_writes(fake_serial[0].writes) == [
+            motor_id for name, motor_id in _MOTOR_IDS.items() if name not in failing
+        ]
+
+    def test_a_closed_bus_claims_no_motor_was_released(self, cwd_tmp):
+        """With no open connection, every motor is reported as still driven.
+
+        Returning an empty "nothing failed" list would read as a complete stop.
+        """
+        controller = MotorController(_PORT)
+
+        assert sorted(controller.disable_torque()) == sorted(_MOTOR_IDS)
+
+    def test_partial_failure_surfaces_as_a_tool_error(self, cwd_tmp, monkeypatch):
+        """The tool reports status=error, not success, when a joint is left driven."""
+
+        def _partial(self) -> list[str]:
+            return ["gripper"]
+
+        monkeypatch.setattr(MotorController, "disable_torque", _partial)
+        monkeypatch.setattr(serial, "Serial", lambda port, baudrate, timeout=1.0: FakeSerial(port, baudrate, timeout))
+
+        result = pose_tool(action="emergency_stop", robot_id="arm", port=_PORT)
+
+        assert result["status"] == "error"
+        text = " ".join(c["text"] for c in result["content"] if "text" in c)
+        assert "gripper" in text
+        assert "INCOMPLETE" in text
+
+
+def test_no_test_calls_emergency_stop_on_the_default_port():
+    """No test anywhere may run ``emergency_stop`` without an explicit port.
+
+    ``pose_tool``'s ``port`` defaults to ``/dev/ttyACM0``. Now that the handler
+    really opens the bus and writes ``Torque_Enable=0``, a portless call
+    de-energizes whatever arm is attached to the machine running the suite --
+    it silently passes on a developer box with nothing plugged in and drops a
+    live arm on one that has hardware. Walk the whole test tree by AST so the
+    hazard cannot be reintroduced in a file nobody thinks to check.
+    """
+    offenders = []
+    for path in sorted(Path("tests").rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if name != "pose_tool":
+                continue
+            kwargs = {kw.arg for kw in node.keywords}
+            action = next(
+                (kw.value.value for kw in node.keywords if kw.arg == "action" and isinstance(kw.value, ast.Constant)),
+                None,
+            )
+            if action == "emergency_stop" and "port" not in kwargs:
+                offenders.append(f"{path}:{node.lineno}")
+
+    assert not offenders, f"emergency_stop called without an explicit port: {offenders}"


### PR DESCRIPTION
## Problem

`pose_tool(action="emergency_stop")` was, in full:

```python
if action == "emergency_stop":
    # This would require torque disable in real implementation
    return {"status": "success", "content": [{"text": "Emergency stop executed (torque disabled)"}]}
```

No code ran. The bus was never opened and no packet was ever written - for any port, connected or not, powered or not. The tool reported that torque had been disabled while the arm kept holding, or kept moving.

This is the worst shape a defect can take on a safety path. Every other failure mode in this repo costs a wrong pose or a lost episode; this one hands an operator - or an agent following the tool's own documented `"emergency_stop": Stop all motor movement` - a confirmation that the arm has been released when nothing has touched it. It is also the one action reached for precisely when something has already gone wrong, so the fabricated success arrives at the moment it is least likely to be double-checked.

A measurement, driving the public tool with the serial layer recorded:

| | Before | After |
|---|---|---|
| bus opened | **no** | yes |
| bytes written | **0** | 6 packets, `Torque_Enable=0` to motor ids 1..6 |
| status | `success` | `success` |
| port that cannot be opened | `success` | `error` - "the arm was NOT de-energized" |
| one motor's write fails | `success` | `error` naming the joints still driven |

## Change

`MotorController.disable_torque() -> list[str]` writes `Torque_Enable = 0` to every configured motor and returns the ones whose write failed. Address 40 (`0x28`, 1 byte) on the Feetech STS/SMS control table; the authority is `lerobot.motors.feetech.tables`, the same table that gives `move_motor` its `Goal_Position` address 42.

Every motor is attempted even after one fails. Stopping at the first failure would leave the later joints driven while reporting nothing about them - a partial stop presented as a whole one is the same defect again, one layer down.

The handler connects, disables torque, disconnects in a `finally`, and reports:

- bus could not be opened -> `error`, "the arm was NOT de-energized ... Use the hardware power cutoff";
- any write failed -> `error`, "torque is still enabled on: `<joints>`";
- otherwise -> `success`, and the text now says the arm **goes limp and falls under gravity, dropping anything held**. That is what de-energizing does and it is not what "stopped" implies; an operator expecting the arm to hold position gets a falling arm and a dropped payload.

## The test-suite hazard this creates, and its guard

`pose_tool`'s `port` defaults to `"/dev/ttyACM0"`. Making the handler real means a portless `pose_tool(action="emergency_stop")` **de-energizes whatever arm is plugged into the machine running the suite** - passing silently on a box with nothing attached and dropping a live arm on one that has hardware. The existing `test_pose_tool_emergency_stop_is_ascii` was exactly that call, harmless only because the handler did nothing.

It now takes the fake serial fixture and an explicit `port="/dev/ttyTEST"`, and a new test walks the whole test tree by AST for any `pose_tool(action="emergency_stop", ...)` call with no `port=` keyword, so the hazard cannot be reintroduced in a file nobody thinks to check.

The shared `FakeSerial` / `fake_serial` / `cwd_tmp` doubles move to `tests/tools/conftest.py` because a second module needs them - importing a fixture across test modules re-binds the name in the importer (ruff F811) and makes one test module an implicit dependency of the other.

## Tests

`tests/tools/test_pose_tool_emergency_stop.py`, 9 tests. They assert against the **bytes that reach the bus**, not the status text, because the status text was the one part that was already correct - a test written against the message would have passed pre-fix.

Pre-fix proof on `upstream/main`:

```
8 failed, 1 passed
  every motor de-energized      -> IndexError: list index out of range   (the bus was never opened)
  packets well-formed           -> IndexError: list index out of range
  port released                 -> IndexError: list index out of range
  success text warns of limp    -> assert 'limp' in 'emergency stop executed (torque disabled)'
  unreachable bus not a stop    -> assert 'success' == 'error'
  failed write names joints     -> AttributeError: no attribute 'disable_torque'
  closed bus claims none freed  -> AttributeError: no attribute 'disable_torque'
  partial failure is an error   -> AttributeError: no attribute 'disable_torque'
this PR: 9 passed
```

`assert 'success' == 'error'` is the whole report in one line: a bus that could not be opened at all was reported as a completed emergency stop.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean (`Success: no issues found in 926 source files`).
- `tests/tools/`: 890 passed, 1 skipped.
- Full suite: **12914 passed, 253 skipped** (414 s). One further note for transparency: a first full run also reported `tests/test_robot_factory.py::TestRobotRegistry::test_all_robots_have_description` failing with `assert 0 > 0 where 0 = len('')`. That is machine state, not this change - the registry tests write to the real `~/.strands_robots/user_robots.json` and a crashed earlier run had left `cache_bot` behind with an empty description. Removing the four leaked entries makes `tests/test_robot_factory.py tests/registry tests/tools` pass 1545/1545. Worth a separate look at that leak; it is orthogonal here.

## Note on visual artifact

None attached, deliberately. The change is a serial write and a status envelope, and the honest artifact for "were the bytes sent" is the recorded bus traffic quoted above rather than a picture. Demonstrating it on hardware would mean de-energizing a real arm to film it fall, which is not a reasonable thing to attach to a PR.

## Scope

The e-stop path only. The calibration-aware degree-to-tick mapping in the same tool is a separate defect with a separate contract (measured: the nominal midpoint mapping is off by up to 152 ticks / 13 degrees per joint against a real SO-101 calibration, and ~2029 ticks on the gripper) and is not folded in here.

## 13. Round changelog

### Branch sync - `main` merged in, no change to this PR's own diff

The single required check was failing on a pin this PR does not touch:

```
FAILED tests/test_hardware_control_loop_rate_guard.py::TestPeriodIsTheOnlyThrottle::
  test_a_non_positive_period_leaves_the_loop_unthrottled
```

That assertion is an absolute iteration floor no GitHub runner reaches (#1707). It is
deterministic rather than flaky: re-running this branch's job at the same commit failed
identically, same assertion, same counts. The fix landed on `main` in #1709, so `main`
is merged into this branch to pick it up.

No file this PR owns changed in that merge. The ruleset dismissed the standing approval
automatically on push (`dismiss_stale_reviews_on_push`, `require_last_push_approval`),
so a re-approval is required for the merge to proceed - the diff under review is
identical to the state that was approved.
