### PR TITLE
test(sim): retire the tendon-ownership premise that #1766 invalidated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,29 @@ hatch run format            # ruff check --fix, ruff format
    `statusCheckRollup.state == SUCCESS` and `mergeStateStatus == CLEAN`
    together, since `reviewDecision` flips before the checks finish.
 
+   Those three together are still not sufficient. They are all evaluated against
+   the base the branch was tested on, so none of them can see a **semantic**
+   conflict with a PR that landed on `main` after those checks ran. #1766 and
+   #1763 both edited `_recompile_preserving_state` for unrelated reasons: the
+   text merged with no conflict, #1763 stayed `MERGEABLE`/`CLEAN` with
+   `SUCCESS` checks after #1766 landed, and the squash still broke `main`,
+   because #1763 carried a *premise* test asserting the very defect #1766 had
+   just fixed. Neither PR's CI ever compiled the two together.
+
+   So when a second approved PR touches a file - especially a function - that a
+   just-merged PR also touched, do not merge on the green alone. Merge `main`
+   into the branch (or check out the merge locally) and run the affected tests
+   before issuing the mutation. A `CLEAN` status is a statement about text, not
+   about meaning. This is cheap: the check that would have caught the above was
+   one `pytest` invocation on two files.
+
+   Fixing forward beats reverting here - the two production changes were both
+   correct, and only an assertion and its justification were stale. Prefer a
+   narrow follow-up that re-pins the invalidated premise over reverting a
+   reviewed change. If a premise test is invalidated by a fix landing, replace it
+   rather than deleting it: the conclusion it supported usually still holds for a
+   different reason, and that reason is what the next reader needs.
+
    The general rule behind all three: **a decision recorded only in a PR or
    issue comment is not durable** - the next contributor will not read the same
    comment. If a decision must survive, it belongs in this file.

--- a/changelog.d/1763-add-robot-scoped-reset.md
+++ b/changelog.d/1763-add-robot-scoped-reset.md
@@ -29,7 +29,10 @@ every held pose in the scene, on the runs where the leftover memory happened to
 be NaN. Those entries are now defined as zero as part of the recompile, before
 anything reads them, which also removes the intermittent
 `Nan, Inf or huge value in CTRL` instability warning that scene mutations could
-already emit. This is done for every actuator rather than per robot, because a
-robot's actuator ids are matched through `actuator_trnid` against its joint ids
-and so exclude any actuator driven through a tendon, site or body - the fixed
-tendon that couples a gripper's fingers, for instance.
+already emit. Those entries are defined positionally - every index the transfer
+left untouched - rather than per robot, because the two answer different
+questions: a robot's actuator ids say *which robot may command an actuator*,
+while the tail says *which entries were never written*, and MuJoCo's check reads
+the whole buffer. Ownership is also not guaranteed to cover the tail: it is empty
+for an actuator that is neither namespace-prefixed nor joint-driven, such as the
+fixed tendon that couples a gripper's fingers.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1511,12 +1511,18 @@ class MuJoCoSimEngine(
         new entry is the recompile's job -- ``_recompile_preserving_state``
         zeroes the tail its positional state transfer leaves undefined, before
         anything reads it. Repeating that here by iterating ``actuator_ids``
-        would be both narrower and less safe: those ids are discovered by
-        matching ``actuator_trnid`` against the robot's joint ids, so an
-        actuator whose transmission is not a joint -- the fixed tendon that
-        couples a gripper's fingers, say -- is missing from the robot that owns
-        it and, because tendon and joint ids are separate id spaces that
-        collide, claimed by whichever robot owns the joint of the same number.
+        would be both narrower and less safe, because the two answer different
+        questions: ``actuator_ids`` is ownership -- which robot may command an
+        actuator -- whereas the tail is a memory fact about which entries the
+        positional transfer never wrote. ``mj_checkCtrl`` reads the whole buffer,
+        so the obligation is positional and unconditional, while ownership is
+        derived and not guaranteed to cover the tail:
+        :func:`~strands_robots.simulation.mujoco.scene_ops.robot_owned_actuator_ids`
+        returns an empty list for an actuator that is neither namespace-prefixed
+        nor joint-driven -- the fixed tendon that couples a gripper's fingers,
+        say, whose transmission is gated out of the driven-joint match by design.
+        Sourcing initialization from it would make this method silently wrong
+        wherever ownership is not a complete cover.
 
         Args:
             robot: The robot to reset. Its ``joint_ids`` are the post-recompile

