### PR TITLE
fix(sim): a body-mounted camera survives the scene rebuild

### DIFF
--- a/changelog.d/1745-mounted-camera-survives-scene-rebuild.md
+++ b/changelog.d/1745-mounted-camera-survives-scene-rebuild.md
@@ -1,0 +1,16 @@
+### Fixed: a body-mounted camera no longer breaks `remove_robot`
+
+`SpecBuilder.build` adds the scene's cameras but deliberately does not attach
+robots, so a camera mounted on a robot body (`parent_body`, e.g. a wrist camera)
+was added before its parent existed. The parent lookup failed and `ValueError`
+escaped `remove_robot` -- a method documented to return a status dict -- so no
+scene carrying a wrist camera could remove a robot at all, and the message told
+the caller to "Pass the fully-qualified body name" for the very name
+`add_camera` had already accepted.
+
+Body-mounted cameras are now deferred and mounted by the new
+`SpecBuilder.add_deferred_cameras` once every surviving robot is attached, so
+such a camera keeps its parent body, its local pose and its tracking across the
+rebuild. A camera mounted on the robot being removed has no mount point left, so
+it is dropped from the registry with a warning -- the same treatment that
+robot's own URDF cameras already get -- instead of aborting the removal.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -338,6 +338,12 @@ sim.add_camera(name="wrist", parent_body=mount,
 
 `list_bodies()` (no `robot_name`) lists every body in the world; with `robot_name` it scopes to that robot and also returns `gripper_body`, the best-guess end-effector mount.
 
