### PR TITLE
fix(sim): refuse a camera pixel dimension that cannot be rendered

### DIFF
--- a/changelog.d/1762-camera-pixel-count-domain.md
+++ b/changelog.d/1762-camera-pixel-count-domain.md
@@ -1,0 +1,40 @@
+### Fixed: a camera pixel dimension one backend refuses is now refused by all of them
+
+`width` / `height` reach two surfaces on every simulation backend - the
+`add_camera` that fixes a camera's resolution, and the render family
+(`render` / `get_frame` / `get_camera_params`) that can override it per call.
+MuJoCo validated both through `_validate_render_dims`; Newton and Isaac
+validated neither and coerced with a bare `int(...)`, which refuses nothing
+useful:
+
+```python
+sim.add_camera(name="wrist", width=0, height=-4)
+# status="success", camera registered 0 x -4 - the failure surfaces at the
+# first render, far from the call that caused it
+
+sim.add_camera(name="wrist", width="big")
+# ValueError: invalid literal for int() with base 10: 'big'
+# raised straight through the structured tool-result contract
+```
+
+Three more classes of the same gap: `int(width or default)` read a falsy `0`
+as *omitted*, so a caller who asked for an impossible resolution was handed the
+default and told it was what they requested; `2.7` and `True` were silently
+truncated to 2 and 1, while Newton's success text echoed the caller's raw value
+and so named a resolution that was never registered; and on Isaac a stored
+negative width was multiplied back out by the DLSS upscale
+(`scale = _MIN_RENDER_PX / w`), giving a native render size of `640 x -76800`
+so that every later render of that camera failed on the negative dimension -
+one bad configuration call disabled the camera for the rest of the session.
+
+Both backends' `add_camera` and render family now validate on
+`strands_robots.utils.positive_count_error`, the domain MuJoCo's floor already
+implements: a true `int` (`bool` refused - an `int` subclass whose `True` would
+act as a silent 1) that is `>= 1`. A pixel dimension is consumed directly as an
+array or framebuffer dimension, where an integral float raises `TypeError`
+rather than being coerced, which is why it shares that domain rather than the
+looser `positive_whole_number_error` used for frame rates. `None` still means
+"take the configured default" - membership decides that, not truthiness. The
+*upper* bound stays backend-specific, since MuJoCo has an offscreen framebuffer
+to overflow and the ray-traced backends do not, so a 5000-pixel-wide Newton
+camera keeps working. Valid resolutions behave exactly as before.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -36,7 +36,12 @@ import numpy as np
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.config import IsaacConfig
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
-from strands_robots.utils import camera_fov_error, coerce_pose_vector, positive_whole_number_error
+from strands_robots.utils import (
+    camera_fov_error,
+    coerce_pose_vector,
+    positive_count_error,
+    positive_whole_number_error,
+)
 
 if TYPE_CHECKING:
     from strands_robots.rendering import CameraParams
@@ -2626,8 +2631,21 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             if not self._world_created:
                 return None, None, {"error": "No world created."}
 
-            w = width or self._config.camera_width
-            h = height or self._config.camera_height
+            # Same shared pixel floor ``add_camera`` applies, so the
+            # config-time and call-time domains agree. These sized the
+            # blank-frame fallbacks below with no validation at all: a negative
+            # width reached ``np.zeros`` as ``ValueError: negative dimensions
+            # are not allowed`` and a fractional or non-numeric one as
+            # ``TypeError: 'float' object cannot be interpreted as an
+            # integer``, both escaping this method's ``(rgb, depth, meta)``
+            # contract. ``None`` still means "take the config default";
+            # membership decides that, not truthiness.
+            for param, value in (("width", width), ("height", height)):
+                if value is not None and (dim_err := positive_count_error(value, param, "render")) is not None:
+                    return None, None, {"error": dim_err}
+
+            w = self._config.camera_width if width is None else width
+            h = self._config.camera_height if height is None else height
 
             if self._config.render_mode == "headless":
                 # Return blank frames in headless mode. Most CI flows
@@ -2796,6 +2814,13 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             if cam.handle is None:
                 raise RuntimeError(f"Camera '{camera_name}' has no live RTX handle; re-add it via add_camera().")
             for arg_name, arg, native in (("width", width, cam.width), ("height", height, cam.height)):
