### PR TITLE
fix(policies): the state-key remedy names an embodiment that binds the observation

### DIFF
--- a/changelog.d/1739-state-key-remedy-names-a-matching-embodiment.md
+++ b/changelog.d/1739-state-key-remedy-names-a-matching-embodiment.md
@@ -1,0 +1,18 @@
+### Fixed: the state-key mismatch diagnostic recommends an embodiment that binds the observation
+
+Both `lerobot_local` state-key diagnostics ended in one fixed sentence for every
+caller, offering `embodiment='so101'` as the example. On a real SO arm that
+advice is a loop: lerobot's `SOFollower` reports `'<motor>.pos'` keys, while the
+`so101` configuration declares the MuJoCo asset's numeric joints `'1'..'6'`, so
+following it lands back on the same all-missing guard that printed it - and its
+`state_units='degrees'` would convert units the hardware reports natively. The
+configuration that does bind that observation, `so_real`, was never named.
+
+The remedy is now derived from the observation. New public
+`matching_embodiments(observation_keys)` returns every shipped embodiment whose
+entire `state_keys` set the observation carries; `state_key_remedy` names the one
+match, lists all of them when the observation cannot distinguish them (the real
+SO, Koch and OMX arms report identical `.pos` keys), and offers no embodiment at
+all when none matches. `set_robot_state_keys([...])` is always offered, quoting
+the observed keys verbatim when short enough to paste. Both the all-missing and
+partial-missing guards use the one helper, so their advice cannot drift.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -317,6 +317,23 @@ warns (or raises under `strict_keys=True`), sets `generic_state_keys_used`, and
 falls back to the observation's own scalar keys so the state is populated rather
 than silently dropped.
 
+Both degradations quote a remedy chosen from the observation itself rather than a
+fixed example. `matching_embodiments(observation_keys)` returns every shipped
+embodiment whose entire `state_keys` set the observation carries, and only those
+are offered:
+
+- one match - the message names it (`embodiment='so100'`);
+- several - all are listed, because an observation cannot always tell them apart
+  (the real SO, Koch and OMX arms all report the same six `'<motor>.pos'` keys);
+- none - no embodiment is suggested at all, only `set_robot_state_keys([...])`,
+  quoted with the observed keys verbatim when the list is short enough to paste.
+
+This matters most on hardware. A real SO arm reports `'<motor>.pos'` keys, while
+the `so101` embodiment declares the MuJoCo asset's numeric joints `'1'..'6'` and
+converts degrees to radians - so recommending it there would re-declare keys the
+observation does not have, landing back on this same guard. `so_real` is the
+configuration that binds that observation, and it is what the message names.
+
 That fallback ordering is **position-only**: a `<joint>.vel` entry is dropped
 when the observation also carries its `<joint>` position companion. The MuJoCo
 backend emits a velocity sibling beside every joint position, so taking its keys

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -241,6 +242,98 @@ def hardware_pos_keys(observation: dict[str, Any]) -> list[str]:
         for key, value in observation.items()
         if isinstance(key, str) and key.endswith(".pos") and _is_joint_scalar(value)
     ]
