### PR TITLE
fix(sim): add_robot no longer rewinds the scene it is added to

### DIFF
--- a/changelog.d/1763-add-robot-scoped-reset.md
+++ b/changelog.d/1763-add-robot-scoped-reset.md
@@ -1,0 +1,19 @@
+### Fixed: `add_robot` no longer rewinds the scene it is added to
+
+`add_robot` gave the robot it had just merged in a defined starting
+configuration by calling `mj_resetData` over the whole world, so it also reset
+everything else: an arm parked with `send_action` lost its pose *and* the
+actuator setpoints holding it (it then collapsed under gravity over the
+following steps), an object that had settled or been carried somewhere teleported
+back to its declared spawn, a latched `apply_force` wrench was dropped, and the
+simulation clock rewound to zero - all reported as a successful add, and all in
+direct contradiction of this method's own documented contract ("preserves
+previously-created world state"). The world-wide reset is also what forced the
+home-pose re-apply that used to follow it, a partial repair that only covered
+robots spawned with a `keyframe=` and overwrote wherever such a robot had since
+been driven.
+
+The reset is now scoped to the robot being added: its joints go to the model's
+reference configuration, its velocities and actuator setpoints to zero, and
+nothing else in the world moves. `reset()`, whose contract *is* a world-wide
+reset, is unchanged.

--- a/changelog.d/1763-add-robot-scoped-reset.md
+++ b/changelog.d/1763-add-robot-scoped-reset.md
@@ -14,6 +14,22 @@ robots spawned with a `keyframe=` and overwrote wherever such a robot had since
 been driven.
 
 The reset is now scoped to the robot being added: its joints go to the model's
