### PR TITLE
fix(hardware): refuse a task duration the control loop cannot honor

### DIFF
--- a/changelog.d/1710-hardware-task-duration-guard.md
+++ b/changelog.d/1710-hardware-task-duration-guard.md
@@ -1,0 +1,24 @@
+### Fixed: a hardware task refuses a duration the control loop cannot honor
+
+`Robot.run_policy` / `start_task` / `execute_task` bounded every rollout by
+comparing elapsed wall-clock time against `duration` without validating it, so a
+budget the loop could not honor was spent on the arm instead of refused. A
+`duration` of `0`, a negative value, or `nan` made the loop condition false on
+its first evaluation: the task reported `status="success"` for a rollout that
+never queried the policy and never commanded a servo, and `start_task` reported
+`Task started` for the same. `inf` never made it false, so the loop commanded
+the servo bus indefinitely and the blocking call never returned. A non-numeric
+budget reached the comparison intact and surfaced a bare `TypeError` naming a
+comparison internal (`'<' not supported between instances of 'float' and
+'str'`) rather than the parameter. `True` ran a silent one-second task.
+
+`duration` is now validated at every public entry point, against the same
+`positive_finite_number_error` domain as the loop's `control_frequency` and the
+simulation's `SimEngine._validate_duration`, so a budget cannot be refused for a
+digital twin and accepted for the arm it mirrors. `start_task` checks before
+submitting the work, so a budget that cannot be honored is reported to the
+caller instead of as a started task, and `_execute_task_sync` checks on its own
+because the agent-tool `execute` action and the mesh `execute` dispatch reach it
+directly with a peer-supplied value. Unlike the simulation - where an `n_steps`
+recomputes `duration` and supersedes it - the hardware loop ANDs the two
+conditions, so `duration` is validated even when a step cap is given.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1096,7 +1096,10 @@ class Robot(TeleopMixin, AgentTool):
         ``policy_object`` (when given) is driven as-is and the provider/port
         arguments are ignored - the ``run_policy`` path. ``n_steps`` caps the
         number of applied actions; the loop stops at whichever of
-        ``duration`` / ``n_steps`` comes first.
+        ``duration`` / ``n_steps`` comes first. The two conditions are ANDed,
+        so ``duration`` bounds the rollout even with a step cap - it is
+        validated at every public entry point rather than only when it is the
+        sole horizon.
 
         Either way the policy's per-episode state is reset before the rollout,
         so a task never begins from the state the previous task left behind.
@@ -1232,6 +1235,47 @@ class Robot(TeleopMixin, AgentTool):
             self._task_state.status = TaskStatus.ERROR
             self._task_state.error_message = str(e)
 
+    @staticmethod
+    def _duration_error(duration: Any, method: str) -> dict[str, Any] | None:
+        """Reject a task ``duration`` the control loop cannot honor.
+
+        ``duration`` is the wall-clock budget the loop compares against
+        (``time.time() - start_time < duration``), and on hardware it bounds
+        every rollout: unlike the simulation's ``run_policy`` - where an
+        ``n_steps`` recomputes ``duration`` and supersedes it - the two
+        conditions are ANDed here, so ``duration`` is the effective horizon
+        even when a step cap is given.
+
+        Only a positive finite value can be honored. A value ``<= 0`` (and
+        ``nan``, which is never ``<= 0`` but fails every comparison it reaches)
+        makes the loop condition false on its first evaluation: the task used
+        to report ``status="success"`` for a rollout that never queried the
+        policy and never commanded the arm. ``inf`` is worse than a fast
+        budget - it never becomes false, so the loop commands the servo bus
+        indefinitely and the blocking entry point never returns. A
+        non-numeric value reached the comparison intact and surfaced a bare
+        ``TypeError`` naming a comparison internal ("'<' not supported between
+        instances of 'float' and 'str'") rather than the parameter.
+
+        The accepted domain is
+        :func:`~strands_robots.utils.positive_finite_number_error`, shared with
+        the loop's ``control_frequency`` guard and with the simulation's
+        :meth:`~strands_robots.simulation.base.SimEngine._validate_duration`,
+        so the same budget cannot be refused for a digital twin and accepted
+        for the arm it mirrors.
+
+        Args:
+            duration: The caller-supplied value to validate.
+            method: Public entry point name, used to prefix the message.
+
+        Returns:
+            A tool-shaped error dict naming ``duration``, or ``None`` when the
+            value can be honored.
+        """
+        if error := positive_finite_number_error(duration, "duration", method):
+            return {"status": "error", "content": [{"text": error}]}
+        return None
+
     def _execute_task_sync(
         self,
         instruction: str,
@@ -1243,6 +1287,12 @@ class Robot(TeleopMixin, AgentTool):
         n_steps: int | None = None,
     ) -> dict[str, Any]:
         """Execute task synchronously in thread - no new event loop."""
