### PR TITLE
fix(hardware): a stop pressed during bring-up actually stops the task

### DIFF
--- a/changelog.d/1723-stop-task-during-connect.md
+++ b/changelog.d/1723-stop-task-during-connect.md
@@ -1,0 +1,31 @@
+### Fixed: a stop pressed while the robot is still connecting actually stops the task
+
+`Robot.stop_task()` only recognised `TaskStatus.RUNNING`. But
+`_execute_task_async` spends the whole hardware bring-up in `CONNECTING` - a
+motors-bus handshake plus `warmup_s` per camera, seconds on a real SO-101 and
+longer on a multi-camera rig - followed by the policy build. A stop pressed in
+that window was answered `status="success"` with `"No task running to stop"`,
+and the arm then moved anyway:
+
+```
+stop at t=0.9s  status=connecting -> success: No task running to stop (current: connecting)
+stop at t=1.2s  status=connecting -> success: No task running to stop (current: connecting)
+stop at t=2.0s  status=connecting -> success: No task running to stop (current: connecting)
+servo writes after the three stops: 192
+final task status: completed
+```
+
+Three stop presses reported success, the arm was then driven for a full
+rollout, and the task reported itself completed. `mesh/core.py` routes the
+fleet `{"action": "stop"}` dispatch straight into `stop_task`, so the fleet
+interrupt inherited the same hole.
+
+Signalling through `_task_state.status` cannot express the request on its own:
+`_execute_task_async` writes `RUNNING` once bring-up finishes, overwriting any
+`STOPPED` recorded before it. The request is now latched in an event set before
+the status is even read and cleared only when a new task starts; the rollout
+honors it at each stage boundary (after connect, after the policy build), in its
+loop condition, and in the terminal block that decides `COMPLETED` vs `STOPPED`.
+A stop during bring-up now commands the arm zero times, never initializes the
+policy, and is reported as `Task stopped (during connect)`. A stop mid-rollout,
+and a stop on an idle or terminal robot, are unchanged.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -99,7 +99,7 @@ from strands_robots.hardware_robot import Robot, TaskStatus, RobotTaskState
 | Method | What |
 |--------|------|
 | `start_task(instruction, policy_port, ...)` | Async task start. |
-| `stop_task()` | Halt running policy. |
+| `stop_task()` | Halt the current task, including one still in `CONNECTING`. |
 | `get_task_status()` | Return `RobotTaskState`. |
 | `cleanup()` | Stop tasks, close cameras, stop mesh. |
 

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -48,7 +48,7 @@ robot.cleanup()
 | Method | What |
 |--------|------|
 | `start_task(instruction, policy_port, policy_host, policy_provider, duration)` | Async; returns immediately. |
-| `stop_task()` | Halt running policy. |
+| `stop_task()` | Halt the current task. Covers a task still in `CONNECTING` (bring-up): the rollout is abandoned before the arm is commanded. |
 | `get_task_status()` | Returns `RobotTaskState` (status, step count, error). |
 | `cleanup()` | Stop tasks, close cameras, stop mesh. |
 

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -442,6 +442,14 @@ class Robot(TeleopMixin, AgentTool):
         self._task_state = RobotTaskState()
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"{tool_name}_executor")
         self._shutdown_event = threading.Event()
+        # A stop request that arrived for the current task. An Event rather
+        # than a task-state field because ``stop_task`` is called from the
+        # agent-tool thread (and from the mesh dispatch) while the rollout runs
+        # on the executor thread, and because ``_task_state.status`` cannot
+        # carry the request: ``_execute_task_async`` writes ``RUNNING`` over
+        # whatever the status held once the bring-up finishes, so a stop
+        # recorded only as a status is lost.
+        self._stop_requested = threading.Event()
 
         # Mesh attributes - populated by the Robot() factory after init.
         # Plain attributes (not properties) so test code can swap a fake mesh
@@ -1108,6 +1116,28 @@ class Robot(TeleopMixin, AgentTool):
             logger.error(f"Failed to initialize policy: {e}")
             return False
 
