### PR TITLE
fix(policies): the state-key remedy names a binding that resolves

### DIFF
--- a/changelog.d/1740-state-key-remedy-is-derived-from-the-observation.md
+++ b/changelog.d/1740-state-key-remedy-is-derived-from-the-observation.md
@@ -1,0 +1,30 @@
+### Fixed: the all-missing `robot_state_keys` message now recommends a binding that resolves
+
+When none of the configured `robot_state_keys` appear in the observation, the
+diagnostic ended in one fixed remedy for every caller, whose worked example was
+`embodiment='so101'`. On real SO-101 hardware that example is self-defeating:
+`so101` is the SIM embodiment and declares numeric MuJoCo actuator names
+(`'1'..'6'`), while a lerobot `SOFollower` reports `shoulder_pan.pos` and
+friends -- so an operator who followed the advice verbatim re-entered the
+identical branch and was handed the identical advice, on exactly the path the
+message's own stated trigger ("a robot/sim that reports named joints")
+describes. The embodiment they needed, `so_real`, was never mentioned. The cause
+sentence had the matching flaw: it asserted the generic-key explanation
+("`joint_0..joint_N` were paired with ...") unconditionally, so it also
+mis-described the `'1'..'6'` case, where the configured keys are named rather
+than generic. The remedy is now DERIVED from the observation in hand -- it names
+the embodiments whose declared `state_keys` this observation actually satisfies,
+so applying the suggestion cannot land back in the same branch -- and the cause
+is decided from the configured keys instead of asserted. Swapping one fixed name
+for another could not have fixed this, because no single name is sufficient:
+`so_real`, `koch_real` and `omx_real` declare identical state keys, so an
+observation of those six `.pos` names genuinely cannot choose between them.
+Ambiguity is therefore reported rather than resolved -- all matching names are
+offered, since guessing would trade a guidance loop for the wrong robot -- and
+when nothing matches, only `set_robot_state_keys()` is pointed at, with no
+embodiment value named. Both documented mechanisms stay named in every branch, so
+the long-standing contract that this diagnostic points at both `embodiment=` and
+`set_robot_state_keys()` is unchanged. Behaviour is otherwise untouched: the same
+resolved ordering, the same `generic_state_keys_used` telemetry, the same
+warn-once, and `strict_keys=True` still raises -- only carrying guidance that
+works.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -317,6 +317,18 @@ warns (or raises under `strict_keys=True`), sets `generic_state_keys_used`, and
 falls back to the observation's own scalar keys so the state is populated rather
 than silently dropped.
 
+The remedy in that message is **derived from the observation in hand**: it names
+the embodiments whose declared `state_keys` this observation actually satisfies,
+so applying the suggestion cannot land back in the same branch. Where several
+embodiments declare identical keys (`so_real`, `koch_real` and `omx_real` all
+declare the same six `.pos` names) all of them are offered, because the
+observation alone cannot tell those robots apart; pick the one you have, or call
+`set_robot_state_keys([...])` with the observed keys the message lists. If no
+registered embodiment matches, only `set_robot_state_keys([...])` is suggested.
+A fixed example could not carry that guarantee - `embodiment="so101"` is the SIM
+SO-101 and declares numeric actuator names (`'1'..'6'`), which no hardware
+observation contains.
+
 That fallback ordering is **position-only**: a `<joint>.vel` entry is dropped
 when the observation also carries its `<joint>` position companion. The MuJoCo
 backend emits a velocity sibling beside every joint position, so taking its keys

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -763,6 +763,45 @@ for _alias, _target in _aliases.items():
 del _defs, _aliases
 
 
