### PR TITLE
fix(mesh): refuse a velocity command the bridge cannot honor

### DIFF
--- a/changelog.d/1719-drive-command-guards.md
+++ b/changelog.d/1719-drive-command-guards.md
@@ -1,0 +1,36 @@
+### Fixed: a mobile base does not move on a velocity command the bridge cannot honor
+
+`RosBridgedRobot.drive` and `RtpsRobot.drive` are the calls that physically move
+a wheeled robot, and neither validated any of the four knobs the command
+carries. `duration` sizes the published burst as
+`max(1, round(duration * publish_rate))`, so the floor turned a hold no message
+count expresses into a single full-speed `Twist`:
+
+```python
+robot.drive(linear=0.5, duration=0)     # status 'success'
+# -> one Twist published at 0.5 m/s: the base starts moving
+robot.drive(linear=0.5, duration=-5)    # status 'success', same single command
+robot.drive(linear=0.5, count=0)        # status 'success', nothing published
+robot.drive(linear=float("inf"))        # status 'success', inf reaches cmd_vel
+robot.drive(linear=0.5, duration=float("nan"))
+# ValueError: cannot convert float NaN to integer  (raised past the result dict)
+```
+
+`use_ros` / `use_rtps` cannot cover this: they validate the topic and interface
+type, but `duration` never reaches them (they receive only the derived message
+count) and neither checks `count` or the Twist field values. Both `drive`
+methods are also bound as agent tools, where raising escapes the
+`{"status": ...}` dispatch contract.
+
+`drive` now reports an error result - publishing nothing - for a `duration` that
+is not positive and finite, a `count` that is not a positive whole number, and a
+`linear`/`angular` velocity that is not a finite number (both signs stay valid;
+reverse and clockwise are real commands). `publish_rate` is refused at
+construction, where a bad topic already raises, because `drive` multiplies by it
+and the transport paces at `1 / rate`, so a non-positive rate removes the pacing
+instead of slowing it. The rules are the shared
+`strands_robots.utils` validators - `positive_finite_number_error`,
+`positive_whole_number_error`, and a new `finite_number_error` for a signed
+physical quantity - so the two transports cannot drift apart. Every command that
+worked before is unchanged, including a hold shorter than one publish period,
+which still sends the command once.

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -298,13 +298,17 @@ agent("drive forward for two seconds, then tell me the pose")
 ```
 
 The bridge is intentionally thin: every method forwards to `use_ros`, so it
-inherits the same in-process rclpy backend and input validation. Construct it
-freely without a ROS 2 environment present - errors surface only when a method
-is actually called and `rclpy` is unavailable.
+inherits the same in-process rclpy backend and its topic/type validation. The
+parameters `use_ros` never sees are checked by the bridge itself - `drive`
+reports an error result without publishing when a velocity is not finite, a
+`duration` is not positive and finite, or a message `count` is not a positive
+whole number, and `publish_rate` is refused at construction. Construct it freely
+without a ROS 2 environment present - errors surface only when a method is
+actually called and `rclpy` is unavailable.
 
 | Method | ROS 2 action | Notes |
 |--------|--------------|-------|
-| `drive(linear, angular, duration=, count=)` | publish `Twist` to `cmd_vel_topic` | `duration` holds the command at `publish_rate` Hz |
+| `drive(linear, angular, duration=, count=)` | publish `Twist` to `cmd_vel_topic` | `duration` holds the command at `publish_rate` Hz; finite velocities, `duration > 0`, `count >= 1` - anything else is refused without publishing |
 | `stop()` | publish zero `Twist` | |
 | `get_pose()` | echo `odom_topic` | |
 | `get_scan()` | echo `scan_topic` | error when no `scan_topic` configured |

--- a/strands_robots/mesh/ros_bridge.py
+++ b/strands_robots/mesh/ros_bridge.py
@@ -5,7 +5,10 @@ A :class:`RosBridgedRobot` wraps a ROS 2 mobile base (or any robot exposing a
 its state with the same ``Agent(tools=[robot])`` pattern used for simulated and
 hardware robots. All ROS 2 I/O is forwarded through the
 :func:`strands_robots.tools.use_ros.use_ros` tool, so the bridge stays thin and
-inherits ``use_ros``'s in-process ``rclpy`` backend and input validation.
+inherits ``use_ros``'s in-process ``rclpy`` backend and its topic/type
+validation. The parameters ``use_ros`` never sees are validated here: a
+:meth:`RosBridgedRobot.drive` command whose velocity, hold duration or message
+count cannot be honored is refused without publishing anything.
 
 Typical usage::
 
@@ -38,6 +41,11 @@ from strands import tool
 from strands.types.tools import AgentTool
 
 from strands_robots.tools.use_ros import use_ros
+from strands_robots.utils import (
+    finite_number_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
 
 _TWIST_TYPE = "geometry_msgs/msg/Twist"
 _NAV_ACTION_TYPE = "nav2_msgs/action/NavigateToPose"
@@ -80,6 +88,10 @@ class RosBridgedRobot:
         scan_type: Interface type of ``scan_topic``. Optional - resolved from
             the live graph when omitted.
         publish_rate: Default rate (Hz) for multi-message :meth:`drive` calls.
+            Must be > 0 and finite: :meth:`drive` multiplies it by ``duration``
+            to size the message burst and ``use_ros`` publishes at ``1 / rate``,
+            so a non-positive rate removes the pacing entirely rather than
+            slowing it. Raises ``ValueError`` at construction otherwise.
         nav_action: Optional Nav2-style action server name (e.g.
             ``/navigate_to_pose``). When set, :meth:`navigate_to` sends
             goal-level navigation instead of raw velocity, and a
@@ -109,7 +121,9 @@ class RosBridgedRobot:
         self.cmd_vel_type = cmd_vel_type
         self.odom_type = odom_type
         self.scan_type = scan_type
-        self.publish_rate = publish_rate
+        if rate_err := positive_finite_number_error(publish_rate, "publish_rate", type(self).__name__):
+            raise ValueError(rate_err)
+        self.publish_rate = float(publish_rate)
         self.nav_action = _check_topic("nav_action", nav_action) if nav_action else None
         self.nav_action_type = nav_action_type
 
@@ -141,16 +155,49 @@ class RosBridgedRobot:
         """Publish a velocity command to the robot's ``cmd_vel`` topic.
 
         Args:
-            linear: Forward linear velocity (m/s), mapped to ``linear.x``.
-            angular: Yaw angular velocity (rad/s), mapped to ``angular.z``.
+            linear: Forward linear velocity (m/s), mapped to ``linear.x``. Must
+                be a finite number; both signs are valid (negative reverses).
+            angular: Yaw angular velocity (rad/s), mapped to ``angular.z``. Must
+                be a finite number; both signs are valid (negative turns the
+                other way).
             duration: When given, hold the command for this many seconds by
-                publishing ``round(duration * publish_rate)`` messages. Takes
-                precedence over ``count``.
+                publishing ``round(duration * publish_rate)`` messages (at least
+                one). Takes precedence over ``count``, and must be > 0 and
+                finite - a zero or negative hold has no message count that
+                expresses it, and publishing a single velocity command anyway
+                would start the robot moving.
             count: Number of messages to publish when ``duration`` is omitted.
+                Must be a positive whole number; ``0`` or a negative count
+                publishes nothing, so reporting a successful drive for it hides
+                a command that never left the process.
 
         Returns:
-            The ``use_ros`` publish result dict.
+            The ``use_ros`` publish result dict, or an ``{"status": "error"}``
+            result naming the parameter when a value cannot be honored - in
+            which case nothing is published.
         """
+        # A velocity command is the one call on this bridge that physically
+        # moves the robot, so every knob it carries is checked before anything
+        # reaches the wire. ``use_ros`` validates the topic and interface type
+        # but never sees ``duration`` at all (it receives only the derived
+        # message count), so the horizon knobs have no guard downstream.
+        cmd_err = (
+            finite_number_error(linear, "linear", "drive")
+            or finite_number_error(angular, "angular", "drive")
+            or (
+                positive_finite_number_error(duration, "duration", "drive")
+                if duration is not None
+                # ``duration`` supersedes ``count``, so ``count`` is only the
+                # effective horizon when no duration was given; refusing a
+                # ``count`` this call never reads would reject a valid command.
+                else positive_whole_number_error(count, "count", "drive")
+            )
+        )
+        if cmd_err:
+            return {"status": "error", "content": [{"text": cmd_err}]}
+        # ``duration`` is positive and finite here, so this floor is a rounding
+        # rule and not a substitute for validation: a hold shorter than one
+        # publish period still means "send the command once".
         n = max(1, round(duration * self.publish_rate)) if duration is not None else count
         fields = {"linear": {"x": float(linear)}, "angular": {"z": float(angular)}}
         return use_ros(

--- a/strands_robots/mesh/rtps_robot.py
+++ b/strands_robots/mesh/rtps_robot.py
@@ -39,6 +39,11 @@ from strands import tool
 from strands.types.tools import AgentTool
 
 from strands_robots.tools.use_rtps import use_rtps
+from strands_robots.utils import (
+    finite_number_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
 
 _TWIST_TYPE = "geometry_msgs/msg/Twist"
 _TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]$")
@@ -66,6 +71,10 @@ class RtpsRobot:
         cmd_vel_type: Interface type for ``cmd_vel_topic`` (default
             ``geometry_msgs/msg/Twist``).
         publish_rate: Default rate (Hz) for multi-message :meth:`drive` calls.
+            Must be > 0 and finite: :meth:`drive` multiplies it by ``duration``
+            to size the message burst and ``use_rtps`` publishes at ``1 / rate``,
+            so a non-positive rate removes the pacing entirely rather than
+            slowing it. Raises ``ValueError`` at construction otherwise.
     """
 
     def __init__(
@@ -79,7 +88,9 @@ class RtpsRobot:
         self.node_name = _check("node_name", node_name, _NAME_RE)
         self.cmd_vel_topic = _check("cmd_vel_topic", cmd_vel_topic, _TOPIC_RE)
         self.cmd_vel_type = cmd_vel_type
-        self.publish_rate = publish_rate
+        if rate_err := positive_finite_number_error(publish_rate, "publish_rate", type(self).__name__):
+            raise ValueError(rate_err)
+        self.publish_rate = float(publish_rate)
 
     @classmethod
     def from_rtps(
@@ -111,12 +122,49 @@ class RtpsRobot:
         """Publish a velocity command over RTPS to the robot's ``cmd_vel`` topic.
 
         Args:
-            linear: Forward linear velocity (m/s), mapped to ``linear.x``.
-            angular: Yaw angular velocity (rad/s), mapped to ``angular.z``.
-            duration: When given, hold the command for this many seconds
-                (publishes ``round(duration * publish_rate)`` messages).
-            count: Message count when ``duration`` is omitted.
+            linear: Forward linear velocity (m/s), mapped to ``linear.x``. Must
+                be a finite number; both signs are valid (negative reverses).
+            angular: Yaw angular velocity (rad/s), mapped to ``angular.z``. Must
+                be a finite number; both signs are valid (negative turns the
+                other way).
+            duration: When given, hold the command for this many seconds by
+                publishing ``round(duration * publish_rate)`` messages (at least
+                one). Takes precedence over ``count``, and must be > 0 and
+                finite - a zero or negative hold has no message count that
+                expresses it, and publishing a single velocity command anyway
+                would start the robot moving.
+            count: Number of messages to publish when ``duration`` is omitted.
+                Must be a positive whole number; ``0`` or a negative count
+                publishes nothing, so reporting a successful drive for it hides
+                a command that never left the process.
+
+        Returns:
+            The ``use_rtps`` publish result dict, or an ``{"status": "error"}``
+            result naming the parameter when a value cannot be honored - in
+            which case nothing is published.
         """
+        # A velocity command is the one call on this bridge that physically
+        # moves the robot, so every knob it carries is checked before anything
+        # reaches the wire. ``use_rtps`` validates the topic and interface type
+        # but never sees ``duration`` at all (it receives only the derived
+        # message count), so the horizon knobs have no guard downstream.
+        cmd_err = (
+            finite_number_error(linear, "linear", "drive")
+            or finite_number_error(angular, "angular", "drive")
+            or (
+                positive_finite_number_error(duration, "duration", "drive")
+                if duration is not None
+                # ``duration`` supersedes ``count``, so ``count`` is only the
+                # effective horizon when no duration was given; refusing a
+                # ``count`` this call never reads would reject a valid command.
+                else positive_whole_number_error(count, "count", "drive")
+            )
+        )
+        if cmd_err:
+            return {"status": "error", "content": [{"text": cmd_err}]}
+        # ``duration`` is positive and finite here, so this floor is a rounding
+        # rule and not a substitute for validation: a hold shorter than one
+        # publish period still means "send the command once".
         n = max(1, round(duration * self.publish_rate)) if duration is not None else count
         fields = {"linear": {"x": float(linear)}, "angular": {"z": float(angular)}}
         return use_rtps(

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -343,6 +343,43 @@ def positive_finite_number_error(value: Any, param: str, context: str) -> str | 
     return None
 
 
+def finite_number_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable finite number of either sign.
+
+    Shared domain for a SIGNED physical quantity a command carries verbatim to a
+    robot - a linear or angular velocity component, an offset, a coordinate read
+    as a scalar. Both signs are legitimate (reverse is a negative linear
+    velocity, clockwise a negative yaw rate), so :func:`positive_finite_number_error`
+    cannot express this domain; only finiteness and numeric-ness are constrained.
+    It lives here rather than beside one of its callers because those callers sit
+    in different layers (:mod:`strands_robots.mesh` must not depend on
+    :mod:`strands_robots.simulation`), and the accepted domain must not diverge
+    between them.
+
+    Only a finite value can be honored. ``nan``/``inf`` serialize into a wire
+    message as a valid IEEE-754 float64, so the transport accepts them and the
+    receiving controller integrates them into its state estimate - a silently
+    poisoned pose rather than a rejected command. A non-real value (a numeric
+    string, ``None``, a list) otherwise raises a bare ``TypeError`` from the
+    ``float()`` coercion, escaping the structured ``{"status": "error"}``
+    tool-result contract. Accepts any real scalar (so a NumPy ``np.float32``
+    velocity read from a policy action passes) and rejects ``bool`` explicitly -
+    an ``int`` subclass whose ``True`` would act as a silent ``1``.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter it came from, used in the message.
+        context: Message prefix identifying the surface that received it -
+            normally the public method name.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if isinstance(value, bool) or not isinstance(value, numbers.Real) or not math.isfinite(float(value)):
+        return f"{context}: {param} must be a finite number, got {value!r}."
+    return None
+
+
 def positive_whole_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive whole number.
 

--- a/tests/mesh/test_drive_command_guards.py
+++ b/tests/mesh/test_drive_command_guards.py
@@ -1,0 +1,227 @@
+"""A velocity command a bridge cannot honor is refused before it reaches the wire.
+
+:meth:`RosBridgedRobot.drive` and :meth:`RtpsRobot.drive` are the calls that
+physically move a mobile base. Both derive the published message count from
+``round(duration * publish_rate)`` and forward the velocity components verbatim,
+so a value that cannot be honored has one of two silent outcomes: a plausible
+burst is published anyway (``duration=0`` becomes a single full-speed command
+via the ``max(1, ...)`` floor), or the arithmetic raises a bare
+``ValueError``/``OverflowError``/``TypeError`` out of a method whose contract is
+a ``{"status": ...}`` result dict - and both ``drive`` methods are exposed to an
+agent as a tool, where raising escapes the dispatch contract entirely.
+
+``use_ros``/``use_rtps`` cannot cover this: they validate the topic and interface
+type, but ``duration`` never reaches them (they receive only the derived count)
+and neither validates ``count`` or the Twist field values. The guards therefore
+belong on the bridge, and these tests assert the two transports agree on exactly
+which commands are refusable.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.ros_bridge as ros_mod
+import strands_robots.mesh.rtps_robot as rtps_mod
+from strands_robots.mesh import RosBridgedRobot, RtpsRobot
+
+
+class _Wire:
+    """Stands in for the transport, recording every published message batch."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+# (label, module, forwarded-symbol name, factory) for each transport.
+_TRANSPORTS: list[tuple[str, Any, str, Callable[..., Any]]] = [
+    ("ros", ros_mod, "use_ros", lambda **kw: RosBridgedRobot("tb", "/cmd_vel", "/odom", **kw)),
+    ("rtps", rtps_mod, "use_rtps", lambda **kw: RtpsRobot("tb", "/cmd_vel", **kw)),
+]
+_TRANSPORT_IDS = [t[0] for t in _TRANSPORTS]
+
+# Values no message count can express: a zero/negative hold, a non-finite hold,
+# and a hold that is not a number at all.
+_BAD_DURATIONS = [0, 0.0, -5, -0.25, float("nan"), float("inf"), float("-inf"), True, "2", [1.0]]
+# ``count`` is the horizon only when no duration is given.
+_BAD_COUNTS = [0, -1, 2.7, float("nan"), float("inf"), True, "3", None]
+# A velocity is signed, so only non-finite and non-numeric values are refusable.
+_BAD_VELOCITIES = [float("nan"), float("inf"), float("-inf"), "1.0", None, [1.0], True]
+
+
+@pytest.fixture(params=_TRANSPORTS, ids=_TRANSPORT_IDS)
+def bridge(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> tuple[Any, _Wire]:
+    """A bridge for one transport plus the wire recorder it forwards to."""
+    _label, module, symbol, factory = request.param
+    wire = _Wire()
+    monkeypatch.setattr(module, symbol, wire)
+    return factory(), wire
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block.get("text", "") for block in result["content"])
+
+
+class TestRefusedCommandNeverReachesTheWire:
+    """A refusable value yields an error result and publishes nothing."""
+
+    @pytest.mark.parametrize("duration", _BAD_DURATIONS)
+    def test_a_hold_no_message_count_expresses_is_refused(self, bridge: tuple[Any, _Wire], duration: Any) -> None:
+        robot, wire = bridge
+        result = robot.drive(linear=0.5, duration=duration)
+        assert result["status"] == "error"
+        assert "duration" in _text(result)
+        assert wire.calls == []
+
+    @pytest.mark.parametrize("count", _BAD_COUNTS)
+    def test_a_message_count_that_publishes_nothing_is_refused(self, bridge: tuple[Any, _Wire], count: Any) -> None:
+        robot, wire = bridge
+        result = robot.drive(linear=0.5, count=count)
+        assert result["status"] == "error"
+        assert "count" in _text(result)
+        assert wire.calls == []
+
+    @pytest.mark.parametrize("velocity", _BAD_VELOCITIES)
+    @pytest.mark.parametrize("param", ["linear", "angular"])
+    def test_a_velocity_the_controller_cannot_integrate_is_refused(
+        self, bridge: tuple[Any, _Wire], param: str, velocity: Any
+    ) -> None:
+        robot, wire = bridge
+        result = robot.drive(**{param: velocity})
+        assert result["status"] == "error"
+        assert param in _text(result)
+        assert wire.calls == []
+
+    def test_the_first_refusable_parameter_is_named(self, bridge: tuple[Any, _Wire]) -> None:
+        """Several bad values at once name one parameter, not a merged message."""
+        robot, wire = bridge
+        result = robot.drive(linear=float("nan"), duration=-1)
+        assert result["status"] == "error"
+        assert "linear" in _text(result) and "duration" not in _text(result)
+        assert wire.calls == []
+
+
+class TestHonoredCommandsStillPublish:
+    """The guards do not narrow the set of commands that already worked."""
+
+    def test_a_duration_sizes_the_burst_from_the_publish_rate(self, bridge: tuple[Any, _Wire]) -> None:
+        robot, wire = bridge
+        assert robot.drive(linear=1.0, duration=1.5)["status"] == "success"
+        assert wire.calls[0]["count"] == 15
+
+    def test_a_hold_shorter_than_one_period_still_sends_the_command_once(self, bridge: tuple[Any, _Wire]) -> None:
+        """The ``max(1, ...)`` floor is a rounding rule for a valid duration."""
+        robot, wire = bridge
+        assert robot.drive(linear=1.0, duration=0.01)["status"] == "success"
+        assert wire.calls[0]["count"] == 1
+
+    @pytest.mark.parametrize("linear,angular", [(-1.5, 0.0), (0.0, -2.0), (0.0, 0.0), (1e-9, 1e9)])
+    def test_a_signed_velocity_is_published_verbatim(
+        self, bridge: tuple[Any, _Wire], linear: float, angular: float
+    ) -> None:
+        robot, wire = bridge
+        assert robot.drive(linear=linear, angular=angular)["status"] == "success"
+        assert wire.calls[0]["fields"] == {"linear": {"x": linear}, "angular": {"z": angular}}
+
+    def test_a_count_the_call_never_reads_is_not_refused(self, bridge: tuple[Any, _Wire]) -> None:
+        """``duration`` supersedes ``count``, so an unread ``count`` is not the horizon."""
+        robot, wire = bridge
+        assert robot.drive(linear=1.0, duration=2.0, count=0)["status"] == "success"
+        assert wire.calls[0]["count"] == 20
+
+    def test_stop_still_publishes_zero_velocity(self, bridge: tuple[Any, _Wire]) -> None:
+        robot, wire = bridge
+        assert robot.stop()["status"] == "success"
+        assert wire.calls[0]["fields"] == {"linear": {"x": 0.0}, "angular": {"z": 0.0}}
+
+
+class TestPublishRateRefusedAtConstruction:
+    """A rate that cannot pace the burst is refused where it is supplied."""
+
+    @pytest.mark.parametrize("publish_rate", [0, -10, float("nan"), float("inf"), True, "10", None])
+    @pytest.mark.parametrize("factory", [t[3] for t in _TRANSPORTS], ids=_TRANSPORT_IDS)
+    def test_a_rate_that_cannot_pace_the_burst_is_refused(self, factory: Any, publish_rate: Any) -> None:
+        with pytest.raises(ValueError, match="publish_rate"):
+            factory(publish_rate=publish_rate)
+
+    @pytest.mark.parametrize("factory", [t[3] for t in _TRANSPORTS], ids=_TRANSPORT_IDS)
+    def test_a_fractional_rate_is_usable_and_normalized(self, factory: Any) -> None:
+        """A rate is continuous - 2.5 Hz is a real setting, unlike a frame count."""
+        robot = factory(publish_rate=2.5)
+        assert isinstance(robot.publish_rate, float)
+        assert robot.publish_rate == pytest.approx(2.5)
+
+
+class TestAgentToolContract:
+    """The bound ``drive_*`` agent tool returns a result; it never raises."""
+
+    @pytest.mark.parametrize("kwargs", [{"duration": float("nan")}, {"duration": 0}, {"linear": float("inf")}])
+    def test_the_bound_drive_tool_reports_instead_of_raising(
+        self, bridge: tuple[Any, _Wire], kwargs: dict[str, Any]
+    ) -> None:
+        robot, wire = bridge
+        drive_tool: Any = next(t for t in robot.tools if t.tool_name.startswith("drive_"))
+        result = drive_tool(**kwargs)
+        assert result["status"] == "error"
+        assert wire.calls == []
+
+
+class TestTransportsAgreeOnTheAcceptedDomain:
+    """One rule per parameter, so the two transports cannot drift apart."""
+
+    @pytest.mark.parametrize("value", [*_BAD_DURATIONS, 1.5, 0.01, 60])
+    def test_both_transports_return_the_same_duration_verdict(
+        self, monkeypatch: pytest.MonkeyPatch, value: Any
+    ) -> None:
+        verdicts = {}
+        for label, module, symbol, factory in _TRANSPORTS:
+            wire = _Wire()
+            monkeypatch.setattr(module, symbol, wire)
+            verdicts[label] = factory().drive(linear=0.5, duration=value)["status"]
+        assert verdicts["ros"] == verdicts["rtps"], f"verdicts differ for duration={value!r}: {verdicts}"
+
+    @pytest.mark.parametrize("value", [*_BAD_VELOCITIES, 0.0, -1.0, 2.5])
+    def test_both_transports_return_the_same_velocity_verdict(
+        self, monkeypatch: pytest.MonkeyPatch, value: Any
+    ) -> None:
+        verdicts = {}
+        for label, module, symbol, factory in _TRANSPORTS:
+            wire = _Wire()
+            monkeypatch.setattr(module, symbol, wire)
+            verdicts[label] = factory().drive(linear=value)["status"]
+        assert verdicts["ros"] == verdicts["rtps"], f"verdicts differ for linear={value!r}: {verdicts}"
+
+
+class TestFiniteNumberErrorDomain:
+    """Unit contract of the shared signed-scalar guard."""
+
+    @pytest.mark.parametrize("value", [0, 0.0, -1, 1e300, -1e300, 2.5])
+    def test_any_finite_real_of_either_sign_is_accepted(self, value: Any) -> None:
+        from strands_robots.utils import finite_number_error
+
+        assert finite_number_error(value, "linear", "drive") is None
+
+    @pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf, True, False, "1.0", None, [1.0]])
+    def test_a_non_finite_or_non_real_value_is_refused_by_name(self, value: Any) -> None:
+        from strands_robots.utils import finite_number_error
+
+        message = finite_number_error(value, "linear", "drive")
+        assert message is not None
+        assert message.startswith("drive: linear must be a finite number")
+
+    def test_a_numpy_scalar_velocity_is_accepted(self) -> None:
+        """A policy action element arrives as a NumPy scalar, not a Python float."""
+        import numpy as np
+
+        from strands_robots.utils import finite_number_error
+
+        assert finite_number_error(np.float32(-0.25), "linear", "drive") is None
+        assert finite_number_error(np.float64("nan"), "linear", "drive") is not None


### PR DESCRIPTION
## Problem

`RosBridgedRobot.drive` and `RtpsRobot.drive` are the calls that physically move a wheeled robot. Neither validated any of the four knobs the command carries, and because `duration` sizes the published burst as `max(1, round(duration * publish_rate))`, the floor converted a hold no message count expresses into a plausible-but-unrequested velocity command:

```python
robot = RosBridgedRobot("tb", "/cmd_vel", "/odom")   # publish_rate 10 Hz

