### PR TITLE
fix(policies): the all-missing state-key diagnostic names a cause it checked

### DIFF
--- a/changelog.d/1742-state-key-cause-is-derived.md
+++ b/changelog.d/1742-state-key-cause-is-derived.md
@@ -1,0 +1,23 @@
+### Fixed: the all-missing state-key diagnostic names a cause it checked
+
+When none of the configured `robot_state_keys` appear in the observation,
+`lerobot_local` ended its message with one fixed explanation - that generic
+auto-generated keys (`joint_0..joint_N`) had been paired with a robot reporting
+named joints - regardless of what the caller had actually configured. It is true
+only for the case it describes, so it mis-described the cause for the callers who
+most need it right: someone who configured the sim `so101` embodiment (`'1'..'6'`)
+against a real SO arm was told the keys they had just chosen deliberately were
+placeholders the library invented.
+
+The cause is now read from the configured keys. A caller who configured a named
+set is told those keys describe a different robot than the one reporting the
+observation; the generic explanation is kept, unchanged, for the keys it was
+written for. Recognition matches the loader's exact output - the consecutive
+zero-based run `joint_0..joint_{n-1}` - rather than a `joint_` prefix, because
+real robots also have `joint_`-prefixed joint names: the shipped `kinova_gen3`
+configuration is `joint_1..joint_7`, and a prefix test called those placeholders
+too.
+
+No behaviour change: the resolved ordering, the registry-checked remedy, the
+`generic_state_keys_used` telemetry, the warn-once fallback and the
+`strict_keys=True` raise are all as before.

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -45,6 +45,49 @@ def _scalar_observation_keys(observation_dict: dict[str, Any]) -> list[str]:
     return [k for k, v in observation_dict.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)]
 
 
