### PR TITLE
test(sim): a misspelled patch_scene_mjcf op key can no longer pass for the wrong reason

### DIFF
--- a/changelog.d/1717-patch-op-key-guard.md
+++ b/changelog.d/1717-patch-op-key-guard.md
@@ -1,0 +1,22 @@
+### Quality: a `patch_scene_mjcf` op key a test misspells can no longer pass for the wrong reason
+
+Two rollback tests sent `"position"` to an `add_body` op, which reads `"pos"`.
+Before the op vocabulary was enforced the key was silently dropped and the body
+was authored at the origin; both tests still passed, because each asserted only
+that the body was *present by name* -- an assertion that cannot distinguish a
+honored pose from a defaulted one. Once the vocabulary began refusing unread
+keys, one of the two started failing and the other kept passing while testing
+nothing: its batch was refused on op #1, so nothing was applied and the
+mid-batch rollback it exists to exercise never ran.
+
+Both ops now use the keys they are read under, and both tests assert the
+authored pose rather than just the name. The refused-batch case additionally
+asserts the failure came from op #2, which is the observable proof that op #1
+was applied and then rolled back.
+
+`tests/simulation/mujoco/test_suite_patch_ops_use_accepted_keys.py` closes the
+gap that let this hide. It reads the op vocabulary from its single source of
+truth and refuses any op-dict literal in the suite whose keys fall outside it,
+exempting only the module whose subject is rejection -- and pins that the
+exemption is still earned, plus that the scanner detects a planted misspelling
+rather than silently matching nothing.

--- a/tests/simulation/mujoco/test_inject_failure_cleanup.py
+++ b/tests/simulation/mujoco/test_inject_failure_cleanup.py
@@ -138,6 +138,23 @@ def _spec_body_names(sim) -> list[str]:
     return [b.name for b in sim._world._backend_state["spec"].bodies]
 
 
+def _spec_body_pos(sim, name: str) -> list[float]:
+    """The position an authored body carries on the live spec."""
+    body = next(b for b in sim._world._backend_state["spec"].bodies if b.name == name)
+    return [float(v) for v in body.pos]
+
+
+def _text(result) -> str:
+    return " ".join(c["text"] for c in result.get("content", []) if "text" in c)
+
+
+# The pose the patched-in body is authored at. Deliberately not the origin:
+# every ``patch_scene_mjcf`` op field is read with a fallback default, so a key
+# outside an op's vocabulary leaves the body at the origin. Asserting a non-zero
+# pose is what distinguishes "the op was honored" from "the op ran on defaults".
+RIG_POS = [0.0, 0.3, 0.5]
+
+
 class TestAddRobotInjectionRollback:
     """A robot whose attach compiles into a model MuJoCo refuses is rolled back."""
 
@@ -253,18 +270,23 @@ class TestRollbackKeepsSpecOnlyState:
         assert sim.detach_bodies(parent="so100/Moving_Jaw", child="cube")["status"] == "success"
 
     def test_an_agent_authored_body_survives_a_refused_robot_add(self, sim, tmp_path):
-        assert (
-            sim.patch_scene_mjcf(ops=[{"op": "add_body", "name": "rig", "position": [0.0, 0.3, 0.5]}])["status"]
-            == "success"
-        )
+        assert sim.patch_scene_mjcf(ops=[{"op": "add_body", "name": "rig", "pos": RIG_POS}])["status"] == "success"
+        # Assert the authored pose, not just the name. A body present at the
+        # origin and a body honored at the requested pose are indistinguishable
+        # by name, so a name-only assertion cannot tell whether the op was
+        # applied or merely ran on its defaults.
+        assert _spec_body_pos(sim, "rig") == pytest.approx(RIG_POS)
 
         bad = tmp_path / "badbot.xml"
         bad.write_text(_UNLOADABLE_MESH_MJCF)
         assert sim.add_robot(name="badbot", urdf_path=str(bad))["status"] == "error"
 
         # "rig" exists only on the spec - SpecBuilder.build has no idea it was
