### PR TITLE
fix(hardware): refuse an action_horizon the control loop cannot honor

### DIFF
--- a/changelog.d/1718-hardware-action-horizon-guard.md
+++ b/changelog.d/1718-hardware-action-horizon-guard.md
@@ -1,0 +1,37 @@
+### Fixed: a hardware task refuses an action_horizon the control loop cannot honor
+
+`Robot.__init__` stored `action_horizon` without validating it, and the task loop
+hands that value to `resolve_chunk_length`, which coerces it with
+`max(int(action_horizon), 1, ...)`. The coercion turned a caller mistake into a
+plausible-but-different rollout on the physical arm rather than an error: a `0`
+or negative horizon was silently clamped to one action per inference, so an
+open-loop chunked checkpoint was re-queried every single step instead of
+replaying the chunk it was trained to emit -- exactly the out-of-distribution
+operation `resolve_chunk_length` documents as the reason not to shrink the
+interval. Measured on a policy emitting an 8-action chunk, `action_horizon=0`
+reported `status="success"` after 38 inferences for 38 applied actions where the
+default horizon needed 5. `2.7` was truncated to 2, `"4"` string-coerced to 4,
+and `True` acted as a silent horizon of 1. A value `int()` cannot convert
+(`None`, `nan`, `inf`, a list) reached that coercion only after the arm was
+connected and the first observation had been inferred on, aborting the task with
+a bare `TypeError`/`ValueError` naming an `int()` internal rather than the
+parameter.
+
+Every one of those values is refused by the simulation's rollout counts, so the
+same horizon was rejected for a digital twin and accepted for the arm it
+mirrors. `action_horizon` now raises `ValueError` at construction, before
+`_initialize_robot` opens the serial port, so a rejected horizon never touches
+the arm -- matching the `control_frequency` guard alongside it.
+
+The positive-integer count domain moves to
+`strands_robots.utils.positive_count_error` so the hardware constructor and
+`SimEngine._validate_positive_int` share one implementation across a layer
+boundary `hardware_robot` cannot cross by importing `simulation`. That also
+closes a `bool` hole in the shared guard: because `bool` is an `int` subclass, a
+bare `value < 1` test rejected `False` while letting `True` through as a silent
+count of 1, so `n_episodes=True`, `max_steps=True` and `action_horizon=True` were
+accepted as 1. Two callers had worked around the hole locally rather than the
+guard enforcing it -- `_validate_control_substeps` rejected `bool` itself before
+delegating, and the `run_policy` agent tool still rejects it for its own required
+`n_episodes` -- and the redundant local branch is now removed. Every existing
+error message is unchanged.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -37,7 +37,7 @@ from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolResult, ToolSpec, ToolUse
 
 from strands_robots.teleop_mixin import TeleopMixin
-from strands_robots.utils import positive_finite_number_error, require_optional
+from strands_robots.utils import positive_count_error, positive_finite_number_error, require_optional
 
 if TYPE_CHECKING:
     from lerobot.robots.config import RobotConfig
@@ -343,7 +343,15 @@ class Robot(TeleopMixin, AgentTool):
             robot: LeRobot Robot instance, RobotConfig, or robot type string
             cameras: Camera configuration dict:
                 {"wrist": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 30}}
-            action_horizon: Actions per inference step
+            action_horizon: Actions consumed from each inferred policy chunk
+                before re-querying. Must be a positive integer - it is a lower
+                bound on the chunk slice the task loop applies
+                (``resolve_chunk_length`` returns
+                ``max(action_horizon, policy.execution_horizon)``), and a
+                ``0``/negative/float/``bool``/non-numeric value raises
+                ``ValueError`` here rather than being silently clamped to a
+                horizon the caller never asked for, or aborting the task mid-run
+                once the arm is already connected.
             data_config: Data configuration (for GR00T compatibility)
             control_frequency: Control loop frequency in Hz (default: 50Hz).
                 Must be a positive finite number - it is the divisor of the
