### PR TITLE
fix(sim): a directly driven PolicyRunner refuses a recording rate it cannot describe

### DIFF
--- a/changelog.d/1749-runner-recording-rate-parity.md
+++ b/changelog.d/1749-runner-recording-rate-parity.md
@@ -1,0 +1,22 @@
+### Fixed: a directly driven PolicyRunner refuses a recording rate it cannot describe
+
+`start_recording(fps=...)` fixes the rate LeRobot timestamps every frame from
+positionally, and the recorder is driven once per control step with no
+decimation - so a rollout capturing at a different `control_frequency` can only
+mislabel the episode. The engine's rollout entry points refuse that
+disagreement, but `PolicyRunner.run` / `PolicyRunner.evaluate` are also driven
+directly, with the entry-point guard off the path.
+
+Driving the runner directly against an open 30 fps recording at
+`control_frequency=50.0` wrote 20 frames declaring 0.0333s each for a capture
+0.0200s apart - a 1.667x distortion - with the rollout and `stop_recording` both
+reporting `status="success"`.
+
+Both runner methods now apply the same check before any frame is written. They
+raise `ValueError` rather than returning an error dict, matching
+`_control_substeps`, whose raise is already documented as "the guarantee for
+callers driving `PolicyRunner` directly" - a direct caller has no tool envelope
+to read. The reason text is shared with the engine's error through a new
+`dataset_rate_mismatch_reason`, so the two surfaces cannot describe the same
+pair of rates differently. A rollout with no recording open, a matching rate,
+and a backend that cannot record are all unaffected.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -41,6 +41,19 @@ from the dataset rate, so a mislabelled episode also replays at the wrong speed.
 To record at a lower rate than you control at, run the rollout at that rate -
 there is no decimating recorder.
 
+`PolicyRunner` is drivable directly, and the engine's check is not on that path,
+so `PolicyRunner.run` / `PolicyRunner.evaluate` apply the same rule themselves.
+They raise `ValueError` rather than returning an error dict, because a direct
+caller has no tool envelope to read:
+
+```python
+runner = PolicyRunner(sim)
+runner.run("so100", policy, control_frequency=50.0, on_frame=hook)
+# -> ValueError: PolicyRunner.run: the active recording declares 30 fps but this
+#    rollout captures at control_frequency=50 Hz. [...] pass control_frequency=30
+#    to PolicyRunner.run()
+```
+
 ## Selecting which cameras to record
 
 By default every camera in the scene is recorded into the dataset - including

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1410,7 +1410,7 @@ class SimEngine(ABC):
         Returns:
             A structured ``{"status": "error", ...}`` dict, or ``None`` when no
             recording is active or the rates agree. See
