### PR TITLE
fix(sim): refuse an Isaac camera pose or fov that is not finite

### DIFF
--- a/changelog.d/1761-isaac-add-camera-finiteness.md
+++ b/changelog.d/1761-isaac-add-camera-finiteness.md
@@ -1,0 +1,26 @@
+### Fixed: an Isaac camera pose or field of view that is not finite is refused
+
+`IsaacSimulation.add_camera` validated none of its numeric inputs, so a camera
+configuration the MuJoCo and Newton backends refuse was accepted here and
+surfaced far from the call that caused it -- or not at all.
+
+`position`/`target` were copied with a bare `list(position)`, which reads no
+element, so a `nan`/`inf` component, a non-numeric element, a `bool` (read as the
+coordinate `1.0`), a wrong-length vector and an empty one were all registered
+under `status="success"` and handed to the USD camera prim and
+`set_camera_view`. A NumPy pose -- the natural product of pose arithmetic -- also
+leaked `np.float64` into the agent-visible status text and the `json` payload.
+
+`fov` was coerced with a bare `float(fov)` from outside the method's try block,
+so a non-numeric value raised a `ValueError` straight through the structured
+tool-result contract, and `nan`/`inf`/`0`/`>= 180` registered a camera the RTX
+pipeline cannot use: the pinhole relation
+`focal_length = horizontal_aperture / (2 * tan(radians(fov) / 2))` raises
+`ZeroDivisionError` for `0` -- a type absent from that try block's except tuple,
+so it escaped the tool call -- and yields `nan` for a `nan` fov and 7.3e-16 mm
+for `180`, both of which `set_focal_length` accepts.
+
+The pose now goes through the shared `coerce_pose_vector` and the field of view
+through `camera_fov_error`, the domains the other two backends' `add_camera`
+already apply, with the identical-eye-and-target refusal they already carry. A
+camera configuration one backend refuses is now refused by all three.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -36,7 +36,7 @@ import numpy as np
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.config import IsaacConfig
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
-from strands_robots.utils import positive_whole_number_error
+from strands_robots.utils import camera_fov_error, coerce_pose_vector, positive_whole_number_error
 
 if TYPE_CHECKING:
     from strands_robots.rendering import CameraParams
@@ -2979,6 +2979,25 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             relation ``focal_length = horizontal_aperture / (2 * tan(fov/2))``
             with the USD-default 24 mm horizontal aperture.
 
+        Validation
+        ----------
+        ``position`` and ``target`` must each be 3 finite numbers (a list,
+        tuple or NumPy array; NumPy scalar elements accepted, ``bool``
+        refused), and must not be identical - a camera whose eye is its own
+        look-at point has no look direction. Omit a vector to take its
+        default; an empty vector is a wrong-length request and is rejected
+        rather than silently placing the camera at the default pose. ``fov``
+        must be a finite angle in the open interval ``(0, 180)`` degrees.
+        These are the same bounds the MuJoCo and Newton backends' ``add_camera``
+        enforces, on the shared
+        :func:`~strands_robots.utils.coerce_pose_vector` /
+        :func:`~strands_robots.utils.camera_fov_error` domains, so a camera
+        configuration one backend refuses is refused by all three. Invalid
+        values are rejected here, before the stage is touched, rather than
+        deferring an uncaught exception (non-numeric ``fov``, ``fov=0``) or a
+        silently degenerate camera (a ``nan`` in the USD pose or in the derived
+        focal length) to the first render.
+
         Returns
         -------
         dict
@@ -2992,6 +3011,49 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             if not self._world_created:
                 return {"status": "error", "content": [{"text": "No world created."}]}
 