+def _state_key_cause(configured: list[str]) -> str:
+    """Name the likely cause of an all-missing ``robot_state_keys`` binding.
+
+    The diagnostic used to assert the generic-key cause unconditionally, which
+    holds only when the configured keys actually have that shape. A caller who
+    configured a NAMED set describing a different robot - the sim ``so101``
+    embodiment names ``'1'..'6'``, none of which a hardware observation's
+    ``'<motor>.pos'`` keys carry - was told their keys were auto-generated
+    ``joint_N`` placeholders they never configured, i.e. the diagnostic
+    mis-described the one mistake it exists to explain. Reading the configured
+    keys keeps the sentence true for either shape.
+
+    The placeholders are recognised by the exact shape the loader emits:
+    ``joint_0`` through ``joint_{n-1}``, consecutive and zero-based. A bare
+    ``joint_`` prefix is NOT enough to conclude a key was auto-generated - the
+    registry ships ``kinova_gen3``, whose real joint names are ``joint_1``
+    through ``joint_7`` (one-based), so a prefix test would tell a Kinova
+    operator that the arm's own joint names were placeholders it invented.
+    Matching the generator exactly keeps both callers' sentences true, and the
+    alternative sentence asserts nothing about genericity, so it holds for every
+    other set - named, one-based, reordered or mixed.
+
+    The loader records no flag when it fills the list in, so the shape is the
+    only signal available - and it is also the honest one, since a hand-written
+    ``joint_0..joint_N`` set carries exactly the ambiguity the generic sentence
+    describes.
+
+    Args:
+        configured: The ``robot_state_keys`` that matched nothing. Empty is
+            accepted (the caller's guard returns before then) and takes the
+            non-generic branch rather than vacuously claiming the shape.
+
+    Returns:
+        One sentence naming the cause, ending in a period.
+    """
+    if configured and configured == [f"{_GENERIC_STATE_KEY_PREFIX}{i}" for i in range(len(configured))]:
+        return (
+            "This usually means generic auto-generated keys (joint_0..joint_N) were "
+            "paired with a robot/sim that reports named joints."
+        )
+    return "The configured keys describe a different robot/sim than the one reporting this observation."
+
+
 def _declared_feature_is_image(name: str, feature: Any = None) -> bool:
     """Return True if a declared input feature is a camera/image (VISUAL) feature.
 
@@ -100,6 +143,16 @@ def _merge_obs_rename(base: dict[str, str], override: dict[str, str | None] | No
             merged.pop(src, None)
     return merged
 
+
+# Prefix of the placeholder state keys the loader fills in when a checkpoint
+# declares a state/action dim but the caller named no joints: it emits the
+# consecutive zero-based run ``joint_0..joint_{n-1}``. The all-missing
+# diagnostic rebuilds that run to decide whether the generic-key explanation
+# applies, and the user-facing sentence quotes the shape, so the three must stay
+# in step. Real robots can also have joint_-prefixed names (the registry's
+# kinova_gen3 is joint_1..joint_7), which is why the run, not the prefix, is
+# what identifies a placeholder.
+_GENERIC_STATE_KEY_PREFIX = "joint_"
 
 _VELOCITY_SUFFIX = ".vel"
 
@@ -2083,6 +2136,13 @@ class LerobotLocalPolicy(Policy):
             fall back to the observation's own scalar keys so the state is
             populated rather than silently dropped.
 
+        The cause that message names is read from the configured keys
+        (:func:`_state_key_cause`) rather than asserted, so a caller who
+        configured a NAMED set describing a different robot is not told their
+        keys were auto-generated placeholders they never configured. The remedy
+        is chosen from the observation (:func:`state_key_remedy`), so the two
+        halves of the message answer the two different questions the caller has.
+
         Any ordering derived from the observation (both the fallback above and
         the no-``robot_state_keys`` case) is position-only: a ``<joint>.vel``
         sibling of a present ``<joint>`` is dropped by
@@ -2113,11 +2173,14 @@ class LerobotLocalPolicy(Policy):
         ellipsis = "..." if len(self.robot_state_keys) > 8 else ""
         msg = (
             f"None of the configured robot_state_keys {shown}{ellipsis} are present "
-            f"in the observation. Observed joint/state keys: {scalar_keys}. This "
-            "usually means generic auto-generated keys (joint_0..joint_N) were "
-            "paired with a robot/sim that reports named joints. " + state_key_remedy(scalar_keys)
-            # Chosen from the observation, so the advice cannot name an
+            f"in the observation. Observed joint/state keys: {scalar_keys}. "
+            # Cause read from the configured keys, so the sentence does not
+            # assert a key shape they do not have.
+            + _state_key_cause(self.robot_state_keys)
+            + " "
+            # Remedy chosen from the observation, so the advice cannot name an
             # embodiment whose state_keys would land back on this same guard.
+            + state_key_remedy(scalar_keys)
         )
         if self.strict_keys:
             raise ValueError("strict_keys=True: " + msg)

--- a/tests/policies/lerobot_local/test_state_key_cause_is_derived.py
+++ b/tests/policies/lerobot_local/test_state_key_cause_is_derived.py
@@ -1,0 +1,192 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""An all-missing state-key diagnostic must name a cause it actually checked.
+
+When none of the configured ``robot_state_keys`` appear in the observation, the
+message used to end in one fixed explanation for every caller: "This usually
+means generic auto-generated keys (joint_0..joint_N) were paired with a
+robot/sim that reports named joints." It was asserted without looking at the
+configured keys, so it was true only for the one case it describes.
+
+The callers it misled are the ones who most need it right. Configuring the sim
+``so101`` embodiment against a real SO arm is the canonical mistake - the sim
+configuration names the MuJoCo asset's numeric joints ``'1'..'6'`` while the arm
+reports ``'<motor>.pos'`` - and those operators were told the keys they had just
+chosen deliberately were auto-generated ``joint_N`` placeholders.
+
+A bare ``joint_`` prefix is not a sound test for a placeholder either: the
+registry ships ``kinova_gen3``, whose real joint names are ``joint_1..joint_7``.
+The loader emits the consecutive zero-based run ``joint_0..joint_{n-1}``, so that
+run - not the prefix - is what identifies a key the library invented.
+
+These tests pin that the cause is read from the configured keys, that the
+generic case keeps the explanation written for it, and that nothing else about
+the guard (remedy, fallback ordering, telemetry, warn-once, strict raise)
+changed.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+
+from strands_robots.policies.lerobot_local.embodiment import EMBODIMENT_MAP
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy, _state_key_cause
+
+# lerobot SOFollower motor feature keys - what a real SO arm reports.
+HARDWARE_KEYS = [
+    "shoulder_pan.pos",
+    "shoulder_lift.pos",
+    "elbow_flex.pos",
+    "wrist_flex.pos",
+    "wrist_roll.pos",
+    "gripper.pos",
+]
+
+# The shape the loader fills in when a checkpoint declares a dim and the caller
+# named no joints: consecutive and zero-based.
+GENERIC_SENTENCE = (
+    "This usually means generic auto-generated keys (joint_0..joint_N) were "
+    "paired with a robot/sim that reports named joints."
+)
+NAMED_SENTENCE = "The configured keys describe a different robot/sim than the one reporting this observation."
+
+
+def _loader_placeholders(n: int) -> list[str]:
+    """The keys the loader auto-generates for an ``n``-dim checkpoint."""
+    return [f"joint_{i}" for i in range(n)]
+
+
+def _visual(shape=(3, 224, 224)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _policy(configured, *, strict_keys=True):
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="molmoact2", strict_keys=strict_keys)
+    policy._input_features = {"observation.images.base": _visual(), "observation.state": _state(6)}
+    policy._device = torch.device("cpu")
+    policy.robot_state_keys = list(configured)
+    return policy
+
+
+def _obs(keys=tuple(HARDWARE_KEYS)):
+    obs = {"base": np.zeros((224, 224, 3), np.uint8)}
+    obs.update(dict.fromkeys(keys, 0.5))
+    return obs
+
+
+def _diagnostic(configured, obs_keys=tuple(HARDWARE_KEYS)) -> str:
+    """The all-missing message raised for ``configured`` against ``obs_keys``."""
+    policy = _policy(configured)
+    with pytest.raises(ValueError) as excinfo:
+        policy._resolve_state_order(_obs(obs_keys), list(obs_keys))
+    return str(excinfo.value)
+
+
+class TestCauseIsReadFromTheConfiguredKeys:
+    """The sentence must match whether the keys really are placeholders."""
+
+    @pytest.mark.parametrize(
+        ("label", "configured", "expect_generic"),
+        [
+            ("loader placeholders", _loader_placeholders(6), True),
+            ("sim so101 numeric joints", EMBODIMENT_MAP["so101"].state_keys, False),
+            ("sim so100 named joints", EMBODIMENT_MAP["so100"].state_keys, False),
+            ("kinova_gen3 one-based joint names", EMBODIMENT_MAP["kinova_gen3"].state_keys, False),
+            ("aloha bimanual named joints", EMBODIMENT_MAP["aloha"].state_keys, False),
+        ],
+    )
+    def test_only_the_placeholder_shape_is_called_auto_generated(self, label, configured, expect_generic):
+        msg = _diagnostic(configured)
+        assert (GENERIC_SENTENCE in msg) is expect_generic, f"{label}: wrong cause in {msg!r}"
+        assert (NAMED_SENTENCE in msg) is not expect_generic, f"{label}: wrong cause in {msg!r}"
+
+    def test_no_shipped_configuration_is_described_as_auto_generated(self):
+        """Every registry entry names a real robot's joints, never a placeholder.
+
+        ``kinova_gen3`` / ``openarm_real`` are the entries that make this worth
+        asserting: their joint names carry the ``joint_`` prefix, so a prefix
+        test would describe a shipped robot's own naming as invented.
+        """
+        for name, embodiment in EMBODIMENT_MAP.items():
+            keys = embodiment.state_keys
+            if not keys:
+                continue
+            assert keys != _loader_placeholders(len(keys)), f"{name} collides with the loader's placeholder run"
+            assert _state_key_cause(list(keys)) == NAMED_SENTENCE, name
+
+    def test_the_placeholder_case_keeps_the_explanation_written_for_it(self):
+        """The generic wording is unchanged for the callers it was correct for."""
+        assert GENERIC_SENTENCE in _diagnostic(_loader_placeholders(6))
+
+
+class TestPlaceholderRecognition:
+    """Only the loader's own output counts as a placeholder run."""
+
+    @pytest.mark.parametrize("dim", [1, 2, 6, 7, 14, 29])
+    def test_the_loader_run_is_recognised_at_every_width(self, dim):
+        assert _state_key_cause(_loader_placeholders(dim)) == GENERIC_SENTENCE
+
+    @pytest.mark.parametrize(
+        "configured",
+        [
+            pytest.param(["joint_1", "joint_2", "joint_3"], id="one-based-run"),
+            pytest.param(["joint_1", "joint_0"], id="reordered-run"),
+            pytest.param(["joint_0", "joint_2"], id="non-consecutive-run"),
+            pytest.param(["joint_0", "Jaw"], id="mixed-with-a-named-key"),
+            pytest.param(["joint_0.pos", "joint_1.pos"], id="suffixed-run"),
+            pytest.param([], id="empty"),
+        ],
+    )
+    def test_anything_else_is_not_claimed_to_be_auto_generated(self, configured):
+        assert _state_key_cause(configured) == NAMED_SENTENCE
+
+    @pytest.mark.parametrize("configured", [_loader_placeholders(3), ["1", "2"], []])
+    def test_every_cause_is_one_plain_ascii_sentence(self, configured):
+        cause = _state_key_cause(configured)
+        cause.encode("ascii")
+        assert cause.endswith(".")
+        assert "\n" not in cause
+
+
+class TestTheRestOfTheDiagnosticIsUnchanged:
+    """Only the cause sentence moved; the guard's contract did not."""
+
+    @pytest.mark.parametrize("configured", [_loader_placeholders(6), EMBODIMENT_MAP["so101"].state_keys])
+    def test_the_registry_checked_remedy_still_follows_the_cause(self, configured):
+        msg = _diagnostic(configured)
+        cause = _state_key_cause(list(configured))
+        assert cause in msg
+        # so_real declares exactly the hardware observation's keys, so the
+        # remedy must still name it - and must come after the cause.
+        assert msg.index(cause) < msg.index("so_real")
+        assert "set_robot_state_keys" in msg
+
+    def test_the_observed_keys_are_still_quoted_back(self):
+        msg = _diagnostic(EMBODIMENT_MAP["so101"].state_keys)
+        assert "gripper.pos" in msg
+        assert "'1', '2'" in msg
+
+    def test_the_lenient_path_still_warns_once_and_falls_back(self, caplog):
+        policy = _policy(EMBODIMENT_MAP["so101"].state_keys, strict_keys=False)
+        obs = _obs()
+        with caplog.at_level("WARNING"):
+            first = policy._resolve_state_order(obs, list(HARDWARE_KEYS))
+            second = policy._resolve_state_order(obs, list(HARDWARE_KEYS))
+        assert first == HARDWARE_KEYS
+        assert second == HARDWARE_KEYS
+        assert policy.generic_state_keys_used is True
+        warnings = [r for r in caplog.records if NAMED_SENTENCE in r.getMessage()]
+        assert len(warnings) == 1
+
+    def test_a_configured_key_that_is_present_still_wins(self):
+        """The guard only fires when NOTHING matches, placeholders included."""
+        configured = [*_loader_placeholders(5), "gripper.pos"]
+        policy = _policy(configured)
+        assert policy._resolve_state_order(_obs(), list(HARDWARE_KEYS)) == configured


