### PR TITLE
test(hardware): bound the unthrottled-loop pin by the throttled loop, not an absolute count

### DIFF
--- a/changelog.d/1707-unthrottled-loop-relative-bound.md
+++ b/changelog.d/1707-unthrottled-loop-relative-bound.md
@@ -1,0 +1,12 @@
+### Tests: the unthrottled control-loop pin measures the throttle, not the runner
+
+`TestPeriodIsTheOnlyThrottle` asserted that a free-running control loop applies
+more than 1000 actions in a 0.2 s window. That count is a property of the host
+and of the coverage tracer the suite runs under, not of the throttle being
+tested: on `ubuntu-latest` runners it lands at 570-693 under `--cov`, so `main`
+went red on every push once the pin merged, and because the suite runs under
+`-x` roughly 17% of the tests stopped executing with it.
+
+The bound is now relative to the throttled loop measured in the same process,
+which `duration * control_frequency` caps at the same value on any host. The
+`control_frequency` guard the test covers is unchanged.

--- a/tests/test_hardware_control_loop_rate_guard.py
+++ b/tests/test_hardware_control_loop_rate_guard.py
@@ -169,8 +169,9 @@ class TestPeriodIsTheOnlyThrottle:
 
     Pins that ``action_sleep_time`` alone bounds the command rate, so a period
     of ``<= 0`` leaves ``_execute_task_async`` free-running against the servo
-    bus. Bounds are deliberately loose (an unthrottled loop overshoots by
-    orders of magnitude) so the assertion holds on any host.
+    bus. The free-running loop is measured against the throttled one in the
+    same process rather than against an absolute iteration count, so what the
+    assertion reflects is the throttle and not the speed of the host.
     """
 
     @staticmethod
@@ -242,6 +243,20 @@ class TestPeriodIsTheOnlyThrottle:
         A period of ``0`` is what ``1 / inf`` produces and what
         ``asyncio.sleep`` returns from immediately, so the loop commands the
         bus as fast as it can be driven.
+
+        The comparison is against the throttled loop measured in the same
+        process. How many iterations a free-running loop fits into ``duration``
+        is a property of the host and of whatever tracing is attached to it,
+        not of the code under test: under the coverage tracer the suite runs
+        with, that count drops to roughly 0.6x of its uninstrumented value.
+        The throttled count is the stable half of the pair -- ``duration *
+        control_frequency`` caps it on any host -- which is what makes it
+        usable as the reference.
         """
-        applied = self._drive(0.0)
-        assert applied > 1000
+        throttled = self._drive(1.0 / 50.0)
+        unthrottled = self._drive(0.0)
+
+        # Both ends: a zero baseline would satisfy any ratio, so pin that the
+        # throttled loop actually ran before comparing against it.
+        assert throttled > 0
+        assert unthrottled > 10 * throttled


### PR DESCRIPTION
Fixes #1707.

## Problem

`main` has been red on every push since #1700 merged at 18:31Z, on one assertion:

```
FAILED tests/test_hardware_control_loop_rate_guard.py::TestPeriodIsTheOnlyThrottle::test_a_non_positive_period_leaves_the_loop_unthrottled - assert 693 > 1000
```

`call-test-lint / Test and Lint` is the only required status check on `main`, and the suite runs under `-x`, so the job stops at 82-83% progress: roughly 17% of the tests have not been executing on pushes to `main` either.

| run | branch | event | observed |
|---|---|---|---|
| 30387845975 | `main` | push | 570 |
| 30388853717 | `pr/consolidated-local-work` | pull_request | 614 |
| 30389476786 | `main` | push | 618 |
| 30392337395 | `main` | push | 693 |

Four runs, two branches, four runners, every observation 1.4-1.75x *below* the threshold. Not an intermittent flake - a bound that does not hold on GitHub's runners.

## Cause

The assertion was an absolute throughput floor over a fixed wall-clock window:

```python
applied = self._drive(0.0)   # free-running loop, duration=0.2 s
assert applied > 1000
```

How many iterations a free-running loop fits into 0.2 s is a property of the host and of whatever tracing is attached to the interpreter, not of the throttle being tested. Driving the same helper directly on an `ubuntu-latest`-class runner:

| condition | `_drive(0.0)` | `_drive(1/50)` |
|---|---|---|
| no coverage | 1062, 1018, **991** | 10, 10, 10 |
| under the coverage tracer, as CI runs it | 584, 595, 593 | 10, 10, 10 |

Two independent problems, and either alone is enough to fail the job:

1. **The floor sits inside the uninstrumented spread** - 991 already misses it. The bound was marginal even with no tracer.
2. **CI always runs `--cov=strands_robots`** (`addopts` in `pyproject.toml`). `sys.settrace` costs roughly 0.6x of the throughput, which reproduces the 570-693 band exactly.

#1700 characterised the underlying bug at ~4784 commands over a 0.4 s task, which is a vantage point a floor of 1000 looks safe from - but that measurement was uninstrumented.

## Change

The throttled loop is the stable half of the pair: `duration * control_frequency` caps it, and it measured **10** in every configuration above, instrumented or not. So the property the test is actually about - a period of `0` leaves the loop free-running - is expressed as a ratio against the throttled loop measured in the same process, which self-calibrates to both the host and the tracer:

```python
throttled = self._drive(1.0 / 50.0)
unthrottled = self._drive(0.0)

# Both ends: a zero baseline would satisfy any ratio, so pin that the
# throttled loop actually ran before comparing against it.
assert throttled > 0
assert unthrottled > 10 * throttled
```

The behaviour under test does not change. The `control_frequency` guard from #1700 is correct and stays exactly as merged; this PR only changes how the pin measures it. The stale claim in the class docstring that the bounds "hold on any host" is corrected to describe the relative comparison.

## Verification

On this branch, under the coverage tracer (the condition that was failing), 5 consecutive runs:

```
2 passed, 49 deselected in 9.60s
2 passed, 49 deselected in 8.46s
2 passed, 49 deselected in 8.88s
2 passed, 49 deselected in 8.39s
2 passed, 49 deselected in 9.00s
```

**Still a pin, not a vacuous one.** If the pathology were absent - if a period of `0` also throttled - the assertion must fail. Standing in a second throttled run for the free-running one under the tracer:

```
throttled=10 pretend_unthrottled=10 assertion_passes=False
NON-VACUOUS: assertion correctly FAILS when the loop is throttled
real unthrottled=457 ratio=46x margin_over_bound=4.6x
```

That 457 is worth noting: this sandbox is slower still than the CI runners that produced 570-693, and the relative bound absorbs it with 4.6x to spare where the absolute floor was off by 2.2x.

## Gate

- `ruff check tests/test_hardware_control_loop_rate_guard.py`: All checks passed.
- `ruff format --check`: 1 file already formatted.
- `python scripts/assemble_changelog.py --check`: changelog fragments OK (10 pending); fragment added at `changelog.d/1707-unthrottled-loop-relative-bound.md`.
- `pytest tests/test_hardware_control_loop_rate_guard.py tests/test_changelog_fragments.py --cov=strands_robots`: **77 passed**.
- No non-ASCII: `grep -nP '[^\x00-\x7F]'` clean on the changed test file.

The diff is 19 insertions / 4 deletions in one test method plus a docstring, and one new changelog fragment. No source file is touched.
