### PR TITLE
fix(hardware): reset a policy's per-episode state at the start of each task

### DIFF
--- a/changelog.d/1712-per-task-policy-reset.md
+++ b/changelog.d/1712-per-task-policy-reset.md
@@ -1,0 +1,15 @@
+### Fixed: a hardware task starts its policy from a clean per-episode state
+
+`Robot._execute_task_async` never called `Policy.reset`, so a policy object
+driven through more than one task carried the previous task's per-episode
+state. `Policy.reset` exists to clear exactly that state - action chunk
+caches, sampler RNG, KV-caches - and the sim runner already calls it once per
+episode; only the hardware loop, where the leftover actions are commanded to a
+physical arm, skipped it. Driving one chunk-caching policy through two tasks
+replayed task one's cached chunk under task two's instruction, so the arm
+executed actions inferred for an instruction the caller never gave.
+
+The control loop now resets the policy once per task, before the first action
+reaches the bus. The reset is best-effort, matching the sim runner: a policy
+whose `reset` raises (for example one forwarding to an unreachable inference
+server) is still driven, and the warning names the stale state.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1097,6 +1097,9 @@ class Robot(TeleopMixin, AgentTool):
         arguments are ignored - the ``run_policy`` path. ``n_steps`` caps the
         number of applied actions; the loop stops at whichever of
         ``duration`` / ``n_steps`` comes first.