+        # Validated here as well as at the public methods below: this is the
+        # chokepoint the agent-tool "execute" action and the mesh "execute"
+        # dispatch reach directly, so a peer-supplied budget is refused before
+        # the arm is commanded rather than after.
+        if err := self._duration_error(duration, "execute_task"):
+            return err
 
         # Import here to avoid conflicts
         import asyncio
@@ -1301,7 +1351,27 @@ class Robot(TeleopMixin, AgentTool):
         policy_provider: str = "groot",
         duration: float = 30.0,
     ) -> dict[str, Any]:
-        """Start robot task asynchronously and return immediately."""
+        """Start robot task asynchronously and return immediately.
+
+        Args:
+            instruction: Natural-language instruction passed to the policy.
+            policy_port: Port of the policy server to query.
+            policy_host: Host of the policy server.
+            policy_provider: Provider name used to build the policy.
+            duration: Wall-clock budget in seconds. Must be positive and
+                finite; it is validated before the task is submitted, so a
+                budget the loop cannot honor is reported here instead of as a
+                started task that commands nothing (or never ends).
+
+        Returns:
+            Tool-shaped result confirming the task started, or an error naming
+            the offending parameter.
+        """
+        # Before the submit: the work happens on a background thread, so a
+        # budget checked inside it would still report "Task started" to the
+        # caller for a task that commands nothing (or never ends).
+        if err := self._duration_error(duration, "start_task"):
+            return err
 
         # Check if task is already running
         if self._task_state.status == TaskStatus.RUNNING:
@@ -1361,7 +1431,10 @@ class Robot(TeleopMixin, AgentTool):
             instruction: Natural-language instruction passed to the policy on
                 every ``get_actions`` call.
             duration: Wall-clock budget in seconds (same default as
-                ``start_task``).
+                ``start_task``). Must be positive and finite; the loop bounds
+                the rollout by it even when ``n_steps`` is given, so a value it
+                cannot honor is refused rather than reported as a rollout that
+                commanded nothing.
             n_steps: Optional cap on applied actions (mirrors the sim
                 ``run_policy`` parameter); the loop stops at whichever of
                 ``duration`` / ``n_steps`` comes first.
@@ -1381,6 +1454,8 @@ class Robot(TeleopMixin, AgentTool):
                 "status": "error",
                 "content": [{"text": f"Task already running: {self._task_state.instruction}"}],
             }
+        if err := self._duration_error(duration, "run_policy"):
+            return err
 
         self._execute_task_sync(instruction, duration=duration, policy_object=policy_object, n_steps=n_steps)
 
@@ -1510,7 +1585,11 @@ class Robot(TeleopMixin, AgentTool):
                         },
                         "duration": {
                             "type": "number",
-                            "description": "Maximum execution time in seconds",
+                            "description": (
+                                "Maximum execution time in seconds. Must be a positive finite "
+                                "number: the loop compares elapsed time against it, so 0 or a "
+                                "negative value commands nothing and infinity never ends."
+                            ),
                             "default": 30.0,
                         },
                     },

