### PR TITLE
fix(policies): refuse an image_keys shape that cannot be honored

### DIFF
--- a/changelog.d/1752-image-keys-shape.md
+++ b/changelog.d/1752-image-keys-shape.md
@@ -1,0 +1,29 @@
+### Fixed: `image_keys` refuses a shape it cannot honor instead of reading a bare string per character
+
+`image_keys` names an ordered list of key names on two policy providers - the
+LeRobot local provider declares the model's VISUAL feature keys with it, and the
+VERA provider names the observation cameras to width-concat with it. Neither
+validated the shape, and both reduced the value with `list(...)`.
+
+`str` is iterable, so `image_keys="wrist"` was read as `['w', 'r', 'i', 's', 't']`
+- five names the caller never wrote, one per character. Nothing downstream could
+tell that apart from a deliberate five-entry list, so it was accepted and the
+consequence surfaced far from the call: on the LeRobot path with no embodiment
+configured, a model built declaring one bogus feature per character; on the VERA
+path, a `KeyError: 'w'` raised mid-rollout, after the policy server had been
+launched and the model loaded.
+
+Two neighbouring shapes failed the same way. A non-`str` entry became a key. A
+repeated entry could not be honored as written: the LeRobot side builds a feature
+dict, where a duplicate collapses and declares fewer features than asked for, and
+the VERA side concatenates one panel per entry, where a duplicate doubles the
+width of the frame the model sees.
+
+All four surfaces that receive the value - `LerobotLocalPolicy.__init__`,
+`LerobotLocalPolicy.preflight`, `derive_image_keys` and `VeraPolicy.__init__` -
+now share one shape domain (`strands_robots.utils.name_list_error`) and each
+refuses before the work it guards: the weight download, the embodiment
+early-return that previously skipped the check entirely, and the VERA server
+handshake. The refusal names the per-character reading and the wrapped list to
+pass instead. A falsy `image_keys` keeps its existing meaning of "not supplied",
+so the list is still derived.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -473,6 +473,28 @@ you declared with `obs_rename_override` so each declared feature is a rename
 target. `image_keys` is a MolmoAct2 knob and is inert for other policy types, so
 this check applies to the MolmoAct2 load path only.
 
+#### `image_keys` is a list of names, not a name
+
+A single key still has to be a one-element list. `str` is iterable, so a bare
+string is read one name per character - `image_keys="wrist"` would declare five
+features named `w`, `r`, `i`, `s` and `t` - and nothing downstream can tell that
+apart from a deliberate five-entry list. Passing one is refused, with the reading
+it would have produced and the list to pass instead:
+
+```
+LerobotLocalPolicy: image_keys must be a list of names, not a single string, got
+'wrist'. A string is iterable per character, so this would be read as
+['w', 'r', 'i', 's', 't'] (5 name(s)). Wrap it in a list: ['wrist'].
+```
+
+A mapping is refused for the mirror-image reason (it iterates over its keys, so
+its values would be dropped), as is a non-string entry, a blank entry, and a
+repeated one - a duplicate collapses in the feature dict, declaring fewer
+features than asked for. `None` and `[]` keep their meaning of "not supplied",
+so the list is derived from the embodiment as usual. The same rule applies to the
+VERA provider's `image_keys`, which names observation cameras rather than model
+features, and the refusal happens before the weight download or server handshake.
+
 ### Single camera with no embodiment
 
 You do not need an embodiment at all for a single-camera checkpoint. Declare the

--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -43,7 +43,7 @@ import json
 import logging
 from typing import Any
 
-from ...utils import require_optionals
+from ...utils import name_list_error, require_optionals
 
 logger = logging.getLogger(__name__)
 
@@ -239,8 +239,20 @@ def derive_image_keys(image_keys: list[str] | None, embodiment_spec: Any | None)
 
     Returns:
         Non-empty list of ``observation.images.*`` feature keys.
