### PR TITLE
fix(hardware): a shut-down Robot refuses task work instead of reporting a rollout it never drove

### DIFF
--- a/changelog.d/1729-shutdown-refuses-task-work.md
+++ b/changelog.d/1729-shutdown-refuses-task-work.md
@@ -1,0 +1,25 @@
+### Fixed: a shut-down hardware `Robot` no longer reports a rollout it never drove
+
+`cleanup()` (and `stop()`, which calls it) sets a shutdown latch and never clears
+it, then releases the task executor, the mesh and the ROS bridges. The control
+loop's condition honored that latch, but nothing else on the task path did, so it
+produced two misreports.
+
+A task started after `cleanup()` was admitted, took the motors-bus claim,
+commanded the arm zero times, and came back
+`Policy rollout completed: 0 steps in 0.0s` with `status="success"`.
+`start_task` was worse: its submit reached the already-shut-down executor and
+surfaced a bare `RuntimeError: cannot schedule new futures after shutdown` past a
+method whose contract is a tool-shaped result. `run_policy`, `start_task` and the
+`execute` action now refuse a shut-down robot by name, before the bus claim, so
+the refusal cannot leave the robot rejecting later work either.
+
+The second misreport could strike a rollout that really was driving the arm.
+`cleanup()` sets the latch first and only then calls `stop_task()` for a rollout
+it finds `RUNNING`; a loop that has already exited on the latch has left
+`RUNNING`, so `stop_task()` is never called and the stop latch stays clear. The
+terminal block consulted only the stop latch, so a rollout truncated two
+hundredths of a second into a thirty-second budget reported
+`completed: 24 steps`. It now consults both latches its own loop condition
+honors and reports `STOPPED`. A rollout that reaches its own budget is still
+`COMPLETED`.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -50,13 +50,21 @@ robot.cleanup()
 | `start_task(instruction, policy_port, policy_host, policy_provider, duration)` | Async; returns immediately. |
 | `stop_task()` | Halt the current task. Covers a task still in `CONNECTING` (bring-up): the rollout is abandoned before the arm is commanded. |
 | `get_task_status()` | Returns `RobotTaskState` (status, step count, error). |
-| `cleanup()` | Stop tasks, close cameras, stop mesh. |
+| `cleanup()` | Stop tasks, close cameras, stop mesh. Terminal - see below. |
 
 One rollout at a time: the arm has a single command bus, so `start_task` /
 `run_policy` / the `execute` action refuse while another task is in flight and
 name it in the error. That includes the `CONNECTING` bring-up window - a motors
 bus handshake plus per-camera warmup, seconds on a real arm - not just
 `RUNNING`. Call `stop_task()` to hand the bus over early.
+
+`cleanup()` (and `stop()`, which calls it) is terminal: it releases the task
+executor, the mesh and the ROS bridges, and there is no `restart`. The same
+three entry points refuse afterwards, naming the shutdown, rather than admitting
+a rollout that would command the arm zero times. A rollout already in flight when
+the shutdown lands is reported `STOPPED`, not `COMPLETED` - a shutdown truncates a
+task exactly as `stop_task()` does, so its step count is a partial one. Construct
+a new `Robot` to run another task.
 
 ## AgentTool actions
 

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1423,14 +1423,32 @@ class Robot(TeleopMixin, AgentTool):
             self._task_state.duration = elapsed
 
             if self._task_state.status == TaskStatus.RUNNING:
+                # Both latches in the loop condition above are consulted here.
                 # A stop can land in the gap between the check above and the
                 # ``RUNNING`` write, which overwrites the ``STOPPED`` status
-                # ``stop_task`` recorded. The latch survives that write, so it
-                # is what decides here - otherwise an interrupted task reports
+                # ``stop_task`` recorded; a shutdown is never recorded on the
+                # status at all. The latches survive that write, so they are
+                # what decide here - otherwise an interrupted task reports
                 # itself completed.
+                #
+                # Shutdown is checked as well as stop because ``cleanup`` sets
+                # ``_shutdown_event`` FIRST and only then calls ``stop_task``
+                # for a rollout it finds ``RUNNING``. A loop that has already
+                # exited on the shutdown latch by that point is no longer
+                # ``RUNNING``, so ``stop_task`` is never called and the stop
+                # latch stays clear - the rollout was truncated with nothing
+                # recording it.
                 if self._stop_requested.is_set():
                     self._task_state.status = TaskStatus.STOPPED
                     logger.info(f"Task stopped: '{instruction}' after {self._task_state.step_count} steps")
