### PR TITLE
fix(hardware): refuse a second rollout while one owns the motors bus

### DIFF
--- a/changelog.d/1725-one-rollout-per-bus.md
+++ b/changelog.d/1725-one-rollout-per-bus.md
@@ -1,0 +1,27 @@
+### Fixed: a second rollout can no longer be admitted onto a busy motors bus
+
+`start_task`, `run_policy` and the agent-tool `execute` action each refused a
+concurrent task with `if self._task_state.status == TaskStatus.RUNNING`. That
+status is only reached after `_connect_robot()` and the policy build, so for the
+whole bring-up window - a motors-bus handshake plus per-camera warmup, seconds
+on a real arm - every caller read a non-running status and was let through. Two
+control loops then drove one bus: with a 1 s `connect()` and two policies
+tagging their own commands, the wire carried
+`BBBB...BABABABABABABABABAB` with two `send_action` transactions in flight at
+once, `connect()` was called twice on the same port, and both calls returned
+`status: "success"`. The bus is half-duplex and not thread-safe, so interleaved
+transactions give framing errors or a `Goal_Position` write from one policy
+landing between the other's read and write - two different intents applied to
+one physical arm. Sharing the single `_task_state` slot also let each rollout
+overwrite the other's step count and terminal status, so one of them reported
+completing steps it never commanded.
+
+Admission is now a claim taken before the bring-up window opens and released
+when the rollout ends - including when it errors or raises, so a failed task
+cannot leave the robot refusing every later one. The check-and-claim runs under
+a lock, so callers racing at the same instant cannot both be admitted, and
+`start_task` claims on the caller's thread rather than inside its executor job:
+it returns before that job begins, so a claim taken there would have reported
+"Task started" and only then turned the caller away. The refusal names the
+rollout that actually holds the bus, which during bring-up was previously
+reported as whichever task ran last.

--- a/changelog.d/1725-one-rollout-per-bus.md
+++ b/changelog.d/1725-one-rollout-per-bus.md
@@ -17,9 +17,10 @@ overwrite the other's step count and terminal status, so one of them reported
 completing steps it never commanded.
 
 Admission is now a claim taken before the bring-up window opens and released
-when the rollout ends - including when it errors or raises, so a failed task
-cannot leave the robot refusing every later one. The check-and-claim runs under
-a lock, so callers racing at the same instant cannot both be admitted, and
+when the rollout ends - including when it errors, raises, or is stopped during
+bring-up, so a failed or interrupted task cannot leave the robot refusing every
+later one. The check-and-claim runs under a lock, so callers racing at the same
+instant cannot both be admitted, and
 `start_task` claims on the caller's thread rather than inside its executor job:
 it returns before that job begins, so a claim taken there would have reported
 "Task started" and only then turned the caller away. The refusal names the

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -52,6 +52,12 @@ robot.cleanup()
 | `get_task_status()` | Returns `RobotTaskState` (status, step count, error). |
 | `cleanup()` | Stop tasks, close cameras, stop mesh. |
 
+One rollout at a time: the arm has a single command bus, so `start_task` /
+`run_policy` / the `execute` action refuse while another task is in flight and
+name it in the error. That includes the `CONNECTING` bring-up window - a motors
+bus handshake plus per-camera warmup, seconds on a real arm - not just
+`RUNNING`. Call `stop_task()` to hand the bus over early.
+
 ## AgentTool actions
 
 | Action | Blocking? | Needs |

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -450,6 +450,17 @@ class Robot(TeleopMixin, AgentTool):
         # whatever the status held once the bring-up finishes, so a stop
         # recorded only as a status is lost.
         self._stop_requested = threading.Event()
+        # Admission control for the motors bus. The arm has one command bus and
+        # this class already models one rollout at a time (a single-slot
+        # ``_task_state``, ``max_workers=1``), but ``_task_state.status`` cannot
+        # decide admission: ``_execute_task_async`` only reaches ``RUNNING``
+        # after ``_connect_robot`` and the policy build, so for the whole
+        # bring-up window a second task would read a non-running status. The
+        # claim is taken before that window opens and released when the rollout
+        # ends, and the lock makes the check-and-claim atomic so two callers
+        # racing at the same instant cannot both be admitted.
+        self._task_admission = threading.Lock()
+        self._task_claimed = False
 
         # Mesh attributes - populated by the Robot() factory after init.
         # Plain attributes (not properties) so test code can swap a fake mesh
@@ -1364,6 +1375,54 @@ class Robot(TeleopMixin, AgentTool):
             return {"status": "error", "content": [{"text": error}]}
         return None
 
