### PR TITLE
fix(mesh): refuse a navigation goal the bridge cannot honor

### DIFF
--- a/changelog.d/1721-navigation-goal-pose-guard.md
+++ b/changelog.d/1721-navigation-goal-pose-guard.md
@@ -1,0 +1,37 @@
+### Fixed: a navigation goal the bridge cannot honor is refused instead of sent
+
+`RosBridgedRobot.navigate_to` hands a goal pose to the robot's own navigation
+stack, so the coordinates are the whole command - and none of them was
+validated. `use_ros` cannot cover this: it checks the action name and interface
+type and (since the transport-option guards) the `timeout`, but the pose travels
+inside the request body, which it forwards verbatim.
+
+```python
+robot.navigate_to(x=float("nan"), y=0.0)   # status 'success'
+# -> goal sent: position {'x': nan, 'y': 0.0}
+robot.navigate_to(x=float("inf"), y=0.0)   # status 'success', inf on the wire
+robot.navigate_to(x=1.0, y=2.0, yaw=float("nan"))
+# -> goal sent with orientation {'z': nan, 'w': nan}: not a rotation at all
+robot.navigate_to(x=1.0, y=2.0, yaw=float("inf"))
+# ValueError: math domain error   (raised past the result dict)
+robot.navigate_to(x=None, y=2.0)
+# TypeError: float() argument must be a string or a real number, not 'NoneType'
+robot.navigate_to(x=True, y=2.0)           # status 'success', goal at x = 1.0 m
+```
+
+A non-finite coordinate serializes as a valid IEEE-754 float64, so the transport
+accepts the goal and the planner receives a target it cannot resolve, with
+nothing reported at the call site. A non-finite heading is worse than
+unresolvable: the planar-quaternion encoding either produces `{z: nan, w: nan}`,
+which no controller can normalize into a heading, or raises out of `math.sin`
+for an infinite angle - and `navigate_to` is bound as a `navigate_*` agent tool,
+where raising escapes the `{"status": ...}` dispatch contract entirely.
+
+`navigate_to` now returns an error result naming the parameter - sending no goal
+- for an `x`, `y` or `yaw` that is not a finite number. The rule is the shared
+`strands_robots.utils.finite_number_error` already used for `drive`'s velocity
+components, since a goal coordinate and a velocity are both signed physical
+quantities: both signs stay valid, and a regression test pins that the two
+methods return the same verdict for the same value so the domains cannot drift.
+The existing "no `nav_action` configured" report still precedes the pose check,
+and every goal that worked before is unchanged.

--- a/strands_robots/mesh/ros_bridge.py
+++ b/strands_robots/mesh/ros_bridge.py
@@ -8,7 +8,10 @@ hardware robots. All ROS 2 I/O is forwarded through the
 inherits ``use_ros``'s in-process ``rclpy`` backend and its topic/type
 validation. The parameters ``use_ros`` never sees are validated here: a
 :meth:`RosBridgedRobot.drive` command whose velocity, hold duration or message
-count cannot be honored is refused without publishing anything.
+count cannot be honored is refused without publishing anything, and a
+:meth:`RosBridgedRobot.navigate_to` goal whose pose cannot be honored is refused
+without sending anything - the goal coordinates travel inside the request body,
+which ``use_ros`` forwards verbatim.
 
 Typical usage::
 
@@ -264,21 +267,45 @@ class RosBridgedRobot:
         cancels the goal so the robot does not keep navigating unattended.
 
         Args:
-            x: Goal position x in ``frame_id`` (meters).
-            y: Goal position y in ``frame_id`` (meters).
-            yaw: Goal heading in radians, encoded as a planar quaternion.
+            x: Goal position x in ``frame_id`` (meters). Must be a finite
+                number; both signs are valid.
+            y: Goal position y in ``frame_id`` (meters). Must be a finite
+                number; both signs are valid.
+            yaw: Goal heading in radians, encoded as a planar quaternion. Must
+                be a finite number; both signs are valid (negative turns the
+                other way).
             frame_id: Frame the goal pose is expressed in (default ``map``).
             timeout: End-to-end budget in seconds for the navigation goal.
