### PR TITLE
fix(hardware): close the motors bus and cameras on cleanup()

### DIFF
--- a/changelog.d/1734-cleanup-disconnects-devices.md
+++ b/changelog.d/1734-cleanup-disconnects-devices.md
@@ -1,0 +1,24 @@
+### Fixed: `cleanup()` now closes the motors bus and the cameras
+
+`Robot.cleanup()` released every resource the library owns -- the shutdown latch,
+a teleop loop, a `RUNNING` task, the task executor, the mesh client, the ROS
+bridge -- but never called `robot.disconnect()`, so the only resources that are a
+physical device were the only ones it left open: the motors bus serial port plus
+a `/dev/video*` node and a read thread per camera. A serial port is exclusive, so
+a second process -- or a re-constructed `Robot` in the same one -- could not open
+the same `/dev/tty*`, which made the documented recovery for a wedged arm (tear
+down, reconnect) unavailable without exiting the process. `cleanup()` is also
+what `__del__` calls, so a script that simply ended left the arm energised at its
+last commanded position instead of going through the driver's disconnect, where
+torque disable and gripper release live; and it was unrecoverable afterwards,
+because the executor is down and the shutdown is latched, while lerobot's gated
+`Robot.disconnect()` refuses in every half-open state. `cleanup()` now
+disconnects, preferring the driver's own `disconnect()` while the robot is
+connected and otherwise closing each device individually -- so a half-open set,
+or one abandoned partway through lerobot's single unguarded disconnect loop,
+still ends with the port released and every camera closed, and a close that
+raises is warned rather than propagated. The disconnect runs last, after the
+teleop loop, the executor drain, the mesh and the ROS bridge, because
+`send_action` re-opens the robot lazily on a command that finds it disconnected:
+a port closed while any command source is still live would be re-opened behind
+the teardown and then stay open for the life of the process.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -101,7 +101,7 @@ from strands_robots.hardware_robot import Robot, TaskStatus, RobotTaskState
 | `start_task(instruction, policy_port, ...)` | Async task start. |
 | `stop_task()` | Halt the current task, including one still in `CONNECTING`. |
 | `get_task_status()` | Return `RobotTaskState`. |
-| `cleanup()` | Stop tasks, close cameras, stop mesh. |
+| `cleanup()` | Stop tasks, disconnect the motors bus and cameras, stop mesh. |
 
 ## `strands_robots.policies`
 

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -50,7 +50,7 @@ robot.cleanup()
 | `start_task(instruction, policy_port, policy_host, policy_provider, duration)` | Async; returns immediately. |
 | `stop_task()` | Halt the current task. Covers a task still in `CONNECTING` (bring-up): the rollout is abandoned before the arm is commanded. |
 | `get_task_status()` | Returns `RobotTaskState` (status, step count, error). |
-| `cleanup()` | Stop tasks, close cameras, stop mesh. Terminal - see below. |
+| `cleanup()` | Stop tasks, disconnect the robot (motors bus + every camera), stop mesh. Terminal - see below. |
 
 One rollout at a time: the arm has a single command bus, so `start_task` /
 `run_policy` / the `execute` action refuse while another task is in flight and
@@ -59,7 +59,13 @@ bus handshake plus per-camera warmup, seconds on a real arm - not just
 `RUNNING`. Call `stop_task()` to hand the bus over early.
 
 `cleanup()` (and `stop()`, which calls it) is terminal: it latches a shutdown,
-releases the task executor, and tears down the mesh and ROS bridges. There is no
+releases the task executor, tears down the mesh and ROS bridges, and disconnects
+the robot. The disconnect goes through the driver's own `disconnect()` while the
+robot is connected - that is where torque disable and gripper release live - and
+closes each device individually otherwise, so a half-open device set still ends
+with the serial port released and every camera node closed. A serial port is
+exclusive, so this is what makes the recovery for a wedged arm - tear down,
+construct a new `Robot` - work without exiting the process. There is no
 `restart`, so those same three entry points refuse permanently afterwards and
 name the shutdown, rather than admitting a rollout that would command the arm
 zero times. A rollout already in flight when the shutdown lands is reported

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1134,39 +1134,46 @@ class Robot(TeleopMixin, AgentTool):
 
         return create_policy(policy_provider, **policy_config)
 
-    def _rollback_half_open_connect(self) -> None:
-        """Close every device a failed connect can leave half-open.
+    def _close_open_devices(self) -> None:
+        """Close every device that is open, one at a time and best-effort.
 