+
+        Either way the policy's per-episode state is reset before the rollout,
+        so a task never begins from the state the previous task left behind.
         """
         # resolve_chunk_length lives in the light policies.base module (no torch);
         # imported lazily to match this file's policy-import convention.
@@ -1144,6 +1147,28 @@ class Robot(TeleopMixin, AgentTool):
             # sim. Without it a wrong assumed rate corrupts RTC blending at every
             # frequency except the assumed one. No-op for non-RTC policies.
             policy_instance.set_control_frequency(self.control_frequency)
+
+            # Clear per-episode policy state before the rollout, mirroring the
+            # per-episode reset PolicyRunner performs in
+            # strands_robots/simulation/policy_runner.py. A caller may drive one
+            # policy object through several tasks (that is the documented
+            # ``run_policy(policy_object=...)`` usage), and Policy.reset exists
+            # to clear exactly the state that must not cross that boundary -
+            # action chunk caches, sampler RNG, KV-caches. Without it the first
+            # actions of a task can be the PREVIOUS task's cached chunk, so the
+            # arm executes commands inferred for a different instruction.
+            # No seed is passed: a hardware task has no per-episode seed to
+            # forward, so this asks only for a state clear.
+            #
+            # Fail-soft, matching PolicyRunner: a policy whose reset raises
+            # still gets driven, with the stale state named in the warning.
+            try:
+                policy_instance.reset()
+            except Exception as e:  # noqa: BLE001 - reset is best-effort
+                logger.warning(
+                    "policy.reset() raised %s; continuing with possibly stale per-episode state",
+                    e,
+                )
 
             self._task_state.status = TaskStatus.RUNNING
             start_time = time.time()
@@ -1330,6 +1355,9 @@ class Robot(TeleopMixin, AgentTool):
                 own device / embodiment / chunking configuration is honored;
                 the loop only injects the robot state keys and the RTC
                 control rate, exactly as it does for server-backed policies.
+                Its per-episode state is cleared via ``Policy.reset`` at the
+                start of every task, so one object can be reused across tasks
+                without the previous task's cached action chunk being driven.
             instruction: Natural-language instruction passed to the policy on
                 every ``get_actions`` call.
             duration: Wall-clock budget in seconds (same default as

--- a/tests/test_hardware_policy_per_task_reset.py
+++ b/tests/test_hardware_policy_per_task_reset.py
@@ -1,0 +1,159 @@
+"""Each hardware task starts the policy from a clean per-episode state.
+
+``Policy.reset`` exists to clear the state that must not cross an episode
+boundary - action chunk caches, sampler RNG, KV-caches (see its docstring in
+MODULE ``strands_robots.policies.base``). The sim runner calls it once per
+episode in MODULE ``strands_robots.simulation.policy_runner``; these tests pin
+that the hardware control loop does the same, because there the leftover
+actions of the previous task are commanded to a physical arm.
+
+Both hardware entry points - ``run_policy(policy_object=...)`` and the
+provider-backed ``start_task`` - funnel through ``_execute_task_async``, so the
+reset is asserted through each of them.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from tests.test_hardware_robot_lifecycle import _FakeLeRobot, _make_robot
+
+
+class _ChunkCachingPolicy:
+    """A VLA-shaped policy: one inference per episode, chunk cached after that.
+
+    ``reset()`` drops the cache, which is the whole contract under test. The
+    cached chunk is derived from the instruction, so an action carrying the
+    wrong value is proof that a previous task's chunk was replayed.
+    """
+
+    def __init__(self) -> None:
+        self._chunk: list[dict[str, Any]] | None = None
+        self.reset_calls = 0
+        self.actions_at_reset: list[int] = []
+        self.driven: list[tuple[str, float]] = []
+        self.robot: _FakeLeRobot | None = None
+
+    def set_robot_state_keys(self, keys: list[str]) -> None:
+        pass
+
+    def set_control_frequency(self, hz: float) -> None:
+        pass
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        pass
+
+    def reset(self, seed: int | None = None) -> None:
+        self.reset_calls += 1
+        self._chunk = None
+        if self.robot is not None:
+            # How many actions had already reached the arm when reset ran.
+            self.actions_at_reset.append(len(self.robot.sent_actions))
+
+    async def get_actions(self, observation: dict[str, Any], instruction: str) -> list[dict[str, Any]]:
+        if self._chunk is None:
+            # Inference happens once; every later step consumes the cache.
+            self._chunk = [{"j0.pos": 1.0 if instruction == "stack the cups" else 9.0}]
+        self.driven.append((instruction, self._chunk[0]["j0.pos"]))
+        return [dict(self._chunk[0])]
+
+
+class _ResetRaisesPolicy(_ChunkCachingPolicy):
+    """A policy whose per-episode reset fails."""
+
+    def reset(self, seed: int | None = None) -> None:
+        self.reset_calls += 1
+        raise RuntimeError("remote reset endpoint unreachable")
+
+
+def _run_two_tasks(hw: Any, policy: Any) -> None:
+    """Drive one policy object through two tasks with different instructions."""
+    hw.run_policy(policy_object=policy, instruction="stack the cups", duration=5.0, n_steps=2)
+    hw.run_policy(policy_object=policy, instruction="open the drawer", duration=5.0, n_steps=2)
+
+
+class TestPerTaskPolicyReset:
+    def test_a_second_task_does_not_drive_the_first_tasks_cached_chunk(self):
+        """The defect: a reused policy object replayed the previous instruction.
+
+        Driving one object through two tasks is the documented
+        ``run_policy(policy_object=...)`` usage. Without a per-task reset the
+        cached chunk inferred for task one is commanded to the arm during task
+        two, so the arm executes actions for an instruction nobody asked for.
+        """
+        fake = _FakeLeRobot()
+        hw = _make_robot(fake)
+        hw.action_horizon = 1
+        policy = _ChunkCachingPolicy()
+
+        _run_two_tasks(hw, policy)
+
+        second_task = {value for instruction, value in policy.driven if instruction == "open the drawer"}
+        assert second_task == {9.0}, f"second task drove the first task's chunk: {policy.driven}"
+        hw.cleanup()
+
+    def test_reset_runs_once_per_task_before_any_action_reaches_the_arm(self):
+        """One clear per task, and it precedes the first commanded action.
+
+        A reset issued after the loop has started would leave the first
+        actions of the task drawn from stale state, which is the failure this
+        guards against - so the ordering is part of the contract, not just the
+        call count.
+        """
+        fake = _FakeLeRobot()
+        hw = _make_robot(fake)
+        hw.action_horizon = 1
+        policy = _ChunkCachingPolicy()
+        policy.robot = fake
+
+        _run_two_tasks(hw, policy)
+
+        assert policy.reset_calls == 2
+        # Task one resets with nothing sent; task two resets with only task
+        # one's actions on the bus - never mid-task.
+        assert policy.actions_at_reset == [0, 2]
+        hw.cleanup()
+
+    def test_a_policy_whose_reset_raises_is_still_driven(self, caplog):
+        """Fail-soft, matching the sim runner: a failed reset never aborts a task.
+
+        A policy that forwards ``reset`` to a remote inference server can fail
+        for reasons unrelated to the task. Refusing to run would strand the
+        operator, so the task proceeds and the warning names the stale state.
+        """
+        fake = _FakeLeRobot()
+        hw = _make_robot(fake)
+        hw.action_horizon = 1
+        policy = _ResetRaisesPolicy()
+
+        with caplog.at_level(logging.WARNING):
+            hw.run_policy(policy_object=policy, instruction="stack the cups", duration=5.0, n_steps=2)
+
+        assert policy.reset_calls == 1
+        assert fake.sent_actions, "a failed reset must not stop the task from running"
+        assert "possibly stale per-episode state" in caplog.text
+        hw.cleanup()
+
+    def test_the_provider_backed_start_task_path_also_resets(self, monkeypatch):
+        """``start_task`` builds its policy from a provider, and resets it too.
+
+        Both entry points share ``_execute_task_async``; this pins that the
+        reset is on the shared path rather than only on the object path, so a
+        server-backed provider cannot carry state between tasks either.
+        """
+        fake = _FakeLeRobot()
+        hw = _make_robot(fake)
+        hw.action_horizon = 1
+        policy = _ChunkCachingPolicy()
+
+        async def _fake_get_policy(port, host, provider):
+            return policy
+
+        monkeypatch.setattr(hw, "_get_policy", _fake_get_policy)
+
+        hw._execute_task_sync("stack the cups", 5555, "localhost", "groot", 5.0)
+
+        assert policy.reset_calls == 1
+        assert fake.sent_actions
+        hw.cleanup()


