### PR TITLE
docs: list every registry alias in the robot catalog

### DIFF
--- a/changelog.d/1714-catalog-alias-column.md
+++ b/changelog.d/1714-catalog-alias-column.md
@@ -1,0 +1,13 @@
+### Docs: the robot catalog lists every alias the registry accepts
+
+The `Aliases` column in the `docs/robots/*.md` catalog tables showed at most three
+aliases per row and dropped the rest with no "+N more" marker, hiding 19 names
+`resolve_name()` accepts today -- including `franka_panda` and
+`franka_emika_panda`, two of the first spellings a reader guesses for
+`Robot("panda")`. Eight of the 72 rows truncated.
+
+Each row now lists every alias its `robots.json` entry declares, in the order the
+entry declares it, and `tests/test_docs_robot_catalog_coverage.py` compares the
+column cell by cell so a newly registered alias cannot fall outside it. The two
+rows that already listed a complete set in a different order were normalised to
+the registry's order, so the column now follows one convention rather than two.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -28,12 +28,12 @@ sim = Robot("so100")            # SO-ARM100 (low-cost Feetech)
 | `kuka_iiwa` | KUKA LBR iiwa 14 (7-DOF collaborative) | 11 | `kuka_iiwa_14` |
 | `omx` | OMX Robot Arm (ROBOTIS, CAN bus motors) _(hardware-only, no sim asset)_ | ? | `omx_follower`, `omx_robot`, `robotis_omx` |
 | `openarm` | Enactic OpenArm (7-DOF, DAMIAO motors, CAN bus) | 9 | `enactic_openarm`, `open_arm`, `openarm_v10` |
-| `panda` | Franka Emika Panda (7-DOF + gripper) | 7 | `bimanual_panda_gripper`, `bimanual_panda_hand`, `franka` |
+| `panda` | Franka Emika Panda (7-DOF + gripper) | 7 | `bimanual_panda_gripper`, `bimanual_panda_hand`, `franka`, `franka_emika_panda`, `franka_panda`, `libero_panda`, `oxe_droid`, `single_panda_gripper` |
 | `piper` | AgileX Piper (6-DOF + gripper) | 11 | `agilex_piper` |
 | `rebot_b601` | Seeed Studio reBot B601-DM (6-DOF + gripper, Damiao CAN motors) _(hardware-only, no sim asset)_ | 7 | `rebot_b601_follower`, `seeed_rebot_b601`, `b601_dm` |
 | `sawyer` | Rethink Robotics Sawyer (7-DOF) | 7 | `rethink_sawyer` |
-| `so100` | TrossenRobotics SO-ARM100 (6-DOF, Feetech servos) | 6 | `so100_4cam`, `so100_dualcam`, `so100_follower` |
-| `so101` | RobotStudio SO-101 (6-DOF, upgraded SO-100) | 6 | `robotstudio_so101`, `so101_dualcam`, `so101_follower` |
+| `so100` | TrossenRobotics SO-ARM100 (6-DOF, Feetech servos) | 6 | `so100_4cam`, `so100_dualcam`, `so100_follower`, `so_arm100`, `trs_so_arm100` |
+| `so101` | RobotStudio SO-101 (6-DOF, upgraded SO-100) | 6 | `robotstudio_so101`, `so101_dualcam`, `so101_follower`, `so101_tricam` |
 | `ur10e` | Universal Robots UR10e (6-DOF industrial) | 6 | - |
 | `ur5e` | Universal Robots UR5e (6-DOF industrial) | 8 | - |
 | `vx300s` | Trossen ViperX 300s (6-DOF + gripper) | 19 | `oxe_widowx`, `trossen_vx300s`, `viper_x300s` |

--- a/docs/robots/bimanual.md
+++ b/docs/robots/bimanual.md
@@ -17,7 +17,7 @@ sim = Robot("trossen_wxai")     # Trossen WX-AI
 
 | Name | Description | Joints | Aliases |
 |------|-------------|-------:|---------|
