### PR TITLE
fix(sim): refuse a Newton camera pose or fov that is not finite

### DIFF
--- a/changelog.d/1760-newton-add-camera-finiteness.md
+++ b/changelog.d/1760-newton-add-camera-finiteness.md
@@ -1,0 +1,26 @@
+### Fixed: a Newton camera pose or field of view that is not finite is refused
+
+The Newton backend's `add_camera` validated neither the contents of
+`position`/`target` nor `fov`, so a camera configuration the MuJoCo backend
+refuses was accepted here and surfaced far from the call that caused it.
+
+`position`/`target` were coerced with a bare `float(v)`, which caught a
+non-numeric element but passed a `nan`/`inf` component - and a `bool`, reading
+`True` as the coordinate `1.0`. Nothing downstream caught it either: the
+degenerate-orientation check compares `abs(pos[i] - tgt[i]) < 1e-9`, which is
+`False` for a `nan`, and `_look_at_quat` then divides the view vector by a `nan`
+norm, so `render`/`get_frame` returned a frame from an all-NaN camera quaternion
+under `status="success"`.
+
+`fov` was coerced by a bare `float(fov)` inside the lock, so a non-numeric value
+raised a `ValueError` straight through the structured tool-result contract, and
+`nan`/`inf`/`0`/`>=180` registered a degenerate camera under a success result:
+`get_camera_params` derives the pinhole intrinsics
+`0.5 * h / tan(radians(fov) / 2)`, which is `nan` for a `nan` fov and raises
+`ZeroDivisionError` for `0`.
+
+Both now use the shared domains MuJoCo's `add_camera` already applies. The pose
+goes through `coerce_pose_vector`, whose contract is that a pose either backend
+entry point refuses must be refused by the other. The fov interval moved out of
+the MuJoCo method into a shared `camera_fov_error` beside `pose_vector_error`, so
+the two backends call one definition and cannot drift apart.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -44,7 +44,6 @@ So: the split is honest about being for file-size, not for decoupling.
 import inspect
 import json
 import logging
-import math
 import numbers
 import os
 import re
