### PR TITLE
fix(sim): refuse a patch op numeric field that is not finite

### DIFF
--- a/changelog.d/1757-patch-op-non-finite.md
+++ b/changelog.d/1757-patch-op-non-finite.md
@@ -1,0 +1,14 @@
+### Fixed: `patch_scene_mjcf` refuses a numeric op field that is not finite
+
+Every numeric field a patch op writes into the compiled MJCF - `pos`, `quat`,
+`size`, `rgba` - is now checked for finite numeric components before the spec is
+touched, the same domain `add_object`, `add_camera` and `move_object` already
+apply to those fields.
+
+MuJoCo does not reject a `nan`/`inf` pose, extent or colour (its one exception is
+a `nan` geom size), so the component was written verbatim into the model and the
+patch reported success. `{"op": "set_body_pos", "pos": [nan, 0, 0.3]}` on a body
+owning a freejoint left `qpos` and `qvel` non-finite after the next step, with the
+patch, the step and the observation read all reporting success - so the same field
+`move_object` refused was accepted by `set_body_pos`, for one identical write to
+`body_pos`.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -319,8 +319,21 @@ sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "position": [0.4, 
 #               Accepted keys: name, op, pos.
 ```
 
+Every numeric field an op writes - `pos`, `quat`, `size`, `rgba` - must hold
+finite numbers, the same domain `add_object` / `add_camera` / `move_object` apply.
+MuJoCo bakes a `nan`/`inf` component into the model without complaint, so an
+unchecked one reports success and only surfaces later as a poisoned physics
+state:
+
+```python
+sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "pos": [float("nan"), 0, 0.3]}])
+# status=error: set_body_pos: 'pos' must contain finite numbers (no nan/inf),
+#               got [nan, 0, 0.3]
+```
+
 The batch is atomic: if any op is rejected the world is rolled back to its
-pre-patch state, so a bad key never leaves a half-applied scene. Use
+pre-patch state, so a bad key or a non-finite component never leaves a
+half-applied scene. Use
 `replace_scene_mjcf(xml)` for MJCF elements this vocabulary does not cover.
 
 ## Cameras

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -38,6 +38,7 @@ from strands_robots.simulation.mujoco.backend import (
     filter_mujoco_attach_noise,
 )
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder
+from strands_robots.utils import finite_vector_error
 
 logger = logging.getLogger(__name__)
 
@@ -1082,6 +1083,55 @@ def _unknown_op_keys_error(kind: str, op: Mapping[str, Any]) -> str | None:
     return f"{kind}: unknown op key(s): {', '.join(described)}. Accepted keys: {', '.join(known)}."
 
 
+# The numeric vector fields each op writes into the compiled MJCF. Every name
+# here is also an accepted key of the same op in :data:`_PATCH_OP_KEYS`; a
+# parity test pins that, so the two tables cannot drift into disagreement about
+# which fields an op reads.
+_PATCH_OP_VECTOR_FIELDS: dict[str, frozenset[str]] = {
+    "add_body": frozenset({"pos", "quat"}),
+    "add_geom": frozenset({"pos", "quat", "size", "rgba"}),
+    "add_site": frozenset({"pos", "size", "rgba"}),
+    "set_body_pos": frozenset({"pos"}),
+    "set_body_quat": frozenset({"quat"}),
+    "delete_body": frozenset(),
+}
+
+
+def _non_finite_op_field_error(kind: str, op: Mapping[str, Any]) -> str | None:
+    """Reject a numeric op field that is not finite numbers, before the spec is touched.
+
+    MuJoCo's compiler does not reject a ``nan``/``inf`` pose, extent or colour
+    (its one exception is a ``nan`` geom size), so an unchecked component is
+    written verbatim into the model and the patch reports success. A non-finite
+    ``pos`` on a body that owns a freejoint then poisons ``qpos``/``qvel`` on the
+    next step, and every call in that chain - the patch, the step, the
+    observation read - keeps reporting success, so a caller has no way to learn
+    the scene is dead.
+
+    Delegates to :func:`~strands_robots.utils.finite_vector_error`, which is the
+    same guard ``add_object``, ``add_camera`` and ``move_object`` already apply to
+    the very same fields: without it ``set_body_pos`` accepted a pose
+    ``move_object`` refuses, for one identical write to ``body_pos``.
+
+    Length is deliberately not checked here. A wrong component count is already
+    refused - by ``_validate_size`` for a geom size, and by the MuJoCo binding
+    for a pose - so this guard adds only the finiteness and numeric-type axis
+    that nothing downstream covers.
+
+    Args:
+        kind: The op name, already known to be in :data:`_PATCH_OP_KEYS`.
+        op: The caller-supplied op dict.
+
+    Returns:
+        An error message naming the op, the field and the offending value, or
+        ``None`` when every numeric field present holds finite numbers.
+    """
+    for field in sorted(_PATCH_OP_VECTOR_FIELDS[kind]):
+        if field in op and (msg := finite_vector_error(kind, field, op[field])) is not None:
+            return msg
+    return None
+
+
 def _find_body(spec: Any, name: str, new_bodies: dict[str, Any]) -> Any:
     """Locate a body by name in a live spec, checking batch-local additions.
 
@@ -1122,6 +1172,8 @@ def _apply_patch_op(spec: Any, op: dict[str, Any], new_bodies: dict[str, Any]) -
     if kind not in _PATCH_OP_KEYS:
         raise ValueError(f"unknown op '{kind}'. Supported: {sorted(_PATCH_OP_KEYS)}")
     if err := _unknown_op_keys_error(str(kind), op):
+        raise ValueError(err)
+    if err := _non_finite_op_field_error(str(kind), op):
         raise ValueError(err)
 
     if kind == "add_body":
@@ -1229,7 +1281,11 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
 
     Each op accepts exactly the keys listed for it in :data:`_PATCH_OP_KEYS`;
     anything else is rejected, because an unread key would leave the op running
-    on its fallback default (see :func:`_unknown_op_keys_error`).
+    on its fallback default (see :func:`_unknown_op_keys_error`). Every numeric
+    field an op writes must hold finite numbers (see
+    :func:`_non_finite_op_field_error`) - MuJoCo bakes a ``nan``/``inf``
+    component into the model without complaint, so it would be accepted here and
+    surface as a dead scene several successful calls later.
 
     The list is applied atomically: if any op raises, the whole patch is
     rejected and the world is left in its original state. After all ops

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -771,11 +771,25 @@ class MuJoCoSimEngine(
         error names the op, the unrecognised key, a close match where one
         exists, and the keys that op accepts.
 
+        Every numeric field an op writes - ``pos``, ``quat``, ``size``,
+        ``rgba`` - must hold finite numbers. MuJoCo bakes a ``nan``/``inf``
+        component into the model without complaint, so an unchecked one is
+        accepted and only surfaces as a poisoned physics state several
+        successful calls later::
+
+            sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate",
+                                   "pos": [float("nan"), 0, 0.3]}])
+            # status=error: set_body_pos: 'pos' must contain finite numbers
+            #               (no nan/inf), got [nan, 0, 0.3]
+
+        This is the same domain ``add_object``, ``add_camera`` and
+        ``move_object`` apply to those fields.
+
         The whole batch is applied, then the spec is recompiled once. If any
         op fails, the batch is rejected and the world is rolled back to its
-        pre-patch state (from an XML snapshot). Use this for fast iterative
-        edits; use ``replace_scene_mjcf`` when you need to express MJCF
-        elements not covered by the supported op vocabulary.
+        pre-patch state (from a deep copy of the spec). Use this for fast
+        iterative edits; use ``replace_scene_mjcf`` when you need to express
+        MJCF elements not covered by the supported op vocabulary.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}

--- a/tests/simulation/mujoco/test_patch_op_numeric_field_validation.py
+++ b/tests/simulation/mujoco/test_patch_op_numeric_field_validation.py
@@ -100,7 +100,7 @@ ALL_NUMERIC_FIELDS = sorted((kind, field) for kind, fields in _PATCH_OP_VECTOR_F
 class TestNonFiniteComponentsAreRefused:
     """A non-finite component is refused on every numeric field of every op."""
 
-    @pytest.mark.parametrize(("kind", "field"), ALL_NUMERIC_FIELDS, ids=lambda v: str(v))
+    @pytest.mark.parametrize(("kind", "field"), ALL_NUMERIC_FIELDS)
     @pytest.mark.parametrize("bad", NON_FINITE, ids=["nan", "inf", "-inf"])
     def test_every_numeric_op_field_refuses_a_non_finite_component(
         self, sim, kind: str, field: str, bad: float

--- a/tests/simulation/mujoco/test_patch_op_numeric_field_validation.py
+++ b/tests/simulation/mujoco/test_patch_op_numeric_field_validation.py
@@ -1,0 +1,277 @@
+"""``patch_scene_mjcf`` refuses a numeric op field that is not finite numbers.
+
+MuJoCo's compiler does not reject a ``nan``/``inf`` pose, extent or colour - its
+one exception is a ``nan`` geom size, and even that lets ``inf`` through - so an
+unchecked component was written verbatim into the compiled model while the patch
+reported success. On a body owning a freejoint the corruption then spread into
+the physics state, with every call in the chain still reporting success::
+
+    patch set_body_pos pos=[nan, 0, 0.3]   status="success"
+    model.body_pos                         [nan, 0.0, 0.3]
+    step(n_steps=20)                       status="success"
+    data.qpos / data.qvel                  non-finite
+
+The same fields written through ``move_object``, ``add_object`` and
+``add_camera`` were already refused, so one identical write to ``body_pos`` had
+two opposite verdicts depending on which method issued it. These tests pin the
+finiteness domain on every numeric field of every op, hold it to the same verdict
+as its ``move_object`` sibling, and pin that the values MuJoCo does define - an
+integer component, a NumPy real scalar, and the all-zero quaternion it reads as
+identity - are still accepted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.scene_ops import (  # noqa: E402
+    _PATCH_OP_KEYS,
+    _PATCH_OP_VECTOR_FIELDS,
+)
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+NON_FINITE = [float("nan"), float("inf"), -float("inf")]
+CRATE_POS = [0.4, 0.0, 0.5]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_patch_numeric", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _seeded_world(sim) -> None:
+    """Compile a world holding a free-floating body ``crate`` at :data:`CRATE_POS`.
+
+    ``sim`` is left un-annotated throughout this module: ``Simulation._world`` is
+    typed ``SimWorld | None``, so annotating it would make every ``_world._model``
+    probe below read as a possible ``None`` even though the fixture guarantees a
+    compiled world.
+
+    The freejoint matters: it is what gives the body ``qpos``/``qvel`` rows, so a
+    non-finite ``body_pos`` can reach the physics state rather than only the
+    static kinematics.
+    """
+    sim.create_world()
+    assert sim.add_object(name="crate", shape="box", size=[0.2, 0.2, 0.2], position=CRATE_POS)["status"] == "success"
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(part.get("text", "") for part in result.get("content", []))
+
+
+def _body_pos(sim, name: str) -> list[float]:
+    model = sim._world._model
+    return [float(v) for v in model.body_pos[model.body(name).id]]
+
+
+def _state_is_finite(sim) -> bool:
+    data = sim._world._data
+    return bool(np.all(np.isfinite(data.qpos))) and bool(np.all(np.isfinite(data.qvel)))
+
+
+# Every (op, field) pair the tables declare, with an op body that is otherwise
+# valid so the only reason to refuse is the non-finite component.
+def _op_with(kind: str, field: str, value: Any) -> dict[str, Any]:
+    bodies: dict[str, dict[str, Any]] = {
+        "add_body": {"op": "add_body", "parent": "world", "name": "fresh"},
+        "add_geom": {"op": "add_geom", "body": "crate", "type": "box", "size": [0.1, 0.1, 0.1]},
+        "add_site": {"op": "add_site", "body": "crate", "name": "tip"},
+        "set_body_pos": {"op": "set_body_pos", "name": "crate"},
+        "set_body_quat": {"op": "set_body_quat", "name": "crate"},
+    }
+    lengths = {"pos": 3, "quat": 4, "rgba": 4, "size": 3}
+    op = dict(bodies[kind])
+    op[field] = [value] + [0.1] * (lengths[field] - 1)
+    return op
+
+
+ALL_NUMERIC_FIELDS = sorted((kind, field) for kind, fields in _PATCH_OP_VECTOR_FIELDS.items() for field in fields)
+
+
+class TestNonFiniteComponentsAreRefused:
+    """A non-finite component is refused on every numeric field of every op."""
+
+    @pytest.mark.parametrize(("kind", "field"), ALL_NUMERIC_FIELDS, ids=lambda v: str(v))
+    @pytest.mark.parametrize("bad", NON_FINITE, ids=["nan", "inf", "-inf"])
+    def test_every_numeric_op_field_refuses_a_non_finite_component(
+        self, sim, kind: str, field: str, bad: float
+    ) -> None:
+        _seeded_world(sim)
+        result = sim.patch_scene_mjcf([_op_with(kind, field, bad)])
+        assert result["status"] == "error", f"{kind}.{field}={bad} was accepted"
+        message = _text(result)
+        assert kind in message
+        assert f"'{field}'" in message
+        assert "finite" in message
+
+    @pytest.mark.parametrize("bad", NON_FINITE, ids=["nan", "inf", "-inf"])
+    def test_a_refused_pose_leaves_the_body_and_the_physics_state_untouched(self, sim, bad: float) -> None:
+        """The headline consequence: the model keeps the old pose and the state stays usable.
+
+        Pre-fix this reported success, wrote the component into ``body_pos`` and
+        left ``qpos``/``qvel`` non-finite after the next step.
+        """
+        _seeded_world(sim)
+        sim.step(n_steps=5)
+        assert _state_is_finite(sim), "fixture premise: the scene starts with a usable state"
+
+        result = sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "pos": [bad, 0.0, 0.3]}])
+
+        assert result["status"] == "error"
+        assert _body_pos(sim, "crate") == pytest.approx(CRATE_POS)
+        assert sim.step(n_steps=20)["status"] == "success"
+        assert _state_is_finite(sim), "a refused patch must not poison qpos/qvel"
+
+    def test_a_non_finite_op_does_not_half_apply_the_batch(self, sim) -> None:
+        """A valid op ahead of a bad one is rolled back, matching the documented atomicity."""
+        _seeded_world(sim)
+        before = sim._world._model.nbody
+
+        result = sim.patch_scene_mjcf(
+            [
+                {"op": "add_body", "parent": "world", "name": "good", "pos": [0.1, 0.0, 0.2]},
+                {"op": "set_body_pos", "name": "crate", "pos": [float("inf"), 0.0, 0.3]},
+            ]
+        )
+
+        assert result["status"] == "error"
+        assert sim._world._model.nbody == before
+        assert _body_pos(sim, "crate") == pytest.approx(CRATE_POS)
+        with pytest.raises(KeyError):
+            sim._world._model.body("good")
+
+
+class TestNonNumericComponentsAreRefused:
+    """The other axis of the shared guard: a component that is not a number at all."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (["a", "b", "c"], "must be numbers"),
+            ([None, 0.0, 0.3], "must be numbers"),
+            ([[0.1], 0.0, 0.3], "must be numbers"),
+            ([True, 0.0, 0.3], "must be numbers"),
+            (0.4, "must be a list/tuple of numbers"),
+        ],
+        ids=["strings", "none", "nested", "bool", "scalar"],
+    )
+    def test_a_non_numeric_pos_is_refused_with_a_structured_error(self, sim, value: Any, expected: str) -> None:
+        _seeded_world(sim)
+        result = sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "pos": value}])
+        assert result["status"] == "error"
+        assert expected in _text(result)
+        assert _body_pos(sim, "crate") == pytest.approx(CRATE_POS)
+
+
+class TestSameVerdictAsTheMoveObjectSibling:
+    """One write to ``body_pos``, one verdict, whichever method issues it."""
+
+    @pytest.mark.parametrize(
+        "pose",
+        [
+            [float("nan"), 0.0, 0.3],
+            [float("inf"), 0.0, 0.3],
+            [-float("inf"), 0.0, 0.3],
+            ["a", "b", "c"],
+            [True, 0.0, 0.3],
+            [0.2, 0.1, 0.4],
+        ],
+        ids=["nan", "inf", "-inf", "strings", "bool", "valid"],
+    )
+    def test_set_body_pos_and_move_object_agree_on_a_position(self, sim, pose: list[Any]) -> None:
+        _seeded_world(sim)
+        via_move = sim.move_object(name="crate", position=list(pose))["status"]
+        via_patch = sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "pos": list(pose)}])["status"]
+        assert via_patch == via_move, f"verdicts differ for pos={pose!r}"
+
+    @pytest.mark.parametrize(
+        "quat",
+        [
+            [float("nan"), 0.0, 0.0, 0.0],
+            [float("inf"), 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+        ],
+        ids=["nan", "inf", "all-zero", "identity"],
+    )
+    def test_set_body_quat_and_move_object_agree_on_an_orientation(self, sim, quat: list[float]) -> None:
+        """Includes the all-zero quaternion, which both sides accept.
+
+        MuJoCo reads an all-zero ``quat`` as the identity rotation rather than
+        normalising it into ``nan``, so it is a defined input and is deliberately
+        not refused - the guard is finiteness, not unit norm.
+        """
+        _seeded_world(sim)
+        via_move = sim.move_object(name="crate", orientation=list(quat))["status"]
+        via_patch = sim.patch_scene_mjcf([{"op": "set_body_quat", "name": "crate", "quat": list(quat)}])["status"]
+        assert via_patch == via_move, f"verdicts differ for quat={quat!r}"
+
+
+class TestUsableValuesStillCompile:
+    """No false positives: the numeric shapes MuJoCo defines are still accepted."""
+
+    @pytest.mark.parametrize(
+        "pos",
+        [[0.2, 0.1, 0.4], [0, 0, 1], [np.float64(0.2), np.float32(0.1), 0.4]],
+        ids=["floats", "ints", "numpy-scalars"],
+    )
+    def test_a_finite_pose_is_applied(self, sim, pos: list[Any]) -> None:
+        _seeded_world(sim)
+        result = sim.patch_scene_mjcf([{"op": "set_body_pos", "name": "crate", "pos": list(pos)}])
+        assert result["status"] == "success"
+        assert _body_pos(sim, "crate") == pytest.approx([float(v) for v in pos])
+
+    def test_a_full_op_vocabulary_batch_still_applies(self, sim) -> None:
+        """Every op writing every numeric field it accepts, with usable values."""
+        _seeded_world(sim)
+        result = sim.patch_scene_mjcf(
+            [
+                {
+                    "op": "add_body",
+                    "parent": "world",
+                    "name": "rig",
+                    "pos": [0.1, 0.0, 0.2],
+                    "quat": [1.0, 0.0, 0.0, 0.0],
+                },
+                {
+                    "op": "add_geom",
+                    "body": "rig",
+                    "type": "sphere",
+                    "size": [0.06, 0.06, 0.06],
+                    "rgba": [0.2, 0.7, 0.3, 1.0],
+                    "pos": [0.0, 0.0, 0.0],
+                    "quat": [1.0, 0.0, 0.0, 0.0],
+                },
+                {
+                    "op": "add_site",
+                    "body": "rig",
+                    "name": "tip",
+                    "pos": [0.0, 0.0, 0.1],
+                    "size": [0.01],
+                    "rgba": [1.0, 0.0, 0.0, 1.0],
+                },
+                {"op": "set_body_quat", "name": "crate", "quat": [1.0, 0.0, 0.0, 0.0]},
+            ]
+        )
+        assert result["status"] == "success", _text(result)
+        assert sim._world._model.body("rig") is not None
+
+
+class TestTheTwoOpTablesCannotDrift:
+    """The numeric-field table is pinned against the accepted-key table."""
+
+    def test_every_op_declares_its_numeric_fields(self) -> None:
+        assert set(_PATCH_OP_VECTOR_FIELDS) == set(_PATCH_OP_KEYS)
+
+    @pytest.mark.parametrize("kind", sorted(_PATCH_OP_KEYS))
+    def test_every_numeric_field_is_an_accepted_key_of_its_op(self, kind: str) -> None:
+        assert _PATCH_OP_VECTOR_FIELDS[kind] <= _PATCH_OP_KEYS[kind]


### PR DESCRIPTION
`patch_scene_mjcf` validates the op name and the op keys, and wrote every numeric **value** straight into the live spec. MuJoCo does not reject a `nan`/`inf` pose, extent or colour, so the component was baked into the compiled model and the patch reported success.

On a body owning a freejoint that reaches the shared state vector, so one op naming one body kills the whole scene:

```
patch set_body_pos pos=[nan, 0.0, 0.33]   status="success"   "1 op(s) applied"
model.body_pos[crate].x                   nan
step(n_steps=400)                         status="success"
data.qpos / data.qvel                     NON-FINITE
get_body_state("crate")                   [nan, nan, nan]
get_body_state("ball")                    [nan, nan, nan]   <- never named by the op
```

Every call in that chain reports success, so a caller has no way to learn the world is dead. MuJoCo only mutters `Nan, Inf or huge value in QPOS` to stderr.

## The same field, two opposite verdicts

`move_object`, `add_object` and `add_camera` already refuse a non-finite component on exactly these fields. `set_body_pos` writes the same `body_pos` row and accepted it:

| value written to `body_pos` | `move_object(position=...)` | `set_body_pos` pos, before |
|---|---|---|
| `[nan, 0.0, 0.3]` | error | **success** |
| `[inf, 0.0, 0.3]` | error | **success** |
| `[-inf, 0.0, 0.3]` | error | **success** |
| `[True, 0.0, 0.3]` | error | **success** (silent 1.0 m) |
| `["a", "b", "c"]` | error | pybind `incompatible function arguments` |

The guard `finite_vector_error` already exists for this, and its docstring names this exact class of consumer - "the numeric vectors a scene-construction call bakes into the compiled MJCF". `patch_scene_mjcf` was the one such surface that never called it.

## Measured across the whole op vocabulary

Before, one non-finite component per field:

| op | field | before | after |
|---|---|---|---|
| `add_body` | `pos`, `quat` | success, non-finite `body_pos` / `xquat` | refused |
| `add_geom` | `pos`, `quat`, `rgba` | success, non-finite `geom_*` | refused |
| `add_geom` | `size` | `nan` refused by MuJoCo; **`inf` accepted** | refused |
| `add_site` | `pos`, `size`, `rgba` | success, non-finite `site_*` | refused |
| `set_body_pos` | `pos` | success, scene state non-finite | refused |
| `set_body_quat` | `quat` | success, `xquat` `nan` (`inf` normalises to `nan`) | refused |

Relying on the compiler is not a strategy: it has exactly one such check (`nan size in geom`) and `inf` walks past it. Where it did refuse, it blamed the wrong thing - `add_geom` with a non-finite `pos` failed as `mass and inertia of moving bodies must be larger than mjMINVAL`, and a non-finite site `size` as `size 0 must be positive`, neither of which names the field the caller got wrong.

## The change

`_PATCH_OP_VECTOR_FIELDS` declares the numeric fields each op writes, and `_non_finite_op_field_error` runs them through the shared `finite_vector_error` before the spec is touched - beside the existing `_unknown_op_keys_error`, so the batch atomicity already documented there covers it and a rejected op leaves nothing half-applied.

Two things deliberately unchanged:

- **Length.** A wrong component count is already refused (`_validate_size` for a geom size, the MuJoCo binding for a pose), so this adds only the finiteness and numeric-type axis. Message quality on that path is a separate ergonomics question.
- **The all-zero quaternion.** MuJoCo reads `[0,0,0,0]` as the identity rotation rather than normalising it into `nan`, and `move_object` accepts it, so it is a defined input. The guard is finiteness, not unit norm - pinned as such, on both sides.

## Sim rollout (headless EGL)

The same scripted scene edit against both trees. The `before` panels are identical to within renderer noise (`max|delta| = 1`), so only the operation differs; the two `after` panels differ on 11.06% of pixels.

![patch op non-finite field refusal](https://raw.githubusercontent.com/cagataycali/robots/artifacts/patch-op-non-finite/patch-op-non-finite.png)

The crate is the body the op names. The ball is not - it goes with it anyway, because both share one state vector.

## Tests

`tests/simulation/mujoco/test_patch_op_numeric_field_validation.py`, 63 tests: every `(op, field)` pair against `nan`/`inf`/`-inf`; the headline consequence (a refused pose leaves `body_pos` and the physics state intact, asserted after a further 20 steps, with a premise assertion that the fixture starts from a usable state so it cannot pass vacuously); batch atomicity; the non-numeric axis; a cross-method parity test holding `set_body_pos`/`set_body_quat` to the same verdict as `move_object` over the whole probe set including the values both accept; no-false-positive cases for integer and NumPy-scalar components and a full op-vocabulary batch; and a parity test pinning `_PATCH_OP_VECTOR_FIELDS` against `_PATCH_OP_KEYS` so the two tables cannot drift.

Pre-fix on this base: **48 failed, 8 passed**. The 8 are the no-false-positive cases plus the one `nan` geom size MuJoCo happens to catch - they are what stop the guard over-reaching, so they are kept rather than trimmed.

## Gate

`ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (962 source files). `MUJOCO_GL=egl pytest tests`: **14069 passed, 253 skipped** (458s). No existing test changed - the scalar-`size` assertions this guard's message would touch are already `add_object` tests pinning the same `finite_vector_error` text.

## Round 2 (8e10b4ec)

CodeQL flagged `ids=lambda v: str(v)` on the `(op, field)` parametrization as an unnecessary lambda. It is right, and the argument was redundant outright rather than merely wrapped: those values are already the op and field name strings, so it produced exactly the ids pytest generates by default. The sibling parametrization in the same file already relies on that default (`parametrize("kind", sorted(_PATCH_OP_KEYS))`), so the argument is gone rather than swapped for a bare `str` reference that would do nothing. Explicit `ids=` now appears in this file only where the values are floats and the default is unusable.

The ids are verified unchanged, not assumed - collected before and after and diffed: 63 before, 63 after, empty diff, so `...[nan-add_geom-size]` reads exactly as before. No new test accompanies it: no behaviour changes, and the property at stake is the generated id set, which that diff pins directly.

Gate re-run on the new head: `ruff check` / `ruff format --check` clean (965 files), `mypy strands_robots tests tests_integ` clean (962 source files), `MUJOCO_GL=egl pytest tests` **14069 passed, 253 skipped** (465s).
