### PR TITLE
fix(sim): honor an integral-float pixel count in the plain-MP4 recorders

### DIFF
--- a/changelog.d/1768-recorder-honors-integral-pixel-counts.md
+++ b/changelog.d/1768-recorder-honors-integral-pixel-counts.md
@@ -1,0 +1,33 @@
+### Fixed: a plain-MP4 recording started at an integral-float pixel count now records
+
+`start_cameras_recording(width=640.0)` returned `status="success"`, announced the
+recording, and then captured nothing: `stop_cameras_recording` also reported
+success with `0 frames  0.0 KB  (N errors)` and no MP4 on disk. The identical
+call with `width=640` recorded normally, so the only difference between a
+working recording and an empty one was a value the `start` call accepted.
+
+The recorders validate their four frame/pixel-count options against the shared
+`positive_whole_number_error` domain, which deliberately admits any real scalar
+with an integral value so an `fps` read out of a config float or a resolution
+probed off a camera as `np.int64` can be honored. `fps` and
+`max_frames_per_camera` were honored - the capture loop only divides by and
+compares against them - but `width`/`height` were forwarded verbatim to
+`render`, whose `_validate_render_dims` requires a true `int` and therefore
+refused every frame. Passing the guard is a promise the value *can* be honored,
+not that it is already in the form its consumer needs.
+
+Both plain-MP4 entry points (`start_cameras_recording` and
+`start_cameras_recording_synchronous`) now normalize an accepted pixel count to
+plain `int` before the capture loop uses it, so `640.0` and `np.int64(640)`
+record at 640 pixels. This is the normalization every other pixel-count surface
+in the library already performs after validating on the same domain -
+`VideoConfig.from_dict`, which is why `run_policy(video={"width": 640.0})` wrote
+a correct MP4 while the recorder sharing its domain wrote none; `HybridCompositor`,
+whose comment states that "a np.int64 must not leak through"; and `mjpeg_frames`,
+whose per-component check exists so `size` and "the recorders' `width`/`height`
+cannot diverge".
+
+The accepted domain itself is unchanged: the guard still runs first, so a
+non-integral `12.5`, a non-positive `0`/`-64`, `nan`/`inf`, a `"64"` string and
+`True` are refused exactly as before rather than silently truncated, and a
+`width`/`height` of `None` keeps its "use the camera's own resolution" meaning.

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -125,6 +125,14 @@ def _cameras_recording_option_error(
     for every frame, and a non-positive ``width``/``height`` failed every render
     call - all reported as success by both ``start`` and ``stop``.
 
+    The accepted domain admits any real scalar with an integral value, so
+    passing this guard is a promise the value *can* be honored, not that it is
+    already in the form its consumer needs. Callers must therefore normalize
+    the pixel counts to plain ``int`` before handing them to ``render``, which
+    requires a true ``int``: accepting ``640.0`` here and forwarding it
+    verbatim reproduced the very empty-recording-reported-as-success failure
+    this guard exists to prevent.
+
     Args:
         method: Public method name, used to prefix the error message.
         fps: Capture/encode frame rate.
@@ -1827,7 +1835,8 @@ class RenderingMixin:
                 ``status="success"`` return.
             width/height: per-frame size. ``None`` uses the camera's configured
                 resolution (else the renderer default); an explicit value must
-                be a positive whole number.
+                be a positive whole number, and an integral ``float`` or
+                ``np.int64`` is normalized to ``int`` rather than refused.
             name: filename tag (auto if None). Validated as a single path
                 component - separators / traversal / metacharacters rejected.
             max_frames_per_camera: safety cap on in-memory buffers. Must be a
@@ -1849,6 +1858,20 @@ class RenderingMixin:
             "start_cameras_recording", fps, width, height, max_frames_per_camera
         ):
             return error
+
+        # The guard above accepts any real scalar with an integral value, so a
+        # ``640.0`` read from a config float and an ``np.int64`` probed from a
+        # camera are both usable pixel counts - honor that by normalizing them
+        # to plain ``int`` here. The capture loop hands these straight to
+        # ``render``, whose ``_validate_render_dims`` requires a true ``int``,
+        # so without this every frame was refused and the recording wrote no
+        # MP4 at all while both ``start`` and ``stop`` reported success. This is
+        # the same normalization every other pixel-count surface in the library
+        # already performs (``VideoConfig.from_dict``, ``HybridCompositor``,
+        # ``mjpeg_frames``). ``None`` keeps its "use the camera's own
+        # resolution" meaning and is passed through untouched.
+        width = None if width is None else int(width)
+        height = None if height is None else int(height)
 
         if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
             cur = self._cams_rec_state["name"]
