### PR TITLE
fix(sim): require a real touch, not proximity, for a contact predicate

### DIFF
--- a/changelog.d/1781-contact-predicates-require-a-real-touch.md
+++ b/changelog.d/1781-contact-predicates-require-a-real-touch.md
@@ -1,0 +1,34 @@
+### Fixed: a contact predicate no longer fires for bodies that are visibly apart
+
+`mjData.contact` lists every geom pair inside the *detection* range, which is
+the pair's `margin` plus its `gap`. MuJoCo hands only the pairs inside `margin`
+to the constraint solver, so a pair between the two thresholds carries **no
+force at all** - it is a proximity report, not a touch. `get_contacts` reported
+`geom1`, `geom2`, `dist` and `pos`, none of which separates the two, so every
+contact predicate answered on geometry alone:
+
+```python
+# cube held 25 mm clear of the plate, gravity off, geoms margin=0.001 gap=0.05
+contact_any()                                 # True  - zero force anywhere
+contact_between("cube_g0", "plate_g0")        # True  - 25 mm apart
+grasped("cube", "plate_g")                    # True  - 25 mm apart
+body_on("cube", "plate", require_contact=True)  # True  - 25 mm apart
+```
+
+`dist` cannot stand in for the distinction: a pair with a wide `margin` is
+load-bearing at a *positive* distance (the body hovers on a real force) and the
+near miss above is positive too, so its sign splits neither case. Assets ship a
+non-zero `margin`/`gap` - a foot geom fractions of a millimetre off the floor is
+the usual one - so a locomotion or placement clause gated on contact inherited
+the proximity verdict.
+
+Each `get_contacts` record now reports `active`, taken from `mjContact.exclude`,
+which is MuJoCo's own decision to hand the pair to the solver; the text summary
+names the touching count and marks the proximity-only pairs. Every predicate
+resolves it through the shared
+`strands_robots.simulation.predicates.contact_is_active`, so they cannot
+disagree about which records count. Proximity reports are still listed - they
+are what a clearance query wants - and `get_contact_forces` still reports the
+load a touching pair carries. A payload that does not report `active` is read as
+a touch, so a backend or stub that cannot make the distinction keeps its
+previous verdict instead of silently answering `False` for every contact.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -96,7 +96,7 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `step` | `n_steps=1` (max 100 000/call) |
 | `set_gravity` | `gravity=[x,y,z]` or a scalar z-component |
 | `set_timestep` | `timestep` |
-| `get_contacts` / `get_contact_forces` | - |
+| `get_contacts` / `get_contact_forces` | - . `get_contacts` lists every geom pair inside the detection range (`margin` + `gap`) and marks each one `active` - MuJoCo hands only the pairs inside `margin` to the solver, so a pair between the two thresholds is a proximity report carrying no force. Contact predicates count only `active` pairs; `get_contact_forces` gives the load a touching pair carries |
 | `apply_force` | `body_name`, `force`, `torque`, `point` - latched on that body and re-applied every step until the next `apply_force` for it, so several bodies can hold wrenches at once (`force=[0,0,0]` stops one, `reset()` stops all) |
 | `get_jacobian` | `body_name` *or* `site_name` *or* `geom_name` |
 | `get_mass_matrix` | - |

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1632,7 +1632,22 @@ class RenderingMixin:
         return ["default", *[n for n in named if n != "default"]]
 
     def get_contacts(self) -> dict[str, Any]:
-        """Return the list of active geom-geom contacts at the current step.
+        """Return the geom-geom pairs MuJoCo detected at the current step.
+
+        ``mjData.contact`` holds every pair inside the *detection* range,
+        which is the pair's ``margin`` plus its ``gap``. MuJoCo hands only
+        the pairs inside ``margin`` to the constraint solver; a pair between
+        the two thresholds is a proximity report that carries no force at
+        all. Each record therefore reports ``active`` - the solver's own
+        decision, taken from ``mjContact.exclude`` - so a caller asking "are
+        these two touching?" can tell a touch from a near miss. Without it
+        every consumer answered on geometry alone, which reports contact for
+        bodies that are visibly apart whenever an asset declares a ``gap``.
+
+        Proximity reports are still listed: they are what a clearance query
+        wants, and suppressing them would hide the detection set from
+        callers who need it. Use :meth:`get_contact_forces` for the magnitude
+        of the load a touching pair carries.
 
         We run ``mj_forward`` first so the contact list reflects the
         current qpos/qvel even immediately after ``reset`` or ``add_robot``
