### PR TITLE
fix(sim): refuse a benchmark spec predicate kwarg that is not a finite number

### DIFF
--- a/changelog.d/1759-predicate-kwarg-finiteness.md
+++ b/changelog.d/1759-predicate-kwarg-finiteness.md
@@ -1,0 +1,28 @@
+### Fixed: a benchmark spec predicate kwarg that is not a finite number is refused
+
+A numeric kwarg in a benchmark spec is coerced with a bare `float(...)` inside
+its predicate factory and then closed over, so a `nan`/`inf` threshold or weight
+compiled clean and only surfaced in the evaluated result.
+
+In a `dense_reward` term it made the episode's `cumulative_reward` and the
+evaluation's `avg_reward` `nan`/`inf`, reported under `status="success"` - a
+poisoned score handed to whatever consumes it. In a `success`, `failure` or
+`stop_when` clause every comparison against `nan` is `False`, so the clause was
+unsatisfiable and the rollout burned its whole step budget reporting an honest
+miss. That second one is the failure mode a typo'd body name is already probed
+against the live sim to prevent; a non-finite threshold reached it by a route
+that was not checked. A non-numeric value escaped as a bare "could not convert
+string to float" naming neither the predicate nor the field it came from.
+
+`make_predicate` now holds every kwarg the factory annotates as numeric to the
+same finite domain the sim setters use. The check lives there rather than in the
+spec compiler because it is the only choke point every predicate call passes
+through: `staged_reward` compiles its per-stage `reward` and `advance_when` calls
+by calling back into `make_predicate`, so a guard in the compiler left nested
+stage calls unchecked. A stage's own `bonus` is not a factory param and carries
+the same domain directly.
+
+The domain is read from the factories' parameter annotations, the same mechanism
+that already classifies a predicate as bool- or float-valued from its return
+annotation, so a predicate added later is covered by declaring its params rather
+than by remembering to extend a list.

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -67,6 +67,8 @@ import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.utils import finite_number_error, finite_vector_error
+
 if TYPE_CHECKING:
     from strands_robots.simulation.base import SimEngine
 
@@ -1501,7 +1503,8 @@ def _staged_reward(stages: list[Any]) -> RewardTerm:
 
     Raises:
         ValueError: stages is not a non-empty list, a stage is malformed, a