-            :func:`~strands_robots.simulation.recording.dataset_rate_mismatch_error`
+            :func:`~strands_robots.simulation.recording.dataset_rate_mismatch_reason`
             for the contract and why a mismatch is refused rather than warned.
         """
         if not self._is_recording():

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -812,6 +812,53 @@ class PolicyRunner:
             return max(1, round((1.0 / control_frequency) / dt))
         return 1
 
+    def _reject_recording_rate_mismatch(self, control_frequency: float, method: str) -> None:
+        """Refuse a rollout the engine's open dataset recording cannot describe.
+
+        The dataset recorder is driven once per control step with no
+        decimation, and LeRobot timestamps each frame positionally from the
+        rate ``start_recording(fps=...)`` wrote into the metadata. A rollout
+        capturing at a different ``control_frequency`` therefore cannot be
+        labelled correctly, only mislabelled - the episode declares a
+        duration it was not captured over, which is the control period a
+        policy trains on and the budget ``replay_episode`` replays it at.
+
+        The engine's rollout entry points already refuse this before a frame
+        is written. ``run`` and ``evaluate`` are also driven directly, with
+        the engine's guard off the path, so the check is repeated here for
+        the same reason :meth:`_control_substeps` raises for a bad
+        ``control_substeps``: this layer owes a direct caller its own
+        guarantee. A backend that cannot record has no ``_is_recording``, and
+        a duck-typed test double may have neither hook, so both are probed
+        rather than assumed.
+
+        Args:
+            control_frequency: Rate this rollout captures frames at.
+            method: Public method name, used to prefix the message.
+
+        Raises:
+            ValueError: If a recording is open at a rate other than
+                ``control_frequency``. Raised rather than returned as an error
+                dict so it cannot be absorbed, and reported before any frame
+                is written so the caller loses nothing.
+        """
+        is_recording = getattr(self.sim, "_is_recording", None)
+        if not callable(is_recording) or not is_recording():
+            return
+        active_recorder = getattr(self.sim, "_active_recorder", None)
+        if not callable(active_recorder):
+            return
+        recorder = active_recorder()
+        if recorder is None:
+            return
+        # Imported here, like the engine's own call site, so the recording
+        # module stays out of this module's import graph.
+        from strands_robots.simulation.recording import dataset_rate_mismatch_reason
+
+        reason = dataset_rate_mismatch_reason(method, recorder, control_frequency)
+        if reason is not None:
+            raise ValueError(reason)
+
     # ------------------------------------------------------------------
     # Recorder per-episode boundary (issue #708)
     # ------------------------------------------------------------------
@@ -1049,6 +1096,8 @@ class PolicyRunner:
         # seed is given, reseed the client RNGs once and forward it to the policy
         # (mirrors the per-episode reseed in evaluate()). Default None leaves RNG
         # state untouched, preserving historical behaviour.
+        # Refuse before any frame reaches the engine's open recording.
+        self._reject_recording_rate_mismatch(control_frequency, "PolicyRunner.run")
         if seed is not None:
             set_eval_seed(seed)
             try:
@@ -2132,6 +2181,8 @@ class PolicyRunner:
             metrics are computed over ``episodes_completed`` (which may be less
             than the requested ``n_episodes``).
         """