--- a/tests/test_hardware_task_duration_guard.py
+++ b/tests/test_hardware_task_duration_guard.py
@@ -1,0 +1,290 @@
+"""Behavior tests for the accepted ``duration`` domain of a hardware task.
+
+``strands_robots.hardware_robot.Robot`` bounds every rollout by comparing
+elapsed wall-clock time against ``duration`` (``time.time() - start_time <
+duration``). On hardware that comparison is ANDed with the optional ``n_steps``
+cap rather than superseded by it, so ``duration`` is the effective horizon of
+every task. These tests pin that a budget the loop cannot honor is refused at
+the public entry point instead of being spent on the arm:
+
+    - ``0`` / negative / ``nan`` makes the loop condition false on its first
+      evaluation, so the task used to report ``status="success"`` for a rollout
+      that never queried the policy and never commanded a servo;
+    - ``inf`` never makes it false, so the loop commanded the bus indefinitely
+      and the blocking entry point never returned;
+    - a non-numeric budget reached the comparison intact and surfaced a bare
+      ``TypeError`` naming a comparison internal rather than the parameter;
+    - the refusal happens before the arm is commanded and, for ``start_task``,
+      before the work is submitted, so a budget that cannot be honored is never
+      reported back as a started task;
+    - ``_execute_task_sync`` refuses too: it is the chokepoint the agent-tool
+      ``execute`` action and the mesh ``execute`` dispatch reach directly, so a
+      peer-supplied budget is bounded by the same rule;
+    - every budget that IS accepted still runs, including a fractional and a
+      NumPy-scalar one;
+    - the accepted domain matches the simulation's rollout budget
+      (``SimEngine._validate_duration``), so the same value cannot be refused
+      for a digital twin and accepted for the arm it mirrors.
+
+No serial/USB hardware is touched: the driver is an in-memory fake and the
+policy is a structural stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.simulation.base import SimEngine
+from tests.test_hardware_control_loop_rate_guard import _FakeArm
+
+# Budgets the loop cannot honor. ``0`` / negative / ``nan`` make the loop
+# condition false immediately (a task that commands nothing); ``inf`` never
+# makes it false (a task that never ends); the rest are not numbers the
+# elapsed-time comparison can be made against at all.
+UNUSABLE_DURATIONS: list[Any] = [
+    0,
+    0.0,
+    -1.0,
+    -30,
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    "5",
+    None,
+    [1.0],
+]
+
+# Budgets that are honorable: any positive finite real, fractional or NumPy.
+USABLE_DURATIONS: list[Any] = [0.25, 2, 30.0, np.float32(0.3), np.int64(1)]
+
+
+class _Policy:
+    """Structural stand-in for a policy: the members the loop reads."""
+
+    supports_rtc = False
+    execution_horizon = 1
+
+    def set_control_frequency(self, hz: float) -> None:
+        return None
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        return None
+
+    async def get_actions(self, observation: Any, instruction: str) -> list[dict[str, Any]]:
+        return [{"j0.pos": 0.1}]
+
+
+@pytest.fixture
+def hw() -> Any:
+    """A ``Robot`` wired to an in-memory arm, with the connect path stubbed.
+
+    Yields the instance. ``policy_inits`` records every policy initialization
+    so a test can assert a refused budget never got that far, and
+    ``robot.sent_actions`` records every command that reached the arm.
+    """
+    robot = HwRobot.__new__(HwRobot)
+    robot.tool_name_str = "test_arm"
+    robot.action_horizon = 1
+    robot.data_config = None
+    robot.control_frequency = 50.0
+    robot.action_sleep_time = 1.0 / 50.0
+    robot._task_state = RobotTaskState()
+    robot._executor = ThreadPoolExecutor(max_workers=1)
+    robot._shutdown_event = threading.Event()
+    robot.mesh = None
+    robot.peer_id = None
+    robot.robot = _FakeArm()
+    robot.policy_inits = []  # type: ignore[attr-defined]
+
+    async def _connected() -> tuple[bool, str]:
+        return (True, "")
+
+    async def _ready() -> bool:
+        return True
+
+    def _init_policy(policy: Any) -> Any:
+        robot.policy_inits.append(policy)  # type: ignore[attr-defined]
+        return _ready()
+
+    def _no_telemetry(observation: dict[str, Any], *, skip_images: bool = False) -> None:
+        return None
+
+    robot._connect_robot = _connected  # type: ignore[method-assign]
+    robot._initialize_policy = _init_policy  # type: ignore[method-assign]
+    robot._publish_ros_telemetry = _no_telemetry  # type: ignore[method-assign]
+    try:
+        yield robot
+    finally:
+        robot._shutdown_event.set()
+        robot._task_state.status = TaskStatus.STOPPED
+        robot._executor.shutdown(wait=False)
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The text of a tool-shaped result."""
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+class TestUnusableBudgetRefused:
+    """Every public entry point refuses a budget the loop cannot honor."""
+
+    @pytest.mark.parametrize("duration", UNUSABLE_DURATIONS)
+    def test_run_policy_refuses(self, hw: Any, duration: Any):
+        """``run_policy`` errors naming the parameter, not a comparison."""
+        result = hw.run_policy(policy_object=_Policy(), instruction="probe", duration=duration)
+
+        assert result["status"] == "error"
+        assert "duration" in _text(result)
+        assert "run_policy" in _text(result)
+
+    @pytest.mark.parametrize("duration", UNUSABLE_DURATIONS)
+    def test_start_task_refuses(self, hw: Any, duration: Any):
+        """``start_task`` errors instead of reporting a started task."""
+        result = hw.start_task("probe", policy_port=9000, duration=duration)
+
+        assert result["status"] == "error"
+        assert "duration" in _text(result)
+        assert "Task started" not in _text(result)
+
+    @pytest.mark.parametrize("duration", UNUSABLE_DURATIONS)
+    def test_the_shared_chokepoint_refuses(self, hw: Any, duration: Any):
+        """``_execute_task_sync`` refuses on its own.
+
+        The agent-tool ``execute`` action and the mesh ``execute`` dispatch call
+        it directly rather than through ``run_policy``, so a peer-supplied
+        budget must be bounded here too.
+        """
+        result = hw._execute_task_sync("probe", policy_port=9000, duration=duration)
+
+        assert result["status"] == "error"
+        assert "duration" in _text(result)
+
+
+class TestRefusalPrecedesTheArm:
+    """A refused budget is never spent on hardware."""
+
+    @pytest.mark.parametrize("duration", [0, -1.0, float("nan"), float("inf"), "5"])
+    def test_no_action_reaches_the_arm(self, hw: Any, duration: Any):
+        """No command is written and no policy is initialized."""
+        hw.run_policy(policy_object=_Policy(), instruction="probe", duration=duration)
+
+        assert hw.robot.sent_actions == []
+        assert hw.policy_inits == []
+
+    @pytest.mark.parametrize("duration", [0, -1.0, float("nan"), float("inf")])
+    def test_start_task_does_not_submit_the_work(self, hw: Any, duration: Any):
+        """The refusal precedes ``executor.submit``.
+
+        A budget checked on the background thread would still have reported
+        "Task started" to the caller, so the guard has to run before the
+        submit - which is observable as no future ever being created.
+        """
+        hw.start_task("probe", policy_port=9000, duration=duration)
+
+        assert hw._task_state.task_future is None
+        assert hw._task_state.status == TaskStatus.IDLE
+
+
+class TestAnEndlessBudgetIsRefused:
+    """``inf`` is a runaway, not a long task."""
+
+    def test_run_policy_returns_instead_of_commanding_forever(self, hw: Any):
+        """The blocking call returns; the loop is never entered.
+
+        ``inf`` never makes ``time.time() - start_time < duration`` false, so
+        the loop kept commanding the servo bus with no bound and the caller
+        never got control back. Driven from a worker thread so the assertion
+        fails as a timeout rather than hanging the suite.
+        """
+        outcome: list[dict[str, Any]] = []
+
+        def drive() -> None:
+            outcome.append(hw.run_policy(policy_object=_Policy(), instruction="probe", duration=float("inf")))
+
+        worker = threading.Thread(target=drive, daemon=True)
+        worker.start()
+        worker.join(timeout=5.0)
+
+        assert not worker.is_alive(), "run_policy(duration=inf) never returned"
+        assert outcome[0]["status"] == "error"
+        assert hw.robot.sent_actions == []
+
+
+class TestUsableBudgetHonored:
+    """Every budget the loop can honor still runs."""
+
+    @pytest.mark.parametrize("duration", USABLE_DURATIONS)
+    def test_the_rollout_runs_and_commands_the_arm(self, hw: Any, duration: Any):
+        """A positive finite budget reaches the loop and moves the arm."""
+        result = hw.run_policy(policy_object=_Policy(), instruction="probe", duration=duration, n_steps=3)
+
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) == 3
+
+
+class TestBudgetBoundsTheRolloutEvenWithAStepCap:
+    """On hardware ``duration`` is effective alongside ``n_steps``.
+
+    The simulation recomputes ``duration`` from ``n_steps`` and validates it
+    only when no step count was given. The hardware loop ANDs the two
+    conditions instead, so an unusable ``duration`` silences a rollout that
+    asked for a specific number of steps - and must be refused even then.
+    """
+
+    @pytest.mark.parametrize("duration", [0, -1.0, float("nan")])
+    def test_a_step_cap_does_not_excuse_the_budget(self, hw: Any, duration: Any):
+        """A step cap does not make an unusable budget acceptable."""
+        result = hw.run_policy(policy_object=_Policy(), instruction="probe", duration=duration, n_steps=10)
+
+        assert result["status"] == "error"
+        assert "duration" in _text(result)
+        assert hw.robot.sent_actions == []
+
+    def test_the_step_cap_still_wins_when_both_are_usable(self, hw: Any):
+        """A usable budget generous enough for the cap applies the cap."""
+        result = hw.run_policy(policy_object=_Policy(), instruction="probe", duration=30.0, n_steps=3)
+
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) == 3
+
+
+class TestDomainMatchesSimulation:
+    """The arm and its digital twin accept the same rollout budgets.
+
+    ``SimEngine._validate_duration`` and the hardware guard both delegate to
+    ``positive_finite_number_error``; this pins that they cannot diverge, so a
+    budget rehearsed in sim is honored on the arm and vice versa.
+    """
+
+    @pytest.mark.parametrize("duration", UNUSABLE_DURATIONS + USABLE_DURATIONS)
+    def test_both_layers_agree(self, hw: Any, duration: Any):
+        """Refused by one layer if and only if refused by the other."""
+        sim_refuses = SimEngine._validate_duration(duration, "run_policy") is not None
+        hw_refuses = hw._duration_error(duration, "run_policy") is not None
+
+        assert hw_refuses == sim_refuses, f"verdicts differ for duration={duration!r}"
+
+    def test_the_message_is_the_shared_one(self, hw: Any):
+        """Both layers name the parameter identically."""
+        sim_error = SimEngine._validate_duration(0, "run_policy")
+        hw_error = hw._duration_error(0, "run_policy")
+
+        assert sim_error is not None and hw_error is not None
+        assert _text(hw_error) == _text(sim_error)
+
+
+def test_the_guard_does_not_need_an_event_loop(hw: Any):
+    """The refusal is synchronous: no event loop is started to produce it."""
+    with pytest.raises(RuntimeError):
+        asyncio.get_running_loop()
+
+    assert hw._duration_error(0, "run_policy") is not None


