### PR TITLE
docs: an empty project read is not evidence of an untracked issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,29 @@ hatch run format            # ruff check --fix, ruff format
 4. All tests must pass, lint must be clean
 5. Open PR from your fork, address all review comments
 6. Track follow-up items as issues on the [project board](https://github.com/orgs/strands-labs/projects/2)
+
+   **Read the board with `PAT_TOKEN`, not the Actions `GITHUB_TOKEN`.** An
+   installation token that cannot see an organization project does not fail the
+   query - `issue.projectItems` comes back as an empty list, which is
+   indistinguishable from an issue nobody has tracked. The same one query, run
+   twice on #1762, #1768 and #1770:
+
+   | token | `issue.projectItems` |
+   |---|---|
+   | `GITHUB_TOKEN` | `[]` for all three |
+   | `PAT_TOKEN` | one item each; #1768 and #1770 already at `Done` |
+
+   Two things follow. First, adding an issue to the board is almost never the
+   missing step: all three items were created by `github-project-automation`
+   within three seconds of the issue itself, and the automation also moves them
+   to `Done` on close, so a merged fix needs no manual flip. What it cannot
+   infer is a status like `In review` while a PR is open - that is the part
+   worth setting by hand. Second, acting on the empty read looks harmless and
+   is not: `addProjectV2ItemById` is idempotent and returns the *existing*
+   item's id, so no duplicate ever appears and the false-empty read leaves no
+   trace - until a `Status` written on the strength of it silently overwrites a
+   value that was never read. Read a field before you set it, and treat an
+   empty project read as unknown rather than as absent.
 7. Squash merge into `main`
 8. **Verify a PR's state by reading it back - before and after you change it.**
    Neither direction can be inferred:


### PR DESCRIPTION
AGENTS.md step 6 tells a contributor to track work on the project board. It does not say that the read which answers *is it already tracked?* returns the same value for "no" and for "you are not allowed to know".

## The read that lies

`issue.projectItems` does not fail when the querying token cannot see an organization project. It returns an empty list. One query, run twice against #1762, #1768 and #1770 within the same minute:

| token | `issue.projectItems` |
|---|---|
| `GITHUB_TOKEN` (Actions installation) | `[]` for all three |
| `PAT_TOKEN` | one item each; #1768 and #1770 already at `Done` |

All three were in fact on the board, placed by `github-project-automation` within **three seconds** of the issue being opened:

| issue | opened | board item created |
|---|---|---|
| #1762 | 09:13:10Z | 09:13:13Z |
| #1768 | 13:49:29Z | 13:49:31Z |
| #1770 | 15:01:11Z | 15:01:14Z |

## Why the failure is quiet rather than loud

The obvious harm - a duplicate item - never happens. `addProjectV2ItemById` is idempotent: adding an issue that is already on the board returns the *existing* item's id. So the false-empty read produces no duplicate, no error, and no trace.

The actual harm is one step later. Having concluded the issue was untracked, the natural next call sets `Status`, and that write lands on a field whose previous value was never read. The board is a shared surface; the value overwritten may have been set deliberately by someone else.

This is the same failure shape already recorded under step 8 for `mergePullRequest` reporting `Pull Request is not mergeable` on a merge that landed: a GitHub read whose reassuring answer and whose true answer are the same bytes. That entry saved a redundant merge on #1772 in this same session, which is the argument for writing this one down too.

## The change

23 lines under step 6 of the PR Workflow, recording three things:

- read the board with `PAT_TOKEN`, and treat an empty project read as *unknown*, not as *absent*;
- adding an issue is almost never the missing step, since the automation places items and moves them to `Done` on close - a merged fix needs no manual flip;
- the only status worth setting by hand is one the automation cannot infer, such as `In review` while a PR is open.

## Scope

One file, 23 insertions, nothing modified or deleted.

No changelog fragment: this is an agent/contributor convention with no user-visible behaviour, matching the precedent of `81bff7b` (#1758, "verify a PR's state by reading it back"), which was likewise AGENTS.md-only.

## Gate

```
grep -P '[^\x00-\x7F]' AGENTS.md            0 non-ASCII lines
unicode dash / emoji scan                    clean
grep -rn 'AGENTS.md' tests/ | open|read_text no test parses this file
diffstat                                     1 file changed, 23 insertions(+)
```

Prose-only, so `.md` is inside the non-blocking prose set of the overlap check that landed in #1771; the file is untouched by any test collector.