-            non-final stage omits ``advance_when``, or ``bonus`` is non-numeric.
+            non-final stage omits ``advance_when``, or ``bonus`` is not a
+            finite number.
         TypeError: surfaced from :func:`make_predicate` for bad sub-kwargs.
     """
     if not isinstance(stages, list) or not stages:
@@ -1554,8 +1557,10 @@ def _staged_reward(stages: list[Any]) -> RewardTerm:
             advance_fn = make_predicate(advance_name, **advance_kwargs)
 
         bonus_raw = stage.get("bonus", 0.0)
-        if isinstance(bonus_raw, bool) or not isinstance(bonus_raw, (int, float)):
-            raise ValueError(f"staged_reward: stage[{i}].bonus must be a number, got {bonus_raw!r}")
+        # Not a registry factory param, so make_predicate's kwarg-domain check
+        # does not see it - the same domain is applied here directly.
+        if (err := finite_number_error(bonus_raw, "bonus", f"staged_reward: stage[{i}]")) is not None:
+            raise ValueError(err)
 
         compiled.append((reward_fn, advance_fn, float(bonus_raw)))
 
@@ -1623,6 +1628,61 @@ def register_predicate(name: str, factory: PredicateFactory) -> None:
     PREDICATE_REGISTRY[name] = factory
 
 
+# Parameter annotations that carry a numeric domain. Read as the strings the
+# module's ``from __future__ import annotations`` leaves in ``__annotations__``,
+# which is the same mechanism :func:`predicate_kind` uses on the return
+# annotation - so a new predicate is covered by declaring its params, with no
+# separate per-predicate table to drift out of step with the registry.
+_SCALAR_NUMBER_ANNOTATIONS = frozenset({"float", "int"})
+_NUMBER_SEQUENCE_ANNOTATIONS = frozenset({"list[float]", "list[int]", "tuple[float, ...]"})
+
+
+def _kwarg_domain_error(name: str, factory: PredicateFactory, kwargs: dict[str, Any]) -> str | None:
+    """Return an error message if a numeric kwarg for *name* is not a finite number.
+
+    A spec kwarg is coerced with a bare ``float(...)`` inside the factory and
+    then closed over, so a ``nan``/``inf`` threshold or weight compiles clean
+    and only shows up in the evaluated result:
+
+    * In a ``dense_reward`` term it makes the episode's ``cumulative_reward``
+      and the eval's ``avg_reward`` ``nan``/``inf``, reported under
+      ``status="success"`` - the score silently poisons whatever consumes it.
+    * In a ``success`` / ``failure`` / ``stop_when`` clause every comparison
+      against ``nan`` is ``False``, so the clause is unsatisfiable and the
+      rollout burns its whole step budget reporting an honest miss. That is the
+      exact failure mode a typo'd body name is probed against the live sim to
+      prevent (see :func:`can_resolve_body`); a non-finite threshold reaches it
+      by a different route and was not checked.
+    * A non-numeric value (``"abc"``) otherwise escapes as a bare
+      ``ValueError: could not convert string to float: 'abc'`` naming neither
+      the predicate nor the clause it came from.
+
+    Only params the factory annotates as numeric are constrained, so a ``str``
+    body name, a ``bool`` flag and a ``str | None`` robot selector are untouched,
+    and a predicate registered via :func:`register_predicate` without
+    annotations is exempt (the caller opted in by registering it).
+
+    Args:
+        name: Predicate name, used in the message.
+        factory: The registered factory whose annotations declare the domain.
+        kwargs: The spec-supplied kwargs, checked by name.
+
+    Returns:
+        An error message, or ``None`` when every numeric kwarg is usable.
+    """
+    annotations = getattr(factory, "__annotations__", {})
+    context = f"predicate '{name}'"
+    for param, value in kwargs.items():
+        annotation = str(annotations.get(param, ""))
+        if annotation in _SCALAR_NUMBER_ANNOTATIONS:
+            if (err := finite_number_error(value, param, context)) is not None:
+                return err
+        elif annotation in _NUMBER_SEQUENCE_ANNOTATIONS:
+            if (err := finite_vector_error(context, param, value)) is not None:
+                return err
+    return None
+
+
 def make_predicate(name: str, **kwargs: Any) -> Callable[[SimEngine], Any]:
     """Instantiate a predicate from its name + kwargs.
 
@@ -1630,6 +1690,14 @@ def make_predicate(name: str, **kwargs: Any) -> Callable[[SimEngine], Any]:
     ``eval`` or ``exec``. Unknown names produce a ``ValueError`` listing
     the valid set; bad kwargs surface as whatever ``TypeError`` the factory
     raises.
+
+    Every numeric kwarg is held to a finite domain here rather than in the
+    spec compiler, because this is the only choke point every predicate call
+    passes through: ``staged_reward`` builds its per-stage ``reward`` /
+    ``advance_when`` calls by calling back into this function, so a guard in
+    :func:`~strands_robots.simulation.benchmark_spec._compile_call` would
+    leave nested stage calls unchecked. See :func:`_kwarg_domain_error` for
+    what a non-finite threshold or weight does when it compiles.
 
     Args:
         name: Predicate name. Must be registered in :data:`PREDICATE_REGISTRY`.
@@ -1640,13 +1708,16 @@ def make_predicate(name: str, **kwargs: Any) -> Callable[[SimEngine], Any]:
         predicate.
 
     Raises:
-        ValueError: If ``name`` is unknown.
+        ValueError: If ``name`` is unknown, or a kwarg the factory annotates
+            as numeric is not a finite number.
         TypeError: If required factory kwargs are missing.
     """
     factory = PREDICATE_REGISTRY.get(name)
     if factory is None:
         valid = sorted(PREDICATE_REGISTRY.keys())
         raise ValueError(f"Unknown predicate '{name}'. Valid: {valid}")
+    if (err := _kwarg_domain_error(name, factory, kwargs)) is not None:
+        raise ValueError(err)
     return factory(**kwargs)
 
 

--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -1048,5 +1048,5 @@ class TestStagedReward:
         }
         for bad_bonus in ("lots", True):
             spec = [{**base, "bonus": bad_bonus}, {"reward": {"predicate": "constant", "value": 2.0}}]
-            with pytest.raises(ValueError, match="bonus must be a number"):
+            with pytest.raises(ValueError, match="bonus must be a finite number"):
                 make_predicate("staged_reward", stages=spec)

--- a/tests/simulation/test_predicate_kwarg_finiteness.py
+++ b/tests/simulation/test_predicate_kwarg_finiteness.py
@@ -1,0 +1,330 @@
+# mypy: disable-error-code="arg-type"
+"""A predicate-DSL kwarg that is not a finite number is refused at compile time.
+
+Every numeric kwarg in a benchmark spec is coerced with a bare ``float(...)``
+inside its predicate factory and then closed over, so before this guard a
+``nan``/``inf`` threshold or weight compiled clean and only surfaced in the
+evaluated result. Measured on the pre-fix tree:
+
+* ``dense_reward: [{predicate: constant, value: .inf}]`` compiled, and a 10-step
+  episode reported ``cumulative_reward = inf`` -> ``avg_reward = inf`` under
+  ``status="success"``, silently poisoning whatever consumes the score.
+* ``success: {all: [{predicate: body_above_z, body: cube, z: .nan}]}`` compiled
+  into a clause that can never be satisfied (every comparison against ``nan`` is
+  ``False``), so the rollout burned its whole step budget reporting an honest
+  miss - the exact failure mode a typo'd body name is probed against the live sim
+  to prevent (``can_resolve_body``), reached by a route that was not checked.
+* ``value: "abc"`` escaped as a bare ``ValueError: could not convert string to
+  float: 'abc'``, naming neither the predicate nor the field.
+
+The guard lives in :func:`make_predicate` rather than in the spec compiler
+because that is the only choke point every predicate call passes through:
+``staged_reward`` compiles its per-stage ``reward`` / ``advance_when`` calls by
+calling back into ``make_predicate``, so a guard in ``_compile_call`` would have
+left nested stage calls unchecked (measured: a nested ``value: .inf`` still
+produced ``on_step reward = inf``).
+
+The registry-wide test below is the drift guard: it derives its cases from
+``PREDICATE_REGISTRY`` and the factories' own parameter annotations, so a
+predicate added later is covered by declaring its params - there is no separate
+table to fall out of step with the registry.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark, compile_stop_when
+from strands_robots.simulation.predicates import (
+    PREDICATE_REGISTRY,
+    make_predicate,
+    register_predicate,
+)
+
+INF = float("inf")
+NAN = float("nan")
+
+# Annotation -> a valid stand-in, so a parametrized case can supply every OTHER
+# required param of a factory while poisoning exactly one.
+# Strictly positive, because some params carry a narrower domain of their own
+# (``base_velocity_tracking``'s ``tracking_sigma`` must be > 0) and this test is
+# about finiteness, not about re-deriving each factory's own range checks.
+_VALID_FOR_ANNOTATION: dict[str, Any] = {
+    "str": "body_x",
+    "float": 1.0,
+    "int": 1,
+    "bool": False,
+    "str | None": None,
+    "list[float]": [1.0, 1.0, 1.0],
+    "list[int]": [1, 1, 1],
+    "tuple[float, ...]": (1.0, 1.0, 1.0),
+}
+# Params whose domain is a nested predicate-call structure, not a number.
+# ``staged_reward``'s stages are pinned explicitly further down.
+_STRUCTURAL_ANNOTATIONS = frozenset({"list[Any]"})
+
+_NUMERIC_ANNOTATIONS = frozenset({"float", "int", "list[float]", "list[int]", "tuple[float, ...]"})
+
+
+def _numeric_params() -> list[tuple[str, str, str]]:
+    """Every ``(predicate, param, annotation)`` in the registry with a numeric domain."""
+    cases: list[tuple[str, str, str]] = []
+    for name, factory in PREDICATE_REGISTRY.items():
+        for param, annotation in getattr(factory, "__annotations__", {}).items():
+            if param == "return":
+                continue
+            if str(annotation) in _NUMERIC_ANNOTATIONS:
+                cases.append((name, param, str(annotation)))
+    return sorted(cases)
+
+
+def _kwargs_for(name: str) -> dict[str, Any]:
+    """Valid kwargs covering every annotated param of *name*'s factory."""
+    factory = PREDICATE_REGISTRY[name]
+    kwargs: dict[str, Any] = {}
+    for param, annotation in getattr(factory, "__annotations__", {}).items():
+        if param == "return":
+            continue
+        kwargs[param] = _VALID_FOR_ANNOTATION[str(annotation)]
+    return kwargs
+
+
+def _spec(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {"name": "finiteness-fixture", "default_robot": "so100", "max_steps": 10}
+    base.update(over)
+    return base
+
+
+class _StubSim:
+    """Fake SimEngine with one resolvable body, in the MuJoCo result shape."""
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        return {"status": "success", "position": [0.0, 0.0, 0.5], "quaternion": [1.0, 0.0, 0.0, 0.0]}
+
+    def get_observation(self) -> dict[str, Any]:
+        return {}
+
+
+# --------------------------------------------------------------------------
+# Registry-wide drift guard
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("name", "param", "annotation"), _numeric_params())
+@pytest.mark.parametrize("bad", [INF, -INF, NAN], ids=["inf", "-inf", "nan"])
+def test_every_numeric_predicate_kwarg_refuses_a_non_finite_value(
+    name: str, param: str, annotation: str, bad: float
+) -> None:
+    kwargs = _kwargs_for(name)
+    kwargs[param] = [bad, 0.0, 0.0] if annotation.startswith(("list", "tuple")) else bad
+    with pytest.raises(ValueError, match=f"{param}"):
+        make_predicate(name, **kwargs)
+
+
+@pytest.mark.parametrize(("name", "param", "annotation"), _numeric_params())
+def test_every_numeric_predicate_kwarg_still_accepts_a_finite_value(name: str, param: str, annotation: str) -> None:
+    """Control for the guard above: the valid domain is unchanged."""
+    make_predicate(name, **_kwargs_for(name))
+
+
+def test_no_registry_param_annotation_escapes_the_guard_unclassified() -> None:
+    """A param annotation that is neither numeric nor a known non-numeric shape fails here.
+
+    Forces a decision when a predicate is added with e.g. ``float | None`` or a
+    ``Decimal`` threshold: either it joins the numeric sets in
+    ``predicates._SCALAR_NUMBER_ANNOTATIONS`` / ``_NUMBER_SEQUENCE_ANNOTATIONS``
+    and gets checked, or it is added here as explicitly non-numeric. Without this
+    the new param would silently pass unvalidated.
+    """
+    known = _NUMERIC_ANNOTATIONS | _STRUCTURAL_ANNOTATIONS | {"str", "bool", "str | None"}
+    unclassified = {
+        (name, param, str(annotation))
+        for name, factory in PREDICATE_REGISTRY.items()
+        for param, annotation in getattr(factory, "__annotations__", {}).items()
+        if param != "return" and str(annotation) not in known
+    }
+    assert not unclassified, f"unclassified predicate param annotations: {sorted(unclassified)}"
+
+
+def test_the_guard_reads_the_same_annotations_the_valid_stand_ins_cover() -> None:
+    """Every non-structural annotation in the registry has a valid stand-in above."""
+    missing = {
+        str(annotation)
+        for factory in PREDICATE_REGISTRY.values()
+        for param, annotation in getattr(factory, "__annotations__", {}).items()
+        if param != "return"
+        and str(annotation) not in _STRUCTURAL_ANNOTATIONS
+        and str(annotation) not in _VALID_FOR_ANNOTATION
+    }
+    assert not missing, f"no valid stand-in for annotations: {sorted(missing)}"
+
+
+# --------------------------------------------------------------------------
+# Consequence pins, one per authoring surface
+# --------------------------------------------------------------------------
+
+
+def test_a_dense_reward_term_with_a_non_finite_weight_is_refused_not_scored_as_inf() -> None:
+    with pytest.raises(ValueError, match="value must be a finite number"):
+        DeclarativeBenchmark.from_dict(_spec(dense_reward=[{"predicate": "constant", "value": INF}]))
+
+
+def test_a_finite_dense_reward_term_still_sums_into_the_episode_reward() -> None:
+    """Control: the fix refuses a poisoned score, it does not stop scoring."""
+    bench = DeclarativeBenchmark.from_dict(_spec(dense_reward=[{"predicate": "constant", "value": 2.0}]))
+    reward = bench.on_step(_StubSim(), {}, {}).reward
+    assert reward == pytest.approx(2.0)
+    assert math.isfinite(reward)
+
+
+def test_a_success_clause_with_a_non_finite_threshold_is_refused_not_unsatisfiable() -> None:
+    with pytest.raises(ValueError, match="z must be a finite number"):
+        DeclarativeBenchmark.from_dict(
+            _spec(success={"all": [{"predicate": "body_above_z", "body": "cube", "z": NAN}]})
+        )
+
+
+def test_a_failure_clause_with_a_non_finite_threshold_is_refused() -> None:
+    with pytest.raises(ValueError, match="z must be a finite number"):
+        DeclarativeBenchmark.from_dict(
+            _spec(failure={"any": [{"predicate": "body_below_z", "body": "cube", "z": INF}]})
+        )
+
+
+def test_a_stop_when_clause_with_a_non_finite_threshold_is_refused_before_the_rollout() -> None:
+    """Same domain as the spec clauses: a clause that can never fire is not armed."""
+    with pytest.raises(ValueError, match="z must be a finite number"):
+        compile_stop_when({"predicate": "body_above_z", "body": "cube", "z": NAN})
+
+
+@pytest.mark.parametrize("param", ["min", "max"])
+def test_a_region_bound_with_a_non_finite_component_is_refused(param: str) -> None:
+    """The ``list[float]`` half of the domain: one poisoned component is enough."""
+    call = {"predicate": "inside_region", "body": "cube", "min": [0.0, 0.0, 0.0], "max": [1.0, 1.0, 1.0]}
+    call[param] = [0.0, NAN, 0.0]
+    with pytest.raises(ValueError, match=f"'{param}' must contain finite numbers"):
+        DeclarativeBenchmark.from_dict(_spec(success={"all": [call]}))
+
+
+# --------------------------------------------------------------------------
+# The nested staged_reward path - why the guard is not in the spec compiler
+# --------------------------------------------------------------------------
+
+
+def test_a_nested_stage_reward_call_with_a_non_finite_kwarg_is_refused() -> None:
+    """A stage's ``reward`` never passes through ``_compile_call``."""
+    with pytest.raises(ValueError, match="value must be a finite number"):
+        DeclarativeBenchmark.from_dict(
+            _spec(
+                dense_reward=[
+                    {"predicate": "staged_reward", "stages": [{"reward": {"predicate": "constant", "value": INF}}]}
+                ]
+            )
+        )
+
+
+def test_a_nested_advance_when_call_with_a_non_finite_threshold_is_refused() -> None:
+    with pytest.raises(ValueError, match="z must be a finite number"):
+        DeclarativeBenchmark.from_dict(
+            _spec(
+                dense_reward=[
+                    {
+                        "predicate": "staged_reward",
+                        "stages": [
+                            {
+                                "reward": {"predicate": "constant", "value": 1.0},
+                                "advance_when": {"predicate": "body_above_z", "body": "cube", "z": NAN},
+                            },
+                            {"reward": {"predicate": "constant", "value": 1.0}},
+                        ],
+                    }
+                ]
+            )
+        )
+
+
+def test_a_stage_bonus_that_is_not_finite_is_refused() -> None:
+    """``bonus`` is not a registry factory param, so it carries the domain itself."""
+    with pytest.raises(ValueError, match=r"stage\[0\]: bonus must be a finite number"):
+        DeclarativeBenchmark.from_dict(
+            _spec(
+                dense_reward=[
+                    {
+                        "predicate": "staged_reward",
+                        "stages": [{"reward": {"predicate": "constant", "value": 1.0}, "bonus": INF}],
+                    }
+                ]
+            )
+        )
+
+
+def test_a_finite_stage_bonus_is_still_accepted() -> None:
+    bench = DeclarativeBenchmark.from_dict(
+        _spec(
+            dense_reward=[
+                {
+                    "predicate": "staged_reward",
+                    "stages": [{"reward": {"predicate": "constant", "value": 1.0}, "bonus": 5.0}],
+                }
+            ]
+        )
+    )
+    assert math.isfinite(bench.on_step(_StubSim(), {}, {}).reward)
+
+
+# --------------------------------------------------------------------------
+# Domain edges: what the guard must NOT change
+# --------------------------------------------------------------------------
+
+
+def test_a_non_numeric_kwarg_now_names_the_predicate_and_the_field() -> None:
+    """Pre-fix this escaped as a bare "could not convert string to float: 'abc'"."""
+    with pytest.raises(ValueError, match="predicate 'constant': value must be a finite number, got 'abc'"):
+        DeclarativeBenchmark.from_dict(_spec(dense_reward=[{"predicate": "constant", "value": "abc"}]))
+
+
+def test_a_bool_is_refused_where_a_number_belongs() -> None:
+    """``True`` is an ``int`` subclass and would act as a silent ``1.0`` threshold."""
+    with pytest.raises(ValueError, match="z must be a finite number"):
+        make_predicate("body_above_z", body="cube", z=True)
+
+
+def test_a_bool_annotated_param_is_untouched_by_the_numeric_guard() -> None:
+    make_predicate("body_on", body_a="a", body_b="b", require_contact=True)
+
+
+def test_an_optional_robot_selector_is_untouched_by_the_numeric_guard() -> None:
+    make_predicate("base_below_z", z=0.1, robot=None)
+
+
+def test_a_negative_value_is_accepted_because_the_domain_is_signed() -> None:
+    """A reward weight and a coordinate are both legitimately negative."""
+    bench = DeclarativeBenchmark.from_dict(_spec(dense_reward=[{"predicate": "constant", "value": -3.5}]))
+    assert bench.on_step(_StubSim(), {}, {}).reward == pytest.approx(-3.5)
+
+
+def test_a_numpy_scalar_threshold_is_accepted() -> None:
+    """Matches the other sim setters: a NumPy real scalar is a number here."""
+    np = pytest.importorskip("numpy")
+    make_predicate("body_above_z", body="cube", z=np.float32(0.2))
+
+
+def test_an_int_threshold_is_accepted() -> None:
+    make_predicate("body_above_z", body="cube", z=0)
+
+
+def test_a_predicate_registered_without_annotations_is_exempt() -> None:
+    """``register_predicate`` is documented as opting into an unsandboxed factory."""
+
+    def _factory(threshold):  # type: ignore[no-untyped-def] # noqa: ANN001, ANN202 - the point of the test
+        return lambda _sim: bool(threshold)
+
+    name = "test_unannotated_exempt_from_finiteness"
+    register_predicate(name, _factory)
+    try:
+        assert make_predicate(name, threshold=NAN) is not None
+    finally:
+        PREDICATE_REGISTRY.pop(name, None)