+                elif self._shutdown_event.is_set():
+                    self._task_state.status = TaskStatus.STOPPED
+                    logger.info(
+                        "%s: task interrupted by shutdown: '%s' after %d steps",
+                        self.tool_name_str,
+                        instruction,
+                        self._task_state.step_count,
+                    )
                 else:
                     self._task_state.status = TaskStatus.COMPLETED
                     logger.info(
@@ -1441,6 +1459,44 @@ class Robot(TeleopMixin, AgentTool):
             logger.error(f"Task execution failed: {e}")
             self._task_state.status = TaskStatus.ERROR
             self._task_state.error_message = str(e)
+
+    def _shutdown_error(self, method: str) -> dict[str, Any] | None:
+        """Refuse task work on a Robot that has already been shut down.
+
+        ``cleanup`` (and ``stop``, which calls it) sets ``_shutdown_event`` and
+        never clears it, then shuts the task executor down and tears down the
+        mesh and ROS bridges. The control loop's condition honors that latch,
+        so a rollout started afterwards exits before its first iteration - but
+        nothing refused the call, so it took the motors-bus claim, commanded
+        the arm zero times and reported a terminal status for a rollout that
+        never ran. ``start_task`` was worse: its submit hits the dead executor
+        and used to surface a bare ``RuntimeError`` past a method whose
+        contract is a tool-shaped result.
+
+        A shut-down Robot cannot be revived - there is no ``restart`` - so this
+        is a permanent refusal by design and names ``cleanup`` as the cause.
+
+        Args:
+            method: Public entry point being refused, named in the message so
+                the caller can see which call was rejected.
+
+        Returns:
+            ``None`` when the Robot is live, or a tool-shaped error when it has
+            been shut down.
+        """
+        if not self._shutdown_event.is_set():
+            return None
+        return {
+            "status": "error",
+            "content": [
+                {
+                    "text": f"{self.tool_name_str}: {method} refused - this robot has been shut down.\n"
+                    f"cleanup() (or stop()) has already released the executor, mesh and ROS bridges, so a "
+                    f"rollout started now would command the arm zero times. Construct a new Robot to run "
+                    f"another task."
+                }
+            ],
+        }
 
     @staticmethod
     def _duration_error(duration: Any, method: str) -> dict[str, Any] | None:
@@ -1553,6 +1609,8 @@ class Robot(TeleopMixin, AgentTool):
         # check is stateless, so it runs before the claim - a rejected budget
         # must not take the bus away from a rollout that could still start.
         if err := self._duration_error(duration, "execute_task"):
+            return err
+        if err := self._shutdown_error("execute_task"):
             return err
         if err := self._claim_task(instruction):
             return err
@@ -1684,12 +1742,23 @@ class Robot(TeleopMixin, AgentTool):
             Tool-shaped result confirming the task started, or an error naming
             the offending parameter. A second task is refused while another
             rollout is in flight - including during its connect/policy-build
-            bring-up - because the arm has a single command bus.
+            bring-up - because the arm has a single command bus. A robot that
+            has been shut down by ``cleanup`` / ``stop`` is refused
+            permanently: its executor and bridges are gone, so a rollout
+            started now would command the arm zero times.
         """
         # Before the submit: the work happens on a background thread, so a
         # budget checked inside it would still report "Task started" to the
         # caller for a task that commands nothing (or never ends).
         if err := self._duration_error(duration, "start_task"):
+            return err
+
+        # Also before the submit, and before the claim: the executor is already
+        # shut down on a cleaned-up robot, so the submit below would raise a
+        # bare ``RuntimeError`` out of a method that reports through a result
+        # dict - and a refused call must not take the bus claim it would then
+        # have to hand back.
+        if err := self._shutdown_error("start_task"):
             return err
 
         # Claim the bus here, not on the executor thread: this method returns
@@ -1751,6 +1820,13 @@ class Robot(TeleopMixin, AgentTool):
         Two rollouts admitted at once would interleave ``send_action`` writes
         on one half-duplex bus and share the single task-state slot.
 
+        Terminal after shutdown: ``cleanup`` / ``stop`` release the executor,
+        mesh and ROS bridges and cannot be undone, so a rollout requested
+        afterwards is refused rather than admitted to command the arm zero
+        times. A rollout already running when the shutdown lands is reported
+        ``STOPPED`` - a shutdown truncates a task exactly as ``stop_task``
+        does, so its step count is a partial one.
+
         Args:
             policy_object: A constructed ``Policy`` instance. The object's
                 own device / embodiment / chunking configuration is honored;
@@ -1782,6 +1858,8 @@ class Robot(TeleopMixin, AgentTool):
                 "content": [{"text": "policy_object is required (for the provider+port path use start_task)"}],
             }
         if err := self._duration_error(duration, "run_policy"):
+            return err
+        if err := self._shutdown_error("run_policy"):
             return err
         if err := self._claim_task(instruction):
             return err

--- a/tests/test_hardware_shutdown_never_reports_completed.py
+++ b/tests/test_hardware_shutdown_never_reports_completed.py
@@ -1,0 +1,270 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""A shut-down robot must refuse task work, not report a rollout it never drove.
+
+``cleanup`` (and ``stop``, which calls it) sets ``_shutdown_event`` and never
+clears it, then shuts the task executor down and tears down the mesh and ROS
+bridges. ``_execute_task_async``'s loop condition honors that latch - but it was
+the only thing that did, so the latch produced two different misreports.
+
+A task started after ``cleanup`` was admitted, took the motors-bus claim,
+commanded the arm zero times, and was reported as finished work::
+
+    run 1 status: success | commands: 176
+    cleanup()
+    run 2 status: success
+    run 2 text  : Policy rollout completed: 0 steps in 0.0s
+    run 2 commands: 0
+
+``start_task`` was worse still: its submit reached the already-shut-down
+executor and surfaced a bare ``RuntimeError: cannot schedule new futures after
+shutdown`` past a method whose contract is a tool-shaped result.
+
+The second misreport is the more serious one, because it can strike a rollout
+that really was driving the arm. ``cleanup`` sets the latch FIRST and only then
+calls ``stop_task`` for a rollout it finds ``RUNNING``; a loop that has already
+exited on the latch by that point is no longer ``RUNNING``, so ``stop_task`` is
+never called and the stop latch stays clear. The terminal block consulted only
+the stop latch, so a rollout truncated two hundredths of a second into a
+thirty-second budget reported itself complete::
+
+    status      : success
+    text        : Policy rollout completed: 24 steps in 0.0s
+    task status : TaskStatus.COMPLETED
+    stop latch  : False | shutdown latch: True
+
+These tests pin both halves of the contract: the entry points refuse a shut-down
+robot by name, and the terminal block treats a shutdown as the interruption it
+is. A rollout that reaches its own budget is still ``COMPLETED``, so the guard
+cannot swallow a genuine success.
+
+No serial port is opened and no arm is commanded: the lerobot driver is an
+in-memory fake and every latch transition is one the test performs explicitly,
+so nothing here depends on wall-clock timing.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.policies.base import Policy
+
+_JOINT = "gripper.pos"
+
+
+class _FakeArm:
+    """In-memory stand-in for a connected lerobot robot.
+
+    ``on_step`` fires after the Nth command reaches the bus, which is how a
+    latch transition is placed at an exact point in the rollout instead of
+    after a sleep.
+    """
+
+    def __init__(self, on_step: tuple[int, Any] | None = None) -> None:
+        self.name = "fake_arm"
+        self.robot_type = "fake_arm"
+        self.sent_actions: list[dict[str, Any]] = []
+        self._on_step = on_step
+
+    def connect(self, calibrate: bool = False) -> None:
+        return None
+
+    @property
+    def is_connected(self) -> bool:
+        return True
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def get_observation(self) -> dict[str, Any]:
+        return {_JOINT: 0.0}
+
+    def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
+        self.sent_actions.append(dict(action))
+        if self._on_step is not None and len(self.sent_actions) == self._on_step[0]:
+            self._on_step[1]()
+        return dict(action)
+
+    def disconnect(self) -> None:
+        return None
+
+
+class _ChunkPolicy(Policy):
+    """Emits a four-action chunk per query, so a rollout accrues steps fast."""
+
+    @property
+    def provider_name(self) -> str:
+        return "test"
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        return None
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        return [{_JOINT: 0.4}] * 4
+
+
+def _rollout_json(result: dict[str, Any]) -> dict[str, Any]:
+    """Pull ``run_policy``'s structured report out of its tool-shaped result."""
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+def _make_robot(arm: _FakeArm) -> HwRobot:
+    """Build a Robot bypassing hardware init (the pattern used across tests/)."""
+    hw = HwRobot.__new__(HwRobot)
+    hw.tool_name_str = "fake_arm"
+    hw.action_horizon = 4
+    hw.data_config = None
+    hw.control_frequency = 500.0
+    hw.action_sleep_time = 1.0 / 500.0
+    hw._task_state = RobotTaskState()
+    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="fake_arm_executor")
+    hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
+    hw.mesh = None
+    hw.peer_id = None
+    hw.robot = arm
+
+    def publish(observation: dict[str, Any], skip_images: bool = False) -> None:
+        return None
+
+    hw._publish_ros_telemetry = publish  # type: ignore[method-assign]
+    return hw
+
+
+@pytest.fixture
+def arm() -> _FakeArm:
+    return _FakeArm()
+
+
+@pytest.fixture
+def hw(arm: _FakeArm) -> Any:
+    robot = _make_robot(arm)
+    yield robot
+    robot._executor.shutdown(wait=False)
+
+
+# Every public way to ask a Robot to drive a task, with the name each reports.
+_ENTRY_POINTS = [
+    ("run_policy", lambda hw: hw.run_policy(_ChunkPolicy(), "pick the cube", duration=5.0, n_steps=4)),
+    ("start_task", lambda hw: hw.start_task("pick the cube", policy_port=5555, duration=5.0)),
+    ("execute_task", lambda hw: hw._execute_task_sync("pick the cube", policy_port=5555, duration=5.0)),
+]
+
+
+class TestAShutDownRobotRefusesTaskWork:
+    """Every task entry point refuses a robot whose resources are already gone."""
+
+    @pytest.mark.parametrize("method,call", _ENTRY_POINTS, ids=[name for name, _ in _ENTRY_POINTS])
+    def test_a_task_started_after_cleanup_is_refused_and_commands_nothing(
+        self, hw: HwRobot, arm: _FakeArm, method: str, call: Any
+    ) -> None:
+        """The refusal is tool-shaped, names the method and the cause, and moves no servo.
+
+        ``start_task`` is the one that used to raise instead of returning: its
+        submit reaches the dead executor. All three must report identically.
+        """
+        hw.cleanup()
+
+        result = call(hw)
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert method in text
+        assert "shut down" in text
+        assert "cleanup()" in text
+        assert arm.sent_actions == []
+
+    def test_a_refused_call_does_not_take_the_motors_bus_claim(self, hw: HwRobot) -> None:
+        """A refusal that claimed the bus would leave the robot refusing every later task.
+
+        The claim is released in ``_drive_claimed_task``'s ``finally``, which a
+        refused call never reaches, so the guard has to run before the claim.
+        """
+        hw.cleanup()
+
+        assert hw.run_policy(_ChunkPolicy(), "pick the cube", duration=5.0)["status"] == "error"
+
+        assert hw._task_claimed is False
+
+    def test_a_refused_call_leaves_the_previous_rollout_report_intact(self, hw: HwRobot, arm: _FakeArm) -> None:
+        """A refusal reports on the call, not on the task state, so history survives it."""
+        first = hw.run_policy(_ChunkPolicy(), "pick the cube", duration=5.0, n_steps=8)
+        assert first["status"] == "success"
+        assert _rollout_json(first)["steps"] == 8
+
+        hw.cleanup()
+        hw.run_policy(_ChunkPolicy(), "pick it again", duration=5.0, n_steps=8)
+
+        assert hw._task_state.step_count == 8
+        assert hw._task_state.instruction == "pick the cube"
+        assert len(arm.sent_actions) == 8
+
+
+class TestAShutdownIsReportedAsAnInterruption:
+    """The terminal block consults both latches its own loop condition honors."""
+
+    def test_cleanup_latches_the_shutdown_without_recording_a_stop(self, hw: HwRobot) -> None:
+        """This is why the truncation below cannot be detected from the stop latch.
+
+        ``cleanup`` sets ``_shutdown_event`` first and only calls ``stop_task``
+        for a rollout it still finds ``RUNNING``. A loop that has already exited
+        on the latch has left ``RUNNING``, so nothing records the interruption
+        anywhere except the latch itself.
+        """
+        hw._task_state.status = TaskStatus.COMPLETED
+
+        hw.cleanup()
+
+        assert hw._shutdown_event.is_set() is True
+        assert hw._stop_requested.is_set() is False
+
+    def test_a_rollout_truncated_by_a_shutdown_is_reported_stopped(self) -> None:
+        """A rollout cut short at 8 of a 5-second budget is an interruption, not a success."""
+        arm = _FakeArm()
+        hw = _make_robot(arm)
+        arm._on_step = (8, hw._shutdown_event.set)
+
+        result = hw.run_policy(_ChunkPolicy(), "pick the cube", duration=5.0)
+
+        assert result["status"] == "error"
+        assert _rollout_json(result)["status"] == TaskStatus.STOPPED.value
+        assert hw._task_state.status is TaskStatus.STOPPED
+        # The interruption was invisible to the stop latch - only the shutdown
+        # latch recorded it, which is exactly what used to be ignored.
+        assert hw._stop_requested.is_set() is False
+        assert len(arm.sent_actions) < 100
+        hw._executor.shutdown(wait=False)
+
+    def test_an_explicit_stop_outranks_a_shutdown_in_the_report(self) -> None:
+        """Both latches set means an operator pressed stop, which is the more specific cause."""
+        arm = _FakeArm()
+        hw = _make_robot(arm)
+
+        def both() -> None:
+            hw.stop_task()
+            hw._shutdown_event.set()
+
+        arm._on_step = (8, both)
+
+        hw.run_policy(_ChunkPolicy(), "pick the cube", duration=5.0)
+
+        assert hw._task_state.status is TaskStatus.STOPPED
+        hw._executor.shutdown(wait=False)
+
+    def test_a_rollout_that_reaches_its_own_budget_still_completes(self, hw: HwRobot, arm: _FakeArm) -> None:
+        """Negative control: the guard must not turn an ordinary success into an error."""
+        result = hw.run_policy(_ChunkPolicy(), "pick the cube", duration=5.0, n_steps=8)
+
+        assert result["status"] == "success"
+        assert hw._task_state.status is TaskStatus.COMPLETED
+        assert len(arm.sent_actions) == 8