### PR DESCRIPTION
## Problem

The hardware control loop bounds every rollout by comparing elapsed wall-clock time against `duration`:

```python
while (
    time.time() - start_time < duration
    and (n_steps is None or self._task_state.step_count < n_steps)
    ...
```

`duration` was never validated, so a budget the loop could not honor was spent on the arm rather than refused. Measured on a stub arm at the default 50 Hz, `action_horizon=1`:

| `duration` | result | commands sent | what happened |
|---|---|---|---|
| `0`, `0.0`, `-1.0`, `-30` | `status="success"` | 0 | condition false on its first evaluation - the policy was never queried |
| `nan` | `status="success"` | 0 | `nan` is never `< duration`, so the same silent no-op |
| `inf` | **never returned** | 484 and climbing | condition never becomes false: the servo bus is commanded indefinitely |
| `True` | `status="success"` | 49 | an `int` subclass - a silent one-second task |
| `"5"`, `None`, `[1.0]` | `status="error"` | 0 | `'<' not supported between instances of 'float' and 'str'` - names a comparison internal, not the parameter |

The `inf` case is the serious one: `run_policy` never returns and the loop keeps writing to the servos with no bound, recoverable only by `stop_task()` from another thread.

`start_task` reported `Task started` for every unusable value above, because the work is submitted to a background thread and nothing on the caller's side looked at the budget.