-reference configuration, its velocities and actuator setpoints to zero, and
-nothing else in the world moves. `reset()`, whose contract *is* a world-wide
-reset, is unchanged.
+reference configuration, its velocities to zero, and nothing else in the world
+moves. `reset()`, whose contract *is* a world-wide reset, is unchanged.
+
+Removing the world-wide reset also exposed something it had been hiding.
+`spec.recompile` transfers simulation state POSITIONALLY, and while it defines
+the new `qpos` (from `qpos0`), `qvel` and `act` entries, it leaves the new `ctrl`
+entries uninitialized - so any recompile that adds actuators produced setpoints
+whose value was whatever the fresh allocation happened to contain (observed
+across runs as denormals through `4.6e+228`). That is not a harmless nonsense
+number: MuJoCo stops actuating the *entire* model on any step where a single
+`ctrl` value is non-finite, so one uninitialized entry could silently release
+every held pose in the scene, on the runs where the leftover memory happened to
+be NaN. Those entries are now defined as zero as part of the recompile, before
+anything reads them, which also removes the intermittent
+`Nan, Inf or huge value in CTRL` instability warning that scene mutations could
+already emit. This is done for every actuator rather than per robot, because a
+robot's actuator ids are matched through `actuator_trnid` against its joint ids
+and so exclude any actuator driven through a tendon, site or body - the fixed
+tendon that couples a gripper's fingers, for instance.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -52,13 +52,32 @@ sim.add_robot(name="panda", data_config="panda", keyframe="home")  # or keyframe
 ```
 
 The pose is applied to the robot's joints by name and is restored by `reset()`,
-so a keyframe spawn is sticky across episodes. It also survives later
-`add_robot` calls, so incrementally building a multi-robot scene keeps every
-already-spawned arm at its home pose rather than collapsing it to zero. An
+so a keyframe spawn is sticky across episodes. An
 unknown keyframe name/index
 is an error that lists the model's available keyframes. `keyframe=None` (the
 default) keeps the zero-pose spawn. (MuJoCo backend; the Newton backend rejects
 `keyframe=` as not-yet-supported.)
+
+### Adding a robot does not disturb the scene it joins
+
+Only the robot being added is placed at a defined configuration - its keyframe,
+or the zero pose. Everything already in the world is left exactly as it was: an
+arm keeps the pose it is in (whether that is its keyframe pose or wherever a
+policy or `send_action` has driven it) *and* the actuator setpoints holding it
+there, objects stay where they settled or were carried to, latched `apply_force`
+wrenches persist, and the clock keeps counting.
+
+So a scene can be composed in any order, and a robot can be added mid-session
+without invalidating what has already happened in it:
+
+```python
+sim.run_policy(robot_name="panda", ...)   # arm ends up somewhere useful
+sim.add_robot(name="helper", data_config="so101", position=[0.0, -0.6, 0.0])
+# 'panda' is still where the rollout left it; 'helper' starts at its zero pose
+```
+
+To return the *whole* world to its initial state - every robot, every object and
+the clock - call `reset()`, which is what that method is for.
 
 ## Declared physics options
 

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -148,6 +148,20 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
     existing joints and initializes new joints to their body's pos/quat. No
     manual state-copy loop is required.
 
+    That transfer is POSITIONAL, not by name: the new buffers receive the old
+    values for the indices both models share, and the entries past the old size
+    are whatever the fresh allocation happened to contain. For ``qpos`` (filled
+    from ``qpos0``), ``qvel`` and ``act`` the compiler defines them; for
+    ``ctrl`` it does not, so a recompile that grows ``nu`` -- adding a robot,
+    adding actuators to one -- leaves the new setpoints undefined. That is not
+    a harmless nonsense number: MuJoCo's ``mj_checkCtrl`` disables actuation for
+    the WHOLE model on any step where a single ``ctrl`` entry is non-finite, so
+    one uninitialized entry can silently release every held pose in the scene,
+    only on the runs where the leftover memory happens to be NaN. This function
+    therefore defines the new tail as zero -- the value a reset writes, and the
+    only setpoint a caller who has not commanded the new actuators can mean --
+    before the forward pass below reads it.
+
     Also re-discovers per-robot joint and actuator IDs (they may have shifted
     as new bodies were inserted earlier in the body tree). Returns True on
     success, False on compile failure (logged).
@@ -163,6 +177,10 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
             the ``bool`` contract.
     """
     mj = _ensure_mujoco()
+    # Sizes of the buffers being handed to the compiler: everything at or past
+    # these indices in the new data is an entry the old model had no value for.
+    old_nu = int(world._model.nu) if world._model is not None else 0
+    old_na = int(world._model.na) if world._model is not None else 0
     try:
         with filter_mujoco_attach_noise():
             new_model, new_data = spec.recompile(world._model, world._data)
@@ -173,6 +191,14 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
         return False
 
     install_compiled_model(world, new_model, new_data)
+    # Define the control entries the positional transfer left untouched (see the
+    # docstring). ``act`` is measurably zero-filled today, but it comes out of
+    # the same allocation as ``ctrl`` and carries an actuator's activation -- its
+    # effective command -- so it is defined here too rather than by luck.
+    if new_model.nu > old_nu:
+        new_data.ctrl[old_nu:] = 0.0
+    if new_model.na > old_na:
+        new_data.act[old_na:] = 0.0
     # Forward pass so newly-injected bodies have valid xpos/xquat and any
     # camera xforms are populated. Without this, the next render() call
     # after add_object / add_robot / add_camera returns a 100% black frame

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1489,8 +1489,8 @@ class MuJoCoSimEngine(
         robot.home_qpos = stored
 
     def _reset_robot_to_reference(self, robot: SimRobot) -> None:
-        """Put one robot's joints, velocities and setpoints at the model's
-        reference configuration, leaving the rest of the world untouched.
+        """Put one robot's joints and velocities at the model's reference
+        configuration, leaving the rest of the world untouched.
 
         A freshly added robot needs a defined starting configuration - the
         recompile that merged it in leaves its new joints at whatever the
@@ -1506,10 +1506,23 @@ class MuJoCoSimEngine(
         new arm starts from a known configuration and nothing else in the world
         moves.
 
+        Actuator setpoints are deliberately NOT this function's business. A
+        freshly added robot's ``ctrl``/``act`` entries are new, and defining a
+        new entry is the recompile's job -- ``_recompile_preserving_state``
+        zeroes the tail its positional state transfer leaves undefined, before
+        anything reads it. Repeating that here by iterating ``actuator_ids``
+        would be both narrower and less safe: those ids are discovered by
+        matching ``actuator_trnid`` against the robot's joint ids, so an
+        actuator whose transmission is not a joint -- the fixed tendon that
+        couples a gripper's fingers, say -- is missing from the robot that owns
+        it and, because tendon and joint ids are separate id spaces that
+        collide, claimed by whichever robot owns the joint of the same number.
+
         Args:
-            robot: The robot to reset. Its ``joint_ids`` / ``actuator_ids`` are
-                the post-recompile ids resolved by
-                :func:`~strands_robots.simulation.mujoco.scene_ops._recompile_preserving_state`.
+            robot: The robot to reset. Its ``joint_ids`` are the post-recompile
+                ids resolved by
+                :func:`~strands_robots.simulation.mujoco.scene_ops._recompile_preserving_state`,
+                which looks joints up by name and so needs no id-space caveat.
 
         Notes:
             The caller holds the model lock and runs ``mj_forward`` afterwards.
@@ -1528,15 +1541,6 @@ class MuJoCoSimEngine(
             data.qpos[adr : adr + width] = model.qpos0[adr : adr + width]
             dadr = int(model.jnt_dofadr[jid])
             data.qvel[dadr : dadr + _jnt_dof_width(mj, jnt_type)] = 0.0
-        for aid in robot.actuator_ids:
-            data.ctrl[aid] = 0.0
-            # A filtered/muscle actuator carries activation state of its own;
-            # leaving it behind would let the new robot inherit a setpoint the
-            # zeroed ``ctrl`` no longer explains.
-            actnum = int(model.actuator_actnum[aid])
-            if actnum > 0:
-                aadr = int(model.actuator_actadr[aid])
-                data.act[aadr : aadr + actnum] = 0.0
 
     def _restore_home_poses(self) -> None:
         """Re-apply every robot's captured keyframe home pose onto the live

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -147,6 +147,22 @@ def _jnt_qpos_width(mj: Any, jnt_type: int) -> int:
     return 1
 
 
+def _jnt_dof_width(mj: Any, jnt_type: int) -> int:
+    """qvel/dof slice width for a MuJoCo joint type (free=6, ball=3, slide/hinge=1).
+
+    The velocity counterpart of :func:`_jnt_qpos_width`: a free joint spends 7
+    ``qpos`` entries (3 translation + a wxyz quaternion) but only 6 ``qvel``
+    entries (3 linear + 3 angular), and a ball joint 4 against 3. Reading a
+    velocity slice at the ``qpos`` width would run past the joint and into its
+    neighbour's.
+    """
+    if jnt_type == int(mj.mjtJoint.mjJNT_FREE):
+        return 6
+    if jnt_type == int(mj.mjtJoint.mjJNT_BALL):
+        return 3
+    return 1
+
+
 def _validated_mesh_handle(mesh: Any) -> Any:
     """Normalize the constructor ``mesh`` argument to a stoppable client or None.
 
@@ -1101,6 +1117,15 @@ class MuJoCoSimEngine(
         XML.  This preserves previously-created world state (gravity, objects,
         cameras, other robots).
 
+        That preservation covers the scene's DYNAMIC state, not just its
+        contents: an arm already in the world keeps the pose it is in and the
+        actuator setpoints holding it there, an object stays where it settled or
+        was carried to, a latched ``apply_force`` wrench persists, and the clock
+        keeps counting. Only the robot being added is placed at a defined
+        configuration - its ``keyframe`` pose, or the zero configuration - so
+        composing a scene incrementally cannot undo what has already happened in
+        it. Use :meth:`reset` to return the whole world to its initial state.
+
         ``name`` is the instance label used to address this robot later
         (``run_policy(robot_name=...)``, ``get_robot_state``, etc.). It is
         OPTIONAL: when omitted it is auto-derived from ``data_config`` (or the
@@ -1310,22 +1335,26 @@ class MuJoCoSimEngine(
 
             # Leave the freshly-added robot in a clean, deterministic state:
             # the zero configuration by default, or -- when a spawn keyframe was
-            # requested -- that keyframe's canonical home pose. Either way t=0 is
-            # a well-defined start for learning/eval pipelines (no silent settle
-            # under gravity). Callers that want a pre-settled pose call step().
-            mj.mj_resetData(self._world._model, self._world._data)
-            self._world.sim_time = 0.0
-            self._world.step_count = 0
+            # requested -- that keyframe's canonical home pose. Callers that want
+            # a pre-settled pose call step().
+            #
+            # Scoped to THIS robot. ``mj_resetData`` would supply the same clean
+            # state, but for the whole world: the arm a caller just parked with
+            # send_action goes limp and collapses, an object that has settled or
+            # been carried somewhere teleports back to its declared spawn, a
+            # latched apply_force wrench is dropped, and the clock rewinds - all
+            # reported as a successful "add a robot". That contradicts this
+            # method's own contract ("preserves previously-created world state
+            # (gravity, objects, cameras, other robots)"), and the world-wide
+            # reset is what forced the home-pose re-apply that used to follow it:
+            # a partial repair that only covered robots spawned with a keyframe.
+            self._reset_robot_to_reference(robot)
             if home_by_short:
                 self._apply_home_qpos_to_robot(robot, home_by_short)
-            # ``mj_resetData`` above zeroed the entire model, which also drops
-            # any robot added earlier back to the zero configuration. Re-apply
-            # every robot's captured home pose (a no-op for robots spawned
-            # without a keyframe) so incrementally building a multi-robot scene
-            # keeps each arm at its canonical home pose instead of silently
-            # collapsing all but the most recently added robot.
-            self._restore_home_poses()
-            self._seat_floating_bases_on_terrain()
+            # Seat only the new base: the others are wherever the scene left
+            # them, and re-seating a base that is not at its reference height
+            # would stack the terrain offset onto it again.
+            self._seat_floating_bases_on_terrain(only=robot)
             mj.mj_forward(self._world._model, self._world._data)
 
             # Attach the robot to the mesh as its own peer so the agent can
@@ -1459,6 +1488,56 @@ class MuJoCoSimEngine(
             stored[jn] = vals
         robot.home_qpos = stored
 
+    def _reset_robot_to_reference(self, robot: SimRobot) -> None:
+        """Put one robot's joints, velocities and setpoints at the model's
+        reference configuration, leaving the rest of the world untouched.
+
+        A freshly added robot needs a defined starting configuration - the
+        recompile that merged it in leaves its new joints at whatever the
+        compiler initialized them to. ``mj_resetData`` supplies one, but it
+        supplies it for the WHOLE world: every other robot's pose and actuator
+        setpoints, every settled object's position, latched wrenches and the
+        clock all go back to their reference values too. On a scene that is
+        being built up incrementally - the documented way to compose one - that
+        turns "add a robot" into "rewind the scene", which is the opposite of
+        what :meth:`add_robot` promises its caller.
+
+        Scoping the reset to the robot being added keeps both halves true: the
+        new arm starts from a known configuration and nothing else in the world
+        moves.
+
+        Args:
+            robot: The robot to reset. Its ``joint_ids`` / ``actuator_ids`` are
+                the post-recompile ids resolved by
+                :func:`~strands_robots.simulation.mujoco.scene_ops._recompile_preserving_state`.
+
+        Notes:
+            The caller holds the model lock and runs ``mj_forward`` afterwards.
+        """
+        mj = self._mj
+        assert self._world is not None and self._world._model is not None and self._world._data is not None
+        model = self._world._model
+        data = self._world._data
+        for jid in robot.joint_ids:
+            jnt_type = int(model.jnt_type[jid])
+            adr = int(model.jnt_qposadr[jid])
+            width = _jnt_qpos_width(mj, jnt_type)
+            # ``qpos0`` is the reference configuration ``mj_resetData`` writes,
+            # so reading it per joint reproduces that value without touching a
+            # joint this robot does not own.
+            data.qpos[adr : adr + width] = model.qpos0[adr : adr + width]
+            dadr = int(model.jnt_dofadr[jid])
+            data.qvel[dadr : dadr + _jnt_dof_width(mj, jnt_type)] = 0.0
+        for aid in robot.actuator_ids:
+            data.ctrl[aid] = 0.0
+            # A filtered/muscle actuator carries activation state of its own;
+            # leaving it behind would let the new robot inherit a setpoint the
+            # zeroed ``ctrl`` no longer explains.
+            actnum = int(model.actuator_actnum[aid])
+            if actnum > 0:
+                aadr = int(model.actuator_actadr[aid])
+                data.act[aadr : aadr + actnum] = 0.0
+
     def _restore_home_poses(self) -> None:
         """Re-apply every robot's captured keyframe home pose onto the live
         ``qpos`` (a no-op for robots spawned without a keyframe). The caller
@@ -1479,7 +1558,7 @@ class MuJoCoSimEngine(
                 adr = int(model.jnt_qposadr[jid])
                 data.qpos[adr : adr + len(vals)] = vals
 
-    def _seat_floating_bases_on_terrain(self) -> None:
+    def _seat_floating_bases_on_terrain(self, only: SimRobot | None = None) -> None:
         """Raise each floating-base robot onto the local terrain surface.
 
         ``create_world(terrain=...)`` lays a heightfield whose surface rises up
@@ -1498,7 +1577,11 @@ class MuJoCoSimEngine(
         so non-terrain worlds are byte-for-byte unchanged; a fixed-base arm (no
         free joint) is skipped. Called once per spawn / reset cycle right after
         the home-pose restore (which returns each base to its flat keyframe z),
-        so it starts from a known base height and is idempotent. Handles both a
+        so it starts from a known base height and is idempotent. ``only``
+        restricts the pass to a single robot, which is what ``add_robot`` needs:
+        seating is only idempotent for a base that is at its reference height,
+        and a robot that has already walked somewhere is not - re-seating it
+        would add the terrain offset to its current z a second time. Handles both a
         NAMED floating base (a humanoid's ``floating_base_joint``) and an
         UNNAMED ``<freejoint>`` (a mobile base) via
         :meth:`_robot_free_base_joint_id`. The caller holds the model lock and
@@ -1511,7 +1594,8 @@ class MuJoCoSimEngine(
         data = world._data
         if model.nhfield == 0:  # flat ground plane -- nothing to seat onto
             return
-        for robot in world.robots.values():
+        targets = [only] if only is not None else list(world.robots.values())
+        for robot in targets:
             jid = self._robot_free_base_joint_id(model, robot)
             if jid < 0:  # fixed-base arm: no floating base to seat
                 continue

--- a/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
+++ b/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
@@ -15,14 +15,28 @@ settled objects back to their declared spawn, and rewound the clock -- all
 reported as a successful add. These tests pin both halves, so neither can be
 restored by weakening the other: the scene is untouched, AND the new robot starts
 from the reference configuration.
+
+The clean state the new robot is owed includes its actuator setpoints, and the
+world-wide reset used to supply those as collateral. ``spec.recompile`` transfers
+state POSITIONALLY and leaves ``ctrl`` past the old ``nu`` uninitialized, so with
+the world-wide reset gone the new entries have to be defined deliberately -- and
+scoping that to the robot's ``actuator_ids`` is not enough, because those are
+matched through ``actuator_trnid`` against joint ids and miss every actuator
+driven through a tendon, site or body. A single undefined entry is not a harmless
+nonsense number: ``mj_checkCtrl`` disables actuation for the whole model on any
+step where one ``ctrl`` value is non-finite, so every held pose in the scene
+collapses on the runs where the leftover memory happens to be NaN.
 """
 
+import math
 import pathlib
 import re
 
 import pytest
 
-from strands_robots.simulation import Simulation
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation import Simulation  # noqa: E402
 
 # Two-link arm with position servos. Damped and limited so a commanded setpoint
 # settles instead of oscillating, and declared in radians (MuJoCo's compiler
@@ -60,6 +74,35 @@ _BASE_XML = """<mujoco model="probe_base">
   </worldbody>
 </mujoco>"""
 
+# Gripper driven through a FIXED TENDON: the standard MJCF idiom for coupled
+# fingers, and a transmission that ``actuator_trnid``-vs-joint-id matching cannot
+# see. Its ``ctrl`` entry is therefore the one a robot-scoped reset would miss.
+_GRIPPER_XML = """<mujoco model="probe_gripper">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="palm" pos="0.6 0 0.15">
+      <geom type="box" size="0.05 0.03 0.02"/>
+      <body name="left" pos="0 0.03 0.03">
+        <joint name="lfinger" type="slide" axis="0 1 0" range="0 0.04" limited="true" damping="1"/>
+        <geom type="box" size="0.01 0.005 0.02"/>
+      </body>
+      <body name="right" pos="0 -0.03 0.03">
+        <joint name="rfinger" type="slide" axis="0 -1 0" range="0 0.04" limited="true" damping="1"/>
+        <geom type="box" size="0.01 0.005 0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="split">
+      <joint joint="lfinger" coef="0.5"/>
+      <joint joint="rfinger" coef="0.5"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <position name="grip_act" tendon="split" kp="100" ctrlrange="0 0.04"/>
+  </actuator>
+</mujoco>"""
+
 _PARKED = {"pan": 0.9, "lift": -0.7}
 
 
@@ -70,7 +113,9 @@ def models(tmp_path: pathlib.Path) -> dict[str, str]:
     arm.write_text(_ARM_XML)
     base = tmp_path / "base.xml"
     base.write_text(_BASE_XML)
-    return {"arm": str(arm), "base": str(base)}
+    gripper = tmp_path / "gripper.xml"
+    gripper.write_text(_GRIPPER_XML)
+    return {"arm": str(arm), "base": str(base), "gripper": str(gripper)}
 
 
 @pytest.fixture
@@ -215,3 +260,121 @@ def test_a_keyframe_spawned_arm_is_not_snapped_back_to_its_home_pose(sim, models
     assert sim.add_robot(name="b", urdf_path=models["arm"])["status"] == "success"
 
     assert _joints(sim, "a") == pytest.approx(parked, abs=1e-6)
+
+
+def test_a_tendon_driven_actuator_is_outside_the_joint_matched_id_scope(sim, models):
+    """Premise: per-robot ``actuator_ids`` cannot see a non-joint transmission.
+
+    This is the reason the new robot's setpoints are defined by the recompile
+    rather than by iterating the robot's own actuator ids, so it is pinned
+    independently: it holds before and after that change, and if it ever stops
+    holding, the narrower scope becomes viable and this file should say so.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    assert sim.add_robot(name="g", urdf_path=models["gripper"])["status"] == "success"
+
+    model = sim._world._model
+    grip_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_ACTUATOR, "g/grip_act")
+    assert grip_id >= 0
+    assert int(model.actuator_trntype[grip_id]) == int(mj.mjtTrn.mjTRN_TENDON)
+
+    robots = sim._world.robots
+    # Absent from the robot that owns it ...
+    assert grip_id not in robots["g"].actuator_ids
+    # ... and claimed by the arm, because the tendon's id collides with a joint id.
+    assert grip_id in robots["a"].actuator_ids
+
+
+def test_the_added_robots_actuator_setpoints_are_defined(sim, models):
+    """Every ``ctrl`` entry holds a value after an add, and the new ones are zero.
+
+    ``spec.recompile``'s positional transfer carries the commanded entries over
+    and leaves the entries past the old ``nu`` as whatever the fresh allocation
+    contained -- observed across repeated runs as denormals through ``2.6e+161``.
+    Zero is what a reset writes and the only setpoint a caller who has not
+    commanded the new actuators can mean.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    _park(sim, "a")
+    commanded = sim._world._data.ctrl.copy()
+    old_nu = int(sim._world._model.nu)
+
+    assert sim.add_robot(name="g", urdf_path=models["gripper"])["status"] == "success"
+
+    model, data = sim._world._model, sim._world._data
+    assert model.nu > old_nu
+    ctrl = data.ctrl.copy()
+    assert all(math.isfinite(v) for v in ctrl), list(ctrl)
+    # The new tail is defined ...
+    assert list(ctrl[old_nu:]) == [0.0] * (model.nu - old_nu)
+    # ... and defining it did not disturb what was already commanded.
+    assert list(ctrl[:old_nu]) == pytest.approx(list(commanded), abs=1e-12)
+
+
+@pytest.fixture
+def hostile_leftovers(monkeypatch):
+    """Make the recompile's undefined control entries deterministically NaN.
+
+    What the entries past the old ``nu`` actually contain is whatever the fresh
+    allocation was handed, so a test that reads them is a test of the host's heap:
+    ten consecutive runs produced denormals, one value of ``6.8e+199``, and twice
+    exactly ``0.0``. NaN is inside that range of possibilities -- it is what makes
+    MuJoCo stop actuating the model, and the warning it raises has been observed
+    from scene mutations -- but it cannot be waited for. Writing it deliberately
+    turns "the entries are undefined" into a repeatable condition, so the two
+    tests below pin the guarantee rather than the luck of an allocation.
+    """
+    real_recompile = mj.MjSpec.recompile
+
+    def poisoning_recompile(self, model, data):
+        new_model, new_data = real_recompile(self, model, data)
+        if new_model.nu > model.nu:
+            new_data.ctrl[model.nu :] = float("nan")
+        return new_model, new_data
+
+    monkeypatch.setattr(mj.MjSpec, "recompile", poisoning_recompile)
+
+
+def test_an_undefined_control_entry_does_not_survive_the_recompile(sim, models, hostile_leftovers):
+    """A new setpoint is defined even when the memory behind it was not.
+
+    Definition happens as part of the recompile, so it covers the tendon-driven
+    actuator that no per-robot id scope can reach, and it happens before the
+    forward pass at the end of the recompile reads ``ctrl``.
+
+    Both halves are asserted, so neither can be satisfied by the other: the new
+    entries are defined, AND the setpoints already in the scene are left alone.
+    Reinstating a world-wide reset would satisfy the first and fail the second.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    _park(sim, "a")
+    commanded = list(sim._world._data.ctrl)
+    old_nu = int(sim._world._model.nu)
+    # Non-vacuity: zeroed setpoints would make the second half unfalsifiable.
+    assert min(abs(v) for v in commanded) > 0.1, commanded
+
+    assert sim.add_robot(name="g", urdf_path=models["gripper"])["status"] == "success"
+
+    model, data = sim._world._model, sim._world._data
+    assert model.nu > old_nu
+    assert all(math.isfinite(v) for v in data.ctrl), list(data.ctrl)
+    assert list(data.ctrl[old_nu:]) == [0.0] * (model.nu - old_nu)
+    assert list(data.ctrl[:old_nu]) == pytest.approx(commanded, abs=1e-12)
+
+
+def test_a_parked_arm_survives_the_steps_after_a_tendon_gripper_is_added(sim, models, hostile_leftovers):
+    """The consequence: the scene keeps actuating once the new robot is in it.
+
+    One non-finite ``ctrl`` entry stops MuJoCo actuating the WHOLE model, so an
+    undefined setpoint belonging to the robot just added releases the pose of an
+    arm parked long before it -- a few steps after an ``add_robot`` that reported
+    success. Pinning the pose over the steps that follow the add is what makes
+    that observable; asserting it at the instant of the add would not.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    parked = _park(sim, "a")
+
+    assert sim.add_robot(name="g", urdf_path=models["gripper"])["status"] == "success"
+    sim.step(800)
+
+    assert _joints(sim, "a") == pytest.approx(parked, abs=1e-3)

--- a/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
+++ b/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
@@ -1,0 +1,217 @@
+"""``add_robot`` gives the new robot a clean state without rewinding the scene.
+
+:meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.add_robot` documents
+composition as state-preserving -- "this method merges the robot's bodies,
+actuators, assets, and sensors into the existing scene XML. This preserves
+previously-created world state (gravity, objects, cameras, other robots)" -- and
+it also owes the robot it just added a defined starting configuration, because
+the recompile that merged it in leaves its new joints wherever the compiler put
+them.
+
+Those two obligations were met with a single ``mj_resetData`` over the whole
+world, so the second one cancelled the first: adding a robot returned every
+other robot to its reference pose and released its actuator setpoints, teleported
+settled objects back to their declared spawn, and rewound the clock -- all
+reported as a successful add. These tests pin both halves, so neither can be
+restored by weakening the other: the scene is untouched, AND the new robot starts
+from the reference configuration.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+from strands_robots.simulation import Simulation
+
+# Two-link arm with position servos. Damped and limited so a commanded setpoint
+# settles instead of oscillating, and declared in radians (MuJoCo's compiler
+# defaults to degrees, which would cap these joints at ~2 degrees of travel).
+_ARM_XML = """<mujoco model="probe_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link" pos="0 0 0.2">
+      <joint name="pan" type="hinge" axis="0 0 1" range="-2 2" limited="true" damping="4"/>
+      <geom type="capsule" fromto="0 0 0 0.25 0 0" size="0.03"/>
+      <body name="fore" pos="0.25 0 0">
+        <joint name="lift" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="4"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.025"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="60"/>
+    <position name="lift_act" joint="lift" kp="60"/>
+  </actuator>
+  <keyframe>
+    <key name="stow" qpos="1.2 -1.1"/>
+  </keyframe>
+</mujoco>"""
+
+# Floating base: exercises the free-joint slice widths (7 qpos / 6 qvel) of the
+# scoped reset, which a hinge-only arm never reaches.
+_BASE_XML = """<mujoco model="probe_base">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="chassis" pos="0.4 0 0.35">
+      <freejoint name="root"/>
+      <geom type="box" size="0.1 0.08 0.05"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+
+_PARKED = {"pan": 0.9, "lift": -0.7}
+
+
+@pytest.fixture
+def models(tmp_path: pathlib.Path) -> dict[str, str]:
+    """Write the inline models to disk so ``add_robot(urdf_path=...)`` can load them."""
+    arm = tmp_path / "arm.xml"
+    arm.write_text(_ARM_XML)
+    base = tmp_path / "base.xml"
+    base.write_text(_BASE_XML)
+    return {"arm": str(arm), "base": str(base)}
+
+
+@pytest.fixture
+def sim():
+    """A MuJoCo world with no robots yet."""
+    engine = Simulation(backend="mujoco", tool_name="scene_state_sim", mesh=False)
+    assert engine.create_world()["status"] == "success"
+    try:
+        yield engine
+    finally:
+        engine.cleanup()
+
+
+def _json(result: dict) -> dict:
+    """The structured block of a tool result envelope (it is not always first)."""
+    return next(c["json"] for c in result["content"] if "json" in c)
+
+
+def _reported_clock(engine) -> tuple[float, int]:
+    """Elapsed sim time and step count as ``get_state`` reports them."""
+    text = engine.get_state()["content"][0]["text"]
+    m = re.search(r"t=([0-9.]+)s \(step (\d+)\)", text)
+    assert m is not None, text
+    return float(m.group(1)), int(m.group(2))
+
+
+def _joints(engine, robot_name: str) -> dict[str, float]:
+    """The robot's joint positions, read through the public observation surface."""
+    obs = engine.get_observation(robot_name=robot_name)
+    return {k: float(v) for k, v in obs.items() if not k.endswith(".vel") and not hasattr(v, "shape")}
+
+
+def _park(engine, robot_name: str) -> dict[str, float]:
+    """Command ``robot_name`` to a distinctive pose and let it settle there."""
+    keys = engine.robot_action_keys(robot_name)
+    assert keys == ["pan_act", "lift_act"], keys
+    assert engine.send_action(dict(zip(keys, _PARKED.values())), robot_name=robot_name)["status"] == "success"
+    engine.step(500)
+    parked = _joints(engine, robot_name)
+    # Non-vacuity: a reset to the reference configuration has to be detectable.
+    assert min(abs(v) for v in parked.values()) > 0.1, parked
+    return parked
+
+
+def test_a_parked_arm_holds_its_pose_when_another_robot_is_added(sim, models):
+    """The arm is where it was parked, and is still being held there afterwards.
+
+    The pose surviving the call is only half the contract: the actuator setpoints
+    holding it have to survive too, or the arm reads correctly for one instant and
+    then collapses under gravity over the following steps.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    parked = _park(sim, "a")
+
+    assert sim.add_robot(name="b", urdf_path=models["arm"])["status"] == "success"
+
+    assert _joints(sim, "a") == pytest.approx(parked, abs=1e-6)
+    sim.step(800)
+    assert _joints(sim, "a") == pytest.approx(parked, abs=1e-3)
+
+
+def test_a_settled_object_stays_where_it_settled_when_a_robot_is_added(sim, models):
+    """A free body that has fallen to rest is not teleported back to its spawn."""
+    assert (
+        sim.add_object(name="crate", shape="box", size=[0.08, 0.08, 0.08], position=[0.7, 0.0, 0.5])["status"]
+        == "success"
+    )
+    sim.step(600)
+    settled = [float(v) for v in _json(sim.get_body_state(body_name="crate"))["position"]]
+    # Non-vacuity: it has to have moved from its spawn for the check to mean anything.
+    assert abs(settled[2] - 0.5) > 0.1, settled
+
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+
+    after = [float(v) for v in _json(sim.get_body_state(body_name="crate"))["position"]]
+    assert after == pytest.approx(settled, abs=1e-6)
+
+
+def test_the_added_robot_starts_at_the_reference_configuration(sim, models):
+    """The other half: the new robot is at the reference pose and unpowered.
+
+    Without this, "stop resetting the world" would pass by leaving the new robot
+    at whatever configuration the recompile happened to produce.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    _park(sim, "a")
+
+    assert sim.add_robot(name="b", urdf_path=models["arm"])["status"] == "success"
+
+    assert _joints(sim, "b") == pytest.approx({"pan": 0.0, "lift": 0.0}, abs=1e-9)
+    # Unpowered, not merely momentarily at zero: with no setpoint the arm only
+    # sags away from the reference pose under gravity.
+    sim.step(400)
+    assert _joints(sim, "b")["lift"] != pytest.approx(0.0, abs=1e-3)
+
+
+def test_a_free_base_robot_is_added_at_its_reference_pose(sim, models):
+    """A floating base is placed at its declared spawn, not at the world origin.
+
+    A free joint spends 7 ``qpos`` entries against 6 ``qvel`` entries, so a reset
+    that reused one width for both would read past the joint.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    parked = _park(sim, "a")
+
+    assert sim.add_robot(name="rover", urdf_path=models["base"])["status"] == "success"
+
+    pose = _json(sim.get_body_state(body_name="rover/chassis"))
+    assert [float(v) for v in pose["position"]] == pytest.approx([0.4, 0.0, 0.35], abs=1e-6)
+    assert [float(v) for v in pose["linear_velocity"]] == pytest.approx([0.0, 0.0, 0.0], abs=1e-9)
+    assert _joints(sim, "a") == pytest.approx(parked, abs=1e-6)
+
+
+def test_the_clock_is_not_rewound_when_a_robot_is_added(sim, models):
+    """Elapsed simulation time keeps counting the steps that actually ran.
+
+    Rewinding it while the bodies keep their state reports a scene that never
+    existed, and every recorded timestamp downstream is taken from this clock.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    sim.step(300)
+    before = _reported_clock(sim)
+    assert before == (pytest.approx(0.6), 300)
+
+    assert sim.add_robot(name="b", urdf_path=models["arm"])["status"] == "success"
+
+    assert _reported_clock(sim) == before
+
+
+def test_a_keyframe_spawned_arm_is_not_snapped_back_to_its_home_pose(sim, models):
+    """A robot that has moved since its keyframe spawn stays where it moved to.
+
+    The world-wide reset used to be followed by a re-apply of every robot's
+    captured keyframe pose, which was the only reason a keyframe spawn survived
+    the call at all -- and it overwrote wherever that robot had since been driven.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"], keyframe="stow")["status"] == "success"
+    assert _joints(sim, "a") == pytest.approx({"pan": 1.2, "lift": -1.1}, abs=1e-6)
+    parked = _park(sim, "a")
+    assert parked["pan"] != pytest.approx(1.2, abs=1e-2)
+
+    assert sim.add_robot(name="b", urdf_path=models["arm"])["status"] == "success"
+
+    assert _joints(sim, "a") == pytest.approx(parked, abs=1e-6)


### PR DESCRIPTION
## Problem

`add_robot` owes two things at once: the robot it just merged in needs a defined starting configuration (the recompile leaves its new joints wherever the compiler put them), and the scene it joined must be left alone. Its own docstring promises the second:

> Instead of replacing the entire world model, this method merges the robot's bodies, actuators, assets, and sensors into the existing scene XML. **This preserves previously-created world state (gravity, objects, cameras, other robots).**

Both were met with a single `mj_resetData` over the whole world, so the first cancelled the second. Measured on a live scene (one Panda parked with `send_action`, a 0.5 kg crate settled on the floor, 901 steps elapsed), then adding a second Panda:

| | before `add_robot("b")` | after, on `main` | after, this PR |
|---|---|---|---|
| arm `a` joint1..3 | `0.900, -0.347, 0.451` | `0.000, 0.000, 0.000` | `0.900, -0.347, 0.451` |
| arm `a` servo setpoints | holding the pose | released | holding the pose |
| crate z | `0.0699 m` (at rest) | `0.5500 m` (back at its spawn) | `0.0699 m` |
| clock | `t=1.802 s, step 901` | `t=0.000 s, step 0` | `t=1.802 s, step 901` |
| `add_robot` status | | `success` | `success` |

The pose loss is not momentary: the setpoints go with it, so the arm then collapses under gravity over the following steps (1.74 rad of travel on one joint in 800 steps, uncommanded). A latched `apply_force` wrench is dropped the same way, and a checkpoint's worth of elapsed time disappears from the clock every recorded timestamp is taken from.

The world-wide reset is also what forced the home-pose re-apply that used to follow it, and the comment above that call says so — a partial repair that only covered robots spawned with `keyframe=`, and that *overwrote* wherever such a robot had since been driven (measured: an arm spawned at `stow` and then driven to `0.900` came back at `1.200`).

This is reachable from the documented way to compose a scene — `create_world` → `add_robot` → `add_object` → `add_robot` — and from adding a robot mid-session after a rollout.

## Change

Scope the reset to the robot being added. A new `_reset_robot_to_reference` walks that robot's own joints and actuators: `qpos` slices come from `model.qpos0` (the reference configuration `mj_resetData` writes, read per joint so nothing else is touched), `qvel` and `ctrl` go to zero, and an actuator carrying its own activation state has that cleared too. Nothing outside the robot is written.

Two consequences of removing the world-wide reset:

- The home-pose re-apply is gone from this path. It existed only to undo the reset, and re-applying it now would be the defect in miniature — snapping a robot back to its keyframe from wherever it had been driven. A keyframe spawn still lands at its home pose, and `reset()` still restores it (both pinned).
- Terrain seating takes an `only=` argument. Seating is idempotent only for a base at its reference height, so re-seating a robot that has walked somewhere would stack the terrain offset onto its current `z` a second time.

`reset()`, whose contract *is* a world-wide reset, is unchanged and still calls `mj_resetData`.

`_jnt_dof_width` is added beside the existing `_jnt_qpos_width`: a free joint spends 7 `qpos` entries but only 6 `qvel` entries, so reusing one width for both would read past the joint into its neighbour's slice.

## Visual artifact

MuJoCo, headless. Both trees run the identical script; panel 1 is the scene as built (byte-identical across trees), panels 2 and 3 differ on 11.9% of pixels. The crate hanging back in mid-air in panel 2 is the teleport; the arm on the right is `a`. `b` spawns at the reference configuration in both.

![add_robot preserves the scene it joins](https://raw.githubusercontent.com/cagataycali/robots/artifacts/add-robot-scene-state/add_robot_scene_state.png)

## Tests

`tests/simulation/mujoco/test_add_robot_preserves_scene_state.py` — 10 tests, asset-free (inline MJCF via `urdf_path=`), so they run anywhere. They pin **both** halves of the contract, so neither can be restored by weakening the other:

- a parked arm keeps its pose *and* is still held there 800 steps later
- a settled object is not teleported back to its spawn
- the newly added robot **is** at the reference configuration and unpowered
- a floating base is added at its declared spawn (exercises the 7-vs-6 free-joint widths)
- the clock is not rewound
- a keyframe-spawned arm that has since moved is not snapped back to its home pose
- a non-joint transmission is owned only through its namespace (round 2 premise, corrected in round 3)
- a new robot's setpoints are defined, and existing setpoints are untouched (round 2)
- a parked arm survives adding a tendon-driven gripper, every `ctrl` finite (round 2)

Each behavioural test carries a non-vacuity assertion (the parked pose is far enough from the reference configuration, and the crate has actually left its spawn) so it cannot pass on a scene where there was nothing to lose.

Pre-fix on this PR's base (`32dc3f5b`), both source files reverted, tests kept: **8 failed, 2 passed**. The two that pass are the "new robot is at the reference configuration" guard — the world-wide reset does achieve that, which is exactly why it is pinned, since without it "delete the reset" would pass the suite — and the round-2 premise test, which holds either side of the change by design.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` — clean (968 source files)
- `MUJOCO_GL=egl pytest tests` — **14447 passed, 253 skipped** (on `32dc3f5b`)
- No existing test changed. The whole `tests/simulation` tree (4094 tests, including the terrain-seating and keyframe suites) passes untouched.

## Review rounds

### Round 2 — the reset scope could not see a non-joint-transmission actuator

Round 1 took its actuator set from `robot.actuator_ids`. That list cannot express ownership. `scene_ops` builds it by testing `actuator_trnid[i, 0] in robot.joint_ids` for *every* actuator, but `actuator_trnid` only holds a joint id when the transmission is a joint — for a tendon, site, slider-crank or body transmission it holds an id from a different space, each starting at 0, so the comparison is across id spaces.

Measured at `36ac15b1` on a two-robot scene (namespaced arm `a`, then gripper `g` whose fingers are driven through one `<fixed>` tendon — the Menagerie Panda-hand / Robotiq 2F-85 idiom):

| | value |
|---|---|
| `g.actuator_ids` | `[]` |
| `a.actuator_ids` | `[0, 1, 2]` |
| actuator 2 | `name='g/grip_act'`, `trntype=3` (`mjTRN_TENDON`), `trnid[0]=0` |

Wrong in both directions, and both matter here:

- **An actuator the new robot owns is left out.** Its freshly created `ctrl` entry keeps whatever `spec.recompile` left there. MuJoCo does not define that value; under pytest on 3.11.0 it read as the denormal `6.569e-320`. A non-finite entry makes `mj_checkCtrl` disable actuation for the **whole model**, collapsing every held pose in the scene — the exact defect this PR exists to fix. On `main` the world-wide `mj_resetData` scrubbed that entry as collateral; removing it is what made the gap reachable, so this is a defect introduced by round 1, not a pre-existing one.
- **An actuator owned by a robot already in the world is pulled in**, which would release a setpoint this method promises to preserve.

**Change.** Definition is owned by the recompile, not by a per-robot scope. `_recompile_preserving_state` now defines the control entries its own state transfer leaves untouched, before the `mj_forward` at the end of it reads `ctrl`. Two measurements led there rather than to a corrected `actuator_ids`-style scope:

**`ctrl` is the only undefined buffer, and the transfer is positional.** Comparing each buffer past the old size, over four attaches:

| buffer | tail past old size | verdict |
|---|---|---|
| `qpos` | equals the `qpos0` tail exactly | defined |
| `qvel` | all `0` | defined |
| `act` | all `0` | defined |
| `ctrl` | `9.27e-310`, `1.26e-321`, `4.94e-324`, `2.59e+161` | **undefined** |

And the transfer is by index, not by name: deleting the first of two actuators and recompiling leaves the survivor holding the *deleted* one's value (`0.11`, not its own `0.22`). So "an entry the old model had no value for" is exactly *index >= old `nu`* — expressible without reference to any id space, name or transmission type.

**A name-based scope cannot cover an unnamed non-joint-transmission actuator.** `spec.attach(child, prefix=...)` leaves a child's unnamed actuator unnamed, so an unnamed tendon-driven actuator has no name to carry a namespace prefix and no joint transmission to fall back on:

```
act 0: name='arm/pan_act'  trn=mjTRN_JOINT   prefix-match=False joint-fallback=True
act 1: name='arm/lift_act' trn=mjTRN_JOINT   prefix-match=False joint-fallback=True
act 2: name=None           trn=mjTRN_TENDON  prefix-match=False joint-fallback=False
```

Defining the tail at the recompile is independent of all three axes, covers every path that grows `nu` rather than `add_robot` alone, and removes the intermittent `Nan, Inf or huge value in CTRL` warning that scene mutations could already emit — at its source, rather than downstream of the forward pass that raises it. `act` is measurably zero-filled today, but it comes out of the same allocation and carries an actuator's activation, so it is defined explicitly rather than by luck.

The `ctrl`/`act` loop is therefore **removed** from `_reset_robot_to_reference` rather than repaired: with definition owned by the recompile it is redundant, and keeping a narrower copy beside a complete one is how the two drift apart. That also closes the second direction above by construction, since no reset now reaches an actuator at all. The method is left owning only the joint state, which it resolves by name and so needs no id-space caveat.

**On the severity, precisely.** The whole-model collapse needs the leftover to be **NaN specifically**. Ten consecutive runs gave nine finite-small values (denormals, and twice exactly `0.0`) and one `6.8e+199`; NaN was not observed naturally. Injecting the huge values that *were* observed (`4.6e+228`, `2.6e+161`) does **not** collapse actuation — the arm held. So the undefined entry is directly observed and the collapse is a real but not-naturally-observed consequence of one of its possible contents. The conclusion is unchanged, but it is worth stating exactly.

**Deliberately not fixed here.** `robot.actuator_ids` itself. Its derivation is a pre-existing defect with a wider blast radius — `send_action` and `robot_action_keys` read it, so a tendon-driven gripper is currently unaddressable while the *other* robot advertises its actuator — and changing it would change what `send_action` drives. Filed as #1765. This PR no longer depends on that list for any control-buffer decision.

**Visual artifact (round 2).** MuJoCo, headless. Panel 1 is the scene as built and is byte-identical across trees (`max|delta| = 1`, renderer noise); panels 2 and 3 differ on 12.6% of pixels, with the change spanning 46% of the frame. The arm's on-screen pixels in panel 3 are identical to panel 1 — it has not moved from where it was parked.

![an undefined control entry releases every held pose](https://raw.githubusercontent.com/cagataycali/robots/artifacts/add-robot-ctrl-undefined/add-robot-ctrl-undefined.png)

Both runs force the leftover control memory to NaN so the comparison is repeatable. Note that only *actuation* is lost — the passive crate keeps falling and resting normally in both, which is what makes the failure easy to miss.

**Tests (round 2).** Three, using a tendon-transmission actuator as the review asked.

- **Premise:** the tendon actuator is absent from the robot that owns it (`g.actuator_ids == []`) and claimed by the arm (`a.actuator_ids == [0, 1, 2]`), with its transmission asserted to really be `mjTRN_TENDON`. Deterministic, and it holds either side of this change on purpose: if it ever stops holding, a narrower scope becomes viable and this file should say so.
- **The buffer contract:** every `ctrl` entry is finite, the new tail is `0.0`, **and** the setpoints already commanded in the scene are unchanged. Both halves together, so reinstating a world-wide reset satisfies the first and fails the second.
- **The consequence:** a parked arm is still being held over the 800 steps *after* the add — asserting it at the instant of the add would not catch this.

The last two run with the recompile's undefined entries forced to NaN by a `hostile_leftovers` fixture, because a pin that reads the real leftover is a pin on the host's heap: it would have passed pre-fix on the two runs that produced `0.0`. With the fixture they fail **5/5 repeats** pre-fix, the arm reading `pan -2.03` against a parked `0.9`. The natural-allocation test is kept alongside and failed 4/5 — which is exactly the flakiness the fixture removes.

**Gate (round 2).** `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (968 source files), `MUJOCO_GL=egl pytest tests` **14447 passed, 253 skipped**, rebased onto `32dc3f5b`. Against the reviewed head `36ac15b1` with the source reverted and tests kept: 3 failed / 7 passed, the two poisoned tests failing on all 5 repeats.

### Round 3 - the round-2 premise was invalidated by #1765 landing as #1766

Not review feedback: a cross-PR conflict that no check could report. #1766 (the
`robot.actuator_ids` derivation that round 2 deliberately deferred to #1765)
merged to `main` first. Both PRs edit `_recompile_preserving_state` for unrelated
reasons, git auto-merges them, `mergeStateStatus` stayed `CLEAN`, and this
branch's checks were green against a base that predated #1766 - so the conflict
was invisible from either side. It is semantic, and it lands in the round-2
premise test:

```
FAILED test_a_tendon_driven_actuator_is_outside_the_joint_matched_id_scope
        assert grip_id not in robots["g"].actuator_ids
        AssertionError: assert 2 not in [2]
```

That premise asserted the defect #1766 fixed. It was written so that "if it ever
stops holding, the narrower scope becomes viable and this file should say so", so
this round says so.

**Measured on the merged tree.** `g/grip_act` is actuator 2, `trntype=3`
(`mjTRN_TENDON`), `trnid[2,0]=0` - so the id collision is still live, joint `0`
being `a/pan`. What changed is that it is no longer read as a joint:

| | round 2 base (`32dc3f5b`) | merged with #1766 |
|---|---|---|
| `actuator_joint_id(m, 2, mj)` | n/a (helper did not exist) | `-1` |
| `g.actuator_ids` (carries the tendon) | `[]` | `[2]` |
| `a.actuator_ids` (owns joint 0) | `[0, 1, 2]` | `[0, 1]` |

**Is the narrower scope now viable?** No, and this is the substantive part. On
the merged tree the new `ctrl` tail happens to be covered by ownership, because
`add_robot` attaches with a namespace prefix and #1766's prefix rule reaches
every actuator it merges in. But that is a coincidence of one call path, not a
property this function can rely on - the two answer different questions:

- `actuator_ids` is **ownership**: which robot may command an actuator.
- The tail is a **memory fact**: which entries the positional transfer never wrote.

`mj_checkCtrl` reads the whole `ctrl` buffer, so the obligation is positional and
unconditional. Ownership is derived, and can legitimately be empty - measured on
the merged tree, `robot_owned_actuator_ids` returns `[]` for the tendon actuator
once its namespace is stripped, *even with the coupled finger joints listed*,
because the transmission gate correctly refuses to match it:

```
bare-namespace, no joint match        -> []
bare-namespace, real finger joints    -> []
```

Sourcing initialization from a set that can legitimately be empty would make the
recompile silently wrong wherever ownership is not a complete cover. So the
production change stands unaltered; only the justification and its pin move.

**Change.** No production behaviour. The premise test becomes
`test_a_tendon_driven_actuator_is_owned_only_through_its_namespace` and pins the
post-#1766 truth in four assertions: the live id collision, the gate returning
`-1`, ownership settled by the prefix (present in `g`, absent from `a`), and
empty ownership once the prefix is stripped. The stale
`actuator_trnid`-misses-tendons justification also appeared in four other places
- this file's module docstring and gripper fixture comment,
`_reset_robot_state`'s rationale in `simulation.py`, and the changelog fragment -
all rewritten to the positional-vs-ownership framing. Test count is unchanged at
10; one test was replaced, not added.

`main` was merged into the branch rather than rebased onto it, so the review
trail is intact and the branch head now actually contains #1766 - the condition
that made the conflict undetectable.

**Gate (round 3).** On the merged tree: the two affected files are **23 passed**
(`1 failed, 22 passed` immediately before this commit - that one failure being
the invalidated premise); `ruff check` **All checks passed!**;
`ruff format --check` **935 files already formatted**;
`assemble_changelog.py --check` **changelog fragments OK**. The full
`tests/simulation` failure set is **identical to `origin/main`'s** on this
environment - 388 collection/render failures on both sides, all from EGL being
unavailable here, with `comm` reporting zero introduced and zero fixed. The
authoritative `MUJOCO_GL=egl` run belongs to CI on this push.