-| `aloha` | ALOHA Bimanual (2x ViperX 300s, 14-DOF + 2 grippers) | 28 | `agibot_dual_arm`, `agibot_dual_arm_dexhand`, `agibot_dual_arm_full` |
+| `aloha` | ALOHA Bimanual (2x ViperX 300s, 14-DOF + 2 grippers) | 28 | `agibot_dual_arm`, `agibot_dual_arm_dexhand`, `agibot_dual_arm_full`, `agibot_dual_arm_gripper`, `agibot_genie1`, `bi_so_follower`, `galaxea_r1_pro` |
 | `bi_openarm` | Bi-manual OpenArm (dual-arm coordination) _(hardware-only, no sim asset)_ | ? | `bi_openarm_follower`, `dual_openarm`, `openarm_bimanual` |
 | `bi_rebot_b601` | Bi-manual reBot B601-DM (dual 6-DOF + gripper, Damiao CAN motors) _(hardware-only, no sim asset)_ | ? | `bi_rebot_b601_follower`, `dual_rebot_b601` |
 | `trossen_wxai` | Trossen WidowX AI Bimanual | 17 | `trossen_ai_bimanual` |

--- a/docs/robots/hands.md
+++ b/docs/robots/hands.md
@@ -20,7 +20,7 @@ sim = Robot("robotiq_2f85")     # Robotiq 2F-85 gripper
 | `ability_hand` | PSYONIC Ability Hand (5-finger prosthetic, 11-DOF) | 11 | `psyonic_ability_hand` |
 | `aero_hand` | Tetheria Aero Hand Open (16-DOF dexterous) | 16 | `tetheria_aero_hand`, `aero_hand_open` |
 | `allegro_hand` | Wonik Allegro Hand (16-DOF dexterous) | 16 | `wonik_allegro` |
-| `hope_jr_hand` | HopeJR Hand (dexterous anthropomorphic hand, Feetech) _(hardware-only, no sim asset)_ | ? | `hope_junior_hand`, `hopejr_hand` |
+| `hope_jr_hand` | HopeJR Hand (dexterous anthropomorphic hand, Feetech) _(hardware-only, no sim asset)_ | ? | `hopejr_hand`, `hope_junior_hand` |
 | `leap_hand` | LEAP Hand (16-DOF dexterous) | 41 | - |
 | `robotiq_2f85` | Robotiq 2F-85 Gripper (2-finger adaptive) | 16 | `robotiq` |
 | `robotiq_2f85_v4` | Robotiq 2F-85 v4 Gripper (updated model) | 6 | - |

--- a/docs/robots/humanoids.md
+++ b/docs/robots/humanoids.md
@@ -24,17 +24,17 @@ sim = Robot("reachy_mini")      # Pollen Reachy Mini (expressive)
 | `booster_t1` | Booster T1 Humanoid (24-DOF) | 24 | - |
 | `cassie` | Agility Cassie Bipedal Robot | 28 | `agility_cassie` |
 | `elf2` | BXI Elf2 Humanoid (25-DOF) | 26 | `bxi_elf2` |
-| `fourier_n1` | Fourier N1 / GR-1 Humanoid (26-DOF) | 26 | `fourier_gr1`, `fourier_gr1_arms_only`, `fourier_gr1_arms_waist` |
+| `fourier_n1` | Fourier N1 / GR-1 Humanoid (26-DOF) | 26 | `fourier_gr1`, `fourier_gr1_arms_only`, `fourier_gr1_arms_waist`, `fourier_gr1_full_upper_body`, `gr1` |
 | `jvrc` | JVRC-1 Humanoid (HRP-based, 45-DOF) | 45 | `jvrc1` |
 | `op3` | ROBOTIS OP3 Humanoid (20-DOF) | 21 | `robotis_op3` |
-| `open_duck_mini` | Open Duck Mini V2 (16-DOF expressive biped, Feetech servos) | 16 | `bdx`, `mini_bdx`, `open_duck` |
+| `open_duck_mini` | Open Duck Mini V2 (16-DOF expressive biped, Feetech servos) | 16 | `bdx`, `mini_bdx`, `open_duck`, `open_duck_mini_v2`, `open_duck_v2` |
 | `rby1` | Rainbow Robotics RB-Y1A Mobile Manipulator (31-DOF) | 31 | `rby1a`, `rainbow_rby1` |
 | `reachy2` | Pollen Reachy 2 _(hardware-only, no sim asset)_ | ? | - |