@@ -101,6 +100,7 @@ from strands_robots.simulation.policy_runner import CooperativeStop
 from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_difficulty, validate_terrain
 from strands_robots.teleop_mixin import TeleopMixin
 from strands_robots.utils import (
+    camera_fov_error,
     coerce_pose_vector,
     finite_vector_error,
     pose_vector_error,
@@ -2958,21 +2958,11 @@ class MuJoCoSimEngine(
         # finite angle in the open interval (0, 180) degrees; otherwise the
         # spec recompile aborts deep inside ``inject_camera_into_scene`` with a
         # cryptic "spec recompile refused", or - for fov <= 0 - silently
-        # registers a degenerate camera that renders nothing useful. Reject it
-        # here with an actionable message, mirroring the position/target checks.
-        # Accept any real number (``numbers.Real``) so a NumPy scalar fov
-        # (e.g. ``np.float32(58.0)`` from a config array) is not rejected as
-        # "not a finite number"; only ``bool`` and non-finite values are refused.
-        if isinstance(fov, bool) or not isinstance(fov, numbers.Real) or not math.isfinite(float(fov)):
-            return {
-                "status": "error",
-                "content": [{"text": f"add_camera: 'fov' must be a finite number in degrees, got {fov!r}."}],
-            }
-        if not (0.0 < float(fov) < 180.0):
-            return {
-                "status": "error",
-                "content": [{"text": f"add_camera: 'fov' must be in the open interval (0, 180) degrees, got {fov}."}],
-            }
+        # registers a degenerate camera that renders nothing useful. The domain
+        # lives in the shared ``camera_fov_error`` so the Newton backend's
+        # ``add_camera`` cannot drift from this one.
+        if (e := camera_fov_error("add_camera", "fov", fov)) is not None:
+            return {"status": "error", "content": [{"text": e}]}
 
         # Validate the render resolution baked into this camera the same way
         # ``render`` validates its dims, so a bad size fails at config time with

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -49,7 +49,7 @@ from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, Sim
 from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
 from strands_robots.simulation.newton.randomization import DomainRandomizationMixin
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
-from strands_robots.utils import require_optional
+from strands_robots.utils import camera_fov_error, coerce_pose_vector, require_optional
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -959,13 +959,31 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         body transform. Empty/``None`` = a world-fixed camera. Call
         :meth:`list_bodies` to discover valid mount points.
 
+        Validation: ``position`` and ``target`` must each be 3 finite numbers
+        (a list, tuple or NumPy array; NumPy scalar elements accepted, ``bool``
+        refused). Omit a vector to take its default - an empty vector is a
+        wrong-length request and is rejected rather than silently placing the
+        camera at the default pose. ``fov`` must be a finite angle in ``(0,
+        180)`` degrees. These are the same bounds the MuJoCo backend's
+        ``add_camera`` enforces, on the shared
+        :func:`~strands_robots.utils.pose_vector_error` /
+        :func:`~strands_robots.utils.camera_fov_error` domains, so a camera
+        configuration one backend refuses is refused by both. Invalid values are
+        rejected here at config time rather than deferring an uncaught
+        ``ValueError`` (non-numeric) or a silently degenerate camera
+        (``nan``/``inf`` in the look-at basis or the derived intrinsics) to the
+        first render.
+
         Args:
             name: Unique camera name. Duplicate names are rejected; remove the
                 existing camera with :meth:`remove_camera` first.
             position: Camera eye ``[x, y, z]`` (world frame, or the parent
-                body's local frame when ``parent_body`` is set).
+                body's local frame when ``parent_body`` is set). 3 finite
+                numbers.
             target: Look-at point ``[x, y, z]`` (same frame as ``position``).
-            fov: Vertical field of view in degrees.
+                3 finite numbers.
+            fov: Vertical field of view in degrees; a finite angle in the open
+                interval ``(0, 180)``.
             width: Render width in pixels for this camera.
             height: Render height in pixels for this camera.
             parent_body: Optional body label to mount the camera on. ``None``
@@ -973,27 +991,32 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         Returns:
             Status dict confirming the registration, or an error dict when no
-            world exists, the pose is invalid, the name is taken, or the mount
-            body is unknown.
+            world exists, the pose or ``fov`` is invalid, the name is taken, or
+            the mount body is unknown. Never raises.
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
 
-        pos = list(position) if position is not None else [1.0, 1.0, 1.0]
-        tgt = list(target) if target is not None else [0.0, 0.0, 0.0]
-        for _lbl, _vec in (("position", pos), ("target", tgt)):
-            try:
-                if len(_vec) != 3:
-                    return {
-                        "status": "error",
-                        "content": [{"text": f"add_camera: '{_lbl}' must be 3 elements [x,y,z], got {len(_vec)}"}],
-                    }
-                _vec[:] = [float(v) for v in _vec]
-            except (TypeError, ValueError):
-                return {
-                    "status": "error",
-                    "content": [{"text": f"add_camera: '{_lbl}' must be a list of 3 numbers"}],
-                }
+        # Validate shape, element type AND finiteness with the shared helpers the
+        # MuJoCo backend uses, so a camera pose one backend refuses is refused by
+        # both - the invariant ``pose_vector_error`` documents. The local
+        # coercion this replaces only applied ``float(v)``: that caught a
+        # non-numeric element but passed a ``nan``/``inf`` component (and a
+        # ``bool``, silently reading ``True`` as the coordinate 1.0) straight
+        # through to the registry. Nothing downstream catches it either - the
+        # degenerate-orientation check below compares
+        # ``abs(pos[i] - tgt[i]) < 1e-9``, which is False for a ``nan``, and
+        # ``_look_at_quat`` then divides the view vector by a ``nan`` norm, so
+        # ``render``/``get_frame`` return a frame from an all-NaN camera
+        # quaternion under a success result.
+        position, _perr = coerce_pose_vector("add_camera", "position", position, 3)
+        if _perr is not None:
+            return {"status": "error", "content": [{"text": _perr}]}
+        target, _terr = coerce_pose_vector("add_camera", "target", target, 3)
+        if _terr is not None:
+            return {"status": "error", "content": [{"text": _terr}]}
+        pos = [1.0, 1.0, 1.0] if position is None else position
+        tgt = [0.0, 0.0, 0.0] if target is None else target
         if all(abs(pos[i] - tgt[i]) < 1e-9 for i in range(3)):
             return {
                 "status": "error",
@@ -1003,6 +1026,16 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     }
                 ],
             }
+        # Validate the field of view at config time, on the same shared domain
+        # the MuJoCo backend uses. It was previously coerced by a bare
+        # ``float(fov)`` inside the lock below, so a non-numeric value raised a
+        # ``ValueError`` straight through the structured tool-result contract,
+        # and ``nan``/``inf``/``0``/``>=180`` registered a degenerate camera
+        # under a success result: :meth:`get_camera_params` derives the pinhole
+        # intrinsics ``0.5 * h / tan(radians(fov) / 2)``, which is ``nan`` for a
+        # ``nan`` fov and raises ``ZeroDivisionError`` for ``0``.
+        if (e := camera_fov_error("add_camera", "fov", fov)) is not None:
+            return {"status": "error", "content": [{"text": e}]}
         if name in (None, "", "default", "free"):
             return {
                 "status": "error",

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -657,3 +657,35 @@ def coerce_pose_vector(
     if (err := pose_vector_error(method, param_name, vec, expected_len)) is not None:
         return None, err
     return [float(v) for v in vec], None
+
+
+def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:
+    """Return an error message if ``value`` is not a usable camera field of view.
+
+    A camera's vertical field of view must be a finite angle in the open
+    interval ``(0, 180)`` degrees. This lives here, beside
+    :func:`pose_vector_error`, for the same reason that one does: the MuJoCo and
+    Newton backends both expose ``add_camera(fov=...)`` and their accepted
+    domain must not diverge - an fov either backend refuses must be refused by
+    the other, and a second copy of the interval would drift from the first.
+
+    Outside that interval a camera is not merely mis-posed but unusable, and
+    each backend fails differently and late rather than at config time:
+
+    * MuJoCo bakes the value into the MJCF ``fovy`` attribute, so the spec
+      recompile aborts inside ``inject_camera_into_scene`` with a cryptic "spec
+      recompile refused".
+    * Newton stores it and derives the pinhole intrinsics
+      ``0.5 * height / tan(radians(fov) / 2)`` at render time, which is ``nan``
+      for a ``nan`` fov and raises ``ZeroDivisionError`` for ``0``.
+
+    A NumPy real scalar is accepted (``np.float32(58.0)`` read out of a config
+    array is a legitimate fov); a ``bool`` is refused because ``float(True)``
+    would silently mean a 1-degree lens. Returns ``None`` when ``value`` is a
+    usable field of view.
+    """
+    if isinstance(value, bool) or not isinstance(value, numbers.Real) or not math.isfinite(float(value)):
+        return f"{method}: '{param_name}' must be a finite number in degrees, got {value!r}."
+    if not (0.0 < float(value) < 180.0):
+        return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {value}."
+    return None

--- a/tests/simulation/newton/test_add_camera_numeric_validation.py
+++ b/tests/simulation/newton/test_add_camera_numeric_validation.py
@@ -1,0 +1,341 @@
+"""Regression tests: the Newton backend's ``add_camera`` refuses a non-finite pose or fov.
+
+``add_camera`` is an agent-callable configuration surface, and on the Newton
+backend it validated neither the contents of ``position`` / ``target`` nor
+``fov`` at all. The two failure classes the numeric-input campaign targets both
+slipped through, each surfacing far from the call that caused it:
+
+* ``position`` / ``target`` were coerced with a bare ``float(v)``. That caught a
+  non-numeric element but passed a ``nan`` / ``inf`` component - and a ``bool``,
+  reading ``True`` as the coordinate ``1.0``. Nothing downstream caught it
+  either: the degenerate-orientation check compares
+  ``abs(pos[i] - tgt[i]) < 1e-9``, which is ``False`` for a ``nan``, and
+  ``_look_at_quat`` then divides the view vector by a ``nan`` norm, so
+  ``render`` / ``get_frame`` produced a frame from an all-NaN camera quaternion
+  while ``add_camera`` reported ``status="success"``.
+* ``fov`` was coerced by a bare ``float(fov)`` inside the lock. A non-numeric
+  value therefore raised a ``ValueError`` straight through the structured
+  ``{"status": "error"}`` tool-result contract, and ``nan`` / ``inf`` / ``0`` /
+  ``>= 180`` registered a degenerate camera under a success result:
+  ``get_camera_params`` derives the pinhole intrinsics
+  ``0.5 * h / tan(radians(fov) / 2)``, which is ``nan`` for a ``nan`` fov and
+  raises ``ZeroDivisionError`` for ``0``.
+
+The fix routes both through the shared
+:func:`~strands_robots.utils.pose_vector_error` /
+:func:`~strands_robots.utils.camera_fov_error` domains that the MuJoCo backend's
+``add_camera`` already uses, so a camera configuration one backend refuses is
+refused by both. ``TestSameVerdictAsTheMujocoSibling`` pins that parity
+directly against the live MuJoCo method.
+
+Most of these need neither the optional ``newton`` / ``warp`` packages nor a
+GPU: the validation runs before ``add_camera`` touches the solver, so calling
+the unbound method with a small stand-in for ``self`` (the pattern
+``test_camera_lookat_quat.py`` uses) exercises it in every environment.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.models import SimCamera
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+# --------------------------------------------------------------------------- #
+# Probe sets, shared by the Newton tests and the MuJoCo parity test below.     #
+# --------------------------------------------------------------------------- #
+_NON_FINITE = (float("nan"), float("inf"), float("-inf"))
+
+#: Values that are not a real number at all. ``True`` is included because
+#: ``bool`` is an ``int`` subclass, so ``float(True)`` would silently write the
+#: coordinate ``1.0`` where a caller passed a truth value by mistake.
+_NON_NUMERIC_ELEMENTS = ("x", None, [0.0], True)
+
+#: ``fov`` values no camera can use. ``0`` divides by zero in the derived
+#: intrinsics and ``180`` is the open-interval boundary (``tan(pi/2)``).
+_BAD_FOVS = (float("nan"), float("inf"), float("-inf"), 0.0, -1.0, -60.0, 180.0, 181.0, 360.0, True)
+
+#: ``fov`` values that must keep working, including a NumPy scalar read out of a
+#: config array and a plain ``int``.
+_GOOD_FOVS = (60.0, 45, 1.0, 179.9, np.float32(58.0), np.float64(90.0))
+
+
+def _engine_stub(body_labels: tuple[str, ...] = ("ground", "ball")) -> types.SimpleNamespace:
+    """A stand-in for ``self`` carrying only what ``add_camera`` reads.
+
+    ``add_camera`` touches ``self._world`` (its ``cameras`` dict), ``self._model``
+    (its ``body_label`` list) and ``self._lock``. None of those need Newton, so a
+    namespace with the three lets the validation run without the optional
+    ``newton`` / ``warp`` packages or a GPU.
+    """
+    return types.SimpleNamespace(
+        _world=types.SimpleNamespace(cameras={}),
+        _model=types.SimpleNamespace(body_label=list(body_labels)),
+        _lock=threading.RLock(),
+    )
+
+
+def _add_camera(stub: types.SimpleNamespace, **kwargs: object) -> dict:
+    return NewtonSimEngine.add_camera(stub, **kwargs)  # type: ignore[arg-type]
+
+
+def _look_at(eye, target):
+    """``_look_at_quat`` via the same newton-free stand-in the sibling test uses."""
+    stub = types.SimpleNamespace(_quat_from_matrix=NewtonSimEngine._quat_from_matrix)
+    return NewtonSimEngine._look_at_quat(stub, eye, target)
+
+
+# --------------------------------------------------------------------------- #
+# position / target                                                           #
+# --------------------------------------------------------------------------- #
+class TestPoseFiniteness:
+    @pytest.mark.parametrize("bad", _NON_FINITE)
+    @pytest.mark.parametrize("param", ["position", "target"])
+    @pytest.mark.parametrize("index", [0, 1, 2])
+    def test_non_finite_component_is_refused(self, param, bad, index):
+        """A nan/inf component in either pose vector is refused, in any slot.
+
+        Pre-fix every one of these returned ``success`` and stored the value.
+        """
+        stub = _engine_stub()
+        vec = [0.5, 0.5, 0.5]
+        vec[index] = bad
+        result = _add_camera(stub, name="cam", **{param: vec})
+        assert result["status"] == "error", result
+        assert "finite" in result["content"][0]["text"]
+        assert stub._world.cameras == {}
+
+    def test_non_finite_survives_the_degeneracy_check(self):
+        """Pin the premise: the degeneracy check cannot stand in for this guard.
+
+        ``abs(nan - 0.0) < 1e-9`` is ``False``, so the identical-position/target
+        check the method already had never rejected a nan pose - which is why
+        the guard has to be its own check rather than a tightening of that one.
+        """
+        assert not (abs(float("nan") - 0.0) < 1e-9)
+
+
+class TestPoseElementType:
+    @pytest.mark.parametrize("bad", _NON_NUMERIC_ELEMENTS)
+    @pytest.mark.parametrize("param", ["position", "target"])
+    def test_non_numeric_component_is_refused(self, param, bad):
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", **{param: [bad, 0.5, 0.5]})
+        assert result["status"] == "error", result
+        assert stub._world.cameras == {}
+
+    def test_bool_component_is_not_read_as_one(self):
+        """``True`` is refused rather than silently coerced to the coordinate 1.0.
+
+        Pre-fix ``float(True)`` placed the camera at x=1.0 under a success
+        result, so the mistake was unobservable from the caller's side.
+        """
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", position=[True, 2.0, 2.0])
+        assert result["status"] == "error", result
+        assert stub._world.cameras == {}
+
+
+class TestPoseLength:
+    @pytest.mark.parametrize("vec", [[], [0.5], [0.5, 0.5], [0.5, 0.5, 0.5, 0.5]])
+    @pytest.mark.parametrize("param", ["position", "target"])
+    def test_wrong_length_is_refused(self, param, vec):
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", **{param: vec})
+        assert result["status"] == "error", result
+        assert stub._world.cameras == {}
+
+    def test_empty_vector_is_not_read_as_omitted(self):
+        """An empty vector is a wrong-length request, not "take the default".
+
+        Membership, not truthiness: reading ``[]`` as omitted would place the
+        camera at the default pose under a success result, silently ignoring
+        what the caller asked for.
+        """
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", position=[])
+        assert result["status"] == "error", result
+        assert "3-element" in result["content"][0]["text"]
+
+
+class TestPoseAccepted:
+    def test_omitted_vectors_take_the_documented_defaults(self):
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam")
+        assert result["status"] == "success", result
+        cam = stub._world.cameras["cam"]
+        assert cam.position == [1.0, 1.0, 1.0]
+        assert cam.target == [0.0, 0.0, 0.0]
+
+    def test_int_components_are_accepted(self):
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", position=[1, 2, 3], target=[0, 0, 0])
+        assert result["status"] == "success", result
+
+    def test_numpy_pose_is_accepted_and_normalised_to_floats(self):
+        """A NumPy pose - the natural product of pose arithmetic - still works.
+
+        The stored pose is plain ``float`` so a raw ``np.float64`` never leaks
+        into the agent-visible status text or the ``SimCamera`` record.
+        """
+        stub = _engine_stub()
+        result = _add_camera(
+            stub,
+            name="cam",
+            position=np.array([0.6, 0.6, 0.5]),
+            target=np.array([0.0, 0.0, 0.15]),
+        )
+        assert result["status"] == "success", result
+        cam = stub._world.cameras["cam"]
+        assert all(type(v) is float for v in cam.position)
+        assert all(type(v) is float for v in cam.target)
+
+    def test_coincident_pose_is_still_refused(self):
+        """The pre-existing degeneracy check is preserved, not replaced."""
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", position=[1.0, 1.0, 1.0], target=[1.0, 1.0, 1.0])
+        assert result["status"] == "error", result
+        assert "look direction" in result["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# fov                                                                         #
+# --------------------------------------------------------------------------- #
+class TestFov:
+    @pytest.mark.parametrize("bad", _BAD_FOVS)
+    def test_unusable_fov_is_refused(self, bad):
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", fov=bad)
+        assert result["status"] == "error", result
+        assert "fov" in result["content"][0]["text"]
+        assert stub._world.cameras == {}
+
+    @pytest.mark.parametrize("good", _GOOD_FOVS)
+    def test_usable_fov_is_accepted(self, good):
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", fov=good)
+        assert result["status"] == "success", result
+        assert stub._world.cameras["cam"].fov == pytest.approx(float(good))
+
+    def test_non_numeric_fov_returns_an_error_and_does_not_raise(self):
+        """The tool-result contract: a bad fov is an error dict, never an exception.
+
+        Pre-fix ``float("wide")`` raised a bare ``ValueError`` from inside the
+        lock, escaping the structured ``{"status": "error"}`` contract that every
+        ``AgentTool`` handler owes its caller.
+        """
+        stub = _engine_stub()
+        result = _add_camera(stub, name="cam", fov="wide")
+        assert result["status"] == "error", result
+
+    def test_zero_fov_would_divide_by_zero_in_the_derived_intrinsics(self):
+        """Pin why ``0`` is outside the domain rather than merely unusual."""
+        with pytest.raises(ZeroDivisionError):
+            0.5 * 480 / math.tan(math.radians(0.0) / 2.0)
+
+
+# --------------------------------------------------------------------------- #
+# The guard is load-bearing: accepted poses render, refused ones would not.    #
+# --------------------------------------------------------------------------- #
+class TestAcceptedPoseAlwaysYieldsAFiniteLookAt:
+    def test_every_accepted_pose_gives_a_finite_camera_quaternion(self):
+        poses = [
+            ([1.0, 1.0, 1.0], [0.0, 0.0, 0.0]),
+            ([0.6, 0.6, 0.5], [0.0, 0.0, 0.15]),
+            ([0.0, 0.0, 1.0], [0.0, 0.0, 0.0]),
+            ([0.0, 0.0, -1.0], [0.0, 0.0, 0.0]),
+            ([1, 2, 3], [0, 0, 0]),
+        ]
+        for pos, tgt in poses:
+            stub = _engine_stub()
+            assert _add_camera(stub, name="cam", position=pos, target=tgt)["status"] == "success"
+            cam = stub._world.cameras["cam"]
+            q = _look_at(tuple(cam.position), tuple(cam.target))
+            assert np.all(np.isfinite(q)), (pos, tgt, q)
+
+    def test_the_refused_pose_would_have_produced_a_non_finite_quaternion(self):
+        """Assert the premise so this file cannot pass vacuously.
+
+        If ``_look_at_quat`` were finite for a nan pose the guard would be
+        pointless; it is not, which is exactly the harm being prevented.
+        """
+        with np.errstate(invalid="ignore"):
+            q = _look_at((float("nan"), 1.0, 1.0), (0.0, 0.0, 0.0))
+        assert not np.all(np.isfinite(q))
+
+
+class TestRefusalLeavesNoPartialState:
+    def test_a_refused_call_does_not_consume_the_camera_name(self):
+        """A rejected configuration leaves the registry untouched.
+
+        The name must still be free afterwards - otherwise the caller has to
+        ``remove_camera`` a camera that was never added.
+        """
+        stub = _engine_stub()
+        assert _add_camera(stub, name="wrist", fov=float("nan"))["status"] == "error"
+        assert stub._world.cameras == {}
+        assert _add_camera(stub, name="wrist", fov=60.0)["status"] == "success"
+        assert isinstance(stub._world.cameras["wrist"], SimCamera)
+
+
+# --------------------------------------------------------------------------- #
+# Cross-backend parity                                                        #
+# --------------------------------------------------------------------------- #
+class TestSameVerdictAsTheMujocoSibling:
+    """The two backends' ``add_camera`` must accept and refuse the same configs.
+
+    ``pose_vector_error`` documents the invariant this pins: a pose either
+    backend entry point refuses must be refused by the other. The headline
+    inconsistency this PR closes was exactly that divergence - MuJoCo refused a
+    nan pose and an unusable fov, Newton accepted both.
+    """
+
+    @pytest.fixture
+    def mj_sim(self):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        s = Simulation(tool_name="test_newton_add_camera_parity_sim", mesh=False)
+        s.create_world(gravity=[0, 0, -9.81])
+        yield s
+        s.cleanup()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            # Refused by both.
+            {"position": [float("nan"), 1.0, 1.0]},
+            {"position": [float("inf"), 1.0, 1.0]},
+            {"target": [0.0, float("-inf"), 0.0]},
+            {"position": [True, 1.0, 1.0]},
+            {"position": ["x", 1.0, 1.0]},
+            {"position": [1.0, 1.0]},
+            {"position": []},
+            {"fov": float("nan")},
+            {"fov": 0.0},
+            {"fov": -30.0},
+            {"fov": 180.0},
+            {"fov": 400.0},
+            {"fov": "wide"},
+            {"fov": True},
+            # Accepted by both.
+            {},
+            {"fov": 60.0},
+            {"fov": 179.9},
+            {"fov": np.float32(58.0)},
+            {"position": [1, 2, 3], "target": [0, 0, 0]},
+            {"position": np.array([0.6, 0.6, 0.5]), "target": np.array([0.0, 0.0, 0.15])},
+        ],
+    )
+    def test_verdicts_agree(self, mj_sim, kwargs):
+        newton_result = _add_camera(_engine_stub(), name="parity_cam", **kwargs)
+        mujoco_result = mj_sim.add_camera(name="parity_cam", **kwargs)
+        assert newton_result["status"] == mujoco_result["status"], (
+            f"{kwargs!r}: newton said {newton_result['status']}, mujoco said {mujoco_result['status']} "
+            f"({newton_result['content'][0].get('text')!r} vs {mujoco_result['content'][0].get('text')!r})"
+        )


### PR DESCRIPTION
## Summary

The Newton backend's `add_camera` validated neither the contents of `position`/`target` nor `fov` at all, so a camera configuration the MuJoCo backend already refuses was accepted here and surfaced far from the call that caused it. Both now route through the shared domains MuJoCo's `add_camera` uses, and the fov interval moves into a shared `camera_fov_error` so the two backends cannot drift.

## The two failure modes

**`position` / `target`** were coerced with a bare `float(v)`. That caught a non-numeric element but passed a `nan`/`inf` component -- and a `bool`, reading `True` as the coordinate `1.0`. Nothing downstream caught it either: the degenerate-orientation check compares `abs(pos[i] - tgt[i]) < 1e-9`, which is `False` for a `nan`, and `_look_at_quat` then divides the view vector by a `nan` norm. So `render`/`get_frame` produced a frame from an all-NaN camera quaternion while `add_camera` reported `status="success"`.

**`fov`** was coerced by a bare `float(fov)` inside the lock, so:

| input | before | after |
|---|---|---|
| `nan` / `inf` | `success`, intrinsics `fy = nan` | structured error |
| `0.0` | `success`, then `ZeroDivisionError` at first render | structured error |
| `180.0` | `success`, `fy ~ 1.5e-14` (degenerate) | structured error |
| `"wide"` | **uncaught `ValueError`** through the tool-result contract | structured error |
| `True` | `success`, a 1-degree lens | structured error |

The `nan` case is the quiet one: `get_camera_params` derives the pinhole intrinsics `0.5 * h / tan(radians(fov) / 2)`, so the poisoned value reaches whatever consumes the camera matrix rather than failing at config time. The `"wide"` case breaks the `AgentTool` contract outright -- an exception escaping instead of `{"status": "error"}`.

## Approach

`position`/`target` go through the existing `coerce_pose_vector`, whose docstring already states the invariant at stake:

> their accepted domain must not diverge - a pose either backend entry point refuses must be refused by the other

Rather than grow a second copy of the fov interval in Newton, the check moves **out** of the MuJoCo method into a shared `camera_fov_error` beside `pose_vector_error` in `utils.py`. Both backends now call the one definition, so the domains are structurally identical instead of being pinned apart by a test. MuJoCo's error strings are unchanged.

## Scope

Finiteness and numeric type only. Pixel-count bounds on `width`/`height` are deliberately **not** in scope: that is an integer domain with its own validator, and MuJoCo draws the same boundary (pose/fov checks vs `_validate_render_dims`). `width="big"` still raises on the Newton backend, and Isaac's `add_camera` has the same gap -- both tracked as follow-ups rather than widened into this diff.

## Tests

New `tests/simulation/newton/test_add_camera_numeric_validation.py`, 82 tests.

Most need neither `newton`/`warp` nor a GPU: the validation runs before `add_camera` touches the solver, so the unbound method is called with a small stand-in for `self` -- the pattern the sibling `test_camera_lookat_quat.py` already uses. This matters because `sim-newton` is not in the `all` extra, so a test gated on the package would **always skip in CI** and pin nothing.

- Non-finite / non-numeric / wrong-length / `bool` components, in each slot of both vectors.
- Accepted inputs keep working: omitted vectors take the documented defaults, ints and NumPy poses are accepted and normalised to plain `float` so no `np.float64` leaks into agent-visible output.
- The full `fov` domain, including that `"wide"` returns an error dict and does not raise.
- A refused call leaves the registry untouched and does not consume the camera name.
- Two tests assert their own premise so the file cannot pass vacuously: that `abs(nan - 0.0) < 1e-9` is `False` (the pre-existing degeneracy check could never have stood in for this guard) and that the refused pose really does yield a non-finite look-at quaternion.
- `TestSameVerdictAsTheMujocoSibling` runs 20 probes through **both** backends' live `add_camera` and asserts the verdicts agree.

**Verified against pre-fix code:** 45 of the 82 fail without the source change (37 pass in both states -- the premise assertions and the accepted-input cases, as intended). The parity failures read exactly as the bug: `{'fov': 400.0}: newton said success, mujoco said error`.

## Gate

- `ruff check` + `ruff format --check` clean (928 files)
- `mypy` clean on the three changed source files
- `tests/simulation/newton/` + `tests/test_utils.py` + the MuJoCo camera suites: **281 passed, 153 skipped**
- MuJoCo backend checked for regression by running the same camera suites with and without the source change: byte-identical results (the 2 remaining failures are pre-existing env gaps in the verification sandbox -- a missing `so101` asset and a render dep -- and fail identically on unmodified `main`)
- No non-ASCII characters, no host paths