--- a/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
+++ b/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
@@ -20,14 +20,17 @@ The clean state the new robot is owed includes its actuator setpoints, and the
 world-wide reset used to supply those as collateral. ``spec.recompile`` transfers
 state POSITIONALLY and leaves ``ctrl`` past the old ``nu`` uninitialized, so with
 the world-wide reset gone the new entries have to be defined deliberately -- and
-scoping that to the robot's ``actuator_ids`` is not enough, because those are
-matched through ``actuator_trnid`` against joint ids and miss every actuator
-driven through a tendon, site or body. A single undefined entry is not a harmless
+the robot's ``actuator_ids`` are not the basis for that, because ownership and
+initialization are different questions. Ownership says which robot may command an
+actuator; the tail says which entries the positional transfer never wrote, and
+``mj_checkCtrl`` reads the whole buffer rather than any robot's subset. A single
+undefined entry is not a harmless
 nonsense number: ``mj_checkCtrl`` disables actuation for the whole model on any
 step where one ``ctrl`` value is non-finite, so every held pose in the scene
 collapses on the runs where the leftover memory happens to be NaN.
 """
 
+import dataclasses
 import math
 import pathlib
 import re
@@ -37,6 +40,7 @@ import pytest
 mj = pytest.importorskip("mujoco")
 
 from strands_robots.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
 
 # Two-link arm with position servos. Damped and limited so a commanded setpoint
 # settles instead of oscillating, and declared in radians (MuJoCo's compiler
@@ -75,8 +79,9 @@ _BASE_XML = """<mujoco model="probe_base">
 </mujoco>"""
 
 # Gripper driven through a FIXED TENDON: the standard MJCF idiom for coupled
-# fingers, and a transmission that ``actuator_trnid``-vs-joint-id matching cannot
-# see. Its ``ctrl`` entry is therefore the one a robot-scoped reset would miss.
+# fingers, and a transmission the driven-joint rule cannot address at all. Its
+# ``ctrl`` entry is therefore the one a robot-scoped reset would miss wherever the
+# attach namespace that does reach it is absent.
 _GRIPPER_XML = """<mujoco model="probe_gripper">
   <compiler angle="radian"/>
   <worldbody>
