### PR TITLE
fix(sim): a physics checkpoint is refused once its model is swapped

### DIFF
--- a/changelog.d/1756-checkpoint-refused-after-model-swap.md
+++ b/changelog.d/1756-checkpoint-refused-after-model-swap.md
@@ -1,0 +1,21 @@
+### Fixed: a physics checkpoint is refused once the model it was taken against is swapped
+
+`save_state` fingerprints a checkpoint with `nq`/`nv`/`na`/`nu` plus a recompile
+generation counter, and `load_state` refuses a checkpoint whose fingerprint no
+longer matches. The counts catch a swap that resizes the state vector; the
+generation exists for the swap that does not, because two models can agree on
+every count and still mean different things at the same state indices.
+
+Only one of the seven code paths that install a compiled model bumped that
+counter, so the rest accepted checkpoints taken against a model that no longer
+existed. `replace_scene_mjcf` was the sharpest case: a checkpoint saved from one
+scene was applied to a completely different scene with matching counts, writing
+each value into whatever joint now occupied that index and reporting success -
+leaving the arm in a pose no checkpoint had ever recorded. `remove_camera`
+accepted a checkpoint that `add_camera` refuses, and a `patch_scene_mjcf` op that
+adds no body left nothing to distinguish the two models.
+
+Every path that swaps the live model now goes through a single
+`install_compiled_model` function that performs the rebind and the invalidation
+together, so a swap site cannot install a model without invalidating the
+checkpoints taken against the previous one.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -102,7 +102,7 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `get_mass_matrix` | - |
 | `inverse_dynamics` | - (compensation torques to hold the current `qpos`/`qvel`) |
 | `forward_kinematics` | `body_name` (optional) |
-| `save_state` / `load_state` | snapshot/restore full physics |
+| `save_state` / `load_state` | `name` - snapshot/restore full physics. A checkpoint is valid only for the model it was taken against: any scene mutation that swaps the compiled model (`add_object`, `add_robot`, `add_camera`, `remove_camera`, `remove_robot`, `patch_scene_mjcf`, `replace_scene_mjcf`) invalidates it, and `load_state` then returns a structured error instead of writing a state vector whose indices now mean something else. Save a fresh checkpoint after mutating the scene |
 | `set_joint_positions` | `positions` (dict or ordered list), `robot_name` (optional) - write `qpos` directly + run FK (teleport / set an initial pose, bypassing actuators) |
 | `set_joint_velocities` | `velocities` (dict or ordered list), `robot_name` (optional) - write `qvel` directly (set an initial dynamic state) |
 | `get_energy` | - |

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -192,9 +192,10 @@ class SimWorld:
     # Kept as a top-level field - requested by @yinsong1986 during review to
     # avoid monkey-patching when ``reset()`` creates a fresh ``SimWorld``.
     _checkpoints: dict[str, Any] = field(default_factory=dict)
-    # Monotonically-incremented generation counter bumped on every
-    # spec.recompile (scene_ops._recompile_preserving_state). Checkpoints
-    # stamp this value so load_state can detect a same-shape recompile
-    # (remove one free-jointed object, add another) that the nq/nv/na/nu
-    # counts alone cannot distinguish.
+    # Monotonically-incremented generation counter bumped whenever ``_model`` is
+    # swapped, by the one function that installs it
+    # (``scene_ops.install_compiled_model``). Checkpoints stamp this value so
+    # load_state can detect a swap that the nq/nv/na/nu counts alone cannot
+    # distinguish - a same-shape recompile (remove one free-jointed object, add
+    # another), or a whole scene replaced by one with the same counts.
     _recompile_generation: int = 0

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -15,6 +15,8 @@ Public API:
 * :func:`inject_robot_into_scene` - ``spec.attach(robot_spec, prefix=...)``.
 * :func:`inject_object_into_scene` - ``SpecBuilder.add_object(spec, obj)`` + recompile.
 * :func:`inject_camera_into_scene` - ``SpecBuilder.add_camera(spec, cam)`` + recompile.
+* :func:`install_compiled_model` - install a compiled model/data pair as the
+  live scene state; the single point every model swap goes through.
 * :func:`eject_body_from_scene` - ``SpecBuilder.remove_body(spec, name)`` + recompile.
 * :func:`reposition_body_in_scene` - edit a body's spec ``pos``/``quat`` + recompile.
 * :func:`eject_robot_from_scene` - walk the spec, delete everything namespaced