@@ -392,6 +400,25 @@ class Robot(TeleopMixin, AgentTool):
         super().__init__()
 
         self.tool_name_str = tool_name
+        # ``action_horizon`` is how many actions of each inferred chunk the task
+        # loop applies to the servo bus before re-querying the policy: it is the
+        # value ``_execute_task_async`` hands to ``resolve_chunk_length``. That
+        # helper coerces it with ``max(int(action_horizon), 1, ...)``, so a
+        # ``0``/negative horizon was silently clamped to a single action per
+        # inference - re-querying an open-loop chunked checkpoint every step
+        # instead of replaying the chunk it was trained to emit, which is exactly
+        # the out-of-distribution operation ``resolve_chunk_length`` documents as
+        # the reason not to shrink the interval - while ``2.7`` was truncated,
+        # ``"4"`` string-coerced and ``True`` acted as a silent 1. A value
+        # ``int()`` cannot convert (``None``/``nan``/``inf``/a list) instead
+        # reached that coercion only once the arm was already connected and the
+        # first observation inferred on, aborting the task with a bare
+        # ``TypeError``/``ValueError``. The identical domain is enforced on the
+        # simulation's rollout counts (``SimEngine._validate_positive_int``);
+        # validated BEFORE ``_initialize_robot`` opens the serial port, so a
+        # rejected horizon never touches the arm.
+        if horizon_error := positive_count_error(action_horizon, "action_horizon", "Robot"):
+            raise ValueError(horizon_error)
         self.action_horizon = action_horizon
         self.data_config = data_config
         # ``action_sleep_time`` is ``1 / control_frequency`` and is the ONLY

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
-from strands_robots.utils import positive_finite_number_error
+from strands_robots.utils import positive_count_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -1033,8 +1033,14 @@ class SimEngine(ABC):
         and would otherwise be silently clamped to 1 by
         :func:`~strands_robots.policies.base.resolve_chunk_length`, hiding the
         caller's mistake behind a rollout that does not run the requested
-        horizon. Returns a structured ``{"status": "error", ...}`` dict to
-        surface, or ``None`` when the value is valid.
+        horizon. ``True`` is rejected for the same reason: it would act as a
+        silent horizon of 1. Returns a structured ``{"status": "error", ...}``
+        dict to surface, or ``None`` when the value is valid.
+
+        The domain is delegated to :meth:`_validate_positive_int`, which the
+        hardware control loop's ``action_horizon`` guard shares through
+        :func:`~strands_robots.utils.positive_count_error`, so a horizon refused
+        for a simulated rollout cannot be accepted for the real arm.
 
         Args:
             action_horizon: The caller-supplied value to validate.
@@ -1047,12 +1053,7 @@ class SimEngine(ABC):
         Returns:
             An error dict naming the offending parameter, or ``None``.
         """
-        if not isinstance(action_horizon, int) or action_horizon < 1:
-            return {
-                "status": "error",
-                "content": [{"text": f"{method}: {param} must be a positive integer, got {action_horizon!r}."}],
-            }
-        return None
+        return SimEngine._validate_positive_int(action_horizon, param, method)
 
     @staticmethod
     def _validate_per_robot_mapping(
@@ -1101,14 +1102,26 @@ class SimEngine(ABC):
         """Reject a non-positive-integer count at the public API.
 
         Shared guard for the rollout count knobs that must be ``>= 1`` -