robot.drive(linear=0.5, duration=0)     # status 'success'
# -> one Twist published, linear.x = 0.5 m/s: the base starts moving
robot.drive(linear=0.5, duration=-5)    # status 'success', same single command
robot.drive(linear=0.5, count=0)        # status 'success', nothing published at all
robot.drive(linear=float("inf"))        # status 'success', inf reaches cmd_vel
robot.drive(linear=0.5, duration=float("nan"))
# ValueError: cannot convert float NaN to integer
robot.drive(linear=0.5, duration=float("inf"))
# OverflowError: cannot convert float infinity to integer
robot.drive(linear=0.5, duration="2")
# TypeError: can't multiply sequence by non-int of type 'float'
```

Three distinct failures from one missing check:

1. **A command the caller did not ask for is published.** `duration=0` means "hold for zero seconds"; the floor makes it one full-speed `Twist`. A ROS 2 base holds the last `cmd_vel` until the next message or its watchdog expires, so a zero or negative hold starts the robot moving.
2. **A drive that never left the process reports success.** `count=0`/`-1` publishes nothing, and `range(-1)` is empty, so the caller is told the robot was commanded when it was not.
3. **The result-dict contract is broken.** `duration=nan`/`inf`/`"2"` raise out of a method documented to return a result dict. Both `drive` methods are bound as agent tools (`drive_<node_name>`), so those raises escape tool dispatch rather than reporting.

`use_ros` / `use_rtps` cannot cover this. They validate the topic and interface type, but **`duration` never reaches them** - they receive only the derived message count - and neither checks `count` or the `Twist` field values. The `RosBridgedRobot` module docstring and `docs/ros2-integration.md` both claimed the bridge "inherits `use_ros`'s ... input validation", which structurally cannot be true for a parameter the transport never sees; both are corrected here.

`publish_rate` is the same defect one layer up: `drive` multiplies by it and the transport paces at `1 / rate`, so `publish_rate=0`/`-10` clamped the count to 1 **and** forwarded a rate that removes the pacing entirely (`period = 1.0 / rate if rate > 0 else 0.0`), while `nan`/`inf` crashed inside `round()`.

## Change

`drive` returns a `{"status": "error"}` result - publishing nothing - when a value cannot be honored:

| Parameter | Accepted domain | Why |
|---|---|---|
| `linear`, `angular` | any **finite** number, either sign | reverse and clockwise are real commands, so the sign is free; `nan`/`inf` serialize as a valid float64 and poison the receiving controller's state estimate |
| `duration` | `> 0` and finite | no message count expresses a zero or negative hold |
| `count` | positive whole number | `0`/negative publishes nothing |
| `publish_rate` | `> 0` and finite, **raises at construction** | it is a multiplier in `drive` and a divisor in the transport; the constructor already raises for a bad topic |

The rules are the shared `strands_robots.utils` validators - `positive_finite_number_error` (already the domain for `control_frequency` / rollout and teleop `duration`) and `positive_whole_number_error` - plus one new `finite_number_error` for a **signed** physical quantity, which neither existing helper can express. Sharing them is what keeps the two transports, which carry line-for-line copies of `drive`, from drifting apart.

Two deliberate scope decisions:

- **`count` is checked only when it is the effective horizon.** `duration` supersedes `count`, so `drive(duration=2.0, count=0)` stays valid - refusing a parameter the call never reads would reject a working command.
- **The `max(1, ...)` floor is kept**, now with a comment saying why: for an *already-validated* positive duration it is a correct rounding rule (a hold shorter than one publish period still means "send the command once"). It was only wrong as a substitute for validation.

Every command that worked before behaves identically: `duration=1.5` is still 15 messages, `duration=0.01` is still 1, a negative velocity is still published verbatim, and `stop()` is unchanged.

## Visual artifact

What each `drive()` call actually puts on the `/cmd_vel` topic, measured by recording the transport call on both trees (the pre-fix panel was generated with the source reverted to `main`). Each tick is one published `Twist`.

![drive command wire trace](https://raw.githubusercontent.com/cagataycali/robots/artifacts/drive-command-guards/drive_wire_trace.png)

| | commands reporting success | `Twist` messages published | non-finite velocity on the wire |
|---|---|---|---|
| before | 5 of 6 (the 6th raised) | 18 | yes (`linear.x = inf`) |
| after | 1 of 6 (the honorable one) | 15 | no |

The three extra pre-fix messages are exactly the ones nobody asked for: `duration=0` and `duration=-5` each published a 0.5 m/s command, and `linear=inf` published a non-finite one.

## Tests

New `tests/mesh/test_drive_command_guards.py` (142 tests, both transports via one parametrized fixture):

- a refusable `duration` / `count` / `linear` / `angular` yields an error result **and the recorder saw no call** - the refusal precedes publishing
- the error names the first refusable parameter, not a merged message
- honored commands are unchanged: `duration=1.5` -> 15 messages, `duration=0.01` -> 1, signed velocities published verbatim, `stop()` unchanged, and `count=0` accepted when a `duration` supersedes it
- `publish_rate` raises at construction on both classes; a fractional `2.5` Hz stays usable and is normalized to `float`
- the bound `drive_*` **agent tool** returns an error result instead of raising
- a **cross-transport parity** test asserts `ros` and `rtps` return the same verdict for every probed value, so one rule cannot be applied to only one transport
- unit contract of `finite_number_error`, including a NumPy scalar velocity (a policy action element) and the `bool` rejection

Pre-fix (source reverted to `main`, tests unchanged): **108 failed, 34 passed**

| pre-fix failure | count |
|---|---|
| `assert 'success' == 'error'` (silently accepted) | 52 |
| `DID NOT RAISE ValueError` (`publish_rate`) | 14 |
| `TypeError: can't multiply sequence by non-int of type 'float'` | 6 |
| `OverflowError: cannot convert float infinity to integer` | 6 |
| `ValueError: cannot convert float NaN to integer` | 5 |
| `TypeError: float() argument must be ... not 'NoneType'` | 5 |
| `TypeError: float() argument must be ... not 'list'` | 5 |
| `ImportError: cannot import name 'finite_number_error'` | 15 |

Post-fix: **142 passed**. The 27 existing `test_ros_bridge.py` / `test_rtps_robot.py` tests pass unmodified.

## Gate

```
ruff check strands_robots tests tests_integ            All checks passed!
ruff format --check strands_robots tests tests_integ   942 files already formatted
mypy strands_robots tests tests_integ                  Success: no issues found in 939 source files
MUJOCO_GL=egl pytest tests -q --no-cov                 13353 passed, 253 skipped in 433s
python scripts/assemble_changelog.py --check           changelog fragments OK
```

Baseline on this commit was 13211 passed / 253 skipped, so the delta is exactly the 142 new tests. Changelog news fragment: `changelog.d/1719-drive-command-guards.md`.