### PR TITLE
fix(sim): refuse a dataset recording at a rate its frames are not captured at

### DIFF
--- a/changelog.d/1746-recording-rate-matches-control-frequency.md
+++ b/changelog.d/1746-recording-rate-matches-control-frequency.md
@@ -1,0 +1,26 @@
+### Fixed: a dataset recording is refused at a rate its frames are not captured at
+
+`start_recording(fps=...)` fixes the frame rate written into the LeRobotDataset
+metadata, and LeRobot derives every timestamp from it positionally
+(`timestamp = frame_index / fps`). The dataset recorder is driven once per
+control step with no decimation, so the rate frames are really captured at is
+the rollout's `control_frequency` - a differing `fps` could not be honored, only
+mislabelled, and nothing compared the two.
+
+The library defaults were exactly such a pair (`fps=30` against
+`control_frequency=50.0`), so the documented record-then-rollout sequence
+silently produced a distorted episode: frames captured 0.0200 s apart were
+timestamped 0.0333 s apart, declaring a 1.30 s episode for a 0.78 s capture,
+with `start_recording`, the rollout and `stop_recording` all reporting
+`status="success"`. That per-frame interval is the control period a policy
+trains on, and `replay_episode` derives its per-frame physics budget from the
+dataset rate on the stated invariant that "the recorded control frequency IS the
+dataset fps" - so the same episode also replayed at the wrong speed (measured on
+a position-servo arm: record then replay round-tripped to 0.0000 rad at matching
+rates and 0.0317 rad at the two defaults).
+
+A rate disagreement is now refused before any frame is written, naming both
+rates, the distortion factor and both remedies, from every rollout entry point
+(`run_policy`, `eval_policy`, `evaluate_benchmark`, `start_policy`,
+`run_multi_policy`). This matches the sibling rate guard in the same module,
+which already refuses an `fps` that disagrees with the dataset on disk.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -8,7 +8,7 @@ description: DatasetRecorder - LeRobot v3 dataset writer used by both Simulation
 from strands_robots import Robot
 
 sim = Robot("so100")
-sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
+sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=50)
 sim.run_policy(robot_name="so100", instruction="pick up the cube",
                policy_provider="mock", duration=10.0)
 sim.stop_recording()
@@ -16,6 +16,30 @@ sim.stop_recording()
 ```
 
 `start_recording` requires `[lerobot]`. Without it, use `start_cameras_recording` for plain MP4.
+
+## `fps` must equal the rollout's `control_frequency`
+
+The recorder captures **one frame per control step and never decimates**, so the
+rate frames arrive at is the rollout's `control_frequency` - and LeRobot derives
+every timestamp from the dataset's declared `fps` positionally
+(`timestamp = frame_index / fps`). A differing `fps` therefore cannot be
+honored, only mislabelled, so it is refused:
+
+```python
+sim.start_recording(repo_id="user/my_dataset", task="t", fps=30)
+sim.run_policy(robot_name="so100", policy_provider="mock")   # default 50.0 Hz
+# -> "run_policy: the active recording declares 30 fps but this rollout captures
+#     at control_frequency=50 Hz. [...] a 1.667x distortion of the episode
+#     duration [...] Align the two rates: pass control_frequency=30 to
+#     run_policy(), or record at the rollout's rate"
+```
+
+The refusal lands before any frame is written, so nothing is lost - pass either
+rate. It matters beyond the label: that per-frame interval is the control period
+a policy trains on, and `replay_episode` derives its per-frame physics budget
+from the dataset rate, so a mislabelled episode also replays at the wrong speed.
+To record at a lower rate than you control at, run the rollout at that rate -
+there is no decimating recorder.
 
 ## Selecting which cameras to record
 
@@ -33,7 +57,7 @@ sim.add_camera(name="camera1", ...)
 sim.add_camera(name="camera2", ...)
 sim.add_camera(name="camera3", ...)
 sim.start_recording(
-    repo_id="user/my_dataset", task="pick up the cube", fps=30,
+    repo_id="user/my_dataset", task="pick up the cube", fps=50,
     cameras=["camera1", "camera2", "camera3"],   # drops the implicit 'default'
 )
 ```
@@ -142,7 +166,7 @@ flushes a dataset episode boundary after each, and resets the sim between
 episodes for you:
 
 ```python
-sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
+sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=50)
 sim.run_policy(robot_name="so100", instruction="pick up the cube",
                policy_provider="mock", n_steps=60, n_episodes=20)
 sim.stop_recording()
@@ -162,7 +186,7 @@ randomization, conditional logic between episodes), drive the loop yourself and
 call `save_episode()` after each rollout to flush it as its own episode:
 
 ```python
-sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
+sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=50)
 for _ in range(20):
     sim.reset()
     sim.run_policy(robot_name="so100", instruction="pick up the cube",
@@ -184,7 +208,7 @@ episode per rollout - the explicit `save_episode()` is optional when you reset
 between rollouts:
 
 ```python
-sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
+sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=50)
 for _ in range(20):
     sim.run_policy(robot_name="so100", instruction="pick up the cube",
                    policy_provider="mock", n_steps=60)

--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -242,7 +242,8 @@ sim = create_simulation("newton", solver="mujoco")
 sim.create_world()
 sim.add_robot("so100")
 
-sim.start_recording(repo_id="local/newton_demo", task="pick the cube", fps=30)
+# fps must equal the rollout's control_frequency (run_policy default: 50.0)
+sim.start_recording(repo_id="local/newton_demo", task="pick the cube", fps=50)
 for _ in range(n_episodes):
     sim.run_policy(robot_name="so100", policy_provider="mock", n_steps=200)
     sim.save_episode()          # flush this rollout as one episode

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -55,7 +55,8 @@ from strands_robots.training import create_trainer, TrainSpec
 sim = Robot("so100", mesh=False)
 sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0, 0.05])
 sim.start_recording(repo_id="local/demo", root="/tmp/demo_ds",
-                    fps=30, task="pick up the red cube", overwrite=True)
+                    # fps must equal the rollout's control_frequency (default 50.0)
+                    fps=50, task="pick up the red cube", overwrite=True)
 sim.run_policy(robot_name="so100", policy_object=MockPolicy(),
                instruction="pick up the red cube", n_steps=60)
 sim.stop_recording()        # writes a LeRobotDataset v3 at /tmp/demo_ds

--- a/docs/training/vla_workflow.md
+++ b/docs/training/vla_workflow.md
@@ -53,7 +53,8 @@ install_wbc_torque_control(sim, policy, "unitree_g1")
 sim.start_recording(
     repo_id="local/g1_locomotion",
     root="/tmp/g1_dataset",
-    fps=30, task="walk forward", overwrite=True,
+    # Matches control_frequency=50.0 below - the dataset rate IS the capture rate.
+    fps=50, task="walk forward", overwrite=True,
 )
 sim.run_policy(
     robot_name="unitree_g1",

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1389,6 +1389,36 @@ class SimEngine(ABC):
             return {"status": "error", "content": [{"text": error}]}
         return None
 
+    def _validate_recording_rate(self, control_frequency: float, method: str) -> dict[str, Any] | None:
+        """Reject a rollout whose rate the active dataset recording cannot describe.
+
+        Instance method (not a ``@staticmethod`` like the other numeric guards)
+        because the value it compares against lives on the engine: the rate is
+        only knowable once a recording is open, which happens one call earlier
+        in ``start_recording``. Backends that cannot record inherit
+        :meth:`_is_recording` returning ``False`` and are unaffected, so this
+        one call site per rollout entry point covers every backend without each
+        needing its own copy.
+
+        Args:
+            control_frequency: Rate the rollout will capture frames at. Validate
+                it with :meth:`_validate_positive_frequency` first, so a
+                non-finite value is reported as the parameter error it is
+                rather than as a rate disagreement.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            A structured ``{"status": "error", ...}`` dict, or ``None`` when no
+            recording is active or the rates agree. See
+            :func:`~strands_robots.simulation.recording.dataset_rate_mismatch_error`
+            for the contract and why a mismatch is refused rather than warned.
+        """
+        if not self._is_recording():
+            return None
+        from strands_robots.simulation.recording import dataset_rate_mismatch_error
+
+        return dataset_rate_mismatch_error(method, self._active_recorder(), control_frequency)
+
     @staticmethod
     def _validate_video_config(video: Any, method: str) -> dict[str, Any] | None:
         """Reject a ``video`` recording config the rollout cannot honor.
@@ -1686,6 +1716,11 @@ class SimEngine(ABC):
         if err := self._validate_action_horizon(action_horizon, "run_policy"):
             return err
         if err := self._validate_control_substeps(control_substeps, "run_policy"):
+            return err
+        # Both rates are known only here: the dataset rate was fixed by
+        # start_recording one call earlier. Checked before any policy is
+        # built so a rate disagreement costs no weight download and no frame.
+        if err := self._validate_recording_rate(control_frequency, "run_policy"):
             return err
 
         # Compile the stop_when early-return clause BEFORE any policy is
@@ -2557,6 +2592,11 @@ class SimEngine(ABC):
             return err
         if err := self._validate_control_substeps(control_substeps, "eval_policy"):
             return err
+        # Both rates are known only here: the dataset rate was fixed by
+        # start_recording one call earlier. Checked before any policy is
+        # built so a rate disagreement costs no weight download and no frame.
+        if err := self._validate_recording_rate(control_frequency, "eval_policy"):
+            return err
         # Coerce to a plain Python float now the value is validated: a NumPy
         # scalar (accepted above via numbers.Real) flows into 1 / control_frequency
         # and time.sleep(...) downstream, and time.sleep rejects a numpy.float32
@@ -2740,6 +2780,11 @@ class SimEngine(ABC):
         if err := self._validate_positive_frequency(control_frequency, "evaluate_benchmark"):
             return err
         if err := self._validate_control_substeps(control_substeps, "evaluate_benchmark"):
+            return err
+        # Both rates are known only here: the dataset rate was fixed by
+        # start_recording one call earlier. Checked before any policy is
+        # built so a rate disagreement costs no weight download and no frame.
+        if err := self._validate_recording_rate(control_frequency, "evaluate_benchmark"):
             return err
         # Coerce to a plain Python float now the value is validated: a NumPy
         # scalar (accepted above via numbers.Real) flows into 1 / control_frequency

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -82,9 +82,11 @@ class RecordingMixin(DatasetRecordingMixin):
             fps: Dataset frame rate recorded in the LeRobot metadata. Must be a
                 positive whole number - a fractional or non-numeric rate cannot
                 be written and is rejected up front rather than aborting the
-                rollout behind a ``status="success"`` return. Set it to the
-                ``run_policy`` ``control_frequency`` so recorded timestamps
-                match the cadence frames were captured at. When an existing
+                rollout behind a ``status="success"`` return. It must EQUAL the
+                rollout's ``control_frequency``: the recorder captures one frame
+                per control step and never decimates, so a differing rate cannot
+                be honored, only mislabelled, and every rollout entry point
+                refuses the disagreement before writing a frame. When an existing
                 dataset is RESUMED (``overwrite=False``), it must equal that
                 dataset's on-disk rate: a resumed dataset keeps the rate it was
                 created at, so a differing request is refused with the on-disk

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -3852,6 +3852,11 @@ class MuJoCoSimEngine(
             return err
         if err := self._validate_policy_mapping(policy_kwargs, "policy_kwargs", "start_policy"):
             return err
+        # Validate the rate against the open recording synchronously, before
+        # the executor submit below - a refusal after submit would report
+        # "started" to a caller whose rollout cannot be recorded correctly.
+        if err := self._validate_recording_rate(control_frequency, "start_policy"):
+            return err
 
         # Concurrent multi-robot policies run on disjoint ctrl slices (physics
         # serialized by _lock). For SYNCHRONIZED multi-robot *recording* (both
@@ -4217,6 +4222,8 @@ class MuJoCoSimEngine(
         # duration path to compute total_steps = int(duration * frequency) = 0
         # and report a rollout that never ran as a success.
         if err := self._validate_positive_frequency(control_frequency, "run_multi_policy"):
+            return err
+        if err := self._validate_recording_rate(control_frequency, "run_multi_policy"):
             return err
         duration, n_steps, horizon_error = self._resolve_horizon(
             n_steps, max_steps, control_frequency, duration, "run_multi_policy"

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -70,20 +70,25 @@ def dataset_recording_option_error(method: str, fps: Any) -> dict[str, Any] | No
     return None
 
 
-def _resumed_dataset_fps(recorder: Any) -> int | None:
-    """Read the on-disk frame rate of a resumed dataset, or None if unavailable.
+def recorder_dataset_fps(recorder: Any) -> int | None:
+    """Read the frame rate of a live recorder's dataset, or None if unavailable.
 
     ``LeRobotDataset`` exposes ``fps`` directly and via ``meta.fps``; both are
     probed so a layout that only carries the metadata object still compares.
 
-    Only a positive WHOLE rate is reported. A dataset whose on-disk rate is
-    fractional cannot be appended to at any rate ``start_recording`` accepts
-    (it requires a positive whole number), so there is no value to advise the
-    caller to pass and the comparison is skipped rather than dead-ending a
-    resume - matching the best-effort posture of the rest of the schema check.
+    Only a positive WHOLE rate is reported. A dataset whose rate is fractional
+    cannot be recorded at any rate ``start_recording`` accepts (it requires a
+    positive whole number), so there is no value to advise the caller to pass
+    and the comparison is skipped rather than dead-ending the call - matching
+    the best-effort posture of the rest of the schema check.
+
+    Shared by the two places that must compare a dataset's declared rate
+    against another rate: the resume schema check (against the ``fps`` the
+    caller asked to append at) and :func:`dataset_rate_mismatch_error`
+    (against the ``control_frequency`` a rollout will actually capture at).
 
     Args:
-        recorder: The resumed ``DatasetRecorder``.
+        recorder: The ``DatasetRecorder`` whose dataset rate to read.
 
     Returns:
         The dataset frame rate as an int, or ``None`` when the dataset does not
@@ -97,6 +102,75 @@ def _resumed_dataset_fps(recorder: Any) -> int | None:
         if value > 0 and float(value).is_integer():
             return int(value)
     return None
+
+
+def dataset_rate_mismatch_error(method: str, recorder: Any, control_frequency: float) -> dict[str, Any] | None:
+    """Reject a rollout whose capture rate the active dataset cannot describe.
+
+    ``start_recording(fps=...)`` fixes the frame rate written into the dataset
+    metadata, and LeRobot derives every frame's timestamp from it positionally
+    (``timestamp = frame_index / fps``). The dataset recorder is driven once per
+    control step with **no decimation**, so the rate frames are actually
+    captured at is the rollout's ``control_frequency`` - which means a differing
+    ``fps`` cannot be honored, only mislabelled.
+
+    The two library defaults are exactly such a pair (``fps=30`` against
+    ``control_frequency=50.0``), so the documented record-then-rollout sequence
+    silently produced a distorted episode: frames captured 0.0200 s apart were
+    timestamped 0.0333 s apart, declaring a 1.30 s episode for a 0.78 s capture.
+    Nothing reported it - ``start_recording``, the rollout and
+    ``stop_recording`` all returned ``status="success"``.
+
+    That distortion is not cosmetic. It is the control period a policy trains
+    on, and :meth:`~strands_robots.simulation.base.SimEngine.replay_episode`
+    derives its per-frame physics budget from the dataset rate on the stated
+    invariant that "the recorded control frequency IS the dataset fps" - so a
+    mislabelled episode also replays at the wrong speed. Measured on a
+    position-servo arm, record then replay round-tripped to 0.0000 rad at
+    matching rates and to 0.0317 rad at the two defaults.
+
+    Refusing (rather than warning) matches the sibling rate guard in this
+    module: ``_verify_resume_schema`` already raises for an ``fps`` that
+    disagrees with the dataset on disk, pointing at the rate to pass instead.
+    This is the same disagreement one step earlier, and it is reported before
+    any frame is written so the caller loses nothing.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        recorder: The active ``DatasetRecorder``.
+        control_frequency: Rate the rollout will capture frames at. Assumed
+            already validated as a positive finite number by the caller's own
+            ``control_frequency`` guard.
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict naming both rates and the
+        remedies, or ``None`` when the rates agree (or the dataset does not
+        report a usable whole rate, which must not block a valid rollout).
+    """
+    fps = recorder_dataset_fps(recorder)
+    if fps is None:
+        return None
+    rate = float(control_frequency)
+    if abs(rate - fps) < 1e-9:
+        return None
+
+    remedy = f"pass control_frequency={fps} to {method}()"
+    if rate.is_integer():
+        # ``fps`` must be a positive whole number, so only an integral capture
+        # rate has a matching dataset rate to advise re-recording at.
+        remedy += (
+            f", or record at the rollout's rate (stop_recording(), then "
+            f"start_recording(fps={int(rate)}, overwrite=True))"
+        )
+    text = (
+        f"{method}: the active recording declares {fps} fps but this rollout captures at "
+        f"control_frequency={rate:g} Hz. The dataset recorder writes one frame per control "
+        f"step with no decimation, so frames captured {1.0 / rate:.4f}s apart would be "
+        f"timestamped {1.0 / fps:.4f}s apart - a {rate / fps:.3f}x distortion of the "
+        f"episode duration, which a policy trains on as its control period and which "
+        f"replay_episode reproduces at the wrong speed. Align the two rates: {remedy}."
+    )
+    return {"status": "error", "content": [{"text": text}]}
 
 
 def _resume_schema_error(diffs: list[str]) -> str:
@@ -780,7 +854,7 @@ class DatasetRecordingMixin:
         # Frame rate first: it is carried by the dataset metadata rather than
         # the feature dict, so it is comparable even on a LeRobot layout whose
         # ``features`` mapping is missing (the early return below).
-        disk_fps = _resumed_dataset_fps(recorder)
+        disk_fps = recorder_dataset_fps(recorder)
         if disk_fps is not None and disk_fps != int(fps):
             diffs.append(
                 f"dataset fps differs: on-disk={disk_fps} vs requested={int(fps)} "

--- a/tests/simulation/mujoco/test_recording_codec_opencv.py
+++ b/tests/simulation/mujoco/test_recording_codec_opencv.py
@@ -78,7 +78,10 @@ def _record_episode(sim, dataset_dir, vcodec=None):
     kwargs = dict(
         repo_id="local/codec_demo",
         root=str(dataset_dir),
-        fps=30,
+        # Must equal the rollout's control_frequency (run_policy's default
+        # 50.0 Hz below): the recorder writes one frame per control step, so
+        # a differing fps only mislabels the timestamps.
+        fps=50,
         task="codec round-trip",
         overwrite=True,
         cameras=["base"],

--- a/tests/simulation/mujoco/test_recording_decode_fidelity.py
+++ b/tests/simulation/mujoco/test_recording_decode_fidelity.py
@@ -82,7 +82,9 @@ def _record(sim, dataset_dir, vcodec=None):
     kwargs = dict(
         repo_id="local/decode_fidelity",
         root=str(dataset_dir),
-        fps=30,
+        # Matches the rollout's control_frequency (run_policy's default 50.0 Hz):
+        # the dataset rate IS the capture rate, with no decimation.
+        fps=50,
         task="decode fidelity",
         overwrite=True,
         cameras=[_CAM],

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -1,0 +1,268 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""A dataset's declared frame rate must be the rate its frames were captured at.
+
+``start_recording(fps=...)`` fixes the rate written into the LeRobotDataset
+metadata, and LeRobot derives every timestamp from it positionally
+(``timestamp = frame_index / fps``). The dataset recorder is driven once per
+control step with **no decimation**, so the rate frames are really captured at
+is the rollout's ``control_frequency`` - a differing ``fps`` cannot be honored,
+only mislabelled.
+
+The two library defaults were exactly such a pair (``fps=30`` against
+``control_frequency=50.0``), which is what the documented record-then-rollout
+sequence in ``docs/recording.md`` used. Measured on a position-servo arm before
+the guard::
+
+    fps=30 cf=50.0 -> captured 0.0200s/frame, timestamped 0.0333s/frame (1.667x)
+    fps=50 cf=50.0 -> captured 0.0200s/frame, timestamped 0.0200s/frame (1.000x)
+
+with ``start_recording``, the rollout and ``stop_recording`` all reporting
+``status="success"`` and no log line. The distortion is the control period a
+policy trains on, and ``replay_episode`` derives its per-frame physics budget
+from the dataset rate on the invariant that "the recorded control frequency IS
+the dataset fps" - so the same episode also replays at the wrong speed
+(round-tripped to 0.0000 rad at matching rates, 0.0317 rad at the defaults).
+
+Refused rather than warned, matching the sibling rate guard in the same module:
+``_verify_resume_schema`` already refuses an ``fps`` that disagrees with the
+dataset on disk. The refusal lands before any frame is written, so a caller
+loses nothing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("lerobot")
+
+from strands_robots.policies.base import Policy  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine  # noqa: E402
+from strands_robots.simulation.recording import (  # noqa: E402
+    dataset_rate_mismatch_error,
+    recorder_dataset_fps,
+)
+
+_ARM = """<mujoco><worldbody><body name="l1">
+<joint name="j1" type="hinge" axis="0 0 1" range="-1.5 1.5" damping="4"/>
+<geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.02"/>
+<body name="l2" pos="0.15 0 0">
+<joint name="j2" type="hinge" axis="0 0 1" range="-1.5 1.5" damping="4"/>
+<geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.02"/></body></body></worldbody>
+<actuator><position name="a1" joint="j1" kp="30" ctrlrange="-1.5 1.5"/>
+<position name="a2" joint="j2" kp="30" ctrlrange="-1.5 1.5"/></actuator></mujoco>"""
+
+
+class _Hold(Policy):
+    """State-only policy: no camera renders, so these tests stay fast."""
+
+    def __init__(self, keys: list[str]) -> None:
+        super().__init__()
+        self._keys = list(keys)
+
+    @property
+    def provider_name(self) -> str:
+        return "hold"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, keys) -> None:  # noqa: ANN001
+        pass
+
+    async def get_actions(self, observation_dict, instruction, **kwargs):  # noqa: ANN001, ANN003
+        return [{k: 0.3 for k in self._keys}]
+
+
+@pytest.fixture
+def sim(tmp_path):
+    """A two-actuator arm needing no asset download."""
+    xml = tmp_path / "arm.xml"
+    xml.write_text(_ARM)
+    engine = MuJoCoSimEngine(tool_name="rate_guard_sim", mesh=False)
+    engine.create_world()
+    engine.add_robot(name="arm", urdf_path=str(xml))
+    yield engine
+    engine.cleanup()
+
+
+def _record(sim, tmp_path, fps: int, name: str = "ds") -> str:
+    """Open a recording at ``fps``; each case gets its OWN root.
+
+    ``start_recording`` RESUMES an existing dataset directory and inherits its
+    rate from disk, so sharing one root across cases makes every case report
+    the first one's fps - which looks exactly like ``fps`` being ignored.
+    """
+    root = tmp_path / name
+    result = sim.start_recording(repo_id=f"local/{name}", task="hold", fps=fps, root=str(root))
+    assert result["status"] == "success"
+    return str(root)
+
+
+def _frames_on_disk(root: str) -> int:
+    parquets = [p for p in Path(root).rglob("*.parquet") if "data" in p.parts]
+    if not parquets:
+        return 0
+    pd = pytest.importorskip("pandas")
+    return sum(len(pd.read_parquet(p)) for p in parquets)
+
+
+class TestTheLibraryDefaultsAreRefused:
+    """The out-of-the-box pair is the mismatch, so it is the headline case."""
+
+    def test_recording_at_30_then_rolling_at_50_is_refused(self, sim, tmp_path):
+        _record(sim, tmp_path, 30)
+        result = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), n_steps=10)
+        assert result["status"] == "error"
+
+    def test_the_refusal_names_both_rates_and_the_distortion(self, sim, tmp_path):
+        _record(sim, tmp_path, 30)
+        text = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), n_steps=10)["content"][0]["text"]
+        assert "30 fps" in text
+        assert "control_frequency=50" in text
+        assert "1.667x" in text
+
+    def test_the_refusal_names_both_remedies(self, sim, tmp_path):
+        _record(sim, tmp_path, 30)
+        text = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), n_steps=10)["content"][0]["text"]
+        assert "control_frequency=30" in text
+        assert "start_recording(fps=50, overwrite=True)" in text
+
+    def test_no_frame_is_written(self, sim, tmp_path):
+        """The refusal precedes capture, so the caller loses no episode."""
+        root = _record(sim, tmp_path, 30)
+        sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), n_steps=10)
+        assert _frames_on_disk(root) == 0
+
+
+class TestMatchingRatesAreUnaffected:
+    def test_a_rollout_at_the_declared_rate_records(self, sim, tmp_path):
+        root = _record(sim, tmp_path, 50)
+        result = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), control_frequency=50.0, n_steps=10)
+        assert result["status"] == "success"
+        sim.stop_recording()
+        assert _frames_on_disk(root) == 10
+
+    def test_the_episode_duration_is_not_distorted(self, sim, tmp_path):
+        """The declared span must equal the captured span - the point of the guard."""
+        pd = pytest.importorskip("pandas")
+        root = _record(sim, tmp_path, 25)
+        sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), control_frequency=25.0, n_steps=10)
+        sim.stop_recording()
+        parquets = [p for p in Path(root).rglob("*.parquet") if "data" in p.parts]
+        stamps = pd.concat([pd.read_parquet(p) for p in parquets])["timestamp"].tolist()
+        assert stamps[-1] - stamps[0] == pytest.approx((len(stamps) - 1) / 25.0, abs=1e-6)
+
+    def test_a_rollout_with_no_recording_open_is_never_refused(self, sim):
+        result = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), control_frequency=17.0, n_steps=5)
+        assert result["status"] == "success"
+
+
+class TestTheAdvisedRemedyIsUsable:
+    """A recommendation that would not work must not be printed."""
+
+    def test_following_the_control_frequency_remedy_records_cleanly(self, sim, tmp_path):
+        root = _record(sim, tmp_path, 30)
+        refused = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), n_steps=10)
+        assert refused["status"] == "error"
+        # The message says: pass control_frequency=30. Do exactly that.
+        result = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), control_frequency=30.0, n_steps=10)
+        assert result["status"] == "success"
+        sim.stop_recording()
+        assert _frames_on_disk(root) == 10
+
+    def test_a_fractional_capture_rate_offers_only_the_rate_it_can(self, sim, tmp_path):
+        """``fps`` must be a whole number, so 33.3 Hz has no re-record remedy."""
+        _record(sim, tmp_path, 30)
+        text = sim.run_policy(robot_name="arm", policy_object=_Hold(["a1", "a2"]), control_frequency=33.3, n_steps=5)[
+            "content"
+        ][0]["text"]
+        assert "control_frequency=30" in text
+        assert "start_recording(fps=" not in text
+
+
+class TestTheGuardHelperIsRobust:
+    def test_matching_rates_return_none(self):
+        assert dataset_rate_mismatch_error("run_policy", _FakeRecorder(30), 30.0) is None
+
+    def test_float_noise_below_the_tolerance_is_not_a_mismatch(self):
+        """A rate carried as a float must not be refused for representation noise."""
+        assert dataset_rate_mismatch_error("run_policy", _FakeRecorder(30), 30.0 + 1e-12) is None
+
+    def test_a_dataset_with_no_readable_rate_does_not_block(self):
+        """An unexpected LeRobot layout must not refuse a valid rollout."""
+        assert dataset_rate_mismatch_error("run_policy", _FakeRecorder(None), 50.0) is None
+
+    def test_a_fractional_dataset_rate_does_not_block(self):
+        assert dataset_rate_mismatch_error("run_policy", _FakeRecorder(29.97), 50.0) is None
+
+    def test_the_message_is_prefixed_with_the_calling_method(self):
+        err = dataset_rate_mismatch_error("eval_policy", _FakeRecorder(30), 50.0)
+        assert err is not None
+        assert err["content"][0]["text"].startswith("eval_policy: ")
+
+    @pytest.mark.parametrize("rate", [30, 30.0])
+    def test_the_rate_is_read_from_either_lerobot_spelling(self, rate):
+        assert recorder_dataset_fps(_FakeRecorder(rate)) == 30
+        assert recorder_dataset_fps(_MetaOnlyRecorder(rate)) == 30
+
+    def test_a_boolean_rate_is_not_read_as_one(self):
+        assert recorder_dataset_fps(_FakeRecorder(True)) is None
+
+
+class _Dataset:
+    def __init__(self, fps, meta: object | None = None) -> None:  # noqa: ANN001
+        self.fps = fps
+        self.meta = meta
+
+
+class _Meta:
+    def __init__(self, fps) -> None:  # noqa: ANN001
+        self.fps = fps
+
+
+class _FakeRecorder:
+    """Exposes the rate the way ``LeRobotDataset`` does, directly."""
+
+    def __init__(self, fps) -> None:  # noqa: ANN001
+        self.dataset = _Dataset(fps)
+
+
+class _MetaOnlyRecorder:
+    """A layout that carries the rate only on the metadata object."""
+
+    def __init__(self, fps) -> None:  # noqa: ANN001
+        self.dataset = _Dataset(None, meta=_Meta(fps))
+
+
+_ENTRY_POINTS = {
+    "strands_robots/simulation/base.py": ("run_policy", "eval_policy", "evaluate_benchmark"),
+    "strands_robots/simulation/mujoco/simulation.py": ("start_policy", "run_multi_policy"),
+}
+
+
+@pytest.mark.parametrize(
+    ("module", "method"),
+    [(m, f) for m, fns in _ENTRY_POINTS.items() for f in fns],
+)
+def test_every_rollout_entry_point_checks_the_recording_rate(module, method):
+    """No rollout driver may capture into a dataset it disagrees with.
+
+    Pinned structurally rather than behaviourally so a driver that needs a
+    checkpoint, a benchmark registration or a live background thread to reach
+    is still covered - and so a newly added driver cannot quietly skip the
+    guard the way ``run_multi_policy`` once skipped ``_validate_action_horizon``.
+    """
+    tree = ast.parse(Path(module).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == method:
+            calls = {
+                n.func.attr for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+            }
+            assert "_validate_recording_rate" in calls, f"{module}::{method} does not check the recording rate"
+            return
+    pytest.fail(f"{method} not found in {module}")

--- a/tests/simulation/test_run_policy_episode_contract.py
+++ b/tests/simulation/test_run_policy_episode_contract.py
@@ -46,7 +46,10 @@ def sim():
 def _record(sim: Simulation, root: str, *, n_episodes: int, n_steps: int = 4) -> dict:
     """Drive a full start -> run_policy -> stop recording cycle; return run json."""
     shutil.rmtree(root, ignore_errors=True)
-    start = sim.start_recording(repo_id="local/episode_contract", task="t", fps=30, root=root, overwrite=True)
+    # fps must equal the control_frequency the rollouts below run at (50): the
+    # recorder captures one frame per control step, so a differing rate would
+    # only mislabel every timestamp.
+    start = sim.start_recording(repo_id="local/episode_contract", task="t", fps=50, root=root, overwrite=True)
     assert start["status"] == "success", start
     run = sim.run_policy(
         robot_name="so100",

--- a/tests/training/test_lerobot_e2e.py
+++ b/tests/training/test_lerobot_e2e.py
@@ -28,7 +28,10 @@ def recorded_dataset(tmp_path_factory):
     start = sim.start_recording(
         repo_id="local/e2e",
         root=root,
-        fps=30,
+        # Must equal the rollout's control_frequency (run_policy's default
+        # 50.0 Hz below): the recorder captures one frame per control step, so
+        # a differing rate would only mislabel every recorded timestamp.
+        fps=50,
         task="pick up the red cube",
         overwrite=True,
     )


### PR DESCRIPTION
## Problem

`start_recording(fps=...)` fixes the frame rate written into the LeRobotDataset metadata, and LeRobot derives every timestamp from it **positionally** (`timestamp = frame_index / fps`). The dataset recorder is driven once per control step and **never decimates**, so the rate frames are really captured at is the rollout's `control_frequency`. A differing `fps` therefore cannot be honored, only mislabelled — and nothing compared the two.

The two library defaults are exactly such a pair (`fps=30` against `control_frequency=50.0`), which is what the documented record-then-rollout sequence in `docs/recording.md` used. Measured on a 40-step position-servo rollout in MuJoCo:

| | `fps` | `control_frequency` | true capture | timestamped | declared episode | actual episode |
|---|---|---|---|---|---|---|
| library defaults | 30 | 50.0 | 0.0200 s/frame | 0.0333 s/frame | **1.30 s** | 0.78 s |
| aligned | 50 | 50.0 | 0.0200 s/frame | 0.0200 s/frame | 0.78 s | 0.78 s |

`start_recording`, the rollout and `stop_recording` all returned `status="success"`, with no log line.

It is not a cosmetic label. That per-frame interval is the control period a policy trains on, and `replay_episode` derives its per-frame physics budget from the dataset rate — on its own stated invariant, in `policy_runner.py`:

> `# dt. The recorded control frequency IS the dataset fps, so derive the`
> `# physics substeps from it (same convention as run() and evaluate()).`

So a mislabelled episode also replays at the wrong speed. Record → replay round-tripped to **0.0000 rad** at matching rates and **0.0315 rad** at the two defaults.

Two further signs this was a known-but-unenforced rule rather than a design choice:

- `start_recording`'s own docstring already *advised* it — "Set it to the `run_policy` `control_frequency` so recorded timestamps match the cadence frames were captured at" — without enforcing it.
- Every existing test that exercises `replay_episode` had already hand-aligned the two rates (`fps=30` with `control_frequency=30`), while the tests that do not replay left them mismatched.

## Change

One shared guard, `SimEngine._validate_recording_rate`, comparing the open recording's rate against the rollout's `control_frequency`. Called from all five rollout entry points: `run_policy`, `eval_policy`, `evaluate_benchmark`, `start_policy`, `run_multi_policy`.

It refuses rather than warns, matching the sibling rate guard in the same module: `_verify_resume_schema` already raises for an `fps` that disagrees with the dataset **on disk**, pointing at the rate to pass instead. This is the same disagreement one step earlier. The refusal lands before any policy is built and before any frame is written, so a caller loses nothing:

```
run_policy: the active recording declares 30 fps but this rollout captures at
control_frequency=50 Hz. The dataset recorder writes one frame per control step
with no decimation, so frames captured 0.0200s apart would be timestamped
0.0333s apart - a 1.667x distortion of the episode duration, which a policy
trains on as its control period and which replay_episode reproduces at the wrong
speed. Align the two rates: pass control_frequency=30 to run_policy(), or record
at the rollout's rate (stop_recording(), then start_recording(fps=50, overwrite=True)).
```

Details worth flagging for review:

- **Backends need no copy.** The guard reads `_is_recording()` / `_active_recorder()`, which every recording backend already overrides and non-recording backends inherit as `False`, so one call site per entry point covers MuJoCo, Newton and Isaac.
- **A fractional capture rate only gets the remedy it can have.** `fps` must be a positive whole number, so `control_frequency=33.3` is offered the `control_frequency` fix and *not* a re-record suggestion it could not accept. Pinned.
- **A dataset that reports no usable whole rate never blocks a rollout** — same best-effort posture as the rest of the schema check.
- `_resumed_dataset_fps` → `recorder_dataset_fps`: renamed in place now that it has a second caller, since the old name described who first needed it rather than what it does. Both call sites updated; no alias.

### Fallout, and why it is the right kind

19 existing tests across five files recorded at `fps=30` while rolling at the default 50 Hz, so they were themselves producing distorted datasets — including `test_run_policy_episode_contract.py`, whose subject *is* dataset truth (parquet row counts, episode indices). Each is a one-line rate alignment. Four documented examples had the same pair and are fixed, plus a new `docs/recording.md` section stating the rule.

## Tests

`tests/simulation/test_recording_rate_matches_control_frequency.py`, 22 tests: the defaults refused; the message names both rates, the distortion and both remedies; **zero frames written** on refusal; matching rates unaffected and the declared span equal to the captured span; a rollout with no recording open never refused; the advised `control_frequency` remedy actually followed and re-run to a clean recording; the fractional-rate case; unreadable/fractional dataset rates not blocking; and an AST parity test that every one of the five entry points calls the guard.

**Pre-fix proof** — behavioural subset run against `main`'s source: **10 failed, 4 passed**. Post-fix: 22 passed. The pre-fix failure text is the defect itself, e.g. `assert 'error' == 'success'` where main reported `"Policy complete on 'arm' | 5 steps | sim_t=0.150s"`.

## Gate

- `ruff check` / `ruff format --check strands_robots tests tests_integ` — clean (960 files)
- `mypy strands_robots tests tests_integ` — `Success: no issues found in 957 source files`
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` — **13814 passed, 253 skipped** (441 s) on base `9b9f6a75`
- `python scripts/assemble_changelog.py --check` — OK

## Artifact

Rollout recorded then replayed in MuJoCo sim (headless, EGL). Left: `main` writes timestamps diverging from the true capture time by 1.667x and reports success. Right: the mismatch is refused with nothing written, and an aligned rate records a truthful timebase. The thumbnail is a frame decoded back out of the dataset's own MP4, so the recording under measurement is real.

![recording rate vs control_frequency](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recording-rate/recording_rate.png)