@@ -2280,6 +2303,20 @@ class RenderingMixin:
             "start_cameras_recording_synchronous", fps, width, height, max_frames_per_camera
         ):
             return error
+
+        # The guard above accepts any real scalar with an integral value, so a
+        # ``640.0`` read from a config float and an ``np.int64`` probed from a
+        # camera are both usable pixel counts - honor that by normalizing them
+        # to plain ``int`` here. The capture loop hands these straight to
+        # ``render``, whose ``_validate_render_dims`` requires a true ``int``,
+        # so without this every frame was refused and the recording wrote no
+        # MP4 at all while both ``start`` and ``stop`` reported success. This is
+        # the same normalization every other pixel-count surface in the library
+        # already performs (``VideoConfig.from_dict``, ``HybridCompositor``,
+        # ``mjpeg_frames``). ``None`` keeps its "use the camera's own
+        # resolution" meaning and is passed through untouched.
+        width = None if width is None else int(width)
+        height = None if height is None else int(height)
 
         if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
             cur = self._cams_rec_state["name"]

--- a/tests/simulation/mujoco/test_cameras_recording_preflight_guards.py
+++ b/tests/simulation/mujoco/test_cameras_recording_preflight_guards.py
@@ -18,6 +18,14 @@ capture thread:
   unusable value produced an empty recording that both ``start`` and ``stop``
   reported as ``status="success"``.
 
+The accepted domain deliberately admits any real scalar with an integral value,
+so a ``640.0`` read from a config float and an ``np.int64`` probed from a camera
+are usable pixel counts. Passing the guard therefore has to mean the recording
+actually happens, which is asserted here against the MP4 on disk rather than
+against the ``start`` status: the pixel counts reach ``render``, which requires
+a true ``int``, so accepting ``640.0`` and forwarding it verbatim reproduced the
+exact empty-recording-reported-as-success failure the guard exists to prevent.
+
 These are LLM-facing tool contracts, so the guards return the structured
 ``{"status": "error", ...}`` shape rather than raising. Pinned here so a
 regression that lets a zero-camera or traversal-carrying request slip through
@@ -173,20 +181,37 @@ class TestRecordingOptionValidation:
         assert result["status"] == "success"
         cam_sim.stop_cameras_recording()
 
-    def test_integral_float_and_numpy_options_are_accepted(self, cam_sim, tmp_path):
-        """A ``30.0``/``np.int64`` option is usable and must not be rejected."""
+    def test_integral_float_and_numpy_options_are_honored(self, cam_sim, tmp_path):
+        """A ``30.0``/``np.int64`` option is usable, so frames must reach disk.
+
+        Asserting only ``start``'s status left this passing while the recording
+        captured nothing: the ``np.int64`` pixel counts were forwarded verbatim
+        to ``render``, which requires a true ``int``, so every frame was refused
+        and ``stop`` reported ``0 frames`` with no MP4 - the failure mode this
+        class exists to pin. "Usable" is a claim about the recording, so it is
+        checked against the file on disk.
+        """
         import numpy as np
 
         result = cam_sim.start_cameras_recording(
             cameras=["cam_a"],
             output_dir=str(tmp_path),
+            name="integral",
             fps=30.0,
             width=np.int64(64),
             height=np.int64(48),
             max_frames_per_camera=np.int64(10),
         )
         assert result["status"] == "success"
-        cam_sim.stop_cameras_recording()
+        time.sleep(0.6)
+        stopped = cam_sim.stop_cameras_recording()
+        assert stopped["status"] == "success"
+        artifacts = next(c["json"] for c in stopped["content"] if "json" in c)["artifacts"]
+        artifact = next(a for a in artifacts if a["camera"] == "cam_a")
+        assert artifact["frames"] > 0, artifact
+        assert artifact["errors"] == 0, artifact
+        mp4 = tmp_path / "integral__cam_a.mp4"
+        assert mp4.exists() and mp4.stat().st_size > 0
 
     def test_valid_options_still_write_an_mp4(self, cam_sim, tmp_path):
         """Round trip: the guard does not disturb a recording it should allow."""
