### PR TITLE
docs: verify a PR's state by reading it back before and after changing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,28 @@ hatch run format            # ruff check --fix, ruff format
 5. Open PR from your fork, address all review comments
 6. Track follow-up items as issues on the [project board](https://github.com/orgs/strands-labs/projects/2)
 7. Squash merge into `main`
+8. **Verify a PR's state by reading it back - before and after you change it.**
+   Neither direction can be inferred:
+   - *Before.* Query `timelineItems(itemTypes: [CLOSED_EVENT, REOPENED_EVENT])`
+     before closing or reopening. A lone `CLOSED_EVENT` is safe to re-apply; an
+     alternating run means something is undoing you, and a further flip only
+     lengthens it. #1667 - the retired `pr/consolidated-local-work` staging PR -
+     was closed and reopened **ten times in under fourteen hours**, each reopen 2-22
+     minutes after the preceding close, because independent contributors read
+     the same PR and reached opposite conclusions. Its extraction plan and
+     terminal state live in #1723; do not flip #1667 again.
+   - *After.* A `mergePullRequest` mutation can report `Pull Request is not
+     mergeable` on a merge that in fact landed - observed on #1756, where the
+     mutation returned that error and the squash was already on `main`. Confirm
+     with `state`/`merged`, or `git log origin/main`, before concluding a merge
+     failed and redoing the work.
+   And before merging, `reviewDecision: APPROVED` alone is not the gate: poll
+   `statusCheckRollup.state == SUCCESS` and `mergeStateStatus == CLEAN`
+   together, since `reviewDecision` flips before the checks finish.
+
+   The general rule behind all three: **a decision recorded only in a PR or
+   issue comment is not durable** - the next contributor will not read the same
+   comment. If a decision must survive, it belongs in this file.
 
 
 ## Registry conventions (strands_robots/registry/robots.json)


### PR DESCRIPTION
## Problem

Three operational rules about PR state have each been learned the hard way, written down in an issue comment, and then re-learned by the next contributor. A comment is not a durable place to record a decision -- the next person to touch the PR will not read the same comment. This adds them to `AGENTS.md` PR Workflow, which is the file contributors are expected to re-read.

The cost of not having them written down is measurable.

### 1. A state change that keeps being undone (the expensive one)

#1667 is the retired `pr/consolidated-local-work` staging PR. Its extraction plan and its terminal state are recorded in #1723. Its own `timelineItems` show a perfectly alternating run:

| | value |
|---|---|
| `ClosedEvent` / `ReopenedEvent` | **10 / 10** |
| strictly alternating | yes |
| span | 13 h 42 m (2026-07-29 15:43:26Z -> 2026-07-30 05:26:01Z) |
| delay from each close to the next reopen | 1.7, 12.0, 7.6, 1.7, 4.8, 12.4, 5.4, 12.2, 15.7, 21.9 min |

Twenty state changes, net effect zero. No workflow does this -- `grep -rniE "reopen" .github/workflows/` in this repo matches only a `pull_request:` trigger filter -- so it is independent contributors reading the same PR and reaching opposite conclusions, each unaware the other had already acted.

The fix is not another flip. It is that the intent has to live somewhere both readers see, and that an alternating run is itself the signal to stop.

### 2. A merge that reports failure after succeeding

Observed on #1756 during this pass: `mergePullRequest` returned `Pull Request is not mergeable`, and the squash commit was already on `main` (`4bf139c`). Acting on the error alone -- concluding the merge failed and redoing the work -- is the trap. Only `state`/`merged`, or `git log origin/main`, settles it.

### 3. `reviewDecision: APPROVED` is not a merge gate on its own

It flips before the check set finishes, so it can read `APPROVED` while CI is still `IN_PROGRESS`. `statusCheckRollup.state == SUCCESS` and `mergeStateStatus == CLEAN` have to be polled with it.

## Change

One new item in `AGENTS.md` PR Workflow (22 added lines, no other file), stating the read-back rule in both directions plus the merge gate, and naming #1723 as where #1667's terminal state lives so the question does not have to be re-decided from the PR alone.

## On the absence of a changelog fragment

Deliberate. `changelog.d/README.md` scopes fragments to what would go in the user-facing log -- "it is fragments, not the log, that **behavioural** PRs write to". This changes contributor process, not library behaviour, so a fragment here would put a note about GraphQL polling into a release changelog. Flagging it explicitly since a missing fragment is normally the defect.

## Gate

- Claims measured, not eyeballed: the counts, the alternating property and the delay list above are computed from `timelineItems` timestamps.
- `tests/test_changelog_fragments.py`, `tests/test_changelog_format.py`, `tests/test_log_strings_are_ascii.py` -- **33 passed**.
- Added lines are pure ASCII (checked per-line; the only non-ASCII in the file remains the pre-existing tree-drawing characters in Repository Structure).
- No Python touched, so no behavioural surface: `git diff --stat` is `AGENTS.md | 22 ++++`.

Provenance: written in a clone of `strands-labs/robots` at `4bf139c`, confirmed with `git remote -v` / `git rev-parse HEAD`.