@@ -262,13 +267,19 @@ def test_a_keyframe_spawned_arm_is_not_snapped_back_to_its_home_pose(sim, models
     assert _joints(sim, "a") == pytest.approx(parked, abs=1e-6)
 
 
-def test_a_tendon_driven_actuator_is_outside_the_joint_matched_id_scope(sim, models):
-    """Premise: per-robot ``actuator_ids`` cannot see a non-joint transmission.
+def test_a_tendon_driven_actuator_is_owned_only_through_its_namespace(sim, models):
+    """Premise: ownership reaches a non-joint transmission by namespace or not at all.
 
     This is the reason the new robot's setpoints are defined by the recompile
-    rather than by iterating the robot's own actuator ids, so it is pinned
-    independently: it holds before and after that change, and if it ever stops
-    holding, the narrower scope becomes viable and this file should say so.
+    rather than by iterating the robot's own actuator ids, so it is pinned here
+    independently of the code that consumes it.
+
+    A fixed tendon is not addressable by the driven-joint rule: the transmission
+    gate returns -1 for it deliberately, because tendon and joint ids are separate
+    spaces that collide. Here the attach prefix settles ownership, so the gripper
+    belongs to the robot carrying it. Strip that prefix and ownership is empty --
+    which is why it is not a safe basis for deciding which ``ctrl`` entries the
+    recompile must define.
     """
     assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
     assert sim.add_robot(name="g", urdf_path=models["gripper"])["status"] == "success"
@@ -279,10 +290,22 @@ def test_a_tendon_driven_actuator_is_outside_the_joint_matched_id_scope(sim, mod
     assert int(model.actuator_trntype[grip_id]) == int(mj.mjtTrn.mjTRN_TENDON)
 
     robots = sim._world.robots
-    # Absent from the robot that owns it ...
-    assert grip_id not in robots["g"].actuator_ids
-    # ... and claimed by the arm, because the tendon's id collides with a joint id.
-    assert grip_id in robots["a"].actuator_ids
+    # The collision is live: the tendon's own id equals one of the arm's joint ids,
+    # which is what the transmission gate exists to stop being read as one.
+    assert int(model.actuator_trnid[grip_id, 0]) in set(robots["a"].joint_ids)
+    assert scene_ops.actuator_joint_id(model, grip_id, mj) == -1
+
+    # Owned by the robot that carries it, through the attach prefix ...
+    assert grip_id in robots["g"].actuator_ids
+    # ... and not claimed by the arm whose joint id the tendon's id equals.
+    assert grip_id not in robots["a"].actuator_ids
+
+    # Without that prefix neither rule reaches it, even though this robot lists the
+    # very finger joints the tendon couples. Initialization cannot be sourced from a
+    # set that can legitimately be empty.
+    bare = dataclasses.replace(robots["g"], namespace="")
+    assert bare.joint_ids == robots["g"].joint_ids != []
+    assert scene_ops.robot_owned_actuator_ids(model, bare, mj) == []
 
 
 def test_the_added_robots_actuator_setpoints_are_defined(sim, models):
@@ -338,9 +361,10 @@ def hostile_leftovers(monkeypatch):
 def test_an_undefined_control_entry_does_not_survive_the_recompile(sim, models, hostile_leftovers):
     """A new setpoint is defined even when the memory behind it was not.
 
-    Definition happens as part of the recompile, so it covers the tendon-driven
-    actuator that no per-robot id scope can reach, and it happens before the
-    forward pass at the end of the recompile reads ``ctrl``.
+    Definition happens as part of the recompile, so it covers every entry the
+    positional transfer left untouched -- including the tendon-driven actuator the
+    driven-joint rule cannot address -- and it happens before the forward pass at
+    the end of the recompile reads ``ctrl``.
 
     Both halves are asserted, so neither can be satisfied by the other: the new
     entries are defined, AND the setpoints already in the scene are left alone.


### PR DESCRIPTION
## `main` is red

`main` at `0e636f8` fails a test it inherited from a PR whose own checks were green:

```
MUJOCO_GL=... pytest tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
FAILED test_a_tendon_driven_actuator_is_outside_the_joint_matched_id_scope
        assert grip_id not in robots["g"].actuator_ids
        AssertionError: assert 2 not in [2]
1 failed, 9 passed
```

## Why no check could catch it

#1766 and #1763 both edit `_recompile_preserving_state`, for unrelated reasons. #1766 corrected how a robot's actuators are scoped; #1763 defined the `ctrl`/`act` entries a recompile leaves undefined. They touch different lines, so:

| | |
|---|---|
| git text merge | clean, no conflict markers |
| `mergeable` / `mergeStateStatus` on #1763 | `MERGEABLE` / `CLEAN` after #1766 landed |
| #1763's `statusCheckRollup` | `SUCCESS` - but measured against base `32dc3f5b`, which **predates** #1766 |
| #1766's checks | green against a base without #1763 |

Neither PR's CI ever compiled the two together, and the merge queue had nothing textual to report. The conflict is purely semantic, and it lands on a test #1763 wrote as a *premise*: that a fixed tendon's actuator is missing from the robot carrying it and claimed by whichever robot owns the joint whose id equals the tendon's. That premise described the exact defect #1766 then fixed.

That test was written anticipating this: *"it holds before and after that change, and if it ever stops holding, the narrower scope becomes viable and this file should say so."* This PR says so.

## Measured on `main`

`g/grip_act` is actuator 2, `trntype=3` (`mjTRN_TENDON`), `trnid[2,0]=0`. The id collision is still live - joint `0` is `a/pan`. What changed is that the collision is no longer *read* as a joint:

| | before #1766 | on `main` now |
|---|---|---|
| `actuator_joint_id(m, 2, mj)` | helper did not exist | `-1` |
| `g.actuator_ids` (carries the tendon) | `[]` | `[2]` |
| `a.actuator_ids` (owns joint 0) | `[0, 1, 2]` | `[0, 1]` |

#1766 is right and #1763's production change is right. Only the premise and its justification are stale.

## Is the narrower per-robot scope now viable?

No - and this is the substantive question, since answering "yes" would mean reverting #1763's production change.

On `main` the new `ctrl` tail *happens* to be covered by ownership, because `add_robot` attaches with a namespace prefix and #1766's prefix rule reaches every actuator it merges in. But that is a coincidence of one call path, not a property `_recompile_preserving_state` can rely on. The two answer different questions:

- `actuator_ids` is **ownership** - which robot may command an actuator.
- The tail is a **memory fact** - which entries the positional state transfer never wrote.

`mj_checkCtrl` reads the whole `ctrl` buffer, so the obligation is positional and unconditional. Ownership is derived, and can legitimately be empty. Measured on `main`, `robot_owned_actuator_ids` returns `[]` for the tendon actuator once its namespace is stripped - *even with the coupled finger joints listed* - because the transmission gate correctly refuses to match it:

```
bare namespace, no joint match       -> []
bare namespace, real finger joints   -> []
```

Sourcing buffer initialization from a set that can legitimately be empty would make the recompile silently wrong wherever ownership is not a complete cover. So the production change stands unaltered; only the justification and its pin move.

## Change

**No production behaviour changes.** Three files, all text and one test:

- `tests/simulation/mujoco/test_add_robot_preserves_scene_state.py` - the premise test becomes `test_a_tendon_driven_actuator_is_owned_only_through_its_namespace`, pinning the post-#1766 truth in four assertions: the live id collision, the gate returning `-1`, ownership settled by the prefix (present in `g`, absent from `a`), and empty ownership once the prefix is stripped. Module docstring and gripper fixture comment rewritten off the stale `actuator_trnid`-misses-tendons framing.
- `strands_robots/simulation/mujoco/simulation.py` - `_reset_robot_state`'s rationale for delegating setpoints to the recompile, restated as positional-vs-ownership. Docstring only.
- `changelog.d/1763-add-robot-scoped-reset.md` - same correction. The existing fragment is edited rather than a new one added, because no user-facing behaviour changes here; this corrects the record of a change already captured.

Test count is unchanged at 10 - one test was replaced, not added.

## Gate

```
pytest test_add_robot_preserves_scene_state.py \
       test_actuator_ownership_by_transmission.py   23 passed  (1 failed / 22 passed on main)
ruff check strands_robots tests                     All checks passed!
ruff format --check strands_robots tests            935 files already formatted
scripts/assemble_changelog.py --check               changelog fragments OK
```

The full `tests/simulation` failure set is identical to `main`'s in the environment used here (EGL unavailable, so 388 render-dependent failures on both sides; `comm` reports zero introduced and zero fixed). The authoritative `MUJOCO_GL=egl` run belongs to CI on this PR.

## Follow-up worth considering separately

This class of break is invisible to every current gate. Requiring branches to be up to date with `main` before merge (`mergeStateStatus: BEHIND` instead of `CLEAN`) would have forced #1763's checks to re-run against a base containing #1766, and caught it. Filing that as an infrastructure issue rather than folding it in here.

## The durable half: AGENTS.md

The second commit amends the merge gate in `AGENTS.md`, because this incident falsified it. That paragraph currently reads:

> before merging, `reviewDecision: APPROVED` alone is not the gate: poll `statusCheckRollup.state == SUCCESS` and `mergeStateStatus == CLEAN` together

All three held here, and the squash still broke `main`. The missing property is that every signal in that gate is evaluated against the base the branch was tested on, so none of them can see a conflict introduced by a merge that happened afterwards. The amendment records:

- what the three signals cannot see, with this pair as the worked example;
- the missing step - when a second approved PR touches a file, especially a function, that a just-merged PR also touched, merge `main` into the branch and run the affected tests before issuing the mutation. One `pytest` invocation on two files would have caught this;
- the fix-forward preference, and specifically that an invalidated *premise* test should be replaced rather than deleted, since the conclusion it supported usually still holds for a different reason - which is exactly the situation here.

`AGENTS.md` itself says a decision recorded only in a PR comment is not durable, so this belongs in the file rather than in this description.
