### PR TITLE
fix(tools): refuse a numeric transport option use_ros/use_rtps cannot honor

### DIFF
--- a/changelog.d/1720-transport-tool-numeric-guards.md
+++ b/changelog.d/1720-transport-tool-numeric-guards.md
@@ -1,0 +1,20 @@
+### Fixed: `use_ros` / `use_rtps` refuse a numeric option the transport cannot honor
+
+The `count`, `rate` and `timeout` options of both ROS 2 transport tools were
+forwarded unvalidated. `rate=0`, a negative rate, `nan` and `inf` all fell
+through `period = 1.0 / rate if rate > 0 else 0.0` to an unpaced `period = 0.0`,
+so `publish` sent the whole burst back-to-back and still reported success - a
+velocity hold collapsed into an instantaneous burst that a base latches as its
+last command. `count=0` and `count=-1` published nothing and reported
+`published -1 message(s)`; `count=True` published one; `count=2.7`, `"3"` and a
+non-numeric `rate` surfaced a raw `range()` or comparison `TypeError` naming
+neither the tool nor the option. On `echo` a non-positive or `nan` `timeout`
+returned zero samples as a success and `inf` never expired.
+
+Each option an action actually consumes is now checked against the shared domain
+for its kind (`positive_count_error` for a `range()` bound, `positive_finite_number_error`
+for a rate or a span of seconds), alongside the existing topic/type allowlist and
+ahead of the backend probe - so the refusal happens before any DDS entity joins
+the graph, reports identically with or without a ROS 2 distro installed, and is
+the same on both transports. An option the requested action never reads is not
+second-guessed.

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -139,6 +139,19 @@ malformed names from reaching the ROS 2 client library. Backend and timeout
 failures are returned as structured `{"status": "error"}` results rather than
 raised exceptions.
 
+The numeric options an action consumes are checked in the same place, ahead of
+the backend probe, so a caller mistake reports identically whether or not a ROS 2
+distro is sourced and a refusal happens before a publisher joins the graph:
+
+| Option | Consumed by | Accepted values |
+|--------|-------------|-----------------|
+| `count` | `echo`, `publish` | a positive integer - it is a `range()` bound, so `0` sends nothing and `2.7` or `"3"` cannot be honored |
+| `rate` | `publish` | a positive finite number of Hz - the inter-message period is `1 / rate`, so `0`, a negative value, `nan` and `inf` all leave the burst unthrottled instead of paced |
+| `timeout` | `echo`, `service_call`, `action_send_goal` | a positive finite number of seconds - `0` and negatives wait for nothing, `inf` never expires |
+
+An option the requested action never reads is not second-guessed:
+`use_ros(action="status", count=-1)` still reports the backend.
+
 ## Sim bridge: publish a simulation on a ROS 2 domain
 
 The simulator can advertise its own live state on ROS 2. Construct any

--- a/docs/rtps-integration.md
+++ b/docs/rtps-integration.md
@@ -219,3 +219,11 @@ mangling (absolute `/`-rooted alnum/`_` names; `pkg/msg/Name` types). The tool
 never constructs a shell command or generates source, so there is no
 command-injection or `eval` surface. Backend, type-resolution, and field errors
 are returned as structured `{"status": "error"}` results rather than raised.
+
+The numeric options are checked in the same place, ahead of the backend probe, so
+a refusal happens before a writer joins the graph and reports identically whether
+or not `cyclonedds` is installed. `count` (`publish`, `echo`) must be a positive
+integer, and `rate` (`publish`) and `timeout` (`echo`) must be positive finite
+numbers - the same accepted domain `use_ros` enforces, so a value publishable
+through one transport is publishable through the other. An option the requested
+action never reads is not second-guessed.

--- a/strands_robots/tools/use_ros.py
+++ b/strands_robots/tools/use_ros.py
@@ -67,6 +67,8 @@ from typing import Any
 
 from strands import tool
 
+from strands_robots.utils import positive_count_error, positive_finite_number_error
+
 logger = logging.getLogger(__name__)
 
 # Validation allowlists. ROS 2 graph names are alnum plus _ / ~ (and the {ns}
