### PR TITLE
fix(hardware): cleanup() releases the robot's devices, not just library state

### DIFF
--- a/changelog.d/1728-camera-rollback-on-failed-connect.md
+++ b/changelog.d/1728-camera-rollback-on-failed-connect.md
@@ -2,7 +2,7 @@
 
 A robot's `connect()` opens its devices in sequence - the motors bus, then each
 camera in turn - and nothing in that loop closes the cameras opened before one
-that fails. `Robot._rollback_half_open_connect` closed only the serial port, so
+that fails. `Robot._close_open_devices` closed only the serial port, so
 a camera set was left half-open, and lerobot gates both recovery paths on
 `is_connected`: the retry raised `DeviceAlreadyConnectedError` on a camera that
 was healthy, masking the camera that actually failed, and `disconnect()` refused

--- a/changelog.d/1731-cleanup-releases-devices.md
+++ b/changelog.d/1731-cleanup-releases-devices.md
@@ -1,0 +1,28 @@
+### Fixed: `cleanup()` disconnects the robot's devices instead of holding them for the life of the process
+
+`Robot.cleanup()` released every resource the library owns - the shutdown latch,
+the task executor, the mesh client, the ROS bridge - but never the ones that are
+physical devices: the motors bus serial port and one `/dev/video*` node plus read
+thread per camera. Both API tables already documented it as closing the cameras.
+A serial port is exclusive, so the port stayed held for the life of the process
+and the documented tear-down-and-reconnect recovery could not work without
+exiting; `cleanup()` is also what `__del__` calls, so a script that finished
+normally left the arm energised at its last commanded position rather than going
+through the driver's own disconnect, where the Feetech
+`disable_torque_on_disconnect` write lives. Nothing could recover it afterwards:
+the executor is shut down and the shutdown latched, so no library entry point
+remained that would reach a disconnect.
+
+`cleanup()` now disconnects the devices, after the task executor has drained so a
+rollout still finishing cannot command a port closing underneath it, preferring
+the driver's own `disconnect()` and then closing each device independently - so a
+half-open set, which that driver call refuses to touch because it is gated on
+every device, is still released, and one camera that will not close cannot keep
+the bus open.
+
+`stop()`, the async spelling of the same teardown, called
+`robot.disconnect()` *before* `cleanup()`. That call raises
+`DeviceNotConnectedError` when the robot is not connected, so stopping a robot
+that was never connected ended the teardown early and left the executor running
+and the shutdown unlatched - the terminal guarantee did not hold for the most
+ordinary case. It now delegates to `cleanup()`, which owns the disconnect.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -101,7 +101,7 @@ from strands_robots.hardware_robot import Robot, TaskStatus, RobotTaskState
 | `start_task(instruction, policy_port, ...)` | Async task start. |
 | `stop_task()` | Halt the current task, including one still in `CONNECTING`. |
 | `get_task_status()` | Return `RobotTaskState`. |
-| `cleanup()` | Stop tasks, close cameras, stop mesh. |
+| `cleanup()` | Stop tasks, disconnect the motors bus and cameras, stop mesh. |
 
 ## `strands_robots.policies`
 

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -50,7 +50,7 @@ robot.cleanup()
 | `start_task(instruction, policy_port, policy_host, policy_provider, duration)` | Async; returns immediately. |
 | `stop_task()` | Halt the current task. Covers a task still in `CONNECTING` (bring-up): the rollout is abandoned before the arm is commanded. |
 | `get_task_status()` | Returns `RobotTaskState` (status, step count, error). |
-| `cleanup()` | Stop tasks, close cameras, stop mesh. Terminal - see below. |
+| `cleanup()` | Stop tasks, disconnect the motors bus and cameras, stop mesh. Terminal - see below. |
 
 One rollout at a time: the arm has a single command bus, so `start_task` /
 `run_policy` / the `execute` action refuse while another task is in flight and
@@ -59,13 +59,22 @@ bus handshake plus per-camera warmup, seconds on a real arm - not just
 `RUNNING`. Call `stop_task()` to hand the bus over early.
 
 `cleanup()` (and `stop()`, which calls it) is terminal: it latches a shutdown,