-| `reachy_mini` | Pollen Reachy Mini (6-DOF Stewart head + antennas, 9 actuators) | 21 | `pollen_reachy_mini`, `reachy`, `reachy-mini` |
+| `reachy_mini` | Pollen Reachy Mini (6-DOF Stewart head + antennas, 9 actuators) | 21 | `pollen_reachy_mini`, `reachy`, `reachy-mini`, `reachymini` |
 | `talos` | PAL Robotics TALOS Humanoid (32-DOF) | 45 | `pal_talos` |
 | `toddlerbot_2xc` | Toddlerbot 2xC Humanoid (45-DOF) | 45 | - |
 | `toddlerbot_2xm` | Toddlerbot 2xM Humanoid (45-DOF) | 45 | - |
-| `unitree_g1` | Unitree G1 Humanoid (29-DOF + dexterous hands) | 46 | `g1`, `g1_wbc`, `unitree_g1_full_body` |
+| `unitree_g1` | Unitree G1 Humanoid (29-DOF + dexterous hands) | 46 | `g1`, `g1_wbc`, `unitree_g1_full_body`, `unitree_g1_locomanip`, `unitree_g1_wbc` |
 | `unitree_h1` | Unitree H1 Humanoid (19-DOF) | 20 | `h1` |
 | `unitree_h1_2` | Unitree H1-2 Humanoid (52-DOF, with hands) | 52 | `h1_2` |
 

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -26,7 +26,7 @@ sim = Robot("crazyflie")        # Bitcraze Crazyflie 2 quadcopter
 | `go1` | Unitree Go1 Quadruped (12-DOF) | 13 | `unitree_go1` |
 | `google_robot` | Google Robot (mobile base + arm, RT-X) | 10 | `oxe_google` |
 | `lekiwi` | LeKiwi mobile manipulator (6-DOF arm on 3-omniwheel base, 9 actuators) | 9 | - |
-| `lekiwi_client` | LeKiwi networked client (drives a remote LeKiwi host over ZMQ) _(hardware-only, no sim asset)_ | ? | `lekiwi_net`, `lekiwi_remote` |
+| `lekiwi_client` | LeKiwi networked client (drives a remote LeKiwi host over ZMQ) _(hardware-only, no sim asset)_ | ? | `lekiwi_remote`, `lekiwi_net` |
 | `robot_soccer_kit` | Robot Soccer Kit (multi-robot soccer, 65-DOF total) | 65 | `rsk` |
 | `skydio_x2` | Skydio X2 Autonomous Drone | 1 | - |
 | `spot` | Boston Dynamics Spot (with arm) | 20 | `boston_dynamics_spot` |

--- a/tests/test_docs_robot_catalog_coverage.py
+++ b/tests/test_docs_robot_catalog_coverage.py
@@ -9,7 +9,7 @@ claimed "40+", "50+" and "68" robots for a registry holding 72, and two
 hardware-only robots (``hope_jr_hand``, ``lekiwi_client``) were absent from
 every catalog table, making them undiscoverable to anyone reading the docs.
 
-Three guards, each with a distinct job:
+Four guards, each with a distinct job:
 
 * :func:`test_every_registered_robot_appears_in_a_catalog_table` and its inverse
   pin *membership* - the catalog lists exactly the registered names.
@@ -18,6 +18,9 @@ Three guards, each with a distinct job:
 * :func:`test_no_robot_count_claim_outside_the_known_sites` is the net that
   catches a *new* claim added somewhere none of the above look. The tests above
   are precise about the sites they know; this one refuses an unknown number.
+* :func:`test_the_alias_column_lists_every_alias_the_registry_accepts` pins the
+  catalog's *Aliases* column cell by cell, so a name ``resolve_name()`` accepts
+  cannot be missing from the row that advertises the robot.
 
 Counts are derived from ``robots.json`` directly rather than from
 :func:`~strands_robots.registry.list_robots`, because ``list_robots()`` also
@@ -25,9 +28,13 @@ returns robots registered at runtime through ``register_robot()`` and from the
 user registry on disk, neither of which the docs describe. This mirrors the
 reasoning in ``tests/test_docs_policy_coverage.py``.
 
