### PR TITLE
docs: tie every documented robot count to the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ sim.step(100)   # publishes /so101/joint_states + camera image_raw on the ROS 2 
 
 - **Sim-first, safe by default.** `Robot("so100")` spins up a MuJoCo world. You
   never accidentally drive real servos - `mode="real"` is an explicit opt-in.
-- **50+ robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones,
+- **70+ robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones,
   bimanual rigs - resolved from a single registry with auto-download of assets.
 - **Any policy.** VLA models (NVIDIA GR00T, LeRobot ACT/Pi0/SmolVLA/Diffusion),
   plus classical motion planners, MPC, and scripted controllers behind one ABC.
@@ -439,7 +439,7 @@ Safety/validation rules:
 
 ## Supported robots
 
-50+ robots across 8 categories, resolved from
+70+ robots across 8 categories, resolved from
 [`registry/robots.json`](strands_robots/registry/robots.json). Assets
 (MJCF + meshes) auto-download from
 [robot_descriptions](https://github.com/robot-descriptions/robot_descriptions.py)
@@ -1175,7 +1175,7 @@ strands_robots/
 │   ├── mock.py            # MockPolicy (non-VLA reference)
 │   ├── groot/             # NVIDIA GR00T (ZMQ/HTTP client + data configs)
 │   └── lerobot_local/     # Direct HuggingFace inference (RTC, processors)
-├── registry/              # robots.json (50+) + policies.json + loaders
+├── registry/              # robots.json (70+) + policies.json + loaders
 ├── simulation/
 │   ├── base.py            # SimEngine ABC
 │   ├── factory.py         # create_simulation() + backend registry

--- a/changelog.d/1713-robot-catalog-count-guard.md
+++ b/changelog.d/1713-robot-catalog-count-guard.md
@@ -1,0 +1,20 @@
+### Docs: the robot catalog now agrees with the registry, and a guard keeps it that way
+
+`registry/robots.json` holds 72 robots in 8 categories, but nothing tied the
+documented counts to it, so they drifted independently: the hero and
+architecture SVGs said "40+ robots", the README said "50+", and
+`docs/robots/index.md`, `docs/architecture.md` and the quickstart said 68. Four
+category cards and the arms page understated their categories, and
+`docs/architecture.md` quoted 106 aliases where the registry declares 114.
+
+Two robots -- `hope_jr_hand` and `lekiwi_client` -- were missing from every
+catalog table, so a reader had no way to discover names `Robot()` accepts. Both
+are now listed with the existing hardware-only row convention.
+
+Every count is corrected, and `tests/test_docs_robot_catalog_coverage.py`
+derives all of them from `robots.json`: the catalog must list exactly the
+registered names on the page for each robot's category, each stated count must
+match the registry (the deliberately round "N+ robots" claims are pinned to the
+current multiple of ten so adding one robot needs no copy edit), and a count
+written anywhere the guard does not already know about is refused rather than
+becoming the next stale number.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ graph TB
 
     subgraph factory_layer[Robot factory  -  strands_robots/robot.py]
         ROBOT["Robot()"]
-        REGISTRY["registry/robots.json<br/>68 robots, 8 categories"]
+        REGISTRY["registry/robots.json<br/>72 robots, 8 categories"]
         ROBOT --> REGISTRY
     end
 
@@ -78,7 +78,7 @@ graph TB
 | Module | What it owns | Key types |
 |--------|--------------|-----------|
 | `strands_robots/robot.py` | Factory `Robot(name, mode, backend, **kwargs)`. Name resolution, sim/real dispatch, mesh attach. | `Robot()` function |
-| `strands_robots/registry/` | 68 robots, 106 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
+| `strands_robots/registry/` | 72 robots, 114 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
 | `strands_robots/simulation/` | MuJoCo `AgentTool` - 60+ actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
 | `strands_robots/simulation/base.py` | Backend ABC for future Isaac/Newton backends. | `SimEngine` |
 | `strands_robots/hardware_robot.py` | Real-servo path. Async task execution + status. | `Robot` (class), `TaskStatus`, `RobotTaskState` |

--- a/docs/assets/architecture_flow.svg
+++ b/docs/assets/architecture_flow.svg
@@ -145,7 +145,7 @@
   <!-- Layer 4: Robots -->
   <g>
     <rect x="80" y="410" width="840" height="74" rx="16" fill="#13161a" stroke="url(#ax)" stroke-width="1.5"/>
-    <text x="104" y="440" font-size="16" font-weight="700" fill="#ffffff">40+ robots</text>
+    <text x="104" y="440" font-size="16" font-weight="700" fill="#ffffff">70+ robots</text>
     <text x="104" y="462" font-size="12" fill="#8a8f99">registry/robots.json &#183; arms &#183; hands &#183; humanoids &#183; mobile</text>
     <g font-size="11.5" font-weight="600" fill="#cfd3da">
       <rect x="470" y="426" width="86" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="513" y="451" text-anchor="middle">SO-101</text>

--- a/docs/assets/hero_loop.svg
+++ b/docs/assets/hero_loop.svg
@@ -143,7 +143,7 @@
     One agent. Any robot. Closed loop.
   </text>
   <text x="600" y="93" text-anchor="middle" font-size="14" fill="#8a8f99" font-weight="500">
-    perceive &#183; reason &#183; act &#183; in MuJoCo sim or on real hardware &#183; 40+ robots
+    perceive &#183; reason &#183; act &#183; in MuJoCo sim or on real hardware &#183; 70+ robots
   </text>
 
   <!-- ===================== closed control loop ring ===================== -->

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -59,5 +59,5 @@ training a policy, and the full streaming data loop, each building on the last.
 ## See also
 
 - [Policy providers](../policies/overview.md) - GR00T, LeRobot Local, Cosmos 3.
-- [Robot catalog](../robots/index.md) - all 68 robots.
+- [Robot catalog](../robots/index.md) - all 72 robots.
 - [Real hardware](../hardware/robot-control.md) - same code, `mode="real"`.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -1,11 +1,11 @@
 ---
-description: 22 single-arm manipulators - from a 2-DOF educational toy to industrial UR10e.
+description: 23 single-arm manipulators - from a 2-DOF educational toy to industrial UR10e.
 ---
 
 # Arms
 
 Single-arm manipulators: industrial robots, research arms, educational kits.
-**22 robots in this category.**
+**23 robots in this category.**
 
 ```python
 from strands_robots import Robot

--- a/docs/robots/hands.md
+++ b/docs/robots/hands.md
@@ -20,6 +20,7 @@ sim = Robot("robotiq_2f85")     # Robotiq 2F-85 gripper
 | `ability_hand` | PSYONIC Ability Hand (5-finger prosthetic, 11-DOF) | 11 | `psyonic_ability_hand` |
 | `aero_hand` | Tetheria Aero Hand Open (16-DOF dexterous) | 16 | `tetheria_aero_hand`, `aero_hand_open` |
 | `allegro_hand` | Wonik Allegro Hand (16-DOF dexterous) | 16 | `wonik_allegro` |
+| `hope_jr_hand` | HopeJR Hand (dexterous anthropomorphic hand, Feetech) _(hardware-only, no sim asset)_ | ? | `hope_junior_hand`, `hopejr_hand` |
 | `leap_hand` | LEAP Hand (16-DOF dexterous) | 41 | - |
 | `robotiq_2f85` | Robotiq 2F-85 Gripper (2-finger adaptive) | 16 | `robotiq` |
 | `robotiq_2f85_v4` | Robotiq 2F-85 v4 Gripper (updated model) | 6 | - |

--- a/docs/robots/index.md
+++ b/docs/robots/index.md
@@ -1,10 +1,10 @@
 ---
-description: 68 robots across 8 categories. Every name addressable from Robot('name').
+description: 72 robots across 8 categories. Every name addressable from Robot('name').
 ---
 
 # Robot catalog
 
-`strands-robots` ships with a registry of **68 robots** across 8 categories. Every robot
+`strands-robots` ships with a registry of **72 robots** across 8 categories. Every robot
 is addressable by name through the factory:
 
 ```python
@@ -18,7 +18,7 @@ sim = Robot("aloha")
 
 <div class="grid cards" markdown>
 
--   :material-arm-flex:{ .lg .middle } **Arms** · 22
+-   :material-arm-flex:{ .lg .middle } **Arms** · 23
 
     ---
 
@@ -26,7 +26,7 @@ sim = Robot("aloha")
 
     [:octicons-arrow-right-24: Arms catalog](arms.md)
 
--   :material-arrow-left-right:{ .lg .middle } **Bimanual** · 3
+-   :material-arrow-left-right:{ .lg .middle } **Bimanual** · 4
 
     ---
 
@@ -42,7 +42,7 @@ sim = Robot("aloha")
 
     [:octicons-arrow-right-24: Humanoids catalog](humanoids.md)
 
--   :material-hand-back-right:{ .lg .middle } **Hands** · 8
+-   :material-hand-back-right:{ .lg .middle } **Hands** · 9
 
     ---
 
@@ -58,7 +58,7 @@ sim = Robot("aloha")
 
     [:octicons-arrow-right-24: Mobile catalog](mobile.md)
 
--   :material-truck:{ .lg .middle } **Mobile manip** · 4
+-   :material-truck:{ .lg .middle } **Mobile manip** · 5
 
     ---
 

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -26,6 +26,7 @@ sim = Robot("crazyflie")        # Bitcraze Crazyflie 2 quadcopter
 | `go1` | Unitree Go1 Quadruped (12-DOF) | 13 | `unitree_go1` |
 | `google_robot` | Google Robot (mobile base + arm, RT-X) | 10 | `oxe_google` |
 | `lekiwi` | LeKiwi mobile manipulator (6-DOF arm on 3-omniwheel base, 9 actuators) | 9 | - |
+| `lekiwi_client` | LeKiwi networked client (drives a remote LeKiwi host over ZMQ) _(hardware-only, no sim asset)_ | ? | `lekiwi_net`, `lekiwi_remote` |
 | `robot_soccer_kit` | Robot Soccer Kit (multi-robot soccer, 65-DOF total) | 65 | `rsk` |
 | `skydio_x2` | Skydio X2 Autonomous Drone | 1 | - |
 | `spot` | Boston Dynamics Spot (with arm) | 20 | `boston_dynamics_spot` |

--- a/tests/test_docs_robot_catalog_coverage.py
+++ b/tests/test_docs_robot_catalog_coverage.py
@@ -1,0 +1,227 @@
+"""Repo hygiene: the robot catalog docs agree with ``registry/robots.json``.
+
+The registry is the source of truth for what ``Robot("<name>")`` accepts, but
+five separate documents restate its contents for humans: the README feature
+list, the hero and architecture SVGs, ``docs/architecture.md``, the quickstart
+"see also", and the ``docs/robots/`` catalog pages. Nothing tied those restated
+numbers to the registry, so they drifted independently - the tree simultaneously
+claimed "40+", "50+" and "68" robots for a registry holding 72, and two
+hardware-only robots (``hope_jr_hand``, ``lekiwi_client``) were absent from
+every catalog table, making them undiscoverable to anyone reading the docs.
+
+Three guards, each with a distinct job:
+
+* :func:`test_every_registered_robot_appears_in_a_catalog_table` and its inverse
+  pin *membership* - the catalog lists exactly the registered names.
+* The ``test_..._claim_matches_registry`` tests pin *the numbers*, and their
+  failure message is the exact string to write, so a fix needs no arithmetic.
+* :func:`test_no_robot_count_claim_outside_the_known_sites` is the net that
+  catches a *new* claim added somewhere none of the above look. The tests above
+  are precise about the sites they know; this one refuses an unknown number.
+
+Counts are derived from ``robots.json`` directly rather than from
+:func:`~strands_robots.registry.list_robots`, because ``list_robots()`` also
+returns robots registered at runtime through ``register_robot()`` and from the
+user registry on disk, neither of which the docs describe. This mirrors the
+reasoning in ``tests/test_docs_policy_coverage.py``.
+
+Aliases are counted but not cross-checked row by row: the catalog's "Aliases"
+column shows only the first few for readability, which is a presentation choice
+this guard deliberately leaves alone.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROBOTS_JSON = REPO_ROOT / "strands_robots" / "registry" / "robots.json"
+DOCS = REPO_ROOT / "docs"
+README = REPO_ROOT / "README.md"
+
+#: Catalog page -> the registry categories it documents.
+CATALOG_PAGES: dict[str, tuple[str, ...]] = {
+    "arms.md": ("arm",),
+    "bimanual.md": ("bimanual",),
+    "hands.md": ("hand",),
+    "humanoids.md": ("humanoid", "expressive"),
+    "mobile.md": ("mobile", "mobile_manip", "aerial"),
+}
+
+#: Claims that count something other than registry entries, so they are not
+#: this guard's business. The README teleoperation section counts the robots a
+#: teleoperator can drive, which is a property of the teleop matrix.
+EXEMPT_CLAIMS: tuple[re.Pattern[str], ...] = (re.compile(r"drive \d+ robots"),)
+
+#: A robot count stated in prose or in SVG label text. Requires the plural so
+#: "ROS 2 robot" and "so100 robot" are not mistaken for counts, and a
+#: non-identifier character before the digits so "so100 robots" is not either.
+COUNT_CLAIM_RE = re.compile(r"(?:^|[^0-9A-Za-z_])(\d+)\+? robots\b")
+
+
+def _registry() -> dict[str, dict]:
+    """Return the built-in robot registry, keyed by canonical name."""
+    return json.loads(ROBOTS_JSON.read_text(encoding="utf-8"))["robots"]
+
+
+def _category_counts() -> Counter[str]:
+    """Return the number of registered robots per category."""
+    return Counter(entry.get("category", "") for entry in _registry().values())
+
+
+def _catalog_rows() -> dict[str, str]:
+    """Return every name listed in a catalog table, mapped to its page.
+
+    Only the ``## Catalog`` section of each page is read, so a name mentioned in
+    a code sample or a "featured render" heading elsewhere on the page does not
+    count as being catalogued.
+    """
+    listed: dict[str, str] = {}
+    for page in CATALOG_PAGES:
+        text = (DOCS / "robots" / page).read_text(encoding="utf-8")
+        section = re.search(r"\n## Catalog\b(.*?)(?:\n## |\Z)", text, re.DOTALL)
+        assert section, f"{page} is missing a '## Catalog' section"
+        for line in section.group(1).splitlines():
+            row = re.match(r"\| `([^`]+)` \|", line)
+            if row:
+                name = row.group(1)
+                assert name not in listed, f"{name} is listed twice ({listed.get(name)}, {page})"
+                listed[name] = page
+    return listed
+
+
+def _count_claims() -> list[tuple[Path, int, str, int]]:
+    """Return every robot-count claim as ``(path, lineno, line, claimed)``."""
+    files = [README, *sorted(DOCS.rglob("*.md")), *sorted(DOCS.rglob("*.svg"))]
+    claims: list[tuple[Path, int, str, int]] = []
+    for path in files:
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if any(exempt.search(line) for exempt in EXEMPT_CLAIMS):
+                continue
+            for match in COUNT_CLAIM_RE.finditer(line):
+                claims.append((path, lineno, line.strip(), int(match.group(1))))
+    return claims
+
+
+def test_every_registered_robot_appears_in_a_catalog_table() -> None:
+    """Every name ``Robot()`` accepts is discoverable from the catalog pages."""
+    missing = sorted(set(_registry()) - set(_catalog_rows()))
+    assert not missing, (
+        f"registered but absent from every docs/robots/ catalog table: {missing}. "
+        "A robot missing from the catalog cannot be discovered by a reader."
+    )
+
+
+def test_no_catalog_row_for_an_unregistered_robot() -> None:
+    """The catalog does not advertise a name the registry cannot resolve."""
+    rows = _catalog_rows()
+    unknown = sorted(set(rows) - set(_registry()))
+    assert not unknown, f"catalogued but not in robots.json: {[(n, rows[n]) for n in unknown]}"
+
+
+def test_each_robot_is_catalogued_on_the_page_for_its_category() -> None:
+    """A robot appears on the page documenting its registry category."""
+    registry, rows = _registry(), _catalog_rows()
+    page_for = {cat: page for page, cats in CATALOG_PAGES.items() for cat in cats}
+    misfiled = [
+        (name, rows[name], page_for[registry[name]["category"]])
+        for name in sorted(rows)
+        if name in registry and rows[name] != page_for.get(registry[name].get("category", ""))
+    ]
+    assert not misfiled, f"listed on the wrong catalog page (name, listed_on, expected): {misfiled}"
+
+
+def test_total_robot_count_claims_match_the_registry() -> None:
+    """Documents quoting an exact registry size quote the current one."""
+    total, categories = len(_registry()), len(_category_counts())
+    expected = [
+        (DOCS / "robots" / "index.md", f"description: {total} robots across {categories} categories."),
+        (DOCS / "robots" / "index.md", f"registry of **{total} robots** across {categories} categories"),
+        (DOCS / "architecture.md", f"{total} robots, {categories} categories"),
+        (DOCS / "getting-started" / "quickstart.md", f"all {total} robots."),
+    ]
+    for path, text in expected:
+        assert text in path.read_text(encoding="utf-8"), (
+            f"{path.relative_to(REPO_ROOT)} should state {text!r} "
+            f"(robots.json holds {total} robots in {categories} categories)"
+        )
+
+
+def test_approximate_robot_count_claims_match_the_current_decade() -> None:
+    """Documents rounding the registry size round it down to the current ten.
+
+    The README and the SVG labels state a deliberately round "N+ robots" so that
+    adding one robot does not require a copy edit. Pinning that to the current
+    multiple of ten keeps the claim both true and current: it only needs a bump
+    when the registry crosses the next ten, which is exactly when "70+" starts
+    understating a registry of 80.
+    """
+    total, categories = len(_registry()), len(_category_counts())
+    decade = total // 10 * 10
+    expected = [
+        (DOCS / "assets" / "hero_loop.svg", f"{decade}+ robots"),
+        (DOCS / "assets" / "architecture_flow.svg", f"{decade}+ robots"),
+        (README, f"**{decade}+ robots, {categories} categories.**"),
+        (README, f"{decade}+ robots across {categories} categories"),
+        (README, f"robots.json ({decade}+)"),
+    ]
+    for path, text in expected:
+        assert text in path.read_text(encoding="utf-8"), (
+            f"{path.relative_to(REPO_ROOT)} should state {text!r} "
+            f"(robots.json holds {total} robots, which rounds down to {decade})"
+        )
+
+
+def test_per_category_count_claims_match_the_registry() -> None:
+    """The category cards and the arms page quote their real category sizes."""
+    counts = _category_counts()
+    index = DOCS / "robots" / "index.md"
+    expected = [
+        (index, f"**Arms** \u00b7 {counts['arm']}"),
+        (index, f"**Bimanual** \u00b7 {counts['bimanual']}"),
+        (index, f"**Humanoids** \u00b7 {counts['humanoid']}"),
+        (index, f"**Hands** \u00b7 {counts['hand']}"),
+        (index, f"**Mobile** \u00b7 {counts['mobile']}"),
+        (index, f"**Mobile manip** \u00b7 {counts['mobile_manip']}"),
+        (index, f"**Aerial** \u00b7 {counts['aerial']}"),
+        (index, f"**Expressive** \u00b7 {counts['expressive']}"),
+        (DOCS / "robots" / "arms.md", f"description: {counts['arm']} single-arm manipulators"),
+        (DOCS / "robots" / "arms.md", f"**{counts['arm']} robots in this category.**"),
+    ]
+    for path, text in expected:
+        assert text in path.read_text(encoding="utf-8"), (
+            f"{path.relative_to(REPO_ROOT)} should state {text!r} (from robots.json)"
+        )
+
+
+def test_alias_count_claim_matches_the_registry() -> None:
+    """The architecture table quotes the real number of registered aliases."""
+    registry = _registry()
+    aliases = sum(len(entry.get("aliases", [])) for entry in registry.values())
+    text = f"{len(registry)} robots, {aliases} aliases, {len(_category_counts())} categories"
+    assert text in (DOCS / "architecture.md").read_text(encoding="utf-8"), f"docs/architecture.md should state {text!r}"
+
+
+def test_no_robot_count_claim_outside_the_known_sites() -> None:
+    """A robot count stated anywhere in the docs is one the registry supports.
+
+    The tests above check the sites that exist today. This one refuses a number
+    that matches neither the registry total, its round-down, nor any category
+    size, so a new claim written somewhere unexpected fails here rather than
+    silently becoming the next stale number.
+    """
+    counts = _category_counts()
+    total = sum(counts.values())
+    allowed = {total, total // 10 * 10, *counts.values()}
+    stale = [
+        (str(path.relative_to(REPO_ROOT)), lineno, claimed, line)
+        for path, lineno, line, claimed in _count_claims()
+        if claimed not in allowed
+    ]
+    assert not stale, (
+        f"robot counts that no registry number supports (allowed: {sorted(allowed)}): {stale}. "
+        "Update the claim, or add it to EXEMPT_CLAIMS if it counts something else."
+    )


### PR DESCRIPTION
## Problem

`strands_robots/registry/robots.json` is the source of truth for what `Robot("<name>")` accepts. Six documents restate its contents for humans, and nothing tied any of them to it, so they drifted apart independently.

**All 17 sites that state a robot count disagreed with the registry**, in three mutually inconsistent directions:

| claim site | on main | registry |
|---|---|---|
| `docs/assets/hero_loop.svg`, `architecture_flow.svg` labels | `40+ robots` | 72 |
| `README.md` x3 (why-bullet, supported-robots, repo tree) | `50+` | 72 |
| `docs/robots/index.md` x2, `docs/architecture.md` x2, `quickstart.md` | `68` | 72 |
| `index.md` Arms / Bimanual / Hands / Mobile-manip cards | 22 / 3 / 8 / 4 | 23 / 4 / 9 / 5 |
| `docs/robots/arms.md` category count | `22 robots in this category` | 23 |
| `docs/architecture.md` module table | `106 aliases` | 114 |

A reader who counted the catalog tables got a fourth number again, because **two registered robots were absent from every catalog table**: `hope_jr_hand` and `lekiwi_client`. Both resolve on main today, aliases included:

```
hope_jr_hand   -> hope_jr_hand   cat=hand         sim=False hw=True
hopejr_hand    -> hope_jr_hand   ...
lekiwi_client  -> lekiwi_client  cat=mobile_manip sim=False hw=True
lekiwi_net     -> lekiwi_client  ...
```

So nothing was broken about them except that the docs gave no way to discover them. Notably `docs/robots/arms.md` already had the correct 23 table rows while its prose said 22: the tables get maintained when a robot lands, the counts do not.

## Change

Every count corrected, the two missing robots listed with the existing hardware-only row convention (`_(hardware-only, no sim asset)_`, `?` joints), and one new guard that derives all of it so the class cannot come back.

`tests/test_docs_robot_catalog_coverage.py` reads `robots.json` **directly** rather than calling `list_robots()`, because `list_robots()` also returns runtime `register_robot()` entries and the on-disk user registry, which the docs do not describe. That is not hypothetical: on this machine `list_robots()` returns 75 against a registry of 72. `tests/test_docs_policy_coverage.py` already documents the same reasoning for the policy registry, so this follows an established precedent rather than inventing a convention.

The guard pins three separable things:

- **Membership** - the catalog lists exactly the registered names, each on the page documenting its category. This is what catches a robot nobody can discover.
- **The numbers** - each stated count equals the registry-derived value, and each assertion message is the exact string to write, so fixing a failure needs no arithmetic.
- **Unknown sites** - a robot count written anywhere the tests above do not look is refused unless it matches a registry number. Without this the guard would only ever check the sites that already existed.

On the round claims: the README and SVG labels deliberately say "N+ robots" so that adding one robot is not a copy edit, and that intent is worth keeping. But `50+` for a registry of 72 is *true* and still the defect being reported, so a `N <= actual` check would have passed on the broken state. The guard therefore pins them to the current multiple of ten (`70+`), which is both true and current: it asks for a bump only when the registry crosses the next ten, which is exactly when `70+` starts understating.

## Verification

![robot count drift](https://raw.githubusercontent.com/cagataycali/robots/artifacts/robot-catalog-counts/catalog_drift.png)

The table is generated by reading each claim site out of `git show upstream/main:<path>` and out of the branch, so no value in it is hand-typed. All 17 sites are red on main and match the registry on this branch.

**The guard fails on main and passes here:**

```
$ git stash push -q -- README.md docs/     # revert the content fix only
$ pytest tests/test_docs_robot_catalog_coverage.py -q
6 failed, 2 passed

FAILED test_every_registered_robot_appears_in_a_catalog_table
  registered but absent from every docs/robots/ catalog table:
  ['hope_jr_hand', 'lekiwi_client']
FAILED test_total_robot_count_claims_match_the_registry
  docs/robots/index.md should state 'description: 72 robots across 8 categories.'
FAILED test_approximate_robot_count_claims_match_the_current_decade
  docs/assets/hero_loop.svg should state '70+ robots'
FAILED test_per_category_count_claims_match_the_registry
  docs/robots/index.md should state '**Arms** \u00b7 23'
FAILED test_alias_count_claim_matches_the_registry
  docs/architecture.md should state '72 robots, 114 aliases, 8 categories'
FAILED test_no_robot_count_claim_outside_the_known_sites
  robot counts that no registry number supports: [10 sites listed]

$ git stash pop -q
$ pytest tests/test_docs_robot_catalog_coverage.py -q
8 passed
```

The 2 that pass pre-fix are the two inverse-membership guards (no catalogued name is unregistered, none is filed under the wrong category) - both were already true on main, and they exist to keep the membership check symmetric.

**Gate** (Thor, aarch64, `MUJOCO_GL=egl`):

```
ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ 936 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 933 source files
pytest tests -q --no-cov                            13098 passed, 253 skipped in 441.77s
python scripts/assemble_changelog.py --check        changelog fragments OK
```

## Deliberately out of scope

The catalog's "Aliases" column shows only the first few aliases per row with no indication that it truncates - `panda` lists 3 of its 8, so `Robot("franka_panda")` works but no page says so. Fixing that is a presentation decision (widen the cell, or add an explicit "+N more"), so it is left alone here and the guard deliberately does not pin that column. Filed separately.

The README teleoperation section's "drive 14 robots" counts teleop-drivable robots, not registry entries, so it is exempted in the guard with a comment saying why.