### PR TITLE
test(hardware): pin the control loop's wait instead of the runner's speed

### DIFF
--- a/changelog.d/1709-control-loop-throttle-pin.md
+++ b/changelog.d/1709-control-loop-throttle-pin.md
@@ -1,0 +1,17 @@
+### Quality: the control-loop throttle test pins the loop's wait, not the runner's speed
+
+`TestPeriodIsTheOnlyThrottle` asserted the pathology by counting how many
+actions an unthrottled loop applied inside a fixed 0.2 s window
+(`assert applied > 1000`). Command throughput is a property of the machine, not
+of the loop: on a loaded runner the same unthrottled loop applies 1-2 actions in
+that window instead of ~2200, so the floor failed on the full suite while
+passing when the file ran alone. Under load the count also stopped separating
+the two regimes at all -- a throttled and an unthrottled loop both applied 2
+actions -- so it carried no signal about the contract it was meant to pin.
+
+Both regimes are now pinned on the delay the loop waits between two
+`send_action` calls, recorded through a wrapper that delegates to the real
+`asyncio.sleep`: a 50 Hz rate is waited as 20 ms after every command, and a
+non-positive period is waited as nothing at all. That separation is exact at
+every load, and it additionally pins the link the guard exists to protect --
+that `control_frequency` reaches the servo bus as the inter-command wait.

--- a/tests/test_hardware_control_loop_rate_guard.py
+++ b/tests/test_hardware_control_loop_rate_guard.py
@@ -169,12 +169,31 @@ class TestPeriodIsTheOnlyThrottle:
 
     Pins that ``action_sleep_time`` alone bounds the command rate, so a period
     of ``<= 0`` leaves ``_execute_task_async`` free-running against the servo
-    bus. Bounds are deliberately loose (an unthrottled loop overshoots by
-    orders of magnitude) so the assertion holds on any host.
+    bus.
+
+    Both regimes are pinned on the delay the loop *waits* between two commands,
+    not on how many commands a host managed inside ``duration``. Command
+    throughput is a property of the machine: on a loaded runner the same
+    unthrottled loop applies orders of magnitude fewer actions in the same
+    window, so a fixed throughput floor asserts the runner's speed rather than
+    the loop's contract. The delay the loop asks for is a property of the loop
+    and is identical on every host.
     """
 
     @staticmethod
-    def _drive(period: float, duration: float = 0.2) -> int:
+    def _drive(period: float, duration: float = 0.2, waits: list[float] | None = None) -> int:
+        """Run one task through the real loop with ``action_sleep_time = period``.
+
+        Args:
+            period: The inter-command wait to install, in seconds.
+            duration: Task budget handed to ``_execute_task_async``.
+            waits: When given, collects the delay the loop waits after each
+                command. The recorder delegates to the real ``asyncio.sleep``,
+                so the loop is observed rather than altered.
+
+        Returns:
+            The number of actions that reached the arm.
+        """
         hw = HwRobot.__new__(HwRobot)
         hw.tool_name_str = "test_arm"
         hw.action_horizon = 1
@@ -216,6 +235,22 @@ class TestPeriodIsTheOnlyThrottle:
         hw._connect_robot = _connected  # type: ignore[method-assign]
         hw._initialize_policy = _init_policy  # type: ignore[method-assign]
         hw._publish_ros_telemetry = _no_telemetry  # type: ignore[method-assign]
+        real_sleep = asyncio.sleep
+        loop_thread = threading.get_ident()
+
+        async def _recording_sleep(delay: float, *args: Any, **kwargs: Any) -> Any:
+            # ``asyncio.sleep`` is module level, so only the loop under test is
+            # recorded: this file shares a process with tests that may leave an
+            # event loop running on another thread, and ``asyncio.run`` below
+            # drives the loop on this one. The real sleep is always awaited, so
+            # the loop is observed rather than altered.
+            if threading.get_ident() == loop_thread:
+                recorded.append(delay)
+            return await real_sleep(delay, *args, **kwargs)
+
+        recorded: list[float] = []
+        if waits is not None:
+            asyncio.sleep = _recording_sleep  # type: ignore[assignment]
         try:
             # ``_Policy`` is a structural stub: it provides the three members the
             # loop reads (supports_rtc / execution_horizon / get_actions) without
@@ -229,19 +264,38 @@ class TestPeriodIsTheOnlyThrottle:
             )
             return len(hw.robot.sent_actions)
         finally:
+            asyncio.sleep = real_sleep  # type: ignore[assignment]
+            if waits is not None:
+                waits.extend(recorded)
             hw._executor.shutdown(wait=False)
 
-    def test_a_positive_period_throttles_the_loop(self):
-        """At 50 Hz a 0.2 s task applies tens of actions, not thousands."""
-        applied = self._drive(1.0 / 50.0)
-        assert 0 < applied < 200
+    def test_a_positive_period_is_waited_between_commands(self):
+        """A 50 Hz rate reaches the bus as a 20 ms wait after every command.
+
+        This is the link the guard protects: ``control_frequency`` is only a
+        throttle because the loop waits ``1 / control_frequency`` between two
+        ``send_action`` calls. The action count is asserted as an upper bound
+        only -- 0.2 s at 50 Hz admits about ten commands and a slower host
+        applies fewer, never more.
+        """
+        waits: list[float] = []
+        applied = self._drive(1.0 / 50.0, waits=waits)
+
+        assert 0 < applied <= 20
+        assert len(waits) == applied
+        assert waits == pytest.approx([1.0 / 50.0] * applied)
 
     def test_a_non_positive_period_leaves_the_loop_unthrottled(self):
-        """The pathology the guard prevents: no throttle at all.
+        """The pathology the guard prevents: no wait between commands at all.
 
         A period of ``0`` is what ``1 / inf`` produces and what
         ``asyncio.sleep`` returns from immediately, so the loop commands the
-        bus as fast as it can be driven.
+        bus as fast as it can be driven -- back to back, with nothing between
+        two writes to the servos.
         """