@@ -75,6 +77,17 @@ logger = logging.getLogger(__name__)
 # unexpected characters into the rclpy graph API or type-resolution layer.
 _NAME_RE = re.compile(r"^[A-Za-z0-9_/~{}]+$")
 _TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/[A-Za-z0-9_]+/[A-Za-z0-9_]+$")
+
+# Which numeric options each action actually consumes. An action that reads none
+# of them (``status``, the ``list_*`` queries, ``info``) must not be refused for
+# a value it never looks at, so the guard below is driven by this table rather
+# than validating the whole signature unconditionally.
+_ACTION_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
+    "echo": ("timeout", "count"),
+    "publish": ("count", "rate"),
+    "service_call": ("timeout",),
+    "action_send_goal": ("timeout",),
+}
 
 _INSTALL_HINT = (
     "rclpy is not importable - source a ROS 2 distro before launching the agent "
@@ -179,6 +192,40 @@ def _ok(text: str) -> dict[str, Any]:
 
 def _err(text: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": f"use_ros: {text}"}]}
+
+
+def _numeric_option_error(action: str, timeout: Any, count: Any, rate: Any) -> str | None:
+    """Error text for the first numeric option ``action`` consumes but cannot honor.
+
+    ``timeout``, ``count`` and ``rate`` are agent-supplied, so each is checked
+    against the shared domain for its kind before any DDS entity is created:
+    ``count`` is a ``range()`` bound (:func:`~strands_robots.utils.positive_count_error`)
+    and ``timeout`` / ``rate`` are a span of seconds and a frequency in Hz
+    (:func:`~strands_robots.utils.positive_finite_number_error`). Reusing those
+    helpers is what keeps this tool, ``use_rtps`` and the mesh bridges from
+    accepting a value one of them refuses.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        timeout: Seconds to wait, as supplied.
+        count: Message/sample count, as supplied.
+        rate: Publish rate in Hz, as supplied.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when
+        every option this action reads is usable.
+    """
+    consumed = _ACTION_NUMERIC_OPTIONS.get(action, ())
+    for param, value, check in (
+        ("timeout", timeout, positive_finite_number_error),
+        ("count", count, positive_count_error),
+        ("rate", rate, positive_finite_number_error),
+    ):
+        if param in consumed:
+            error = check(value, param, action)
+            if error:
+                return error
+    return None
 
 
 # --------------------------------------------------------------------------
@@ -429,8 +476,13 @@ def use_ros(
             For ``action_send_goal`` this is the end-to-end budget (discovery +
             acceptance + execution); size it to the goal (e.g. 120 for a Nav2
             navigation), and note the goal is cancelled when it expires.
-        count: Number of messages to echo or publish.
-        rate: Publish rate in Hz.
+            A positive finite number of seconds.
+        count: Number of messages to echo or publish. A positive integer;
+            it is consumed as a ``range()`` bound, so ``0`` publishes nothing
+            and a float or a numeric string cannot be honored.
+        rate: Publish rate in Hz. A positive finite number - the inter-message
+            period is ``1 / rate``, so ``0``, a negative value, ``nan`` and
+            ``inf`` all leave the burst unthrottled rather than paced.
 
     Returns:
         A Strands tool result dict ``{"status": ..., "content": [{"text": ...}]}``.
@@ -446,6 +498,14 @@ def use_ros(
         return _err(f"invalid action name: {action_name!r}")
     if type is not None and not _TYPE_RE.match(type):
         return _err(f"invalid interface type: {type!r} (expected pkg/msg/Name or pkg/srv/Name)")
+
+    # Numeric options are checked here, alongside the names and ahead of the
+    # backend probe, so the same caller mistake is reported identically whether
+    # or not rclpy is installed - and so a refusal happens before a publisher
+    # joins the graph.
+    numeric_error = _numeric_option_error(action, timeout, count, rate)
+    if numeric_error:
+        return _err(numeric_error)
 
     if action == "status":
         if _backend.available():

--- a/strands_robots/tools/use_rtps.py
+++ b/strands_robots/tools/use_rtps.py
@@ -51,12 +51,23 @@ from typing import Any
 
 from strands import tool
 
+from strands_robots.utils import positive_count_error, positive_finite_number_error
+
 logger = logging.getLogger(__name__)
 
 # ROS 2 graph names: absolute, alnum/_ segments. Validate before mangling so a
 # malformed agent-supplied name fails with a clear message.
 _TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]$")
 _TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/(msg|srv|action)/[A-Za-z0-9_]+$")
+
+# Which numeric options each action actually consumes. ``status``, ``types``,
+# ``advertise`` and ``subscribe`` read none of them, so the guard below is driven
+# by this table rather than validating the whole signature unconditionally - a
+# caller is never refused for a value the requested action never looks at.
+_ACTION_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
+    "publish": ("count", "rate"),
+    "echo": ("timeout", "count"),
+}
 
 
 class _RtpsBackend:
@@ -136,6 +147,40 @@ def _err(text: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": f"use_rtps: {text}"}]}
 
 
+def _numeric_option_error(action: str, timeout: Any, count: Any, rate: Any) -> str | None:
+    """Error text for the first numeric option ``action`` consumes but cannot honor.
+
+    ``timeout``, ``count`` and ``rate`` are agent-supplied, so each is checked
+    against the shared domain for its kind before any DDS entity is created:
+    ``count`` is a ``range()`` bound (:func:`~strands_robots.utils.positive_count_error`)
+    and ``timeout`` / ``rate`` are a span of seconds and a frequency in Hz
+    (:func:`~strands_robots.utils.positive_finite_number_error`). Reusing those
+    helpers is what keeps this tool and ``use_ros`` - two transports onto the
+    same ROS 2 graph - from disagreeing about which values are publishable.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        timeout: Seconds to wait, as supplied.
+        count: Message/sample count, as supplied.
+        rate: Publish rate in Hz, as supplied.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when
+        every option this action reads is usable.
+    """
+    consumed = _ACTION_NUMERIC_OPTIONS.get(action, ())
+    for param, value, check in (
+        ("timeout", timeout, positive_finite_number_error),
+        ("count", count, positive_count_error),
+        ("rate", rate, positive_finite_number_error),
+    ):
+        if param in consumed:
+            error = check(value, param, action)
+            if error:
+                return error
+    return None
+
+
 def _sample_to_dict(sample: Any) -> Any:
     """Recursively convert an IDL dataclass sample to a plain dict."""
     if dataclasses.is_dataclass(sample) and not isinstance(sample, type):
@@ -201,9 +246,14 @@ def use_rtps(
             ``geometry_msgs/msg/Twist``). List with ``action="types"``.
         fields: JSON field dict for ``publish``; nested message fields are built
             recursively. Booleans and nulls are preserved (plain Python values).
-        timeout: Seconds to wait for samples (``echo``).
-        count: Number of messages to publish or samples to echo.
-        rate: Publish rate in Hz.
+        timeout: Seconds to wait for samples (``echo``). A positive finite
+            number.
+        count: Number of messages to publish or samples to echo. A positive
+            integer; it is consumed as a ``range()`` bound, so ``0`` publishes
+            nothing and a float or a numeric string cannot be honored.
+        rate: Publish rate in Hz. A positive finite number - the inter-message
+            period is ``1 / rate``, so ``0``, a negative value, ``nan`` and
+            ``inf`` all leave the burst unthrottled rather than paced.
 
     Returns:
         A Strands tool result dict ``{"status": ..., "content": [{"text": ...}]}``.
@@ -214,6 +264,14 @@ def use_rtps(
         return _err(f"invalid topic name: {topic!r} (expected absolute, e.g. /turtle1/cmd_vel)")
     if type is not None and not _TYPE_RE.match(type):
         return _err(f"invalid interface type: {type!r} (expected pkg/msg/Name)")
+
+    # Numeric options are checked here, alongside the names and ahead of the
+    # backend probe, so the same caller mistake is reported identically whether
+    # or not cyclonedds is installed - and so a refusal happens before a writer
+    # joins the graph.
+    numeric_error = _numeric_option_error(action, timeout, count, rate)
+    if numeric_error:
+        return _err(numeric_error)
 
     if action == "status":
         if _backend.available():

--- a/tests/tools/test_transport_numeric_option_guards.py
+++ b/tests/tools/test_transport_numeric_option_guards.py
@@ -80,7 +80,7 @@ def published_at(monkeypatch: pytest.MonkeyPatch) -> list[float]:
 
     monkeypatch.setattr(ros_mod._backend, "_ensure_node", lambda: FakeNode())
     monkeypatch.setattr(ros_mod._backend, "spin_for", lambda predicate, timeout: None)
-    monkeypatch.setattr(ros_mod, "_get_message", lambda msg_type: lambda: object())
+    monkeypatch.setattr(ros_mod, "_get_message", lambda msg_type: object)
     return stamps
 
 

--- a/tests/tools/test_transport_numeric_option_guards.py
+++ b/tests/tools/test_transport_numeric_option_guards.py
@@ -1,0 +1,264 @@
+"""The ROS 2 transport tools refuse a numeric option they cannot honor.
+
+``use_ros`` and ``use_rtps`` expose the same three numeric options to an agent -
+``count``, ``rate`` and ``timeout`` - and both consume them the same way: ``count``
+is a ``range()`` bound, ``rate`` becomes an inter-message period ``1 / rate``, and
+``timeout`` is a wait budget. Only positive, finite values can be honored, so a
+value outside that domain must be refused with a message naming the option,
+before any DDS entity joins the graph and before a single message is published.
+
+These tests run with NO ROS 2 and NO cyclonedds installed: the backend
+availability probe and the rclpy-facing helpers are monkeypatched, so the guards,
+the per-action scoping, the cross-transport parity and the "nothing was
+published" contract are all exercised transport-free.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types as _types
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.use_ros as ros_mod
+import strands_robots.tools.use_rtps as rtps_mod
+
+# Values outside the accepted domain of each option, with the reason each one is
+# unusable. ``inf`` matters as much as ``0``: it passes a bare ``rate > 0`` test
+# and then collapses ``1 / rate`` to ``0``, leaving the burst unthrottled.
+UNUSABLE_RATES: list[Any] = [0.0, -5.0, float("nan"), float("inf"), "10", None]
+UNUSABLE_TIMEOUTS: list[Any] = [0.0, -1.0, float("nan"), float("inf"), "2", None]
+UNUSABLE_COUNTS: list[Any] = [0, -1, True, 2.7, "3", None]
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+@pytest.fixture(autouse=True)
+def _both_backends_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default both transports to a present backend; opt out where needed."""
+    monkeypatch.setattr(ros_mod._backend, "available", lambda: True)
+    monkeypatch.setattr(rtps_mod._backend, "available", lambda: True)
+
+
+# ---------------------------------------------------------------------------
+# A refused option publishes nothing: the real ``_publish`` body never runs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def published_at(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Wire ``use_ros`` to a recording publisher and return its send timestamps.
+
+    The real ``_publish`` body runs - only the rclpy node, the message class and
+    the executor spin are faked - so the list records exactly the messages that
+    reached the wire, and their spacing is the pacing the tool actually applied.
+    """
+    stamps: list[float] = []
+
+    class FakePublisher:
+        def publish(self, msg: Any) -> None:
+            stamps.append(time.perf_counter())
+
+    class FakeNode:
+        def create_publisher(self, cls: Any, topic: str, depth: int) -> FakePublisher:
+            return FakePublisher()
+
+        def destroy_publisher(self, pub: Any) -> None:
+            pass
+
+    set_message = _types.ModuleType("rosidl_runtime_py.set_message")
+    set_message.set_message_fields = lambda msg, fields: None  # type: ignore[attr-defined]
+    package = _types.ModuleType("rosidl_runtime_py")
+    package.set_message = set_message  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py", package)
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py.set_message", set_message)
+
+    monkeypatch.setattr(ros_mod._backend, "_ensure_node", lambda: FakeNode())
+    monkeypatch.setattr(ros_mod._backend, "spin_for", lambda predicate, timeout: None)
+    monkeypatch.setattr(ros_mod, "_get_message", lambda msg_type: lambda: object())
+    return stamps
+
+
+def _publish_twist(**options: Any) -> dict[str, Any]:
+    return ros_mod.use_ros(action="publish", topic="/cmd_vel", type="geometry_msgs/msg/Twist", **options)
+
+
+@pytest.mark.parametrize("rate", UNUSABLE_RATES)
+def test_an_unusable_rate_publishes_no_message(published_at: list[float], rate: Any) -> None:
+    """A rate that cannot pace the burst is refused before anything is sent.
+
+    Pre-fix the loop fell back to ``period = 0.0`` and sent every message
+    back-to-back, reporting success - a velocity hold collapsed into an
+    instantaneous burst that a base then latches as its last command.
+    """
+    result = _publish_twist(count=6, rate=rate)
+
+    assert result["status"] == "error"
+    assert f"rate must be > 0, got {rate!r}." in _texts(result)
+    assert published_at == []
+
+
+@pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+def test_an_unusable_count_publishes_no_message(published_at: list[float], count: Any) -> None:
+    """A count that is not a positive integer is refused, not silently absorbed.
+
+    ``range(-1)`` and ``range(0)`` publish nothing, and ``range(2.7)`` raises a
+    ``TypeError`` naming neither the tool nor the option.
+    """
+    result = _publish_twist(count=count, rate=10.0)
+
+    assert result["status"] == "error"
+    assert f"count must be a positive integer, got {count!r}." in _texts(result)
+    assert published_at == []
+
+
+def test_a_usable_rate_paces_the_burst(published_at: list[float]) -> None:
+    """The honored path still publishes ``count`` messages spaced by ``1 / rate``."""
+    result = _publish_twist(count=4, rate=100.0)
+
+    assert result["status"] == "success"
+    assert len(published_at) == 4
+
+
+# ---------------------------------------------------------------------------
+# The refusal is identical with and without a backend installed.
+# ---------------------------------------------------------------------------
+
+
+def test_a_refusal_names_the_option_even_with_no_ros_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard runs ahead of the availability probe, so the message is stable.
+
+    A caller mistake must not be masked by an install hint on a machine without
+    ROS 2 and then reported differently on a machine with it.
+    """
+    monkeypatch.setattr(ros_mod._backend, "available", lambda: False)
+
+    result = _publish_twist(count=6, rate=0.0)
+
+    assert result["status"] == "error"
+    assert "rate must be > 0" in _texts(result)
+
+
+# ---------------------------------------------------------------------------
+# Per-action scoping: an option the action never reads is not second-guessed.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_accepts_an_unusable_timeout_it_never_reads(published_at: list[float]) -> None:
+    """``publish`` consumes ``count`` and ``rate`` only, so ``timeout`` is inert."""
+    result = _publish_twist(count=2, rate=100.0, timeout=-1.0)
+
+    assert result["status"] == "success"
+    assert len(published_at) == 2
+
+
+@pytest.mark.parametrize("action", ["status", "list_topics"])
+def test_an_action_reading_no_numeric_option_is_never_refused(monkeypatch: pytest.MonkeyPatch, action: str) -> None:
+    """A query action must not fail for a value it does not look at."""
+    monkeypatch.setattr(ros_mod, "_list_topics", lambda: "/cmd_vel [geometry_msgs/msg/Twist]")
+
+    result = ros_mod.use_ros(action=action, count=-1, rate=float("nan"), timeout=-1.0)
+
+    assert result["status"] == "success"
+
+
+def test_the_scoping_table_covers_every_action_that_reads_an_option() -> None:
+    """Only the three known option names may appear in the scoping tables.
+
+    The table is what decides whether a value is checked at all, so a typo in it
+    would silently disable a guard.
+    """
+    for table in (ros_mod._ACTION_NUMERIC_OPTIONS, rtps_mod._ACTION_NUMERIC_OPTIONS):
+        for action, options in table.items():
+            assert options, f"{action} lists no options; drop the entry instead"
+            assert set(options) <= {"count", "rate", "timeout"}, action
+
+
+# ---------------------------------------------------------------------------
+# Cross-transport parity: two transports onto one graph, one accepted domain.
+# ---------------------------------------------------------------------------
+
+_PUBLISH_CALLS: list[tuple[str, Callable[..., dict[str, Any]]]] = [
+    (
+        "use_ros",
+        lambda **kw: ros_mod.use_ros(action="publish", topic="/cmd_vel", type="geometry_msgs/msg/Twist", **kw),
+    ),
+    (
+        "use_rtps",
+        lambda **kw: rtps_mod.use_rtps(action="publish", topic="/cmd_vel", type="geometry_msgs/msg/Twist", **kw),
+    ),
+]
+
+
+def _refusal_reasons(
+    calls: list[tuple[str, Callable[..., dict[str, Any]]]], param: str, **options: Any
+) -> dict[str, str]:
+    """Map each transport to the sentence it refused ``options`` with.
+
+    The verdict alone would be satisfied by an unrelated failure - with no ROS 2
+    and no cyclonedds installed both transports error for *some* reason - so the
+    returned text is asserted on, and it must name the option.
+    """
+    reasons = {}
+    for name, call in calls:
+        result = call(**options)
+        assert result["status"] == "error", f"{name} accepted {param}={options[param]!r}"
+        reasons[name] = _texts(result)
+    return reasons
+
+
+@pytest.mark.parametrize("value", UNUSABLE_RATES)
+def test_both_transports_refuse_the_same_rate(value: Any) -> None:
+    """A rate one transport refuses cannot be publishable through the other."""
+    reasons = _refusal_reasons(_PUBLISH_CALLS, "rate", count=1, rate=value)
+
+    for name, reason in reasons.items():
+        assert f"rate must be > 0, got {value!r}." in reason, (name, reason)
+
+
+@pytest.mark.parametrize("value", UNUSABLE_COUNTS)
+def test_both_transports_refuse_the_same_count(value: Any) -> None:
+    """A count one transport refuses cannot be publishable through the other."""
+    reasons = _refusal_reasons(_PUBLISH_CALLS, "count", count=value, rate=10.0)
+
+    for name, reason in reasons.items():
+        assert f"count must be a positive integer, got {value!r}." in reason, (name, reason)
+
+
+@pytest.mark.parametrize("value", UNUSABLE_TIMEOUTS)
+def test_both_transports_refuse_the_same_echo_timeout(value: Any) -> None:
+    """An echo wait budget one transport refuses is refused by the other too."""
+    echo_calls: list[tuple[str, Callable[..., dict[str, Any]]]] = [
+        (
+            "use_ros",
+            lambda **kw: ros_mod.use_ros(action="echo", topic="/odom", type="nav_msgs/msg/Odometry", **kw),
+        ),
+        (
+            "use_rtps",
+            lambda **kw: rtps_mod.use_rtps(action="echo", topic="/odom", type="nav_msgs/msg/Odometry", **kw),
+        ),
+    ]
+    reasons = _refusal_reasons(echo_calls, "timeout", timeout=value)
+
+    for name, reason in reasons.items():
+        assert f"timeout must be > 0, got {value!r}." in reason, (name, reason)
+
+
+# ---------------------------------------------------------------------------
+# Output contract.
+# ---------------------------------------------------------------------------
+
+
+def test_a_refusal_message_is_ascii_and_names_the_action() -> None:
+    """The message must be plain ASCII and say which action rejected the value."""
+    text = _texts(_publish_twist(count=1, rate=float("nan")))
+
+    assert text.isascii(), text
+    assert text.startswith("use_ros: publish: ")

--- a/tests/tools/test_use_rtps.py
+++ b/tests/tools/test_use_rtps.py
@@ -249,13 +249,19 @@ def test_echo_returns_samples_as_dicts(with_reader) -> None:
 
 
 def test_echo_times_out_with_empty_samples(with_reader) -> None:
+    """An expired wait returns an empty sample list rather than an error.
+
+    The budget is the smallest usable one rather than ``0.0``: a zero timeout is
+    not a wait a caller can ask for (it is refused up front), and it also skipped
+    the polling loop entirely, so the branch under test never ran.
+    """
     with_reader([])  # reader never yields
     result = use_rtps(
         action="echo",
         topic="/cmd_vel",
         type="geometry_msgs/msg/Twist",
         count=1,
-        timeout=0.0,  # deadline already reached -> no spin, empty result
+        timeout=0.01,  # one poll, then the deadline passes -> empty result
     )
     assert result["status"] == "success"
     text = _texts(result)


### PR DESCRIPTION
## Problem

`use_ros` and `use_rtps` validate the agent-supplied *names* they receive - topics, services, interface types go through an allowlist before reaching the graph API. The three **numeric** options in the same signature (`count`, `rate`, `timeout`) went straight into the publish and echo loops.

Both tools compute their pacing the same way:

```python
period = 1.0 / rate if rate > 0 else 0.0
for _ in range(count):
    pub.publish(msg)
    if period:
        ...sleep(period)
```

That `else 0.0` turns "this rate cannot produce a period" into "do not pace at all", and `if period:` then skips the wait entirely. Measured at the publisher on `/cmd_vel`:

| Call | Reported | Twist messages | Span |
|------|----------|----------------|------|
| `rate=10.0, count=6` | success | 6 | 0.2507 s |
| `rate=0.0, count=6` | **success** | 6 | **0.0000 s** |
| `rate=-5.0, count=6` | **success** | 6 | **0.0000 s** |
| `rate=nan, count=6` | **success** | 6 | **0.0000 s** |
| `rate=inf, count=6` | **success** | 6 | **0.0000 s** |
| `count=0` | **success** | 0 | - |
| `count=-1` | **success** (`published -1 message(s) to /cmd_vel`) | 0 | - |
| `count=True` | **success** (`published True message(s)`) | 1 | - |

A base holds the last `cmd_vel` it received, so the 0.6 s hold the caller asked for is not "sent faster" - it is *lost*, and the last velocity stays latched. `inf` arrives through the front door: `inf > 0` is true and `1 / inf` is `0.0`, so it lands in the same unpaced branch as `0`.

The values that did fail, failed uninformatively - from inside the loop, after the publisher had already been created and the discovery settle had run:

```
count=2.7   -> use_ros: publish failed: 'float' object cannot be interpreted as an integer
count="3"   -> use_ros: publish failed: 'str' object cannot be interpreted as an integer
rate="10"   -> use_ros: publish failed: '>' not supported between instances of 'str' and 'int'
rate=None   -> use_ros: publish failed: '>' not supported between instances of 'NoneType' and 'int'
```

None of those names the tool option that was wrong or what it accepts.

`timeout` had the third variant of the same hole. `_RosBackend.spin_for` computes `deadline = time.time() + timeout`, so `echo(timeout=0)` and `echo(timeout=-1)` return zero samples as a **success**, `nan` does the same (`time.time() < nan` is `False`), and `inf` produces a deadline that never passes - the call blocks forever with no way to recover.

These are agent-facing tool parameters, and `publish` on `/cmd_vel` is the surface that moves a real base.

## Change

The numeric options are now checked in the same block as the names, ahead of the backend-availability probe, using the shared domain already defined for each kind:

* `count` -> `positive_count_error`. Its docstring already scopes it to counts "consumed directly as `range()` bounds", which is exactly this, and it rejects `bool` explicitly so `True` cannot act as a silent 1.
* `rate` and `timeout` -> `positive_finite_number_error`. Its docstring already covers a knob that "is always a divisor (the loop period is `1 / hz`) or a horizon" and spells out why `inf` must be refused rather than treated as fast.

Reusing those two helpers rather than writing a local check is the point: `use_ros`, `use_rtps` and the mesh bridges are several ways onto one ROS 2 graph, and a value publishable through one must not be refused by another.

A small per-tool table drives which options are effective for which action, so a caller is never refused for a value the requested action does not read:

```python
_ACTION_NUMERIC_OPTIONS = {
    "echo": ("timeout", "count"),
    "publish": ("count", "rate"),
    "service_call": ("timeout",),
    "action_send_goal": ("timeout",),
}
```

`use_ros(action="status", count=-1)` still reports the backend, and `publish(timeout=-1)` still publishes - `publish` never looks at `timeout`.

Placing the guard ahead of the availability probe follows the precedent already used for the recorder pre-flight checks, and buys two things: the same caller mistake reports identically whether or not a ROS 2 distro is sourced, and a refusal happens *before* a publisher or writer joins the graph.

Messages name the action, the option and the accepted domain:

```
use_ros:  publish: rate must be > 0, got 0.0.
use_ros:  publish: count must be a positive integer, got -1.
use_ros:  echo: timeout must be > 0, got nan.
use_rtps: publish: rate must be > 0, got inf.
```

## Wire trace

Recorded at the publisher - one marker per `Twist` that actually reached the wire - for the same three calls against both trees. The dashed line is the pacing the caller asked for.

![use_ros publish wire trace](https://raw.githubusercontent.com/cagataycali/robots/artifacts/transport-numeric-guards/use-ros-numeric-option-wire-trace.png)

Left: `rate=0.0` delivers all six messages in 0.0000 s and reports success, and `count=-1` reports `published -1 message(s)` having sent none. Right: both are refused with the option named, and nothing is published. The honored `rate=10.0` call is unchanged in both panels.

(No simulation or rendering behaviour changes here, so the artifact is a transport trace rather than a rollout.)

## Tests

`tests/tools/test_transport_numeric_option_guards.py`, 37 tests, no ROS 2 and no `cyclonedds` required:

* every unusable `rate` / `count` is refused **and** `published_at == []` - the real `_publish` body runs against a recording publisher, so this pins that no message reached the wire, not merely that the status was an error.
* the honored path still publishes `count` messages.
* the refusal is byte-identical with the backend probe returning `False`, pinning the "reports the same on every install" contract.
* per-action scoping in both directions: `publish` accepts an unusable `timeout`, and `status` / `list_topics` accept all three.
* cross-transport parity over the whole probe set, asserting the **reason** rather than the verdict - with neither backend installed both tools error for *some* reason, so a status-only assertion would pass vacuously.

Pre-fix / post-fix on this base:

```
upstream/main   33 failed, 4 passed
this branch     37 passed
```

The 4 that pass on both are the positive-path and no-false-positive cases, which should hold either way.

`tests/tools/test_use_rtps.py::test_echo_times_out_with_empty_samples` used `timeout=0.0` as a shortcut to reach the empty-result branch. A zero timeout is not a wait a caller can ask for, and it also skipped the polling loop entirely, so the branch it was written for never ran. It now uses `0.01`, which expires against a never-yielding reader after one real poll; the assertion is unchanged.

## Gate

```
ruff check strands_robots tests tests_integ         All checks passed!
ruff format --check strands_robots tests tests_integ 946 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 943 source files
MUJOCO_GL=egl pytest tests -q --no-cov              13386 passed, 253 skipped in 451s
```

Docs: the `Safety` section of `docs/ros2-integration.md` gains the accepted domain for each option and which actions read it; `docs/rtps-integration.md` gets the equivalent paragraph noting the domain is shared with `use_ros`.

## Review rounds

### Round 1

Static analysis flagged the `_get_message` fake in the new test as a redundant lambda wrapper (`tests/tools/test_transport_numeric_option_guards.py:83`).

The finding is correct and worth taking rather than dismissing as a test-only nit: the production contract is that `_get_message` returns a message *class*, which `_publish` then calls as a constructor (`msg_cls()`). The fake returned `lambda msg_type: lambda: object()`, adding a factory layer the real contract does not have. It now returns `object` directly, which models the actual contract.

Behaviour is unchanged - `msg_cls()` still constructs the same instance - and the positive-path assertions (`len(published_at) == 4` and `== 2`) continue to exercise that construction call, so the line is still covered rather than merely made to pass. 37/37 tests pass after the change.

No production code touched in this round.