+                # Shared pixel floor first: the comparison below coerces
+                # with ``int(arg)``, which raises an uninformative
+                # ``ValueError`` for a non-numeric value instead of naming
+                # the parameter that was wrong.
+                if arg is not None:
+                    if (dim_err := positive_count_error(arg, arg_name, "get_frame")) is not None:
+                        raise ValueError(dim_err)
                 if arg is not None and int(arg) != int(native):
                     raise ValueError(
                         f"Isaac cameras render at the resolution fixed at add_camera time; "
@@ -2827,14 +2852,15 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         Args:
             camera_name: a camera previously added via ``add_camera``.
             width: must be ``None`` or the camera's native render width (the
-                handle's intrinsics are only valid at native resolution).
+                handle's intrinsics are only valid at native resolution), and
+                a positive integer when supplied.
             height: same contract as ``width``.
 
         Raises:
             RuntimeError: no world, or the camera has no live RTX handle.
             KeyError: unknown camera name.
-            ValueError: ``width``/``height`` differ from the native render
-                resolution.
+            ValueError: ``width``/``height`` is not a positive integer, or
+                differs from the native render resolution.
         """
         from strands_robots.rendering import CameraParams
 
@@ -2850,6 +2876,13 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     "read off a registration-only camera. Re-add it via add_camera()."
                 )
             for arg_name, arg, native in (("width", width, cam.width), ("height", height, cam.height)):
+                # Shared pixel floor first: the comparison below coerces
+                # with ``int(arg)``, which raises an uninformative
+                # ``ValueError`` for a non-numeric value instead of naming
+                # the parameter that was wrong.
+                if arg is not None:
+                    if (dim_err := positive_count_error(arg, arg_name, "get_camera_params")) is not None:
+                        raise ValueError(dim_err)
                 if arg is not None and int(arg) != int(native):
                     raise ValueError(
                         f"Isaac camera intrinsics are only valid at the native render resolution; "
@@ -2970,9 +3003,11 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             If ``None``, the camera keeps its constructed orientation
             (identity).
         width : int, optional
-            Image width in pixels. Defaults to ``IsaacConfig.camera_width``.
+            Image width in pixels; a positive integer. ``None`` (omitted)
+            takes ``IsaacConfig.camera_width``.
         height : int, optional
-            Image height in pixels. Defaults to ``IsaacConfig.camera_height``.
+            Image height in pixels; a positive integer. ``None`` (omitted)
+            takes ``IsaacConfig.camera_height``.
         fov : float
             Horizontal field of view in degrees. Default 60.0. Mapped
             onto ``Camera.set_focal_length`` using the standard pinhole
@@ -2987,16 +3022,25 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         look-at point has no look direction. Omit a vector to take its
         default; an empty vector is a wrong-length request and is rejected
         rather than silently placing the camera at the default pose. ``fov``
-        must be a finite angle in the open interval ``(0, 180)`` degrees.
-        These are the same bounds the MuJoCo and Newton backends' ``add_camera``
-        enforces, on the shared
+        must be a finite angle in the open interval ``(0, 180)`` degrees, and
+        ``width`` / ``height`` must each be a positive integer (omit one to take
+        the ``IsaacConfig`` default - ``0`` is a request for an impossible
+        resolution, not an omission). These are the same bounds the MuJoCo and
+        Newton backends' ``add_camera`` enforces, on the shared
         :func:`~strands_robots.utils.coerce_pose_vector` /
-        :func:`~strands_robots.utils.camera_fov_error` domains, so a camera
+        :func:`~strands_robots.utils.camera_fov_error` /
+        :func:`~strands_robots.utils.positive_count_error` domains, so a camera
         configuration one backend refuses is refused by all three. Invalid
         values are rejected here, before the stage is touched, rather than
         deferring an uncaught exception (non-numeric ``fov``, ``fov=0``) or a
         silently degenerate camera (a ``nan`` in the USD pose or in the derived
         focal length) to the first render.
+
+        A non-positive ``width`` is especially costly here because the DLSS
+        upscale below multiplies it back out: ``scale = _MIN_RENDER_PX / w`` for
+        ``w = -4`` gave a native render size of ``640 x -76800``, and every
+        later render of that camera then failed on the negative dimension - one
+        bad configuration call disabled the camera for the rest of the session.
 
         Returns
         -------
@@ -3053,6 +3097,21 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             # usable under a success result.
             if (fov_err := camera_fov_error("add_camera", "fov", fov)) is not None:
                 return {"status": "error", "content": [{"text": fov_err}]}
+            # Pixel dimensions on the shared floor
+            # (:func:`~strands_robots.utils.positive_count_error`) the MuJoCo
+            # backend's ``_validate_render_dims`` already applies, so a
+            # resolution one backend refuses is refused by all of them. The
+            # ``int(width or ...)`` this replaces validated nothing and read a
+            # falsy value as *omitted*: ``width=0`` silently substituted the
+            # config default and reported it as the resolution, so the caller
+            # was told a size it never asked for. A negative was stored
+            # verbatim, a fractional or ``bool`` value was truncated, and a
+            # non-numeric / ``nan`` / ``inf`` value raised ``ValueError`` /
+            # ``OverflowError`` from ``int()`` - outside the try block below, so
+            # it escaped the structured ``{"status": "error"}`` contract.
+            for param, value in (("width", width), ("height", height)):
+                if value is not None and (dim_err := positive_count_error(value, param, "add_camera")) is not None:
+                    return {"status": "error", "content": [{"text": dim_err}]}
 
             if name in self._cameras:
                 return {
@@ -3060,8 +3119,8 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     "content": [{"text": f"Camera '{name}' already exists."}],
                 }
 
-            w = int(width or self._config.camera_width)
-            h = int(height or self._config.camera_height)
+            w = self._config.camera_width if width is None else width
+            h = self._config.camera_height if height is None else height
             fov_deg = float(fov)
 
             # RTX cameras: render at a higher NATIVE resolution if the

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -49,7 +49,7 @@ from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, Sim
 from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
 from strands_robots.simulation.newton.randomization import DomainRandomizationMixin
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
-from strands_robots.utils import camera_fov_error, coerce_pose_vector, require_optional
+from strands_robots.utils import camera_fov_error, coerce_pose_vector, positive_count_error, require_optional
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -974,6 +974,12 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         (``nan``/``inf`` in the look-at basis or the derived intrinsics) to the
         first render.
 
+        ``width`` and ``height`` must each be a positive integer, the same
+        floor :meth:`render` and the MuJoCo backend's ``add_camera`` enforce
+        (:func:`~strands_robots.utils.positive_count_error`). Newton ray-traces
+        each frame on demand and has no offscreen framebuffer, so unlike MuJoCo
+        there is no upper cap.
+
         Args:
             name: Unique camera name. Duplicate names are rejected; remove the
                 existing camera with :meth:`remove_camera` first.
@@ -984,15 +990,15 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 3 finite numbers.
             fov: Vertical field of view in degrees; a finite angle in the open
                 interval ``(0, 180)``.
-            width: Render width in pixels for this camera.
-            height: Render height in pixels for this camera.
+            width: Render width in pixels for this camera; a positive integer.
+            height: Render height in pixels for this camera; a positive integer.
             parent_body: Optional body label to mount the camera on. ``None``
                 or empty leaves the camera world-fixed.
 
         Returns:
             Status dict confirming the registration, or an error dict when no
-            world exists, the pose or ``fov`` is invalid, the name is taken, or
-            the mount body is unknown. Never raises.
+            world exists, the pose, ``fov`` or a pixel dimension is invalid, the
+            name is taken, or the mount body is unknown. Never raises.
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
@@ -1036,6 +1042,22 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         # ``nan`` fov and raises ``ZeroDivisionError`` for ``0``.
         if (e := camera_fov_error("add_camera", "fov", fov)) is not None:
             return {"status": "error", "content": [{"text": e}]}
+        # Validate the pixel dimensions on the shared floor the MuJoCo backend's
+        # ``_validate_render_dims`` already applies, so a resolution one backend
+        # refuses is refused by all of them. They were previously coerced by a
+        # bare ``int(width)`` inside the lock below, which validated nothing: a
+        # non-numeric value raised ``ValueError`` straight through the structured
+        # tool-result contract (``None`` a ``TypeError``, ``nan`` a
+        # ``ValueError``, ``inf`` an ``OverflowError``), and ``0`` / a negative
+        # registered a camera that cannot produce a frame under a success
+        # result - deferring the failure to the first render, far from the call
+        # that caused it. A fractional or ``bool`` value was silently truncated
+        # (``2.7`` stored as 2, ``True`` as 1) while the success text below
+        # echoed the value the caller passed, reporting a resolution that was
+        # never registered.
+        for _param, _value in (("width", width), ("height", height)):
+            if (e := positive_count_error(_value, _param, "add_camera")) is not None:
+                return {"status": "error", "content": [{"text": e}]}
         if name in (None, "", "default", "free"):
             return {
                 "status": "error",
@@ -1069,8 +1091,8 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 position=pos,
                 target=tgt,
                 fov=float(fov),
-                width=int(width),
-                height=int(height),
+                width=width,
+                height=height,
                 parent_body=mount,
             )
         where = f" mounted on '{mount}'" if mount else ""
@@ -1355,24 +1377,42 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         :meth:`get_camera_params` so all three agree on the built-in default
         view and per-camera config fallbacks.
 
+        A supplied ``width`` / ``height`` is validated on the same shared floor
+        (:func:`~strands_robots.utils.positive_count_error`) that
+        ``add_camera`` applies, so the config-time and call-time domains agree
+        and every render entry point reports the same refusal. ``None`` means
+        "take the camera's configured size"; membership decides that, not
+        truthiness - reading ``0`` as omitted would render at the default
+        resolution and report it as the requested one.
+
         Raises:
             KeyError: unknown camera name.
-            ValueError: the camera's mount body is no longer in the model.
+            ValueError: ``width`` / ``height`` is not a positive integer, or
+                the camera's mount body is no longer in the model.
         """
+        for param, value in (("width", width), ("height", height)):
+            if value is not None and (text := positive_count_error(value, param, "render")) is not None:
+                raise ValueError(text)
         if camera_name in (None, "", "default", "free"):
             return (
                 (0.6, 0.6, 0.5),
                 (0.0, 0.0, 0.15),
                 50.0,
-                int(width or self.default_width),
-                int(height or self.default_height),
+                self.default_width if width is None else width,
+                self.default_height if height is None else height,
             )
         assert camera_name is not None  # the free-camera tokens were handled above
         cam = self._world.cameras.get(camera_name) if self._world is not None else None
         if cam is None:
             raise KeyError(f"Camera '{camera_name}' not found. Available: {self.list_cameras()}")
         eye, target = self._resolve_camera_pose(cam)
-        return eye, target, float(cam.fov), int(width or cam.width), int(height or cam.height)
+        return (
+            eye,
+            target,
+            float(cam.fov),
+            cam.width if width is None else width,
+            cam.height if height is None else height,
+        )
 
     # Interactive viewer
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -422,22 +422,33 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
 def positive_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive integer count.
 
-    Shared domain for the discrete knobs that count iterations of a control or
-    rollout loop - the simulation's ``n_episodes`` / ``max_steps`` /
-    ``control_substeps`` / ``action_horizon`` and the hardware control loop's
-    ``action_horizon``. It lives here rather than beside one of its callers
-    because those callers sit in different layers
-    (:mod:`strands_robots.hardware_robot` must not depend on
-    :mod:`strands_robots.simulation`), and the accepted domain must not diverge
-    between them: the same count cannot be refused for a digital twin and
-    accepted for the arm it mirrors.
+    Shared domain for two families of discrete quantity:
+
+    * The knobs that count iterations of a control or rollout loop - the
+      simulation's ``n_episodes`` / ``max_steps`` / ``control_substeps`` /
+      ``action_horizon`` and the hardware control loop's ``action_horizon``.
+    * A camera's pixel dimensions - the ``width`` / ``height`` of
+      ``add_camera`` and of the render family (``render``, ``get_frame``,
+      ``get_camera_params``) on every simulation backend. A backend may add
+      an upper bound of its own on top of this floor (MuJoCo caps at the
+      offscreen framebuffer size; the ray-traced backends have no such
+      buffer), but the floor itself must not differ between them: the same
+      camera configuration cannot be refused on one backend and accepted on
+      another.
+
+    It lives here rather than beside one of its callers because those callers
+    sit in different layers (:mod:`strands_robots.hardware_robot` must not
+    depend on :mod:`strands_robots.simulation`), and the accepted domain must
+    not diverge between them: the same count cannot be refused for a digital
+    twin and accepted for the arm it mirrors.
 
     Distinct from :func:`positive_whole_number_error`, which accepts any real
     scalar with an integral value so a ``30.0`` read from a config or an
-    ``np.int64`` probed from a camera can be honored. The counts guarded here are
-    consumed directly as ``range()`` bounds and slice indices, where an integral
-    float raises ``TypeError`` ("``'float' object cannot be interpreted as an
-    integer``") rather than being coerced, so only a true ``int`` can be honored.
+    ``np.int64`` probed from a camera can be honored. The values guarded here
+    are consumed directly as ``range()`` bounds, slice indices, or an array /
+    framebuffer dimension, where an integral float raises ``TypeError``
+    ("``'float' object cannot be interpreted as an integer``") rather than being
+    coerced, so only a true ``int`` can be honored.
 
     ``bool`` is rejected explicitly. It is an ``int`` subclass, so a bare
     ``value < 1`` test lets ``True`` through as a silent count of 1 while

--- a/tests/simulation/test_camera_pixel_count_domain.py
+++ b/tests/simulation/test_camera_pixel_count_domain.py
@@ -1,0 +1,478 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: every backend's camera pixel dimensions share one floor.
+
+``width`` / ``height`` reach two surfaces on every simulation backend - the
+``add_camera`` that fixes a camera's resolution, and the render family
+(``render`` / ``get_frame`` / ``get_camera_params``) that can override it per
+call. MuJoCo validated both through ``_validate_render_dims``; Newton and Isaac
+validated neither, and coerced with a bare ``int(...)`` that refuses nothing
+useful. Coercion is validation only when the coercion rejects.
+
+Measured on both backends before the fix:
+
+* **An uncatchable exception through the tool-result contract.** ``width="big"``
+  raised ``ValueError: invalid literal for int() with base 10: 'big'`` out of
+  ``add_camera``, ``None`` a ``TypeError``, ``nan`` a ``ValueError`` and ``inf``
+  an ``OverflowError``. On Isaac the ``int()`` sat *outside* the method's try
+  block, so none of them could even be converted into an error envelope.
+* **A camera that cannot produce a frame, reported as success.**
+  ``add_camera(width=0, height=-4)`` returned ``status="success"`` and stored the
+  values, deferring the failure to the first render - far from the call that
+  caused it. On Isaac a stored negative width made every later render of that
+  camera fail (``ValueError: negative dimensions are not allowed`` out of the
+  blank-frame ``np.zeros``), so one bad configuration call disabled the camera
+  for the rest of the session.
+* **Truthiness where membership was meant.** Isaac's
+  ``int(width or self._config.camera_width)`` and Newton's
+  ``int(width or self.default_width)`` read a falsy ``0`` as *omitted*, so the
+  caller asked for an impossible resolution and was handed the default while
+  being told it was what they requested - the harder failure to notice of the
+  two, and the same shape as the ``position or <default>`` bug
+  ``coerce_pose_vector``'s docstring documents.
+* **Silent truncation, with the success text disagreeing with the registry.**
+  ``width=2.7`` stored 2 and ``True`` stored 1, while Newton's success message
+  echoed the caller's raw value (``"Camera 'cam' added (2.7x480, ...)"`` /
+  ``"(Truex480, ...)"``) - reporting a resolution that was never registered.
+
+The fix routes all four surfaces through
+:func:`~strands_robots.utils.positive_count_error`, the domain MuJoCo's floor
+already implements: a true ``int`` (``bool`` refused - it is an ``int`` subclass
+whose ``True`` would act as a silent 1) that is ``>= 1``. A pixel dimension is
+consumed directly as an array / framebuffer dimension, where an integral float
+raises ``TypeError`` rather than being coerced, which is why it belongs to that
+domain rather than to the looser
+:func:`~strands_robots.utils.positive_whole_number_error` used for frame rates.
+The *upper* bound stays backend-specific: MuJoCo caps at its offscreen
+framebuffer, and the ray-traced backends have no such buffer, so
+``TestSameVerdictAcrossBackends`` pins agreement on the floor only.
+
+None of this needs ``newton`` / ``warp`` / Isaac Sim or a GPU: the validation
+runs before either backend touches its solver or its stage, so the newton-free
+stub and the ``__new__`` Isaac skeleton the sibling ``add_camera`` tests
+already establish exercise it in every environment.
+"""
+
+from __future__ import annotations
+
+import types
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.simulation import _MIN_RENDER_PX
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import positive_count_error
+
+from .isaac.test_add_camera_numeric_validation import _engine as _isaac_engine
+from .newton.test_add_camera_numeric_validation import _engine_stub
+
+#: Pixel dimensions no camera can be built or rendered at. Each was accepted or
+#: raised past the tool-result contract on both backends before the fix.
+_BAD_DIMS: tuple[Any, ...] = (
+    0,
+    -4,
+    -1,
+    2.7,
+    640.0,
+    True,
+    False,
+    "big",
+    "640",
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    [640],
+)
+
+#: Dimensions that must keep working. ``5000`` is included deliberately: it is
+#: above MuJoCo's framebuffer cap but perfectly renderable by a ray tracer, so
+#: it pins that the shared rule is a floor and not a ceiling.
+_GOOD_DIMS: tuple[int, ...] = (1, 16, 320, 640, 5000)
+
+
+def _newton_stub() -> types.SimpleNamespace:
+    """The sibling test's ``add_camera`` stub, plus what the render family reads.
+
+    ``_resolve_camera_view`` additionally reads ``self.default_width`` /
+    ``self.default_height`` (the built-in view) and calls
+    ``_resolve_camera_pose`` (which, for a world-fixed camera, returns the
+    stored pose without touching the solver). Both it and ``list_cameras`` are
+    bound as real methods rather than replaced, so ``render`` exercises the
+    production resolver instead of a stand-in for it.
+    """
+    stub = _engine_stub()
+    stub.default_width = 640
+    stub.default_height = 480
+    for method in ("_resolve_camera_pose", "_resolve_camera_view", "list_cameras"):
+        setattr(stub, method, types.MethodType(getattr(NewtonSimEngine, method), stub))
+    return stub
+
+
+def _newton_add_camera(stub: types.SimpleNamespace, **kwargs: Any) -> dict[str, Any]:
+    """Call ``add_camera`` with arguments deliberately outside its annotations.
+
+    Every bad dimension below is a value a caller must never pass, because the
+    contract under test is that it is refused at runtime - in a structured
+    result - rather than by a type checker that an agent dispatching this tool
+    never runs. Funnelling the calls through one ``**kwargs: Any`` boundary
+    states that once, the shape both sibling ``add_camera`` tests use, instead
+    of scattering per-call suppressions.
+    """
+    return NewtonSimEngine.add_camera(stub, **kwargs)  # type: ignore[arg-type]
+
+
+def _newton_resolve(stub: types.SimpleNamespace, camera_name: str | None, **kwargs: Any) -> tuple:
+    """``_resolve_camera_view``, the funnel Newton's three render surfaces share."""
+    return NewtonSimEngine._resolve_camera_view(stub, camera_name, kwargs.get("width"), kwargs.get("height"))  # type: ignore[arg-type]
+
+
+def _verdict(call: Callable[[], Any]) -> str:
+    """``"refused"`` / ``"accepted"``; an exception the API leaked is its own verdict.
+
+    A leaked exception is reported rather than swallowed: it is a contract
+    violation in its own right, and folding it into a refusal would let the
+    parity tests below pass against the pre-fix code that raised ``ValueError``
+    out of ``int()``. Every type that code leaked - ``ValueError``,
+    ``TypeError``, ``OverflowError`` - is an ``Exception``, which is where the
+    boundary sits.
+
+    It deliberately does not sit at ``BaseException``. A ``KeyboardInterrupt``
+    or a pytest outcome (``Skipped`` / ``Failed``, both of which derive from
+    ``BaseException`` without deriving from ``Exception``) is not something the
+    API under test leaked - it is the operator's or the framework's control flow
+    passing through. Absorbing those would turn an interrupted run into a
+    verdict string, and an ``importorskip`` in one of the helpers into a
+    confusing failure instead of a skip, so they propagate.
+    """
+    try:
+        result = call()
+    except Exception as exc:  # noqa: BLE001 - an exception the API leaked is the finding
+        return f"raised {type(exc).__name__}"
+    return "refused" if result["status"] == "error" else "accepted"
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheSharedDomain:
+    """What ``positive_count_error`` accepts is what a pixel dimension can be."""
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    def test_every_probe_value_is_outside_the_domain(self, bad):
+        """Pin the premise so a weakened guard cannot make this file vacuous."""
+        assert positive_count_error(bad, "width", "render") is not None
+
+    @pytest.mark.parametrize("good", _GOOD_DIMS)
+    def test_every_good_value_is_inside_the_domain(self, good):
+        assert positive_count_error(good, "width", "render") is None
+
+    def test_an_integral_float_is_refused_because_it_cannot_be_used_as_a_dimension(self):
+        """``640.0`` is outside the domain, and this is why.
+
+        The looser :func:`positive_whole_number_error` accepts it - correct for a
+        frame rate read out of a config float. A pixel dimension is handed
+        straight to an array constructor, which refuses it, so the two knobs
+        genuinely need different domains rather than one shared spelling.
+        """
+        with pytest.raises(TypeError, match="cannot be interpreted as an integer"):
+            np.zeros((480, 640.0, 3), dtype=np.uint8)
+
+
+# --------------------------------------------------------------------------- #
+# Newton                                                                      #
+# --------------------------------------------------------------------------- #
+class TestNewtonAddCamera:
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_unusable_dimension_is_refused(self, param, bad):
+        """Pre-fix these were stored verbatim, truncated, or raised out of the call."""
+        stub = _newton_stub()
+        result = _newton_add_camera(stub, name="cam", **{param: bad})
+        assert result["status"] == "error", result
+        assert result["content"][0]["text"] == f"add_camera: {param} must be a positive integer, got {bad!r}."
+        assert stub._world.cameras == {}
+
+    @pytest.mark.parametrize("good", _GOOD_DIMS)
+    def test_usable_dimension_is_stored_and_reported_as_given(self, good):
+        """The registry and the success text must agree on the resolution.
+
+        Pre-fix the message interpolated the caller's raw value while the
+        registry held ``int(...)`` of it, so ``width=2.7`` announced a ``2.7``
+        pixel-wide camera that was actually 2 wide.
+        """
+        stub = _newton_stub()
+        result = _newton_add_camera(stub, name="cam", width=good, height=good)
+        assert result["status"] == "success", result
+        cam = stub._world.cameras["cam"]
+        assert (cam.width, cam.height) == (good, good)
+        assert f"{good}x{good}" in result["content"][0]["text"]
+
+    def test_defaults_are_unchanged(self):
+        stub = _newton_stub()
+        assert _newton_add_camera(stub, name="cam")["status"] == "success"
+        cam = stub._world.cameras["cam"]
+        assert (cam.width, cam.height) == (640, 480)
+
+    def test_a_refused_dimension_does_not_consume_the_camera_name(self):
+        """A rejected configuration leaves the registry untouched.
+
+        The name must still be free afterwards - otherwise the caller has to
+        ``remove_camera`` a camera that was never added.
+        """
+        stub = _newton_stub()
+        assert _newton_add_camera(stub, name="wrist", width=0)["status"] == "error"
+        assert _newton_add_camera(stub, name="wrist", width=320)["status"] == "success"
+        assert stub._world.cameras["wrist"].width == 320
+
+
+class TestNewtonRenderFamily:
+    """``_resolve_camera_view`` is the funnel ``render`` / ``get_frame`` /
+    ``get_camera_params`` share, so one guard covers all three."""
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    @pytest.mark.parametrize("camera", ["default", "cam"])
+    def test_unusable_override_is_refused(self, camera, param, bad):
+        stub = _newton_stub()
+        assert _newton_add_camera(stub, name="cam", width=320, height=240)["status"] == "success"
+        with pytest.raises(ValueError, match=f"render: {param} must be a positive integer"):
+            _newton_resolve(stub, camera, **{param: bad})
+
+    def test_zero_is_refused_rather_than_read_as_omitted(self):
+        """Membership, not truthiness.
+
+        Pre-fix ``int(width or self.default_width)`` resolved ``width=0`` to the
+        engine default and rendered at 640 wide, reporting that as the size the
+        caller requested. ``0`` is a request for an impossible resolution, not an
+        omission - and ``bool(0) is False`` is the whole reason it was mistaken
+        for one.
+        """
+        assert not bool(0)
+        stub = _newton_stub()
+        with pytest.raises(ValueError, match="width must be a positive integer, got 0"):
+            _newton_resolve(stub, "default", width=0)
+
+    @pytest.mark.parametrize("camera", ["default", "cam"])
+    def test_none_still_means_take_the_configured_size(self, camera):
+        stub = _newton_stub()
+        assert _newton_add_camera(stub, name="cam", width=320, height=240)["status"] == "success"
+        _eye, _target, _fov, w, h = _newton_resolve(stub, camera)
+        assert (w, h) == ((640, 480) if camera == "default" else (320, 240))
+
+    @pytest.mark.parametrize("good", _GOOD_DIMS)
+    def test_usable_override_is_honored_exactly(self, good):
+        stub = _newton_stub()
+        assert _newton_add_camera(stub, name="cam", width=320, height=240)["status"] == "success"
+        _eye, _target, _fov, w, h = _newton_resolve(stub, "cam", width=good, height=good)
+        assert (w, h) == (good, good)
+
+    def test_render_reports_the_refusal_as_a_structured_error(self):
+        """``render`` owes its caller an envelope, not an exception.
+
+        It already converts a ``ValueError`` from the shared resolver into one,
+        which is why the guard raises there rather than being duplicated per
+        entry point.
+        """
+        stub = _newton_stub()
+        result = NewtonSimEngine.render(stub, camera_name="default", width=0)  # type: ignore[arg-type]
+        assert result["status"] == "error", result
+        assert "width must be a positive integer" in result["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# Isaac                                                                       #
+# --------------------------------------------------------------------------- #
+class TestIsaacAddCamera:
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_unusable_dimension_is_refused_before_the_stage_is_touched(self, param, bad):
+        engine = _isaac_engine()
+        result = engine.add_camera(name="cam", **{param: bad})
+        assert result["status"] == "error", result
+        assert result["content"][0]["text"] == f"add_camera: {param} must be a positive integer, got {bad!r}."
+        assert engine._cameras == {}
+        # The prim recorder never fired: nothing was created on the stage, so
+        # there is no partial camera to clean up.
+        assert engine.prim_calls == []
+
+    @pytest.mark.parametrize("good", _GOOD_DIMS)
+    def test_usable_dimension_is_honored(self, good):
+        engine = _isaac_engine()
+        result = engine.add_camera(name="cam", width=good, height=good)
+        assert result["status"] == "success", result
+        assert (engine._cameras["cam"].width, engine._cameras["cam"].height) == (good, good)
+
+    def test_zero_is_refused_rather_than_read_as_the_config_default(self):
+        """Pre-fix ``int(width or camera_width)`` reported ``640x480`` for ``width=0``.
+
+        The caller asked for a resolution no camera can have and was told the
+        config default was what they requested - a success naming a size that
+        was never requested is harder to notice than a stored ``0``.
+        """
+        engine = _isaac_engine()
+        result = engine.add_camera(name="cam", width=0)
+        assert result["status"] == "error", result
+        assert engine._cameras == {}
+
+    def test_omitted_dimensions_still_take_the_config_defaults(self):
+        engine = _isaac_engine()
+        assert engine.add_camera(name="cam")["status"] == "success"
+        cam = engine._cameras["cam"]
+        assert (cam.width, cam.height) == (engine._config.camera_width, engine._config.camera_height)
+
+    def test_the_dlss_upscale_would_have_amplified_a_negative_width(self):
+        """Pin why a non-positive width was worse here than a mis-sized frame.
+
+        ``add_camera`` raises the native render size to ``_MIN_RENDER_PX`` when
+        the requested width is below it, preserving the aspect ratio via
+        ``scale = _MIN_RENDER_PX / w``. For ``w = -4`` that scale is negative, so
+        the height was multiplied out to ``-76800`` and stored - and every later
+        render of that camera then failed on the negative dimension. Refusing
+        ``w`` at the entry point is what keeps this arithmetic unreachable.
+        """
+        w = -4
+        scale = _MIN_RENDER_PX / float(w)
+        assert int(round(480 * scale)) == -76800
+        with pytest.raises(ValueError, match="negative dimensions"):
+            np.zeros((int(round(480 * scale)), _MIN_RENDER_PX, 3), dtype=np.uint8)
+
+
+class TestIsaacRenderFamily:
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_render_reports_an_unusable_override_as_an_error(self, param, bad):
+        """``_render_frame`` owes its caller ``(rgb, depth, meta)``, never an exception.
+
+        Pre-fix a negative dimension reached ``np.zeros`` as ``ValueError:
+        negative dimensions are not allowed`` and a fractional or non-numeric one
+        as ``TypeError``, both escaping that contract.
+        """
+        engine = _isaac_engine()
+        rgb, depth, meta = engine._render_frame("default", **{param: bad})
+        assert rgb is None and depth is None
+        assert meta["error"] == f"render: {param} must be a positive integer, got {bad!r}."
+
+    def test_render_envelope_carries_the_refusal(self):
+        engine = _isaac_engine()
+        result = engine.render(camera_name="default", width=-4)
+        assert result["status"] == "error", result
+        assert "width must be a positive integer" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("good", (16, 320, 640))
+    def test_usable_override_still_renders(self, good):
+        engine = _isaac_engine()
+        rgb, _depth, meta = engine._render_frame("default", good, good)
+        assert rgb is not None and rgb.shape == (good, good, 3), meta
+
+    def test_none_still_means_take_the_config_default(self):
+        engine = _isaac_engine()
+        rgb, _depth, _meta = engine._render_frame("default")
+        assert rgb is not None
+        assert rgb.shape == (engine._config.camera_height, engine._config.camera_width, 3)
+
+
+# --------------------------------------------------------------------------- #
+# Cross-backend parity                                                        #
+# --------------------------------------------------------------------------- #
+class TestSameVerdictAcrossBackends:
+    """A pixel dimension one backend refuses must be refused by all of them.
+
+    The headline inconsistency this closes was exactly that divergence: MuJoCo
+    refused every value below at both surfaces, Newton and Isaac accepted most
+    of them and raised on the rest. Parity is pinned here rather than by sharing
+    the message text, because the *upper* bound is legitimately
+    backend-specific - MuJoCo has an offscreen framebuffer to overflow and the
+    ray tracers do not - so only the floor is common.
+    """
+
+    @pytest.fixture
+    def mj_sim(self):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        s = Simulation(tool_name="test_camera_pixel_count_parity_sim", mesh=False)
+        s.create_world(gravity=[0, 0, -9.81])
+        yield s
+        s.cleanup()
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_add_camera_agrees_on_the_floor(self, mj_sim, param, bad):
+        mujoco_verdict = _verdict(lambda: mj_sim.add_camera(name="parity_cam", **{param: bad}))
+        newton_verdict = _verdict(lambda: _newton_add_camera(_newton_stub(), name="parity_cam", **{param: bad}))
+        isaac_verdict = _verdict(lambda: _isaac_engine().add_camera(name="parity_cam", **{param: bad}))
+        assert mujoco_verdict == newton_verdict == isaac_verdict == "refused", (
+            f"{param}={bad!r}: mujoco={mujoco_verdict}, newton={newton_verdict}, isaac={isaac_verdict}"
+        )
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    def test_the_render_family_agrees_on_the_floor(self, mj_sim, bad):
+        mujoco_verdict = _verdict(lambda: mj_sim.render(camera_name="default", width=bad, height=480))
+        isaac_verdict = _verdict(lambda: _isaac_engine().render(camera_name="default", width=bad))
+        newton_verdict = _verdict(
+            lambda: NewtonSimEngine.render(_newton_stub(), camera_name="default", width=bad)  # type: ignore[arg-type]
+        )
+        assert mujoco_verdict == newton_verdict == isaac_verdict == "refused", (
+            f"width={bad!r}: mujoco={mujoco_verdict}, newton={newton_verdict}, isaac={isaac_verdict}"
+        )
+
+    @pytest.mark.parametrize("good", (16, 320, 640))
+    def test_a_usable_dimension_is_accepted_everywhere(self, mj_sim, good):
+        """The guard is a floor, not a tightening: ordinary sizes still work."""
+        assert _verdict(lambda: mj_sim.add_camera(name=f"ok_{good}", width=good, height=good)) == "accepted"
+        assert _verdict(lambda: _newton_add_camera(_newton_stub(), name="ok", width=good, height=good)) == "accepted"
+        assert _verdict(lambda: _isaac_engine().add_camera(name="ok", width=good, height=good)) == "accepted"
+
+
+class TestTheVerdictClassifier:
+    """The helper the parity tests share must not absorb control flow.
+
+    :func:`_verdict` turns one call into ``"refused"`` / ``"accepted"`` /
+    ``"raised X"`` so a divergence between three backends is reported in a
+    single assertion message. That reporting is sound only for exceptions the
+    API leaked, so the boundary is pinned here in both directions: a classifier
+    that also caught pytest's own outcomes would report a skipped optional
+    dependency as a failure, and an interrupted run as a verdict.
+    """
+
+    def test_an_envelope_is_classified_by_its_status(self):
+        """The two ordinary outcomes: a structured refusal and an acceptance."""
+        assert _verdict(lambda: {"status": "error"}) == "refused"
+        assert _verdict(lambda: {"status": "success"}) == "accepted"
+
+    @pytest.mark.parametrize("leaked", [ValueError, TypeError, OverflowError])
+    def test_an_exception_the_api_leaked_becomes_a_verdict(self, leaked):
+        """Each type the pre-fix backends leaked out of ``int()`` is still reported.
+
+        Reporting rather than propagating is what stops the parity tests passing
+        against code that raises instead of refusing, so it has to survive the
+        narrowing of the caught set.
+        """
+
+        def leak() -> dict[str, Any]:
+            raise leaked("leaked past the tool-result contract")
+
+        assert _verdict(leak) == f"raised {leaked.__name__}"
+
+    @pytest.mark.parametrize(
+        "control_flow",
+        [pytest.skip.Exception, pytest.fail.Exception, KeyboardInterrupt, SystemExit],
+    )
+    def test_control_flow_is_not_absorbed(self, control_flow):
+        """A pytest outcome or an operator interrupt passes straight through.
+
+        All four derive from ``BaseException`` without deriving from
+        ``Exception``, and none of them is the API's to leak. Absorbing them
+        would turn a skipped dependency into a failure and a ``Ctrl-C`` into the
+        string ``"raised KeyboardInterrupt"``, compared against the other
+        backends' verdicts as though it were an answer.
+        """
+
+        def interrupted() -> dict[str, Any]:
+            raise control_flow("not the API's to leak")
+
+        with pytest.raises(control_flow):
+            _verdict(interrupted)


### PR DESCRIPTION
Closes #1762.

`width` / `height` reach two surfaces on every simulation backend - the `add_camera` that fixes a camera's resolution, and the render family (`render` / `get_frame` / `get_camera_params`) that can override it per call. MuJoCo validated both through `_validate_render_dims`; Newton and Isaac validated neither and coerced with a bare `int(...)`. Coercion is validation only when the coercion rejects, and these rejected nothing useful.

## The gap, measured

Requested `width`, on each backend. MuJoCo is the reference and is unchanged by this PR.

| requested `width` | MuJoCo `add_camera` | Newton `add_camera` | Isaac `add_camera` | Newton render | Isaac render |
|---|---|---|---|---|---|
| `0` | refused | **accepted**, stored `0` | **accepted**, stored `640` | **rendered 640x480** | **rendered 640x480** |
| `-4` | refused | **accepted**, stored `-4` | **accepted**, stored `-4` | **resolved -4x480** | raised `ValueError` |
| `2.7` | refused | **accepted**, stored `2` | **accepted**, stored `2` | **resolved 2x480** | raised `TypeError` |
| `True` | refused | **accepted**, stored `1` | **accepted**, stored `1` | **resolved 1x480** | raised `TypeError` |
| `"big"` | refused | raised `ValueError` | raised `ValueError` | raised `ValueError` | raised `TypeError` |
| `nan` | refused | raised `ValueError` | raised `ValueError` | raised `ValueError` | raised `TypeError` |
| `inf` | refused | raised `OverflowError` | raised `OverflowError` | raised `OverflowError` | raised `TypeError` |

Four distinct failure classes:

**An exception through the tool-result contract.** `add_camera(width="big")` raised `ValueError: invalid literal for int() with base 10: 'big'` out of the call; `None` a `TypeError`, `nan` a `ValueError`, `inf` an `OverflowError`. On Isaac the `int()` sat *outside* the method's try block, so none of them could even be converted into an error envelope. Every `AgentTool` handler owes its caller a structured result.

**A camera that cannot produce a frame, reported as success.** `add_camera(width=0, height=-4)` returned `status="success"` and stored the values, deferring the failure to the first render - far from the call that caused it.

**Truthiness where membership was meant.** `int(width or default)` reads a falsy `0` as *omitted*, so a caller who asked for an impossible resolution was handed the default and told it was what they requested. This is the hardest of the four to notice, and it is the same shape as the `position or <default>` bug `coerce_pose_vector`'s docstring already documents.

**Silent truncation, with the success text disagreeing with the registry.** `width=2.7` stored 2 and `True` stored 1, while Newton's success message interpolated the caller's raw value - announcing `Camera 'cam' added (2.7x480, ...)` for a camera that is 2 pixels wide.

## The consequence on Isaac's RTX path

A stored non-positive width is not merely a mis-sized frame there. `add_camera` raises the native render size to `_MIN_RENDER_PX` when the request is below it, preserving aspect ratio via `scale = _MIN_RENDER_PX / w` - which is negative for a negative `w`:

| caller asked | `add_camera` | native render size | first render |
|---|---|---|---|
| `width=0` | success | `640 x 480` (default substituted) | 640x480 |
| `width=-4` | success | **`640 x -76800`** | `ValueError: negative dimensions are not allowed` |
| `width=320` | success | `640 x 960` | 640x960 |

One bad configuration call disabled that camera for the rest of the session, and the failure surfaced at an unrelated render. The `width=320` row is the control: the DLSS upscale itself is correct and is unchanged.

## The change

Both backends' `add_camera` and render family now validate on `strands_robots.utils.positive_count_error` - the domain MuJoCo's floor already implements: a true `int` (`bool` refused, since it is an `int` subclass whose `True` would act as a silent 1) that is `>= 1`.

No new helper. A pixel dimension is consumed directly as an array or framebuffer dimension, where an integral float raises `TypeError` rather than being coerced - which is verbatim the reason `positive_count_error`'s docstring already gives for existing separately from the looser `positive_whole_number_error` used for frame rates. Its docstring now names pixel dimensions as the second family of the same rule rather than a second helper being introduced for them.

- **Newton** - `add_camera`, plus `_resolve_camera_view`, the funnel `render` / `get_frame` / `get_camera_params` share, so one guard covers all three. It raises `ValueError`, which `render` already converts into a structured error and which `get_frame` / `get_camera_params` propagate as their docstrings state.
- **Isaac** - `add_camera`, `_render_frame` (behind `render` and `get_frame`), and `get_camera_params`, whose native-resolution comparison coerced with `int(arg)` and so reported a non-numeric value without naming the parameter.
- `None` still means "take the configured default" on every surface that accepts it; membership decides that, not truthiness.
- The **upper** bound stays backend-specific. MuJoCo has an offscreen framebuffer to overflow and the ray tracers do not, so a 5000-pixel-wide Newton camera keeps working and the parity test pins agreement on the floor only.

MuJoCo is not touched: its floor is already this rule, and parity is pinned by a test rather than by sharing the message text, which keeps every existing message pin intact.

## Artifact

Every cell below is a measurement dumped by one script run against both trees; the figure generator re-derives each caption from those dumps and asserts them before saving.

![camera pixel-count domain, measured across backends](https://raw.githubusercontent.com/cagataycali/robots/artifacts/camera-pixel-count/pixel_domain.png)

The bottom-right panel is a real headless render taken through `add_camera(width=320, height=240)` -> `render(...)`, confirming the accepted path is unchanged.

## Tests

`tests/simulation/test_camera_pixel_count_domain.py`, 228 tests. Per-backend behavioural coverage of both surfaces, plus a three-way parity class asserting MuJoCo / Newton / Isaac reach the same verdict for every probe value, so the floors cannot drift apart again. Everything runs without `newton` / `warp` / Isaac Sim or a GPU: the validation precedes any solver or stage access, so the newton-free stub and the `__new__` Isaac skeleton the sibling `add_camera` tests already establish exercise it in every environment.

Non-vacuity pins, so a weakened guard cannot make the file pass:

- Every probe value is asserted to be outside `positive_count_error`'s domain, and every accepted value inside it.
- `np.zeros((480, 640.0, 3))` is asserted to raise `TypeError`, which is *why* an integral float belongs outside this domain even though the frame-rate domain accepts it.
- The DLSS arithmetic is pinned directly: `int(round(480 * (_MIN_RENDER_PX / -4))) == -76800`, and that dimension is asserted to raise in `np.zeros`.
- A refusal is asserted to leave no partial state - the camera name is still free, and Isaac's prim recorder never fired, so nothing reached the stage.
- Accepted values, omitted values (`None` -> default) and a 5000-wide camera are all asserted to keep working.

**Pre-fix:** 174 failed / 46 passed at `32dc3f5b`. **Post-fix:** 228 passed. The 46 that pass pre-fix are the domain premises and accepted-value controls - the guards that stop this change over-reaching.

## Gate

```
ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ 971 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 968 source files
MUJOCO_GL=egl pytest tests -q                       14663 passed, 255 skipped in 459s
python scripts/assemble_changelog.py --check        changelog fragments OK
```

No existing test changed: the guard is a floor added where there was none, so nothing that previously worked is now refused.

## Out of scope

While measuring this I found the same divergence on the media surfaces, where a render pixel count is validated on the looser frame-rate domain instead: `start_cameras_recording(width=640.0, fps=10)` returns `status="success"`, then writes `0 frames (10 errors)` because every render refuses `640.0`, and `stop_cameras_recording` also reports success. `VideoConfig`'s `width` / `height` feed `sim.render(...)` through the same looser check. That is a different parameter set on a different surface with its own symptom, so it is filed separately rather than folded in here.

## Round 2 - the parity test's verdict classifier catches `Exception`

`_verdict` turns one call into `"refused"` / `"accepted"` / `"raised X"` so a divergence between three backends lands in a single assertion message. It caught `BaseException`, which was wider than that job needs.

Narrowing it to `Exception` costs nothing, because every type the pre-fix code leaked out of `int()` is an `Exception`:

| call | `except BaseException` (previous head) | `except Exception` (now) |
|---|---|---|
| `int("big")` -> ValueError | `'raised ValueError'` | `'raised ValueError'` |
| `int(None)` -> TypeError | `'raised TypeError'` | `'raised TypeError'` |
| `int(inf)` -> OverflowError | `'raised OverflowError'` | `'raised OverflowError'` |
| `{"status": "error"}` | `'refused'` | `'refused'` |
| `{"status": "success"}` | `'accepted'` | `'accepted'` |
| `pytest.skip()` -> `Skipped` | `'raised Skipped'` | **propagates** |
| `pytest.fail()` -> `Failed` | `'raised Failed'` | **propagates** |
| Ctrl-C -> `KeyboardInterrupt` | `'raised KeyboardInterrupt'` | **propagates** |
| `SystemExit` | `'raised SystemExit'` | **propagates** |

All five API outcomes are reported identically, so no discrimination is lost. What the wider set additionally absorbed was control flow that is not the API's to leak: `Skipped` / `Failed` / `KeyboardInterrupt` / `SystemExit` all derive from `BaseException` without deriving from `Exception`, so an interrupted run became the verdict string `"raised KeyboardInterrupt"` and was then compared against the other two backends as though it were an answer, and an `importorskip` inside one of the helpers would surface as a failure rather than a skip.

Two changes came with it:

- `_verdict` is promoted from a `@staticmethod` on the parity class to a module-level helper, alongside the file's existing `_newton_stub` / `_newton_add_camera` / `_newton_resolve`. That is the file's own convention, and it makes the classifier testable without reaching into a test class's privates.
- `TestTheVerdictClassifier` (8 tests) pins the boundary in both directions, so neither the reporting behaviour nor the control-flow passthrough can regress. The helper's docstring now states where the boundary sits and why.

Pre-fix for the new class - this file with `BaseException` restored and everything else identical - is `4 failed, 4 passed`: the failures are all `test_control_flow_is_not_absorbed[...]` (`DID NOT RAISE Skipped` / `Failed` / `KeyboardInterrupt` / `SystemExit`), and the 4 that pass are the reporting property the narrowing preserves.

No production code changed in this round, so the measured behaviour and the artifact above are unaffected.