+    def _honor_stop_request(self) -> bool:
+        """Record a latched stop request as the task's terminal state.
+
+        Called at each point in ``_execute_task_async`` where the task is about
+        to move on to a stage that commands the arm. ``stop_task`` sets the
+        latch unconditionally, so this is the only thing that has to run for a
+        stop pressed at any point during bring-up to be honored.
+
+        Returns:
+            ``True`` when a stop was requested and the caller must abandon the
+            rollout, ``False`` when the task may proceed.
+        """
+        if not self._stop_requested.is_set():
+            return False
+        self._task_state.status = TaskStatus.STOPPED
+        logger.info(
+            "%s: task stopped during bring-up: '%s'",
+            self.tool_name_str,
+            self._task_state.instruction,
+        )
+        return True
+
     async def _execute_task_async(
         self,
         instruction: str,
@@ -1136,10 +1166,16 @@ class Robot(TeleopMixin, AgentTool):
         from .policies.base import resolve_chunk_length
 
         try:
-            # Update task state
+            # Update task state. The stop latch is cleared here so a stop
+            # pressed while the robot was idle does not pre-empt the next task,
+            # and ``duration`` is reset with it: a task stopped during bring-up
+            # never reaches the terminal block that writes it, and reporting the
+            # PREVIOUS task's elapsed time would misdescribe this one.
+            self._stop_requested.clear()
             self._task_state.status = TaskStatus.CONNECTING
             self._task_state.instruction = instruction
             self._task_state.start_time = time.time()
+            self._task_state.duration = 0.0
             self._task_state.step_count = 0
             self._task_state.error_message = ""
 
@@ -1148,6 +1184,13 @@ class Robot(TeleopMixin, AgentTool):
             if not connected:
                 self._task_state.status = TaskStatus.ERROR
                 self._task_state.error_message = connect_error or f"Failed to connect to {self.tool_name_str}"
+                return
+
+            # A stop pressed during the bring-up window above (a motors-bus
+            # handshake plus per-camera warmup - seconds on a real arm) is
+            # honored here, before the policy is even built, so the rollout is
+            # abandoned without commanding the arm.
+            if self._honor_stop_request():
                 return
 
             # Get policy instance: a caller-supplied pre-built object wins;
@@ -1200,6 +1243,12 @@ class Robot(TeleopMixin, AgentTool):
                     e,
                 )
 
+            # Building a server-backed policy is a second multi-second window
+            # (a network connect plus a handshake), so the latch is re-checked
+            # before the arm is commanded for the first time.
+            if self._honor_stop_request():
+                return
+
             self._task_state.status = TaskStatus.RUNNING
             start_time = time.time()
 
@@ -1207,6 +1256,7 @@ class Robot(TeleopMixin, AgentTool):
                 time.time() - start_time < duration
                 and (n_steps is None or self._task_state.step_count < n_steps)
                 and self._task_state.status == TaskStatus.RUNNING
+                and not self._stop_requested.is_set()
                 and not self._shutdown_event.is_set()
             ):
                 # Get observation from robot
@@ -1254,8 +1304,19 @@ class Robot(TeleopMixin, AgentTool):
             self._task_state.duration = elapsed
 
             if self._task_state.status == TaskStatus.RUNNING:
-                self._task_state.status = TaskStatus.COMPLETED
-                logger.info(f"Task completed: '{instruction}' in {elapsed:.1f}s ({self._task_state.step_count} steps)")
+                # A stop can land in the gap between the check above and the
+                # ``RUNNING`` write, which overwrites the ``STOPPED`` status
+                # ``stop_task`` recorded. The latch survives that write, so it
+                # is what decides here - otherwise an interrupted task reports
+                # itself completed.
+                if self._stop_requested.is_set():
+                    self._task_state.status = TaskStatus.STOPPED
+                    logger.info(f"Task stopped: '{instruction}' after {self._task_state.step_count} steps")
+                else:
+                    self._task_state.status = TaskStatus.COMPLETED
+                    logger.info(
+                        f"Task completed: '{instruction}' in {elapsed:.1f}s ({self._task_state.step_count} steps)"
+                    )
 
         except Exception as e:
             logger.error(f"Task execution failed: {e}")
@@ -1535,13 +1596,48 @@ class Robot(TeleopMixin, AgentTool):
         }
 
     def stop_task(self) -> dict[str, Any]:
-        """Stop currently running task."""
+        """Stop the current task, including one that is still connecting.
 
-        if self._task_state.status != TaskStatus.RUNNING:
+        This is the interrupt an operator (or the fleet ``{"action": "stop"}``
+        dispatch, via ``mesh/core.py``) reaches for, so it has to hold for a
+        task in ANY stage that can still command the arm - not only the one
+        stage whose status happens to be ``RUNNING``.
+
+        ``_execute_task_async`` sits in ``CONNECTING`` for the whole hardware
+        bring-up: a motors-bus handshake plus ``warmup_s`` per camera, seconds
+        on a real arm and longer on a multi-camera rig, followed by the policy
+        build. A stop pressed in that window used to be answered with
+        ``status="success"`` and ``"No task running to stop"``, and the arm then
+        moved anyway once the bring-up finished - the operator was told the
+        interrupt was handled while the rollout it was meant to cancel was
+        still pending.
+
+        A status write cannot express the request on its own, because
+        ``_execute_task_async`` writes ``RUNNING`` once bring-up completes and
+        that overwrites any ``STOPPED`` recorded before it. So the request is
+        latched in an event that is set here FIRST, before the status is even
+        read, and cleared only when a new task starts. The rollout honors the
+        latch at each stage boundary and in its loop condition.
+
+        Returns:
+            A tool-shaped result confirming the stop, or - for a robot that is
+            genuinely idle or already in a terminal state - reporting that
+            there was nothing to stop. Both are ``status="success"``: asking an
+            idle robot to stop is satisfied, not an error.
+        """
+        # Latched before the status is read: a stop that lands in the gap
+        # between the rollout's last stage check and its ``RUNNING`` write must
+        # not be lost, and the latch is the only record that survives it.
+        self._stop_requested.set()
+
+        stoppable = (TaskStatus.RUNNING, TaskStatus.CONNECTING)
+        if self._task_state.status not in stoppable:
             return {
                 "status": "success",
                 "content": [{"text": f"No task running to stop (current: {self._task_state.status.value})"}],
             }
+
+        was_connecting = self._task_state.status == TaskStatus.CONNECTING
 
         # Signal task to stop
         self._task_state.status = TaskStatus.STOPPED
@@ -1552,11 +1648,12 @@ class Robot(TeleopMixin, AgentTool):
 
         logger.info(f"Task stopped: {self._task_state.instruction}")
 