-        lerobot's ``MotorsBus.connect()`` opens the serial port *before* the
-        motor handshake, so a failed handshake (e.g. an unpowered bus) leaves
-        ``is_connected`` True while fire-and-forget writes to the dead bus
-        keep "succeeding". A robot's ``connect()`` then opens its cameras one
-        at a time (``for cam in self.cameras.values(): cam.connect()``) with
-        no cleanup of its own, so a camera that fails to open leaves every
-        camera ahead of it in the set still streaming.
+        Two callers need exactly this, both for a device set that is only
+        *partly* open -- the state lerobot's own ``Robot.disconnect()`` cannot
+        recover, because it is gated on ``is_connected``
+        (``bus.is_connected and all(cam.is_connected ...)``):
 
-        Either leak makes the *next* attempt unrecoverable rather than merely
-        failing. The retry raises ``DeviceAlreadyConnectedError`` on a device
-        that is perfectly healthy, which masks the device that actually
-        failed, and ``Robot.disconnect()`` cannot recover the state because it
-        is gated on ``is_connected`` -- false while any one device is still
-        shut. Closing every device that is open is what makes the next attempt
-        retry the connect and keep surfacing the real failure.
+        - **A failed connect.** lerobot's ``MotorsBus.connect()`` opens the
+          serial port *before* the motor handshake, so a failed handshake
+          (e.g. an unpowered bus) leaves ``is_connected`` True while
+          fire-and-forget writes to the dead bus keep "succeeding". A robot's
+          ``connect()`` then opens its cameras one at a time
+          (``for cam in self.cameras.values(): cam.connect()``) with no
+          cleanup of its own, so a camera that fails to open leaves every
+          camera ahead of it in the set still streaming. Either leak makes the
+          *next* attempt unrecoverable rather than merely failing: the retry
+          raises ``DeviceAlreadyConnectedError`` on a device that is perfectly
+          healthy, which masks the device that actually failed.
+        - **Teardown.** ``cleanup()`` prefers the driver's own ``disconnect()``
+          while the robot is fully connected, and falls back here when it is
+          not -- or when that disconnect raised partway and abandoned the
+          devices behind it.
 
-        Each device is closed independently and best-effort: a rollback runs
-        from an ``except`` handler, so one close that raises must neither mask
-        the original connect error nor stop the remaining devices from being
-        closed.
+        Each device is closed independently: one close that raises must
+        neither mask the caller's original error nor stop the remaining
+        devices from being closed, which is the failure mode lerobot's single
+        unguarded disconnect loop has.
         """
         bus = getattr(self.robot, "bus", None)
         try:
             if bus is not None and getattr(bus, "is_connected", False):
-                # disable_torque=False: the handshake already failed, so the
-                # default disconnect's torque write would only raise again
-                # (before ``closePort``) and leave the port open.
+                # disable_torque=False: this runs only where the driver's own
+                # disconnect is unavailable, would be refused, or has already
+                # raised, so a torque write here would most likely raise again
+                # -- before ``closePort``, leaving the port open, which is the
+                # one outcome this method exists to prevent.
                 bus.disconnect(disable_torque=False)
         except Exception:  # noqa: BLE001 - best-effort cleanup
-            logger.debug("%s post-connect-failure port close failed", self.tool_name_str)
+            logger.debug("%s port close failed", self.tool_name_str)
 
         # lerobot builds ``cameras`` with ``make_cameras_from_configs``, whose
         # contract is ``dict[str, Camera]``; anything else is not a camera set
@@ -1182,10 +1189,48 @@ class Robot(TeleopMixin, AgentTool):
             except Exception:  # noqa: BLE001 - best-effort, and per camera so
                 # one stuck camera cannot keep the rest of the set open.
                 logger.debug(
-                    "%s post-connect-failure camera %s close failed",
+                    "%s camera %s close failed",
                     self.tool_name_str,
                     name,
                 )
+
+    def _disconnect_devices(self) -> None:
+        """Close the physical devices this robot holds: motors bus and cameras.
+
+        Every other teardown branch in ``cleanup()`` releases a resource the
+        *library* owns -- the teleop loop, the task executor, the mesh client,
+        the ROS bridge. The devices are the only resources that are physical,
+        and they were the only ones left open: a serial port is exclusive on
+        Linux and macOS, so a second process (or a re-constructed ``Robot`` in
+        this one) could not open the same ``/dev/tty*``, which made the
+        documented recovery for a wedged arm -- tear down and reconnect --
+        unavailable without exiting the process. Each camera also holds a
+        ``/dev/video*`` node and a read thread.
+
+        The driver's own ``disconnect()`` is preferred while it is callable,
+        because that is where a follower disables torque and releases the
+        gripper; closing the port underneath it skips both and leaves the arm
+        energised at its last commanded position.
+        """
+        disconnect = getattr(self.robot, "disconnect", None)
+        if callable(disconnect) and getattr(self.robot, "is_connected", False):
+            try:
+                disconnect()
+                return
+            except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+                logger.warning(
+                    "%s: robot.disconnect() raised during cleanup: %s",
+                    self.tool_name_str,
+                    exc,
+                )
+
+        # Reached when the driver exposes no ``disconnect``, when it would
+        # refuse (lerobot gates it on ``is_connected``, false in every
+        # half-open state), or when it raised partway through its own single
+        # unguarded loop and so abandoned every device after the one that
+        # failed. Closing each device independently is what still gets the
+        # port and the surviving cameras shut.
+        self._close_open_devices()
 
     async def _connect_robot(self) -> tuple[bool, str]:
         """Connect to robot hardware with proper error handling.