+
+    Raises:
+        ValueError: When ``image_keys`` is supplied but is not a list of
+            distinct non-blank names - most often a single key passed as a bare
+            string, which is iterable per character.
     """
     if image_keys:
+        # The single funnel for the model feature list: build_policy and the
+        # pre-flight converse check (_undeclared_image_feature_error) both route
+        # here, so validating the shape once covers the load path and the check
+        # that reports on it. Without this a bare string reaches list() and is
+        # read one feature per character.
+        if err := name_list_error(image_keys, "image_keys", "molmoact2"):
+            raise ValueError(err)
         return list(image_keys)
 
     targets = _embodiment_image_targets(embodiment_spec)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -20,6 +20,7 @@ from typing import Any
 import numpy as np
 import torch
 
+from ...utils import name_list_error
 from .. import Policy, align_action_values, chunk_count_error
 from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys, state_key_remedy
 from .processor import ProcessorBridge
@@ -207,7 +208,10 @@ def _undeclared_image_feature_error(
     ):
         return None
 
-    declared = _molmoact2.derive_image_keys(list(image_keys), policy_config.get("embodiment"))
+    # Forwarded verbatim rather than through list(): derive_image_keys owns the
+    # shape contract, and coercing here first would split a bare string into
+    # per-character names before it can be reported as one.
+    declared = _molmoact2.derive_image_keys(image_keys, policy_config.get("embodiment"))
     undeclared = [t for t in targets if t not in set(declared)]
     if not undeclared:
         return None
@@ -527,6 +531,11 @@ class LerobotLocalPolicy(Policy):
         # dedicated load path (see lerobot_local.molmoact2). These are inert
         # for every other policy type.
         self._molmoact2_norm_tag = norm_tag
+        # Refused here rather than at first use so a shape mistake is reported
+        # before the multi-minute weight download below, and before a bare
+        # string is read one feature per character.
+        if image_keys and (err := name_list_error(image_keys, "image_keys", "LerobotLocalPolicy")):
+            raise ValueError(err)
         self._molmoact2_image_keys = image_keys
         self._molmoact2_inference_action_mode = inference_action_mode
 
@@ -1404,15 +1413,21 @@ class LerobotLocalPolicy(Policy):
         or when the embodiment name/spec cannot be resolved (``create_policy``
         surfaces that error authoritatively).
 
+        The parameter-shape guards below (``actions_per_step``, ``image_keys``)
+        run before that early-return, because both are honored whether or not an
+        embodiment is configured.
+
         Args:
             observation_keys: Runtime observation keys (joint + camera names).
             **policy_config: Provider kwargs (``embodiment``,
                 ``obs_rename_override``, ...).
 
         Raises:
-            ValueError: When a model image feature has no satisfiable source
-                camera key in ``observation_keys``, or when an explicit
-                ``image_keys`` withholds a feature the embodiment feeds.
+            ValueError: When ``actions_per_step`` is not a positive whole number,
+                when ``image_keys`` is not a list of distinct non-blank names,
+                when a model image feature has no satisfiable source camera key
+                in ``observation_keys``, or when an explicit ``image_keys``
+                withholds a feature the embodiment feeds.
         """
         # Checked before the embodiment early-return below, so a chunk count
         # the consumer cannot execute is refused for every configuration rather
@@ -1424,6 +1439,14 @@ class LerobotLocalPolicy(Policy):
             error = chunk_count_error(policy_config["actions_per_step"], "actions_per_step", "lerobot_local")
             if error:
                 raise ValueError(error)
+
+        # Same reasoning for the image_keys shape: it is honored whether or not
+        # an embodiment is configured, so a shape mistake must be refused on
+        # both paths. Ordered after the chunk-count guard so the parameter error
+        # that landed first keeps its existing precedence.
+        supplied_image_keys = policy_config.get("image_keys")
+        if supplied_image_keys and (err := name_list_error(supplied_image_keys, "image_keys", "preflight")):
+            raise ValueError(err)
 
         spec = policy_config.get("embodiment")
         if spec is None:

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -41,6 +41,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
+from strands_robots.utils import name_list_error
 
 from .client import VeraWebsocketClient
 from .config import VeraConfig
@@ -111,7 +112,9 @@ class VeraPolicy(Policy):
         host: Server hostname.
         image_keys: Explicit ordered camera keys to width-concat. When ``None``
             the server's ``view_keys`` (from the connect handshake) are used,