+            # Validate the pose and the field of view on the shared domains the
+            # MuJoCo and Newton backends' ``add_camera`` already applies, before
+            # anything touches the stage. ``coerce_pose_vector``'s contract is
+            # that a pose either backend entry point refuses must be refused by
+            # the other, and this was the entry point that refused nothing: the
+            # ``list(position)`` below copied the caller's vector element-wise
+            # without reading it, so a ``nan``/``inf`` component, a non-numeric
+            # element, a ``bool`` (the coordinate 1.0) and a wrong-length vector
+            # all reached ``_create_camera_prim`` under ``status="success"``, and
+            # a NumPy pose leaked ``np.float64`` into the status text and the
+            # json payload. ``float(fov)`` accepted ``nan``/``inf``/``0``/
+            # ``>= 180`` and raised a bare ``ValueError`` on a non-numeric value
+            # - from outside the try block below, so it escaped the structured
+            # ``{"status": "error"}`` contract entirely. Coercion is validation
+            # only when the coercion rejects; these did not.
+            position, pos_err = coerce_pose_vector("add_camera", "position", position, 3)
+            if pos_err is not None:
+                return {"status": "error", "content": [{"text": pos_err}]}
+            target, tgt_err = coerce_pose_vector("add_camera", "target", target, 3)
+            if tgt_err is not None:
+                return {"status": "error", "content": [{"text": tgt_err}]}
+            pos = [2.0, 2.0, 2.0] if position is None else position
+            tgt = target
+            if tgt is not None and all(abs(pos[i] - tgt[i]) < 1e-9 for i in range(3)):
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": f"add_camera: 'position' and 'target' are identical ({pos}); camera has no look direction."
+                        }
+                    ],
+                }
+            # An fov outside (0, 180) is not merely mis-framed here: the pinhole
+            # relation ``focal_length = horizontal_aperture / (2 * tan(fov / 2))``
+            # in :meth:`_create_camera_prim` raises ``ZeroDivisionError`` for
+            # ``0`` - which is NOT in the except tuple below, so it propagates
+            # out of this method - and yields a ``nan`` focal length for a
+            # ``nan`` fov and 7.3e-16 mm for ``180``, both of which
+            # ``set_focal_length`` accepts, giving a camera that renders nothing
+            # usable under a success result.
+            if (fov_err := camera_fov_error("add_camera", "fov", fov)) is not None:
+                return {"status": "error", "content": [{"text": fov_err}]}
+
             if name in self._cameras:
                 return {
                     "status": "error",
@@ -3000,8 +3062,6 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
             w = int(width or self._config.camera_width)
             h = int(height or self._config.camera_height)
-            pos = list(position) if position is not None else [2.0, 2.0, 2.0]
-            tgt = list(target) if target is not None else None
             fov_deg = float(fov)
 
             # RTX cameras: render at a higher NATIVE resolution if the

--- a/tests/simulation/isaac/test_add_camera_numeric_validation.py
+++ b/tests/simulation/isaac/test_add_camera_numeric_validation.py
@@ -1,0 +1,398 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: Isaac's ``add_camera`` refuses a pose or fov the siblings refuse.
+
+``add_camera`` is an agent-callable configuration surface, and on the Isaac
+backend it validated none of its numeric inputs. It was the weakest of the three
+implementations: ``position``/``target`` were copied with a bare
+``list(position)``, which reads no element at all, so every one of these was
+registered under ``status="success"`` and handed to ``_create_camera_prim``:
+
+* a ``nan``/``inf`` component, baked into the USD camera's world pose and into
+  the ``set_camera_view`` look-at basis;
+* a non-numeric element (``["x", 2.0, 2.0]``) and a ``bool`` (``True`` read as
+  the coordinate ``1.0``);
+* a wrong-length vector - ``[2.0, 2.0]`` and ``[]`` both reached the ``Camera``
+  constructor;
+* a NumPy pose, which then leaked ``np.float64(2.0)`` into the agent-visible
+  status text and the ``json`` payload.
+
+``fov`` was coerced with a bare ``float(fov)``, *outside* the method's try block,
+so a non-numeric value raised a ``ValueError`` straight through the structured
+``{"status": "error"}`` tool-result contract every ``AgentTool`` handler owes its
+caller, and ``nan``/``inf``/``0``/``>= 180`` registered a camera the RTX pipeline
+cannot use: ``_create_camera_prim`` derives
+``focal_length = horizontal_aperture / (2 * tan(radians(fov) / 2))``, which
+raises ``ZeroDivisionError`` for ``0`` - a type absent from that try block's
+except tuple, so it escapes ``add_camera`` - and yields ``nan`` (for ``nan``) or
+7.3e-16 mm (for ``180``), both of which ``set_focal_length`` accepts.
+
+The fix routes the pose through the shared
+:func:`~strands_robots.utils.coerce_pose_vector` and the fov through
+:func:`~strands_robots.utils.camera_fov_error`, the same domains the MuJoCo and
+Newton backends' ``add_camera`` already use.
+``TestSameVerdictAsTheMujocoSibling`` pins that parity against the live MuJoCo
+method, which is the invariant ``pose_vector_error``'s docstring states: a pose
+either backend entry point refuses must be refused by the other.
+
+None of this needs Isaac Sim or a GPU. The validation runs before the method
+touches the stage, and the one call that would (``_create_camera_prim``) is
+replaced on the instance, so the accepted-value paths are exercised too - the
+skeleton-via-``__new__`` fixture shape ``test_cameras_recording_preflight_guards.py``
+uses.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+_NON_FINITE = (float("nan"), float("inf"), float("-inf"))
+
+#: Values that are not a real number at all. ``True`` is included because
+#: ``bool`` is an ``int`` subclass, so a coercion would silently write the
+#: coordinate ``1.0`` where a caller passed a truth value by mistake.
+_NON_NUMERIC_ELEMENTS = ("x", None, [0.0], True)
+
+#: ``fov`` values no camera can use. ``0`` divides by zero in the derived focal
+#: length and ``180`` is the open-interval boundary (``tan(pi/2)``).
+_BAD_FOVS = (float("nan"), float("inf"), float("-inf"), 0.0, -1.0, -60.0, 180.0, 181.0, 360.0, True, "wide")
+
+#: ``fov`` values that must keep working, including a NumPy scalar read out of a
+#: config array and a plain ``int``.
+_GOOD_FOVS = (60.0, 45, 1.0, 179.9, np.float32(58.0), np.float64(90.0))
+
+
+class _FakeCameraHandle:
+    """Stand-in for the Isaac ``Camera`` sensor handle."""
+
+
+def _engine() -> IsaacSimulation:
+    """Skeleton ``IsaacSimulation`` carrying only what ``add_camera`` reads.
+
+    ``_create_camera_prim`` is the single call that needs the Kit runtime; it is
+    replaced with a recorder so a refused configuration can be distinguished
+    from an accepted one by whether the prim was ever requested.
+    """
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig()
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {}
+    engine._objects = {}
+    engine._cameras = {}
+    engine._prim_registry = []
+    engine._cam_out_size = {}
+    engine._camera_warmup_steps = 0
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._main_tid = threading.get_ident()
+
+    prim_calls: list[dict[str, Any]] = []
+
+    def _create_camera_prim(**kwargs: Any) -> tuple[Any, float]:
+        prim_calls.append(kwargs)
+        return _FakeCameraHandle(), 24.0
+
+    engine._create_camera_prim = _create_camera_prim  # type: ignore[method-assign]
+    engine.prim_calls = prim_calls  # type: ignore[attr-defined]
+    return engine
+
+
+def _add_camera(engine: IsaacSimulation, **kwargs: Any) -> dict[str, Any]:
+    """Call ``add_camera`` with arguments deliberately outside its annotations.
+
+    Most inputs below are values a caller must never pass - a non-numeric pose
+    element, a ``bool``, a wrong-length vector, a string ``fov`` - because the
+    contract under test is that they are refused at runtime, in a structured
+    result, rather than by a type checker that an agent dispatching this tool
+    never runs. The NumPy poses are the opposite case: the method accepts them
+    (``coerce_pose_vector`` normalizes them) but the ``list[float]`` annotation
+    all three backends share does not describe them. Funnelling every call
+    through one ``**kwargs: Any`` boundary states that once, the shape the
+    Newton sibling test uses, instead of scattering per-call suppressions.
+    """
+    return engine.add_camera(**kwargs)
+
+
+def _assert_refused(engine: IsaacSimulation, result: dict, needle: str = "") -> None:
+    """A refusal is a structured error that left no trace of the camera."""
+    assert result["status"] == "error", result
+    assert needle in result["content"][0]["text"], result
+    assert engine._cameras == {}
+    assert engine._prim_registry == []
+    assert engine._cam_out_size == {}
+    # The stage was never touched: validation runs ahead of the one call that
+    # would create the USD prim.
+    assert engine.prim_calls == []  # type: ignore[attr-defined]
+
+
+# --------------------------------------------------------------------------- #
+# position / target                                                           #
+# --------------------------------------------------------------------------- #
+class TestPoseFiniteness:
+    @pytest.mark.parametrize("bad", _NON_FINITE)
+    @pytest.mark.parametrize("param", ["position", "target"])
+    @pytest.mark.parametrize("index", [0, 1, 2])
+    def test_non_finite_component_is_refused(self, param: str, bad: float, index: int) -> None:
+        """A nan/inf component in either pose vector is refused, in any slot.
+
+        Pre-fix every one of these returned ``success`` and passed the component
+        to the USD camera's world pose.
+        """
+        engine = _engine()
+        vec = [1.0, 1.0, 1.0]
+        vec[index] = bad
+        result = _add_camera(engine, name="cam", **{param: vec})
+        _assert_refused(engine, result, "finite")
+
+
+class TestPoseElementType:
+    @pytest.mark.parametrize("bad", _NON_NUMERIC_ELEMENTS)
+    @pytest.mark.parametrize("param", ["position", "target"])
+    def test_non_numeric_component_is_refused(self, param: str, bad: object) -> None:
+        engine = _engine()
+        result = _add_camera(engine, name="cam", **{param: [bad, 1.0, 1.0]})
+        _assert_refused(engine, result)
+
+    def test_bool_component_is_not_read_as_one(self) -> None:
+        """``True`` is refused rather than reaching the prim as the coordinate 1.0."""
+        engine = _engine()
+        result = _add_camera(engine, name="cam", position=[True, 2.0, 2.0])
+        _assert_refused(engine, result)
+
+
+class TestPoseLength:
+    @pytest.mark.parametrize("vec", [[], [0.5], [0.5, 0.5], [0.5, 0.5, 0.5, 0.5]])
+    @pytest.mark.parametrize("param", ["position", "target"])
+    def test_wrong_length_is_refused(self, param: str, vec: list[float]) -> None:
+        engine = _engine()
+        result = _add_camera(engine, name="cam", **{param: vec})
+        _assert_refused(engine, result)
+
+    def test_empty_vector_is_not_read_as_omitted(self) -> None:
+        """An empty vector is a wrong-length request, not "take the default"."""
+        engine = _engine()
+        result = _add_camera(engine, name="cam", position=[])
+        _assert_refused(engine, result, "3-element")
+
+
+class TestCoincidentPose:
+    def test_eye_equal_to_target_is_refused(self) -> None:
+        """A camera whose eye is its own look-at point has no look direction.
+
+        Both siblings already refuse it; Isaac handed the pair to
+        ``set_camera_view``, whose forward axis is then a zero vector.
+        """
+        engine = _engine()
+        result = _add_camera(engine, name="cam", position=[1.0, 1.0, 1.0], target=[1.0, 1.0, 1.0])
+        _assert_refused(engine, result, "look direction")
+
+    def test_omitted_target_is_not_a_coincident_pose(self) -> None:
+        """``target=None`` keeps the constructed orientation - not a refusal.
+
+        Isaac's documented default is no look-at at all (unlike MuJoCo/Newton,
+        which default the target to the origin), so the check must be scoped to
+        a target the caller actually supplied.
+        """
+        engine = _engine()
+        result = _add_camera(engine, name="cam", position=[0.0, 0.0, 0.0])
+        assert result["status"] == "success", result
+        assert engine.prim_calls[0]["target"] is None  # type: ignore[attr-defined]
+
+
+class TestPoseAccepted:
+    def test_omitted_vectors_take_the_documented_defaults(self) -> None:
+        engine = _engine()
+        result = _add_camera(engine, name="cam")
+        assert result["status"] == "success", result
+        assert result["content"][0]["json"]["position"] == [2.0, 2.0, 2.0]
+        assert result["content"][0]["json"]["target"] is None
+
+    def test_int_components_are_accepted(self) -> None:
+        engine = _engine()
+        result = _add_camera(engine, name="cam", position=[1, 2, 3], target=[0, 0, 0])
+        assert result["status"] == "success", result
+
+    def test_numpy_pose_is_accepted_and_normalised_to_floats(self) -> None:
+        """A NumPy pose still works, and no ``np.float64`` reaches the caller.
+
+        Pre-fix the echoed json and the status text read
+        ``[np.float64(2.0), np.float64(2.0), np.float64(2.0)]``, because
+        ``list(np.array(...))`` copies the array's scalars unchanged.
+        """
+        engine = _engine()
+        result = _add_camera(
+            engine,
+            name="cam",
+            position=np.array([0.6, 0.6, 0.5]),
+            target=np.array([0.0, 0.0, 0.15]),
+        )
+        assert result["status"] == "success", result
+        cam_info = result["content"][0]["json"]
+        assert all(type(v) is float for v in cam_info["position"])
+        assert all(type(v) is float for v in cam_info["target"])
+        assert "np.float64" not in result["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# fov                                                                         #
+# --------------------------------------------------------------------------- #
+class TestFov:
+    @pytest.mark.parametrize("bad", _BAD_FOVS)
+    def test_unusable_fov_is_refused(self, bad: object) -> None:
+        engine = _engine()
+        result = _add_camera(engine, name="cam", fov=bad)
+        _assert_refused(engine, result, "fov")
+
+    @pytest.mark.parametrize("good", _GOOD_FOVS)
+    def test_usable_fov_is_accepted(self, good: object) -> None:
+        engine = _engine()
+        result = _add_camera(engine, name="cam", fov=good)
+        assert result["status"] == "success", result
+        fov_deg = result["content"][0]["json"]["fov"]
+        assert type(fov_deg) is float
+        assert fov_deg == pytest.approx(float(good))  # type: ignore[arg-type]
+
+    def test_non_numeric_fov_returns_an_error_and_does_not_raise(self) -> None:
+        """The tool-result contract: a bad fov is an error dict, never an exception.
+
+        Pre-fix ``float("wide")`` raised a bare ``ValueError`` from outside the
+        method's own try block, so nothing converted it into the structured
+        response.
+        """
+        engine = _engine()
+        result = _add_camera(engine, name="cam", fov="wide")
+        assert result["status"] == "error", result
+
+    def test_zero_fov_would_divide_by_zero_in_the_derived_focal_length(self) -> None:
+        """Pin why ``0`` is outside the domain rather than merely unusual.
+
+        ``ZeroDivisionError`` is not in ``add_camera``'s except tuple, so on a
+        real Isaac install this propagated out of the tool call.
+        """
+        with pytest.raises(ZeroDivisionError):
+            24.0 / (2.0 * math.tan(math.radians(0.0) / 2.0))
+
+    def test_boundary_fov_would_give_a_degenerate_focal_length(self) -> None:
+        """``180`` does not raise - it silently produces an unusable lens."""
+        assert 24.0 / (2.0 * math.tan(math.radians(180.0) / 2.0)) == pytest.approx(0.0, abs=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Refusals leave nothing behind                                               #
+# --------------------------------------------------------------------------- #
+class TestRefusalLeavesNoPartialState:
+    def test_a_refused_call_does_not_consume_the_camera_name(self) -> None:
+        """The name must still be free afterwards.
+
+        Otherwise the caller has to ``remove_camera`` a camera that was never
+        added.
+        """
+        engine = _engine()
+        assert _add_camera(engine, name="wrist", fov=float("nan"))["status"] == "error"
+        assert engine._cameras == {}
+        assert _add_camera(engine, name="wrist", fov=60.0)["status"] == "success"
+        assert "wrist" in engine._cameras
+
+    def test_a_bad_pose_is_reported_even_when_the_name_is_taken(self) -> None:
+        """Pose and fov are checked before the duplicate-name check.
+
+        That is the order both siblings use, so a call that is wrong on two
+        counts gets the same diagnosis from every backend.
+        """
+        engine = _engine()
+        assert _add_camera(engine, name="front")["status"] == "success"
+        result = _add_camera(engine, name="front", position=[float("nan"), 1.0, 1.0])
+        assert result["status"] == "error", result
+        assert "finite" in result["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# Cross-backend parity                                                        #
+# --------------------------------------------------------------------------- #
+class TestSameVerdictAsTheMujocoSibling:
+    """The backends' ``add_camera`` must accept and refuse the same configs.
+
+    ``pose_vector_error`` documents the invariant this pins: a pose either
+    backend entry point refuses must be refused by the other. Isaac was the
+    entry point that refused nothing.
+    """
+
+    @pytest.fixture
+    def mj_sim(self):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="test_isaac_add_camera_parity_sim", mesh=False)
+        sim.create_world(gravity=[0, 0, -9.81])
+        yield sim
+        sim.cleanup()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            # Refused by both.
+            {"position": [float("nan"), 1.0, 1.0]},
+            {"position": [float("inf"), 1.0, 1.0]},
+            {"target": [0.0, float("-inf"), 0.0]},
+            {"position": [True, 1.0, 1.0]},
+            {"position": ["x", 1.0, 1.0]},
+            {"position": [1.0, 1.0]},
+            {"position": []},
+            {"target": []},
+            {"position": [1.0, 1.0, 1.0], "target": [1.0, 1.0, 1.0]},
+            {"fov": float("nan")},
+            {"fov": 0.0},
+            {"fov": -30.0},
+            {"fov": 180.0},
+            {"fov": 400.0},
+            {"fov": "wide"},
+            {"fov": True},
+            # Accepted by both.
+            {},
+            {"fov": 60.0},
+            {"fov": 179.9},
+            {"fov": np.float32(58.0)},
+            {"position": [1, 2, 3], "target": [0, 0, 0]},
+            {"position": np.array([0.6, 0.6, 0.5]), "target": np.array([0.0, 0.0, 0.15])},
+        ],
+    )
+    def test_verdicts_agree(self, mj_sim, kwargs: dict) -> None:
+        isaac_result = _add_camera(_engine(), name="parity_cam", **kwargs)
+        mujoco_result = mj_sim.add_camera(name="parity_cam", **kwargs)
+        assert isaac_result["status"] == mujoco_result["status"], (
+            f"{kwargs!r}: isaac said {isaac_result['status']}, mujoco said {mujoco_result['status']} "
+            f"({isaac_result['content'][0].get('text')!r} vs {mujoco_result['content'][0].get('text')!r})"
+        )
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"position": [float("nan"), 1.0, 1.0]},
+            {"target": [0.0, float("-inf"), 0.0]},
+            {"position": ["x", 1.0, 1.0]},
+            {"position": [1.0, 1.0]},
+            {"fov": float("nan")},
+            {"fov": 0.0},
+            {"fov": "wide"},
+            {"position": [1.0, 1.0, 1.0], "target": [1.0, 1.0, 1.0]},
+        ],
+    )
+    def test_refusal_text_is_the_shared_one(self, mj_sim, kwargs: dict) -> None:
+        """One definition, not a copy: the two backends word it identically.
+
+        A duplicated interval or finiteness check would drift; identical text is
+        evidence both callers reach the same helper.
+        """
+        isaac_result = _add_camera(_engine(), name="parity_cam", **kwargs)
+        mujoco_result = mj_sim.add_camera(name="parity_cam", **kwargs)
+        assert isaac_result["content"][0]["text"] == mujoco_result["content"][0]["text"]


