### PR TITLE
fix(policies): the camera pre-flight check verifies the model declares the features the embodiment feeds

### DIFF
--- a/changelog.d/1744-preflight-checks-declared-image-features.md
+++ b/changelog.d/1744-preflight-checks-declared-image-features.md
@@ -1,0 +1,24 @@
+### Fixed: the camera pre-flight check refuses an `image_keys` list that withholds a fed feature
+
+`Policy.preflight` exists to catch a camera-routing mismatch before the
+multi-minute weight download, but it only checked one direction: that every
+image rename TARGET the embodiment declares has a source key present in the
+runtime observation. It never checked that those targets are features the model
+will actually declare.
+
+An explicit `image_keys=` is priority 1 in `derive_image_keys`, so it replaces
+the feature list that would otherwise be derived from the embodiment's
+`obs_rename` targets. A list that does not cover them therefore builds a model
+without the inputs the embodiment routes, and `EmbodimentMap.validate` refuses
+exactly that -- but only after the download, and on the MolmoAct2 load path the
+call is unguarded, so the load aborts. Measured with `embodiment='so_real'`
+(which feeds `observation.images.image` and `observation.images.wrist_image`),
+both `image_keys=['base', 'wrist']` and `image_keys=['observation.images.top']`
+passed pre-flight and then failed post-download.
+
+Both sides of that verdict are already in `policy_config` before anything is
+fetched, so pre-flight now reports it, naming the features the embodiment feeds,
+the list the caller declared, and three remedies. The check applies to the
+MolmoAct2 load path only, where `image_keys` is honored -- it is documented as
+inert for every other policy type -- so a list another checkpoint would ignore is
+not refused.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -449,6 +449,30 @@ Two ways to fix it:
    )
    ```
 
+#### `image_keys` must declare what the embodiment feeds
+
+The pre-flight check works in both directions. An explicit `image_keys=` is
+priority 1 in `derive_image_keys`, so it *replaces* the feature list that would
+otherwise be derived from the embodiment's `obs_rename` targets. If the list does
+not cover those targets, the model is built without the inputs the embodiment
+routes and its configuration is refused after the weight download, so pre-flight
+refuses it up front instead:
+
+```
+Embodiment 'so_real' feeds image feature(s) ['observation.images.image',
+'observation.images.wrist_image'], but the explicit image_keys=['base', 'wrist']
+does not declare them, so the model would be built without the inputs the
+embodiment routes and its configuration is refused after the weight download.
+Either: (a) drop image_keys= ..., or (b) pass image_keys=[...] ..., or
+(c) pass policy_config={'obs_rename_override': {...}} for EVERY key you declared ...
+```
+
+Any of the three named fixes resolves it: drop `image_keys` so the features come
+from the embodiment, declare the embodiment's own targets, or retarget every key
+you declared with `obs_rename_override` so each declared feature is a rename
+target. `image_keys` is a MolmoAct2 knob and is inert for other policy types, so
+this check applies to the MolmoAct2 load path only.
+
 ### Single camera with no embodiment
 
 You do not need an embodiment at all for a single-camera checkpoint. Declare the

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -104,6 +104,75 @@ def _merge_obs_rename(base: dict[str, str], override: dict[str, str | None] | No
 _VELOCITY_SUFFIX = ".vel"
 
 
+def _undeclared_image_feature_error(
+    targets: list[str],
+    embodiment_name: str,
+    policy_config: dict[str, Any],
+) -> str | None:
+    """Report image features the embodiment feeds but ``image_keys`` withholds.
+
+    An explicit ``image_keys=`` is priority 1 in
+    :func:`~strands_robots.policies.lerobot_local.molmoact2.derive_image_keys`,
+    so it replaces the feature list that would otherwise be derived from the
+    embodiment's ``obs_rename`` targets. When the supplied list does not cover
+    those targets, the model is built declaring features the pipeline never
+    feeds, and ``EmbodimentMap.validate`` refuses the mismatch - but only after
+    the weight download, which is exactly what :meth:`LerobotLocalPolicy.preflight`
+    exists to get ahead of. Both inputs are in ``policy_config``, so the verdict
+    is available for free beforehand.
+
+    Scope: ``image_keys`` is honored only on the MolmoAct2 load path and is
+    documented as inert for every other policy type, so the check defers to
+    :func:`~strands_robots.policies.lerobot_local.molmoact2.is_molmoact2` rather
+    than refusing a list some other checkpoint would ignore. That predicate
+    short-circuits with no I/O when the caller declared ``policy_type``; in
+    auto-detect mode it reads ``config.json`` (cached, and returning ``None`` on
+    any failure), which the load path reads anyway.
+
+    Args:
+        targets: Image rename targets the embodiment feeds, as collected by
+            :meth:`LerobotLocalPolicy.preflight`.
+        embodiment_name: Resolved embodiment name, for the message.
+        policy_config: Provider kwargs (``image_keys``, ``policy_type``,
+            ``pretrained_name_or_path``, ``embodiment``, ...).
+
+    Returns:
+        The refusal message, or ``None`` when the configuration is consistent
+        (no explicit ``image_keys``, a non-MolmoAct2 checkpoint, or every target
+        declared).
+    """
+    image_keys = policy_config.get("image_keys")
+    if not image_keys:
+        # Not supplied: the feature list is derived FROM the embodiment, so the
+        # two sides cannot diverge.
+        return None
+
+    from . import molmoact2 as _molmoact2
+
+    if not _molmoact2.is_molmoact2(
+        policy_config.get("pretrained_name_or_path") or "", policy_config.get("policy_type")
+    ):
+        return None
+
+    declared = _molmoact2.derive_image_keys(list(image_keys), policy_config.get("embodiment"))
+    undeclared = [t for t in targets if t not in set(declared)]
+    if not undeclared:
+        return None
+
+    return (
+        f"Embodiment {embodiment_name!r} feeds image feature(s) {undeclared}, but the explicit "
+        f"image_keys={list(declared)} does not declare them, so the model would be built without "
+        f"the inputs the embodiment routes and its configuration is refused after the weight "
+        f"download. Either:\n"
+        f"  (a) drop image_keys= so the features are derived from the embodiment "
+        f"(-> {list(targets)}), or\n"
+        f"  (b) pass image_keys={list(targets)!r} to declare what the embodiment feeds, or\n"
+        f"  (c) pass policy_config={{'obs_rename_override': {{'<your_camera_name>': "
+        f"{declared[0]!r}}}}} for EVERY key you declared, so each declared feature is a "
+        f"rename target."
+    )
+
+
 def _drop_velocity_siblings(scalar_keys: list[str]) -> list[str]:
     """Drop each ``<joint>.vel`` whose ``<joint>`` position companion is present.
 
@@ -1254,6 +1323,15 @@ class LerobotLocalPolicy(Policy):
         ``obs_rename`` first, so an explicit override that maps a present camera
         onto the feature satisfies the check.
 
+        The converse is also checked: an explicit ``image_keys=`` replaces the
+        feature list that would be derived from those same rename targets (it is
+        priority 1 in ``derive_image_keys``), so a list that does not cover them
+        builds a model without the inputs the embodiment routes. That mismatch is
+        refused by ``EmbodimentMap.validate`` only after the weight download, and
+        both sides of it are already in ``policy_config`` here - see
+        :func:`_undeclared_image_feature_error`, which also explains why the check
+        applies to the MolmoAct2 load path only.
+
         No-op when no ``embodiment`` is configured (the policy then uses the
         legacy heuristic camera routing, which this hook cannot reason about),
         or when the embodiment name/spec cannot be resolved (``create_policy``
@@ -1266,7 +1344,8 @@ class LerobotLocalPolicy(Policy):
 
         Raises:
             ValueError: When a model image feature has no satisfiable source
-                camera key in ``observation_keys``.
+                camera key in ``observation_keys``, or when an explicit
+                ``image_keys`` withholds a feature the embodiment feeds.
         """
         spec = policy_config.get("embodiment")
         if spec is None:
@@ -1290,6 +1369,13 @@ class LerobotLocalPolicy(Policy):
                 targets.setdefault(dst, []).append(src)
         if not targets:
             return
+
+        # A declared-feature contradiction is independent of the runtime camera
+        # names and no camera rename can resolve it, so it is reported before the
+        # source-availability check below.
+        undeclared_error = _undeclared_image_feature_error(sorted(targets), embodiment.name, policy_config)
+        if undeclared_error:
+            raise ValueError(undeclared_error)
 
         obs = set(observation_keys)
         unsatisfied = {dst: srcs for dst, srcs in targets.items() if not any(s in obs for s in srcs)}

--- a/tests/policies/lerobot_local/test_preflight_declared_image_features.py
+++ b/tests/policies/lerobot_local/test_preflight_declared_image_features.py
@@ -1,0 +1,227 @@
+"""An explicit ``image_keys`` must declare the features the embodiment feeds.
+
+``Policy.preflight`` exists for one purpose, in its own words: catch a camera
+routing mismatch before "the multi-minute weight download". It checked one
+direction only - that each image rename TARGET has a source key present in the
+observation - and never checked that those targets are features the model will
+actually declare.
+
+An explicit ``image_keys=`` is priority 1 in
+:func:`~strands_robots.policies.lerobot_local.molmoact2.derive_image_keys`, so it
+replaces the feature list otherwise derived from the embodiment's ``obs_rename``
+targets. A list disjoint from those targets therefore builds a model without the
+inputs the embodiment routes, and ``EmbodimentMap.validate`` refuses it - but
+only after the download, on the MolmoAct2 path unguarded by any ``try`` (see
+``_load_molmoact2_model``), so the load aborts. Both sides of that verdict are in
+``policy_config`` before anything is fetched.
+
+These tests pin:
+
+* the withholding configuration is refused up front, naming both sides;
+* every remedy the message names is verified by configuring it and re-running
+  BOTH ``preflight`` and ``EmbodimentMap.validate`` (a recommendation that would
+  not work cannot pass);
+* two-way parity - ``preflight`` refuses a list exactly when ``validate`` would;
+* no false positive where ``image_keys`` is inert (non-MolmoAct2 checkpoints) or
+  absent (the targets are then derived from the embodiment and cannot diverge);
+* the declared-feature contradiction is reported before the camera-source check,
+  since no camera rename can resolve it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from lerobot.configs.types import FeatureType, PolicyFeature
+
+from strands_robots.policies.lerobot_local import molmoact2 as molmoact2_mod
+from strands_robots.policies.lerobot_local.embodiment import load_embodiment
+from strands_robots.policies.lerobot_local.molmoact2 import derive_image_keys
+from strands_robots.policies.lerobot_local.policy import (
+    LerobotLocalPolicy,
+    _merge_obs_rename,
+)
+
+EMBODIMENT = "so_real"
+# Declaring the type short-circuits is_molmoact2 with no I/O, so these tests
+# never touch the network.
+MOLMOACT2 = {
+    "policy_type": "molmoact2",
+    "pretrained_name_or_path": "allenai/MolmoAct2-SO100_101",
+}
+
+
+def _embodiment_targets() -> list[str]:
+    """The image rename targets the embodiment feeds, in sorted order."""
+    emb = load_embodiment(EMBODIMENT)
+    return sorted({dst for dst in emb.obs_rename.values() if "image" in dst})
+
+
+def _observation_keys() -> set[str]:
+    """A runtime observation carrying the embodiment's joints and source cameras."""
+    emb = load_embodiment(EMBODIMENT)
+    sources = {src for src, dst in emb.obs_rename.items() if "image" in dst}
+    return set(emb.state_keys) | sources
+
+
+def _validate_after_download(
+    image_keys: list[str] | None,
+    obs_rename_override: dict[str, str | None] | None = None,
+) -> str | None:
+    """Return ``validate``'s post-download refusal for a config, or ``None``.
+
+    Reproduces the declared-feature construction ``molmoact2.build_policy``
+    performs after the weight download, so the comparison is against what the
+    model really declares rather than an invented feature set.
+    """
+    emb = load_embodiment(EMBODIMENT)
+    if obs_rename_override:
+        emb = replace(emb, obs_rename=_merge_obs_rename(emb.obs_rename, obs_rename_override))
+    declared = derive_image_keys(image_keys, EMBODIMENT)
+    input_features = {k: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 224, 224)) for k in declared}
+    input_features["observation.state"] = PolicyFeature(type=FeatureType.STATE, shape=(6,))
+    output_features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(6,))}
+    try:
+        emb.validate(input_features, output_features)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _preflight(image_keys: list[str] | None = None, **extra: object) -> str | None:
+    """Return ``preflight``'s refusal for a config, or ``None`` when accepted."""
+    config: dict[str, object] = {"embodiment": EMBODIMENT, **MOLMOACT2, **extra}
+    if image_keys is not None:
+        config["image_keys"] = image_keys
+    try:
+        LerobotLocalPolicy.preflight(_observation_keys(), **config)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The defect
+# ---------------------------------------------------------------------------
+def test_image_keys_withholding_an_embodiment_feature_is_refused():
+    """A list disjoint from the rename targets is refused before the download."""
+    message = _preflight(["base", "wrist"])
+    assert message is not None, "preflight accepted a list that validate() refuses"
+    for target in _embodiment_targets():
+        assert target in message, message
+
+
+def test_refusal_names_both_the_fed_features_and_the_declared_list():
+    """The message names what the embodiment feeds AND what the caller declared."""
+    message = _preflight(["base", "wrist"])
+    assert message is not None
+    assert "'base'" in message and "'wrist'" in message, message
+    assert "image_keys" in message, message
+
+
+def test_a_prefixed_but_unrelated_key_is_also_refused():
+    """Following the naming convention does not make a wrong feature satisfiable."""
+    assert _preflight(["observation.images.top"]) is not None
+
+
+# ---------------------------------------------------------------------------
+# Every remedy the message names must work
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("label", "image_keys", "override"),
+    [
+        ("(a) drop image_keys", None, None),
+        ("(b) declare what the embodiment feeds", "TARGETS", None),
+        ("(c) retarget every declared key", ["base", "wrist"], {"front": "base", "wrist": "wrist"}),
+    ],
+)
+def test_every_remedy_the_message_names_is_accepted_end_to_end(label, image_keys, override):
+    """Configuring any offered remedy passes preflight AND the post-download check."""
+    keys = _embodiment_targets() if image_keys == "TARGETS" else image_keys
+    extra = {"obs_rename_override": override} if override else {}
+    assert _preflight(keys, **extra) is None, f"{label} was refused by preflight"
+    assert _validate_after_download(keys, override) is None, f"{label} fails after the download"
+
+
+def test_a_partial_retarget_is_still_refused():
+    """Remedy (c) requires every declared key; one rename does not suffice."""
+    assert _preflight(["base", "wrist"], obs_rename_override={"front": "base"}) is not None
+
+
+# ---------------------------------------------------------------------------
+# Two-way parity with the post-download check
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "image_keys",
+    [
+        None,
+        ["base", "wrist"],
+        ["observation.images.top"],
+        ["observation.images.image"],
+        ["observation.images.image", "observation.images.wrist_image"],
+        ["observation.images.image", "observation.images.wrist_image", "observation.images.spare"],
+    ],
+)
+def test_preflight_refuses_exactly_what_validate_refuses(image_keys):
+    """The pre-download verdict matches the post-download one for every list."""
+    assert (_preflight(image_keys) is None) == (_validate_after_download(image_keys) is None), (
+        f"verdicts differ for image_keys={image_keys!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# No false positives
+# ---------------------------------------------------------------------------
+def test_omitted_image_keys_is_unaffected():
+    """Without an explicit list the features are derived from the embodiment."""
+    assert _preflight(None) is None
+
+
+def test_an_empty_list_falls_back_to_the_embodiment():
+    """An empty list is not an override; derive_image_keys ignores it."""
+    assert _preflight([]) is None
+
+
+def test_a_non_molmoact2_checkpoint_is_unaffected():
+    """``image_keys`` is inert off the MolmoAct2 path, so it is not refused there."""
+    config = {
+        "embodiment": EMBODIMENT,
+        "image_keys": ["base", "wrist"],
+        "policy_type": "act",
+        "pretrained_name_or_path": "lerobot/act_so101",
+    }
+    LerobotLocalPolicy.preflight(_observation_keys(), **config)
+
+
+def test_autodetected_molmoact2_checkpoint_is_checked(monkeypatch):
+    """Auto-detect is the documented MolmoAct2 path, so it is covered too."""
+    monkeypatch.setattr(
+        molmoact2_mod,
+        "_read_config_json",
+        lambda _path: {"model_type": "molmoact2"},
+    )
+    config = {
+        "embodiment": EMBODIMENT,
+        "image_keys": ["base", "wrist"],
+        "pretrained_name_or_path": "some-org/molmoact2-so101",
+    }
+    with pytest.raises(ValueError):
+        LerobotLocalPolicy.preflight(_observation_keys(), **config)
+
+
+def test_no_embodiment_is_still_a_noop():
+    """The hook cannot reason about heuristic routing, so it stays a no-op."""
+    LerobotLocalPolicy.preflight({"front", "wrist"}, image_keys=["base"], **MOLMOACT2)
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+def test_declared_feature_contradiction_is_reported_before_a_camera_mismatch():
+    """No camera rename can fix a withheld feature, so it is reported first."""
+    config = {"embodiment": EMBODIMENT, "image_keys": ["base", "wrist"], **MOLMOACT2}
+    with pytest.raises(ValueError) as ei:
+        # Camera names are wrong too; the config contradiction still wins.
+        LerobotLocalPolicy.preflight({"realsense_top", "realsense_side"}, **config)
+    assert "does not declare them" in str(ei.value), str(ei.value)


### PR DESCRIPTION
## Problem

`Policy.preflight` exists for one purpose, in its own words: catch a camera-routing mismatch before "the multi-minute weight download". It checked one direction only — that each image rename **target** the embodiment declares has a source key present in the runtime observation. It never checked that those targets are features the model will actually **declare**.

An explicit `image_keys=` is priority 1 in `derive_image_keys`, so it *replaces* the feature list that would otherwise be derived from the embodiment's `obs_rename` targets. A list that does not cover them builds a model without the inputs the embodiment routes, and `EmbodimentMap.validate` refuses exactly that ("targets a feature the model doesn't declare") — but only after the download. On the MolmoAct2 load path `_configure_embodiment()` is called **unguarded** (`_load_molmoact2_model`), unlike the generic path which catches `ValueError`, so the load aborts.

Both inputs to that verdict are in `policy_config` before anything is fetched: `preflight` reads only `embodiment` and `obs_rename_override`, and `image_keys` arrives in the same mapping.

## Measured

`embodiment='so_real'` (feeds `observation.images.image` + `observation.images.wrist_image`), compared against the declared-feature set `molmoact2.build_policy` really constructs:

| `image_keys=` | model declares | pre-flight | after the download |
|---|---|---|---|
| omitted | the embodiment's own targets | passes | loads |
| `['base', 'wrist']` | `base`, `wrist` | **passes** | **load aborts** |
| `['observation.images.top']` | `observation.images.top` | **passes** | **load aborts** |
| `['observation.images.image']` | `observation.images.image` | **passes** | **load aborts** |

3 of 4 spellings reach the download and then abort — including the last one, a *partial* list that declares one target and withholds the other, which is the easiest of the four to write by accident.

## Change

`preflight` now also reports the withheld features, naming both sides and three remedies. The contradiction is independent of the runtime camera names and no rename can resolve it, so it is reported before the existing source-availability check.

```
Embodiment 'so_real' feeds image feature(s) ['observation.images.image',
'observation.images.wrist_image'], but the explicit image_keys=['base', 'wrist']
does not declare them, so the model would be built without the inputs the
embodiment routes and its configuration is refused after the weight download.
Either:
  (a) drop image_keys= so the features are derived from the embodiment (-> [...]), or
  (b) pass image_keys=[...] to declare what the embodiment feeds, or
  (c) pass policy_config={'obs_rename_override': {'<your_camera_name>': 'base'}} for
      EVERY key you declared, so each declared feature is a rename target.
