### PR TITLE
fix(sim): a dataset frame the recorder could not write fails the rollout

### DIFF
--- a/changelog.d/1747-lost-recording-frame-is-not-telemetry.md
+++ b/changelog.d/1747-lost-recording-frame-is-not-telemetry.md
@@ -1,0 +1,14 @@
+### Fixed: a dataset frame the recorder could not write now fails the rollout
+
+`DatasetRecorder` defaults to `strict=True` and raises when a write fails, but that
+raise reached the rollout drivers through the same `on_frame` hook they use for caller
+telemetry, which tolerates a bounded number of *consecutive* failures and resets its
+counter on every success. An intermittent write failure therefore never reached the
+limit: a 20-step rollout that lost every other frame reported `status="success"` and
+`stop_recording` reported a saved episode, while the dataset held 10 frames re-stamped
+from the declared `fps` into half the span they were captured over.
+
+The recorder now raises `RecordingFrameError` (chaining the original failure), and
+every rollout loop excludes that type from the telemetry tolerance - the rollout ends
+at the first lost frame with an error naming it. A caller's own `on_frame` hook keeps
+its tolerance, and `strict=False` recording still drops, counts and continues.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -383,6 +383,30 @@ recorder = DatasetRecorder.create(
 Use `resume()` (not `create(overwrite=True)`) when you want to **append**
 episodes to the existing dataset instead of replacing it.
 
+### A frame the recorder cannot write fails the rollout
+
+`DatasetRecorder` is fail-fast by default (`strict=True`): if the underlying
+`LeRobotDataset` write fails, it raises
+`strands_robots.dataset_recorder.RecordingFrameError` instead of continuing. When
+the recorder is driven by `run_policy`, that ends the rollout with
+`status="error"` naming the frame the recording stopped being complete at:
+
+```
+Policy failed: dataset add_frame failed after 7 frame(s) written; the recording
+is incomplete from this frame on (strict=True, so it is not dropped silently):
+<the underlying error>
+```
+
+Continuing past a lost frame is not a smaller failure. Timestamps are derived
+positionally from the declared `fps`, so the surviving frames are re-stamped into
+a shorter span than they were captured over - a rollout that loses every other
+frame at 50 Hz produces an episode labelled at 2x speed, with no gap to detect.
+
+Construct the recorder with `strict=False` to trade that for best-effort
+recording: a failed write is counted in `dropped_frame_count`, warned about at
+`WARNING` (on the 1st, 2nd, 4th, 8th ... failure so a 50 Hz loop cannot flood the
+log), and the rollout continues.
+
 ## Instance methods
 
 | Method | What |

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -525,6 +525,25 @@ def unrecordable_action_columns_error(
     )
 
 
+class RecordingFrameError(RuntimeError):
+    """A frame the dataset recorder could not write, in fail-fast mode.
+
+    Raised by :meth:`DatasetRecorder.add_frame` when the underlying
+    ``LeRobotDataset`` write fails and the recorder was constructed with
+    ``strict=True`` (the default). The frame is already gone at that point, so
+    the episode on disk is shorter than the rollout that produced it and every
+    surviving frame is re-timestamped from the declared ``fps`` - the caller has
+    to be told.
+
+    A distinct type, rather than the underlying error, so a rollout driver can
+    tell a lost recording frame apart from a failure in a caller's telemetry
+    hook. The drivers deliberately tolerate a few consecutive telemetry
+    failures; granting that tolerance to a lost recording frame truncates the
+    dataset while the rollout still reports success. The originating error is
+    chained and its text preserved.
+    """
+
+
 class DatasetRecorder:
     """Bridge between strands-robots control loops and LeRobotDataset.
 
@@ -972,6 +991,10 @@ class DatasetRecorder:
         Raises:
             ValueError: A column in ``required_action_keys`` is declared by
                 the dataset schema but absent from ``action``.
+            RecordingFrameError: The dataset write failed and this recorder is
+                ``strict`` (the default). With ``strict=False`` the frame is
+                counted in ``dropped_frame_count`` and a warning is logged
+                instead.
         """
         if self._closed:
             return
@@ -1132,7 +1155,16 @@ class DatasetRecorder:
             self.episode_frame_count += 1
         except Exception as e:
             if self.strict:
-                raise  # Fail-fast per AGENTS.md convention #5
+                # Fail-fast per AGENTS.md convention #5. Raised as
+                # RecordingFrameError so a rollout driver does not absorb it
+                # into the tolerance it grants a caller's telemetry hook - the
+                # frame is lost, so silently continuing writes a short episode
+                # and reports success. The original error is chained.
+                raise RecordingFrameError(
+                    f"dataset add_frame failed after {self.frame_count} frame(s) written; "
+                    f"the recording is incomplete from this frame on "
+                    f"(strict=True, so it is not dropped silently): {e}"
+                ) from e
             self.dropped_frame_count += 1
             n = self.dropped_frame_count
             # Log at 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, then every 1000

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -45,6 +45,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots._async_utils import _resolve_coroutine
+from strands_robots.dataset_recorder import RecordingFrameError
 from strands_robots.policies.base import resolve_chunk_length
 from strands_robots.utils import positive_whole_number_error, process_rss_mb, require_optional
 
@@ -502,6 +503,14 @@ class _RolloutVideoWriter:
 # (e.g. a recording hook with a typo'd observation key), we'd complete a 500-step
 # episode with zero frames written and silently corrupt the dataset. After this
 # many *consecutive* failures, the runner raises and fails the episode loudly.
+#
+# The counter resets on every success, so this bounds an ALWAYS-failing hook and
+# nothing else: a hook failing every other step never reaches the limit. That is
+# the right trade for caller telemetry, which is why
+# :class:`~strands_robots.dataset_recorder.RecordingFrameError` is excluded from
+# the tolerance entirely - a lost dataset frame is data loss, not telemetry, and
+# tolerating it writes a short, re-timestamped episode under a successful
+# rollout.
 #
 # Overridable via the ``max_onframe_failures`` kwarg on ``PolicyRunner.run``.
 # See GH #117.
@@ -1258,6 +1267,14 @@ class PolicyRunner:
                         consecutive_onframe_failures = 0
                     except CooperativeStop:
                         # Backend (e.g. MuJoCo) signalled a graceful stop.
+                        raise
+                    except RecordingFrameError:
+                        # A frame the dataset recorder could not write is data
+                        # loss, not telemetry: the episode on disk is already
+                        # shorter than this rollout. Never counted against the
+                        # telemetry tolerance below, which resets on every
+                        # success and so would let an intermittent recorder
+                        # failure truncate the dataset without ever tripping.
                         raise
                     except Exception as e:
                         # on_frame is user-provided telemetry - never fatal
@@ -2275,6 +2292,11 @@ class PolicyRunner:
                     # honors). Propagate to the episode loop; never swallow
                     # it as a best-effort telemetry failure.
                     raise
+                except RecordingFrameError:
+                    # Data loss, not telemetry - see the note on the tolerance
+                    # constant. Propagate so the caller learns the episode is
+                    # incomplete instead of reading a successful eval.
+                    raise
                 except Exception as e:  # noqa: BLE001 - hook is best-effort telemetry
                     logger.warning("on_frame hook failed at global_step=%d: %s", global_step, e)
             global_step += 1
@@ -2698,6 +2720,10 @@ class PolicyRunner:
                                 except CooperativeStop:
                                     # Documented graceful early-stop; propagate
                                     # to the episode loop instead of swallowing.
+                                    raise
+                                except RecordingFrameError:
+                                    # Data loss, not telemetry - see the note on
+                                    # the tolerance constant.
                                     raise
                                 except Exception as e:  # noqa: BLE001 - hook is best-effort
                                     logger.warning(

--- a/tests/simulation/test_recording_frame_loss_is_not_tolerated.py
+++ b/tests/simulation/test_recording_frame_loss_is_not_tolerated.py
@@ -1,0 +1,273 @@
+"""A dataset frame the recorder could not write must fail the rollout.
+
+``PolicyRunner`` tolerates a bounded number of *consecutive* ``on_frame``
+failures because that hook is caller telemetry (see
+``TestOnFrameFailureCounter`` in the behaviour suite, whose
+``test_consecutive_counter_resets_on_success`` pins the reset). The library's
+own dataset recorder is fed through that same hook, and ``DatasetRecorder``
+defaults to ``strict=True`` - fail-fast - so a failed write raises. Absorbed by
+the telemetry tolerance, whose counter resets on every success, an intermittent
+write failure never reaches the limit: the rollout reports success while the
+episode on disk is short and every surviving frame has been re-timestamped from
+the declared ``fps``.
+
+These tests pin the split: a lost recording frame is fatal, a caller's telemetry
+failure keeps its tolerance.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import strands_robots.simulation.policy_runner as policy_runner_module
+from strands_robots.dataset_recorder import DatasetRecorder, RecordingFrameError
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+_FEATURES: dict[str, Any] = {
+    "observation.state": {"dtype": "float32", "names": ["1", "2", "3", "4", "5", "6"]},
+    "action": {"dtype": "float32", "names": ["1", "2", "3", "4", "5", "6"]},
+}
+
+
+class _FlakyDataset:
+    """Fake LeRobotDataset whose write fails on a chosen subset of frames."""
+
+    def __init__(self, *, fail_every: int) -> None:
+        self.repo_id = "local/flaky"
+        self.root = "/tmp/local-flaky"
+        self.features = _FEATURES
+        self.fail_every = fail_every
+        self.attempts = 0
+        self.written = 0
+
+    def add_frame(self, frame: dict[str, Any]) -> None:
+        self.attempts += 1
+        if self.fail_every and self.attempts % self.fail_every == 0:
+            raise RuntimeError(f"transient dataset write failure at frame {self.attempts}")
+        self.written += 1
+
+    def save_episode(self) -> None:
+        return None
+
+
+def _recording_sim(recorder: Any) -> Simulation:
+    """A one-robot sim with ``recorder`` attached as the live session's writer.
+
+    Opens a recording session without a real ``LeRobotDataset`` - the same
+    injection seam the chunk-alignment and episode-boundary regressions use.
+    """
+    sim = Simulation(tool_name="frame_loss", mesh=False)
+    sim.create_world()
+    sim.add_robot(name="arm", data_config="so100")
+    assert sim._world is not None
+    sim._world._backend_state["recording"] = True
+    sim._world._backend_state["trajectory"] = []
+    sim._world._backend_state["dataset_recorder"] = recorder
+    return sim
+
+
+def _policy(sim: Simulation) -> MockPolicy:
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    return policy
+
+
+class TestALostRecordingFrameIsFatal:
+    def test_an_intermittent_write_failure_aborts_the_rollout(self) -> None:
+        """Every other frame failing must fail the rollout, not truncate it.
+
+        The telemetry counter resets on each success, so alternating failures
+        never reach the consecutive limit. Pre-fix this rollout reported success
+        with half of its frames missing from the dataset.
+        """
+        ds = _FlakyDataset(fail_every=2)
+        sim = _recording_sim(DatasetRecorder(dataset=ds, task="t"))
+        try:
+            result = sim.run_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_steps=20,
+                control_frequency=50.0,
+                fast_mode=True,
+            )
+        finally:
+            sim.cleanup()
+
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        assert "transient dataset write failure" in text
+        assert "the recording is incomplete" in text
+        # Stopped at the first lost frame rather than writing 10 of 20.
+        assert ds.attempts == 2
+        assert ds.written == 1
+
+    def test_a_persistent_write_failure_aborts_on_the_first_frame(self) -> None:
+        """A recorder that can never write must not burn the tolerance window.
+
+        The generic tolerance would spend ``max_onframe_failures`` steps before
+        aborting; a lost dataset frame is already data loss on the first one.
+        """
+        ds = _FlakyDataset(fail_every=1)
+        sim = _recording_sim(DatasetRecorder(dataset=ds, task="t"))
+        try:
+            result = sim.run_policy(
+                robot_name="arm",
+                policy_object=_policy(sim),
+                n_steps=20,
+                control_frequency=50.0,
+                fast_mode=True,
+            )
+        finally:
+            sim.cleanup()
+
+        assert result["status"] == "error", result
+        assert ds.attempts == 1
+        assert ds.written == 0
+
+    def test_the_eval_loop_does_not_swallow_it_either(self) -> None:
+        """``eval_policy`` must surface it, not log it as best-effort telemetry.
+
+        Its sibling pin ``test_on_frame_exception_is_logged_not_fatal`` asserts a
+        generic hook failure leaves the eval successful; this is the exception to
+        that rule. It surfaces as a raise rather than an error envelope because
+        that is how ``eval_policy`` already surfaces every rollout failure - a
+        policy raising from ``get_actions`` propagates the same way, unchanged
+        here.
+        """
+        sim = Simulation(tool_name="frame_loss_eval", mesh=False)
+        sim.create_world()
+        sim.add_robot(name="arm", data_config="so100")
+        steps: list[int] = []
+
+        def lose_a_frame(step: int, obs: dict[str, Any], action: dict[str, Any]) -> None:
+            steps.append(step)
+            raise RecordingFrameError("dataset add_frame failed after 0 frame(s) written")
+
+        try:
+            with pytest.raises(RecordingFrameError, match="add_frame failed"):
+                sim.eval_policy(
+                    robot_name="arm",
+                    policy_object=_policy(sim),
+                    n_episodes=1,
+                    max_steps=4,
+                    control_frequency=50.0,
+                    on_frame=lose_a_frame,
+                )
+        finally:
+            sim.cleanup()
+
+        # Aborted on the first lost frame instead of running the episode out.
+        assert steps == [0]
+
+
+class TestCallerTelemetryKeepsItsTolerance:
+    def test_an_alternating_telemetry_failure_still_completes(self) -> None:
+        """The exclusion is scoped to the recorder, not to every hook failure."""
+        sim = Simulation(tool_name="frame_loss_telemetry", mesh=False)
+        sim.create_world()
+        sim.add_robot(name="arm", data_config="so100")
+        calls = {"n": 0}
+
+        def flaky_telemetry(step: int, obs: dict[str, Any], action: dict[str, Any]) -> None:
+            calls["n"] += 1
+            if calls["n"] % 2 == 0:
+                raise ValueError(f"telemetry hiccup {calls['n']}")
+
+        try:
+            runner = PolicyRunner(sim)
+            result = runner.run(
+                "arm",
+                _policy(sim),
+                n_steps=20,
+                control_frequency=50,
+                fast_mode=True,
+                on_frame=flaky_telemetry,
+            )
+        finally:
+            sim.cleanup()
+
+        assert result["status"] == "success", result
+        assert calls["n"] == 20
+
+    def test_a_non_strict_recorder_failure_remains_tolerated(self, caplog: pytest.LogCaptureFixture) -> None:
+        """``strict=False`` still drops, counts and completes - unchanged."""
+        ds = _FlakyDataset(fail_every=2)
+        recorder = DatasetRecorder(dataset=ds, task="t", strict=False)
+        sim = _recording_sim(recorder)
+        try:
+            with caplog.at_level(logging.WARNING, logger="strands_robots.dataset_recorder"):
+                result = sim.run_policy(
+                    robot_name="arm",
+                    policy_object=_policy(sim),
+                    n_steps=20,
+                    control_frequency=50.0,
+                    fast_mode=True,
+                )
+        finally:
+            sim.cleanup()
+
+        assert result["status"] == "success", result
+        assert ds.attempts == 20
+        assert recorder.dropped_frame_count == 10
+
+
+class TestRecorderRaisesADistinguishableError:
+    def test_strict_add_frame_raises_recording_frame_error_chaining_the_cause(self) -> None:
+        """The type is what the runner keys on; the cause must stay readable."""
+        ds = _FlakyDataset(fail_every=1)
+        recorder = DatasetRecorder(dataset=ds, task="t")
+
+        with pytest.raises(RecordingFrameError) as excinfo:
+            recorder.add_frame(observation={"1": 1.0}, action={"1": 0.1}, task="t")
+
+        assert "transient dataset write failure at frame 1" in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+        # The strict path re-raises rather than dropping, so the drop counter -
+        # which only describes swallowed frames - must stay at zero.
+        assert recorder.dropped_frame_count == 0
+        assert recorder.frame_count == 0
+
+
+def test_every_on_frame_call_site_excludes_a_lost_recording_frame() -> None:
+    """No rollout loop may absorb a lost dataset frame into hook tolerance.
+
+    Walks every ``try`` that invokes the ``on_frame`` hook - including the
+    benchmark-spec eval loop, which needs a registered benchmark to reach
+    behaviourally - and requires each to handle ``RecordingFrameError``.
+    """
+    source = Path(policy_runner_module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    def calls_on_frame(node: ast.Try) -> bool:
+        return any(
+            isinstance(child, ast.Call) and isinstance(child.func, ast.Name) and child.func.id == "on_frame"
+            for stmt in node.body
+            for child in ast.walk(stmt)
+        )
+
+    containing = [t for t in ast.walk(tree) if isinstance(t, ast.Try) and calls_on_frame(t)]
+    containing_ids = {id(t) for t in containing}
+    # Keep only the innermost guard per call site: an enclosing rollout ``try``
+    # also contains the call, and it is not the handler that decides tolerance.
+    guarded = [
+        t
+        for t in containing
+        if not any(isinstance(o, ast.Try) and o is not t and id(o) in containing_ids for o in ast.walk(t))
+    ]
+    assert len(guarded) >= 3, f"expected every on_frame call site to be guarded, found {len(guarded)}"
+
+    for node in guarded:
+        names = {h.type.id for h in node.handlers if isinstance(h.type, ast.Name)}
+        assert "RecordingFrameError" in names, (
+            f"the on_frame try at line {node.lineno} does not exclude RecordingFrameError "
+            f"from its tolerance (handlers: {sorted(names)})"
+        )

--- a/tests/simulation/test_recording_frame_loss_is_not_tolerated.py
+++ b/tests/simulation/test_recording_frame_loss_is_not_tolerated.py
@@ -18,15 +18,15 @@ failure keeps its tolerance.
 from __future__ import annotations
 
 import ast
+import inspect
 import logging
-from pathlib import Path
+import sys
 from typing import Any
 
 import pytest
 
 pytest.importorskip("mujoco")
 
-import strands_robots.simulation.policy_runner as policy_runner_module
 from strands_robots.dataset_recorder import DatasetRecorder, RecordingFrameError
 from strands_robots.policies.mock import MockPolicy
 from strands_robots.simulation.mujoco.simulation import Simulation
@@ -244,7 +244,7 @@ def test_every_on_frame_call_site_excludes_a_lost_recording_frame() -> None:
     benchmark-spec eval loop, which needs a registered benchmark to reach
     behaviourally - and requires each to handle ``RecordingFrameError``.
     """
-    source = Path(policy_runner_module.__file__).read_text(encoding="utf-8")
+    source = inspect.getsource(sys.modules[PolicyRunner.__module__])
     tree = ast.parse(source)
 
     def calls_on_frame(node: ast.Try) -> bool:


### PR DESCRIPTION
## Problem

`DatasetRecorder` is fail-fast by default (`strict=True`) and raises when the underlying `LeRobotDataset` write fails. But the recorder is fed to the rollout through the *same* `on_frame` hook the loops use for caller telemetry, and that handler is scoped to telemetry by its own comment:

```python
# on_frame hooks that raise are logged at WARN - user-provided telemetry is
# not allowed to kill the rollout. BUT if the hook raises on every single step
# ... After this many *consecutive* failures, the runner raises
```

The counter resets on every success (`test_consecutive_counter_resets_on_success` pins that), so it bounds an **always**-failing hook and nothing else. An intermittently failing writer never reaches the limit — it logs `on_frame hook failed (1/5 consecutive)` forever.

Measured on a 30-step MuJoCo rollout whose dataset write fails every second frame, `fps = control_frequency = 50 Hz`:

| | main | this PR |
|---|---|---|
| `run_policy` | `success` — "30 steps" | `error` at the first lost frame |
| `stop_recording` | `success` — "15 frames, 1 episode(s)" | rollout already reported the loss |
| frames on disk | **15 of 30** | aborted after 2 write attempts |
| episode timebase | **2.00x too fast** | no misleading episode written |
| `dropped_frame_count` | **0** | 0 |

Two things make this worse than a short episode:

- **The survivors are re-timestamped.** LeRobot derives timestamps positionally from the declared `fps`, so the 15 surviving frames span `0.28 s` of a `0.56 s` capture. There is no gap left in the episode to detect the loss from — it reads as a valid, faster trajectory, and trains as one.
- **Nothing counts it.** `dropped_frame_count` describes *swallowed* frames, and the `strict` path re-raises instead of dropping, so it stays at `0`. Between the raise being absorbed and the counter not applying, the loss has no representation anywhere.

## Change

`DatasetRecorder.add_frame` raises a distinct `RecordingFrameError` in the `strict` branch, chaining the original failure and preserving its text. Each of the three `on_frame` call sites in `PolicyRunner` excludes that type from the tolerance and re-raises: a lost dataset frame is data loss, not telemetry.

Deliberately unchanged:

- A caller's own `on_frame` hook keeps its full consecutive tolerance — the exclusion is keyed on the type the recorder raises, not on "a hook failed".
- `strict=False` recording still drops the frame, counts it in `dropped_frame_count`, warns, and continues.
- It surfaces out of `eval_policy` as a raise rather than an error envelope, because that is already how `eval_policy` surfaces every rollout failure (a policy raising from `get_actions` propagates identically). Making that surface envelope-shaped is a separate change.
- `stop_recording` still saves the frames written before the abort; the rollout error is the signal, and the `stop_recording` payload shape is being changed elsewhere.

## Evidence

![before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/lost-recording-frame/frame_loss.png)

Top row: three frames decoded back out of each episode's **own MP4** — the round trip through what was actually written. Left is the 15-frame episode `main` produced and reported as a success; right is the same rollout with a healthy writer. Middle: recorded timestamp against the wall time each frame was captured at, showing the 2.00x compression. Bottom: the measured verdict table, including a healthy-writer control confirming the guard does not touch normal recording (30/30 frames, exact timebase).

## Tests

`tests/simulation/test_recording_frame_loss_is_not_tolerated.py` — 7 tests driving a real `DatasetRecorder` over an intermittently failing dataset, attached to a real MuJoCo rollout:

- an intermittent write failure fails the rollout, having attempted 2 writes rather than silently completing 15 of 30;
- a persistent write failure aborts on the first frame instead of spending the tolerance window;
- the eval loop does not swallow it either, aborting on step 0;
- **control:** a caller telemetry hook failing on alternate steps still completes all 20 steps;
- **control:** a `strict=False` recorder still drops, counts 10 and completes;
- the recorder raises `RecordingFrameError`, chains the cause, and leaves `dropped_frame_count` at 0;
- an AST parity test requiring every `on_frame` call site to exclude the type — this covers the benchmark-spec eval loop, which needs a registered benchmark to reach behaviourally, and it caught a third call site that reading the two obvious ones did not surface.

**Pre-fix:** 5 failed / 2 passed against unmodified `main` (the 2 passing are the deliberate controls above). The headline failure is `AssertionError: {'status': 'success', ...}`. **Post-fix:** 7 passed.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` — clean (957 source files).
- `MUJOCO_GL=egl pytest tests` — **13799 passed, 253 skipped** (447 s).
- `scripts/assemble_changelog.py --check` — OK; news fragment added.
- `docs/recording.md` documents the fail-fast contract, why continuing past a lost frame is not a smaller failure, and the `strict=False` trade.

## Review rounds

### Round 2 — `a635bc8`

- **Code scanning: `policy_runner` imported with both `import` and `import from`.** The AST parity test held a module handle purely to reach `__file__`; it now reads the source off the class it already imports (`inspect.getsource(sys.modules[PolicyRunner.__module__])`), matching the `inspect.getsource` convention the other source-assertion tests use, and drops the now-unused `pathlib` import. Test-only; no change to the fix under review.
  - Confirmed the lookup still resolves the real module rather than silently reading nothing: removing one `RecordingFrameError` handler from `policy_runner` makes the parity test fail and name the offending line (`the on_frame try at line 1265 does not exclude RecordingFrameError`). The pre-existing `len(guarded) >= 3` assertion also keeps the test from passing vacuously.
  - `ruff check` / `ruff format --check` / `mypy` clean on the file; all 7 tests in the file pass.

The non-blocking observation raised in review — a recording opened *after* `start_policy` is already running is not rate-checked — is pre-existing and out of scope here; it belongs to the sibling rate-guard change rather than being widened into this PR.