+    def _claim_task(self, instruction: str) -> dict[str, Any] | None:
+        """Claim the motors bus for one rollout, or refuse a concurrent one.
+
+        Admission has to be decided here rather than from
+        ``_task_state.status``: that status only becomes ``RUNNING`` once
+        ``_execute_task_async`` has finished connecting and building the
+        policy, so a status-based check admits every caller that arrives during
+        bring-up - a motors-bus handshake plus per-camera warmup, seconds on a
+        real arm. Two admitted rollouts then interleave ``send_action`` writes
+        on one half-duplex bus, and because they share the single
+        ``_task_state`` slot they also overwrite each other's step count and
+        terminal status, so both report success while only one of them was
+        actually driving the arm.
+
+        The claimed instruction is recorded on the task state immediately, so a
+        refusal names the rollout that actually holds the bus instead of
+        whichever task ran last.
+
+        Args:
+            instruction: Instruction of the rollout being admitted, used for
+                the refusal text shown to a second caller.
+
+        Returns:
+            ``None`` when the caller now owns the bus and must eventually call
+            :meth:`_release_task`, or a tool-shaped error naming the rollout
+            already in flight.
+        """
+        with self._task_admission:
+            if self._task_claimed:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": f"Task already running: {self._task_state.instruction}\n"
+                            f"{self.tool_name_str} drives one rollout at a time - the arm has a single "
+                            f"command bus. Wait for it to finish or call action='stop' first."
+                        }
+                    ],
+                }
+            self._task_claimed = True
+            self._task_state.instruction = instruction
+        return None
+
+    def _release_task(self) -> None:
+        """Release the motors-bus claim taken by :meth:`_claim_task`."""
+        with self._task_admission:
+            self._task_claimed = False
+
     def _execute_task_sync(
         self,
         instruction: str,
@@ -1374,14 +1433,76 @@ class Robot(TeleopMixin, AgentTool):
         policy_object: Policy | None = None,
         n_steps: int | None = None,
     ) -> dict[str, Any]:
-        """Execute task synchronously in thread - no new event loop."""
-        # Validated here as well as at the public methods below: this is the
-        # chokepoint the agent-tool "execute" action and the mesh "execute"
-        # dispatch reach directly, so a peer-supplied budget is refused before
-        # the arm is commanded rather than after.
+        """Execute task synchronously in thread - no new event loop.
+
+        This is the chokepoint the agent-tool ``execute`` action and the mesh
+        ``execute`` dispatch reach directly, so it both validates the
+        peer-supplied budget and claims the motors bus before the arm is
+        commanded.
+        """
+        # Validated here as well as at the public methods below: a peer-supplied
+        # budget is refused before the arm is commanded rather than after. The
+        # check is stateless, so it runs before the claim - a rejected budget
+        # must not take the bus away from a rollout that could still start.
         if err := self._duration_error(duration, "execute_task"):
             return err
+        if err := self._claim_task(instruction):
+            return err
 
+        return self._drive_claimed_task(
+            instruction,
+            policy_port,
+            policy_host,
+            policy_provider,
+            duration,
+            policy_object=policy_object,
+            n_steps=n_steps,
+        )
+
+    def _drive_claimed_task(
+        self,
+        instruction: str,
+        policy_port: int | None = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        policy_object: Policy | None = None,
+        n_steps: int | None = None,
+    ) -> dict[str, Any]:
+        """Run the control loop for an already-admitted task and report it.
+
+        The caller must already hold the claim from :meth:`_claim_task`; this
+        method always releases it, including when the rollout raises, so a
+        failed task never leaves the robot permanently refusing new ones. The
+        claim is taken by the callers rather than here because ``start_task``
+        returns before its executor job begins: it has to be able to refuse a
+        second caller synchronously instead of reporting a task as started and
+        only then turning that caller away on the background thread.
+        """
+        try:
+            return self._run_control_loop(
+                instruction,
+                policy_port,
+                policy_host,
+                policy_provider,
+                duration,
+                policy_object=policy_object,
+                n_steps=n_steps,
+            )
+        finally:
+            self._release_task()
+
+    def _run_control_loop(
+        self,
+        instruction: str,
+        policy_port: int | None = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        policy_object: Policy | None = None,
+        n_steps: int | None = None,
+    ) -> dict[str, Any]:
+        """Drive the rollout on its own event loop and report the outcome."""
         # Import here to avoid conflicts
         import asyncio
 
@@ -1453,7 +1574,9 @@ class Robot(TeleopMixin, AgentTool):
 
         Returns:
             Tool-shaped result confirming the task started, or an error naming
-            the offending parameter.
+            the offending parameter. A second task is refused while another
+            rollout is in flight - including during its connect/policy-build
+            bring-up - because the arm has a single command bus.
         """
         # Before the submit: the work happens on a background thread, so a
         # budget checked inside it would still report "Task started" to the
@@ -1461,17 +1584,23 @@ class Robot(TeleopMixin, AgentTool):
         if err := self._duration_error(duration, "start_task"):
             return err
 
-        # Check if task is already running
-        if self._task_state.status == TaskStatus.RUNNING:
-            return {
-                "status": "error",
-                "content": [{"text": f"Task already running: {self._task_state.instruction}"}],
-            }
+        # Claim the bus here, not on the executor thread: this method returns
+        # before its job begins, so a claim taken inside the job would report
+        # "Task started" to a second caller and only then turn it away, with
+        # nobody left to tell.
+        if err := self._claim_task(instruction):
+            return err
 
-        # Start task in background
-        self._task_state.task_future = self._executor.submit(
-            self._execute_task_sync, instruction, policy_port, policy_host, policy_provider, duration
-        )
+        # Start task in background. The claim is released by
+        # ``_drive_claimed_task`` when the rollout ends; if the submit itself
+        # fails (a shut-down executor) nothing would ever run to release it.
+        try:
+            self._task_state.task_future = self._executor.submit(
+                self._drive_claimed_task, instruction, policy_port, policy_host, policy_provider, duration
+            )
+        except BaseException:
+            self._release_task()
+            raise
 
         return {
             "status": "success",
@@ -1508,6 +1637,12 @@ class Robot(TeleopMixin, AgentTool):
         thread. For the server-backed provider path (and for fire-and-forget
         execution) use ``start_task``.
 
+        Exclusive: the arm has a single command bus, so this is refused while
+        another rollout is in flight - including while that rollout is still
+        connecting or building its policy, before it reports ``RUNNING``.
+        Two rollouts admitted at once would interleave ``send_action`` writes
+        on one half-duplex bus and share the single task-state slot.
+
         Args:
             policy_object: A constructed ``Policy`` instance. The object's
                 own device / embodiment / chunking configuration is honored;
@@ -1530,22 +1665,20 @@ class Robot(TeleopMixin, AgentTool):
         Returns:
             Tool-shaped result: a text summary plus a ``{"json": ...}`` block
             carrying ``status`` / ``steps`` / ``duration_s`` / ``instruction``
-            / ``policy`` (and ``error`` when one occurred).
+            / ``policy`` (and ``error`` when one occurred), or an error naming
+            the rollout already in flight.
         """
         if policy_object is None:
             return {
                 "status": "error",
                 "content": [{"text": "policy_object is required (for the provider+port path use start_task)"}],
             }