@@ -107,6 +109,35 @@ def _snapshot_spec(spec: Any, *, context: str) -> Any | None:
         return None
 
 
+def install_compiled_model(world: SimWorld, model: Any, data: Any) -> None:
+    """Install a compiled ``model``/``data`` pair as ``world``'s live scene state.
+
+    Every path that swaps the live model goes through here, because the swap has
+    a consequence that is easy to leave behind: ``world._recompile_generation``
+    is the only part of the ``save_state`` / ``load_state`` fingerprint that
+    changes when the new model happens to keep the previous ``nq``/``nv``/``na``/
+    ``nu``. A site that rebinds ``world._model`` without bumping it lets a
+    checkpoint taken against the previous model be applied to this one - the
+    state vector is the right length, so it is written index by index into
+    whatever those indices now mean.
+
+    Concentrating the rebind here makes that impossible to forget: a new swap
+    site cannot install a model without also invalidating the checkpoints taken
+    against the old one.
+
+    Args:
+        world: The scene whose live model/data are replaced.
+        model: The freshly compiled ``MjModel``.
+        data: An ``MjData`` matching ``model``.
+    """
+    world._model = model
+    world._data = data
+    # Any swap invalidates every outstanding checkpoint, including one whose
+    # state vector still has the right length: only this counter distinguishes
+    # a same-shape model from the one the checkpoint was taken against.
+    world._recompile_generation += 1
+
+
 def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal: bool = False) -> bool:
     """Recompile ``spec`` in place, replacing ``world._model`` and ``_data``.
 
@@ -138,13 +169,7 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
             raise
         return False
 
-    world._model = new_model
-    world._data = new_data
-
-    # Bump recompile generation so save_state/load_state can detect stale
-    # checkpoints even when nq/nv/na/nu happen to stay the same (e.g.
-    # remove one free-jointed object, add another of the same shape).
-    world._recompile_generation += 1
+    install_compiled_model(world, new_model, new_data)
     # Forward pass so newly-injected bodies have valid xpos/xquat and any
     # camera xforms are populated. Without this, the next render() call
     # after add_object / add_robot / add_camera returns a 100% black frame
@@ -776,8 +801,7 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
         logger.error("eject_robot: fresh compile failed: %s", e)
         return False
 
-    world._model = new_model
-    world._data = new_data
+    install_compiled_model(world, new_model, new_data)
     world._backend_state["spec"] = new_spec
     _sync_cached_xml(world, new_spec)
 
@@ -1009,8 +1033,7 @@ def replace_scene_mjcf(world: SimWorld, xml: str) -> bool:
     new_data = mj.MjData(new_model)
 
     world._backend_state["spec"] = new_spec
-    world._model = new_model
-    world._data = new_data
+    install_compiled_model(world, new_model, new_data)
 
     # Run a single forward pass so geom positions / camera xforms are
     # populated. Without this, the very first sim.render() call after
@@ -1265,7 +1288,8 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
 
     # One recompile for the whole batch - preserves qpos/qvel for unchanged joints.
     with filter_mujoco_attach_noise():
-        world._model, world._data = spec.recompile(world._model, world._data)
+        new_model, new_data = spec.recompile(world._model, world._data)
+    install_compiled_model(world, new_model, new_data)
 
     # Forward pass so new bodies' xpos / xquat / cam_xmat are populated for
     # the very next render() or get_body_state() call. Same reasoning as

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -86,6 +86,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     inject_camera_into_scene,
     inject_object_into_scene,
     inject_robot_into_scene,
+    install_compiled_model,
     patch_scene_mjcf,
     persist_world_option,
     replace_scene_mjcf,
@@ -670,8 +671,7 @@ class MuJoCoSimEngine(
         with self._lock:
             world = SimWorld()
             world._backend_state["spec"] = spec
-            world._model = model
-            world._data = data
+            install_compiled_model(world, model, data)
             world.status = SimStatus.IDLE
 
             # Cache the canonical serialisation; legacy readers use this.
@@ -818,8 +818,8 @@ class MuJoCoSimEngine(
         spec = SpecBuilder.build(self._world)
         self._world._backend_state["spec"] = spec
         with filter_mujoco_attach_noise():
-            self._world._model = spec.compile()
-        self._world._data = mj.MjData(self._world._model)
+            model = spec.compile()
+        install_compiled_model(self._world, model, mj.MjData(model))
         # Forward the freshly-allocated MjData so derived state
         # (xpos / xquat / xmat) is populated - same rationale as in
         # ``load_scene`` (#168). Without this, the first
@@ -3057,7 +3057,8 @@ class MuJoCoSimEngine(
             SpecBuilder.remove_camera(spec, mj_name)
             # Recompile so nbody/ncam in _model match the new spec.
             try:
-                self._world._model, self._world._data = spec.recompile(self._world._model, self._world._data)
+                new_model, new_data = spec.recompile(self._world._model, self._world._data)
+                install_compiled_model(self._world, new_model, new_data)
                 try:
                     with filter_mujoco_attach_noise():
                         self._world._backend_state["xml"] = spec.to_xml()

--- a/tests/simulation/mujoco/test_checkpoint_refused_after_model_swap.py
+++ b/tests/simulation/mujoco/test_checkpoint_refused_after_model_swap.py
@@ -1,0 +1,306 @@
+"""A physics checkpoint is refused once the model it was taken against is gone.
+
+``save_state`` stamps a checkpoint with a fingerprint - ``nq``/``nv``/``na``/``nu``
+plus ``SimWorld._recompile_generation`` - and ``load_state`` refuses to apply a
+checkpoint whose fingerprint no longer matches the live model. The counts catch a
+swap that resizes the state vector. The generation exists for the swap that does
+NOT: two models can agree on every count and still mean different things at the
+same state indices.
+
+The established contract, set by the dominant mutation path, is that ANY model
+swap invalidates an outstanding checkpoint - ``add_camera`` refuses one even
+though adding a camera leaves the state vector byte-identical. These tests pin
+the sibling swap paths to the same contract:
+
+* ``replace_scene_mjcf`` installs a whole new scene, so a checkpoint from the old
+  one is written index by index into whatever those indices now mean.
+* ``remove_camera`` is ``add_camera``'s mirror and leaves the state size
+  untouched, so nothing but the generation distinguishes the two models.
+* ``patch_scene_mjcf`` edits the live spec; an op that adds no body (``add_geom``)
+  leaves the state size untouched while changing what the model describes.
+
+``eject_robot_from_scene`` is deliberately not pinned behaviourally here: removing
+a robot always drops ``nbody``, and the state vector includes ``xfrc_applied``
+(``nbody`` x 6), so the size check refuses it on its own. It is covered by the
+structural test at the bottom, which is what keeps every swap site consistent.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.scene_ops import install_compiled_model  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Two scenes that agree on nq/nv/na/nu/nbody and disagree on what qpos[0] means:
+# in PAN the hinge turns the arm about z, in LIFT it swings it about y. A
+# checkpoint taken from one describes a pose the other never held.
+_PAN_SCENE = """<mujoco model="pan">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <light pos="0 0 3"/>
+    <body name="post" pos="0 0 0.3">
+      <joint name="swing" type="hinge" axis="0 0 1" range="-3 3" limited="true" damping="1"/>
+      <geom name="arm" type="box" size="0.30 0.05 0.05" pos="0.30 0 0" rgba="0.2 0.5 0.9 1"/>
+    </body>
+  </worldbody>
+  <actuator><position name="swing_act" joint="swing" kp="30" ctrlrange="-3 3"/></actuator>
+</mujoco>"""
+
+_LIFT_SCENE = _PAN_SCENE.replace('model="pan"', 'model="lift"').replace('axis="0 0 1"', 'axis="0 1 0"')
+
+_SAVED_SWING = 0.9
+
+
+# The fixture parameter is left un-annotated in these helpers: ``sim._world`` is
+# ``SimWorld | None`` on the class, and every probe below runs against a world the
+# fixture already created.
+def _state_size(sim) -> int:
+    """Length of the state vector a checkpoint stores for the live model."""
+    return int(mj.mj_stateSize(sim._world._model, mj.mjtState.mjSTATE_INTEGRATION))
+
+
+def _arm_position(sim) -> list[float]:
+    """World position of the arm geom - where the restored pose actually put it."""
+    model, data = sim._world._model, sim._world._data
+    mj.mj_forward(model, data)
+    gid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, "arm")
+    assert gid >= 0, "fixture scene must expose the 'arm' geom"
+    return [float(v) for v in data.geom_xpos[gid]]
+
+
+def _set_swing(sim, value: float) -> None:
+    """Drive the single hinge to ``value`` and refresh derived state."""
+    sim._world._data.qpos[0] = value
+    mj.mj_forward(sim._world._model, sim._world._data)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="checkpoint_swap_sim", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+class TestReplaceSceneMjcfInvalidatesCheckpoints:
+    def test_a_checkpoint_from_the_replaced_scene_is_refused(self, sim):
+        """The new scene keeps every count, so only the generation can refuse it.
+
+        Pre-fix ``replace_scene_mjcf`` rebound the live model without bumping the
+        generation, so the fingerprint still matched and the checkpoint was
+        applied to a different scene.
+        """
+        assert sim.replace_scene_mjcf(_PAN_SCENE)["status"] == "success"
+        _set_swing(sim, _SAVED_SWING)
+        size_before = _state_size(sim)
+        assert sim.save_state(name="panned")["status"] == "success"
+
+        assert sim.replace_scene_mjcf(_LIFT_SCENE)["status"] == "success"
+        assert _state_size(sim) == size_before, (
+            "fixture must keep the state size identical across the swap, otherwise "
+            "the size check refuses the checkpoint and the generation is untested"
+        )
+
+        result = sim.load_state(name="panned")
+        assert result["status"] == "error"
+        assert "stale" in result["content"][0]["text"].lower()
+
+    def test_the_refused_checkpoint_leaves_the_new_scene_at_rest(self, sim):
+        """A refusal must not half-apply the state it declined.
+
+        Pre-fix the saved hinge value was written into the new scene's hinge,
+        which swings the arm about a different axis: the arm ended up in a pose
+        no checkpoint ever recorded.
+        """
+        assert sim.replace_scene_mjcf(_PAN_SCENE)["status"] == "success"
+        _set_swing(sim, _SAVED_SWING)
+        panned_arm = _arm_position(sim)
+        assert sim.save_state(name="panned")["status"] == "success"
+
+        assert sim.replace_scene_mjcf(_LIFT_SCENE)["status"] == "success"
+        at_rest = _arm_position(sim)
+
+        assert sim.load_state(name="panned")["status"] == "error"
+
+        assert _arm_position(sim) == pytest.approx(at_rest), "the new scene must be untouched by a refused checkpoint"
+        # And the pose the stale vector would have produced is a real, different
+        # place - so the assertion above is not vacuous.
+        assert _arm_position(sim) != pytest.approx(panned_arm)
+
+    def test_a_checkpoint_saved_after_the_replacement_still_loads(self, sim):
+        """The refusal is scoped to checkpoints older than the swap."""
+        assert sim.replace_scene_mjcf(_PAN_SCENE)["status"] == "success"
+        assert sim.replace_scene_mjcf(_LIFT_SCENE)["status"] == "success"
+
+        _set_swing(sim, 0.5)
+        lifted = _arm_position(sim)
+        assert sim.save_state(name="lifted")["status"] == "success"
+
+        _set_swing(sim, 0.0)
+        assert _arm_position(sim) != pytest.approx(lifted)
+
+        assert sim.load_state(name="lifted")["status"] == "success"
+        assert _arm_position(sim) == pytest.approx(lifted)
+
+
+class TestCameraRemovalMatchesCameraAddition:
+    def test_remove_camera_invalidates_a_checkpoint_exactly_as_add_camera_does(self, sim):
+        """Both directions swap the model and neither changes the state size.
+
+        Pre-fix ``add_camera`` refused the checkpoint and ``remove_camera``
+        accepted it - the same checkpoint, opposite verdicts, for two halves of
+        one operation.
+        """
+        assert sim.add_camera(name="look", position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])["status"] == "success"
+        assert sim.save_state(name="two_cams")["status"] == "success"
+        size_before = _state_size(sim)
+
+        added = sim.add_camera(name="second", position=[0.0, 2.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert added["status"] == "success"
+        assert _state_size(sim) == size_before, "adding a camera must not resize the state vector"
+        after_add = sim.load_state(name="two_cams")
+
+        assert sim.save_state(name="three_cams")["status"] == "success"
+        assert sim.remove_camera("second")["status"] == "success"
+        assert _state_size(sim) == size_before, "removing a camera must not resize the state vector"
+        after_remove = sim.load_state(name="three_cams")
+
+        assert after_add["status"] == "error"
+        assert after_remove["status"] == after_add["status"], (
+            "adding and removing a camera must reach the same verdict on a "
+            f"checkpoint taken before it (add={after_add['status']}, "
+            f"remove={after_remove['status']})"
+        )
+        assert "stale" in after_remove["content"][0]["text"].lower()
+
+    def test_a_checkpoint_saved_after_the_removal_still_loads(self, sim):
+        assert sim.add_camera(name="look", position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])["status"] == "success"
+        assert sim.remove_camera("look")["status"] == "success"
+        assert sim.save_state(name="fresh")["status"] == "success"
+        assert sim.load_state(name="fresh")["status"] == "success"
+
+
+class TestPatchSceneMjcfInvalidatesCheckpoints:
+    def test_a_patch_that_adds_no_body_still_invalidates_a_checkpoint(self, sim):
+        """``add_geom`` keeps the state size and changes what the body describes.
+
+        A body without an explicit ``<inertial>`` derives its mass and inertia
+        from the geoms it owns, so this patch produces a different model at the
+        same state indices. Pre-fix nothing distinguished the two.
+        """
+        assert (
+            sim.add_object(name="cube", shape="box", size=[0.1, 0.1, 0.1], position=[0.0, 0.0, 0.5])["status"]
+            == "success"
+        )
+        size_before = _state_size(sim)
+        assert sim.save_state(name="one_geom")["status"] == "success"
+
+        patched = sim.patch_scene_mjcf(
+            ops=[{"op": "add_geom", "body": "cube", "type": "sphere", "size": [0.04], "name": "bump"}]
+        )
+        assert patched["status"] == "success"
+        assert _state_size(sim) == size_before, (
+            "fixture must keep the state size identical, otherwise the size check "
+            "refuses the checkpoint and the generation is untested"
+        )
+
+        result = sim.load_state(name="one_geom")
+        assert result["status"] == "error"
+        assert "stale" in result["content"][0]["text"].lower()
+
+    def test_a_checkpoint_saved_after_the_patch_still_loads(self, sim):
+        assert (
+            sim.add_object(name="cube", shape="box", size=[0.1, 0.1, 0.1], position=[0.0, 0.0, 0.5])["status"]
+            == "success"
+        )
+        assert (
+            sim.patch_scene_mjcf(
+                ops=[{"op": "add_geom", "body": "cube", "type": "sphere", "size": [0.04], "name": "bump"}]
+            )["status"]
+            == "success"
+        )
+        assert sim.save_state(name="fresh")["status"] == "success"
+        assert sim.load_state(name="fresh")["status"] == "success"
+
+
+# The live model/data pair a checkpoint is fingerprinted against.
+_LIVE_MODEL_ATTRS = frozenset({"_model", "_data"})
+
+# The one function allowed to install them, which is also what bumps the
+# generation. Any other site would be a swap that leaves the fingerprint behind.
+_INSTALLER = "install_compiled_model"
+
+
+def _assignment_sites(source: str) -> dict[str, list[int]]:
+    """Map enclosing function name -> lines assigning a live model attribute.
+
+    Attributes assignments to :data:`_LIVE_MODEL_ATTRS` are reported against the
+    innermost enclosing function (``"<module>"`` for a top-level statement), so a
+    nested helper is never charged to its parent.
+    """
+    sites: dict[str, list[int]] = {}
+
+    def visit(node: ast.AST, enclosing: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                visit(child, child.name)
+                continue
+            if isinstance(child, ast.Assign):
+                for target in child.targets:
+                    elements = target.elts if isinstance(target, ast.Tuple) else [target]
+                    for element in elements:
+                        if isinstance(element, ast.Attribute) and element.attr in _LIVE_MODEL_ATTRS:
+                            sites.setdefault(enclosing, []).append(child.lineno)
+            visit(child, enclosing)
+
+    visit(ast.parse(source), "<module>")
+    return sites
+
+
+class TestEverySwapSiteGoesThroughTheInstaller:
+    def test_only_the_installer_assigns_the_live_model(self):
+        """A swap site that rebinds the model directly cannot bump the generation.
+
+        The generation is the only part of the fingerprint that changes when a
+        swap keeps every count, so a site that assigns ``_model`` outside the
+        installer silently accepts checkpoints taken against the previous model.
+        Scoped to the MuJoCo backend: it is the only backend whose ``SimWorld``
+        carries a compiled model and data pair.
+        """
+        backend = Path(inspect.getfile(install_compiled_model)).parent
+        modules = sorted(backend.glob("*.py"))
+        assert modules, f"no backend modules found under {backend.name}"
+
+        offenders: dict[str, dict[str, list[int]]] = {}
+        for module in modules:
+            found = _assignment_sites(module.read_text(encoding="utf-8"))
+            extra = {name: lines for name, lines in found.items() if name != _INSTALLER}
+            if extra:
+                offenders[module.name] = extra
+
+        assert not offenders, (
+            f"these sites assign the live model outside {_INSTALLER}(), so a "
+            f"checkpoint taken against the previous model would still be "
+            f"accepted: {offenders}"
+        )
+
+    def test_the_installer_is_the_site_the_scan_finds(self):
+        """Guard against a scan that matches nothing and therefore proves nothing."""
+        source = Path(inspect.getfile(install_compiled_model)).read_text(encoding="utf-8")
+        assert _INSTALLER in _assignment_sites(source)
+
+    def test_a_planted_swap_site_is_detected(self):
+        """The scan must fail for a site it is meant to catch."""
+        planted = "def swap_it(world, model, data):\n    world._model = model\n    world._data = data\n"
+        assert _assignment_sites(planted) == {"swap_it": [2, 3]}
+
+        tuple_form = "def swap_it(world, spec):\n    world._model, world._data = spec.recompile()\n"
+        assert _assignment_sites(tuple_form) == {"swap_it": [2, 2]}

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -68,6 +68,7 @@ _EXPECTED_FUNCTIONS = {
     "scene_ops.py::inject_camera_into_scene",
     "scene_ops.py::inject_object_into_scene",
     "scene_ops.py::inject_robot_into_scene",
+    "scene_ops.py::install_compiled_model",
     "scene_ops.py::patch_scene_mjcf",
     "scene_ops.py::persist_body_mass",
     "scene_ops.py::persist_geom_properties",


### PR DESCRIPTION
## Problem

`save_state` stamps a checkpoint with a fingerprint - `nq`/`nv`/`na`/`nu` plus `SimWorld._recompile_generation` - and `load_state` refuses to apply a checkpoint whose fingerprint no longer matches the live model.

The counts catch a swap that resizes the state vector. The generation exists for the swap that does **not**: two models can agree on every count and still mean different things at the same state indices. `_recompile_preserving_state` says so in a comment, and `TestStateCheckpointing::test_load_state_after_same_shape_recompile_returns_error` already pins the pathology - "applying the stale vector would silently teleport the new object into the old object's saved pose/velocity".

Only one of the seven paths that install a compiled model bumped that counter:

| path | swaps the live model | bumped the generation |
|---|---|---|
| `scene_ops._recompile_preserving_state` | yes | **yes** |
| `scene_ops.eject_robot_from_scene` | yes | no |
| `scene_ops.replace_scene_mjcf` | yes | no |
| `scene_ops.patch_scene_mjcf` | yes | no |
| `simulation.remove_camera` | yes | no |
| `simulation._compile_world` | first model of a fresh world | n/a |
| `simulation.load_scene` | installs a fresh `SimWorld` | n/a |

So six of the seven left the fingerprint behind, and the checkpoint was accepted against a model that no longer existed.

## Measured on `main`

**`replace_scene_mjcf` - the state vector is written into a different scene.** Two scenes agreeing on `nq/nv/na/nu = 1/1/0/1` and on a **18-float** state vector, differing only in what the single hinge does (pan about z vs lift about y):

| step | result |
|---|---|
| pose the pan hinge to `qpos[0]=0.9`, arm at `[0.2611, 0.329, 0.45]` | `save_state` -> success |
| `replace_scene_mjcf(lift scene)`, arm at rest `[0.42, 0.0, 0.45]` | success, state size still 18 |
| `load_state` | **success** - arm now at `[0.2611, 0.0, 0.121]` |

The saved pan value drove the lift hinge: the arm dropped from `z=0.45` to `z=0.121`, into a pose no checkpoint ever recorded, and the call reported success.

**`remove_camera` disagrees with `add_camera` about the same checkpoint.** Neither direction changes the state size, so only the generation can tell the models apart:

| operation | verdict on a checkpoint taken before it |
|---|---|
| `add_camera` | `error` - "Checkpoint is stale" |
| `remove_camera` | **`success`** |

**`patch_scene_mjcf` with an op that adds no body.** `add_geom` leaves `nbody` and the state size untouched while changing what the body describes (a body without an explicit `<inertial>` derives its mass and inertia from the geoms it owns), and the checkpoint was accepted.

The conservative direction is already the established contract: `add_camera` invalidates a checkpoint even though adding a camera leaves the state vector byte-identical. This change makes the sibling paths agree with it rather than making anything newly strict.

## Change

One `install_compiled_model(world, model, data)` in `scene_ops` performs the rebind and the invalidation together, and all seven sites call it. Concentrating the rebind is the point: a swap site cannot install a model without invalidating the checkpoints taken against the previous one, which is what let five sites drift in the first place. `SimWorld._recompile_generation`'s comment named that single call site rather than the invariant; it now states the invariant.

`_compile_world` and `load_scene` are routed through it too so the rule has no exceptions to remember. Both produce a world's *first* model, where the counter's starting value is unobservable - a fresh `SimWorld` has no checkpoints.

## Sim artifact

MuJoCo headless (EGL). Same scene pair, same camera, both trees; the two "before" renders are byte-identical, so only the operation differs.

![checkpoint refused after a model swap](https://raw.githubusercontent.com/cagataycali/robots/artifacts/checkpoint-model-swap/checkpoint-model-swap.png)

Panel 3 is `main`: `load_state` returns success and the arm is pitched down into a pose that was never saved. Panel 4 is this PR: the checkpoint is refused and the render is byte-identical to the at-rest panel, so the refusal does not half-apply the state it declined.

## Tests

`tests/simulation/mujoco/test_checkpoint_refused_after_model_swap.py` (10 tests):

- `replace_scene_mjcf`: the checkpoint is refused, **and** the new scene is left at rest - asserted against the pose the stale vector would have produced, so the "untouched" assertion cannot pass vacuously.
- `remove_camera` reaches the same verdict as `add_camera` on the same checkpoint, with the state size asserted unchanged in both directions.
- `patch_scene_mjcf(add_geom)` invalidates a checkpoint, with the state size asserted unchanged so the size check cannot be what refuses it.
- Each swap path: a checkpoint saved *after* the swap still loads and restores the value, so the refusal is scoped to older checkpoints.
- A structural test asserting the live model is only ever assigned inside `install_compiled_model`, plus two meta-tests - that the scan finds the installer, and that it detects a planted swap site in both the plain and tuple-assignment forms - so a scan matching nothing cannot look like a clean tree.

`eject_robot_from_scene` is deliberately not pinned behaviourally: removing a robot always drops `nbody`, and the state vector includes `xfrc_applied` (`nbody` x 6), so the size check refuses it on its own. Writing a behavioural test there would pass pre-fix and prove nothing; the structural test is what keeps it consistent.

Pre-fix on `28df033c`: **5 failed / 4 passed**. The structural failure enumerates every drifted site:

```
{'scene_ops.py': {'_recompile_preserving_state': [141, 142], 'eject_robot_from_scene': [779, 780],
                  'replace_scene_mjcf': [1012, 1013], 'patch_scene_mjcf': [1268, 1268]},
 'simulation.py': {'load_scene': [673, 674], '_compile_world': [821, 822], 'remove_camera': [3060, 3060]}}
```

The 4 pre-fix passes are the "saved after the swap still loads" cases and the planted-offender meta-test - properties that were already true, kept so the fix cannot regress them.

## Gate

- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` - no issues in 962 source files.
- `MUJOCO_GL=egl pytest tests` - **14016 passed, 253 skipped** (`28df033c` + this PR).
- Docs: the `save_state` / `load_state` row in `docs/simulation/overview.md` now states the validity contract and lists the mutations that invalidate a checkpoint.