-            matched against the observation's image keys.
+            matched against the observation's image keys. Must be a list of
+            distinct non-blank names; a single key passed as a bare string is
+            refused rather than read one key per character.
         action_mapping: ``{action_column_name: robot_actuator_name}`` rename of
             the server's action columns to robot actuator names. When ``None``
             columns keep their server names (``action_0``, ``action_1``, …).
@@ -152,6 +155,12 @@ class VeraPolicy(Policy):
         server_runner: VeraServerRunner | None = None,
         config: VeraConfig | None = None,
     ) -> None:
+        # Refused before any server or config work: image_keys names the camera
+        # keys read out of the observation, and a bare string is iterable per
+        # character, so an unchecked one raises KeyError mid-rollout - after the
+        # policy server has been launched and the model loaded.
+        if image_keys and (err := name_list_error(image_keys, "image_keys", "VeraPolicy")):
+            raise ValueError(err)
         self.config = config or VeraConfig(
             embodiment=embodiment,  # type: ignore[arg-type]
             host=host,

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -5,6 +5,7 @@ import logging
 import math
 import numbers
 import os
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -456,6 +457,92 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
     """
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         return f"{context}: {param} must be a positive integer, got {value!r}."
+    return None
+
+
+def name_list_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable list of distinct key names.
+
+    Shared domain for the parameters that carry an ordered list of KEY NAMES
+    into a policy: the LeRobot ``image_keys`` (model VISUAL feature keys to
+    declare on the config) and the VERA ``image_keys`` (observation camera keys
+    to width-concat into one frame). The two name different vocabularies, but
+    the shape contract is identical - several distinct non-blank names, in the
+    order the caller wants them - and both consumers reach the same failure when
+    it is not met, so the rule lives here rather than beside either of them.
+
+    The mistake this exists for is a single name passed as a bare string.
+    ``str`` is iterable, so ``list("wrist")`` yields ``['w', 'r', 'i', 's', 't']``
+    - five names the caller never wrote, one per character. Nothing downstream
+    can tell that apart from a deliberate five-entry list, so it is accepted and
+    the consequence surfaces far from the call: a model built declaring
+    per-character features, or a ``KeyError: 'w'`` raised mid-rollout when the
+    frame for a one-letter camera is looked up.
+
+    A ``Mapping`` is refused for the same reason in the other direction: it is
+    iterable over its keys, so its values would be silently discarded.
+
+    A repeated name is refused because it cannot be honored as written - the
+    LeRobot side builds a feature dict, where a duplicate collapses and declares
+    fewer features than asked for, and the VERA side concatenates one panel per
+    entry, where a duplicate doubles the width of the frame the model sees.
+
+    Only a :class:`~collections.abc.Sequence` is accepted, which excludes
+    one-shot iterators. That matters on the LeRobot path, where the value is
+    read twice - once by the pre-flight check and again at load - so a generator
+    exhausted by the first read would present as empty to the second.
+
+    Callers gate this check on a truthy value, because in both consumers a falsy
+    ``image_keys`` (``None``, or an empty list) already means "not supplied" and
+    the list is derived instead. So an empty sequence is not rejected here, and
+    ``None`` is the caller's to skip rather than this function's to accept - a
+    surface where an absent value IS an error keeps that verdict its own.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it - the
+            public method name, or the class name for a constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if isinstance(value, str | bytes):
+        shown = value.decode(errors="replace") if isinstance(value, bytes) else value
+        return (
+            f"{context}: {param} must be a list of names, not a single string, got {value!r}. "
+            f"A string is iterable per character, so this would be read as "
+            f"{[c for c in shown][:6]}{' ...' if len(shown) > 6 else ''} "
+            f"({len(shown)} name(s)). Wrap it in a list: [{shown!r}]."
+        )
+    if isinstance(value, Mapping):
+        return (
+            f"{context}: {param} must be a list of names, not a mapping, got {value!r}. "
+            f"A mapping is iterable over its keys, so its values would be discarded - "
+            f"pass the names as a list: {list(value)!r}."
+        )
+    if not isinstance(value, Sequence):
+        return (
+            f"{context}: {param} must be a list of names, got {type(value).__name__} "
+            f"({value!r}). Pass a list or tuple; a one-shot iterator cannot be used "
+            f"because the value is read more than once."
+        )
+    for i, entry in enumerate(value):
+        if not isinstance(entry, str):
+            return f"{context}: {param}[{i}] must be a name (str), got {type(entry).__name__} ({entry!r})."
+        if not entry.strip():
+            return f"{context}: {param}[{i}] must be a non-blank name, got {entry!r}."
+    seen: set[str] = set()
+    repeated: set[str] = set()
+    for entry in value:
+        if entry in seen:
+            repeated.add(entry)
+        seen.add(entry)
+    if repeated:
+        return (
+            f"{context}: {param} must not repeat a name, got {list(value)!r} "
+            f"({sorted(repeated)!r} appears more than once)."
+        )
     return None
 
 

--- a/tests/policies/test_image_keys_shape.py
+++ b/tests/policies/test_image_keys_shape.py
@@ -1,0 +1,275 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A single camera key passed as a bare string must not be read one key per character.
+
+``image_keys`` names an ordered list of key names on two providers: the LeRobot
+local provider declares model VISUAL feature keys with it
+(:func:`~strands_robots.policies.lerobot_local.molmoact2.derive_image_keys`), and
+the VERA provider names the observation cameras to width-concat with it
+(``VeraPolicy._resolve_view_keys``). Neither validated the shape, and both reduced
+the value with ``list(...)``.
+
+``str`` is iterable, so ``list("wrist")`` is ``['w', 'r', 'i', 's', 't']`` - five
+names the caller never wrote. Nothing downstream can tell that apart from a
+deliberate five-entry list, so it was accepted and the consequence surfaced far
+from the call:
+
+* LeRobot, with no embodiment configured (``preflight`` returned early in that
+  case): a model built declaring one bogus VISUAL feature per character;
+* VERA: ``KeyError: 'w'`` raised from ``_extract_frame`` mid-rollout, after the
+  policy server had been launched and the model loaded.
+
+Two neighbouring shapes failed the same way: a non-``str`` entry became a key,
+and a repeated entry could not be honored as written - the LeRobot side builds a
+feature dict, where a duplicate collapses and declares fewer features than asked
+for, and the VERA side concatenates one panel per entry, where a duplicate
+doubles the width of the frame the model sees.
+
+These tests pin the shared domain
+(:func:`strands_robots.utils.name_list_error`), that all four surfaces that
+receive the value agree on it, that each refusal precedes the expensive work it
+guards, and that a falsy value keeps its "not supplied" meaning.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.lerobot_local import molmoact2
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.policies.vera import VeraPolicy
+from strands_robots.utils import name_list_error
+
+# Shapes that cannot be honored, with the reason each is refused for. Kept as a
+# table so every surface below is probed with exactly the same set.
+BAD_SHAPES: list[tuple[str, Any, str]] = [
+    ("a single name as a bare string", "observation.images.image", "not a single string"),
+    ("a short bare string", "wrist", "not a single string"),
+    ("bytes", b"wrist", "not a single string"),
+    ("a mapping", {"observation.images.image": 1}, "not a mapping"),
+    ("an int", 3, "must be a list of names"),
+    ("a one-shot iterator", iter(["a", "b"]), "must be a list of names"),
+    ("a non-str entry", ["observation.images.image", 7], "[1] must be a name (str)"),
+    ("a blank entry", ["observation.images.image", "  "], "[1] must be a non-blank name"),
+    ("a repeated entry", ["obs.a", "obs.b", "obs.a"], "must not repeat a name"),
+]
+
+GOOD_SHAPES: list[tuple[str, Any]] = [
+    ("one name", ["observation.images.image"]),
+    ("two names", ["observation.images.image", "observation.images.wrist_image"]),
+    ("a tuple", ("observation.images.image",)),
+]
+
+# Falsy values mean "not supplied" in both providers, which derive the list
+# instead. The guards are gated on a truthy value so that meaning is preserved.
+ABSENT_VALUES: list[tuple[str, Any]] = [("None", None), ("an empty list", [])]
+
+
+class _FakeVeraClient:
+    """In-memory stand-in for the VERA websocket client (no server, no GPU)."""
+
+    def __init__(self) -> None:
+        self.handshakes = 0
+
+    def get_server_metadata(self) -> dict[str, Any]:
+        self.handshakes += 1
+        return {"view_keys": ["front"], "needs_prompt": False}
+
+    def infer(self, req: dict[str, Any]) -> dict[str, Any]:
+        return {"action": np.zeros((1, 6), np.float32)}
+
+    def close(self) -> None:
+        pass
+
+
+def _vera(image_keys: Any, client: _FakeVeraClient | None = None) -> VeraPolicy:
+    return VeraPolicy(
+        embodiment="pusht",
+        image_keys=image_keys,
+        # Structural stub: get_server_metadata / infer / close is the whole
+        # surface VeraPolicy uses, and the guard under test runs before any of it.
+        client=client or _FakeVeraClient(),  # type: ignore[arg-type]
+        auto_launch_server=False,
+    )
+
+
+def _observation() -> dict[str, np.ndarray]:
+    return {
+        "front": np.zeros((64, 64, 3), np.uint8),
+        "wrist": np.full((64, 64, 3), 200, np.uint8),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain
+# --------------------------------------------------------------------------- #
+class TestNameListDomain:
+    @pytest.mark.parametrize(("label", "value", "reason"), BAD_SHAPES, ids=[c[0] for c in BAD_SHAPES])
+    def test_a_shape_that_cannot_be_honored_is_reported_with_its_own_reason(
+        self, label: str, value: Any, reason: str
+    ) -> None:
+        err = name_list_error(value, "image_keys", "Surface")
+        assert err is not None, f"{label} was accepted"
+        assert reason in err
+        assert err.startswith("Surface: image_keys")
+
+    @pytest.mark.parametrize(("label", "value"), GOOD_SHAPES, ids=[c[0] for c in GOOD_SHAPES])
+    def test_a_usable_list_is_accepted(self, label: str, value: Any) -> None:
+        assert name_list_error(value, "image_keys", "Surface") is None
+
+    def test_the_bare_string_message_quotes_the_per_character_reading_and_the_fix(self) -> None:
+        """The remedy has to be copy-pasteable, and the cause has to be visible.
+
+        Naming only the type leaves the caller to work out why a string is not a
+        list of one name; quoting what it would have been read as is what makes
+        the per-character split self-evident.
+        """
+        err = name_list_error("wrist", "image_keys", "VeraPolicy")
+        assert err is not None
+        assert "['w', 'r', 'i', 's', 't']" in err
+        assert "5 name(s)" in err
+        assert "['wrist']" in err
+
+    def test_an_empty_sequence_is_left_to_the_caller_to_interpret(self) -> None:
+        assert name_list_error([], "image_keys", "Surface") is None
+
+
+# --------------------------------------------------------------------------- #
+# The defect, on the LeRobot feature-declaration path
+# --------------------------------------------------------------------------- #
+class TestLerobotFeatureKeys:
+    def test_a_bare_string_is_not_declared_as_one_feature_per_character(self) -> None:
+        with pytest.raises(ValueError, match="not a single string"):
+            molmoact2.derive_image_keys("observation.images.image", None)  # type: ignore[arg-type]
+
+    def test_a_repeated_key_is_refused_rather_than_collapsing_the_feature_dict(self) -> None:
+        with pytest.raises(ValueError, match="must not repeat a name"):
+            molmoact2.derive_image_keys(["obs.a", "obs.a"], None)
+
+    def test_a_usable_list_is_still_honored_verbatim(self) -> None:
+        keys = ["observation.images.image", "observation.images.wrist_image"]
+        assert molmoact2.derive_image_keys(keys, None) == keys
+
+    @pytest.mark.parametrize(("label", "value"), ABSENT_VALUES, ids=[c[0] for c in ABSENT_VALUES])
+    def test_an_absent_value_still_derives_the_default_list(self, label: str, value: Any) -> None:
+        assert molmoact2.derive_image_keys(value, None) == list(molmoact2.DEFAULT_IMAGE_KEYS)
+
+    def test_the_refusal_precedes_the_weight_load(self) -> None:
+        """A shape mistake must not cost a multi-minute download first."""
+        with patch.object(LerobotLocalPolicy, "_load_model") as load:
+            with pytest.raises(ValueError, match="not a single string"):
+                LerobotLocalPolicy(pretrained_name_or_path="org/mm2", image_keys="wrist")  # type: ignore[arg-type]
+        load.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# The pre-flight surface, including the path that used to return early
+# --------------------------------------------------------------------------- #
+class TestPreflight:
+    def test_the_shape_is_checked_with_no_embodiment_configured(self) -> None:
+        """``preflight`` returns early when no embodiment is set, but
+        ``image_keys`` is honored on that path too - so it is checked first."""
+        with pytest.raises(ValueError, match="not a single string"):
+            LerobotLocalPolicy.preflight({"front"}, image_keys="wrist")
+
+    def test_the_shape_is_checked_with_an_embodiment_configured(self) -> None:
+        with pytest.raises(ValueError, match="not a single string"):
+            LerobotLocalPolicy.preflight({"front", "wrist"}, embodiment="so_real", image_keys="wrist")
+
+    def test_a_usable_list_still_reaches_the_undeclared_feature_check(self) -> None:
+        """The sibling check that reports a list withholding a fed feature must
+        keep working: the shape guard runs before it, not instead of it."""
+        with pytest.raises(ValueError, match="does not declare them"):
+            LerobotLocalPolicy.preflight(
+                {"front", "wrist"},
+                embodiment="so_real",
+                policy_type="molmoact2",
+                pretrained_name_or_path="org/mm2",
+                image_keys=["observation.images.image"],
+            )
+
+    def test_an_absent_value_is_not_refused(self) -> None:
+        LerobotLocalPolicy.preflight({"front"})
+        LerobotLocalPolicy.preflight({"front"}, image_keys=None)
+        LerobotLocalPolicy.preflight({"front"}, image_keys=[])
+
+
+# --------------------------------------------------------------------------- #
+# The defect, on the VERA camera-key path
+# --------------------------------------------------------------------------- #
+class TestVeraViewKeys:
+    def test_a_bare_string_is_refused_instead_of_raising_keyerror_mid_rollout(self) -> None:
+        with pytest.raises(ValueError, match="not a single string"):
+            _vera("front")
+
+    def test_the_refusal_precedes_the_server_handshake(self) -> None:
+        client = _FakeVeraClient()
+        with pytest.raises(ValueError, match="not a single string"):
+            _vera("front", client=client)
+        assert client.handshakes == 0
+
+    def test_a_usable_list_still_selects_one_panel_per_named_view(self) -> None:
+        policy = _vera(["front"])
+        frame = policy._extract_frame(_observation(), {"view_keys": ["front"]})
+        one_panel_width = frame.shape[1]
+
+        policy = _vera(["front", "wrist"])
+        frame = policy._extract_frame(_observation(), {"view_keys": ["front"]})
+        assert frame.shape[1] == 2 * one_panel_width
+
+    def test_a_repeated_view_is_refused_rather_than_doubling_the_frame_width(self) -> None:
+        """A duplicate silently widened the frame the model sees, which is a
+        different input from the single view the caller named."""
+        with pytest.raises(ValueError, match="must not repeat a name"):
+            _vera(["front", "front"])
+
+    @pytest.mark.parametrize(("label", "value"), ABSENT_VALUES, ids=[c[0] for c in ABSENT_VALUES])
+    def test_an_absent_value_still_falls_back_to_the_server_views(self, label: str, value: Any) -> None:
+        policy = _vera(value)
+        assert policy.image_keys is None
+        assert policy._resolve_view_keys(_observation(), {"view_keys": ["front"]}) == ["front"]
+
+
+# --------------------------------------------------------------------------- #
+# The surfaces must not diverge
+# --------------------------------------------------------------------------- #
+def _verdict(call: Any) -> str:
+    try:
+        call()
+    except ValueError:
+        return "refused"
+    return "accepted"
+
+
+class TestCrossProviderParity:
+    """One option name, one shape contract.
+
+    The two providers name different vocabularies with ``image_keys`` - model
+    feature keys against observation camera keys - but a value either is a list
+    of distinct names or is not, so a shape refused by one surface cannot be
+    accepted by another.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        [(c[0], c[1]) for c in BAD_SHAPES] + GOOD_SHAPES + ABSENT_VALUES,
+        ids=[c[0] for c in BAD_SHAPES] + [c[0] for c in GOOD_SHAPES] + [c[0] for c in ABSENT_VALUES],
+    )
+    def test_every_surface_reaches_the_same_verdict(self, label: str, value: Any) -> None:
+        # A one-shot iterator is consumed by whichever surface reads it first,
+        # so each gets its own.
+        def fresh() -> Any:
+            return iter(["a", "b"]) if label == "a one-shot iterator" else value
+
+        with patch.object(LerobotLocalPolicy, "_load_model"):
+            verdicts = {
+                "LerobotLocalPolicy": _verdict(lambda: LerobotLocalPolicy(image_keys=fresh())),
+                "preflight": _verdict(lambda: LerobotLocalPolicy.preflight({"front"}, image_keys=fresh())),
+                "derive_image_keys": _verdict(lambda: molmoact2.derive_image_keys(fresh(), None)),
+                "VeraPolicy": _verdict(lambda: _vera(fresh())),
+            }
+        assert len(set(verdicts.values())) == 1, f"surfaces disagree for {label}: {verdicts}"


