### PR TITLE
fix(sim): report a non-string entity name instead of crashing the process

### DIFF
--- a/changelog.d/1773-entity-name-lookup-type-safety.md
+++ b/changelog.d/1773-entity-name-lookup-type-safety.md
@@ -1,0 +1,20 @@
+### Fixed: a MuJoCo entity name that is not a string is reported instead of crashing the process
+
+`mujoco.mj_name2id` declares its name parameter as `const char *`, and the pybind11
+binding maps Python `None` onto a NULL pointer rather than rejecting it. MuJoCo
+dereferences that pointer while comparing names, so the call does not raise - it
+terminates the interpreter with SIGSEGV. Five agent-callable methods passed a
+caller-supplied name straight into that binding, so one argument of the wrong type
+killed the process: `get_body_state`, `set_body_properties`, `apply_force`,
+`attach_bodies`, and `set_joint_positions` (where the name arrives as a mapping key).
+Nothing above the call could recover - the agent-tool envelope, the caller's `except`
+clauses and any open recording all died with it.
+
+Three further methods - `move_object`, `remove_object` and `remove_camera` - reached
+the shared "did you mean" reporter instead, where `difflib.get_close_matches` raised a
+bare `TypeError` past the envelope those methods document as their only failure channel.
+
+Every lookup now goes through `mj_name_to_id`, which resolves a non-string name to
+"not found" so the existing unknown-entity message reports it, naming the value and
+listing what the model does contain. An AST check pins that no module reaches the
+binding directly, so a lookup added later inherits the guard.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -425,7 +425,7 @@ class SimEngine(ABC):
         """
         known = self.list_robots()
         msg = f"Robot '{requested}' not found."
-        if known:
+        if known and isinstance(requested, str):
             matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
             if matches:
                 msg += " Did you mean: " + ", ".join(matches) + "?"

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -233,6 +233,40 @@ def _ensure_mujoco() -> "Any":
 
 _rendering_available: bool | None = None
 
+
+def mj_name_to_id(model: Any, obj_type: int, name: Any) -> int:
+    """Resolve a MuJoCo entity name to its id, refusing a name that is not a string.
+
+    ``mujoco.mj_name2id`` declares its third parameter as ``const char *``, and the
+    pybind11 binding maps Python ``None`` onto a NULL pointer instead of rejecting
+    it. MuJoCo then dereferences that pointer while comparing names, so the call
+    does not raise - it terminates the interpreter with SIGSEGV. Nothing above it
+    can recover: the agent-tool envelope, the caller's ``except`` clauses and any
+    open recording all die with the process.
+
+    A value that is not a string cannot name an entity, so it resolves to "not
+    found" (``-1``) and the caller's existing unknown-entity message reports it -
+    naming the value and listing what the model does contain. Routing every
+    lookup through here, rather than adding a type check at each public entry
+    point, means a lookup added later is safe by construction.
+
+    Args:
+        model: The compiled ``MjModel`` to search.
+        obj_type: A ``mujoco.mjtObj`` enum member (``mjOBJ_BODY``, ``mjOBJ_JOINT``, ...).
+        name: The entity name to resolve. Anything that is not a ``str``
+            resolves to ``-1`` without reaching the binding.
+
+    Returns:
+        The entity id, or ``-1`` when *name* is not a string or names nothing
+        of *obj_type* in *model*.
+    """
+    if not isinstance(name, str):
+        return -1
+    import mujoco as _mj
+
+    return int(_mj.mj_name2id(model, obj_type, name))
+
+
 # One-shot guard so the software-rendering warning fires at most once per
 # process. A set (mutated via .add, never reassigned) avoids a `global`
 # rebind so static analysis sees it as used.

--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco, mj_name_to_id
 from strands_robots.simulation.mujoco.scene_ops import (
     actuate_robot_in_scene,
     actuator_joint_id,
@@ -223,8 +223,8 @@ class ManipulationMixin:
         mj = _ensure_mujoco()
         with self._lock:
             model, data = self._world._model, self._world._data
-            parent_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, parent)
-            child_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, child)
+            parent_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, parent)
+            child_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, child)
             for label, body_id in (("parent", parent_id), ("child", child_id)):
                 if body_id < 0:
                     name = parent if label == "parent" else child
@@ -381,8 +381,8 @@ class ManipulationMixin:
         model, data = world._model, world._data
         stale: list[str] = []
         for child, record in attachments.items():
-            parent_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, str(record["parent"]))
-            child_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, child)
+            parent_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, str(record["parent"]))
+            child_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, child)
             free_jid = _find_free_joint(mj, model, child_id) if child_id >= 0 else -1
             if parent_id < 0 or child_id < 0 or free_jid < 0:
                 stale.append(child)

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -55,7 +55,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots.registry.robots import get_robot
-from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, mj_name_to_id
 from strands_robots.utils import coerce_pose_vector
 
 logger = logging.getLogger(__name__)
@@ -357,12 +357,12 @@ class MotionPrimitivesMixin:
         """
         mj = self._mj
         if frame_type == "site":
