### PR TITLE
fix(tools): refuse a camera option that cannot be honored

### DIFF
--- a/changelog.d/1782-lerobot-camera-numeric-options.md
+++ b/changelog.d/1782-lerobot-camera-numeric-options.md
@@ -1,0 +1,27 @@
+### Fixed: the camera tool refuses a numeric option it cannot honor
+
+`lerobot_camera` validated its `save_path` at the boundary and forwarded every
+numeric option raw, into a camera configuration, an MP4 container header and a
+capture loop's bound. `capture_duration <= 0` made the recording loop's bound
+`int(fps * capture_duration)` zero, so the loop body never ran - and the tool
+returned `status="success"` with a summary whose `Saved:` line named a 258-byte
+MP4 that no decoder will open, a recording reported as complete that contains no
+video. `capture_duration=nan` leaked `cannot convert float NaN to integer`, an
+`int()` internal naming neither the tool nor the parameter, and left that stub
+behind; `capture_duration=True` silently recorded one second. `fps` in
+`{0, -10, 2.7, nan, inf, True}` was refused only by the camera driver, which
+compares the requested rate against the rate the attached device reports - so a
+value impossible on every camera was reported as a property of this one, after
+the device had already been opened and reconfigured.
+
+Each option is now checked against the shared domain for its kind before a
+camera is opened: `width` / `height` / `fps` count pixels and frames
+(`positive_whole_number_error`, which already owns the recorders' geometry and
+rate), and `capture_duration` / `preview_duration` / `timeout_ms` are continuous
+spans of time (`positive_finite_number_error`). Only the options an action
+actually consumes are checked, so `record` still accepts a `timeout_ms` it never
+reads (its asynchronous read passes a fixed one), `timeout_ms` is effective only
+under `async_mode`, and `discover` / `list` are unaffected. Because the geometry
+shares the recorders' domain, an integral float is now honored rather than
+refused: `width=640.0` reaches the camera and the container as `640` instead of
+dying in an OpenCV overload-resolution dump.

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -37,6 +37,7 @@ except ImportError as e:
 from strands import tool
 
 from strands_robots.tools._path_validation import validate_save_path