+                Forwarded to ``use_ros``, which refuses a non-positive or
+                non-finite budget.
 
         Returns:
             The ``use_ros`` action result dict (goal status, result, feedback
-            samples), or an error result when no ``nav_action`` was configured.
+            samples), or an ``{"status": "error"}`` result when no
+            ``nav_action`` was configured or when a pose component cannot be
+            honored - in which case no goal is sent.
         """
         if not self.nav_action:
             return {
                 "status": "error",
                 "content": [{"text": "navigate_to: no nav_action configured for this robot"}],
             }
+        # The goal pose is the part of this call ``use_ros`` never validates: it
+        # checks the action name and interface type, but the coordinates travel
+        # inside ``fields`` and are serialized into the request verbatim. A
+        # non-finite coordinate is a valid IEEE-754 float64 on the wire, so the
+        # goal is accepted and handed to a planner that cannot resolve it, and
+        # ``yaw`` additionally reaches ``math.sin``/``math.cos``, which raise a
+        # bare ``ValueError`` for an infinite angle - out of a method whose
+        # contract is a result dict, and out of the bound ``navigate_*`` tool.
+        # ``timeout`` does reach ``use_ros`` and is guarded there.
+        pose_err = (
+            finite_number_error(x, "x", "navigate_to")
+            or finite_number_error(y, "y", "navigate_to")
+            or finite_number_error(yaw, "yaw", "navigate_to")
+        )
+        if pose_err:
+            return {"status": "error", "content": [{"text": pose_err}]}
         half = 0.5 * float(yaw)
         fields = {
             "pose": {

--- a/tests/mesh/test_navigation_goal_guards.py
+++ b/tests/mesh/test_navigation_goal_guards.py
@@ -1,0 +1,168 @@
+"""A navigation goal the bridge cannot honor is refused before it is sent.
+
+:meth:`RosBridgedRobot.navigate_to` hands a goal pose to the robot's own
+navigation stack, so the coordinates are the whole command. They travel inside
+the action request body, which ``use_ros`` forwards verbatim - it validates the
+action name and interface type, and it guards ``timeout``, but it never inspects
+the pose. Without a guard on the bridge a pose that cannot be honored has two
+silent outcomes: a non-finite coordinate serializes as a valid IEEE-754 float64
+and the goal is accepted by the transport and handed to a planner that cannot
+resolve it, or the planar-quaternion encoding raises a bare
+``ValueError``/``TypeError`` out of a method whose contract is a
+``{"status": ...}`` result dict - and ``navigate_to`` is exposed to an agent as a
+``navigate_*`` tool, where raising escapes the dispatch contract entirely.
+
+The pose components are signed physical quantities, so they share the accepted
+domain of :meth:`RosBridgedRobot.drive`'s velocity components; the parity test
+here pins that one rule rather than two.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.ros_bridge as ros_mod
+from strands_robots.mesh import RosBridgedRobot
+
+_NAV_ACTION = "/navigate_to_pose"
+
+# A coordinate and a heading are signed, so only non-finite and non-numeric
+# values are refusable. ``inf`` yaw is the one that raises today (``math.sin``
+# rejects an infinite angle); ``nan`` yaw is the one that silently ships an
+# unnormalizable quaternion.
+_BAD_POSE_VALUES = [math.nan, math.inf, -math.inf, "1.0", None, [1.0], True, False]
+
+
+class _Wire:
+    """Stands in for ``use_ros``, recording every forwarded request."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"status": "success", "content": [{"text": "goal reached"}]}
+
+
+@pytest.fixture
+def bridge(monkeypatch: pytest.MonkeyPatch) -> tuple[RosBridgedRobot, _Wire]:
+    """A nav-capable bridge plus the wire recorder it forwards goals to."""
+    wire = _Wire()
+    monkeypatch.setattr(ros_mod, "use_ros", wire)
+    return RosBridgedRobot("tb", "/cmd_vel", "/odom", nav_action=_NAV_ACTION), wire
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block.get("text", "") for block in result["content"])
+
+
+def _goal_pose(call: dict[str, Any]) -> dict[str, Any]:
+    pose: dict[str, Any] = call["fields"]["pose"]["pose"]
+    return pose
+
+
+class TestRefusedGoalNeverReachesTheWire:
+    """A refusable pose component yields an error result and sends nothing."""
+
+    @pytest.mark.parametrize("value", _BAD_POSE_VALUES)
+    @pytest.mark.parametrize("param", ["x", "y", "yaw"])
+    def test_a_pose_component_the_planner_cannot_resolve_is_refused(
+        self, bridge: tuple[RosBridgedRobot, _Wire], param: str, value: Any
+    ) -> None:
+        robot, wire = bridge
+        goal: dict[str, Any] = {"x": 1.0, "y": 2.0}
+        goal[param] = value
+        result = robot.navigate_to(**goal)
+        assert result["status"] == "error"
+        assert param in _text(result)
+        assert wire.calls == []
+
+    def test_the_first_refusable_component_is_named(self, bridge: tuple[RosBridgedRobot, _Wire]) -> None:
+        """Several bad components at once name one parameter, not a merged message."""
+        robot, wire = bridge
+        result = robot.navigate_to(x=math.nan, y=math.inf, yaw=math.nan)
+        assert result["status"] == "error"
+        assert "x" in _text(result)
+        assert "y must" not in _text(result) and "yaw" not in _text(result)
+        assert wire.calls == []
+
+    def test_a_missing_nav_action_is_still_reported_before_the_pose(self) -> None:
+        """The capability check precedes the parameter guard, as ``drive``'s does."""
+        robot = RosBridgedRobot("tb", "/cmd_vel", "/odom")
+        result = robot.navigate_to(x=math.nan, y=math.nan)
+        assert result["status"] == "error"
+        assert "no nav_action configured" in _text(result)
+
+
+class TestHonoredGoalsAreStillSent:
+    """The guard does not narrow the set of goals that already worked."""
+
+    def test_a_planar_goal_is_encoded_as_a_unit_quaternion(self, bridge: tuple[RosBridgedRobot, _Wire]) -> None:
+        robot, wire = bridge
+        assert robot.navigate_to(x=1.5, y=-2.5, yaw=math.pi / 2)["status"] == "success"
+        pose = _goal_pose(wire.calls[0])
+        assert pose["position"] == {"x": 1.5, "y": -2.5}
+        assert pose["orientation"]["z"] == pytest.approx(math.sin(math.pi / 4))
+        assert pose["orientation"]["w"] == pytest.approx(math.cos(math.pi / 4))
+
+    @pytest.mark.parametrize("x,y,yaw", [(0.0, 0.0, 0.0), (-12.0, 8.5, -math.pi), (1e-9, 1e9, 2.5)])
+    def test_a_signed_finite_goal_is_forwarded_verbatim(
+        self, bridge: tuple[RosBridgedRobot, _Wire], x: float, y: float, yaw: float
+    ) -> None:
+        robot, wire = bridge
+        assert robot.navigate_to(x=x, y=y, yaw=yaw)["status"] == "success"
+        assert _goal_pose(wire.calls[0])["position"] == {"x": x, "y": y}
+
+    def test_an_integer_goal_is_usable(self, bridge: tuple[RosBridgedRobot, _Wire]) -> None:
+        """A coordinate is continuous, so a whole-number goal is a valid one."""
+        robot, wire = bridge
+        assert robot.navigate_to(x=3, y=-4)["status"] == "success"
+        assert _goal_pose(wire.calls[0])["position"] == {"x": 3.0, "y": -4.0}
+
+    def test_a_numpy_scalar_goal_is_usable(self, bridge: tuple[RosBridgedRobot, _Wire]) -> None:
+        """A goal read out of a pose array arrives as a NumPy scalar."""
+        import numpy as np
+
+        robot, wire = bridge
+        # Splatted so the NumPy scalars reach the runtime guard as an agent
+        # would supply them, rather than being narrowed to ``float`` statically.
+        goal: dict[str, Any] = {"x": np.float32(0.5), "y": np.float64(-0.25)}
+        assert robot.navigate_to(**goal)["status"] == "success"
+        assert _goal_pose(wire.calls[0])["position"]["x"] == pytest.approx(0.5)
+
+    def test_the_frame_and_timeout_are_still_forwarded(self, bridge: tuple[RosBridgedRobot, _Wire]) -> None:
+        robot, wire = bridge
+        assert robot.navigate_to(x=1.0, y=1.0, frame_id="odom", timeout=30.0)["status"] == "success"
+        assert wire.calls[0]["fields"]["pose"]["header"]["frame_id"] == "odom"
+        assert wire.calls[0]["timeout"] == 30.0
+
+
+class TestAgentToolContract:
+    """The bound ``navigate_*`` agent tool returns a result; it never raises."""
+
+    @pytest.mark.parametrize("kwargs", [{"yaw": math.inf}, {"x": None}, {"y": [1.0]}, {"x": math.nan}])
+    def test_the_bound_navigate_tool_reports_instead_of_raising(
+        self, bridge: tuple[RosBridgedRobot, _Wire], kwargs: dict[str, Any]
+    ) -> None:
+        robot, wire = bridge
+        goal: dict[str, Any] = {"x": 1.0, "y": 2.0, **kwargs}
+        navigate_tool: Any = next(t for t in robot.tools if t.tool_name.startswith("navigate_"))
+        result = navigate_tool(**goal)
+        assert result["status"] == "error"
+        assert wire.calls == []
+
+
+class TestPoseAndVelocityShareOneDomain:
+    """A goal coordinate and a velocity component are both signed scalars."""
+
+    @pytest.mark.parametrize("value", [*_BAD_POSE_VALUES, 0.0, -1.0, 2.5, 1e300])
+    def test_navigate_to_and_drive_return_the_same_verdict(
+        self, bridge: tuple[RosBridgedRobot, _Wire], value: Any
+    ) -> None:
+        robot, _wire = bridge
+        nav = robot.navigate_to(x=value, y=0.0)["status"]
+        drive = robot.drive(linear=value)["status"]
+        assert nav == drive, f"verdicts differ for {value!r}: navigate_to={nav}, drive={drive}"


