### PR TITLE
fix(sim): scope a robot's actuators by transmission, not by a raw id

### DIFF
--- a/changelog.d/1765-actuator-ownership-by-transmission.md
+++ b/changelog.d/1765-actuator-ownership-by-transmission.md
@@ -1,0 +1,22 @@
+### Fixed: a robot's actuator set is scoped by transmission, not by a raw id comparison
+
+`SimRobot.actuator_ids` was derived by comparing every actuator's
+`actuator_trnid[i, 0]` against the robot's joint ids. That field holds a joint id
+only for a `mjTRN_JOINT` / `mjTRN_JOINTINPARENT` transmission; for a tendon,
+site, slider-crank or body transmission it indexes a different table, and those
+id spaces each start at 0. A fixed tendon coupling a gripper's fingers - the
+standard MJCF idiom, used by the Menagerie Panda hand and the Robotiq 2F-85 -
+therefore landed on whichever robot owned the joint whose id equalled the
+tendon's, and was missing from the robot carrying it.
+
+In a two-robot scene that made the outcome depend on the order the robots were
+added: `set_gripper` reported the gripper's actuator did not exist in the model,
+a robot declaring no actuators claimed another robot's gripper, and
+`actuate_robot` refused to add servos to an unactuated robot on the grounds that
+it already had some.
+
+Ownership is now the union of a namespace-prefix match and a driven-joint match
+resolved through the new `scene_ops.actuator_joint_id`, which returns `-1` for a
+non-joint transmission. Both duplicated derivations (`_recompile_preserving_state`
+and `eject_robot_from_scene`) and the two remaining raw reads in `actuate_robot`
+share that one gate. Actuator order is unchanged - only membership is corrected.

--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -37,6 +37,7 @@ import numpy as np
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
 from strands_robots.simulation.mujoco.scene_ops import (
     actuate_robot_in_scene,
+    actuator_joint_id,
     add_weld_constraint,
     remove_equality_constraint,
 )
@@ -488,7 +489,10 @@ class ManipulationMixin:
 
             robot_joint_ids = set(robot.joint_ids)
             for act_id in range(model.nu):