@@ -1246,7 +1291,7 @@ class Robot(TeleopMixin, AgentTool):
             # Same rollback as the lazy teleop connect: without it a half-open
             # port makes the NEXT _connect_robot short-circuit on
             # "already connected" and report success against a dead bus.
-            self._rollback_half_open_connect()
+            self._close_open_devices()
             return False, error_msg
 
     async def _initialize_policy(self, policy: Policy) -> bool:
@@ -2185,8 +2230,10 @@ class Robot(TeleopMixin, AgentTool):
     def cleanup(self) -> None:
         """Cleanup resources and stop any running tasks.
 
-        Terminal: this latches a shutdown, releases the task executor, and
-        tears down the mesh and ROS bridges. There is no ``restart``, so
+        Terminal: this latches a shutdown, releases the task executor, tears
+        down the mesh and ROS bridges, and disconnects the robot -- the motors
+        bus and every camera -- so no device node stays held. There is no
+        ``restart``, so
         ``run_policy`` / ``start_task`` / the ``execute`` action refuse
         permanently afterwards rather than admit a rollout that would command
         the arm zero times, and a rollout still in flight when this runs is
@@ -2234,6 +2281,14 @@ class Robot(TeleopMixin, AgentTool):
 
             # Tear down the ROS 2 telemetry bridge if one was created.
             self._shutdown_ros_bridge()
+
+            # Close the devices last, once every source of commands is down.
+            # ``send_action`` re-opens the robot lazily on a command that finds
+            # it disconnected, so a port closed before the teleop loop, the
+            # task executor, the mesh and the ROS bridge have stopped can be
+            # re-opened behind this teardown -- and would then stay open for
+            # the life of the process, since nothing runs after ``cleanup()``.
+            self._disconnect_devices()
 
             logger.info(f"{self.tool_name_str} cleanup completed")
 
@@ -2323,7 +2378,7 @@ class Robot(TeleopMixin, AgentTool):
                 try:
                     self.robot.connect(False)
                 except Exception:
-                    self._rollback_half_open_connect()
+                    self._close_open_devices()
                     raise
             self.robot.send_action(action)
             return {"status": "success", "content": [{"text": "ok"}]}

--- a/tests/test_hardware_camera_rollback.py
+++ b/tests/test_hardware_camera_rollback.py
@@ -1,6 +1,6 @@
 """A failed connect must not leave a camera it already opened streaming.
 
-``strands_robots.hardware_robot.Robot._rollback_half_open_connect`` exists so a
+``strands_robots.hardware_robot.Robot._close_open_devices`` exists so a
 connect that fails partway can be retried. lerobot's robots open their devices
 in sequence -- ``bus.connect()``, then ``for cam in self.cameras.values():
 cam.connect()`` -- and neither the loop nor the failing camera closes the

