### PR TITLE
fix(sim): refuse an entity name that cannot address what it creates

### DIFF
--- a/changelog.d/1777-entity-name-addressability.md
+++ b/changelog.d/1777-entity-name-addressability.md
@@ -1,0 +1,27 @@
+### Fixed: `add_object` / `add_camera` / `add_robot` refuse a name that cannot address the entity they create
+
+These three methods claim a name twice - as the world-registry key and as the MJCF
+element name - and three kinds of value silently broke the link between those layers.
+
+A non-`str` was hashable often enough to be registered (`7` and `True` both are) and
+only then reached the spec build, where pybind11 raised
+`TypeError: add_body(): incompatible function arguments`. That escaped the result dict
+these methods document, and it landed *after* the registry write, so the world was left
+holding a key for an entity with no body in the model.
+
+An empty name is MuJoCo's own sentinel for an unnamed element, so the entity compiled
+anonymously and nothing could address it afterwards: `get_body_state(body_name="")`
+reported the body as missing while it simulated, `render(camera_name="")` routed to the
+free camera by an explicit token check - handing back an image from a camera the caller
+never placed - and the recording schema dropped the anonymous camera rather than declare
+an empty feature key, so a two-camera scene silently recorded one.
+
+A name containing a NUL left the two layers disagreeing: MuJoCo compares names only up
+to the NUL, so `"a\0b"` compiled as `"a"` and answered to that, while the registry kept
+the full string.
+
+All three are now refused through the normal error result, before the registry write, by
+a shared `strands_robots.utils.entity_name_error` so the creators' accepted domain cannot
+diverge. Nothing further is constrained, because nothing further was broken - `"a/b"`,
+`"a b"` and `"a-b"` each compile under the name given and remain accepted. `add_robot`
+still derives a label from the model when no name is supplied, exactly as documented.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -111,6 +111,7 @@ from strands_robots.teleop_mixin import TeleopMixin
 from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
+    entity_name_error,
     finite_vector_error,
     pose_vector_error,
 )