-            sid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, frame_name)
+            sid = mj_name_to_id(model, mj.mjtObj.mjOBJ_SITE, frame_name)
             pos = np.array(data.site_xpos[sid], dtype=np.float64)
             quat = np.zeros(4, dtype=np.float64)
             mj.mju_mat2Quat(quat, np.asarray(data.site_xmat[sid], dtype=np.float64).reshape(9))
             return pos, quat
-        bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, frame_name)
+        bid = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, frame_name)
         return np.array(data.xpos[bid], dtype=np.float64), np.array(data.xquat[bid], dtype=np.float64)
 
     # -- primitives ----------------------------------------------------------

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -26,6 +26,7 @@ from strands_robots.simulation.mujoco.backend import (
     _NO_WORLD_MSG,
     _ensure_mujoco,
     filter_mujoco_attach_noise,
+    mj_name_to_id,
 )
 from strands_robots.simulation.mujoco.scene_ops import (
     persist_body_mass,
@@ -822,18 +823,21 @@ class PhysicsMixin:
         which is non-deterministic - this is a deliberate
         "unambiguous or explicit" contract.
         """
-        import mujoco as _mj
 
         assert self._world is not None and self._world._model is not None
         model = self._world._model
-        mid = _mj.mj_name2id(model, obj_type, name)
+        mid = mj_name_to_id(model, obj_type, name)
         if mid >= 0:
             return int(mid)
+        if not isinstance(name, str):
+            # mj_name_to_id already refused it; the namespace retry below
+            # would only reach `in` / `+` on a value that supports neither.
+            return -1
         if "/" in name:  # already namespaced, no point retrying
             return -1
         for robot in self._world.robots.values():
             if robot.namespace:
-                mid = _mj.mj_name2id(model, obj_type, robot.namespace + name)
+                mid = mj_name_to_id(model, obj_type, robot.namespace + name)
                 if mid >= 0:
                     return int(mid)
         return -1
@@ -868,7 +872,7 @@ class PhysicsMixin:
             "Joint": (_mj.mjtObj.mjOBJ_JOINT, model.njnt),
         }[kind]
         known = [nm for i in range(int(count)) if (nm := _mj.mj_id2name(model, obj_type, i)) and nm != "world"]
-        if known:
+        if known and isinstance(requested, str):
             import difflib
 
             matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
@@ -2188,7 +2192,7 @@ class PhysicsMixin:
             mj.mj_camlight(model, data)
 
             if body_name is not None:
-                bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, body_name)
+                bid = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, body_name)
                 if bid < 0:
                     return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Body", body_name)}]}
                 body_payload = {

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -11,7 +11,7 @@ from strands_robots.simulation.base import (
     randomization_seed_error,
     unknown_kwargs_error,
 )
-from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco, mj_name_to_id
 
 logger = logging.getLogger(__name__)
 
@@ -234,7 +234,7 @@ class RandomizationMixin:
                 for obj_name, obj in self._world.objects.items():
                     if not obj.is_static:
                         jnt_name = f"{obj_name}_joint"
-                        jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                        jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
                         if jnt_id >= 0:
                             qpos_addr = model.jnt_qposadr[jnt_id]
                             noise = rng.uniform(-position_noise, position_noise, size=3)

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -11,7 +11,7 @@ resume-schema guard.
 import logging
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco, mj_name_to_id
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
@@ -228,9 +228,9 @@ class RecordingMixin(DatasetRecordingMixin):
                 pfx = robot.namespace or ""
                 scalar_joint_names: list[str] = []
                 for jn in robot.joint_names:
-                    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, (pfx + jn) if pfx else jn)
+                    jid = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, (pfx + jn) if pfx else jn)
                     if jid < 0 and pfx:
-                        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jn)
+                        jid = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jn)
                     if jid >= 0 and model.jnt_type[jid] == mj.mjtJoint.mjJNT_FREE:
                         continue
                     scalar_joint_names.append(jn)

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -16,6 +16,7 @@ from strands_robots.simulation.mujoco.backend import (
     _can_render,
     _ensure_mujoco,
     capture_stderr_fd,
+    mj_name_to_id,
 )
 from strands_robots.simulation.safe_output import (
     atomic_write_bytes,
@@ -346,9 +347,9 @@ class RenderingMixin:
         mj = _ensure_mujoco()
         for jnt_name in robot.joint_names:
             lookup = pfx + jnt_name if pfx else jnt_name
-            jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
+            jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
             if jnt_id < 0 and pfx:
-                jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jnt_id < 0:
                 continue
             body = int(model.jnt_bodyid[jnt_id])
@@ -375,9 +376,9 @@ class RenderingMixin:
         pfx = robot.namespace or ""
         for jnt_name in robot.joint_names:
             lookup = pfx + jnt_name if pfx else jnt_name
-            jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
+            jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
             if jnt_id < 0 and pfx:
-                jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jnt_id >= 0 and model.jnt_type[jnt_id] == mj.mjtJoint.mjJNT_FREE:
                 return int(jnt_id)
         return self._robot_base_free_joint(model, robot, pfx)
@@ -404,9 +405,9 @@ class RenderingMixin:
         for jnt_name in robot.joint_names:
             # Try namespaced name first (multi-robot), fall back to raw.
             lookup = pfx + jnt_name if pfx else jnt_name
-            jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
+            jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
             if jnt_id < 0 and pfx:
-                jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jnt_id >= 0:
                 # A FREE joint (6-DoF floating base) has no single hinge/slide
                 # position: its qpos is [xyz(3) + quat(4)] and qvel is
@@ -474,7 +475,7 @@ class RenderingMixin:
         for cname in cameras_to_render:
             if not cname:
                 continue
-            cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, cname)
+            cam_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_CAMERA, cname)
             cam_info = self._world.cameras.get(cname)
             h = cam_info.height if cam_info else self.default_height
             w = cam_info.width if cam_info else self.default_width
@@ -635,10 +636,10 @@ class RenderingMixin:
         def _lookup(obj_type: Any, name: str) -> int:
             """Try namespaced lookup first, fall back to raw."""
             if pfx:
-                i = mj.mj_name2id(model, obj_type, pfx + name)
+                i = mj_name_to_id(model, obj_type, pfx + name)
                 if i >= 0:
                     return i
-            return int(mj.mj_name2id(model, obj_type, name))
+            return int(mj_name_to_id(model, obj_type, name))
 
         unresolved: list[str] = []
         for key, value in action_dict.items():
@@ -980,7 +981,7 @@ class RenderingMixin:
                 cam_id = -1
                 label = "free (default)"
             else:
-                cam_id = mj.mj_name2id(self._world._model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+                cam_id = mj_name_to_id(self._world._model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
                 if cam_id < 0:
                     return {
                         "status": "error",
@@ -1100,7 +1101,7 @@ class RenderingMixin:
                 cam_id = -1
                 label = "free (default)"
             else:
-                cam_id = mj.mj_name2id(self._world._model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+                cam_id = mj_name_to_id(self._world._model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
                 if cam_id < 0:
                     return {
                         "status": "error",
@@ -1303,7 +1304,7 @@ class RenderingMixin:
             if camera_name in (None, "", "default", "free"):
                 cam_id = -1
             else:
-                cam_id = mj.mj_name2id(self._world._model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+                cam_id = mj_name_to_id(self._world._model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
                 if cam_id < 0:
                     raise KeyError(f"Camera '{camera_name}' not found. Available: {self._list_camera_names()}")
 
@@ -1420,7 +1421,7 @@ class RenderingMixin:
                 K_explicit = None
             else:
                 R, t, fovy_deg = self._named_camera_pose(mj, model, self._world._data, camera_name)
-                cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+                cam_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
                 K_explicit = self._explicit_intrinsics_K(_np, model, cam_id, w, h)
 
         if K_explicit is not None:
@@ -1522,7 +1523,7 @@ class RenderingMixin:
         Raises:
             KeyError: no camera of that name exists in the model.
         """
-        cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+        cam_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
         if cam_id < 0:
             raise KeyError(f"Camera '{camera_name}' not found. Available: {self._list_camera_names()}")
         mj.mj_forward(model, data)

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -37,10 +37,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
-from strands_robots.simulation.mujoco.backend import (
-    _ensure_mujoco,
-    filter_mujoco_attach_noise,
-)
+from strands_robots.simulation.mujoco.backend import _ensure_mujoco, filter_mujoco_attach_noise, mj_name_to_id
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder
 from strands_robots.utils import finite_vector_error
 
@@ -295,9 +292,9 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
         for jnt_name in robot.joint_names:
             jid = -1
             if pfx:
-                jid = mj.mj_name2id(new_model, mj.mjtObj.mjOBJ_JOINT, pfx + jnt_name)
+                jid = mj_name_to_id(new_model, mj.mjtObj.mjOBJ_JOINT, pfx + jnt_name)
             if jid < 0:
-                jid = mj.mj_name2id(new_model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                jid = mj_name_to_id(new_model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jid >= 0:
                 robot.joint_ids.append(jid)
         robot.actuator_ids = robot_owned_actuator_ids(new_model, robot, mj)
@@ -891,7 +888,7 @@ def _restore_joint_state(
     data = world._data
     restored = 0
     for name, (qpos_vals, qvel_vals) in snapshot.items():
-        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, name)
+        jid = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, name)
         if jid < 0:
             continue  # joint no longer exists (expected for ejected robot)
         qpos_adr = int(model.jnt_qposadr[jid])
@@ -1026,9 +1023,9 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
         for jnt_name in robot.joint_names:
             jid = -1
             if pfx:
-                jid = mj.mj_name2id(new_model, mj.mjtObj.mjOBJ_JOINT, pfx + jnt_name)
+                jid = mj_name_to_id(new_model, mj.mjtObj.mjOBJ_JOINT, pfx + jnt_name)
             if jid < 0:
-                jid = mj.mj_name2id(new_model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                jid = mj_name_to_id(new_model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jid >= 0:
                 robot.joint_ids.append(jid)
         robot.actuator_ids = robot_owned_actuator_ids(new_model, robot, mj)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -72,6 +72,7 @@ from strands_robots.simulation.mujoco.backend import (
     _NO_WORLD_MSG,
     _ensure_mujoco,
     filter_mujoco_attach_noise,
+    mj_name_to_id,
 )
 from strands_robots.simulation.mujoco.manipulation import ManipulationMixin
 from strands_robots.simulation.mujoco.motion_primitives import MotionPrimitivesMixin
@@ -1050,7 +1051,7 @@ class MuJoCoSimEngine(
         than a dead-end "Object 'X' not found."."""
         known = list(self._world.objects.keys()) if self._world is not None else []
         msg = f"Object '{requested}' not found."
-        if known:
+        if known and isinstance(requested, str):
             import difflib
 
             matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
@@ -1073,7 +1074,7 @@ class MuJoCoSimEngine(
         teaches, mirroring the ``list_objects`` hint in ``_unknown_object_msg``."""
         known = self._list_camera_names()
         msg = f"Camera '{requested}' not found."
-        if known:
+        if known and isinstance(requested, str):
             import difflib
 
             matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
@@ -1090,7 +1091,7 @@ class MuJoCoSimEngine(
         into a discovery round-trip on every typo."""
         known = list(self._world.robots.keys()) if self._world is not None else []
         msg = f"Robot '{requested}' not found."
-        if known:
+        if known and isinstance(requested, str):
             import difflib
 
             matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
@@ -1562,7 +1563,7 @@ class MuJoCoSimEngine(
             if not hq:
                 continue
             for jn, vals in hq.items():
-                jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jn)
+                jid = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jn)
                 if jid < 0:
                     continue
                 adr = int(model.jnt_qposadr[jid])
@@ -2362,9 +2363,9 @@ class MuJoCoSimEngine(
         for jnt_name in robot.joint_names:
             jnt_id = -1
             if pfx:
-                jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, pfx + jnt_name)
+                jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, pfx + jnt_name)
             if jnt_id < 0:
-                jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jnt_id < 0:
                 continue
             # A FREE joint (6-DoF floating base, e.g. a humanoid's named
@@ -2879,7 +2880,7 @@ class MuJoCoSimEngine(
         # lock additionally excludes the render/recorder daemon.
         with self._lock:
             model, data = self._world._model, self._world._data
-            jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
+            jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
             if jnt_id >= 0:
                 # Dynamic object: a freejoint carries its pose, so move it cheaply
                 # through data.qpos + a forward pass (no recompile).
@@ -3083,7 +3084,7 @@ class MuJoCoSimEngine(
         if parent_body:
             mj = self._mj
             model = self._world._model
-            if mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, parent_body) < 0:
+            if mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, parent_body) < 0:
                 available = [
                     mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i)
                     for i in range(model.nbody)

--- a/tests/simulation/mujoco/test_entity_name_lookup_type_safety.py
+++ b/tests/simulation/mujoco/test_entity_name_lookup_type_safety.py
@@ -1,0 +1,252 @@
+"""A MuJoCo entity name that is not a string is reported, not crashed on.
+
+``mujoco.mj_name2id`` declares its name parameter as ``const char *`` and the
+pybind11 binding maps Python ``None`` onto a NULL pointer instead of rejecting
+it. MuJoCo dereferences that pointer while comparing names, so the call does not
+raise - it terminates the interpreter with SIGSEGV. Five agent-callable methods
+routed a caller-supplied name straight into that binding, so a single argument of
+the wrong type killed the process::
+
+    get_body_state(body_name=None)        SIGSEGV
+    set_body_properties(body_name=None)   SIGSEGV
+    apply_force(body_name=None)           SIGSEGV
+    attach_bodies(parent=None)            SIGSEGV
+    set_joint_positions({None: 0.1})      SIGSEGV
+
+Nothing above the call could recover: the agent-tool envelope, the caller's
+``except`` clauses, and any open recording all died with the process. Three more
+methods reached the shared "did you mean" reporter instead, where
+``difflib.get_close_matches(None, ...)`` raised a bare ``TypeError`` past the
+envelope those methods document as their only failure channel.
+
+These tests pin that every one of those names now resolves to "not found" and is
+reported through the envelope, that the reporter can render a non-string name,
+and - by walking the AST - that no module reaches the binding directly, so a
+lookup added later inherits the guard instead of re-opening the crash.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.mujoco.backend import mj_name_to_id  # noqa: E402
+
+# Names that cannot identify an entity. ``None`` is the one an agent produces by
+# omitting a value it believes optional; the others cover the neighbouring scalar
+# types. All are hashable, which keeps the probe on the tables this change owns:
+# an unhashable name (``["crate"]``) is refused earlier by the registry's own
+# ``name in dict`` membership test raising ``TypeError: unhashable type``, which
+# is a separate mechanism with its own call sites and is not in scope here.
+NON_STRING_NAMES: tuple[Any, ...] = (None, 5, 2.5, True, b"crate")
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_entity_name_types", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _seeded_world(sim) -> None:
+    """Compile a world holding one free-floating body named ``crate``.
+
+    ``sim`` is left un-annotated: ``Simulation`` is a lazy module re-export, so
+    annotating it makes mypy read every ``sim._world`` access as ``None``.
+
+    The body matters. Every assertion below is that a *non-string* name is
+    refused, which would also hold vacuously in an empty world - the reporter
+    short-circuits when the model has nothing to suggest, and the crash sites
+    are only reachable once there is a name table to compare against.
+    """
+    assert sim.create_world()["status"] == "success"
+    added = sim.add_object(name="crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.0, 0.0, 0.3])
+    assert added["status"] == "success"
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "".join(block.get("text", "") for block in result.get("content", []))
+
+
+class TestTheBindingIsGenuinelyUnsafe:
+    """The hazard the wrapper exists for, measured rather than asserted."""
+
+    def test_the_raw_binding_does_not_survive_a_none_name(self) -> None:
+        """Calling ``mj_name2id`` with ``None`` never returns normally.
+
+        Run out-of-process because the failure mode under test is fatal: an
+        in-process call would take the test session down with it. The assertion
+        is deliberately "did not complete", not "crashed with SIGSEGV", so it
+        still holds if a later mujoco starts rejecting the argument instead -
+        either way the wrapper is what turns it into a reportable miss.
+        """
+        source = (
+            "import mujoco as mj\n"
+            "m = mj.MjModel.from_xml_string("
+            '\'<mujoco><worldbody><body name="a"><geom size="0.1"/></body></worldbody></mujoco>\')\n'
+            "mj.mj_name2id(m, mj.mjtObj.mjOBJ_BODY, None)\n"
+            "print('RETURNED')\n"
+        )
+        done = subprocess.run([sys.executable, "-c", source], capture_output=True, text=True, timeout=180)
+        assert "RETURNED" not in done.stdout, "mujoco accepted a None name and returned; wrapper premise stale"
+        assert done.returncode != 0
+
+
+class TestTheWrapperResolvesToNotFound:
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_a_non_string_name_resolves_to_minus_one(self, name: Any) -> None:
+        model = mujoco.MjModel.from_xml_string(
+            '<mujoco><worldbody><body name="a"><geom size="0.1"/></body></worldbody></mujoco>'
+        )
+        assert mj_name_to_id(model, mujoco.mjtObj.mjOBJ_BODY, name) == -1
+
+    def test_a_string_name_still_resolves(self) -> None:
+        """The wrapper is transparent for the names that do identify an entity."""
+        model = mujoco.MjModel.from_xml_string(
+            '<mujoco><worldbody><body name="a"><geom size="0.1"/></body></worldbody></mujoco>'
+        )
+        assert mj_name_to_id(model, mujoco.mjtObj.mjOBJ_BODY, "a") == 1
+        assert mj_name_to_id(model, mujoco.mjtObj.mjOBJ_BODY, "nosuch") == -1
+
+
+class TestTheCrashSitesReportInstead:
+    """Each of these terminated the process with SIGSEGV before the guard."""
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_get_body_state(self, sim, name: Any) -> None:
+        _seeded_world(sim)
+        result = sim.get_body_state(body_name=name)
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_set_body_properties(self, sim, name: Any) -> None:
+        _seeded_world(sim)
+        result = sim.set_body_properties(body_name=name, mass=1.0)
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_apply_force(self, sim, name: Any) -> None:
+        _seeded_world(sim)
+        result = sim.apply_force(body_name=name, force=[1.0, 0.0, 0.0])
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_attach_bodies(self, sim, name: Any) -> None:
+        _seeded_world(sim)
+        result = sim.attach_bodies(parent=name, child="crate")
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_set_joint_positions_dict_key(self, sim, name: Any) -> None:
+        """The name arrives as a mapping KEY on this method rather than a value."""
+        _seeded_world(sim)
+        result = sim.set_joint_positions({name: 0.1})
+        assert result["status"] == "error"
+        assert "not joints in this model" in _text(result)
+
+
+class TestTheReporterCanRenderANonStringName:
+    """These three reached the shared "did you mean" block and raised there."""
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_move_object(self, sim, name: Any) -> None:
+        _seeded_world(sim)
+        result = sim.move_object(name=name, position=[0.2, 0.0, 0.3])
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_remove_object(self, sim, name: Any) -> None:
+        _seeded_world(sim)
+        result = sim.remove_object(name=name)
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    @pytest.mark.parametrize("name", NON_STRING_NAMES, ids=repr)
+    def test_remove_camera(self, sim, name: Any) -> None:
+        _seeded_world(sim)
+        result = sim.remove_camera(name=name)
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    def test_the_suggestion_is_still_offered_for_a_string_typo(self, sim) -> None:
+        """Guarding the reporter must not cost the close-match it exists for."""
+        _seeded_world(sim)
+        result = sim.get_body_state(body_name="crat")
+        assert result["status"] == "error"
+        assert "Did you mean" in _text(result)
+        assert "crate" in _text(result)
+
+
+class TestTheSessionSurvives:
+    def test_the_world_is_still_usable_after_a_refused_lookup(self, sim) -> None:
+        """The point of the guard: a bad name costs one error, not the session.
+
+        Pre-fix there was nothing to assert here - the interpreter was gone.
+        """
+        _seeded_world(sim)
+        assert sim.get_body_state(body_name=None)["status"] == "error"
+        assert sim.apply_force(body_name=None, force=[1.0, 0.0, 0.0])["status"] == "error"
+        assert sim.get_body_state(body_name="crate")["status"] == "success"
+        assert sim.step(n_steps=5)["status"] == "success"
+        assert sim.render(camera_name="default")["status"] == "success"
+
+
+def _mujoco_backend_dir() -> Path:
+    """Locate the backend package from a symbol, not from a path literal."""
+    from strands_robots.simulation.mujoco import backend
+
+    return Path(inspect.getfile(backend)).parent
+
+
+def _direct_binding_calls(source: str) -> list[str]:
+    """Every ``<mod>.mj_name2id(...)`` call in *source*, as ``line:attr`` labels."""
+    found = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "mj_name2id":
+            found.append(f"{node.lineno}:{node.func.attr}")
+    return found
+
+
+class TestNoModuleReachesTheBindingDirectly:
+    """The guard is only complete while every lookup goes through the wrapper."""
+
+    def test_only_the_wrapper_calls_the_binding(self) -> None:
+        backend_dir = _mujoco_backend_dir()
+        offenders = {}
+        for path in sorted(backend_dir.glob("*.py")):
+            if path.name == "backend.py":
+                continue  # defines the wrapper; its own call is the sanctioned one
+            calls = _direct_binding_calls(path.read_text(encoding="utf-8"))
+            if calls:
+                offenders[path.name] = calls
+        assert not offenders, (
+            f"these modules call mujoco's name binding directly: {offenders}. "
+            "Use mj_name_to_id from .backend so a non-string name cannot crash the process."
+        )
+
+    def test_the_scanner_detects_a_planted_call(self) -> None:
+        """A scanner that silently matched nothing would look like a clean suite."""
+        planted = "def f(model, mj, name):\n    return mj.mj_name2id(model, 1, name)\n"
+        assert _direct_binding_calls(planted) == ["2:mj_name2id"]
+        assert _direct_binding_calls("def f():\n    return 1\n") == []
+
+    def test_the_wrapper_module_still_owns_exactly_one_call(self) -> None:
+        """Locates the one sanctioned call site, so the exemption cannot go stale."""
+        backend_source = (_mujoco_backend_dir() / "backend.py").read_text(encoding="utf-8")
+        assert len(_direct_binding_calls(backend_source)) == 1

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -61,6 +61,7 @@ _EXPECTED_CLASSES = {
 _EXPECTED_FUNCTIONS = {
     "backend.py::capture_stderr_fd",
     "backend.py::filter_mujoco_attach_noise",
+    "backend.py::mj_name_to_id",
     "scene_ops.py::actuate_robot_in_scene",
     "scene_ops.py::actuator_joint_id",
     "scene_ops.py::add_weld_constraint",


### PR DESCRIPTION
## Problem

`mujoco.mj_name2id` declares its name parameter as `const char *`, and the pybind11 binding maps Python `None` onto a NULL pointer rather than rejecting it. MuJoCo dereferences that pointer while comparing names, so the call does not raise - it terminates the interpreter with **SIGSEGV**.

Five agent-callable methods passed a caller-supplied name straight into that binding, so one argument of the wrong type killed the process. Measured on `main` (`b19420f2`), mujoco 3.11.0, one `Simulation` per row:

| call | before | after |
|---|---|---|
| `get_body_state(body_name=None)` | **SIGSEGV** (exit 139) | `status="error"`, `Body 'None' not found.` |
| `set_body_properties(body_name=None, mass=1.0)` | **SIGSEGV** | `status="error"` |
| `apply_force(body_name=None, force=[1,0,0])` | **SIGSEGV** | `status="error"` |
| `attach_bodies(parent=None, child="crate")` | **SIGSEGV** | `status="error"` |
| `set_joint_positions({None: 0.1})` | **SIGSEGV** | `status="error"` |
| `move_object(name=None, position=[...])` | `TypeError: 'NoneType' object is not iterable` | `status="error"` |
| `remove_object(name=None)` | `TypeError: 'NoneType' object is not iterable` | `status="error"` |
| `remove_camera(name=None)` | `TypeError: 'NoneType' object is not iterable` | `status="error"` |

The crash is not recoverable at any layer above it: the agent-tool envelope, the caller's `except` clauses, and any open recording all die with the process. `None` is the value a caller produces by omitting an argument it believes optional, and `get_body_state` is a read-only introspection call - the least likely place to expect a fatal outcome.

The last three take a different route to the same cause. They resolve past the binding and reach the shared "did you mean" reporter, where `difflib.get_close_matches(None, known, ...)` raises a bare `TypeError` past the envelope those methods document as their only failure channel - so the reporter written to make an unresolved name recoverable could not report the name it was given.

The root cause is one assumption held in two places: that an entity name is a string. `_resolve_mj_name` is annotated `name: str` and forwards the value verbatim, and 36 lookups across 8 modules called the binding directly, so each was its own copy of the hazard.

## Change

One lookup helper, `mj_name_to_id`, in `simulation/mujoco/backend.py` - the module every MuJoCo mixin already imports. A value that is not a string cannot name an entity, so it resolves to "not found" (`-1`) without reaching the binding, and the caller's existing unknown-entity message reports it, naming the value and listing what the model does contain. No new error path is introduced at any of the 36 sites, and no message text changes.

Routing every lookup through it, rather than adding a type check at each public entry point, is what makes the fix complete: a lookup added later inherits the guard, and the AST check below is what keeps that true.

Three supporting edits:

- `_resolve_mj_name` returns `-1` for a non-string name before its namespace retry, which would otherwise reach `in` / `+` on a value that supports neither.
- The five "did you mean" blocks that compare a caller-supplied name (`_unknown_robot_msg` on `SimEngine`, plus the MuJoCo `Object` / `Camera` / `Robot` / entity variants) run difflib only for a string. `_unknown_model_msg` is deliberately untouched: its suggestion lookup already sits inside a broad best-effort `try/except`, so it degrades rather than raises.
- `mj_name_to_id` is added to the public-member docstring pin.

## Out of scope, measured

An *unhashable* name (`move_object(name=["crate"])`) is refused earlier still, by the registry's own `name in dict` membership test raising `TypeError: unhashable type: 'list'`. That is a different table with its own ~20 call sites and a non-fatal consequence, so it is not folded in here; the probe set is restricted to hashable non-strings and says so. Filing separately.

`render(camera_name=None)` is unchanged and correct: `None` is an explicit token for the free camera (`if camera_name in (None, "", "default", "free")`), documented as "no silent fallback to default", and it is checked before the lookup.

## Tests

`tests/simulation/mujoco/test_entity_name_lookup_type_safety.py`, 52 tests:

- Each of the five crash sites and the three reporter sites returns an error envelope for every hashable non-string name.
- The hazard itself is measured rather than asserted: a subprocess calling the raw binding with `None` never returns normally. It is deliberately phrased as "did not complete" rather than "crashed with SIGSEGV", so it still holds if a later mujoco starts rejecting the argument - either way the wrapper is what turns it into a reportable miss. Out-of-process because an in-process call would take the session down with it.
- The wrapper stays transparent for names that do resolve (`"a" -> 1`, `"nosuch" -> -1`), and the close-match suggestion is still offered for a string typo (`"crat" -> Did you mean: crate?`) - guarding the reporter must not cost the recovery it exists for.
- An AST walk asserts no module under `simulation/mujoco/` calls the binding directly, plus two meta-tests: the scanner detects a planted call (a scanner that silently matched nothing would look like a clean suite), and the wrapper module still owns exactly one call, so the exemption cannot go stale.
- The fixture seeds a named body and asserts it compiled, so the refusals cannot pass vacuously in an empty world.

**Pre-fix**, against `b19420f2` with only the source reverted: the pytest session is **terminated by SIGSEGV** at `test_get_body_state`, after one test has passed - `Fatal Python error: Segmentation fault`, core dumped. Running only the non-fatal classes (the crash sites cannot report a failure, they end the session) gives **14 failed / 6 passed**, with the AST check listing all 36 direct call sites. Post-fix: **52 passed**.

## Verification

Rebased onto `77173e65`. `#1772` touched `rendering.py` at lines 125 / 1827 / 1850 / 2281 and this change touches 16 / 338-1514, so the rebase was clean; verified afterwards that both `#1772`'s symbols and this change's routing are present in that file.

```
ruff check strands_robots tests tests_integ      All checks passed!
ruff format --check strands_robots tests tests_integ  974 files already formatted
mypy strands_robots tests tests_integ            Success: no issues found in 971 source files
MUJOCO_GL=egl pytest tests -q --no-cov           14555 passed, 255 skipped in 458s
```

No existing test changed behaviour; the only edit to an existing test file is the one-line docstring pin for the new public function.

## Rollout in MuJoCo (headless, EGL)

The same script on both trees: build a Panda scene with two objects and a look-at camera, settle 200 steps, render, call `get_body_state(body_name=None)`, then render again and keep using the session. On `main` there is no second frame - the process is gone. The two "before" frames agree to a max pixel delta of 1 (renderer noise), so the rig is identical and only the operation under test differs; after the refused call the scene is unchanged to the same tolerance.

![get_body_state(body_name=None) on main terminates the process with SIGSEGV; with this change it returns an error envelope and the session keeps rendering and stepping](https://raw.githubusercontent.com/cagataycali/robots/artifacts/entity-name-segfault/entity_name_segfault.png)