+from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -74,6 +75,90 @@ def _frame_to_image_content(frame: np.ndarray, format: str = "jpg") -> dict[str,
     except Exception as e:
         logger.error(f"Failed to convert frame to image content: {e}")
         return {"text": f"Failed to encode image: {str(e)}"}
+
+
+# Which numeric options each action actually consumes. Every action that opens a
+# camera is configured with the caller's geometry, so width/height/fps are
+# effective for all of them; each duration knob drives exactly one loop, and
+# "discover"/"list" open no camera with caller-supplied geometry at all.
+# "record" is deliberately absent from the timeout_ms rows: its asynchronous read
+# passes a fixed timeout rather than the caller's, so refusing a value that
+# action never consumes would be a false rejection.
+_ACTION_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
+    "capture": ("width", "height", "fps", "timeout_ms"),
+    "capture_batch": ("width", "height", "fps", "timeout_ms"),
+    "record": ("width", "height", "fps", "capture_duration"),
+    "preview": ("width", "height", "fps", "preview_duration", "timeout_ms"),
+    "test": ("width", "height", "fps", "timeout_ms"),
+    "configure": ("width", "height", "fps"),
+}
+
+
+def _numeric_option_error(
+    action: str,
+    *,
+    width: Any,
+    height: Any,
+    fps: Any,
+    capture_duration: Any,
+    preview_duration: Any,
+    timeout_ms: Any,
+    async_mode: Any,
+) -> str | None:
+    """Error text for the first numeric option ``action`` consumes but cannot honor.
+
+    Every value here is agent-supplied, so each is checked against the shared
+    domain for its kind before a camera is opened: ``width`` / ``height`` / ``fps``
+    count pixels and frames
+    (:func:`~strands_robots.utils.positive_whole_number_error`, which already owns
+    the recorders' geometry and rate), while the two durations and ``timeout_ms``
+    are continuous spans of time
+    (:func:`~strands_robots.utils.positive_finite_number_error`). Reusing those
+    helpers is what keeps this tool from accepting a frame size or a rate that the
+    plain-MP4 recorders refuse.
+
+    Validating here rather than letting the camera driver object is what makes the
+    refusal a property of the request instead of the device: the driver compares
+    the rate it was asked for against the rate the attached camera reports, so its
+    complaint names an ``actual_fps`` and is only raised once the device has been
+    opened and reconfigured. A rate of ``0`` is impossible on every camera, and the
+    tool has its own stake in these values regardless of the device - ``fps`` is
+    written into the MP4 container as its timebase and is the divisor of the
+    preview's frame period.
+
+    ``timeout_ms`` is only effective under ``async_mode``: the synchronous read
+    takes no timeout, so a value it never consumes is not refused.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        width: Frame width in pixels, as supplied.
+        height: Frame height in pixels, as supplied.
+        fps: Frame rate, as supplied.
+        capture_duration: Recording span in seconds, as supplied.
+        preview_duration: Preview span in seconds, as supplied.
+        timeout_ms: Asynchronous read budget in milliseconds, as supplied.
+        async_mode: Whether the asynchronous read path is selected.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when every
+        option this action reads is usable.
+    """
+    consumed = set(_ACTION_NUMERIC_OPTIONS.get(action, ()))
+    if not async_mode:
+        consumed.discard("timeout_ms")
+    for param, value, check in (
+        ("width", width, positive_whole_number_error),
+        ("height", height, positive_whole_number_error),
+        ("fps", fps, positive_whole_number_error),
+        ("capture_duration", capture_duration, positive_finite_number_error),
+        ("preview_duration", preview_duration, positive_finite_number_error),
+        ("timeout_ms", timeout_ms, positive_finite_number_error),
+    ):
+        if param in consumed:
+            error = check(value, param, action)
+            if error:
+                return error
+    return None
 
 
 @tool
