### PR TITLE
fix(docs): every install hint names an extra that exists

### DIFF
--- a/changelog.d/1738-install-hints-name-declared-extras.md
+++ b/changelog.d/1738-install-hints-name-declared-extras.md
@@ -1,0 +1,30 @@
+### Fixed: every install hint names an extra that exists
+
+The VERA docs led their install section with a command for an extra that had
+been deleted a month earlier:
+
+```bash
+pip install 'strands-robots[vera]'   # exits 0, installs nothing VERA-related
+# WARNING: strands-robots does not provide the extra 'vera'
+```
+
+`pip` does not fail on an unknown extra. It warns on one line, installs the
+base package with none of the dependencies the reader was promised, and exits
+0 - so the reader sees a successful install, follows the next code block, and
+hits a `ModuleNotFoundError` that looks unrelated to the step that caused it.
+
+The `vera` extra was not a typo but a deliberate removal: VERA ships only as a
+git repository, PyPI rejects metadata carrying a VCS reference, and the extra
+was dropped for exactly that reason. `pyproject.toml` and the provider's module
+docstring both say so; only the doc still disagreed. It now gives the sequence
+those two already documented - client deps, then VERA from git, then
+`[vera-sim]` for the sim example. Two further sites named `[isaac]` and
+`[sim-libero]` for what are really `sim-isaac` and `benchmark-libero`.
+
+Two guards pin the surfaces that hand an extra name to a user: a sweep of every
+qualified `strands-robots[...]` mention in the tree (358 today), and an AST
+audit of the literal `require_optional(extra=...)` call sites (30 today), whose
+value is interpolated straight into the `ImportError` a user reads. Names are
+compared PEP 685-normalized, so a spelling `pip` would accept is not reported
+as broken. `CHANGELOG.md` and `changelog.d/` are outside the sweep on purpose:
+an entry that fixes an extra name has to be free to quote the broken one.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -195,8 +195,18 @@ VERA_LIVE=1 hatch run test-integ tests_integ/policies/vera/
 ## Install
 
 ```bash
-pip install 'strands-robots[vera]'        # provider + the VERA git dep (subprocess mode)
-pip install 'strands-robots[vera-sim]'    # + MimicGen sim deps for the example (also pulls the experimental PushT env)
+# 1. Provider client deps. There is no `vera` extra: the provider needs only a
+#    msgpack + websocket client, and VERA itself is distributed as a git
+#    repository, which no extra can pull (PyPI rejects package metadata
+#    carrying a VCS reference).
+pip install strands-robots websockets msgpack 'numpy>=1.24'
+
+# 2. VERA itself, for the managed-server (subprocess) mode.
+pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'
+
+# 3. Only for the MimicGen sim example: MimicGen sim deps (also pulls the
+#    experimental PushT env).
+pip install 'strands-robots[vera-sim]'
 ```
 
 > **Note on MimicGen.** The `vera-sim` extra does **not** install NVlabs

--- a/examples/isaac_gs/render_demo.py
+++ b/examples/isaac_gs/render_demo.py
@@ -223,7 +223,8 @@ def main() -> None:
     available, reason = IsaacSimulation.is_available()
     if not available:
         raise RuntimeError(
-            f"Isaac Sim is not available on this host: {reason}. " "Install Isaac Sim (RTX GPU) and the [isaac] extra."
+            f"Isaac Sim is not available on this host: {reason}. "
+            "Install Isaac Sim (RTX GPU) and the strands-robots[sim-isaac] extra."
         )
 
     from examples.isaac_gs.compositor import IsaacHybridCompositor

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -4215,8 +4215,8 @@ class _LiberoOSCController:
 
         # Cache mujoco module reference for the substep loop. Lazy import
         # is required because the OSC controller path is only exercised
-        # under the `[sim-libero]` extra; the top-level adapter import
-        # must work without mujoco available.
+        # under the ``strands-robots[benchmark-libero]`` extra; the top-level
+        # adapter import must work without mujoco available.
         import mujoco as mj
 
         n_arm = len(self.arm_actuator_ids)

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -9,7 +9,9 @@ both the live ``pyproject.toml`` and that the reusable audit in
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -470,3 +472,188 @@ def test_ik_install_hints_name_only_declared_extras() -> None:
                     closure = _extra_closure(name)
                     missing = [pkg for pkg in _IK_SOLVER_PACKAGES if pkg not in closure]
                     assert not missing, f"{label} hint points at [{name}], which does not provide {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Every extra a reader is told to install must be an extra that exists.
