### PR TITLE
docs(changelog): drop the renamed private helper from the #1728 fragment

### DIFF
--- a/changelog.d/1728-camera-rollback-on-failed-connect.md
+++ b/changelog.d/1728-camera-rollback-on-failed-connect.md
@@ -2,8 +2,8 @@
 
 A robot's `connect()` opens its devices in sequence - the motors bus, then each
 camera in turn - and nothing in that loop closes the cameras opened before one
-that fails. `Robot._rollback_half_open_connect` closed only the serial port, so
-a camera set was left half-open, and lerobot gates both recovery paths on
+that fails. The connect-failure rollback closed only the serial port, so a
+camera set was left half-open, and lerobot gates both recovery paths on
 `is_connected`: the retry raised `DeviceAlreadyConnectedError` on a camera that
 was healthy, masking the camera that actually failed, and `disconnect()` refused
 to run at all while one camera was still shut. A second attempt therefore


### PR DESCRIPTION
One line of an unreleased news fragment names a private method that no longer exists.

#1734 renamed `Robot._rollback_half_open_connect` to `_close_open_devices`, because teardown became a second caller of the same per-device sweep. The #1728 fragment - still pending, so still destined for the next assembled `CHANGELOG.md` - narrates the pre-#1728 behaviour by that old name:

```
that fails. `Robot._rollback_half_open_connect` closed only the serial port, so
```

So the next release would ship notes naming a symbol that is not in the tree.

## The change

The sentence drops the private symbol and describes the rollback by what it is:

```diff
-that fails. `Robot._rollback_half_open_connect` closed only the serial port, so
-a camera set was left half-open, and lerobot gates both recovery paths on
+that fails. The connect-failure rollback closed only the serial port, so a
+camera set was left half-open, and lerobot gates both recovery paths on
```

Rewrapped to keep the paragraph at the same width. Two lines touched, no other file.

Naming it rather than renaming it is deliberate: `_close_open_devices` closes every device, so writing "`Robot._close_open_devices` closed only the serial port" would make the sentence false as well as private. The fix sentence four lines below already calls it "The rollback", so the paragraph is now consistent with itself, and a reader of the release notes is not sent looking for an underscore-prefixed method.

## Scope

I swept every fragment for symbols that no longer resolve in `strands_robots/`. This was the only one - the other two fragments that name private attributes (`changelog.d/1712-per-task-policy-reset.md` -> `Robot._execute_task_async`, `changelog.d/1718-hardware-action-horizon-guard.md` -> `Robot.__init__`) both still resolve and are left alone.

No behaviour change, so no fragment of its own: this is a correction to pending release notes, not a library change.

## Gate

`python scripts/assemble_changelog.py --check` -> `changelog fragments OK (38 pending)`. Structure is untouched (one `### ` heading, no `## `), so `tests/test_changelog_fragments.py` and `tests/test_changelog_format.py` see the same shape as before.

Refs #1728, #1734