-releases the task executor, and tears down the mesh and ROS bridges. There is no
-`restart`, so those same three entry points refuse permanently afterwards and
-name the shutdown, rather than admitting a rollout that would command the arm
-zero times. A rollout already in flight when the shutdown lands is reported
-`STOPPED`, not `COMPLETED` - a shutdown truncates a task exactly as
-`stop_task()` does, so its step count is a partial one. Construct a new `Robot`
-to run another task.
+releases the task executor, disconnects the robot's devices, and tears down the
+mesh and ROS bridges. There is no `restart`, so those same three entry points
+refuse permanently afterwards and name the shutdown, rather than admitting a
+rollout that would command the arm zero times. A rollout already in flight when
+the shutdown lands is reported `STOPPED`, not `COMPLETED` - a shutdown truncates
+a task exactly as `stop_task()` does, so its step count is a partial one.
+Construct a new `Robot` to run another task.
+
+The disconnect is part of that teardown, not something to do first: the serial
+port is exclusive, so releasing it is what lets the next `Robot` - in this
+process or another one - open the same `/dev/tty*`. It runs after the task
+executor has drained, so a rollout still finishing cannot command a port being
+closed underneath it, and it goes through the driver's own `disconnect()`, which
+is where the Feetech `disable_torque_on_disconnect` write lives. Each device is
+then closed independently, so one camera that will not close cannot keep the bus
+or the rest of the set open.
 
 ## AgentTool actions
 

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1134,58 +1134,105 @@ class Robot(TeleopMixin, AgentTool):
 
         return create_policy(policy_provider, **policy_config)
 
-    def _rollback_half_open_connect(self) -> None:
-        """Close every device a failed connect can leave half-open.
+    def _close_open_devices(self) -> None:
+        """Close every device that is still open, one device at a time.
 
-        lerobot's ``MotorsBus.connect()`` opens the serial port *before* the
-        motor handshake, so a failed handshake (e.g. an unpowered bus) leaves
-        ``is_connected`` True while fire-and-forget writes to the dead bus
-        keep "succeeding". A robot's ``connect()`` then opens its cameras one
-        at a time (``for cam in self.cameras.values(): cam.connect()``) with
-        no cleanup of its own, so a camera that fails to open leaves every
-        camera ahead of it in the set still streaming.
+        lerobot opens a robot's devices in sequence -- ``bus.connect()``, then
+        ``for cam in self.cameras.values(): cam.connect()`` -- and closes them
+        in one unguarded loop, so a partial open and a partial close both
+        leave a subset of the set holding its device node. This sweep closes
+        whatever is still open, independently per device.
 
-        Either leak makes the *next* attempt unrecoverable rather than merely
-        failing. The retry raises ``DeviceAlreadyConnectedError`` on a device
-        that is perfectly healthy, which masks the device that actually
-        failed, and ``Robot.disconnect()`` cannot recover the state because it
-        is gated on ``is_connected`` -- false while any one device is still
-        shut. Closing every device that is open is what makes the next attempt
-        retry the connect and keep surfacing the real failure.
+        Two callers need it, for the same reason:
 
