### PR TITLE
fix(sim): refuse an action value that is not finite

### DIFF
--- a/changelog.d/1754-send-action-finite-values.md
+++ b/changelog.d/1754-send-action-finite-values.md
@@ -1,0 +1,28 @@
+### Fixed: send_action refuses an action value that is not finite
+
+`SimEngine._coerce_action` validated that every action value coerces to a scalar
+`float` and that an ordered vector's length matches the robot's actuator count,
+but not that the value is finite -- and `nan`/`inf` are perfectly good `float`
+objects. A non-finite value was therefore admitted, written to `data.ctrl` and
+handed to the integrator, with `send_action` reporting `status="success"`. The
+ctrl-clamp warning passed it through as well, and attributed a `nan` to clamping.
+
+`nan` is not clamped. MuJoCo finds the resulting non-finite `qacc` and resets the
+world to its initial pose -- on every substep, so the whole call's physics is
+discarded, and for *every* robot in the scene rather than only the commanded one.
+Measured on two Panda arms parked at `joint1=0.9000`, one `nan` sent to the first
+arm alone left both reporting `joint1=0.0023`; the arm that was never addressed
+had been teleported home. Because any later finite command integrates normally
+the teleport leaves no residue, so a recording rollout reports success for every
+step and the dataset simply holds a trajectory no robot followed. `inf` *is*
+clamped into `ctrlrange`, i.e. silently rewritten into a full-travel command:
+the same `joint1` was driven to its limit of `2.8973`.
+
+Both accepted action shapes are now held to the shared rule the sibling state
+writers `set_joint_positions` / `set_joint_velocities` already applied, so a
+mapping value and a vector entry cannot diverge on it. A mapping error names the
+offending key; a vector error names the position and the actuator key it binds
+to. The refusal happens before any actuator is written, so a good key alongside a
+non-finite one applies neither. The accepted domain is finiteness alone: a
+numeric string remains an accepted spelling of a scalar, and a finite magnitude
+outside `ctrlrange` remains a units question surfaced by the clamp warning.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -232,6 +232,46 @@ def randomization_seed_error(value: Any, context: str) -> str | None:
     return None
 
 