### PR DESCRIPTION
## Closed - the production change landed as #1730

#1730 merged as `63ee040` while this PR's last check was finishing, and it carries the **identical** production change: the same `_shutdown_error(method)` refusal on `run_policy` / `start_task` / `_execute_task_sync` sited before the bus claim, and the same `_shutdown_event` term added to the terminal-status discriminator. Rebasing this branch would re-apply a guard that is already on `main`, so it is closed rather than conflict-resolved.

Both PRs were cut from the same #1723 ledger item (`test_hardware_after_shutdown.py`), which the ledger records as taken twice - once at 12:43 and again at 13:00, 17 minutes apart. That is a sequencing defect: the ledger note for an item was written without first checking whether an open PR already claimed it. Noted on #1723 so the next extraction does not repeat it.

### What in this diff is not on `main`

The test file is a duplicate in substance - the behaviour it pins is pinned by the merged `tests/test_hardware_after_shutdown.py` - so it is not being re-landed. Three documentation points are genuinely absent from `main`, because #1730 shipped the refusal without describing it anywhere user-facing:

| location on `main` | drift |
|---|---|
| `docs/hardware/robot-control.md`, `cleanup()` row | reads "Stop tasks, close cameras, stop mesh" - does not say it is terminal |
| `docs/hardware/robot-control.md`, task-lifecycle prose | documents the one-rollout-at-a-time refusal but not the permanent post-shutdown refusal, and does not say an in-flight rollout is reported `STOPPED` |
| `start_task` `Returns:` / `run_policy` "Exclusive:" docstrings | describe only the concurrent-rollout refusal, so the permanent one is undocumented at the call site |

Those three are being re-landed as one docs-only PR against current `main`. Nothing else here is carried forward.

---

<details>
<summary>Original description</summary>

Superseded - see #1730 for the change as merged.

</details>