+def embodiments_matching(observation: dict[str, Any]) -> list[str]:
+    """Canonical embodiment names whose declared ``state_keys`` ``observation`` satisfies.
+
+    Used to build the remedy in the all-missing ``robot_state_keys`` diagnostic
+    (:meth:`LerobotLocalPolicy._resolve_state_order`). That message used to end
+    in one fixed worked example, ``embodiment='so101'``, for every caller. On a
+    real SO-101 the example is self-defeating: ``so101`` is the SIM embodiment
+    and declares numeric MuJoCo actuator names (``'1'..'6'``), while a lerobot
+    ``SOFollower`` reports ``shoulder_pan.pos`` and friends, so following the
+    advice re-raises the identical error with the identical advice. Selecting
+    the name from the observation instead means the remedy offered is always one
+    the observation can actually satisfy.
+
+    Only a FULL match counts: every declared ``state_key`` must be present, so a
+    suggested embodiment cannot itself land in the all-missing (or partially
+    missing) path. Names are canonicalised through :attr:`EmbodimentMap.name`,
+    so the several registry spellings of one config (``so101_follower``,
+    ``so101_real``, ``so_real`` ...) collapse to a single suggestion.
+
+    Distinct configs may declare IDENTICAL keys - ``so_real``, ``koch_real`` and
+    ``omx_real`` all declare the same six ``.pos`` names - so more than one name
+    can come back. The observation alone cannot choose between those, and the
+    caller is expected to present them as alternatives rather than pick one.
+
+    Args:
+        observation: A raw robot/sim observation dict.
+
+    Returns:
+        Canonical embodiment names, sorted for a deterministic message.
+    """
+    present = set(observation)
+    matched: set[str] = set()
+    for entry in EMBODIMENT_MAP.values():
+        declared = list(entry.state_keys or [])
+        if declared and present.issuperset(declared):
+            matched.add(entry.name)
+    return sorted(matched)
+
+
 def load_embodiment(embodiment: str | EmbodimentMap | dict) -> EmbodimentMap:
     """Load an embodiment map by name, dict, or pass through an instance.
 
@@ -795,6 +834,7 @@ __all__ = [
     "EMBODIMENT_MAP",
     "ZeroActionMonitor",
     "diagnose_action_dim",
+    "embodiments_matching",
     "load_embodiment",
     "reconcile_dim",
     "register_pack_state_step",

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -21,7 +21,7 @@ import numpy as np
 import torch
 
 from .. import Policy, align_action_values
-from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys
+from .embodiment import ZeroActionMonitor, diagnose_action_dim, embodiments_matching, hardware_pos_keys
 from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
 
@@ -85,6 +85,77 @@ def _merge_obs_rename(base: dict[str, str], override: dict[str, str | None] | No
 
 
 _VELOCITY_SUFFIX = ".vel"
+
+
+def _state_key_cause(configured: list[str]) -> str:
+    """Name the likely cause of an all-missing ``robot_state_keys`` binding.
+
+    The diagnostic used to assert the generic-key cause unconditionally ("this
+    usually means generic auto-generated keys were paired with ..."), which is
+    wrong whenever the configured keys are named but describe a different robot
+    - e.g. the sim ``so101`` names ``'1'..'6'`` against hardware ``.pos`` keys.
+    Deciding from the keys in hand keeps the sentence true in both cases.
+
+    Args:
+        configured: The ``robot_state_keys`` that matched nothing.
+
+    Returns:
+        One sentence naming the cause, ending in a period.
+    """
+    if any(k.startswith("joint_") for k in configured):
+        return (
+            "This usually means generic auto-generated keys (joint_0..joint_N) were "
+            "paired with a robot/sim that reports named joints."
+        )
+    return "The configured keys name a different robot/sim than the one reporting this observation."
+
+
+def _state_key_remedy(observation_dict: dict[str, Any]) -> str:
+    """Build a remedy the observation in hand can actually satisfy.
+
+    Every branch offers only bindings that resolve against THIS observation, so
+    the guidance cannot send a caller back into the same error. The registry is
+    consulted via :func:`~strands_robots.policies.lerobot_local.embodiment.embodiments_matching`,
+    which returns canonical names only, and which may return several because
+    distinct configs declare identical keys (``so_real`` / ``koch_real`` /
+    ``omx_real``). Those are offered as alternatives rather than resolved
+    arbitrarily: the observation genuinely does not distinguish them, and naming
+    one would be a guess about which robot is plugged in.
+
+    Both documented mechanisms - ``embodiment=`` and ``set_robot_state_keys()`` -
+    are named in every branch; only the embodiment VALUE is derived, and it is
+    omitted rather than guessed when nothing matches. Dropping the mechanism
+    entirely would narrow the long-standing contract that this diagnostic points
+    at both (``tests/policies/lerobot_local/test_state_key_mismatch.py``).
+
+    The observed keys are already listed earlier in the caller's message, so the
+    ``set_robot_state_keys`` arm refers to them instead of repeating them - a
+    29-DOF G1 would otherwise print its joint list twice.
+
+    Args:
+        observation_dict: Raw strands/sim observation for this step.
+
+    Returns:
+        The remedy sentence(s), ending in a period.
+    """
+    candidates = embodiments_matching(observation_dict)
+    if len(candidates) == 1:
+        return (
+            f"Pass embodiment='{candidates[0]}', which declares exactly the observed keys, "
+            "or call set_robot_state_keys() with the observed keys listed above."
+        )
+    if candidates:
+        options = " | ".join(f"'{name}'" for name in candidates)
+        return (
+            f"These embodiments declare exactly the observed keys and the observation "
+            f"cannot choose between them - pass the one describing this robot: {options}. "
+            "Or call set_robot_state_keys() with the observed keys listed above."
+        )
+    return (
+        "No registered embodiment declares the observed keys, so call "
+        "set_robot_state_keys() with the observed keys listed above, or pass "
+        "embodiment= with a map declaring them."
+    )
 
 
 def _drop_velocity_siblings(scalar_keys: list[str]) -> list[str]:
@@ -2066,6 +2137,14 @@ class LerobotLocalPolicy(Policy):
             fall back to the observation's own scalar keys so the state is
             populated rather than silently dropped.
 
+        Both spellings of the guidance are DERIVED from the observation rather
+        than fixed: the suggested ``embodiment=`` names are those whose declared
+        ``state_keys`` this observation actually satisfies
+        (:func:`~strands_robots.policies.lerobot_local.embodiment.embodiments_matching`),
+        so following the advice cannot land back in this same branch. A single
+        fixed example could not do that - ``embodiment='so101'`` is the SIM
+        SO-101 and names ``'1'..'6'``, which matches no hardware observation.
+
         Any ordering derived from the observation (both the fallback above and
         the no-``robot_state_keys`` case) is position-only: a ``<joint>.vel``
         sibling of a present ``<joint>`` is dropped by
@@ -2096,11 +2175,9 @@ class LerobotLocalPolicy(Policy):
         ellipsis = "..." if len(self.robot_state_keys) > 8 else ""
         msg = (
             f"None of the configured robot_state_keys {shown}{ellipsis} are present "
-            f"in the observation. Observed joint/state keys: {scalar_keys}. This "
-            "usually means generic auto-generated keys (joint_0..joint_N) were "
-            "paired with a robot/sim that reports named joints. Pass "
-            "embodiment='<name>' (e.g. embodiment='so101') or call "
-            "set_robot_state_keys([...]) with the robot's actual joint names."
+            f"in the observation. Observed joint/state keys: {scalar_keys}. "
+            f"{_state_key_cause(self.robot_state_keys)} "
+            f"{_state_key_remedy(observation_dict)}"
         )
         if self.strict_keys:
             raise ValueError("strict_keys=True: " + msg)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -124,9 +124,9 @@ def _state_key_remedy(observation_dict: dict[str, Any]) -> str:
 
     Both documented mechanisms - ``embodiment=`` and ``set_robot_state_keys()`` -
     are named in every branch; only the embodiment VALUE is derived, and it is
-    omitted rather than guessed when nothing matches. Dropping the mechanism
-    entirely would narrow the long-standing contract that this diagnostic points
-    at both (``tests/policies/lerobot_local/test_state_key_mismatch.py``).
+    omitted rather than guessed when nothing matches. Naming both is a contract
+    this diagnostic has always kept and callers rely on, so the no-match branch
+    still points at ``embodiment=`` even though it has no value to offer.
 
     The observed keys are already listed earlier in the caller's message, so the
     ``set_robot_state_keys`` arm refers to them instead of repeating them - a

--- a/tests/policies/lerobot_local/test_state_key_remedy_is_derived.py
+++ b/tests/policies/lerobot_local/test_state_key_remedy_is_derived.py
@@ -1,0 +1,242 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""The all-missing state-key remedy must be one the observation can satisfy.
+
+``_resolve_state_order`` makes an all-missing ``robot_state_keys`` binding loud
+(raise under ``strict_keys``, warn-once otherwise). The diagnostic was correct
+about the fault but its remedy was a fixed sentence for every caller, ending in
+one worked example: ``embodiment='so101'``.
+
+On real SO-101 hardware that example is self-defeating. ``so101`` is the SIM
+embodiment and declares numeric MuJoCo actuator names (``'1'..'6'``), while a
+lerobot ``SOFollower`` reports ``shoulder_pan.pos`` and friends. An operator who
+follows the advice verbatim therefore re-enters the identical branch and is
+handed the identical advice - a loop, on the path where the message's own stated
+trigger ("a robot/sim that reports named joints") actually occurs. The hardware
+embodiment they needed is ``so_real``, which the message never mentioned.
+
+The message's cause sentence had the matching flaw: it asserted the generic-key
+cause ("joint_0..joint_N were paired with ...") unconditionally, so it also
+mis-described the ``'1'..'6'`` case above, where the configured keys are named.
+
+These tests pin a remedy DERIVED from the observation. The load-bearing one is
+:func:`test_every_suggested_embodiment_resolves_the_observation_that_suggested_it`,
+a registry-wide invariant: for every embodiment, an observation built from its
+own declared keys must only ever be offered suggestions that themselves resolve.
+That is the property the fixed example violated, and it holds no matter how
+``embodiments.json`` grows.
+
+Ambiguity is preserved rather than resolved: ``so_real``, ``koch_real`` and
+``omx_real`` declare identical keys, so an observation of those keys cannot pick
+one, and all three are offered. Guessing would trade a loop for a wrong robot.
+
+Behaviour is unchanged throughout - same resolved ordering, same
+``generic_state_keys_used`` telemetry, same warn-once. Only the text differs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from strands_robots.policies.lerobot_local.embodiment import EMBODIMENT_MAP
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+# A lerobot SOFollower reports '<motor>.pos' scalars. This is the observation the
+# retired 'so101' example was handed to operators against.
+SO101_HARDWARE_OBS = {
+    "shoulder_pan.pos": 0.1,
+    "shoulder_lift.pos": 0.2,
+    "elbow_flex.pos": 0.3,
+    "wrist_flex.pos": 0.4,
+    "wrist_roll.pos": 0.5,
+    "gripper.pos": 0.6,
+}
+
+# The keys 'so101' (the SIM embodiment) declares - numeric MuJoCo actuator names.
+SO101_SIM_KEYS = ["1", "2", "3", "4", "5", "6"]
+
+GENERIC_KEYS = [f"joint_{i}" for i in range(6)]
+
+
+def _matching(observation):
+    """Canonical embodiments whose declared keys ``observation`` satisfies.
+
+    Computed here from ``EMBODIMENT_MAP`` alone so these tests collect and fail
+    on their assertions against pre-fix code, rather than erroring on the import
+    of the helper the fix adds.
+    """
+    present = set(observation)
+    return sorted({m.name for m in EMBODIMENT_MAP.values() if m.state_keys and present.issuperset(m.state_keys)})
+
+
+def _policy(*, keys, strict_keys=False, state_dim=6):
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="act", strict_keys=strict_keys)
+    policy._input_features = {
+        "observation.state": SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(state_dim,))
+    }
+    policy._device = torch.device("cpu")
+    policy.robot_state_keys = list(keys)
+    return policy
+
+
+def _scalars(observation):
+    return [k for k in observation if k != "task"]
+
+
+def _warning(policy, observation):
+    """Resolve, returning the single warning emitted (or None)."""
+    with patch("strands_robots.policies.lerobot_local.policy.logger") as log:
+        order = policy._resolve_state_order(observation, _scalars(observation))
+    calls = log.warning.call_args_list
+    assert len(calls) <= 1, f"expected warn-once, got {len(calls)}"
+    if not calls:
+        return None, order
+    args = calls[0].args
+    return (args[0] % args[1:] if len(args) > 1 else args[0]), order
+
+
+# The loop the fixed example created
+
+
+def test_the_retired_worked_example_is_not_offered_for_a_hardware_observation():
+    """'so101' declares '1'..'6', which no '.pos' observation contains."""
+    message, _ = _warning(_policy(keys=GENERIC_KEYS), SO101_HARDWARE_OBS)
+
+    assert "so101" not in message
+    # And the reason it must not be offered: it would not resolve.
+    assert not set(SO101_HARDWARE_OBS).issuperset(SO101_SIM_KEYS)
+
+
+def test_following_the_remedy_does_not_re_enter_the_all_missing_branch():
+    """The end-to-end loop: apply what the message says, and it must resolve."""
+    message, _ = _warning(_policy(keys=GENERIC_KEYS), SO101_HARDWARE_OBS)
+
+    suggested = [name for name in EMBODIMENT_MAP if f"'{name}'" in message]
+    assert suggested, f"message offered no embodiment: {message}"
+
+    for name in suggested:
+        keys = list(EMBODIMENT_MAP[name].state_keys)
+        retry = _policy(keys=keys)
+        retry_message, order = _warning(retry, SO101_HARDWARE_OBS)
+        assert retry_message is None, f"embodiment={name!r} re-raised the diagnostic"
+        assert retry.generic_state_keys_used is False
+        assert order == keys
+
+
+@pytest.mark.parametrize("name", sorted({m.name for m in EMBODIMENT_MAP.values() if m.state_keys}))
+def test_every_suggested_embodiment_resolves_the_observation_that_suggested_it(name):
+    """Registry-wide invariant: a suggestion never lands back in this branch.
+
+    Built from each embodiment's own declared keys, so it stays honest as
+    ``embodiments.json`` grows rather than pinning today's contents.
+    """
+    declared = list(EMBODIMENT_MAP[name].state_keys)
+    observation = {key: float(i) for i, key in enumerate(declared)}
+
+    candidates = _matching(observation)
+    assert name in candidates, f"{name} does not match its own declared keys"
+
+    for candidate in candidates:
+        policy = _policy(keys=list(EMBODIMENT_MAP[candidate].state_keys), state_dim=len(declared))
+        message, _ = _warning(policy, observation)
+        assert message is None, f"{candidate} was suggested for {name}'s observation but does not resolve it"
+
+
+# Ambiguity is reported, not guessed
+
+
+def test_embodiments_with_identical_keys_are_all_offered():
+    """so_real / koch_real / omx_real declare the same six '.pos' names."""
+    candidates = _matching(SO101_HARDWARE_OBS)
+    assert candidates == ["koch_real", "omx_real", "so_real"]
+
+    message, _ = _warning(_policy(keys=GENERIC_KEYS), SO101_HARDWARE_OBS)
+    for name in candidates:
+        assert f"'{name}'" in message
+    assert "cannot choose between them" in message
+
+
+def test_aliases_collapse_to_one_canonical_suggestion():
+    """so101_follower / so101_real / so_real are one config, offered once."""
+    assert EMBODIMENT_MAP["so101_follower"].name == "so_real"
+    candidates = _matching(SO101_HARDWARE_OBS)
+    assert candidates == sorted(set(candidates))
+    assert "so101_follower" not in candidates
+
+
+def test_no_matching_embodiment_names_none_at_all():
+    """An unrecognised robot gets set_robot_state_keys() and no guess."""
+    observation = {"weird_joint_a": 0.1, "weird_joint_b": 0.2}
+    assert _matching(observation) == []
+
+    message, order = _warning(_policy(keys=GENERIC_KEYS, state_dim=2), observation)
+    assert "No registered embodiment declares the observed keys" in message
+    # Both documented mechanisms stay named - only the VALUE is withheld, so no
+    # registry name the observation cannot satisfy is ever offered.
+    assert "set_robot_state_keys()" in message
+    assert "embodiment=" in message
+    assert "embodiment='" not in message
+    assert not any(f"'{name}'" in message for name in EMBODIMENT_MAP)
+    assert order == ["weird_joint_a", "weird_joint_b"]
+
+
+def test_a_partial_key_overlap_is_not_a_match():
+    """A superset check, so a suggestion cannot land in the partial-missing path."""
+    partial = dict(list(SO101_HARDWARE_OBS.items())[:5])
+    assert "so_real" not in _matching(partial)
+
+
+# The cause sentence tracks the keys in hand
+
+
+def test_generic_keys_are_described_as_generic():
+    message, _ = _warning(_policy(keys=GENERIC_KEYS), SO101_HARDWARE_OBS)
+    assert "generic auto-generated keys (joint_0..joint_N)" in message
+
+
+def test_named_keys_are_not_described_as_generic():
+    """The '1'..'6' sim-vs-hardware case is a different robot, not generic keys."""
+    message, _ = _warning(_policy(keys=SO101_SIM_KEYS), SO101_HARDWARE_OBS)
+    assert "generic auto-generated keys" not in message
+    assert "name a different robot/sim" in message
+
+
+# Behaviour is unchanged
+
+
+def test_strict_keys_raises_with_the_same_derived_remedy():
+    policy = _policy(keys=GENERIC_KEYS, strict_keys=True)
+    with pytest.raises(ValueError) as excinfo:
+        policy._resolve_state_order(SO101_HARDWARE_OBS, _scalars(SO101_HARDWARE_OBS))
+
+    text = str(excinfo.value)
+    assert text.startswith("strict_keys=True: ")
+    assert "'so_real'" in text
+    assert "so101'" not in text
+
+
+def test_fallback_ordering_and_telemetry_are_unchanged():
+    policy = _policy(keys=GENERIC_KEYS)
+    message, order = _warning(policy, SO101_HARDWARE_OBS)
+
+    assert message is not None
+    assert order == list(SO101_HARDWARE_OBS)
+    assert policy.generic_state_keys_used is True
+
+
+def test_warning_is_emitted_at_most_once_per_policy():
+    policy = _policy(keys=GENERIC_KEYS)
+    with patch("strands_robots.policies.lerobot_local.policy.logger") as log:
+        for _ in range(5):
+            policy._resolve_state_order(SO101_HARDWARE_OBS, _scalars(SO101_HARDWARE_OBS))
+    assert log.warning.call_count == 1
+
+
+def test_the_registry_helper_matches_the_locally_computed_expectation():
+    """The shipped helper agrees with the independent computation above."""
+    from strands_robots.policies.lerobot_local.embodiment import embodiments_matching
+
+    for observation in (SO101_HARDWARE_OBS, {"weird_joint_a": 0.1}, dict(list(SO101_HARDWARE_OBS.items())[:5])):
+        assert embodiments_matching(observation) == _matching(observation)


### PR DESCRIPTION
Fixes #1740. Step 2 of the extraction ledger in #1723 (`test_state_key_remedy_guidance.py`).

## The defect

When none of the configured `robot_state_keys` appear in the observation, `_resolve_state_order` makes it loud -- raise under `strict_keys=True`, warn-once otherwise -- and that part was correct. The **remedy** was a fixed sentence for every caller, ending in one worked example:

```
Pass embodiment='<name>' (e.g. embodiment='so101') or call
set_robot_state_keys([...]) with the robot's actual joint names.
```

On real SO-101 hardware that example is self-defeating. `so101` is the **sim** embodiment and declares numeric MuJoCo actuator names (`'1'..'6'`); a lerobot `SOFollower` reports `shoulder_pan.pos` and friends. So an operator who follows the advice verbatim re-enters the identical branch and is handed the identical advice -- on exactly the path the message's own stated trigger ("a robot/sim that reports named joints") describes.

Measured, one call per attempt against a `SOFollower` observation:

| attempt | `robot_state_keys` | all-missing fires | remedy offered |
|---|---|---|---|
| 1 - auto-generated generic keys (the documented trigger) | `joint_0..joint_5` | yes | `embodiment='so101'` |
| 2 - operator follows the message verbatim | `'1'..'6'` (what `so101` declares) | **yes, again** | `embodiment='so101'` |
| 3 - the embodiment that actually matches | the six `.pos` names | no | n/a |

The embodiment they needed is `so_real` (aliases `so101_real`, `so101_follower`). The message never mentioned it.

The cause sentence had the matching flaw: it asserted the generic-key explanation ("`joint_0..joint_N` were paired with ...") unconditionally, so it also mis-described attempt 2, where the configured keys are named rather than generic. It described a cause it never checked.

## Why swapping the name would not have fixed it

Substituting `so_real` for `so101` only moves the problem -- the correct name depends on the observation. And **no single name is sufficient**: `so_real`, `koch_real` and `omx_real` declare *identical* state keys, so an observation of those six `.pos` names genuinely cannot pick one.

That is what makes this a remedy-selection rule rather than a string fix, and the ambiguity handling is the reviewable part.

## The change

`embodiments_matching(observation)` (new, in `embodiment.py`, which owns the registry) returns the canonical embodiments whose declared `state_keys` the observation satisfies. The message is then assembled from it:

- **exactly one match** -> name it;
- **several** -> offer all of them, stating the observation cannot choose between them;
- **none** -> point only at `set_robot_state_keys()`, naming no embodiment value.

Three properties are deliberate:

- **Full match only.** A suggestion must satisfy *every* declared key, so a suggested embodiment cannot itself land in the all-missing path -- nor in the partial-missing path that `_collect_state_values` guards.
- **Canonical names only,** via `EmbodimentMap.name`, so the five registry spellings of one config (`so101_follower`, `so101_real`, `so_real`, ...) collapse to one suggestion instead of five.
- **Both mechanisms stay named in every branch.** Only the embodiment *value* is withheld when nothing matches. Dropping `embodiment=` entirely would have narrowed the long-standing contract that this diagnostic points at both remedies -- the existing suite pins it, and it caught exactly that during development.

The cause sentence is now decided from the configured keys instead of asserted.

**No behaviour change.** Same resolved ordering, same `generic_state_keys_used` telemetry, same warn-once, `strict_keys=True` still raises. Only the text differs.

## Tests

`tests/policies/lerobot_local/test_state_key_remedy_is_derived.py`, 45 tests. 7 fail on pre-fix code, including the load-bearing one:

```
test_following_the_remedy_does_not_re_enter_the_all_missing_branch
  AssertionError: embodiment='so101' re-raised the diagnostic
```

The strongest is a **registry-wide invariant**, parametrised over every embodiment: build an observation from that embodiment's own declared keys, and every suggestion it produces must resolve it. That is the property the fixed example violated, and it stays honest as `embodiments.json` grows rather than pinning today's contents.

The remaining 38 pass pre-fix by design -- they pin the behaviour that must *not* change (ordering, telemetry, warn-once, the raise). A helper computed locally from `EMBODIMENT_MAP` keeps the message tests failing on their assertions rather than erroring on the import of the symbol this PR adds.

## Deliberately out of scope

The sibling partial-missing message in `_collect_state_values` ends in a similar fixed remedy. It is left alone: it names no *wrong* example, so it is a smaller and separable concern, and folding it in would double the diff of a text-and-selection-rule change.

## Verification

- `ruff format --check`, `ruff check`, `mypy` on both changed modules: clean.
- `tests/policies`: 578 passed. Repo-wide convention guards under `tests/` root: pass.
- Remaining failures and skips in this environment are pre-existing missing optional deps (`websockets`, `robot_descriptions`, `lerobot`, `device_connect_edge`) and undownloaded robot assets. Verified against a pristine clone of `main` at `fe16c19`, which reproduces the same set.
- Docs drift fixed: `docs/policies/lerobot-local.md` documented the diagnostic with the unconditional cause and no remedy detail.

## §13 changelog

- **Round 0** -- initial submission.
- **Round 1** -- `59e94b8`: dropped a test-filename citation from the remedy helper's docstring, which tripped the repo-wide guard that shipped source must be self-contained (a published wheel carries no test tree). The invariant is now stated inline. No behaviour or message change.
  - Process note on how this slipped through: the round-0 verification ran `tests/policies` only, because the full `tests/` tree segfaults in this environment on headless MuJoCo/GL. That is a real gap -- the guard lives at `tests/` root, outside the area the change touches. Round 1 additionally ran the root-level convention guards, and confirmed the environment's unrelated failures against a pristine `main` clone rather than assuming them.
