### PR TITLE
fix(deps): declare the QP backend that [sim-mujoco]'s IK solve needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ extras you need:
 
 | Extra | Installs | Use for |
 |-------|----------|---------|
-| `sim-mujoco` | MuJoCo, robot_descriptions, imageio, mink + qpsolvers | Simulation (recommended starting point). mink/qpsolvers are the differential-IK solver behind the `move_to` Cartesian transport primitive. |
+| `sim-mujoco` | MuJoCo, robot_descriptions, imageio, mink + qpsolvers[daqp] | Simulation (recommended starting point). mink/qpsolvers are the differential-IK solver behind the `move_to` Cartesian transport primitive; `qpsolvers` ships no solver of its own, so the `[daqp]` backend extra is declared with it. |
 | `sim-newton` | Newton, Warp, MuJoCo-Warp, trimesh | GPU-native simulation (NVIDIA GPU; batched envs, headless ray-traced render) |
 | `sim-isaac` | usd-core, imageio (Isaac Sim installed out-of-band) | NVIDIA Isaac Sim backend - photorealistic RTX rendering, synthetic data, GPU-batched sensors, USD-native scenes. Isaac Sim itself is **not** pip-installable; install it via the Omniverse Launcher, Isaac Lab, or the NGC docker image. This extra pulls only the pip-installable Python helpers. (NVIDIA RTX GPU; GPU-only, not in `[all]`.) |
 | `sim-gs` | gsplat, plyfile, torch | 3D Gaussian Splatting hybrid rendering (`strands_robots.rendering`): composite any sim backend's robot over a captured photoreal 3DGS scene. `gsplat` ships as a source dist that JIT-compiles CUDA kernels via `nvcc` on first use - probe with `strands_robots.rendering.gsplat_rasterizer_available()`; the zero-GPU `PanoramaBackground` works without this extra. (CUDA GPU; GPU-only, not in `[all]`.) |

--- a/changelog.d/1788-sim-mujoco-declares-a-qp-backend.md
+++ b/changelog.d/1788-sim-mujoco-declares-a-qp-backend.md
@@ -1,0 +1,12 @@
+### Fixed: `[sim-mujoco]` declares the QP backend its IK solve needs
+
+`qpsolvers` is a solver-agnostic front end that ships no solver of its own, so
+the extra shipping the `move_to` Cartesian transport primitive declared
+`qpsolvers` without any backend and got one only through `mink`'s own
+`qpsolvers[daqp]` pin. With no backend installed `mink.solve_ik` cannot run and
+`move_to` returns `IK bridge unavailable: No qpsolvers backend is installed`,
+whose remedy advises installing `strands-robots[sim-mujoco]` - the extra that
+did not declare one. `[sim-mujoco]` now declares `qpsolvers[daqp]` explicitly,
+matching how `[cosmos3-sim]` already declared its backend for the same
+mink + qpsolvers stack. `daqp` is both the bridge's first preference and the
+backend `mink` pulls, so the resolved package set is unchanged.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ graph TB
 
 | Extra | Pulls in | When |
 |-------|----------|------|