### PR DESCRIPTION
## Problem

`image_keys` names an ordered list of key names on two policy providers. The LeRobot local provider declares the model's VISUAL feature keys with it (`derive_image_keys`, priority 1 over the embodiment-derived list); the VERA provider names the observation cameras to width-concat into one frame with it (`_resolve_view_keys`). Neither validated the shape, and both reduced the value with `list(...)`.

`str` is iterable, so `image_keys="wrist"` was read as `['w', 'r', 'i', 's', 't']` — five names the caller never wrote, one per character. Nothing downstream can tell that apart from a deliberate five-entry list, so it was accepted and the consequence surfaced far from the call.

Measured, `VeraPolicy` over two real MuJoCo camera renders:

| `image_keys=` | main | this PR |
|---|---|---|
| `["front"]` | 252x252 frame fed | unchanged — 252x252 fed |
| `["front", "front"]` | **252x504 fed** — two panels for one named view | refused, naming the repeat |
| `"front"` | **`KeyError: 'f'`** from `_extract_frame` | refused, naming the per-character reading |
| `{"front": 1}` | values silently discarded, keys used | refused |
| `["front", 7]` | `KeyError: 7` mid-rollout | refused, naming index 1 |
| `3` | bare `TypeError: 'int' object is not iterable` | refused |

