### PR TITLE
fix(sim): tearing the world down mid-primitive aborts it instead of raising

### DIFF
--- a/changelog.d/1711-primitive-teardown-world-handoff.md
+++ b/changelog.d/1711-primitive-teardown-world-handoff.md
@@ -1,0 +1,37 @@
+### Fixed: tearing the world down during a motion primitive aborts it instead of raising
+
+`move_to`, `set_gripper` and `rotate_wrist` each document "Never raises.", and
+`_primitive_abort_reason` documents the intended outcome for exactly this case:
+"the world can legitimately be destroyed, the model recompiled, or a policy
+started while a primitive runs. Each of those aborts the primitive with a
+structured error rather than stepping a stale/contended model."
+
+A concurrent `destroy()` / `cleanup()` did neither. `cleanup` handed the world
+off (`self._world = None`) without holding `self._lock`, so the handoff could
+land inside a primitive's control tick - between the tick's own world check and
+its write-back of `sim_time` / `step_count`. All three primitives then raised
+`AttributeError: 'NoneType' object has no attribute 'sim_time'` from
+`_primitive_tick`, on the caller's thread:
+
+| teardown during | before | after |
+| --- | --- | --- |
+| `move_to` | `AttributeError` | structured "world was destroyed ... aborting" |
+| `set_gripper` | `AttributeError` | structured "world was destroyed ... aborting" |
+| `rotate_wrist` | `AttributeError` | structured "world was destroyed ... aborting" |
+
+`cleanup`'s existing reasoning covers the workers it can await: it signals
+`policy_running = False` and joins every outstanding Future before nulling the
+world. A motion primitive is neither. It runs on its CALLER's thread, so no
+Future awaits it, and the cooperative-stop flag never applies to it - a
+primitive refuses to start while a policy runs, so it never sets that flag.
+`self._lock`, which it takes per control tick, was its only synchronisation, and
+teardown was the one world-lifecycle operation that did not take it: `load_scene`
+already brackets its own world handoff with the lock for the same reason,
+`reset` does its work under the lock, and `create_world` refuses outright when a
+world already exists.
+
+The handoff now happens under `self._lock`. The Future join stays outside it - a
+live policy worker takes the lock per step, so awaiting one while holding the
+lock would deadlock - and the acquire is bounded (`_WORLD_HANDOFF_LOCK_TIMEOUT`),
+making the same tradeoff the bounded Future join already makes: warn and tear
+down regardless rather than hang the host process on exit.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4764,6 +4764,13 @@ class MuJoCoSimEngine(
     # Override in tests via ``cleanup(policy_stop_timeout=...)`` if needed.
     _DEFAULT_POLICY_STOP_TIMEOUT = 5.0
 
+    # Bounded wait for the world-handoff lock (seconds). A motion primitive
+    # holds ``self._lock`` only for one control tick (a few physics substeps,
+    # sub-millisecond), so this ceiling is generous; it exists so cleanup can
+    # never hang the host process on a wedged lock holder - the same tradeoff
+    # ``_DEFAULT_POLICY_STOP_TIMEOUT`` makes for a wedged policy worker.
+    _WORLD_HANDOFF_LOCK_TIMEOUT = 5.0
+
     def cleanup(self, policy_stop_timeout: float | None = None) -> None:
         """Release every resource owned by this Simulation instance.
 
@@ -4785,7 +4792,12 @@ class MuJoCoSimEngine(
              outside MuJoCo and a stale-pointer segfault is the lesser evil
              than hanging the host process on exit.
           4. Only AFTER workers have unwound do we null ``self._world``
-             and tear down renderers / the viewer / the executor.
+             and tear down renderers / the viewer / the executor. The
+             nulling itself happens under ``self._lock`` (bounded acquire):
+             an analytic motion primitive runs on its caller's thread rather
+             than through the executor, so the join in step 2 cannot cover
+             it and the lock is the only thing that keeps the handoff from
+             landing inside one of its control ticks.
 
         Args:
             policy_stop_timeout: Seconds to wait per active policy future.
@@ -4864,11 +4876,42 @@ class MuJoCoSimEngine(
                     )
             self._policy_threads.clear()
 
-        # Step 3: now it's safe to null the world. Any worker still alive
-        # at this point has already escaped MuJoCo (we've confirmed via
-        # fut.result()), so a nulled _model / _data is no longer racy.
-        if self._world:
-            self._world = None
+        # Step 3: hand the world off UNDER ``self._lock``.
+        #
+        # The join above covers every worker submitted to the executor, but a
+        # motion primitive (``move_to`` / ``set_gripper`` / ``rotate_wrist``)
+        # runs on its CALLER's thread: no Future awaits it, and the
+        # ``policy_running`` flag signalled in step 1 never applies to it
+        # (primitives refuse to start while a policy runs, so they never set
+        # it). ``self._lock`` is the only synchronisation such a primitive
+        # has - it takes the lock per control tick to re-check the world,
+        # step physics, then write back ``sim_time`` / ``step_count``.
+        # Nulling ``self._world`` outside the lock therefore lands INSIDE a
+        # tick, and the write-back raises ``AttributeError`` out of an API
+        # documented never to raise. Holding the lock makes the handoff
+        # atomic against a tick, so the primitive's next
+        # ``_primitive_abort_reason`` check reports the structured
+        # "world was destroyed ... aborting" error instead - the outcome that
+        # helper is written to produce. ``load_scene`` brackets its own world
+        # handoff the same way and for the same reason.
+        #
+        # The join must stay OUTSIDE the lock: a live policy worker takes the
+        # lock per step, so awaiting it while holding the lock deadlocks. The
+        # acquire is bounded for the same reason step 2 is bounded - cleanup
+        # must not hang the host process on a wedged lock holder.
+        handoff_locked = self._lock.acquire(timeout=self._WORLD_HANDOFF_LOCK_TIMEOUT)
+        if not handoff_locked:
+            logger.warning(
+                "cleanup: world-handoff lock still held after %.1fs; nulling the world anyway "
+                "(a concurrent control tick may raise).",
+                self._WORLD_HANDOFF_LOCK_TIMEOUT,
+            )
+        try:
+            if self._world:
+                self._world = None
+        finally:
+            if handoff_locked:
+                self._lock.release()
 
         self._close_viewer()
         # close main-thread renderers before dropping the TLS object.

--- a/tests/simulation/mujoco/test_primitive_teardown_abort.py
+++ b/tests/simulation/mujoco/test_primitive_teardown_abort.py
@@ -1,0 +1,221 @@
+"""Tearing the world down while a motion primitive runs aborts it, never raises.
+
+``move_to`` / ``set_gripper`` / ``rotate_wrist`` run on their CALLER's thread:
+no Future awaits them, and the ``policy_running`` flag ``cleanup`` signals does
+not apply to them (a primitive refuses to start while a policy runs, so it never
+sets that flag). ``self._lock`` - taken per control tick - is their only
+synchronisation against another thread reshaping the world.
+
+Each primitive documents "Never raises.", and
+``_primitive_abort_reason`` documents the intended outcome: "the world can
+legitimately be destroyed, the model recompiled, or a policy started while a
+primitive runs. Each of those aborts the primitive with a structured error
+rather than stepping a stale/contended model."
+
+These tests pin that contract for the teardown path, which handed ``self._world``
+off without holding the lock: the handoff landed inside a tick's physics substep
+loop and the tick's write-back of ``sim_time`` raised ``AttributeError`` out of
+all three primitives.
+
+The interleave is forced rather than raced: a ``mj_step`` hook starts the
+teardown from another thread at the exact production window - inside the substep
+loop, after the tick's own ``assert self._world is not None``. Without a locked
+handoff that window is fatal every time; with one, the teardown either lands
+between ticks (structured abort) or after the primitive finishes (normal result).
+Both are correct, so these tests assert the contract - the call returns a result
+instead of raising - rather than which of the two the scheduler picked. The lock
+itself is pinned directly in :class:`TestWorldHandoffLock`, and the structured
+abort text in :class:`TestPolicyStartedMidRun`.
+"""
+
+import threading
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_motion_primitives import ARM_XML, REACHABLE  # noqa: E402
+
+# Long enough that the servo cannot converge before the hook fires, so every
+# primitive is genuinely mid-flight when the world is taken away.
+_LONG_RUN = {"max_steps": 4000}
+# Looser than the IK residual this 4-DOF arm leaves on REACHABLE, so ``move_to``
+# enters its servo loop instead of refusing the target up front.
+_REACHABLE_TOL = 0.002
+
+
+@pytest.fixture
+def sim(tmp_path):
+    path = tmp_path / "prim_arm.xml"
+    path.write_text(ARM_XML)
+    s = Simulation(tool_name="test_primitive_teardown", mesh=False)
+    assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+    assert s.add_robot("arm", urdf_path=str(path))["status"] == "success"
+    yield s
+    s.cleanup(policy_stop_timeout=2.0)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(b["text"] for b in result["content"] if "text" in b)
+
+
+class _MjHook:
+    """Delegate to the real ``mujoco`` module, firing a hook inside ``mj_step``.
+
+    ``mj_step`` is where a primitive control tick spends its time, so a hook
+    installed here runs at the same point a concurrent teardown would land in
+    production: after the tick's own world check, before it writes ``sim_time``
+    back to the world.
+    """
+
+    def __init__(self, mj: Any, hook: Any, at_call: int) -> None:
+        self._mj = mj
+        self._hook = hook
+        self._at_call = at_call
+        self._calls = 0
+        self.fired = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._mj, name)
+
+    def mj_step(self, model: Any, data: Any) -> Any:
+        self._calls += 1
+        if self._calls == self._at_call:
+            self.fired = True
+            self._hook()
+        return self._mj.mj_step(model, data)
+
+
+def _teardown_from_another_thread(s: Simulation, join_timeout: float = 0.75) -> list[threading.Thread]:
+    """Install a hook that calls ``cleanup()`` from a second thread mid-tick.
+
+    The hook joins that thread with a bounded timeout: without a locked handoff
+    the teardown needs nothing this tick holds, so it completes and the tick then
+    writes into a nulled world; with a locked handoff the join times out because
+    the teardown is blocked on the lock this tick holds, and it lands only once
+    the tick has finished.
+    """
+    threads: list[threading.Thread] = []
+
+    def hook() -> None:
+        t = threading.Thread(target=lambda: s.cleanup(policy_stop_timeout=0.1), daemon=True)
+        threads.append(t)
+        t.start()
+        t.join(timeout=join_timeout)
+
+    s._mj = _MjHook(s._mj, hook, at_call=3)
+    return threads
+
+
+class TestTeardownDuringAPrimitive:
+    """A world torn down mid-primitive returns a result; it never raises.
+
+    Pre-fix every one of these raised
+    ``AttributeError: 'NoneType' object has no attribute 'sim_time'`` from the
+    control tick's write-back, out of three methods documented "Never raises."
+    """
+
+    def _assert_returned_a_result(self, sim, result, threads):
+        for t in threads:
+            t.join(timeout=30.0)
+        assert result["status"] in ("success", "error")
+        if result["status"] == "error":
+            # The teardown won the lock between two ticks: the documented abort.
+            assert "aborting" in _text(result) or "did not reach" in _text(result)
+        assert sim._world is None
+
+    def test_move_to_returns_a_result_instead_of_raising(self, sim):
+        pytest.importorskip("mink")
+        threads = _teardown_from_another_thread(sim)
+
+        result = sim.move_to(robot_name="arm", position=REACHABLE, tol=_REACHABLE_TOL, **_LONG_RUN)
+
+        self._assert_returned_a_result(sim, result, threads)
+
+    def test_set_gripper_returns_a_result_instead_of_raising(self, sim):
+        threads = _teardown_from_another_thread(sim)
+
+        result = sim.set_gripper(robot_name="arm", state="close", steps=_LONG_RUN["max_steps"])
+
+        self._assert_returned_a_result(sim, result, threads)
+
+    def test_rotate_wrist_returns_a_result_instead_of_raising(self, sim):
+        threads = _teardown_from_another_thread(sim)
+
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=1.2, tol=_REACHABLE_TOL, **_LONG_RUN)
+
+        self._assert_returned_a_result(sim, result, threads)
+
+
+class TestWorldHandoffLock:
+    """``cleanup`` hands the world off under the per-tick lock, but bounded."""
+
+    def test_handoff_waits_for_a_control_tick_to_finish(self, sim):
+        """The world survives until the lock a tick holds is released."""
+        done = threading.Event()
+
+        with sim._lock:
+            worker = threading.Thread(target=lambda: (sim.cleanup(policy_stop_timeout=0.1), done.set()), daemon=True)
+            worker.start()
+            # Cannot observe "blocked" directly; what matters is that the world
+            # is still intact for as long as a tick could be using it.
+            assert not done.wait(timeout=0.5)
+            assert sim._world is not None
+
+        assert done.wait(timeout=30.0)
+        worker.join(timeout=30.0)
+        assert sim._world is None
+
+    def test_teardown_does_not_hang_when_the_lock_is_never_released(self, sim, monkeypatch, caplog):
+        """A wedged lock holder must not hang the host process on exit.
+
+        The same tradeoff step 2 makes for a policy worker that ignores the
+        cooperative-stop flag: warn, then tear down regardless.
+        """
+        monkeypatch.setattr(type(sim), "_WORLD_HANDOFF_LOCK_TIMEOUT", 0.2)
+        holder_has_lock = threading.Event()
+        release = threading.Event()
+
+        def hold() -> None:
+            with sim._lock:
+                holder_has_lock.set()
+                release.wait(timeout=30.0)
+
+        holder = threading.Thread(target=hold, daemon=True)
+        holder.start()
+        assert holder_has_lock.wait(timeout=10.0)
+        try:
+            finished = threading.Event()
+            worker = threading.Thread(
+                target=lambda: (sim.cleanup(policy_stop_timeout=0.1), finished.set()), daemon=True
+            )
+            worker.start()
+            assert finished.wait(timeout=30.0), "cleanup hung on the world-handoff lock"
+            worker.join(timeout=30.0)
+            assert sim._world is None
+            assert "world-handoff lock still held" in caplog.text
+        finally:
+            release.set()
+            holder.join(timeout=30.0)
+
+
+class TestPolicyStartedMidRun:
+    """The other documented mid-run abort: a policy claims the robot."""
+
+    def test_primitive_aborts_when_a_policy_claims_the_robot(self, sim):
+        """``policy_running`` is what ``start_policy`` sets and the primitive reads."""
+
+        def claim() -> None:
+            sim._world.robots["arm"].policy_running = True
+
+        sim._mj = _MjHook(sim._mj, claim, at_call=3)
+
+        result = sim.set_gripper(robot_name="arm", state="close", steps=4000)
+
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "a policy started on 'arm' mid-run" in text
+        assert "stop_policy" in text


### PR DESCRIPTION
## Problem

`move_to`, `set_gripper` and `rotate_wrist` each document **"Never raises."**, and `_primitive_abort_reason` documents the intended outcome for exactly this case:

> The primitive loops release the lock between control ticks, so the world can legitimately be destroyed, the model recompiled, or a policy started while a primitive runs. Each of those aborts the primitive with a structured error rather than stepping a stale/contended model.

A concurrent `destroy()` / `cleanup()` did neither. All three primitives raised on the caller's thread:

```
AttributeError: 'NoneType' object has no attribute 'sim_time'
  at strands_robots/simulation/mujoco/motion_primitives.py:207, in _primitive_tick
```

| teardown during | before | after |
| --- | --- | --- |
| `move_to` | `AttributeError` | structured `"world was destroyed ... aborting"` |
| `set_gripper` | `AttributeError` | structured `"world was destroyed ... aborting"` |
| `rotate_wrist` | `AttributeError` | structured `"world was destroyed ... aborting"` |

## Root cause

`cleanup` handed the world off (`self._world = None`) **without holding `self._lock`**, so the handoff could land inside a primitive's control tick — between the tick's own world check and its write-back of `sim_time` / `step_count`.

The existing reasoning at that line covers the workers `cleanup` can await: it signals `policy_running = False`, then joins every outstanding Future before nulling the world, and concludes "any worker still alive at this point has already escaped MuJoCo (we've confirmed via `fut.result()`)".

A motion primitive is neither of those things. It runs on its **caller's** thread, so no Future awaits it, and the cooperative-stop flag never applies to it — a primitive refuses to *start* while a policy runs, so it never sets that flag. `self._lock`, which it takes per control tick, was its only synchronisation.

Teardown was the one world-lifecycle operation that did not take it:

| operation | world handoff |
| --- | --- |
| `load_scene` | under `self._lock` — and its comment already says why: "so a concurrent render/recorder thread never observes a half-built world" |
| `reset` | all of its work under `self._lock` |
| `create_world` | refuses outright when a world already exists |
| `cleanup` / `destroy` | **no lock** |

## Change

The handoff now happens under `self._lock`. Two constraints kept:

- **The Future join stays outside the lock.** A live policy worker takes the lock per step, so awaiting one while holding it would deadlock.
- **The acquire is bounded** (`_WORLD_HANDOFF_LOCK_TIMEOUT`), making the same tradeoff the bounded Future join already makes one step above: warn and tear down regardless rather than hang the host process on exit.

No public API and no environment variable added; the contract lives in the `cleanup` docstring, updated here.

## Rollout in MuJoCo sim (headless, EGL)

`destroy()` forced to land inside a `set_gripper` control tick, same scene and same tick on both trees. The frames differ by L1 = 53 (renderer noise) — nothing physical differs at the teardown instant; only what the API returns does.

![teardown mid-primitive: raise vs structured abort](https://raw.githubusercontent.com/cagataycali/robots/artifacts/primitive-teardown/teardown_abort.png)

## Tests

`tests/simulation/mujoco/test_primitive_teardown_abort.py` (6 tests). The interleave is forced rather than raced: a `mj_step` hook starts the teardown from another thread at the exact production window — inside the substep loop, after the tick's own `assert self._world is not None`.

With the lock, the teardown either lands between ticks (structured abort) or after the primitive finishes (normal result); both are correct, so the three end-to-end tests assert the contract — *the call returns a result instead of raising* — rather than which outcome the scheduler picked. The lock itself is pinned directly, and the structured abort text is pinned by the policy-claims-the-robot test, which needs no threads at all.

- `test_{move_to,set_gripper,rotate_wrist}_returns_a_result_instead_of_raising`
- `test_handoff_waits_for_a_control_tick_to_finish` — the world survives while the per-tick lock is held
- `test_teardown_does_not_hang_when_the_lock_is_never_released` — bounded acquire, warns, tears down anyway
- `test_primitive_aborts_when_a_policy_claims_the_robot` — the abort helper's third documented branch

**Pre-fix (source reverted to `main`): 5 failed, 1 passed** — the three primitives each raise `AttributeError` at `motion_primitives.py:207`, and the handoff-lock test fails because `cleanup` completed while the lock was held. Post-fix 6/6, stable over 5 consecutive runs.

Coverage of `mujoco/motion_primitives.py`: **88% -> 89%** (46 -> 42 uncovered), newly covering the abort helper's world-destroyed and policy-started branches plus two of its three call sites. The remaining `robot was removed mid-run` branch is not reachable through the public API — `remove_robot` recompiles, so the model-changed branch fires first — and was left alone rather than pinned artificially.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` — clean (`Success: no issues found in 927 source files`)
- `MUJOCO_GL=egl python -m pytest tests` — **12936 passed, 253 skipped** (baseline on this commit: 12930 + the 6 new tests)
- `python scripts/assemble_changelog.py --check` — OK; changelog fragment added