### PR DESCRIPTION
## What

`IsaacSimulation.add_camera` validated none of its numeric inputs. The pose now goes through the shared `coerce_pose_vector` and the field of view through `camera_fov_error` — the domains the MuJoCo and Newton backends' `add_camera` already apply — plus the identical-eye-and-target refusal both siblings already carry.

Closes #1761, the follow-up #1760 filed after closing the same gap on Newton.

## Measured on `main` (`e019a1a`)

Isaac was not merely missing the finiteness check — it was the weakest of the three implementations. `position`/`target` were copied with a bare `list(position)`, which reads no element at all, so it did not even reject what Newton's pre-fix `float(v)` coercion did:

| `add_camera(name="cam", ...)` | pre-fix | this PR |
|---|---|---|
| `position=[nan, 2, 2]` | `success`, prim pose `[nan, 2.0, 2.0]` | refused: `'position' must contain finite numbers (no nan/inf)` |
| `target=[0, -inf, 0]` | `success`, look-at `[0.0, -inf, 0.0]` | refused |
| `position=[True, 2, 2]` | `success`, prim pose `[True, 2.0, 2.0]` | refused: elements must be numbers |
| `position=['x', 2, 2]` | `success` | refused |
| `position=[2, 2]` | `success`, 2-element pose to the `Camera` ctor | refused: must be a 3-element vector |
| `position=[]` | `success`, empty pose | refused (not read as "omitted") |
| `position=np.array([2,2,2])` | `success`, text reads `[np.float64(2.0), ...]` | `success`, plain floats |
| `position=target=[2,2,2]` | `success`, no look direction | refused (the message both siblings use) |
| `fov=nan` / `inf` | `success`, `fov=nan` stored | refused: must be a finite number in degrees |
| `fov=0` / `-60` / `180` / `400` | `success` | refused: must be in the open interval (0, 180) |
| `fov=True` | `success`, **a 1-degree lens** | refused |
| `fov="wide"` | **raises `ValueError`** | refused, structured |