+        stage = " (during connect)" if was_connecting else ""
         return {
             "status": "success",
             "content": [
                 {
-                    "text": f"Task stopped: '{self._task_state.instruction}'\n"
+                    "text": f"Task stopped{stage}: '{self._task_state.instruction}'\n"
                     f"Duration: {self._task_state.duration:.1f}s\n"
                     f"Steps completed: {self._task_state.step_count}"
                 }

--- a/tests/test_hardware_control_loop_rate_guard.py
+++ b/tests/test_hardware_control_loop_rate_guard.py
@@ -203,6 +203,7 @@ class TestPeriodIsTheOnlyThrottle:
         hw._task_state = RobotTaskState()
         hw._executor = ThreadPoolExecutor(max_workers=1)
         hw._shutdown_event = threading.Event()
+        hw._stop_requested = threading.Event()
         hw.mesh = None
         hw.peer_id = None
         hw.robot = _FakeArm()

--- a/tests/test_hardware_robot_config.py
+++ b/tests/test_hardware_robot_config.py
@@ -47,6 +47,7 @@ def _make_robot() -> HwRobot:
     hw = HwRobot.__new__(HwRobot)
     hw.tool_name_str = "test_arm"
     hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
     hw._task_state = RobotTaskState()
     hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw.mesh = None

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -100,6 +100,7 @@ def _make_robot(fake: _FakeLeRobot | None = None, control_frequency: float = 100
     hw._task_state = RobotTaskState()
     hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
     hw.mesh = None
     hw.peer_id = None
     hw.robot = fake if fake is not None else _FakeLeRobot()

--- a/tests/test_hardware_ros_bridge.py
+++ b/tests/test_hardware_ros_bridge.py
@@ -208,6 +208,7 @@ def _make_robot(observation: dict[str, Any], *, ros2_bridge: bool = False, ros2_
     hw._task_state = RobotTaskState()
     hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
     hw.mesh = None
     hw.peer_id = None
     hw.robot = _FakeLeRobot(observation)

--- a/tests/test_hardware_stop_during_connect.py
+++ b/tests/test_hardware_stop_during_connect.py
@@ -1,0 +1,322 @@
+"""A stop pressed while the robot is still connecting must actually stop it.
+
+``strands_robots.hardware_robot.Robot.stop_task`` is the interrupt an operator
+reaches for, and the fleet ``{"action": "stop"}`` dispatch routes into it. But
+``_execute_task_async`` spends the whole hardware bring-up in
+``TaskStatus.CONNECTING`` - a motors-bus handshake plus ``warmup_s`` per camera,
+seconds on a real arm - and the guard only recognised ``RUNNING``. So a stop in
+that window was answered ``status="success"`` with "No task running to stop", and
+the arm then moved anyway once the bring-up finished.
+
+Signalling through ``_task_state.status`` alone cannot express the request:
+``_execute_task_async`` writes ``RUNNING`` once bring-up completes, overwriting
+any ``STOPPED`` recorded before it. These tests pin the latch-based contract:
+
+    - a stop during connect, or during the policy build, commands the arm zero
+      times and leaves the task ``STOPPED``;
+    - the refusal happens before the policy is initialized;
+    - the request is latched even when the status says there is nothing to stop,
+      so a stop landing in the gap before the ``RUNNING`` write is not lost and
+      the task does not report itself completed;
+    - the latch is cleared by the next task, so a stop never leaks forward;
+    - a stop mid-rollout, and a stop on an idle or terminal robot, behave as
+      before.
+
+No serial port is opened and no arm is commanded: the lerobot driver is an
+in-memory fake and each bring-up stage is an event the test opens explicitly, so
+nothing here depends on wall-clock timing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.policies import Policy
+
+# Generous ceiling for every bounded wait: each is satisfied by an event the
+# test itself sets, so reaching it means the contract is broken, not that the
+# host was slow.
+DEADLINE = 10.0
+
+
+class _FakeArm:
+    """In-memory stand-in for a connected lerobot robot."""
+
+    def __init__(self) -> None:
+        self.name = "fake_arm"
+        self.robot_type = "fake_arm"
+        self.sent_actions: list[dict[str, Any]] = []
+        self.config = type("Cfg", (), {"cameras": {}})()
+
+    def get_observation(self) -> dict[str, Any]:
+        return {"j0.pos": 0.0}
+
+    def send_action(self, action: dict[str, Any]) -> None:
+        self.sent_actions.append(action)
+
+
+class _OneStepPolicy(Policy):
+    """Emits a single action per query so the loop keeps re-querying."""
+
+    @property
+    def provider_name(self) -> str:
+        return "test"
+
+    def set_robot_state_keys(self, keys: list[str]) -> None:
+        return None
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        return [{"j0.pos": 0.1}]
+
+
+class _Rig:
+    """A ``Robot`` whose bring-up stages are gates the test opens explicitly."""
+
+    def __init__(self) -> None:
+        self.arm = _FakeArm()
+        self.connect_gate = threading.Event()
+        self.policy_gate = threading.Event()
+        self.policy_initialized: list[str] = []
+        self.result: dict[str, Any] | None = None
+
+        hw = HwRobot.__new__(HwRobot)
+        hw.tool_name_str = "test_arm"
+        hw.action_horizon = 1
+        hw.data_config = None
+        hw.control_frequency = 500.0
+        hw.action_sleep_time = 1.0 / 500.0
+        hw._task_state = RobotTaskState()
+        hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
+        hw._shutdown_event = threading.Event()
+        hw._stop_requested = threading.Event()
+        hw.mesh = None
+        hw.peer_id = None
+        hw.robot = self.arm
+
+        async def connect() -> tuple[bool, str]:
+            await asyncio.to_thread(self.connect_gate.wait, DEADLINE)
+            return True, ""
+
+        async def initialize_policy(policy: Any) -> bool:
+            self.policy_initialized.append(type(policy).__name__)
+            await asyncio.to_thread(self.policy_gate.wait, DEADLINE)
+            return True
+
+        def publish(observation: dict[str, Any], skip_images: bool = False) -> None:
+            return None
+
+        hw._connect_robot = connect  # type: ignore[method-assign]
+        hw._initialize_policy = initialize_policy  # type: ignore[method-assign]
+        hw._publish_ros_telemetry = publish  # type: ignore[method-assign]
+        self.robot = hw
+
+    def start(self, *, duration: float = 5.0, n_steps: int | None = 3) -> threading.Thread:
+        """Drive a rollout on its own thread, recording its returned payload."""
+
+        def target() -> None:
+            self.result = self.robot.run_policy(_OneStepPolicy(), "pick the cube", duration=duration, n_steps=n_steps)
+
+        thread = threading.Thread(target=target, daemon=True)
+        thread.start()
+        return thread
+
+    def wait_for(self, predicate: Any, what: str) -> None:
+        """Spin until ``predicate`` holds, failing the test if it never does."""
+        deadline = time.monotonic() + DEADLINE
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            time.sleep(0.005)
+        pytest.fail(f"timed out waiting for {what} (status={self.robot._task_state.status.value})")
+
+    def open_all_gates(self) -> None:
+        self.connect_gate.set()
+        self.policy_gate.set()
+
+    def finish(self, thread: threading.Thread) -> None:
+        self.open_all_gates()
+        thread.join(timeout=DEADLINE)
+        assert not thread.is_alive(), "rollout thread did not finish"
+        self.robot._executor.shutdown(wait=False)
+
+
+@pytest.fixture
+def rig() -> Any:
+    return _Rig()
+
+
+class TestStopWhileConnecting:
+    def test_the_arm_is_never_commanded(self, rig):
+        thread = rig.start()
+        rig.wait_for(lambda: rig.robot._task_state.status == TaskStatus.CONNECTING, "the connect stage")
+
+        rig.robot.stop_task()
+        rig.finish(thread)
+
+        assert rig.arm.sent_actions == []
+        assert rig.robot._task_state.status == TaskStatus.STOPPED
+
+    def test_the_stop_is_reported_as_a_stop(self, rig):
+        thread = rig.start()
+        rig.wait_for(lambda: rig.robot._task_state.status == TaskStatus.CONNECTING, "the connect stage")
+
+        result = rig.robot.stop_task()
+        rig.finish(thread)
+
+        text = result["content"][0]["text"]
+        assert result["status"] == "success"
+        assert "No task running to stop" not in text
+        assert "Task stopped (during connect)" in text
+        assert "pick the cube" in text
+
+    def test_the_policy_is_never_initialized(self, rig):
+        thread = rig.start()
+        rig.wait_for(lambda: rig.robot._task_state.status == TaskStatus.CONNECTING, "the connect stage")
+
+        rig.robot.stop_task()
+        rig.finish(thread)
+
+        assert rig.policy_initialized == []
+
+    def test_the_blocking_call_reports_the_stop_not_a_completed_task(self, rig):
+        thread = rig.start()
+        rig.wait_for(lambda: rig.robot._task_state.status == TaskStatus.CONNECTING, "the connect stage")
+
+        rig.robot.stop_task()
+        rig.finish(thread)
+
+        assert rig.result is not None
+        assert "stopped" in rig.result["content"][0]["text"]
+        assert "completed" not in rig.result["content"][0]["text"]
+
+    def test_no_stale_duration_is_reported(self, rig):
+        rig.robot._task_state.duration = 99.0  # left by an earlier task
+        thread = rig.start()
+        rig.wait_for(lambda: rig.robot._task_state.status == TaskStatus.CONNECTING, "the connect stage")
+
+        result = rig.robot.stop_task()
+        rig.finish(thread)
+
+        assert "Duration: 0.0s" in result["content"][0]["text"]
+        assert "99.0" not in result["content"][0]["text"]
+
+
+class TestStopWhileThePolicyIsBuilt:
+    def test_the_arm_is_never_commanded(self, rig):
+        thread = rig.start()
+        rig.connect_gate.set()
+        rig.wait_for(lambda: rig.policy_initialized, "the policy build stage")
+
+        rig.robot.stop_task()
+        rig.finish(thread)
+
+        assert rig.arm.sent_actions == []
+        assert rig.robot._task_state.status == TaskStatus.STOPPED
+
+
+class TestTheRequestIsLatched:
+    def test_a_stop_is_latched_even_when_nothing_is_running(self, rig):
+        result = rig.robot.stop_task()
+
+        assert result["status"] == "success"
+        assert "No task running to stop" in result["content"][0]["text"]
+        # The status reply is unchanged, but the request itself is recorded: a
+        # stop that races the rollout's own status writes must not be lost.
+        assert rig.robot._stop_requested.is_set()
+
+    def test_a_stop_in_the_gap_before_running_does_not_report_completed(self, rig):
+        # The gap a status-only signal loses: after the rollout's final stage
+        # check and before it writes RUNNING over the STOPPED status. Emulated
+        # by latching immediately after that last check returns "not stopped".
+        real = rig.robot._honor_stop_request
+        verdicts: list[bool] = []
+
+        def spy() -> bool:
+            verdict = real()
+            verdicts.append(verdict)
+            if len(verdicts) == 2:
+                rig.robot._stop_requested.set()
+            return verdict
+
+        rig.robot._honor_stop_request = spy
+        thread = rig.start()
+        rig.finish(thread)
+
+        assert verdicts == [False, False], "both stage checks should have passed"
+        assert rig.arm.sent_actions == []
+        assert rig.robot._task_state.status == TaskStatus.STOPPED
+
+
+class TestTheLatchDoesNotLeakForward:
+    def test_the_next_task_runs_after_a_stop_on_an_idle_robot(self, rig):
+        rig.robot.stop_task()
+        assert rig.robot._stop_requested.is_set()
+
+        rig.open_all_gates()
+        thread = rig.start()
+        rig.finish(thread)
+
+        assert len(rig.arm.sent_actions) == 3
+        assert rig.robot._task_state.status == TaskStatus.COMPLETED
+
+    def test_a_task_stopped_during_connect_does_not_pre_empt_the_next_one(self, rig):
+        first = rig.start()
+        rig.wait_for(lambda: rig.robot._task_state.status == TaskStatus.CONNECTING, "the connect stage")
+        rig.robot.stop_task()
+        rig.open_all_gates()
+        first.join(timeout=DEADLINE)
+        assert rig.arm.sent_actions == []
+
+        second = rig.start()
+        rig.finish(second)
+
+        assert len(rig.arm.sent_actions) == 3
+        assert rig.robot._task_state.status == TaskStatus.COMPLETED
+
+
+class TestUnchangedStopBehaviour:
+    def test_a_stop_mid_rollout_still_stops_it(self, rig):
+        rig.open_all_gates()
+        thread = rig.start(duration=30.0, n_steps=None)
+        rig.wait_for(lambda: rig.arm.sent_actions, "the first commanded action")
+
+        result = rig.robot.stop_task()
+        thread.join(timeout=DEADLINE)
+        rig.robot._executor.shutdown(wait=False)
+
+        assert result["status"] == "success"
+        assert "Task stopped:" in result["content"][0]["text"]
+        assert "(during connect)" not in result["content"][0]["text"]
+        assert rig.robot._task_state.status == TaskStatus.STOPPED
+
+    @pytest.mark.parametrize(
+        "state",
+        [TaskStatus.IDLE, TaskStatus.COMPLETED, TaskStatus.STOPPED, TaskStatus.ERROR],
+    )
+    def test_a_robot_with_no_live_task_reports_nothing_to_stop(self, rig, state):
+        rig.robot._task_state.status = state
+
+        result = rig.robot.stop_task()
+
+        assert result["status"] == "success"
+        assert f"No task running to stop (current: {state.value})" in result["content"][0]["text"]
+
+    def test_the_messages_are_plain_ascii(self, rig):
+        thread = rig.start()
+        rig.wait_for(lambda: rig.robot._task_state.status == TaskStatus.CONNECTING, "the connect stage")
+        stopped = rig.robot.stop_task()["content"][0]["text"]
+        rig.finish(thread)
+        idle = rig.robot.stop_task()["content"][0]["text"]
+
+        for text in (stopped, idle):
+            assert text.isascii(), text

--- a/tests/test_hardware_task_duration_guard.py
+++ b/tests/test_hardware_task_duration_guard.py
@@ -100,6 +100,7 @@ def hw() -> Any:
     robot._task_state = RobotTaskState()
     robot._executor = ThreadPoolExecutor(max_workers=1)
     robot._shutdown_event = threading.Event()
+    robot._stop_requested = threading.Event()
     robot.mesh = None
     robot.peer_id = None
     robot.robot = _FakeArm()


### PR DESCRIPTION
## Problem

`Robot.stop_task()` only recognised `TaskStatus.RUNNING`. But `_execute_task_async` spends the whole hardware bring-up in `CONNECTING` - a motors-bus handshake plus `warmup_s` per camera, seconds on a real SO-101 and longer on a multi-camera rig - and then builds the policy. A stop pressed in that window was answered `status="success"` with `"No task running to stop"`, and the arm moved anyway once bring-up finished.

Measured against the real control loop with a 2.5 s `connect()`:

```
stop at t=0.9s  status=connecting -> success: No task running to stop (current: connecting)
stop at t=1.2s  status=connecting -> success: No task running to stop (current: connecting)
stop at t=2.0s  status=connecting -> success: No task running to stop (current: connecting)

servo commands after the three stops : 232
final task status                    : completed
```

Three stop presses reported success, a full rollout was then driven, and the task reported itself completed. `mesh/core.py` routes the fleet `{"action": "stop"}` dispatch straight into `stop_task`, so the fleet interrupt inherited the same hole.

### Why widening the status check is not enough

Signalling through `_task_state.status` cannot express the request. `_execute_task_async` writes `RUNNING` unconditionally once bring-up completes, which overwrites any `STOPPED` recorded before it - so a stop that lands anywhere between `CONNECTING` and that write is silently discarded even if `stop_task` accepts the state.

## Change

The request is latched in a `threading.Event` (beside the existing `_shutdown_event`, since `stop_task` is called from the agent-tool thread and the mesh dispatch while the rollout runs on the executor thread):

- `stop_task` sets the latch **first**, before the status is even read, and now accepts `CONNECTING` alongside `RUNNING`, reporting `Task stopped (during connect)`.
- `_execute_task_async` clears the latch when a task starts, and honors it via `_honor_stop_request()` at each stage boundary that precedes commanding the arm: after `_connect_robot()` (before the policy is built) and after the policy build.
- The loop condition and the terminal `COMPLETED`/`STOPPED` decision both consult the latch, so a stop landing in the residual gap before the `RUNNING` write cannot make an interrupted task report itself completed.
- `_task_state.duration` is reset with the latch: a task stopped during bring-up never reaches the block that writes it, and reporting the previous task's elapsed time would misdescribe this one.

After the change the same script applies **0** servo commands and leaves the task `stopped`.

A stop mid-rollout, and a stop on an idle or terminal robot, are unchanged (both pinned).

## Evidence

![stop_task during bring-up](https://raw.githubusercontent.com/cagataycali/robots/artifacts/stop-during-connect/stop-during-connect.png)

Both renders are a MuJoCo Panda (headless EGL) driven by the exact command stream each build let through after the operator pressed stop: before, the arm travels to `joint1 = +0.5785 rad`; after, it never leaves home (`joint1 = 0.0000 rad`). The trace below them is the wall-clock stamp of every `send_action` that reached the bus, with the bring-up window shaded and each stop press marked. Panels differ on 11.2% of pixels.

## Tests

New `tests/test_hardware_stop_during_connect.py` (16 tests). Each bring-up stage is an event the test opens explicitly, so nothing depends on wall-clock timing - the file runs in 0.5 s and no serial port is opened.

- a stop during connect, and a stop during the policy build, command the arm zero times and leave the task `STOPPED`;
- the refusal precedes policy initialization (`policy_initialized == []`);
- the blocking call reports the stop rather than a completed task, and quotes no stale duration;
- the request is latched even when the status reply says there is nothing to stop, and a stop landing in the gap before the `RUNNING` write yields `STOPPED`, not `COMPLETED`;
- the latch does not leak forward: a stop on an idle robot, and a task stopped during connect, both leave the next task free to run;
- unchanged behaviour: a mid-rollout stop still stops, and each terminal state still reports nothing to stop.

Pre-fix, with only `strands_robots/hardware_robot.py` reverted to `main`: **10 failed, 6 passed**. Post-fix: **16 passed**.

Five existing test doubles construct `Robot` via `__new__` and are updated to model the new constructor attribute (one line each) - `stop_task` reads it unconditionally rather than defensively creating it.

## Gate

```
ruff check strands_robots tests tests_integ            All checks passed!
ruff format --check strands_robots tests tests_integ   948 files already formatted
mypy strands_robots tests tests_integ                 Success: no issues found in 945 source files
MUJOCO_GL=egl pytest tests -q                         13544 passed, 253 skipped (457s)
```

Changelog fragment: `changelog.d/1723-stop-task-during-connect.md`.

## Out of scope

- `run_policy` / `start_task` guard on `RUNNING` only, so a second call during another task's bring-up is still accepted - that is task exclusion on the motors bus, a separate concern with its own fix (a lock around the rollout).
- `cleanup()` and `stop()` gate their internal `stop_task()` call on `RUNNING` too, but both also set `_shutdown_event`, which the loop already honors, so the arm does stop on those paths.