### PR TITLE
fix(policies): the state fallback does not interleave velocity siblings

### DIFF
--- a/changelog.d/1723-state-fallback-excludes-velocities.md
+++ b/changelog.d/1723-state-fallback-excludes-velocities.md
@@ -1,0 +1,32 @@
+### Fixed: the observation-derived state ordering no longer interleaves velocity siblings
+
+`LerobotLocalPolicy._resolve_state_order` falls back to the observation's own
+scalar keys when the configured `robot_state_keys` match nothing in it -- the
+generic `joint_0..joint_N` vs named-joint mismatch. It took those keys in the
+observation's insertion order, and the MuJoCo backend emits a velocity sibling
+beside every joint position (`simulation/mujoco/rendering.py`: `obs[jnt_name]`
+then `obs[f"{jnt_name}.vel"]`), so that order alternates
+`[pos0, vel0, pos1, vel1, ...]`.
+
+The result was twice the DOF count, then truncated to the model's declared
+`observation.state` dim -- so HALF the slots held velocities and the trailing
+joints were dropped entirely. On a 6-DoF arm driven to distinct known values the
+resolved order was `['shoulder_pan', 'shoulder_pan.vel', 'shoulder_lift', ...]`
+and the state vector fed to the model was
+`[0.2981, -0.4700, -0.1973, 0.6561, 0.4978, -0.5439]` against correct positions
+`[0.2981, -0.1973, 0.4978, 0.0987, -0.3974, 0.2474]`, with `wrist_flex`,
+`wrist_roll` and `gripper` absent. Nothing raised and nothing logged about it:
+the policy ran on a wrong state vector while reporting success. The producer
+documents `<name>.vel` as an ADDITIVE key that position-only consumers are
+unaffected by, and this consumer was the exception.
+
+An ordering derived from the observation now drops each `<joint>.vel` whose
+`<joint>` position companion is present. A `.vel` key with NO companion is kept,
+because some embodiments legitimately declare velocity state -- `embodiments.json`
+gives LeKiwi body-frame base velocities `x.vel` / `y.vel` / `theta.vel` with no
+`x` / `y` / `theta` position key -- so pairing is decided per key rather than by
+suffix. An explicitly configured `robot_state_keys` ordering is returned
+untouched: an operator naming `elbow.vel` is stating the model's input, and this
+only cleans up an ordering inferred from whatever the observation happened to
+contain. The mismatch warning and its `generic_state_keys_used` telemetry are
+unchanged, so the misconfiguration that reaches the fallback is still surfaced.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -303,6 +303,30 @@ producing off-policy / micro-motion trajectories. An explicit
 `processor_overrides={"device_processor": {"device": ...}}` is still honored
 as-is and takes precedence over the automatic reconciliation.
 