### PR DESCRIPTION
## Problem

`RosBridgedRobot.navigate_to` hands a goal pose to the robot's own navigation stack, so the coordinates *are* the whole command. None of `x`, `y` or `yaw` was validated.

`use_ros` cannot cover this. It checks the action name and interface type, and since the transport-option guards it also refuses a non-positive or non-finite `timeout` - but the pose travels inside the action request body, which `use_ros` forwards verbatim. The module docstring already states the contract this method was missing: *"The parameters `use_ros` never sees are validated here"* - and it named only `drive`.

Measured against a recording transport, with the goal that reached the wire printed verbatim:

| call | status | goal sent |
|---|---|---|
| `navigate_to(x=2.5, y=1.5, yaw=0.79)` | `success` | `position {x: 2.5, y: 1.5}`, `orientation {z: 0.385, w: 0.923}` |
| `navigate_to(x=nan, y=1.5)` | `success` | `position {x: nan, y: 1.5}` |
| `navigate_to(x=inf, y=1.5)` | `success` | `position {x: inf, y: 1.5}` |
| `navigate_to(x=2.5, y=1.5, yaw=nan)` | `success` | `orientation {z: nan, w: nan}` |
| `navigate_to(x=2.5, y=1.5, yaw=inf)` | **raised** `ValueError: math domain error` | - |
| `navigate_to(x=None, y=1.5)` | **raised** `TypeError: float() argument must be a string or a real number, not 'NoneType'` | - |
| `navigate_to(x=True, y=1.5)` | `success` | `position {x: 1.0, y: 1.5}` |

