### PR TITLE
fix(sim): resolve a body's geoms consistently in contact predicates

### DIFF
--- a/changelog.d/1780-contact-geom-name-resolution.md
+++ b/changelog.d/1780-contact-geom-name-resolution.md
@@ -1,0 +1,23 @@
+### Fixed: body-level contact predicates now resolve a body's geoms consistently
+
+`get_contacts` reports a contact as a pair of geom **names**, and for a geom the
+asset left unnamed it synthesizes `"<body>/geom_<id>"`. Two body-level predicates
+consume those names -- `grasped` and `body_on(require_contact=True)`, the gate
+every LIBERO `(on A B)` goal is compiled with -- and they resolved them
+differently:
+
+- `_body_contact` matched only the `<body>_g` prefix inline, so a geom named
+  exactly after its body did not match, while `grasped` accepted that same name.
+  For one contact list the two predicates returned **opposite** answers.
+- Neither matcher recognised `"<body>/geom_<id>"`, the form `get_contacts` itself
+  emits. A Panda scene has 81 unnamed geoms out of 82, so on real MJCF the payload
+  producer and its consumers disagreed about the name format and a body physically
+  resting on another read as "not touching": a settled cube carrying 2.119 N over
+  four contacts failed `body_on(require_contact=True)` while the geometric-only
+  check passed.
+
+`_geom_belongs_to_body` is now the single owner of the body-to-geom name mapping
+and covers the synthesized name, so the two predicates cannot disagree. The
+synthesized form is matched exactly rather than as a `<body>/` prefix, because
+bodies are themselves namespaced -- a broad prefix would let body `panda` claim
+`panda/link0/geom_1`, which belongs to `panda/link0`.

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -34,7 +34,7 @@ Available predicates (bool):
     inside_region(body, min, max)
     contact_between(geom_a, geom_b)
     contact_any()
-    body_on(body_a, body_b, z_offset=0.02, xy_tol=0.15)
+    body_on(body_a, body_b, z_offset=0.02, xy_tol=0.15, require_contact=False)
     body_inside(body, container, xy_tol=0.15, z_tol=0.15)
     body_upright(body, tol=0.15)
     grasped(body, gripper_prefix)
@@ -541,6 +541,38 @@ def _contact_any() -> BoolPredicate:
     return check
 
 