--- a/tests/test_hardware_cleanup_disconnects.py
+++ b/tests/test_hardware_cleanup_disconnects.py
@@ -1,0 +1,444 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""``cleanup()`` must close the devices, not just the resources the library owns.
+
+``Robot.cleanup()`` tears down everything *software* holds -- it latches
+``_shutdown_event``, stops a teleop loop, stops a ``RUNNING`` task, shuts the
+task executor, stops the mesh client and the ROS bridge. It never called
+``self.robot.disconnect()``, so the only resources that are a physical device --
+the motors bus serial port, plus one ``/dev/video*`` node and one read thread
+per camera -- were the only ones it left open. Measured with a driver double
+recording every call, on a one-camera arm:
+
+    after                          bus open   camera open   disconnect calls
+    connect + a healthy rollout      yes          yes              0
+    cleanup()                        yes          yes              0
+    a second cleanup()               yes          yes              0
+
+That is not untidiness. A serial port is exclusive on Linux and macOS, so a
+second process -- or a re-constructed ``Robot`` in this one -- cannot open the
+same ``/dev/tty*``, which makes the documented recovery for a wedged arm (tear
+down, reconnect) unavailable without exiting the process. ``cleanup()`` is also
+what ``__del__`` calls, so a script that simply ends left the arm energised at
+its last commanded position instead of going through the driver's disconnect,
+where torque disable and gripper release live. And it was unrecoverable
+afterwards: the executor is shut down and ``_shutdown_event`` is set, so no
+library entry point remained that would reach a disconnect, while lerobot's
+``Robot.disconnect()`` is ``@check_if_not_connected`` and so cannot be called by
+hand in a half-open state.
+
+What these tests pin:
+
+    - the round trip -- connect, rollout, ``cleanup()`` -- closes the bus and
+      every camera, each disconnected exactly once, and the port is free for
+      the next holder;
+    - ``cleanup()`` stays idempotent: a second call disconnects nothing again
+      rather than raising ``DeviceNotConnectedError`` from the driver;
+    - the driver's own ``disconnect()`` is what runs while it can, because that
+      is where torque disable lives;
+    - a camera whose close raises does not keep the bus or the remaining
+      cameras open, and is warned rather than propagated -- lerobot's own
+      ``disconnect()`` is a single unguarded loop, so the first close that
+      raises abandons every device after it;
+    - a half-open robot (``is_connected`` False with the port still open) still
+      gets that port closed, which is the state no other entry point can reach;
+    - a driver exposing no ``disconnect`` at all is not an error;
+    - the devices close *last*, after the mesh and the ROS bridge, and after the
+      executor has drained -- ``send_action`` re-opens the robot lazily, so a
+      port closed while any command source is still live gets re-opened behind
+      the teardown and then stays open for the life of the process.
+
+No serial port and no camera device is opened: the lerobot driver, its bus and
+its cameras are in-memory doubles that mirror lerobot's connect ordering, its
+``is_connected`` composition and its decorator contracts. Port exclusivity is
+modelled explicitly so the consequence, not just the call, is asserted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState
+
+#: Upper bound on any wait, so a broken contract fails instead of hanging.
+DEADLINE = 10.0
+
+
+class _Port:
+    """An exclusive device node: at most one holder at a time.
+
+    Modelled because it is the reason the leak matters. Asserting only that
+    ``disconnect()`` was called would pass on a driver that records the call
+    and keeps the node.
+    """
+
+    def __init__(self) -> None:
+        self.held_by: str | None = None
+
+    def open(self, holder: str) -> None:
+        if self.held_by is not None:
+            raise OSError(f"[Errno 16] Device or resource busy: /dev/ttyACM0 held by {self.held_by}")
+        self.held_by = holder
+
+    def close(self) -> None:
+        self.held_by = None
+
+
+class _Bus:
+    """Motors-bus double holding an exclusive port and recording every close."""
+
+    def __init__(self, port: _Port, *, holder: str = "arm", log: list[str] | None = None) -> None:
+        self.port = port
+        self.holder = holder
+        self.log = log if log is not None else []
+        self.is_connected = False
+        self.connect_calls = 0
+        self.disconnect_calls: list[bool] = []
+
+    def connect(self) -> None:
+        self.connect_calls += 1
+        self.port.open(self.holder)
+        self.is_connected = True
+
+    def disconnect(self, disable_torque: bool = True) -> None:
+        self.disconnect_calls.append(disable_torque)
+        self.log.append("bus.disconnect")
+        self.port.close()
+        self.is_connected = False
+
+
+class _Camera:
+    """Mirrors ``OpenCVCamera``'s connect / disconnect / ``is_connected``."""
+
+    def __init__(self, name: str, *, close_raises: bool = False, log: list[str] | None = None) -> None:
+        self.name = name
+        self.log = log if log is not None else []
+        self._close_raises = close_raises
+        self.is_connected = False
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+
+    def connect(self, warmup: bool = True) -> None:  # noqa: ARG002 - lerobot signature
+        self.connect_calls += 1
+        if self.is_connected:
+            raise DeviceAlreadyConnectedError(f"{self.name} is already connected.")
+        self.is_connected = True
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self.log.append(f"camera.{self.name}.disconnect")
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self.name} is not connected.")
+        if self._close_raises:
+            raise OSError(f"{self.name} close failed")
+        self.is_connected = False
+
+
+class _Driver:
+    """Mirrors lerobot ``SOFollower``: composed ``is_connected``, gated methods.
+
+    ``disconnect()`` reproduces lerobot's single unguarded loop -- the bus
+    first, then each camera in turn, with nothing catching a close that raises
+    -- because that shape is what the fallback has to cover.
+    """
+
+    def __init__(self, cameras: dict[str, _Camera], bus: _Bus, log: list[str] | None = None) -> None:
+        self.name = self.robot_type = "fake_arm"
+        self.bus = bus
+        self.cameras = cameras
+        self.log = log if log is not None else []
+        self.is_calibrated = True
+        self.disconnect_calls = 0
+        self.commands: list[dict[str, Any]] = []
+        self.config = type("Cfg", (), {"cameras": cameras})()
+
+    @property
+    def is_connected(self) -> bool:
+        return self.bus.is_connected and all(c.is_connected for c in self.cameras.values())
+
+    def connect(self, calibrate: bool = True) -> None:  # noqa: ARG002 - lerobot signature
+        if self.is_connected:  # @check_if_already_connected
+            raise DeviceAlreadyConnectedError("fake_arm is already connected.")
+        self.bus.connect()
+        for cam in self.cameras.values():
+            cam.connect()
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self.log.append("robot.disconnect")
+        if not self.is_connected:  # @check_if_not_connected
+            raise DeviceNotConnectedError("fake_arm is not connected. Run `.connect()` first.")
+        self.bus.disconnect(True)
+        for cam in self.cameras.values():
+            cam.disconnect()
+
+    def get_observation(self) -> dict[str, Any]:
+        return {"j0.pos": 0.0}
+
+    def send_action(self, action: dict[str, Any]) -> None:
+        self.commands.append(action)
+
+
+class _BusOnlyDriver:
+    """A driver exposing a bus but no ``disconnect`` of its own."""
+
+    def __init__(self, bus: _Bus) -> None:
+        self.name = self.robot_type = "bus_only_arm"
+        self.bus = bus
+        self.cameras: dict[str, _Camera] = {}
+        self.is_calibrated = True
+
+    @property
+    def is_connected(self) -> bool:
+        return self.bus.is_connected
+
+    def connect(self, calibrate: bool = True) -> None:  # noqa: ARG002 - lerobot signature
+        self.bus.connect()
+
+
+class _Mesh:
+    """Mesh component double: any object exposing ``stop()``."""
+
+    def __init__(self, log: list[str]) -> None:
+        self.log = log
+
+    def stop(self) -> None:
+        self.log.append("mesh.stop")
+
+
+class _Bridge:
+    """ROS 2 bridge double, torn down by ``_shutdown_ros_bridge()``."""
+
+    def __init__(self, log: list[str]) -> None:
+        self.log = log
+
+    def shutdown(self) -> None:
+        self.log.append("ros_bridge.shutdown")
+
+
+def _make_robot(driver: Any) -> HwRobot:
+    """Construct a ``Robot`` around ``driver``, bypassing hardware init."""
+    hw = HwRobot.__new__(HwRobot)
+    hw.tool_name_str = "test_arm"
+    hw.action_horizon = 8
+    hw.data_config = None
+    hw.control_frequency = 1000.0
+    hw.action_sleep_time = 0.001
+    hw._task_state = RobotTaskState()
+    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
+    hw._shutdown_event = threading.Event()
+    hw._stop_requested = threading.Event()
+    hw.mesh = None
+    hw.peer_id = None
+    hw.robot = driver
+    return hw
+
+
+def _arm(port: _Port | None = None, log: list[str] | None = None, **camera_kwargs: Any) -> _Driver:
+    """A one-camera arm on its own port."""
+    shared: list[str] = log if log is not None else []
+    return _Driver(
+        {"wrist": _Camera("wrist_cam", log=shared, **camera_kwargs)},
+        _Bus(port or _Port(), log=shared),
+        log=shared,
+    )
+
+
+class TestCleanupClosesTheDevices:
+    """The round trip: connect, drive, ``cleanup()``, nothing left open."""
+
+    def test_cleanup_closes_the_bus_and_every_camera(self) -> None:
+        """Every device the bring-up opened is shut, each exactly once.
+
+        The bus close carries ``disable_torque=True``: the driver's own
+        ``disconnect()`` ran, which is where a follower disables torque and
+        releases the gripper. Closing the port underneath it would skip both
+        and leave the arm energised at its last commanded position.
+        """
+        driver = _arm()
+        hw = _make_robot(driver)
+        ok, _ = asyncio.run(hw._connect_robot())
+        assert ok is True
+        hw.send_action({"j0.pos": 1.0})
+
+        hw.cleanup()
+
+        assert driver.disconnect_calls == 1
+        assert driver.bus.is_connected is False
+        assert driver.bus.disconnect_calls == [True]
+        assert driver.cameras["wrist"].is_connected is False
+        assert driver.cameras["wrist"].disconnect_calls == 1
+
+    def test_the_port_is_free_for_the_next_holder(self) -> None:
+        """The documented recovery for a wedged arm works without exiting.
+
+        A serial port is exclusive, so this is the user-visible consequence:
+        while ``cleanup()`` held the node, a re-constructed ``Robot`` on the
+        same port raised ``EBUSY`` and the only recovery was a new process.
+        """
+        port = _Port()
+        first = _make_robot(_arm(port))
+        asyncio.run(first._connect_robot())
+        first.cleanup()
+
+        second = _make_robot(_arm(port))
+        ok, err = asyncio.run(second._connect_robot())
+
+        assert ok is True, err
+        assert port.held_by == "arm"
+        second.cleanup()
+
+    def test_a_second_cleanup_does_not_disconnect_again(self) -> None:
+        """``cleanup()`` is called by ``__del__`` as well as by hand, so a
+        repeat must be a no-op rather than a ``DeviceNotConnectedError`` from
+        the driver's gated ``disconnect()``."""
+        driver = _arm()
+        hw = _make_robot(driver)
+        asyncio.run(hw._connect_robot())
+        hw.cleanup()
+
+        hw.cleanup()
+
+        assert driver.disconnect_calls == 1
+        assert driver.bus.disconnect_calls == [True]
+        assert driver.cameras["wrist"].disconnect_calls == 1
+
+    def test_cleanup_on_a_robot_that_never_connected_touches_nothing(self) -> None:
+        """Nothing is open, so nothing is closed -- and the gated driver
+        ``disconnect()`` is not called just to have it raise."""
+        driver = _arm()
+        hw = _make_robot(driver)
+
+        hw.cleanup()
+
+        assert driver.disconnect_calls == 0
+        assert driver.bus.disconnect_calls == []
+        assert driver.cameras["wrist"].disconnect_calls == 0
+
+
+class TestOneStuckDeviceCannotKeepTheRestOpen:
+    """lerobot's ``disconnect()`` abandons every device after a close that
+    raises. The teardown has to survive that, not inherit it."""
+
+    def test_a_camera_that_will_not_close_leaves_nothing_else_open(self) -> None:
+        """The driver's loop raises on the camera, so the cameras behind it are
+        never reached. The fallback closes each remaining device
+        independently, and the port -- the exclusive resource -- ends free."""
+        port = _Port()
+        log: list[str] = []
+        driver = _Driver(
+            {
+                "wrist": _Camera("wrist_cam", close_raises=True, log=log),
+                "top": _Camera("top_cam", log=log),
+            },
+            _Bus(port, log=log),
+            log=log,
+        )
+        hw = _make_robot(driver)
+        asyncio.run(hw._connect_robot())
+
+        hw.cleanup()
+
+        assert driver.cameras["wrist"].is_connected is True  # genuinely stuck
+        assert driver.cameras["top"].is_connected is False  # closed by the fallback
+        assert driver.cameras["top"].disconnect_calls == 1
+        assert port.held_by is None
+
+    def test_the_stuck_camera_is_warned_not_raised(self, caplog: pytest.LogCaptureFixture) -> None:
+        """``cleanup()`` is a teardown and is called from ``__del__``: it
+        reports the failure and finishes the rest, and the report names the
+        disconnect rather than being swallowed at debug level."""
+        driver = _arm(close_raises=True)
+        hw = _make_robot(driver)
+        asyncio.run(hw._connect_robot())
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.hardware_robot"):
+            hw.cleanup()
+
+        assert any("robot.disconnect() raised during cleanup" in r.getMessage() for r in caplog.records)
+
+    def test_a_half_open_robot_still_gets_its_port_closed(self) -> None:
+        """The state no other entry point can recover.
+
+        With the port open and a camera shut, ``is_connected`` is False, so
+        lerobot's ``@check_if_not_connected`` ``disconnect()`` refuses. The
+        fallback closes what is actually open -- and without a torque write,
+        which on a bus in this state would raise before ``closePort`` and
+        leave the node held.
+        """
+        port = _Port()
+        driver = _arm(port)
+        hw = _make_robot(driver)
+        asyncio.run(hw._connect_robot())
+        driver.cameras["wrist"].disconnect()  # half-open: port up, camera down
+        assert driver.is_connected is False
+
+        hw.cleanup()
+
+        assert driver.disconnect_calls == 0  # not called only to be refused
+        assert driver.bus.disconnect_calls == [False]
+        assert port.held_by is None
+
+    def test_a_driver_without_a_disconnect_is_not_an_error(self) -> None:
+        """``self.robot`` is any lerobot-shaped object, including one whose
+        teardown is its bus. The port still ends closed."""
+        port = _Port()
+        driver = _BusOnlyDriver(_Bus(port))
+        hw = _make_robot(driver)
+        asyncio.run(hw._connect_robot())
+
+        hw.cleanup()
+
+        assert driver.bus.is_connected is False
+        assert port.held_by is None
+
+
+class TestTheDevicesCloseLast:
+    """A port closed while any command source is still live gets re-opened."""
+
+    def test_the_devices_close_after_the_mesh_and_the_ros_bridge(self) -> None:
+        """``send_action`` re-opens the robot lazily on a command that finds it
+        disconnected, and both the mesh dispatch and the ROS bridge command
+        thread reach it. Closing the devices before those are down would let a
+        late command re-open the port behind the teardown -- where nothing
+        remains that would close it again."""
+        log: list[str] = []
+        driver = _arm(log=log)
+        hw = _make_robot(driver)
+        hw.mesh = _Mesh(log)
+        hw._ros_bridge = _Bridge(log)
+        asyncio.run(hw._connect_robot())
+
+        hw.cleanup()
+
+        assert log.index("mesh.stop") < log.index("robot.disconnect")
+        assert log.index("ros_bridge.shutdown") < log.index("robot.disconnect")
+
+    def test_a_command_still_draining_finds_an_open_port(self) -> None:
+        """The disconnect runs after ``_executor.shutdown(wait=True)`` returns,
+        so a rollout still draining commands a live bus instead of a closed
+        one -- and its command does not lazily re-open what was just shut."""
+        driver = _arm()
+        hw = _make_robot(driver)
+        asyncio.run(hw._connect_robot())
+
+        def _late_command() -> None:
+            time.sleep(0.05)  # still in flight when cleanup() starts
+            hw.send_action({"j0.pos": 2.0})
+
+        future = hw._executor.submit(_late_command)
+
+        hw.cleanup()
+
+        future.result(timeout=DEADLINE)
+        assert driver.commands == [{"j0.pos": 2.0}]
+        assert driver.bus.connect_calls == 1  # never re-opened
+        assert driver.bus.is_connected is False