On the LeRobot side the same value reached `derive_image_keys`, which returned 24 single-character feature keys for `image_keys="observation.images.image"`. That is silent when no embodiment is configured, because `preflight` returned early in exactly that case — so the model was built declaring one bogus VISUAL feature per character. With an embodiment configured it was refused, but by the sibling *undeclared-feature* check, whose message listed 24 characters as "the explicit image_keys" and offered a remedy keyed on `'o'` — a dead end that never mentions the string.

Two neighbouring shapes fail the same way. A non-`str` entry became a key. A repeated entry cannot be honored as written: the LeRobot side builds a feature dict, where a duplicate collapses and declares fewer features than asked for, and the VERA side concatenates one panel per entry, where a duplicate doubles the width of the frame the model sees.

## Change

One shared shape domain, `strands_robots.utils.name_list_error(value, param, context)` — several distinct non-blank names, in the caller's order — alongside the existing shared numeric domains there. It lives in `utils` because the two consumers are separate provider packages and the accepted shape must not diverge between them: a value either is a list of names or is not, whichever vocabulary it names.

It is called from all four surfaces that receive the value, each refusing before the work it guards:

- `LerobotLocalPolicy.__init__` — before `_load_model()`, so a shape mistake does not cost a weight download first;
- `LerobotLocalPolicy.preflight` — **before** the `embodiment is None` early-return, since `image_keys` is honored on that path too;
- `derive_image_keys` — the single funnel for the feature list, so the load path and the check that reports on it are both covered;
- `VeraPolicy.__init__` — before the server handshake.