Two consequences are worth naming precisely, because they are why this is a defect rather than untidiness:

1. **`fov="wide"` and `fov=0` escape the tool-result contract.** `fov_deg = float(fov)` sat *outside* the method's `try`, so the `ValueError` propagated out of an `AgentTool` handler that owes its caller `{"status": "error"}`. And `_create_camera_prim` derives `focal_length = horizontal_aperture / (2 * tan(radians(fov) / 2))`, which raises `ZeroDivisionError` for `fov=0` — a type **absent from that `try`'s except tuple** (`RuntimeError, ValueError, OSError, AttributeError, TypeError, ImportError`), so it escapes too.
2. **The survivors are silently degenerate, not loudly wrong.** The same derivation yields `nan` mm for a `nan` fov and `7.35e-16` mm for `180`, and `set_focal_length` accepts both, so the camera registers under `success` and renders nothing usable.

The argument that makes this a one-pass fix is the asymmetry, not the corruption: `coerce_pose_vector`/`pose_vector_error` already state the invariant — *a pose either backend entry point refuses must be refused by the other* — and Isaac was the entry point that refused nothing. `camera_fov_error` was lifted into `utils.py` by #1760 for exactly this reason and had two of three callers.

## Scope

**In scope:** `position`, `target` (finiteness, element type, length, coincidence), `fov`.