```

**Scope.** `image_keys` is honored only on the MolmoAct2 load path and is documented as "inert for every other policy type", so the check defers to the library's own `is_molmoact2` predicate rather than refusing a list another checkpoint would ignore — pinned by a test that an ACT checkpoint is unaffected. That predicate short-circuits with no I/O when the caller declared `policy_type`; in auto-detect mode (the documented MolmoAct2 usage passes no type) it reads `config.json`, which is cached, returns `None` on any failure, and the load path reads anyway. The read only happens when `image_keys` was explicitly supplied.

## Tests

`tests/policies/lerobot_local/test_preflight_declared_image_features.py`, 19 tests. Pre-fix **9 failed / 10 passed**; post-fix 19 passed. The 10 that already pass are the no-false-positive and already-working-remedy cases — they are what stops the guard over-reaching.

- **Every remedy the message names is configured and re-measured** through both `preflight` and `EmbodimentMap.validate`, so a recommendation that would not actually work cannot pass review. A partial retarget is pinned as still refused.
- **Two-way parity**: over six `image_keys` spellings, `preflight` refuses a list exactly when `validate` would — so the pre- and post-download domains cannot drift apart.
- No false positives: omitted list, empty list, non-MolmoAct2 checkpoint, no embodiment.
- Auto-detected MolmoAct2 checkpoint is covered (monkeypatched `config.json`, no network).
- Ordering: the declared-feature contradiction wins over a simultaneous camera-name mismatch.

The post-download half of every assertion reproduces `build_policy`'s feature construction with the real lerobot `PolicyFeature`, so the comparison is against what the model really declares rather than an invented feature set.

## Gate

- `ruff check` / `ruff format --check` clean (958 files); `mypy strands_robots tests tests_integ` clean (955 source files).
- Full suite on this tree: **13753 passed, 253 skipped** (`MUJOCO_GL=egl python -m pytest tests -q --no-cov`).
- Docs updated in `docs/policies/lerobot-local.md` beside the existing pre-flight section; `changelog.d/` fragment added.

## Artifact

Every cell below is measured by one script run against both trees, not transcribed; the generator asserts the counts before saving.

![pre-flight declared image feature verdicts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/preflight-declared-image-features/preflight-declared-image-features.png)

## Out of scope

`image_keys` is silently ignored on non-MolmoAct2 paths (a separate dropped-option question), and a non-list `image_keys` (e.g. a bare string) is split per character by `derive_image_keys`. Neither is touched here.