### PR TITLE
fix(sim): resizing a geom re-derives the owning body's inertia

### DIFF
--- a/changelog.d/1753-geom-resize-rederives-inertia.md
+++ b/changelog.d/1753-geom-resize-rederives-inertia.md
@@ -1,0 +1,31 @@
+### Fixed: resizing a geom re-derives the owning body's mass, center of mass and inertia
+
+A body that declares no `<inertial>` takes its whole inertial row from the geoms it
+owns, integrated once by the compiler, and no step recomputes it.
+`set_geom_properties(size=...)` refreshed the geom's collision bounds but left that
+row describing the shape the body used to have, so the body collided as its new
+shape while resisting rotation as the old one - 0.1 Nm for 1 s spun a cube grown
+from 0.1 m to 0.4 m to 60.0 rad/s where its geometry implies 3.75 rad/s. Where the
+geom carried a density rather than a mass, the stale row also kept the old mass and
+balance point: growing one weight of a dumbbell left it 2.22 kg and centered
+instead of 15.52 kg with its center of mass 17 cm off axis.
+
+It was also order-dependent. The new size is recorded in the spec, so any later
+scene mutation recompiles it and the compiler silently corrects the tensor - the
+same two calls produced 16x different physics depending on whether an unrelated
+`add_object` happened afterwards.
+
+The row is now read from a compile of the persisted spec, so it equals what the
+next recompile produces for every size-defined primitive and for a body with
+several geoms, with no per-shape formulas to keep correct. `body_subtreemass` and
+the reference constants the constraint solver scales with are refreshed with it. A
+body that declares its own `<inertial>` takes nothing from geometry and is left
+untouched, and a resize whose geometry cannot be compiled is refused with the spec
+and the model still describing the same shape.
+
+Re-deriving the row leaves the running scene exactly where it was. The reference
+constants are evaluated at the model's reference configuration, so the MuJoCo call
+that recomputes them is given its own scratch state rather than the scene's - handed
+the scene's own it would rewind every joint and body pose to its declared value
+while leaving the velocities untouched, so a resize issued after any stepping (the
+documented mid-run randomization path) would silently teleport the scene.

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -93,6 +93,13 @@ A mesh / height-field / SDF geom takes its extent from asset data and defines no
 `geom_size` component, so `size` is refused for it (resize the asset instead).
 Growing a size-defined primitive refreshes its broadphase and mid-phase collision
 bounds, so other bodies collide with the new extent rather than passing through it.