-        applied = self._drive(0.0)
-        assert applied > 1000
+        waits: list[float] = []
+        applied = self._drive(0.0, waits=waits)
+
+        assert applied >= 1
+        assert len(waits) == applied
+        assert set(waits) == {0.0}


### PR DESCRIPTION
Fixes #1707.

## Problem

`tests/test_hardware_control_loop_rate_guard.py::TestPeriodIsTheOnlyThrottle` asserted the pathology its guard prevents by counting how many actions an unthrottled loop applied inside a fixed 0.2 s window:

```python
applied = self._drive(0.0)
assert applied > 1000
```

Command throughput is a property of the machine, not of the loop. The assertion fails on a loaded runner:

```
FAILED tests/test_hardware_control_loop_rate_guard.py::TestPeriodIsTheOnlyThrottle::
  test_a_non_positive_period_leaves_the_loop_unthrottled - assert 987 > 1000
```

That is the whole suite failing on `main`. The same file run alone passes in 0.8 s, so the outcome depends on what else the machine is doing.

The class docstring claimed the bound was safe because "an unthrottled loop overshoots by orders of magnitude". Measured, that is not so - the loop's per-iteration cost puts the ceiling right at the threshold, and background work collapses it:

| background CPU-bound threads | actions applied, `period = 0` | `assert applied > 1000` | actions applied, `period = 1/50 s` |
|---|---|---|---|
| 0 | 2187 | pass | 10 |
| 1 | 6 | **fail** | 3 |
| 2 | 1 | **fail** | 2 |
| 4 | 2 | **fail** | 1 |
| 8 | 1 | **fail** | 1 |

Under load the count does not merely dip below the floor, it stops separating the two regimes at all - and at 2 and 4 threads the *unthrottled* run applied fewer actions than the throttled one. So the number the test asserted on carried no information about the contract it existed to pin.

## Change

Both regimes are pinned on the delay the loop waits between two `send_action` calls. `_execute_task_async` has exactly one `await asyncio.sleep(self.action_sleep_time)`, immediately after each command, so the recorder - a wrapper that delegates to the real `asyncio.sleep` - observes the throttle itself rather than its side effect on this host:

```python
waits: list[float] = []
applied = self._drive(1.0 / 50.0, waits=waits)
assert 0 < applied <= 20
assert waits == pytest.approx([1.0 / 50.0] * applied)
```

```python
waits: list[float] = []
applied = self._drive(0.0, waits=waits)
assert applied >= 1
assert set(waits) == {0.0}
```

The action count survives only as an upper bound (0.2 s at 50 Hz admits about ten commands; a slower host applies fewer, never more), which is the direction a busy machine cannot violate.