### PR DESCRIPTION
## Problem

`Robot._execute_task_async` never called `Policy.reset`, so a policy object driven through more than one task began each task from the state the previous one left behind.

`Policy.reset` exists for exactly this boundary. Its own docstring says so:

> Reset per-episode policy state. [...] Policies that hold per-episode state (e.g. diffusion sampler RNG, action chunk caches, KV-caches) should override to apply the reset.

The sim runner honors it: `PolicyRunner` calls `policy.reset(...)` once per episode (`simulation/policy_runner.py:1055`, `:2594`), fail-soft, warning `"continuing without per-episode reset"`. The hardware loop -- the one place those leftover actions are commanded to a **physical arm** -- was the only driver that skipped it. `grep '\.reset(' strands_robots/hardware_robot.py` returned nothing.

Reusing one object is the documented usage: `run_policy`'s docstring describes driving a policy "already constructed in-process ... without standing up a policy server", and nothing suggested a fresh object was needed per task.

## Reproduction

One chunk-caching policy (the shape of any VLA: infer once, consume the chunk over the following steps) driven through two tasks with different instructions:

```python
policy = ChunkCachingPolicy()          # chunk depends on the instruction
hw.run_policy(policy_object=policy, instruction="stack the cups",  n_steps=2)
hw.run_policy(policy_object=policy, instruction="open the drawer", n_steps=2)
```

```
policy.reset() calls : 0
(instruction, value) : [('stack the cups', 1.0), ('stack the cups', 1.0),
                       ('open the drawer', 1.0), ('open the drawer', 1.0)]
                                            ^^^ task 1's cached chunk
```

Task two asked its policy for a chunk, the cache answered with task one's, and the arm executed actions inferred for an instruction the caller never gave. Because the cache short-circuits inference, the second task never performed one at all.

## Change

One reset before the rollout, at the point the loop already mirrors `PolicyRunner._run_policy_rollout` (next to the RTC `set_control_frequency` contract call):

```python
try:
    policy_instance.reset()
except Exception as e:  # noqa: BLE001 - reset is best-effort
    logger.warning(
        "policy.reset() raised %s; continuing with possibly stale per-episode state", e
    )
```

- **No seed is passed.** A hardware task has no per-episode seed to forward (sim passes `episode_seed` for reproducibility across an eval sweep); this asks only for a state clear, and the default `Policy.reset` remains a no-op for policies that hold nothing.
- **Fail-soft, matching the sim runner.** A policy forwarding `reset` to a remote inference server can fail for reasons unrelated to the task; refusing to run would strand the operator. The task proceeds and the warning names the stale state.
- **Both entry points covered.** `run_policy(policy_object=...)` and the provider-backed `start_task` both funnel through `_execute_task_async`, so the guard sits on the shared path.

## Artifact

What the control loop commanded during task two, replayed onto a Panda in MuJoCo (headless EGL) and rendered. Left panel generated with the source reverted, so it is genuinely pre-fix behavior.

![task 2 pose, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/per-task-policy-reset/per_task_policy_reset.png)

| | task 2 requested | commanded to the arm | `reset()` calls |
|---|---|---|---|
| before | `1:+1.60 2:+0.95 4:-0.60 6:+0.90` | `1:-1.60 2:+0.55 4:-1.90 6:+2.40` | 0 |
| after | `1:+1.60 2:+0.95 4:-0.60 6:+0.90` | `1:+1.60 2:+0.95 4:-0.60 6:+0.90` | 1 per task |

The pre-fix arm holds task one's pose through the whole of task two. Panels differ on 11.4% of pixels (L1 7.35e6).

## Tests

`tests/test_hardware_policy_per_task_reset.py` -- 4 tests, **4 failed pre-fix, 4 pass after**:

- a second task does not drive the first task's cached chunk (the defect)
- reset runs once per task and **before any action reaches the arm** -- a reset issued after the loop started would still leave the task's first actions drawn from stale state, so the ordering is part of the contract
- a policy whose `reset` raises is still driven, and the warning names the stale state
- the provider-backed `start_task` path resets too (pins the guard to the shared path, not just the object path)

Fixtures reused from `tests/test_hardware_robot_lifecycle.py`; no serial or USB traffic.

Pre-fix, with only the source reverted:

```
FAILED ...::test_a_second_task_does_not_drive_the_first_tasks_cached_chunk
FAILED ...::test_reset_runs_once_per_task_before_any_action_reaches_the_arm - assert 0 == 2
FAILED ...::test_a_policy_whose_reset_raises_is_still_driven - assert 0 == 1
FAILED ...::test_the_provider_backed_start_task_path_also_resets - assert 0 == 1
4 failed
```

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -- clean (933 source files)
- `MUJOCO_GL=egl pytest tests` -- **13094 passed, 253 skipped** (423s)
- `scripts/assemble_changelog.py --check` -- OK; `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py` -- 30 passed

Docstrings for `run_policy` and `_execute_task_async` now state the per-task reset, since the caller owns the object being reset.