### PR TITLE
ci: refuse a pull request whose base moved under the files it edits

### DIFF
--- a/.github/workflows/merge-base-overlap.yml
+++ b/.github/workflows/merge-base-overlap.yml
@@ -1,0 +1,78 @@
+# .github/workflows/merge-base-overlap.yml
+#
+# Reports the files a pull request edits that its base branch also changed since
+# the two diverged. A non-empty overlap means the combination has never been
+# compiled: every check on the branch ran against a base that predates those
+# commits, so a green result is evidence about a different tree than the one
+# that would be merged.
+#
+# This exists because `main` went red at 0e636f8 from two individually green,
+# textually non-conflicting pull requests (#1766 and #1763) that both edited
+# _recompile_preserving_state in scene_ops.py. See issue #1770 and
+# scripts/check_merge_base_overlap.py for the full account.
+#
+# It is the targeted form of branch protection's "Require branches to be up to
+# date before merging": that setting demands an update plus a full re-run before
+# every merge, this one only when the branch and its base actually edited the
+# same file. The remedy is self-clearing - merging the base advances the merge
+# base, which both empties the overlap and re-runs the checks against a base
+# containing the landed commits - so no bypass switch is needed.
+#
+# Whether a failure here blocks a merge is a branch-protection decision, not a
+# property of this file. Until the job is added to the required set it surfaces
+# the overlap and leaves the call to the reviewer.
+#
+
+name: Merge Base Overlap Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  overlap:
+    name: Detect an untested overlap with the base branch
+    runs-on: ubuntu-latest
+
+    steps:
+      # The pull request HEAD, deliberately not the default
+      # refs/pull/<n>/merge commit: that commit already contains the base tip,
+      # so the merge base would be the base tip, the base-side path set would be
+      # empty, and this check would pass unconditionally without saying it had
+      # stopped testing anything. Pinned by
+      # tests/test_merge_base_overlap.py::test_a_merge_commit_head_defeats_the_check
+      - name: Checkout the pull request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history: a merge base cannot be computed in a shallow clone.
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Fetched explicitly rather than relying on the checkout above, which
+      # fetches the requested commit and not necessarily the base branch when
+      # `ref` is a SHA. Full depth for the same merge-base reason.
+      - name: Fetch the base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # Standard library only, so there is nothing to install. The script writes
+      # its report to the job summary and emits a file annotation per
+      # overlapping path.
+      - name: Check for an untested overlap with the base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python3 scripts/check_merge_base_overlap.py --base-ref "$BASE_REF"