-        if self._task_state.status == TaskStatus.RUNNING:
-            return {
-                "status": "error",
-                "content": [{"text": f"Task already running: {self._task_state.instruction}"}],
-            }
         if err := self._duration_error(duration, "run_policy"):
             return err
+        if err := self._claim_task(instruction):
+            return err
 
-        self._execute_task_sync(instruction, duration=duration, policy_object=policy_object, n_steps=n_steps)
+        self._drive_claimed_task(instruction, duration=duration, policy_object=policy_object, n_steps=n_steps)
 
         succeeded = self._task_state.status == TaskStatus.COMPLETED
         summary = (

--- a/tests/mesh/test_mesh_robustness.py
+++ b/tests/mesh/test_mesh_robustness.py
@@ -240,6 +240,8 @@ def test_hardware_robot_cleanup_stops_mesh() -> None:
 
     hw.tool_name_str = "fakebot"
     hw._shutdown_event = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
     hw._task_state = MagicMock()
     hw._task_state.status = "IDLE"
     hw._executor = ThreadPoolExecutor(max_workers=1)

--- a/tests/mesh/test_teleop_identifier_source_scoping.py
+++ b/tests/mesh/test_teleop_identifier_source_scoping.py
@@ -181,6 +181,8 @@ def hardware_robot() -> Any:
     hw._task_state = RobotTaskState()
     hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="teleop_guard")
     hw._shutdown_event = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
     return hw
 
 

--- a/tests/test_hardware_control_loop_rate_guard.py
+++ b/tests/test_hardware_control_loop_rate_guard.py
@@ -204,6 +204,8 @@ class TestPeriodIsTheOnlyThrottle:
         hw._executor = ThreadPoolExecutor(max_workers=1)
         hw._shutdown_event = threading.Event()
         hw._stop_requested = threading.Event()
+        hw._task_admission = threading.Lock()
+        hw._task_claimed = False
         hw.mesh = None
         hw.peer_id = None
         hw.robot = _FakeArm()