`_undeclared_image_feature_error` no longer coerces with `list()` before calling `derive_image_keys`. That eager coercion pre-split a bare string into per-character names before the shape could be reported as one, so the wrong reason was printed and an `int` still leaked a bare `TypeError`; forwarding verbatim leaves `derive_image_keys` as the one owner of the contract.

The refusal quotes what the value would have been read as and the list to pass instead:

```
VeraPolicy: image_keys must be a list of names, not a single string, got 'front'.
A string is iterable per character, so this would be read as ['f', 'r', 'o', 'n', 't']
(5 name(s)). Wrap it in a list: ['front'].
```

### Scope

A falsy `image_keys` (`None`, `[]`) already means "not supplied" in both providers, which derive the list instead, so the guards are gated on a truthy value and that meaning is preserved — the change is purely additive, and no previously working call is refused. A one-shot iterator is excluded deliberately: the LeRobot path reads the value twice, once in pre-flight and again at load, so a generator exhausted by the first read would present as empty to the second. `image_keys` remaining inert for non-MolmoAct2 LeRobot policy types is unchanged and out of scope.

## Verification

New `tests/policies/test_image_keys_shape.py` — 44 tests, **9 fail on main**, covering the domain, the defect on each provider, guard placement (`_load_model` not called; server handshake count 0), and a cross-provider parity test asserting all four surfaces reach the same verdict for every probed shape. The 21 that pass pre-fix are the positive controls — a usable list still honored verbatim, an absent value still deriving the default list, and the sibling undeclared-feature check still firing — so deleting the feature cannot pass the suite.