-        Each device is closed independently and best-effort: a rollback runs
-        from an ``except`` handler, so one close that raises must neither mask
-        the original connect error nor stop the remaining devices from being
-        closed.
+        - **a failed connect** (:meth:`_connect_robot`, and the lazy connect in
+          :meth:`send_action`). ``MotorsBus.connect()`` opens the serial port
+          *before* the motor handshake, so a failed handshake leaves
+          ``is_connected`` True while fire-and-forget writes to the dead bus
+          keep "succeeding"; and a camera that fails to open leaves every
+          camera ahead of it in the set still streaming. Either leak makes the
+          *next* attempt unrecoverable rather than merely failing: the retry
+          raises ``DeviceAlreadyConnectedError`` on a device that is perfectly
+          healthy, masking the device that actually failed, and
+          ``Robot.disconnect()`` cannot recover the state because it is gated
+          on ``is_connected`` -- false while any one device is still shut.
+        - **teardown** (:meth:`_disconnect_robot_devices`), where the driver's
+          own ``disconnect()`` is likewise gated on ``is_connected`` and so
+          refuses to run at all on that same half-open set.
+
+        Best-effort by design: both callers run after something has already
+        gone wrong, so one close that raises must neither mask the original
+        failure nor stop the remaining devices from being closed.
         """
-        bus = getattr(self.robot, "bus", None)
+        bus = getattr(getattr(self, "robot", None), "bus", None)
         try:
             if bus is not None and getattr(bus, "is_connected", False):
-                # disable_torque=False: the handshake already failed, so the
-                # default disconnect's torque write would only raise again
-                # (before ``closePort``) and leave the port open.
+                # disable_torque=False: this runs only after the driver's own
+                # ordered disconnect could not, so the torque write would most
+                # likely raise again (before ``closePort``) and leave the port
+                # open. Releasing the port is the recoverable outcome.
                 bus.disconnect(disable_torque=False)
         except Exception:  # noqa: BLE001 - best-effort cleanup
-            logger.debug("%s post-connect-failure port close failed", self.tool_name_str)
+            logger.debug("%s port close failed", self.tool_name_str)
 
         # lerobot builds ``cameras`` with ``make_cameras_from_configs``, whose
         # contract is ``dict[str, Camera]``; anything else is not a camera set
         # this rollback can walk.
-        cameras = getattr(self.robot, "cameras", None)
+        cameras = getattr(getattr(self, "robot", None), "cameras", None)
         for name, camera in cameras.items() if isinstance(cameras, Mapping) else ():
             try:
                 # A camera that failed to open already released its own
-                # resources in ``connect()``; disconnecting it again would
-                # raise ``DeviceNotConnectedError``.
+                # resources in ``connect()``, and a camera the driver's
+                # disconnect loop already closed reports the same; either way
+                # disconnecting it again would raise
+                # ``DeviceNotConnectedError``.
                 if getattr(camera, "is_connected", False):
                     camera.disconnect()
             except Exception:  # noqa: BLE001 - best-effort, and per camera so
                 # one stuck camera cannot keep the rest of the set open.
                 logger.debug(
-                    "%s post-connect-failure camera %s close failed",
+                    "%s camera %s close failed",
                     self.tool_name_str,
                     name,
                 )
+
+    def _disconnect_robot_devices(self) -> None:
+        """Release the driver's devices: the motors bus and every camera.
+
+        The serial port is exclusive on Linux and macOS, so leaving it open
+        holds it for the life of the process: a second process, or a
+        re-constructed ``Robot`` in this one, cannot open the same
+        ``/dev/tty*``. The documented recovery for a wedged arm -- tear down
+        and reconnect -- depends on this running.
+
+        Prefers the driver's own ``disconnect()``, which is where the Feetech
+        drivers do their ``disable_torque_on_disconnect`` write, so a normal
+        teardown de-energises the arm rather than leaving it holding the last
+        commanded position. That call is gated on ``is_connected`` (a robot's
+        bus *and* every camera), so it is skipped when the set is already
+        closed or only partly open; :meth:`_close_open_devices` then closes
+        whatever is still holding a device node, which is the only way out of
+        the half-open states a failed connect can leave.
+
+        Best-effort: this runs from :meth:`cleanup`, which must release every
+        remaining resource whatever else has failed, so a driver whose
+        ``disconnect()`` raises is warned about and swept up rather than
+        aborting the teardown.
+        """
+        try:
+            if getattr(getattr(self, "robot", None), "is_connected", False):
+                self.robot.disconnect()
+        except Exception as disconnect_exc:  # noqa: BLE001 - teardown is best-effort
+            logger.warning(
+                "%s: robot.disconnect() raised during cleanup: %s",
+                self.tool_name_str,
+                disconnect_exc,
+            )
+        # Unconditional: lerobot's ``disconnect()`` is a single unguarded loop
+        # over the devices, so the first close that raises abandons the rest.
+        # Sweeping afterwards makes "no device is left open" hold whether that
+        # loop ran, ran partway, or was skipped.
+        self._close_open_devices()
 
     async def _connect_robot(self) -> tuple[bool, str]:
         """Connect to robot hardware with proper error handling.
