### PR TITLE
ci: refuse a changelog entry written outside a fragment

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -1,0 +1,89 @@
+# .github/workflows/changelog-fragment.yml
+#
+# Refuses a pull request that writes a new entry straight into `CHANGELOG.md`'s
+# `## [Unreleased]` section instead of recording it as a `changelog.d/` fragment.
+#
+# The rule is stated in `changelog.d/README.md` and in `AGENTS.md`, and its cost
+# is measured rather than stylistic: every branch appends at the same anchor, so
+# two open at once conflict on ordering alone, and because a push dismisses a
+# stale approval, clearing that conflict costs a full re-approval round per
+# affected branch. Sixty-seven fragments follow the rule. Nothing enforced it:
+# with three entries inserted directly beneath `## [Unreleased]`,
+# `assemble_changelog.py --check` exits 0 and the 30 tests in
+# `tests/test_changelog_format.py` + `tests/test_changelog_fragments.py` all
+# pass, because a fragment that was never written leaves nothing to inspect.
+# See issue #1784 and scripts/check_changelog_fragment.py for the full account.
+#
+# It is a base diff and not a test because `[Unreleased]` on `main` already
+# carries 168 entries from before the convention existed, so no static assertion
+# about the section's contents can hold. What is wrong is the act of adding to
+# it, and an act is only visible between two commits.
+#
+# The release path stays open: `assemble_changelog.py --apply` renders a fragment
+# verbatim and deletes the fragment it consumed, so each entry a release adds is
+# matched to a fragment deleted in the same diff. That is checked per entry, so a
+# release that also hand-writes an entry is still refused.
+#
+# The remedy is self-clearing, as with the merge-base overlap check: moving the
+# entry into a fragment removes the addition from the diff, so doing the thing
+# the check asks for makes it pass and no bypass switch is needed.
+#
+# Whether a failure here blocks a merge is a branch-protection decision, not a
+# property of this file. Until the job is added to the required set it surfaces
+# the addition and leaves the call to the reviewer.
+#
+
+name: Changelog Fragment Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fragment:
+    name: Refuse a changelog entry written outside a fragment
+    runs-on: ubuntu-latest
+
+    steps:
+      # The pull request HEAD, for consistency with the merge-base overlap check
+      # and because it is the tree under review. Unlike that check, this one is
+      # NOT defeated by the default refs/pull/<n>/merge commit: it asks what
+      # entries the head carries that the base does not, and a branch's appended
+      # entry is on the head and absent from the base whichever commit is used.
+      # Measured, not assumed, by
+      # tests/test_changelog_fragment_gate.py::test_a_merge_commit_head_still_sees_the_branchs_append
+      - name: Checkout the pull request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history: a merge base cannot be computed in a shallow clone.
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Fetched explicitly rather than relying on the checkout above, which
+      # fetches the requested commit and not necessarily the base branch when
+      # `ref` is a SHA. Full depth for the same merge-base reason.
+      - name: Fetch the base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # Standard library only, so there is nothing to install. The script writes
+      # its report to the job summary and emits a CHANGELOG.md annotation per
+      # unaccounted entry.
+      - name: Check for a changelog entry written outside a fragment
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python3 scripts/check_changelog_fragment.py --base-ref "$BASE_REF"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,9 @@ hatch run format            # ruff check --fix, ruff format
    round that reviews no changed behaviour. A fragment is its own file, so there
    is nothing to conflict on. `CHANGELOG.md` is assembled from the accumulated
    fragments when a tag is cut (`python scripts/assemble_changelog.py --apply`).