+
+
+# Above this many observation keys the remedy points at the list the diagnostic
+# already printed instead of repeating it - a 29-joint humanoid would otherwise
+# print the same long list twice in one message.
+_REMEDY_KEYS_INLINE_MAX = 8
+
+
+def matching_embodiments(observation_keys: Iterable[Any]) -> list[str]:
+    """Shipped embodiment names whose entire ``state_keys`` set the observation carries.
+
+    The registry is the only place that knows which joint namings the library
+    can already bind, so a diagnostic that wants to recommend an ``embodiment=``
+    must ask it rather than hardcode an example. An embodiment qualifies only
+    when EVERY one of its declared ``state_keys`` is present, because a partial
+    match would reproduce the very mismatch the caller is trying to escape.
+
+    Several embodiments can qualify at once and that is not an error: the real
+    SO, Koch and OMX arms all report the same six ``'<motor>.pos'`` keys, so an
+    observation cannot distinguish them. Callers should present all of them.
+
+    Aliases are excluded so the result names one spelling per configuration.
+
+    Args:
+        observation_keys: Keys of the observation being diagnosed. Non-string
+            entries are ignored rather than rejected, since an observation is
+            not guaranteed to be string-keyed.
+
+    Returns:
+        Sorted matching configuration names; empty when none match.
+    """
+    present = {key for key in observation_keys if isinstance(key, str)}
+    if not present:
+        return []
+    return sorted(
+        name
+        for name, embodiment in EMBODIMENT_MAP.items()
+        if name in _CONFIG_NAMES and embodiment.state_keys and present.issuperset(embodiment.state_keys)
+    )
+
+
+def state_key_remedy(observation_keys: Iterable[Any]) -> str:
+    """Advice for a state-key mismatch, chosen from what the observation contains.
+
+    A fixed example cannot be right for every caller. Recommending
+    ``embodiment='so101'`` to a real SO arm is not merely unhelpful: that
+    configuration declares the MuJoCo asset's numeric joints (``'1'..'6'``),
+    none of which a ``'<motor>.pos'`` hardware observation carries, so following
+    the advice lands back on the same all-missing mismatch - and its
+    ``state_units='degrees'`` would convert units the hardware reports natively.
+
+    So the embodiment is named only when the registry confirms it binds THIS
+    observation (see :func:`matching_embodiments`), and when nothing matches no
+    embodiment is offered at all. ``set_robot_state_keys`` is always offered as
+    the unambiguous alternative, quoting the observed keys verbatim when the
+    list is short enough to paste.
+
+    Args:
+        observation_keys: Keys of the observation being diagnosed, in the order
+            they should be bound.
+
+    Returns:
+        One to three sentences of remedy, plain ASCII, ending in a period. An
+        observation with no string keys at all gets no remedy to follow, only a
+        statement that nothing can bind it.
+    """
+    keys = [key for key in observation_keys if isinstance(key, str)]
+    if not keys:
+        return (
+            "This observation carries no scalar state keys at all, so no embodiment or "
+            "set_robot_state_keys([...]) ordering can bind it - check that the robot/sim "
+            "is reporting joint positions."
+        )
+    if len(keys) <= _REMEDY_KEYS_INLINE_MAX:
+        set_keys = f"call set_robot_state_keys({keys!r})"
+    else:
+        set_keys = "call set_robot_state_keys([...]) with the observed keys above"
+
+    candidates = matching_embodiments(keys)
+    if not candidates:
+        return (
+            f"No shipped embodiment declares state_keys this observation carries, so {set_keys}. "
+            "Passing an embodiment chosen by robot name instead would re-declare keys the "
+            "observation does not have and land back here."
+        )
+    if len(candidates) == 1:
+        return f"Pass embodiment='{candidates[0]}', whose state_keys this observation carries, or {set_keys}."
+    listed = " / ".join(f"'{name}'" for name in candidates)
+    return (
+        f"Pass embodiment= one of {listed} - each declares state_keys this observation "
+        f"carries, so pick the one matching your robot - or {set_keys}."
+    )
 
 
 # Action diagnostics
@@ -757,6 +850,10 @@ EMBODIMENT_MAP: dict[str, EmbodimentMap] = {}
 _defs, _aliases = _load_defs()
 for _cfg_name in _defs:
     EMBODIMENT_MAP[_cfg_name] = _resolve(_cfg_name, _defs)
+# Configuration names only. EMBODIMENT_MAP also holds every alias pointing at
+# the same object, so a diagnostic listing candidates must filter to these or it
+# offers the caller several spellings of one configuration.
+_CONFIG_NAMES: frozenset[str] = frozenset(_defs)
 for _alias, _target in _aliases.items():
     if _target in EMBODIMENT_MAP:
         EMBODIMENT_MAP[_alias] = EMBODIMENT_MAP[_target]
@@ -796,6 +893,8 @@ __all__ = [
     "ZeroActionMonitor",
     "diagnose_action_dim",
     "load_embodiment",
+    "matching_embodiments",
     "reconcile_dim",
     "register_pack_state_step",
+    "state_key_remedy",
 ]

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -21,11 +21,28 @@ import numpy as np
 import torch
 
 from .. import Policy, align_action_values
-from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys
+from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys, state_key_remedy
 from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
 
 logger = logging.getLogger(__name__)