@@ -1246,7 +1293,7 @@ class Robot(TeleopMixin, AgentTool):
             # Same rollback as the lazy teleop connect: without it a half-open
             # port makes the NEXT _connect_robot short-circuit on
             # "already connected" and report success against a dead bus.
-            self._rollback_half_open_connect()
+            self._close_open_devices()
             return False, error_msg
 
     async def _initialize_policy(self, policy: Policy) -> bool:
@@ -2185,8 +2232,9 @@ class Robot(TeleopMixin, AgentTool):
     def cleanup(self) -> None:
         """Cleanup resources and stop any running tasks.
 
-        Terminal: this latches a shutdown, releases the task executor, and
-        tears down the mesh and ROS bridges. There is no ``restart``, so
+        Terminal: this latches a shutdown, releases the task executor,
+        disconnects the robot's devices, and tears down the mesh and ROS
+        bridges. There is no ``restart``, so
         ``run_policy`` / ``start_task`` / the ``execute`` action refuse
         permanently afterwards rather than admit a rollout that would command
         the arm zero times, and a rollout still in flight when this runs is
@@ -2216,6 +2264,12 @@ class Robot(TeleopMixin, AgentTool):
 
             # Shutdown executor
             self._executor.shutdown(wait=True)
+
+            # Release the physical devices: the motors bus and the cameras.
+            # After the executor has drained, so a rollout still finishing
+            # cannot issue ``send_action`` on a port that is being closed
+            # underneath it.
+            self._disconnect_robot_devices()
 
             # Tear down the Zenoh mesh component if one was attached.
             # ``self.mesh`` is any object exposing ``.stop()``; falsy values
@@ -2323,7 +2377,7 @@ class Robot(TeleopMixin, AgentTool):
                 try:
                     self.robot.connect(False)
                 except Exception:
-                    self._rollback_half_open_connect()
+                    self._close_open_devices()
                     raise
             self.robot.send_action(action)
             return {"status": "success", "content": [{"text": "ok"}]}
@@ -2335,18 +2389,24 @@ class Robot(TeleopMixin, AgentTool):
             }
 
     async def stop(self) -> None:
-        """Stop robot and disconnect."""
+        """Stop robot and disconnect.
+
+        Terminal, exactly as :meth:`cleanup` is -- this is the async spelling
+        of it. The disconnect is part of that cleanup rather than a step ahead
+        of it: lerobot's ``Robot.disconnect()`` is gated on ``is_connected``
+        and raises ``DeviceNotConnectedError`` when it is not, so calling it
+        first meant stopping a robot that was never connected raised before
+        ``cleanup()`` was reached and left the executor running and the
+        shutdown unlatched.
+        """
         try:
             # Stop any running task first
             if self._task_state.status == TaskStatus.RUNNING:
                 self.stop_task()
 
-            # Disconnect robot hardware
-            if hasattr(self.robot, "disconnect"):
-                await asyncio.to_thread(self.robot.disconnect)
-
-            # Cleanup resources
-            self.cleanup()
+            # Off the event loop: cleanup() joins the task executor and closes
+            # the serial port, both of which block.
+            await asyncio.to_thread(self.cleanup)
 
             logger.info(f"{self.tool_name_str} stopped and disconnected")
 

--- a/tests/test_hardware_camera_rollback.py
+++ b/tests/test_hardware_camera_rollback.py
@@ -1,7 +1,7 @@
 """A failed connect must not leave a camera it already opened streaming.
 
-``strands_robots.hardware_robot.Robot._rollback_half_open_connect`` exists so a
-connect that fails partway can be retried. lerobot's robots open their devices
+``strands_robots.hardware_robot.Robot._close_open_devices`` exists so a connect
+that fails partway can be retried. lerobot's robots open their devices
 in sequence -- ``bus.connect()``, then ``for cam in self.cameras.values():
 cam.connect()`` -- and neither the loop nor the failing camera closes the
 cameras opened before it. Rolling back only the serial port therefore leaves