**Out of scope, deliberately:** pixel-count bounds on `width`/`height`. Measured and still live here — `width="big"` raises `ValueError: invalid literal for int()`, `height=-4` stores `640x-4`, and `width=0` silently substitutes the config default because the coercion is `int(width or self._config.camera_width)` — but they are a separate integer domain whose shared-helper lift is #1762. That issue's `render` half applies to Isaac too; noted there rather than pulled in here.

Also not touched: the `_MIN_RENDER_PX` DLSS upscale path and the warm-up step, which read the already-validated values.

## Ordering

The guards run before the duplicate-name check, which is the order both siblings use, so a call that is wrong on two counts gets the same diagnosis from every backend. Pinned by `test_a_bad_pose_is_reported_even_when_the_name_is_taken`.

One backend-specific deviation, pinned as a control: Isaac's documented default is `target=None` (no look-at at all), where MuJoCo and Newton default the target to the origin. The coincidence check is therefore scoped to a target the caller actually supplied — `test_omitted_target_is_not_a_coincident_pose`.

## Tests

`tests/simulation/isaac/test_add_camera_numeric_validation.py`, 93 cases. **76 fail on the pre-fix tree, all 93 pass with the fix**, in every environment: the validation runs before the stage is touched, and the one call that needs the Kit runtime (`_create_camera_prim`) is replaced on the skeleton instance, so the accepted-value paths are exercised too. That skeleton-via-`__new__` shape is the one `test_cameras_recording_preflight_guards.py` already uses.