+
+
+def _scalar_observation_keys(observation_dict: dict[str, Any]) -> list[str]:
+    """Observation keys that can carry a joint/state scalar, in observation order.
+
+    Excludes ``task`` (the instruction string) and any array with 2+ dimensions
+    (a camera frame). Both observation-to-batch paths derive their state-ordering
+    fallback from this, and the state-key diagnostics quote it back to the
+    caller, so all three must agree on what counts as a state key.
+
+    Args:
+        observation_dict: Raw strands/sim observation for this step.
+
+    Returns:
+        The candidate state keys, in the observation's own insertion order.
+    """
+    return [k for k, v in observation_dict.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)]
 
 
 def _declared_feature_is_image(name: str, feature: Any = None) -> bool:
@@ -2098,9 +2115,9 @@ class LerobotLocalPolicy(Policy):
             f"None of the configured robot_state_keys {shown}{ellipsis} are present "
             f"in the observation. Observed joint/state keys: {scalar_keys}. This "
             "usually means generic auto-generated keys (joint_0..joint_N) were "
-            "paired with a robot/sim that reports named joints. Pass "
-            "embodiment='<name>' (e.g. embodiment='so101') or call "
-            "set_robot_state_keys([...]) with the robot's actual joint names."
+            "paired with a robot/sim that reports named joints. " + state_key_remedy(scalar_keys)
+            # Chosen from the observation, so the advice cannot name an
+            # embodiment whose state_keys would land back on this same guard.
         )
         if self.strict_keys:
             raise ValueError("strict_keys=True: " + msg)
@@ -2174,8 +2191,10 @@ class LerobotLocalPolicy(Policy):
                 f"observation: {shown}{ellipsis}. Present joints keep their index and the "
                 "missing dims are zero-filled in place, but the sim/robot does not report "
                 "those joints - commonly a mimic/tendon gripper whose actuator name differs "
-                "from the observation's finger-joint names. Pass embodiment='<name>' or call "
-                "set_robot_state_keys([...]) with names the observation actually contains."
+                "from the observation's finger-joint names. "
+                # Same registry-checked remedy as the all-missing guard, so one
+                # rule serves both degradations.
+                + state_key_remedy(_scalar_observation_keys(observation_dict))
             )
             if self.strict_keys:
                 raise ValueError("strict_keys=True: " + msg)
@@ -2280,9 +2299,7 @@ class LerobotLocalPolicy(Policy):
             used_feats.add(feat)
 
         # 2) Collect scalar joint values into observation.state.
-        scalar_keys = [
-            k for k, v in observation_dict.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)
-        ]
+        scalar_keys = _scalar_observation_keys(observation_dict)
         # Resolve the joint-state ordering, raising/warning loudly when the
         # configured robot_state_keys cannot describe this observation (the
         # generic joint_0..N vs named-joint mismatch) instead of silently
@@ -2607,9 +2624,7 @@ class LerobotLocalPolicy(Policy):
         # raises (strict_keys) or warns + falls back to the observation's own
         # scalar keys, instead of silently dropping observation.state and
         # running the policy open-loop (see _resolve_state_order).
-        scalar_keys = [
-            k for k, v in observation_dict.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)
-        ]
+        scalar_keys = _scalar_observation_keys(observation_dict)
         order = self._resolve_state_order(observation_dict, scalar_keys)
 
         # Collect state values index-aligned with the resolved order. A key in

--- a/tests/policies/lerobot_local/test_state_key_mismatch.py
+++ b/tests/policies/lerobot_local/test_state_key_mismatch.py
@@ -54,6 +54,24 @@ def _named_obs():
     return obs
 
 
+def _assert_actionable(msg: str) -> None:
+    """The message names the observed keys and a remedy that would bind them.
+
+    ``NAMED_JOINTS`` are bare lowercase SO motor names, which no shipped
+    embodiment declares - the sim configurations use the assets' own joint names
+    (``'1'..'6'`` for so101, ``Rotation``/``Pitch``/... for so100) and ``so_real``
+    uses lerobot's ``'<motor>.pos'``. So the remedy here is deliberately
+    ``set_robot_state_keys`` ONLY, quoted with the observed keys so it can be
+    pasted. This assertion used to require the literal ``embodiment=`` instead,
+    which meant it passed while the message recommended ``embodiment='so101'`` -
+    a configuration that declares none of these keys either, so following the
+    advice landed back on the guard that printed it.
+    """
+    assert "shoulder_pan" in msg
+    assert f"set_robot_state_keys({NAMED_JOINTS!r})" in msg
+    assert "embodiment=" not in msg
+
+
 class TestStrictKeysRaises:
     """strict_keys=True turns a state-key mismatch into a clear, actionable error."""
 
