### PR TITLE
fix(policies): refuse a per-inference chunk count the consumer cannot execute

### DIFF
--- a/changelog.d/1750-chunk-count-domain.md
+++ b/changelog.d/1750-chunk-count-domain.md
@@ -1,0 +1,30 @@
+### Fixed: a per-inference chunk count the consumer cannot execute is refused instead of floored
+
+`actions_per_step` (how many actions of one inference chunk a consumer executes
+before re-querying) and `actions_per_chunk` were stored verbatim by both LeRobot
+providers and only reconciled on the read path, where `Policy.execution_horizon`
+resolves them through `max(1, int(...))`. That floor turned a count no consumer
+can execute into `1` under a successful call: `0`, `-5` and `False` all became a
+single-action horizon, `2.7` was truncated to `2`, `"4"` was string-coerced, and
+`None` / `nan` / `inf` / `[4]` raised a bare `TypeError` / `ValueError` /
+`OverflowError` from a property read inside the rollout loop.
+
+For `lerobot_local` the floor was worse than the default it replaced.
+`_auto_detect_actions_per_step` treats any value other than the default `1` as a
+horizon the caller pinned deliberately and returns without adopting
+`config.n_action_steps`, so on a checkpoint trained to replay a 100-action chunk
+open-loop, `actions_per_step=0` both skipped that adoption and floored the
+horizon to `1` - re-querying the model every step, the out-of-distribution
+operation the auto-detection exists to prevent - where the default would have
+executed the trained 100. It also flipped `is_chunk_emitting()` to `False`,
+silently disabling async-RTC latency masking for a chunk-emitting model.
+
+Both counts are now validated where the caller supplies them, through a shared
+`chunk_count_error` domain so the two providers cannot drift apart, and before
+any checkpoint is fetched: in each constructor and in `lerobot_local.preflight`,
+which the rollout entry points run first, so the same mistake surfaces as a
+structured error rather than a raise. `actions_per_chunk` is checked too, since
+it is the default for `actions_per_step`. `None` remains `lerobot_async`'s
+documented "use `actions_per_chunk`". The floor in `resolve_chunk_length` is
+unchanged: it is the default for a duck-typed chunk source that never passed
+through a provider constructor.

