### PR TITLE
fix(sim): report an entity name that is not a string instead of raising

### DIFF
--- a/changelog.d/1774-total-registry-lookup.md
+++ b/changelog.d/1774-total-registry-lookup.md
@@ -1,0 +1,16 @@
+### Fixed: an entity name that is not a string is reported instead of raising `TypeError`
+
+Every simulation entity is addressed by name, and each backend resolves a
+caller-supplied name against a name-keyed registry. A bare `name in registry` /
+`registry.get(name)` is not total: for a name that is not hashable (a list, a
+dict, a set) the lookup itself raised `TypeError: unhashable type`, so the
+unknown-entity error path it guards was never reached and the exception escaped
+the agent-tool dict those methods document as their only failure channel.
+Twenty-one MuJoCo entry points were affected, `move_object`, `send_action`,
+`render` and `move_to` among them, and Newton had the same lookups.
+
+The lookup is now total: `registered` and `registry_entry` resolve a name that
+cannot be a registry key to "absent", and the caller reports it with the message
+it already had, so no error text changed and a name that does resolve is
+unaffected. Entity *creation* is unchanged - claiming a name that cannot be one
+needs a contract for what a name may be, not a total lookup.

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -15,6 +15,7 @@ signatures reference them (e.g. ``create_world() → SimWorld``).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -199,3 +200,50 @@ class SimWorld:
     # distinguish - a same-shape recompile (remove one free-jointed object, add
     # another), or a whole scene replaced by one with the same counts.
     _recompile_generation: int = 0
+
+
+def registered(registry: Mapping[str, object], name: object) -> bool:
+    """Whether ``name`` is an entity registered in ``registry``.
+
+    A simulation entity is addressed by a ``str`` name, and the registries that
+    hold entities are keyed by one - the :class:`SimWorld` ``robots``,
+    ``objects`` and ``cameras`` maps, and the engine's own per-robot maps such
+    as its policy threads. A name of any other type cannot be one of their
+    keys, so the honest answer is that no such entity exists.
+
+    A bare ``name in registry`` cannot say that: the membership test itself
+    raises ``TypeError: unhashable type`` for a name that is not hashable (a
+    list, a dict, a set), so the unknown-entity error path the test guards is
+    never reached and the exception escapes the agent-tool dict that the
+    surrounding method documents as its only failure channel. This test is
+    total instead: every name resolves to a verdict, and a name that cannot be
+    a key resolves to ``False``, which lets the caller report it with the
+    message it already has.
+
+    Args:
+        registry: A name-keyed registry of simulation entities.
+        name: A caller-supplied entity name, of any type.
+
+    Returns:
+        ``True`` only when ``name`` is a string that keys ``registry``.
+    """
+    return isinstance(name, str) and name in registry
+
+
+def registry_entry[V](registry: Mapping[str, V], name: object) -> V | None:
+    """The entry ``name`` refers to in ``registry``, or ``None`` if there is none.
+
+    The fetching counterpart to :func:`registered`, for the lookups that need
+    the entry rather than only its existence, and total for the same reason:
+    ``registry.get(name)`` raises ``TypeError`` for an unhashable name, so the
+    absent case cannot be reported by the code that handles it.
+
+    Args:
+        registry: A name-keyed registry of simulation entities.
+        name: A caller-supplied entity name, of any type.
+
+    Returns:
+        The registered entry, or ``None`` when ``name`` is not a string or
+        names nothing in ``registry``.
+    """
+    return registry.get(name) if isinstance(name, str) else None