@@ -230,6 +255,43 @@ class TestSharedPositiveWholeNumberDomain:
         assert positive_whole_number_error(good, "fps", "start_cameras_recording") is None
         assert VideoConfig.validation_error({"path": "/tmp/a.mp4", "fps": good}) is None
 
+    @pytest.mark.parametrize("good", [64, 64.0])
+    def test_video_config_and_recorder_agree_on_honoring_a_pixel_count(self, good, sim, tmp_path):
+        """Both MP4 surfaces record at a pixel count they both accept.
+
+        ``VideoConfig.from_dict`` has always normalized its ``width``/``height``
+        with ``int(...)``, so ``run_policy(video={"width": 64.0})`` wrote a
+        correct MP4 while the recorder that shares the domain wrote none. The
+        docstring on ``VideoConfig._positive_int_error`` says the shared domain
+        exists so the two surfaces "cannot drift apart on what counts as a
+        usable ``fps`` / ``width`` / ``height``" - they agreed on accepting and
+        drifted on honoring, which this pins.
+        """
+        sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+
+        rollout_mp4 = tmp_path / "rollout.mp4"
+        rolled = sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            n_steps=10,
+            control_frequency=10.0,
+            video={"path": str(rollout_mp4), "fps": 10, "camera": "cam_a", "width": good, "height": 48},
+        )
+        assert rolled["status"] == "success"
+        assert rollout_mp4.exists() and rollout_mp4.stat().st_size > 0
+
+        started = sim.start_cameras_recording(
+            cameras=["cam_a"], output_dir=str(tmp_path), name="recorder", fps=10, width=good, height=48
+        )
+        assert started["status"] == "success"
+        time.sleep(0.6)
+        stopped = sim.stop_cameras_recording()
+        assert stopped["status"] == "success"
+        artifacts = next(c["json"] for c in stopped["content"] if "json" in c)["artifacts"]
+        assert next(a for a in artifacts if a["camera"] == "cam_a")["frames"] > 0
+        recorder_mp4 = tmp_path / "recorder__cam_a.mp4"
+        assert recorder_mp4.exists() and recorder_mp4.stat().st_size > 0
+
     def test_error_text_names_the_receiving_surface(self):
         from strands_robots.utils import positive_whole_number_error
 
@@ -238,3 +300,169 @@ class TestSharedPositiveWholeNumberDomain:
             positive_whole_number_error(0, "fps", "start_cameras_recording")
             == "start_cameras_recording: fps must be a positive whole number, got 0."
         )
