### PR TITLE
fix(hardware): refuse a max_relative_target the driver cannot honor

### DIFF
--- a/changelog.d/1727-servo-travel-clamp-domain.md
+++ b/changelog.d/1727-servo-travel-clamp-domain.md
@@ -1,0 +1,12 @@
+### Fixed: refuse a `max_relative_target` the driver cannot honor
+
+`Robot(...)` forwarded the `max_relative_target` servo travel clamp to lerobot's
+robot config without validating it, and the driver honors a narrower domain than
+the config dataclass accepts. `nan` or `inf` disabled the clamp with no signal, a
+negative limit inverted it into a fixed-magnitude step that ignores the requested
+goal, `0` discarded every commanded motion while the rollout reported success, and
+an `int` limit - type-correct against the field's `float` annotation under PEP 484's
+numeric tower - raised a bare `TypeError(10)` at the first servo command. The limit
+is now validated and normalized when the config is built, before the serial port is
+opened, and the same domain applies to every value of a per-motor mapping. `None`
+still means the clamp is disabled.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -64,6 +64,16 @@ Forwardable kwargs: `port`, `robot_ip`, `kp`, `kd`, `default_positions`, `contro
 `is_simulation`, `gravity_compensation`, `controller`, `calibration_dir`, `mock`,
 `use_degrees`, `max_relative_target`, `disable_torque_on_disconnect`.
 
+Forwardable values are passed to the driver as given, because their accepted domains are
+robot-specific. `max_relative_target` is the exception: it caps how far each commanded goal
+position may move from the joint's present position, so it must be a positive finite number
+(or a mapping of motor name to one). `0`, a negative limit, `nan`, `inf`, a bool or a
+non-numeric value raises `ValueError` when the config is built, before the serial port is
+opened - a non-finite limit would otherwise disable the clamp with no signal, and a negative
+one inverts it into a fixed-magnitude step that ignores the policy. An `int` limit is
+normalized to `float` so it reaches the motors. Omit the parameter (or pass `None`) to leave
+the clamp disabled.
+
 ## Mesh
 
 ```python

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -204,6 +204,88 @@ def _build_camera_config(camera_name: str, config: Any) -> Any:
         ) from exc
 
 