+It also re-derives the owning body's mass, center of mass and inertia tensor from
+the new shape - those are integrated from the body's geoms at compile time and are
+never recomputed by a step, so without this a resized body would collide as its new
+shape while resisting rotation as the old one. The values are read from a compile of
+the persisted spec, so a resize means the same thing whether or not another scene
+mutation follows it. A body that declares its own `<inertial>` takes nothing from
+geometry and is left alone.
 
 ## Sensor noise
 

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -30,6 +30,7 @@ from strands_robots.simulation.mujoco.backend import (
 from strands_robots.simulation.mujoco.scene_ops import (
     persist_body_mass,
     persist_geom_properties,
+    refresh_body_inertial_from_geometry,
 )
 
 logger = logging.getLogger(__name__)
@@ -1777,10 +1778,15 @@ class PhysicsMixin:
         to whatever the scene was compiled with - after this call had already
         reported the new one.
 
-        A resize is the one property with a further consequence at recompile time:
-        the model write resizes the geom without re-deriving the owning body's
-        inertia, whereas the recompile integrates the inertia from the persisted
-        shape - the physically consistent value for the new extents.
+        A resize also changes what the owning body's geometry weighs and how it is
+        balanced, so the body's mass, center of mass and inertia tensor - all
+        integrated from its geoms at compile time, and never recomputed by a step -
+        are re-derived from the resized shape. They are read from a compile of the
+        persisted spec, so they equal the values the next scene recompile produces
+        and the resize means the same thing whether or not anything follows it. A
+        body that declares its own ``<inertial>`` takes nothing from geometry and is
+        left alone. The cost is one spec compile per resize; the live model is not
+        swapped, so entity ids and joint state are preserved.
 
         Every vector must carry the exact number of components its target
         defines, because there is no meaningful value to invent for a component
@@ -1913,6 +1919,9 @@ class PhysicsMixin:
             # geom silently reverts after this call reported the new value.
             # Record it in the spec first, so a scene that cannot carry the
             # change is refused before either representation is touched.
+            # Kept so a refresh that cannot be honored restores the spec to the
+            # size the model is still compiled with, leaving the two in step.
+            prior_size = None if size is None else model.geom_size[gid, : len(size)].tolist()
             if reason := persist_geom_properties(self._world, gid, color=color, friction=friction, size=size):
                 return {"status": "error", "content": [{"text": f"set_geom_properties: {reason}"}]}
 
@@ -1927,6 +1936,17 @@ class PhysicsMixin:
                 changes.append(f"friction → {friction}")
 
             if size is not None:
+                # A resize changes the shape the owning body's inertial row was
+                # integrated from. Re-derive that row from the spec, which now
+                # carries the new size, BEFORE touching the model: a scene whose
+                # resized geometry cannot be compiled is refused with both
+                # representations restored rather than left describing different
+                # shapes. The reported result is then the one the next recompile
+                # reproduces, so the resize does not depend on what follows it.
+                if reason := refresh_body_inertial_from_geometry(self._world, gid):
+                    persist_geom_properties(self._world, gid, size=prior_size)
+                    return {"status": "error", "content": [{"text": f"set_geom_properties: {reason}"}]}
+
                 # Validated as exactly the component count this geom's type
                 # defines; the unused tail of the 3-wide row stays as compiled.
                 model.geom_size[gid, : len(size)] = size

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -19,6 +19,8 @@ Public API:
 * :func:`reposition_body_in_scene` - edit a body's spec ``pos``/``quat`` + recompile.
 * :func:`eject_robot_from_scene` - walk the spec, delete everything namespaced
   under ``{robot_name}/``, then recompile.
+* :func:`refresh_body_inertial_from_geometry` - re-derive a body's mass /
+  center of mass / inertia after one of its geoms was resized at runtime.
 
 Every function takes a ``SimWorld`` whose ``_backend_state["spec"]`` holds the
 live ``MjSpec``. They return ``True`` on success, ``False`` on failure (matching
@@ -267,6 +269,106 @@ def persist_geom_properties(
         spec_geom.friction[:] = friction
     if size is not None:
         spec_geom.size[: len(size)] = size
+    return None
+
+
+def refresh_body_inertial_from_geometry(world: SimWorld, geom_id: int) -> str | None:
+    """Re-derive the inertial row of the body owning ``geom_id`` from its geometry.
+
+    A body that does not declare an ``<inertial>`` takes its mass, center of mass
+    and inertia tensor from the shapes it owns: the compiler integrates them over
+    the geoms once, at compile time. ``model.body_mass`` / ``body_ipos`` /
+    ``body_iquat`` / ``body_inertia`` are therefore DERIVED from ``geom_size``, and
+    no ``mj_forward`` / ``mj_step`` recomputes them. Resizing a geom in the model
+    alone leaves the body describing the shape it used to have, so it resists
+    rotation as the old geometry did while colliding as the new one - and for a
+    geom whose mass comes from a density, it also keeps the old mass and the old
+    balance point.
+
+    The values are read from a compile of a *copy* of the live spec, which already
+    carries the new geometry (see :func:`persist_geom_properties`). That makes the
+    refreshed row equal, by construction, to the one the next scene recompile will
+    produce - so the same resize no longer means two different things depending on
+    whether an unrelated ``add_object`` happens afterwards. Deriving it from
+    MuJoCo's own integrator rather than from per-primitive formulas is also what
+    makes a multi-geom body and a shifted center of mass come out right, with no
+    shape-by-shape special cases to keep correct.
+
+    The live model is not swapped and the scene's own ``mjData`` is never passed to
+    MuJoCo, so entity ids, joint state and the recompile generation are untouched -
+    the refresh reads geometry and writes constants, and a resize therefore leaves
+    the scene exactly where it was. The cost is one spec compile plus one scratch
+    ``mjData``, paid only for a resize of a geom whose body derives its inertia
+    from geometry.
+
+    Args:
+        world: The scene holding the live spec and compiled model.
+        geom_id: Compiled geom index whose size has already been recorded in the
+            spec, as resolved by the caller.
+
+    Returns:
+        ``None`` once the row is refreshed - including when the owning body
+        declares its own ``<inertial>``, which takes nothing from geometry and so
+        needs no refresh - otherwise the reason it could not be, leaving both the
+        model and the spec untouched so the caller can restore them.
+    """
+    mj = _ensure_mujoco()
+    model = world._model
+    if model is None:
+        return "the scene has no compiled model whose inertia could be re-derived"
+
+    spec = _get_spec(world)
+    if spec is None:
+        return _NO_SPEC_REASON
+
+    body_id = int(model.geom_bodyid[geom_id])
+    spec_body, reason = _spec_element_by_id(spec.bodies, body_id, "body")
+    if spec_body is None:
+        return reason
+    if spec_body.explicitinertial:
+        # The compiler ignores a body's geoms when the body declares its own
+        # <inertial>, so that row does not describe the geometry and a resize
+        # cannot make it stale. Returning early also keeps resizing a robot
+        # link's collision geom free, since those links declare their inertials.
+        return None
+
+    try:
+        with filter_mujoco_attach_noise():
+            candidate = spec.copy().compile()
+    except (ValueError, RuntimeError) as e:
+        return f"the resized geometry does not compile, so the body's inertia cannot be re-derived: {e}"
+
+    # Writing a row read from a model with a different body ordering would move
+    # one body's inertia onto another, which is a worse outcome than leaving the
+    # row stale and saying so.
+    if candidate.nbody != model.nbody:
+        return (
+            "the scene spec no longer agrees with the compiled model: it compiles to "
+            f"{candidate.nbody} bodies against the model's {model.nbody}"
+        )
+    if mj.mj_id2name(candidate, mj.mjtObj.mjOBJ_BODY, body_id) != mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, body_id):
+        return (
+            "the scene spec no longer agrees with the compiled model: body "
+            f"{body_id} is named differently in a fresh compile"
+        )
+
+    model.body_mass[body_id] = candidate.body_mass[body_id]
+    model.body_ipos[body_id] = candidate.body_ipos[body_id]
+    model.body_iquat[body_id] = candidate.body_iquat[body_id]
+    model.body_inertia[body_id] = candidate.body_inertia[body_id]
+    # body_subtreemass and the invweight / M0 reference constants the constraint
+    # solver scales with are themselves derived from the inertial rows and are not
+    # refreshed by a step. mj_setConst recomputes them, which is what makes the
+    # whole inertial state of the live model equal to that of a fresh compile.
+    #
+    # It is handed a scratch mjData, never the scene's own. Those constants are by
+    # definition evaluated at the model's reference configuration, so mj_setConst
+    # writes qpos0 into whatever data it is given and does not put back what was
+    # there. Passing the live data would rewind every joint and body pose to its
+    # declared value while leaving qvel as it was, so a resize issued after any
+    # stepping would teleport the scene into a state it never occupied - the
+    # order-dependent silent damage this refresh exists to remove.
+    mj.mj_setConst(model, mj.MjData(model))
     return None
 
 

--- a/tests/simulation/mujoco/test_geom_resize_rederives_body_inertia.py
+++ b/tests/simulation/mujoco/test_geom_resize_rederives_body_inertia.py
@@ -1,0 +1,436 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Resizing a geom re-derives the owning body's mass, center of mass and inertia.
+
+A body that declares no ``<inertial>`` takes its whole inertial row from the shapes
+it owns, integrated once by the compiler. ``model.body_mass`` / ``body_ipos`` /
+``body_iquat`` / ``body_inertia`` are therefore derived from ``geom_size``, and no
+``mj_forward`` / ``mj_step`` recomputes them - so ``set_geom_properties(size=...)``
+resized the geom and left the body describing the shape it used to have:
+
+    add_object("cube", box, size=0.1, mass=1.0)     body_inertia 0.0016667
+    set_geom_properties(size=[0.2] * 3)             body_inertia 0.0016667  (!)
+    a fresh compile at those extents                body_inertia 0.0266667
+
+The body then collided as the new shape while resisting rotation as the old one:
+0.1 Nm for 1 s spun the resized cube to 60.0 rad/s where its geometry implies
+3.75 rad/s. On a body whose geom carries a density rather than a mass, the stale
+row also kept the old mass and the old balance point - a dumbbell whose left
+weight was grown stayed 2.22 kg and perfectly balanced instead of 15.52 kg with
+its center of mass 17 cm off axis.
+
+Worse, it was order-dependent. The size is recorded in the spec, so any later
+scene mutation recompiles it and the compiler silently corrects the tensor: the
+same two calls produced 16x different physics depending on whether an unrelated
+``add_object`` happened afterwards.
+
+These pin the contract: the inertial row the setter leaves behind is the one a
+fresh compile of that geometry produces, for every size-defined primitive, for a
+body with several geoms, and whether or not anything follows the resize. A body
+that declares its own ``<inertial>`` takes nothing from geometry and is left
+alone, and a resize whose geometry cannot be compiled is refused with the spec and
+the model still describing the same shape.
+
+The refresh also has to leave the running scene alone. ``set_geom_properties`` is
+the documented mid-run domain-randomization path, so it is issued on a scene that
+has already been stepped, and re-deriving the row must not move anything: the
+reference constants the solver scales with are evaluated at the model's reference
+configuration, so the MuJoCo call that recomputes them writes ``qpos0`` into
+whatever ``mjData`` it is handed. Handed the scene's own, a resize rewound every
+joint and body pose to its declared value while leaving ``qvel`` untouched - a
+state the scene never occupied, reported as ``status="success"``. Every test above
+resizes at ``t=0``, where ``qpos == qpos0``, so none of them can observe it; the
+two below run the scene first.
+"""
+
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco import Simulation
+
+# The helpers below take a sim un-annotated: ``Simulation`` is re-exported lazily,
+# so it is a module attribute rather than a name a type checker can resolve.
+_INERTIAL_ARRAYS = ("body_mass", "body_ipos", "body_iquat", "body_inertia")
+
+# Derived from the inertial rows at compile time and not refreshed by a step:
+# body_subtreemass, and the reference constants the constraint solver scales with.
+_INERTIA_DERIVED_ARRAYS = ("body_subtreemass", "body_invweight0", "dof_invweight0", "dof_M0")
+
+# One free body carrying one geom, declared with a density so that a resize moves
+# the body's mass as well as its inertia.
+_ONE_GEOM = """
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <geom name="ground" type="plane" size="5 5 0.1"/>
+    <body name="obj" pos="0 0 1"><freejoint/>
+      <geom name="obj_g" type="{gtype}" size="{size}" density="1200"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# A body whose inertia comes from several geoms, beside one that declares its own
+# <inertial> and so takes nothing from geometry.
+_MULTI_GEOM = """
+<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <geom name="ground" type="plane" size="5 5 0.1"/>
+    <body name="dumbbell" pos="0 0 1"><freejoint/>
+      <geom name="left_weight" type="sphere" size="0.05" pos="-0.2 0 0" density="2000"/>
+      <geom name="right_weight" type="sphere" size="0.05" pos="0.2 0 0" density="2000"/>
+    </body>
+    <body name="declared" pos="1 0 1"><freejoint/>
+      <inertial pos="0 0 0" mass="2.0" diaginertia="0.5 0.5 0.5"/>
+      <geom name="declared_g" type="box" size="0.05 0.05 0.05"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# An articulated body beside two free ones, under gravity so that running the scene
+# moves every joint away from the pose it was declared at.
+_RUNNING_SCENE = """
+<mujoco>
+  <option gravity="0 0 -9.81"/>
+  <worldbody>
+    <geom name="ground" type="plane" size="5 5 0.1"/>
+    <body name="arm" pos="0 0 0.55">
+      <joint name="pan" type="hinge" axis="0 0 1"/>
+      <geom name="link" type="capsule" fromto="0 0 0 0.34 0 0" size="0.035" density="900"/>
+    </body>
+    <body name="crate" pos="0.42 0.3 0.09"><freejoint/>
+      <geom name="crate_g" type="box" size="0.07 0.07 0.07" density="900"/>
+    </body>
+    <body name="ball" pos="-0.3 -0.26 0.07"><freejoint/>
+      <geom name="ball_g" type="sphere" size="0.06" density="700"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# (geom type, declared size, resized size) for every size-defined primitive.
+_PRIMITIVES = [
+    ("box", "0.1 0.15 0.2", [0.2, 0.05, 0.3]),
+    ("sphere", "0.1", [0.17]),
+    ("capsule", "0.05 0.2", [0.09, 0.31]),
+    ("cylinder", "0.05 0.2", [0.11, 0.07]),
+    ("ellipsoid", "0.1 0.2 0.3", [0.25, 0.06, 0.14]),
+]
+
+
+def _scene(sim, xml: str):
+    assert sim.create_world()["status"] == "success"
+    assert sim.replace_scene_mjcf(xml)["status"] == "success"
+    return sim
+
+
+def _body_id(sim, name: str) -> int:
+    return int(mujoco.mj_name2id(sim._world._model, mujoco.mjtObj.mjOBJ_BODY, name))
+
+
+def _inertial_row(sim, name: str) -> dict[str, np.ndarray]:
+    model, body_id = sim._world._model, _body_id(sim, name)
+    # body_mass is a scalar per body; atleast_1d keeps every row uniformly indexable.
+    return {array: np.atleast_1d(np.array(getattr(model, array)[body_id], dtype=float)) for array in _INERTIAL_ARRAYS}
+
+
+def _pose(sim, name: str) -> dict[str, list[float]]:
+    """The body's pose as a caller reads it, rather than as the model stores it."""
+    state = sim.get_body_state(body_name=name)
+    payload = next(block["json"] for block in state["content"] if "json" in block)
+    return {"position": list(payload["position"]), "quaternion": list(payload["quaternion"])}
+
+
+def _run_scene(sim):
+    """Move the scene off the pose it was declared at, then let it settle.
+
+    The hinge is driven away from zero and the two free bodies fall onto the ground,
+    so every element of ``qpos`` differs from ``qpos0`` - which is the only state in
+    which a rewind is observable.
+    """
+    _scene(sim, _RUNNING_SCENE)
+    assert sim.set_joint_positions({"pan": 1.05})["status"] == "success"
+    assert sim.step(400)["status"] == "success"
+    data = sim._world._data
+    assert not np.allclose(data.qpos, sim._world._model.qpos0), "the scene never left its declared pose"
+    return data
+
+
+def _spin(sim, body: str, torque: float, steps: int) -> tuple[float, float]:
+    """Spin a free body with a constant torque about x.
+
+    The scenes are declared with zero gravity, so the body is in free space and its
+    angular velocity is the torque divided by the inertia the model holds - which is
+    the quantity under test. A body resting on the ground would instead measure its
+    contact, and would read near zero whatever the inertia was.
+
+    Returns:
+        ``(angular velocity about x, elapsed sim seconds)``.
+    """
+    assert sim.apply_force(body_name=body, torque=[torque, 0.0, 0.0])["status"] == "success"
+    assert sim.step(steps)["status"] == "success"
+    state = sim.get_body_state(body_name=body)
+    payload = next(block["json"] for block in state["content"] if "json" in block)
+    elapsed = steps * float(sim._world._model.opt.timestep)
+    return float(payload["angular_velocity"][0]), elapsed
+
+
+@pytest.fixture
+def resized_and_declared(request):
+    """A resized scene and an independent one declaring the resized geometry.
+
+    The second scene never calls the setter, so it is the compiler's own answer for
+    those extents rather than a hand-derived formula - which is what makes the
+    comparison able to catch a per-primitive mistake.
+    """
+    gtype, declared, resized = request.param
+    grown = Simulation(tool_name=f"grown_{gtype}", mesh=False)
+    reference = Simulation(tool_name=f"reference_{gtype}", mesh=False)
+    _scene(grown, _ONE_GEOM.format(gtype=gtype, size=declared))
+    _scene(reference, _ONE_GEOM.format(gtype=gtype, size=" ".join(str(v) for v in resized)))
+    yield grown, reference, resized
+    grown.cleanup()
+    reference.cleanup()
+
+
+@pytest.mark.parametrize("resized_and_declared", _PRIMITIVES, ids=[p[0] for p in _PRIMITIVES], indirect=True)
+def test_a_resized_primitive_carries_the_inertia_of_its_new_shape(resized_and_declared):
+    grown, reference, resized = resized_and_declared
+    stale = _inertial_row(grown, "obj")
+
+    assert grown.set_geom_properties(geom_name="obj_g", size=resized)["status"] == "success"
+
+    expected = _inertial_row(reference, "obj")
+    actual = _inertial_row(grown, "obj")
+    for array in _INERTIAL_ARRAYS:
+        assert actual[array] == pytest.approx(expected[array], abs=1e-12), array
+    # The resize has to have moved something, or the comparison proves nothing.
+    assert actual["body_inertia"] != pytest.approx(stale["body_inertia"], abs=1e-12)
+
+
+@pytest.mark.parametrize("resized_and_declared", _PRIMITIVES, ids=[p[0] for p in _PRIMITIVES], indirect=True)
+def test_the_constants_the_solver_scales_with_follow_the_new_inertia(resized_and_declared):
+    grown, reference, resized = resized_and_declared
+
+    assert grown.set_geom_properties(geom_name="obj_g", size=resized)["status"] == "success"
+
+    for array in _INERTIA_DERIVED_ARRAYS:
+        assert np.asarray(getattr(grown._world._model, array), dtype=float) == pytest.approx(
+            np.asarray(getattr(reference._world._model, array), dtype=float), abs=1e-12
+        ), array
+
+
+def test_a_resized_body_rotates_as_its_new_geometry_implies():
+    """The observable consequence: a constant torque spins it at torque / inertia.
+
+    A cube's inertia is isotropic, so a torque about x stays on a principal axis and
+    the exact answer is ``torque * t / inertia``. Asserting that identity - rather
+    than only that the two runs agree - is what makes the measurement independent of
+    the value under test, and what fails loudly if the body ever stops spinning
+    freely and the comparison starts measuring something else.
+    """
+    grown = Simulation(tool_name="grown_spin", mesh=False)
+    reference = Simulation(tool_name="reference_spin", mesh=False)
+    try:
+        _scene(grown, _ONE_GEOM.format(gtype="box", size="0.05 0.05 0.05"))
+        _scene(reference, _ONE_GEOM.format(gtype="box", size="0.2 0.2 0.2"))
+        stale_inertia = _inertial_row(grown, "obj")["body_inertia"][0]
+        assert grown.set_geom_properties(geom_name="obj_g", size=[0.2, 0.2, 0.2])["status"] == "success"
+
+        measured, elapsed = _spin(grown, "obj", 0.1, 500)
+
+        resized_inertia = _inertial_row(reference, "obj")["body_inertia"][0]
+        assert measured == pytest.approx(0.1 * elapsed / resized_inertia, rel=1e-3)
+        assert measured == pytest.approx(_spin(reference, "obj", 0.1, 500)[0], rel=1e-9)
+        # The stale row would have spun it 16x faster, so the two are far apart and
+        # the assertion above cannot be satisfied by both.
+        assert 0.1 * elapsed / stale_inertia > 10 * measured
+    finally:
+        grown.cleanup()
+        reference.cleanup()
+
+
+def test_the_resize_means_the_same_thing_whether_or_not_anything_follows_it():
+    """A later unrelated mutation recompiles the spec; both paths must agree."""
+    alone = Simulation(tool_name="resize_alone", mesh=False)
+    followed = Simulation(tool_name="resize_followed", mesh=False)
+    try:
+        for sim in (alone, followed):
+            _scene(sim, _ONE_GEOM.format(gtype="box", size="0.05 0.05 0.05"))
+            assert sim.set_geom_properties(geom_name="obj_g", size=[0.2, 0.2, 0.2])["status"] == "success"
+        assert (
+            followed.add_object(name="unrelated", shape="sphere", size=[0.02] * 3, position=[2.0, 2.0, 2.0])["status"]
+            == "success"
+        )
+
+        for array in _INERTIAL_ARRAYS:
+            assert _inertial_row(alone, "obj")[array] == pytest.approx(
+                _inertial_row(followed, "obj")[array], abs=1e-12
+            ), array
+        spun_alone, elapsed = _spin(alone, "obj", 0.1, 500)
+        assert spun_alone == pytest.approx(_spin(followed, "obj", 0.1, 500)[0], rel=1e-9)
+        # Holding the exact torque / inertia identity is what rules out the agreement
+        # being two bodies that both failed to rotate: a body resting on the ground
+        # reads four orders of magnitude below it.
+        assert spun_alone == pytest.approx(0.1 * elapsed / _inertial_row(alone, "obj")["body_inertia"][0], rel=1e-3)
+    finally:
+        alone.cleanup()
+        followed.cleanup()
+
+
+def test_growing_one_geom_of_a_body_moves_its_mass_and_balance_point():
+    grown = Simulation(tool_name="grown_dumbbell", mesh=False)
+    reference = Simulation(tool_name="reference_dumbbell", mesh=False)
+    try:
+        _scene(grown, _MULTI_GEOM)
+        _scene(
+            reference,
+            _MULTI_GEOM.replace(
+                'name="left_weight" type="sphere" size="0.05"', 'name="left_weight" type="sphere" size="0.12"'
+            ),
+        )
+        before = _inertial_row(grown, "dumbbell")
+
+        assert grown.set_geom_properties(geom_name="left_weight", size=[0.12])["status"] == "success"
+
+        expected, actual = _inertial_row(reference, "dumbbell"), _inertial_row(grown, "dumbbell")
+        for array in _INERTIAL_ARRAYS:
+            assert actual[array] == pytest.approx(expected[array], abs=1e-12), array
+        # The two properties a single-geom body would not have exercised.
+        assert actual["body_mass"][0] > before["body_mass"][0] * 2
+        assert abs(actual["body_ipos"][0]) > 0.1
+    finally:
+        grown.cleanup()
+        reference.cleanup()
+
+
+def test_a_body_that_declares_its_own_inertial_is_left_alone():
+    """Its geoms do not define its inertia, so a resize cannot make the row stale."""
+    sim = Simulation(tool_name="declared_inertial", mesh=False)
+    try:
+        _scene(sim, _MULTI_GEOM)
+        before = _inertial_row(sim, "declared")
+
+        assert sim.set_geom_properties(geom_name="declared_g", size=[0.2, 0.2, 0.2])["status"] == "success"
+
+        after = _inertial_row(sim, "declared")
+        for array in _INERTIAL_ARRAYS:
+            assert after[array] == pytest.approx(before[array], abs=1e-12), array
+        assert after["body_mass"][0] == pytest.approx(2.0)
+    finally:
+        sim.cleanup()
+
+
+def test_only_a_resize_of_geometry_derived_inertia_pays_a_compile(monkeypatch):
+    """The compile is the cost of re-deriving; nothing else should be charged it."""
+    sim = Simulation(tool_name="compile_budget", mesh=False)
+    try:
+        _scene(sim, _MULTI_GEOM)
+        compiles: list[int] = []
+        original = mujoco.MjSpec.copy
+
+        def counting_copy(self):
+            compiles.append(1)
+            return original(self)
+
+        monkeypatch.setattr(mujoco.MjSpec, "copy", counting_copy)
+
+        assert sim.set_geom_properties(geom_name="left_weight", color=[1.0, 0.0, 0.0])["status"] == "success"
+        assert sim.set_geom_properties(geom_name="left_weight", friction=[1.0, 0.5, 0.001])["status"] == "success"
+        assert compiles == []
+
+        assert sim.set_geom_properties(geom_name="declared_g", size=[0.2, 0.2, 0.2])["status"] == "success"
+        assert compiles == []
+
+        assert sim.set_geom_properties(geom_name="left_weight", size=[0.07])["status"] == "success"
+        assert len(compiles) == 1
+    finally:
+        sim.cleanup()
+
+
+def test_a_resize_that_cannot_be_re_derived_is_refused_with_both_forms_in_step(monkeypatch):
+    """Neither representation may be left describing a shape the other does not."""
+    sim = Simulation(tool_name="refresh_refused", mesh=False)
+    try:
+        _scene(sim, _MULTI_GEOM)
+        model = sim._world._model
+        geom_id = int(mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "left_weight"))
+        spec_geom = sim._world._backend_state["spec"].geoms[geom_id]
+        before_model = np.array(model.geom_size[geom_id], dtype=float)
+        before_spec = np.array(spec_geom.size, dtype=float)
+        before_row = _inertial_row(sim, "dumbbell")
+
+        def refusing_copy(self):
+            raise ValueError("synthetic compiler refusal")
+
+        monkeypatch.setattr(mujoco.MjSpec, "copy", refusing_copy)
+
+        result = sim.set_geom_properties(geom_name="left_weight", size=[0.12])
+
+        assert result["status"] == "error"
+        assert "synthetic compiler refusal" in result["content"][0]["text"]
+        assert np.array(model.geom_size[geom_id], dtype=float) == pytest.approx(before_model)
+        assert np.array(spec_geom.size, dtype=float) == pytest.approx(before_spec)
+        for array in _INERTIAL_ARRAYS:
+            assert _inertial_row(sim, "dumbbell")[array] == pytest.approx(before_row[array], abs=1e-12), array
+    finally:
+        sim.cleanup()
+
+
+def test_a_mid_run_resize_leaves_the_scene_where_it_was():
+    """A resize reports the new geometry; it must not also move the scene.
+
+    Recomputing the solver's reference constants evaluates them at the model's
+    reference configuration, so the MuJoCo call that does it overwrites whatever
+    ``mjData`` it is handed with ``qpos0``. Handed the scene's own, this resize
+    teleported the swung arm back to zero and dropped both objects back to their
+    declared heights while their velocities stayed as they were.
+    """
+    sim = Simulation(tool_name="mid_run_resize", mesh=False)
+    try:
+        data = _run_scene(sim)
+        before_poses = {name: _pose(sim, name) for name in ("arm", "crate", "ball")}
+        before_qpos = np.array(data.qpos, dtype=float)
+        before_qvel = np.array(data.qvel, dtype=float)
+
+        assert sim.set_geom_properties(geom_name="crate_g", size=[0.12, 0.12, 0.12])["status"] == "success"
+
+        for name, before in before_poses.items():
+            after = _pose(sim, name)
+            assert after["position"] == pytest.approx(before["position"], abs=1e-9), name
+            assert after["quaternion"] == pytest.approx(before["quaternion"], abs=1e-9), name
+        assert np.array(data.qpos, dtype=float) == pytest.approx(before_qpos, abs=1e-12)
+        assert np.array(data.qvel, dtype=float) == pytest.approx(before_qvel, abs=1e-12)
+    finally:
+        sim.cleanup()
+
+
+def test_a_mid_run_resize_still_re_derives_the_inertia():
+    """Leaving the scene alone may not cost the refresh the resize exists for.
+
+    Pinned beside the rewind so the state above cannot be preserved by simply not
+    refreshing: a resize issued on a running scene owes the same inertial row, and
+    the same solver reference constants, as one issued before the first step.
+    """
+    sim = Simulation(tool_name="mid_run_refresh", mesh=False)
+    reference = Simulation(tool_name="mid_run_reference", mesh=False)
+    try:
+        _run_scene(sim)
+        _scene(reference, _RUNNING_SCENE.replace('size="0.07 0.07 0.07"', 'size="0.12 0.12 0.12"'))
+
+        assert sim.set_geom_properties(geom_name="crate_g", size=[0.12, 0.12, 0.12])["status"] == "success"
+
+        expected = _inertial_row(reference, "crate")
+        for array in _INERTIAL_ARRAYS:
+            assert _inertial_row(sim, "crate")[array] == pytest.approx(expected[array], abs=1e-12), array
+        for array in _INERTIA_DERIVED_ARRAYS:
+            assert np.asarray(getattr(sim._world._model, array)) == pytest.approx(
+                np.asarray(getattr(reference._world._model, array)), abs=1e-12
+            ), array
+    finally:
+        sim.cleanup()
+        reference.cleanup()

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -72,6 +72,7 @@ _EXPECTED_FUNCTIONS = {
     "scene_ops.py::persist_body_mass",
     "scene_ops.py::persist_geom_properties",
     "scene_ops.py::persist_world_option",
+    "scene_ops.py::refresh_body_inertial_from_geometry",
     "scene_ops.py::remove_equality_constraint",
     "scene_ops.py::replace_scene_mjcf",
     "scene_ops.py::reposition_body_in_scene",


### PR DESCRIPTION
## Problem

A body that declares no `<inertial>` takes its whole inertial row from the geoms it owns: the compiler integrates mass, center of mass and the inertia tensor over those shapes **once, at compile time**. `model.body_mass` / `body_ipos` / `body_iquat` / `body_inertia` are therefore derived from `geom_size`, and no `mj_forward` / `mj_step` recomputes them.

`set_geom_properties(size=...)` already refreshes the *collision* quantities that are derived the same way (`geom_rbound`, `geom_aabb`) but left the *inertial* ones alone, so a resized body collided as its new shape while resisting rotation as the old one:

```python
sim.add_object("cube", shape="box", size=[0.1, 0.1, 0.1], mass=1.0)   # body_inertia 0.0016667
sim.set_geom_properties(geom_name="cube", size=[0.2, 0.2, 0.2])       # body_inertia 0.0016667  (!)
#                       a fresh compile at those extents                body_inertia 0.0266667
```

`0.1 Nm` for `1 s` then spun that cube to **60.0 rad/s where its geometry implies 3.75 rad/s** - 16x off, `status="success"`, nothing logged.

Where the geom carries a density rather than a mass, the stale row also keeps the old **mass** and the old **balance point**. Growing one weight of a dumbbell left it `2.22 kg`, perfectly centered, against a true `15.52 kg` with its center of mass `17 cm` off axis.

The method's own docstring described the divergence and named which side was right - "the recompile integrates the inertia from the persisted shape - the physically consistent value for the new extents" - while shipping the other one.

### It was order-dependent, which is what made it hard to see

The new size is recorded in the spec, so any later scene mutation recompiles it and the compiler silently corrects the tensor. The same two calls therefore meant two different things:

| sequence | `body_inertia` | ω after 0.1 Nm for 1 s |
|---|---|---|
| resize | 0.0016667 | **60.00 rad/s** |
| resize, then an unrelated `add_object` | 0.0266667 | 3.75 rad/s |

## Change

The inertial row is re-derived from the spec - which `persist_geom_properties` has just written the new size into - by compiling a copy of it and reading the affected body's row. New `scene_ops.refresh_body_inertial_from_geometry`.

Reading it from the compiler rather than from per-primitive formulas is the point:

- it is **equal by construction to what the next recompile produces**, which is what removes the order-dependence rather than just picking a value;
- a **multi-geom** body and a **shifted center of mass** come out right with no shape-by-shape cases to keep correct;
- whether a resize is a mass change or a density change is settled per geom by the same rule the scene was built with (a geom declaring a mass keeps it and only its inertia moves; one declaring a density gains mass).

`body_subtreemass` and the `invweight0` / `M0` reference constants the constraint solver scales with are derived from the inertial rows the same way, so `mj_setConst` refreshes them too. Measured after the change, every one of those arrays is bit-equal to a fresh compile (`body_invweight0` was 562.5 out before).

The live model is **not** swapped, so entity ids, joint state and the recompile generation are untouched.

Two scoping decisions:

- A body that declares its own `<inertial>` takes nothing from geometry, so its row cannot go stale and it returns before the compile - which also keeps resizing a robot link's collision geom free, since those links declare their inertials.
- A resize whose geometry cannot be compiled is **refused**, with the spec restored to the size the model is still compiled with. That follows the existing rule in this method that a scene which cannot carry a change is refused before either representation is touched.

`set_body_properties(mass=...)` ~50 lines above already maintains `body_inertia` for the same reason, and says so: "updating `body_mass` alone leaves a physically inconsistent body - heavy in translation but with the old rotational resistance". This applies the same rule to the other input that row is derived from.

## Rollout in MuJoCo sim (headless)

Identical scene, identical call, identical 0.13 Nm torque - a 0.1 m cube grown to 0.4 m. Left is `main`, right is this PR.

![resized cube spinning at the inertia of the old shape vs the new one](https://raw.githubusercontent.com/cagataycali/robots/artifacts/geom-resize-inertia/geom_resize_inertia.gif)

| | `main` | this PR |
|---|---|---|
| `set_geom_properties` | success | success |
| `body_inertia` | 0.0016667 kg m² | **0.0266667 kg m²** |
| `body_mass` | 1.001 kg | 1.001 kg (a resize at fixed geom mass is a density change) |
| ω after 0.13 Nm for 0.86 s | 67.39 rad/s | **4.21 rad/s** |
| turns in the clip | 4.63 | 0.29 |

Both the inertia and the resulting ω are off by exactly 16.000x, as a 4x linear resize at fixed mass implies. The `main` panel was rendered with the fix stashed; the camera is added *before* the resize in both runs, because adding one afterwards recompiles the spec and would have silently corrected the very value being measured.

## Tests

`tests/simulation/mujoco/test_geom_resize_rederives_body_inertia.py`, 16 tests. **15 fail on `main`, 16 pass here.**

The oracle is a second scene that **declares the resized geometry from the start and never calls the setter**, so the comparison is against the compiler's own answer for those extents rather than a hand-derived formula - which is what lets it catch a per-primitive mistake. Parametrized over every size-defined primitive (box, sphere, capsule, cylinder, ellipsoid).

- the resized row matches that independent compile, for each primitive, and the resize is asserted to have actually moved the row;
- `body_subtreemass` / `invweight0` / `M0` match it too;
- the observable consequence: a torque about a cube's principal axis gives exactly `torque * t / inertia`. That identity - not merely "the two runs agree" - is asserted, so the test cannot pass with both bodies failing to rotate, and the scenes declare zero gravity so a resting contact is not measured instead;
- the same resize gives the same row and the same ω whether or not an unrelated `add_object` follows;
- growing one geom of a dumbbell moves its mass and its balance point to the compiled truth;
- a body declaring its own `<inertial>` is left byte-identical;
- only a resize of geometry-derived inertia pays a compile - a colour or friction change pays none, and neither does a resize on a body with a declared `<inertial>`;
- a refresh that cannot be honored is refused with the spec and the model still describing the same shape.

The one test that already passes on `main` is the declared-`<inertial>` case: it is what pins the fix against over-reaching.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (960 source files).
- `MUJOCO_GL=egl python -m pytest tests -q`: **13993 passed, 253 skipped** (464 s).
- Docs: the per-geom perturbation section of `docs/simulation/domain-randomization.md`, next to the existing note about the collision bounds being refreshed.

## Round 2 - the refresh no longer disturbs the running scene

Review found that `mj_setConst` was called with the scene's own `mjData`. Those
reference constants are by definition evaluated at the model's reference
configuration, so `mj_setConst` writes `qpos0` into whatever `mjData` it is handed
and does not put back what was there. A resize issued after any stepping therefore
rewound every joint and body pose to its declared value while leaving `qvel` as it
was - a state the scene never occupied, reported as `status="success"` - on exactly
the mid-run domain-randomization path this change documents.

It is not version-specific: `qpos` is overwritten on 3.11.0 as well as 3.8.x.
Sweeping the rest of `mjData`, `qpos` is the only field affected (`qvel`, `ctrl`,
`act`, `time`, `xfrc_applied`, `qfrc_applied`, `qacc_warmstart` and `mocap_pos` all
survive), so the whole damage is the position rewind.

`mj_setConst` is now handed its own scratch `MjData`, and
`refresh_body_inertial_from_geometry` no longer binds `world._data` at all - with no
reference to the scene's state it cannot disturb it, which is a stronger guarantee
than restoring it afterwards. Verified against a from-scratch compile of the resized
scene as the oracle: the constants are bit-identical either way, so the scene is
preserved at no cost to the refresh.

| variant | `qpos` kept | `qvel` kept | max abs diff vs fresh compile |
|---|---|---|---|
| live `mjData` | no | yes | 0.000e+00 |
| scratch `MjData` | **yes** | yes | 0.000e+00 |

Zero across `body_subtreemass`, `body_invweight0`, `dof_invweight0`, `dof_M0`,
`jnt_solref` and the four inertial arrays.

### Rollout in MuJoCo sim (headless)

A hinge arm swung to 60.16 deg (green post marks where the run left it, red post
where it was declared), a crate and a ball settled on the ground, 400 steps - then
the crate is grown 0.07 m to 0.12 m and nothing else is touched.

![mid-run resize preserves the scene](https://raw.githubusercontent.com/cagataycali/robots/artifacts/geom-resize-mid-run/mid-run-resize-preserves-scene.png)

Both rows report `status="success"` and both leave the crate at the resized body's
own 12.4416 kg / Ixx 0.119439 kg m^2 - the inertia refresh is identical; only
whether the running scene survives it differs. The blue link's pixel centroid moves
71 px on the top row and 0 px on the bottom.

| | main | this change |
|---|---|---|
| arm yaw across the resize | 60.16 -> **0.00 deg** | 60.16 -> 60.16 deg |
| crate z | 0.0699 -> **0.0900** (declared) | 0.0699 -> 0.0699 |
| ball z | 0.0596 -> **0.0700** (declared) | 0.0596 -> 0.0596 |
| `qpos` preserved | no | yes |

### Pinned

`test_a_mid_run_resize_leaves_the_scene_where_it_was` runs the scene first (drives
the hinge off zero, drops both bodies, asserts `qpos != qpos0` so it cannot pass
vacuously), then asserts every body's `get_body_state` pose and the raw
`qpos`/`qvel` vectors are unchanged across the resize. It fails on the previous head
with `assert [1.0, 0.0, 0.0, 0.0] == approx([0.8653..., 0.5012...])`.

Beside it, `test_a_mid_run_resize_still_re_derives_the_inertia` asserts a resize on
a running scene owes the same inertial row and solver constants as one issued before
the first step - it passes on the previous head by design, so that the state above
cannot be preserved by simply not refreshing. The module docstring records why the
original 16 could not observe this: all of them resize at `t=0`, where
`qpos == qpos0`.

Also in this push: dropped a duplicate news fragment (two `###` headings for one
change would have assembled two CHANGELOG entries), and rebased onto current main.