Three distinct failures from one missing check:

- **A non-finite coordinate is accepted and forwarded.** It serializes as a valid IEEE-754 float64, so the transport accepts the goal and the planner receives a target it cannot resolve. Every `nan` comparison is false, so a bounds check on the receiving side passes rather than rejects. Nothing is reported at the call site.
- **A non-finite heading is not a rotation.** `yaw=nan` produces `{z: nan, w: nan}`, which no controller can normalize into a heading, and it ships under `status: success`. `yaw=inf` instead raises out of `math.sin`, past a method documented to return a result dict.
- **A non-real value raises past the tool contract.** `navigate_to` is bound as a `navigate_*` agent tool, so `x=None` or `x=[1.0]` escapes `{"status": ...}` dispatch entirely with a bare `TypeError` from the `float()` coercion - naming neither the method nor the parameter.

`x=True` is the quiet one: `bool` is an `int` subclass, so it slid through as a goal one metre out on x.

## Change

`navigate_to` returns an error result naming the parameter - sending no goal - for an `x`, `y` or `yaw` that is not a finite number.

The rule is the shared `strands_robots.utils.finite_number_error` already used for `drive`'s `linear`/`angular`. A goal coordinate and a velocity component are the same kind of quantity: a signed physical scalar the bridge forwards verbatim, where both signs are legitimate (a goal behind the robot, a reverse velocity) so only finiteness and numeric-ness can be constrained. Reusing that one function is what keeps the two methods' accepted domains from diverging, and `TestPoseAndVelocityShareOneDomain` pins it by asserting `navigate_to` and `drive` return the same verdict for the same value.