### Why this was missed

Every neighbouring knob is already guarded. `control_frequency` in the same constructor is validated against `positive_finite_number_error`, and the simulation validates the same parameter via `SimEngine._validate_duration` - which delegates to that same domain function. `duration` was the one knob in the product `duration x control_frequency` left unchecked on the hardware side.

## Change

`duration` is validated at every public entry point, against the **same** `positive_finite_number_error` domain the loop's `control_frequency` and the simulation's `_validate_duration` already use, so a budget cannot be refused for a digital twin and accepted for the arm it mirrors.

Three call sites, each for its own reason:

- **`run_policy`** - it discards `_execute_task_sync`'s return value and reports from `_task_state`, so it needs its own check before the arm is touched.
- **`start_task`** - checked *before* `executor.submit`. A budget checked on the background thread would still have reported `Task started` to the caller; the guard running first is observable as no future ever being created.
- **`_execute_task_sync`** - the chokepoint the agent-tool `execute` action and the mesh `execute` dispatch reach *directly*, so a peer-supplied budget is bounded by the same rule.

### One contract difference from sim, deliberately

The simulation validates `duration` only when `n_steps is None`, because there an `n_steps` recomputes `duration` and supersedes it. The hardware loop **ANDs** the two conditions, so `duration` bounds the rollout even with a step cap - `run_policy(duration=0, n_steps=10)` applied 0 steps and returned success. It is therefore validated unconditionally here, and a test pins that difference so it is not "corrected" into the sim's rule later.