+A mounted camera survives `remove_robot`, which rebuilds the whole scene: it is
+re-mounted on its body once every surviving robot is re-attached, keeping its
+local pose and its tracking. Removing the robot the camera is mounted ON leaves
+it with no mount point, so that camera is dropped (with a warning naming it)
+rather than blocking the removal.
+
 ## Multi-robot policies
 
 ```python

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -748,6 +748,22 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
             joint_names = SpecBuilder.attach_robot(new_spec, robot, robot.urdf_path)
         robot.joint_names = joint_names
 
+    # Step 2b: mount the body-mounted cameras ``SpecBuilder.build`` deferred,
+    # now that every surviving robot's bodies exist in the spec. A camera whose
+    # parent belonged to the robot being ejected has no parent left, so it is
+    # dropped from the registry with a warning rather than aborting the eject -
+    # the same treatment the robot's own URDF cameras get above. Without this
+    # step the rebuild raised ``ValueError`` straight out of ``remove_robot``,
+    # so a scene with a wrist camera could not remove any robot at all.
+    for cname in SpecBuilder.add_deferred_cameras(new_spec, world):
+        logger.warning(
+            "eject_robot: dropping camera %r - its parent body %r belonged to the removed robot %r.",
+            cname,
+            getattr(world.cameras[cname], "parent_body", ""),
+            robot_name,
+        )
+        del world.cameras[cname]
+
     # Step 3: compile fresh and install. No spec.recompile(model, data)
     # here - recompile implicitly preserves qpos state which doesn't
     # make sense across a scene rebuild, and forcing a fresh compile

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -316,6 +316,28 @@ def _target_quat(position: list[float], target: list[float]) -> list[float] | No
     return quat.tolist()
 
 
+def _find_spec_body(spec: Any, name: str) -> Any | None:
+    """Resolve a body by name in ``spec``, or ``None`` when it is not there.
+
+    ``spec.body(name)`` only resolves bodies that existed at the last compile,
+    and it RETURNS ``None`` for a body added since (rather than raising), so a
+    lookup that trusts it alone misses every body introduced by
+    ``spec.attach()`` or ``add_body`` in the current editing session. Falling
+    back to a scan of ``spec.bodies`` covers those, mirroring the robustness
+    of ``scene_ops._find_body``.
+    """
+    try:
+        body = spec.body(name)
+    except (KeyError, ValueError):
+        body = None
+    if body is not None:
+        return body
+    for candidate in spec.bodies:
+        if candidate.name == name:
+            return candidate
+    return None
+
+
 # SpecBuilder - the public API
 
 
@@ -348,12 +370,18 @@ class SpecBuilder:
           * mesh assets for any objects with ``shape == "mesh"``
           * lights (``main_light``, ``fill_light``)
           * ground plane (if ``world.ground_plane``)
-          * cameras
+          * world-fixed cameras
           * objects
 
         Robots are NOT included here - they're attached separately via
         :meth:`attach_robot` because each attach consumes a fresh MjSpec
         loaded from the URDF/MJCF file on disk.
+
+        Because no robot is attached yet, a BODY-MOUNTED camera (one with
+        ``parent_body`` set, e.g. a wrist camera) has no parent to mount on
+        and is deferred: the caller must invoke :meth:`add_deferred_cameras`
+        after attaching robots and before compiling, or those cameras are
+        absent from the model.
 
         Caller is responsible for ``spec.compile()`` to produce an MjModel.
         """
@@ -470,12 +498,19 @@ class SpecBuilder:
                     condim=3,
                 )
 
-        # Cameras. Skip cameras that were discovered inside a robot's URDF -
-        # they'll come back automatically via ``spec.attach(robot_spec)``.
-        # Re-adding them at the top level would collide with the attached
-        # namespaced copy at compile time.
+        # Cameras. Two kinds are skipped here.
+        #
+        # Cameras discovered inside a robot's URDF come back automatically via
+        # ``spec.attach(robot_spec)``; re-adding them at the top level would
+        # collide with the attached namespaced copy at compile time.
+        #
+        # Body-mounted cameras are DEFERRED: ``build`` does not attach robots
+        # (see this method's own contract), so a camera whose ``parent_body``
+        # is a robot body has no parent in the spec yet. Adding it here raised
+        # ``ValueError`` and aborted the whole rebuild. The caller mounts them
+        # with :meth:`add_deferred_cameras` once every robot is attached.
         for cam in world.cameras.values():
-            if getattr(cam, "origin_robot", ""):
+            if getattr(cam, "origin_robot", "") or getattr(cam, "parent_body", ""):
                 continue
             SpecBuilder.add_camera(spec, cam)
 
@@ -744,20 +779,9 @@ class SpecBuilder:
 
         parent_name = getattr(cam, "parent_body", "") or ""
         if parent_name:
-            # Mount on the named body. spec.body() only resolves bodies that
-            # existed at the last compile; robot bodies introduced via
-            # spec.attach() may not be visible that way, so fall back to a
-            # full scan (mirrors scene_ops._find_body's robustness).
-            parent = None
-            try:
-                parent = spec.body(parent_name)
-            except (KeyError, ValueError):
-                parent = None
-            if parent is None:
-                for body in spec.bodies:
-                    if body.name == parent_name:
-                        parent = body
-                        break
+            # Mount on the named body, so cam.position/target are read in that
+            # body's LOCAL frame and the camera rides along with it.
+            parent = _find_spec_body(spec, parent_name)
             if parent is None:
                 raise ValueError(
                     f"add_camera: parent_body {parent_name!r} not found in scene. "
@@ -766,6 +790,35 @@ class SpecBuilder:
             parent.add_camera(**kwargs)
         else:
             spec.worldbody.add_camera(**kwargs)
+
+    # deferred (body-mounted) cameras
+    @staticmethod
+    def add_deferred_cameras(spec: Any, world: SimWorld) -> list[str]:
+        """Mount the body-mounted cameras :meth:`build` deferred.
+
+        :meth:`build` deliberately does not attach robots, so a camera whose
+        ``parent_body`` names a robot body cannot be added while the base spec
+        is being assembled. Call this once every robot has been attached and
+        before ``spec.compile()``.
+
+        Returns:
+            The names of cameras that could NOT be mounted because their
+            ``parent_body`` is absent from the rebuilt spec -- which happens
+            when the body belonged to a robot that is being removed. They are
+            reported rather than raised so removing a robot stays possible;
+            the caller decides what to do with the now-parentless entries.
+        """
+        unmounted: list[str] = []
+        for cam in world.cameras.values():
+            # Both fields are declared on SimCamera, so read them directly.
+            parent_name = cam.parent_body
+            if not parent_name or cam.origin_robot:
+                continue
+            if _find_spec_body(spec, parent_name) is None:
+                unmounted.append(cam.name)
+                continue
+            SpecBuilder.add_camera(spec, cam)
+        return unmounted
 
     # body remove
     @staticmethod

--- a/tests/simulation/mujoco/test_multi_robot_eject.py
+++ b/tests/simulation/mujoco/test_multi_robot_eject.py
@@ -11,22 +11,33 @@ than one robot depends on:
 
 * a surviving robot keeps its joint state across the rebuild AND has its
   actuator/joint ids re-resolved against the freshly compiled model, so it can
-  still be driven after a sibling is removed; and
+  still be driven after a sibling is removed;
 * the documented fail-soft contract: if the rebuild cannot compile, the eject
   reports failure rather than leaving a half-mutated world, and
-  ``remove_robot`` surfaces that as a structured error.
+  ``remove_robot`` surfaces that as a structured error; and
+* a BODY-MOUNTED camera (a wrist camera, ``parent_body`` set) survives the
+  rebuild still parented to its body. ``SpecBuilder.build`` does not attach
+  robots, so it added such a camera before its parent existed and raised
+  ``ValueError`` straight out of ``remove_robot`` - meaning no scene carrying a
+  wrist camera could remove a robot at all, and the message blamed the caller
+  ("Pass the fully-qualified body name") for the very name ``add_camera`` had
+  just accepted. Mounted cameras are now deferred to
+  ``SpecBuilder.add_deferred_cameras``, run after every survivor is attached.
 """
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 pytest.importorskip("mujoco")
 
 from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.mujoco.spec_builder import SpecBuilder  # noqa: E402
 
 # Two single-joint arms; attaching both namespaces them as ``armN/...`` so the
 # rebuild has to re-resolve ids by fully-qualified name.
@@ -47,14 +58,33 @@ _ARM_XML = """
 
 
 @pytest.fixture
-def two_arm_sim(tmp_path):
+def arm_path(tmp_path):
+    """The single-joint arm written to disk, ready for ``add_robot``."""
+    path = tmp_path / "arm.xml"
+    path.write_text(_ARM_XML)
+    return path
+
+
+@pytest.fixture
+def two_arm_sim(arm_path):
     """A compiled world holding two attached single-joint arms."""
-    arm_path = tmp_path / "arm.xml"
-    arm_path.write_text(_ARM_XML)
     sim = Simulation(tool_name="devx_multi_eject", mesh=False)
     sim.create_world()
     sim.add_robot(name="arm1", urdf_path=str(arm_path))
     sim.add_robot(name="arm2", urdf_path=str(arm_path))
+    try:
+        yield sim
+    finally:
+        sim.cleanup(policy_stop_timeout=0.5)
+
+
+@pytest.fixture
+def three_arm_sim(arm_path):
+    """A compiled world holding three attached single-joint arms."""
+    sim = Simulation(tool_name="devx_multi_eject_3", mesh=False)
+    sim.create_world()
+    for name in ("arm1", "arm2", "arm3"):
+        sim.add_robot(name=name, urdf_path=str(arm_path))
     try:
         yield sim
     finally:
@@ -69,6 +99,32 @@ def _joint_qpos(sim: Simulation, joint_name: str) -> float:
     assert jid >= 0, f"joint {joint_name!r} not in compiled model"
     adr = int(world._model.jnt_qposadr[jid])
     return float(world._data.qpos[adr])
+
+
+def _camera_parent_body(sim: Simulation, cam_name: str) -> str:
+    """Name of the compiled body the camera hangs off (``"world"`` if unmounted)."""
+    world = sim._world
+    assert world is not None and world._model is not None
+    mj = sim._mj
+    cid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_CAMERA, cam_name)
+    assert cid >= 0, f"camera {cam_name!r} not in compiled model"
+    return str(world._model.body(int(world._model.cam_bodyid[cid])).name)
+
+
+def _camera_xpos(sim: Simulation, cam_name: str) -> np.ndarray:
+    """The camera's world position, as MuJoCo resolves it from its parent body."""
+    world = sim._world
+    assert world is not None and world._model is not None and world._data is not None
+    mj = sim._mj
+    cid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_CAMERA, cam_name)
+    assert cid >= 0, f"camera {cam_name!r} not in compiled model"
+    return np.array(world._data.cam_xpos[cid], dtype=float).copy()
+
+
+def _mount_wrist(sim: Simulation, robot: str, name: str = "wrist") -> None:
+    """Mount a wrist camera on ``robot``'s only body, the way a real rig does."""
+    result = sim.add_camera(name=name, parent_body=f"{robot}/link0", position=[0.05, 0.0, 0.02])
+    assert result["status"] == "success", result
 
 
 def test_remove_robot_preserves_survivor_state_and_reresolves_actuators(two_arm_sim):
@@ -153,3 +209,170 @@ def test_eject_from_scene_returns_false_when_recompile_fails(two_arm_sim, monkey
     assert scene_ops.eject_robot_from_scene(world, "arm1") is False
     # The failed rebuild did not swap in the broken model.
     assert world._model is prior_model
+
+
+class TestBodyMountedCameraSurvivesTheRebuild:
+    """A wrist camera must not make ``remove_robot`` unusable."""
+
+    def test_remove_robot_succeeds_with_a_body_mounted_camera(self, two_arm_sim):
+        """The rebuild completes instead of raising out of the tool contract.
+
+        ``SpecBuilder.build`` added the mounted camera before any robot was
+        attached, so the parent lookup failed and ``ValueError`` escaped
+        ``remove_robot`` entirely - not even a structured error dict.
+        """
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1")
+
+        result = sim.remove_robot("arm2")
+
+        assert result["status"] == "success", result
+        assert "arm2" not in sim.list_robots()
+
+    def test_the_camera_is_still_registered_and_compiled(self, two_arm_sim):
+        """The survivor's camera comes back in both the registry and the model."""
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1")
+
+        assert sim.remove_robot("arm2")["status"] == "success"
+
+        assert "wrist" in sim.list_cameras()
+        # Present in the freshly compiled model, not merely in the registry.
+        assert _camera_parent_body(sim, "wrist") == "arm1/link0"
+
+    def test_the_camera_is_still_mounted_not_reparented_to_the_world(self, two_arm_sim):
+        """Mounting is the whole point: a world-fixed fallback would be wrong.
+
+        Silently re-adding the camera under ``worldbody`` would keep
+        ``remove_robot`` working while quietly turning a wrist camera into a
+        static one, so the parent body is asserted explicitly.
+        """
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1")
+        before = _camera_parent_body(sim, "wrist")
+        assert before == "arm1/link0"
+
+        assert sim.remove_robot("arm2")["status"] == "success"
+
+        assert _camera_parent_body(sim, "wrist") == before
+
+    def test_the_camera_still_tracks_its_body_after_the_rebuild(self, two_arm_sim):
+        """Driving the survivor moves its camera - the observable effect of mounting."""
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1")
+        assert sim.remove_robot("arm2")["status"] == "success"
+
+        at_rest = _camera_xpos(sim, "wrist")
+        send = sim.send_action({"arm1/pan": 1.2}, robot_name="arm1")
+        assert not (isinstance(send, dict) and send.get("status") == "error"), send
+        for _ in range(200):
+            sim.step()
+
+        assert _joint_qpos(sim, "arm1/pan") > 0.5, "survivor did not track the command"
+        travelled = float(np.linalg.norm(_camera_xpos(sim, "wrist") - at_rest))
+        assert travelled > 1e-3, f"camera did not follow its body (moved {travelled:.6f} m)"
+
+    def test_the_camera_still_renders_after_the_rebuild(self, two_arm_sim):
+        """The camera is usable as an observation source, not just present."""
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1")
+        assert sim.remove_robot("arm2")["status"] == "success"
+
+        result = sim.render(camera_name="wrist", width=64, height=48)
+
+        assert result["status"] == "success", result
+
+    def test_a_world_fixed_camera_is_unaffected(self, two_arm_sim):
+        """Control: only ``parent_body`` cameras were ever at risk."""
+        sim = two_arm_sim
+        assert sim.add_camera(name="overhead", position=[1.2, -1.2, 0.9], target=[0.0, 0.0, 0.3])["status"] == "success"
+
+        assert sim.remove_robot("arm2")["status"] == "success"
+
+        assert "overhead" in sim.list_cameras()
+        assert _camera_parent_body(sim, "overhead") == "world"
+
+    def test_the_camera_survives_two_consecutive_rebuilds(self, three_arm_sim):
+        """Each rebuild re-runs the deferral, so it must be idempotent."""
+        sim = three_arm_sim
+        _mount_wrist(sim, "arm1")
+
+        assert sim.remove_robot("arm3")["status"] == "success"
+        assert sim.remove_robot("arm2")["status"] == "success"
+
+        remaining = sim.list_robots()
+        assert "arm1" in remaining and "arm2" not in remaining and "arm3" not in remaining
+        assert _camera_parent_body(sim, "wrist") == "arm1/link0"
+
+
+class TestCameraOnTheRemovedRobot:
+    """A camera whose parent is being removed has no parent to keep."""
+
+    def test_it_is_dropped_rather_than_aborting_the_removal(self, two_arm_sim, caplog):
+        """Removing the mount point must stay possible, and say what it dropped.
+
+        The alternative - refusing the removal - would make a robot carrying a
+        wrist camera unremovable, which is the defect this replaces. Dropping
+        matches how the robot's own URDF cameras are already handled.
+        """
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm2", name="doomed")
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.scene_ops"):
+            result = sim.remove_robot("arm2")
+
+        assert result["status"] == "success", result
+        assert "doomed" not in sim.list_cameras(), "a camera with no parent stayed registered"
+        assert "doomed" in caplog.text and "arm2" in caplog.text
+
+    def test_a_sibling_mounted_camera_is_untouched(self, two_arm_sim):
+        """Only the parentless camera goes; the survivor's is mounted as usual."""
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1", name="keeper")
+        _mount_wrist(sim, "arm2", name="doomed")
+
+        assert sim.remove_robot("arm2")["status"] == "success"
+
+        assert "doomed" not in sim.list_cameras()
+        assert _camera_parent_body(sim, "keeper") == "arm1/link0"
+
+
+class TestDeferralContract:
+    """``build`` defers mounted cameras; ``add_deferred_cameras`` mounts them."""
+
+    def test_build_defers_a_mounted_camera_and_reports_it(self, two_arm_sim):
+        """A bare ``build`` spec holds no robot bodies, so it can mount nothing."""
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1")
+        world = sim._world
+        assert world is not None
+
+        spec = SpecBuilder.build(world)
+
+        assert [c.name for c in spec.cameras] == ["default"]
+        # Nothing to mount on yet, so the camera is reported, not raised.
+        assert SpecBuilder.add_deferred_cameras(spec, world) == ["wrist"]
+
+    def test_it_mounts_once_the_parent_is_attached(self, two_arm_sim):
+        """With the robot attached, the same call mounts and reports nothing."""
+        sim = two_arm_sim
+        _mount_wrist(sim, "arm1")
+        world = sim._world
+        assert world is not None
+        robot = world.robots["arm1"]
+
+        spec = SpecBuilder.build(world)
+        SpecBuilder.attach_robot(spec, robot, robot.urdf_path)
+
+        assert SpecBuilder.add_deferred_cameras(spec, world) == []
+        assert "wrist" in [c.name for c in spec.cameras]
+
+    def test_a_parent_body_that_exists_nowhere_is_still_refused(self, two_arm_sim):
+        """The deferral must not weaken the guard on a genuinely bad mount point."""
+        sim = two_arm_sim
+
+        result = sim.add_camera(name="bad", parent_body="nosuchrobot/link0", position=[0.0, 0.0, 0.1])
+
+        assert result["status"] == "error", result
+        assert "nosuchrobot/link0" in result["content"][0]["text"]
+        assert "bad" not in sim.list_cameras()


### PR DESCRIPTION
## Problem

`SpecBuilder.build` adds the scene's cameras but deliberately does not attach robots — `eject_robot_from_scene` attaches them afterwards, one fresh `MjSpec` per robot. So a camera mounted on a robot body (`parent_body`, i.e. a wrist camera) was added *before its parent existed*, the parent lookup failed, and `ValueError` escaped `remove_robot` — a method documented to return a status dict:

```python
sim.add_robot(name="arm", data_config="panda")
sim.add_robot(name="spare", data_config="panda", position=[0.9, 0, 0])
sim.add_camera(name="wrist", parent_body="arm/hand", position=[0, 0, 0.04])  # success
sim.remove_robot(name="spare")
# ValueError: add_camera: parent_body 'arm/hand' not found in scene.
#            Pass the fully-qualified body name (e.g. 'so101/gripper').
```

Two things make this worse than a crash. **No scene carrying a wrist camera could remove a robot at all** — and a wrist camera is the standard manipulation rig, documented in `docs/simulation/world-building.md`. And the message blames the caller for the very name `add_camera` had just accepted, so the advice it gives cannot help.

Only the full-rebuild path was affected: `add_object` / `add_robot` / `reset` / `patch_scene_mjcf` recompile the *live* spec, where the parent body already exists.

## Measured

| scene | `remove_robot` on `main` |
|---|---|
| camera mounted on a **surviving** robot | **raises `ValueError`** |
| camera mounted on the **removed** robot | **raises `ValueError`** |
| world-fixed camera (control) | success |

The control confirms the defect is specific to `parent_body`.

## Change

`build` defers body-mounted cameras, and the new `SpecBuilder.add_deferred_cameras` mounts them once every surviving robot is attached (before the compile). A mounted camera therefore keeps its parent body, its local pose and its tracking across the rebuild.

A camera mounted on the robot **being removed** has no mount point left. It is reported by `add_deferred_cameras` and dropped from the registry with a warning naming it, rather than aborting the removal — the same treatment that robot's own URDF cameras already get six lines earlier in the same function. Refusing instead would make a robot carrying a wrist camera unremovable, which is the defect this replaces.

`build`'s docstring now states the deferral, since it follows from the existing "robots are NOT included here" contract rather than being new behaviour to discover.

The parent lookup — `spec.body()` then a scan of `spec.bodies`, needed because `spec.body()` returns `None` (rather than raising) for a body added since the last compile — is extracted to `_find_spec_body` and shared by both call sites instead of duplicated.

## Tests

12 added to the existing eject-contract suite (`tests/simulation/mujoco/test_multi_robot_eject.py`), whose docstring already enumerates the rebuild contracts it pins. Pre-fix **10 failed / 5 passed**; post-fix 15 passed.

The 5 that already pass are the no-false-positive cases and are what stops the fix over-reaching: the 3 pre-existing eject tests, a world-fixed camera being unaffected, and a genuinely absent `parent_body` still being refused.

- The camera is asserted **still parented to its body** via `model.cam_bodyid`, not merely present: silently re-adding it under `worldbody` would keep `remove_robot` working while quietly turning a wrist camera into a static one.
- It is asserted to **still track** — driving the survivor moves the camera, the observable point of mounting — and to still render.
- Two consecutive rebuilds, so the deferral is idempotent.
- The orphan case asserts the warning names the camera, and that a sibling's mounted camera is untouched.
- Unit-level: `build` mounts nothing and *reports* the deferred camera; the same call mounts it once the parent is attached.

The suite uses the file's existing asset-free inline arm MJCF, so it needs no download in CI. `two_arm_sim` now shares the on-disk arm with a new `three_arm_sim` fixture.

## Gate

- `ruff check` / `ruff format --check` clean (959 files); `mypy strands_robots tests tests_integ` clean (956 source files).
- Full suite: **13792 passed, 253 skipped** (`MUJOCO_GL=egl python -m pytest tests -q --no-cov`).
- Docs updated in `docs/simulation/world-building.md` beside the existing `parent_body` section; `changelog.d/` fragment added.

## Artifact

The wrist camera's own view, rendered headless in MuJoCo. Panel 1 is byte-identical on both trees (mean abs diff `0.0`), so only the removal differs. Every cell of the table is read from the measured run, not transcribed.

![wrist camera survives the scene rebuild](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mounted-camera-rebuild/mounted-camera-survives-scene-rebuild.png)

The rebuild alone changes 0.25% of the wrist view (the pose is preserved); driving the arm afterwards changes 25.7% and moves the camera 0.335 m, which is the tracking still working.

## Out of scope

`_recompile_generation` is bumped only by `_recompile_preserving_state`, so the full rebuild and `replace_scene_mjcf` swap `world._model` without it and a same-shape rebuild can accept a stale `load_state` checkpoint. Real, but a separate concern in a different function — not touched here.