This also pins a link nothing asserted before. Other tests in the file check that `control_frequency` is refused when the period cannot be computed and that `action_sleep_time == 1 / control_frequency`; none checked that the loop *waits* that period between commands, which is the only reason the parameter throttles anything.

One subtlety, commented at the recorder: `asyncio.sleep` is module level, so the recorder ignores sleeps issued on any thread other than the one `asyncio.run` drives. Other files in the suite leave an event loop running on a background thread, and an unfiltered recorder attributed their `sleep(0)` calls to the loop under test (`assert 1844 == 1838` when this file ran after `tests/test_robot_factory.py`).

## Evidence

![throughput is a property of the host; the wait is a property of the loop](https://raw.githubusercontent.com/cagataycali/robots/artifacts/throttle-pin/throttle-pin.png)

Left: the quantity the old assertion used, against runner load - the dashed line is the old floor, and the two regimes converge and cross. Right: the quantity the new assertions use, over the same runs - exactly 20 ms and exactly 0 ms at every load.

## Verification

Runner load emulated with background CPU-bound threads, three attempts per test per load:

| | idle | 4 background threads |
|---|---|---|
| assertions on `main` | 3/3 pass | **3/3 fail** at `assert applied > 1000` |
| assertions in this PR | 3/3 pass | 3/3 pass |

Stability of the file itself: 6 consecutive full-file runs, 51/51 passed each; 4 runs of the `tests/test_robot_factory.py` + this file combination that exposed the cross-file leak, 154/154 passed each; 3 randomized-order runs including `tests/test_teleop.py`, 194/194 passed each.

Gate at `72a9670c`:

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` - clean (924 source files, no issues)
- `python scripts/assemble_changelog.py --check` - OK
- `MUJOCO_GL=egl python -m pytest tests -q -p no:randomly --no-cov` - **12906 passed, 253 skipped** in 413 s. The same command on `main` at this commit is `1 failed, 12905 passed`, the failure being the assertion this PR replaces.

No library code changes, so no behavioural artifact applies; the chart above is the measurement the change is based on.

## 13. Round changelog

### Round 1 - claim the tracking issue, retire the duplicate

No code change in this round. Two open PRs were fixing the same red `main`: this one and #1708, which took the relative-bound direction prescribed in #1707 (`assert unthrottled > 10 * throttled`). #1708 is now closed as superseded and this PR carries `Fixes #1707`, so the flake is one issue and one PR rather than two competing diffs.

The direction was chosen on measurement, not preference. #1708's premise is that the throttled count is the stable half of the pair, "capped at the same value on any host" by `duration * control_frequency`. Re-measured on a 2-CPU host with the coverage tracer attached, under contention from N busy *processes* (rather than GIL-bound threads, which do not free a core):

| CPU contention | throttled | unthrottled | ratio | old floor `> 1000` | #1708 bound `> 10x throttled` |
|---|---|---|---|---|---|
| none | 10 | 1331, 1379 | 133-138x | pass | pass |
| 2 processes | 10 | 554, 638 | 55-64x | **fail** | pass |
| 4 processes | 10 | 589, 849 | 59-85x | **fail** | pass |
| 8 processes | **7, 9** | 147, 443 | **21-49x** | **fail** | pass |
| 16 processes | **8, 8** | 178, 189 | **22-24x** | **fail** | pass |

Two readings:

- The premise does not hold at the tail. `duration * control_frequency` is an upper bound on the throttled count, not a floor, and once the host cannot service 50 Hz the count falls out of the cap - observed decaying 10 -> 7. The relative bound is therefore a quotient of two load-dependent quantities, and its margin decays monotonically with load (133x -> 22x against a 10x floor). It survived every load I could produce here, but it is the same class of assertion as the one it replaces, with a wider safety factor rather than a different basis.
- The premise this PR rests on is load-invariant by construction. The awaited delay is read off the loop itself, so `20 ms` and `0 ms` are exact at every row of that table; there is no margin to erode.

The measurements also independently confirm the shared diagnosis in #1707: the old floor failed at every non-zero contention level and passed only on a fully idle host, so `main` is deterministically red on a busy runner rather than intermittently flaky.

#1708's coverage-tracer finding (`sys.settrace` costing roughly 0.6x of throughput) is real and is subsumed here - it is one of the reasons a throughput floor cannot be calibrated, and this PR removes the dependence on throughput altogether.