- Per-slot / per-parameter refusals for non-finite, non-numeric, `bool` and wrong-length poses, each asserting the registry, the prim registry, the output-size map **and** the prim call are all untouched — a refusal leaves no partial state and does not consume the camera name.
- Accepted-value controls: omitted vectors take the documented `[2, 2, 2]` default, ints and NumPy poses work, and no `np.float64` reaches the status text or the json payload.
- Premise pins so the file cannot pass vacuously: `24.0 / (2*tan(radians(0)/2))` raises `ZeroDivisionError`, and the `180` boundary yields a ~0 mm focal length.
- `TestSameVerdictAsTheMujocoSibling`: 22 configurations, verdicts compared against the **live** MuJoCo `add_camera`, plus 8 where the refusal *text* must be byte-identical — a duplicated interval or finiteness check would drift, identical text is evidence both callers reach one helper.

## Verification

Full suite, on a machine with EGL and the assets cached, so nothing is masked by
a missing GL context:

```
MUJOCO_GL=egl python -m pytest tests -q            14437 passed, 253 skipped   (459s)

ruff check strands_robots tests tests_integ        All checks passed!
ruff format --check strands_robots tests tests_integ   970 files already formatted
mypy strands_robots tests tests_integ              Success: no issues found in 967 source files
```