-        ``n_episodes`` (how many reset->rollout episodes to run) and
-        ``max_steps`` (the per-episode step cap). A zero/negative/non-int
-        value would otherwise flow into the rollout loop and produce a
-        degenerate result that still reports ``status="success"``: an eval
-        over zero episodes, or episodes of zero length, that fabricate a 0%
-        success rate (``Episodes: -2 | Success: 0/-2``) instead of surfacing
-        the caller's mistake. Returns a structured ``{"status": "error", ...}``
-        dict to surface, or ``None`` when the value is valid.
+        ``n_episodes`` (how many reset->rollout episodes to run), ``max_steps``
+        (the per-episode step cap), ``control_substeps`` and
+        ``action_horizon``. A zero/negative/non-int value would otherwise flow
+        into the rollout loop and produce a degenerate result that still reports
+        ``status="success"``: an eval over zero episodes, or episodes of zero
+        length, that fabricate a 0% success rate (``Episodes: -2 | Success:
+        0/-2``) instead of surfacing the caller's mistake. Returns a structured
+        ``{"status": "error", ...}`` dict to surface, or ``None`` when the value
+        is valid.
+
+        Thin binding of the shared count domain
+        (:func:`~strands_robots.utils.positive_count_error`) to this class's
+        tool-error envelope. The domain lives in :mod:`strands_robots.utils`
+        because the hardware control loop's ``action_horizon`` must enforce the
+        identical rule and :mod:`strands_robots.hardware_robot` cannot import
+        :mod:`strands_robots.simulation`; sharing one implementation is what
+        stops the same count being refused for a digital twin and accepted for
+        the arm it mirrors. ``bool`` is part of that shared domain rather than
+        each caller's business: a bare ``value < 1`` test lets ``True`` through
+        as a silent count of 1 while rejecting ``False``.
 
         Args:
             value: The caller-supplied value to validate.
@@ -1118,11 +1131,8 @@ class SimEngine(ABC):
         Returns:
             An error dict naming the offending parameter, or ``None``.
         """
-        if not isinstance(value, int) or value < 1:
-            return {
-                "status": "error",
-                "content": [{"text": f"{method}: {name} must be a positive integer, got {value!r}."}],
-            }
+        if error := positive_count_error(value, name, method):
+            return {"status": "error", "content": [{"text": error}]}
         return None
 
     @staticmethod
@@ -1140,13 +1150,13 @@ class SimEngine(ABC):
         exists to avoid - the arm integrates ~2 ms of a 20 ms control period, so
         the rollout reports ``status="success"`` while the policy looks like a
         no-op. A float (``2.7``) was silently truncated, ``True`` acted as a
-        silent 1 substep (``bool`` is an ``int`` subclass, so it is rejected
-        explicitly as in :meth:`_validate_positive_frequency`), and ``nan`` /
-        ``inf`` reached ``int()`` deep inside the runner and surfaced as a bare
+        silent 1 substep (``bool`` is an ``int`` subclass), and ``nan`` / ``inf``
+        reached ``int()`` deep inside the runner and surfaced as a bare
         ``ValueError``/``OverflowError`` instead of the structured tool-error
         dict the public API contracts.
 
-        The positive-integer domain itself is delegated to
+        The positive-integer domain itself - including the ``bool`` rejection,
+        which this guard used to repeat locally - is delegated to
         :meth:`_validate_positive_int` so this guard and the rollout count knobs
         cannot drift apart.
 
@@ -1160,13 +1170,6 @@ class SimEngine(ABC):
         """
         if control_substeps is None:
             return None
