### PR TITLE
fix(sim): refuse a recording opened at a rate a running rollout does not capture at

### DIFF
--- a/changelog.d/1748-recording-start-rate-guard.md
+++ b/changelog.d/1748-recording-start-rate-guard.md
@@ -1,0 +1,37 @@
+### Fixed: opening a recording against a running rollout no longer mislabels the episode
+
+A dataset's declared `fps` must be the rate its frames were captured at: the
+recorder is driven once per control step with no decimation, and LeRobot derives
+every timestamp from `fps` positionally. Every rollout entry point already
+refused a `control_frequency` that disagreed with an open recording, but the
+inverse ordering was unguarded. `start_policy` submits its rollout and returns
+while it continues, so a recording could be opened against a rollout already in
+flight - and the two library defaults collide (`fps=30` against
+`control_frequency=50.0`), so no unusual argument was needed:
+
+```python
+sim.start_policy(robot_name="arm", policy_object=policy)   # 50.0 Hz
+sim.start_recording(repo_id="local/ds", task="t", fps=30)  # was: success
+...
+sim.stop_recording()   # was: success, "81 frames, 1 episode(s)"
+```
+
+That episode declared 0.0333 s between frames captured 0.0200 s apart: a 2.6667 s
+episode for a 1.62 s capture, with all three calls reporting `status="success"`
+and no log line. The distortion is the control period a policy trains on, and
+`replay_episode` derives its per-frame physics budget from the dataset rate, so
+the same episode also replays at the wrong speed.
+
+`start_recording` now refuses the disagreement before creating the dataset,
+naming the running rollout, both rates and both remedies - record at the
+rollout's rate, or stop the rollout and restart it at the recording's rate. The
+explanatory text is shared with the rollout-entry guard, so the two orderings
+cannot describe the same distortion differently. Rollouts running at *different*
+rates are refused outright even when `fps` matches one of them: their frames
+interleave into one episode whose single declared rate cannot describe both, so
+there is no `fps` to pass instead.
+
+Matching rates are unaffected, and a backend with no asynchronous rollout is
+unaffected: the new `SimEngine._active_rollout_rates()` hook reports an empty
+mapping unless a backend overrides it, so the guard is inert where no rollout can
+be in flight when `start_recording` is reached.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -54,6 +54,27 @@ runner.run("so100", policy, control_frequency=50.0, on_frame=hook)
 #    to PolicyRunner.run()
 ```
 
+The rule holds whichever call comes first. `start_policy` returns while its
+rollout keeps running, so a recording can be opened against a rollout already in
+flight - and on the defaults (`fps=30` against `control_frequency=50.0`) that
+recorded a 1.667x mislabelled episode with every call reporting success.
+`start_recording` refuses the same disagreement, before creating the dataset:
+
+```python
+sim.start_policy(robot_name="so100", policy_provider="mock")   # default 50.0 Hz
+sim.start_recording(repo_id="user/my_dataset", task="t", fps=30)
+# -> "start_recording: this recording would declare 30 fps but a rollout is
+#     already running ('so100' at 50 Hz). [...] Align the two rates: record at
+#     the rollout's rate (start_recording(fps=50)), or restart the rollout at the
+#     recording's rate (stop_policy(robot_name='so100'), then
+#     start_policy(..., control_frequency=30))"
+```
+
+Rollouts running at *different* rates are refused outright, even when `fps`
+matches one of them: their frames interleave into one episode whose single
+declared rate cannot describe both, so there is no `fps` to pass instead. Stop
+all but one, or restart them at a common `control_frequency`.
+
 ## Selecting which cameras to record
 
 By default every camera in the scene is recorded into the dataset - including

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1419,6 +1419,46 @@ class SimEngine(ABC):
 
         return dataset_rate_mismatch_error(method, self._active_recorder(), control_frequency)
 
+    def _validate_recording_start_rate(self, fps: Any, method: str) -> dict[str, Any] | None:
+        """Reject opening a recording at a rate an in-flight rollout does not capture at.
+
+        The inverse ordering of :meth:`_validate_recording_rate`, and the same
+        disagreement: that guard runs when a rollout starts against an open
+        recording, this one when a recording is opened against a rollout that is
+        already running. ``start_policy`` makes the second ordering reachable by
+        design - it submits the rollout and returns while it continues - and the
+        two library defaults collide (``fps=30`` against
+        ``control_frequency=50.0``), so the plain sequence produced a 1.667x
+        mislabelled episode with every call reporting success.
+
+        Instance method for the same reason as :meth:`_validate_recording_rate`:
+        the value it compares against lives on the engine. Backends with no
+        asynchronous rollout inherit :meth:`_active_rollout_rates` returning an
+        empty mapping and are unaffected, so one call site per backend's
+        ``start_recording`` covers every backend without each needing its own
+        copy of the rule.
+
+        Args:
+            fps: Caller-supplied dataset frame rate. Validate it with
+                :func:`~strands_robots.simulation.recording.dataset_recording_option_error`
+                first, so a value no dataset can be written at is reported as
+                the parameter error it is rather than as a rate disagreement.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            A structured ``{"status": "error", ...}`` dict, or ``None`` when no
+            rollout is in flight or every one of them already captures at
+            ``fps``. See
+            :func:`~strands_robots.simulation.recording.rollout_rate_mismatch_reason`
+            for the contract and the measured consequence.
+        """
+        rates = self._active_rollout_rates()
+        if not rates:
+            return None
+        from strands_robots.simulation.recording import rollout_rate_mismatch_error
+
+        return rollout_rate_mismatch_error(method, fps, rates)
+
     @staticmethod
     def _validate_video_config(video: Any, method: str) -> dict[str, Any] | None:
         """Reject a ``video`` recording config the rollout cannot honor.
@@ -2158,6 +2198,23 @@ class SimEngine(ABC):
         flushes episode boundaries on backends that actually record.
         """
         return False
+
+    def _active_rollout_rates(self) -> dict[str, float]:
+        """Capture rate in Hz of every rollout currently in flight, per robot.
+
+        Backends that can run a rollout asynchronously - returning to the caller
+        while it continues, as the MuJoCo ``start_policy`` does - override this
+        so :meth:`_validate_recording_start_rate` can compare a recording about
+        to be opened against what is already capturing frames. The base runs
+        every rollout to completion before returning, so no rollout can be in
+        flight when a caller reaches ``start_recording`` and the mapping is
+        empty.
+
+        Returns:
+            ``{robot_name: control_frequency}`` for live rollouts only; an empty
+            mapping when none is running.
+        """
+        return {}
 
     def _active_recorder(self) -> Any:
         """Return the active dataset recorder object, or ``None``.

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -198,6 +198,13 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         if error := dataset_recording_option_error("start_recording", fps):
             return error
 
+        # Reject a rate a rollout already in flight is not capturing at. The
+        # rollout entry points cover the record-then-rollout ordering; this is
+        # the same disagreement with the calls the other way round, refused
+        # before any dataset is created so a refusal leaves nothing on disk.
+        if error := self._validate_recording_start_rate(fps, "start_recording"):
+            return error
+
         _DatasetRecorder: Any = None
         _has_lerobot = False
         try:

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -85,8 +85,11 @@ class RecordingMixin(DatasetRecordingMixin):
                 rollout behind a ``status="success"`` return. It must EQUAL the
                 rollout's ``control_frequency``: the recorder captures one frame
                 per control step and never decimates, so a differing rate cannot
-                be honored, only mislabelled, and every rollout entry point
-                refuses the disagreement before writing a frame. When an existing
+                be honored, only mislabelled. The disagreement is refused
+                before any frame is written whichever call comes first: by every
+                rollout entry point when a rollout starts against an open
+                recording, and here when a recording is opened against a rollout
+                already in flight. When an existing
                 dataset is RESUMED (``overwrite=False``), it must equal that
                 dataset's on-disk rate: a resumed dataset keeps the rate it was
                 created at, so a differing request is refused with the on-disk
@@ -134,6 +137,13 @@ class RecordingMixin(DatasetRecordingMixin):
         # probe so the same caller mistake reports the same way regardless of
         # which optional extras this install has.
         if error := dataset_recording_option_error("start_recording", fps):
+            return error
+
+        # Reject a rate a rollout already in flight is not capturing at. The
+        # rollout entry points cover the record-then-rollout ordering; this is
+        # the same disagreement with the calls the other way round, refused
+        # before any dataset is created so a refusal leaves nothing on disk.
+        if error := self._validate_recording_start_rate(fps, "start_recording"):
             return error
 
         _DatasetRecorder: Any = None

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -299,6 +299,13 @@ class MuJoCoSimEngine(
         # pruned by ``_active_policy_futures()``/``_prune_done_futures()`` so
         # the dict never grows unboundedly and never reports stale "running".
         self._policy_threads: dict[str, Future] = {}
+        # Capture rate of each rollout in ``_policy_threads``, recorded where
+        # the Future is tracked so it is readable from another thread the
+        # instant ``start_policy`` returns (``start_recording`` compares against
+        # it). ``_policy_threads`` stays the sole authority on which rollouts
+        # are live: this table is swept to it by ``_prune_done_futures``, so it
+        # can never report a rate for a rollout that is not running.
+        self._policy_rates: dict[str, float] = {}
         self._shutdown_event = threading.Event()
         # ``self._lock`` (RLock) serializes ALL access to MuJoCo
         # ``model``/``data`` arrays - both reads and writes. MuJoCo arrays
@@ -3635,6 +3642,12 @@ class MuJoCoSimEngine(
         done = [k for k, f in self._policy_threads.items() if f.done()]
         for k in done:
             self._policy_threads.pop(k, None)
+        # The capture-rate table is keyed the same way and is only meaningful
+        # while the rollout's Future is tracked, so it follows _policy_threads
+        # here rather than at each of that dict's own removal sites
+        # (remove_robot deletes an entry, cleanup clears them all).
+        for stale in [k for k in self._policy_rates if k not in self._policy_threads]:
+            self._policy_rates.pop(stale, None)
 
     def _active_policy_robots(self) -> list[str]:
         """Names of robots with a live (not-done) policy Future.
@@ -3644,6 +3657,18 @@ class MuJoCoSimEngine(
         """
         self._prune_done_futures()
         return list(self._policy_threads.keys())
+
+    def _active_rollout_rates(self) -> dict[str, float]:
+        """Capture rate of every ``start_policy`` rollout still in flight.
+
+        Overrides :meth:`SimEngine._active_rollout_rates` so
+        ``start_recording`` can refuse a dataset rate a running rollout is not
+        capturing at. Prunes stale entries first (via
+        :meth:`_prune_done_futures`, which also sweeps the rate table against
+        ``_policy_threads``) so a finished rollout cannot block a recording.
+        """
+        self._prune_done_futures()
+        return dict(self._policy_rates)
 
     def _require_no_running_policy(self, action_name: str, robot_name: str | None = None) -> dict[str, Any] | None:
         """Return an error dict if a disallowed policy is running, else None.
@@ -3883,6 +3908,7 @@ class MuJoCoSimEngine(
             seed=seed,
         )
         self._policy_threads[robot_name] = future
+        self._policy_rates[robot_name] = float(control_frequency)
 
         return {
             "status": "success",

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -130,6 +130,13 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         if error := dataset_recording_option_error("start_recording", fps):
             return error
 
+        # Reject a rate a rollout already in flight is not capturing at. The
+        # rollout entry points cover the record-then-rollout ordering; this is
+        # the same disagreement with the calls the other way round, refused
+        # before any dataset is created so a refusal leaves nothing on disk.
+        if error := self._validate_recording_start_rate(fps, "start_recording"):
+            return error
+
         _DatasetRecorder: Any = None
         _has_lerobot = False
         try:

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -28,6 +28,7 @@ enforceable protocol.
 
 import logging
 import shutil
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -104,6 +105,32 @@ def recorder_dataset_fps(recorder: Any) -> int | None:
     return None
 
 
+def rate_mismatch_explanation(fps: int, rate: float) -> str:
+    """State why a dataset rate other than the capture rate can only mislabel.
+
+    Shared by both orderings of the same disagreement - a rollout started
+    against an open recording (:func:`dataset_rate_mismatch_reason`) and a
+    recording opened against a running rollout
+    (:func:`rollout_rate_mismatch_reason`) - so the two cannot explain the same
+    physics differently.
+
+    Args:
+        fps: Rate the dataset declares (or would declare) in its metadata.
+        rate: Rate frames are actually captured at, in Hz.
+
+    Returns:
+        One sentence naming both intervals, the resulting distortion factor and
+        what downstream consumes it. Callers supply their own prefix and remedy.
+    """
+    return (
+        f"The dataset recorder writes one frame per control step with no decimation, so "
+        f"frames captured {1.0 / rate:.4f}s apart would be timestamped {1.0 / fps:.4f}s "
+        f"apart - a {rate / fps:.3f}x distortion of the episode duration, which a policy "
+        f"trains on as its control period and which replay_episode reproduces at the wrong "
+        f"speed."
+    )
+
+
 def dataset_rate_mismatch_reason(method: str, recorder: Any, control_frequency: float) -> str | None:
     """Explain why the active dataset cannot describe a rollout's capture rate.
 
@@ -166,11 +193,8 @@ def dataset_rate_mismatch_reason(method: str, recorder: Any, control_frequency: 
         )
     text = (
         f"{method}: the active recording declares {fps} fps but this rollout captures at "
-        f"control_frequency={rate:g} Hz. The dataset recorder writes one frame per control "
-        f"step with no decimation, so frames captured {1.0 / rate:.4f}s apart would be "
-        f"timestamped {1.0 / fps:.4f}s apart - a {rate / fps:.3f}x distortion of the "
-        f"episode duration, which a policy trains on as its control period and which "
-        f"replay_episode reproduces at the wrong speed. Align the two rates: {remedy}."
+        f"control_frequency={rate:g} Hz. {rate_mismatch_explanation(fps, rate)} "
+        f"Align the two rates: {remedy}."
     )
     return text
 
@@ -190,6 +214,107 @@ def dataset_rate_mismatch_error(method: str, recorder: Any, control_frequency: f
         is refused rather than warned.
     """
     reason = dataset_rate_mismatch_reason(method, recorder, control_frequency)
+    if reason is None:
+        return None
+    return {"status": "error", "content": [{"text": reason}]}
+
+
+def rollout_rate_mismatch_reason(method: str, fps: Any, rates: Mapping[str, float]) -> str | None:
+    """Explain why an opening recording cannot describe an in-flight rollout.
+
+    The inverse ordering of :func:`dataset_rate_mismatch_reason`. That guard
+    covers a rollout started against an open recording; this one covers a
+    recording opened against a rollout that is already running - which
+    ``start_policy`` makes reachable by design, since it submits the rollout to
+    an executor and returns while it continues.
+
+    Both orderings produce the same distortion, because the frames and the
+    timestamps come from the same two rates whichever call happened first: the
+    recorder is driven once per control step with no decimation, and LeRobot
+    derives each timestamp positionally from the declared ``fps``. Measured on
+    the library defaults - ``start_policy(control_frequency=50.0)`` followed by
+    ``start_recording(fps=30)`` - the episode saved 81 frames captured 0.0200 s
+    apart and declared them 0.0333 s apart: a 2.6667 s episode for a 1.62 s
+    capture, with ``start_policy``, ``start_recording`` and ``stop_recording``
+    all returning ``status="success"``.
+
+    Concurrent rollouts at different rates are refused outright, even when
+    ``fps`` matches one of them: the frames interleave into one episode whose
+    single declared rate can only describe one capture rate, so there is no
+    value the caller could pass instead.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        fps: Caller-supplied dataset frame rate. Validate it with
+            :func:`dataset_recording_option_error` first; a value outside that
+            domain returns ``None`` here so it is reported as the parameter
+            error it is rather than as a rate disagreement.
+        rates: Capture rate in Hz per robot with a rollout in flight, as
+            reported by
+            :meth:`~strands_robots.simulation.base.SimEngine._active_rollout_rates`.
+
+    Returns:
+        The reason text naming the rollout(s), both rates and the remedies, or
+        ``None`` when nothing is running or every running rollout already
+        captures at ``fps``.
+    """
+    if not rates:
+        return None
+    if isinstance(fps, bool) or not isinstance(fps, int | float):
+        return None
+    declared = float(fps)
+    if declared <= 0 or not declared.is_integer():
+        return None
+    fps_int = int(declared)
+
+    listed = ", ".join(f"'{name}' at {rate:g} Hz" for name, rate in sorted(rates.items()))
+    distinct = {round(rate, 9) for rate in rates.values()}
+    if len(distinct) > 1:
+        return (
+            f"{method}: this recording would declare {fps_int} fps but {len(rates)} rollouts are "
+            f"already running at {len(distinct)} different capture rates ({listed}). The dataset "
+            f"recorder writes one frame per control step with no decimation and LeRobot timestamps "
+            f"every frame from the single declared rate, so no fps can describe them all - their "
+            f"frames interleave into one episode on a timebase that mislabels at least one of "
+            f"them. Stop all but one rollout (stop_policy(robot_name=...)), or restart them at a "
+            f"common control_frequency, then record at that rate."
+        )
+
+    rate = float(next(iter(rates.values())))
+    if abs(rate - fps_int) < 1e-9:
+        return None
+
+    remedy = ""
+    if rate.is_integer():
+        # ``fps`` must be a positive whole number, so only an integral capture
+        # rate is one this method could be re-invoked with.
+        remedy = f"record at the rollout's rate ({method}(fps={int(rate)})), or "
+    stop_targets = ", ".join(f"stop_policy(robot_name='{name}')" for name in sorted(rates))
+    remedy += (
+        f"restart the rollout at the recording's rate ({stop_targets}, then "
+        f"start_policy(..., control_frequency={fps_int}))"
+    )
+    return (
+        f"{method}: this recording would declare {fps_int} fps but a rollout is already running "
+        f"({listed}). {rate_mismatch_explanation(fps_int, rate)} Align the two rates: {remedy}."
+    )
+
+
+def rollout_rate_mismatch_error(method: str, fps: Any, rates: Mapping[str, float]) -> dict[str, Any] | None:
+    """Envelope form of :func:`rollout_rate_mismatch_reason` for tool callers.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        fps: Caller-supplied dataset frame rate.
+        rates: Capture rate in Hz per robot with a rollout in flight.
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict carrying the reason text,
+        or ``None`` when there is nothing to refuse. See
+        :func:`rollout_rate_mismatch_reason` for the contract and why a mismatch
+        is refused rather than warned.
+    """
+    reason = rollout_rate_mismatch_reason(method, fps, rates)
     if reason is None:
         return None
     return {"status": "error", "content": [{"text": reason}]}
@@ -228,6 +353,16 @@ class DatasetRecordingMixin:
         _world: "SimWorld | None"
         default_width: int
         default_height: int
+
+        def _validate_recording_start_rate(self, fps: Any, method: str) -> dict[str, Any] | None:
+            """Type-only stub for the engine-provided rate guard.
+
+            Declared once here rather than in each backend mixin: all three
+            ``start_recording`` implementations call it and all three inherit
+            this class, so one declaration keeps the contract in a single
+            place. Implemented by
+            :meth:`~strands_robots.simulation.base.SimEngine._validate_recording_start_rate`.
+            """
 
     def _recording_state(self) -> dict[str, Any] | None:
         """Mutable recording-state mapping, or ``None`` when no world exists.

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -23,15 +23,26 @@ from the dataset rate on the invariant that "the recorded control frequency IS
 the dataset fps" - so the same episode also replays at the wrong speed
 (round-tripped to 0.0000 rad at matching rates, 0.0317 rad at the defaults).
 
+The disagreement has two orderings and both are refused. A rollout started
+against an open recording is refused at every rollout entry point; a recording
+opened against a rollout already in flight is refused by ``start_recording``.
+``start_policy`` makes the second ordering reachable by design - it submits the
+rollout to an executor and returns while it continues - and on the same colliding
+defaults it saved 81 frames captured 0.0200s apart and declared them 0.0333s
+apart: a 2.6667s episode for a 1.62s capture, with ``start_policy``,
+``start_recording`` and ``stop_recording`` all reporting success.
+
 Refused rather than warned, matching the sibling rate guard in the same module:
 ``_verify_resume_schema`` already refuses an ``fps`` that disagrees with the
-dataset on disk. The refusal lands before any frame is written, so a caller
-loses nothing.
+dataset on disk. The refusal lands before any frame is written - and, in the
+inverse ordering, before any dataset is created - so a caller loses nothing.
 """
 
 from __future__ import annotations
 
 import ast
+import contextlib
+import time
 from pathlib import Path
 
 import pytest
@@ -45,7 +56,10 @@ from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
 from strands_robots.simulation.recording import (  # noqa: E402
     dataset_rate_mismatch_error,
     dataset_rate_mismatch_reason,
+    rate_mismatch_explanation,
     recorder_dataset_fps,
+    rollout_rate_mismatch_error,
+    rollout_rate_mismatch_reason,
 )
 
 _ARM = """<mujoco><worldbody><body name="l1">
@@ -358,6 +372,279 @@ class _MetaOnlyRecorder:
 
     def __init__(self, fps) -> None:  # noqa: ANN001
         self.dataset = _Dataset(None, meta=_Meta(fps))
+
+
+@pytest.fixture
+def two_arm_sim(tmp_path):
+    """Two independent arms, so two ``start_policy`` rollouts can overlap."""
+    xml = tmp_path / "arm.xml"
+    xml.write_text(_ARM)
+    engine = MuJoCoSimEngine(tool_name="rate_guard_multi", mesh=False)
+    engine.create_world()
+    engine.add_robot(name="armA", urdf_path=str(xml))
+    engine.add_robot(name="armB", urdf_path=str(xml), position=[0.6, 0.0, 0.0])
+    yield engine
+    engine.cleanup()
+
+
+@contextlib.contextmanager
+def _running_rollout(sim, robot: str, control_frequency: float):
+    """A real in-flight ``start_policy`` rollout on ``robot``, stopped on exit.
+
+    The horizon is long enough that the rollout cannot finish mid-test and be
+    pruned, which would otherwise look like the guard failing to fire. Waits for
+    the worker to have installed its per-frame hook before yielding: until then
+    the hook has not set ``policy_running``, so a ``stop_policy`` on exit would be
+    overwritten and the rollout would outlive the test.
+    """
+    keys = sim.robot_action_keys(robot)
+    result = sim.start_policy(
+        robot_name=robot,
+        policy_object=_Hold(keys),
+        duration=60.0,
+        control_frequency=control_frequency,
+    )
+    assert result["status"] == "success", result
+    handle = sim._world.robots[robot]
+    deadline = time.monotonic() + 20.0
+    while not handle.policy_running:
+        if time.monotonic() > deadline:
+            pytest.fail(f"the rollout on {robot!r} never started")
+        time.sleep(0.005)
+    try:
+        yield
+    finally:
+        sim.stop_policy(robot_name=robot)
+        future = sim._policy_threads.get(robot)
+        if future is not None:
+            # Joined without suppressing: a rollout that outlives its stop would
+            # otherwise leak into the next case as a spurious "already running".
+            future.result(timeout=30.0)
+
+
+class TestARecordingOpenedAgainstARunningRolloutIsRefused:
+    """The inverse ordering: ``start_policy`` first, then ``start_recording``."""
+
+    def test_the_library_defaults_are_refused(self, sim, tmp_path):
+        """``control_frequency=50.0`` running, ``fps=30`` requested - the default pair."""
+        with _running_rollout(sim, "arm", 50.0):
+            result = sim.start_recording(repo_id="local/inverse", task="hold", fps=30, root=str(tmp_path / "inv"))
+        assert result["status"] == "error"
+
+    def test_the_refusal_names_the_rollout_both_rates_and_the_distortion(self, sim, tmp_path):
+        with _running_rollout(sim, "arm", 50.0):
+            text = sim.start_recording(repo_id="local/inverse", task="hold", fps=30, root=str(tmp_path / "inv"))[
+                "content"
+            ][0]["text"]
+        assert "'arm' at 50 Hz" in text
+        assert "30 fps" in text
+        assert "1.667x" in text
+
+    def test_the_refusal_names_both_remedies(self, sim, tmp_path):
+        with _running_rollout(sim, "arm", 50.0):
+            text = sim.start_recording(repo_id="local/inverse", task="hold", fps=30, root=str(tmp_path / "inv"))[
+                "content"
+            ][0]["text"]
+        assert "start_recording(fps=50)" in text
+        assert "stop_policy(robot_name='arm')" in text
+        assert "control_frequency=30" in text
+
+    def test_no_dataset_is_created(self, sim, tmp_path):
+        """The refusal precedes dataset creation, so nothing is left on disk."""
+        root = tmp_path / "inv"
+        with _running_rollout(sim, "arm", 50.0):
+            sim.start_recording(repo_id="local/inverse", task="hold", fps=30, root=str(root))
+        assert not root.exists() or not any(root.iterdir())
+
+    def test_the_recording_session_is_not_left_open(self, sim, tmp_path):
+        """A refused open must not flip the engine into a recording state."""
+        with _running_rollout(sim, "arm", 50.0):
+            sim.start_recording(repo_id="local/inverse", task="hold", fps=30, root=str(tmp_path / "inv"))
+            assert sim._is_recording() is False
+            assert sim._active_recorder() is None
+
+    def test_a_matching_rate_is_accepted_while_the_rollout_runs(self, sim, tmp_path):
+        """The agreeing case is untouched - the guard refuses disagreement only."""
+        with _running_rollout(sim, "arm", 50.0):
+            result = sim.start_recording(repo_id="local/agree", task="hold", fps=50, root=str(tmp_path / "agree"))
+            assert result["status"] == "success", result
+            sim.stop_recording()
+
+    def test_an_unusable_fps_is_still_reported_as_the_parameter_error(self, sim, tmp_path):
+        """Name-and-value guards keep priority: ``fps`` itself is the complaint."""
+        with _running_rollout(sim, "arm", 50.0):
+            text = sim.start_recording(repo_id="local/bad", task="hold", fps=2.7, root=str(tmp_path / "bad"))[
+                "content"
+            ][0]["text"]
+        assert "fps" in text
+        assert "already running" not in text
+
+
+class TestTheAdvisedRemedyIsUsableInTheInverseOrdering:
+    """Every option the refusal names must actually work when followed."""
+
+    def test_recording_at_the_rollouts_rate_records_cleanly(self, sim, tmp_path):
+        """The message says: start_recording(fps=50). Do exactly that."""
+        with _running_rollout(sim, "arm", 50.0):
+            refused = sim.start_recording(repo_id="local/r1", task="hold", fps=30, root=str(tmp_path / "r1"))
+            assert refused["status"] == "error"
+            assert "start_recording(fps=50)" in refused["content"][0]["text"]
+            accepted = sim.start_recording(repo_id="local/r1", task="hold", fps=50, root=str(tmp_path / "r1"))
+            assert accepted["status"] == "success", accepted
+            sim.stop_recording()
+
+    def test_restarting_the_rollout_at_the_recordings_rate_records_cleanly(self, sim, tmp_path):
+        """The message says: stop_policy, then start_policy(control_frequency=30)."""
+        with _running_rollout(sim, "arm", 50.0):
+            refused = sim.start_recording(repo_id="local/r2", task="hold", fps=30, root=str(tmp_path / "r2"))
+            assert refused["status"] == "error"
+        # The context already ran stop_policy(robot_name='arm'), the first half of
+        # the remedy; now restart at the recording's rate as advised.
+        with _running_rollout(sim, "arm", 30.0):
+            accepted = sim.start_recording(repo_id="local/r2", task="hold", fps=30, root=str(tmp_path / "r2"))
+            assert accepted["status"] == "success", accepted
+            sim.stop_recording()
+
+
+class TestConcurrentRolloutsAtDifferentRatesAreRefusedOutright:
+    """Interleaved frames on one declared rate cannot describe two capture rates."""
+
+    def test_two_rates_are_refused_even_when_fps_matches_one_of_them(self, two_arm_sim, tmp_path):
+        with _running_rollout(two_arm_sim, "armA", 50.0), _running_rollout(two_arm_sim, "armB", 25.0):
+            result = two_arm_sim.start_recording(
+                repo_id="local/multi", task="hold", fps=50, root=str(tmp_path / "multi")
+            )
+        assert result["status"] == "error"
+
+    def test_the_refusal_names_every_rollout_and_its_rate(self, two_arm_sim, tmp_path):
+        with _running_rollout(two_arm_sim, "armA", 50.0), _running_rollout(two_arm_sim, "armB", 25.0):
+            text = two_arm_sim.start_recording(
+                repo_id="local/multi", task="hold", fps=30, root=str(tmp_path / "multi")
+            )["content"][0]["text"]
+        assert "'armA' at 50 Hz" in text
+        assert "'armB' at 25 Hz" in text
+        assert "2 different capture rates" in text
+
+    def test_two_rollouts_at_one_shared_rate_may_record_at_that_rate(self, two_arm_sim, tmp_path):
+        with _running_rollout(two_arm_sim, "armA", 40.0), _running_rollout(two_arm_sim, "armB", 40.0):
+            result = two_arm_sim.start_recording(
+                repo_id="local/shared", task="hold", fps=40, root=str(tmp_path / "shared")
+            )
+            assert result["status"] == "success", result
+            two_arm_sim.stop_recording()
+
+
+class TestOnlyLiveRolloutsCanBlockARecording:
+    """A finished rollout must not keep refusing a rate it no longer captures."""
+
+    def test_no_rollout_running_never_refuses(self, sim, tmp_path):
+        result = sim.start_recording(repo_id="local/idle", task="hold", fps=30, root=str(tmp_path / "idle"))
+        assert result["status"] == "success"
+        sim.stop_recording()
+
+    def test_a_stopped_rollout_stops_blocking(self, sim, tmp_path):
+        with _running_rollout(sim, "arm", 50.0):
+            assert sim._active_rollout_rates() == {"arm": 50.0}
+        # The context stopped and joined the rollout; its rate must be gone.
+        assert sim._active_rollout_rates() == {}
+        result = sim.start_recording(repo_id="local/after", task="hold", fps=30, root=str(tmp_path / "after"))
+        assert result["status"] == "success", result
+        sim.stop_recording()
+
+    def test_the_rate_table_is_swept_when_a_robot_is_removed(self, sim):
+        """``remove_robot`` drops the Future directly; the rate must follow it."""
+        with _running_rollout(sim, "arm", 50.0):
+            assert sim._active_rollout_rates() == {"arm": 50.0}
+            assert sim.remove_robot("arm")["status"] == "success"
+            assert sim._active_rollout_rates() == {}
+            assert sim._policy_rates == {}
+
+
+class TestTheRolloutRateGuardHelperIsRobust:
+    def test_no_running_rollout_returns_none(self):
+        assert rollout_rate_mismatch_reason("start_recording", 30, {}) is None
+
+    def test_an_agreeing_rate_returns_none(self):
+        assert rollout_rate_mismatch_reason("start_recording", 50, {"arm": 50.0}) is None
+
+    def test_float_noise_below_the_tolerance_is_not_a_mismatch(self):
+        assert rollout_rate_mismatch_reason("start_recording", 50, {"arm": 50.0 + 1e-12}) is None
+
+    @pytest.mark.parametrize("fps", [2.7, True, "30", None, 0, -5, float("nan"), float("inf")])
+    def test_an_fps_outside_the_writable_domain_is_left_to_its_own_guard(self, fps):
+        """Reporting it here would name a rate disagreement instead of the parameter."""
+        assert rollout_rate_mismatch_reason("start_recording", fps, {"arm": 50.0}) is None
+
+    def test_an_integral_float_fps_is_read_as_that_whole_rate(self):
+        assert rollout_rate_mismatch_reason("start_recording", 50.0, {"arm": 50.0}) is None
+        assert rollout_rate_mismatch_reason("start_recording", 30.0, {"arm": 50.0}) is not None
+
+    def test_a_fractional_capture_rate_offers_only_the_remedy_it_can(self):
+        """``fps`` must be whole, so 33.3 Hz has no rate to advise recording at."""
+        reason = rollout_rate_mismatch_reason("start_recording", 30, {"arm": 33.3})
+        assert reason is not None
+        assert "record at the rollout's rate" not in reason
+        assert "stop_policy(robot_name='arm')" in reason
+
+    def test_the_message_is_prefixed_with_the_calling_method(self):
+        reason = rollout_rate_mismatch_reason("start_recording", 30, {"arm": 50.0})
+        assert reason is not None
+        assert reason.startswith("start_recording: ")
+
+    def test_the_envelope_carries_the_reason_verbatim(self):
+        envelope = rollout_rate_mismatch_error("start_recording", 30, {"arm": 50.0})
+        reason = rollout_rate_mismatch_reason("start_recording", 30, {"arm": 50.0})
+        assert envelope is not None
+        assert envelope["content"][0]["text"] == reason
+        assert envelope["status"] == "error"
+
+    def test_a_backend_with_no_async_rollout_reports_no_rates(self):
+        """The base hook is what makes one call site per backend safe."""
+        from strands_robots.simulation.base import SimEngine
+
+        assert SimEngine._active_rollout_rates(object()) == {}  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("fps", "rate"),
+    [(30, 50.0), (50, 30.0), (30, 30.0), (50, 50.0), (25, 25.0), (30, 33.3), (60, 50.0)],
+)
+def test_both_orderings_reach_the_same_verdict_and_explanation(fps, rate):
+    """One disagreement, so the two orderings may not disagree about it.
+
+    Whichever call came first, the frames and the timestamps come from the same
+    two rates - so a caller who reverses the order of two calls must not be told
+    the pair is acceptable in one direction and not the other, nor be given two
+    different accounts of the distortion.
+    """
+    forward = dataset_rate_mismatch_reason("run_policy", _FakeRecorder(fps), rate)
+    inverse = rollout_rate_mismatch_reason("start_recording", fps, {"arm": rate})
+    assert (forward is None) == (inverse is None), f"the two orderings disagree for fps={fps!r} capture rate={rate!r}"
+    if forward is not None and inverse is not None:
+        shared = rate_mismatch_explanation(fps, rate)
+        assert shared in forward
+        assert shared in inverse
+
+
+_START_RECORDING_BACKENDS = (
+    "strands_robots/simulation/mujoco/recording.py",
+    "strands_robots/simulation/isaac/recording.py",
+    "strands_robots/simulation/newton/recording.py",
+)
+
+
+@pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+def test_every_backend_start_recording_checks_the_running_rollout_rate(module):
+    """``start_recording`` is per backend, so each copy must reach the shared guard.
+
+    Pinned structurally rather than behaviourally because the Isaac and Newton
+    backends need their simulators installed to drive, and a backend that grows
+    an asynchronous rollout later must not inherit a ``start_recording`` that
+    silently skipped the check.
+    """
+    assert "_validate_recording_start_rate" in _self_calls(module, "start_recording"), (
+        f"{module}::start_recording does not check the running rollout rate"
+    )
 
 
 _ENTRY_POINTS = {


### PR DESCRIPTION
Closes #1748.

## Problem

A dataset's declared `fps` must be the rate its frames were captured at. The recorder is driven once per control step with **no decimation**, and LeRobot derives every timestamp from `fps` positionally (`timestamp = frame_index / fps`), so a differing rate cannot be honored - only mislabelled. Every rollout entry point already refuses a `control_frequency` that disagrees with an open recording.

The inverse ordering was unguarded. `start_policy` submits its rollout to an executor and returns while it continues, so a recording can be opened against a rollout already in flight - and the two library defaults collide (`fps=30` against `control_frequency=50.0`), so reaching it needs no unusual argument:

```python
sim.start_policy(robot_name="arm", policy_object=policy)   # 50.0 Hz
sim.start_recording(repo_id="local/ds", task="t", fps=30)  # was: success
...
sim.stop_recording()   # was: success, "78 frames, 1 episode(s)"
```

Measured on a position-servo arm in MuJoCo: the saved episode declared **0.0333 s** between frames captured **0.0200 s** apart - a 2.5667 s episode for a 1.54 s capture, **1.667x** - with all three calls returning `status="success"` and no log line. That interval is the control period a policy trains on, and `replay_episode` derives its per-frame physics budget from the dataset rate on the stated invariant that "the recorded control frequency IS the dataset fps", so the same episode also replays at the wrong speed.

`start_recording`'s own `fps` docstring claimed "every rollout entry point refuses the disagreement before writing a frame" - true as written, but it reads as covering both orderings, and it did not.

## Change

`start_recording` refuses the same disagreement, before the dataset is created, so a refusal leaves nothing on disk:

```
start_recording: this recording would declare 30 fps but a rollout is already
running ('arm' at 50 Hz). The dataset recorder writes one frame per control step
with no decimation, so frames captured 0.0200s apart would be timestamped
0.0333s apart - a 1.667x distortion of the episode duration, which a policy
trains on as its control period and which replay_episode reproduces at the wrong
speed. Align the two rates: record at the rollout's rate (start_recording(fps=50)),
or restart the rollout at the recording's rate (stop_policy(robot_name='arm'),
then start_policy(..., control_frequency=30)).
```

- The explanatory sentence is extracted into `rate_mismatch_explanation` and shared with the rollout-entry guard, so the two orderings cannot describe the same distortion differently. A parity test asserts both reach the same verdict and carry the same explanation for every rate pair.
- **Concurrent rollouts at different rates are refused outright**, even when `fps` matches one of them: their frames interleave into one episode whose single declared rate can only describe one capture rate, so there is no value the caller could pass instead. This is reachable today - nothing serialises a second `start_policy` against the first at a different rate.
- Only the *effective* complaint is reported: an `fps` no dataset can be written at (`2.7`, `"30"`, `True`) is still reported by `dataset_recording_option_error` as the parameter error it is, not as a rate disagreement.
- Matching rates are untouched, and a `start_recording` with nothing running behaves exactly as before.

### Where the running rate lives

`start_policy` records the rate where it tracks the `Future`, so it is readable from another thread the instant that call returns. `_policy_threads` stays the sole authority on which rollouts are live: `_prune_done_futures` sweeps the rate table to it, which is one rule in one place rather than a drop at each of that dict's own removal sites (`remove_robot` deletes an entry, `cleanup` clears them all). A finished or removed rollout therefore cannot keep refusing a rate it no longer captures - pinned in both directions.

The guard itself is shared on `SimEngine`, reading a new `_active_rollout_rates()` hook that returns an empty mapping on the base. Backends with no asynchronous rollout are inert, so one call site per backend `start_recording` covers all three without each carrying its own copy of the rule. An AST parity test pins every backend's `start_recording` against the guard - it fails 3/3 pre-fix and runs with Isaac Sim and Newton uninstalled, which is the same structural pin #1746 and #1747 use.

## Verification in sim (headless, MUJOCO_GL=egl)

Same script against both trees: an image-consuming policy sweeping the arm at `control_frequency=50.0`, a recording opened mid-rollout at `fps=30`, then `stop_recording`. Top row is three frames **decoded back out of the dataset's own MP4** (round-trip); bottom row is the recorded `timestamp` column against true capture time.

![recording rate declared vs captured, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recording-start-rate/recording_start_rate.png)

| | before | after |
|---|---|---|
| `start_recording(fps=30)` | success | **error**, dataset not created |
| advised remedy `start_recording(fps=50)` | - | success |
| `stop_recording()` | success, 78 frames | success, 80 frames |
| declared per-frame interval | 0.0333 s | 0.0200 s |
| captured per-frame interval | 0.0200 s | 0.0200 s |
| declared span / true span | 2.5667 s / 1.54 s = **1.667x** | 1.5800 s / 1.58 s = **1.000x** |
| frames decoded back from the MP4 | 78 (197.0 KB) | 80 (172.9 KB) |

Every remedy the message names is followed and re-measured in the test suite, so a recommendation that would not work cannot be printed.

## Tests

31 new cases in `tests/simulation/test_recording_rate_matches_control_frequency.py` (the existing home for this contract, whose module docstring now covers both orderings): the defaults refused, the message content, no dataset created, the session not left half-open, the matching-rate control, `fps`-parameter priority, concurrent rollouts at two rates, two rollouts at one shared rate accepted, both remedies followed end to end, only-live-rollouts-block (stop and `remove_robot`), the guard-helper branches, the cross-ordering parity test, and the AST parity test over all three backends.

Pre-fix on `e8e143e8`, with the source reverted and the new symbols stubbed out of the module so the behavioural cases still run: **12 failed / 42 passed**. The 42 passing are the pre-existing forward-ordering cases plus the controls that stop this guard over-reaching. Post-fix: 79 passed in 7.9 s.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (958 source files).
- Full suite: `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **13878 passed, 253 skipped** in 472 s.
- `python scripts/assemble_changelog.py --check` OK; `docs/recording.md` documents the ordering and the multi-rate refusal.

## Out of scope

A `start_policy` landing *simultaneously* with this check - between it and the recorder being attached - is not closed here. Both sides would need a shared claim taken across check-and-commit, and `_policy_threads` is a dict rather than a claim; holding the engine lock across dataset creation (seconds) to close it would stall the physics loop. That is a concurrent-admission concern of the same shape as #1725, separate from this deterministic ordering, which is the one the documented sequence and the colliding defaults produce. A blocking `run_policy` driven on a caller's own thread is in the same class.