--- a/tests/simulation/test_staged_reward.py
+++ b/tests/simulation/test_staged_reward.py
@@ -207,7 +207,7 @@ def test_rejects_non_numeric_bonus() -> None:
         },
         {"reward": {"predicate": "constant", "value": 1.0}},
     ]
-    with pytest.raises(ValueError, match="bonus must be a number"):
+    with pytest.raises(ValueError, match="bonus must be a finite number"):
         make_predicate("staged_reward", stages=bad)
 
 


### PR DESCRIPTION
## What

A numeric kwarg in a benchmark spec is coerced with a bare `float(...)` inside its predicate factory and then closed over, so a `nan`/`inf` threshold or weight compiled clean and only surfaced in the *evaluated result*. `make_predicate` now holds every kwarg the factory annotates as numeric to the shared finite domain.

Extracted from the retired `pr/consolidated-local-work` staging branch (tracked in #1723) as `test_benchmark_spec_finite_kwargs.py`, the item the previous pass named as the suggested next candidate.

## Measured on `main` (81bff7b)

**1. A `dense_reward` term poisons the score, reported as success.** 10-step episode, `dense_reward: [{predicate: constant, value: .inf}]`:

| | pre-fix | this PR |
|---|---|---|
| `from_dict` | `success` (compiled) | refused, naming the field |
| `cumulative_reward` | `inf` | no benchmark to score |
| `avg_reward` | `inf` | -- |
| reported status | `success` | -- |

With `nan` both read `nan`. Anything consuming the eval score gets a poisoned number under a success status.

**2. A clause threshold makes the clause unsatisfiable.** `success: {all: [{predicate: body_above_z, body: cube, z: .nan}]}` compiled, and `is_success()` returned `False` for a body at *any* height -- every comparison against `nan` is `False`. Identical for `failure` and for `run_policy(stop_when=...)`, where the rollout burns its whole step budget and reports `stopped_reason="budget"`.

That is the exact failure mode the entity-name probe already exists to prevent. `stop_when_referenced_entities`' own docstring states a typo'd name would "compile clean, degrade to a constant False at evaluation time, and burn the whole step budget reporting stopped_reason='budget' - indistinguishable from an honest miss", which is why names are probed against the live sim before the clause is armed. A non-finite threshold reaches the same end state by a different route and was not checked. The asymmetry, not the corruption, is the argument for this PR.

**3. A non-numeric value escaped the structured contract.** `value: "abc"` raised a bare `ValueError: could not convert string to float: 'abc'` -- naming neither the predicate nor the clause. `_compile_call` re-raises `ValueError` verbatim on the documented assumption that it is an unknown-predicate error "already carrying the valid list"; a coercion failure is not that. It now reads `predicate 'constant': value must be a finite number, got 'abc'`.

## Why the guard is in `make_predicate`, not in the spec compiler

The tracking issue scoped this to `_compile_call`, "which every spec predicate flows through". Measured, that is not true: `staged_reward` compiles its per-stage `reward` and `advance_when` calls by calling back into `make_predicate` directly, so a nested `value: .inf` still produced `on_step reward = inf` with a guard at the compiler. `make_predicate` is the only real choke point, and it covers `success` / `failure` / `dense_reward` / `stop_when` / nested stages with one check. A stage's own `bonus` is not a factory param, so it carries the same domain directly (its previous check accepted `nan`, being `isinstance(x, float)`).

## Why annotation-driven

The domain is read from the factories' parameter annotations -- the same mechanism `predicate_kind` already uses on the *return* annotation, and for the same stated reason: it "stays in lock-step with the registry with no separate table to drift". A predicate added later is covered by declaring its params. `test_no_registry_param_annotation_escapes_the_guard_unclassified` fails if a param arrives with an annotation that is neither classified numeric nor explicitly non-numeric, so a `float | None` threshold forces a decision instead of silently passing unvalidated.

## Not in scope, deliberately

- **Clause-index context in the message.** The error names the predicate, the param and the value, but not `dense_reward[0]`. Adding that means changing `_compile_call`'s verbatim re-raise, which also governs unknown-predicate messages -- a separate concern.
- **`register_predicate` factories without annotations** stay exempt. That function already documents itself as opting into an unsandboxed factory; pinned as a control.
- **Unit-norm quaternions and other non-finiteness domains.** This is finiteness only, matching #1757.

## Tests

`tests/simulation/test_predicate_kwarg_finiteness.py`, 165 cases. **112 fail on the pre-fix tree, all 165 pass with the fix.**

- Registry-wide drift guard, parametrized over every `(predicate, numeric param)` pair x `{inf, -inf, nan}`, plus the finite-value control for each pair.
- One consequence pin per authoring surface: `dense_reward`, `success`, `failure`, `stop_when`, `list[float]` region bounds, and the three nested `staged_reward` paths (`reward`, `advance_when`, `bonus`).
- Domain-edge controls that must not change: a finite term still sums into the episode reward, negative values accepted (the domain is signed), `int` and NumPy real scalars accepted, `bool`-annotated and `str | None` params untouched, a `bool` refused where a number belongs, an unannotated registered predicate exempt.

Two existing assertions on the `bonus` message were updated to the strengthened wording (`must be a number` -> `must be a finite number`).

## Verification

```
ruff check / ruff format --check / mypy   clean
tests/simulation + 9 files importing the touched modules:
  this PR   226 failed, 3992 passed, 334 skipped, 45 errors
  main      226 failed, 3827 passed, 334 skipped, 45 errors   (control)
```

Identical failure / skip / error counts, `+165 passed` = exactly the new pins. The 226 failures and 45 errors are environmental in this sandbox (no asset fetch, so `so100` never resolves; optional extras absent) and reproduce on clean `main`, which is why the control run was needed to say so rather than assumed.

Provenance: measured in a clone of `strands-labs/robots` at `81bff7b`, `git remote -v` confirmed, mujoco 3.11.0, `MUJOCO_GL=disable`.

Refs #1723

## 13. Changelog

**Round 1** -- initial submission.