Guard placement follows `drive`'s: the existing "no `nav_action` configured" capability report still comes first (a bridge with no navigation stack should say so rather than critique the pose), then the parameter guard, then the quaternion encoding and the forward. So a refused goal never reaches `math.sin` and never reaches the transport.

`timeout` is deliberately not re-checked here - it does reach `use_ros`, which already refuses a non-positive or non-finite budget. The docstring now says so, so the division of responsibility is readable at the call site.

## Tests

New `tests/mesh/test_navigation_goal_guards.py`, 49 tests, sibling to the existing `test_drive_command_guards.py`:

- **`TestRefusedGoalNeverReachesTheWire`** - every refusable value on each of `x`/`y`/`yaw` yields an error naming that parameter and leaves the recording transport with zero calls; several bad components at once name one parameter rather than a merged message; a bridge with no `nav_action` still reports that first.
- **`TestHonoredGoalsAreStillSent`** - a planar goal is still encoded as a unit quaternion, signed and integer and NumPy-scalar goals are still honored, `frame_id` and `timeout` are still forwarded.
- **`TestAgentToolContract`** - the bound `navigate_*` tool reports instead of raising for the four values that used to raise or silently ship.
- **`TestPoseAndVelocityShareOneDomain`** - the parity test above.

Pre-fix on this base: **37 failed, 12 passed**. Post-fix: **49 passed**. The pre-fix failures are the defect verbatim, including the two that are not assertion failures at all:

```
FAILED ...[x-nan]     - AssertionError: assert 'success' == 'error'
FAILED ...[yaw-inf]   - ValueError: math domain error
FAILED ...[x-None]    - TypeError: float() argument must be a string or a real number, not 'NoneType'
FAILED ...same_verdict[True] - AssertionError: verdicts differ for True: navigate_to=success, drive=error
```

## Visual artifact

The goals recorded at the transport boundary, same six calls against both trees, plotted in the map frame. Before, four of six goals reach the navigation stack: one honored, one with a heading that is not a rotation, and two with no location on the map at all. After, one of six reaches it - the one that was honored all along - and the other five are refused by name with nothing sent.

![navigate_to goal wire trace](https://raw.githubusercontent.com/cagataycali/robots/artifacts/navigation-goal-pose-guard/nav_goal_guard.png)

## Gate

- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - 948 files already formatted
- `mypy strands_robots tests tests_integ` - `Success: no issues found in 945 source files`
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` - **13577 passed, 253 skipped** in 465s
- `python scripts/assemble_changelog.py --check` - OK; news fragment `changelog.d/1721-navigation-goal-pose-guard.md`