-Aliases are counted but not cross-checked row by row: the catalog's "Aliases"
-column shows only the first few for readability, which is a presentation choice
-this guard deliberately leaves alone.
+The alias column is a *faithful projection* of ``robots.json``: every alias the
+entry declares, in the order the entry declares it, joined with ", " (or ``-``
+when the entry declares none). It used to show only the first three, silently,
+which hid 19 accepted names -- including ``franka_panda``, one of the first
+spellings a reader guesses. Mirroring the registry's own order rather than
+sorting keeps the projection transformation-free, so the expected cell can be
+quoted verbatim in the failure message.
 """
 
 from __future__ import annotations
@@ -91,6 +98,37 @@ def _catalog_rows() -> dict[str, str]:
                 assert name not in listed, f"{name} is listed twice ({listed.get(name)}, {page})"
                 listed[name] = page
     return listed
+
+
+def _catalog_alias_cells() -> dict[str, str]:
+    """Return each catalogued robot's raw *Aliases* cell, keyed by robot name.
+
+    Reads only the ``## Catalog`` table, and asserts each row has the expected
+    four columns so a stray ``|`` inside a cell fails here rather than silently
+    shifting which text is read as the alias list.
+    """
+    cells: dict[str, str] = {}
+    for page in CATALOG_PAGES:
+        text = (DOCS / "robots" / page).read_text(encoding="utf-8")
+        section = re.search(r"\n## Catalog\b(.*?)(?:\n## |\Z)", text, re.DOTALL)
+        assert section, f"{page} is missing a '## Catalog' section"
+        for line in section.group(1).splitlines():
+            row = re.match(r"\| `([^`]+)` \|", line)
+            if not row:
+                continue
+            columns = line.split("|")
+            assert len(columns) == 6, (
+                f"{page}: expected a 4-column row for {row.group(1)!r}, got {len(columns) - 2}: {line!r}. "
+                "A literal '|' inside a cell must be escaped as '\\|'."
+            )
+            cells[row.group(1)] = columns[4].strip()
+    return cells
+
+
+def _expected_alias_cell(entry: dict) -> str:
+    """Return the *Aliases* cell text a registry entry should produce."""
+    aliases = entry.get("aliases", [])
+    return ", ".join(f"`{alias}`" for alias in aliases) if aliases else "-"
 
 
 def _count_claims() -> list[tuple[Path, int, str, int]]:
@@ -224,4 +262,24 @@ def test_no_robot_count_claim_outside_the_known_sites() -> None:
     assert not stale, (
         f"robot counts that no registry number supports (allowed: {sorted(allowed)}): {stale}. "
         "Update the claim, or add it to EXEMPT_CLAIMS if it counts something else."
+    )
+
+
+def test_the_alias_column_lists_every_alias_the_registry_accepts() -> None:
+    """Each catalog row advertises exactly the aliases its registry entry declares.
+
+    ``resolve_name()`` accepts every alias in ``robots.json``, so an alias the
+    row omits is a working name no reader can find, and an alias the row invents
+    is a name that does not resolve. Both are failures of the same projection,
+    so the whole cell is compared and the expected text is quoted verbatim -
+    fixing a row is a copy-paste, not a merge.
+    """
+    registry, cells = _registry(), _catalog_alias_cells()
+    wrong = [
+        (name, cells[name], _expected_alias_cell(registry[name]))
+        for name in sorted(cells)
+        if name in registry and cells[name] != _expected_alias_cell(registry[name])
+    ]
+    assert not wrong, "docs/robots/ alias cells that do not match robots.json:\n" + "\n".join(
+        f"  {name}\n    is:     {actual}\n    should: {expected}" for name, actual, expected in wrong
     )


### PR DESCRIPTION
Closes #1714.

## Problem

The `Aliases` column in the `docs/robots/*.md` catalog tables shows at most three aliases per row and drops the rest, with no ellipsis or "+N more" to say it truncated. 8 of the 72 catalogued robots are affected, hiding **19 alias names `resolve_name()` accepts today**.

The hidden names include the ones a reader is most likely to guess first: `Robot("franka_panda")` and `Robot("franka_emika_panda")` both work, and no page said so.

Measured on `main` by diffing each row's backticked alias tokens against `robots.json`:

```
8 of 72 rows truncate; 19 aliases hidden

  aloha            bimanual.md   shows 3/7  hidden: agibot_dual_arm_gripper, agibot_genie1,
                                                    bi_so_follower, galaxea_r1_pro
  fourier_n1       humanoids.md  shows 3/5  hidden: fourier_gr1_full_upper_body, gr1
  open_duck_mini   humanoids.md  shows 3/5  hidden: open_duck_mini_v2, open_duck_v2
  panda            arms.md       shows 3/8  hidden: franka_emika_panda, franka_panda,
                                                    libero_panda, oxe_droid, single_panda_gripper
  reachy_mini      humanoids.md  shows 3/4  hidden: reachymini
  so100            arms.md       shows 3/5  hidden: so_arm100, trs_so_arm100
  so101            arms.md       shows 3/4  hidden: so101_tricam
  unitree_g1       humanoids.md  shows 3/5  hidden: unitree_g1_locomanip, unitree_g1_wbc
```

Every affected row shows exactly 3, so this was a width cap whose "and more" marker was never written, not 8 independent omissions. All 114 registered aliases resolve correctly (`resolve_name(alias) == canonical` for every one) - the names work, the docs just do not mention them.

## Change

Each catalog row now lists **every** alias its `robots.json` entry declares, in the order the entry declares it. The column becomes a transformation-free projection of the registry, which is what lets the guard below quote the expected cell verbatim.

Two further rows changed. `hope_jr_hand` and `lekiwi_client` already carried a complete set but in a different order from the registry, so the column was following two conventions at once; they are normalised to the registry's order. 6 of the 8 registry entries whose aliases are not alphabetically sorted were already displayed in registry order, so registry order is the existing majority convention and the one kept.

`tests/test_docs_robot_catalog_coverage.py` gains a fourth guard, `test_the_alias_column_lists_every_alias_the_registry_accepts`, which compares the whole cell and prints the exact text to write:

```
docs/robots/ alias cells that do not match robots.json:
  panda
    is:     `bimanual_panda_gripper`, `bimanual_panda_hand`, `franka`
    should: `bimanual_panda_gripper`, `bimanual_panda_hand`, `franka`, `franka_emika_panda`, ...
```

So a newly registered alias cannot silently fall outside the docs, and fixing a row is a copy-paste rather than a merge. The row parser asserts each row has four columns, so a literal `|` inside a cell fails there instead of silently shifting which text is read as the alias list. That file's module docstring previously recorded the truncation as a deliberate presentation choice this guard leaves alone; that paragraph now states the projection rule instead.

## Why list them rather than mark the truncation

#1714 named three options. Only listing them in full, or capping the table and listing them in full elsewhere, make every accepted name discoverable; a `(+5 more)` marker stops the column being silent but still leaves a reader unable to find `franka_panda` from the page. Between the two complete options, listing in the row needs no indirection and no second surface to keep in sync, and the measured cost is small: the widest resulting alias cell is 148 characters against a 97-character description cell already in the same table, so it is not a new order of magnitude, and table cells wrap. 10 of 72 rows change.

## Tests

Pre-fix (docs reverted, guard present) - the guard fails and names all 10 rows with the exact replacement text:

```
1 failed, 8 passed in 0.07s
```

Post-fix:

```
tests/test_docs_robot_catalog_coverage.py .........   9 passed
```

## Gate

```
ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ  939 files already formatted
mypy strands_robots tests tests_integ                Success: no issues found in 936 source files
python scripts/assemble_changelog.py --check         changelog fragments OK (22 pending)
MUJOCO_GL=egl python -m pytest tests -q --no-cov     13129 passed, 253 skipped in 437.79s
```

(13128 passed on `main` at `ef92db93`; +1 is the new guard.)

No visual artifact: this changes documentation text and a docs guard only, no library behaviour.

> **AI Disclosure:** This pull request was authored by an autonomous AI contributor (strands-robots-agent). Every count and alias list above was measured against `robots.json` at `ef92db93`.