@@ -1657,6 +1672,11 @@ class RenderingMixin:
                     "geom2": int(data.contact[i].geom2),
                     "dist": float(data.contact[i].dist),
                     "pos": data.contact[i].pos.tolist(),
+                    # ``exclude == 0`` is MuJoCo's own decision to hand the
+                    # pair to the constraint solver, i.e. the pair is close
+                    # enough to push back. Anything else is in the gap and
+                    # carries no force.
+                    "active": int(data.contact[i].exclude) == 0,
                 }
                 for i in range(ncon)
             ]
@@ -1680,12 +1700,16 @@ class RenderingMixin:
         for c in contact_snapshot:
             g1 = _resolve_geom(c["geom1"])
             g2 = _resolve_geom(c["geom2"])
-            contacts.append({"geom1": g1, "geom2": g2, "dist": c["dist"], "pos": c["pos"]})
+            contacts.append({"geom1": g1, "geom2": g2, "dist": c["dist"], "pos": c["pos"], "active": c["active"]})
 
-        text = f"{len(contacts)} contacts" if contacts else "No contacts."
         if contacts:
+            n_active = sum(1 for c in contacts if c["active"])
+            text = f"{len(contacts)} contacts ({n_active} touching)"
             for c in contacts[:10]:
-                text += f"\n  - {c['geom1']} <-> {c['geom2']} (d={c['dist']:.4f})"
+                touch = "" if c["active"] else ", proximity only - no force"
+                text += f"\n  - {c['geom1']} <-> {c['geom2']} (d={c['dist']:.4f}{touch})"
+        else:
+            text = "No contacts."
 
         return {
             "status": "success",

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -18,6 +18,12 @@ backend does not support them. A predicate that silently evaluates to
 ``False`` because of an unimplemented backend call is a bug in the
 predicate, not the benchmark - file an issue.
 
+Contact predicates count a geom pair only when the physics engine reports it
+as a real touch. ``get_contacts`` also lists pairs inside the detection range
+that carry no force -- see :func:`contact_is_active` -- and counting those
+would make ``contact_any`` / ``contact_between`` / ``grasped`` /
+``body_on(require_contact=True)`` fire for bodies that are visibly apart.
+
 When the backend *does* support a lookup but the referenced ``body`` /
 ``joint`` name cannot be resolved (almost always a spec typo), the term still
 degrades to a constant (``False`` / ``0.0``) but the offending name is logged
@@ -64,7 +70,7 @@ from __future__ import annotations
 
 import logging
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.utils import finite_number_error, finite_vector_error
@@ -487,6 +493,39 @@ def _inside_region(body: str, min: list[float], max: list[float]) -> BoolPredica
     return check
 
 
+def contact_is_active(record: Mapping[str, Any]) -> bool:
+    """True when a ``get_contacts`` record is a touch rather than a near miss.
+
+    ``get_contacts`` reports every geom pair inside the *detection* range,
+    which is the pair's ``margin`` plus its ``gap``. Only the pairs inside
+    ``margin`` reach the constraint solver; a pair between the two thresholds
+    carries no force, so treating it as contact answers "touching" for bodies
+    that are visibly apart. Assets ship a non-zero ``margin``/``gap`` -- a
+    foot geom fractions of a millimetre off the floor is the usual case -- so
+    this is the difference between a locomotion or placement clause firing on
+    physics and firing on proximity.
+
+    ``dist`` cannot stand in for this: a pair with a wide ``margin`` is
+    load-bearing at a *positive* distance (the body hovers on a real force),
+    while the near miss above is also positive, so the sign of ``dist`` splits
+    neither case. The solver's own admission decision does, and
+    ``get_contacts`` reports it as ``active``.
+
+    This is the single owner of that reading, so every contact predicate
+    agrees about which records count -- the same role
+    :func:`_geom_belongs_to_body` plays for body-to-geom names.
+
+    A record that does not report ``active`` is treated as a touch, so a
+    payload from a backend or test stub that cannot make the distinction keeps
+    its previous verdict rather than silently answering ``False`` for every
+    contact.
+    """
+    flag = record.get("active")
+    if flag is None:
+        return True
+    return bool(flag)
+
+
 def _contact_between(geom_a: str, geom_b: str) -> BoolPredicate:
     """Pairwise contact predicate.
 
@@ -510,7 +549,7 @@ def _contact_between(geom_a: str, geom_b: str) -> BoolPredicate:
             return False
         want = {geom_a, geom_b}
         for c in contacts:
-            if not isinstance(c, dict):
+            if not isinstance(c, dict) or not contact_is_active(c):
                 continue
             pair = {c.get("geom1"), c.get("geom2")}
             if want <= pair:
@@ -533,10 +572,14 @@ def _contact_any() -> BoolPredicate:
             logger.debug("contact_any() failed: %s", e)
             return False
         payload = _extract_json(result)
-        if payload.get("n_contacts", 0) > 0:
-            return True
         contacts = payload.get("contacts")
-        return bool(isinstance(contacts, list) and contacts)
+        if isinstance(contacts, list):
+            # The per-record list wins over a bare count: only a record
+            # carries the touch/proximity flag, which ``n_contacts`` cannot
+            # express. The count is the fallback for payloads that report
+            # nothing else.
+            return any(isinstance(c, dict) and contact_is_active(c) for c in contacts)
+        return bool(payload.get("n_contacts", 0) > 0)
 
     return check
 
@@ -611,7 +654,7 @@ def _body_contact(sim: SimEngine, body_a: str, body_b: str) -> bool | None:
         return None
 
     for c in contacts:
-        if not isinstance(c, dict):
+        if not isinstance(c, dict) or not contact_is_active(c):
             continue
         g1 = c.get("geom1") or ""
         g2 = c.get("geom2") or ""
@@ -769,7 +812,7 @@ def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
         if not isinstance(contacts, list):
             return False
         for c in contacts:
-            if not isinstance(c, dict):
+            if not isinstance(c, dict) or not contact_is_active(c):
                 continue
             g1 = c.get("geom1") or ""
             g2 = c.get("geom2") or ""
@@ -1823,6 +1866,7 @@ __all__ = [
     "StatefulRewardTerm",
     "can_resolve_body",
     "can_resolve_joint",
+    "contact_is_active",
     "make_predicate",
     "predicate_kind",
     "register_predicate",

--- a/tests/simulation/mujoco/test_contact_predicates_require_a_real_touch.py
+++ b/tests/simulation/mujoco/test_contact_predicates_require_a_real_touch.py
@@ -20,6 +20,10 @@ Two fixture requirements, both load-bearing for these tests: the moving body
 needs a freejoint (a static/static pair is dropped at collision time, leaving
 ``ncon == 0`` and nothing to assert), and gravity must be off, or the cube
 simply falls into real contact.
+
+The engine-backed tests additionally require the ``margin``/``gap`` semantics
+MuJoCo 3.9.0 introduced; see :data:`_GAP_SEMANTICS_MUJOCO`. The tests that only
+read the flag need no engine and run on every version the project supports.
 """
 
 from __future__ import annotations
@@ -29,7 +33,7 @@ from typing import Any
 
 import pytest
 
-pytest.importorskip("mujoco")
+mujoco = pytest.importorskip("mujoco")
 
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 from strands_robots.simulation.predicates import (  # noqa: E402
@@ -58,6 +62,35 @@ _SCENE = """
 </mujoco>
 """
 
+_GAP_SEMANTICS_MUJOCO = (3, 9)
+"""First MuJoCo release whose ``margin``/``gap`` semantics this scene assumes.
+
+3.9.0 (upstream commit ``a4e49f2d``) redesigned both attributes: detection moved
+from ``dist < margin`` to ``dist < margin + gap``, and force generation from
+``dist < margin - gap`` to ``dist < margin``. A pair that is *reported yet
+carries no force* is therefore spelled differently on either side of that
+release - upstream's own migration transform is ``margin_new = margin_old -
+gap_old`` - so no single scene expresses it on both and rewriting the fixture
+cannot make it portable.
+
+Measured with the scene above:
+
+===========  =========================  =========================
+mujoco       clear (``z=0.065``)        touching (``z=0.0399``)
+===========  =========================  =========================
+3.8.1        ``ncon=0`` - no pair       ``exclude=1``, zero force
+3.9 - 3.11   ``exclude=1``, zero force  ``exclude=0``, force > 0
+===========  =========================  =========================
+
+Under the old semantics the clear scene reports nothing at all, so the premise
+"a pair is reported yet carries no force" is unreachable and the
+predicate-is-False cases would pass *vacuously*, while the touching scene is
+rejected by the solver so every predicate-is-True case fails. The project's
+bound (``mujoco>=3.2.0,<4.0.0``) still admits those releases, so these fixtures
+skip there rather than fail a suite the production code handles correctly: the
+``active`` flag agrees with zero normal force on 3.8.1 too.
+"""
+
 # 25 mm of clear air: inside the detection range, outside ``margin``.
 _CLEAR_Z = 0.065
 # 0.1 mm of penetration: the solver takes the pair and pushes back.
@@ -81,7 +114,26 @@ _PREDICATES: list[tuple[str, str, dict[str, Any]]] = [
 ]
 
 
+def _require_gap_semantics() -> None:
+    """Skip when the running engine predates the ``margin``/``gap`` redesign.
+
+    ``pytest.importorskip(..., minversion=...)`` also skips, but it reports only
+    the two version numbers - it honours ``reason`` solely when the *import*
+    fails - so the log would not say why an older engine cannot run these
+    scenes.
+    """
+    running = tuple(int(part) for part in mujoco.__version__.split(".")[:2])
+    if running < _GAP_SEMANTICS_MUJOCO:
+        wanted = ".".join(str(part) for part in _GAP_SEMANTICS_MUJOCO)
+        pytest.skip(
+            f"mujoco {mujoco.__version__} predates the margin/gap redesign of "
+            f"{wanted}: this scene's clear case reports no pair at all there, so "
+            "the premise these tests assert on is unreachable"
+        )
+
+
 def _build(tmp_path: Path, cube_z: float, name: str) -> Any:
+    _require_gap_semantics()
     scene = tmp_path / f"{name}.xml"
     scene.write_text(_SCENE.format(cube_z=cube_z))
     sim = Simulation()

--- a/tests/simulation/mujoco/test_contact_predicates_require_a_real_touch.py
+++ b/tests/simulation/mujoco/test_contact_predicates_require_a_real_touch.py
@@ -1,0 +1,258 @@
+"""Contact predicates must fire on physics, not on proximity.
+
+``mjData.contact`` lists every geom pair inside the *detection* range, which
+is the pair's ``margin`` plus its ``gap``. MuJoCo hands only the pairs inside
+``margin`` to the constraint solver, so a pair between the two thresholds is a
+proximity report that carries **no force at all**.
+
+``get_contacts`` reports the solver's own decision as ``active``, and every
+contact predicate resolves it through
+:func:`~strands_robots.simulation.predicates.contact_is_active`. Without that
+flag the predicates answered on geometry alone, so ``contact_any``,
+``contact_between``, ``grasped`` and ``body_on(require_contact=True)`` all
+reported contact for a cube held 25 mm clear of a plate.
+
+``dist`` cannot substitute for the flag, which is why the payload needs it: a
+pair with a wide ``margin`` is load-bearing at a *positive* distance, and the
+near miss here is positive too, so the sign of ``dist`` separates neither case.
+
+Two fixture requirements, both load-bearing for these tests: the moving body
+needs a freejoint (a static/static pair is dropped at collision time, leaving
+``ncon == 0`` and nothing to assert), and gravity must be off, or the cube
+simply falls into real contact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.predicates import (  # noqa: E402
+    contact_is_active,
+    make_predicate,
+)
+
+# A plate and a cube, both declaring a narrow ``margin`` with a wide ``gap`` so
+# the detection range reaches far past the force-generation threshold. The cube
+# sits 25 mm above the plate's top face (plate half 0.02 + cube half 0.02 =
+# 0.04 of contact height; the cube's origin is at 0.065).
+_SCENE = """
+<mujoco model="proximity_vs_touch">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <light pos="0.3 -0.3 1.2" dir="-0.3 0.3 -1"/>
+    <body name="plate" pos="0 0 0">
+      <geom name="plate_g0" type="box" size="0.10 0.10 0.02" margin="0.001" gap="0.05"/>
+    </body>
+    <body name="cube" pos="0 0 {cube_z}">
+      <freejoint/>
+      <geom name="cube_g0" type="box" size="0.02 0.02 0.02" margin="0.001" gap="0.05"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# 25 mm of clear air: inside the detection range, outside ``margin``.
+_CLEAR_Z = 0.065
+# 0.1 mm of penetration: the solver takes the pair and pushes back.
+_TOUCHING_Z = 0.0399
+
+_PREDICATES: list[tuple[str, str, dict[str, Any]]] = [
+    ("contact_any", "contact_any", {}),
+    ("contact_between", "contact_between", {"geom_a": "cube_g0", "geom_b": "plate_g0"}),
+    ("grasped", "grasped", {"body": "cube", "gripper_prefix": "plate_g"}),
+    (
+        "body_on",
+        "body_on",
+        {
+            "body_a": "cube",
+            "body_b": "plate",
+            "z_offset": 0.01,
+            "xy_tol": 0.2,
+            "require_contact": True,
+        },
+    ),
+]
+
+
+def _build(tmp_path: Path, cube_z: float, name: str) -> Any:
+    scene = tmp_path / f"{name}.xml"
+    scene.write_text(_SCENE.format(cube_z=cube_z))
+    sim = Simulation()
+    assert sim.load_scene(str(scene))["status"] == "success"
+    return sim
+
+
+@pytest.fixture
+def clear_sim(tmp_path: Path):
+    """Cube held 25 mm clear of the plate - reported pairs, zero force."""
+    sim = _build(tmp_path, _CLEAR_Z, "clear")
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+@pytest.fixture
+def touching_sim(tmp_path: Path):
+    """Cube genuinely resting on the plate - the solver pushes back."""
+    sim = _build(tmp_path, _TOUCHING_Z, "touching")
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+def _records(sim: Any) -> list[dict[str, Any]]:
+    result = sim.get_contacts()
+    assert result["status"] == "success"
+    payload = next(b["json"] for b in result["content"] if "json" in b)
+    contacts: list[dict[str, Any]] = payload["contacts"]
+    return contacts
+
+
+def _total_normal_force(sim: Any) -> float:
+    """Sum ``get_contact_forces``' normal force - an independent oracle.
+
+    Reading the load from the sibling method rather than recomputing it here
+    keeps the premise of these tests honest: the claim "this pair carries no
+    force" is measured by the engine surface that exists to report force.
+    """
+    result = sim.get_contact_forces()
+    assert result["status"] == "success"
+    blocks = [b["json"] for b in result["content"] if "json" in b]
+    if not blocks:  # "No active contacts." - no json block at all.
+        return 0.0
+    return sum(abs(float(c["normal_force"])) for c in blocks[0]["contacts"])
+
+
+def _cube_height(sim: Any) -> float:
+    result = sim.get_body_state(body_name="cube")
+    assert result["status"] == "success"
+    state = next(b["json"] for b in result["content"] if "json" in b)
+    return float(state["position"][2])
+
+
+# Fixture premises. Without these the predicate assertions below could pass
+# for the wrong reason - "no contact reported at all" is not the case under
+# test, and a fixture that quietly fell into real contact would test nothing.
+
+
+def test_the_clear_fixture_reports_pairs_that_carry_no_force(clear_sim: Any) -> None:
+    """The cube is 25 mm clear, pairs ARE reported, and the load is exactly zero."""
+    records = _records(clear_sim)
+    assert records, "the wide gap must still put the pair in the detection set"
+    # 0.02 plate half + 0.02 cube half = 0.04 of contact height.
+    assert _cube_height(clear_sim) - 0.04 == pytest.approx(0.025, abs=1e-6)
+    assert all(r["dist"] > 0 for r in records), "surfaces are separated"
+    assert _total_normal_force(clear_sim) == 0.0
+
+
+def test_the_touching_fixture_reports_a_pair_that_carries_load(touching_sim: Any) -> None:
+    """The resting cube's pair is admitted by the solver and carries real force."""
+    assert _records(touching_sim), "a penetrating pair must be reported"
+    assert _total_normal_force(touching_sim) > 0.0
+
+
+# The payload carries the solver's decision.
+
+
+def test_get_contacts_marks_a_zero_force_pair_inactive(clear_sim: Any) -> None:
+    """A pair inside the gap but outside ``margin`` is reported, flagged inactive."""
+    records = _records(clear_sim)
+    assert [r["active"] for r in records] == [False] * len(records)
+
+
+def test_get_contacts_marks_a_load_bearing_pair_active(touching_sim: Any) -> None:
+    """A pair the solver admits is flagged active."""
+    records = _records(touching_sim)
+    assert records
+    assert all(r["active"] for r in records)
+
+
+def test_get_contacts_text_separates_touching_from_proximity(clear_sim: Any) -> None:
+    """The agent-readable summary must not call a zero-force pair a contact."""
+    result = clear_sim.get_contacts()
+    text = next(b["text"] for b in result["content"] if "text" in b)
+    n = len(_records(clear_sim))
+    assert f"{n} contacts (0 touching)" in text
+    assert "proximity only - no force" in text
+
+
+# The predicates.
+
+
+@pytest.mark.parametrize(("label", "name", "kwargs"), _PREDICATES, ids=[p[0] for p in _PREDICATES])
+def test_predicate_is_false_for_a_pair_that_carries_no_force(
+    clear_sim: Any, label: str, name: str, kwargs: dict[str, Any]
+) -> None:
+    """No predicate may report contact for a body held 25 mm clear."""
+    assert make_predicate(name, **kwargs)(clear_sim) is False
+
+
+@pytest.mark.parametrize(("label", "name", "kwargs"), _PREDICATES, ids=[p[0] for p in _PREDICATES])
+def test_predicate_is_true_when_the_bodies_really_touch(
+    touching_sim: Any, label: str, name: str, kwargs: dict[str, Any]
+) -> None:
+    """Filtering the detection set must not cost a real touch its verdict."""
+    assert make_predicate(name, **kwargs)(touching_sim) is True
+
+
+# The shared reading of the flag.
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        ({"active": True}, True),
+        ({"active": False}, False),
+        ({"active": 1}, True),
+        ({"active": 0}, False),
+        ({}, True),
+        ({"active": None}, True),
+    ],
+)
+def test_contact_is_active_reads_the_flag(record: dict[str, Any], expected: bool) -> None:
+    """Present-and-falsy means proximity; absent means "cannot tell, assume touch"."""
+    assert contact_is_active(record) is expected
+
+
+class _StubContactSim:
+    """Sim whose ``get_contacts`` payload is supplied verbatim by the test."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def get_contacts(self) -> dict[str, Any]:
+        return {"status": "success", "content": [{"json": self._payload}]}
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        z = {"cube": 0.1, "plate": 0.0}[body_name]
+        return {
+            "status": "success",
+            "content": [{"json": {"position": [0.0, 0.0, z], "quaternion": [1.0, 0.0, 0.0, 0.0]}}],
+        }
+
+
+@pytest.mark.parametrize(("label", "name", "kwargs"), _PREDICATES, ids=[p[0] for p in _PREDICATES])
+def test_a_payload_without_the_flag_keeps_its_verdict(label: str, name: str, kwargs: dict[str, Any]) -> None:
+    """A backend that cannot report the distinction must not lose every contact.
+
+    Answering ``False`` for a payload that simply omits the key would turn an
+    unreported capability into "nothing is ever touching", which is the silent
+    degradation the predicate module treats as a bug.
+    """
+    sim = _StubContactSim({"contacts": [{"geom1": "cube_g0", "geom2": "plate_g0", "dist": -0.001}]})
+    assert make_predicate(name, **kwargs)(sim) is True  # type: ignore[arg-type]
+
+
+def test_contact_any_falls_back_to_the_count_without_a_record_list() -> None:
+    """``n_contacts`` remains the fallback for payloads that report nothing else."""
+    assert make_predicate("contact_any")(_StubContactSim({"n_contacts": 2})) is True  # type: ignore[arg-type]
+    assert make_predicate("contact_any")(_StubContactSim({"n_contacts": 0})) is False  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #1781.

## The defect

`mjData.contact` lists every geom pair inside the **detection** range, which is the pair's `margin` plus its `gap`. MuJoCo hands only the pairs inside `margin` to the constraint solver, so a pair between the two thresholds carries **no force at all** -- it is a proximity report, not a touch.

`get_contacts` reported `geom1`, `geom2`, `dist` and `pos`. None of those separates the two, so every contact predicate answered on geometry alone. A 4 cm cube held **25 mm clear** of a plate, `gravity="0 0 0"`, both geoms `margin="0.001" gap="0.05"`:

```
get_contacts()      -> 4 contacts, total normal force 0.000000 N
get_body_state()    -> cube z = 0.06500, i.e. 25.0 mm of clear air

contact_any()                                    True
contact_between("cube_g0", "plate_g0")           True
grasped("cube", "plate_g")                       True
body_on("cube", "plate", require_contact=True)   True
```

Assets ship a non-zero `margin`/`gap` -- a foot geom fractions of a millimetre off the floor is the usual one -- so a locomotion or placement clause gated on contact inherited the proximity verdict. `bddl_parser` sets `require_contact: True` for every `(on A B)` goal, so LIBERO placement goals ran through it.

## Why `dist` cannot carry the distinction

The obvious fix is to read the separation that is already in the payload. Measured (mujoco 3.11.0), it does not work -- `margin` is the force-generation threshold and `gap` an *additional* detection buffer on top of it, so a wide `margin` is load-bearing at a **positive** distance:

| `margin` | `gap` | `dist` | `exclude` | total \|Fn\| | reading |
|---|---|---|---|---|---|
| 0.05 | 0.0 | **+0.025** | 0 | 12.468 N | load-bearing; the body hovers on a real force |
| 0.001 | 0.05 | **+0.025** | 1 | 0.000000 N | proximity report; nothing is touching |

Both are positive at the same separation, so the sign of `dist` splits neither case.

Force is not the right discriminator either. A solver-admitted pair is load-bearing in proportion to its penetration, so it can be arbitrarily small -- 3.88e-11 N at 1 pm -- while `dist == 0` exactly is *excluded*:

```
clearance  0.0     exclude=1 efc=-1  Fn=0.0
clearance -1e-12   exclude=0 efc= 0  Fn=3.88e-11
clearance -1e-09   exclude=0 efc= 0  Fn=3.88e-08
```

A `normal_force > 0` test happens to be correct, but any epsilon on it silently reinstates the defect. What actually answers "are these two touching?" is the solver's own admission decision.

## The change

Each `get_contacts` record now reports `active`, taken from `mjContact.exclude` -- MuJoCo's decision to hand the pair to the constraint solver. Over a 272-record sweep of `margin`/`gap`/clearance/gravity combinations, `exclude == 0` and `efc_address >= 0` never disagreed, and only `exclude` values 0 and 1 occur.

Every predicate resolves the flag through one new public helper, `predicates.contact_is_active`, so `contact_any` / `contact_between` / `grasped` / `body_on(require_contact=True)` cannot disagree about which records count -- the same single-owner role `_geom_belongs_to_body` already plays for body-to-geom names. The text summary names the touching count and marks the proximity-only pairs, since that string is what an agent reads.

The payload gains one derived boolean rather than a force field: `get_contact_forces` already calls `mj_contactForce` per pair in the same locked `mj_forward` block and reports `normal_force`, so the load is available from the method named for it and does not need a second home.

Proximity reports are still listed. They are what a clearance query wants, and suppressing them would hide the detection set from callers who need it. A record that does not report `active` is read as a touch, so a payload from a backend or a test stub that cannot make the distinction keeps its previous verdict instead of silently answering `False` for every contact -- the silent degradation the predicate module's docstring already calls a bug.

## Scope

`policy_runner`'s `success_fn="contact"` is deliberately untouched. It reads `result["contacts"]` / `result["n_contacts"]` directly, while MuJoCo returns a `{"status", "content"}` envelope, so it already answers `False` for the real engine and the defect above cannot reach it. That unreachability is its own issue and is not folded in here.

## Verification

Pre-fix, against `upstream/main` (the new helper's unit test removed so the module still imports): **7 failed, 11 passed**. The four predicate cases fail `assert True is False`, the two payload cases fail `KeyError: 'active'`, and the text case fails on the old summary. The 11 that already pass are the fixture premises and the real-touch controls -- they are what stops the fix over-reaching, so they are expected to pass both before and after.

Post-fix: 24 passed.

The fixture premises are asserted rather than assumed, because "no contact was reported at all" would make the predicate assertions pass for the wrong reason: pairs **are** reported, the cube **is** 25 mm clear, and the zero load is measured through `get_contact_forces` rather than recomputed in the test.

Gate, run headless with `MUJOCO_GL=egl`:

```
ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ 980 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 977 source files
pytest tests                                        15147 passed, 255 skipped in 476.24s
```

No existing test changed.

## Rollout in MuJoCo sim (headless)

![contact predicate: proximity vs touch](https://raw.githubusercontent.com/cagataycali/robots/artifacts/contact-predicates/contact_predicates.png)

Left: the cube held 25 mm clear, with the four reported pairs projected through `get_camera_params` and marked where the library placed them -- in mid-air, carrying 0.000 N. Right: the same scene with the cube genuinely resting, 0.349 N of load. The two renders are **byte-identical on `main` and on this branch** (`max|delta| = 0`): the physics is untouched, only the reading of the contact list changes. Every number in the figure is re-derived from the two measured runs by the generator before it is drawn.