--- a/changelog.d/1770-merge-base-overlap-check.md
+++ b/changelog.d/1770-merge-base-overlap-check.md
@@ -1,0 +1,35 @@
+### Added: a CI check that refuses a pull request whose base moved under the files it edits
+
+`main` went red at `0e636f8` from two pull requests that were each individually
+green and textually non-conflicting. #1766 and #1763 both edited
+`_recompile_preserving_state` in `strands_robots/simulation/mujoco/scene_ops.py`,
+for unrelated reasons. #1766 landed first, after which every signal the merge
+gate offers still read green on #1763 -- `reviewDecision: APPROVED`,
+`statusCheckRollup: SUCCESS`, `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`
+-- and the squash broke the suite anyway, because #1763 carried a *premise* test
+asserting the exact defect #1766 had just fixed.
+
+None of those four signals could have caught it. They are all computed against
+the base the branch was tested on, so the first evaluation of the two changes
+together was `main` itself. `mergeStateStatus: CLEAN` is a statement about
+**text**: git had no conflicting hunks to report, and it is not git's job to know
+that one branch's assertion describes the other branch's bug.
+
+`scripts/check_merge_base_overlap.py`, run by the new
+`Merge Base Overlap Check` workflow on every pull request, intersects the paths
+the branch edits since its merge base with the paths its base branch changed over
+the same span. A non-empty intersection does not prove the combination is broken;
+it proves the weaker and still blocking fact that **the combination has never
+been compiled**. For the pair above the intersection is one entry, `scene_ops.py`.
+
+The remedy is self-clearing: merging the base branch advances the merge base,
+which both empties the intersection and re-runs the checks against a base
+containing the landed commits. That is why the check ships with no bypass
+switch. An overlap confined to `.md` / `.rst` / `.txt` is reported without
+blocking, since prose cannot change what the suite or the package does and a
+genuine collision inside one surfaces as a merge conflict.
+
+This is the targeted form of branch protection's "Require branches to be up to
+date before merging", which demands an update plus a full ~14.7k-test re-run
+before every merge; this asks for one only when the branch and its base actually
+edited the same file.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Report the files a pull request edits that its base also changed since it branched.
+
+Why this exists
+---------------
+``main`` went red at ``0e636f8`` from two pull requests that were each
+individually green and textually non-conflicting. #1766 and #1763 both edit
+``_recompile_preserving_state`` in
+``strands_robots/simulation/mujoco/scene_ops.py``, for unrelated reasons. #1766
+landed first. Every signal the merge gate offers then read green on #1763 --
+``reviewDecision: APPROVED``, ``statusCheckRollup: SUCCESS``,
+``mergeable: MERGEABLE``, ``mergeStateStatus: CLEAN`` -- and the squash still
+broke the suite, because #1763 carried a *premise* test asserting the exact
+defect #1766 had just fixed::
+
+    FAILED test_a_tendon_driven_actuator_is_outside_the_joint_matched_id_scope
+            AssertionError: assert 2 not in [2]
+
+None of those four signals could have caught it. They are all computed against
+the base the branch was tested on: #1763's checks ran against ``32dc3f5b``,
+which predates #1766, so the first evaluation of the two changes *together* was
+``main`` itself. ``mergeStateStatus: CLEAN`` in particular is a statement about
+**text** -- git had no conflicting hunks to report, and it is not git's job to
+know that one branch's assertion describes the other branch's bug.
+
+What this computes
+------------------
+The overlap between two path sets, both taken from the branch's merge base ``M``
+with its base branch:
+
+- ``M..head`` -- what the pull request edits.
+- ``M..base`` -- what landed on the base branch after the pull request branched.
+
+A non-empty intersection does not prove the combination is broken. It proves
+something weaker and still worth blocking on: **the combination has never been
+compiled**, so every green check on the pull request is evidence about a tree
+that is not the tree being merged. For the pair above the intersection is
+exactly one entry, ``strands_robots/simulation/mujoco/scene_ops.py``, and one
+``pytest`` invocation over the two touched test files would have caught it.
+
+Why the remedy is cheap, and self-clearing
+------------------------------------------
+Merging the base branch into the pull request advances the merge base to the
+base tip. The ``M..base`` set becomes empty, so the intersection does too, and
+the checks then re-run against a base that *contains* the newly-landed commits.
+The check needs no override to clear: doing the thing it asks for makes it pass.
+
+This is the targeted form of branch protection's "Require branches to be up to
+date before merging". That setting demands an update plus a full re-run before
+*every* merge, which serialises merges and costs a ~14.7k-test suite each time.
+This demands one only when the branch and its base actually edited the same
+file, which is the only case where the base moving can invalidate a result.
+
+Prose is reported but does not block
+------------------------------------
+An overlap confined to ``.md`` / ``.rst`` / ``.txt`` cannot change what the test
+suite or the built package does; if two branches edit the same prose region, git
+reports a conflict and the merge gate already stops it. Those paths are listed
+in the report -- suppressing them entirely would hide a signal a reader may
+want -- but they do not set the exit status, so a docs PR that happens to share
+a file with a landed docs PR is not asked to re-run a full test suite for a
+result that cannot change.
+
+Usage
+-----
+``--base-ref``  the branch being merged into (default ``main``). Resolved as
+                ``origin/<ref>`` when that exists, else as ``<ref>``.
+``--head``      the commit under test (default ``HEAD``). In CI this must be the
+                pull request's *head* commit, never the
+                ``refs/pull/<n>/merge`` commit ``actions/checkout`` produces by
+                default -- that commit already contains the base tip, which
+                drives the merge base to the base tip and the overlap to the
+                empty set, so the check would pass unconditionally.
+``--repo``      repository root (default: the current working directory).
+
+Exit status is ``1`` when a behaviour-bearing path overlaps, else ``0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+#: Suffixes whose overlap cannot change the outcome of the test suite or the
+#: contents of the built package, and so is reported without blocking.
+PROSE_SUFFIXES = frozenset({".md", ".rst", ".txt"})
+
+
+class GitError(RuntimeError):
+    """A git invocation this script depends on did not succeed.
+
+    Raised rather than returning a sentinel: every caller here needs the real
+    commit or path set to say anything true, and a check that silently reports
+    "no overlap" because it could not reach the base branch is worse than one
+    that fails loudly. A missing base ref in CI is a workflow bug, not a
+    property of the pull request.
+    """
+
+
+def _git(*args: str, repo: Path | None = None) -> str:
+    """Run one git command and return its stdout, raising ``GitError`` on failure."""
+    command = ["git"]
+    if repo is not None:
+        command += ["-C", str(repo)]
+    command += list(args)
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise GitError(f"{' '.join(command)} exited {completed.returncode}: {completed.stderr.strip()}")
+    return completed.stdout
+
+
+def resolve_base_ref(base_ref: str, repo: Path | None = None) -> str:
+    """Return the revision to treat as the base branch tip.
+
+    Prefers the remote-tracking ref, because a CI checkout of a pull request
+    head usually has no local branch for the base: ``actions/checkout`` fetches
+    the base as ``refs/remotes/origin/<ref>`` and never creates ``<ref>``. Falls
+    back to the bare name so the script is runnable in a normal local clone.
+    """
+    for candidate in (f"origin/{base_ref}", base_ref):
+        try:
+            _git("rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}", repo=repo)
+        except GitError:
+            continue
+        return candidate
+    raise GitError(f"cannot resolve base ref {base_ref!r} as either 'origin/{base_ref}' or '{base_ref}'")
+
+
+def merge_base(base: str, head: str, repo: Path | None = None) -> str:
+    """Return the commit where ``head`` diverged from ``base``."""
+    revision = _git("merge-base", base, head, repo=repo).strip()
+    if not revision:
+        raise GitError(f"no merge base between {base!r} and {head!r} - is the history shallow?")
+    return revision
+
+
+def changed_paths(start: str, end: str, repo: Path | None = None) -> frozenset[str]:
+    """Return the paths that differ between two commits.
+
+    ``--no-renames`` is deliberate. With rename detection a file the base
+    renamed appears only under its new name, so a pull request still editing the
+    old name would not intersect it. Reporting a rename as its delete plus its
+    add puts both names in the set, which is the conservative direction for a
+    check whose failure mode is a missed overlap.
+    """
+    output = _git("diff", "--name-only", "--no-renames", f"{start}..{end}", repo=repo)
+    return frozenset(line for line in output.splitlines() if line)
+
+
+def is_prose(path: str) -> bool:
+    """Whether a path is documentation, and so reported without blocking."""
+    return Path(path).suffix.lower() in PROSE_SUFFIXES
+
+
+def partition_overlap(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Split overlapping paths into ``(behaviour_bearing, prose)``, each sorted.
+
+    Sorting is what makes the report and the annotations reproducible across
+    runs: ``git diff`` order follows the tree, and a set has no order at all.
+    """
+    ordered = sorted(set(paths))
+    return (
+        tuple(path for path in ordered if not is_prose(path)),
+        tuple(path for path in ordered if is_prose(path)),
+    )
+
+
+def overlapping_paths(pr_paths: Iterable[str], base_paths: Iterable[str]) -> tuple[str, ...]:
+    """Return the sorted paths edited both by the pull request and by its base."""
+    return tuple(sorted(frozenset(pr_paths) & frozenset(base_paths)))
+
+
+def render_report(
+    *,
+    base_ref: str,
+    merge_base_sha: str,
+    blocking: Sequence[str],
+    prose: Sequence[str],
+    base_change_count: int,
+) -> str:
+    """Render the Markdown report written to stdout and the CI job summary."""
+    lines = ["## Merge-base overlap check", ""]
+
+    if not blocking and not prose:
+        lines += [
+            f"No overlap. This branch edits nothing that `{base_ref}` has changed since "
+            f"the two diverged at `{merge_base_sha[:8]}` "
+            f"({base_change_count} path(s) changed on `{base_ref}` in that span).",
+            "",
+            "The checks on this branch were computed against a base that cannot have invalidated them.",
+        ]
+        return "\n".join(lines) + "\n"
+
+    if blocking:
+        lines += [
+            f"This branch and `{base_ref}` have both changed **{len(blocking)}** "
+            f"behaviour-bearing path(s) since they diverged at `{merge_base_sha[:8]}`:",
+            "",
+        ]
+        lines += [f"- `{path}`" for path in blocking]
+        lines += [
+            "",
+            "Every check on this branch ran against a base that predates those commits, "
+            "so the combination has not been compiled. A green result here is evidence "
+            "about a different tree than the one that would be merged.",
+            "",
+            "**To clear this:** merge "
+            f"`{base_ref}` into this branch and push. That advances the merge base, "
+            "re-runs the checks against a base containing the landed commits, and makes "
+            "this check pass. Run the tests covering the paths above first - that is "
+            "the cheap part, and it is what the check exists to prompt.",
+        ]
+
+    if prose:
+        if blocking:
+            lines += [""]
+        lines += [
+            f"Also overlapping, not blocking ({len(prose)} documentation path(s)) - "
+            "prose cannot change what the suite or the package does, and a genuine "
+            "collision inside one would surface as a merge conflict:",
+            "",
+        ]
+        lines += [f"- `{path}`" for path in prose]
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Compute the overlap and return the process exit status."""
+    parser = argparse.ArgumentParser(
+        prog="check_merge_base_overlap.py",
+        description="Report files a pull request edits that its base also changed since it branched.",
+    )
+    parser.add_argument("--base-ref", default="main", help="branch being merged into (default: main)")
+    parser.add_argument("--head", default="HEAD", help="commit under test (default: HEAD)")
+    parser.add_argument("--repo", default=None, help="repository root (default: current directory)")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo) if args.repo is not None else None
+
+    try:
+        base = resolve_base_ref(args.base_ref, repo=repo)
+        fork_point = merge_base(base, args.head, repo=repo)
+        pr_paths = changed_paths(fork_point, args.head, repo=repo)
+        base_paths = changed_paths(fork_point, base, repo=repo)
+    except GitError as error:
+        # Loud and non-zero: a check that cannot compute its answer must not
+        # report the reassuring one.
+        print(f"::error::merge-base overlap check could not run: {error}", file=sys.stderr)
+        return 1
+
+    blocking, prose = partition_overlap(overlapping_paths(pr_paths, base_paths))
+    report = render_report(
+        base_ref=args.base_ref,
+        merge_base_sha=fork_point,
+        blocking=blocking,
+        prose=prose,
+        base_change_count=len(base_paths),
+    )
+
+    print(report, end="")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report)
+
+    for path in blocking:
+        print(
+            f"::error file={path}::{path} was also changed on {args.base_ref} after this "
+            f"branch diverged; the checks on this branch never compiled the two together.",
+        )
+
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -182,48 +182,63 @@ def render_report(
     prose: Sequence[str],
     base_change_count: int,
 ) -> str:
-    """Render the Markdown report written to stdout and the CI job summary."""
+    """Render the Markdown report written to stdout and the CI job summary.
+
+    Every multi-line paragraph below is built as a named local with explicit
+    ``+`` rather than from adjacent literals inside the ``lines`` list. Implicit
+    concatenation there is indistinguishable from a forgotten comma: a paragraph
+    split across two elements silently becomes two report lines, and two
+    paragraphs missing their separator silently become one. The join that
+    produces the report cannot tell the difference, and neither can a reader.
+    """
     lines = ["## Merge-base overlap check", ""]
 
     if not blocking and not prose:
-        lines += [
+        no_overlap = (
             f"No overlap. This branch edits nothing that `{base_ref}` has changed since "
-            f"the two diverged at `{merge_base_sha[:8]}` "
-            f"({base_change_count} path(s) changed on `{base_ref}` in that span).",
-            "",
-            "The checks on this branch were computed against a base that cannot have invalidated them.",
-        ]
+            + f"the two diverged at `{merge_base_sha[:8]}` "
+            + f"({base_change_count} path(s) changed on `{base_ref}` in that span)."
+        )
+        lines.append(no_overlap)
+        lines.append("")
+        lines.append("The checks on this branch were computed against a base that cannot have invalidated them.")
         return "\n".join(lines) + "\n"
 
     if blocking:
-        lines += [
+        heading = (
             f"This branch and `{base_ref}` have both changed **{len(blocking)}** "
-            f"behaviour-bearing path(s) since they diverged at `{merge_base_sha[:8]}`:",
-            "",
-        ]
-        lines += [f"- `{path}`" for path in blocking]
-        lines += [
-            "",
+            + f"behaviour-bearing path(s) since they diverged at `{merge_base_sha[:8]}`:"
+        )
+        why = (
             "Every check on this branch ran against a base that predates those commits, "
-            "so the combination has not been compiled. A green result here is evidence "
-            "about a different tree than the one that would be merged.",
-            "",
+            + "so the combination has not been compiled. A green result here is evidence "
+            + "about a different tree than the one that would be merged."
+        )
+        remedy = (
             "**To clear this:** merge "
-            f"`{base_ref}` into this branch and push. That advances the merge base, "
-            "re-runs the checks against a base containing the landed commits, and makes "
-            "this check pass. Run the tests covering the paths above first - that is "
-            "the cheap part, and it is what the check exists to prompt.",
-        ]
+            + f"`{base_ref}` into this branch and push. That advances the merge base, "
+            + "re-runs the checks against a base containing the landed commits, and makes "
+            + "this check pass. Run the tests covering the paths above first - that is "
+            + "the cheap part, and it is what the check exists to prompt."
+        )
+        lines.append(heading)
+        lines.append("")
+        lines += [f"- `{path}`" for path in blocking]
+        lines.append("")
+        lines.append(why)
+        lines.append("")
+        lines.append(remedy)
 
     if prose:
         if blocking:
-            lines += [""]
-        lines += [
+            lines.append("")
+        prose_heading = (
             f"Also overlapping, not blocking ({len(prose)} documentation path(s)) - "
-            "prose cannot change what the suite or the package does, and a genuine "
-            "collision inside one would surface as a merge conflict:",
-            "",
-        ]
+            + "prose cannot change what the suite or the package does, and a genuine "
+            + "collision inside one would surface as a merge conflict:"
+        )
+        lines.append(prose_heading)
+        lines.append("")
         lines += [f"- `{path}`" for path in prose]
 
     return "\n".join(lines) + "\n"
@@ -270,10 +285,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             handle.write(report)
 
     for path in blocking:
-        print(
+        annotation = (
             f"::error file={path}::{path} was also changed on {args.base_ref} after this "
-            f"branch diverged; the checks on this branch never compiled the two together.",
+            + "branch diverged; the checks on this branch never compiled the two together."
         )
+        print(annotation)
 
     return 1 if blocking else 0
 

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -1,0 +1,348 @@
+"""Contract pins for the merge-base overlap check.
+
+``scripts/check_merge_base_overlap.py`` exists because four green signals are not
+enough to merge safely. #1766 and #1763 both edited
+``strands_robots/simulation/mujoco/scene_ops.py``; #1766 landed first; #1763 then
+read ``APPROVED`` / ``SUCCESS`` / ``MERGEABLE`` / ``CLEAN`` and its squash still
+broke ``main``, because it carried a premise test asserting the defect #1766 had
+just fixed. Every one of those signals is computed against the base the branch
+was tested on, so none of them can see it.
+
+The checks below pin the three properties that make the script worth having:
+
+- it **flags** the #1763/#1766 topology, replayed here as real commits in a real
+  repository rather than as a hand-built path set;
+- it is **self-clearing** -- merging the base branch makes it pass, so the
+  remedy it asks for is the remedy that satisfies it, with no override to add;
+- it is **quiet** where an overlap cannot matter: disjoint edits and prose-only
+  overlaps do not block.
+
+The git-topology tests are the load-bearing ones. The overlap is a statement
+about merge bases, and a merge base is exactly the thing a hand-built fixture
+would assume rather than exercise -- including the one way to get this wrong in
+CI, pinned by ``test_a_merge_commit_head_defeats_the_check``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check_merge_base_overlap.py"
+
+#: The file both #1766 and #1763 edited. Used verbatim in the replay so the
+#: pinned scenario is recognisable as the incident it came from.
+_SHARED = "strands_robots/simulation/mujoco/scene_ops.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_merge_base_overlap", _SCRIPT_PATH)
+    assert spec and spec.loader, f"cannot load {_SCRIPT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_merge_base_overlap"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_module()
+
+
+# --- git fixtures ---------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+def _write(repo: Path, relative: str, text: str) -> None:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+#: A file with enough distinct lines that two branches can edit it in regions far
+#: enough apart for git to merge them without a conflict -- which is the whole
+#: point of the incident: the text merged cleanly and the meaning did not.
+_SHARED_BODY = "\n".join(f"line {index}" for index in range(1, 41)) + "\n"
+
+
+def _edit_line(repo: Path, relative: str, line_number: int, text: str) -> None:
+    path = repo / relative
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines[line_number - 1] = text
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repository on ``main`` with one commit, ready to branch from."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "checks@example.invalid")
+    _git(root, "config", "user.name", "Merge Base Overlap Tests")
+    _git(root, "config", "commit.gpgsign", "false")
+    _write(root, _SHARED, _SHARED_BODY)
+    _write(root, "docs/simulation/world-building.md", "# World building\n\nOriginal prose.\n")
+    _commit(root, "initial commit")
+    return root
+
+
+def _branch_editing_shared(repo: Path) -> None:
+    """Branch off ``main`` and edit the shared file, as #1763 did."""
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _edit_line(repo, _SHARED, 40, "line 40  # edited by the pull request")
+    _write(repo, "tests/simulation/mujoco/test_add_robot_preserves_scene_state.py", "# premise test\n")
+    _commit(repo, "the pull request's commit")
+
+
+def _land_on_main_editing_shared(repo: Path) -> None:
+    """Land a commit on ``main`` touching the shared file, as #1766 did."""
+    _git(repo, "checkout", "-q", "main")
+    _edit_line(repo, _SHARED, 1, "line 1  # edited by the commit that landed first")
+    _commit(repo, "the commit that landed on main first")
+    _git(repo, "checkout", "-q", "pr")
+
+
+def _run(repo: Path) -> int:
+    return int(check.main(["--repo", str(repo), "--base-ref", "main", "--head", "HEAD"]))
+
+
+# --- the incident, replayed -----------------------------------------------------
+
+
+def test_the_1763_1766_pair_is_flagged(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The acceptance criterion: replayed, the pair that broke main is caught.
+
+    Both branches edit the shared file in regions git merges without complaint,
+    so this is not a conflict the existing gate would have stopped.
+    """
+    _branch_editing_shared(repo)
+    _land_on_main_editing_shared(repo)
+
+    assert _run(repo) == 1, "an untested combination must not report success"
+    out = capsys.readouterr().out
+    assert _SHARED in out, "the report must name the overlapping path"
+    assert "merge" in out and "main" in out, "the report must state the remedy"
+
+
+def test_the_pair_merges_without_a_text_conflict(repo: Path) -> None:
+    """Non-vacuity for the test above: git itself has nothing to report here.
+
+    If the two edits conflicted, the existing merge gate would already block the
+    merge and this check would be redundant. The incident happened precisely
+    because they did not.
+    """
+    _branch_editing_shared(repo)
+    _land_on_main_editing_shared(repo)
+
+    _git(repo, "merge", "--no-edit", "-q", "main")  # raises CalledProcessError on conflict
+    assert "line 1  # edited by the commit that landed first" in (repo / _SHARED).read_text(encoding="utf-8")
+    assert "line 40  # edited by the pull request" in (repo / _SHARED).read_text(encoding="utf-8")
+
+
+def test_merging_the_base_clears_the_check(repo: Path) -> None:
+    """Self-clearing: the remedy the report asks for is what makes it pass.
+
+    This is why the check needs no bypass label. Merging the base advances the
+    merge base to the base tip, which empties the base-side path set, and the
+    re-run then happens against a base containing the landed commits.
+    """
+    _branch_editing_shared(repo)
+    _land_on_main_editing_shared(repo)
+    assert _run(repo) == 1
+
+    _git(repo, "merge", "--no-edit", "-q", "main")
+
+    assert _run(repo) == 0, "after merging the base there is nothing untested left to flag"
+
+
+# --- where an overlap cannot matter ---------------------------------------------
+
+
+def test_an_unmoved_base_does_not_overlap(repo: Path) -> None:
+    _branch_editing_shared(repo)
+    assert _run(repo) == 0
+
+
+def test_disjoint_edits_do_not_overlap(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A base that moved under *other* files invalidates nothing."""
+    _branch_editing_shared(repo)
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, "strands_robots/policies/mock.py", "# unrelated landing\n")
+    _commit(repo, "an unrelated commit on main")
+    _git(repo, "checkout", "-q", "pr")
+
+    assert _run(repo) == 0
+    assert "No overlap" in capsys.readouterr().out
+
+
+def test_a_prose_only_overlap_is_reported_but_does_not_block(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Documentation cannot change what the suite does, so it does not gate."""
+    doc = "docs/simulation/world-building.md"
+    _git(repo, "checkout", "-q", "-b", "pr")
+    _write(repo, doc, "# World building\n\nOriginal prose.\n\nAdded by the pull request.\n")
+    _commit(repo, "docs from the pull request")
+
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, doc, "# World building\n\nRewritten on main.\n")
+    _commit(repo, "docs on main")
+    _git(repo, "checkout", "-q", "pr")
+
+    assert _run(repo) == 0, "a prose overlap must not demand a full re-run"
+    out = capsys.readouterr().out
+    assert doc in out, "it is still reported - the reader may want to know"
+    assert "not blocking" in out
+
+
+# --- the way to get this wrong in CI -------------------------------------------
+
+
+def test_a_merge_commit_head_defeats_the_check(repo: Path) -> None:
+    """Pins why the workflow must check out the head SHA, not the merge commit.
+
+    ``actions/checkout`` defaults to ``refs/pull/<n>/merge`` on a pull request.
+    That commit already contains the base tip, so the merge base *is* the base
+    tip, the base-side set is empty, and the check would pass unconditionally --
+    silently, with no signal that it had stopped testing anything.
+    """
+    _branch_editing_shared(repo)
+    _land_on_main_editing_shared(repo)
+    head = _git(repo, "rev-parse", "HEAD").strip()
+    assert _run(repo) == 1
+
+    _git(repo, "checkout", "-q", "-b", "simulated-merge-ref")
+    _git(repo, "merge", "--no-edit", "-q", "main")
+    merge_commit = _git(repo, "rev-parse", "HEAD").strip()
+    assert merge_commit != head
+
+    against_merge_commit = int(check.main(["--repo", str(repo), "--base-ref", "main", "--head", merge_commit]))
+    assert against_merge_commit == 0, (
+        "documents the trap: run against the merge commit and the check is vacuous, "
+        "which is why the workflow pins the head SHA"
+    )
+
+
+def test_a_rename_on_the_base_still_overlaps_the_old_path(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--no-renames`` keeps a renamed file's old name in the base-side set."""
+    _branch_editing_shared(repo)
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "mv", _SHARED, "strands_robots/simulation/mujoco/scene_operations.py")
+    _commit(repo, "rename on main")
+    _git(repo, "checkout", "-q", "pr")
+
+    assert _run(repo) == 1
+    assert _SHARED in capsys.readouterr().out
+
+
+def test_an_unresolvable_base_ref_fails_loudly(repo: Path) -> None:
+    """A check that cannot compute its answer must not report the reassuring one."""
+    _branch_editing_shared(repo)
+    assert int(check.main(["--repo", str(repo), "--base-ref", "no-such-branch", "--head", "HEAD"])) == 1
+
+
+def test_the_remote_tracking_ref_wins_over_a_local_branch(repo: Path) -> None:
+    """CI has only ``origin/<base>``, so that is what must be preferred.
+
+    Pinned by pointing ``origin/main`` at a commit that overlaps while the local
+    ``main`` does not: the check must follow the remote-tracking ref.
+    """
+    _branch_editing_shared(repo)
+    _git(repo, "checkout", "-q", "main")
+    _edit_line(repo, _SHARED, 1, "line 1  # only on the remote-tracking ref")
+    landed = _commit(repo, "a commit reachable only via origin/main")
+    _git(repo, "update-ref", "refs/remotes/origin/main", landed)
+    _git(repo, "reset", "-q", "--hard", "HEAD~1")  # local main no longer has it
+    _git(repo, "checkout", "-q", "pr")
+
+    assert check.resolve_base_ref("main", repo=repo) == "origin/main"
+    assert _run(repo) == 1, "the overlap is only visible through origin/main"
+
+
+# --- the pure core --------------------------------------------------------------
+
+
+def test_overlap_is_the_sorted_intersection() -> None:
+    assert check.overlapping_paths(["b.py", "a.py", "c.py"], ["c.py", "a.py"]) == ("a.py", "c.py")
+
+
+def test_overlap_is_empty_for_disjoint_sets() -> None:
+    assert check.overlapping_paths(["a.py"], ["b.py"]) == ()
+
+
+@pytest.mark.parametrize("path", ["CHANGELOG.md", "docs/guide.md", "notes.rst", "requirements.txt", "A.MD"])
+def test_prose_paths_are_classified_as_prose(path: str) -> None:
+    assert check.is_prose(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "strands_robots/simulation/mujoco/scene_ops.py",
+        "tests/test_thing.py",
+        "strands_robots/registry/robots.json",
+        "pyproject.toml",
+        "mkdocs.yml",
+        ".github/workflows/test-lint.yml",
+    ],
+)
+def test_behaviour_bearing_paths_are_not_classified_as_prose(path: str) -> None:
+    """Non-vacuity: the prose carve-out must not swallow anything that runs."""
+    assert not check.is_prose(path)
+
+
+def test_partition_splits_and_sorts() -> None:
+    blocking, prose = check.partition_overlap(["z.md", "b.py", "a.py", "a.md", "b.py"])
+    assert blocking == ("a.py", "b.py"), "deduplicated and sorted"
+    assert prose == ("a.md", "z.md")
+
+
+def test_report_names_every_blocking_path_and_the_remedy() -> None:
+    report = check.render_report(
+        base_ref="main",
+        merge_base_sha="32dc3f5b2ca5f226842e4f8e40aaa8e64108e383",
+        blocking=[_SHARED],
+        prose=["CHANGELOG.md"],
+        base_change_count=5,
+    )
+    assert _SHARED in report
+    assert "CHANGELOG.md" in report
+    assert "not blocking" in report
+    assert "32dc3f5b" in report, "the merge base is what makes the claim checkable"
+    assert "merge" in report
+
+
+def test_report_says_so_when_there_is_no_overlap() -> None:
+    report = check.render_report(
+        base_ref="main",
+        merge_base_sha="0123456789abcdef",
+        blocking=[],
+        prose=[],
+        base_change_count=0,
+    )
+    assert "No overlap" in report
+
+
+def test_no_emoji_in_the_script_or_its_output() -> None:
+    """Project rule: plain ASCII in anything an agent reads programmatically."""
+    source = _SCRIPT_PATH.read_text(encoding="utf-8")
+    offenders = [(index, char) for index, char in enumerate(source) if ord(char) > 0x7F]
+    assert offenders == [], f"non-ASCII in {_SCRIPT_PATH.name}: {offenders[:5]}"