+#
+# History: docs/policies/vera.md led its install section with
+# ``pip install 'strands-robots[vera]'`` -- an extra that pyproject.toml explains
+# at length can never exist, because VERA ships only as a git repository and PyPI
+# rejects metadata carrying a VCS reference. Two further sites named ``[isaac]``
+# and ``[sim-libero]`` for what are really ``sim-isaac`` and ``benchmark-libero``.
+#
+# The failure mode is silent in the worst direction: pip does NOT fail on an
+# unknown extra. ``pip install 'strands-robots[vera]'`` exits 0, prints one
+# ``WARNING: strands-robots does not provide the extra 'vera'``, and installs the
+# base package with none of the dependencies the reader was promised. The reader
+# sees a successful install, then hits an ImportError somewhere unrelated-looking
+# with nothing tying it back to the install step. That makes an extra name in an
+# install hint load-bearing, and a typo in one is not cosmetic.
+#
+# Two guards, one per surface that hands a name to a user: written instructions,
+# and the runtime ``require_optional(extra=...)`` messages.
+# ---------------------------------------------------------------------------
+
+# A qualified mention -- ``strands-robots[NAME]``. Only the qualified form is
+# swept: a bare ``[wbc]`` in prose is ambiguous, because lerobot's own extras
+# (``[smolvla]``, ``[pi]``, ``[dataset]``) are written exactly the same way, so
+# requiring the distribution name keeps the sweep free of false positives.
+_EXTRA_MENTION_RE = re.compile(r"strands[-_]robots\[([^\]\s]+)\]")
+
+# A token that can be an extra name at all. Anything else caught by the mention
+# regex is a template hole rather than an instruction -- ``[{extra}]`` in the
+# message formatters, ``[<extra>]`` in a docstring, ``[...]`` as prose ellipsis --
+# and naming a hole is not naming a missing extra.
+_EXTRA_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# Trees that can carry an install instruction. CHANGELOG.md and changelog.d/ are
+# deliberately absent, not overlooked: the log is a historical record, so an entry
+# that fixes an extra name has to be free to quote the broken name, and an entry
+# written while an extra existed must not be rewritten when it is later renamed.
+_EXTRA_SCAN_ROOTS = ("strands_robots", "tests", "tests_integ", "examples", "docs", "scripts")
+_EXTRA_SCAN_FILES = ("README.md", "pyproject.toml")
+
+# Skipped by suffix rather than selected by it, so a mention in a file type nobody
+# thought of -- a Dockerfile, a notebook, a compose file -- is still swept.
+_BINARY_SUFFIXES = frozenset(
+    {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".ico",
+        ".svg",
+        ".pdf",
+        ".mp4",
+        ".webm",
+        ".mov",
+        ".zip",
+        ".gz",
+        ".tar",
+        ".whl",
+        ".npy",
+        ".npz",
+        ".pt",
+        ".pth",
+        ".onnx",
+        ".safetensors",
+        ".usd",
+        ".usda",
+        ".usdc",
+        ".stl",
+        ".obj",
+        ".dae",
+        ".bin",
+        ".so",
+        ".dylib",
+        ".pyc",
+        ".woff",
+        ".woff2",
+        ".ttf",
+    }
+)
+
+_EXTRA_MENTION_ALLOWED = {
+    # This test states the rule, so it quotes the broken names the rule forbids.
+    "tests/test_dependency_audit.py",
+    # Exercises the require_optional message formatter with a deliberately
+    # synthetic extra ("my-extra"). It asserts the formatting, not the name.
+    "tests/test_utils.py",
+}
+
+
+def _declared_extras() -> set[str]:
+    """Normalized names in ``[project.optional-dependencies]``."""
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return {_normalize_extra(name) for name in data["project"]["optional-dependencies"]}
+
+
+def _normalize_extra(name: str) -> str:
+    """Normalize an extra the way PEP 685 requires a resolver to compare them.
+
+    ``strands-robots[Sim_Isaac]`` really does install ``sim-isaac``, so comparing
+    raw spelling would report a working command as broken.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _iter_scanned_files() -> list[Path]:
+    files = [_REPO_ROOT / name for name in _EXTRA_SCAN_FILES]
+    for root in _EXTRA_SCAN_ROOTS:
+        files.extend(
+            path
+            for path in (_REPO_ROOT / root).rglob("*")
+            if path.is_file() and path.suffix.lower() not in _BINARY_SUFFIXES and "__pycache__" not in path.parts
+        )
+    return [path for path in files if path.exists()]
+
+
+def test_written_install_hints_name_only_declared_extras() -> None:
+    """Every ``strands-robots[...]`` in the tree must name a declared extra.
+
+    An undeclared name here is an instruction that installs nothing and still
+    exits 0, so the reader is stranded by a command that reported success.
+    """
+    extras = _declared_extras()
+    offenders: list[str] = []
+    mentions = 0
+    for path in _iter_scanned_files():
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        if rel in _EXTRA_MENTION_ALLOWED:
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
+            for match in _EXTRA_MENTION_RE.finditer(line):
+                for raw in (part.strip() for part in match.group(1).split(",")):
+                    if not _EXTRA_NAME_RE.match(raw):
+                        continue
+                    mentions += 1
+                    if _normalize_extra(raw) not in extras:
+                        offenders.append(f"{rel}:{lineno} names [{raw}] -- {line.strip()[:100]}")
+    # The sweep is only meaningful if it is actually reading the tree.
+    assert mentions > 100, f"the extras sweep matched only {mentions} mentions; the scan roots have drifted"
+    assert not offenders, (
+        "these sites tell a reader to install an extra that does not exist; pip exits 0 on an "
+        "unknown extra and installs none of the dependencies, so the failure surfaces later and "
+        f"misattributed. Declared extras: {sorted(extras)}\n" + "\n".join(offenders)
+    )
+
+
+def test_require_optional_call_sites_name_declared_extras() -> None:
+    """``require_optional(extra=...)`` must name a declared extra.
+
+    The value is interpolated straight into the ImportError a user sees
+    (``pip install strands-robots[<extra>]``), so an undeclared name here hands
+    out a no-op install command at the exact moment the user needs a working one.
+    """
+    extras = _declared_extras()
+    offenders: list[str] = []
+    checked = 0
+    for path in sorted((_REPO_ROOT / "strands_robots").rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name not in {"require_optional", "require_optionals"}:
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != "extra" or not isinstance(keyword.value, ast.Constant):
+                    continue
+                value = keyword.value.value
+                if not isinstance(value, str):
+                    continue
+                checked += 1
+                if _normalize_extra(value.strip()) not in extras:
+                    rel = path.relative_to(_REPO_ROOT).as_posix()
+                    offenders.append(f"{rel}:{node.lineno} passes extra={value!r}")
+    assert checked > 20, f"only {checked} literal extra= call sites found; the audit has stopped seeing them"
+    assert not offenders, (
+        "these require_optional call sites name an extra that does not exist, so the ImportError "
+        "they raise tells the user to run an install that silently does nothing. Declared extras: "
+        f"{sorted(extras)}\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## What

Three sites told a reader to install a `strands-robots` extra that does not exist, and a guard so a fourth cannot be added.

| Site | Said | Real extra |
|---|---|---|
| `docs/policies/vera.md:198` | `pip install 'strands-robots[vera]'` | no such extra, and there can never be one |
| `examples/isaac_gs/render_demo.py:226` | `the [isaac] extra` (in a `RuntimeError`) | `sim-isaac` |
| `strands_robots/benchmarks/libero/adapter.py:4218` | `the [sim-libero] extra` (comment) | `benchmark-libero` |

## Why this is worth a PR rather than a typo sweep

**pip does not fail on an unknown extra.** `pip install 'strands-robots[vera]'` exits 0, prints one line:

```
WARNING: strands-robots does not provide the extra 'vera'
```

and installs the base package with *none* of the dependencies the reader was promised. So the reader sees a successful install, follows the next code block, and hits a `ModuleNotFoundError` somewhere that looks unrelated, with nothing tying it back to the install step. An install hint is the one place where being wrong is worse than being absent, and this failure is deferred and misattributed.

## The `vera` case is not a typo - the extra was deliberately deleted

`pyproject.toml` carries an explicit note saying a `vera` extra can never exist:

> There is intentionally no `vera` extra. VERA is only distributed as a git repository and PyPI rejects any package whose metadata contains a direct URL/VCS reference (HTTP 400 on upload).

Git history shows exactly how the doc came to contradict it:

- `25dd6b7` (#663, 2026-06-25) added the `vera` extra **and** the `strands-robots[vera]` line in the doc.
- `123b220` (#950, 2026-07-01) removed the extra - "remove git-only vera extra that breaks PyPI upload" - and left the doc line behind.

The headline install command in the VERA docs has therefore been a silent no-op for ~695 commits. `strands_robots/policies/vera/__init__.py` already documents the correct sequence in its module docstring; the doc is the only surface that disagreed, so this brings it in line rather than inventing new guidance.

The `benchmark-libero` case is likewise demonstrably a typo and not a different referent: `adapter.py:781`, in the same file, already writes `pip install 'strands-robots[benchmark-libero]'` correctly.

## Guards

Both land in `tests/test_dependency_audit.py`, which already owns extras correctness and the closely-related `test_ik_install_hints_name_only_declared_extras` from #1683. This generalises that guarantee from the four IK hints to the whole tree.

1. **`test_written_install_hints_name_only_declared_extras`** - sweeps every qualified `strands-robots[...]` mention under `strands_robots/`, `tests/`, `tests_integ/`, `examples/`, `docs/`, `scripts/`, plus `README.md` and `pyproject.toml`, and asserts each name is declared. 358 mentions are checked today.

2. **`test_require_optional_call_sites_name_declared_extras`** - AST audit of the 30 literal `require_optional(extra=...)` / `require_optionals(extra=...)` call sites, whose value is interpolated straight into the `ImportError` a user reads. All 30 are correct today; this is the higher-severity surface (a runtime message, not prose), so it is pinned rather than left to the next rename.

### Design decisions a reviewer will want to check

- **Only the *qualified* form is swept.** A bare `[wbc]` in prose is ambiguous, because lerobot's own extras (`[smolvla]`, `[pi]`, `[dataset]`) are written identically. Requiring the distribution name keeps the sweep at zero false positives - which is also why the fixes to `render_demo.py` and `adapter.py` *qualify* the mention rather than only correcting the word: that is what brings them under the guard.
- **Names are compared PEP 685-normalised** (`[-_.]+` collapsed to `-`, lowercased), because `strands-robots[Sim_Isaac]` genuinely does resolve `sim-isaac`. Comparing raw spelling would report a working command as broken.
- **Binary files are skipped by a suffix denylist, not selected by an allowlist**, so a mention in a file type nobody anticipated is still swept. That is not hypothetical: a `Dockerfile`, four `.ipynb` notebooks, two `docker-compose.yml` and a `.sh` all carry qualified mentions today, and an allowlist keyed on `.py`/`.md` would have missed every one.
- **`CHANGELOG.md` and `changelog.d/` are excluded on purpose**, and this is the one exclusion I would push back on myself if it were unexplained: the log is a historical record, so an entry that *fixes* an extra name has to be free to quote the broken name, and an entry written while an extra existed must not be rewritten when it is later renamed. Scanning them would make every future extra rename a changelog-editing task. This PR's own fragment quotes `strands-robots[vera]` and would fail the sweep without that exclusion.
- Two files are allowlisted, each because it is *about* the pattern: this test (it quotes the forbidden names to state the rule, the same posture as `tests/test_no_host_paths.py` allowlisting itself) and `tests/test_utils.py` (asserts the message formatter with a deliberately synthetic `my-extra`).
- Template holes (`[{extra}]` in the formatters, `[<extra>]` in a docstring, `[...]` as prose ellipsis) are skipped by a name-shape check. Naming a hole is not naming a missing extra.

## Verification

Each fix is pinned - reverting any one of the three fails the sweep, and the guard was written before I trusted it:

```
1. revert vera.md   -> docs/policies/vera.md:198 names [vera]                    FAILED
2. regress site A   -> examples/isaac_gs/render_demo.py:227 names [isaac]        FAILED
3. regress site C   -> strands_robots/benchmarks/libero/adapter.py:4218 ...      FAILED
4. tree as shipped  -> 1 passed
```

The sweep also caught three things I had got wrong in the first draft (`{extra}` placeholders in the formatters, `__pycache__/*.pyc` artifacts, and this test file quoting the bad names in its own comments), which is the main reason I believe it is reading the tree rather than agreeing with me.

```
ruff check strands_robots tests tests_integ   All checks passed
ruff format --check ...                       955 files already formatted
mypy tests/test_dependency_audit.py           Success: no issues found
python scripts/assemble_changelog.py --check  changelog fragments OK (39 pending)
pytest tests/test_dependency_audit.py tests/test_utils.py tests/test_no_host_paths.py \
       tests/test_changelog_fragments.py tests/test_changelog_format.py \
       tests/test_lerobot_dependency_docs.py                          117 passed
```

Both guards assert a floor on what they matched (`mentions > 100`, `checked > 20`) so they fail loudly if the scan roots drift rather than passing vacuously.

## Scope

Docs + one error message + one comment + tests + the news fragment. No behaviour change, no dependency change: `pyproject.toml` is untouched, so nothing about what any extra installs moves in this PR.

Deliberately **not** included: `docs/policies/vera.md:164` references `strands-cosmos[cosmos3]`, a different distribution I cannot verify from this repo, so it is left alone.