+def _geom_belongs_to_body(geom: str, body: str) -> bool:
+    """True when geom name ``geom`` is one of ``body``'s geoms.
+
+    This is the single owner of the body-to-geom name mapping: every
+    body-level contact predicate resolves through it, so ``grasped`` and
+    ``body_on(require_contact=True)`` cannot disagree about whether a
+    reported contact belongs to a body.
+
+    Handles the geom-naming conventions across the supported scene sources:
+
+    - exact ``body`` (single-geom scenes whose geom is named after the body),
+    - ``<body>_geom`` (strands :meth:`add_object`),
+    - ``<body>_g<idx>`` (LIBERO / robosuite multi-geom objects), and
+    - ``<body>/geom_<id>`` - the name ``get_contacts`` **synthesizes** for a
+      geom the asset left unnamed, which is the dominant case in real MJCF
+      (a Panda scene has 81 unnamed geoms out of 82).
+
+    The ``<body>_g`` prefix subsumes both ``<body>_geom`` and ``<body>_g<idx>``;
+    the ``_g`` boundary keeps distinct names apart (``cube_1_g`` does not match
+    ``cube_10_g0``). The synthesized form is matched exactly rather than as a
+    ``<body>/`` prefix, because bodies are themselves namespaced: a broad
+    prefix would let body ``panda`` claim ``panda/link0/geom_1``, which belongs
+    to ``panda/link0``.
+    """
+    if geom == body or geom.startswith(f"{body}_g"):
+        return True
+    # ``get_contacts`` names an unnamed geom after its parent body as
+    # ``<body>/geom_<id>``; anything else after ``<body>/`` is a child body.
+    suffix = geom.removeprefix(f"{body}/geom_")
+    return suffix != geom and suffix.isdigit()
+
+
 def _body_contact(sim: SimEngine, body_a: str, body_b: str) -> bool | None:
     """Best-effort body-contact lookup.
 
@@ -550,12 +582,10 @@ def _body_contact(sim: SimEngine, body_a: str, body_b: str) -> bool | None:
     caller can decide whether to gracefully degrade (fall back to
     geometric-only checks) or hard-fail.
 
-    Heuristic: matches contacts by **geom name prefix** (``<bddl_name>_g``
-    for LIBERO scenes; works for any scene whose geoms follow the
-    ``<body_name>_g<idx>`` convention). Mirrors how upstream LIBERO's
-    ``ObjectState.check_contact`` walks the per-object geom list, but
-    avoids hard-coding the body→geom map by using the naming
-    convention.
+    Body-geom matching is delegated to :func:`_geom_belongs_to_body`, which
+    owns every supported geom-naming convention. This mirrors how upstream
+    LIBERO's ``ObjectState.check_contact`` walks the per-object geom list, but
+    avoids hard-coding the body→geom map by using the naming conventions.
 
     Used by the contact-aware branch of :func:`_body_on` (LIBERO's
     ``On(A, B)`` predicate semantics requires
@@ -580,17 +610,16 @@ def _body_contact(sim: SimEngine, body_a: str, body_b: str) -> bool | None:
     if not isinstance(contacts, list):
         return None
 
-    prefix_a = f"{body_a}_g"
-    prefix_b = f"{body_b}_g"
     for c in contacts:
         if not isinstance(c, dict):
             continue
         g1 = c.get("geom1") or ""
         g2 = c.get("geom2") or ""
-        # Geom-prefix matching: ``<bddl_name>_g<idx>`` is LIBERO's
-        # convention. Either direction (a-then-b or b-then-a) counts.
-        if (g1.startswith(prefix_a) and g2.startswith(prefix_b)) or (
-            g1.startswith(prefix_b) and g2.startswith(prefix_a)
+        # Resolve both sides through the shared body-to-geom mapping so this
+        # agrees with ``grasped``. Either direction (a-then-b or b-then-a)
+        # counts.
+        if (_geom_belongs_to_body(g1, body_a) and _geom_belongs_to_body(g2, body_b)) or (
+            _geom_belongs_to_body(g1, body_b) and _geom_belongs_to_body(g2, body_a)
         ):
             return True
     return False
@@ -706,23 +735,6 @@ def _body_upright(body: str, tol: float = 0.15) -> BoolPredicate:
     return check
 
 
-def _geom_belongs_to_body(geom: str, body: str) -> bool:
-    """True when geom name ``geom`` is one of ``body``'s geoms.
-
-    Handles the geom-naming conventions across the supported scene sources:
-
-    - exact ``body`` (single-geom scenes whose geom is named after the body),
-    - ``<body>_geom`` (strands :meth:`add_object`), and
-    - ``<body>_g<idx>`` (LIBERO / robosuite multi-geom objects).
-
-    The ``<body>_g`` prefix subsumes both ``<body>_geom`` and ``<body>_g<idx>``;
-    it mirrors the prefix :func:`_body_contact` uses so contact-based
-    predicates agree on what counts as a body's geom. The ``_g`` boundary
-    keeps distinct names apart (``cube_1_g`` does not match ``cube_10_g0``).
-    """
-    return geom == body or geom.startswith(f"{body}_g")
-
-
 def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
     """True when ``body`` is in contact with any geom whose name starts with ``gripper_prefix``.
 
@@ -731,14 +743,12 @@ def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
     for Panda covers both fingers. A body is "grasped" as long as any one
     gripper geom is in contact with any geom belonging to ``body``.
 
-    Body-geom matching follows the same naming conventions as
-    :func:`_body_contact`, so ``grasped`` fires on real LIBERO/robosuite
+    Body-geom matching is delegated to :func:`_geom_belongs_to_body`, the
+    shared owner of that mapping, so ``grasped`` fires on real LIBERO/robosuite
     scenes (where a BDDL object ``cube_1`` owns collision geoms
-    ``cube_1_g0`` / ``cube_1_g1`` ...) as well as on strands-native
-    ``add_object`` scenes (``<body>_geom``) and single-geom scenes whose
-    geom is named exactly after the body. Previously only the exact
-    ``body`` / ``<body>_geom`` names matched, so ``(grasped cube_1)`` BDDL
-    goals silently never fired on LIBERO scenes.
+    ``cube_1_g0`` / ``cube_1_g1`` ...), on strands-native ``add_object`` scenes
+    (``<body>_geom``), on single-geom scenes whose geom is named exactly after
+    the body, and on assets whose geoms are unnamed.
 
     Backends must implement ``get_contacts()`` returning the MuJoCo
     ``{"contacts": [{"geom1", "geom2", ...}]}`` shape. Other backends are