### PR DESCRIPTION
Closes #1770.

`main` went red at `0e636f8` from two pull requests that were each individually green and textually non-conflicting. Every signal the merge gate offers read green on the second one, and the squash broke the suite anyway.

## What the gate could not see

#1766 and #1763 both edit `_recompile_preserving_state` in `strands_robots/simulation/mujoco/scene_ops.py`, for unrelated reasons - #1766 corrects per-robot actuator scoping, #1763 defines the `ctrl`/`act` entries a recompile leaves undefined. #1766 landed first. The signals on #1763 afterwards:

| signal on #1763, after #1766 landed | value |
|---|---|
| `reviewDecision` | `APPROVED` |
| `statusCheckRollup.state` | `SUCCESS` |
| `mergeable` | `MERGEABLE` |
| `mergeStateStatus` | `CLEAN` |

```
FAILED test_a_tendon_driven_actuator_is_outside_the_joint_matched_id_scope
        AssertionError: assert 2 not in [2]
```

#1763 carried a *premise* test asserting the exact defect #1766 had just fixed. All four signals are computed against the base the branch was tested on: #1763's checks ran against `32dc3f5b`, which predates #1766, so the first evaluation of the two changes together was `main` itself. `mergeStateStatus: CLEAN` in particular is a statement about **text** - git had no conflicting hunks to report, and it is not git's job to know that one branch's assertion describes the other branch's bug.