+def _normalize_max_relative_target(value: Any, robot_type: str) -> float | dict[str, float] | None:
+    """Validate and normalize the ``max_relative_target`` servo safety clamp.
+
+    ``max_relative_target`` caps how far each commanded goal position may move
+    from the joint's present position. It is the only per-command travel limit
+    on the hardware path, so a value the driver cannot honor is a safety defect
+    rather than a cosmetic one - and lerobot's own consumer,
+    ``lerobot.robots.utils.ensure_safe_goal_position``, honors a narrower set of
+    values than the config dataclass accepts:
+
+    - a non-finite limit disables the clamp with no signal. ``min(diff, nan)``
+      and ``max(diff, -nan)`` both return ``diff`` unchanged, so the caller
+      believes travel is limited while every goal is applied in full.
+    - a negative limit inverts it. ``min(diff, -c)`` then ``max(..., c)``
+      resolves to ``present + c`` for any requested goal, turning the clamp
+      into a fixed-magnitude step generator that ignores the policy.
+    - a zero limit discards every commanded motion, so the rollout is a no-op
+      reported as success - the same outcome the rollout horizon guards refuse
+      for ``duration`` and ``control_substeps``.
+    - an ``int`` limit is refused outright at the first servo command, with a
+      bare ``TypeError(10)`` naming neither the parameter nor the reason: that
+      consumer dispatches on ``isinstance(value, float)``, while both the
+      dataclass field (annotated ``float | dict[str, float] | None``) and PEP
+      484's numeric tower accept an ``int``. So the one spelling a type checker
+      is happiest with is the one that cannot reach the motors.
+
+    Normalizing to ``float`` is therefore load-bearing, not cosmetic: it is what
+    lets a type-correct ``max_relative_target=10`` reach the bus at all.
+
+    Per-motor mapping values are held to the same domain. Their KEYS are not
+    checked here - the motor names are known only once the bus is connected, so
+    a mismatch is left to the driver's own ``keys must match`` refusal.
+
+    Args:
+        value: The caller-supplied limit: ``None`` to leave the clamp disabled,
+            a positive finite number, or a mapping of motor name to one.
+        robot_type: The lerobot robot type, named in the error so a fleet
+            reports which arm was misconfigured.
+
+    Returns:
+        ``None`` unchanged, or the limit with every magnitude coerced to
+        ``float``.
+
+    Raises:
+        ValueError: If the limit is not one the driver can honor.
+    """
+    param = "max_relative_target"
+    context = f"Robot(robot_type={robot_type!r})"
+    advice = (
+        f"{param} caps how far each commanded goal position may move from the present "
+        f"position, so only a finite positive limit can be honored. Omit it (or pass "
+        f"None) to leave the clamp disabled."
+    )
+
+    if value is None:
+        return None
+
+    if isinstance(value, Mapping):
+        if not value:
+            raise ValueError(
+                f"{context}: {param} must not be an empty mapping. A per-motor mapping has to name "
+                f"every motor the driver reads, so an empty one is refused at the first servo "
+                f"command. {advice}"
+            )
+        normalized: dict[str, float] = {}
+        for key, limit in value.items():
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"{context}: {param} keys must be motor names (str), got "
+                    f"{type(key).__name__}: {key!r}. A non-name key can never match a motor, so "
+                    f"the mapping is refused at the first servo command."
+                )
+            if err := positive_finite_number_error(limit, f"{param}[{key!r}]", context):
+                raise ValueError(f"{err} {advice}")
+            normalized[key] = float(limit)
+        return normalized
+
+    if err := positive_finite_number_error(value, param, context):
+        raise ValueError(f"{err} {advice}")
+    return float(value)
+
+
 @functools.cache
 def _ensure_lerobot_robots_registered() -> None:
     """Import every robot driver subpackage so RobotConfig is populated.
@@ -848,6 +930,20 @@ class Robot(TeleopMixin, AgentTool):
         Each entry of ``cameras`` follows the same contract, resolved against
         the fields of lerobot's ``OpenCVCameraConfig`` -- see
         :func:`_build_camera_config`.
+
+        Forwarded values are otherwise passed through as given, because their
+        accepted domains are robot-specific. ``max_relative_target`` is the
+        exception: it is the per-command servo travel limit, and the driver
+        honors a narrower domain than the dataclass accepts, so it is validated
+        and normalized here -- see :func:`_normalize_max_relative_target`.
+
+        Raises:
+            ValueError: If a kwarg is unknown to both the cross-robot allowlist
+                and the resolved dataclass, if a ``cameras`` entry is malformed,
+                if ``max_relative_target`` is not a limit the driver can honor,
+                or if the resolved config class refuses the assembled values.
+            TypeError: If lerobot resolves ``robot_type`` to a non-dataclass
+                config class, which would make kwarg filtering unsafe.
         """
         # ``lerobot`` is already a hard dep at this point (``_initialize_robot``
         # imports it eagerly). Importing the camera + config modules here is
@@ -990,6 +1086,18 @@ class Robot(TeleopMixin, AgentTool):
                 f"{sorted(valid_fields)}. The cross-robot allowlist is: "
                 f"{sorted(set(forwardable) | always_allowed)}. "
                 f"(If this is a typo, fix it.)"
+            )
+
+        # ``max_relative_target`` is the per-command servo travel limit, and the
+        # driver honors a narrower domain than this dataclass accepts - see
+        # ``_normalize_max_relative_target``. Validated after both forwarding
+        # loops and the kwarg-name gate, so it is checked exactly when it is the
+        # effective knob: a robot whose config does not declare the field never
+        # reads it, and refusing a value that robot would drop anyway would
+        # report an error for a parameter it has no opinion about.
+        if "max_relative_target" in config_data:
+            config_data["max_relative_target"] = _normalize_max_relative_target(
+                config_data["max_relative_target"], robot_type
             )
 
         try:

--- a/tests/test_hardware_servo_safety_clamp.py
+++ b/tests/test_hardware_servo_safety_clamp.py
@@ -1,0 +1,219 @@
+"""Behavior tests for the ``max_relative_target`` servo travel clamp.
+
+``max_relative_target`` is the only per-command travel limit on the hardware
+path: it caps how far each commanded goal position may move from the joint's
+present position, so a value the driver cannot honor is a safety defect. The
+config dataclass declares it as ``float | dict[str, float] | None`` and performs
+no validation, while lerobot's consumer -
+``lerobot.robots.utils.ensure_safe_goal_position`` - honors a narrower set of
+values than that. The contracts pinned here:
+
+    - a limit outside the honorable domain (non-finite, non-positive, ``bool``,
+      non-numeric) is refused when the config is built, before the serial port
+      is opened, instead of disabling the clamp or inverting it mid-rollout;
+    - an ``int`` limit - type-correct against the field's annotation under PEP
+      484's numeric tower - is normalized to ``float`` so it reaches the motors,
+      rather than raising ``TypeError`` at the first servo command;
+    - the same domain applies to every value of a per-motor mapping;
+    - ``None`` still means "clamp disabled", the field's documented default;
+    - every limit this layer accepts really does clamp an over-large goal when
+      handed to lerobot's own consumer - the parity that keeps the two domains
+      from drifting apart again.
+
+No serial/USB hardware is touched: only config dataclasses are constructed, and
+``make_robot_from_config`` is stubbed for the driver-construction branch.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+pytest.importorskip("lerobot")
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState
+
+ROBOT_TYPE = "so101_follower"
+
+# Limits no driver can honor, with what each one does when it reaches the bus.
+UNHONORABLE = [
+    pytest.param(float("nan"), id="nan-disables-the-clamp"),
+    pytest.param(float("inf"), id="inf-disables-the-clamp"),
+    pytest.param(-5.0, id="negative-inverts-the-clamp"),
+    pytest.param(-1, id="negative-int"),
+    pytest.param(0.0, id="zero-discards-every-motion"),
+    pytest.param(0, id="zero-int"),
+    pytest.param(True, id="bool-acts-as-one-tick"),
+    pytest.param(False, id="bool-false"),
+    pytest.param("5", id="numeric-looking-string"),
+    pytest.param([5.0], id="list"),
+]
+
+
+def _make_robot() -> HwRobot:
+    """A Robot wired with just the attributes ``_create_minimal_config`` /
+    ``_initialize_robot`` need, plus the handful the destructor's cleanup path
+    reads (so teardown is silent) - never touching hardware."""
+    hw = HwRobot.__new__(HwRobot)
+    hw.tool_name_str = "test_arm"
+    hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
+    hw._task_state = RobotTaskState()
+    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
+    hw.mesh = None
+    return hw
+
+
+def _build(limit: Any) -> Any:
+    """Build the real lerobot config through the strands forwarding path."""
+    return _make_robot()._create_minimal_config(ROBOT_TYPE, None, port="/dev/null", max_relative_target=limit)
+
+
+def _clamp_verdict(limit: Any) -> str:
+    """How ``limit`` behaves when the driver applies it to a servo command.
+
+    Drives lerobot's own ``ensure_safe_goal_position`` with an over-large move
+    in BOTH directions - an inverted limit only shows itself on a move toward a
+    goal below the present position - and reports the first way it fails to be
+    a travel clamp:
+
+        - ``"raises"``: refused outright at the first servo command;
+        - ``"unbounded"``: the full requested travel is applied, so the limit
+          is not limiting anything;
+        - ``"wrong-direction"``: the command moves away from the goal;
+        - ``"frozen"``: no motion is permitted at all;
+        - ``"clamps"``: bounded, toward the goal, and non-zero - a real clamp.
+    """
+    from lerobot.robots.utils import ensure_safe_goal_position
+
+    present = 0.0
+    for goal in (1000.0, -1000.0):
+        try:
+            safe = ensure_safe_goal_position({"shoulder_pan": (goal, present)}, limit)["shoulder_pan"]
+        except (TypeError, ValueError):
+            return "raises"
+        travel = safe - present
+        requested = goal - present
+        if not math.isfinite(safe) or abs(travel) >= abs(requested):
+            return "unbounded"
+        if travel == 0.0:
+            return "frozen"
+        if (travel > 0) != (requested > 0):
+            return "wrong-direction"
+    return "clamps"
+
+
+class TestUnhonorableLimitIsRefused:
+    @pytest.mark.parametrize("limit", UNHONORABLE)
+    def test_scalar_limit_outside_the_domain_is_refused(self, limit):
+        """A limit the driver cannot honor is refused, naming the parameter.
+
+        Pre-fix every one of these built a config: ``nan``/``inf`` silently
+        disabled the clamp, a negative limit turned it into a fixed-magnitude
+        step generator, ``0`` froze the arm while the rollout reported success,
+        and ``True``/``"5"``/``[5.0]`` surfaced a bare ``TypeError(True)`` at the
+        first servo command with no parameter name in sight.
+        """
+        with pytest.raises(ValueError, match="max_relative_target"):
+            _build(limit)
+
+    @pytest.mark.parametrize("limit", UNHONORABLE)
+    def test_per_motor_limit_outside_the_domain_is_refused(self, limit):
+        """A mapping value gets the same domain as a scalar, named per motor."""
+        with pytest.raises(ValueError, match=r"max_relative_target\['shoulder_pan'\]"):
+            _build({"shoulder_pan": limit})
+
+    def test_empty_mapping_is_refused(self):
+        """An empty per-motor mapping can never match the driver's motor set."""
+        with pytest.raises(ValueError, match="must not be an empty mapping"):
+            _build({})
+
+    def test_non_name_mapping_key_is_refused(self):
+        """A key that is not a motor name can never match one."""
+        with pytest.raises(ValueError, match="keys must be motor names"):
+            _build({1: 5.0})
+
+    def test_refusal_precedes_driver_construction(self, monkeypatch):
+        """The limit is refused before lerobot builds a driver for the port.
+
+        Guard placement matters: a value rejected only once the driver exists
+        has already opened the serial port and energized the bus.
+        """
+        import lerobot.robots.utils as lru
+
+        made: list[Any] = []
+        monkeypatch.setattr(lru, "make_robot_from_config", lambda config: made.append(config))
+
+        hw = _make_robot()
+        with pytest.raises(ValueError, match="max_relative_target"):
+            hw._initialize_robot(ROBOT_TYPE, None, port="/dev/null", max_relative_target=float("nan"))
+        assert made == []
+
+
+class TestHonorableLimitReachesTheMotors:
+    def test_int_limit_is_normalized_so_it_clamps(self):
+        """An ``int`` limit is normalized to ``float`` and really does clamp.
+
+        The field is annotated ``float | dict[str, float] | None`` and PEP 484's
+        numeric tower makes an ``int`` assignable to it, so ``10`` type-checks -
+        but lerobot's consumer dispatches on ``isinstance(value, float)`` and
+        pre-fix raised ``TypeError(10)`` on every servo command.
+        """
+        from lerobot.robots.utils import ensure_safe_goal_position
+
+        cfg = _build(5)
+        assert cfg.max_relative_target == 5.0
+        assert isinstance(cfg.max_relative_target, float)
+        # Goal 40 from a present 0 exceeds the 5-tick limit, so it is capped.
+        assert ensure_safe_goal_position({"shoulder_pan": (40.0, 0.0)}, cfg.max_relative_target) == {
+            "shoulder_pan": 5.0
+        }
+
+    def test_per_motor_int_limits_are_normalized(self):
+        cfg = _build({"shoulder_pan": 5, "wrist_flex": 2.5})
+        assert cfg.max_relative_target == {"shoulder_pan": 5.0, "wrist_flex": 2.5}
+        assert all(isinstance(v, float) for v in cfg.max_relative_target.values())
+
+    def test_none_still_means_the_clamp_is_disabled(self):
+        """``None`` is the field's documented default and stays a valid value."""
+        assert _build(None).max_relative_target is None
+
+    def test_omitting_the_limit_leaves_the_field_at_its_default(self):
+        cfg = _make_robot()._create_minimal_config(ROBOT_TYPE, None, port="/dev/null")
+        assert cfg.max_relative_target is None
+
+
+class TestDomainMatchesTheDriverConsumer:
+    """Parity: what this layer accepts is exactly what the driver can honor.
+
+    Without this the two domains drift - which is how a value the config
+    dataclass accepts came to be one the consumer refuses.
+    """
+
+    @pytest.mark.parametrize(
+        "limit",
+        [
+            pytest.param(5.0, id="float"),
+            pytest.param(5, id="int"),
+            pytest.param(2.5, id="fractional"),
+            pytest.param({"shoulder_pan": 5}, id="mapping-of-int"),
+            pytest.param({"shoulder_pan": 2.5}, id="mapping-of-float"),
+        ],
+    )
+    def test_every_accepted_limit_behaves_as_a_clamp(self, limit):
+        assert _clamp_verdict(_build(limit).max_relative_target) == "clamps"
+
+    @pytest.mark.parametrize("limit", UNHONORABLE)
+    def test_every_refused_limit_would_not_have_behaved_as_a_clamp(self, limit):
+        """Each refused limit misbehaves on the wire, in its own way.
+
+        This is the other half of the parity: the guard is not merely stricter
+        than the consumer, it refuses exactly the values whose outcome at the
+        motors is wrong.
+        """
+        assert _clamp_verdict(limit) != "clamps"