+_NON_FINITE_ACTION_REASON = (
+    "A non-finite value is not clamped into the actuator's control range - the "
+    "integrator has no usable target for it. On MuJoCo the physics step is "
+    "discarded and every robot in the scene is reset to its initial pose, so no "
+    "robot follows the command and the reset is not scoped to the commanded "
+    "actuator or robot."
+)
+
+
+def _non_finite_action_error(label: str, value: Any) -> dict[str, Any] | None:
+    """Structured error when an already-coerced action value is not finite.
+
+    ``nan``/``inf`` are valid ``float`` objects, so a scalar-coercion check
+    admits them and they reach the actuator command unexamined. The sibling
+    state writers (``set_joint_positions`` / ``set_joint_velocities``) already
+    refuse a non-finite value; this is the same rule for the actuator-command
+    path, applied to both accepted action shapes so a mapping value and a vector
+    entry cannot diverge.
+
+    Args:
+        label: How to name the offending element in the message - the caller
+            supplies it because a mapping names a key while a vector names a
+            position and the actuator key it binds to.
+        value: The value, already confirmed to coerce to a scalar ``float`` by
+            the caller (so the coercion here cannot raise).
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict, or ``None`` when the
+        value is finite and therefore usable.
+    """
+    if math.isfinite(float(value)):
+        return None
+    return {
+        "status": "error",
+        "content": [
+            {"text": (f"send_action: {label} must be finite (no nan/inf), got {value!r}. {_NON_FINITE_ACTION_REASON}")}
+        ],
+    }
+
+
 class SimEngine(ABC):
     """Abstract base class for simulation engines.
 
@@ -810,6 +850,22 @@ class SimEngine(ABC):
         error rather than raised as an unhandled ``TypeError`` deep in the
         actuator-application loop.
 
+        Every value must additionally be **finite**. ``nan``/``inf`` are valid
+        ``float`` objects, so the scalar-coercion check above admits them and they
+        reach the actuator command unexamined. A non-finite command is not clamped
+        into the actuator's range: MuJoCo finds the resulting non-finite ``qacc``,
+        discards the step and resets the world to its initial pose - on every
+        substep, and for *every* robot in the scene rather than only the commanded
+        one - while ``send_action`` still reports success, so a rollout recording
+        such a step writes a trajectory no robot followed. An ``inf`` is instead
+        clamped into ``ctrlrange``, i.e. silently rewritten into a full-travel
+        command. The sibling state writers (:meth:`set_joint_positions` /
+        :meth:`set_joint_velocities`) already refuse a non-finite value, so this
+        holds the actuator-command path to the same rule. The domain is finiteness
+        alone: a numeric string is an accepted spelling of a scalar here, and a
+        finite magnitude outside ``ctrlrange`` is a units question already
+        surfaced by the clamp warning.
+
         Args:
             action: A ``{name: value}`` mapping, or an ordered numeric vector
                 whose entries correspond to ``robot_action_keys(robot_name)``.
@@ -866,6 +922,8 @@ class SimEngine(ABC):
                             }
                         ],
                     }
+                if error := _non_finite_action_error(f"action value for key '{key}'", value):
+                    return None, error
                 normalized[key] = value
             return normalized, None
 
@@ -909,7 +967,12 @@ class SimEngine(ABC):
                     }
                 ],
             }
-        return {name: value for name, value in zip(action_keys, values)}, None
+        bound: dict[str, Any] = {}
+        for idx, (name, value) in enumerate(zip(action_keys, values)):
+            if error := _non_finite_action_error(f"action vector entry {idx} ('{name}')", value):
+                return None, error
+            bound[name] = value
+        return bound, None
 
     @abstractmethod
     def send_action(

--- a/tests/simulation/mujoco/test_send_action_finite_values.py
+++ b/tests/simulation/mujoco/test_send_action_finite_values.py
@@ -1,0 +1,281 @@
+"""Regression tests: send_action refuses a non-finite action value.
+
+``_coerce_action`` validated that every action value coerces to a scalar
+``float`` and that a vector's length matches the robot's actuator count. It did
+not validate finiteness, and ``nan``/``inf`` are perfectly good ``float``
+objects, so a non-finite value was admitted, written to ``data.ctrl`` and handed
+to ``mj_step``. Nothing further down looked at it either: the ctrl-clamp warning
+passes a ``nan`` straight through.
+
+Two distinct consequences, both reported as ``status="success"``:
+
+* ``nan`` is not clamped. MuJoCo finds the resulting non-finite ``qacc`` and
+  resets the world to its initial pose - on every substep, so the whole call's
+  physics is discarded, and for *every* robot in the scene rather than only the
+  commanded one. Because any later finite command integrates normally, the
+  teleport leaves no residue: a recording rollout reports success for each step
+  and the dataset simply holds a trajectory no robot followed.
+* ``inf`` *is* clamped into ``ctrlrange``, i.e. silently rewritten into a
+  full-travel command - the fabricated-absolute-position hazard class.
+
+The sibling state writers ``set_joint_positions`` / ``set_joint_velocities``
+already refuse a non-finite value, and ``get_ground_height`` refuses one for a
+read-only terrain query, so these pin the actuator-command path to the same rule
+and pin that the two accepted action shapes (mapping and ordered vector) cannot
+diverge on it. The accepted domain is finiteness alone: a numeric string stays an
+accepted spelling of a scalar, and a finite magnitude outside ``ctrlrange``
+remains a units question surfaced by the clamp warning.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+# Two-hinge position-servo arm. Inline so the test needs no asset download, and
+# mounted high enough that neither link can reach the ground plane - a link in
+# contact would hold the arm off its commanded target and make the parked pose
+# (the non-vacuity premise of the scene-reset test below) indeterminate.
+ARM_XML = """
+<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.9">
+      <joint name="shoulder" type="hinge" axis="0 1 0" range="-1.5 1.5" limited="true" damping="4"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.03"/>
+      <body name="link2" pos="0.2 0 0">
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-1.5 1.5" limited="true" damping="4"/>
+        <geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.025"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a_shoulder" joint="shoulder" kp="50" ctrlrange="-1.5 1.5"/>
+    <position name="a_elbow" joint="elbow" kp="50" ctrlrange="-1.5 1.5"/>
+  </actuator>
+</mujoco>
+"""
+
+PARKED = 0.8
+"""Commanded parking angle, well away from the model's ``qpos0`` of zero."""
+
+NON_FINITE = [
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(float("-inf"), id="-inf"),
+    pytest.param(np.float32("nan"), id="np.float32-nan"),
+    pytest.param(np.float64("inf"), id="np.float64-inf"),
+]
+
+
+@pytest.fixture
+def arm_xml(tmp_path):
+    path = tmp_path / "arm.xml"
+    path.write_text(ARM_XML)
+    return str(path)
+
+
+@pytest.fixture
+def sim(arm_xml):
+    """Two independent arms, both parked away from ``qpos0``.
+
+    Gravity is off so the parked pose is held by the servos alone, which is what
+    makes an uncommanded robot's pose a usable witness for a whole-scene reset.
+    """
+    s = Simulation()
+    s.create_world(gravity=[0.0, 0.0, 0.0])
+    # Offset in y so the two arms cannot touch each other - co-located arms
+    # collide and hold each other off their commanded targets. Both are added
+    # before either is parked: adding a robot recompiles the model, which does
+    # not carry ``ctrl`` over, so an arm parked first would be driven back to
+    # zero while the second arm parks.
+    for name, y in (("alice", -0.6), ("bob", 0.6)):
+        s.add_robot(name=name, urdf_path=arm_xml, position=[0.0, y, 0.0])
+    for name in ("alice", "bob"):
+        s.send_action(
+            {"a_shoulder": PARKED, "a_elbow": PARKED},
+            robot_name=name,
+            n_substeps=1,
+        )
+    s.step(1200)
+    yield s
+    s.cleanup()
+
+
+def _pose(sim, robot):
+    obs = sim.get_observation(robot_name=robot, skip_images=True)
+    return (float(obs["shoulder"]), float(obs["elbow"]))
+
+
+def _ctrl(sim, actuator):
+    return float(sim.mj_data.ctrl[sim.mj_model.actuator(actuator).id])
+
+
+class TestNonFiniteMappingValueRefused:
+    """A mapping value that is not finite is refused, naming the key."""
+
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_non_finite_mapping_value_is_refused(self, sim, value):
+        result = sim.send_action({"a_shoulder": value}, robot_name="alice")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "finite (no nan/inf)" in text
+        assert "'a_shoulder'" in text
+
+    def test_message_names_the_real_consequence_not_clamping(self, sim):
+        """The clamp warning attributes a ``nan`` to clamping; it is a reset."""
+        result = sim.send_action({"a_shoulder": float("nan")}, robot_name="alice")
+        text = result["content"][0]["text"]
+        assert "reset" in text
+        assert "not clamped" in text
+
+    def test_single_element_non_finite_value_is_refused(self, sim):
+        """The length-1 unwrap must not smuggle a ``nan`` past the check."""
+        result = sim.send_action({"a_shoulder": [float("nan")]}, robot_name="alice")
+        assert result["status"] == "error"
+        assert "finite (no nan/inf)" in result["content"][0]["text"]
+
+
+class TestNonFiniteVectorEntryRefused:
+    """The ordered-vector shape is held to the same rule as the mapping."""
+
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_non_finite_vector_entry_is_refused(self, sim, value):
+        result = sim.send_action([value, PARKED], robot_name="alice")
+        assert result["status"] == "error"
+        assert "finite (no nan/inf)" in result["content"][0]["text"]
+
+    def test_message_names_the_position_and_the_actuator_it_binds_to(self, sim):
+        """A vector has no key, so the message must locate the entry itself."""
+        result = sim.send_action([PARKED, float("nan")], robot_name="alice")
+        text = result["content"][0]["text"]
+        assert "entry 1" in text
+        assert "'a_elbow'" in text
+
+    def test_numpy_action_vector_entry_is_refused(self, sim):
+        result = sim.send_action(np.array([float("nan"), PARKED]), robot_name="alice")
+        assert result["status"] == "error"
+        assert "finite (no nan/inf)" in result["content"][0]["text"]
+
+    def test_a_length_mismatch_is_still_reported_before_finiteness(self, sim):
+        """A wrong-length vector reports the length error, which lists the keys.
+
+        The length mismatch is the more structural error and its message carries
+        the actuator ordering the caller needs, so it must not be displaced by a
+        finiteness complaint about an entry that would never have been bound.
+        """
+        result = sim.send_action([float("nan")], robot_name="alice")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "does not match robot" in text
+        assert "finite (no nan/inf)" not in text
+
+
+class TestRefusalPrecedesAnyActuatorWrite:
+    """A refused action writes no ctrl at all, for any key."""
+
+    def test_a_good_key_alongside_a_non_finite_key_applies_neither(self, sim):
+        before = _ctrl(sim, "alice/a_elbow")
+        result = sim.send_action(
+            {"a_elbow": 0.2, "a_shoulder": float("nan")},
+            robot_name="alice",
+        )
+        assert result["status"] == "error"
+        assert _ctrl(sim, "alice/a_elbow") == before
+
+    def test_no_actuator_in_the_scene_holds_a_non_finite_command(self, sim):
+        sim.send_action({"a_shoulder": float("inf")}, robot_name="alice")
+        assert all(math.isfinite(float(c)) for c in sim.mj_data.ctrl)
+
+
+class TestNonFiniteCommandNoLongerResetsTheScene:
+    """The headline consequence: one ``nan`` discarded the whole scene's state."""
+
+    def test_the_parked_pose_is_a_usable_witness(self, sim):
+        """Non-vacuity premise: parked is far from ``qpos0``, so a reset shows."""
+        for robot in ("alice", "bob"):
+            assert min(abs(v) for v in _pose(sim, robot)) > 0.1
+
+    def test_an_uncommanded_robot_keeps_its_pose(self, sim):
+        """``bob`` is never addressed, so nothing may move it."""
+        before = _pose(sim, "bob")
+        result = sim.send_action(
+            {"a_shoulder": float("nan")},
+            robot_name="alice",
+            n_substeps=200,
+        )
+        assert result["status"] == "error"
+        assert _pose(sim, "bob") == pytest.approx(before, abs=1e-9)
+
+    def test_the_commanded_robot_keeps_its_pose_too(self, sim):
+        """The refusal is atomic, so not even the addressed arm is disturbed."""
+        before = _pose(sim, "alice")
+        sim.send_action({"a_shoulder": float("nan")}, robot_name="alice", n_substeps=200)
+        assert _pose(sim, "alice") == pytest.approx(before, abs=1e-9)
+
+    def test_an_inf_no_longer_becomes_a_full_travel_command(self, sim):
+        """``inf`` clamped into ``ctrlrange`` drove the joint to its limit."""
+        before = _pose(sim, "alice")
+        sim.send_action({"a_shoulder": float("inf")}, robot_name="alice", n_substeps=400)
+        assert _pose(sim, "alice") == pytest.approx(before, abs=1e-9)
+
+
+class TestFiniteValuesStillAccepted:
+    """The guard constrains finiteness only - nothing else narrows."""
+
+    def test_ordinary_finite_command_moves_the_arm(self, sim):
+        before = _pose(sim, "alice")
+        result = sim.send_action({"a_shoulder": 0.2}, robot_name="alice", n_substeps=400)
+        assert result["status"] == "success", result
+        assert abs(_pose(sim, "alice")[0] - before[0]) > 1e-3
+
+    def test_a_numeric_string_is_still_an_accepted_scalar(self, sim):
+        """A documented tolerance: ``float("0.5")`` is finite and exact."""
+        result = sim.send_action({"a_shoulder": "0.5"}, robot_name="alice", n_substeps=2)
+        assert result["status"] == "success", result
+
+    def test_a_finite_magnitude_outside_ctrlrange_is_still_accepted(self, sim):
+        """Out-of-range-but-finite stays the clamp warning's business."""
+        result = sim.send_action({"a_shoulder": 1e300}, robot_name="alice", n_substeps=2)
+        assert result["status"] == "success", result
+
+    def test_a_finite_action_vector_is_still_accepted(self, sim):
+        result = sim.send_action([0.3, 0.2], robot_name="alice", n_substeps=2)
+        assert result["status"] == "success", result
+
+    def test_numpy_finite_scalars_are_still_accepted(self, sim):
+        result = sim.send_action(
+            {"a_shoulder": np.float64(0.3), "a_elbow": np.float32(0.2)},
+            robot_name="alice",
+            n_substeps=2,
+        )
+        assert result["status"] == "success", result
+
+
+class TestParityWithSiblingStateWriters:
+    """``send_action`` accepts a value iff the sibling state writer does.
+
+    ``set_joint_positions`` refused a non-finite value while the actuator
+    command path admitted it, so the same scene had two different domains for
+    the same kind of number. Parametrizing both over one probe set keeps them
+    from drifting apart again.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(float("nan"), id="nan"),
+            pytest.param(float("inf"), id="inf"),
+            pytest.param(float("-inf"), id="-inf"),
+            pytest.param(0.3, id="finite"),
+            pytest.param(1e300, id="large-finite"),
+        ],
+    )
+    def test_the_two_writers_agree_on_the_value(self, sim, value):
+        action = sim.send_action({"a_shoulder": value}, robot_name="alice", n_substeps=2)
+        state = sim.set_joint_positions({"shoulder": value}, robot_name="alice")
+        assert (action["status"] == "error") == (state["status"] == "error"), (
+            f"verdicts differ for {value!r}: send_action={action['status']} set_joint_positions={state['status']}"
+        )


### PR DESCRIPTION
Closes #1754.

## Problem

`SimEngine._coerce_action` validated that every action value coerces to a scalar `float` and that an ordered vector's length matches the robot's actuator count. It did not validate finiteness, and `nan`/`inf` are perfectly good `float` objects. A non-finite value was therefore admitted, written to `data.ctrl` and handed to the integrator, with `send_action` reporting `status="success"`. Nothing further down looked at it either -- `_write_ctrl` applies the scaler and the ctrl-clamp warning, and both pass a `nan` straight through.

Two distinct consequences.

**`nan` discards the state of the whole scene.** MuJoCo finds the resulting non-finite `qacc` and resets the world to its initial pose -- on every substep, so the entire call's physics is thrown away, and for *every* robot in the scene rather than only the commanded one. Because any later finite command integrates normally the teleport leaves no residue, so a recording rollout reports success for each step and the dataset simply holds a trajectory no robot followed.

**`inf` is silently rewritten into a full-travel command.** MuJoCo clamps it into `ctrlrange`, so `inf` means "drive to the joint limit at servo speed" -- a fabricated absolute-position command reported as success.

Both accepted action shapes were affected: a mapping value, a mapping value arriving as a length-1 sequence (the `Policy.get_actions` `list[float]` shape), and an entry of an ordered action vector.

## Why this is the sibling rule, not a new one

The same engine already refuses a non-finite number everywhere else it is asked to write one, so the actuator-command path was the outlier:

| surface | non-finite value | writes |
|---|---|---|
| `set_joint_positions` / `set_joint_velocities` | refused: `"'positions' value for joint 'shoulder' must be finite (no nan/inf)"` | `data.qpos` / `data.qvel` |
| `get_ground_height(x, y)` | refused: `"x must be a finite number"` | nothing -- a read-only terrain query |
| `apply_force(force=, torque=)` | refused | `data.xfrc_applied` |
| `drive(linear=)` / `navigate_to(x=)` (ROS 2 / RTPS) | refused via `utils.finite_number_error` | a wire message |
| **`send_action`** | **admitted** | **`data.ctrl`, then runs the physics** |

So a value that could not be used to *ask where the ground is* could be used to command an actuator and step the world.

## Change

One guard in the shared `_coerce_action`, which is the only funnel into `_apply_sim_action` and is used by both the MuJoCo and Newton backends -- so every driver (`PolicyRunner`'s five call sites, `replay_episode`, `run_multi_policy`, `teleoperate`, the RL env, the mesh input receiver, the agent tool) is covered by one rule and the two action shapes cannot diverge on it.

- A mapping error names the offending key; a vector error names the position **and** the actuator key it binds to, since a vector entry has no name of its own.
- The refusal precedes any actuator write, so a good key alongside a non-finite one applies neither (`_coerce_action` already returns before the `ctrl` write, so atomicity comes for free -- it is pinned).
- The message states the real consequence. This is what makes the existing clamp warning's `nan` wording -- which attributes it to clamping and advises rescaling the units -- unreachable rather than merely wrong.

### Accepted domain: finiteness alone

Deliberately narrower than `utils.finite_number_error`, which also declines a non-real value. `test_scalar_like_values_still_accepted` pins a numeric string as an accepted spelling of a scalar here (`"0.05"` coerces to exactly `0.05` and commands it), so widening to that shared helper would flip a documented tolerance with no silent-failure claim behind it. A finite magnitude outside `ctrlrange` also stays accepted -- that is a units question the clamp warning already surfaces. Both are pinned so the domain cannot quietly narrow later.

## Verified in sim

Two Panda arms, both parked at `joint1=0.9000  joint2=0.5592  joint4=-1.9051  joint6=1.8995`, then one value sent to the **first arm only**. Rendered headless.

![send_action refuses a non-finite action value](https://raw.githubusercontent.com/cagataycali/robots/artifacts/send-action-finite-values/send_action_finite_values.png)

| | main | this PR |
|---|---|---|
| `send_action` verdict, `nan` | `success` (`"Action applied to 'alice' (1 keys)."`) | `error`, naming the key |
| commanded arm `joint1` after `nan` | `0.0023` | `0.9000` |
| **uncommanded** arm `joint1` after `nan` | `0.0023` | `0.9000` |
| **uncommanded** arm `joint2` after `nan` | `0.0441` | `0.5592` |
| `send_action` verdict, `inf` | `success` | `error` |
| commanded arm `joint1` after `inf` | `2.8973` (its `ctrlrange` limit) | `0.9000` |

The parked pose is the witness: MuJoCo's reset restores `qpos0`, so an arm that was never addressed reporting a changed pose *is* the whole scene's state being discarded. The two panels differ on 12.1% of pixels for the `nan` case; on this PR both post-call renders are byte-identical to the parked reference, i.e. nothing happened.

## Tests

`tests/simulation/mujoco/test_send_action_finite_values.py`, 31 tests: both action shapes over `nan` / `inf` / `-inf` / NumPy non-finite scalars, the length-1 unwrap path, message content (names the key, and the position plus bound actuator key for a vector), atomicity, the scene-reset and full-travel consequences, the still-accepted controls, and a parity test asserting `send_action` accepts a value iff `set_joint_positions` does -- which is what keeps the two domains from drifting apart again.

The fixture is an inline two-hinge MJCF (no asset download) with two arms parked away from `qpos0`, and carries an explicit non-vacuity test that the parked pose is far enough from `qpos0` for a reset to be detectable -- without it the reset tests could pass on an arm that was never posed.

**Pre-fix: 22 failed / 9 passed.** Representative failures:

```
verdicts differ for nan: send_action=success set_joint_positions=error
test_the_commanded_robot_keeps_its_pose_too  (0.00205..., ...) == approx((0.8000..., ...))
test_an_inf_no_longer_becomes_a_full_travel_command  (1.49999..., ...) == approx((0.8000..., ...))
test_message_names_the_real_consequence_not_clamping  assert 'reset' in "Action applied to 'alice' (1 keys)."
```

The 9 that already passed are the still-accepted controls, the non-vacuity premise, and the guard-ordering test -- they are what stop the fix from over-reaching, so they are kept rather than removed to make the pre-fix number look cleaner.

## Gate

- `ruff check` / `ruff format --check` clean (964 files); `mypy strands_robots tests tests_integ` -- `Success: no issues found in 961 source files`.
- `MUJOCO_GL=egl python -m pytest tests` -- **14006 passed, 253 skipped** (464s), including this PR's 31 new tests. No existing test needed changing.

## Out of scope

- **`bool`**. `send_action({"actuator8": True})` writes `ctrl 1.0`, which the tendon-gripper scaler then reads as a normalized *fraction* -- measured on a Panda: `True` -> `ctrl 255` (gripper fully open, gap `0.0400`), `False` -> `ctrl 0` (closed). Refusing it is a separate contract decision, since a boolean gripper spelling is a plausible shipped recipe and `set_gripper` is the intended API for it.
- **`HardwareRobot.send_action`** forwards to lerobot's `Robot.send_action` with no finiteness check either. Different blast radius (real motors, and lerobot's own `ensure_safe_goal_position` domain) and not measurable in sim, as #1754 notes.
- **`ctrl` is not carried across a recompile**, so an arm parked before a later `add_robot` is driven back toward zero. Found while building the fixture (which now adds both arms before parking either) and unrelated to this guard.