@@ -61,21 +79,15 @@ class TestStrictKeysRaises:
         policy = _policy("molmoact2", strict_keys=True)
         with pytest.raises(ValueError) as exc:
             policy._to_lerobot_observation(_named_obs())
-        msg = str(exc.value)
-        # Names the actual observation keys ...
-        assert "shoulder_pan" in msg
-        # ... and points at the two documented remedies.
-        assert "embodiment=" in msg
-        assert "set_robot_state_keys" in msg
+
+        _assert_actionable(str(exc.value))
 
     def test_strands_native_path_raises_with_actionable_message(self):
         policy = _policy("act", strict_keys=True)
         with pytest.raises(ValueError) as exc:
             policy._build_batch_from_strands_format(_named_obs(), {})
-        msg = str(exc.value)
-        assert "shoulder_pan" in msg
-        assert "embodiment=" in msg
-        assert "set_robot_state_keys" in msg
+
+        _assert_actionable(str(exc.value))
 
 
 class TestNonStrictWarnsAndFallsBack:

--- a/tests/policies/lerobot_local/test_state_key_remedy_guidance.py
+++ b/tests/policies/lerobot_local/test_state_key_remedy_guidance.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""A state-key mismatch must recommend a binding the observation can actually use.
+
+The mismatch diagnostics ended in one fixed sentence for every caller: "Pass
+embodiment='<name>' (e.g. embodiment='so101') or call set_robot_state_keys([...])
+with the robot's actual joint names". Against a real SO arm that example is not
+merely unhelpful - it is a loop. lerobot's ``SOFollower`` keys joints as
+``'<motor>.pos'``, while the ``so101`` configuration declares the MuJoCo asset's
+numeric joints ``'1'..'6'``; none of those are present, so following the printed
+advice lands on the same all-missing guard that printed it. Its
+``state_units='degrees'`` would also convert units the hardware reports natively.
+
+The registry already ships the configuration that does bind that observation
+(``so_real``), and it was never named.
+
+So the remedy is now chosen from the observation: an ``embodiment=`` is offered
+only when the registry confirms every one of its ``state_keys`` is present, all
+qualifying configurations are listed when the observation cannot tell them apart
+(the real SO, Koch and OMX arms report identical ``.pos`` keys), and when nothing
+matches no embodiment is offered at all.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+
+from strands_robots.policies.lerobot_local.embodiment import (
+    EMBODIMENT_MAP,
+    matching_embodiments,
+    state_key_remedy,
+)
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+# lerobot SOFollower motor feature keys - what a real SO arm reports.
+HARDWARE_KEYS = [
+    "shoulder_pan.pos",
+    "shoulder_lift.pos",
+    "elbow_flex.pos",
+    "wrist_flex.pos",
+    "wrist_roll.pos",
+    "gripper.pos",
+]
+# robotstudio_so101 MuJoCo asset joints - what the so101 configuration declares.
+SIM_SO101_KEYS = ["1", "2", "3", "4", "5", "6"]
+
+
+def _visual(shape=(3, 224, 224)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _policy(*, strict_keys=False):
+    """A policy whose robot_state_keys are the generic auto-filled names.
+
+    ``joint_0..joint_5`` match neither observation shape, which is the mismatch
+    both diagnostics exist to report.
+    """
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="molmoact2", strict_keys=strict_keys)
+    policy._input_features = {"observation.images.base": _visual(), "observation.state": _state(6)}
+    policy._device = torch.device("cpu")
+    policy.robot_state_keys = [f"joint_{i}" for i in range(6)]
+    return policy
+
+
+def _obs(keys):
+    obs = {"base": np.zeros((224, 224, 3), np.uint8)}
+    obs.update(dict.fromkeys(keys, 0.5))
+    return obs
+
+
+class TestRecommendedEmbodimentBindsTheObservation:
+    """The whole point: following the advice must not land back on the guard."""
+
+    @pytest.mark.parametrize("keys", [HARDWARE_KEYS, SIM_SO101_KEYS], ids=["hardware", "sim"])
+    def test_every_named_embodiment_resolves_the_observation(self, keys):
+        """Configure each recommended embodiment and re-run the resolution."""
+        candidates = matching_embodiments(keys)
+        assert candidates, f"no embodiment offered for {keys}"
+
+        for name in candidates:
+            policy = _policy(strict_keys=True)
+            policy.robot_state_keys = list(EMBODIMENT_MAP[name].state_keys)
+            # Would raise the very mismatch the remedy is escaping.
+            assert policy._resolve_state_order(_obs(keys), keys) == policy.robot_state_keys
+
+    def test_the_old_fixed_example_would_not_have(self):
+        """Regression: 'e.g. embodiment=so101' was a loop on a real arm."""
+        policy = _policy(strict_keys=True)
+        policy.robot_state_keys = list(EMBODIMENT_MAP["so101"].state_keys)
+
+        with pytest.raises(ValueError, match="None of the configured robot_state_keys"):
+            policy._resolve_state_order(_obs(HARDWARE_KEYS), HARDWARE_KEYS)
+
+        assert "so101" not in matching_embodiments(HARDWARE_KEYS)
+
+
+class TestRemedyContent:
+    def test_hardware_observation_is_pointed_at_the_hardware_configuration(self):
+        remedy = state_key_remedy(HARDWARE_KEYS)
+
+        assert "so_real" in remedy
+        # The sim configuration must not be recommended for a .pos observation.
+        assert "embodiment='so101'" not in remedy
+
+    def test_indistinguishable_configurations_are_all_listed(self):
+        """so_real / koch_real / omx_real declare identical .pos keys."""
+        remedy = state_key_remedy(HARDWARE_KEYS)
+
+        for name in ("so_real", "koch_real", "omx_real"):
+            assert name in remedy, remedy
+
+    def test_a_sim_observation_gets_its_single_configuration(self):
+        remedy = state_key_remedy(SIM_SO101_KEYS)
+
+        assert "embodiment='so101'" in remedy
+        assert "so_real" not in remedy
+
+    def test_no_embodiment_is_offered_when_none_matches(self):
+        remedy = state_key_remedy(["alpha", "beta", "gamma"])
+
+        assert "embodiment=" not in remedy
+        assert "set_robot_state_keys(['alpha', 'beta', 'gamma'])" in remedy
+
+    def test_short_key_lists_are_quoted_verbatim_so_the_fix_is_pasteable(self):
+        assert f"set_robot_state_keys({HARDWARE_KEYS!r})" in state_key_remedy(HARDWARE_KEYS)
+
+    def test_a_long_key_list_is_not_repeated_inline(self):
+        """A 29-joint humanoid must still be named, without printing 29 keys twice."""
+        keys = list(EMBODIMENT_MAP["unitree_g1"].state_keys)
+        remedy = state_key_remedy(keys)
+
+        assert "unitree_g1" in remedy
+        assert "with the observed keys above" in remedy
+        assert keys[0] not in remedy
+
+
+class TestMatchingEmbodiments:
+    def test_a_partial_match_does_not_qualify(self):
+        """A configuration missing even one key would reproduce the mismatch."""
+        assert "so_real" not in matching_embodiments(HARDWARE_KEYS[:-1])
+
+    def test_extra_observation_keys_do_not_disqualify(self):
+        """Observations carry more than the model's state (velocities, base pose)."""
+        assert "so_real" in matching_embodiments([*HARDWARE_KEYS, "battery", "x.vel"])
+
+    def test_aliases_are_not_offered_as_separate_candidates(self):
+        """EMBODIMENT_MAP holds aliases too; one spelling per configuration."""
+        candidates = matching_embodiments(SIM_SO101_KEYS)
+
+        assert candidates == ["so101"]
+
+    def test_result_is_sorted_so_the_message_is_deterministic(self):
+        candidates = matching_embodiments(HARDWARE_KEYS)
+
+        assert candidates == sorted(candidates)
+
+
+class TestRobustness:
+    def test_non_string_keys_are_ignored_rather_than_rejected(self):
+        assert matching_embodiments([1, None, *SIM_SO101_KEYS]) == ["so101"]
+        assert "embodiment='so101'" in state_key_remedy([1, None, *SIM_SO101_KEYS])
+
+    def test_an_observation_with_no_state_keys_says_nothing_can_bind_it(self):
+        remedy = state_key_remedy([])
+
+        assert "no scalar state keys" in remedy
+        # Offering a remedy here would be advice that cannot work.
+        assert "embodiment=" not in remedy
+
+    @pytest.mark.parametrize(
+        "keys", [HARDWARE_KEYS, SIM_SO101_KEYS, ["alpha"], []], ids=["hardware", "sim", "unknown", "empty"]
+    )
+    def test_remedy_is_plain_ascii(self, keys):
+        """AGENTS.md: user-facing strings are ASCII only."""
+        remedy = state_key_remedy(keys)
+
+        assert remedy.isascii(), remedy
+
+
+class TestBothDiagnosticsCarryIt:
+    """The all-missing and partial-missing guards must not drift apart."""
+
+    def test_all_missing_warning_names_a_matching_embodiment(self, caplog):
+        import logging
+
+        policy = _policy()
+
+        with caplog.at_level(logging.WARNING):
+            order = policy._resolve_state_order(_obs(HARDWARE_KEYS), HARDWARE_KEYS)
+
+        assert order == HARDWARE_KEYS  # fell back to the observation's own keys
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("so_real" in m for m in warnings), warnings
+        assert not any("embodiment='so101'" in m for m in warnings), warnings
+
+    def test_all_missing_error_names_a_matching_embodiment(self):
+        policy = _policy(strict_keys=True)
+
+        with pytest.raises(ValueError, match="so_real"):
+            policy._resolve_state_order(_obs(HARDWARE_KEYS), HARDWARE_KEYS)
+
+    def test_partial_missing_error_names_a_matching_embodiment(self):
+        """One configured key present, the rest absent - the tendon-gripper case."""
+        policy = _policy(strict_keys=True)
+        policy.robot_state_keys = [*HARDWARE_KEYS[:5], "left/gripper"]
+        observation = _obs(HARDWARE_KEYS)
+
+        with pytest.raises(ValueError) as excinfo:
+            policy._collect_state_values(observation, policy.robot_state_keys)
+
+        assert "so_real" in str(excinfo.value)
+        assert "embodiment='<name>'" not in str(excinfo.value)
+
+    def test_partial_missing_remedy_ignores_camera_keys(self):
+        """The camera in the observation must not be offered as a state key."""
+        policy = _policy(strict_keys=True)
+        policy.robot_state_keys = [*HARDWARE_KEYS[:5], "left/gripper"]
+
+        with pytest.raises(ValueError) as excinfo:
+            policy._collect_state_values(_obs(HARDWARE_KEYS), policy.robot_state_keys)
+
+        assert "'base'" not in str(excinfo.value)