--- a/docs/policies/lerobot-async.md
+++ b/docs/policies/lerobot-async.md
@@ -83,8 +83,8 @@ sim.run_policy(
 | `policy_type`              | -             | **Required.** LeRobot policy type the server loads -- the async-servable set from lerobot's `SUPPORTED_POLICIES` (`act`, `smolvla`, `diffusion`, `tdmpc`, `vqbet`, `pi0`, `pi05`, `groot`, ...); validated client-side against the live lerobot constant |
 | `pretrained_name_or_path`  | -             | **Required.** HuggingFace id or path the server loads       |
 | `device`                   | `cuda`        | Device for **server-side** inference; set `cpu` for a CPU server |
-| `actions_per_chunk`        | `50`          | Max actions the server returns per chunk                    |
-| `actions_per_step`         | `actions_per_chunk` | Actions executed from one chunk before re-querying (the re-query interval) |
+| `actions_per_chunk`        | `50`          | Max actions the server returns per chunk. Positive `int` (it is also the default for `actions_per_step`) |
+| `actions_per_step`         | `actions_per_chunk` | Actions executed from one chunk before re-querying (the re-query interval). Positive `int`, or `None` for the default |
 | `connect_timeout`          | `10.0`        | Seconds to wait for the gRPC `Ready` handshake              |
 | `request_timeout`          | `60.0`        | Seconds to wait for each observation/action RPC             |
 | `rename_map`               | `{}`          | `{robot_obs_key: model_feature_key}` forwarded to the server; renames observation keys before the policy sees them (async analog of `lerobot_local`'s `obs_rename`) |

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -26,7 +26,7 @@ LerobotLocalPolicy(
     pretrained_name_or_path="",          # HF model_id or local checkpoint dir (required)
     policy_type=None,                    # override auto-detected class
     device=None,                         # "cuda" | "cpu" | "mps"
-    actions_per_step=1,                   # auto-set from config.n_action_steps if left at 1
+    actions_per_step=1,                  # positive int; auto-set from config.n_action_steps if left at 1
     use_processor=True,                  # observation/action processor bridge
     processor_overrides=None,
     tokenizer_max_length=48,

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -40,6 +40,7 @@ from strands_robots.policies.base import (
     ChunkedPolicy,
     Policy,
     align_action_values,
+    chunk_count_error,
     resolve_chunk_length,
 )
 
@@ -69,6 +70,7 @@ __all__ = [
     "ChunkedPolicy",
     "resolve_chunk_length",
     "align_action_values",
+    "chunk_count_error",
     "MockPolicy",
     "Cosmos3Policy",
     "CompositePolicy",

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -29,6 +29,8 @@ from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
+from strands_robots.utils import positive_count_error
+
 
 class Policy(ABC):
     """Abstract base class for robot policies (VLA, motion planners, MPC, scripted).
@@ -483,3 +485,46 @@ def resolve_chunk_length(policy: "Policy", action_horizon: int) -> int:
         # RTC owns the interval; action_horizon cannot override it.
         return horizon_int
     return max(int(action_horizon), 1, horizon_int)
+
+
+def chunk_count_error(value: object, param: str, provider: str) -> str | None:
+    """Error text when a per-inference chunk count is not one a policy can execute.
+
+    Shared domain for the counts that describe one inference chunk - how many
+    actions a provider emits (``actions_per_chunk``) and how many of them a
+    consumer executes before re-querying (``actions_per_step``). Both are
+    consumed as slice bounds over the action chunk, so only a true positive
+    ``int`` can be honored; :func:`~strands_robots.utils.positive_count_error`
+    supplies that domain (and rejects ``bool``, which as an ``int`` subclass
+    would otherwise pass as a silent count of one).
+
+    It lives here rather than beside one of its callers because the providers
+    that accept these counts sit in sibling packages
+    (:mod:`strands_robots.policies.lerobot_local` and
+    :mod:`strands_robots.policies.lerobot_async`) and the accepted domain must
+    not diverge between them: the same chunk count cannot be refused by a local
+    checkpoint and accepted by the server serving it.
+
+    Why the count has to be checked where it arrives, rather than where it is
+    read: :attr:`Policy.execution_horizon` resolves the re-query interval
+    through ``max(1, int(...))``, which turns a count no consumer can execute
+    into ``1``. That floor is the right default for a duck-typed chunk source
+    that never passed through a provider constructor, but as a guard it is
+    silently destructive - and specifically so for a provider that treats the
+    default count as a request to adopt the checkpoint's own trained chunk
+    length, because a rejected-then-floored value has already suppressed that
+    adoption and cannot be distinguished from a deliberate single-step request.
+
+    Args:
+        value: The caller-supplied count.
+        param: The parameter name it came from, used in the message.
+        provider: Provider name, used as the message prefix.
+
+    Returns:
+        An error message naming the parameter and the remedy, or ``None`` when
+        the count is usable.
+    """
+    error = positive_count_error(value, param, provider)
+    if error:
+        return f"{error} Omit it to use the provider default."
+    return None

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -57,7 +57,7 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.policies.base import Policy, align_action_values
+from strands_robots.policies.base import Policy, align_action_values, chunk_count_error
 from strands_robots.utils import require_optional
 
 logger = logging.getLogger(__name__)
@@ -125,11 +125,15 @@ class LerobotAsyncPolicy(Policy):
             offload inference to a GPU host; override with ``device="cpu"`` for a
             CPU server.
         actions_per_chunk: Max number of actions the server returns per chunk.
+            Must be a positive ``int``; it is also the default for
+            ``actions_per_step``, so it is held to the same domain.
         actions_per_step: Number of actions the consumer executes from one chunk
             before re-querying (the :attr:`execution_horizon`). Defaults to
             ``actions_per_chunk`` so a chunked open-loop policy (ACT, diffusion)
             executes the whole chunk per network round-trip instead of paying a
-            round-trip per control step.
+            round-trip per control step. ``None`` selects that default; any
+            other value must be a positive ``int``, since it bounds a slice of
+            the returned chunk.
         connect_timeout: Seconds to wait for the gRPC ``Ready`` handshake.
         request_timeout: Seconds to wait for each observation/action RPC.
         rename_map: Optional ``{robot_obs_key: model_feature_key}`` map forwarded
@@ -193,6 +197,16 @@ class LerobotAsyncPolicy(Policy):
         self.policy_type = policy_type
         self.pretrained_name_or_path = pretrained_name_or_path
         self.device = device
+        # ``actions_per_chunk`` is validated too, not just as a sibling knob:
+        # it is the default for ``actions_per_step``, so leaving it unchecked
+        # would let a chunk count the consumer cannot execute reach
+        # ``execution_horizon`` through the omitted parameter.
+        for _param, _value in (("actions_per_chunk", actions_per_chunk), ("actions_per_step", actions_per_step)):
+            if _value is None:
+                continue  # omitted: actions_per_step then defaults to the chunk length
+            error = chunk_count_error(_value, _param, "lerobot_async")
+            if error:
+                raise ValueError(error)
         self.actions_per_chunk = int(actions_per_chunk)
         self.actions_per_step = int(actions_per_step) if actions_per_step is not None else self.actions_per_chunk
         self.connect_timeout = connect_timeout

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -20,7 +20,7 @@ from typing import Any
 import numpy as np
 import torch
 
-from .. import Policy, align_action_values
+from .. import Policy, align_action_values, chunk_count_error
 from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys, state_key_remedy
 from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
@@ -383,7 +383,11 @@ class LerobotLocalPolicy(Policy):
             call. Defaults to 1 (closed-loop). When left at the default,
             it is auto-set from the loaded model's ``config.n_action_steps``
             (the model's trained open-loop chunk size) if that exceeds 1;
-            pass an explicit value > 1 to override the auto-detection.
+            pass an explicit value > 1 to override the auto-detection. Must be
+            a positive ``int`` - it bounds a slice of the action chunk, and any
+            other value both suppresses that auto-detection (which only fires
+            at the default) and is floored to 1 when the horizon is read, so it
+            is refused here instead.
         use_processor: Whether to load the model's processor pipeline.
         processor_overrides: Dict of overrides for processor pipeline steps.
         tokenizer_max_length: Max token length for VLA language tokenization.
@@ -446,6 +450,16 @@ class LerobotLocalPolicy(Policy):
         self.revision = revision
         self.policy_type = policy_type
         self.requested_device = device
+        # Validated here, where the caller's value arrives and before any
+        # checkpoint is downloaded (``_load_model`` below): the read path
+        # (``execution_horizon``) floors it to 1, which for this provider
+        # ALSO silently forfeits the auto-adoption of the checkpoint's
+        # trained chunk length, since _auto_detect_actions_per_step reads
+        # any value other than the default 1 as a horizon the caller pinned
+        # deliberately. See ``chunk_count_error``.
+        error = chunk_count_error(actions_per_step, "actions_per_step", "lerobot_local")
+        if error:
+            raise ValueError(error)
         self.actions_per_step = actions_per_step
         self.use_processor = use_processor
         self.processor_overrides = processor_overrides
@@ -1400,6 +1414,17 @@ class LerobotLocalPolicy(Policy):
                 camera key in ``observation_keys``, or when an explicit
                 ``image_keys`` withholds a feature the embodiment feeds.
         """
+        # Checked before the embodiment early-return below, so a chunk count
+        # the consumer cannot execute is refused for every configuration rather
+        # than only for the ones that declare an embodiment. Running here (and
+        # not only in ``__init__``) is what turns it into a structured error
+        # from the rollout entry point instead of a raise, and refuses it before
+        # the weight download rather than after.
+        if "actions_per_step" in policy_config:
+            error = chunk_count_error(policy_config["actions_per_step"], "actions_per_step", "lerobot_local")
+            if error:
+                raise ValueError(error)
+
         spec = policy_config.get("embodiment")
         if spec is None:
             return

--- a/tests/policies/test_chunk_count_domain.py
+++ b/tests/policies/test_chunk_count_domain.py
@@ -1,0 +1,249 @@
+"""A per-inference chunk count the consumer cannot execute is refused, not floored.
+
+``actions_per_step`` (how many actions of one inference chunk a consumer executes
+before re-querying) and ``actions_per_chunk`` (how many the provider emits) were
+stored verbatim by both LeRobot providers and only ever reconciled on the read
+path, where :attr:`~strands_robots.policies.base.Policy.execution_horizon`
+resolves them through ``max(1, int(...))``. That floor converts a count no
+consumer can execute into ``1`` and reports success.
+
+For ``lerobot_local`` the floor is not merely lossy, it is worse than the
+default. ``_auto_detect_actions_per_step`` treats any value other than the
+default ``1`` as a horizon the caller pinned deliberately ("caller pinned an
+explicit horizon - never override it") and returns without adopting
+``config.n_action_steps``. So on a checkpoint trained to replay a 100-action
+chunk open-loop, ``actions_per_step=0`` skipped that adoption AND floored the
+horizon to ``1`` - re-querying the model every step, the out-of-distribution
+operation the auto-detection exists to prevent - while the default ``1`` would
+have executed the trained 100. It also flipped
+:meth:`~strands_robots.policies.base.Policy.is_chunk_emitting` to ``False``,
+silently disabling the async-RTC latency masking for a chunk-emitting model.
+
+These tests pin:
+
+* the degraded regime is unreachable, against a measured control showing what
+  the default does with the same checkpoint;
+* every value outside the domain is refused by both providers, with parity
+  between them apart from the one documented asymmetry (``None`` is
+  ``lerobot_async``'s "use ``actions_per_chunk``" and not a count at all);
+* the refusal precedes the checkpoint download, in the constructor and in
+  ``preflight`` (which the rollout entry points run first, so the same mistake
+  surfaces as a structured error rather than a raise);
+* ``actions_per_chunk`` is refused too - it is the default for
+  ``actions_per_step``, so an unchecked one reopens the same path;
+* the duck-typed floor in ``resolve_chunk_length`` is deliberately untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from strands_robots.policies import MockPolicy, preflight_policy
+from strands_robots.policies.base import resolve_chunk_length
+from strands_robots.policies.lerobot_async.policy import LerobotAsyncPolicy
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+# Values no chunk consumer can execute, or cannot execute as written. Each is a
+# plausible way to spell an intent the loop has no way to honor.
+REJECTED: list[Any] = [0, -5, False, True, 2.7, "4", float("nan"), float("inf"), [4]]
+
+# The trained chunk length of the checkpoint the fixtures below emulate.
+TRAINED_CHUNK = 100
+
+# Annotated ``Any`` so mypy does not narrow the splat against the mixed-type
+# signature; the two required identifiers are strings.
+ASYNC_REQUIRED: dict[str, Any] = {"policy_type": "act", "pretrained_name_or_path": "acme/act-cube"}
+
+
+class _ChunkTrainedConfig:
+    """An ACT-shaped config: a 100-action chunk trained for open-loop replay."""
+
+    temporal_ensemble_coeff = None
+    n_obs_steps = 1
+    n_action_steps = TRAINED_CHUNK
+
+
+class _ChunkTrainedModel:
+    config = _ChunkTrainedConfig()
+
+
+def _local(**config: Any) -> LerobotLocalPolicy:
+    """Build a ``lerobot_local`` policy with the model load stubbed out."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        return LerobotLocalPolicy(pretrained_name_or_path="acme/act-cube", **config)
+
+
+def _regime(policy: LerobotLocalPolicy) -> tuple[Any, int, bool]:
+    """Resolve the inference regime a loaded chunk-trained checkpoint yields."""
+    policy._policy = _ChunkTrainedModel()
+    policy._auto_detect_actions_per_step()
+    return policy.actions_per_step, policy.execution_horizon, policy.is_chunk_emitting()
+
+
+class TestTheDegradedRegimeIsUnreachable:
+    """The count that discarded the trained chunk is refused up front."""
+
+    def test_the_default_adopts_the_checkpoints_trained_chunk(self) -> None:
+        """Control: left at the default, the trained 100-action chunk is executed whole."""
+        actions_per_step, horizon, chunk_emitting = _regime(_local())
+
+        assert actions_per_step == TRAINED_CHUNK
+        assert horizon == TRAINED_CHUNK
+        assert chunk_emitting is True
+
+    def test_a_pinned_count_is_still_honored_verbatim(self) -> None:
+        """Control: an explicit, executable count overrides the auto-detection."""
+        actions_per_step, horizon, chunk_emitting = _regime(_local(actions_per_step=8))
+
+        assert actions_per_step == 8
+        assert horizon == 8
+        assert chunk_emitting is True
+
+    def test_a_zero_count_cannot_discard_the_trained_chunk(self) -> None:
+        """``0`` is refused rather than skipping the adoption and flooring to 1.
+
+        Pre-fix this constructed, and ``_regime`` then reported
+        ``(0, 1, False)`` - no adoption of the trained 100, a re-query every
+        step, and chunk emission undetected - all under a successful call.
+        """
+        with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+            _local(actions_per_step=0)
+
+    def test_a_fractional_count_is_not_truncated(self) -> None:
+        """``2.7`` is refused rather than silently executing 2 actions per chunk."""
+        with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+            _local(actions_per_step=2.7)
+
+    def test_a_non_numeric_count_is_refused_where_it_arrives(self) -> None:
+        """A value ``int()`` cannot read is refused at the constructor.
+
+        ``execution_horizon`` is a property read by ``resolve_chunk_length``
+        inside the rollout loop, so on the read path these surfaced as a bare
+        ``TypeError``/``ValueError``/``OverflowError`` mid-rollout.
+        """
+        for value in (None, [4], float("nan"), float("inf")):
+            with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+                _local(actions_per_step=value)
+
+
+class TestTheRefusalPrecedesTheCheckpointLoad:
+    """Nothing is downloaded for a configuration that cannot run."""
+
+    def test_the_constructor_refuses_before_loading_the_model(self) -> None:
+        loads: list[int] = []
+
+        def record(self: LerobotLocalPolicy) -> None:
+            loads.append(1)
+
+        with patch.object(LerobotLocalPolicy, "_load_model", record):
+            with pytest.raises(ValueError, match="actions_per_step"):
+                LerobotLocalPolicy(pretrained_name_or_path="acme/act-cube", actions_per_step=0)
+
+        assert loads == [], "the checkpoint load must not be reached for a refused count"
+
+    def test_preflight_refuses_the_count_with_no_embodiment_configured(self) -> None:
+        """The check runs before ``preflight``'s embodiment early-return.
+
+        The rollout entry points run ``preflight`` before ``create_policy``, so
+        this is what turns the same mistake into a structured error instead of a
+        raise. Scoping it behind an embodiment would leave every configuration
+        that declares none unguarded on that path.
+        """
+        with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+            LerobotLocalPolicy.preflight(set(), actions_per_step=0)
+
+    def test_the_provider_preflight_entry_point_refuses_it(self) -> None:
+        """Reached through the same function the rollout entry points call."""
+        with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+            preflight_policy("lerobot_local", {"joint_1", "front"}, actions_per_step=-5)
+
+    def test_preflight_passes_an_executable_count(self) -> None:
+        preflight_policy("lerobot_local", {"joint_1", "front"}, actions_per_step=30)
+
+
+class TestBothProvidersShareTheDomain:
+    """The same chunk count cannot be refused locally and accepted remotely."""
+
+    @pytest.mark.parametrize("value", REJECTED, ids=repr)
+    def test_lerobot_local_refuses_it(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+            _local(actions_per_step=value)
+
+    @pytest.mark.parametrize("value", REJECTED, ids=repr)
+    def test_lerobot_async_refuses_it(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+            LerobotAsyncPolicy(**ASYNC_REQUIRED, actions_per_step=value)
+
+    @pytest.mark.parametrize("value", REJECTED, ids=repr)
+    def test_the_two_providers_reach_the_same_verdict(self, value: Any) -> None:
+        """Parity, so the domains cannot drift apart again."""
+
+        def verdict(build: Any) -> str:
+            try:
+                build()
+            except ValueError as exc:
+                return "refused" if "must be a positive integer" in str(exc) else "other-error"
+            return "accepted"
+
+        local = verdict(lambda: _local(actions_per_step=value))
+        remote = verdict(lambda: LerobotAsyncPolicy(**ASYNC_REQUIRED, actions_per_step=value))
+        assert local == remote, f"verdicts differ for actions_per_step={value!r}"
+
+    @pytest.mark.parametrize("value", [1, 8, 30, TRAINED_CHUNK])
+    def test_both_providers_accept_an_executable_count(self, value: int) -> None:
+        assert _local(actions_per_step=value).actions_per_step == value
+        assert LerobotAsyncPolicy(**ASYNC_REQUIRED, actions_per_step=value).actions_per_step == value
+
+
+class TestTheAsyncChunkLength:
+    """``actions_per_chunk`` is the default for ``actions_per_step``, so it is checked too."""
+
+    @pytest.mark.parametrize("value", REJECTED, ids=repr)
+    def test_an_unusable_chunk_length_cannot_supply_the_step_count(self, value: Any) -> None:
+        """Otherwise omitting ``actions_per_step`` reopens the same path."""
+        with pytest.raises(ValueError, match="actions_per_chunk must be a positive integer"):
+            LerobotAsyncPolicy(**ASYNC_REQUIRED, actions_per_chunk=value)
+
+    def test_omitting_the_step_count_still_adopts_the_chunk_length(self) -> None:
+        """``None`` is this provider's documented default, not a count."""
+        policy = LerobotAsyncPolicy(**ASYNC_REQUIRED, actions_per_chunk=32, actions_per_step=None)
+
+        assert policy.actions_per_step == 32
+        assert policy.execution_horizon == 32
+
+    def test_lerobot_local_has_no_such_default_and_refuses_none(self) -> None:
+        """The one asymmetry, and it follows from the two signatures.
+
+        ``lerobot_local`` declares ``actions_per_step: int = 1``, so ``None`` is
+        not a spelling of its default and there is no chunk length to fall back
+        to.
+        """
+        with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
+            _local(actions_per_step=None)
+
+
+class TestTheDuckTypedFloorIsUntouched:
+    """The read-path floor stays: it is the default for a non-provider chunk source."""
+
+    def test_resolve_chunk_length_still_floors_an_unvalidated_source(self) -> None:
+        """A duck-typed object never passed through a provider constructor.
+
+        ``resolve_chunk_length`` reads ``execution_horizon`` off anything that
+        offers one, so its floor is the only thing standing between an
+        unvalidated chunk source and a zero-length slice. Narrowing it is a
+        separate contract (see ``test_chunked_policy_contract``); this fix
+        checks the counts where a caller supplies them instead.
+        """
+
+        class _Unvalidated:
+            actions_per_step = 0
+
+        # Not a Policy by declared type - that is exactly the caller this
+        # floor exists for; it only needs an ``actions_per_step`` attribute.
+        assert resolve_chunk_length(_Unvalidated(), action_horizon=0) == 1  # type: ignore[arg-type]
+
+    def test_a_single_step_policy_is_unaffected(self) -> None:
+        assert resolve_chunk_length(MockPolicy(), action_horizon=8) == 8


### PR DESCRIPTION
## Problem

`actions_per_step` (how many actions of one inference chunk a consumer executes before re-querying) and `actions_per_chunk` are stored verbatim by both LeRobot providers and only reconciled on the read path, where `Policy.execution_horizon` resolves them through `max(1, int(...))`. That floor converts a count no consumer can execute into `1` and reports success.

Measured on `LerobotLocalPolicy`, against a checkpoint whose `config.n_action_steps` is 30 (the MolmoAct2 SO-100/101 trained chunk):

| `actions_per_step` | stored | `execution_horizon` | `is_chunk_emitting()` |
|---|---|---|---|
| _omitted_ (the default `1`) | `30` | `30` | `True` |
| `8` | `8` | `8` | `True` |
| `0` | `0` | **`1`** | **`False`** |
| `-5` | `-5` | **`1`** | **`False`** |
| `False` | `False` | **`1`** | **`False`** |
| `2.7` | `2.7` | **`2`** | `True` |
| `"4"` | `"4"` | `4` | `True` |
| `None` / `nan` / `inf` / `[4]` | as given | **raises** `TypeError` / `ValueError` / `OverflowError` | - |

Two things are wrong here beyond the floor itself.

**`0` is strictly worse than omitting the parameter.** `_auto_detect_actions_per_step` treats any value other than the default `1` as a horizon the caller pinned deliberately - _"caller pinned an explicit horizon - never override it"_ - and returns without adopting `config.n_action_steps`. So `actions_per_step=0` both skips that adoption and is then floored to `1`, which is exactly the operation the auto-detection exists to prevent; its own docstring calls the default-`1` regime _"a closed-loop convention that re-queries every step; for a chunk-trained model that is out of distribution and the shift compounds every chunk"_. Omitting the parameter executes the trained 30; asking for `0` re-queries every step. Nothing is logged on that path.

It also flips `is_chunk_emitting()` to `False`, which is the signal `run_policy(async_rtc=None)` uses to auto-enable latency masking - so a chunk-emitting model silently loses it.

**The non-numeric values fail on the read path.** `execution_horizon` is a property that `resolve_chunk_length` reads inside the rollout loop, so `None`/`nan`/`inf`/`[4]` surface as a bare `TypeError`/`ValueError`/`OverflowError` mid-rollout rather than as a rejected argument.

## Evidence

The cadence is measured in a real MuJoCo rollout (headless, 120 control steps at 50 Hz on a Panda), counting model inferences at each horizon the library resolves. Both lanes execute all 120 actions; only the re-query interval differs.

![inference cadence for a chunk count that cannot be executed](https://raw.githubusercontent.com/cagataycali/robots/artifacts/chunk-count-domain/chunk_count.png)

120 inferences versus 5 for the same 120 actions - a 24x over-query, off the distribution the checkpoint was trained on.

## Change

Both counts are validated where the caller supplies them, and before any checkpoint is fetched.

- **`chunk_count_error(value, param, provider)`** in `policies/base.py`, delegating to the existing `positive_count_error` domain (strict `int`, `bool` rejected - as an `int` subclass it would otherwise pass as a silent count of one). It is shared because the two providers sit in sibling packages and the domain must not diverge: the same chunk count cannot be refused by a local checkpoint and accepted by the server serving it.
- **`lerobot_local`**: checked in `__init__` before `_load_model()`, and in `preflight` - which the rollout entry points run before `create_policy` specifically to catch a misconfiguration _"BEFORE the expensive model-weight download"_, so the same mistake surfaces there as a structured error rather than a raise. The check runs before `preflight`'s embodiment early-return, otherwise every configuration that declares no embodiment stays unguarded on that path.
- **`lerobot_async`**: checked in `__init__` for `actions_per_step` **and** `actions_per_chunk`. The latter is not a sibling knob added for symmetry - it is the default for `actions_per_step`, so leaving it unchecked reopens the same path through the omitted parameter. `None` remains this provider's documented "use `actions_per_chunk`"; `lerobot_local` declares `actions_per_step: int = 1`, so `None` is not a spelling of its default and is refused. That asymmetry is pinned.

### Deliberately unchanged

The `max(1, ...)` floor in `resolve_chunk_length` / `Policy.execution_horizon`. It reads `execution_horizon` off anything that offers one, so for a duck-typed chunk source that never passed through a provider constructor it is the only thing standing between an unvalidated count and a zero-length slice. `test_chunked_policy_contract` pins it and still passes; a control test here records why it was left alone. This change checks the counts where a caller supplies them instead.

## Tests

`tests/policies/test_chunk_count_domain.py`, 53 tests - **37 fail before the change, 53 pass after**. The 16 that already pass are the controls (the default adopts the trained chunk, executable counts are honored verbatim, the duck-typed floor still applies); they are what keeps the guard from over-reaching.

They pin: the degraded regime is unreachable, measured against a control showing what the default does with the same checkpoint; every out-of-domain value is refused by both providers; cross-provider parity of the verdict, so the domains cannot drift apart again; the refusal precedes the checkpoint load (asserted by recording `_load_model` calls) and is reachable through `preflight_policy`, the function the rollout entry points call; and `actions_per_chunk` cannot supply an unusable step count.

No existing test changes. The only ones exercising degenerate counts use a duck-typed `MockChunkedPolicy` against the untouched floor.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (`Success: no issues found in 958 source files`).
- `MUJOCO_GL=egl python -m pytest tests` -> **13867 passed, 253 skipped** (457s), no failures.

Docs updated in the same change: both constructor docstrings state the domain and the reason, plus the parameter tables in `docs/policies/lerobot-local.md` and `docs/policies/lerobot-async.md`.