+   This is enforced by `.github/workflows/changelog-fragment.yml`: the rule was
+   documented in two places and enforced by nothing until #1784, and a pull
+   request reached `APPROVED` / `SUCCESS` / `CLEAN` having appended to the log.
 4. All tests must pass, lint must be clean
 5. Open PR from your fork, address all review comments
 6. Track follow-up items as issues on the [project board](https://github.com/orgs/strands-labs/projects/2)

--- a/changelog.d/1784-changelog-fragment-gate.md
+++ b/changelog.d/1784-changelog-fragment-gate.md
@@ -1,0 +1,43 @@
+### Docs: the changelog fragment rule is enforced instead of only documented
+
+`changelog.d/README.md` and `AGENTS.md` both state that a behavioural change
+records itself as a `changelog.d/<number>-<slug>.md` fragment and never appends
+to `## [Unreleased]` in `CHANGELOG.md`. The reason is measured rather than
+stylistic: every branch appends at the same anchor, so two open at once conflict
+on ordering alone -- never on meaning -- and because a push dismisses a stale
+approval, clearing that conflict costs a full re-approval round per affected
+branch.
+
+Sixty-seven fragments and every recently merged pull request follow the rule.
+Nothing checked it. With three entries inserted directly beneath the anchor:
+
+```
+$ python scripts/assemble_changelog.py --check
+changelog fragments OK (66 pending)                      # exit 0
+$ pytest tests/test_changelog_format.py tests/test_changelog_fragments.py
+30 passed
+```
+
+Neither suite can see it. One checks the log's version-heading structure, the
+other the contents of the fragment directory, and a fragment that was never
+written leaves nothing for either to inspect -- so the one rule the convention
+rests on was the one rule with no gate behind it, and a branch could reach
+`APPROVED` / `SUCCESS` / `CLEAN` having ignored it.
+
+`scripts/check_changelog_fragment.py` compares the `### ` entry headings under
+`[Unreleased]` at the merge base with the same set at the branch head, and names
+any the branch added. It is a base diff and not a test because `[Unreleased]` on
+`main` already carries 168 entries from before the convention existed, so no
+static assertion about that section's contents can hold: what is wrong is the act
+of adding to it, and an act is only visible between two commits.
+
+The release path stays open, and exactly. `assemble_changelog.py --apply` renders
+a fragment verbatim and deletes the fragment it consumed, so every entry a
+release adds is matched to a `changelog.d/*.md` file deleted in the same diff.
+That is checked per entry, so a release that also hand-writes an extra entry is
+still refused and only the extra one is named. Editing, rewording, reordering, or
+retiring an entry already in the log adds no heading and is silent.
+
+Like the merge-base overlap check, the remedy is self-clearing: moving the entry
+into a fragment removes the addition from the diff, so doing what the check asks
+makes it pass and there is no bypass switch to add.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -16,6 +16,14 @@ reconcile.
 release bookkeeping (collapsing `[Unreleased]` into a dated section). It is
 fragments, not the log, that behavioural PRs write to.
 
+This rule is enforced by `.github/workflows/changelog-fragment.yml`, which names
+any `### ` entry a branch adds to `[Unreleased]` that no fragment accounts for.
+It is a base diff rather than a test because `[Unreleased]` already carries
+entries from before this convention, so no static assertion about that section
+can hold. Release bookkeeping is unaffected: `--apply` deletes each fragment it
+folds in, so an assembled entry is matched to the fragment it came from, and
+editing or reordering an entry already in the log adds no heading.
+
 ## Adding a fragment
 
 Create `changelog.d/<number>-<slug>.md`, where `<number>` is your PR (or issue)

--- a/scripts/check_changelog_fragment.py
+++ b/scripts/check_changelog_fragment.py
@@ -286,8 +286,8 @@ def render_report(
             f"would have gone into `{CHANGELOG_PATH}` -- see `{FRAGMENT_DIR}/README.md`.",
             "",
             "Every branch appends at the same anchor, so two doing it at once conflict on ordering alone, "
-            "and clearing that conflict costs a re-approval round because a push dismisses a stale approval. "
-            "A fragment is its own file, so there is nothing to reconcile.",
+            + "and clearing that conflict costs a re-approval round because a push dismisses a stale approval. "
+            + "A fragment is its own file, so there is nothing to reconcile.",
             "",
             f"`{CHANGELOG_PATH}` is assembled from the accumulated fragments when a tag is cut: "
             "`python scripts/assemble_changelog.py --apply`.",

--- a/scripts/check_changelog_fragment.py
+++ b/scripts/check_changelog_fragment.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Refuse a pull request that writes a new entry straight into ``CHANGELOG.md``.
+
+Why this exists
+---------------
+``changelog.d/README.md`` states the rule and its cost: every pull request that
+appended straight to ``## [Unreleased]`` inserted at the *same anchor*, so any
+two open at once conflicted the moment either merged -- on ordering alone, never
+on meaning -- and because stale approvals are dismissed on push, clearing that
+conflict cost a full re-approval round per affected branch. ``AGENTS.md`` repeats
+it. Sixty-seven fragments and the ten most recent merged pull requests follow it.
+
+Nothing enforced it. Measured on ``ebe2297b``, with three ``### `` entries
+inserted directly beneath ``## [Unreleased]``::
+
+    $ python scripts/assemble_changelog.py --check
+    changelog fragments OK (66 pending)                      # exit 0
+    $ pytest tests/test_changelog_format.py tests/test_changelog_fragments.py
+    30 passed
+
+Both suites are about the *shape* of the log and the *contents* of the fragment
+directory. Neither can see a fragment that was never written, because a missing
+file leaves nothing to inspect. So the one rule the convention rests on was the
+one rule with no gate behind it, and a pull request could reach ``APPROVED`` /
+``SUCCESS`` / ``CLEAN`` having ignored it -- which is how this check came to be
+written.
+
+Why it is a base diff, not a test
+---------------------------------
+The obvious pin -- assert ``[Unreleased]`` holds no entries, since the assembler
+fills it at release time -- cannot be written here: ``[Unreleased]`` on ``main``
+already carries **168** entries from before the convention existed. A static
+assertion would have to fail on ``main`` today or grandfather a threshold that
+silently ratchets. What is actually wrong is not the section's contents but the
+*act* of adding to it, and an act is only visible as a difference between two
+commits. So this compares the entry headings under ``[Unreleased]`` at the merge
+base against the same set at the branch head: the legacy 168 appear on both
+sides and cancel, and only what this branch adds is left.
+
+Why the release path is not caught by it
+---------------------------------------
+``[Unreleased]`` does legitimately gain entries -- ``assemble_changelog.py
+--apply`` folds the accumulated fragments into it when a tag is cut. Two
+properties of that tool make the exemption exact rather than a blanket "skip
+release pull requests":
+
+- it renders a fragment verbatim (``render`` joins ``fragment.body.strip("\\n")``),
+  so a folded entry's heading is byte-identical to the one in its fragment; and
+- it deletes each fragment it consumed (``fragment.path.unlink()``).
+
+So every entry an assemble run adds is accounted for by a ``changelog.d/*.md``
+file *deleted in the same diff* whose heading it is. That is checked per entry,
+not per pull request: a release that also hand-writes an extra entry is still
+refused, and only the extra one is named.
+
+Collapsing ``[Unreleased]`` into a dated section at release does not trip this
+either -- the entries move *out* of ``[Unreleased]``, and a heading added under
+``## [1.2.3] - 2026-01-01`` is not an addition to ``[Unreleased]``.
+
+What is deliberately not checked
+--------------------------------
+Editing an entry already in the log: fixing a typo, rewording a summary,
+reordering the section. Those change no heading set, or move headings that were
+already present, and none of them create the anchor-conflict this exists to
+prevent. Only a *new* entry heading counts, so release bookkeeping and prose
+repair stay unimpeded.
+
+The remedy, like the merge-base overlap check's, is self-clearing: move the
+entry into ``changelog.d/<number>-<slug>.md`` and the addition disappears from
+the diff.
+
+Usage
+-----
+``--base-ref``  the branch being merged into (default ``main``). Resolved as
+                ``origin/<ref>`` when that exists, else as ``<ref>``.
+``--head``      the commit under test (default ``HEAD``). CI passes the pull
+                request's *head* commit, for consistency with the merge-base
+                overlap check and because it is the tree under review. Unlike
+                that check, this one is not defeated by the
+                ``refs/pull/<n>/merge`` commit ``actions/checkout`` produces by
+                default: the question here is which entries the head carries
+                that the base does not, and a branch's appended entry is on the
+                head and absent from the base whichever commit is used. Pinned
+                by ``test_a_merge_commit_head_still_sees_the_branchs_append``.
+``--repo``      repository root (default: the current working directory).
+
+Exit status is ``1`` when an unaccounted entry was added, else ``0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+#: The log the convention protects, and the anchor within it.
+CHANGELOG_PATH = "CHANGELOG.md"
+UNRELEASED_HEADING = "## [Unreleased]"
+
+#: Where a behavioural change records itself instead.
+FRAGMENT_DIR = "changelog.d"
+
+#: Files in the fragment directory that are documentation, not entries. Kept in
+#: step with ``scripts/assemble_changelog.py``'s ``RESERVED_NAMES``; a deleted
+#: README is not a consumed fragment and must not excuse an added entry.
+RESERVED_NAMES = frozenset({"README.md"})
+
+
+class GitError(RuntimeError):
+    """A git invocation this script depends on did not succeed.
+
+    Raised rather than returning a sentinel. Every caller needs the real commit
+    or file contents to say anything true, and a check that reports "nothing was
+    added" because it could not reach the base branch is worse than one that
+    fails loudly. An unresolvable base ref in CI is a workflow bug, not a
+    property of the pull request.
+    """
+
+
+def _git(*args: str, repo: Path | None = None) -> str:
+    """Run one git command and return its stdout, raising ``GitError`` on failure."""
+    command = ["git"]
+    if repo is not None:
+        command += ["-C", str(repo)]
+    command += list(args)
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise GitError(f"{' '.join(command)} exited {completed.returncode}: {completed.stderr.strip()}")
+    return completed.stdout
+
+
+def resolve_base_ref(base_ref: str, repo: Path | None = None) -> str:
+    """Return the revision to treat as the base branch tip.
+
+    Prefers the remote-tracking ref, because a CI checkout of a pull request
+    head usually has no local branch for the base: ``actions/checkout`` fetches
+    the base as ``refs/remotes/origin/<ref>`` and never creates ``<ref>``. Falls
+    back to the bare name so the script is runnable in a normal local clone.
+    """
+    for candidate in (f"origin/{base_ref}", base_ref):
+        try:
+            _git("rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}", repo=repo)
+        except GitError:
+            continue
+        return candidate
+    raise GitError(f"cannot resolve base ref {base_ref!r} as either 'origin/{base_ref}' or '{base_ref}'")
+
+
+def merge_base(base: str, head: str, repo: Path | None = None) -> str:
+    """Return the commit where ``head`` diverged from ``base``."""
+    revision = _git("merge-base", base, head, repo=repo).strip()
+    if not revision:
+        raise GitError(f"no merge base between {base!r} and {head!r} - is the history shallow?")
+    return revision
+
+
+def file_at(revision: str, path: str, repo: Path | None = None) -> str:
+    """Return a file's contents at a revision, or ``""`` when it is absent there.
+
+    Absence is not an error: a branch may introduce ``CHANGELOG.md`` itself, and
+    an empty base-side log correctly yields an empty base-side entry set.
+    """
+    try:
+        return _git("show", f"{revision}:{path}", repo=repo)
+    except GitError:
+        return ""
+
+
+def deleted_fragments(start: str, end: str, repo: Path | None = None) -> tuple[str, ...]:
+    """Return the fragment paths this branch deleted, sorted.
+
+    ``--no-renames`` so a fragment recorded as a rename is reported as its delete
+    plus its add. A renamed fragment has not been consumed by the assembler and
+    must not excuse an added entry, and the conservative direction for this check
+    is to see the delete and then find no matching heading.
+    """
+    output = _git(
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "--diff-filter=D",
+        f"{start}..{end}",
+        "--",
+        FRAGMENT_DIR,
+        repo=repo,
+    )
+    return tuple(sorted(line for line in output.splitlines() if line and Path(line).name not in RESERVED_NAMES))
+
+
+def unreleased_entries(changelog_text: str) -> tuple[str, ...]:
+    """Return the ``### `` entry headings under ``[Unreleased]``, in file order.
+
+    Reading stops at the next level-2 heading, so entries belonging to a released
+    version are not counted. A log with no ``[Unreleased]`` heading yields an
+    empty tuple: there is no section to append to, so nothing can be appended.
+    """
+    entries: list[str] = []
+    inside = False
+    for line in changelog_text.splitlines():
+        if line.strip() == UNRELEASED_HEADING:
+            inside = True
+            continue
+        if inside and line.startswith("## "):
+            break
+        if inside and line.startswith("### "):
+            entries.append(line.rstrip())
+    return tuple(entries)
+
+
+def fragment_entry(fragment_text: str) -> str | None:
+    """Return a fragment's entry heading, or ``None`` if it has none.
+
+    The heading is its first non-blank line, which is the contract
+    ``scripts/assemble_changelog.py`` validates fragments against. Returned
+    ``rstrip``ed to match ``unreleased_entries``, so trailing whitespace cannot
+    make an entry look unaccounted for.
+    """
+    for line in fragment_text.splitlines():
+        if not line.strip():
+            continue
+        return line.rstrip() if line.startswith("### ") else None
+    return None
+
+
+def added_entries(base_entries: Iterable[str], head_entries: Iterable[str]) -> tuple[str, ...]:
+    """Return the entry headings present at the head and not at the base.
+
+    A multiset difference, not a set difference: ``[Unreleased]`` on ``main``
+    contains two entries whose headings are both a bare ``### Fixed:``, so a set
+    difference would let a branch add a third copy of an existing heading
+    unnoticed. Sorted for a reproducible report.
+    """
+    surplus = Counter(head_entries) - Counter(base_entries)
+    return tuple(sorted(surplus.elements()))
+
+
+def unaccounted_entries(added: Iterable[str], consumed: Iterable[str]) -> tuple[str, ...]:
+    """Return the added entries no consumed fragment accounts for.
+
+    Also a multiset difference: folding two fragments in must delete two
+    fragments, and one deleted fragment cannot license two identical entries.
+    """
+    surplus = Counter(added) - Counter(consumed)
+    return tuple(sorted(surplus.elements()))
+
+
+def render_report(
+    *,
+    base_ref: str,
+    merge_base_sha: str,
+    added: Sequence[str],
+    accounted: Sequence[str],
+    unaccounted: Sequence[str],
+) -> str:
+    """Render the job-summary report for this run."""
+    lines = [
+        "## Changelog fragment check",
+        "",
+        f"Base `{base_ref}`, merge base `{merge_base_sha[:12]}`.",
+        "",
+    ]
+
+    if not added:
+        lines += [
+            f"No entry was added to `{CHANGELOG_PATH}`'s `{UNRELEASED_HEADING}` section.",
+            "",
+        ]
+        return "\n".join(lines) + "\n"
+
+    if unaccounted:
+        lines += [
+            f"This branch adds {len(unaccounted)} entr"
+            + ("y" if len(unaccounted) == 1 else "ies")
+            + f" to `{UNRELEASED_HEADING}` in `{CHANGELOG_PATH}` that no fragment accounts for:",
+            "",
+        ]
+        lines += [f"- `{entry}`" for entry in unaccounted]
+        lines += [
+            "",
+            f"Record each one as `{FRAGMENT_DIR}/<number>-<slug>.md` instead, where `<number>` is this "
+            "pull request's number, and drop it from the log. The fragment holds exactly the text that "
+            f"would have gone into `{CHANGELOG_PATH}` -- see `{FRAGMENT_DIR}/README.md`.",
+            "",
+            "Every branch appends at the same anchor, so two doing it at once conflict on ordering alone, "
+            "and clearing that conflict costs a re-approval round because a push dismisses a stale approval. "
+            "A fragment is its own file, so there is nothing to reconcile.",
+            "",
+            f"`{CHANGELOG_PATH}` is assembled from the accumulated fragments when a tag is cut: "
+            "`python scripts/assemble_changelog.py --apply`.",
+            "",
+        ]
+
+    if accounted:
+        lines += [
+            f"Accounted for by a fragment this branch consumed ({len(accounted)}):",
+            "",
+        ]
+        lines += [f"- `{entry}`" for entry in accounted]
+        lines += [""]
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Compare the two entry sets and return the process exit status."""
+    parser = argparse.ArgumentParser(
+        prog="check_changelog_fragment.py",
+        description="Refuse a pull request that writes a new CHANGELOG.md entry instead of a changelog.d fragment.",
+    )
+    parser.add_argument("--base-ref", default="main", help="branch being merged into (default: main)")
+    parser.add_argument("--head", default="HEAD", help="commit under test (default: HEAD)")
+    parser.add_argument("--repo", default=None, help="repository root (default: current directory)")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo) if args.repo is not None else None
+
+    try:
+        base = resolve_base_ref(args.base_ref, repo=repo)
+        fork_point = merge_base(base, args.head, repo=repo)
+        base_entries = unreleased_entries(file_at(fork_point, CHANGELOG_PATH, repo=repo))
+        head_entries = unreleased_entries(file_at(args.head, CHANGELOG_PATH, repo=repo))
+        consumed = [
+            entry
+            for path in deleted_fragments(fork_point, args.head, repo=repo)
+            if (entry := fragment_entry(file_at(fork_point, path, repo=repo))) is not None
+        ]
+    except GitError as error:
+        # Loud and non-zero: a check that cannot compute its answer must not
+        # report the reassuring one.
+        print(f"::error::changelog fragment check could not run: {error}", file=sys.stderr)
+        return 1
+
+    added = added_entries(base_entries, head_entries)
+    unaccounted = unaccounted_entries(added, consumed)
+    accounted = unaccounted_entries(added, unaccounted)
+
+    report = render_report(
+        base_ref=args.base_ref,
+        merge_base_sha=fork_point,
+        added=added,
+        accounted=accounted,
+        unaccounted=unaccounted,
+    )
+
+    print(report, end="")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report)
+
+    for entry in unaccounted:
+        print(
+            f"::error file={CHANGELOG_PATH}::{entry} was added to {UNRELEASED_HEADING} directly; "
+            f"record it as {FRAGMENT_DIR}/<number>-<slug>.md instead (see {FRAGMENT_DIR}/README.md)."
+        )
+
+    return 1 if unaccounted else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_changelog_fragment_gate.py
+++ b/tests/test_changelog_fragment_gate.py
@@ -1,0 +1,551 @@
+"""Contract pins for the changelog fragment check.
+
+``scripts/check_changelog_fragment.py`` exists because the one rule the changelog
+convention rests on had no gate behind it. ``changelog.d/README.md`` and
+``AGENTS.md`` both say a behavioural change records itself as a
+``changelog.d/<number>-<slug>.md`` fragment and never appends to
+``## [Unreleased]``; sixty-seven fragments follow it; and with three entries
+inserted directly beneath that heading, ``assemble_changelog.py --check`` exits 0
+and the 30 tests in ``tests/test_changelog_format.py`` +
+``tests/test_changelog_fragments.py`` all pass. Neither suite can see a fragment
+that was never written, because a missing file leaves nothing to inspect.
+
+The checks below pin the four properties that make the script worth having:
+
+- it **refuses** a direct append, replayed as real commits in a real repository
+  rather than as a hand-built string pair;
+- it is **self-clearing** -- moving the entry into a fragment makes it pass, so
+  the remedy it asks for is the remedy that satisfies it, with no override;
+- it **does not obstruct a release**: the assembler renders a fragment verbatim
+  and deletes what it consumed, so an assemble run's entries are accounted for
+  per entry -- and a release that *also* hand-writes one is still refused, for
+  only that one;
+- it is **quiet** where nothing was added: editing, rewording, or reordering an
+  entry already in the log, and the 168 legacy entries on ``main``, are not
+  additions.
+
+The git-topology tests are the load-bearing ones. The question is what a branch
+*added*, which is a statement about a merge base, and a merge base is exactly the
+thing a hand-built fixture would assume rather than exercise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check_changelog_fragment.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_changelog_fragment", _SCRIPT_PATH)
+    assert spec and spec.loader, f"cannot load {_SCRIPT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_changelog_fragment"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_module()
+
+
+# --- git fixtures ---------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+def _write(repo: Path, relative: str, text: str) -> None:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+#: A log shaped like the real one: an ``[Unreleased]`` section that already holds
+#: entries -- the 168 on ``main`` are why no static assertion about this section
+#: can be written -- followed by a released, dated section.
+_LEGACY_LOG = """# CHANGELOG
+
+All notable behavioural changes to `strands-robots` are logged here.
+
+## [Unreleased]
+
+### Fixed: a legacy entry that predates the fragment convention
+
+Body of the legacy entry.
+
+### Fixed: a second legacy entry
+
+Body of the second legacy entry.
+
+## [0.1.0] - 2026-01-01
+
+### Added: the first release
+
+Body.
+"""
+
+
+def _unreleased_body(log_text: str) -> str:
+    """The text between ``## [Unreleased]`` and the next level-2 heading."""
+    _, _, rest = log_text.partition("## [Unreleased]\n")
+    body, _, _ = rest.partition("\n## ")
+    return body
+
+
+def _append_to_unreleased(repo: Path, entry: str) -> None:
+    """Append an entry at the top of ``[Unreleased]``, as a direct edit does."""
+    path = repo / "CHANGELOG.md"
+    text = path.read_text(encoding="utf-8")
+    path.write_text(text.replace("## [Unreleased]\n", f"## [Unreleased]\n\n{entry}", 1), encoding="utf-8")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repository on ``main`` with a populated log and one pending fragment."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "checks@example.invalid")
+    _git(root, "config", "user.name", "Changelog Fragment Tests")
+    _git(root, "config", "commit.gpgsign", "false")
+    _write(root, "CHANGELOG.md", _LEGACY_LOG)
+    _write(root, "changelog.d/README.md", "# changelog.d - news fragments\n")
+    _write(
+        root,
+        "changelog.d/1700-a-pending-change.md",
+        "### Fixed: a change already recorded as a fragment\n\nBody of the pending fragment.\n",
+    )
+    _commit(root, "initial commit")
+    return root
+
+
+def _run(repo: Path, head: str = "HEAD") -> int:
+    return int(check.main(["--repo", str(repo), "--base-ref", "main", "--head", head]))
+
+
+#: The entry text a direct append inserts, matching the shape of a real one.
+_APPENDED = "### Fixed: an entry written straight into the log\n\nBody of the appended entry.\n"
+
+
+def _branch(repo: Path, name: str = "pr") -> None:
+    _git(repo, "checkout", "-q", "-b", name)
+
+
+# --- the escape this exists to close --------------------------------------------
+
+
+def test_a_direct_unreleased_append_is_refused(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The #1783 shape: a behavioural change recorded in the log, with no fragment."""
+    _branch(repo)
+    _write(repo, "strands_robots/dataset_recorder.py", "# the behavioural change\n")
+    _append_to_unreleased(repo, _APPENDED)
+    _commit(repo, "fix something, and record it in CHANGELOG.md")
+
+    assert _run(repo) == 1
+    output = capsys.readouterr().out
+    assert "### Fixed: an entry written straight into the log" in output
+    assert "changelog.d/<number>-<slug>.md" in output
+
+
+def test_three_appended_entries_are_each_named(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """#1783 added three entries in one diff; the report must not name only the first."""
+    _branch(repo)
+    for index in range(3):
+        _append_to_unreleased(repo, f"### Fixed: appended entry number {index}\n\nBody.\n")
+    _commit(repo, "record three changes in CHANGELOG.md")
+
+    assert _run(repo) == 1
+    output = capsys.readouterr().out
+    for index in range(3):
+        assert f"### Fixed: appended entry number {index}" in output
+
+
+def test_moving_the_entry_into_a_fragment_clears_the_check(repo: Path) -> None:
+    """The remedy the report asks for is the remedy that satisfies the check."""
+    _branch(repo)
+    _write(repo, "strands_robots/dataset_recorder.py", "# the behavioural change\n")
+    _append_to_unreleased(repo, _APPENDED)
+    _commit(repo, "fix something, and record it in CHANGELOG.md")
+    assert _run(repo) == 1
+
+    # Exactly what the report says to do: drop it from the log, write a fragment.
+    _git(repo, "checkout", "-q", "HEAD~1", "--", "CHANGELOG.md")
+    _write(repo, "changelog.d/1783-a-fragment-instead.md", _APPENDED)
+    _commit(repo, "record the change as a fragment instead")
+
+    assert _run(repo) == 0
+
+
+def test_a_fragment_only_branch_passes(repo: Path) -> None:
+    """The path every recent merged pull request takes."""
+    _branch(repo)
+    _write(repo, "strands_robots/dataset_recorder.py", "# the behavioural change\n")
+    _write(repo, "changelog.d/1785-the-normal-path.md", _APPENDED)
+    _commit(repo, "fix something, recorded as a fragment")
+
+    assert _run(repo) == 0
+
+
+# --- the release path stays open ------------------------------------------------
+
+
+def test_an_assemble_run_that_deletes_its_fragment_passes(repo: Path) -> None:
+    """``--apply`` folds a fragment into the log and deletes it; that is not an append."""
+    _branch(repo, "release")
+    folded = (repo / "changelog.d/1700-a-pending-change.md").read_text(encoding="utf-8")
+    _append_to_unreleased(repo, folded)
+    (repo / "changelog.d/1700-a-pending-change.md").unlink()
+    _commit(repo, "assemble the pending fragments into the log")
+
+    assert _run(repo) == 0
+
+
+def test_an_assemble_run_that_also_hand_writes_an_entry_is_refused_for_only_that_entry(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The exemption is per entry, so a release cannot carry an unaccounted one along."""
+    _branch(repo, "release")
+    folded = (repo / "changelog.d/1700-a-pending-change.md").read_text(encoding="utf-8")
+    _append_to_unreleased(repo, folded)
+    (repo / "changelog.d/1700-a-pending-change.md").unlink()
+    _append_to_unreleased(repo, _APPENDED)
+    _commit(repo, "assemble the fragments, and smuggle one entry in by hand")
+
+    assert _run(repo) == 1
+    output = capsys.readouterr().out
+    unaccounted, _, accounted = output.partition("Accounted for by a fragment")
+    assert "### Fixed: an entry written straight into the log" in unaccounted
+    assert "### Fixed: a change already recorded as a fragment" not in unaccounted
+    assert "### Fixed: a change already recorded as a fragment" in accounted
+
+
+def test_two_added_entries_need_two_deleted_fragments(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """One consumed fragment cannot license two copies of its entry."""
+    _branch(repo, "release")
+    folded = (repo / "changelog.d/1700-a-pending-change.md").read_text(encoding="utf-8")
+    _append_to_unreleased(repo, folded)
+    _append_to_unreleased(repo, folded)
+    (repo / "changelog.d/1700-a-pending-change.md").unlink()
+    _commit(repo, "fold one fragment in twice")
+
+    assert _run(repo) == 1
+    assert "that no fragment accounts for" in capsys.readouterr().out
+
+
+def test_a_deleted_readme_does_not_account_for_an_added_entry(repo: Path) -> None:
+    """``README.md`` is documentation, not a consumed fragment."""
+    _branch(repo)
+    _append_to_unreleased(repo, _APPENDED)
+    (repo / "changelog.d/README.md").unlink()
+    _commit(repo, "append an entry and delete the fragment directory's README")
+
+    assert _run(repo) == 1
+
+
+def test_collapsing_unreleased_into_a_dated_section_passes(repo: Path) -> None:
+    """Release bookkeeping moves entries out of ``[Unreleased]``, and out is not in."""
+    _branch(repo, "release")
+    path = repo / "CHANGELOG.md"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "## [Unreleased]\n", "## [Unreleased]\n\n## [0.2.0] - 2026-02-01\n", 1
+        ),
+        encoding="utf-8",
+    )
+    _commit(repo, "cut 0.2.0")
+
+    assert _run(repo) == 0
+
+
+def test_an_entry_added_under_a_released_version_is_not_flagged(repo: Path) -> None:
+    """Only the ``[Unreleased]`` anchor has the conflict property this protects."""
+    _branch(repo, "release")
+    path = repo / "CHANGELOG.md"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "## [0.1.0] - 2026-01-01\n", f"## [0.1.0] - 2026-01-01\n\n{_APPENDED}", 1
+        ),
+        encoding="utf-8",
+    )
+    _commit(repo, "correct the 0.1.0 section")
+
+    assert _run(repo) == 0
+
+
+# --- quiet where nothing was added ----------------------------------------------
+
+
+def test_an_unchanged_branch_adds_nothing(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The 168 legacy entries appear on both sides of the diff and cancel."""
+    _branch(repo)
+    _write(repo, "strands_robots/dataset_recorder.py", "# a change with no log entry at all\n")
+    _commit(repo, "a branch that does not touch the log")
+
+    assert _run(repo) == 0
+    assert "No entry was added" in capsys.readouterr().out
+
+
+def test_rewording_an_existing_entry_heading_is_reported(repo: Path) -> None:
+    """A typo fix in a heading replaces an entry rather than adding one.
+
+    The replaced heading is a *different string*, so this is the one shape where
+    the multiset difference reports an addition on an edit. It is allowed
+    deliberately: the guard is against a branch introducing an entry, and a
+    reworded heading is one the log already carried -- pinned so a future
+    tightening to "any heading not present at the base" is a conscious choice
+    rather than an accident.
+    """
+    _branch(repo)
+    path = repo / "CHANGELOG.md"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "### Fixed: a legacy entry that predates the fragment convention",
+            "### Fixed: a legacy entry that predates the fragment convention (typo fixed)",
+        ),
+        encoding="utf-8",
+    )
+    _commit(repo, "fix a typo in an existing entry heading")
+
+    # Reported, because the string differs; the point of the pin is that this is
+    # the *only* edit shape that is, and that it is visibly a rewording.
+    assert _run(repo) == 1
+
+
+def test_editing_an_entry_body_is_not_an_addition(repo: Path) -> None:
+    """Prose repair beneath an existing heading changes no heading at all."""
+    _branch(repo)
+    path = repo / "CHANGELOG.md"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("Body of the legacy entry.", "Body of the legacy entry, clarified."),
+        encoding="utf-8",
+    )
+    _commit(repo, "clarify the body of an existing entry")
+
+    assert _run(repo) == 0
+
+
+def test_reordering_existing_entries_is_not_an_addition(repo: Path) -> None:
+    """A multiset comparison is order-insensitive, so a reshuffle is silent."""
+    _branch(repo)
+    path = repo / "CHANGELOG.md"
+    text = path.read_text(encoding="utf-8")
+    body = _unreleased_body(text)
+    first, _, second = body.partition("### Fixed: a second legacy entry")
+    path.write_text(
+        text.replace(body, "\n### Fixed: a second legacy entry" + second + first.rstrip("\n") + "\n"),
+        encoding="utf-8",
+    )
+    _commit(repo, "reorder the unreleased entries")
+
+    assert _run(repo) == 0
+
+
+def test_deleting_an_existing_entry_is_not_an_addition(repo: Path) -> None:
+    """Removal is the opposite direction and must not be reported as an append."""
+    _branch(repo)
+    path = repo / "CHANGELOG.md"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "### Fixed: a second legacy entry\n\nBody of the second legacy entry.\n\n", ""
+        ),
+        encoding="utf-8",
+    )
+    _commit(repo, "retire an unreleased entry")
+
+    assert _run(repo) == 0
+
+
+def test_a_duplicate_of_an_existing_heading_is_flagged(repo: Path) -> None:
+    """Why the comparison is a multiset: ``[Unreleased]`` really does repeat headings.
+
+    Two entries on ``main`` are both a bare ``### Fixed:``, so a set difference
+    would let a branch add a third copy of a heading already present.
+    """
+    _branch(repo)
+    _append_to_unreleased(repo, "### Fixed: a second legacy entry\n\nA third copy of an existing heading.\n")
+    _commit(repo, "append an entry whose heading is already in the log")
+
+    assert _run(repo) == 1
+
+
+# --- git topology ---------------------------------------------------------------
+
+
+def test_an_entry_landing_on_the_base_is_not_attributed_to_the_branch(repo: Path) -> None:
+    """An entry added on ``main`` after the branch diverged is not the branch's."""
+    _branch(repo)
+    _write(repo, "strands_robots/dataset_recorder.py", "# an unrelated change\n")
+    _commit(repo, "the branch's own commit")
+
+    _git(repo, "checkout", "-q", "main")
+    _append_to_unreleased(repo, _APPENDED)
+    _commit(repo, "someone else appends to the log on main")
+    _git(repo, "checkout", "-q", "pr")
+
+    assert _run(repo) == 0
+
+
+def test_a_merge_commit_head_still_sees_the_branchs_append(repo: Path) -> None:
+    """Measured, not assumed: the ``refs/pull/<n>/merge`` head does not hide it.
+
+    The sibling merge-base overlap check is defeated by that commit, because it
+    compares two path sets either side of the merge base and the merge commit
+    drives the merge base to the base tip, emptying the base side. This check
+    asks a different question -- what entries does the head carry that the base
+    does not -- and the branch's appended entry is on the head and not on the
+    base whichever of the two commits is used. Pinned so the workflow's use of
+    the head SHA is understood as consistency with its sibling and as reviewing
+    the tree under review, not as load-bearing for correctness here.
+    """
+    _branch(repo)
+    _append_to_unreleased(repo, _APPENDED)
+    _commit(repo, "append an entry")
+
+    _git(repo, "checkout", "-q", "main")
+    _write(repo, "strands_robots/robot.py", "# main moves on\n")
+    _commit(repo, "an unrelated commit on main")
+    _git(repo, "checkout", "-q", "pr")
+    _git(repo, "merge", "-q", "--no-ff", "-m", "merge main into pr", "main")
+
+    assert _run(repo, head="HEAD") == 1
+
+
+def test_a_branch_that_introduces_the_changelog_is_handled(tmp_path: Path) -> None:
+    """An absent base-side log yields an empty base-side set, not a crash."""
+    root = tmp_path / "fresh"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "checks@example.invalid")
+    _git(root, "config", "user.name", "Changelog Fragment Tests")
+    _git(root, "config", "commit.gpgsign", "false")
+    _write(root, "README.md", "# fresh\n")
+    _commit(root, "initial commit")
+
+    _branch(root)
+    _write(root, "CHANGELOG.md", _LEGACY_LOG)
+    _commit(root, "introduce the changelog")
+
+    # Every entry in the new log is an addition, and none is accounted for.
+    assert _run(root) == 1
+
+
+def test_an_unresolvable_base_ref_fails_loudly(repo: Path) -> None:
+    """A check that cannot compute its answer must not report the reassuring one."""
+    assert int(check.main(["--repo", str(repo), "--base-ref", "no-such-branch", "--head", "HEAD"])) == 1
+
+
+def test_the_remote_tracking_ref_wins_over_a_local_branch(repo: Path, tmp_path: Path) -> None:
+    """CI has ``origin/main`` and no local ``main``; the resolution order matches."""
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", str(repo), str(clone)], check=True)
+    assert check.resolve_base_ref("main", repo=clone) == "origin/main"
+
+
+# --- unit pins on the pieces ----------------------------------------------------
+
+
+def test_unreleased_entries_stops_at_the_next_version_heading() -> None:
+    assert check.unreleased_entries(_LEGACY_LOG) == (
+        "### Fixed: a legacy entry that predates the fragment convention",
+        "### Fixed: a second legacy entry",
+    )
+
+
+def test_unreleased_entries_is_empty_without_the_anchor() -> None:
+    assert check.unreleased_entries("# CHANGELOG\n\n## [0.1.0] - 2026-01-01\n\n### Added: a thing\n") == ()
+
+
+def test_unreleased_entries_ignores_deeper_headings() -> None:
+    log = "## [Unreleased]\n\n### Fixed: an entry\n\n#### A sub-heading in its body\n"
+    assert check.unreleased_entries(log) == ("### Fixed: an entry",)
+
+
+def test_fragment_entry_reads_the_first_non_blank_line() -> None:
+    assert check.fragment_entry("\n\n### Fixed: a thing\n\nBody.\n") == "### Fixed: a thing"
+
+
+def test_fragment_entry_is_none_when_the_first_line_is_not_an_entry() -> None:
+    assert check.fragment_entry("Some prose with no heading.\n") is None
+    assert check.fragment_entry("") is None
+
+
+def test_fragment_entry_and_log_entries_agree_on_trailing_whitespace() -> None:
+    """Both sides ``rstrip``, so a trailing space cannot fake an unaccounted entry."""
+    assert (
+        check.fragment_entry("### Fixed: a thing   \n")
+        == check.unreleased_entries("## [Unreleased]\n\n### Fixed: a thing\n")[0]
+    )
+
+
+def test_added_entries_is_a_multiset_difference() -> None:
+    assert check.added_entries(["### a"], ["### a", "### a", "### b"]) == ("### a", "### b")
+
+
+def test_added_entries_is_empty_when_nothing_was_added() -> None:
+    assert check.added_entries(["### a", "### b"], ["### b", "### a"]) == ()
+
+
+def test_unaccounted_entries_is_a_multiset_difference() -> None:
+    assert check.unaccounted_entries(["### a", "### a"], ["### a"]) == ("### a",)
+    assert check.unaccounted_entries(["### a"], ["### a", "### b"]) == ()
+
+
+def test_the_report_names_the_entry_and_the_remedy() -> None:
+    report = check.render_report(
+        base_ref="main",
+        merge_base_sha="0123456789abcdef",
+        added=("### Fixed: an entry",),
+        accounted=(),
+        unaccounted=("### Fixed: an entry",),
+    )
+    assert "### Fixed: an entry" in report
+    assert "changelog.d/<number>-<slug>.md" in report
+    assert "assemble_changelog.py --apply" in report
+    assert "re-approval round" in report
+
+
+def test_the_report_says_so_when_nothing_was_added() -> None:
+    report = check.render_report(
+        base_ref="main",
+        merge_base_sha="0123456789abcdef",
+        added=(),
+        accounted=(),
+        unaccounted=(),
+    )
+    assert "No entry was added" in report
+    assert "changelog.d/<number>-<slug>.md" not in report
+
+
+def test_reserved_names_match_the_assembler() -> None:
+    """A name the assembler skips must not be counted as a consumed fragment."""
+    assembler = (_REPO_ROOT / "scripts" / "assemble_changelog.py").read_text(encoding="utf-8")
+    for name in check.RESERVED_NAMES:
+        assert f'"{name}"' in assembler, f"{name} is not reserved by the assembler"
+
+
+def test_no_emoji_in_the_script_or_its_output() -> None:
+    """Project rule: agent-read strings are plain ASCII, including U+FE0F."""
+    for path in (_SCRIPT_PATH, _REPO_ROOT / ".github" / "workflows" / "changelog-fragment.yml"):
+        text = path.read_text(encoding="utf-8")
+        offenders = [(index, char) for index, char in enumerate(text) if ord(char) > 0x7F]
+        assert not offenders, f"{path.name} holds non-ASCII characters: {offenders[:5]}"

--- a/tests/test_changelog_fragment_gate.py
+++ b/tests/test_changelog_fragment_gate.py
@@ -524,6 +524,39 @@ def test_the_report_names_the_entry_and_the_remedy() -> None:
     assert "re-approval round" in report
 
 
+def test_a_report_paragraph_written_as_several_literals_stays_one_line() -> None:
+    """Each paragraph is one report line, so a sentence is never split mid-clause.
+
+    ``render_report`` builds the report as a list of lines and joins it with
+    newlines, so one element is one line. Three of its paragraphs are written as
+    several adjacent literals for source width, and each is a single element --
+    the explicit ``+`` between the parts says so rather than leaving it to be
+    read as a missing comma.
+
+    Adding the commas instead splits those paragraphs across lines, breaking a
+    sentence in the middle of a clause. Every substring assertion above still
+    passes when that happens, since each fragment survives on a line of its own,
+    which is why the shape is pinned here rather than left to the wording checks.
+    """
+    report = check.render_report(
+        base_ref="main",
+        merge_base_sha="0123456789abcdef",
+        added=("### Fixed: an entry",),
+        accounted=(),
+        unaccounted=("### Fixed: an entry",),
+    )
+    lines = report.splitlines()
+    paragraphs = (
+        ("Every branch appends at the same anchor", "so there is nothing to reconcile."),
+        ("Record each one as", "/README.md`."),
+        ("is assembled from the accumulated fragments", "--apply`."),
+    )
+    for opening, ending in paragraphs:
+        holding = [line for line in lines if opening in line]
+        assert len(holding) == 1, f"{opening!r} appears on {len(holding)} lines, expected 1"
+        assert holding[0].endswith(ending), f"paragraph starting {opening!r} does not end with {ending!r}"
+
+
 def test_the_report_says_so_when_nothing_was_added() -> None:
     report = check.render_report(
         base_ref="main",


### PR DESCRIPTION
`changelog.d/README.md` and `AGENTS.md` both state that a behavioural change records itself as a `changelog.d/<number>-<slug>.md` fragment and never appends to `## [Unreleased]` in `CHANGELOG.md`. The reason is measured, not stylistic: every branch appends at the same anchor, so two open at once conflict on ordering alone -- never on meaning -- and because a push dismisses a stale approval, clearing that conflict costs a full re-approval round per affected branch.

67 fragments follow the rule, as do all twelve most recently merged pull requests. Nothing checked it.

Closes #1784.

## The defect

With three `### ` entries inserted directly beneath `## [Unreleased]` at `ebe2297b`:

```
$ python scripts/assemble_changelog.py --check
changelog fragments OK (66 pending)                      # exit 0
$ pytest tests/test_changelog_format.py tests/test_changelog_fragments.py
30 passed
```

Neither suite can see it, and neither is broken. `test_changelog_format.py` checks the log's version-heading structure; `test_changelog_fragments.py` checks the contents of the fragment directory. **A fragment that was never written leaves nothing for either to inspect**, so the one rule the whole convention rests on was the one rule with no gate behind it.

That is not hypothetical. Run against the open pull requests, the check written here refuses **#1783**, which is `APPROVED` with `SUCCESS` checks and `CLEAN` mergeability:

```
$ python3 scripts/check_changelog_fragment.py --base-ref main --head pr1783
This branch adds 3 entries to `## [Unreleased]` in `CHANGELOG.md` that no fragment accounts for:

- `### Fixed: notebook 5 recorded zero frames while reporting success`
- `### Fixed: notebook 5 streamed from a bucket path it never wrote to`
- `### Fixed: re-syncing into an existing bucket failed on the create step`
EXIT=1
```

A green board is reasonably read as the conventions being satisfied, which is precisely why a documented-only rule erodes.

## Why a base diff and not a test

The obvious pin -- assert `[Unreleased]` holds no entries, since the assembler fills it at release time -- is unavailable. `[Unreleased]` on `main` already carries **168** entries predating the convention. A static assertion would have to fail on `main` today, or grandfather a count that silently ratchets upward.

What is wrong is not the section's contents but the *act* of adding to it, and an act is only visible as a difference between two commits. So this compares the `### ` entry headings under `[Unreleased]` at the merge base against the head: the legacy 168 appear on both sides and cancel, and only what the branch adds remains. Same shape as `merge-base-overlap.yml` / `scripts/check_merge_base_overlap.py` (#1771): workflow, stdlib-only script, unit-pinned.

## The release path stays open, per entry

`[Unreleased]` does legitimately gain entries when `assemble_changelog.py --apply` folds fragments in at release time. Two properties of that tool make the exemption exact rather than a blanket "skip release pull requests":

- `render()` joins `fragment.body.strip("\n")`, so a folded entry's heading is byte-identical to its fragment's; and
- `--apply` deletes each fragment it consumed (`fragment.path.unlink()`).

So every entry an assemble run adds is accounted for by a `changelog.d/*.md` file **deleted in the same diff** whose heading it is. Checked per entry rather than per pull request, so a release that also hand-writes an extra entry is still refused and only the extra one is named. Collapsing `[Unreleased]` into a dated section is silent too -- entries move *out*, and a heading under `## [1.2.3] - ...` is not an addition to `[Unreleased]`.

A deleted `changelog.d/README.md` does not excuse anything: `RESERVED_NAMES` is kept in step with the assembler and pinned by a test that greps the assembler for each name.

## Deliberately not flagged

Editing an entry already in the log -- body prose, reordering, retiring one -- changes no heading set and creates none of the anchor conflict this exists to prevent. The one edit shape that *is* reported is rewording a heading, since the string differs; that is pinned by name (`test_rewording_an_existing_entry_heading_is_reported`) so tightening or loosening it later is a conscious choice rather than an accident.

## A claim I checked instead of copying

The sibling workflow pins the PR head SHA because the default `refs/pull/<n>/merge` commit defeats it -- that commit contains the base tip, driving the merge base to the base tip and emptying the base-side path set. I initially wrote the same rationale here. **It is false for this check**, and the test says so rather than the comment asserting it: this check asks which entries the head carries that the base does not, and a branch's appended entry is on the head and absent from the base whichever commit is used. `test_a_merge_commit_head_still_sees_the_branchs_append` measures it at exit 1. The workflow still uses the head SHA -- for consistency with its sibling and because it is the tree under review -- and now says that, rather than claiming a correctness property it does not have.

## No false positives

| tree | result |
|---|---|
| 12 most recently merged commits on `main`, each vs its parent | 12/12 `No entry was added`, exit 0 |
| open #1782, #1722, #1110, #1035, #1087 | exit 0 |
| open #1783 | exit 1, names all three entries |
| this branch against `main` | exit 0 |

#1000 exits 1 only in my shallow local clone, where `git merge-base` has no common ancestor to find. That is the `GitError` path doing its job -- a check that cannot compute its answer must not report the reassuring one -- and it is why the workflow uses `fetch-depth: 0`.

## Tests

35 tests in `tests/test_changelog_fragment_gate.py`, git-topology first: the escape is replayed as real commits in a real repository, because the question is about a merge base and a merge base is exactly what a hand-built fixture would assume rather than exercise. Covered: the direct append refused and all three entries named; the remedy self-clearing; the assemble-run exemption and its per-entry limit; one consumed fragment not licensing two identical entries; a duplicate of an existing heading caught (why the comparison is a multiset -- two entries on `main` are both a bare `### Fixed:`); dated-section bookkeeping silent; an entry landing on the base not attributed to the branch; an unresolvable base ref failing loudly; a branch that introduces `CHANGELOG.md` handled rather than crashing.

## Gate

- `ruff check` / `ruff format --check` on both new files: clean
- `mypy --disallow-untyped-defs --warn-return-any`: `Success: no issues found in 2 source files`
- `pytest tests/test_changelog_fragment_gate.py tests/test_changelog_format.py tests/test_changelog_fragments.py tests/test_merge_base_overlap.py`: **92 passed**
- full suite, `MUJOCO_GL=egl pytest tests`: **15083 passed, 255 skipped** in 476s
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean, `no issues found in 976 source files`
- `scripts/check_merge_base_overlap.py --base-ref main`: exit 0, `No overlap`
- `python scripts/assemble_changelog.py --check`: `changelog fragments OK (67 pending)`
- non-ASCII sweep (`grep -P '[^\x00-\x7F]'`) on all five new/changed files: 0 lines

## Docs

`changelog.d/README.md` and `AGENTS.md` each stated the rule; both now name the gate behind it, so the next reader does not have to infer whether it is advisory.

## Not in scope

Whether this job blocks a merge is a branch-protection decision, not a property of the file -- same posture as `merge-base-overlap.yml`, which says so in its own header. Until it is added to the required set it surfaces the addition and leaves the call to the reviewer.

The 168 legacy entries in `[Unreleased]` are untouched, as is the one malformed among them (a bare `### Fixed:` with no summary). Retiring or repairing those is release bookkeeping and a separate change.


## Round 2 -- explicit concatenation in the report

CodeQL reported `py/implicit-string-concatenation-in-list` on the anchor-conflict paragraph in `render_report`. It was worth more than a style note, because the two remedies it names are not equivalent and nothing in the suite could tell them apart.

`render_report` joins its list of lines with newlines, so one element is one line. Rendering the same case three ways:

| variant | report lines | lines holding the paragraph | `assert "re-approval round" in report` |
|---|---|---|---|
| implicit | 14 | 1 | passes |
| explicit `+` | 14 | 1 | passes |
| commas added | **16** | **3** | **passes** |

Reading it as a missing comma splits the paragraph into three report lines and breaks a sentence mid-clause, while every wording assertion keeps passing. So the ambiguity the rule names is one this suite genuinely could not see.

Only that element is reported, and the AST says why: the list's four multi-line elements are one `BinOp`, two `JoinedStr` (an f-string part is evidence of deliberate construction, which the rule skips), and this one pure `Constant`. It is also the repo's first instance -- 0 other open alerts of that rule on `main`.

Explicit `+` between the three parts, matching the multi-part element twelve lines above it. Output is byte-identical across all four branches of `render_report`. `test_a_report_paragraph_written_as_several_literals_stays_one_line` pins the one-line shape of all three multi-literal paragraphs and fails on the comma form, so the choice is a conscious one -- same posture as `test_rewording_an_existing_entry_heading_is_reported`. No fragment change, since the rendered report does not change.