### PR DESCRIPTION
## Problem

Both `lerobot_local` state-key diagnostics ended in one fixed sentence for every caller:

> Pass embodiment='<name>' (e.g. embodiment='so101') or call set_robot_state_keys([...]) with the robot's actual joint names.

Against a **real SO arm that advice is a loop.** lerobot's `SOFollower` reports `'<motor>.pos'` keys, while the `so101` configuration declares the MuJoCo asset's numeric joints `'1'..'6'`. None of those are present, so configuring the recommended embodiment lands back on the same all-missing guard that printed the recommendation. Its `state_units='degrees'` would also convert units the hardware reports natively.

The configuration that *does* bind that observation, `so_real`, was never named - even though the registry ships it and `hardware_pos_keys()` already existed as the public "is this hardware?" detector.

Measured by configuring whatever embodiment the message names and re-running the identical resolution:

| observation | `main` recommends | following it | after |
|---|---|---|---|
| real SO arm (`.pos` x6) | `embodiment='so101'` | **same mismatch** | `so_real` / `koch_real` / `omx_real` - all bind |
| MuJoCo so101 sim (`'1'..'6'`) | `embodiment='so101'` | binds | `so101` - binds |
| Unitree G1 (29 DOF) | `embodiment='so101'` | **same mismatch** | `unitree_g1` / `unitree_g1_arms` - both bind |
| unrecognised robot | `embodiment='so101'` | **same mismatch** | no embodiment offered, keys quoted verbatim |