### PR DESCRIPTION
## Problem

`Robot.cleanup()` tears down every resource the *library* owns -- it latches `_shutdown_event`, stops a teleop loop, stops a `RUNNING` task, shuts the executor, stops the mesh client and the ROS bridge. It never called `self.robot.disconnect()`, so the only resources that are a **physical device** -- the motors bus serial port, plus one `/dev/video*` node and one read thread per camera -- were the only ones it left open.

Measured with a driver double recording every call, on a one-camera arm:

| after | bus open | camera open | `disconnect()` calls |
|---|---|---|---|
| `connect` + a healthy rollout | yes | yes | 0 |
| `cleanup()` | **yes** | **yes** | **0** |
| a second `cleanup()` | **yes** | **yes** | **0** |

Why that is more than untidiness:

- **The port stays held.** A serial port is exclusive on Linux and macOS, so a second process -- or a re-constructed `Robot` in this one -- cannot open the same `/dev/tty*`. The documented recovery for a wedged arm (tear down, reconnect) was therefore unavailable without exiting the process.
- **`cleanup()` is what `__del__` calls.** A script that simply ends left the arm energised at its last commanded position instead of going through the driver's disconnect, which is where torque disable and gripper release live.
- **It was unrecoverable afterwards.** The executor is shut down and the shutdown is latched, so no library entry point remained that would reach a disconnect, while lerobot's `Robot.disconnect()` is `@check_if_not_connected` and so refuses in every half-open state.