@@ -764,13 +774,10 @@ def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
             g1 = c.get("geom1") or ""
             g2 = c.get("geom2") or ""
             # One side must be a geom of the grasped body; the other must
-            # start with the gripper prefix. Match the body's geoms across
-            # the naming conventions in play: an exact ``body`` name, the
-            # strands ``add_object`` ``<body>_geom`` name, and the
-            # LIBERO/robosuite ``<body>_g<idx>`` multi-geom convention
-            # (``<body>_geom`` is itself covered by the ``<body>_g`` prefix).
-            # This mirrors :func:`_body_contact`'s prefix matching so a
-            # LIBERO ``(grasped cube_1)`` goal fires on ``cube_1_g0`` etc.
+            # start with the gripper prefix. ``_geom_belongs_to_body`` owns
+            # every geom-naming convention, so a LIBERO ``(grasped cube_1)``
+            # goal fires on ``cube_1_g0`` and a scene with unnamed geoms
+            # fires on the synthesized ``cube_1/geom_<id>`` name.
             body_match = _geom_belongs_to_body(g1, body) or _geom_belongs_to_body(g2, body)
             gripper_match = any(isinstance(g, str) and g.startswith(gripper_prefix) for g in (g1, g2))
             if body_match and gripper_match:

--- a/tests/simulation/test_contact_geom_name_resolution.py
+++ b/tests/simulation/test_contact_geom_name_resolution.py
@@ -1,0 +1,232 @@
+"""Regression tests: body-level contact predicates resolve a body's geoms.
+
+``get_contacts`` reports a contact as a pair of geom NAMES, and for a geom the
+asset left unnamed it synthesizes ``"<body>/geom_<id>"``. Two body-level
+predicates consume those names -- ``grasped`` and
+``body_on(require_contact=True)``, the gate every LIBERO ``(on A B)`` goal runs
+through -- and they used two different matchers:
+
+* ``_body_contact`` matched only the ``<body>_g`` prefix inline, so a geom named
+  exactly after its body did not match. ``grasped`` accepted that same name via
+  ``_geom_belongs_to_body``, so the two predicates returned OPPOSITE answers for
+  one contact list.
+* Neither matcher recognised ``"<body>/geom_<id>"`` -- the form ``get_contacts``
+  itself emits. A Panda scene has 81 unnamed geoms out of 82, so on real MJCF the
+  payload producer and its consumers disagreed about the name format and every
+  contact check read as "not touching".
+
+These tests pin the single shared mapping: both matchers agree on every naming
+convention, the synthesized name resolves, and a namespaced child's geom is not
+claimed by its parent body.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.predicates import (
+    _body_contact,
+    _geom_belongs_to_body,
+    make_predicate,
+)
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Every geom-naming convention a supported scene source produces, plus the
+# negatives that must stay unmatched.
+_MATCHING = [
+    ("mug", "a single-geom scene whose geom is named after the body"),
+    ("mug_geom", "the strands add_object convention"),
+    ("mug_g0", "the LIBERO / robosuite <body>_g<idx> convention"),
+    ("mug_g11", "a double-digit LIBERO geom index"),
+    ("mug/geom_2", "the name get_contacts synthesizes for an unnamed geom"),
+    ("mug/geom_81", "a double-digit synthesized id"),
+]
+_NOT_MATCHING = [
+    ("mug_collision", "an unrelated suffix"),
+    ("mugx", "a longer body name"),
+    ("plate_g0", "another body's geom"),
+    ("mug/geom_", "the synthesized prefix with no id"),
+    ("mug/geom_x", "a non-numeric suffix"),
+    ("mug/link0/geom_1", "a namespaced CHILD body's geom"),
+]
+
+
+class _ContactPairSim:
+    """Engine exposing exactly one contact between two given geom names."""
+
+    def __init__(self, geom1: str, geom2: str) -> None:
+        self._geom1 = geom1
+        self._geom2 = geom2
+
+    def get_contacts(self) -> dict[str, Any]:
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "json": {
+                        "contacts": [
+                            {"geom1": self._geom1, "geom2": self._geom2, "dist": -1e-4, "pos": [0.0, 0.0, 0.0]}
+                        ]
+                    }
+                }
+            ],
+        }
+
+
+def _contact_pair(geom1: str, geom2: str) -> Any:
+    """Return a duck-typed engine exposing one contact between two geom names.
+
+    Returned as ``Any`` deliberately. The predicates probe for ``get_contacts``
+    via ``getattr`` and fall back when it is absent - documented in the
+    ``strands_robots.simulation.predicates`` module docstring - so a stub
+    exposing only that method is a valid engine for them, even though it does
+    not satisfy the ``SimEngine`` annotation.
+    """
+    return _ContactPairSim(geom1, geom2)
+
+
+class TestSharedGeomNameMapping:
+    """``_geom_belongs_to_body`` owns the body-to-geom name mapping."""
+
+    @pytest.mark.parametrize("geom, why", _MATCHING)
+    def test_supported_conventions_resolve(self, geom: str, why: str) -> None:
+        assert _geom_belongs_to_body(geom, "mug") is True, why
+
+    @pytest.mark.parametrize("geom, why", _NOT_MATCHING)
+    def test_unrelated_names_do_not_resolve(self, geom: str, why: str) -> None:
+        assert _geom_belongs_to_body(geom, "mug") is False, why
+
+    def test_index_boundary_keeps_distinct_bodies_apart(self) -> None:
+        """``cube_1`` must not claim ``cube_10``'s geoms."""
+        assert _geom_belongs_to_body("cube_10_g0", "cube_1") is False
+
+    def test_a_parent_body_does_not_claim_a_namespaced_childs_geom(self) -> None:
+        """The synthesized form is matched exactly, not as a ``<body>/`` prefix.
+
+        ``add_robot`` namespaces bodies, so a Panda's links are ``panda/link0``
+        and their unnamed geoms are reported as ``panda/link0/geom_<id>``. A
+        broad ``panda/`` prefix would let the body ``panda`` claim them.
+        """
+        assert _geom_belongs_to_body("panda/link0/geom_1", "panda/link0") is True
+        assert _geom_belongs_to_body("panda/link0/geom_1", "panda") is False
+
+
+class TestBodyLevelPredicatesAgree:
+    """The two body-level matchers cannot disagree about one contact list."""
+
+    @pytest.mark.parametrize("geom, why", _MATCHING + _NOT_MATCHING)
+    def test_body_contact_matches_the_shared_mapping(self, geom: str, why: str) -> None:
+        expected = _geom_belongs_to_body(geom, "mug")
+        sim = _contact_pair(geom, "plate_g0")
+        assert _body_contact(sim, "mug", "plate") is expected, why
+
+    @pytest.mark.parametrize("geom, why", _MATCHING)
+    def test_body_contact_and_grasped_agree(self, geom: str, why: str) -> None:
+        """One contact list, one verdict -- whichever predicate reads it."""
+        sim = _contact_pair(geom, "gripper_pad")
+        grasped = make_predicate("grasped", body="mug", gripper_prefix="gripper")
+        assert _body_contact(sim, "mug", "gripper_pad") is True, why
+        assert grasped(sim) is True, why
+
+    def test_contact_is_direction_agnostic(self) -> None:
+        """A pair reported (b, a) counts the same as (a, b)."""
+        assert _body_contact(_contact_pair("plate/geom_1", "mug/geom_2"), "mug", "plate") is True
+        assert _body_contact(_contact_pair("mug/geom_2", "plate/geom_1"), "mug", "plate") is True
+
+
+# --- live MuJoCo scenes ------------------------------------------------------
+#
+# A cube resting on a plate under gravity. The two variants differ ONLY in
+# whether the geoms carry names, which is what decides the reported name format.
+
+_SCENE = """
+<mujoco>
+  <compiler angle="radian"/>
+  <option gravity="0 0 -9.81"/>
+  <worldbody>
+    <geom name="ground" type="plane" size="2 2 .1"/>
+    <body name="plate" pos="0 0 0.02">
+      <geom {plate_name}type="box" size=".12 .12 .02"/>
+    </body>
+    <body name="mug" pos="0 0 0.10">
+      <freejoint/>
+      <geom {mug_name}type="box" size=".03 .03 .03"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _settled(xml: str):
+    sim = Simulation(tool_name="contact_names", mesh=False)
+    sim.create_world()
+    sim.replace_scene_mjcf(xml)
+    sim.step(400)
+    return sim
+
+
+@pytest.fixture
+def unnamed_geoms():
+    """A resting contact between geoms the asset left unnamed."""
+    sim = _settled(_SCENE.format(plate_name="", mug_name=""))
+    yield sim
+    sim.cleanup()
+
+
+@pytest.fixture
+def geoms_named_after_bodies():
+    """A resting contact where each body's single geom carries the body's name."""
+    sim = _settled(_SCENE.format(plate_name='name="plate" ', mug_name='name="mug" '))
+    yield sim
+    sim.cleanup()
+
+
+def _reported_pairs(sim) -> list[tuple[str, str]]:
+    result = sim.get_contacts()
+    assert result["status"] == "success", result
+    payload = next(c["json"] for c in result["content"] if "json" in c)
+    return [(c["geom1"], c["geom2"]) for c in payload["contacts"]]
+
+
+class TestRestingContactIsDetected:
+    """A body physically resting on another must read as touching."""
+
+    @pytest.mark.parametrize("fixture_name", ["unnamed_geoms", "geoms_named_after_bodies"])
+    def test_body_on_require_contact_succeeds(self, fixture_name: str, request) -> None:
+        """The gate every LIBERO ``(on A B)`` goal is compiled with."""
+        sim = request.getfixturevalue(fixture_name)
+        # Premise: the scene really is in contact, so a False verdict below
+        # would be a false negative rather than an honest miss.
+        pairs = _reported_pairs(sim)
+        assert pairs, "fixture reported no contacts - nothing to resolve"
+
+        pred = make_predicate("body_on", body_a="mug", body_b="plate", require_contact=True)
+        assert pred(sim) is True
+
+    @pytest.mark.parametrize("fixture_name", ["unnamed_geoms", "geoms_named_after_bodies"])
+    def test_every_reported_geom_resolves_to_its_body(self, fixture_name: str, request) -> None:
+        """The payload producer and its consumers agree on the name format.
+
+        Derived from the compiled model rather than from hand-written names, so a
+        future change to how ``get_contacts`` names a geom fails here.
+        """
+        sim = request.getfixturevalue(fixture_name)
+        pairs = _reported_pairs(sim)
+        assert pairs, "fixture reported no contacts - nothing to resolve"
+        for geom1, geom2 in pairs:
+            assert _geom_belongs_to_body(geom1, "plate"), geom1
+            assert _geom_belongs_to_body(geom2, "mug"), geom2
+
+    def test_grasped_fires_on_unnamed_geoms(self, unnamed_geoms) -> None:
+        """``grasped`` treats the other side as a geom-name prefix set."""
+        pred = make_predicate("grasped", body="mug", gripper_prefix="plate")
+        assert pred(unnamed_geoms) is True
+
+    def test_an_unrelated_body_is_not_in_contact(self, unnamed_geoms) -> None:
+        """The fix must not make every body read as touching every other."""
+        assert _body_contact(unnamed_geoms, "mug", "ground") is False


### PR DESCRIPTION
## Problem

`get_contacts` reports a contact as a pair of geom **names**, and for a geom the asset left unnamed it synthesizes `"<body>/geom_<id>"`. Two body-level predicates consume those names -- `grasped` and `body_on(require_contact=True)`, the gate every LIBERO `(on A B)` goal is compiled with (`bddl_parser.py:215` sets `require_contact: True`) -- and they resolved them through two different matchers.

`_geom_belongs_to_body`'s docstring says it "mirrors the prefix `_body_contact` uses so contact-based predicates agree on what counts as a body's geom", and `_grasped`'s says "Body-geom matching follows the same naming conventions as `_body_contact`". They did not agree. `_body_contact` matched only the `<body>_g` prefix inline; `_geom_belongs_to_body` also accepted a geom named exactly after its body. And **neither recognised the name `get_contacts` itself emits.**

Measured against `main` (mujoco 3.11.0), for a body `mug`:

| geom name | `_geom_belongs_to_body` | `_body_contact` | |
|---|---|---|---|
| `mug` -- single-geom scene named after its body | True | **False** | diverges |
| `mug_geom` -- `add_object` | True | True | |
| `mug_g0` -- LIBERO / robosuite | True | True | |
| `mug/geom_2` -- **what `get_contacts` synthesizes** | **False** | **False** | neither |
| `mug_collision`, `mug_10_g0` | False | False | correct |

Only the `<body>_g` form worked, and every existing test happened to hand-write that form, so the gap was invisible in the suite.

### Consequence

Unnamed geoms are the dominant case in real MJCF -- a Panda scene compiles **81 unnamed geoms out of 82** -- so the payload producer and its consumers disagreed about the name format and a body physically resting on another read as "not touching". A cube settled on a plate, carrying **2.119 N over four contacts** with `exclude=0` and `efc_address >= 0`:

| | `main` | this change |
|---|---|---|
| `get_contacts` reports | `plate/geom_1 <-> mug/geom_2` | same |
| contacts / total normal force | 4 / 2.119 N | same |
| `body_on(mug, plate)` geometric-only | True | True |
| `body_on(..., require_contact=True)` | **False** | True |
| `grasped(body=mug, ...)` | **False** | True |

So the physics gate turned a correct geometric verdict into a false negative. In the variant where each geom carries its body's name, the divergence is visible directly: on `main` `grasped` returns **True** while `_body_contact` returns **False** for the *same* contact list.

## Change

`_geom_belongs_to_body` becomes the single owner of the body-to-geom name mapping. It moves above its consumers, gains the synthesized `<body>/geom_<id>` form, and `_body_contact` resolves both sides through it instead of matching prefixes inline -- so the two predicates cannot disagree.

The synthesized form is matched **exactly**, not as a `<body>/` prefix, because bodies are themselves namespaced: `add_robot` names a Panda's links `panda/link0`, whose unnamed geoms are reported as `panda/link0/geom_1`. A broad prefix would let the body `panda` claim them. Verified both directions -- `panda/link0/geom_1` resolves to `panda/link0` and not to `panda`.

No new error path, no payload change, and every previously-matching name still matches: the change is purely additive on the accept side.

## Verification

**Visual artifact** -- the scene is rendered headless in MuJoCo with the four reported contact points projected into pixels through `get_camera_params`. The render is **byte-identical on both trees** (`max|delta| = 0`); the physics is unchanged and only the verdict differs, which is asserted in the figure generator.

![contact geom name resolution](https://raw.githubusercontent.com/cagataycali/robots/artifacts/contact-geom-name-resolution/contact_geom_name_resolution.png)

**Regression test** -- `tests/simulation/test_contact_geom_name_resolution.py`, 39 tests. Pre-fix **15 failed / 24 passed**; post-fix 39 passed. The 24 that pass pre-fix are the negatives and the already-working forms -- they are what stops the fix over-reaching.

The two strongest pins:

- a parity test over every naming convention asserting `_body_contact`'s verdict equals the shared mapping's, plus one asserting `_body_contact` and `grasped` agree -- one contact list, one verdict;
- `test_every_reported_geom_resolves_to_its_body`, which walks the contacts `get_contacts` actually emits for a live settled scene and asserts each name resolves to the body it belongs to. It is derived from the compiled model rather than from hand-written names, so a future change to how `get_contacts` names a geom fails here.

Each live-scene test also asserts its own premise (the fixture really is in contact) so a False verdict cannot pass as an honest miss.

**Gate** (Thor, aarch64, mujoco 3.11.0, `MUJOCO_GL=egl`):

```
ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ 978 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 975 source files
MUJOCO_GL=egl pytest tests                          15048 passed, 255 skipped in 490.73s
```

Zero existing tests changed. Branched from `bb582dbc`, re-checked immediately before pushing.

## Out of scope

`get_contacts` reports geometry only (`geom1`, `geom2`, `dist`, `pos`) and exposes neither the contact force nor MuJoCo's `exclude` flag, so a pair inside `gap` -- listed for detection but generating exactly zero force -- is indistinguishable from a load-bearing one. That is a payload change across backends plus a decision about whether a zero-force proximity record should be reported at all, so it is a separate concern; filed as #1781 with measurements rather than folded in here.

`contact_between(geom_a, geom_b)` is left alone: it takes literal geom names and matches them exactly, which is correct for a geom-level predicate.