Three of four representative observations were handed advice that reproduces the failure. The one that worked is the one the hardcoded example happened to describe.

![state-key remedy verdicts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/state-key-remedy/state_key_remedy.png)

Every cell in that figure is measured by the same script run against both trees, not written by hand.

## Change

The remedy is derived from the observation instead of hardcoded.

- **`matching_embodiments(observation_keys)`** (new, public, in `embodiment.py` beside the registry and `hardware_pos_keys`) returns every shipped embodiment whose **entire** `state_keys` set the observation carries. A partial match is deliberately excluded - it would reproduce the very mismatch the caller is escaping. Aliases are filtered out so one spelling per configuration is offered.
- **`state_key_remedy(observation_keys)`** (new, public) builds the advice:
  - one match -> names it;
  - several -> lists all, because an observation genuinely cannot tell them apart (the real SO, Koch and OMX arms declare identical `.pos` keys);
  - none -> offers **no** embodiment at all, and says why suggesting one by robot name would land back here;
  - `set_robot_state_keys([...])` always offered, quoted with the observed keys verbatim when the list is short enough to paste (a 29-joint humanoid points at the list the message already printed rather than repeating it).
- Both the all-missing guard (`_resolve_state_order`) and the partial-missing guard (`_collect_state_values`) call the one helper, so their advice cannot drift apart.
- The scalar-key expression those guards and both observation-to-batch paths each inlined is now a single `_scalar_observation_keys` (it was already duplicated verbatim twice; the remedy needed it a third time). This also keeps camera keys out of the suggested state ordering.