+## State routing
+
+`observation.state` is composed from `robot_state_keys` (set explicitly with
+`set_robot_state_keys([...])`, or by an `embodiment`). That ordering is used
+verbatim whenever at least one of its keys is present in the observation; a
+configured key the observation does not carry is zero-filled IN PLACE so the
+present joints keep their index.
+
+When NONE of the configured keys match - typically generic auto-generated names
+(`joint_0..joint_N`) paired with a sim that reports named joints - the policy
+warns (or raises under `strict_keys=True`), sets `generic_state_keys_used`, and
+falls back to the observation's own scalar keys so the state is populated rather
+than silently dropped.
+
+That fallback ordering is **position-only**: a `<joint>.vel` entry is dropped
+when the observation also carries its `<joint>` position companion. The MuJoCo
+backend emits a velocity sibling beside every joint position, so taking its keys
+in observation order would otherwise interleave velocities into the state vector
+and push the trailing joints past the model's declared state dim. A `.vel` key
+with no position companion is kept, because some embodiments legitimately declare
+velocity state (LeKiwi's body-frame base velocities `x.vel` / `y.vel` /
+`theta.vel`). Explicit `robot_state_keys` are never filtered - naming `elbow.vel`
+there states the model's input.
+
 ## Camera routing
 
 Robot/sim observations use bare camera names (`top`, `wrist`, `side`); the policy

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -84,6 +84,44 @@ def _merge_obs_rename(base: dict[str, str], override: dict[str, str | None] | No
     return merged
 
 
+_VELOCITY_SUFFIX = ".vel"
+
+
+def _drop_velocity_siblings(scalar_keys: list[str]) -> list[str]:
+    """Drop each ``<joint>.vel`` whose ``<joint>`` position companion is present.
+
+    Used only for the OBSERVATION-DERIVED state ordering (see
+    :meth:`LerobotLocalPolicy._resolve_state_order`), which is built from the
+    observation's own insertion order. The MuJoCo backend emits a velocity
+    sibling beside every joint position (``simulation/mujoco/rendering.py``:
+    ``obs[jnt_name] = qpos`` then ``obs[f"{jnt_name}.vel"] = qvel``), so that
+    order alternates ``[pos0, vel0, pos1, vel1, ...]``. Feeding it to a policy
+    trained on positions puts a velocity in every other slot of
+    ``observation.state`` and, once truncated to the model's state dim, drops
+    the trailing joints entirely - a wrong state vector with no error raised.
+    The producer documents ``<name>.vel`` as an ADDITIVE key that position-only
+    consumers are unaffected by; this restores that contract here.
+
+    A ``.vel`` key with NO position companion is KEPT, because some embodiments
+    legitimately declare velocity state and dropping it would corrupt those
+    instead: ``embodiments.json`` gives LeKiwi body-frame base velocities
+    ``x.vel`` / ``y.vel`` / ``theta.vel`` with no ``x`` / ``y`` / ``theta``
+    position key. Pairing is therefore decided per key, not by suffix alone.
+
+    Explicitly configured ``robot_state_keys`` are NOT filtered - an operator
+    naming ``elbow.vel`` is stating the model's input, and this only cleans up
+    an ordering inferred from whatever the observation happened to contain.
+
+    Args:
+        scalar_keys: Candidate state keys in observation insertion order.
+
+    Returns:
+        The same list, order preserved, minus the paired velocity siblings.
+    """
+    present = set(scalar_keys)
+    return [k for k in scalar_keys if not (k.endswith(_VELOCITY_SUFFIX) and k[: -len(_VELOCITY_SUFFIX)] in present)]
+
+
 # Fallback control rate used ONLY when RTC runs without the runtime having
 # called set_control_frequency(). Used to keep a standalone (no-runner) RTC
 # call functional; the runner always plumbs the real rate. A loud one-time
@@ -2028,20 +2066,30 @@ class LerobotLocalPolicy(Policy):
             fall back to the observation's own scalar keys so the state is
             populated rather than silently dropped.
 
+        Any ordering derived from the observation (both the fallback above and
+        the no-``robot_state_keys`` case) is position-only: a ``<joint>.vel``
+        sibling of a present ``<joint>`` is dropped by
+        :func:`_drop_velocity_siblings`, so a MuJoCo observation does not
+        interleave velocities into ``observation.state``. An unpaired ``.vel``
+        key (LeKiwi's base velocities) is kept, and an explicitly configured
+        ``robot_state_keys`` ordering is returned untouched.
+
         Args:
             observation_dict: Raw strands/sim observation for this step.
             scalar_keys: Non-image, non-``task`` scalar keys present in the
                 observation, used as the fallback ordering.
 
         Returns:
-            The ordered keys to pull scalar joint values from.
+            The ordered keys to pull scalar joint values from - the configured
+            ``robot_state_keys`` verbatim, or an observation-derived ordering
+            with paired velocity siblings removed.
 
         Raises:
             ValueError: When ``strict_keys`` is set and no configured key
                 matches the observation.
         """
         if not self.robot_state_keys:
-            return scalar_keys
+            return _drop_velocity_siblings(scalar_keys)
         if any(k in observation_dict for k in self.robot_state_keys):
             return self.robot_state_keys
         shown = self.robot_state_keys[:8]
@@ -2063,7 +2111,7 @@ class LerobotLocalPolicy(Policy):
         if not self._state_key_mismatch_warned:
             logger.warning(msg)
             self._state_key_mismatch_warned = True
-        return scalar_keys
+        return _drop_velocity_siblings(scalar_keys)
 
     def _collect_state_values(self, observation_dict: dict[str, Any], order: list[str]) -> list[float]:
         """Pull the joint-state vector from ``observation_dict`` in ``order``.

--- a/tests/policies/lerobot_local/test_state_fallback_excludes_velocities.py
+++ b/tests/policies/lerobot_local/test_state_fallback_excludes_velocities.py
@@ -1,0 +1,226 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""The observation-derived state ordering must not interleave velocity siblings.
+
+When the configured ``robot_state_keys`` match nothing in the observation (the
+generic ``joint_0..joint_N`` vs named-joint mismatch), the ordering falls back
+to the observation's own scalar keys. The MuJoCo backend emits a velocity
+sibling beside every joint position -- ``simulation/mujoco/rendering.py``::
+
+    obs[jnt_name] = float(data.qpos[model.jnt_qposadr[jnt_id]])
+    obs[f"{jnt_name}.vel"] = float(data.qvel[model.jnt_dofadr[jnt_id]])
+
+-- so the observation's insertion order is ``[pos0, vel0, pos1, vel1, ...]``.
+Taking it unfiltered made ``observation.state`` twice the DOF count, then
+truncated it to the model's declared state dim, so HALF the slots held
+velocities and the trailing joints were dropped entirely.
+
+Measured on a 6-DoF arm driven to distinct known values::
+
+    resolved order        ['1','1.vel','2','2.vel','3','3.vel','4','4.vel','5','5.vel','6','6.vel']
+    first 6 (6-dim model) [0.2981, -0.4700, -0.1973, 0.6561, 0.4978, -0.5439]
+    CORRECT positions     [0.2981, -0.1973, 0.4978, 0.0987, -0.3974, 0.2474]
+    dropped joints        ['wrist_flex', 'wrist_roll', 'gripper']
+
+A wrong state vector, with nothing raised and nothing logged about it.
+
+A ``.vel`` key with NO position companion is KEPT: ``embodiments.json`` declares
+LeKiwi body-frame base velocities ``x.vel`` / ``y.vel`` / ``theta.vel`` with no
+``x`` / ``y`` / ``theta`` position key, so a blanket suffix drop would corrupt
+those instead. Pairing is decided per key.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+# A 6-DoF SO-style arm, in MJCF declaration order.
+_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+_POSITIONS = [0.2981, -0.1973, 0.4978, 0.0987, -0.3974, 0.2474]
+_VELOCITIES = [-0.4700, 0.6561, -0.5439, 0.3310, 0.1200, -0.2900]
+
+# Keys that match nothing a named-joint sim reports -> forces the fallback.
+_GENERIC_KEYS = [f"joint_{i}" for i in range(6)]
+
+
+def _mujoco_observation() -> dict[str, float]:
+    """An observation in exactly the key order mujoco/rendering.py emits."""
+    obs: dict[str, float] = {}
+    for name, pos, vel in zip(_JOINTS, _POSITIONS, _VELOCITIES, strict=True):
+        obs[name] = pos
+        obs[f"{name}.vel"] = vel
+    return obs
+
+
+def _make_policy(*, state_dim: int = 6, robot_state_keys: list[str] | None = _GENERIC_KEYS):
+    """A policy that appears loaded, with a declared ``observation.state`` dim."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path="test/model")
+    policy._loaded = True
+    policy._device = torch.device("cpu")
+    state_feat = MagicMock()
+    state_feat.shape = (state_dim,)
+    policy._input_features = {"observation.state": state_feat}
+    action_feat = MagicMock()
+    action_feat.shape = (6,)
+    policy._output_features = {"action": action_feat}
+    if robot_state_keys is not None:
+        policy.set_robot_state_keys(list(robot_state_keys))
+    return policy
+
+
+def _state_of(policy, observation: dict[str, float]) -> list[float]:
+    """The ``observation.state`` vector the policy would feed the model."""
+    batch = policy._build_observation_batch(observation, "pick up the cube")
+    return [round(float(v), 4) for v in batch["observation.state"].flatten().tolist()]
+
+
+class TestTheStateVectorHoldsPositionsOnly:
+    def test_the_state_vector_is_the_joint_positions(self):
+        """Regression: it was [pos0, vel0, pos1, vel1, pos2, vel2]."""
+        assert _state_of(_make_policy(), _mujoco_observation()) == _POSITIONS
+
+    def test_no_velocity_reading_reaches_the_state_vector(self):
+        state = _state_of(_make_policy(), _mujoco_observation())
+
+        assert not (set(state) & set(_VELOCITIES)), f"velocity value(s) in state: {state}"
+
+    def test_no_joint_is_dropped_by_truncation(self):
+        """Half the slots being velocities pushed the last 3 joints out."""
+        state = _state_of(_make_policy(), _mujoco_observation())
+
+        for name, pos in zip(_JOINTS, _POSITIONS, strict=True):
+            assert pos in state, f"{name} is missing from observation.state"
+
+    def test_declaration_order_is_preserved(self):
+        obs = _mujoco_observation()
+
+        assert _state_of(_make_policy(), obs) == [obs[j] for j in _JOINTS]
+
+    def test_the_width_is_the_dof_count_not_twice_it(self):
+        policy = _make_policy(state_dim=12)
+
+        # 12 declared dims, 6 real joints: the 6 unreported dims are zero-filled
+        # in place rather than back-filled with velocities.
+        assert _state_of(policy, _mujoco_observation()) == _POSITIONS + [0.0] * 6
+
+    def test_the_other_build_path_agrees(self):
+        """``_to_lerobot_observation`` (processor path) resolves the same order."""
+        policy = _make_policy()
+
+        state = policy._to_lerobot_observation(_mujoco_observation())["observation.state"]
+
+        assert [round(float(v), 4) for v in np.asarray(state).flatten().tolist()] == _POSITIONS
+
+
+class TestUnpairedVelocityKeysSurvive:
+    """LeKiwi declares x.vel/y.vel/theta.vel with no position companion."""
+
+    def test_base_velocities_with_no_position_companion_are_kept(self):
+        policy = _make_policy(state_dim=4)
+        obs = {"shoulder_pan.pos": 0.1, "x.vel": 0.5, "y.vel": -0.2, "theta.vel": 0.05}
+
+        assert _state_of(policy, obs) == [0.1, 0.5, -0.2, 0.05]
+
+    def test_a_mobile_manipulator_keeps_base_and_drops_arm_siblings(self):
+        """Both rules apply to one observation: pair -> drop, unpaired -> keep."""
+        policy = _make_policy(state_dim=4)
+        obs = {"elbow": 0.3, "elbow.vel": 9.9, "x.vel": 0.5, "theta.vel": 0.05}
+
+        assert _state_of(policy, obs) == [0.3, 0.5, 0.05, 0.0]
+
+    def test_a_position_key_named_with_the_pos_suffix_is_not_a_companion(self):
+        """``elbow.pos`` does not pair with ``elbow.vel`` - only ``elbow`` does."""
+        policy = _make_policy(state_dim=2)
+        obs = {"elbow.pos": 0.3, "elbow.vel": 1.5}
+
+        assert _state_of(policy, obs) == [0.3, 1.5]
+
+
+class TestConfiguredKeysAreHonoredVerbatim:
+    def test_an_explicitly_configured_vel_key_is_not_filtered(self):
+        """An operator naming a velocity is stating the model's input."""
+        policy = _make_policy(state_dim=2, robot_state_keys=["elbow", "elbow.vel"])
+        obs = {"elbow": 0.3, "elbow.vel": 1.5}
+
+        assert _state_of(policy, obs) == [0.3, 1.5]
+
+    def test_a_partial_match_still_uses_the_configured_order(self):
+        """One configured key present is enough - no fallback, no filtering."""
+        policy = _make_policy(state_dim=3, robot_state_keys=["elbow", "elbow.vel", "absent"])
+        obs = {"elbow": 0.3, "elbow.vel": 1.5}
+
+        assert _state_of(policy, obs) == [0.3, 1.5, 0.0]
+
+
+class TestTheNoConfiguredKeysPathIsFilteredToo:
+    """With no configured keys the ordering is ENTIRELY observation-derived.
+
+    Only the processor path reaches it: ``_build_batch_from_strands_format``
+    refuses an empty ``robot_state_keys`` outright (pinned below), while
+    ``_to_lerobot_observation`` resolves the order from the observation.
+    """
+
+    def test_a_policy_with_no_robot_state_keys_gets_positions_only(self):
+        policy = _make_policy(robot_state_keys=None)
+        assert policy.robot_state_keys == []
+
+        state = policy._to_lerobot_observation(_mujoco_observation())["observation.state"]
+
+        assert [round(float(v), 4) for v in np.asarray(state).flatten().tolist()] == _POSITIONS
+
+    def test_the_other_path_still_refuses_empty_keys(self):
+        """Unchanged: it cannot map an observation without them."""
+        policy = _make_policy(robot_state_keys=None)
+
+        with pytest.raises(ValueError, match="robot_state_keys is empty"):
+            _state_of(policy, _mujoco_observation())
+
+
+class TestUnchangedBehaviour:
+    def test_the_mismatch_warning_still_fires(self, caplog):
+        """Filtering must not quiet the misconfiguration that caused it."""
+        policy = _make_policy()
+
+        with caplog.at_level(logging.WARNING):
+            _state_of(policy, _mujoco_observation())
+
+        assert any("robot_state_keys" in r.getMessage() for r in caplog.records), caplog.records
+
+    def test_the_degradation_telemetry_is_still_set(self):
+        policy = _make_policy()
+        _state_of(policy, _mujoco_observation())
+
+        assert policy.generic_state_keys_used is True
+
+    def test_strict_keys_still_raises_before_filtering(self):
+        policy = _make_policy()
+        policy.strict_keys = True
+
+        with pytest.raises(ValueError, match="strict_keys=True"):
+            _state_of(policy, _mujoco_observation())
+
+    def test_a_velocity_only_observation_is_unchanged(self):
+        """No position companion anywhere: nothing to drop, so nothing changes."""
+        policy = _make_policy(state_dim=2)
+        obs = {"a.vel": 1.0, "b.vel": 2.0}
+
+        assert _state_of(policy, obs) == [1.0, 2.0]
+
+    def test_an_observation_with_no_velocities_is_unchanged(self):
+        policy = _make_policy()
+        obs = dict(zip(_JOINTS, _POSITIONS, strict=True))
+
+        assert _state_of(policy, obs) == _POSITIONS
+
+    def test_the_task_key_is_still_excluded(self):
+        policy = _make_policy(state_dim=6)
+        obs = _mujoco_observation() | {"task": "pick up the cube"}
+
+        assert _state_of(policy, obs) == _POSITIONS


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._resolve_state_order` falls back to the observation's own scalar keys when none of the configured `robot_state_keys` are present in it - the generic `joint_0..joint_N` vs named-joint mismatch. It took those keys in the observation's **insertion order**, and the MuJoCo backend emits a velocity sibling beside every joint position (`strands_robots/simulation/mujoco/rendering.py`):

```python
obs[jnt_name] = float(data.qpos[model.jnt_qposadr[jnt_id]])
# Additive key (``<name>.vel``) - existing position-only
# consumers (dataset recording, arm policies) are unaffected;
obs[f"{jnt_name}.vel"] = float(data.qvel[model.jnt_dofadr[jnt_id]])
```

So the resolved order alternates `[pos0, vel0, pos1, vel1, ...]`: twice the DOF count, then truncated to the model's declared `observation.state` dim. Half the slots held velocities and the trailing joints were dropped entirely.

Measured on a 6-DoF arm driven to distinct known values, 6-dim model:

```
resolved order        ['shoulder_pan', 'shoulder_pan.vel', 'shoulder_lift', 'shoulder_lift.vel', 'elbow_flex', 'elbow_flex.vel']
fed to the model      [0.2981, -0.4700, -0.1973,  0.6561,  0.4978, -0.5439]
CORRECT positions     [0.2981, -0.1973,  0.4978,  0.0987, -0.3974,  0.2474]

wrong slots           5 of 6
joints absent entirely wrist_flex, wrist_roll, gripper
```

Nothing raised and nothing logged about it: the policy ran on a wrong state vector while reporting success. The producer's own comment above documents `<name>.vel` as an **additive** key that position-only consumers are unaffected by - this consumer was the exception to a contract stated in the code.

## Change

An ordering **derived from the observation** now drops each `<joint>.vel` whose `<joint>` position companion is present, via a new `_drop_velocity_siblings` helper applied at the two points in `_resolve_state_order` that return an observation-derived ordering (the all-missing fallback, and the no-`robot_state_keys` early return).

Three things the rule deliberately does **not** do:

- **It is not a suffix drop.** A `.vel` key with no position companion is kept, because some embodiments legitimately declare velocity state: `embodiments.json` gives LeKiwi body-frame base velocities `x.vel` / `y.vel` / `theta.vel` with no `x` / `y` / `theta` position key. A blanket drop would corrupt those instead. Pairing is decided per key.
- **It does not touch configured keys.** An explicitly configured `robot_state_keys` ordering is returned verbatim - an operator naming `elbow.vel` is stating the model's input. This only cleans up an ordering inferred from whatever the observation happened to contain.
- **It does not quiet the misconfiguration.** The mismatch warning and its `generic_state_keys_used` telemetry fire exactly as before, and `strict_keys=True` still raises before any filtering. Reaching the fallback is still a mistake worth surfacing; it just no longer corrupts the vector on the way.

## Evidence

![observation.state before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/state-fallback-velocities/state-fallback-velocities.png)

Both panels are the same observation through the same live code path - `BEFORE` is produced by neutralising the new filter to the identity function, not by transcribing numbers - so the two are directly comparable. Grey is the true joint position, coloured is what reached the model as `observation.state`.

## Tests

New `tests/policies/lerobot_local/test_state_fallback_excludes_velocities.py` (19 tests), asserting on the resulting `observation.state` tensor through `_build_observation_batch` / `_to_lerobot_observation` rather than on the resolved key list, so they pin the behaviour and not the mechanism.

- the state vector is the joint positions, no velocity reading reaches it, no joint is dropped by truncation, declaration order preserved, and a 12-dim model zero-fills the 6 unreported dims rather than back-filling velocities;
- both build paths agree (`_build_batch_from_strands_format` and the processor path `_to_lerobot_observation`);
- unpaired velocities survive: the LeKiwi base case, a mixed observation where both rules apply at once, and `elbow.pos` correctly *not* treated as a companion of `elbow.vel`;
- configured keys are honored verbatim, including a deliberate `elbow.vel` and a partial match;
- the no-`robot_state_keys` path is filtered too, and the other build path still refuses empty keys;
- unchanged behaviour: the mismatch warning still fires, `generic_state_keys_used` is still set, `strict_keys` still raises, and observations with no velocities / only velocities are untouched.

Pre-fix, with only `strands_robots/policies/lerobot_local/policy.py` reverted to `main`: **9 failed, 10 passed**. Post-fix: **19 passed**.

## Gate

```
ruff check strands_robots tests tests_integ            All checks passed!
ruff format --check strands_robots tests tests_integ   949 files already formatted
mypy (changed files)                                  Success: no issues found in 2 source files
pytest tests -q                                       12280 passed
```

Full-suite regression check: the set of failing node IDs is **identical** with and without this change (327 node IDs, all pre-existing gaps from optional deps absent in this sandbox - `lerobot`, `huggingface_hub`, `robot_descriptions`, `av`, `device_connect_edge`). Zero failures are attributable to the change; the 7 remaining `mypy` errors are all in untouched files and come from the same missing optional deps.

Docs: new `## State routing` section in `docs/policies/lerobot-local.md`, as the companion to the existing `## Camera routing`. Changelog fragment: `changelog.d/1723-state-fallback-excludes-velocities.md`.

## Scope

One concern, extracted per #1723 order step 2, cut fresh from `main`. Files are disjoint from #1724 (`hardware_robot.py`), so the two do not conflict.

Out of scope: the six core-module rewrites on the staged branch, and the remaining hardware/teleop cluster items, which touch `hardware_robot.py` and should follow #1724 rather than stack a conflicting diff on it.

Refs #1723