### PR DESCRIPTION
Closes #1742.

## Problem

When none of the configured `robot_state_keys` appear in the observation, `LerobotLocalPolicy._resolve_state_order` ended its message with one fixed explanation for every caller:

> This usually means generic auto-generated keys (joint_0..joint_N) were paired with a robot/sim that reports named joints.

It was asserted without looking at the configured keys, so it was true only for the one case it describes. The callers it misled are the ones who most need it right: configuring the sim `so101` embodiment against a real SO arm is the canonical mistake -- the sim configuration names the MuJoCo asset's numeric joints `'1'..'6'` while the arm reports `'<motor>.pos'` -- and those operators were told the keys they had just chosen deliberately were auto-generated `joint_N` placeholders the library invented.

Measured on `main` at `700e68b6`, one call per row against a lerobot `SOFollower` observation (six `.pos` keys), `strict_keys=True`:

| configured `robot_state_keys` | really placeholders? | cause the message states | verdict |
|---|---|---|---|
| `joint_0..joint_5` (loader-filled) | yes | auto-generated placeholders | correct |
| `'1'..'6'` (`embodiment='so101'`) | no | auto-generated placeholders | **mis-describes** |
| `Rotation, Pitch, ...` (`embodiment='so100'`) | no | auto-generated placeholders | **mis-describes** |
| `joint_1..joint_7` (`embodiment='kinova_gen3'`) | no | auto-generated placeholders | **mis-describes** |
| `left/waist, ...` (`embodiment='aloha'`) | no | auto-generated placeholders | **mis-describes** |