### PR DESCRIPTION
## Problem

`max_relative_target` is the only per-command servo travel limit on the hardware path: it caps how far each commanded goal position may move from the joint's present position. `Robot(...)` forwarded it to lerobot's robot config verbatim, and the driver's consumer (`lerobot.robots.utils.ensure_safe_goal_position`) honors a narrower domain than the config dataclass accepts - so four different values built a working config and then misbehaved at the motors.

Measured on `so101_follower`, one joint at present position 0, driving that consumer with a `+40` then a `-40` tick request:

| `max_relative_target` | commanded travel | outcome |
|---|---|---|
| `5.0` | `+5.0` / `-5.0` | clamped correctly |
| `5` (int) | - | `TypeError(5)` at the first servo command |
| `-5.0` | `+5.0` / `+5.0` | commands move **away** from the goal |
| `0.0` | `0.0` / `0.0` | no motion permitted at all |
| `nan` | `+40.0` / `-40.0` | clamp silently disabled |

Each failure has a distinct mechanism:

- **A non-finite limit disables the clamp with no signal.** `min(diff, nan)` and `max(diff, -nan)` both return `diff` unchanged, so the caller believes travel is limited while every goal is applied in full.
- **A negative limit inverts it.** `min(diff, -c)` then `max(..., c)` resolves to `present + c` for any request - which is why a `-40` request is commanded as `+5`. The clamp becomes a fixed-magnitude step generator that ignores the policy.
- **A zero limit discards every commanded motion**, so the rollout is a no-op reported as success - the outcome the rollout horizon guards already refuse for `duration` (#1638) and `control_substeps` (#1639).
- **An `int` limit cannot reach the motors at all.** The field is annotated `float | dict[str, float] | None` and PEP 484's numeric tower makes an `int` assignable to it, so `max_relative_target=10` type-checks (verified: `mypy` accepts it against the real dataclass). The consumer dispatches on `isinstance(value, float)` and raises a bare `TypeError(10)` naming neither the parameter nor the reason - so the spelling a type checker is happiest with is the one that cannot reach the bus.

## Change

`_normalize_max_relative_target` validates and normalizes the limit when the config is built, before the serial port is opened, reusing the shared `positive_finite_number_error` domain so the rule cannot diverge from the other continuous knobs. Normalizing to `float` is load-bearing rather than cosmetic: it is what lets a type-correct `int` limit reach the bus at all.

Every value of a per-motor mapping is held to the same domain and named individually (`max_relative_target['shoulder_pan']`). The mapping **keys** are left to the driver's own `keys must match` refusal, since the motor names are known only once the bus is connected. `None` still means the clamp is disabled, and omitting the parameter is unchanged.

The guard sits after both forwarding loops and the kwarg-name gate, so it is checked exactly when it is the effective knob - a robot whose config does not declare the field never reads it, and refusing a value that robot would drop anyway would report an error for a parameter it has no opinion about - while a misspelled kwarg *name* still reports before a malformed *value*.

Other forwarded kwargs are deliberately untouched: their accepted domains are robot-specific (`kp`/`kd`/`default_positions` are per-driver vectors), whereas this one has a single documented meaning across every driver that declares it.

## Measurement

![max_relative_target travel clamp, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/servo-travel-clamp/servo-travel-clamp.png)

Dashed outlines are the travel the policy requested; solid bars are what the driver actually commanded. Both panels are generated by the same script against the two trees, driving lerobot's own `ensure_safe_goal_position` - the pre-fix panel with the source reverted to `main`.

## Tests

`tests/test_hardware_servo_safety_clamp.py`, 42 tests. **Pre-fix on `main`: 26 failed, 16 passed. Post-fix: 42 passed.**

The load-bearing one is a two-way parity check. A helper drives lerobot's consumer with an over-large request **in both directions** - an inverted limit only reveals itself on a move toward a goal *below* the present position - and classifies the result as `raises` / `unbounded` / `frozen` / `wrong-direction` / `clamps`. Then:

- every limit this layer accepts must classify as `clamps`;
- every limit it refuses must **not**.

That second half is what shows the guard is not merely stricter than the consumer: it refuses exactly the values whose outcome at the motors is wrong. Together they stop the two domains drifting apart again, which is how a value the dataclass accepts came to be one the consumer refuses.

Also pinned: the refusal precedes driver construction (`make_robot_from_config` is never called, so no port is opened); an `int` limit really does clamp an over-large goal after normalization; per-motor mapping values are normalized; and `None`/omission still leave the clamp disabled.

No serial/USB hardware is touched - only config dataclasses are built, and the driver factory is stubbed for the one dispatch test.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (947 source files)
- `MUJOCO_GL=egl pytest tests`: **13635 passed, 253 skipped** (457s)
- `scripts/assemble_changelog.py --check` OK; `changelog.d/` fragment added

## Docs

`docs/getting-started/robot-factory.md` documents the accepted domain beside the forwardable-kwargs list, matching the `control_frequency` paragraph already there.