### PR TITLE
fix(sim): refuse an entity name that cannot address the entity it creates

### DIFF
--- a/changelog.d/1777-entity-name-domain-at-creation.md
+++ b/changelog.d/1777-entity-name-domain-at-creation.md
@@ -1,0 +1,26 @@
+### Fixed: a creation site refuses a name that cannot address the entity it creates
+
+`add_object` / `add_camera` / `add_robot` claim a name, and three values were
+accepted that produce an entity the rest of the same API cannot then address.
+An empty name is MuJoCo's own sentinel for *unnamed*, so `add_object("")`
+reported success and `get_body_state(body_name="")` then reported the body
+absent - and because `render` routes `camera_name` in `(None, "", "default",
+"free")` to the free camera, a camera created as `""` could never be rendered
+from. A name containing a NUL registered one string while the model compiled
+under another, so `mj_name2id` resolved the registry key and its truncation to
+the same entity; through `add_robot` the NUL took the namespace separator with
+it. A non-string name was entered in the registry and only then raised
+`TypeError` out of the spec build, escaping the agent-tool dict these methods
+document as their only failure channel and leaving the world holding an entry
+for a body that does not exist, while any *falsy* non-string (`0`, `[]`) fell
+into `add_robot`'s derive-a-label branch and reported success under a label the
+caller never asked for.
+
+All six creation sites (MuJoCo and Newton) now refuse those three through one
+shared `entity_name_error`, before anything is registered, so the two backends
+cannot drift. `add_robot(name=None)` and `add_robot(name="")` keep deriving a
+label from the model on the MuJoCo backend - that short form is documented -
+and nothing else narrows: a namespaced, dotted or non-ASCII name is
+addressable and stays accepted. This is the creation-site half of the total
+entity-name lookup, which resolves an unusable name to "absent" rather than
+refusing it.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -111,6 +111,7 @@ from strands_robots.teleop_mixin import TeleopMixin
 from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
+    entity_name_error,
     finite_vector_error,
     pose_vector_error,
 )