```
# main:      9 failed, 21 passed
# this PR:  44 passed
ruff check / ruff format --check  strands_robots tests tests_integ   clean (962 files)
mypy strands_robots tests tests_integ                                Success: 959 source files
MUJOCO_GL=egl pytest tests -q --no-cov -p no:randomly                13881 passed, 253 skipped (454s)
```

## What the policy is fed

Each row is one caller-supplied shape, run through `VeraPolicy`'s own view selection and frame assembly over two real MuJoCo camera renders (headless EGL). The `main` column is captured against unmodified sources.

![image_keys shape verification](https://raw.githubusercontent.com/cagataycali/robots/artifacts/image-keys-shape/image_keys_shape.png)

The middle row is the one worth reading twice: nothing raises, nothing is logged, and the policy is handed a two-panel frame for the single view the caller named.

---

## Rebase note (no review had been submitted at this point)

Rebased onto `main` after #1750 and #1751 merged. #1750 added a sibling parameter guard to the same `preflight` method, which conflicted textually with the `image_keys` guard here. Still one commit; the branch was force-pushed only because a rebase requires it, and no review trail existed to preserve.

Resolution, all of it in `strands_robots/policies/lerobot_local/policy.py`:

- **Both guards kept**, both still ahead of the `embodiment is None` early-return. The already-merged `actions_per_step` check is ordered **first**, so #1750's landed precedence is unchanged and this PR only adds a check after it.
- **Docstring corrected.** This PR's own sentence claimed `image_keys` "is shape-checked first", which the rebase made false — the chunk count is now first. It had also come to sit after the `Args:` block, which is not valid Google style. Replaced with an accurate sentence covering both guards, placed before `Args:`, and the `Raises:` entry now names `actions_per_step` as well, since the method visibly raises for it.

Re-verified on the rebased head:

```
pytest tests/policies/test_image_keys_shape.py      44 passed
pytest tests/policies/test_chunk_count_domain.py    53 passed   (#1750's guard intact)
ruff check / ruff format --check (touched files)    clean
```

Pin check still holds after the rebase: removing only the `image_keys` guard fails 11 of the 44, including the cross-provider parity test, which reports `preflight` as `accepted` while the other three surfaces stay `refused`. Restoring it returns 44/44.

The wider-suite numbers quoted above were measured pre-rebase; the full run is left to CI on this head.