+        # Refuse before any frame reaches the engine's open recording.
+        self._reject_recording_rate_mismatch(control_frequency, "PolicyRunner.evaluate")
         if spec is not None and success_fn is not None:
             return {
                 "status": "error",

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -104,8 +104,8 @@ def recorder_dataset_fps(recorder: Any) -> int | None:
     return None
 
 
-def dataset_rate_mismatch_error(method: str, recorder: Any, control_frequency: float) -> dict[str, Any] | None:
-    """Reject a rollout whose capture rate the active dataset cannot describe.
+def dataset_rate_mismatch_reason(method: str, recorder: Any, control_frequency: float) -> str | None:
+    """Explain why the active dataset cannot describe a rollout's capture rate.
 
     ``start_recording(fps=...)`` fixes the frame rate written into the dataset
     metadata, and LeRobot derives every frame's timestamp from it positionally
@@ -143,9 +143,11 @@ def dataset_rate_mismatch_error(method: str, recorder: Any, control_frequency: f
             ``control_frequency`` guard.
 
     Returns:
-        A structured ``{"status": "error", ...}`` dict naming both rates and the
-        remedies, or ``None`` when the rates agree (or the dataset does not
-        report a usable whole rate, which must not block a valid rollout).
+        The reason text naming both rates and the remedies, or ``None`` when the
+        rates agree (or the dataset does not report a usable whole rate, which
+        must not block a valid rollout). Callers reporting through a tool
+        envelope want :func:`dataset_rate_mismatch_error`; a caller that must
+        raise - a directly driven ``PolicyRunner`` - uses this text verbatim.
     """
     fps = recorder_dataset_fps(recorder)
     if fps is None:
@@ -170,7 +172,27 @@ def dataset_rate_mismatch_error(method: str, recorder: Any, control_frequency: f
         f"episode duration, which a policy trains on as its control period and which "
         f"replay_episode reproduces at the wrong speed. Align the two rates: {remedy}."
     )
-    return {"status": "error", "content": [{"text": text}]}
+    return text
+
+
+def dataset_rate_mismatch_error(method: str, recorder: Any, control_frequency: float) -> dict[str, Any] | None:
+    """Envelope form of :func:`dataset_rate_mismatch_reason` for tool callers.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        recorder: The active ``DatasetRecorder``.
+        control_frequency: Rate the rollout will capture frames at.
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict carrying the reason text,
+        or ``None`` when there is nothing to refuse. See
+        :func:`dataset_rate_mismatch_reason` for the contract and why a mismatch
+        is refused rather than warned.
+    """
+    reason = dataset_rate_mismatch_reason(method, recorder, control_frequency)
+    if reason is None:
+        return None
+    return {"status": "error", "content": [{"text": reason}]}
 
 
 def _resume_schema_error(diffs: list[str]) -> str:

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -41,8 +41,10 @@ pytest.importorskip("lerobot")
 
 from strands_robots.policies.base import Policy  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine  # noqa: E402
+from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
 from strands_robots.simulation.recording import (  # noqa: E402
     dataset_rate_mismatch_error,
+    dataset_rate_mismatch_reason,
     recorder_dataset_fps,
 )
 
@@ -214,6 +216,125 @@ class TestTheGuardHelperIsRobust:
         assert recorder_dataset_fps(_FakeRecorder(True)) is None
 
 
+class TestTheRunnerLayerCarriesItsOwnGuarantee:
+    """``PolicyRunner`` is driven directly, with the engine's guard off the path.
+
+    ``docs/policies/lerobot-local.md`` names ``PolicyRunner.run`` beside
+    ``run_policy`` as a caller surface, and ``_control_substeps`` already raises
+    for a bad ``control_substeps`` on the stated grounds that "the public entry
+    points reject such a value ... this raise is the guarantee for callers
+    driving ``PolicyRunner`` directly". The recording rate needs the same
+    treatment: measured before the guard, a direct rollout at ``fps=30`` /
+    ``control_frequency=50`` wrote 20 frames declaring 0.0333s each for a
+    capture 0.0200s apart (1.667x) and reported ``status="success"``.
+    """
+
+    def _keys(self, sim) -> list[str]:  # noqa: ANN001
+        return list(sim.robot_action_keys("arm"))
+
+    def test_direct_run_refuses_a_rate_the_recording_cannot_describe(self, sim, tmp_path):
+        root = _record(sim, tmp_path, fps=30)
+        with pytest.raises(ValueError) as excinfo:
+            PolicyRunner(sim).run(
+                "arm",
+                _Hold(self._keys(sim)),
+                n_steps=20,
+                control_frequency=50.0,
+                on_frame=sim._make_run_policy_hook("arm", "hold"),
+            )
+        message = str(excinfo.value)
+        assert message.startswith("PolicyRunner.run: ")
+        assert "declares 30 fps" in message
+        assert "control_frequency=50 Hz" in message
+        # Refused before the recorder was touched, so nothing has to be undone.
+        assert sim._active_recorder().frame_count == 0
+        assert _frames_on_disk(root) == 0
+
+    def test_direct_evaluate_refuses_the_same_disagreement(self, sim, tmp_path):
+        """The eval loop writes into the same open recording, so it refuses too."""
+        root = _record(sim, tmp_path, fps=30, name="eval_ds")
+        with pytest.raises(ValueError) as excinfo:
+            PolicyRunner(sim).evaluate(
+                "arm",
+                _Hold(self._keys(sim)),
+                n_episodes=1,
+                max_steps=20,
+                control_frequency=50.0,
+                on_frame=sim._make_run_policy_hook("arm", "hold"),
+            )
+        assert str(excinfo.value).startswith("PolicyRunner.evaluate: ")
+        assert _frames_on_disk(root) == 0
+
+    def test_a_matching_rate_still_records_an_exact_timebase(self, sim, tmp_path):
+        """Control: the guard must not cost a correctly configured direct caller."""
+        root = _record(sim, tmp_path, fps=50, name="aligned_ds")
+        result = PolicyRunner(sim).run(
+            "arm",
+            _Hold(self._keys(sim)),
+            n_steps=20,
+            control_frequency=50.0,
+            on_frame=sim._make_run_policy_hook("arm", "hold"),
+        )
+        assert result["status"] == "success"
+        assert sim.stop_recording()["status"] == "success"
+        assert _frames_on_disk(root) == 20
+        pd = pytest.importorskip("pandas")
+        parquets = [p for p in Path(root).rglob("*.parquet") if "data" in p.parts]
+        stamps = pd.concat([pd.read_parquet(p) for p in parquets])["timestamp"].tolist()
+        assert stamps[1] - stamps[0] == pytest.approx(1.0 / 50.0, abs=1e-9)
+
+    def test_a_rollout_with_no_recording_open_is_unaffected(self, sim):
+        """Control: the rates are only comparable while a recording is open."""
+        result = PolicyRunner(sim).run("arm", _Hold(self._keys(sim)), n_steps=5, control_frequency=50.0)
+        assert result["status"] == "success"
+
+    def test_a_sim_without_the_recording_hooks_is_not_probed(self):
+        """A backend that cannot record, or a test double, has neither hook."""
+        PolicyRunner(object())._reject_recording_rate_mismatch(50.0, "PolicyRunner.run")
+
+    def test_a_sim_reporting_no_active_recorder_is_not_probed(self):
+        """``_is_recording`` and ``_active_recorder`` can disagree; trust neither alone."""
+
+        class _Engine:
+            def _is_recording(self) -> bool:
+                return True
+
+            def _active_recorder(self) -> None:
+                return None
+
+        PolicyRunner(_Engine())._reject_recording_rate_mismatch(50.0, "PolicyRunner.run")
+
+
+@pytest.mark.parametrize(
+    ("fps", "control_frequency"),
+    [(30, 50.0), (50, 30.0), (30, 30.0), (50, 50.0), (25, 25.0), (None, 50.0), (29.97, 50.0)],
+)
+def test_the_runner_and_the_engine_refuse_the_same_rates(fps, control_frequency):
+    """One rule, two surfaces: the verdict and the reason must not diverge.
+
+    The engine reports through a tool envelope and the runner raises, so only a
+    shared reason keeps a caller from being told two different things about the
+    same pair of rates.
+    """
+    recorder = _FakeRecorder(fps)
+    envelope = dataset_rate_mismatch_error("run_policy", recorder, control_frequency)
+    reason = dataset_rate_mismatch_reason("run_policy", recorder, control_frequency)
+    assert (envelope is None) == (reason is None), (
+        f"the two surfaces disagree for fps={fps!r} control_frequency={control_frequency!r}"
+    )
+    if envelope is not None and reason is not None:
+        assert envelope["content"][0]["text"] == reason
+
+
+def test_the_reason_names_the_method_the_caller_actually_called():
+    """The remedy must advise changing ``PolicyRunner.run``, not ``run_policy``."""
+    reason = dataset_rate_mismatch_reason("PolicyRunner.run", _FakeRecorder(30), 50.0)
+    assert reason is not None
+    assert reason.startswith("PolicyRunner.run: ")
+    assert "pass control_frequency=30 to PolicyRunner.run()" in reason
+    assert "run_policy" not in reason
+
+
 class _Dataset:
     def __init__(self, fps, meta: object | None = None) -> None:  # noqa: ANN001
         self.fps = fps
@@ -244,6 +365,24 @@ _ENTRY_POINTS = {
     "strands_robots/simulation/mujoco/simulation.py": ("start_policy", "run_multi_policy"),
 }
 
+# ``PolicyRunner`` is driven directly too, so it repeats the check under its own
+# name. Kept as a separate table because the guard it calls differs: the engine
+# returns a tool envelope, the runner raises for a caller that has no envelope.
+_RUNNER_ENTRY_POINTS = {
+    "strands_robots/simulation/policy_runner.py": ("run", "evaluate"),
+}
+
+
+def _self_calls(module: str, method: str) -> set[str]:
+    """Names of the ``self.x(...)`` calls made anywhere inside ``module::method``."""
+    tree = ast.parse(Path(module).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == method:
+            return {
+                n.func.attr for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+            }
+    pytest.fail(f"{method} not found in {module}")
+
 
 @pytest.mark.parametrize(
     ("module", "method"),
@@ -257,12 +396,17 @@ def test_every_rollout_entry_point_checks_the_recording_rate(module, method):
     is still covered - and so a newly added driver cannot quietly skip the
     guard the way ``run_multi_policy`` once skipped ``_validate_action_horizon``.
     """
-    tree = ast.parse(Path(module).read_text())
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == method:
-            calls = {
-                n.func.attr for n in ast.walk(node) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
-            }
-            assert "_validate_recording_rate" in calls, f"{module}::{method} does not check the recording rate"
-            return
-    pytest.fail(f"{method} not found in {module}")
+    assert "_validate_recording_rate" in _self_calls(module, method), (
+        f"{module}::{method} does not check the recording rate"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "method"),
+    [(m, f) for m, fns in _RUNNER_ENTRY_POINTS.items() for f in fns],
+)
+def test_every_directly_drivable_runner_method_checks_the_recording_rate(module, method):
+    """The runner cannot rely on a guard that is not on a direct caller's path."""
+    assert "_reject_recording_rate_mismatch" in _self_calls(module, method), (
+        f"{module}::{method} does not check the recording rate"
+    )


### PR DESCRIPTION
## Problem

`start_recording(fps=...)` fixes the rate written into the LeRobotDataset metadata, and LeRobot derives every timestamp from it positionally (`timestamp = frame_index / fps`). The recorder is driven once per control step with **no decimation**, so the rate frames are really captured at is the rollout's `control_frequency` - a differing `fps` cannot be honored, only mislabelled.

The engine's five rollout entry points refuse that disagreement before a frame is written (`SimEngine._validate_recording_rate`). `PolicyRunner.run` / `PolicyRunner.evaluate` are **also driven directly** - `docs/policies/lerobot-local.md` names `PolicyRunner.run` beside `run_policy` as a caller surface - and the entry-point guard is not on that path.

Measured on a two-actuator arm, an open 30 fps recording, a direct rollout at `control_frequency=50.0`:

| | main | this PR |
|---|---|---|
| `PolicyRunner.run` | `status="success"` | raises `ValueError` |
| frames written | **20** | 0, refused first |
| declared vs captured interval | **0.0333s vs 0.0200s (1.667x)** | nothing written |
| `stop_recording` | `success` - "20 frames, 1 episode(s)" | `error` - captured no frames |
| `PolicyRunner.evaluate`, same pair | `status="success"` | raises `ValueError` |

The survivors are not merely mislabelled in the metadata: timestamps are positional, so the episode reads as a valid, 1.667x-faster trajectory. That interval is the control period a policy trains on, and `replay_episode` derives its per-frame physics budget from the dataset rate, so the episode also replays at the wrong speed. Nothing in the payloads reports it.

## Change

A `_reject_recording_rate_mismatch` check at the top of both directly drivable runner methods, before any frame reaches the engine's open recording.

It **raises `ValueError`** rather than returning an error dict, matching the sibling guard in the same class - `_control_substeps`, whose docstring already states the principle this PR applies to a second value:

> The public entry points reject such a value with a structured error before reaching the runner; this raise is the guarantee for callers driving `PolicyRunner` directly.

The reason text is shared with the engine's error through a new `dataset_rate_mismatch_reason`; `dataset_rate_mismatch_error` becomes a thin envelope wrapper around it, so its text is byte-identical and the two surfaces cannot describe one pair of rates differently. The method name is threaded through, so a direct caller is advised to change `PolicyRunner.run()`, not `run_policy()`.

Deliberately unchanged:

- The engine entry points keep returning the structured envelope - a tool caller reads a status, a direct caller has no envelope to read.
- `_evaluate_with_spec` gets no second copy: it is private and reached only from `evaluate`, which now guards. Adding one there would be a duplicate guard, not a second surface.
- A rollout with no recording open, a matching rate, a backend that cannot record (no `_is_recording`) and a duck-typed sim without either hook are all untouched. Both hooks are probed rather than assumed, because they can disagree.
- The inverse ordering (a recording opened *while* an async rollout runs) is #1748, which needs the active rate to be readable at that point first.

## Evidence

![before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/runner-recording-rate/runner_recording_rate.png)

Top row: three frames decoded back out of the episode's **own MP4** that `main` produced and reported as a success - 20 real frames carrying a timebase nothing compared. Middle: recorded timestamp against the rate the frames were actually captured at, with the matching-rate control coinciding exactly. Bottom: the measured verdicts, including the controls confirming the guard costs a correctly configured caller nothing.

## Tests

Extended `tests/simulation/test_recording_rate_matches_control_frequency.py` - the existing home for this contract - rather than adding a second file:

- `TestTheRunnerLayerCarriesItsOwnGuarantee`: a direct `run` and a direct `evaluate` each refuse the disagreement, naming both rates, with `recorder.frame_count == 0` and nothing on disk;
- **control:** a matching rate still records 20 frames whose interval round-trips to exactly `1/50` s off the parquet;
- **control:** a rollout with no recording open, a sim without the recording hooks, and a sim whose `_is_recording` and `_active_recorder` disagree;
- a parity test over seven `(fps, control_frequency)` pairs asserting the envelope and the raised reason agree on both the verdict and the text - the guard against the two surfaces drifting;
- the remedy names the method the caller actually called;
- a structural pin over `run` / `evaluate` mirroring the entry-point pin, so a newly drivable runner method cannot quietly skip the guard.

The existing structural walk was factored into a shared `_self_calls` helper so both layers use one implementation.

**Pre-fix:** 6 failed / 24 passed against unmodified `main`, headline `Failed: DID NOT RAISE ValueError` on both direct entry points. The 24 passing are the pre-existing engine cases plus the controls above - they are what stop the guard over-reaching. **Post-fix:** 38 passed.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` - clean (957 source files).
- `MUJOCO_GL=egl pytest tests` - **13830 passed, 253 skipped** (443 s).
- `scripts/assemble_changelog.py --check` - OK; news fragment added.
- `docs/recording.md` documents the direct-runner surface and why it raises.

## Review rounds

### Round 1 - `9bb0b2f`

- **Code scanning: explicit returns mixed with implicit (fall through) returns**, on the `_self_calls` helper this PR factored out. The matching definition was returned from inside the `ast.walk` loop, and the not-found path relied on `pytest.fail` terminating the function rather than on a return of its own. The helper now collects the matching definitions first, fails on an empty list, and returns the call-name set as its only exit. Test-only; no change to the guard under review.
  - Behaviour pinned by running both implementations over every entry in both entry-point tables: all seven resolve to an identical set of call names (`definitions[0]` is the same node the loop returned on), the engine pin still sees `_validate_recording_rate` on the five entry points, the runner pin still sees `_reject_recording_rate_mismatch` on `run` / `evaluate`, and a method that does not exist still fails with the same message.
  - `ruff check` / `ruff format --check` clean on the file; `mypy` reports nothing on it - `pytest.fail` is `NoReturn`, so the empty-list branch needs no return of its own.