Pre-fix proof — the new file against this branch's own base (`e019a1a`), source
reverted, tests kept:

```
tests/simulation/isaac/test_add_camera_numeric_validation.py
  main       76 failed, 17 passed
  this PR    93 passed
```

The 17 that already pass are the accepted-value controls and the premise pins;
they are what stop the guard from over-reaching, so they are expected to pass on
both trees.

The two sibling files still pass unchanged, which is the parity claim:
`tests/simulation/newton/test_add_camera_numeric_validation.py` and
`tests/simulation/mujoco/test_vector_params_read_by_membership.py` — 190 passed
together with this file.

Isaac Sim is not installed here, so every claim about `_create_camera_prim`'s
downstream behaviour (the `ZeroDivisionError`, the `nan` focal length, the
7.3e-16 mm at `180`) is read from the source arithmetic in this repo and stated
as such rather than measured on RTX. What *is* measured live is the part that
matters for the contract: the verdict `add_camera` returns, on all three
backends.

## Which configurations each backend refuses

Each backend's own `add_camera` called with the same 15 configurations — MuJoCo
live, Newton and Isaac through the package-free skeletons — before and after:

![add_camera verdict parity across the three backends](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-add-camera-parity/isaac_add_camera_parity.png)

On `main`, Isaac diverges from both siblings on **12 of the 12** unusable
configurations: 11 return `status="success"`, and `fov="wide"` raises
`ValueError` out of the structured result contract. With this change all three
agree on all 15 rows, including the three that must keep working.

Refs #1723

## Rounds

Round 1 — initial submission.

Round 2 — `mypy` fix, no functional change. The new test file drives
`add_camera` with values outside its declared annotations on purpose (that is
the contract under test: a runtime refusal, not a static one), and with NumPy
poses, which the method accepts but the `list[float]` annotation all three
backends share does not describe. Round 1 spelled that with three per-call
`# type: ignore` comments and left the dict-splat and NumPy call sites
unsuppressed, so `mypy` reported 9 `arg-type` errors and CI failed at the lint
step — which meant the test step never ran and none of these tests had
actually been executed by CI. Both are now routed through one `_add_camera`
funnel typed `**kwargs: Any`, which states the intent once with a reason
instead of scattering suppressions, matches the shape the merged Newton
sibling test uses, and lets the three per-call suppressions go. Library code
is untouched in this round; the verification above is the first run of these
tests end to end.