-| `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg`, `mink`, `qpsolvers` | `Robot(mode="sim")`; `mink`/`qpsolvers` solve IK for the `move_to` primitive |
+| `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg`, `mink`, `qpsolvers[daqp]` | `Robot(mode="sim")`; `mink`/`qpsolvers` solve IK for the `move_to` primitive (the `[daqp]` backend extra is what makes the solve runnable - `qpsolvers` alone ships no solver) |
 | `[lerobot]` | `lerobot>=0.6.0,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` ZMQ |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,11 +220,18 @@ sim-mujoco = [
     # primitive in this backend's agent-callable action enum, solves IK on the
     # same mujoco.MjModel via strands_robots.simulation.ik.MinkIKBridge, so the
     # solver is part of what this extra ships rather than an add-on the caller
-    # has to name themselves. `mink` pulls a QP backend of its own
-    # (qpsolvers[daqp], the bridge's first preference); `qpsolvers` is declared
-    # here too because simulation/ik.py imports it directly.
+    # has to name themselves. `qpsolvers` is declared here because
+    # simulation/ik.py imports it directly, and the `[daqp]` backend extra
+    # because qpsolvers on its own solves nothing: with no backend installed
+    # `mink.solve_ik` cannot run and `move_to` returns "IK bridge unavailable:
+    # No qpsolvers backend is installed", whose remedy names THIS extra. daqp is
+    # both the bridge's first preference (ik._PREFERRED_QP_SOLVERS) and the
+    # backend `mink` pulls for itself, so this changes nothing about what
+    # resolves - it stops the guarantee resting on a transitive of `mink` that
+    # this extra does not control. `[cosmos3-sim]`, which drives the same
+    # mink + qpsolvers stack, declares its backend the same way.
     "mink>=0.0.4",
-    "qpsolvers>=4.0.0",
+    "qpsolvers[daqp]>=4.0.0",
 ]
 # Newton GPU-native backend (newton-physics/newton on NVIDIA Warp +
 # MuJoCo-Warp). GPU-batched parallel envs, headless ray-traced rendering, and

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -158,6 +158,7 @@ def test_direct_reference_check_ignores_extras_specifiers_and_markers(tmp_path):
 # resolution. This guard fails if either half regresses.
 import tomllib  # noqa: E402
 
+import pytest  # noqa: E402
 from packaging.requirements import Requirement  # noqa: E402
 from packaging.version import Version  # noqa: E402
 
@@ -367,19 +368,24 @@ _SELF_NAME = "strands-robots"
 _IK_SOLVER_PACKAGES = ("mink", "qpsolvers")
 
 
-def _extra_closure(extra: str) -> set[str]:
-    """Canonical names an extra pulls in, following ``strands-robots[...]`` self-references.
+def _extra_requirements(extra: str) -> dict[str, set[str]]:
+    """Distributions an extra pulls in, each mapped to the extras requested on it.
+
+    Follows ``strands-robots[...]`` self-references, so a composite extra such as
+    ``[all]`` reports its full closure.
 
     Args:
         extra: Name of the extra in ``[project.optional-dependencies]``.
 
     Returns:
-        The set of distribution names reachable from *extra*, lower-cased.
+        Mapping of lower-cased distribution name to the union of extras
+        requested on that distribution (an empty set when it is required
+        without any).
     """
     data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
     extras = data["project"]["optional-dependencies"]
     seen: set[str] = set()
-    names: set[str] = set()
+    requested: dict[str, set[str]] = {}
     pending = [extra]
     while pending:
         current = pending.pop()
@@ -392,8 +398,20 @@ def _extra_closure(extra: str) -> set[str]:
             if req.name.lower() == _SELF_NAME:
                 pending.extend(req.extras)
                 continue
-            names.add(req.name.lower())
-    return names
+            requested.setdefault(req.name.lower(), set()).update(req.extras)
+    return requested
+
+
+def _extra_closure(extra: str) -> set[str]:
+    """Canonical names an extra pulls in, following ``strands-robots[...]`` self-references.
+
+    Args:
+        extra: Name of the extra in ``[project.optional-dependencies]``.
+
+    Returns:
+        The set of distribution names reachable from *extra*, lower-cased.
+    """
+    return set(_extra_requirements(extra))
 
 
 def test_sim_mujoco_extra_declares_the_ik_solver_stack() -> None:
@@ -656,4 +674,81 @@ def test_require_optional_call_sites_name_declared_extras() -> None:
         "these require_optional call sites name an extra that does not exist, so the ImportError "
         "they raise tells the user to run an install that silently does nothing. Declared extras: "
         f"{sorted(extras)}\n" + "\n".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Declaring `qpsolvers` is not the same as declaring a QP backend.
+#
+# `qpsolvers` is a solver-agnostic front end: it ships no solver of its own, and
+# each backend arrives through one of its extras (`qpsolvers[daqp]`, `[quadprog]`,
+# ...). With none installed, `qpsolvers.available_solvers` is empty,
+# `mink.solve_ik` cannot run, and `move_to` returns
+#     IK bridge unavailable: No qpsolvers backend is installed; the mink IK
+#     bridge needs one (e.g. 'daqp' or 'quadprog'). Install the sim extra:
+#     uv pip install 'strands-robots[sim-mujoco]'.
+# -- advising the extra that shipped the primitive. So an extra that solves IK
+# has to declare a backend, or its own remedy cannot fix it.
+#
+# The `_IK_SOLVER_PACKAGES` guards above check distribution NAMES, which a bare
+# `qpsolvers` satisfies; these check that a backend comes with it.
+_QP_FRONTEND = "qpsolvers"
+
+#: Extras whose code path calls `mink.solve_ik`: `[sim-mujoco]` ships `move_to`,
+#: `[cosmos3-sim]` ships the Cosmos 3 -> MuJoCo bridge (both via MinkIKBridge).
+_MINK_IK_EXTRAS = ("sim-mujoco", "cosmos3-sim")
+
+
+def _declared_qp_backends(extra: str) -> set[str]:
+    """qpsolvers backend extras that *extra* requests, following self-references."""
+    return _extra_requirements(extra).get(_QP_FRONTEND, set())
+
+
+@pytest.mark.parametrize("extra", _MINK_IK_EXTRAS)
+def test_mink_ik_extra_declares_a_qp_backend(extra: str) -> None:
+    """Every extra that solves IK through mink must declare a QP backend.
+
+    Relying on `mink`'s own `qpsolvers[daqp]` pin leaves the guarantee resting on
+    a transitive of a third-party package: if mink ever drops or renames it, the
+    IK primitives break for anyone who installed exactly what this project asked
+    them to.
+    """
+    backends = _declared_qp_backends(extra)
+    assert backends, (
+        f"[{extra}] solves IK via mink but declares {_QP_FRONTEND!r} with no "
+        f"backend extra, so resolving 'strands-robots[{extra}]' need not install "
+        f"any QP solver and mink.solve_ik cannot run. Declare one, e.g. "
+        f"'{_QP_FRONTEND}[daqp]>=4.0.0'."
+    )
+
+
+def test_all_extra_declares_a_qp_backend() -> None:
+    """`pip install 'strands-robots[all]'` must be able to complete an IK solve.
+
+    `[all]` advertises `move_to` by installing the MuJoCo backend, so the QP
+    backend that action needs has to be part of the same closure.
+    """
+    assert _declared_qp_backends("all"), (
+        "pip install 'strands-robots[all]' advertises move_to but declares no "
+        f"{_QP_FRONTEND} backend, so the action can return 'IK bridge unavailable'"
+    )
+
+
+def test_declared_qp_backends_are_real_qpsolvers_extras() -> None:
+    """A declared backend must be an extra `qpsolvers` actually publishes.
+
+    An unknown extra is not an install error - pip warns and installs nothing -
+    so a typo such as `qpsolvers[dapq]` would resolve "successfully" and leave
+    the solver missing exactly as before.
+    """
+    import importlib.metadata
+
+    provided = importlib.metadata.metadata(_QP_FRONTEND).get_all("Provides-Extra") or []
+    published = {name.lower() for name in provided}
+    assert published, f"could not read {_QP_FRONTEND} extras from installed metadata"
+    declared = {backend for extra in _MINK_IK_EXTRAS for backend in _declared_qp_backends(extra)}
+    unknown = sorted(b for b in declared if b.lower() not in published)
+    assert not unknown, (
+        f"declared {_QP_FRONTEND} backend(s) {unknown} are not published extras of "
+        f"{_QP_FRONTEND}; pip installs nothing for an unknown extra. Published: {sorted(published)}"
     )


### PR DESCRIPTION
## Problem

`qpsolvers` is a **solver-agnostic front end** — it ships no solver of its own, and each backend arrives through one of its extras (`qpsolvers[daqp]`, `[quadprog]`, …). `[sim-mujoco]` declared it with no backend:

```toml
"mink>=0.0.4",
"qpsolvers>=4.0.0",     # no backend extra
```

The only reason a backend resolves today is `mink`'s own pin, `qpsolvers[daqp]>=4.12.0`. So the guarantee for `move_to` — the Cartesian transport primitive in this backend's agent-callable action enum — rested on a transitive of a third-party package this project does not control.

With no backend installed, `qpsolvers.available_solvers` is empty, `mink.solve_ik` cannot run, and `move_to` returns:

```
move_to: IK bridge unavailable: No qpsolvers backend is installed; the mink IK
bridge needs one (e.g. 'daqp' or 'quadprog'). Install the sim extra:
uv pip install 'strands-robots[sim-mujoco]'.
```

The advised remedy names **the extra that declared no backend**, so following it need not fix anything.

### The sibling already declared one

`[cosmos3-sim]` drives the same `mink` + `qpsolvers` stack (`MinkIKBridge`) and declares `"qpsolvers[quadprog]>=4.0.0"`. Two extras, one solver stack, only one with a backend.

### Why the existing guards did not catch it

The IK-stack guards added for the earlier `mink` gap check distribution **names**:

```python
_IK_SOLVER_PACKAGES = ("mink", "qpsolvers")
```

A bare `qpsolvers` satisfies that, so a missing backend was invisible to them.

## Measured consequence

Same scene, same call, only the resolved backend differing (Panda, `move_to(position=[0.42, 0.0, 0.42], tol=0.02)`):

| `available_solvers` | status | hand position | error to target |
|---|---|---|---|
| `[]` | `error` | `[0.088, -0.0, 0.926]` (home) | **0.6052 m** — never moved |
| `['daqp']` | `success` | `[0.4238, -0.0, 0.4006]` | **0.0198 m** — reached |

![move_to with and without a declared QP backend](https://raw.githubusercontent.com/cagataycali/robots/artifacts/sim-mujoco-qp-backend/qp_backend.png)

Rollout rendered in MuJoCo, headless. The two "home" frames are byte-identical across both runs (`max|delta| = 1`, renderer noise), so the rig is the same and only the resolved backend differs; the refused run's after-frame is identical to its home frame, i.e. the arm genuinely never moved. The two after-panels differ on 21.2% of pixels.

## Change

`[sim-mujoco]` declares `qpsolvers[daqp]>=4.0.0`. `daqp` is both the bridge's first preference (`ik._PREFERRED_QP_SOLVERS[0]`) and the backend `mink` pulls for itself, so **nothing about what resolves changes** — it stops the guarantee resting on a transitive.

Dry-run resolve of `strands-robots[sim-mujoco]`, before vs after:

```
before: 69 packages   daqp=YES  qpsolvers=YES
after : 69 packages   daqp=YES  qpsolvers=YES
delta : added=[]  removed=[]
```

## Tests

Extends the existing IK-stack guards so they can see a missing backend. The single closure walk was refactored to carry the extras it already parsed and discarded (`_extra_requirements`), with `_extra_closure` kept as a thin derivation — no second walk.

- `test_mink_ik_extra_declares_a_qp_backend[sim-mujoco]` / `[cosmos3-sim]` — every extra whose code path calls `mink.solve_ik` must declare a backend.
- `test_all_extra_declares_a_qp_backend` — `pip install 'strands-robots[all]'` advertises `move_to`, so it must be able to complete a solve.
- `test_declared_qp_backends_are_real_qpsolvers_extras` — a declared backend must be an extra `qpsolvers` actually publishes. An unknown extra is **not** an install error (pip warns and installs nothing), so `qpsolvers[dapq]` would resolve "successfully" and leave the solver missing exactly as before.

Pre-fix (pyproject reverted, tests kept), on this PR's base:

```
FAILED test_mink_ik_extra_declares_a_qp_backend[sim-mujoco]
FAILED test_all_extra_declares_a_qp_backend
2 failed, 2 passed
```

The 2 that pass pre-fix are deliberate: `[cosmos3-sim]` had already declared its backend (the control showing this only closes the sibling that had not), and the published-extras check was already satisfied by `quadprog`.

## Gate (Thor, aarch64, base `c19a19e6`)

```
ruff check strands_robots tests tests_integ      All checks passed!
ruff format --check ...                          980 files already formatted
mypy strands_robots tests tests_integ            Success: no issues found in 977 source files
MUJOCO_GL=egl pytest tests -q --no-cov           15162 passed, 255 skipped in 470.64s
```

`tests/test_dependency_audit.py` alone: 28 passed.

## Out of scope

`[sim-mujoco]` declares `qpsolvers>=4.0.0` while `mink` requires `>=4.12.0`; the resolver takes the stricter bound, so this is not a defect and the floor is left alone.