1 of 5 correct. This also compounds with the remedy fixed in #1739: the advice sends a caller to a configuration, and the message then explains their failure with a cause that does not apply to it.

## Change

The cause is read from the configured keys (`_state_key_cause`) instead of asserted. The generic wording is kept **unchanged** for the keys it was written for; anything else gets a sentence that asserts nothing about genericity, so it holds for named, one-based, reordered and mixed sets alike.

Recognition matches the loader's **exact** output -- the consecutive zero-based run `joint_0..joint_{n-1}` -- rather than a `joint_` prefix. The prefix is not a sound test, and the registry itself is the counterexample: `kinova_gen3` declares `joint_1..joint_7`, which are the arm's real joint names, so a prefix test tells a Kinova operator that their arm's own naming was invented. (This is a deliberate deviation from the shape sketched on the issue, which used a prefix check; the registry entry is what ruled it out.) `openarm_real` is a second such entry (`joint_1.pos..joint_7.pos`).

The two halves of the message now answer the two different questions a caller has, from the two different inputs that can answer them: the **cause** from the configured keys, the **remedy** from the observation (`state_key_remedy`, #1739). A regression test pins that ordering so they cannot be reassembled the wrong way round.

After, the same five rows are 5 of 5 correct, and the full message reads:

```
strict_keys=True: None of the configured robot_state_keys ['1', '2', '3', '4', '5', '6'] are
present in the observation. Observed joint/state keys: ['shoulder_pan.pos', ...]. The
configured keys describe a different robot/sim than the one reporting this observation. Pass
embodiment= one of 'koch_real' / 'omx_real' / 'so_real' - each declares state_keys this
observation carries, so pick the one matching your robot - or call
set_robot_state_keys(['shoulder_pan.pos', ...]).
```

## No behaviour change

Resolved ordering, the registry-checked remedy, `generic_state_keys_used` telemetry, the warn-once lenient fallback and the `strict_keys=True` raise are all as before, each pinned by a test in `TestTheRestOfTheDiagnosticIsUnchanged`.

## Measured verdicts

Every cell below is produced by one script run against both trees (pre-fix with the source reverted), not hand-written.

![state-key cause verdicts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/state-key-cause/state_key_cause.png)

## Tests

`tests/policies/lerobot_local/test_state_key_cause_is_derived.py`, 27 tests:

- the cause matches whether the keys really are placeholders, over an explicit table of loader / sim-numeric / sim-named / one-based-real / bimanual-real key sets;
- **no shipped configuration is described as auto-generated** -- swept over the whole registry, so a future entry that collides with the placeholder run fails here rather than shipping a wrong sentence;
- the placeholder run is recognised at every width, and one-based, reordered, non-consecutive, suffixed, mixed and empty sets are not claimed to be auto-generated;
- the remedy still follows the cause and still names `so_real`; the observed keys are still quoted back; the lenient path still warns once, sets `generic_state_keys_used` and falls back to the observation's own keys; a configured key that *is* present still wins.

Pre-fix (source reverted to `main`, new-symbol import replaced by the expected contract so the behavioural tests still collect): **6 failed, 6 passed**. Post-fix: **12 passed**. The sharpest pre-fix failure is `kinova_gen3` -- a shipped robot's real joint names reported as placeholders.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -- clean (958 files formatted, 955 source files, no issues).
- `MUJOCO_GL=egl python -m pytest tests -q` -- **13761 passed, 253 skipped** (448s), at base `700e68b6`.
- Repo-wide root guards run explicitly (docstring doc-refs, internal source paths, changelog fragments/format): 38 passed. `python scripts/assemble_changelog.py --check` OK.

## Out of scope

The partial-missing guard in `_collect_state_values` hedges a different cause ("commonly a mimic/tendon gripper whose actuator name differs..."). That one is a claim about the robot's mechanism, which the function cannot observe -- it sees only key names -- so it is not fixable by the same read-what-you-have change and is left alone here.