No inference, motion, rendering or recording behaviour changes - the diagnostic text and two new discovery helpers only.

## Tests

`tests/policies/lerobot_local/test_state_key_remedy_guidance.py`, 23 tests. The load-bearing one closes the loop rather than asserting on wording: it takes every embodiment the message names, configures it, and re-runs the resolution that produced the message - so a recommendation that would fail cannot pass review. Also pinned: the old fixed example demonstrably would not have; indistinguishable configurations are all listed; nothing is offered when nothing matches; a long key list is referenced not repeated; partial matches and aliases are excluded; extra observation keys (velocities, base pose) do not disqualify; non-string keys and an observation with no state keys do not crash; ASCII only; and both guards carry it.

**Pre-fix**, the behavioural class run against `main` (new-symbol imports stripped so the module collects): **3 failed, 1 passed** -

```
FAILED ...::test_all_missing_warning_names_a_matching_embodiment
FAILED ...::test_all_missing_error_names_a_matching_embodiment
  Expected regex: 'so_real'
  Actual message: "... Pass embodiment='<name>' (e.g. embodiment='so101') or call set_robot_state_keys([...]) ..."
FAILED ...::test_partial_missing_error_names_a_matching_embodiment
```

The one that passed (`..._remedy_ignores_camera_keys`) did so vacuously: the old message listed no keys at all, so the camera key was trivially absent.

### Two existing assertions corrected, not shimmed

`test_state_key_mismatch.py`'s two `..._raises_with_actionable_message` tests asserted the literal `"embodiment="`. Their fixture is bare lowercase SO motor names (`shoulder_pan`, ...), which **no** shipped embodiment declares - the sim configurations use the assets' own names and `so_real` uses `.pos`. So those tests were passing while the message recommended `embodiment='so101'` for an observation that configuration cannot bind either: the assertion pinned the defect. They now assert what "actionable" means for that observation - the observed keys named, and the exact copy-pasteable `set_robot_state_keys(...)` call - with the reason recorded in the shared helper's docstring.

## Gate

- `ruff check` / `ruff format --check strands_robots tests tests_integ` clean (956 files)
- `mypy strands_robots tests tests_integ` - `Success: no issues found in 953 source files`
- `MUJOCO_GL=egl pytest tests` - **13721 passed, 253 skipped** in 433s (pure `main` at `9307a25d`: 13719 passed / 253 skipped)
- `scripts/assemble_changelog.py --check` OK; `tests/test_changelog_fragments.py tests/test_changelog_format.py` 30 passed

## Docs

`docs/policies/lerobot-local.md` State routing gains the selection rule and spells out the hardware case, since that is where the old advice was actively misleading.