-        # ever authored - so a registry rebuild is where it disappeared.
+        # ever authored - so a registry rebuild is where it disappeared. The
+        # pose has to survive too: restoring the body at the origin would leave
+        # the name intact while silently relocating it.
         assert "rig" in _spec_body_names(sim)
+        assert _spec_body_pos(sim, "rig") == pytest.approx(RIG_POS)
         assert sim.add_object(name="marker", shape="box", position=[0.3, 0.0, 0.1])["status"] == "success"
 
     def test_a_refused_patch_batch_leaves_the_scene_mutable(self, sim):
@@ -274,11 +296,16 @@ class TestRollbackKeepsSpecOnlyState:
         # that had nothing to do with it.
         result = sim.patch_scene_mjcf(
             ops=[
-                {"op": "add_body", "name": "rig", "position": [0.0, 0.3, 0.5]},
-                {"op": "add_geom", "body": "no_such_body", "shape": "box"},
+                {"op": "add_body", "name": "rig", "pos": RIG_POS},
+                {"op": "add_geom", "body": "no_such_body", "type": "box"},
             ]
         )
         assert result["status"] == "error"
+        # The failure must come from op #2. A batch refused on op #1 applies
+        # nothing, so there is no half-applied scene to roll back and every
+        # assertion below holds trivially - the message naming op #2 is the
+        # observable proof that op #1 was applied and then undone.
+        assert "op #2" in _text(result)
 
         assert "rig" not in _spec_body_names(sim)
         assert sim.add_object(name="marker", shape="box", position=[0.3, 0.0, 0.1])["status"] == "success"