Also updated: the `duration` entry in the agent tool spec now states the accepted domain (a description-only change), and the `run_policy` / `start_task` / `_execute_task_async` docstrings say that the budget is refused rather than silently spent.

## Visual artifact

Cumulative commands written to the arm, `run_policy` driven on a stub arm at 50 Hz, observed for 10 s. The pre-fix panel was produced from the unmodified source.

![duration guard command trace](https://raw.githubusercontent.com/cagataycali/robots/artifacts/hardware-task-duration-guard/duration_guard.png)

Left: `duration=inf` had **not returned after 10 s** with 484 commands already on the bus, and `duration=0` returned `status="success"` having commanded nothing. Right: both are refused in under a millisecond, 0 commands, with the parameter named (`run_policy: duration must be > 0, got inf.`).

## Tests

New `tests/test_hardware_task_duration_guard.py` (70 tests), covering: refusal at all three entry points; the refusal preceding any command to the arm and any policy initialization; `start_task` never submitting the work; `inf` returning instead of commanding forever (driven from a worker thread so the pin fails as a timeout rather than hanging the suite); usable budgets still running, including fractional and NumPy scalars; the step-cap contract above; and a parity test asserting the hardware and `SimEngine._validate_duration` verdicts agree value-for-value so the two domains cannot drift.

**Pre-fix, on this branch's base:** `64 failed, 6 passed`.

```
FAILED ...::test_run_policy_refuses[0]   - AssertionError: assert 'success' == 'error'
FAILED ...::test_run_policy_refuses[nan] - AssertionError: assert 'success' == 'error'
FAILED ...::test_run_policy_refuses[inf] - Failed: Timeout (>120.0s) from pytest-timeout
E       assert 'duration' in "... Error: '<' not supported between instances of 'float' and 'str'"
```

The `inf` pin failing as a 120 s pytest timeout is the runaway, reported by the test framework itself.

**Post-fix:** `70 passed`.

## Gate

- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - 928 files already formatted
- `mypy strands_robots tests tests_integ` - `Success: no issues found in 925 source files`
- Full suite: **12976 passed, 253 skipped** in 437 s
- `python scripts/assemble_changelog.py --check` - OK; `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py` - 30 passed

No hardware is required by the tests: the driver is an in-memory fake and the policy a structural stub.

## Round 1

`0b90c85` merges current `main` into the branch. **The diff under review is unchanged** - the net change against `main` is still the same three files (`hardware_robot.py`, the new test, the changelog fragment).

The pre-merge CI failure was:

```
FAILED tests/test_hardware_control_loop_rate_guard.py::TestPeriodIsTheOnlyThrottle::test_a_non_positive_period_leaves_the_loop_unthrottled - assert 583 > 1000
```

That assertion is not on this branch's diff. It was a command-throughput floor on a pre-existing test, and #1709 replaced it with a pin on the delay the loop *waits* between commands - because a fixed throughput floor asserts the runner's speed rather than the loop's contract, and a loaded runner applies far fewer actions in the same window. This branch predated that fix, so CI was still running the old floor against it.

Verified after the merge: `tests/test_hardware_task_duration_guard.py` + `tests/test_hardware_control_loop_rate_guard.py` -> **121 passed**; `ruff check` clean; `ruff format --check` 895 files already formatted; `mypy` on the changed files `Success: no issues found in 2 source files`.