This is not specific to that pair. Any two branches that edit the same function, where one's assertions depend on the other's behaviour, reproduce it.

## The change

`scripts/check_merge_base_overlap.py` intersects two path sets, both taken from the branch's merge base `M` with its base branch:

- `M..head` - what the pull request edits.
- `M..base` - what landed on the base branch after the pull request branched.

A non-empty intersection does not prove the combination is broken. It proves something weaker and still worth blocking on: **the combination has never been compiled**, so every green check on the branch is evidence about a tree that is not the tree being merged.

## Measured, on the real commits

Not a hand-built fixture. Branch reconstructed at #1763's actual merge base (`32dc3f5b`) with #1763's content cherry-picked onto it, and `3aabba0` (#1766) as the base tip:

```
merge-base(base, HEAD) = 32dc3f5b

## Merge-base overlap check

This branch and `3aabba0` have both changed **1** behaviour-bearing path(s)
since they diverged at `32dc3f5b`:

- `strands_robots/simulation/mujoco/scene_ops.py`

Every check on this branch ran against a base that predates those commits, so
the combination has not been compiled. ...

exit=1
```

One entry, and it is the right one. Then the self-clearing property, on those same commits:

```
$ git merge --no-edit <base>
Auto-merging strands_robots/simulation/mujoco/scene_ops.py

## Merge-base overlap check

No overlap. This branch edits nothing that `<base>` has changed since the
two diverged at `3aabba09` (0 path(s) changed on `<base>` in that span).

exit=0
```

Note that `git merge` reports `Auto-merging`, not a conflict. That is the incident in one line: the text merged cleanly and the meaning did not.

## Why the remedy needs no bypass switch

Merging the base advances the merge base to the base tip. The `M..base` set becomes empty, so the intersection does too, and the checks then re-run against a base that *contains* the newly-landed commits. Doing the thing the check asks for is what makes it pass, so there is no override to add and none to leave lying around.

This is the targeted form of branch protection's "Require branches to be up to date before merging" (option 1 in the issue). That setting demands an update plus a full re-run before *every* merge, which serialises merges and costs a ~14.7k-test suite each time. This asks for one only when the branch and its base actually edited the same file - the only case where the base moving can invalidate a result.

## Prose is reported, and does not block

An overlap confined to `.md` / `.rst` / `.txt` cannot change what the suite or the built package does, and a genuine collision inside one surfaces as a merge conflict. Those paths are still listed - suppressing them would hide a signal a reader may want - but they do not set the exit status, so a docs PR sharing a file with a landed docs PR is not asked to re-run a test suite for a result that cannot change.

The carve-out is by suffix and is pinned in both directions: `.py`, `.json`, `.toml`, `.yml` and `.github/workflows/*.yml` are all asserted **not** to be prose, so it cannot quietly grow to swallow something that runs.

## The one way to get this wrong in CI

`actions/checkout` defaults to `refs/pull/<n>/merge` on a pull request. That commit already contains the base tip, so the merge base *is* the base tip, the base-side set is empty, and the check would pass unconditionally - silently, with no signal that it had stopped testing anything. The workflow therefore pins `ref: ${{ github.event.pull_request.head.sha }}`, and `test_a_merge_commit_head_defeats_the_check` pins the trap itself so a future workflow edit cannot reintroduce it without a red test.

## Tests

`tests/test_merge_base_overlap.py`, 27 tests. The load-bearing ones build **real commits in real repositories** rather than hand-built path sets, because the overlap is a statement about merge bases and a merge base is exactly what a fixture would assume rather than exercise:

- `test_the_1763_1766_pair_is_flagged` - the issue's acceptance criterion, replayed.
- `test_the_pair_merges_without_a_text_conflict` - non-vacuity for the above: git itself has nothing to report on this topology, which is why the existing gate is not redundant with this one.
- `test_merging_the_base_clears_the_check` - the self-clearing property.
- `test_a_merge_commit_head_defeats_the_check` - the CI trap above.
- `test_disjoint_edits_do_not_overlap`, `test_an_unmoved_base_does_not_overlap`, `test_a_prose_only_overlap_is_reported_but_does_not_block` - quiet where an overlap cannot matter.
- `test_a_rename_on_the_base_still_overlaps_the_old_path` - `--no-renames` is deliberate; with rename detection a file the base renamed appears only under its new name, so a branch still editing the old name would not intersect it.
- `test_an_unresolvable_base_ref_fails_loudly` - a check that cannot compute its answer must not report the reassuring one.
- `test_the_remote_tracking_ref_wins_over_a_local_branch` - CI has only `origin/<base>`; pinned by pointing `origin/main` at a commit that overlaps while local `main` does not.

**Mutation-tested.** With `overlapping_paths` stubbed to return `()` - a vacuous check - the file is `7 failed, 20 passed`. The guard cannot be weakened into a no-op while the file still passes.

## Gate

```
pytest tests/test_merge_base_overlap.py            27 passed
ruff check <new files>                             All checks passed!
ruff format --check <new files>                    2 files already formatted
mypy tests/test_merge_base_overlap.py             Success: no issues found
python scripts/assemble_changelog.py --check      changelog fragments OK (60 pending)
pytest test_no_host_paths test_changelog_*         32 passed
pytest test_source_strings_no_emoji \
       test_source_strings_no_unicode_dashes \
       test_log_strings_are_ascii                  9 passed
grep -P '[^\x00-\x7F]' <new files>                0 non-ASCII lines (all 4)
```

Both `uses:` refs pin a full 40-character SHA with the version tag as a trailing comment, per the action-pinning rule. The script is standard library only, so the job installs nothing.

## Scope

Four new files, nothing modified or deleted - no existing behaviour can regress:

| file | |
|---|---|
| `scripts/check_merge_base_overlap.py` | the check |
| `tests/test_merge_base_overlap.py` | 27 pins |
| `.github/workflows/merge-base-overlap.yml` | runs it on every PR to `main` / `dev` |
| `changelog.d/1770-merge-base-overlap-check.md` | news fragment |

## Rollout note, and what this PR deliberately does not do

Whether a failure here **blocks** a merge is a branch-protection decision, not a property of this diff. Until the job is added to the required set it surfaces the overlap and leaves the call to the reviewer - which is the issue's second acceptance clause. Promoting it to blocking is then a settings toggle with zero code change.

Worth knowing before flipping that toggle: several currently-open pull requests branched weeks ago against these same simulation modules, so this check will read red on them immediately. That is the correct verdict - their checks genuinely predate what has landed - but it is a queue to drain deliberately, not a surprise to discover after making the job required.

This addresses option 3 from the issue. Option 2 (a GitHub merge queue) remains the actual fix, since it tests the combination rather than only reporting that it is untested; the issue notes they compose, and this one needs no infrastructure decision to land.

---

## Round 2 - report paragraphs are built explicitly (`49bc2b3`)

Review feedback: implicit string concatenation inside the report's list literal.

The concern is real beyond the lint. In a list of report lines, adjacent literals are indistinguishable from a forgotten comma, and the failure is silent in **both** directions:

| written | rendered |
|---|---|
| `"a " "b",` (intended one paragraph) | one line, `"a b"` |
| `"a ", "b",` (comma slipped in) | **two** lines |
| `"a", "b",` (intended two paragraphs) | two lines |
| `"a" "b",` (comma dropped) | **one** line, `"ab"` |

`"\n".join(lines)` cannot tell those apart, and neither can a reader - in a file whose only job is to be believed about why a merge is unsafe.

Every multi-line paragraph in `render_report` is now a named local built with explicit `+`. The same shape was in the annotation loop in `main()`, which was not flagged but had the identical ambiguity (`print` takes `*args`, so a dropped comma prints one joined string and an added one prints two space-separated), so that is explicit now too. `render_report`'s docstring records why, so a future tidy does not fold it back.

**Output is unchanged, verified rather than asserted:**

- `render_report` is byte-identical across all three report shapes - blocking+prose, empty, prose-only - against output captured from the previous head.
- the #1763/#1766 replay on the real commits emits the same report and the same `::error` annotation, `exit=1`, naming `scene_ops.py`.

`ruff check` / `ruff format --check` / `mypy` clean, 27 tests pass, file still pure ASCII. No test changed: the round is a refactor of how three strings are assembled, not of what they say.

One note from review left deliberately un-acted: `.txt` in `PROSE_SUFFIXES` classifies a `requirements.txt` as non-blocking. Today the only such file is `docs/requirements.txt`, which feeds the docs build rather than the suite or the package, so the carve-out holds - but if a pip-installed requirements file ever gates CI, that suffix should be revisited. Changing it now would alter behaviour with no driver, so it belongs in a follow-up rather than in this round.