--- a/tests/simulation/mujoco/test_suite_patch_ops_use_accepted_keys.py
+++ b/tests/simulation/mujoco/test_suite_patch_ops_use_accepted_keys.py
@@ -1,0 +1,117 @@
+"""No test sends a ``patch_scene_mjcf`` op key that op does not read.
+
+Every field of every structured op is read with a fallback default, so a key
+outside an op's vocabulary is refused rather than silently applied (see
+``test_patch_scene_mjcf_unknown_op_keys.py`` for that contract). A test that
+sends such a key therefore fails loudly - *as long as it expected the op to
+succeed*.
+
+When the test expects the batch to be **rejected**, the same mistake is silent.
+The batch is refused during the first op's key check, nothing is applied, and
+every assertion about the rejected-and-rolled-back scene holds trivially. The
+test keeps passing while exercising none of the path it was written for. That is
+not hypothetical: ``test_a_refused_patch_batch_leaves_the_scene_mutable`` sent
+``"position"`` where ``add_body`` reads ``"pos"``, so the batch died on op #1 and
+the mid-batch rollback under test never ran.
+
+This guard closes that gap statically: it reads the op vocabulary from its single
+source of truth and refuses any op-dict literal in the suite whose keys fall
+outside it. Only literal ``str`` keys are inspected, which is what a hand-written
+op dict uses.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.scene_ops import _PATCH_OP_KEYS  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEST_ROOTS = ("tests", "tests_integ")
+
+# The one module whose subject *is* rejection: it sends misspelled and
+# out-of-vocabulary keys on purpose and asserts each is refused. Exempting it by
+# name keeps the guard's intent readable - anywhere else, an unread key means the
+# author believed the op reads it.
+REJECTION_MODULE = "test_patch_scene_mjcf_unknown_op_keys.py"
+
+
+def _unread_keys_in(source: str, filename: str) -> list[tuple[int, str, list[str]]]:
+    """Locate op-dict literals in ``source`` whose keys are outside the vocabulary.
+
+    Args:
+        source: Python source text to scan.
+        filename: Name used in parse errors.
+
+    Returns:
+        One ``(lineno, op, sorted unread keys)`` tuple per offending literal.
+    """
+    findings: list[tuple[int, str, list[str]]] = []
+    for node in ast.walk(ast.parse(source, filename=filename)):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = {key.value for key in node.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
+        op = next(
+            (
+                value.value
+                for key, value in zip(node.keys, node.values, strict=True)
+                if isinstance(key, ast.Constant)
+                and key.value == "op"
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ),
+            None,
+        )
+        if op is None or op not in _PATCH_OP_KEYS:
+            continue
+        if unread := sorted(keys - _PATCH_OP_KEYS[op]):
+            findings.append((node.lineno, op, unread))
+    return findings
+
+
+def _suite_modules() -> list[Path]:
+    return sorted(
+        path for root in TEST_ROOTS if (REPO_ROOT / root).is_dir() for path in (REPO_ROOT / root).rglob("test_*.py")
+    )
+
+
+def test_no_test_module_sends_an_unread_patch_op_key():
+    offenders = []
+    for path in _suite_modules():
+        if path.name == REJECTION_MODULE:
+            continue
+        for lineno, op, unread in _unread_keys_in(path.read_text(encoding="utf-8"), path.name):
+            accepted = ", ".join(sorted(_PATCH_OP_KEYS[op]))
+            offenders.append(
+                f"{path.relative_to(REPO_ROOT)}:{lineno}: {op} does not read {unread} (accepted: {accepted})"
+            )
+    assert not offenders, (
+        "patch_scene_mjcf op literal(s) use keys the op does not read. Such an op "
+        "is refused, so a test that expects an error still passes while testing "
+        "nothing:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_scanner_detects_a_planted_unread_key():
+    # Without this, a scanner that silently matched nothing would look like a
+    # clean suite.
+    planted = 'sim.patch_scene_mjcf([{"op": "add_body", "name": "rig", "position": [0, 0, 1]}])\n'
+    assert _unread_keys_in(planted, "planted.py") == [(1, "add_body", ["position"])]
+
+
+def test_a_correctly_spelled_op_is_not_flagged():
+    ok = 'sim.patch_scene_mjcf([{"op": "add_body", "name": "rig", "pos": [0, 0, 1]}])\n'
+    assert _unread_keys_in(ok, "ok.py") == []
+
+
+def test_the_exempted_module_still_earns_its_exemption():
+    # If the deliberate-typo module ever stops carrying unread keys, the
+    # exemption is stale and should be deleted rather than left as a hole.
+    exempt = [p for p in _suite_modules() if p.name == REJECTION_MODULE]
+    assert exempt, f"{REJECTION_MODULE} not found - drop the exemption"
+    assert _unread_keys_in(exempt[0].read_text(encoding="utf-8"), REJECTION_MODULE)


### PR DESCRIPTION
`main` is red. `tests/simulation/mujoco/test_inject_failure_cleanup.py::TestRollbackKeepsSpecOnlyState::test_an_agent_authored_body_survives_a_refused_robot_add` fails at `f55f8442`, blocking every open PR (CI stops at the first failure, so it reports only this one).

## What happened

Two rollback tests sent `"position"` to an `add_body` op. That op reads `"pos"`:

```
add_body       op, parent, name, pos, quat
```

While unread keys were silently dropped, `"position"` was inert-looking: the body was authored at the origin instead of the requested pose, and both tests passed anyway, because each asserted only that the body was **present by name**. A name lookup cannot distinguish a honored pose from a defaulted one, so nothing in either test could see the mistake.

Once the op vocabulary began refusing keys it does not read, the two tests diverged:

| test | before the vocabulary was enforced | at `f55f8442` |
|---|---|---|
| `test_an_agent_authored_body_survives_a_refused_robot_add` | passed, body silently at the origin | **fails** - `assert 'error' == 'success'` |
| `test_a_refused_patch_batch_leaves_the_scene_mutable` | passed | passes, **testing nothing** |

The second one is the more interesting half. Its batch is a valid `add_body` followed by an `add_geom` on a body that does not exist, and it asserts the world is rolled back and still mutable. With `"position"` on op #1 the batch is refused during op #1's key check, so nothing is ever applied:

```
ops sent by the test today:
  status = error
  text   = MJCF patch failed: patch op #1 failed: add_body: unknown op key(s):
           'position' (did you mean 'pos'?). Accepted keys: name, op, parent, pos, quat.

with the keys the ops are read under:
  status = error
  text   = MJCF patch failed: patch op #2 failed: add_geom: body 'no_such_body' not found
```

There is no half-applied scene, so "rolled back" and "still mutable" hold trivially. The mid-batch rollback the test exists for never ran.

## The change

Both ops now use the keys they are read under (`pos`, and `type` rather than `shape` on the `add_geom`, so op #2 fails for the reason the test documents - an unknown body - rather than on a key). Beyond that:

- Both tests assert the **authored pose**, not just the name. That is the assertion whose absence let the wrong key through, and it is now checked both when the body is authored and after the refused robot add, since restoring it at the origin would keep the name intact while silently relocating it.
- The refused-batch test asserts the failure came from **op #2**. That is the observable proof that op #1 was accepted and then undone; without it the test cannot tell a real rollback from a batch that was rejected before it started.

`tests/simulation/mujoco/test_suite_patch_ops_use_accepted_keys.py` closes the gap that let this hide. An unread key is loud when a test expects success and silent when it expects an error, so a static check is the only thing that catches the second case. It reads `_PATCH_OP_KEYS` - the single source of truth for the vocabulary - and refuses any op-dict literal anywhere in `tests/` or `tests_integ/` whose keys fall outside it.

One module is exempt: `test_patch_scene_mjcf_unknown_op_keys.py`, whose subject *is* rejection and which sends 11 out-of-vocabulary keys deliberately. Two further tests keep that exemption honest - one asserts the exempted module still carries unread keys (a stale exemption should be deleted, not left as a hole), and one asserts the scanner detects a planted misspelling, so a scanner that quietly matched nothing could not look like a clean suite.

No library code changes.

## Pre-fix proof

The guard against `main`'s test file, naming every offender and the accepted keys:

```
FAILED test_suite_patch_ops_use_accepted_keys.py::test_no_test_module_sends_an_unread_patch_op_key
  test_inject_failure_cleanup.py:257: add_body does not read ['position'] (accepted: name, op, parent, pos, quat)
  test_inject_failure_cleanup.py:277: add_body does not read ['position'] (accepted: name, op, parent, pos, quat)
  test_inject_failure_cleanup.py:278: add_geom does not read ['shape'] (accepted: body, name, op, pos, quat, rgba, size, type)
1 failed, 3 passed
```

The failure message is the fix instruction. `TestRollbackKeepsSpecOnlyState` on `main` is `1 failed, 2 passed`; with this change the class and the guard are `17 passed`.

## Why a name-only assertion could not see it

Both calls below report `status=success` and both leave a body named `rig` on the spec. Rendered headless from the same camera, `MUJOCO_GL=egl`:

![patch op key pose assertion](https://raw.githubusercontent.com/cagataycali/robots/artifacts/patch-op-key-pose-assertion/patch_op_key_pose_assertion.png)

| | ops | `'rig' in spec` | spec `pos` |
|---|---|---|---|
| left | `{'op': 'add_body', 'name': 'rig'}` | `True` | `[0.0, 0.0, 0.0]` - the origin, inside the robot base |
| right | `{'op': 'add_body', 'name': 'rig', 'pos': [0, 0.3, 0.34]}` | `True` | `[0.0, 0.3, 0.34]` |

The left panel is the scene the dropped key produced, reproduced here by omitting the pose key so `pos` takes its documented default. The two frames differ on 3.24% of pixels; the name assertion accepts both, and only the pose assertion added here separates them.

## Gate

`ruff check` clean, `ruff format --check` 941 files, `mypy strands_robots tests tests_integ` clean (938 source files), changelog fragments OK. `MUJOCO_GL=egl pytest tests -q --no-cov`: **13211 passed, 253 skipped** in 438s, against `f55f8442` where the same suite is `1 failed, 13206 passed, 253 skipped`.

---

> **AI Disclosure:** This change was authored by an autonomous AI contributor (strands-robots-agent). All behavioural claims and measurements were verified locally against `main` at `f55f8442`.