+
+
+class TestIntegralPixelCountsAreHonored:
+    """A pixel count the guard accepts is a pixel count the recorder records at.
+
+    ``positive_whole_number_error`` accepts any real scalar with an integral
+    value - by design, so an ``fps`` read out of a config float or a resolution
+    probed off a camera as ``np.int64`` can be honored. The plain-MP4 recorders
+    validated ``width``/``height`` on that domain and then handed the raw value
+    to ``render``, whose ``_validate_render_dims`` requires a true ``int``. So
+    ``width=640.0`` was accepted by ``start`` and refused by every single frame:
+    ``stop`` reported ``0 frames  (N errors)`` and no MP4 existed, with both
+    calls returning ``status="success"``.
+
+    ``fps`` and ``max_frames_per_camera`` never had this problem - the capture
+    loop only divides by / compares against them - which is what made the two
+    pixel counts the odd pair out among four options on one method.
+
+    Every other pixel-count surface in the library already normalizes after
+    validating on this same domain (``VideoConfig.from_dict``'s ``int(...)``,
+    ``HybridCompositor``'s "a np.int64 must not leak through",
+    ``mjpeg_frames``' per-component ``int(...)``), so these tests pin the
+    recorders into that established convention.
+    """
+
+    # An integral ``float`` (resolution arithmetic or a JSON config produces
+    # one) and an ``np.int64`` (what a camera probe returns) are the two value
+    # classes ``positive_whole_number_error``'s docstring names as honorable.
+    _INTEGRAL_KINDS = ["float", "numpy"]
+
+    @staticmethod
+    def _value(kind, number):
+        """The same pixel count spelled as an integral float / an ``np.int64``."""
+        if kind == "float":
+            return float(number)
+        import numpy as np
+
+        return np.int64(number)
+
+    @staticmethod
+    def _artifact(result, camera):
+        """The per-camera ``{frames, errors, path}`` block from stop/finalize.
+
+        Asserted on instead of the human-readable summary line: ``frames`` and
+        ``errors`` are the recorder's own count of what reached the encoder, so
+        a refused frame cannot hide behind a ``status="success"``.
+        """
+        artifacts = next(c["json"] for c in result["content"] if "json" in c)["artifacts"]
+        return next(a for a in artifacts if a["camera"] == camera)
+
+    @pytest.fixture
+    def cam_sim(self, sim):
+        sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+        return sim
+
+    @pytest.mark.parametrize("kind", _INTEGRAL_KINDS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_daemon_recorder_records_at_an_integral_pixel_count(self, cam_sim, param, kind, tmp_path):
+        """One integral pixel count still writes a non-empty MP4."""
+        sizes = {"width": 64, "height": 48}
+        sizes[param] = self._value(kind, sizes[param])
+        started = cam_sim.start_cameras_recording(
+            cameras=["cam_a"], output_dir=str(tmp_path), name="honored", fps=10, **sizes
+        )
+        assert started["status"] == "success"
+        time.sleep(0.6)
+        stopped = cam_sim.stop_cameras_recording()
+        assert stopped["status"] == "success"
+        artifact = self._artifact(stopped, "cam_a")
+        assert artifact["frames"] > 0, artifact
+        assert artifact["errors"] == 0, artifact
+        mp4 = tmp_path / "honored__cam_a.mp4"
+        assert mp4.exists() and mp4.stat().st_size > 0
+
+    @pytest.mark.parametrize("kind", _INTEGRAL_KINDS)
+    def test_recorded_frames_have_the_requested_size(self, cam_sim, kind, tmp_path):
+        """The integral value is honored, not merely tolerated.
+
+        Decodes the MP4 and compares its frame shape against the requested
+        size, so a fix that recorded at some *other* resolution (the camera
+        default, say) fails here rather than passing on "an MP4 exists".
+        """
+        imageio = pytest.importorskip("imageio", reason="imageio not installed")
+        pytest.importorskip("imageio_ffmpeg", reason="imageio-ffmpeg not installed")
+
+        width, height = 96, 64
+        started = cam_sim.start_cameras_recording(
+            cameras=["cam_a"],
+            output_dir=str(tmp_path),
+            name="sized",
+            fps=10,
+            width=self._value(kind, width),
+            height=self._value(kind, height),
+        )
+        assert started["status"] == "success"
+        time.sleep(0.6)
+        stopped = cam_sim.stop_cameras_recording()
+        assert stopped["status"] == "success"
+        assert self._artifact(stopped, "cam_a")["frames"] > 0
+
+        mp4 = tmp_path / "sized__cam_a.mp4"
+        assert mp4.exists() and mp4.stat().st_size > 0
+        reader = imageio.get_reader(str(mp4))
+        try:
+            frame = reader.get_data(0)
+        finally:
+            reader.close()
+        assert frame.shape[:2] == (height, width), frame.shape
+
+    @pytest.mark.parametrize("kind", _INTEGRAL_KINDS)
+    def test_synchronous_recorder_records_at_an_integral_pixel_count(self, cam_sim, kind, tmp_path):
+        """The ``(on_frame, finalize)`` entry point honors the same domain.
+
+        Both recorders share ``_cameras_recording_option_error``, so a
+        normalization applied to only one of them would leave the other
+        accepting a pixel count it cannot render.
+        """
+        result = cam_sim.start_cameras_recording_synchronous(
+            cameras=["cam_a"],
+            output_dir=str(tmp_path),
+            name="sync",
+            fps=10,
+            width=self._value(kind, 64),
+            height=self._value(kind, 48),
+        )
+        assert result["status"] == "success"
+        json_block = next(c["json"] for c in result["content"] if "json" in c)
+        on_frame, finalize = json_block["on_frame"], json_block["finalize"]
+        for step in range(4):
+            on_frame(step, {}, {})
+
+        final = finalize()
+        assert final["status"] == "success"
+        artifact = self._artifact(final, "cam_a")
+        assert artifact["frames"] == 4, artifact
+        assert artifact["errors"] == 0, artifact
+        mp4 = tmp_path / "sync__cam_a.mp4"
+        assert mp4.exists() and mp4.stat().st_size > 0
+
+    # ``None`` is deliberately absent: for a pixel count it is the documented
+    # "use the camera's own resolution" opt-out, pinned by
+    # ``test_an_omitted_pixel_count_still_means_camera_default`` below.
+    @pytest.mark.parametrize("bad", [0, -64, 12.5, float("nan"), float("inf"), "64", True])
+    def test_a_pixel_count_outside_the_domain_is_still_refused(self, cam_sim, bad, tmp_path):
+        """Normalizing the accepted values does not widen the accepted domain.
+
+        ``int(12.5)`` would silently record at 12 pixels, so the guard still
+        runs first: only values it already accepted are normalized.
+        """
+        result = cam_sim.start_cameras_recording(cameras=["cam_a"], output_dir=str(tmp_path), width=bad)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert text.startswith("start_cameras_recording: width must be a positive whole number"), text
+        assert "No active camera recording" in cam_sim.get_cameras_recording_status()["content"][0]["text"]
+
+    def test_an_omitted_pixel_count_still_means_camera_default(self, cam_sim, tmp_path):
+        """``None`` is passed through, not coerced into a ``0``-pixel request."""
+        started = cam_sim.start_cameras_recording(
+            cameras=["cam_a"], output_dir=str(tmp_path), name="defaulted", fps=10, width=None, height=None
+        )
+        assert started["status"] == "success"
+        time.sleep(0.6)
+        stopped = cam_sim.stop_cameras_recording()
+        assert stopped["status"] == "success"
+        assert self._artifact(stopped, "cam_a")["frames"] > 0
+        assert (tmp_path / "defaulted__cam_a.mp4").stat().st_size > 0


### PR DESCRIPTION
Closes #1768.

## Problem

`start_cameras_recording(width=640.0)` returns `status="success"`, announces the recording, and captures nothing. `stop_cameras_recording` also returns success, reporting `0 frames  0.0 KB  (N errors)`, and no MP4 exists. The identical call with `width=640` records normally — so the only difference between a working recording and an empty one is a value the `start` call accepted.

Measured on `main` @ `b19420f2`, MuJoCo, one camera, `MUJOCO_GL=egl`, a 320x240 clip at 20 fps:

| | `width=320.0` (main) | `width=320.0` (this PR) |
|---|---|---|
| `start_cameras_recording` | `status="success"` | `status="success"` |
| `stop_cameras_recording` | `status="success"` | `status="success"` |
| frames captured | **0** | **41** |
| render errors | **40** | **0** |
| MP4 files on disk | **0** (0 bytes) | **1** (55672 bytes) |
| decoded frame size | — nothing to decode | **320x240**, as requested |

## Cause

Both recorders validate their four frame/pixel-count options against the shared `positive_whole_number_error` domain, which *deliberately* admits any real scalar with an integral value — its docstring says so, "so a `30.0` read from a config or an `np.int64` probed from a camera can be honored".

`fps` and `max_frames_per_camera` are honored, because the capture loop only divides by and compares against them. `width`/`height` are forwarded verbatim to `render`, whose `_validate_render_dims` requires a true `int`:

```
render: width/height must be int, got float/int.
```

So every frame is refused, and because the per-camera flush is best-effort the failure only surfaces as an `errors` counter inside a `status="success"` payload. Passing the guard is a promise the value *can* be honored, not that it is already in the form its consumer needs.

This reaches `np.int64` too — the exact value class the guard's docstring names as honorable — so a resolution probed off a camera and passed straight through records nothing.

## Fix

Normalize an accepted pixel count to plain `int` before the capture loop uses it, on both plain-MP4 entry points (`start_cameras_recording` and `start_cameras_recording_synchronous`, which share the guard).

This is the normalization **every other pixel-count surface in the library already performs** after validating on this same domain:

- `VideoConfig.from_dict` — `width=int(cls._pick(d, "width", 640))`. This is why `run_policy(video={"width": 640.0})` writes a correct MP4 while the recorder sharing its domain writes none. `VideoConfig._positive_int_error`'s own docstring says the shared domain exists so this dict schema and "the plain-MP4 recorder's keyword parameters cannot drift apart on what counts as a usable `fps` / `width` / `height`" — they agreed on *accepting* and drifted on *honoring*.
- `HybridCompositor` — `int(default_width)`, commented "Normalize to plain ints/floats … so a np.int64 must not leak through".
- `mjpeg_frames` — `(int(size[0]), int(size[1]))`, whose validator exists "per component so `size` and the recorders' `width`/`height` cannot diverge".

**The accepted domain is unchanged.** The guard still runs first, so a non-integral `12.5` (which `int()` would silently truncate to 12 pixels), a non-positive `0`/`-64`, `nan`/`inf`, a `"64"` string and `True` are refused exactly as before, and `width`/`height` of `None` keeps its "use the camera's own resolution" meaning.

### Scope

The MuJoCo recorders are the only plain-MP4 surfaces taking pixel counts: Isaac's `start_cameras_recording` takes none (each camera carries its own resolution) and Newton has no plain-MP4 recorder. `VideoConfig` already normalizes, so it needs no change — a regression test pins that the two surfaces now agree on honoring, not only on rejecting.

The alternative direction #1768 raises — loosening `render` to coerce an integral float — is deliberately not taken here: it widens a public accepted domain across five call sites, whereas normalizing at the configuration boundary is the convention the four surfaces above already establish, with `render` left as the strict low-level primitive they normalize for.

## Visual artifact

One call, both trees. Left is what `main` produced; right is a frame decoded back out of the MP4 this PR produced, at the requested 320x240.

![recorder pixel count](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recorder-pixel-count/recorder_pixel_count.png)

Round trip on the recording this PR writes — the arm sweep, decoded back out of `clip__bench_cam.mp4` (41 frames, 11.43% of pixels differ between the first and last frame, so the clip carries real motion rather than a static frame):

![recorded clip](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recorder-pixel-count/recorded_clip.gif)

[MP4 as written by the recorder](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recorder-pixel-count/recorded_clip.mp4) · both panels generated by one script run against each tree, every quoted number read back from the run rather than typed.

## Tests

`tests/simulation/mujoco/test_cameras_recording_preflight_guards.py` — the existing home for these contracts, whose module docstring already stated the one being violated ("each unusable value produced an empty recording that both `start` and `stop` reported as `status=\"success\"`", and `640.0` *is* a positive whole number).

New `TestIntegralPixelCountsAreHonored` asserts against the recorder's own per-camera `frames`/`errors` counters and the MP4 on disk, never the `start` status:

- an integral `float` and an `np.int64` `width`/`height` each record a non-empty MP4 with zero render errors, on both entry points;
- the **decoded** frame shape equals the requested size, so a fix that recorded at some *other* resolution (the camera default, say) fails rather than passing on "an MP4 exists";
- every value outside the domain is still refused, and `None` still means camera default — these are what stop the change over-reaching.

One existing test is corrected rather than shimmed: `test_integral_float_and_numpy_options_are_accepted` claimed `np.int64(64)` was "usable and must not be rejected" while asserting only the `start` status, so it passed against a recording that captured zero frames. It is renamed `..._are_honored` and now checks the file on disk — "usable" is a claim about the recording.

## Verification

On `b19420f2`:

- **Pre-fix** (source file reverted, tests kept): `10 failed, 51 passed`, e.g. `AssertionError: {'camera': 'cam_a', ..., 'frames': 0, 'errors': 6}`. The 51 include the refusal and `None` controls, which must pass both before and after.
- **Post-fix**: `61 passed`.
- **Full suite**: `MUJOCO_GL=egl python -m pytest tests -q --no-cov` → `14476 passed, 255 skipped` (461s).
- **Lint**: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean (`no issues found in 969 source files`).
- `python scripts/assemble_changelog.py --check` OK.

mujoco 3.11.0, `MUJOCO_GL=egl`.