--- a/tests/test_hardware_cleanup_releases_devices.py
+++ b/tests/test_hardware_cleanup_releases_devices.py
@@ -1,0 +1,262 @@
+"""``cleanup()`` must release the devices it documents, not just library state.
+
+``Robot.cleanup()`` tears down everything the *library* owns -- the shutdown
+latch, the task executor, the mesh client, the ROS bridge -- and both API
+tables document it as "stop tasks, disconnect the arm and cameras, stop mesh".
+The one resource that is a physical device was the only thing it left alone:
+the ``FeetechMotorsBus`` serial port, plus one ``/dev/video*`` node and one
+read thread per camera.
+
+That is not tidiness. A serial port is exclusive on Linux and macOS, so a
+second process -- or a re-constructed ``Robot`` in this one -- cannot open the
+same ``/dev/tty*`` afterwards, which is exactly the documented recovery for a
+wedged arm. ``cleanup()`` is also what ``__del__`` calls, so a script that
+finishes normally left the arm energised at its last commanded position instead
+of going through the driver's own disconnect, where the Feetech
+``disable_torque_on_disconnect`` write lives. And nothing else could recover
+it: the executor is shut down and the shutdown is latched, so no library entry
+point remained that would reach a disconnect.
+
+``stop()`` -- the async spelling of the same teardown -- had the mirror-image
+defect. It called ``self.robot.disconnect()`` *before* ``cleanup()``, and
+lerobot's ``Robot.disconnect()`` is ``@check_if_not_connected``, so stopping a
+robot that was never connected raised ``DeviceNotConnectedError`` inside
+``stop()``'s own handler and ``cleanup()`` was never reached at all: the
+executor kept running and the shutdown stayed unlatched, so the terminal
+guarantee ``stop()`` documents did not hold.
+
+These tests pin the whole teardown contract:
+
+    - a connected robot's bus and cameras are closed, exactly once each, and
+      through the driver's own ``disconnect()`` so the torque write happens;
+    - the disconnect runs *after* the task executor has drained, so a rollout
+      still finishing cannot command a port being closed underneath it;
+    - a half-open device set -- which the driver's own ``disconnect()`` refuses
+      to touch because it is gated on every device -- is still closed;
+    - one device whose close raises does not keep the rest of the set open, and
+      does not propagate out of the teardown;
+    - ``cleanup()`` is idempotent, and safe on a driver that exposes no devices
+      at all;
+    - ``stop()`` is terminal whether or not the robot was ever connected.
+
+No serial port and no camera device is opened: the lerobot driver and its
+cameras are the in-memory fakes from ``test_hardware_camera_rollback``, which
+mirror lerobot's connect ordering, its unguarded disconnect loop and its
+``is_connected`` / decorator contracts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+from tests.test_hardware_camera_rollback import (
+    _FakeCamera,
+    _FakeCameraRobot,
+    _make_robot,
+)
+
+DEADLINE = 5.0
+"""Seconds. A blocked teardown must fail the test, not hang the suite."""
+
+
+def _connected_robot(**camera_kwargs: Any) -> tuple[Any, Any]:
+    """A one-camera arm, connected, plus the ``Robot`` wrapping it."""
+    fake = _FakeCameraRobot({"wrist": _FakeCamera("wrist_cam", **camera_kwargs)})
+    hw = _make_robot(fake)
+    ok, err = asyncio.run(hw._connect_robot())
+    assert ok is True, err
+    assert fake.is_connected is True
+    return fake, hw
+
+
+class TestCleanupReleasesTheDevices:
+    """The physical devices are part of what ``cleanup()`` releases."""
+
+    def test_the_bus_and_every_camera_are_closed(self) -> None:
+        """Leaving them open holds the serial port for the life of the
+        process, so the documented tear-down-and-reconnect recovery cannot
+        work without exiting."""
+        fake, hw = _connected_robot()
+
+        hw.cleanup()
+
+        assert fake.bus.is_connected is False
+        assert fake.cameras["wrist"].is_connected is False
+        assert fake.is_connected is False
+
+    def test_the_driver_disconnect_does_the_torque_write(self) -> None:
+        """Going through the driver's own ``disconnect()`` is what de-energises
+        the arm: ``disable_torque_on_disconnect`` lives there, so force-closing
+        the port instead would leave the arm holding its last command."""
+        fake, hw = _connected_robot()
+
+        hw.cleanup()
+
+        assert fake.bus.disconnect_calls == [True]
+        assert fake.cameras["wrist"].disconnect_calls == 1
+
+    def test_a_second_cleanup_does_not_disconnect_again(self) -> None:
+        """``cleanup()`` is reachable twice -- explicitly and then from
+        ``__del__`` -- and a device that is already closed raises
+        ``DeviceNotConnectedError`` if asked again."""
+        fake, hw = _connected_robot()
+
+        hw.cleanup()
+        hw.cleanup()
+
+        assert fake.bus.disconnect_calls == [True]
+        assert fake.cameras["wrist"].disconnect_calls == 1
+
+    def test_a_driver_exposing_no_devices_is_tolerated(self) -> None:
+        """``robot=`` accepts any lerobot ``Robot``, and the base class
+        declares ``disconnect()`` as a no-op with no bus or camera attributes
+        at all. Teardown must not depend on them existing."""
+
+        class _Minimal:
+            is_connected = False
+
+            def disconnect(self) -> None:
+                raise AssertionError("must not be called on a disconnected robot")
+
+        hw = _make_robot(_Minimal())
+
+        hw.cleanup()  # must not raise
+
+        assert hw._shutdown_event.is_set() is True
+
+
+class TestCleanupOrdering:
+    """The port must not close under a rollout that is still draining."""
+
+    def test_the_disconnect_waits_for_the_task_executor(self) -> None:
+        """``send_action`` on a closed port is the failure this ordering
+        exists to prevent, so the disconnect has to follow
+        ``executor.shutdown(wait=True)`` rather than precede it."""
+        fake, hw = _connected_robot()
+        log: list[str] = []
+        gate = threading.Event()
+
+        def _draining_rollout() -> None:
+            log.append("rollout-start")
+            gate.wait(DEADLINE)
+            log.append(f"rollout-sees-bus-open={fake.bus.is_connected}")
+            log.append("rollout-end")
+
+        original_disconnect = fake.bus.disconnect
+
+        def _recording_disconnect(disable_torque: bool = True) -> None:
+            log.append("bus-disconnect")
+            original_disconnect(disable_torque)
+
+        fake.bus.disconnect = _recording_disconnect  # type: ignore[method-assign]
+
+        hw._executor.submit(_draining_rollout)
+        # Opened from a third thread, so the rollout genuinely spans the
+        # teardown instead of finishing before it starts.
+        threading.Timer(0.2, gate.set).start()
+
+        hw.cleanup()
+
+        assert log == [
+            "rollout-start",
+            "rollout-sees-bus-open=True",
+            "rollout-end",
+            "bus-disconnect",
+        ]
+
+
+class TestCleanupIsBestEffort:
+    """One device that cannot be closed must not keep the others open."""
+
+    def test_a_half_open_set_is_still_closed(self) -> None:
+        """``Robot.disconnect()`` is gated on ``is_connected`` -- the bus *and*
+        every camera -- so it refuses to run while any one camera is shut. The
+        port would otherwise stay open with no library path left to release
+        it."""
+        fake, hw = _connected_robot()
+        fake.cameras["wrist"].is_connected = False  # e.g. a camera that dropped out
+        assert fake.is_connected is False
+        assert fake.bus.is_connected is True
+
+        hw.cleanup()
+
+        assert fake.bus.is_connected is False
+        # Force-closed rather than through the driver: its ordered disconnect,
+        # and with it the torque write, could not run on a half-open set.
+        assert fake.bus.disconnect_calls == [False]
+
+    def test_a_camera_that_cannot_close_does_not_keep_the_rest_open(self) -> None:
+        """lerobot's ``disconnect()`` is one unguarded loop, so the first close
+        that raises abandons every device after it. Closing each device
+        independently afterwards is what bounds the damage to the stuck one."""
+        fake = _FakeCameraRobot(
+            {
+                "stuck": _FakeCamera("stuck_cam", close_raises=True),
+                "healthy": _FakeCamera("healthy_cam"),
+            }
+        )
+        hw = _make_robot(fake)
+        asyncio.run(hw._connect_robot())
+        assert fake.is_connected is True
+
+        hw.cleanup()  # must not raise
+
+        assert fake.bus.is_connected is False
+        assert fake.cameras["healthy"].is_connected is False
+        assert fake.cameras["stuck"].is_connected is True
+
+    def test_a_driver_disconnect_that_raises_does_not_abort_the_teardown(self) -> None:
+        """``cleanup()`` releases every remaining resource whatever else has
+        failed, so a driver that raises on disconnect must not stop the mesh
+        and ROS bridges from being torn down."""
+        fake, hw = _connected_robot()
+        mesh_stops: list[str] = []
+        hw.mesh = type("Mesh", (), {"stop": lambda _self: mesh_stops.append("stopped")})()
+
+        def _raising_disconnect() -> None:
+            raise OSError("bus went away")
+
+        fake.disconnect = _raising_disconnect  # type: ignore[method-assign]
+
+        hw.cleanup()  # must not raise
+
+        assert mesh_stops == ["stopped"]
+        # Swept up device by device once the driver's own loop could not run.
+        assert fake.bus.is_connected is False
+        assert fake.cameras["wrist"].is_connected is False
+
+
+class TestStopIsTerminal:
+    """``stop()`` is the async spelling of ``cleanup()``, on every path."""
+
+    def test_stopping_a_robot_that_was_never_connected_still_shuts_it_down(self) -> None:
+        """``Robot.disconnect()`` raises ``DeviceNotConnectedError`` when the
+        robot is not connected. Doing it ahead of ``cleanup()`` meant that
+        error ended the teardown early, leaving the executor running and the
+        shutdown unlatched -- so the terminal guarantee did not hold for the
+        most ordinary case of all."""
+        fake = _FakeCameraRobot({"wrist": _FakeCamera("wrist_cam")})
+        hw = _make_robot(fake)
+        executor = hw._executor
+        assert fake.is_connected is False
+
+        asyncio.run(asyncio.wait_for(hw.stop(), timeout=DEADLINE))
+
+        assert hw._shutdown_event.is_set() is True
+        assert executor._shutdown is True
+        assert fake.bus.disconnect_calls == []
+
+    def test_stopping_a_connected_robot_disconnects_it_once(self) -> None:
+        """The disconnect moved into ``cleanup()``, so it must not also happen
+        in ``stop()``: a second one would raise on the now-closed devices."""
+        fake, hw = _connected_robot()
+        executor = hw._executor
+
+        asyncio.run(asyncio.wait_for(hw.stop(), timeout=DEADLINE))
+
+        assert fake.bus.disconnect_calls == [True]
+        assert fake.cameras["wrist"].disconnect_calls == 1
+        assert fake.is_connected is False
+        assert executor._shutdown is True


### PR DESCRIPTION
Closes #1731.

`Robot.cleanup()` tears down every resource the library owns - the shutdown latch, the task executor, the mesh client, the ROS bridge. The only resources it left open were the ones that are physical devices: the motors bus serial port, plus one `/dev/video*` node and one read thread per camera. Both API tables already documented it as closing the cameras (`docs/api-reference.md`, `docs/hardware/robot-control.md`: "Stop tasks, close cameras, stop mesh").

That is not tidiness:

- **the port stays held.** A serial port is exclusive on Linux and macOS, so a second process - or a re-constructed `Robot` in this one - cannot open the same `/dev/tty*`. The documented recovery for a wedged arm, tear down and reconnect, therefore could not work without exiting the process.
- **`cleanup()` is what `__del__` calls**, so a script that finishes normally left the arm energised at whatever it was last commanded, instead of going through the driver's own `disconnect()` - which is where the Feetech `disable_torque_on_disconnect` write lives.
- **it was unrecoverable after the fact.** The executor is shut down and the shutdown is latched, so no library entry point remained that would reach a disconnect, and lerobot's `Robot.disconnect()` is `@check_if_not_connected` so it cannot be called by hand on the half-open sets #1728 documented.

## Measured, on a real camera device

One SO-arm driver with a real `/dev/video2` camera, `connect()` then `cleanup()`. The left panel is a frame the camera **still delivered after `cleanup()` returned** - the device node was genuinely streaming, not merely mis-flagged.

![cleanup device release](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cleanup-devices/cleanup_devices.png)

| measured | before | after |
|---|---|---|
| motors bus port, after `cleanup()` | held | released |
| camera device node, after `cleanup()` | held (`async_read()` returned a live 640x480 frame) | released (`DeviceNotConnectedError`) |
| driver `disconnect()` calls (the torque-disable write) | 0 | 1 |
| `stop()` on a never-connected robot: shutdown latched | no | yes |
| `stop()` on a never-connected robot: executor released | no | yes |

A second `cleanup()` changed nothing either way - it was not a case of the teardown being deferred.

## The second symptom: `stop()` was not terminal

`stop()` is the async spelling of the same teardown, and it ran `self.robot.disconnect()` *before* `cleanup()`. That call raises `DeviceNotConnectedError` when the robot is not connected, and `stop()` catches it in its own outer handler - so `cleanup()` was never reached: the executor kept running and the shutdown stayed unlatched. Stopping a robot that was never connected, or was already disconnected, silently did not stop it, which is the opposite of the terminal guarantee the method documents.

## The change

`cleanup()` now releases the devices, in one new step placed **after** `self._executor.shutdown(wait=True)`:

- **the driver's own `disconnect()` first**, when the robot reports connected, so the ordered teardown and its torque-disable write happen.
- **then a per-device sweep**, unconditionally. lerobot's `disconnect()` is a single unguarded loop (`bus.disconnect(...)` then `for cam in self.cameras.values(): cam.disconnect()`), so the first close that raises abandons every device after it - reproducing that shape inside a teardown would defeat it. Sweeping afterwards makes "no device is left open" hold whether that loop ran, ran partway, or was skipped. Being gated on `is_connected` (the bus *and* every camera) is exactly why it is skipped on a half-open set, and closing those is the only way out of the states #1728 documented as unrecoverable.
- **ordering:** after the executor drains, so a rollout still finishing cannot issue `send_action` on a port being closed underneath it. It has to be after `stop_task()` too, and `stop_task()` is reached earlier in the same method.
- **best-effort**, matching every other branch in `cleanup()`: a driver whose `disconnect()` raises is warned about and swept up rather than aborting the rest of the teardown.

`stop()` drops its own disconnect and delegates to `cleanup()`, off the event loop (that call joins the executor and closes a serial port, both blocking).

The sweep `_rollback_half_open_connect` is renamed `_close_open_devices`, with its docstring generalised to name both callers: teardown is now a second caller, so the name states what it does rather than which caller first needed it. Three call sites updated; nothing else references it. The pending #1728 fragment names the helper, so it follows the rename.

### Considered and rejected

**Reusing the connect-failure set.** The rollback deliberately passes `disable_torque=False` because a failed handshake makes the torque write raise again before `closePort`. Using only that path for a normal teardown would silently drop the torque-disable write, so the driver's own `disconnect()` has to be the preferred path and the sweep the salvage.

**Leaving the devices open, and documenting that.** Both API tables already promised the opposite, so there was no contract to preserve - and there is no other library path to a disconnect once `cleanup()` has run, so "call it yourself" is not available to a caller.

## Tests

`tests/test_hardware_cleanup_releases_devices.py`, 10 tests, pinning the whole teardown contract: bus and cameras closed exactly once each and through the driver's own `disconnect()`; the disconnect ordered after the executor drains (a job spanning the teardown records that it saw the bus open, and the log asserts the disconnect follows it); a half-open set still released; one camera whose close raises not keeping the bus or the rest of the set open, and not propagating; a driver whose `disconnect()` raises not aborting the mesh teardown; idempotence; a driver exposing no devices at all; and `stop()` terminal whether or not the robot was ever connected.

No serial port and no camera device is opened - the driver and cameras are the in-memory fakes from `test_hardware_camera_rollback`, which mirror lerobot's connect ordering, its unguarded disconnect loop and its `is_connected` / decorator contracts.

Against `main`: **8 failed, 2 passed**. The two that pass are properties already true - a driver with no devices is tolerated, and `stop()` on a *connected* robot did disconnect it - kept so the change cannot regress them.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (952 source files).
- Full suite: **13698 passed, 253 skipped** in 463s.