-                if int(model.actuator_trnid[act_id, 0]) in robot_joint_ids:
+                # Gate on the transmission: an actuator driving a tendon, site or
+                # body carries an id from a different space, so comparing it raw
+                # refuses a robot whose joint merely shares a number with one.
+                if actuator_joint_id(model, act_id, mj) in robot_joint_ids:
                     return {
                         "status": "error",
                         "content": [
@@ -573,8 +577,11 @@ class ManipulationMixin:
             # robot.actuator_ids.
             model, data = self._world._model, self._world._data
             for act_id in robot.actuator_ids:
-                jnt_id = int(model.actuator_trnid[act_id, 0])
-                if 0 <= jnt_id < model.njnt:
+                # A non-joint transmission has no joint position to hold, and its
+                # trnid indexes another entity table - seeding ctrl from it would
+                # command a gripper from an unrelated joint's angle.
+                jnt_id = actuator_joint_id(model, act_id, mj)
+                if jnt_id >= 0:
                     data.ctrl[act_id] = data.qpos[int(model.jnt_qposadr[jnt_id])]
             mj.mj_forward(model, data)
             n_added = len(kp_by_joint)

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -112,6 +112,83 @@ def _snapshot_spec(spec: Any, *, context: str) -> Any | None:
         return None
 
 
+def actuator_joint_id(model: Any, act_id: int, mj: Any) -> int:
+    """Return the joint id actuator ``act_id`` drives, or ``-1`` if it drives none.
+
+    ``actuator_trnid[act_id, 0]`` holds a JOINT id only when the actuator's
+    transmission is ``mjTRN_JOINT`` or ``mjTRN_JOINTINPARENT``. For the other
+    transmissions it holds a tendon, site, slider-crank or body id instead --
+    separate id spaces that each start at 0, so a raw comparison against joint
+    ids matches an unrelated entity that merely shares a number. A fixed tendon
+    coupling a gripper's fingers is the standard MJCF idiom for that (the
+    Menagerie Panda hand and the Robotiq 2F-85 both use one), so the collision
+    is reachable with stock assets rather than only with exotic models.
+
+    Reading the transmission through this function is what keeps "which joint
+    does this actuator drive" a single rule, rather than one that each call site
+    re-derives and can omit.
+
+    Args:
+        model: The compiled ``MjModel``.
+        act_id: Actuator index in ``range(model.nu)``.
+        mj: The ``mujoco`` module.
+
+    Returns:
+        The driven joint id, or ``-1`` when the transmission is not a joint.
+    """
+    joint_trn = {int(mj.mjtTrn.mjTRN_JOINT)}
+    if hasattr(mj.mjtTrn, "mjTRN_JOINTINPARENT"):
+        joint_trn.add(int(mj.mjtTrn.mjTRN_JOINTINPARENT))
+    if int(model.actuator_trntype[act_id]) not in joint_trn:
+        return -1
+    return int(model.actuator_trnid[act_id, 0])
+
+
+def robot_owned_actuator_ids(model: Any, robot: SimRobot, mj: Any) -> list[int]:
+    """Return the actuator ids ``robot`` owns, in model order.
+
+    Ownership is the union of two rules, because neither alone covers every
+    actuator a robot can carry:
+
+    * **Namespace.** ``spec.attach(other, prefix=...)`` prefixes every actuator
+      name it merges in, so a prefixed name settles ownership whatever the
+      transmission drives -- the only rule that reaches a tendon, site or body
+      transmission.
+    * **Driven joint.** :func:`actuate_robot_in_scene` names the position
+      actuators it injects ``"<robot>_act_<joint>"``, which carries no namespace
+      prefix, so those are recognized by the joint they drive.
+
+    The second rule resolves the joint through :func:`actuator_joint_id`, so an
+    actuator whose transmission is not a joint is never assigned by an id-space
+    collision. Ungated, a tendon-driven gripper is claimed by whichever robot
+    owns the joint whose id equals the tendon's and is missing from the robot
+    that actually carries it -- the gripper then has no owner to operate it, and
+    the other robot advertises an actuator that moves a different machine.
+
+    Args:
+        model: The compiled ``MjModel``.
+        robot: The robot to scope. Reads its ``namespace`` and its already
+            resolved ``joint_ids``.
+        mj: The ``mujoco`` module.
+
+    Returns:
+        Owned actuator ids, ascending. Ascending model order is the contract:
+        :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.robot_action_keys`
+        and the recorded dataset action columns are ordered by actuator index,
+        so the sequence is stable and only membership is corrected here.
+    """
+    pfx = robot.namespace or ""
+    joint_ids = set(robot.joint_ids)
+    owned: list[int] = []
+    for act_id in range(int(model.nu)):
+        name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id) or ""
+        if pfx and name.startswith(pfx):
+            owned.append(act_id)
+        elif actuator_joint_id(model, act_id, mj) in joint_ids:
+            owned.append(act_id)
+    return owned
+
+
 def install_compiled_model(world: SimWorld, model: Any, data: Any) -> None:
     """Install a compiled ``model``/``data`` pair as ``world``'s live scene state.
 
@@ -189,7 +266,6 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
     for robot in world.robots.values():
         pfx = robot.namespace or ""
         robot.joint_ids = []
-        robot.actuator_ids = []
         for jnt_name in robot.joint_names:
             jid = -1
             if pfx:
@@ -198,12 +274,12 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
                 jid = mj.mj_name2id(new_model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jid >= 0:
                 robot.joint_ids.append(jid)
-        for i in range(new_model.nu):
-            jnt_id = new_model.actuator_trnid[i, 0]
-            if jnt_id in robot.joint_ids:
-                robot.actuator_ids.append(i)
-        # Single-robot fallback: if no actuators matched by joint, assume
-        # all actuators belong to this robot. Matches the legacy behaviour.
+        robot.actuator_ids = robot_owned_actuator_ids(new_model, robot, mj)
+        # Single-robot fallback. Ownership above is settled by namespace or by
+        # driven joint; a lone robot whose actuators are neither prefixed nor
+        # joint-driven (a tendon or site transmission in a scene loaded whole,
+        # so no attach prefix) matches on neither, and in a one-robot scene
+        # every actuator is unambiguously that robot's.
         if not robot.actuator_ids and len(world.robots) == 1:
             robot.actuator_ids = list(range(new_model.nu))
 
@@ -921,7 +997,6 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     for robot in world.robots.values():
         pfx = robot.namespace or ""
         robot.joint_ids = []
-        robot.actuator_ids = []
         for jnt_name in robot.joint_names:
             jid = -1
             if pfx:
@@ -930,10 +1005,8 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
                 jid = mj.mj_name2id(new_model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jid >= 0:
                 robot.joint_ids.append(jid)
-        for i in range(new_model.nu):
-            jnt_id = new_model.actuator_trnid[i, 0]
-            if jnt_id in robot.joint_ids:
-                robot.actuator_ids.append(i)
+        robot.actuator_ids = robot_owned_actuator_ids(new_model, robot, mj)
+        # See _recompile_preserving_state for why the lone-robot case falls back.
         if not robot.actuator_ids and len(world.robots) == 1:
             robot.actuator_ids = list(range(new_model.nu))
 

--- a/tests/simulation/mujoco/test_actuator_ownership_by_transmission.py
+++ b/tests/simulation/mujoco/test_actuator_ownership_by_transmission.py
@@ -1,0 +1,338 @@
+"""Which actuators a robot owns is decided by transmission, not by a raw id.
+
+``SimRobot.actuator_ids`` is derived after every recompile by matching each
+actuator against the robot. ``actuator_trnid[i, 0]`` holds a JOINT id only for a
+``mjTRN_JOINT`` / ``mjTRN_JOINTINPARENT`` transmission; for a tendon, site,
+slider-crank or body transmission it indexes a different table. Those id spaces
+each start at 0, so comparing the raw value against a robot's ``joint_ids``
+assigns an actuator to whichever robot happens to own the joint whose id equals
+the other entity's.
+
+A fixed tendon coupling a gripper's fingers is the standard MJCF idiom for a
+coupled gripper, so the collision is reachable with ordinary two-robot scenes:
+the gripper lands on the wrong robot and is missing from the one that carries
+it, which makes it unoperable through ``set_gripper`` and lets the other robot
+advertise an actuator that moves a different machine.
+
+Every model here is inline MJCF loaded through ``add_robot(urdf_path=...)``, so
+none of it downloads an asset.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.scene_ops import (  # noqa: E402
+    actuator_joint_id,
+    robot_owned_actuator_ids,
+)
+
+# A two-hinge arm driven by two direct joint-transmission position actuators.
+ARM_XML = """
+<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base">
+      <geom type="box" size="0.04 0.04 0.04"/>
+      <body name="link1" pos="0 0 0.08">
+        <joint name="shoulder" type="hinge" axis="0 0 1" range="-2 2" limited="true" damping="1"/>
+        <geom type="capsule" fromto="0 0 0 0.18 0 0" size="0.02"/>
+        <body name="link2" pos="0.18 0 0">
+          <joint name="elbow" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="1"/>
+          <geom type="capsule" fromto="0 0 0 0.14 0 0" size="0.018"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_act" joint="shoulder" kp="30" dampratio="1"/>
+    <position name="elbow_act" joint="elbow" kp="30" dampratio="1"/>
+  </actuator>
+</mujoco>
+"""
+
+# The same arm with no actuators at all, to show a robot claiming an actuator
+# it does not carry rather than merely being handed the wrong one.
+UNACTUATED_ARM_XML = ARM_XML.replace(
+    """  <actuator>
+    <position name="shoulder_act" joint="shoulder" kp="30" dampratio="1"/>
+    <position name="elbow_act" joint="elbow" kp="30" dampratio="1"/>
+  </actuator>
+""",
+    "",
+)
+
+# A gripper whose two fingers are coupled by one fixed tendon, driven by a
+# single tendon-transmission actuator - the Panda-hand / Robotiq 2F-85 idiom.
+# The ctrlrange is in tendon units, wider than any finger travel.
+GRIPPER_XML = """
+<mujoco model="gripper">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="palm">
+      <geom type="box" size="0.03 0.03 0.02"/>
+      <body name="finger_left" pos="0.02 0 0.03">
+        <joint name="finger1" type="slide" axis="1 0 0" range="0 0.04" limited="true" damping="2"/>
+        <geom type="box" size="0.005 0.01 0.02"/>
+      </body>
+      <body name="finger_right" pos="-0.02 0 0.03">
+        <joint name="finger2" type="slide" axis="-1 0 0" range="0 0.04" limited="true" damping="2"/>
+        <geom type="box" size="0.005 0.01 0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="grip">
+      <joint joint="finger1" coef="1"/>
+      <joint joint="finger2" coef="1"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <position name="finger_act" tendon="grip" kp="40" ctrlrange="0 255"/>
+  </actuator>
+</mujoco>
+"""
+
+
+# The ``sim`` parameter is left un-annotated in the helpers below: the engine
+# types ``_world`` as ``SimWorld | None``, so an annotated helper would need a
+# narrowing assert before every model read. Same convention as the sibling
+# scene-mutation suites.
+
+
+def _write(tmp_path: Path, name: str, xml: str) -> str:
+    path = tmp_path / name
+    path.write_text(xml, encoding="utf-8")
+    return str(path)
+
+
+def _sim():
+    from strands_robots.simulation import create_simulation
+
+    return create_simulation("mujoco", tool_name="ownership_sim", mesh=False)
+
+
+def _build(tmp_path: Path, order: tuple[str, ...], *, arm_xml: str = ARM_XML):
+    """Build a scene holding an arm and a tendon gripper, added in ``order``."""
+    sim = _sim()
+    assert sim.create_world()["status"] == "success"
+    xml_by_robot = {
+        "arm": (_write(tmp_path, "arm.xml", arm_xml), [0.0, 0.0, 0.0]),
+        "grip": (_write(tmp_path, "grip.xml", GRIPPER_XML), [0.5, 0.0, 0.0]),
+    }
+    for name in order:
+        path, pos = xml_by_robot[name]
+        assert sim.add_robot(name=name, urdf_path=path, position=pos)["status"] == "success"
+    return sim
+
+
+def _actuator_names(sim, robot_name: str) -> list[str]:
+    model = sim._world._model
+    return [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) for i in sim._world.robots[robot_name].actuator_ids
+    ]
+
+
+def _assert_collision_is_reproduced(sim, *, other: str) -> int:
+    """Assert the fixture really does collide a tendon id with ``other``'s joint id.
+
+    Without this the ownership assertions below could pass on a scene where the
+    two id spaces never overlap, so nothing was being tested.
+    """
+    model = sim._world._model
+    tendon_acts = [i for i in range(model.nu) if int(model.actuator_trntype[i]) == int(mujoco.mjtTrn.mjTRN_TENDON)]
+    assert len(tendon_acts) == 1, tendon_acts
+    act_id = tendon_acts[0]
+    raw = int(model.actuator_trnid[act_id, 0])
+    assert raw in set(sim._world.robots[other].joint_ids), (
+        f"fixture does not reproduce the collision: tendon id {raw} is not a joint id of {other!r}"
+    )
+    return act_id
+
+
+# -- ownership ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("order", [("arm", "grip"), ("grip", "arm")], ids=["arm_first", "gripper_first"])
+def test_each_robot_owns_exactly_its_own_actuators(tmp_path: Path, order: tuple[str, ...]) -> None:
+    """A tendon-driven gripper belongs to the robot that carries it, either order."""
+    sim = _build(tmp_path, order)
+    try:
+        _assert_collision_is_reproduced(sim, other="arm" if order[0] == "arm" else "grip")
+        assert sorted(_actuator_names(sim, "arm")) == ["arm/elbow_act", "arm/shoulder_act"]
+        assert _actuator_names(sim, "grip") == ["grip/finger_act"]
+    finally:
+        sim.cleanup()
+
+
+def test_ownership_does_not_depend_on_the_order_robots_were_added(tmp_path: Path) -> None:
+    """The same scene yields the same per-robot actuator names whatever the order.
+
+    Pre-fix the gripper's owner was decided by which robot's joint ids happened
+    to start at 0, so the two orders disagreed about who owns what.
+    """
+    by_order: dict[tuple[str, ...], dict[str, list[str]]] = {}
+    for order in (("arm", "grip"), ("grip", "arm")):
+        sim = _build(tmp_path, order)
+        try:
+            by_order[order] = {name: sorted(_actuator_names(sim, name)) for name in ("arm", "grip")}
+        finally:
+            sim.cleanup()
+    assert by_order[("arm", "grip")] == by_order[("grip", "arm")]
+
+
+def test_a_robot_declaring_no_actuators_owns_none(tmp_path: Path) -> None:
+    """An unactuated robot must not be handed another robot's tendon actuator."""
+    sim = _build(tmp_path, ("arm", "grip"), arm_xml=UNACTUATED_ARM_XML)
+    try:
+        _assert_collision_is_reproduced(sim, other="arm")
+        assert sim._world.robots["arm"].actuator_ids == []
+        assert _actuator_names(sim, "grip") == ["grip/finger_act"]
+    finally:
+        sim.cleanup()
+
+
+def test_a_lone_robot_falls_back_to_every_actuator(tmp_path: Path) -> None:
+    """The single-robot fallback is kept, and this is the case it exists for.
+
+    A robot whose actuators are neither namespace-prefixed nor joint-driven
+    matches neither ownership rule. In a one-robot scene every actuator is
+    unambiguously that robot's, so the fallback claims them rather than leaving
+    the robot with an empty action surface.
+    """
+    sim = _sim()
+    try:
+        assert sim.create_world()["status"] == "success"
+        path = _write(tmp_path, "grip.xml", GRIPPER_XML)
+        assert sim.add_robot(name="grip", urdf_path=path)["status"] == "success"
+        robot = sim._world.robots["grip"]
+        robot.namespace = ""  # emulate a scene loaded whole, with no attach prefix
+        assert robot_owned_actuator_ids(sim._world._model, robot, mujoco) == []
+        assert sim.reset()["status"] == "success"
+        assert robot.actuator_ids == list(range(int(sim._world._model.nu)))
+    finally:
+        sim.cleanup()
+
+
+def test_ownership_is_recomputed_when_a_robot_is_ejected(tmp_path: Path) -> None:
+    """``remove_robot`` rebuilds the scene, and the surviving robot keeps its own."""
+    sim = _build(tmp_path, ("grip", "arm"))
+    try:
+        assert sim.remove_robot("arm")["status"] == "success"
+        assert _actuator_names(sim, "grip") == ["grip/finger_act"]
+    finally:
+        sim.cleanup()
+
+
+# -- the capability the mis-assignment removed -------------------------------
+
+
+@pytest.mark.parametrize("order", [("arm", "grip"), ("grip", "arm")], ids=["arm_first", "gripper_first"])
+def test_set_gripper_operates_a_tendon_gripper_in_either_order(tmp_path: Path, order: tuple[str, ...]) -> None:
+    """``set_gripper`` resolves its actuator from ``actuator_ids``, so it needs the right list.
+
+    Pre-fix, with the arm's joint ids starting at 0 the gripper's actuator was
+    absent from the gripper and ``set_gripper`` reported that the actuator did
+    not exist in the model - blaming the model for an actuator that is in it.
+    """
+    sim = _build(tmp_path, order)
+    try:
+        model, data = sim._world._model, sim._world._data
+        f1 = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "grip/finger1")
+        gap_before = float(data.qpos[model.jnt_qposadr[f1]])
+        result = sim.set_gripper(robot_name="grip", state="open")
+        assert result["status"] == "success", result["content"][0]["text"]
+        gap_after = float(sim._world._data.qpos[model.jnt_qposadr[f1]])
+        assert gap_after > gap_before + 0.005, (gap_before, gap_after)
+    finally:
+        sim.cleanup()
+
+
+def test_actuate_robot_is_not_refused_by_a_tendon_id_collision(tmp_path: Path) -> None:
+    """Adding servos to an unactuated robot is refused only if it really has some.
+
+    The double-actuate guard compared every actuator's raw ``trnid`` against the
+    robot's joint ids, so a tendon whose id matched one of them made the guard
+    report actuators the robot does not have.
+    """
+    sim = _build(tmp_path, ("arm", "grip"), arm_xml=UNACTUATED_ARM_XML)
+    try:
+        _assert_collision_is_reproduced(sim, other="arm")
+        nu_before = int(sim._world._model.nu)
+        result = sim.actuate_robot(robot_name="arm", kp=40.0)
+        assert result["status"] == "success", result["content"][0]["text"]
+        assert int(sim._world._model.nu) == nu_before + 2
+    finally:
+        sim.cleanup()
+
+
+def test_injected_position_actuators_are_owned_by_the_robot_that_asked(tmp_path: Path) -> None:
+    """``actuate_robot`` names its actuators without the namespace prefix.
+
+    They are owned via the joint they drive, which is why ownership is the union
+    of the two rules rather than the namespace alone.
+    """
+    sim = _build(tmp_path, ("arm", "grip"), arm_xml=UNACTUATED_ARM_XML)
+    try:
+        assert sim.actuate_robot(robot_name="arm", kp=40.0)["status"] == "success"
+        names = sorted(_actuator_names(sim, "arm"))
+        assert names == ["arm_act_elbow", "arm_act_shoulder"], names
+        assert not any(n.startswith("arm/") for n in names)
+        assert _actuator_names(sim, "grip") == ["grip/finger_act"]
+    finally:
+        sim.cleanup()
+
+
+def test_actuate_robot_holds_the_pose_without_seeding_a_tendon_drive(tmp_path: Path) -> None:
+    """The hold-pose init reads a driven joint, so a tendon drive is left alone.
+
+    Seeding it would write the gripper's setpoint from the angle of whatever
+    joint the tendon's id collides with.
+    """
+    sim = _build(tmp_path, ("arm", "grip"), arm_xml=UNACTUATED_ARM_XML)
+    try:
+        model = sim._world._model
+        grip_act = _assert_collision_is_reproduced(sim, other="arm")
+        sim._world._data.ctrl[grip_act] = 7.0
+        assert sim.set_joint_positions({"shoulder": 0.9}, robot_name="arm")["status"] == "success"
+        assert sim.actuate_robot(robot_name="arm", kp=40.0)["status"] == "success"
+        new_model = sim._world._model
+        new_grip = mujoco.mj_name2id(new_model, mujoco.mjtObj.mjOBJ_ACTUATOR, "grip/finger_act")
+        assert float(sim._world._data.ctrl[new_grip]) == pytest.approx(7.0)
+        shoulder_act = mujoco.mj_name2id(new_model, mujoco.mjtObj.mjOBJ_ACTUATOR, "arm_act_shoulder")
+        assert float(sim._world._data.ctrl[shoulder_act]) == pytest.approx(0.9, abs=1e-3)
+        assert model is not new_model
+    finally:
+        sim.cleanup()
+
+
+# -- the shared gate ---------------------------------------------------------
+
+
+def test_actuator_joint_id_resolves_a_joint_transmission(tmp_path: Path) -> None:
+    """A joint-transmission actuator reports the joint it drives."""
+    sim = _build(tmp_path, ("arm", "grip"))
+    try:
+        model = sim._world._model
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "arm/shoulder_act")
+        jnt = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "arm/shoulder")
+        assert actuator_joint_id(model, act, mujoco) == jnt
+    finally:
+        sim.cleanup()
+
+
+def test_actuator_joint_id_refuses_a_non_joint_transmission(tmp_path: Path) -> None:
+    """A tendon drive reports no joint, even though its ``trnid`` is a valid joint id."""
+    sim = _build(tmp_path, ("arm", "grip"))
+    try:
+        model = sim._world._model
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "grip/finger_act")
+        raw = int(model.actuator_trnid[act, 0])
+        assert 0 <= raw < int(model.njnt), "the raw id must look like a joint id for this to matter"
+        assert actuator_joint_id(model, act, mujoco) == -1
+    finally:
+        sim.cleanup()

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -62,6 +62,7 @@ _EXPECTED_FUNCTIONS = {
     "backend.py::capture_stderr_fd",
     "backend.py::filter_mujoco_attach_noise",
     "scene_ops.py::actuate_robot_in_scene",
+    "scene_ops.py::actuator_joint_id",
     "scene_ops.py::add_weld_constraint",
     "scene_ops.py::eject_body_from_scene",
     "scene_ops.py::eject_robot_from_scene",
@@ -77,6 +78,7 @@ _EXPECTED_FUNCTIONS = {
     "scene_ops.py::remove_equality_constraint",
     "scene_ops.py::replace_scene_mjcf",
     "scene_ops.py::reposition_body_in_scene",
+    "scene_ops.py::robot_owned_actuator_ids",
     "spec_builder.py::material_spec_error",
 }
 


### PR DESCRIPTION
Closes #1765.

## The defect

`SimRobot.actuator_ids` is re-derived after every recompile. It was built by comparing each actuator's `actuator_trnid[i, 0]` against the robot's joint ids:

```python
for i in range(new_model.nu):
    jnt_id = new_model.actuator_trnid[i, 0]
    if jnt_id in robot.joint_ids:
        robot.actuator_ids.append(i)
```

That field holds a **joint** id only when the transmission is `mjTRN_JOINT` / `mjTRN_JOINTINPARENT`. For a tendon, site, slider-crank or body transmission it indexes a different table, and those id spaces each start at 0 - so the comparison is between two different id spaces and matches an unrelated entity that merely shares a number.

A fixed tendon coupling a gripper's fingers is the standard MJCF idiom for a coupled gripper (the Menagerie Panda hand and the Robotiq 2F-85 both use one), so this is reachable with stock assets rather than only with exotic models.

## Measured (mujoco 3.11.0, at `32dc3f5b`)

One scene, two registry robots, differing only in the order they were added:

| added | `arm2` (so101_follower) owns | `panda` owns |
|---|---|---|
| panda, then arm2 | its own six | all eight - correct **by luck** |
| arm2, then panda | its own six **+ `panda/actuator8`** | seven - **missing its own gripper** |

The second row is what an incrementally built scene produces. `panda/actuator8` is the tendon drive; its `trnid[0]` is `0`, which equals `arm2`'s first joint id.

Three consequences, all on documented paths:

1. **The gripper becomes unoperable, and the error blames the model.** `set_gripper` resolves its actuator from `actuator_ids`, so with the gripper missing it reports `Registry gripper metadata for 'panda' ... names actuators ['actuator8'] but none exist in the model` - for an actuator that is plainly in the model. The jaw stays shut (finger gap `0.0000` m).
2. **A robot advertises an actuator that moves a different machine.** An unactuated inline arm added before the panda reports `actuator_ids == [7]`, i.e. `panda/actuator8`.
3. **`actuate_robot` refuses a robot that has no actuators.** Its double-actuate guard made the same raw comparison, so it answered `robot 'arm' already has actuators mapped to its joints; refusing to double-actuate` for a robot declaring none - making the documented way to add position servos to a URDF robot impossible.

A fourth read, `actuate_robot`'s hold-pose init, would seed a tendon drive's `ctrl` from `qpos[jnt_qposadr[<tendon id>]]` - the gripper's setpoint taken from an unrelated joint's angle.

## The change

One rule, in one place. New `scene_ops.actuator_joint_id(model, act_id, mj)` returns the driven joint id, or `-1` when the transmission is not a joint. `scene_ops.robot_owned_actuator_ids` builds ownership as the **union** of two rules, because neither alone covers every actuator a robot can carry:

* **Namespace** - `spec.attach(other, prefix=...)` prefixes every actuator name it merges in, so a prefixed name settles ownership whatever the transmission drives. This is the only rule that reaches a tendon, site or body transmission.
* **Driven joint** - `actuate_robot_in_scene` names the actuators it injects `"<robot>_act_<joint>"`, which carries no namespace prefix, so those are recognized by the joint they drive (through the gate above). Dropping this half would have regressed `actuate_robot`.

Both duplicated derivations (`_recompile_preserving_state` and `eject_robot_from_scene` carried line-for-line copies) now call it, and the two remaining raw reads in `actuate_robot` go through the same gate. Ascending actuator order is unchanged, so `robot_action_keys` and recorded dataset action-column order are untouched - only membership is corrected.

This matches how the rest of the package already reads a transmission: `motion_primitives._joint_actuator_map` gates on `actuator_trntype` and documents why, and `rendering._actuator_for_joint` gates and additionally resolves the tendon-wrap case. The derivations feeding `actuator_ids` were the sites that skipped it.

### One correction to the issue

#1765 states that `send_action` and `robot_action_keys` read `actuator_ids`. Neither does - both resolve by name against the robot's namespace (`_get_valid_action_keys`), which is why `robot_action_keys` reported the gripper correctly even while `actuator_ids` omitted it. The real consumers are `set_gripper` / `move_to` (via `_resolve_gripper_actuators`), `actuate_robot`, and the `n_actuators` field reported by `list_robots` / the scene summary.

### The single-robot fallback

Kept, with a test pinning the case it exists for: a robot whose actuators are neither namespace-prefixed nor joint-driven (a tendon or site transmission in a scene loaded whole, so there is no attach prefix) matches neither rule, and in a one-robot scene every actuator is unambiguously that robot's. It no longer masks the multi-robot defect, because the derivation it backstops is now correct.

## Verification

`tests/simulation/mujoco/test_actuator_ownership_by_transmission.py`, 13 tests, all inline MJCF via `add_robot(urdf_path=...)` so nothing downloads an asset. Each ownership test first asserts the fixture really does collide a tendon id with the other robot's joint id, so it cannot pass on a scene where the id spaces never overlap.

Pre-fix (source reverted to `main`, the three tests that call the new symbols removed since they cannot exist): **7 failed / 3 passed**.

```
FAILED test_each_robot_owns_exactly_its_own_actuators[arm_first]
  assert ['arm/elbow_act', 'arm/shoulder_act', 'grip/finger_act'] == ['arm/elbow_act', 'arm/shoulder_act']
FAILED test_ownership_does_not_depend_on_the_order_robots_were_added
  assert {'arm': [...  'grip/finger_act'], 'grip': []} == {'arm': [...], 'grip': ['grip/finger_act']}
FAILED test_a_robot_declaring_no_actuators_owns_none            assert [0] == []
FAILED test_set_gripper_operates_a_tendon_gripper_in_either_order[arm_first]
  set_gripper: could not resolve a gripper actuator for 'grip' ... Actuators: [].
FAILED test_actuate_robot_is_not_refused_by_a_tendon_id_collision
  actuate_robot: robot 'arm' already has actuators mapped to its joints; refusing to double-actuate.
FAILED test_injected_position_actuators_are_owned_by_the_robot_that_asked
FAILED test_actuate_robot_holds_the_pose_without_seeding_a_tendon_drive
```

The 3 that pass pre-fix are exactly the arrangements that were accidentally correct - gripper added first, so the tendon's id collides with its *own* joint. That they pass is itself the point: the old result was decided by add order, not by a rule. They are kept so the fix cannot regress them.

Gate on this branch:

* `ruff check strands_robots tests tests_integ` - clean
* `ruff format --check strands_robots tests tests_integ` - 971 files already formatted
* `mypy strands_robots tests tests_integ` - `Success: no issues found in 968 source files`
* `MUJOCO_GL=egl python -m pytest tests -q --no-cov` - **14450 passed, 253 skipped** (469s), no failures
* `python scripts/assemble_changelog.py --check` - OK

## Rollout in MuJoCo (headless)

Same scene both times - `so101_follower` added first, then `panda` - and the same call. Left is `main`, right is this change; the fact rows under each panel are read out of the two runs, not typed. Panels differ on 29.8% of pixels.

![tendon gripper ownership](https://raw.githubusercontent.com/cagataycali/robots/artifacts/actuator-ownership/actuator-ownership-by-transmission.png)

| | main | this change |
|---|---|---|
| `arm2` owns | 7 actuators, incl. `panda/actuator8` | its own six |
| `panda` owns | 7 actuators, missing `panda/actuator8` | all eight |
| `set_gripper(panda, 'open')` | `error` - "none exist in the model" | `success` |
| finger gap | `0.0000` -> `0.0000` m | `0.0000` -> `0.0499` m |

## Note for review

#1763 edits the same function (`_recompile_preserving_state`) but at disjoint lines - its hunks end well above the ownership loop this PR replaces, and it deliberately avoided `actuator_ids` for its reset scope precisely because of this defect. Whichever lands first, the other rebases without a content conflict.