## Change

`cleanup()` now disconnects, and answers the three open questions from the issue explicitly:

1. **Unconditional?** No -- conditional on something actually being open, but not optional. `_disconnect_devices()` prefers the driver's own `disconnect()` while `robot.is_connected` (that is the path with torque disable and gripper release) and falls back to closing each device individually when the robot is half-open, exposes no `disconnect`, or raised partway through its own single unguarded loop and abandoned every device behind the failure. A robot that never connected is left untouched rather than having a gated `disconnect()` called only to be refused.
2. **Ordering.** Last -- after the teleop teardown, `stop_task()`, `_executor.shutdown(wait=True)`, `mesh.stop()` and `_shutdown_ros_bridge()`. Not just "after the executor": `send_action` re-opens the robot lazily on a command that finds it disconnected, and both the mesh dispatch and the ROS bridge command thread reach it, so a port closed while any command source is still live would be re-opened *behind* the teardown -- and would then stay open for the life of the process, since nothing runs after `cleanup()`.
3. **Failure handling.** Best-effort and per device, like every other branch in `cleanup()`: a driver `disconnect()` that raises is warned, not propagated (`cleanup()` is also the `__del__` path), and the fallback then still closes the port and the cameras the driver's loop never reached.

The per-device close is exactly what `_rollback_half_open_connect` already did for a failed connect -- same behaviour, same reason (a partly-open set that lerobot's gated `disconnect()` cannot recover) -- so it is renamed `_close_open_devices` and shared by both callers instead of duplicated. No behaviour change for the connect-rollback callers; `disable_torque=False` still applies, and the docstring now states both entry reasons.

Deliberately **not** in this PR: `stop()` performs its own unguarded `await asyncio.to_thread(self.robot.disconnect)` *before* `cleanup()`, so on a robot that is not fully connected it raises, is swallowed by the method's `except`, and skips `cleanup()` entirely. That is a separate defect with a different blast radius (a tool-facing async entry point) and is filed as #1735 rather than folded in here.

## Tests

`tests/test_hardware_cleanup_disconnects.py` -- 10 tests, 9 of which fail on pre-fix `main` (the 10th, "a robot that never connected is untouched", passes before and after and is there to pin that the fix does not start calling a gated `disconnect()` speculatively). Port exclusivity is modelled explicitly, so the *consequence* is asserted, not just the call:

- the round trip (connect, drive, `cleanup()`) closes the bus and every camera exactly once, with `disable_torque=True` -- i.e. through the driver's own path;
- the port is free for the next holder: a re-constructed `Robot` on the same port connects, which is the recovery that previously needed a new process;
- a second `cleanup()` disconnects nothing again instead of raising `DeviceNotConnectedError`;
- a camera whose close raises keeps neither the bus nor the remaining cameras open, and is warned rather than propagated;
- a half-open robot (port up, camera down, so `is_connected` False) still gets its port closed, and without a torque write;
- a driver exposing no `disconnect` is not an error;
- the devices close after `mesh.stop()` and the ROS bridge shutdown, and a command still draining in the executor finds an open port and does not lazily re-open a closed one.

No serial port and no camera device is opened: the driver, bus and cameras are in-memory doubles mirroring lerobot's connect ordering, its composed `is_connected`, and its decorator contracts.

Local gate: `ruff check` / `ruff format --check` / `mypy` clean on the changed files; `tests/test_hardware_cleanup_disconnects.py`, `tests/test_hardware_camera_rollback.py`, `tests/test_hardware_after_shutdown.py` and the changelog-fragment guards green.

## Docs

`docs/hardware/robot-control.md` and `docs/api-reference.md` described `cleanup()` as "Stop tasks, close cameras, stop mesh" -- which was already a promise the code did not keep. Both now say it disconnects the motors bus and every camera, and the terminal-semantics paragraph states which disconnect path runs and why the released port is what makes tear-down-and-reconnect work. `changelog.d/1734-cleanup-disconnects-devices.md` carries the news fragment.

Closes #1731
Refs #1723, #1728, #1730, #1735