@@ -1140,7 +1141,9 @@ class MuJoCoSimEngine(
         OPTIONAL: when omitted it is auto-derived from ``data_config`` (or the
         URDF filename), with a numeric suffix appended if that label is already
         taken -- so ``add_robot(data_config="so101")`` twice yields ``so101``
-        and ``so101_2`` instead of erroring.
+        and ``so101_2`` instead of erroring. A name that IS supplied must be a
+        non-empty string with no NUL, so that the label can address the robot it
+        was given to; omitting it keeps the auto-derived label above.
 
         ``keyframe`` (name ``str`` or index ``int``) spawns the robot in a
         canonical pose declared by a ``<keyframe>`` in its source model
@@ -1188,6 +1191,14 @@ class MuJoCoSimEngine(
         # label): an explicit name that resolves to no model is a
         # mistyped/unknown robot, not a 'you forgot a model source' case.
         explicit_name = name
+        # Validate a name the caller SUPPLIED. An omitted one is derived just
+        # below, which is this method's documented behaviour, so the guard is
+        # gated on the same truthiness test that branch already uses: every
+        # value that derives today still derives, and only a supplied name is
+        # held to the shared domain.
+        if name and (name_err := entity_name_error(name, "name", "add_robot")) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
+
         # Auto-derive an instance label when the caller didn't supply one.
         # Friction fix: ``name`` used to be required, so a natural
         # ``add_robot(data_config="so101")`` failed with "requires parameter
@@ -2551,6 +2562,12 @@ class MuJoCoSimEngine(
 
         Args:
             name: Unique object name. Its geom is injected as ``"<name>_geom"``.
+                Must be a non-empty string with no NUL: the name is both the
+                registry key and the MJCF body name, and a value that cannot
+                serve as both leaves the object unaddressable (an empty name
+                is MuJoCo's unnamed sentinel) or addressable under a
+                different name than was asked for (MuJoCo compares only up
+                to a NUL). ``/``, spaces and ``-`` are fine.
             shape: ``"box"``, ``"sphere"``, ``"cylinder"``, ``"capsule"``,
                 ``"ellipsoid"``, ``"plane"``, or ``"mesh"``.
             position: World position ``[x, y, z]`` of the body origin (default
@@ -2614,6 +2631,8 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_object"):
             return err
+        if (name_err := entity_name_error(name, "name", "add_object")) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
         if name in self._world.objects:
             return {"status": "error", "content": [{"text": f"Object '{name}' exists."}]}
 
@@ -3017,7 +3036,11 @@ class MuJoCoSimEngine(
         values are rejected here at config time with an actionable error rather
         than deferring an uncaught ``TypeError`` (non-numeric), a silently
         degenerate camera (``nan``/``inf`` baked into ``xyaxes``), or a cryptic
-        spec-recompile / GL failure to the first render.
+        spec-recompile / GL failure to the first render. ``name`` is held to the
+        same standard, and for the same reason: an empty name is the explicit
+        free-camera token in ``render``, so a camera stored under it could never
+        be the one rendered from, and it is dropped from a recording schema
+        rather than declared as an empty feature key.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -3074,6 +3097,9 @@ class MuJoCoSimEngine(
         if dim_err := self._validate_render_dims(width, height):
             text = dim_err["content"][0]["text"].replace("render:", "add_camera:", 1)
             return {"status": "error", "content": [{"text": text}]}
+
+        if (name_err := entity_name_error(name, "name", "add_camera")) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
 
         # reject duplicate camera names.  Previously a second
         # add_camera(name=existing) silently overwrote the registry entry but

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -700,3 +700,70 @@ def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:
     if not (0.0 < float(value) < 180.0):
         return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {value}."
     return None
+
+
+def entity_name_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` cannot address the entity it would name.
+
+    Shared domain for the ``name`` a scene-construction call CLAIMS for the
+    object, camera or robot it creates. It lives here, beside the numeric
+    domains, for the reason those do: three entry points take this parameter and
+    their accepted domain must not diverge - a name one creator refuses must be
+    refused by the others.
+
+    The invariant is addressability: a name a creation call accepts must address
+    the entity it created. Three values break it, each silently and in a
+    different layer:
+
+    * A non-``str`` is hashable often enough to be registered - an ``int`` and a
+      ``bool`` both are - and only then reaches the MJCF spec build, which
+      raises ``TypeError: add_body(): incompatible function arguments`` from
+      pybind11. That escapes the result dict these methods document, and it
+      lands after the registry entry is written, so the world is left holding an
+      entry for an entity that does not exist.
+    * An empty name is MuJoCo's own sentinel for an UNNAMED element, so the
+      entity compiles anonymously and ``mj_name2id`` answers ``-1`` for it.
+      Nothing can then address it: ``get_body_state(body_name="")`` reports the
+      body as missing while it is simulating, an empty camera name is the
+      explicit free-camera token in ``render``, so a camera created under it is
+      never the one rendered from, and the recording schema drops an anonymous
+      camera outright rather than declare an empty feature key.
+    * A name containing a NUL makes the two layers disagree about which entity
+      they hold. MuJoCo compares names only up to the NUL, so ``"a\x00b"``
+      compiles as ``"a"`` and answers to that name, while the Python registry
+      keeps the full string. One entity, two names, neither layer aware of the
+      other's.
+
+    Nothing further is constrained, because nothing further is broken. ``"a/b"``,
+    ``"a b"`` and ``"a-b"`` each compile under the name given and are addressable
+    by it, so a character allowlist would refuse names that work.
+
+    Args:
+        value: The caller-supplied name.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it - the
+            public method name.
+
+    Returns:
+        An error message, or ``None`` when the name can address its entity.
+    """
+    if not isinstance(value, str):
+        return (
+            f"{context}: {param} must be a string naming the entity, got {value!r} "
+            f"({type(value).__name__}). The name is used both as the registry key and as "
+            f"the MJCF element name, and MJCF names are strings - pass {str(value)!r} if "
+            f"that is the name you want."
+        )
+    if not value:
+        return (
+            f"{context}: {param} must be a non-empty string, got {value!r}. An empty name is "
+            f"MuJoCo's sentinel for an unnamed element, so the entity would be created but "
+            f"nothing could address it afterwards."
+        )
+    if "\x00" in value:
+        return (
+            f"{context}: {param} must not contain a NUL character, got {value!r}. MuJoCo "
+            f"compares names only up to the NUL, so the entity would answer to "
+            f"{value.split(chr(0))[0]!r} while the registry kept the full string."
+        )
+    return None

--- a/tests/simulation/mujoco/test_entity_name_addressability.py
+++ b/tests/simulation/mujoco/test_entity_name_addressability.py
@@ -1,0 +1,218 @@
+"""A scene-creation call refuses a name that cannot address the entity it creates.
+
+``add_object`` / ``add_camera`` / ``add_robot`` each CLAIM a name: they write it
+into the world registry as a key and into the MJCF spec as an element name. Three
+kinds of value break the link between those two layers, and each did so silently:
+
+* A non-``str`` is hashable often enough to be registered - ``7`` and ``True``
+  both are - and only then reaches the spec build, where pybind11 raises
+  ``TypeError: add_body(): incompatible function arguments``. That escapes the
+  result dict these methods document, and it lands AFTER the registry write, so
+  the world was left holding a key for an entity with no body in the model.
+* An empty name is MuJoCo's own sentinel for an unnamed element, so the entity
+  compiled anonymously. ``get_body_state(body_name="")`` then reports the body as
+  missing while it simulates, and ``render(camera_name="")`` routes to the FREE
+  camera by an explicit token check - so a camera created under that name is
+  never the camera rendered from, and the caller is handed an image anyway.
+* A NUL leaves the layers disagreeing: MuJoCo compares names only up to it, so
+  ``"a\\x00b"`` compiles as ``"a"`` while the registry keeps the full string.
+
+The domain stops there because nothing else is broken: ``"a/b"``, ``"a b"``,
+``"a-b"`` and a name carrying a newline or a quote each compile under the name
+given and are addressable by it, so they are pinned as accepted here to keep the
+guard from widening into a character allowlist that would refuse working names.
+
+``add_robot`` documents a falsy ``name`` as "derive one from the model", so its
+guard is gated on the same truthiness test that branch already uses: every value
+that derives today still derives, and only a supplied name is held to the domain.
+"""
+
+import mujoco as mj
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.utils import entity_name_error
+
+# Values that cannot address the entity they would name, with the layer each
+# breaks. Parametrized as (label, value) so a failure names the case.
+UNUSABLE: list[tuple[str, object]] = [
+    ("empty", ""),
+    ("nul", "a\x00b"),
+    ("int", 7),
+    ("bool", True),
+    ("unhashable", ["x"]),
+]
+
+# Names that round-trip: the compiled element answers to exactly the string
+# given. These are the guard's over-reach controls.
+USABLE = ["plain", "a/b", "a b", "a-b", 'a"b']
+
+_ARM_XML = """<mujoco>
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1" damping="1" range="-2 2" limited="true"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+    </body>
+  </worldbody>
+  <actuator><position name="pan_act" joint="pan" kp="20" ctrlrange="-1 1"/></actuator>
+</mujoco>
+"""
+
+
+# ``sim`` is deliberately un-annotated: ``Simulation`` is a lazy re-export, and
+# annotating it makes mypy read ``sim._world`` as ``SimWorld | None`` at every
+# model probe below.
+@pytest.fixture
+def sim():
+    engine = Simulation(backend="mujoco", tool_name="name_domain", mesh=False)
+    engine.create_world()
+    yield engine
+    engine.cleanup()
+
+
+@pytest.fixture
+def arm_xml(tmp_path):
+    path = tmp_path / "arm.xml"
+    path.write_text(_ARM_XML, encoding="utf-8")
+    return str(path)
+
+
+def _body_names(sim) -> list[str]:
+    model = sim._world._model
+    return [mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i) for i in range(model.nbody)]
+
+
+class TestMuJoCoTreatsTheseNamesAsUnusable:
+    """The premises the refusals rest on, measured against MuJoCo itself.
+
+    Without these, the guard's domain would be a matter of taste. With them it is
+    a property of the engine the names are compiled into.
+    """
+
+    def test_an_empty_name_is_mujocos_unnamed_sentinel(self, sim):
+        model = sim._world._model
+        assert mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "") == -1
+
+    def test_mujoco_compares_a_name_only_up_to_a_nul(self, sim):
+        # Compiled under the full string; MuJoCo answers to the prefix, and to
+        # the prefix ALONE - one entity reachable under a name nobody asked for.
+        sim._world.objects.clear()
+        assert sim.add_object(name="a", shape="box", size=[0.05] * 3, position=[0, 0, 0.3])["status"] == "success"
+        model = sim._world._model
+        assert mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "a\x00b") == mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "a")
+
+    def test_an_empty_camera_name_is_the_free_camera_token(self, sim):
+        # ``render`` documents "", None, "default" and "free" as free-camera
+        # tokens, so a camera stored under "" could never be the one rendered
+        # from - the caller is handed the free view and told it succeeded.
+        assert sim.add_camera(name="probe", position=[0.6, 0.6, 0.5], target=[0, 0, 0])["status"] == "success"
+        free = sim.render(camera_name="", width=64, height=48)
+        assert free["status"] == "success"
+        assert any("image" in chunk for chunk in free["content"])
+
+
+class TestACreatorRefusesAnUnaddressableName:
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE, ids=[label for label, _ in UNUSABLE])
+    def test_add_object_refuses_it_and_registers_nothing(self, sim, label, value):
+        result = sim.add_object(name=value, shape="box", size=[0.05] * 3, position=[0, 0, 0.3])
+        assert result["status"] == "error"
+        assert "add_object: name" in result["content"][0]["text"]
+        # The refusal precedes the registry write, so there is no orphan entry
+        # to roll back - which is what the escaping TypeError used to leave.
+        assert sim._world.objects == {}
+        assert _body_names(sim) == ["world"]
+
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE, ids=[label for label, _ in UNUSABLE])
+    def test_add_camera_refuses_it_and_registers_nothing(self, sim, label, value):
+        result = sim.add_camera(name=value, position=[0.6, 0.6, 0.5], target=[0, 0, 0])
+        assert result["status"] == "error"
+        assert "add_camera: name" in result["content"][0]["text"]
+        assert list(sim._world.cameras) == ["default"]
+
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE, ids=[label for label, _ in UNUSABLE])
+    def test_add_robot_refuses_a_supplied_one(self, sim, arm_xml, label, value):
+        if not value:
+            pytest.skip("a falsy name is documented as 'derive one from the model'")
+        result = sim.add_robot(name=value, urdf_path=arm_xml)
+        assert result["status"] == "error"
+        assert "add_robot: name" in result["content"][0]["text"]
+        assert sim._world.robots == {}
+
+
+class TestAWorkingNameIsStillAccepted:
+    """The guard must not widen into a character allowlist."""
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_add_object_accepts_it_and_the_body_answers_to_it(self, sim, name):
+        assert sim.add_object(name=name, shape="box", size=[0.05] * 3, position=[0, 0, 0.3])["status"] == "success"
+        assert name in _body_names(sim)
+        assert sim.get_body_state(body_name=name)["status"] == "success"
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_add_camera_accepts_it_and_renders_from_it(self, sim, name):
+        assert sim.add_camera(name=name, position=[0.6, 0.6, 0.5], target=[0, 0, 0])["status"] == "success"
+        rendered = sim.render(camera_name=name, width=64, height=48)
+        assert rendered["status"] == "success"
+        assert any("image" in chunk for chunk in rendered["content"])
+
+    @pytest.mark.parametrize("omitted", [None, ""])
+    def test_add_robot_still_derives_a_label_when_none_is_supplied(self, sim, arm_xml, omitted):
+        result = sim.add_robot(name=omitted, urdf_path=arm_xml)
+        assert result["status"] == "success"
+        assert list(sim._world.robots) == ["arm"]
+
+
+class TestTheThreeCreatorsShareOneDomain:
+    """A name one creator refuses must be refused by the others.
+
+    Parametrized over factories rather than values so that each creator is
+    handed its own instance of the value.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        [(label, value) for label, value in UNUSABLE if value],
+        ids=[label for label, value in UNUSABLE if value],
+    )
+    def test_every_creator_refuses_the_same_unusable_name(self, sim, arm_xml, label, value):
+        verdicts = {
+            "add_object": sim.add_object(name=value, shape="box", size=[0.05] * 3)["status"],
+            "add_camera": sim.add_camera(name=value, position=[0.6, 0.6, 0.5])["status"],
+            "add_robot": sim.add_robot(name=value, urdf_path=arm_xml)["status"],
+        }
+        assert set(verdicts.values()) == {"error"}, verdicts
+
+    @pytest.mark.parametrize("name", USABLE)
+    def test_every_creator_accepts_the_same_usable_name(self, sim, arm_xml, name):
+        verdicts = {
+            "add_object": sim.add_object(name=name, shape="box", size=[0.05] * 3)["status"],
+            "add_camera": sim.add_camera(name=f"{name}_cam", position=[0.6, 0.6, 0.5])["status"],
+            "add_robot": sim.add_robot(name=f"{name}_arm", urdf_path=arm_xml)["status"],
+        }
+        assert set(verdicts.values()) == {"success"}, verdicts
+
+
+class TestEntityNameErrorMessages:
+    def test_a_usable_name_returns_none(self):
+        assert entity_name_error("crate", "name", "add_object") is None
+
+    def test_a_non_string_names_the_type_and_offers_the_string_form(self):
+        message = entity_name_error(7, "name", "add_object")
+        assert message is not None
+        assert "must be a string" in message
+        assert "(int)" in message
+        # The remedy has to be pasteable, so the quoted form is the one to pass.
+        assert "'7'" in message
+
+    def test_an_empty_name_says_why_nothing_could_address_it(self):
+        message = entity_name_error("", "name", "add_camera")
+        assert message is not None
+        assert message.startswith("add_camera: name must be a non-empty string")
+        assert "unnamed element" in message
+
+    def test_a_nul_name_reports_the_name_the_entity_would_answer_to(self):
+        message = entity_name_error("crate\x00x", "name", "add_object")
+        assert message is not None
+        assert "NUL" in message
+        assert "'crate'" in message


### PR DESCRIPTION
Closes #1777.

`add_object` / `add_camera` / `add_robot` each **claim** a name twice: as the world-registry key, and as the MJCF element name. Three kinds of value break the link between those two layers, and each did so under `status="success"`.

`add_camera`'s own docstring already promised this would not happen — that invalid values "are rejected here at config time with an actionable error rather than deferring an uncaught `TypeError` (non-numeric), a silently degenerate camera ..., or a cryptic spec-recompile / GL failure to the first render." The `name` parameter deferred all three.

## Measured on `main` (7a0ff3ac, mujoco 3.11.0)

One `create_world()`, then `add_object(<name>, shape="box", size=[0.06]*3)`:

| name | result | state afterwards |
|---|---|---|
| `""` | `success` | registry key `''`; the body compiles **unnamed**, so `get_body_state(body_name="")` reports it missing while it simulates |
| `"a\x00b"` | `success` | registry key `'a\x00b'`; the compiled body is `'a'`, and answers only to that |
| `7` | **`TypeError: add_body(): incompatible function arguments`** | registry key `7` **left behind**, no body in the model |
| `True` | same `TypeError` | registry key `True` left behind |
| `["x"]` | `TypeError: unhashable type: 'list'` | nothing registered |

The non-`str` row is the worst of the three: `int` and `bool` are perfectly hashable, so the duplicate-name check passes (correctly — it is not a duplicate) and the registry is written; only *then* does the spec build reach pybind11 and raise. That escapes the result dict these methods document, **and** it lands after the registry write, so the world is left inconsistent. Making the membership test total does not fix it — the membership test is not what fails, which is why this was split out of #1776 rather than folded into it.

## The empty name is the one that looks like it worked

`""` is MuJoCo's own sentinel for an unnamed element, so nothing can address the entity afterwards. For a camera it compounds, because `""` is also an explicit **free-camera token** in `render` (`camera_name in (None, "", "default", "free")`):

![blank camera name aliases the free camera](https://raw.githubusercontent.com/cagataycali/robots/artifacts/entity-name-addressability/blank_camera_name.png)

MuJoCo headless (EGL). Both columns place a camera at the identical pose, `position=[0.42, 0.34, 0.26], target=[0.16, 0.0, 0.11]`. On `main` the call answers `Camera '' added at [0.42, 0.34, 0.26]` — it confirms the pose — and `render(camera_name="")` then returns a `success` image that is the **free camera**, differing from the placed view on **70.2% of pixels**. There is no error anywhere on that path.

The same name also costs the recording. The schema derivation drops an anonymous camera rather than declare an empty feature key (the behaviour `tests/simulation/mujoco/test_recording_skips_unnamed_camera.py` exists to pin), so in that world `start_recording` declared **`1 joints, 1 cameras`** while `world.cameras` held `['default', '']`. The placed camera can be neither rendered from nor recorded. Following the message's remedy gives `2 cameras`, verified in the third column.

## Change

One shared `strands_robots.utils.entity_name_error(value, param, context)`, beside the numeric domains and for the reason those live there: three entry points take this parameter and their accepted domain must not diverge. Called in each creator **before the registry write**, so a refused name leaves nothing to roll back.

The domain is exactly what the measurements justify — a non-empty `str` with no NUL — and **stops there, because nothing else is broken**: `"a/b"`, `"a b"`, `"a-b"`, and names carrying a newline or a quote each compile under the name given and are addressable by it, so a character allowlist would refuse names that work. Those are pinned as accepted.

`add_robot` documents a falsy `name` as "derive one from the model", so its guard is gated on the same truthiness test that branch already uses: every value that derives today still derives, and only a *supplied* name is held to the domain.

Messages name the layer that breaks and carry the remedy — e.g. `add_object: name must be a string naming the entity, got 7 (int). The name is used both as the registry key and as the MJCF element name, and MJCF names are strings - pass '7' if that is the name you want.`

## Tests

`tests/simulation/mujoco/test_entity_name_addressability.py`, 43 tests. **Pre-fix 18 failed / 24 passed / 1 skipped; post-fix 42 passed / 1 skipped** (the skip is `add_robot` with a falsy name, which is documented to derive).

The 24 that pass pre-fix are deliberate and are what keeps the guard from over-reaching: the accepted-name controls, the helper's own unit tests, and three **premise** tests measured against MuJoCo itself — that `mj_name2id(model, BODY, "")` is `-1`, that `"a\x00b"` and `"a"` resolve to the same id, and that `render(camera_name="")` is the free camera. Those premises are why the refused domain is a property of the engine these names are compiled into rather than a matter of taste.

A cross-creator parity test asserts a name one creator refuses is refused by all three, and one it accepts is accepted by all three.

No existing test changed; nothing pinned any of this as intended.

## Out of scope

The Newton and Isaac backends have the same unguarded `name` on their own creators. Their names go into different registries with different downstream consumers, and the empty-name consequences measured here are MuJoCo-specific (`mj_name2id`'s sentinel, `render`'s token, the MJCF schema), so extending the shared helper there wants its own measurements rather than an assumed parity.

## Gate

`ruff check` / `ruff format --check` clean (977 files); `mypy strands_robots tests tests_integ` clean (974 source files); `MUJOCO_GL=egl python -m pytest tests` → **14857 passed, 256 skipped** in 480s. Rebased onto 7a0ff3ac so the base has not moved under the one file this shares with it.