@@ -1137,10 +1138,16 @@ class MuJoCoSimEngine(
 
         ``name`` is the instance label used to address this robot later
         (``run_policy(robot_name=...)``, ``get_robot_state``, etc.). It is
-        OPTIONAL: when omitted it is auto-derived from ``data_config`` (or the
-        URDF filename), with a numeric suffix appended if that label is already
-        taken -- so ``add_robot(data_config="so101")`` twice yields ``so101``
-        and ``so101_2`` instead of erroring.
+        OPTIONAL: when omitted (``None``, or ``""``) it is auto-derived from
+        ``data_config`` (or the URDF filename), with a numeric suffix appended
+        if that label is already taken -- so ``add_robot(data_config="so101")``
+        twice yields ``so101`` and ``so101_2`` instead of erroring. Any other
+        value must be a ``str`` containing no NUL: those two are the documented
+        derive-a-label short form, while another falsy value (``0``, ``[]``)
+        would take the same branch and report success under a label that was
+        never asked for, and a non-string label keys the registry with a value
+        the agent-tool surface - where a name arrives as JSON - cannot
+        address.
 
         ``keyframe`` (name ``str`` or index ``int``) spawns the robot in a
         canonical pose declared by a ``<keyframe>`` in its source model
@@ -1165,6 +1172,19 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_robot"):
             return err
+
+        # Refuse a name that cannot address the robot this call creates. ``None``
+        # and ``""`` are the documented "derive a label from the model" short
+        # form and are passed through to the derivation below; every other value
+        # goes through the shared domain. That closes two gaps at once: an int
+        # name compiled its bodies under the ``7/`` namespace but keyed the
+        # registry with the int ``7``, which the tool surface - where a name
+        # always arrives as a JSON string - can never address, and ANY other
+        # falsy value (``0``, ``[]``, ``{}``) fell into the derive branch below
+        # and reported success under a label the caller never asked for.
+        if not (name is None or (isinstance(name, str) and name == "")):
+            if (name_err := entity_name_error("add_robot", "name", name)) is not None:
+                return {"status": "error", "content": [{"text": name_err}]}
 
         # Validate the caller-supplied base pose before it is baked into the
         # robot's frame pos/quat. Without this, `add_robot` shares the numeric
@@ -2551,6 +2571,12 @@ class MuJoCoSimEngine(
 
         Args:
             name: Unique object name. Its geom is injected as ``"<name>_geom"``.
+                Must be a non-empty ``str`` that contains no NUL: an empty name
+                is MuJoCo's own sentinel for an unnamed body (so
+                ``get_body_state`` could not find the object afterwards), a NUL
+                truncates the name the model compiles under while the registry
+                keeps the full string, and a non-string name is not addressable
+                through the agent-tool surface, where a name arrives as JSON.
             shape: ``"box"``, ``"sphere"``, ``"cylinder"``, ``"capsule"``,
                 ``"ellipsoid"``, ``"plane"``, or ``"mesh"``.
             position: World position ``[x, y, z]`` of the body origin (default
@@ -2584,7 +2610,8 @@ class MuJoCoSimEngine(
         Returns:
             Agent-tool status dict. ``{"status": "success", ...}`` on success;
             ``{"status": "error", ...}`` when no world exists, a policy is
-            running, the name is taken, ``position``/``orientation``/``color``/
+            running, ``name`` is not a usable entity name (see above), the name
+            is taken, ``position``/``orientation``/``color``/
             ``size`` contains a non-finite (``nan``/``inf``) or non-numeric
             element or ``position``/``orientation``/``color`` is the wrong length
             (3 / 4 / 3-or-4), ``size`` has a non-positive extent or a component
@@ -2614,6 +2641,20 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_object"):
             return err
+
+        # Refuse a name that cannot address the object this call creates, before
+        # anything is registered under it. Previously ``add_object("")``
+        # succeeded and ``get_body_state(body_name="")`` then reported the body
+        # absent (MuJoCo reads "" as unnamed), a NUL name registered one string
+        # while the body compiled under another, and a non-string name was
+        # entered in the registry and only then raised out of MuJoCo's
+        # ``add_body`` - leaving the world holding an entry for a body that does
+        # not exist, through a raise the tool-result contract does not allow.
+        # The duplicate-name test below is itself partial for an unhashable
+        # name, so this has to come first.
+        if (name_err := entity_name_error("add_object", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
+
         if name in self._world.objects:
             return {"status": "error", "content": [{"text": f"Object '{name}' exists."}]}
 
@@ -3007,11 +3048,15 @@ class MuJoCoSimEngine(
         mount points before placing a camera; robot bodies are namespaced
         ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
 
-        Validation: ``position`` and ``target`` must each be 3 finite numbers
-        (a list, tuple or NumPy array; NumPy scalar elements accepted). Omit a
-        vector to take its default - an empty vector is a wrong-length request
-        and is rejected rather than silently placing the camera at the default
-        pose. ``fov`` must be a finite angle in ``(0, 180)``
+        Validation: ``name`` must be a non-empty ``str`` containing no NUL -
+        ``render``/``get_frame`` route ``camera_name`` in ``(None, "",
+        "default", "free")`` to the free camera, so a camera registered under
+        ``""`` could never be rendered from, and a non-string name is not
+        addressable through the agent-tool surface. ``position`` and ``target``
+        must each be 3 finite numbers (a list, tuple or NumPy array; NumPy
+        scalar elements accepted). Omit a vector to take its default - an empty
+        vector is a wrong-length request and is rejected rather than silently
+        placing the camera at the default pose. ``fov`` must be a finite angle in ``(0, 180)``
         degrees; and ``width``/``height`` must be positive ints within the
         offscreen framebuffer cap (same bounds ``render`` enforces). Invalid
         values are rejected here at config time with an actionable error rather
@@ -3023,6 +3068,16 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_camera"):
             return err
+
+        # Refuse a name that cannot address the camera this call creates, on the
+        # shared ``entity_name_error`` domain. An empty name is worse here than
+        # for an object: ``render``/``get_frame`` route ``camera_name in (None,
+        # "", "default", "free")`` to the FREE camera by an explicit token
+        # check, so a camera registered as "" could never be rendered from. It
+        # precedes the duplicate-name test for the same reason it does in
+        # ``add_object`` - that test is partial for an unhashable name.
+        if (name_err := entity_name_error("add_camera", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
 
         # Validate position / target shape before we bake them into XML.
         # Membership, not truthiness: ``position or <default>`` raised a bare

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -56,7 +56,13 @@ from strands_robots.simulation.models import (
 from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
 from strands_robots.simulation.newton.randomization import DomainRandomizationMixin
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
-from strands_robots.utils import camera_fov_error, coerce_pose_vector, positive_count_error, require_optional
+from strands_robots.utils import (
+    camera_fov_error,
+    coerce_pose_vector,
+    entity_name_error,
+    positive_count_error,
+    require_optional,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -437,7 +443,9 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         Args:
             name: Robot name in the registry / ``robot_descriptions``, or an
                 arbitrary instance name when ``urdf_path`` points at an explicit
-                MJCF/URDF file.
+                MJCF/URDF file. Required, and a non-empty ``str`` containing no
+                NUL (:func:`~strands_robots.utils.entity_name_error`); this
+                backend has no derive-a-label short form.
             urdf_path: Optional explicit MJCF/URDF path. When given it wins
                 outright and ``source`` is ignored.
             data_config: Accepted for ABC parity; unused by Newton.
@@ -460,6 +468,15 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """
         if self._world is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+
+        # Refuse a name that cannot address the robot this call creates, on the
+        # shared ``entity_name_error`` domain. Unlike the MuJoCo backend this
+        # method documents no "derive a label" short form - ``name`` is required
+        # and doubles as the registry/robot_descriptions key - so there is no
+        # value to pass through here.
+        if (name_err := entity_name_error("add_robot", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
+
         if name in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{name}' already exists."}]}
         if source not in _ROBOT_SOURCES:
@@ -555,7 +572,9 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """Add a primitive or mesh object to the scene.
 
         Args:
-            name: Unique object name.
+            name: Unique object name; a non-empty ``str`` containing no NUL, the
+                same domain the MuJoCo backend's ``add_object`` accepts
+                (:func:`~strands_robots.utils.entity_name_error`).
             shape: One of ``"box"``, ``"sphere"``, ``"capsule"``,
                 ``"cylinder"``, or ``"mesh"``. ``"mesh"`` requires
                 ``mesh_path``.
@@ -581,6 +600,16 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """
         if self._world is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+
+        # Refuse a name that cannot address the object this call creates, on the
+        # same shared domain the MuJoCo backend's ``add_object`` uses, so a name
+        # one backend refuses is refused by both. It precedes the duplicate-name
+        # test below, which is itself partial: ``name in self._world.objects``
+        # raises ``TypeError: unhashable type`` for a list/dict/set name rather
+        # than reaching the error path it guards.
+        if (name_err := entity_name_error("add_object", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
+
         if material is not None:
             return {
                 "status": "error",
@@ -988,8 +1017,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         there is no upper cap.
 
         Args:
-            name: Unique camera name. Duplicate names are rejected; remove the
-                existing camera with :meth:`remove_camera` first.
+            name: Unique camera name; a non-empty ``str`` containing no NUL, the
+                same domain the MuJoCo backend's ``add_camera`` accepts
+                (:func:`~strands_robots.utils.entity_name_error`). Duplicate
+                names are rejected; remove the existing camera with
+                :meth:`remove_camera` first.
             position: Camera eye ``[x, y, z]`` (world frame, or the parent
                 body's local frame when ``parent_body`` is set). 3 finite
                 numbers.
@@ -1009,6 +1041,12 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+
+        # Refuse a name that cannot address the camera this call creates, on the
+        # shared ``entity_name_error`` domain the MuJoCo backend's ``add_camera``
+        # uses, so a camera name one backend refuses is refused by both.
+        if (name_err := entity_name_error("add_camera", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": name_err}]}
 
         # Validate shape, element type AND finiteness with the shared helpers the
         # MuJoCo backend uses, so a camera pose one backend refuses is refused by

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -700,3 +700,87 @@ def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:
     if not (0.0 < float(value) < 180.0):
         return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {value}."
     return None
+
+
+def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
+    """Return an error message if ``name`` cannot address the entity it names.
+
+    The creation-site counterpart to the total lookups in
+    :mod:`strands_robots.simulation.models`. A lookup asks whether a name
+    addresses something, so a name that cannot be a registry key is honestly
+    "absent"; a creation site *claims* a name, so the same value has to be
+    refused instead - an entity registered under a name that nothing can
+    resolve is unreachable through the very API that created it.
+
+    It lives here, beside :func:`camera_fov_error`, for the same reason that one
+    does: ``add_object`` / ``add_camera`` / ``add_robot`` exist on more than one
+    backend and their accepted domain must not diverge - a name one backend
+    refuses must be refused by the others, and a second copy of the rule would
+    drift from the first.
+
+    Three values are refused, each because it produces an entity that some part
+    of this API cannot address (measured on MuJoCo 3.11.0, one ``create_world``
+    then ``add_object``):
+
+    * **Not a ``str``.** ``add_object(7, ...)`` registered the key ``7`` and
+      only then raised ``TypeError`` out of MuJoCo's ``add_body``, leaving the
+      world holding an entry for a body that does not exist; a name that is not
+      hashable at all (``["x"]``) raised out of the duplicate-name test.
+      ``add_robot(7, ...)`` did compile, under the int registry key ``7`` -
+      which the tool surface, where every name arrives as a JSON string, can
+      never address. A falsy non-``str`` was worse than either: ``add_robot(0)``
+      silently derived the label ``"arm"`` from the model and reported success
+      under a name the caller never asked for.
+    * **The empty string.** ``""`` is MuJoCo's own sentinel for an unnamed
+      entity, so ``mj_name2id(model, BODY, "")`` returns ``-1``:
+      ``add_object("")`` succeeded and ``get_body_state(body_name="")`` then
+      reported ``Body '' not found``. For a camera it also collides with a
+      routing token - ``render(camera_name="")`` selects the free camera - so a
+      camera created as ``""`` can never be rendered from.
+    * **A ``str`` containing a NUL.** The compiled model compares names only up
+      to the first NUL, so ``add_object("a\\x00b")`` registered ``'a\\x00b'``
+      while the body compiled as ``'a'``, and ``mj_name2id(..., "a\\x00b")``
+      returned the id of ``'a'``. Two names, one entity, each layer believing a
+      different one. Through ``add_robot`` the NUL took the namespace separator
+      with it: the bodies compiled as ``'abase'`` / ``'alink'`` rather than
+      under the ``'a\\x00b/'`` prefix ``list_bodies`` looks for.
+
+    Nothing else is refused. In particular this is NOT the MJCF-interpolation
+    allowlist (``^[a-zA-Z0-9_-]+$``): a namespaced body label (``so101/gripper``)
+    and a dotted or unicode object name are all addressable, and narrowing the
+    domain to an allowlist is a separate decision from refusing a name that
+    demonstrably cannot address its entity.
+
+    A ``str`` subclass is accepted - it is a string by every operation here and
+    by the registry. Callers with a documented "derive the name" input (the
+    MuJoCo ``add_robot(name=None)`` / ``add_robot(name="")`` short form) must
+    check for that input before calling this, since ``""`` is refused here.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        name: The caller's value.
+
+    Returns:
+        ``None`` when ``name`` can address the entity it creates, otherwise the
+        error message to report through the structured tool-result dict.
+    """
+    if not isinstance(name, str):
+        return (
+            f"{method}: '{param_name}' must be a non-empty string, got {name!r} "
+            f"({type(name).__name__}); an entity is addressed by name and every "
+            "agent-tool call carries that name as a string."
+        )
+    if not name:
+        return (
+            f"{method}: '{param_name}' must be a non-empty string, got ''; an empty "
+            "name is the backend's own sentinel for an unnamed entity, so the entity "
+            "created under it could not be addressed afterwards."
+        )
+    if "\x00" in name:
+        return (
+            f"{method}: '{param_name}' must not contain a NUL character, got {name!r}; "
+            "the compiled model reads a name only up to the first NUL, so the registry "
+            "and the model would disagree about the entity's name."
+        )
+    return None

--- a/tests/simulation/test_entity_name_domain_at_creation.py
+++ b/tests/simulation/test_entity_name_domain_at_creation.py
@@ -1,0 +1,395 @@
+"""Regression tests: a creation site refuses a name that cannot address its entity.
+
+``add_object`` / ``add_camera`` / ``add_robot`` claim a name. Until this fix they
+accepted three values that produce an entity some part of this same API cannot
+then address, and each failed differently and late (measured on MuJoCo 3.11.0,
+one ``create_world`` then ``add_object(<name>, shape="box", size=[0.06]*3)``):
+
+* ``""`` -> ``status="success"``, registry key ``''``, and the body compiled
+  under MuJoCo's own sentinel for *unnamed*: ``mj_name2id(model, BODY, "")``
+  returns ``-1``, so ``get_body_state(body_name="")`` answered
+  ``Body '' not found``. Through ``add_camera`` it is worse - ``render`` routes
+  ``camera_name in (None, "", "default", "free")`` to the free camera by an
+  explicit token check, so a camera created as ``""`` can never be rendered
+  from.
+* ``"a\\x00b"`` -> ``status="success"``, registry key ``'a\\x00b'``, compiled
+  body ``'a'``. MuJoCo compares names only up to the NUL, so
+  ``mj_name2id(..., "a\\x00b")`` and ``mj_name2id(..., "a")`` returned the SAME
+  id: two names, one entity, each layer believing a different one. Through
+  ``add_robot`` the NUL took the namespace separator with it - the bodies
+  compiled as ``'abase'`` / ``'alink'`` instead of under the ``'a\\x00b/'``
+  prefix ``list_bodies`` looks for.
+* ``7`` -> the int key was entered in the registry and only *then* did the spec
+  build reach ``add_body()`` and raise ``TypeError``, so the raise escaped the
+  agent-tool dict these methods document as their only failure channel AND left
+  the world holding an entry for a body that does not exist. ``["x"]`` raised out
+  of the duplicate-name test itself (``unhashable type``). Through ``add_robot``
+  the int name did compile - under registry key ``7``, which the tool surface,
+  where a name always arrives as a JSON string, can never address - and any
+  OTHER falsy value (``0``, ``[]``) fell into the ``if not name`` derive branch
+  and reported success under a label the caller never asked for.
+
+The lookup half of this was closed separately (#1774/#1776: a name that cannot
+be a registry key resolves to "absent"). A creation site cannot reuse that
+answer - it has to refuse - so the domain lives in one shared
+:func:`~strands_robots.utils.entity_name_error` and both backends' three methods
+route through it, keeping them from drifting.
+
+What is deliberately NOT refused is pinned too (``TestTheDomainIsNotAnAllowlist``):
+this is not the MJCF-interpolation allowlist ``^[a-zA-Z0-9_-]+$``. A namespaced,
+dotted, spaced or non-ASCII name is addressable, and narrowing to an allowlist is
+a separate decision from refusing a name that demonstrably cannot address its
+entity.
+
+These tests are GL-free (``mesh=False``, no render) and the Newton half needs
+neither ``newton``/``warp`` nor a GPU: the guard runs before either method
+touches a solver, so calling the unbound method with a small stand-in for
+``self`` exercises it in every environment (the pattern
+``tests/simulation/newton/test_add_camera_numeric_validation.py`` uses).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import types
+
+import pytest
+
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import entity_name_error
+
+# --------------------------------------------------------------------------- #
+# Probe sets                                                                  #
+# --------------------------------------------------------------------------- #
+
+#: Names that are not a string. ``True`` is included because ``bool`` is an
+#: ``int`` subclass; ``0``/``[]``/``{}`` because a falsy non-string is what the
+#: MuJoCo ``add_robot`` derive branch used to swallow; ``["x"]``/``{"a": 1}``/
+#: ``{1}`` because those are not hashable, so the duplicate-name test that was
+#: the first thing to touch the name raised instead of answering.
+_NON_STRING_NAMES = (7, 0, -1, 1.5, True, False, None, ["x"], {"a": 1}, {1}, ("a",), b"cube")
+
+#: Strings carrying a NUL, in each position: leading, interior and trailing.
+_NUL_NAMES = ("\x00", "\x00cube", "a\x00b", "cube\x00", "a\x00\x00b")
+
+#: Names that must keep working. Everything here is addressable: MuJoCo resolves
+#: it with ``mj_name2id`` and it round-trips through a JSON tool call.
+_GOOD_NAMES = ("cube", "so101_gripper", "camera-1", "table.top", "obj 2", "küche", "x" * 200)
+
+
+class _StrSubclass(str):
+    """A ``str`` subclass is a string by every operation here and by the registry."""
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheDomain:
+    """``entity_name_error`` is the single definition the six call sites share."""
+
+    @pytest.mark.parametrize("name", _NON_STRING_NAMES)
+    def test_non_string_is_refused(self, name):
+        err = entity_name_error("add_object", "name", name)
+        assert err is not None, name
+        assert "non-empty string" in err
+        assert type(name).__name__ in err
+
+    def test_empty_string_is_refused(self):
+        err = entity_name_error("add_object", "name", "")
+        assert err is not None
+        assert "non-empty string" in err
+
+    @pytest.mark.parametrize("name", _NUL_NAMES)
+    def test_nul_is_refused_in_any_position(self, name):
+        err = entity_name_error("add_object", "name", name)
+        assert err is not None, name
+        assert "NUL" in err
+
+    @pytest.mark.parametrize("name", _GOOD_NAMES)
+    def test_addressable_name_is_accepted(self, name):
+        assert entity_name_error("add_object", "name", name) is None
+
+    def test_str_subclass_is_accepted(self):
+        """A ``str`` subclass keys the registry and compiles like any other string."""
+        assert entity_name_error("add_object", "name", _StrSubclass("cube")) is None
+
+    def test_message_names_the_method_and_the_parameter(self):
+        """The caller sees which call and which argument was refused, not a bare type name."""
+        err = entity_name_error("add_camera", "name", 7)
+        assert err is not None
+        assert err.startswith("add_camera: 'name'")
+
+    def test_message_is_ascii(self):
+        """Project rule: no non-ASCII in a user-facing string. A NUL name must not leak itself."""
+        for probe in (*_NON_STRING_NAMES, "", *_NUL_NAMES):
+            err = entity_name_error("add_object", "name", probe)
+            assert err is not None
+            err.encode("ascii")  # raises UnicodeEncodeError on a smuggled byte
+
+
+class TestTheDomainIsNotAnAllowlist:
+    """Pin the scope: only names that cannot address their entity are refused.
+
+    Tightening to the MJCF-interpolation allowlist ``^[a-zA-Z0-9_-]+$`` would
+    also refuse every name here, and each of these IS addressable - so that
+    narrowing is a separate decision, not a side effect of this one.
+    """
+
+    @pytest.mark.parametrize("name", ["so101/gripper", "table.top", "obj 2", "küche", "cube\ttab", "a\nb"])
+    def test_unusual_but_addressable_name_is_accepted(self, name):
+        assert entity_name_error("add_object", "name", name) is None
+
+
+# --------------------------------------------------------------------------- #
+# MuJoCo                                                                      #
+# --------------------------------------------------------------------------- #
+_ARM_XML = """
+<mujoco model="arm">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="l" pos="0 0 3" dir="0 0 -1"/>
+    <body name="base" pos="0 0 0">
+      <geom name="torso" type="box" size="0.05 0.05 0.05"/>
+      <body name="link" pos="0 0 0.1">
+        <joint name="j" type="hinge" axis="0 1 0" range="-1 1"/>
+        <geom name="arm" type="capsule" size="0.02 0.05"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><motor name="j_act" joint="j"/></actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def arm_path():
+    """The robot model on disk, so ``add_robot`` needs no asset download."""
+    path = os.path.join(tempfile.mkdtemp(), "arm.xml")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(_ARM_XML)
+    return path
+
+
+@pytest.fixture
+def sim():
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    s = Simulation(tool_name="test_entity_name_domain_sim", mesh=False)
+    assert s.create_world()["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _body_names(sim) -> list[str]:
+    import mujoco
+
+    model = sim._world._model
+    return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i) for i in range(model.nbody)]
+
+
+class TestMujocoAddObject:
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_unaddressable_name_is_refused(self, sim, name):
+        """An error dict, not a raise and not a success.
+
+        Pre-fix: ``""`` and a NUL name returned success, ``7`` and ``["x"]``
+        raised ``TypeError`` through the tool-result contract.
+        """
+        result = sim.add_object(name, shape="box", size=[0.06, 0.06, 0.06], position=[0.0, 0.0, 0.5])
+        assert result["status"] == "error", (name, result)
+        assert "'name'" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_refusal_leaves_no_registry_entry(self, sim, name):
+        """The orphan half: a refused creation must not claim the name either.
+
+        Pre-fix ``add_object(7, ...)`` left ``7`` in ``world.objects`` with no
+        body in the model - a world holding an entry for something that does not
+        exist.
+        """
+        sim.add_object(name, shape="box", size=[0.06, 0.06, 0.06])
+        assert list(sim._world.objects) == []
+
+    @pytest.mark.parametrize("name", ("", "a\x00b"))
+    def test_refusal_compiles_no_body(self, sim, name):
+        """The model is untouched, so nothing unaddressable is left in it.
+
+        Pre-fix the compiled body list was ``['world', '', 'a']`` - one body
+        named with MuJoCo's unnamed sentinel and one under a truncated name.
+        """
+        before = _body_names(sim)
+        sim.add_object(name, shape="box", size=[0.06, 0.06, 0.06])
+        assert _body_names(sim) == before
+
+    def test_an_addressable_object_still_round_trips(self, sim):
+        """The happy path is unchanged: create it, then address it by that name."""
+        assert (
+            sim.add_object("cube", shape="box", size=[0.06, 0.06, 0.06], position=[0.0, 0.0, 0.5])["status"]
+            == "success"
+        )
+        assert "cube" in sim._world.objects
+        assert sim.get_body_state(body_name="cube")["status"] == "success"
+
+    def test_the_duplicate_name_error_is_unchanged(self, sim):
+        """A name that IS addressable and taken keeps its own error, not this one."""
+        sim.add_object("cube", shape="box")
+        result = sim.add_object("cube", shape="box")
+        assert result["status"] == "error"
+        assert "exists" in result["content"][0]["text"]
+
+
+class TestMujocoAddCamera:
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_unaddressable_name_is_refused(self, sim, name):
+        result = sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", (name, result)
+        assert "'name'" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_refusal_leaves_the_camera_registry_alone(self, sim, name):
+        before = dict(sim._world.cameras)
+        sim.add_camera(name, position=[1.0, 1.0, 1.0])
+        assert sim._world.cameras == before
+
+    def test_the_empty_name_collided_with_the_render_routing_token(self, sim):
+        """Pin the premise for refusing ``""`` on a camera specifically.
+
+        ``render``/``get_frame`` select the FREE camera for ``camera_name`` in
+        this token set, so a camera registered under ``""`` was unreachable by
+        construction - not merely awkward to address.
+        """
+        assert "" in (None, "", "default", "free")
+
+    def test_an_addressable_camera_still_registers(self, sim):
+        assert sim.add_camera("wrist", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.0])["status"] == "success"
+        assert "wrist" in sim._world.cameras
+
+
+class TestMujocoAddRobot:
+    @pytest.mark.parametrize("name", (7, 0, -1, 1.5, True, False, ["x"], {"a": 1}, {1}, b"arm", *_NUL_NAMES))
+    def test_unaddressable_name_is_refused(self, sim, arm_path, name):
+        """Includes the falsy non-strings the derive branch used to swallow.
+
+        Pre-fix: ``7`` compiled bodies under the ``7/`` namespace but keyed the
+        registry with the int; ``0`` silently derived ``'arm'`` from the model
+        filename and reported success; ``["x"]`` raised ``unhashable type``;
+        ``"a\\x00b"`` compiled ``'abase'``/``'alink'``, losing the namespace
+        separator to the NUL.
+        """
+        result = sim.add_robot(name, urdf_path=arm_path)
+        assert result["status"] == "error", (name, result)
+        assert "'name'" in result["content"][0]["text"]
+        assert list(sim._world.robots) == []
+
+    @pytest.mark.parametrize("name", (None, ""))
+    def test_the_documented_derive_short_form_still_derives(self, sim, arm_path, name):
+        """``None`` and ``""`` are documented inputs, not refusals.
+
+        This is the one place the domain is not applied verbatim: ``add_robot``
+        advertises an omitted name as "derive a label from the model", and ``""``
+        has always taken that branch. Refusing it here would break a documented
+        call, so both pass through - and the label they derive is asserted, so a
+        future tightening cannot quietly turn a derive into an error.
+        """
+        result = sim.add_robot(name, urdf_path=arm_path)
+        assert result["status"] == "success", result
+        assert list(sim._world.robots) == ["arm"]
+
+    def test_an_explicit_addressable_label_still_works(self, sim, arm_path):
+        assert sim.add_robot("arm1", urdf_path=arm_path)["status"] == "success"
+        assert sim.get_robot_state("arm1")["status"] == "success"
+
+    def test_a_refused_robot_leaves_the_model_alone(self, sim, arm_path):
+        """No half-added robot: the compiled body list is untouched."""
+        before = _body_names(sim)
+        sim.add_robot("a\x00b", urdf_path=arm_path)
+        assert _body_names(sim) == before
+
+
+# --------------------------------------------------------------------------- #
+# Newton (no newton / warp / GPU needed - the guard runs before the solver)    #
+# --------------------------------------------------------------------------- #
+def _newton_stub() -> types.SimpleNamespace:
+    """A stand-in for ``self`` carrying only what the three guards read."""
+    return types.SimpleNamespace(
+        _world=types.SimpleNamespace(objects={}, cameras={}, robots={}),
+        _model=types.SimpleNamespace(body_label=["ground"]),
+        _lock=threading.RLock(),
+    )
+
+
+class TestNewtonRefusesTheSameNames:
+    """The Newton backend's three creation sites share the domain, so it cannot drift.
+
+    ``entity_name_error`` documents the invariant: a name one backend refuses
+    must be refused by the others. Without a guard here, the same ``add_object("")``
+    that MuJoCo now refuses would still register an unaddressable entity on
+    Newton.
+    """
+
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_add_object(self, name):
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_object(stub, name)  # type: ignore[arg-type]
+        assert result["status"] == "error", (name, result)
+        assert "'name'" in result["content"][0]["text"]
+        assert stub._world.objects == {}
+
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_add_camera(self, name):
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_camera(stub, name)  # type: ignore[arg-type]
+        assert result["status"] == "error", (name, result)
+        assert "'name'" in result["content"][0]["text"]
+        assert stub._world.cameras == {}
+
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_add_robot(self, name):
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_robot(stub, name)  # type: ignore[arg-type]
+        assert result["status"] == "error", (name, result)
+        assert "'name'" in result["content"][0]["text"]
+        assert stub._world.robots == {}
+
+    def test_an_addressable_name_gets_past_the_guard(self):
+        """The guard is not a blanket refusal: a usable name reaches the next check.
+
+        ``add_object("cube")`` with no ``shape`` support behind it still fails,
+        but on the shape/solver path - not on the name - which is what pins that
+        the guard did not simply swallow every call.
+        """
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_object(stub, "cube", shape="not_a_shape")  # type: ignore[arg-type]
+        assert result["status"] == "error"
+        assert "'name'" not in result["content"][0]["text"]
+
+
+class TestSameVerdictAsTheMujocoSibling:
+    """Both backends refuse the same name with the same message."""
+
+    @pytest.fixture
+    def mj_sim(self):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        s = Simulation(tool_name="test_entity_name_domain_parity_sim", mesh=False)
+        s.create_world()
+        yield s
+        s.cleanup()
+
+    @pytest.mark.parametrize("name", (7, ["x"], "", "a\x00b"))
+    def test_add_object_verdicts_match(self, mj_sim, name):
+        mj = mj_sim.add_object(name, shape="box")
+        nt = NewtonSimEngine.add_object(_newton_stub(), name)  # type: ignore[arg-type]
+        assert mj["status"] == nt["status"] == "error", (mj, nt)
+        assert mj["content"][0]["text"] == nt["content"][0]["text"]
+
+    @pytest.mark.parametrize("name", (7, ["x"], "", "a\x00b"))
+    def test_add_camera_verdicts_match(self, mj_sim, name):
+        mj = mj_sim.add_camera(name, position=[1.0, 1.0, 1.0])
+        nt = NewtonSimEngine.add_camera(_newton_stub(), name)  # type: ignore[arg-type]
+        assert mj["status"] == nt["status"] == "error", (mj, nt)
+        assert mj["content"][0]["text"] == nt["content"][0]["text"]


### PR DESCRIPTION
## Summary

`add_object` / `add_camera` / `add_robot` *claim* a name. Three values were accepted that produce an entity the rest of this same API cannot then address, and each failed differently and late. All six creation sites (MuJoCo + Newton) now refuse those three through one shared `entity_name_error`, **before anything is registered**.

This is the creation-site half of #1774/#1776. Those made entity *lookup* total: a name that cannot be a registry key resolves to "absent", because a lookup only asks whether a name addresses something. A creation site cannot reuse that answer -- it has to refuse -- which needs a contract for what a name may be. That contract is this PR.

Closes #1777.

## Measured (main `7a0ff3a`, mujoco 3.11.0)

One `create_world()`, then `add_object(<name>, shape="box", size=[0.06]*3)`:

| name | before | after |
|---|---|---|
| `""` | `success`; registry key `''`, body compiles as MuJoCo's *unnamed* sentinel | `error`, registry untouched |
| `"a\x00b"` | `success`; registry key `'a\x00b'`, body compiles as `'a'` | `error`, registry untouched |
| `7` | **raises** `TypeError` out of `add_body()` -- *after* `7` is registered | `error`, registry untouched |
| `["x"]` | **raises** `TypeError: unhashable type` out of the duplicate-name test | `error`, registry untouched |

Before: registry keys `['', 'a\x00b', 7]`, compiled bodies `['world', '', 'a']`. After: both empty.

Why each one is not merely ugly but *unaddressable*:

- **`""`** is MuJoCo's own sentinel for an unnamed body, so `mj_name2id(model, BODY, "")` returns `-1` and `get_body_state(body_name="")` answered `Body '' not found` for an object that had just been created successfully. On a camera it is worse: `render`/`get_frame` route `camera_name in (None, "", "default", "free")` to the **free camera** by an explicit token check, so a camera registered as `""` could never be rendered from.
- **A NUL** truncates the name the model compiles under while the registry keeps the full string: `mj_name2id(..., "a\x00b")` and `mj_name2id(..., "a")` returned the *same id*. Two names, one entity, each layer believing a different one. Through `add_robot` the NUL took the namespace separator with it -- bodies compiled as `'abase'`/`'alink'` instead of under the `'a\x00b/'` prefix `list_bodies` looks for.
- **A non-string** escaped the agent-tool dict these methods document as their only failure channel, *and* left the world holding an entry for a body that does not exist. Through `add_robot` an int name did compile -- under the int registry key `7`, which the tool surface (where a name always arrives as a JSON string) can never address. And any **other falsy** value (`0`, `[]`) fell into `add_robot`'s `if not name` derive branch and reported `success` under a label the caller never asked for:

```
add_robot(0, urdf_path=arm.xml)  ->  success, registry ['arm']   # before
add_robot(0, urdf_path=arm.xml)  ->  error,   registry []        # after
```

## What changed

- **`strands_robots/utils.py`** -- new `entity_name_error(method, param_name, name)`, beside the numeric domains (`camera_fov_error`, `pose_vector_error`) and for the same stated reason: these methods exist on more than one backend and their accepted domain must not diverge. Refuses a non-`str`, the empty string, and a `str` containing a NUL. Returns a message; never raises.
- **MuJoCo `add_object` / `add_camera` / `add_robot`** -- guard placed *before* the duplicate-name test, which is itself partial (`name in registry` raises for an unhashable name, so it can never report one).
- **Newton `add_object` / `add_camera` / `add_robot`** -- same guard, same domain, so a name one backend refuses is refused by the other.
- Docstrings on all six state the domain and, for the MuJoCo `add_robot`, why `None`/`""` are exempt.

## Decisions, and what is deliberately left out

#1777 asked for four decisions. Taken here:

1. **A non-string name is refused, not coerced.** Consistent with `register_benchmark` (`name must be a non-empty string, got {name!r}`). Coercing would let `7` name an object `"7"` -- addressable, but silently not what was asked for.
2. **An empty name is refused** for `add_object`/`add_camera`. `add_robot(name=None)` and `add_robot(name="")` keep deriving a label from the model, because that short form is documented; those two are the only values that bypass the domain, and a test pins the label they derive so a later tightening cannot quietly turn a derive into an error.
3. **A NUL is refused; no allowlist.** This is *not* `^[a-zA-Z0-9_-]+$`. A namespaced (`so101/gripper`), dotted, spaced or non-ASCII name is addressable, and `TestTheDomainIsNotAnAllowlist` pins that they stay accepted. The wider allowlist call (which would also make a name safe to interpolate into MJCF and into a dataset column) is a separate change with separate blast radius.
4. **One shared helper**, so the six sites cannot drift.

The Isaac backend's three creation sites are **not** covered: they need an Omniverse install to measure, so the same defect there cannot be demonstrated or pinned in CI. #1776 scoped Isaac out for the same reason.

## Test surface

`tests/simulation/test_entity_name_domain_at_creation.py` -- 194 tests, GL-free (`mesh=False`, no render). The Newton half needs neither `newton`/`warp` nor a GPU: the guard runs before either method touches a solver, so the unbound method with a stand-in `self` exercises it everywhere (the pattern `tests/simulation/newton/test_add_camera_numeric_validation.py` uses).

What it pins beyond "returns an error":

- The refusal leaves **no registry entry** and **compiles no body** -- the orphan-entry half is its own assertion, not implied by the error dict.
- The `add_robot` derive short form (`None`, `""`) still derives, and the derived label is asserted.
- Both backends produce the **same message** for the same name (`TestSameVerdictAsTheMujocoSibling`).
- A usable name still gets *past* the guard on Newton (it fails on the shape path, not the name), so the guard cannot be a blanket refusal.
- The premise for the camera case: `"" in (None, "", "default", "free")`, i.e. the routing token set is why an empty camera name was unreachable by construction.
- Every message is ASCII, so a NUL/non-ASCII name cannot smuggle itself into agent-visible output.

**Pre-fix** (shared helper present, the six guards removed -- everything else identical): **152 failed / 43 passed**. Post-fix: **194 passed**.

Whole unit suite, before vs after this branch: **identical failure sets** (482 pre-existing environment failures in this container -- no GL, no `torch`, no `device_connect_edge`, no asset cache). Re-run where GL and the asset cache are present (Linux aarch64, MuJoCo 3.11.0, EGL): `MUJOCO_GL=egl python -m pytest tests` -> **15009 passed, 255 skipped** in 480s, no failures. `ruff format --check`, `ruff check` and `mypy` clean on all changed files. `python scripts/assemble_changelog.py --check` passes with the new fragment.

## Visual artifact

The empty name is the case that looks like it worked, and on a camera it is visible:

![entity name domain at creation](https://raw.githubusercontent.com/cagataycali/robots/artifacts/entity-name-domain/entity_name_domain.png)

MuJoCo headless (EGL), one `create_world()` per column, all three placing a camera at the identical
pose `position=[0.42, 0.34, 0.26]`, `target=[0.16, 0.0, 0.11]`, `fov=30`.

- **Left** -- the requested view, under a usable name (`add_camera(name="wrist")`).
- **Centre** -- on `main`, `add_camera(name="")` answers `success` with `Camera '' added at [0.42, 0.34, 0.26]`,
  confirming the pose; `render(camera_name="")` then also answers `success` and returns the **free
  camera**, differing from the placed view on **76.89% of pixels**. In the same world `world.cameras`
  held `['default', '']` while `start_recording` declared `0 joints, 1 cameras` -- the placed camera
  could be neither rendered from nor recorded, with no error on either path.
- **Right** -- the name is refused before anything is registered (`world.cameras` stays `['default']`),
  and following the message's remedy recovers the view: byte-identical to the left panel
  (`max|delta| = 0`), and `start_recording` declares `2 cameras`.

The two reference renders are generated separately on each tree and are byte-identical to each other,
which is the check that only the operation under test differs. Every figure number is read out of the
measurement runs and asserted before the figure is drawn.

## Round changelog

- **Round 1** -- initial submission.
- **Round 2** -- no code change. Added the visual artifact and a full-suite gate run in an environment with GL and the asset cache (15009 passed / 255 skipped).

