### PR TITLE
docs(hardware): say that cleanup() is terminal for task work

### DIFF
--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -50,13 +50,22 @@ robot.cleanup()
 | `start_task(instruction, policy_port, policy_host, policy_provider, duration)` | Async; returns immediately. |
 | `stop_task()` | Halt the current task. Covers a task still in `CONNECTING` (bring-up): the rollout is abandoned before the arm is commanded. |
 | `get_task_status()` | Returns `RobotTaskState` (status, step count, error). |
-| `cleanup()` | Stop tasks, close cameras, stop mesh. |
+| `cleanup()` | Stop tasks, close cameras, stop mesh. Terminal - see below. |
 
 One rollout at a time: the arm has a single command bus, so `start_task` /
 `run_policy` / the `execute` action refuse while another task is in flight and
 name it in the error. That includes the `CONNECTING` bring-up window - a motors
 bus handshake plus per-camera warmup, seconds on a real arm - not just
 `RUNNING`. Call `stop_task()` to hand the bus over early.
+
+`cleanup()` (and `stop()`, which calls it) is terminal: it latches a shutdown,
+releases the task executor, and tears down the mesh and ROS bridges. There is no
+`restart`, so those same three entry points refuse permanently afterwards and
+name the shutdown, rather than admitting a rollout that would command the arm
+zero times. A rollout already in flight when the shutdown lands is reported
+`STOPPED`, not `COMPLETED` - a shutdown truncates a task exactly as
+`stop_task()` does, so its step count is a partial one. Construct a new `Robot`
+to run another task.
 
 ## AgentTool actions
 

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1785,7 +1785,10 @@ class Robot(TeleopMixin, AgentTool):
             Tool-shaped result confirming the task started, or an error naming
             the offending parameter. A second task is refused while another
             rollout is in flight - including during its connect/policy-build
-            bring-up - because the arm has a single command bus.
+            bring-up - because the arm has a single command bus. A robot that
+            ``cleanup`` / ``stop`` has shut down is refused permanently: the
+            executor and bridges are gone, so a rollout started now would
+            command the arm zero times.
         """
         # Before the submit: the work happens on a background thread, so a
         # budget checked inside it would still report "Task started" to the
@@ -1858,6 +1861,13 @@ class Robot(TeleopMixin, AgentTool):
         connecting or building its policy, before it reports ``RUNNING``.
         Two rollouts admitted at once would interleave ``send_action`` writes
         on one half-duplex bus and share the single task-state slot.
+
+        Terminal after shutdown: ``cleanup`` / ``stop`` release the task
+        executor, the mesh and the ROS bridges and cannot be undone, so a
+        rollout requested afterwards is refused rather than admitted to command
+        the arm zero times. A rollout already running when the shutdown lands is
+        reported ``STOPPED`` - a shutdown truncates a task exactly as
+        ``stop_task`` does, so its step count is a partial one.
 
         Args:
             policy_object: A constructed ``Policy`` instance. The object's
@@ -2173,7 +2183,16 @@ class Robot(TeleopMixin, AgentTool):
             )
 
     def cleanup(self) -> None:
-        """Cleanup resources and stop any running tasks."""
+        """Cleanup resources and stop any running tasks.
+
+        Terminal: this latches a shutdown, releases the task executor, and
+        tears down the mesh and ROS bridges. There is no ``restart``, so
+        ``run_policy`` / ``start_task`` / the ``execute`` action refuse
+        permanently afterwards rather than admit a rollout that would command
+        the arm zero times, and a rollout still in flight when this runs is
+        reported ``STOPPED`` rather than ``COMPLETED``. Construct a new
+        ``Robot`` to run another task.
+        """
         try:
             # Signal shutdown
             self._shutdown_event.set()


### PR DESCRIPTION
## Problem

#1730 shipped the post-shutdown refusal but described it nowhere a caller would look. On `main` at `63ee040`:

| location | what it says | what it omits |
|---|---|---|
| `docs/hardware/robot-control.md`, `cleanup()` row | "Stop tasks, close cameras, stop mesh." | that it cannot be undone |
| `docs/hardware/robot-control.md`, task-lifecycle prose | the one-rollout-at-a-time refusal, including the `CONNECTING` window | that the same three entry points refuse *permanently* after `cleanup()`, and that a rollout the shutdown truncates is reported `STOPPED` |
| `start_task` `Returns:` | "A second task is refused while another rollout is in flight" | the permanent refusal |
| `run_policy` "Exclusive:" paragraph | the concurrent-rollout refusal | same |
| `cleanup()` docstring | "Cleanup resources and stop any running tasks." | everything above |

Grepping the docs tree for `terminal`, `shutdown`, or a refusal naming a shutdown returns nothing, so a reader who calls `cleanup()` and then `run_policy()` gets an error that no document predicts. The `_shutdown_error` docstring #1730 added does explain it, but it is a private method - not what a caller reads.

## Change

Prose only, in the four places above. Every claim was checked against `main` rather than carried over from a description:

- `cleanup()` sets `_shutdown_event`, stops teleop, stops a `RUNNING` task, calls `self._executor.shutdown(wait=True)`, stops the mesh and calls `_shutdown_ros_bridge()` - so "latches a shutdown, releases the task executor, and tears down the mesh and ROS bridges" is what it does, in that order.
- `_shutdown_error` is called from exactly three sites (`execute_task`, `start_task`, `run_policy`), which is why the docs say "those same three entry points".
- `grep -c 'def restart'` is 0, so "there is no `restart`" is accurate and the refusal is permanent rather than clearable.
- The terminal block reports `STOPPED` when either latch is set, so an in-flight rollout truncated by a shutdown is `STOPPED`, not `COMPLETED`.

## Deliberately out of scope

**The `cleanup()` row's "close cameras" claim is wrong, and this PR does not fix it.** `cleanup()` never calls `self.robot.disconnect()`, so the motors bus and cameras stay open - that is #1731. Correcting the row here would either document a leak that #1731 is about to remove, or pre-announce #1731's fix; either way it is a second concern with a different blast radius. The row is left as-is apart from the `Terminal - see below.` pointer, and the added prose makes no claim about devices being closed.

No changelog fragment: the behaviour this describes already has one (`changelog.d/1730-no-rollout-after-shutdown.md`, still unassembled), and a second entry for the same change would double it in the released log. Per `changelog.d/README.md` it is behavioural PRs that write fragments.

## Verification

The Python edit is docstrings only, and that is proven rather than asserted - parsing `main`'s `hardware_robot.py` and this branch's, normalizing every docstring constant to a fixed string, then comparing `ast.dump`:

```
AST identical ignoring docstrings: True
```

So there is no reachable behaviour difference in this diff.

- `ruff check` + `ruff format --check` on `strands_robots/hardware_robot.py`: clean
- `pytest tests/test_docs_home_navigation.py tests/test_docs_brand_visuals.py tests/test_changelog_fragments.py tests/test_changelog_format.py tests/test_no_host_paths.py tests/test_source_strings_no_internal_file_paths.py`: **42 passed**
- non-ASCII sweep over the added lines: clean

## Provenance

These four edits are the only part of the closed #1729 not already on `main`. #1729 and #1730 were cut from the same #1723 ledger item 17 minutes apart and carried the identical production guard; #1730 merged first, so #1729 is closed and its documentation delta is re-landed here against current `main` instead of being rebased through a conflicting duplicate.

Refs #1723, #1730.