--- a/tests/test_hardware_one_rollout_per_bus.py
+++ b/tests/test_hardware_one_rollout_per_bus.py
@@ -1,0 +1,329 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Only one rollout at a time may drive the motors bus.
+
+``start_task`` / ``run_policy`` / the agent-tool ``execute`` action all guarded
+concurrency with ``if self._task_state.status == TaskStatus.RUNNING``. But
+``_execute_task_async`` writes ``CONNECTING`` first and only reaches ``RUNNING``
+after ``_connect_robot()`` and the policy build - a motors-bus handshake plus
+per-camera warmup, seconds on a real arm. Every caller arriving inside that
+window read a non-running status and was admitted, so two control loops drove
+one ``FeetechMotorsBus`` at once.
+
+Measured against the real loop with a 1 s ``connect()`` and two policies tagging
+their own commands::
+
+    status during 2nd call        : connecting
+    2nd run_policy verdict        : success        <- admitted
+    connect() calls on one bus    : 2
+    commands on the wire          : BBBB...BABABABABABABABABAB
+    peak concurrent transactions  : 2              <- two loops mid-transaction
+    per-tag counts                : {'B': 108, 'A': 38}
+
+The bus is half-duplex and not thread-safe: interleaved ``sync_read`` /
+``sync_write`` transactions give framing errors, or a ``Goal_Position`` write
+from one policy landing between the other's read and write - two different
+intents applied to one physical arm. And because both rollouts share the single
+``_task_state`` slot, they overwrite each other's step count and terminal
+status, so both calls report success while only one was really driving.
+
+The fix is an admission claim taken before the bring-up window opens and
+released when the rollout ends, with the check-and-claim under a lock so two
+callers racing at the same instant cannot both be admitted.
+
+No serial port is opened and no arm is commanded: a gated in-memory double
+stands in for the driver, and the bring-up window is opened by the test rather
+than slept through, so every assertion here is deterministic.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.policies.base import Policy
+
+#: Upper bound on any wait, so a broken contract fails instead of hanging.
+DEADLINE = 10.0
+
+#: ``gripper.pos`` value -> the policy that commanded it. Rollouts are attributed
+#: by the value they write on a declared joint, so the double never receives a
+#: key a real driver would reject.
+TAGS: dict[float, str] = {0.11: "A", 0.22: "B"}
+
+
+class GatedBus:
+    """Motors-bus double whose ``connect()`` blocks until the test opens it.
+
+    Records which rollout's commands reached the wire and the peak number of
+    ``send_action`` calls in flight at once - anything above 1 means two loops
+    were mid-transaction on one half-duplex port.
+    """
+
+    def __init__(self) -> None:
+        self.name = self.robot_type = "gated_arm"
+        self.is_calibrated = True
+        self.config = type("Cfg", (), {"cameras": {}})()
+        self._connected = False
+        self.connect_calls = 0
+        self.connect_entered = threading.Event()
+        self.connect_gate = threading.Event()
+        self.writers: list[str] = []
+        self.max_concurrent = 0
+        self._in_flight = 0
+        self._lock = threading.Lock()
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def connect(self, calibrate: bool = False) -> None:
+        self.connect_calls += 1
+        self.connect_entered.set()
+        if not self.connect_gate.wait(DEADLINE):  # pragma: no cover - deadline
+            raise TimeoutError("bring-up gate never opened")
+        self._connected = True
+
+    def disconnect(self) -> None:
+        self._connected = False
+
+    def get_observation(self) -> dict[str, Any]:
+        return {"gripper.pos": 0.0}
+
+    def send_action(self, action: dict[str, Any]) -> None:
+        with self._lock:
+            self._in_flight += 1
+            self.max_concurrent = max(self.max_concurrent, self._in_flight)
+            self.writers.append(TAGS[action["gripper.pos"]])
+            self._in_flight -= 1
+
+
+class TaggedPolicy(Policy):
+    """Commands one identifying ``gripper.pos`` value every step."""
+
+    def __init__(self, tag: str) -> None:
+        self.value = next(v for v, t in TAGS.items() if t == tag)
+
+    @property
+    def provider_name(self) -> str:
+        return "tagged"
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        pass
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        return [{"gripper.pos": self.value}] * 4
+
+
+def make_robot(bus: GatedBus | None = None) -> HwRobot:
+    """Build a Robot bypassing hardware init (the pattern used across tests/)."""
+    hw = HwRobot.__new__(HwRobot)
+    hw.tool_name_str = "gated_arm"
+    hw.action_horizon = 4
+    hw.data_config = None
+    hw.control_frequency = 500.0
+    hw.action_sleep_time = 1.0 / 500.0
+    hw._task_state = RobotTaskState()
+    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gated_arm_executor")
+    hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
+    hw.mesh = None
+    hw.peer_id = None
+    hw.robot = bus if bus is not None else GatedBus()
+    return hw
+
+
+@pytest.fixture
+def bus() -> GatedBus:
+    return GatedBus()
+
+
+@pytest.fixture
+def hw(bus: GatedBus) -> Any:
+    robot = make_robot(bus)
+    yield robot
+    bus.connect_gate.set()
+    robot.cleanup()
+
+
+def _rollout_in_bringup(hw: HwRobot, bus: GatedBus, tag: str, steps: int) -> tuple[threading.Thread, dict]:
+    """Start a rollout on a thread and return once it is inside ``connect()``."""
+    out: dict[str, Any] = {}
+    thread = threading.Thread(
+        target=lambda: out.__setitem__(
+            "result",
+            hw.run_policy(policy_object=TaggedPolicy(tag), instruction=f"rollout {tag}", n_steps=steps),
+        ),
+        daemon=True,
+    )
+    thread.start()
+    assert bus.connect_entered.wait(DEADLINE), "rollout never reached connect()"
+    assert hw._task_state.status is TaskStatus.CONNECTING
+    return thread, out
+
+
+class TestBringUpWindowIsExclusive:
+    """The window a status-based guard could not see."""
+
+    def test_a_second_rollout_during_bring_up_never_reaches_the_bus(self, hw: HwRobot, bus: GatedBus):
+        thread, first = _rollout_in_bringup(hw, bus, "A", steps=6)
+
+        # Bring-up is opened by a third thread rather than after the refusal, so
+        # a wrongly admitted second rollout also gets past connect() and its
+        # commands reach the wire. What keeps the bus single-writer here is the
+        # refusal, not the test holding the gate shut.
+        opener = threading.Timer(0.2, bus.connect_gate.set)
+        opener.start()
+        try:
+            second = hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=6)
+        finally:
+            opener.join(DEADLINE)
+
+        assert second["status"] == "error"
+        assert "already running" in second["content"][0]["text"].lower()
+
+        thread.join(DEADLINE)
+        assert first["result"]["status"] == "success"
+
+        # Only the admitted rollout drove the arm, it connected once, and no two
+        # transactions were ever in flight together.
+        assert set(bus.writers) == {"A"}
+        assert bus.connect_calls == 1
+        assert bus.max_concurrent == 1
+        assert hw._task_state.step_count == 6
+
+    def test_start_task_during_bring_up_is_refused_synchronously(self, hw: HwRobot, bus: GatedBus):
+        thread, _ = _rollout_in_bringup(hw, bus, "A", steps=4)
+        before = hw._task_state.task_future
+
+        result = hw.start_task("rollout B", policy_port=5555)
+
+        # Refused by the caller's own thread: start_task returns before its
+        # executor job runs, so a claim taken inside the job would have reported
+        # "Task started" and only then turned this caller away.
+        assert result["status"] == "error"
+        assert "already running" in result["content"][0]["text"].lower()
+        assert hw._task_state.task_future is before
+
+        bus.connect_gate.set()
+        thread.join(DEADLINE)
+        assert set(bus.writers) == {"A"}
+
+    def test_the_execute_chokepoint_during_bring_up_is_refused(self, hw: HwRobot, bus: GatedBus):
+        # The agent-tool "execute" action and the mesh execute dispatch reach
+        # this method directly, bypassing run_policy/start_task entirely.
+        thread, _ = _rollout_in_bringup(hw, bus, "A", steps=4)
+
+        result = hw._execute_task_sync("rollout B", policy_port=5555)
+
+        assert result["status"] == "error"
+        assert "already running" in result["content"][0]["text"].lower()
+
+        bus.connect_gate.set()
+        thread.join(DEADLINE)
+        assert set(bus.writers) == {"A"}
+        assert bus.connect_calls == 1
+
+    def test_the_refusal_names_the_rollout_that_holds_the_bus(self, hw: HwRobot, bus: GatedBus):
+        hw._task_state.instruction = "a task that already finished"
+        thread, _ = _rollout_in_bringup(hw, bus, "A", steps=4)
+
+        text = hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=4)["content"][0]["text"]
+
+        # Named from the claim, not from whatever ran last: the task state's
+        # instruction is otherwise only written once bring-up is under way.
+        assert "rollout A" in text
+        assert "a task that already finished" not in text
+
+        bus.connect_gate.set()
+        thread.join(DEADLINE)
+
+
+class TestTheClaimIsAlwaysReleased:
+    """A robot that refused one task must not refuse every later one."""
+
+    def test_a_completed_rollout_hands_the_bus_back(self, hw: HwRobot, bus: GatedBus):
+        bus.connect_gate.set()
+
+        first = hw.run_policy(policy_object=TaggedPolicy("A"), instruction="rollout A", n_steps=4)
+        second = hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=4)
+
+        assert first["status"] == "success"
+        assert second["status"] == "success"
+        assert bus.writers == ["A"] * 4 + ["B"] * 4
+
+    def test_a_failed_connect_hands_the_bus_back(self, hw: HwRobot, bus: GatedBus):
+        bus.connect_gate.set()
+        bus.is_calibrated = False
+
+        failed = hw.run_policy(policy_object=TaggedPolicy("A"), instruction="rollout A", n_steps=4)
+        assert failed["status"] == "error"
+
+        bus.is_calibrated = True
+        assert hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=4)["status"] == "success"
+
+    def test_a_raising_rollout_hands_the_bus_back(self, hw: HwRobot, bus: GatedBus, monkeypatch):
+        bus.connect_gate.set()
+
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("driver exploded")
+
+        monkeypatch.setattr(hw, "_run_control_loop", boom)
+        with pytest.raises(RuntimeError, match="driver exploded"):
+            hw.run_policy(policy_object=TaggedPolicy("A"), instruction="rollout A", n_steps=4)
+
+        monkeypatch.undo()
+        assert hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=4)["status"] == "success"
+
+    def test_a_refused_duration_does_not_take_the_bus(self, hw: HwRobot, bus: GatedBus):
+        bus.connect_gate.set()
+
+        refused = hw.run_policy(policy_object=TaggedPolicy("A"), instruction="rollout A", duration=-1.0)
+        assert refused["status"] == "error"
+        assert "duration" in refused["content"][0]["text"]
+
+        # The budget check is stateless, so rejecting it must not have taken the
+        # bus away from a rollout that can still start.
+        assert hw._task_claimed is False
+        assert hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=4)["status"] == "success"
+
+    def test_a_failed_submit_does_not_leak_the_claim(self, hw: HwRobot, bus: GatedBus):
+        hw._executor.shutdown(wait=True)
+
+        with pytest.raises(RuntimeError):
+            hw.start_task("rollout B", policy_port=5555)
+
+        # Nothing ran to release the claim, so start_task has to unwind it
+        # itself or the robot refuses every task for the rest of its life.
+        assert hw._task_claimed is False
+
+
+class TestAdmissionIsAtomic:
+    def test_simultaneous_callers_admit_exactly_one(self, hw: HwRobot, bus: GatedBus):
+        # Every thread calls in at the same instant, so a check that is not
+        # atomic with the claim lets more than one through.
+        callers = 8
+        start = threading.Barrier(callers)
+        verdicts: list[str | None] = [None] * callers
+
+        def caller(index: int) -> None:
+            start.wait(DEADLINE)
+            verdicts[index] = hw._claim_task(f"rollout {index}") is None and "admitted" or "refused"
+
+        threads = [threading.Thread(target=caller, args=(i,), daemon=True) for i in range(callers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(DEADLINE)
+
+        assert verdicts.count("admitted") == 1
+        assert verdicts.count("refused") == callers - 1
+        hw._release_task()

--- a/tests/test_hardware_one_rollout_per_bus.py
+++ b/tests/test_hardware_one_rollout_per_bus.py
@@ -295,6 +295,30 @@ class TestTheClaimIsAlwaysReleased:
         assert hw._task_claimed is False
         assert hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=4)["status"] == "success"
 
+    def test_a_rollout_stopped_during_bring_up_hands_the_bus_back(self, hw: HwRobot, bus: GatedBus):
+        # Where the two bring-up fixes meet. A stop latched during bring-up is
+        # honored by ``_execute_task_async`` as soon as connect() returns, which
+        # abandons the rollout *before* the arm is commanded - so it never
+        # reaches the terminal block, and the release has to come from the
+        # ``finally`` rather than from a rollout that ran to completion. Without
+        # that, stopping a task during bring-up would cost the bus permanently.
+        thread, stopped = _rollout_in_bringup(hw, bus, "A", steps=4)
+
+        assert hw.stop_task()["status"] == "success"
+        bus.connect_gate.set()
+        thread.join(DEADLINE)
+
+        assert hw._task_state.status is TaskStatus.STOPPED
+        assert stopped["result"]["status"] == "error"
+        # Abandoned during bring-up, so nothing was ever put on the wire.
+        assert bus.writers == []
+        assert hw._task_claimed is False
+
+        # And the bus is genuinely usable again, not merely unclaimed.
+        second = hw.run_policy(policy_object=TaggedPolicy("B"), instruction="rollout B", n_steps=4)
+        assert second["status"] == "success"
+        assert set(bus.writers) == {"B"}
+
     def test_a_failed_submit_does_not_leak_the_claim(self, hw: HwRobot, bus: GatedBus):
         hw._executor.shutdown(wait=True)
 

--- a/tests/test_hardware_robot_config.py
+++ b/tests/test_hardware_robot_config.py
@@ -48,6 +48,8 @@ def _make_robot() -> HwRobot:
     hw.tool_name_str = "test_arm"
     hw._shutdown_event = threading.Event()
     hw._stop_requested = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
     hw._task_state = RobotTaskState()
     hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw.mesh = None

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -101,6 +101,8 @@ def _make_robot(fake: _FakeLeRobot | None = None, control_frequency: float = 100
     hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw._shutdown_event = threading.Event()
     hw._stop_requested = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
     hw.mesh = None
     hw.peer_id = None
     hw.robot = fake if fake is not None else _FakeLeRobot()
@@ -175,9 +177,16 @@ class TestStopTask:
 
 class TestStartTask:
     def test_start_when_already_running_returns_error(self):
+        """A second start is refused while a rollout owns the motors bus.
+
+        The in-flight rollout is represented by taking the real admission
+        claim rather than by writing ``RUNNING`` onto the task state: the
+        status only reaches ``RUNNING`` after connect and the policy build, so
+        it is not what decides admission (see
+        ``tests/test_hardware_one_rollout_per_bus.py``).
+        """
         hw = _make_robot()
-        hw._task_state.status = TaskStatus.RUNNING
-        hw._task_state.instruction = "busy"
+        assert hw._claim_task("busy") is None
         result = hw.start_task("new task", policy_port=5555)
         assert result["status"] == "error"
         assert "already running" in result["content"][0]["text"].lower()
@@ -189,18 +198,22 @@ class TestStartTask:
 
         captured = {}
 
-        def _fake_sync(instruction, port, host, provider, duration):
+        def _fake_loop(instruction, port, host, provider, duration, **_kw):
             captured["instruction"] = instruction
             hw._task_state.status = TaskStatus.COMPLETED
             return {"status": "success", "content": [{"text": "done"}]}
 
-        hw._execute_task_sync = _fake_sync  # type: ignore[assignment]
+        # Stubs the control loop rather than the callable start_task submits, so
+        # the submitted wrapper still releases the motors-bus claim it was
+        # started under.
+        hw._run_control_loop = _fake_loop  # type: ignore[assignment]
         result = hw.start_task("grab", policy_port=5555, duration=1.0)
         assert result["status"] == "success"
         assert "grab" in result["content"][0]["text"]
         # Wait for the background future to run.
         hw._task_state.task_future.result(timeout=5)
         assert captured["instruction"] == "grab"
+        assert hw._task_claimed is False
         hw.cleanup()
 
 
@@ -431,13 +444,17 @@ class TestRunPolicyObject:
         hw.cleanup()
 
     def test_rejects_concurrent_task(self):
+        """A rollout is refused while another one owns the motors bus.
+
+        As above, the in-flight rollout is represented by the real admission
+        claim; ``_task_state.status`` is not the admission predicate.
+        """
         hw = _make_robot()
-        hw._task_state.status = TaskStatus.RUNNING
-        hw._task_state.instruction = "busy"
+        assert hw._claim_task("busy") is None
         result = hw.run_policy(policy_object=_StubPolicy(), instruction="pick", n_steps=1)
         assert result["status"] == "error"
         assert "already running" in result["content"][0]["text"].lower()
-        hw._task_state.status = TaskStatus.IDLE
+        hw._release_task()
         hw.cleanup()
 
     def test_connect_failure_reports_error_payload(self):

--- a/tests/test_hardware_ros_bridge.py
+++ b/tests/test_hardware_ros_bridge.py
@@ -209,6 +209,8 @@ def _make_robot(observation: dict[str, Any], *, ros2_bridge: bool = False, ros2_
     hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw._shutdown_event = threading.Event()
     hw._stop_requested = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
     hw.mesh = None
     hw.peer_id = None
     hw.robot = _FakeLeRobot(observation)

--- a/tests/test_hardware_stop_during_connect.py
+++ b/tests/test_hardware_stop_during_connect.py
@@ -99,6 +99,8 @@ class _Rig:
         hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
         hw._shutdown_event = threading.Event()
         hw._stop_requested = threading.Event()
+        hw._task_admission = threading.Lock()
+        hw._task_claimed = False
         hw.mesh = None
         hw.peer_id = None
         hw.robot = self.arm

--- a/tests/test_hardware_task_duration_guard.py
+++ b/tests/test_hardware_task_duration_guard.py
@@ -101,6 +101,8 @@ def hw() -> Any:
     robot._executor = ThreadPoolExecutor(max_workers=1)
     robot._shutdown_event = threading.Event()
     robot._stop_requested = threading.Event()
+    robot._task_admission = threading.Lock()
+    robot._task_claimed = False
     robot.mesh = None
     robot.peer_id = None
     robot.robot = _FakeArm()


### PR DESCRIPTION
## Problem

`start_task`, `run_policy` and the agent-tool `execute` action each refused a concurrent task with the same predicate:

```python
if self._task_state.status == TaskStatus.RUNNING:
    return {"status": "error", ...}
```

That status is written by `_execute_task_async` only *after* `_connect_robot()` and the policy build (`hardware_robot.py:1203` on main). Everything before it reports `CONNECTING`, so for the whole bring-up window - a motors-bus handshake plus per-camera warmup, seconds on a real arm - a second caller read a non-running status and was admitted.

Two control loops then drove one bus. Measured against the real loop with a 1 s `connect()` and two rollouts asking the arm for two different poses, each tagging its own commands:

| | before | after |
|---|---|---|
| status when the 2nd call arrived | `connecting` | `connecting` |
| 2nd call verdict | **`success`** | `error` - `Task already running: lift the cube` |
| rollouts whose commands reached the wire | **`['A', 'B']`** | `['A']` |
| command order on the wire (tail) | **`ABAABABABABABABABABABABABABAB...`** | `AAAAAAAAAAAAAAAAAAAAAAAAAAAA...` |
| peak `send_action` transactions in flight | **2** | 1 |
| `connect()` calls on one port | **2** | 1 |
| commands per rollout | **`{'A': 40, 'B': 84}`** | `{'A': 124}` |
| what each call reported | **both** `completed: 124 steps` | `completed: 124 steps` / refused |

The bus is half-duplex and not thread-safe: `sync_read` / `sync_write` share one port handler, so interleaved transactions give framing errors, or a `Goal_Position` write from one policy lands between the other's read and write - two different intents applied to one physical arm.

The reporting is wrong in the same breath. Both rollouts share the single `_task_state` slot, so each overwrote the other's step count and terminal status: both calls returned `completed: 124 steps` even though rollout A had put only 40 commands on the wire. A second `_execute_task_async` also re-ran `_connect_robot()` on an already-connected arm and reset `step_count` under the first rollout.

The class already models exclusivity everywhere else - a single-slot `_task_state`, `ThreadPoolExecutor(max_workers=1)`. Only the admission predicate disagreed.

## Change

Admission is a claim on the bus, taken before the bring-up window opens and released when the rollout ends:

- `_claim_task(instruction)` / `_release_task()` - the check-and-claim runs under a lock, so callers racing at the same instant cannot both be admitted (a plain flag read followed by a write would let several through).
- `_drive_claimed_task` releases the claim in a `finally`, so a rollout that errors *or raises* cannot leave the robot refusing every later task.
- `start_task` claims on the **caller's** thread, not inside its executor job. It returns before that job begins, so a claim taken there would have replied "Task started" and only then turned the caller away, with nobody left to tell. `submit` failing unwinds the claim rather than leaking it.
- `_execute_task_sync` claims too: the agent-tool `execute` action and the mesh `execute` dispatch (`mesh/core.py:1705`) reach it directly, bypassing both public methods. This mirrors why `_duration_error` is already checked at all three sites.
- The budget check still runs *before* the claim at each site - it is stateless, so rejecting it must not take the bus from a rollout that could still start.
- The refusal names the rollout that actually holds the bus. During bring-up the old message named whichever task ran last, because `_task_state.instruction` was only written once the background thread got going.

`_task_state.status` keeps its job of *reporting* state; it is no longer asked to decide admission.

## Visual artifact

The captured command streams replayed onto a Panda in MuJoCo (headless), one frame per two commands. The border and caption name the rollout that owns each command as it lands. Left: both rollouts admitted, so the arm is pulled between two targets. Right: the second is refused and one rollout drives.

![two rollouts on one bus](https://raw.githubusercontent.com/cagataycali/robots/artifacts/one-rollout-per-bus/two_writers.gif)

The same streams as commanded setpoints. Rollout A asks `actuator1` for 0.0 rad and rollout B ramps it to 1.25 rad; before the fix the arm receives them alternately, so consecutive commands disagree by 1.25 rad every ~4 ms.

![commanded actuator1](https://raw.githubusercontent.com/cagataycali/robots/artifacts/one-rollout-per-bus/commanded_trace.png)

## Tests

New `tests/test_hardware_one_rollout_per_bus.py` (11 tests). No serial port is opened and no arm is commanded: a gated in-memory driver stands in, and the bring-up window is **opened by the test** rather than slept through, so every assertion is deterministic (0.8 s for the file). In the headline test the gate is opened from a third thread, so a wrongly admitted second rollout does get past `connect()` and its commands reach the wire - the refusal is what keeps the bus single-writer, not the test holding the gate shut.

- a second `run_policy` during bring-up is refused, and afterwards only the admitted rollout's commands are on the wire, `connect()` ran once, and no two transactions were ever in flight
- `start_task` during bring-up is refused **synchronously**, with no second job submitted
- the `_execute_task_sync` chokepoint (the `execute` action / mesh dispatch) is refused too
- the refusal names the in-flight rollout, not whichever task ran last
- the claim is released by a completed rollout, by a failed connect, and by a raising one - a later task is still admitted in all three cases
- the claim is released by a rollout **stopped during bring-up** too - the path #1724 added, where the rollout is abandoned before the arm is commanded and never reaches the terminal block, so only the `finally` can hand the bus back
- a refused `duration` does not take the bus; a failed `submit` does not leak the claim
- eight callers released from a barrier at the same instant admit exactly one

Pre-fix on this base, `6 failed, 4 passed` in the new file, the headline failures being `assert 'success' == 'error'` - the second rollout was admitted. The four that pass pre-fix are the release-path and ordering pins, which have nothing to reinstate on old code.

Two existing pins in `test_hardware_robot_lifecycle.py` represented the in-flight rollout by writing `RUNNING` onto the task state. That was the shortcut the defect hid behind, so they now take the real claim; their assertions are unchanged. `test_start_submits_and_completes` stubs the control loop rather than the callable `start_task` submits, so the wrapper still releases the claim, and it now also asserts the claim was released.

Eight `__new__`-based `Robot` doubles gained the two new attributes (2 lines each) - the eighth is the rig in `test_hardware_stop_during_connect.py`, which arrived with #1724.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (946 source files)
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **13587 passed, 253 skipped** (459 s)
- `python scripts/assemble_changelog.py --check` OK; docs updated in `docs/hardware/robot-control.md`

## Out of scope

A stop pressed during the same bring-up window is a separate defect on the same path, fixed in #1724, which has now merged; this change still does not touch `stop_task`, and the point where the two meet is pinned (see the round 2 changelog). Recovering a half-open camera set on a failed connect, and a rollout started after `cleanup()`, remain open.

---

## 13. Round 2 changelog

**Concern: the branch was `CONFLICTING` and could not merge.** #1724 landed on
`main` while this PR was open, touching the same hardware bring-up path.

### Conflict resolution

All six conflicts were the same shape - both sides adding at one anchor with
nothing removed - so all six resolve as a union, and no behaviour is resolved
away from either side:

| anchor | main (#1724) added | this branch added |
|---|---|---|
| `Robot.__init__` | `_stop_requested` | `_task_admission`, `_task_claimed` |
| 5 `__new__` doubles | `_stop_requested` | the two claim attributes |

`main`'s line is kept in place and this branch's appended, so the diff against
`main` stays minimal.

### The union alone was not enough - 19 tests failed

Each side of the merge brought a **new test file with its own `Robot.__new__`
double**, and neither knew about the other's attribute:

- the rig in `test_hardware_stop_during_connect.py` (from #1724) had no claim
  attributes, so `_claim_task` raised and every rollout stayed `idle` - 13
  failures, including `test_the_arm_is_never_commanded`
- `make_robot` in `test_hardware_one_rollout_per_bus.py` had no
  `_stop_requested`, so `_execute_task_async` raised on `.clear()` - 6 failures

Each double gains the missing attribute: the same two lines the other five
already carry. Both suites are now green (27 tests).

### One pin added, where the two fixes meet

A stop latched during bring-up is honored as soon as `connect()` returns, which
abandons the rollout *before the arm is commanded* - so it never reaches the
terminal block, and the claim can only be released by `_drive_claimed_task`'s
`finally`. The existing release tests cover a completed, a failed-connect and a
raising rollout; none exercises a stop. `test_a_rollout_stopped_during_bring_up_hands_the_bus_back`
asserts the arm was never commanded, the claim is clear, and a later rollout
actually drives.

**Shown load-bearing, not decorative:** making the release skip only the
`STOPPED` path leaves the other 10 tests in the file green and fails exactly
this one, so it is not restating cover the file already had.

### Verification

Failure sets diffed line-for-line against a clean `upstream/main` checkout in
the same environment (`tests`, excluding the `simulation` / `training` /
`benchmarks` trees, which need a GL backend this host lacks):

| | main | this branch |
|---|---|---|
| failing/erroring node ids | 277 | **277 - byte-identical** |
| passed | 8335 | **8346 (+11)** |

The `+11` is exactly the 11 new tests; the 277 are missing optional deps
(`device_connect_edge`, `mujoco` GL, ...) present on `main` too. **Zero
regressions.**

`ruff check` / `ruff format --check` / `assemble_changelog.py --check` clean.
`mypy` reports one error, `strands_robots/simulation/ik.py:106` - byte-identical
on a clean `main` checkout, in a file this PR does not touch
(`git diff upstream/main HEAD -- strands_robots/simulation/ik.py` is empty).

### Note on history

Pushed as one commit **on top of** the existing branch head rather than as a
force-push, so the resolution and this pin stay reviewable as a delta instead of
overwriting the commit that was already reviewed. The prior approval was
dismissed automatically by the push (`require_last_push_approval`); nothing in
production code changed in this round - the only non-test edits are the
changelog fragment's list of release cases.