--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from strands_robots.simulation.models import registry_entry
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco, mj_name_to_id
 from strands_robots.simulation.mujoco.scene_ops import (
     actuate_robot_in_scene,
@@ -469,7 +470,7 @@ class ManipulationMixin:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("actuate_robot", robot_name):
             return err
-        robot = self._world.robots.get(robot_name)
+        robot = registry_entry(self._world.robots, robot_name)
         if robot is None:
             return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
         if not _finite_non_negative(damping):
@@ -637,7 +638,7 @@ class ManipulationMixin:
                 data.qacc_warmstart[:] = 0.0
                 scope = f"all {int(model.nv)} DOFs"
             else:
-                robot = self._world.robots.get(robot_name)
+                robot = registry_entry(self._world.robots, robot_name)
                 if robot is None:
                     return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
                 n_zeroed = 0

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -55,6 +55,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots.registry.robots import get_robot
+from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, mj_name_to_id
 from strands_robots.utils import coerce_pose_vector
 
@@ -161,7 +162,7 @@ class MotionPrimitivesMixin:
                 robot_name = self._resolve_single_robot(None)
             except ValueError as e:
                 return None, _err(str(e))
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return None, _err(self._unknown_robot_msg(robot_name))
         guard = self._require_no_running_policy(action, robot_name=robot_name)
         if guard is not None:
@@ -179,7 +180,7 @@ class MotionPrimitivesMixin:
         world = self._world
         if world is None or world._model is not model or world._data is None:
             return _err(f"{action}: world was destroyed or the model was recompiled mid-run; aborting.")
-        robot = world.robots.get(robot_name)
+        robot = registry_entry(world.robots, robot_name)
         if robot is None:
             return _err(f"{action}: robot '{robot_name}' was removed mid-run; aborting.")
         if robot.policy_running:

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -11,6 +11,7 @@ resume-schema guard.
 import logging
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.simulation.models import registry_entry
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco, mj_name_to_id
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
@@ -289,7 +290,9 @@ class RecordingMixin(DatasetRecordingMixin):
                 safe_name = cam_name.replace("/", "__")
                 raw_to_safe[cam_name] = safe_name
                 camera_keys.append(safe_name)
-                cam_info = self._world.cameras.get(cam_name) or self._world.cameras.get(safe_name)
+                cam_info = registry_entry(self._world.cameras, cam_name) or registry_entry(
+                    self._world.cameras, safe_name
+                )
                 if cam_info is not None:
                     camera_dims[safe_name] = (int(cam_info.height), int(cam_info.width))
                 else:

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
     from strands_robots.rendering import CameraParams
 
+from strands_robots.simulation.models import registry_entry
 from strands_robots.simulation.mujoco.backend import (
     _NO_WORLD_MSG,
     _can_render,
@@ -476,7 +477,7 @@ class RenderingMixin:
             if not cname:
                 continue
             cam_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_CAMERA, cname)
-            cam_info = self._world.cameras.get(cname)
+            cam_info = registry_entry(self._world.cameras, cname)
             h = cam_info.height if cam_info else self.default_height
             w = cam_info.width if cam_info else self.default_width
             try:
@@ -535,7 +536,7 @@ class RenderingMixin:
         mj = _ensure_mujoco()
         assert self._world is not None  # callers must check
         model, data = self._world._model, self._world._data
-        robot = self._world.robots.get(robot_name)
+        robot = registry_entry(self._world.robots, robot_name)
         pfx = robot.namespace if robot else ""
 
         # Action-controller fast path: adapter-installed transform
@@ -952,7 +953,11 @@ class RenderingMixin:
         # with get_observation, which already keys off the per-camera config.
         # The free camera ("default"/"free") and model-only cameras that have no
         # SimCamera entry fall back to the engine default.
-        cam_cfg = self._world.cameras.get(camera_name) if camera_name not in (None, "", "default", "free") else None
+        cam_cfg = (
+            registry_entry(self._world.cameras, camera_name)
+            if camera_name not in (None, "", "default", "free")
+            else None
+        )
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
@@ -1089,7 +1094,11 @@ class RenderingMixin:
         # frame render() produces for the same camera (and with get_observation).
         # The free camera and model-only cameras with no SimCamera entry fall
         # back to the engine default.
-        cam_cfg = self._world.cameras.get(camera_name) if camera_name not in (None, "", "default", "free") else None
+        cam_cfg = (
+            registry_entry(self._world.cameras, camera_name)
+            if camera_name not in (None, "", "default", "free")
+            else None
+        )
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
@@ -1286,7 +1295,11 @@ class RenderingMixin:
             raise RuntimeError(_NO_WORLD_MSG)
 
         mj = _ensure_mujoco()
-        cam_cfg = self._world.cameras.get(camera_name) if camera_name not in (None, "", "default", "free") else None
+        cam_cfg = (
+            registry_entry(self._world.cameras, camera_name)
+            if camera_name not in (None, "", "default", "free")
+            else None
+        )
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
@@ -1399,7 +1412,7 @@ class RenderingMixin:
         # The free camera is not a model camera: it has no name to resolve and
         # no SimCamera entry, so its resolution and default size differ.
         free_camera = camera_name in (None, "", "default", "free")
-        cam_cfg = None if free_camera else self._world.cameras.get(camera_name)
+        cam_cfg = None if free_camera else registry_entry(self._world.cameras, camera_name)
 
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -67,7 +67,15 @@ from strands_robots.simulation.model_registry import (
 from strands_robots.simulation.model_registry import (
     register_urdf as _register_urdf,
 )
-from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimStatus, SimWorld
+from strands_robots.simulation.models import (
+    SimCamera,
+    SimObject,
+    SimRobot,
+    SimStatus,
+    SimWorld,
+    registered,
+    registry_entry,
+)
 from strands_robots.simulation.mujoco.backend import (
     _NO_WORLD_MSG,
     _ensure_mujoco,
@@ -400,7 +408,7 @@ class MuJoCoSimEngine(
             if not self._world.robots:
                 return {}
             robot_name = next(iter(self._world.robots))
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return {}
         if skip_images and self._world is not None and self._world._backend_state.get("recording"):
             # T26: dataset recording needs every frame's image obs. Override
@@ -448,7 +456,7 @@ class MuJoCoSimEngine(
             if not self._world.robots:
                 return {"status": "error", "content": [{"text": "No robots in the world."}]}
             robot_name = next(iter(self._world.robots))
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
         action_map, coerce_error = self._coerce_action(action, robot_name)
         if coerce_error is not None:
@@ -1325,7 +1333,7 @@ class MuJoCoSimEngine(
                 # registry is keyed on the short name and we re-attach the
                 # namespace when passing to the renderer.
                 short = cam_name[len(pfx) :] if cam_name.startswith(pfx) else cam_name
-                if short not in self._world.cameras:
+                if not registered(self._world.cameras, short):
                     self._world.cameras[short] = SimCamera(
                         name=cam_name,
                         camera_id=i,
@@ -1630,13 +1638,13 @@ class MuJoCoSimEngine(
         target robot's own policy first (cooperatively), then require no
         OTHER robot is running a policy.
         """
-        if self._world is None or name not in self._world.robots:
+        if self._world is None or not registered(self._world.robots, name):
             return {"status": "error", "content": [{"text": self._unknown_robot_msg(name)}]}
 
         # Step 1: cooperatively stop THIS robot's policy if running.
         # Has to happen before the global check so remove_robot works even
         # when the target robot has an active policy (the common case).
-        if name in self._policy_threads:
+        if registered(self._policy_threads, name):
             self._world.robots[name].policy_running = False
             try:
                 self._policy_threads[name].result(timeout=5.0)
@@ -1708,7 +1716,7 @@ class MuJoCoSimEngine(
 
     def robot_joint_names(self, robot_name: str) -> list[str]:
         """Ordered joint names for ``robot_name`` (SimEngine ABC)."""
-        if self._world is None or robot_name not in self._world.robots:
+        if self._world is None or not registered(self._world.robots, robot_name):
             return []
         return list(self._world.robots[robot_name].joint_names)
 
@@ -1729,7 +1737,7 @@ class MuJoCoSimEngine(
         :meth:`_get_valid_action_keys`, which strips the trailing-slash
         namespace prefix (e.g. ``"xarm7/"``).
         """
-        if self._world is None or robot_name not in self._world.robots:
+        if self._world is None or not registered(self._world.robots, robot_name):
             return []
         namespace = self._world.robots[robot_name].namespace or ""
         return self._get_valid_action_keys(namespace)
@@ -1747,7 +1755,7 @@ class MuJoCoSimEngine(
             return
         if self._world is None or self._world._model is None:
             return
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return
         namespace = self._world.robots[robot_name].namespace or ""
         try:
@@ -2349,7 +2357,7 @@ class MuJoCoSimEngine(
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError as e:
             return {"status": "error", "content": [{"text": str(e)}]}
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
 
         mj = self._mj
@@ -2453,7 +2461,7 @@ class MuJoCoSimEngine(
 
         prefix = ""
         if robot_name is not None:
-            if robot_name not in self._world.robots:
+            if not registered(self._world.robots, robot_name):
                 return {
                     "status": "error",
                     "content": [
@@ -2788,7 +2796,7 @@ class MuJoCoSimEngine(
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
-        if name not in self._world.objects:
+        if not registered(self._world.objects, name):
             return {"status": "error", "content": [{"text": self._unknown_object_msg(name)}]}
         if err := self._require_no_running_policy("remove_object"):
             return err
@@ -2851,7 +2859,7 @@ class MuJoCoSimEngine(
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
-        if name not in self._world.objects:
+        if not registered(self._world.objects, name):
             return {"status": "error", "content": [{"text": self._unknown_object_msg(name)}]}
         # Guard: move_object writes qpos + calls mj_forward, racing a running policy.
         if err := self._require_no_running_policy("move_object"):
@@ -3142,7 +3150,7 @@ class MuJoCoSimEngine(
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
-        if name not in self._world.cameras:
+        if not registered(self._world.cameras, name):
             return {"status": "error", "content": [{"text": self._unknown_camera_msg(name)}]}
         if err := self._require_no_running_policy("remove_camera"):
             return err
@@ -3595,7 +3603,7 @@ class MuJoCoSimEngine(
         all_camera_names = [n for n in all_camera_names if n]
 
         if robot_name is not None:
-            if robot_name not in self._world.robots:
+            if not registered(self._world.robots, robot_name):
                 return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
             robot = self._world.robots[robot_name]
             ns = (getattr(robot, "namespace", "") or "").rstrip("/")
@@ -3746,7 +3754,7 @@ class MuJoCoSimEngine(
         # while the rollout's Future is tracked, so it follows _policy_threads
         # here rather than at each of that dict's own removal sites
         # (remove_robot deletes an entry, cleanup clears them all).
-        for stale in [k for k in self._policy_rates if k not in self._policy_threads]:
+        for stale in [k for k in self._policy_rates if not registered(self._policy_threads, k)]:
             self._policy_rates.pop(stale, None)
 
     def _active_policy_robots(self) -> list[str]:
@@ -3793,7 +3801,7 @@ class MuJoCoSimEngine(
         """
         self._prune_done_futures()
         if robot_name is not None:
-            fut = self._policy_threads.get(robot_name)
+            fut = registry_entry(self._policy_threads, robot_name)
             if fut is not None and not fut.done():
                 return {
                     "status": "error",
@@ -3937,7 +3945,7 @@ class MuJoCoSimEngine(
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError as e:
             return {"status": "error", "content": [{"text": str(e)}]}
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
 
         # Per-robot gate: another policy running on a DIFFERENT robot is fine.
@@ -4029,7 +4037,7 @@ class MuJoCoSimEngine(
         from strands_robots.simulation.models import TrajectoryStep
 
         world = self._world
-        if world is None or robot_name not in world.robots:
+        if world is None or not registered(world.robots, robot_name):
             return None
 
         robot = world.robots[robot_name]
@@ -4201,7 +4209,7 @@ class MuJoCoSimEngine(
                 stop_when=stop_when,
             )
         finally:
-            if self._world is not None and robot_name in self._world.robots:
+            if self._world is not None and registered(self._world.robots, robot_name):
                 self._world.robots[robot_name].policy_running = False
 
     def run_multi_policy(
@@ -4288,13 +4296,13 @@ class MuJoCoSimEngine(
 
         # Validate every robot exists.
         for rname in policies:
-            if rname not in self._world.robots:
+            if not registered(self._world.robots, rname):
                 return {"status": "error", "content": [{"text": self._unknown_robot_msg(rname)}]}
 
         # Reject if any of these robots already has a running async policy
         # (would double-step physics on that robot).
         self._prune_done_futures()
-        busy = [r for r in policies if (f := self._policy_threads.get(r)) is not None and not f.done()]
+        busy = [r for r in policies if (f := registry_entry(self._policy_threads, r)) is not None and not f.done()]
         if busy:
             names = ", ".join(f"'{n}'" for n in busy)
             return {
@@ -4557,7 +4565,7 @@ class MuJoCoSimEngine(
             completed_cleanly = True
         finally:
             for rname in policies:
-                if rname in self._world.robots:
+                if registered(self._world.robots, rname):
                     self._world.robots[rname].policy_running = False
             # Bailed mid-episode on an unexpected error (e.g. empty action
             # chunk): drop the partially-recorded frames so the next episode
@@ -4831,7 +4839,7 @@ class MuJoCoSimEngine(
                 "status": "error",
                 "content": [{"text": "stop_policy requires 'robot_name'."}],
             }
-        if self._world is None or robot_name not in self._world.robots:
+        if self._world is None or not registered(self._world.robots, robot_name):
             return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
         robot = self._world.robots[robot_name]
         was_running = robot.policy_running

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -27,6 +27,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.simulation.models import registered
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
@@ -363,7 +364,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         from strands_robots.simulation.policy_runner import _extract_frame_ndarray
 
         world = self._world
-        if world is None or robot_name not in world.robots:
+        if world is None or not registered(world.robots, robot_name):
             return None
 
         robot = world.robots[robot_name]

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -45,7 +45,14 @@ from strands_robots.simulation.model_registry import (
 from strands_robots.simulation.model_registry import (
     register_urdf as _register_urdf,
 )
-from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
+from strands_robots.simulation.models import (
+    SimCamera,
+    SimObject,
+    SimRobot,
+    SimWorld,
+    registered,
+    registry_entry,
+)
 from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
 from strands_robots.simulation.newton.randomization import DomainRandomizationMixin
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
@@ -511,7 +518,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
     def remove_robot(self, name: str) -> dict[str, Any]:
         """Remove a robot and rebuild the world."""
-        if self._world is None or name not in self._world.robots:
+        if self._world is None or not registered(self._world.robots, name):
             return {"status": "error", "content": [{"text": f"Robot '{name}' not found."}]}
         with self._lock:
             del self._world.robots[name]
@@ -526,7 +533,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
     def robot_joint_names(self, robot_name: str) -> list[str]:
         """Return ordered short joint names for ``robot_name``."""
-        if self._world is None or robot_name not in self._world.robots:
+        if self._world is None or not registered(self._world.robots, robot_name):
             return []
         return list(self._world.robots[robot_name].joint_names)
 
@@ -632,7 +639,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
     def remove_object(self, name: str) -> dict[str, Any]:
         """Remove an object and rebuild the world."""
-        if self._world is None or name not in self._world.objects:
+        if self._world is None or not registered(self._world.objects, name):
             return {"status": "error", "content": [{"text": f"Object '{name}' not found."}]}
         with self._lock:
             del self._world.objects[name]
@@ -662,7 +669,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
-        if name not in self._world.objects:
+        if not registered(self._world.objects, name):
             return {"status": "error", "content": [{"text": f"Object '{name}' not found."}]}
         with self._lock:
             obj = self._world.objects[name]
@@ -726,7 +733,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError:
             return {}
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return {}
         if skip_images and self._world._backend_state.get("recording"):
             # T26: dataset recording needs every frame's image obs. Override
@@ -811,7 +818,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError as exc:
             return {"status": "error", "content": [{"text": str(exc)}]}
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
         action_map, coerce_error = self._coerce_action(action, robot_name)
@@ -1091,7 +1098,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
-        if name not in self._world.cameras:
+        if not registered(self._world.cameras, name):
             return {
                 "status": "error",
                 "content": [{"text": f"Camera '{name}' not found. Registered: {list(self._world.cameras)}"}],
@@ -1368,7 +1375,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 int(height or self.default_height),
             )
         assert camera_name is not None  # the free-camera tokens were handled above
-        cam = self._world.cameras.get(camera_name) if self._world is not None else None
+        cam = registry_entry(self._world.cameras, camera_name) if self._world is not None else None
         if cam is None:
             raise KeyError(f"Camera '{camera_name}' not found. Available: {self.list_cameras()}")
         eye, target = self._resolve_camera_pose(cam)
@@ -1607,7 +1614,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError as exc:
             return {"status": "error", "content": [{"text": str(exc)}]}
-        if robot_name not in self._world.robots:
+        if not registered(self._world.robots, robot_name):
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
         with self._lock:
@@ -1695,7 +1702,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
 
         if robot_name is not None:
-            if robot_name not in self._world.robots:
+            if not registered(self._world.robots, robot_name):
                 return {
                     "status": "error",
                     "content": [
@@ -1745,7 +1752,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         m = self._model
         if robot_name is not None:
-            if robot_name not in self._world.robots:
+            if not registered(self._world.robots, robot_name):
                 return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
             joint_names = list(self._world.robots[robot_name].joint_names)
             scoped = {robot_name: self._world.robots[robot_name]}

--- a/tests/simulation/test_unhashable_entity_name_is_reported.py
+++ b/tests/simulation/test_unhashable_entity_name_is_reported.py
@@ -1,0 +1,300 @@
+"""A registry lookup reports any entity name instead of raising on it.
+
+Every simulation entity is addressed by name, and each backend resolves a
+caller-supplied name against a name-keyed registry before it does anything
+else. A bare ``name in registry`` / ``registry.get(name)`` is not total: for a
+name that is not hashable (a list, a dict, a set) the lookup itself raises
+``TypeError: unhashable type``, so the unknown-entity error path that the
+lookup guards is never reached and the exception escapes the agent-tool dict
+that the surrounding method documents as its only failure channel.
+
+These tests pin the lookup as total on both backends that keep such a registry:
+a name of any type resolves to a verdict, a name that cannot be a key resolves
+to "absent", and the message the method already had reports it. The AST check
+at the end is what keeps a lookup added later inside that rule.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.models import SimRobot, SimWorld, registered, registry_entry
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# A name that cannot key a registry, one per unhashable builtin a caller might
+# plausibly pass by mistake (a single-element list is what wrapping a name in
+# brackets produces; a dict is what a half-built kwargs mapping looks like).
+UNHASHABLE: list[tuple[str, Any]] = [
+    ("list", ["crate"]),
+    ("dict", {"crate": 1}),
+    ("set", {"crate"}),
+    ("bytearray", bytearray(b"crate")),
+]
+
+# One hinge with a position servo: enough for a registered robot with joints and
+# actuators, and it needs no downloaded asset so this runs anywhere.
+ARM_XML = """
+<mujoco model="probe_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1" range="-1.5 1.5" limited="true" damping="1"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+    </body>
+  </worldbody>
+  <actuator><position name="pan_act" joint="pan" kp="20" ctrlrange="-1.5 1.5"/></actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim(tmp_path):
+    xml = tmp_path / "arm.xml"
+    xml.write_text(ARM_XML)
+    s = Simulation(tool_name="unhashable_name_sim", mesh=False)
+    s.create_world()
+    s.add_object("crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.3, 0.0, 0.05], is_static=False)
+    s.add_robot(name="arm", urdf_path=str(xml))
+    s.add_camera(name="look", position=[0.9, -0.9, 0.6], target=[0.3, 0.0, 0.1])
+    # The refusals below are only meaningful against a world that does hold the
+    # entities being asked for, so pin the premise rather than assuming it.
+    assert "crate" in s._world.objects
+    assert "arm" in s._world.robots
+    assert "look" in s._world.cameras
+    yield s
+    s.cleanup()
+
+
+def _mujoco_lookups(s: Simulation) -> dict[str, Any]:
+    """Every MuJoCo entry point that resolves a caller-supplied name."""
+    return {
+        "move_object": lambda n: s.move_object(name=n, position=[0.2, 0.0, 0.3]),
+        "remove_object": lambda n: s.remove_object(name=n),
+        "remove_camera": lambda n: s.remove_camera(name=n),
+        "remove_robot": lambda n: s.remove_robot(name=n),
+        "send_action": lambda n: s.send_action({"pan_act": 0.1}, robot_name=n),
+        "get_robot_state": lambda n: s.get_robot_state(robot_name=n),
+        "list_bodies": lambda n: s.list_bodies(robot_name=n),
+        "get_features": lambda n: s.get_features(robot_name=n),
+        "start_policy": lambda n: s.start_policy(robot_name=n, duration=0.2),
+        "stop_policy": lambda n: s.stop_policy(robot_name=n),
+        "move_to": lambda n: s.move_to(robot_name=n, position=[0.2, 0.0, 0.2]),
+        "rotate_wrist": lambda n: s.rotate_wrist(robot_name=n, target_yaw=0.2),
+        "actuate_robot": lambda n: s.actuate_robot(robot_name=n),
+        "run_policy": lambda n: s.run_policy(robot_name=n, n_steps=2),
+        "eval_policy": lambda n: s.eval_policy(robot_name=n, n_episodes=1, max_steps=2),
+        "render": lambda n: s.render(camera_name=n, width=64, height=48),
+        "render_depth": lambda n: s.render_depth(camera_name=n, width=64, height=48),
+    }
+
+
+@pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])
+def test_an_unhashable_name_is_reported_as_absent(sim, label, name):
+    """Each name-taking method returns its error envelope, not a TypeError."""
+    failures = {}
+    for method, call in _mujoco_lookups(sim).items():
+        try:
+            result = call(name)
+        except BaseException as exc:  # noqa: BLE001 - the escape is what is under test
+            failures[method] = f"raised {type(exc).__name__}: {exc}"
+            continue
+        if not isinstance(result, dict) or result.get("status") != "error":
+            failures[method] = f"expected an error envelope, got {result!r}"
+    assert not failures, f"a {label} name escaped or was accepted:\n" + "\n".join(
+        f"  {k}: {v}" for k, v in sorted(failures.items())
+    )
+
+
+@pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])
+def test_a_best_effort_lookup_reports_nothing_rather_than_raising(sim, label, name):
+    """The two lookups documented as best-effort keep returning an empty list."""
+    assert sim.robot_joint_names(name) == []
+    assert sim.robot_action_keys(name) == []
+    # get_observation has no error channel either; it must still not raise.
+    assert isinstance(sim.get_observation(robot_name=name), dict)
+
+
+def test_the_reported_message_names_the_value_and_what_exists(sim):
+    """The existing unknown-entity message is reused, so the caller can recover."""
+    text = sim.move_object(name=["crate"], position=[0.2, 0.0, 0.3])["content"][0]["text"]
+    assert "not found" in text
+    assert "crate" in text  # the available objects are still listed
+
+
+def test_a_registered_name_is_unaffected(sim):
+    """Guarding the lookup must not cost the lookups that resolve."""
+    assert sim.move_object(name="crate", position=[0.25, 0.0, 0.2])["status"] == "success"
+    assert sim.get_robot_state(robot_name="arm")["status"] == "success"
+    assert sim.render(camera_name="look", width=64, height=48)["status"] == "success"
+
+
+def test_an_unknown_string_name_is_unaffected(sim):
+    """A misspelled name still reports the same way it always did."""
+    text = sim.move_object(name="crat", position=[0.2, 0.0, 0.3])["content"][0]["text"]
+    assert "Object 'crat' not found" in text
+    assert "crate" in text
+
+
+# --------------------------------------------------------------------------- #
+# the shared rule                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_registered_answers_for_a_name_of_any_type():
+    registry = {"crate": object()}
+    assert registered(registry, "crate") is True
+    assert registered(registry, "nosuch") is False
+    for _label, name in UNHASHABLE:
+        assert registered(registry, name) is False
+    assert registered(registry, None) is False
+    assert registered(registry, 3) is False
+
+
+def test_registry_entry_returns_the_entry_or_none():
+    entry = object()
+    registry = {"crate": entry}
+    assert registry_entry(registry, "crate") is entry
+    assert registry_entry(registry, "nosuch") is None
+    for _label, name in UNHASHABLE:
+        assert registry_entry(registry, name) is None
+    assert registry_entry(registry, None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Newton keeps the same registries, so it answers the same way                #
+# --------------------------------------------------------------------------- #
+
+
+def _newton_engine():
+    """A Newton engine holding one registered robot, without the newton package.
+
+    Only the registry and the lookup are under test, so the parts of the engine
+    that need the simulator are never reached.
+    """
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    engine = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._lock = threading.Lock()
+    engine._model = object()  # only its presence is read by the lookups under test
+    engine._world = SimWorld()
+    engine._world.robots["arm"] = SimRobot(name="arm", urdf_path="", joint_names=["pan"])
+    return engine
+
+
+@pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])
+def test_newton_reports_an_unhashable_name_the_same_way(label, name):
+    engine = _newton_engine()
+    for method in ("remove_robot", "get_robot_state", "list_bodies", "get_features"):
+        result = getattr(engine, method)(name)
+        assert isinstance(result, dict) and result.get("status") == "error", (
+            f"newton {method} accepted a {label} name: {result!r}"
+        )
+
+
+def test_newton_still_resolves_a_registered_name():
+    """A registered name gets past the lookup on Newton too.
+
+    Each of these methods goes on to read simulator state that this skeleton
+    does not build, so failing on that state is itself the evidence that the
+    name resolved: a name the lookup rejected would have returned the
+    unknown-robot envelope instead, without reaching it.
+    """
+    for method in ("get_robot_state", "list_bodies", "get_features", "remove_robot"):
+        with pytest.raises(AttributeError):
+            getattr(_newton_engine(), method)("arm")
+
+
+# --------------------------------------------------------------------------- #
+# no backend may re-introduce a partial lookup                                #
+# --------------------------------------------------------------------------- #
+
+# Registries keyed by an entity name. ``_policy_threads`` is the engine's own
+# per-robot map, reached before the world registries by the guard that refuses a
+# mutation while a policy runs.
+_REGISTRY_ATTRS = frozenset({"objects", "cameras", "robots", "_policy_threads"})
+
+# Creating an entity is a different question from looking one up: there the name
+# is not resolved but claimed, and a name that cannot be a key has to be refused
+# rather than reported absent - which needs a contract for what a name may be,
+# not just a total lookup. Those tests are left as they are, and pinned below so
+# this exemption cannot outlive them.
+_CREATION_FUNCTIONS = frozenset({"add_robot", "add_object", "add_camera"})
+
+
+def _backend_dirs() -> list[Path]:
+    """The backend packages, located from a symbol rather than a path literal."""
+    simulation_dir = Path(inspect.getfile(registered)).parent
+    return [simulation_dir / "mujoco", simulation_dir / "newton"]
+
+
+def _is_registry(node: ast.AST) -> bool:
+    """Whether ``node`` reads a name-keyed entity registry."""
+    return isinstance(node, ast.Attribute) and node.attr in _REGISTRY_ATTRS
+
+
+def _raw_lookups(source: str) -> list[tuple[str, int]]:
+    """(enclosing function, line) for each registry lookup not using the helpers."""
+    tree = ast.parse(source)
+    owner: dict[int, str] = {}
+
+    def annotate(node: ast.AST, name: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                annotate(child, child.name)
+            else:
+                if hasattr(child, "lineno"):
+                    owner[child.lineno] = name
+                annotate(child, name)
+
+    annotate(tree, "<module>")
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare) and any(isinstance(op, ast.In | ast.NotIn) for op in node.ops):
+            hit = any(_is_registry(c) for c in node.comparators)
+        elif isinstance(node, ast.Call):
+            fn = node.func
+            hit = isinstance(fn, ast.Attribute) and fn.attr == "get" and _is_registry(fn.value)
+        else:
+            continue
+        if hit:
+            found.append((owner.get(node.lineno, "<module>"), node.lineno))
+    return found
+
+
+def test_every_backend_lookup_uses_the_shared_rule():
+    """Only entity creation may test a registry directly."""
+    offenders = []
+    for directory in _backend_dirs():
+        for path in sorted(directory.glob("*.py")):
+            for function, line in _raw_lookups(path.read_text()):
+                if function not in _CREATION_FUNCTIONS:
+                    offenders.append(f"{path.name}:{line} in {function}()")
+    assert not offenders, "these registry lookups are not total:\n" + "\n".join(f"  {o}" for o in offenders)
+
+
+def test_the_creation_exemption_still_describes_real_code():
+    """A stale exemption must be deleted, not left as a hole in the check."""
+    exempt = {
+        function
+        for directory in _backend_dirs()
+        for path in directory.glob("*.py")
+        for function, _line in _raw_lookups(path.read_text())
+    }
+    assert exempt and exempt <= _CREATION_FUNCTIONS, f"the exemption no longer matches the code: found {sorted(exempt)}"
+
+
+def test_the_check_detects_a_partial_lookup():
+    """A scanner that silently matched nothing would look like a clean backend."""
+    planted = "def look(self, name):\n    if name not in self._world.robots:\n        return None\n"
+    assert _raw_lookups(planted) == [("look", 2)]
+    guarded = "def look(self, name):\n    if not registered(self._world.robots, name):\n        return None\n"
+    assert _raw_lookups(guarded) == []

--- a/tests/simulation/test_unhashable_entity_name_is_reported.py
+++ b/tests/simulation/test_unhashable_entity_name_is_reported.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import ast
 import inspect
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -97,21 +98,97 @@ def _mujoco_lookups(s: Simulation) -> dict[str, Any]:
     }
 
 
+def _envelope_miss(call: Callable[[Any], Any], name: Any) -> str | None:
+    """Describe how ``call`` failed to report ``name``, or ``None`` if it reported.
+
+    An exception is reported rather than propagated, so one run names every
+    method that escaped instead of stopping at the first. That reporting is
+    sound only for an exception the method leaked, which is where the caught set
+    stops: the escape under test is a ``TypeError`` out of a partial lookup, and
+    every type these methods can leak is an ``Exception``.
+
+    It deliberately does not sit at ``BaseException``. A pytest outcome
+    (``Skipped`` / ``Failed``) or an operator interrupt (``KeyboardInterrupt`` /
+    ``SystemExit``) derives from ``BaseException`` without deriving from
+    ``Exception``, and none of them is the API's to leak - absorbing them would
+    turn an interrupted run into a verdict string and report a skipped
+    dependency as an envelope escape. :class:`TestTheEnvelopeProbe` pins the
+    boundary in both directions.
+    """
+    try:
+        result = call(name)
+    except Exception as exc:  # noqa: BLE001 - the escape is what is under test
+        return f"raised {type(exc).__name__}: {exc}"
+    if not isinstance(result, dict) or result.get("status") != "error":
+        return f"expected an error envelope, got {result!r}"
+    return None
+
+
 @pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])
 def test_an_unhashable_name_is_reported_as_absent(sim, label, name):
     """Each name-taking method returns its error envelope, not a TypeError."""
-    failures = {}
-    for method, call in _mujoco_lookups(sim).items():
-        try:
-            result = call(name)
-        except BaseException as exc:  # noqa: BLE001 - the escape is what is under test
-            failures[method] = f"raised {type(exc).__name__}: {exc}"
-            continue
-        if not isinstance(result, dict) or result.get("status") != "error":
-            failures[method] = f"expected an error envelope, got {result!r}"
+    failures = {
+        method: miss
+        for method, call in _mujoco_lookups(sim).items()
+        if (miss := _envelope_miss(call, name)) is not None
+    }
     assert not failures, f"a {label} name escaped or was accepted:\n" + "\n".join(
         f"  {k}: {v}" for k, v in sorted(failures.items())
     )
+
+
+class TestTheEnvelopeProbe:
+    """The probe the sweep above shares must not absorb control flow.
+
+    :func:`_envelope_miss` turns one call into a miss description or ``None`` so
+    that a single assertion can name every method that escaped. Reporting an
+    exception is what makes that message useful, and it has to stay bounded to
+    exceptions the API leaked: a probe that also caught pytest's own outcomes
+    would report a skipped optional dependency as an envelope escape, and an
+    interrupted run as an answer.
+    """
+
+    def test_an_error_envelope_is_what_the_probe_asks_for(self):
+        assert _envelope_miss(lambda n: {"status": "error"}, ["crate"]) is None
+
+    @pytest.mark.parametrize("accepted", [{"status": "success"}, None, "ok"])
+    def test_anything_other_than_an_error_envelope_is_a_miss(self, accepted):
+        """A name that cannot address an entity must not be reported as resolved."""
+        miss = _envelope_miss(lambda n: accepted, ["crate"])
+        assert miss is not None and "expected an error envelope" in miss
+
+    @pytest.mark.parametrize("leaked", [TypeError, ValueError, KeyError])
+    def test_an_exception_the_method_leaked_is_reported(self, leaked):
+        """The escape under test is a leaked ``TypeError``; it must stay reported.
+
+        Reporting rather than propagating is what lets one run list every method
+        that escaped, so it has to survive the narrowing of the caught set.
+        """
+
+        def leak(name: Any) -> dict[str, Any]:
+            raise leaked("unhashable type: 'list'")
+
+        miss = _envelope_miss(leak, ["crate"])
+        assert miss is not None and miss.startswith(f"raised {leaked.__name__}")
+
+    @pytest.mark.parametrize(
+        "control_flow",
+        [pytest.skip.Exception, pytest.fail.Exception, KeyboardInterrupt, SystemExit],
+    )
+    def test_control_flow_is_not_absorbed(self, control_flow):
+        """A pytest outcome or an operator interrupt passes straight through.
+
+        All four derive from ``BaseException`` without deriving from
+        ``Exception``, and none is something a lookup leaked. Absorbing them
+        would turn a ``Ctrl-C`` into ``"raised KeyboardInterrupt"`` and then
+        assert on it as though the lookup had answered.
+        """
+
+        def interrupt(name: Any) -> dict[str, Any]:
+            raise control_flow("not the API's to leak")
+
+        with pytest.raises(control_flow):
+            _envelope_miss(interrupt, ["crate"])
 
 
 @pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])


### PR DESCRIPTION
## Problem

Every simulation entity is addressed by name, and each backend resolves a caller-supplied name against a name-keyed registry before it does anything else. A bare `name in registry` / `registry.get(name)` is not total: for a name that is not hashable (a list, a dict, a set) **the lookup itself raises**, so the unknown-entity error path the lookup guards is never reached and a `TypeError` escapes the agent-tool dict those methods document as their only failure channel.

The raise comes from the membership test that precedes the message, e.g. `mujoco/simulation.py`:

```python
if name not in self._world.cameras:
    return {"status": "error", "content": [{"text": self._unknown_camera_msg(name)}]}
```

Measured on `main` (`77173e65`), mujoco 3.11.0, on a world that holds an object `crate`, a robot `arm` and a camera `look`. Nineteen MuJoCo entry points raise, for every unhashable name tried (`["crate"]`, `{"crate": 1}`, `{"crate"}`, `bytearray(b"crate")`):

| entry point | before | after |
|---|---|---|
| `move_object`, `remove_object` | `TypeError: unhashable type: 'list'` | `status="error"`, `Object '['crate']' not found. Available objects: [...]` |
| `remove_camera`, `render`, `render_depth` | `TypeError` | `status="error"`, `Camera '...' not found. Available: [...]` |
| `remove_robot`, `send_action`, `get_robot_state`, `list_bodies`, `get_features`, `get_observation`, `start_policy`, `stop_policy`, `run_policy`, `actuate_robot` | `TypeError` | `status="error"`, `Robot '...' not found. Available robots: [...]` |
| `move_to`, `rotate_wrist` (and `set_gripper`, same resolver) | `TypeError` | `status="error"` |
| `robot_joint_names`, `robot_action_keys` | `TypeError` | `[]`, as documented for a name they cannot resolve |

Newton keeps the same registries and the same lookups, so `remove_robot`, `get_robot_state`, `list_bodies` and `get_features` raise there too.

Unlike a name that reaches `mujoco.mj_name2id`, this is recoverable - the session survives and the exception is catchable. What it costs is the contract: a caller that checks `result["status"]`, which is what these methods ask of it, never gets to.

## Change

Two total lookups in `simulation/models.py`, beside the `SimWorld` they read - the module both backends already import and one with no dependencies of its own:

```python
def registered(registry: Mapping[str, object], name: object) -> bool:
    return isinstance(name, str) and name in registry

def registry_entry[V](registry: Mapping[str, V], name: object) -> V | None:
    return registry.get(name) if isinstance(name, str) else None
```

Registry keys are always `str`, so a name of any other type is genuinely absent and "not found" is the honest verdict. All 46 lookups across both backends route through them, so **no new error path is introduced and no message text changes** - each caller reports the name with the message it already had, naming the value and listing what the world does contain. They mirror `in` and `.get` rather than collapsing into one helper, so every call site keeps its own shape.

Routing every lookup, rather than guarding each public entry point, is what makes this complete: a lookup added later inherits the rule, and the AST check below keeps that true.

The check earned its keep immediately. It found three sites that a grep for `self._world.<registry>` missed because they read through a local alias (`world = self._world`) - in `_make_run_policy_hook` on both backends and in `_primitive_abort_reason` - and it is what surfaced that the engine's own per-robot policy-thread map is a fourth registry with the same hazard, reached *before* the world registries by the guard that refuses a mutation while a policy runs. That last one is why `actuate_robot` still raised after the first pass.

## Out of scope, measured

**Entity creation.** `add_object`, `add_camera` and `add_robot` test a registry too, but to claim a name rather than resolve one, and a name that cannot be a key has to be *refused* there rather than reported absent - making the test total would only move the raise to the spec build. That needs a contract for what a name may be, which is the same question as `add_object(name="")` (accepted; the geom compiles as `"_geom"` and `get_body_state(body_name="")` then reports `Body '' not found`) and `add_object(name="a\x00b")` (accepted; the registry key keeps the NUL and the compiled body is named `'a'`). Filing separately. Those four sites are the AST check's only exemption, and a second test pins that they still exist so the exemption cannot outlive them.

**`mujoco.mj_name2id`.** `get_body_state`, `set_body_properties`, `attach_bodies` and `set_geom_properties` fail at the C binding, not at a registry, and `get_camera_params` / `get_frame` reach it after this change resolves their registry read to `None` - correctly, because the compiled model is the authority for a camera that a scene MJCF declares and the Python registry never saw. #1773 makes that binding total; the two changes are disjoint and together every name-taking method reports.

**`save_state` / `load_state`.** Keyed by a caller-chosen checkpoint name that is documented as any hashable, so the rule there is hashability, not being a string.

**Mapping-keyed names** (`set_joint_positions({name: ...})`, `run_multi_policy(policies={name: ...})`) are unreachable: an unhashable key cannot be put in a dict in the first place.

## Tests

`tests/simulation/test_unhashable_entity_name_is_reported.py`, 21 tests:

- Every affected MuJoCo entry point returns an error envelope for each of the four unhashable names, collected so one failure names every method that escaped rather than stopping at the first.
- The two best-effort lookups still return `[]`, and `get_observation`, which has no error channel, still does not raise.
- The reported message still names the value and lists what exists, so the mistake is recoverable.
- Guarding the lookup costs nothing that worked: a registered name still resolves (`move_object`, `get_robot_state`, `render`), and an unknown *string* name reports exactly as before.
- Newton answers the same way, on a skeleton engine that needs no `newton` install. Its positive case asserts that a registered name gets *past* the lookup - each of those methods then reads simulator state the skeleton does not build, which is itself the evidence, since a rejected name would have returned the envelope without reaching it.
- Unit tests for both helpers over string, unknown-string, unhashable, `None` and `int` names.
- The AST check, plus two meta-tests: the creation exemption still describes real code, and the scanner detects a planted partial lookup (a scanner that silently matched nothing would look like a clean backend).
- The fixture asserts the world really holds the three entities, so no refusal can pass vacuously.

**Pre-fix**, against `77173e65` with only the source reverted: **13 failed / 3 passed**. The three that pass are the over-reach controls - a registered name, an unknown string name, and the message shape - which is what stops "delete the guard" from being a valid fix. Post-fix: **21 passed**.

## Verification

```
ruff check strands_robots tests tests_integ         All checks passed!
ruff format --check strands_robots tests tests_integ  974 files already formatted
mypy strands_robots tests tests_integ              Success: no issues found in 971 source files
MUJOCO_GL=egl pytest tests -q --no-cov             14524 passed, 255 skipped in 486s
```

No existing test changed.

## Rollout in MuJoCo (headless, EGL)

One batch of five scene edits on both trees, issued as an agent would - each result checked before the next, no `try`/`except`, because the envelope *is* the contract. The third call wraps the object name in brackets, which is what reading a name out of a list produces.

![On main the TypeError leaves the batch at step 3 and the last two edits never run, so the scene ends with 2 of 4 objects; with this change the mistake is reported with the available objects and the batch finishes with all 4](https://raw.githubusercontent.com/cagataycali/robots/artifacts/total-registry-lookup/registry_lookup.png)

On `main` the batch ends at step 3 and the two remaining edits never run: 2 of 4 objects. With this change step 3 reports `Object '['crate']' not found. Available objects: ['crate', 'beacon']`, the caller carries on, and the scene is complete. Same script, same camera; the panels differ on 23.4% of pixels.

## Round 2 - rebased onto the merged #1773, and the probe catches `Exception`

Two things, neither of which changes what this PR does to production behaviour.

### The base moved: #1773 landed as `f420516d`

This branch was cut from `77173e65`, and #1773 - the fatal half of the same
question - has since merged. It routed all 36 `mujoco.mj_name2id` call sites
through a `mj_name_to_id` wrapper, and five of the files it touched are files
this PR also edits, so the two changes met in four places. Every one of them was
compositional rather than contradictory - #1773 replaces the *binding* call, this
PR replaces the *registry* lookup - and the resolution keeps both:

| file | resolution |
|---|---|
| `mujoco/manipulation.py` | import `registry_entry` **and** `mj_name_to_id` |
| `mujoco/motion_primitives.py` | import `registered`, `registry_entry` **and** `mj_name_to_id` |
| `mujoco/recording.py` | import `registry_entry` **and** `mj_name_to_id` |
| `mujoco/rendering.py` | `cam_id = mj_name_to_id(...)` **and** `cam_info = registry_entry(self._world.cameras, cname)` - adjacent lines, one from each change |

The composition is checked rather than assumed, and each side has an AST test
that is exactly the check needed:

- #1773's scanner asserts no module under `simulation/mujoco/` calls the binding
  directly. It passes, so this rebase reintroduced no raw `mj_name2id` - which is
  the failure mode a hand-resolved import conflict would produce.
- This PR's scanner asserts every backend registry lookup is total. It passes, so
  #1773 introduced no new partial lookup while this branch was open.
- Both test modules run green together on the rebased tree: **73 passed**
  (#1773's 52 + this PR's 21, before the class added below).

### The probe caught `BaseException`

The sweep that reports which methods escaped the envelope reported an exception
rather than propagating it, so that one run names every method that escaped
instead of stopping at the first. That is worth keeping, but the caught set was
wider than the job needs.

Narrowing it to `Exception` costs nothing, because every type these methods can
leak is an `Exception` - the escape under test is `TypeError: unhashable type`
out of a partial lookup:

| the probe sees | `except BaseException` (previous head) | `except Exception` (now) |
|---|---|---|
| `TypeError: unhashable type: 'list'` | `'raised TypeError: ...'` | `'raised TypeError: ...'` |
| `ValueError` / `KeyError` | reported | reported |
| `{"status": "error"}` | `None` (reported properly) | `None` (reported properly) |
| `{"status": "success"}` | `'expected an error envelope'` | `'expected an error envelope'` |
| a non-dict result | `'expected an error envelope'` | `'expected an error envelope'` |
| `pytest.skip()` -> `Skipped` | `'raised Skipped'` | **propagates** |
| `pytest.fail()` -> `Failed` | `'raised Failed'` | **propagates** |
| Ctrl-C -> `KeyboardInterrupt` | `'raised KeyboardInterrupt'` | **propagates** |
| `SystemExit` | `'raised SystemExit'` | **propagates** |

Every outcome the API can produce is reported identically, so no discrimination
is lost. What the wider set additionally absorbed was control flow that is not
the API's to leak: `Skipped` / `Failed` / `KeyboardInterrupt` / `SystemExit` all
derive from `BaseException` without deriving from `Exception`, so an interrupted
run became a verdict string that the sweep then asserted on as though the lookup
had answered, and an `importorskip` inside one of the probed methods would have
surfaced as an envelope escape rather than a skip.

Two changes came with it:

- The loop body is promoted to a module-level `_envelope_miss` helper, beside the
  file's existing `_mujoco_lookups` / `_newton_engine` module-level helpers. That
  is the file's own convention, and it makes the boundary testable without
  reaching into a test's locals.
- `TestTheEnvelopeProbe` (11 tests) pins the boundary in both directions, so
  neither the reporting behaviour nor the control-flow passthrough can regress.
  The helper's docstring now states where the boundary sits and why.

Pre-fix for the new class - this file with `BaseException` restored and
everything else identical - is **4 failed / 28 passed**: the failures are all
`test_control_flow_is_not_absorbed[...]` (`DID NOT RAISE Skipped` / `Failed` /
`KeyboardInterrupt` / `SystemExit`), and the 28 that pass are the reporting
properties the narrowing preserves. Post-fix, this file: **32 passed** (was 21).

### Verification on the rebased head

```
ruff check strands_robots tests tests_integ            All checks passed!
ruff format --check strands_robots tests tests_integ    975 files already formatted
python scripts/assemble_changelog.py --check           changelog fragments OK (63 pending)
pytest tests/simulation/test_unhashable_entity_name_is_reported.py
       tests/simulation/mujoco/test_entity_name_lookup_type_safety.py    73 -> 84 passed
```

The full-suite number in the section above was measured on the pre-rebase head
in an EGL environment. This round's runner has only software GL, where 348 tests
under `tests/simulation` fail on rendering before any of this is reached, so
rather than quote a number that a reader cannot compare, the regression claim is
made as a controlled difference: `tests/simulation` was run on `origin/main` and
on this head in the same environment, and the sets of failing test ids are
**byte-identical** (348 failed / 34 errors on both, `diff` empty). This head
differs only by **+32 passed**, which is this PR's own file. So every failure in
that environment predates this branch and none is attributable to it; CI runs the
full suite under EGL.

No production code changed in this round, so the measured behaviour and the
artifact above are unaffected.