@@ -114,16 +199,16 @@ def lerobot_camera(
         save_path: Directory to save captured images/videos
         filename: Custom filename (without extension)
         camera_ids: List of camera IDs for batch operations
-        width: Frame width in pixels
-        height: Frame height in pixels
-        fps: Frames per second
+        width: Frame width in pixels (a positive whole number)
+        height: Frame height in pixels (a positive whole number)
+        fps: Frames per second (a positive whole number)
         color_mode: Color mode ("RGB" or "BGR")
         rotation: Image rotation ("NO_ROTATION", "ROTATE_90", "ROTATE_180", "ROTATE_270")
         format: Image format ("jpg", "png", "bmp")
-        capture_duration: Duration for video recording (seconds)
-        preview_duration: Duration for preview display (seconds)
+        capture_duration: Duration for video recording (positive seconds)
+        preview_duration: Duration for preview display (positive seconds)
         async_mode: Use async reading for better performance
-        timeout_ms: Timeout for async operations (milliseconds)
+        timeout_ms: Timeout for async operations (positive milliseconds; read only when async_mode is on)
         warmup: Enable camera warmup on connection
         save_config: Save camera configuration to file
 
@@ -132,6 +217,24 @@ def lerobot_camera(
     """
 
     try:
+        numeric_error = _numeric_option_error(
+            action,
+            width=width,
+            height=height,
+            fps=fps,
+            capture_duration=capture_duration,
+            preview_duration=preview_duration,
+            timeout_ms=timeout_ms,
+            async_mode=async_mode,
+        )
+        if numeric_error:
+            return {"status": "error", "content": [{"text": numeric_error}]}
+        if action in _ACTION_NUMERIC_OPTIONS:
+            # Accepted above as integral values; coerce so the camera config's
+            # declared int fields, the VideoWriter frame size and the progress
+            # modulo each receive a true int rather than an integral float.
+            width, height, fps = int(width), int(height), int(fps)
+
         if action == "discover":
             return _discover_cameras()
         elif action == "list":

--- a/tests/tools/test_lerobot_camera_numeric_options.py
+++ b/tests/tools/test_lerobot_camera_numeric_options.py
@@ -1,0 +1,282 @@
+"""The ``lerobot_camera`` tool must refuse a numeric option it cannot honor.
+
+Every numeric option this agent tool exposes is forwarded straight into a camera
+configuration, an MP4 container header or a capture loop's bound, and none of them
+was checked. The consequences differed per option and none of them was reportable:
+
+* ``capture_duration <= 0`` made the recording loop's bound
+  ``int(fps * capture_duration)`` zero, so the loop body never ran. The tool then
+  returned ``status="success"`` and a summary whose ``Saved:`` line named a
+  258-byte MP4 that no decoder will open - a recording reported as complete that
+  contains no video.
+* ``capture_duration=nan`` leaked ``cannot convert float NaN to integer`` - an
+  ``int()`` internal naming neither the tool, the action nor the parameter - and
+  still left that stub file behind.
+* ``capture_duration=True`` silently recorded one second, since ``True`` is an
+  ``int`` worth 1.
+* ``width=640.0`` reached ``cv2.VideoWriter`` and died in a raw OpenCV overload
+  resolution dump, even though the sibling plain-MP4 recorders honor an integral
+  float for exactly this parameter.
+* ``fps`` in ``{0, -10, 2.7, nan, inf, True}`` was refused only by the camera
+  driver, which compares the requested rate against the rate the attached device
+  reports - so the complaint named an ``actual_fps`` and arrived only after the
+  device had been opened and reconfigured, making a request that is impossible on
+  every camera look like a property of this one.
+
+The tool already validated its ``save_path`` at the boundary, so the numeric
+options were the one option class forwarded unchecked.
+
+These tests pin the domain, the per-action scoping (an option an action never
+reads must not be refused), the coercion that lets an integral float through, and
+parity with the shared helpers so this tool cannot drift from the recorders.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+# The module object itself is needed - for the ``cv2``/``os`` handles the tool
+# module imports and for the drift guard's ``vars()`` scan - so every name in it,
+# the tool included, is reached through this one alias.
+import strands_robots.tools.lerobot_camera as cam_mod
+from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
+
+# Actions that open a camera configured with the caller's geometry. Every one of
+# them must therefore have its geometry validated.
+CAMERA_ACTIONS = ("capture", "capture_batch", "record", "preview", "test", "configure")
+
+# One value per rejection reason, for each domain.
+BAD_WHOLE_NUMBERS = (0, -10, 2.7, float("nan"), float("inf"), True, "10", None)
+BAD_SPANS = (0.0, -3.0, float("nan"), float("inf"), True, "1", None, [1.0])
+
+
+class _Recorder:
+    """A camera stand-in that records the geometry it was configured with."""
+
+    def __init__(self) -> None:
+        self.opened: list[tuple[Any, Any, Any]] = []
+        self.width = 8
+        self.height = 6
+        self.fps = 30
+        self.color_mode = type("_M", (), {"value": "RGB"})()
+        self.rotation: Any = None
+
+    def connect(self, warmup: bool = True) -> None:
+        return None
+
+    def disconnect(self) -> None:
+        return None
+
+    def read(self) -> np.ndarray:
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+    def async_read(self, timeout_ms: float = 1000) -> np.ndarray:
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    """Substitute the camera factory and record every geometry it is handed."""
+    cam = _Recorder()
+
+    def _create(camera_type: str, camera_id: Any, width: Any, height: Any, fps: Any, *rest: Any) -> _Recorder:
+        cam.opened.append((width, height, fps))
+        return cam
+
+    monkeypatch.setattr(cam_mod, "_create_camera", _create)
+    return cam
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with agent-shaped keyword values.
+
+    The tool annotates these options ``int`` / ``float``, but an agent supplies
+    JSON, and the values under test here are deliberately outside those
+    annotations - a string rate, a ``None`` span, an integral-float geometry.
+    Funnelling every call through one ``**kwargs: Any`` helper states that once,
+    rather than scattering a suppression over every call site.
+    """
+    return cam_mod.lerobot_camera(**kwargs)
+
+
+class TestARecordingThatCannotHappenIsRefused:
+    """The headline: a non-positive span reported a complete recording."""
+
+    @pytest.mark.parametrize("duration", BAD_SPANS)
+    def test_a_capture_duration_that_records_no_frame_is_refused(
+        self, recorder: _Recorder, tmp_path: Any, duration: Any
+    ) -> None:
+        result = _call(
+            action="record",
+            camera_id=0,
+            save_path=str(tmp_path),
+            fps=10,
+            capture_duration=duration,
+        )
+
+        assert result["status"] == "error"
+        assert "capture_duration" in _text(result)
+        # The refusal precedes the device, so no camera is opened and - the point
+        # of the fix - no file is left behind for the summary to call "Saved".
+        assert recorder.opened == []
+        assert list(tmp_path.iterdir()) == []
+
+    def test_the_refusal_names_the_action_and_the_option(self, recorder: _Recorder, tmp_path: Any) -> None:
+        text = _text(_call(action="record", camera_id=0, save_path=str(tmp_path), fps=10, capture_duration=0.0))
+
+        assert text.startswith("record:")
+        assert "capture_duration" in text
+        assert all(ord(c) < 128 for c in text), text
+
+    def test_a_usable_span_still_records(
+        self, recorder: _Recorder, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        writer = type("_W", (), {"write": lambda self, f: None, "release": lambda self: None})()
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter", lambda *a, **k: writer)
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter_fourcc", lambda *a, **k: 0, raising=False)
+        monkeypatch.setattr(cam_mod.os.path, "getsize", lambda p: 1234)
+
+        result = _call(action="record", camera_id=0, save_path=str(tmp_path), fps=2, capture_duration=0.5)
+
+        assert result["status"] == "success"
+        assert "Frames: 1" in _text(result)
+
+
+class TestGeometryIsValidatedOnEveryCameraAction:
+    """A frame size or rate no camera can be configured with is refused up front."""
+
+    @pytest.mark.parametrize("action", CAMERA_ACTIONS)
+    @pytest.mark.parametrize("param", ("width", "height", "fps"))
+    def test_a_geometry_no_camera_can_honor_is_refused(
+        self, recorder: _Recorder, tmp_path: Any, action: str, param: str
+    ) -> None:
+        result = _call(action=action, camera_id=0, camera_ids=[0], save_path=str(tmp_path), **{param: 0})
+
+        assert result["status"] == "error"
+        assert param in _text(result)
+        assert recorder.opened == []
+
+    @pytest.mark.parametrize("value", BAD_WHOLE_NUMBERS)
+    def test_every_unusable_rate_is_refused(self, recorder: _Recorder, tmp_path: Any, value: Any) -> None:
+        result = _call(action="record", camera_id=0, save_path=str(tmp_path), fps=value, capture_duration=1.0)
+
+        assert result["status"] == "error"
+        assert "fps" in _text(result)
+        assert recorder.opened == []
+
+    def test_an_integral_float_geometry_is_honored_as_an_int(
+        self, recorder: _Recorder, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``640.0`` is usable, and reaches the camera and the container as ``640``."""
+        writer = type("_W", (), {"write": lambda self, f: None, "release": lambda self: None})()
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter", lambda *a, **k: writer)
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter_fourcc", lambda *a, **k: 0, raising=False)
+        monkeypatch.setattr(cam_mod.os.path, "getsize", lambda p: 1234)
+
+        result = _call(
+            action="record",
+            camera_id=0,
+            save_path=str(tmp_path),
+            width=640.0,
+            height=480.0,
+            fps=2.0,
+            capture_duration=0.5,
+        )
+
+        assert result["status"] == "success"
+        assert recorder.opened == [(640, 480, 2)]
+        assert [type(v) for v in recorder.opened[0]] == [int, int, int]
+
+
+class TestOnlyTheOptionsAnActionReadsAreValidated:
+    """Refusing a value an action never consumes would be a false rejection."""
+
+    @pytest.mark.parametrize("action", ("discover", "list"))
+    def test_an_action_that_opens_no_configured_camera_ignores_geometry(self, action: str) -> None:
+        result = _call(action=action, camera_type="opencv", width="nonsense", fps=-1)
+
+        assert result["status"] != "error" or "width" not in _text(result)
+
+    def test_record_does_not_refuse_a_timeout_it_never_reads(
+        self, recorder: _Recorder, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``_record_video_sequence`` passes a fixed timeout to its async read."""
+        writer = type("_W", (), {"write": lambda self, f: None, "release": lambda self: None})()
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter", lambda *a, **k: writer)
+        monkeypatch.setattr(cam_mod.cv2, "VideoWriter_fourcc", lambda *a, **k: 0, raising=False)
+        monkeypatch.setattr(cam_mod.os.path, "getsize", lambda p: 1234)
+
+        result = _call(
+            action="record",
+            camera_id=0,
+            save_path=str(tmp_path),
+            fps=2,
+            capture_duration=0.5,
+            timeout_ms=-1.0,
+        )
+
+        assert result["status"] == "success"
+
+    def test_a_timeout_is_effective_only_on_the_asynchronous_read(self, recorder: _Recorder, tmp_path: Any) -> None:
+        common = {"action": "capture", "camera_id": 0, "save_path": str(tmp_path), "timeout_ms": -1.0}
+
+        assert _call(async_mode=False, **common)["status"] == "success"
+
+        refused = _call(async_mode=True, **common)
+        assert refused["status"] == "error"
+        assert "timeout_ms" in _text(refused)
+
+
+class TestTheDomainCannotDriftFromTheSharedHelpers:
+    """One domain per kind, shared with the recorders that write the same MP4."""
+
+    @pytest.mark.parametrize("value", BAD_WHOLE_NUMBERS + BAD_SPANS + (1, 30, 0.5, 2.5, np.int64(64)))
+    def test_the_tool_agrees_with_the_shared_domain_for_a_rate(
+        self, recorder: _Recorder, tmp_path: Any, value: Any
+    ) -> None:
+        tool_refuses = (
+            _call(action="record", camera_id=0, save_path=str(tmp_path), fps=value, capture_duration=1.0)["status"]
+            == "error"
+        )
+
+        assert tool_refuses == (positive_whole_number_error(value, "fps", "record") is not None)
+
+    @pytest.mark.parametrize("value", BAD_SPANS + (0.5, 2.5, 30, np.float32(1.5)))
+    def test_the_tool_agrees_with_the_shared_domain_for_a_span(
+        self, recorder: _Recorder, tmp_path: Any, value: Any
+    ) -> None:
+        tool_refuses = (
+            _call(action="record", camera_id=0, save_path=str(tmp_path), fps=10, capture_duration=value)["status"]
+            == "error"
+        )
+
+        assert tool_refuses == (positive_finite_number_error(value, "capture_duration", "record") is not None)
+
+    def test_every_camera_opening_handler_has_a_table_row(self) -> None:
+        """A new action configured with the caller's geometry must be validated too."""
+        handlers = {
+            name
+            for name, obj in vars(cam_mod).items()
+            if inspect.isfunction(obj)
+            and "width" in inspect.signature(obj).parameters
+            and name not in ("_create_camera", "_numeric_option_error")
+        }
+
+        assert handlers == {
+            "_capture_single_image",
+            "_capture_batch_images",
+            "_record_video_sequence",
+            "_preview_camera_live",
+            "_test_camera_performance",
+            "_configure_camera_settings",
+        }
+        assert set(cam_mod._ACTION_NUMERIC_OPTIONS) == set(CAMERA_ACTIONS)
+        assert len(handlers) == len(cam_mod._ACTION_NUMERIC_OPTIONS)


### PR DESCRIPTION
`lerobot_camera` validates its `save_path` at the boundary and forwards every numeric option raw, into a camera configuration, an MP4 container header and a capture loop's bound. The numeric options were the one option class the tool never checked.

![lerobot_camera numeric option domain, measured on a live camera](https://raw.githubusercontent.com/cagataycali/robots/artifacts/lerobot-camera-numeric-options/lerobot_camera_numeric_options.png)

## The defect

Measured on one live UVC camera through lerobot's `OpenCVCamera`, at `bb582dbc`:

| call | main | this PR |
|---|---|---|
| `record(..., capture_duration=0.0)` | **`success`** -- `Saved:` a 258-byte MP4, **undecodable** | `error`, no file |
| `record(..., capture_duration=-3.0)` | **`success`** -- same 258-byte stub | `error`, no file |
| `record(..., capture_duration=nan)` | `error: cannot convert float NaN to integer`, stub still written | `error`, no file |
| `record(..., capture_duration=True)` | **`success`** -- silently one second | `error`, no file |
| `record(..., fps=0 / -10 / 2.7 / nan / inf / True)` | `error`, after the device was opened and reconfigured | `error`, before it is opened |
| `record(width=640.0, height=480.0, fps=10.0)` | `error` -- raw OpenCV overload dump | **`success`** -- 10 frames, 81,897 bytes |
| `record(..., fps=10, capture_duration=1.0)` | `success`, 10 frames | `success`, 10 frames |
| `record(..., timeout_ms=-1.0)` (never read) | `success` | `success` |

Four distinct failures from one missing check:

**A recording reported as complete that contains no video.** `capture_duration <= 0` makes the loop's bound `int(fps * capture_duration)` zero, so the loop body never runs. The tool then returns `status="success"` with a summary reading `Frames: 0 @ 10 FPS` whose `Saved:` line names a 258-byte file that no decoder will open. Nothing on any path reports this -- not the status, not the summary, not a log line.

**An internal that names nothing.** `capture_duration=nan` surfaces `cannot convert float NaN to integer` from `int()`, naming neither the tool, the action, nor the parameter -- and still leaves the stub file behind.

**A silent substitution.** `capture_duration=True` records one second, since `True` is an `int` worth 1.

**A request refused as though it were a property of the device.** `fps` in `{0, -10, 2.7, nan, inf, True}` was refused only by the camera driver, which compares the requested rate against the rate the *attached* camera reports. So the complaint names an `actual_fps` (`failed to set fps=0 (actual_fps=5.0)`) and arrives only after the device has been opened and reconfigured -- for a rate that is impossible on every camera. The tool also has its own stake in `fps` regardless of the device: it is written into the MP4 container as its timebase and is the divisor of the preview's frame period.

## The change

Each option is checked against the shared domain for its kind, before a camera is opened:

- `width` / `height` / `fps` count pixels and frames -> `positive_whole_number_error`, whose docstring already names "the recorders' `fps`, `width`, `height`" as its domain.
- `capture_duration` / `preview_duration` / `timeout_ms` are continuous spans of time -> `positive_finite_number_error`, the domain already used for a rollout or teleop `duration`.

No new helper: reusing those is what keeps this tool from accepting a frame size or a rate the plain-MP4 recorders refuse, and a parity test pins it in both directions over the whole probe set.

**Only the options an action consumes are validated**, driven from one `_ACTION_NUMERIC_OPTIONS` table so the two cannot diverge. `record` still accepts a `timeout_ms` it never reads (its asynchronous read passes a fixed timeout), `timeout_ms` is effective only under `async_mode` (the synchronous read takes none), and `discover` / `list` open no camera with caller-supplied geometry and are untouched.

**An integral float is now honored rather than refused.** Because the geometry shares the recorders' domain -- which exists precisely so a `640.0` computed from a config or an `np.int64` probed from a camera passes -- `width=640.0` is accepted and coerced, reaching the camera config's declared `int` fields, `VideoWriter`'s frame size and the progress modulo as `640`. On main it died in an OpenCV overload-resolution dump. This is a capability gain, not a narrowing.

Guard placement follows the established order for this class: the caller's parameters are validated before the device is touched, so the same mistake reports identically whatever camera is attached, and a refused call leaves no file and no device churn behind.

## Out of scope

`record` does not forward the caller's `timeout_ms` at all -- its asynchronous read passes a fixed `1000` -- so a caller supplying one there has it dropped. That is a separate question from the domain, and this change deliberately does not refuse a value that action never reads.

## Visual artifact

The figure above is measured: one script, two trees, both dumping JSON, every caption re-derived from those dumps by the generator (which asserts each claim before saving). The bottom-right panel is a frame **decoded back out of the MP4 the honored call produced** -- the round-trip proof that `width=640.0` now yields a real recording. The top-left panel carries text rather than an image because there is nothing to show: on main that "successful" recording is a 258-byte file with no stream.

## Tests

75 new tests in `tests/tools/test_lerobot_camera_numeric_options.py`. With `strands_robots/tools/lerobot_camera.py` reverted to `ebe2297b` and the tests kept, **44 fail and 31 pass**; all 75 pass with the fix. One of the 44 is the structural drift test failing on `AttributeError` because `_ACTION_NUMERIC_OPTIONS` is introduced by the fix, so **43 of them are behavioural**. The 31 that pass pre-fix are the accepted-value controls and the not-refused rows -- they are what stop the guard over-reaching, and one of them (`record` with a bad `timeout_ms`) would fail if the per-action scoping were dropped. **Zero existing tests changed:** every pre-existing test already used a usable value, which is exactly why a green suite hid this.

The headline test asserts the two things the fix is for: no camera is opened, and `tmp_path` is empty afterwards -- no file for a summary to call `Saved`. A structural test asserts every handler configured with the caller's geometry has a table row, so a seventh camera action cannot be added unvalidated.

## Gate

- `ruff check` / `ruff format --check strands_robots tests tests_integ`: clean (979 files)
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 976 source files`
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **15123 passed, 255 skipped** in 484s (at base `ebe2297b`)
- Behavioural verification on a live UVC camera, both trees, for every row of the table above

## Round 2 -- no change to library behaviour

CodeQL flagged `py/import-and-import-from` on the test module: it named
`strands_robots.tools.lerobot_camera` both as a module alias and via `from ... import`. The
module object is genuinely needed -- for the `cv2`/`os` handles the tool module imports and for
the drift guard's `vars()` scan -- so the `from` line was the redundant one and is gone; the two
symbols it provided are reached through the alias, as the same-directory
`tests/tools/test_lerobot_train.py` and `tests/tools/test_use_lerobot.py` already do. Deriving the
module from a symbol instead (`sys.modules[lerobot_camera.__module__]`, which does work -- `@tool`
preserves `__module__`) was rejected as two lines of indirection to reach a module the file already
holds. The alias carries a comment saying why, so the `from` line is not re-added later.

Measured: modules imported both ways in that file went from
`['strands_robots.tools.lerobot_camera']` to none, and the collected test set is byte-identical
(75 before, 75 after, `diff` of the two id sets empty).

Also rebased onto `ebe2297b` (#1780). Zero file overlap, and the reviewed change is provably
unaffected -- the only content-line differences between `bb582dbc..18e9e7a0` and
`ebe2297b..bdb90822` are the eight import-style lines, with no production-source line moved.