-        if isinstance(control_substeps, bool):
-            return {
-                "status": "error",
-                "content": [
-                    {"text": f"{method}: control_substeps must be a positive integer, got {control_substeps!r}."}
-                ],
-            }
         return SimEngine._validate_positive_int(control_substeps, "control_substeps", method)
 
     @staticmethod

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -381,6 +381,47 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     return None
 
 
+def positive_count_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable positive integer count.
+
+    Shared domain for the discrete knobs that count iterations of a control or
+    rollout loop - the simulation's ``n_episodes`` / ``max_steps`` /
+    ``control_substeps`` / ``action_horizon`` and the hardware control loop's
+    ``action_horizon``. It lives here rather than beside one of its callers
+    because those callers sit in different layers
+    (:mod:`strands_robots.hardware_robot` must not depend on
+    :mod:`strands_robots.simulation`), and the accepted domain must not diverge
+    between them: the same count cannot be refused for a digital twin and
+    accepted for the arm it mirrors.
+
+    Distinct from :func:`positive_whole_number_error`, which accepts any real
+    scalar with an integral value so a ``30.0`` read from a config or an
+    ``np.int64`` probed from a camera can be honored. The counts guarded here are
+    consumed directly as ``range()`` bounds and slice indices, where an integral
+    float raises ``TypeError`` ("``'float' object cannot be interpreted as an
+    integer``") rather than being coerced, so only a true ``int`` can be honored.
+
+    ``bool`` is rejected explicitly. It is an ``int`` subclass, so a bare
+    ``value < 1`` test lets ``True`` through as a silent count of 1 while
+    rejecting ``False`` - a value the caller never meant either way.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter name it came from, used in the message. Callers that
+            accept a ``{robot_name: count}`` mapping pass a subscripted label
+            (``"action_horizon['alice']"``) so the message names the entry the
+            caller got wrong rather than the whole mapping.
+        context: Message prefix identifying the surface that received it - the
+            public method name, or the class name for a constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return f"{context}: {param} must be a positive integer, got {value!r}."
+    return None
+
+
 def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     """Return an error message if any element of ``vec`` is not a finite number.
 

--- a/tests/test_hardware_action_horizon_guard.py
+++ b/tests/test_hardware_action_horizon_guard.py
@@ -1,0 +1,284 @@
+"""Behavior tests for the hardware control loop's accepted ``action_horizon`` domain.
+
+``action_horizon`` is how many actions of each inferred chunk
+``strands_robots.hardware_robot.Robot`` applies to the servo bus before
+re-querying the policy: the task loop hands it to
+:func:`~strands_robots.policies.base.resolve_chunk_length`, which coerces it with
+``max(int(action_horizon), 1, ...)``. That coercion turned a caller mistake into a
+plausible-but-different rollout instead of an error, and turned a non-numeric
+value into a mid-task abort. These tests pin that a horizon the loop cannot
+honor is refused at construction:
+
+    - a ``0`` / negative horizon raises ``ValueError`` naming ``action_horizon``
+      instead of being silently clamped to one action per inference - which
+      re-queries an open-loop chunked checkpoint every step rather than replaying
+      the chunk it was trained to emit;
+    - ``2.7`` is refused instead of truncated, ``"4"`` instead of string-coerced,
+      and ``True`` instead of acting as a silent horizon of 1;
+    - ``None`` / ``nan`` / ``inf`` / a list are refused at construction rather
+      than reaching ``int()`` only after the arm is connected and the first
+      observation has been inferred on, aborting the task with a bare
+      ``TypeError`` / ``ValueError``;
+    - the refusal happens BEFORE the lerobot driver is built, so a rejected
+      horizon never opens a serial port;
+    - every horizon that IS accepted is the number of actions the loop applies
+      per inference;
+    - the accepted domain matches the simulation's rollout-count domain
+      (``SimEngine._validate_positive_int``), so the same horizon cannot be
+      refused for a digital twin and accepted for the arm it mirrors.
+
+The ``bool`` half of that domain also closes a hole two callers previously worked
+around locally (``SimEngine._validate_control_substeps`` rejected ``bool`` itself
+before delegating, and the ``run_policy`` agent tool still rejects it for its own
+required ``n_episodes``): a bare ``value < 1`` test lets ``True`` through as a
+silent count of 1 while rejecting ``False``.
+
+No serial/USB hardware is touched: ``_initialize_robot`` is stubbed with an
+in-memory fake and the calibration migration is a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.simulation.base import SimEngine
+from strands_robots.utils import positive_count_error
+from tests.test_hardware_robot_lifecycle import _FakeLeRobot, _make_robot
+
+# Horizons the loop cannot honor. ``0`` / negative collapse to a single action
+# per inference; ``2.7`` truncates; ``"4"`` string-coerces; ``True`` acts as a
+# silent 1; the rest are values ``int()`` cannot convert at all, so they abort
+# the task only once the arm is already connected.
+#
+# ``8.0`` is refused for domain parity rather than because this loop could not
+# use it: the simulation's rollout counts are consumed directly as ``range()``
+# bounds where an integral float raises, and one shared rule is what keeps a
+# horizon from being accepted here and refused for the matching simulated
+# rollout. A caller holding a float from a config passes ``int(...)``.
+UNUSABLE_HORIZONS: list[Any] = [
+    0,
+    -1,
+    -8,
+    2.7,
+    8.0,
+    "4",
+    True,
+    False,
+    None,
+    [4],
+    float("nan"),
+    float("inf"),
+]
+
+# Every positive integer is honorable, including the documented default.
+USABLE_HORIZONS: list[Any] = [1, 2, 8, 64]
+
+
+class _ChunkPolicy:
+    """Emits a fixed 8-action chunk per inference, re-queried every action.
+
+    ``execution_horizon`` of 1 makes ``action_horizon`` the sole decider of how
+    much of each chunk the loop consumes (``resolve_chunk_length`` returns
+    ``max(action_horizon, 1)``), so the applied-actions-per-inference ratio is
+    exactly the horizon under test.
+    """
+
+    supports_rtc = False
+    execution_horizon = 1
+    actions_per_step = 1
+    CHUNK = 8
+
+    def __init__(self) -> None:
+        self.inferences = 0
+
+    def set_robot_state_keys(self, keys: list[str]) -> None:
+        pass
+
+    def set_control_frequency(self, hz: float) -> None:
+        pass
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        pass
+
+    def reset(self, seed: int | None = None) -> None:
+        pass
+
+    async def get_actions(self, observation: dict[str, Any], instruction: str) -> list[dict[str, Any]]:
+        self.inferences += 1
+        return [{"j0.pos": float(i)} for i in range(self.CHUNK)]
+
+
+@pytest.fixture
+def hw_init(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Construct a real ``Robot.__init__`` without touching hardware.
+
+    Returns a callable taking the keywords under test, carrying a ``built`` list
+    that records every ``_initialize_robot`` call so a test can assert whether
+    the lerobot driver was constructed.
+    """
+    built: list[Any] = []
+
+    def fake_initialize_robot(self: HwRobot, robot: Any, cameras: Any, **kwargs: Any) -> _FakeLeRobot:
+        built.append(robot)
+        return _FakeLeRobot()
+
+    monkeypatch.setattr(HwRobot, "_initialize_robot", fake_initialize_robot)
+    monkeypatch.setattr(HwRobot, "_migrate_legacy_calibration", lambda self: None)
+
+    def construct(**kwargs: Any) -> HwRobot:
+        return HwRobot(tool_name="test_arm", robot="fake_arm", **kwargs)
+
+    construct.built = built  # type: ignore[attr-defined]
+    return construct
+
+
+class TestUnusableHorizonRefused:
+    @pytest.mark.parametrize("horizon", UNUSABLE_HORIZONS, ids=repr)
+    def test_horizon_the_loop_cannot_honor_raises(self, hw_init, horizon):
+        """A horizon with no honorable chunk length is refused, naming the parameter."""
+        with pytest.raises(ValueError, match="action_horizon"):
+            hw_init(action_horizon=horizon)
+
+    @pytest.mark.parametrize("horizon", UNUSABLE_HORIZONS, ids=repr)
+    def test_refusal_precedes_driver_construction(self, hw_init, horizon):
+        """A rejected horizon never opens a serial port.
+
+        The guard sits ahead of ``_initialize_robot``, which is what builds the
+        lerobot driver and connects to the bus.
+        """
+        with pytest.raises(ValueError):
+            hw_init(action_horizon=horizon)
+        assert hw_init.built == []
+
+    def test_message_reports_the_offending_value(self, hw_init):
+        with pytest.raises(ValueError) as excinfo:
+            hw_init(action_horizon=0)
+        assert str(excinfo.value) == "Robot: action_horizon must be a positive integer, got 0."
+
+    def test_a_valid_rate_does_not_excuse_an_invalid_horizon(self, hw_init):
+        """The horizon is validated on its own, not only when siblings are bad."""
+        with pytest.raises(ValueError, match="action_horizon"):
+            hw_init(action_horizon=-4, control_frequency=50.0)
+
+
+class TestUsableHorizonAccepted:
+    @pytest.mark.parametrize("horizon", USABLE_HORIZONS, ids=repr)
+    def test_accepted_horizon_is_kept_verbatim(self, hw_init, horizon):
+        hw = hw_init(action_horizon=horizon)
+        try:
+            assert hw.action_horizon == horizon
+            assert hw_init.built == ["fake_arm"]
+        finally:
+            hw.cleanup()
+
+    def test_default_horizon_is_accepted(self, hw_init):
+        hw = hw_init()
+        try:
+            assert hw.action_horizon == 8
+        finally:
+            hw.cleanup()
+
+
+class TestAcceptedHorizonReachesTheLoop:
+    """The horizon is the number of actions applied per inference.
+
+    Nothing else pinned that ``action_horizon`` is what bounds the chunk slice
+    the servo bus receives, which is the whole reason a wrong value matters.
+    """
+
+    @pytest.mark.parametrize("horizon", [1, 2, 4, 8], ids=repr)
+    def test_actions_per_inference_equals_the_horizon(self, horizon):
+        hw = _make_robot()
+        hw.action_horizon = horizon
+        policy = _ChunkPolicy()
+        try:
+            result = hw.run_policy(policy_object=policy, instruction="probe", n_steps=4 * horizon)
+            assert result["status"] == "success", result
+            assert len(hw.robot.sent_actions) == 4 * horizon
+            assert policy.inferences == 4
+        finally:
+            hw.cleanup()
+
+
+class TestHardwareAndSimulationShareOneDomain:
+    """A count refused for a simulated rollout is refused for the real arm.
+
+    The hardware constructor and the simulation's rollout-count guards bind the
+    same :func:`~strands_robots.utils.positive_count_error` domain, so the two
+    cannot drift apart on what counts as an honorable horizon.
+    """
+
+    @pytest.mark.parametrize("horizon", UNUSABLE_HORIZONS + USABLE_HORIZONS, ids=repr)
+    def test_verdicts_match_the_simulation_rollout_guard(self, hw_init, horizon):
+        sim_refuses = SimEngine._validate_action_horizon(horizon, "run_policy") is not None
+        try:
+            hw = hw_init(action_horizon=horizon)
+        except ValueError:
+            hardware_refuses = True
+        else:
+            hardware_refuses = False
+            hw.cleanup()
+        assert hardware_refuses == sim_refuses, (
+            f"verdicts differ for action_horizon={horizon!r}: "
+            f"hardware refuses={hardware_refuses}, simulation refuses={sim_refuses}"
+        )
+
+    def test_both_surfaces_report_the_same_wording(self, hw_init):
+        with pytest.raises(ValueError) as excinfo:
+            hw_init(action_horizon=-3)
+        sim_text = SimEngine._validate_action_horizon(-3, "Robot")["content"][0]["text"]
+        assert str(excinfo.value) == sim_text
+
+
+class TestBoolIsOutsideTheSharedCountDomain:
+    """``True`` cannot pass for a count of 1 on any surface.
+
+    ``bool`` is an ``int`` subclass, so a bare ``value < 1`` test rejected
+    ``False`` while letting ``True`` through - a value the caller never meant
+    either way. Two callers worked around that locally rather than the shared
+    guard enforcing it.
+    """
+
+    @pytest.mark.parametrize("param", ["n_episodes", "max_steps"])
+    def test_rollout_counts_reject_true(self, param):
+        result = SimEngine._validate_positive_int(True, param, "eval_policy")
+        assert result is not None
+        assert f"{param} must be a positive integer" in result["content"][0]["text"]
+
+    def test_action_horizon_rejects_true(self):
+        result = SimEngine._validate_action_horizon(True, "run_policy")
+        assert result is not None
+        assert "action_horizon must be a positive integer, got True." in result["content"][0]["text"]
+
+    def test_control_substeps_still_rejects_true_after_delegating(self):
+        """The local ``bool`` branch was removed; the shared domain covers it."""
+        result = SimEngine._validate_control_substeps(True, "run_policy")
+        assert result is not None
+        assert result["content"][0]["text"] == "run_policy: control_substeps must be a positive integer, got True."
+
+    def test_control_substeps_still_accepts_none(self):
+        """``None`` means "auto-derive" and is the one documented exception."""
+        assert SimEngine._validate_control_substeps(None, "run_policy") is None
+
+    def test_shared_rule_rejects_both_bools(self):
+        for value in (True, False):
+            assert positive_count_error(value, "action_horizon", "Robot") is not None
+
+
+class TestSharedCountDomainRejectsIntegralFloats:
+    """The counts are ``range()`` bounds and slice indices, so only ``int`` works.
+
+    This is what separates the rule from
+    :func:`~strands_robots.utils.positive_whole_number_error`, whose media
+    dimensions are arithmetic operands and may legitimately arrive as ``30.0``.
+    """
+
+    def test_integral_float_is_refused(self):
+        assert positive_count_error(8.0, "action_horizon", "Robot") is not None
+
+    def test_the_reason_is_real(self):
+        with pytest.raises(TypeError):
+            range(8.0)  # type: ignore[arg-type]


### PR DESCRIPTION
## Problem

`Robot.__init__` stores `action_horizon` without validating it, and the task loop hands that value to `resolve_chunk_length`, which coerces it with `max(int(action_horizon), 1, ...)`. The coercion turns a caller mistake into a plausible-but-different rollout on the physical arm rather than an error.

Measured against a policy emitting an 8-action chunk over one task (fake in-memory driver, no serial traffic):

| `action_horizon` | reported | inferences | actions applied | actions per inference |
|---|---|---|---|---|
| `8` (default) | `success` | 6 | 48 | 8.0 |
| `0` | `success` | **48** | 48 | **1.0** |
| `-5` | `success` | 48 | 48 | 1.0 |
| `2.7` | `success` | 24 | 48 | 2.0 (truncated) |
| `"4"` | `success` | 12 | 48 | 4.0 (string-coerced) |
| `True` | `success` | 48 | 48 | 1.0 (silent 1) |
| `None` / `[4]` / `nan` / `inf` | `error` | 1 | 0 | aborted mid-task |

A `0`/negative horizon is silently clamped to one action per inference, so an open-loop chunked checkpoint is re-queried every single step instead of replaying the chunk it was trained to emit. That is exactly the out-of-distribution operation `resolve_chunk_length` documents as the reason not to shrink the interval:

> clamping to a smaller `action_horizon` drops the chunk tail and forces an out-of-distribution re-query

The four non-numeric values are worse than a plain rejection: they reach `int()` only **after** the arm is connected and the first observation has been inferred on, so the task aborts with a bare `TypeError`/`ValueError` naming an `int()` internal (`int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`) rather than the parameter the caller got wrong.

Every one of those values is already refused by the simulation's rollout counts, so the same horizon was rejected for a digital twin and accepted for the arm it mirrors.

## Change

`action_horizon` now raises `ValueError` at construction, before `_initialize_robot` opens the serial port, so a rejected horizon never touches the arm - matching the `control_frequency` guard immediately alongside it.

The positive-integer count domain moves to `strands_robots.utils.positive_count_error` so the hardware constructor and `SimEngine._validate_positive_int` share **one** implementation. It has to live in `utils` rather than beside either caller: `hardware_robot` cannot import `simulation`, and a second copy of the rule is what lets the two surfaces drift.

That also closes a `bool` hole in the shared guard. Because `bool` is an `int` subclass, a bare `value < 1` test rejected `False` while letting `True` through as a silent count of 1, so `n_episodes=True`, `max_steps=True` and `action_horizon=True` were all accepted as 1. Two callers had already worked around that hole locally rather than the guard enforcing it:

- `SimEngine._validate_control_substeps` rejected `bool` itself before delegating, with a comment explaining why;
- the `run_policy` agent tool still rejects it for its own required `n_episodes`, under a test whose docstring reads "bool is an int subclass in Python; the loop guard MUST reject it so True/False can't sneak through as '1'/'0'".

The rule now lives in the guard those two work around, and `_validate_control_substeps`'s redundant local branch is removed. `_validate_action_horizon` also stops duplicating the check and delegates instead.

**Every existing error message is byte-identical.** The shared helper reproduces the wording the simulation already used, so all existing pins hold and both surfaces now report the same sentence:

```
run_policy: action_horizon must be a positive integer, got 0.
Robot: action_horizon must be a positive integer, got 0.
```

### Why an integral float is refused

`positive_count_error` rejects `8.0`, unlike the sibling `positive_whole_number_error` used for media dimensions. These counts are consumed directly as `range()` bounds and slice indices (`for ep in range(n_episodes)`, `for _ in range(max_steps)`), where an integral float raises `TypeError: 'float' object cannot be interpreted as an integer` instead of being coerced - so widening to integral reals would have traded a silent clamp for a bare crash. Media dimensions are arithmetic operands and may legitimately arrive as a `30.0` from a config or an `np.int64` from a camera probe, which is why that domain stays separate. Both docstrings now state the distinction.

## Verification

The artifact below was produced by driving the real task loop twice with the same policy and the same 8-action chunk, recording a wall-clock stamp for every applied action and every inference, and by running the whole probe set through the real constructor on both trees. The pre-fix column was generated with the source files stashed.

![action_horizon guard: cadence and constructor verdicts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/action-horizon-guard/action_horizon_guard.png)

Left: identical task, identical policy - the clamped horizon re-queries the policy once per action (48 inferences for 48 actions) where the honored horizon needs 6, and both report `status="success"`. Right: the constructor's verdict for every probe value, before and after.

### Tests

`tests/test_hardware_action_horizon_guard.py` - 60 tests, no serial/USB hardware touched (`_initialize_robot` stubbed with an in-memory fake):

- every unusable horizon raises `ValueError` naming the parameter;
- the refusal precedes driver construction, asserted by recording `_initialize_robot` calls, so a rejected horizon never opens a serial port;
- every accepted horizon is kept verbatim **and** is the number of actions the loop applies per inference - a link nothing previously pinned, and the whole reason a wrong value matters;
- a parity test over the full probe set asserts the hardware constructor and `SimEngine._validate_action_horizon` return the same verdict for every value, and the same wording;
- `bool` is refused on all four count surfaces, `control_substeps` still refuses `True` after its local branch was deleted, and still accepts `None` (the one documented exception, meaning "auto-derive").

**Pre-fix: 41 failed / 16 passed. Post-fix: 60 passed.** (The pre-fix run drops the two blocks that import the new symbol directly, so the module still collects and reports per-test behaviour rather than one `ImportError`.)

### Gate

```
ruff check strands_robots tests tests_integ         All checks passed!
ruff format --check strands_robots tests tests_integ 941 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 938 source files
MUJOCO_GL=egl pytest tests -q --no-cov              13266 passed, 253 skipped in 430s
```

The full-suite run above was taken one commit before this branch's base; its single failure was `test_an_agent_authored_body_survives_a_refused_robot_add`, which #1717 fixed and which passes on this base (`tests/simulation/mujoco/test_inject_failure_cleanup.py` - 13 passed). The 537 tests of the directly affected suites (`test_run_policy_horizon_validation`, `test_control_substeps_validation`, `test_benchmark_dispatch`, `test_run_policy_multi_episode`, `tools/test_run_policy`, and the three hardware modules) all pass unchanged.

### Known, pre-existing and out of scope

A constructor that raises leaves the object without `_shutdown_event`, so `__del__` -> `cleanup()` logs a benign, swallowed `Cleanup error for <name>: 'Robot' object has no attribute '_shutdown_event'`. This is identical for the already-merged `control_frequency` guard on `main` and is not introduced here.

---

> **AI Disclosure:** This change was authored by an autonomous AI contributor (strands-robots-agent). All measurements above were taken on the branch and on pre-fix sources.