### PR TITLE
ci: read a gate's own script from the base branch, not the tree under review

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -52,28 +52,50 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # The pull request HEAD, for consistency with the merge-base overlap check
-      # and because it is the tree under review. Unlike that check, this one is
-      # NOT defeated by the default refs/pull/<n>/merge commit: it asks what
-      # entries the head carries that the base does not, and a branch's appended
-      # entry is on the head and absent from the base whichever commit is used.
-      # Measured, not assumed, by
-      # tests/test_changelog_fragment_gate.py::test_a_merge_commit_head_still_sees_the_branchs_append
-      - name: Checkout the pull request head
+      # The BASE branch, not the pull request head. This job reads two different
+      # things from two different places: the *question* is about the branch, but
+      # the *script that answers it* has to come from a tree guaranteed to contain
+      # it, and the branch under review is not that tree.
+      #
+      # A branch that forked before this check landed does not carry the script, so
+      # running it out of the head tree dies before the check begins:
+      #
+      #     python3: can't open file '.../check_changelog_fragment.py'
+      #     Process completed with exit code 2
+      #
+      # The script reserves exit 1 for a real finding and 0 for clean. 2 is neither,
+      # and the checks UI renders 1 and 2 as the same red X - so the gate accuses a
+      # branch that may have done nothing wrong, and can never report its real
+      # signal there because it never gets far enough to compute one. Nor is such a
+      # branch an edge case: a `pull_request` workflow definition is read from the
+      # merge commit, so this job runs against heads that contain neither it nor
+      # the script. Measured on #1786, forked one commit before the gate it failed.
+      # See issue #1791.
+      #
+      # Checking out the base costs no fidelity, because the script reads no file
+      # from the working tree at all - `git show <rev>:<path>` and
+      # `git diff <a>..<b>` for every input, so only reachability matters, and the
+      # fetch below settles that. The commit under test is named by `--head`
+      # instead, which is what that argument is documented for. Pinned by
+      # tests/test_changelog_fragment_gate.py::test_the_verdict_does_not_depend_on_the_checked_out_tree
+      - name: Checkout the base branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.base_ref }}
           # Full history: a merge base cannot be computed in a shallow clone.
           fetch-depth: 0
           persist-credentials: false
 
-      # Fetched explicitly rather than relying on the checkout above, which
-      # fetches the requested commit and not necessarily the base branch when
-      # `ref` is a SHA. Full depth for the same merge-base reason.
-      - name: Fetch the base branch
+      # `refs/pull/<n>/head` rather than the head SHA on its own, because it is the
+      # one name that resolves for a fork's branch as well as for a branch in this
+      # repository, and pull requests here come from forks. This only makes the
+      # commit reachable; which commit is checked is still the SHA passed to
+      # `--head` below. A push racing this fetch cannot leave that SHA unreachable,
+      # because the concurrency group above cancels this run when it arrives.
+      - name: Fetch the pull request head
         env:
-          BASE_REF: ${{ github.base_ref }}
-        run: git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch --no-tags origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -83,7 +105,16 @@ jobs:
       # Standard library only, so there is nothing to install. The script writes
       # its report to the job summary and emits a CHANGELOG.md annotation per
       # unaccounted entry.
+      #
+      # `--head` is the pull request's head SHA, deliberately not the default
+      # refs/pull/<n>/merge commit. This check is not in fact defeated by that
+      # commit - it asks what entries the head carries that the base does not, and
+      # a branch's appended entry is on the head and absent from the base whichever
+      # commit is used, measured by
+      # tests/test_changelog_fragment_gate.py::test_a_merge_commit_head_still_sees_the_branchs_append
+      # - but naming the head keeps the report about the commit under review.
       - name: Check for a changelog entry written outside a fragment
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: python3 scripts/check_changelog_fragment.py --base-ref "$BASE_REF"
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check_changelog_fragment.py --base-ref "$BASE_REF" --head "$HEAD_SHA"

--- a/.github/workflows/merge-base-overlap.yml
+++ b/.github/workflows/merge-base-overlap.yml
@@ -42,27 +42,50 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # The pull request HEAD, deliberately not the default
-      # refs/pull/<n>/merge commit: that commit already contains the base tip,
-      # so the merge base would be the base tip, the base-side path set would be
-      # empty, and this check would pass unconditionally without saying it had
-      # stopped testing anything. Pinned by
-      # tests/test_merge_base_overlap.py::test_a_merge_commit_head_defeats_the_check
-      - name: Checkout the pull request head
+      # The BASE branch, not the pull request head. This job reads two different
+      # things from two different places: the *question* is about the branch, but
+      # the *script that answers it* has to come from a tree guaranteed to contain
+      # it, and the branch under review is not that tree.
+      #
+      # A branch that forked before this check landed does not carry the script, so
+      # running it out of the head tree dies before the check begins:
+      #
+      #     python3: can't open file '.../check_merge_base_overlap.py'
+      #     Process completed with exit code 2
+      #
+      # The script reserves exit 1 for a real finding and 0 for clean. 2 is neither,
+      # and the checks UI renders 1 and 2 as the same red X - so the gate accuses a
+      # branch that may have done nothing wrong, and can never report its real
+      # signal there because it never gets far enough to compute one. Nor is such a
+      # branch an edge case: a `pull_request` workflow definition is read from the
+      # merge commit, so this job runs against heads that contain neither it nor
+      # the script. Measured on #1786, forked one commit before the gate it failed.
+      # See issue #1791.
+      #
+      # Checking out the base costs no fidelity, because the script reads no file
+      # from the working tree at all - `git show <rev>:<path>` and
+      # `git diff <a>..<b>` for every input, so only reachability matters, and the
+      # fetch below settles that. The commit under test is named by `--head`
+      # instead, which is what that argument is documented for. Pinned by
+      # tests/test_merge_base_overlap.py::test_the_overlap_does_not_depend_on_the_checked_out_tree
+      - name: Checkout the base branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.base_ref }}
           # Full history: a merge base cannot be computed in a shallow clone.
           fetch-depth: 0
           persist-credentials: false
 
-      # Fetched explicitly rather than relying on the checkout above, which
-      # fetches the requested commit and not necessarily the base branch when
-      # `ref` is a SHA. Full depth for the same merge-base reason.
-      - name: Fetch the base branch
+      # `refs/pull/<n>/head` rather than the head SHA on its own, because it is the
+      # one name that resolves for a fork's branch as well as for a branch in this
+      # repository, and pull requests here come from forks. This only makes the
+      # commit reachable; which commit is checked is still the SHA passed to
+      # `--head` below. A push racing this fetch cannot leave that SHA unreachable,
+      # because the concurrency group above cancels this run when it arrives.
+      - name: Fetch the pull request head
         env:
-          BASE_REF: ${{ github.base_ref }}
-        run: git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch --no-tags origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -72,7 +95,15 @@ jobs:
       # Standard library only, so there is nothing to install. The script writes
       # its report to the job summary and emits a file annotation per
       # overlapping path.
+      #
+      # `--head` is the pull request's head SHA, deliberately not the default
+      # refs/pull/<n>/merge commit: that commit already contains the base tip, so
+      # the merge base would be the base tip, the base-side path set would be
+      # empty, and this check would pass unconditionally without saying it had
+      # stopped testing anything. Pinned by
+      # tests/test_merge_base_overlap.py::test_a_merge_commit_head_defeats_the_check
       - name: Check for an untested overlap with the base
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: python3 scripts/check_merge_base_overlap.py --base-ref "$BASE_REF"
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check_merge_base_overlap.py --base-ref "$BASE_REF" --head "$HEAD_SHA"

--- a/changelog.d/1791-gate-script-from-base-checkout.md
+++ b/changelog.d/1791-gate-script-from-base-checkout.md
@@ -1,0 +1,37 @@
+### Fixed: a CI gate no longer accuses a branch that forked before the gate existed
+
+`.github/workflows/changelog-fragment.yml` checked out the pull request head and
+then ran `scripts/check_changelog_fragment.py` out of that tree. A branch that
+forked before the gate landed does not carry the script, so the step died before
+the check began:
+
+```
+python3: can't open file '.../scripts/check_changelog_fragment.py'
+Process completed with exit code 2
+```
+
+The script reserves exit 1 for a real unaccounted entry and 0 for clean. Exit 2
+is neither, and the checks UI renders 1 and 2 as the same red X -- so the gate
+reported a changelog violation against a branch that had not committed one, and
+in the other direction could never report its real signal there, because it never
+got far enough to compute one. Measured on two open pull requests whose only
+relevant difference is where they forked: #1786, one commit before the gate,
+FAILURE with exit 2; #1788, after it, SUCCESS.
+
+Such a branch is not an edge case. A `pull_request` workflow definition is read
+from the merge commit, so the job runs against heads that contain neither it nor
+the script: #1786's head carries neither, and the check ran anyway.
+
+The workflow conflated two trees that coincide only by accident -- the tree under
+review, and the tree the script is read from. It now checks out the base branch,
+where a gate's own script is guaranteed to exist, fetches `refs/pull/<n>/head` so
+a fork's commit is reachable, and names the commit under test with `--head`, which
+is what that argument was documented for. Fidelity is unchanged because the script
+reads no file from the working tree: every input comes from `git show <rev>:<path>`
+and `git diff <a>..<b>`, so only reachability can affect the answer. Replayed
+against #1786's head, the same commit that produced exit 2 now produces a verdict
+-- clean, which it always was.
+
+`.github/workflows/merge-base-overlap.yml` had the identical shape and is fixed
+the same way. Its failure was latent rather than active only because every
+currently open branch happens to postdate it.

--- a/scripts/check_changelog_fragment.py
+++ b/scripts/check_changelog_fragment.py
@@ -73,10 +73,15 @@ Usage
 -----
 ``--base-ref``  the branch being merged into (default ``main``). Resolved as
                 ``origin/<ref>`` when that exists, else as ``<ref>``.
-``--head``      the commit under test (default ``HEAD``). CI passes the pull
-                request's *head* commit, for consistency with the merge-base
-                overlap check and because it is the tree under review. Unlike
-                that check, this one is not defeated by the
+``--head``      the commit under test (default ``HEAD``). CI *names* the pull
+                request's head commit here rather than checking it out, and runs
+                this script from the base branch instead: a branch that forked
+                before this gate landed does not carry the script, so running it
+                out of the head tree died with exit 2 before the check began
+                (issue #1791). Nothing is lost by that -- every input below is
+                read from the object database and never from the working tree, so
+                which tree is checked out cannot change the answer. Unlike the
+                merge-base overlap check, this one is also not defeated by the
                 ``refs/pull/<n>/merge`` commit ``actions/checkout`` produces by
                 default: the question here is which entries the head carries
                 that the base does not, and a branch's appended entry is on the

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -70,7 +70,12 @@ Usage
                 ``refs/pull/<n>/merge`` commit ``actions/checkout`` produces by
                 default -- that commit already contains the base tip, which
                 drives the merge base to the base tip and the overlap to the
-                empty set, so the check would pass unconditionally.
+                empty set, so the check would pass unconditionally. CI *names*
+                that commit rather than checking it out, and runs this script
+                from the base branch instead: a branch that forked before a gate
+                landed does not carry that gate's script (issue #1791). Sound
+                because every input below is read from the object database and
+                never from the working tree.
 ``--repo``      repository root (default: the current working directory).
 
 Exit status is ``1`` when a behaviour-bearing path overlaps, else ``0``.

--- a/tests/test_changelog_fragment_gate.py
+++ b/tests/test_changelog_fragment_gate.py
@@ -582,3 +582,67 @@ def test_no_emoji_in_the_script_or_its_output() -> None:
         text = path.read_text(encoding="utf-8")
         offenders = [(index, char) for index, char in enumerate(text) if ord(char) > 0x7F]
         assert not offenders, f"{path.name} holds non-ASCII characters: {offenders[:5]}"
+
+
+# --- the tree the gate is read from ---------------------------------------------
+
+
+def test_the_verdict_does_not_depend_on_the_checked_out_tree(repo: Path) -> None:
+    """Same commits, same verdict, whichever tree happens to be checked out.
+
+    This is the property that lets CI run the script from the *base* checkout while
+    judging the branch, and CI must: a branch that forked before this check landed
+    carries no copy of the script, so running it out of the head tree exits 2 before
+    the check begins -- a red X indistinguishable from exit 1, which the script
+    reserves for a real unaccounted entry. Measured on #1786, whose head forked one
+    commit before the gate it failed; see issue #1791.
+
+    It holds because nothing here reads the working tree: ``file_at`` is
+    ``git show <rev>:<path>`` and ``deleted_fragments`` is ``git diff <a>..<b>``, so
+    only reachability matters and the checkout is irrelevant to the answer.
+    """
+    _branch(repo)
+    _append_to_unreleased(repo, _APPENDED)
+    head = _commit(repo, "append straight to the log")
+
+    # The branch checked out, as the workflow used to do.
+    assert _run(repo, head) == 1
+
+    # The base checked out, as the workflow now does. The appended entry is not in
+    # the tree on disk at all, and it is still found and still refused.
+    _git(repo, "checkout", "-q", "main")
+    appended_heading = _APPENDED.splitlines()[0]
+    assert appended_heading not in (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert _run(repo, head) == 1
+
+
+def test_a_recorded_change_still_passes_from_the_base_checkout(repo: Path) -> None:
+    """The other direction: reading from the base does not fail every branch.
+
+    Without this, the test above is satisfied by a check that refuses everything.
+    """
+    _branch(repo)
+    _write(repo, "changelog.d/1791-a-recorded-change.md", _APPENDED)
+    head = _commit(repo, "record the change as a fragment")
+
+    _git(repo, "checkout", "-q", "main")
+    assert _run(repo, head) == 0
+
+
+def test_the_workflow_reads_the_script_from_the_base_and_names_the_head() -> None:
+    """The workflow must not require its own script in the tree under review.
+
+    A ``pull_request`` workflow definition is read from the merge commit, so this job
+    runs against heads that contain neither it nor the script -- #1786's head
+    ``2c98cfb6`` carries neither, and the check ran against it regardless. Checking
+    such a head out and invoking ``scripts/check_changelog_fragment.py`` from it is
+    what produced the exit 2 in issue #1791.
+    """
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "changelog-fragment.yml").read_text(encoding="utf-8")
+
+    assert "ref: ${{ github.base_ref }}" in workflow, "the gate's script must come from the base branch"
+    assert "ref: ${{ github.event.pull_request.head.sha }}" not in workflow, (
+        "checking the head out is what made the script's presence a precondition"
+    )
+    assert "HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in workflow
+    assert '--head "$HEAD_SHA"' in workflow, "the commit under test is named, not checked out"

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -122,8 +122,13 @@ def _land_on_main_editing_shared(repo: Path) -> None:
     _git(repo, "checkout", "-q", "pr")
 
 
+def _run_at(repo: Path, head: str) -> int:
+    """Check a named commit, which is what CI does: the head SHA, never ``HEAD``."""
+    return int(check.main(["--repo", str(repo), "--base-ref", "main", "--head", head]))
+
+
 def _run(repo: Path) -> int:
-    return int(check.main(["--repo", str(repo), "--base-ref", "main", "--head", "HEAD"]))
+    return _run_at(repo, "HEAD")
 
 
 # --- the incident, replayed -----------------------------------------------------
@@ -346,3 +351,64 @@ def test_no_emoji_in_the_script_or_its_output() -> None:
     source = _SCRIPT_PATH.read_text(encoding="utf-8")
     offenders = [(index, char) for index, char in enumerate(source) if ord(char) > 0x7F]
     assert offenders == [], f"non-ASCII in {_SCRIPT_PATH.name}: {offenders[:5]}"
+
+
+# --- the tree the gate is read from ---------------------------------------------
+
+
+def test_the_overlap_does_not_depend_on_the_checked_out_tree(repo: Path) -> None:
+    """Same commits, same overlap, whichever tree happens to be checked out.
+
+    This is the property that lets CI run the script from the *base* checkout while
+    judging the branch, and CI must: a branch that forked before a gate landed
+    carries no copy of that gate's script, so running it out of the head tree exits
+    2 before the check begins -- a red X indistinguishable from exit 1, which the
+    script reserves for a real untested overlap. That failure was measured on the
+    sibling changelog gate in issue #1791; this one shares its shape and is latent
+    only because every currently open branch happens to postdate it.
+
+    It holds because nothing here reads the working tree: the path sets come from
+    ``git diff --name-only <a>..<b>``, so only reachability matters.
+    """
+    _branch_editing_shared(repo)
+    _land_on_main_editing_shared(repo)
+    head = _git(repo, "rev-parse", "HEAD").strip()
+
+    # The branch checked out, as the workflow used to do.
+    assert _run_at(repo, head) == 1
+
+    # The base checked out, as the workflow now does. The branch's edit is not in
+    # the tree on disk, and the overlap is still reported.
+    _git(repo, "checkout", "-q", "main")
+    assert "line 40  # edited by the pull request" not in (repo / _SHARED).read_text(encoding="utf-8")
+    assert _run_at(repo, head) == 1
+
+
+def test_a_branch_with_no_overlap_still_passes_from_the_base_checkout(repo: Path) -> None:
+    """The other direction: reading from the base does not fail every branch.
+
+    Without this, the test above is satisfied by a check that refuses everything.
+    """
+    _branch_editing_shared(repo)
+    head = _git(repo, "rev-parse", "HEAD").strip()
+
+    _git(repo, "checkout", "-q", "main")
+    assert _run_at(repo, head) == 0
+
+
+def test_the_workflow_reads_the_script_from_the_base_and_names_the_head() -> None:
+    """The workflow must not require its own script in the tree under review.
+
+    A ``pull_request`` workflow definition is read from the merge commit, so a gate
+    runs against heads that contain neither it nor its script. The sibling changelog
+    gate exited 2 for exactly that reason (issue #1791); this workflow had the same
+    shape.
+    """
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "merge-base-overlap.yml").read_text(encoding="utf-8")
+
+    assert "ref: ${{ github.base_ref }}" in workflow, "the gate's script must come from the base branch"
+    assert "ref: ${{ github.event.pull_request.head.sha }}" not in workflow, (
+        "checking the head out is what made the script's presence a precondition"
+    )
+    assert "HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in workflow
+    assert '--head "$HEAD_SHA"' in workflow, "the commit under test is named, not checked out"


### PR DESCRIPTION
Closes #1791.

## The failure

`.github/workflows/changelog-fragment.yml` checked out the pull request head and then ran `scripts/check_changelog_fragment.py` out of that tree. A branch that forked before the gate landed does not carry the script, so the step died before the check began:

```
python3: can't open file '/home/runner/work/robots/robots/scripts/check_changelog_fragment.py': [Errno 2] No such file or directory
Process completed with exit code 2
```

The script's docstring assigns the exit codes: `1` is "an unaccounted entry was added", `0` is clean. `2` is neither -- it is the interpreter failing to open a file -- and the checks UI renders `1` and `2` as the same red X. So the gate accused a branch that had committed no violation, and in the other direction could never report its real signal there, because it never got far enough to compute one.

Measured on two open pull requests whose only relevant difference is where they forked. Both rows are pinned to a commit, because one of them has since moved -- see *What happened to the motivating case* below:

| PR | commit | forked at | head carries the script | gate |
|---|---|---|---|---|
| #1786 | `2c98cfb6` | `c46439a8`, one commit before the gate | no | **FAILURE**, exit 2 ([run 30596441905](https://github.com/strands-labs/robots/actions/runs/30596441905)) |
| #1788 | `d6069436` | after the gate | yes | SUCCESS |

That is not an edge case. A `pull_request` workflow definition is read from the merge commit, so the job runs against heads that contain neither it nor the script -- `2c98cfb6` carries neither, and the check ran anyway. Every open pull request that forked before the gate gets this red X on its next push: #1722, #1110, #1087, #1000.

## What happened to the motivating case

While this fix was being written, #1786 was rebased onto `c19a19e` (main's tip) and force-pushed. Its gate is now SUCCESS, because the rebase pulled the script into the branch. The symptom cleared itself; the defect did not.

That rebase is the clearest statement of what this costs. #1786 had done nothing wrong -- it records its change as a fragment, and the verdict below proves it was clean at `2c98cfb6` all along -- yet the only way for it to clear the gate was to rewrite its history onto main. A mid-review force-push dismisses a stale approval and discards the review trail, which is the exact cost `changelog.d/README.md` cites as the reason the fragment convention exists: "clearing that conflict costs a full re-approval round per affected branch". A broken enforcement of that convention was charging branches the very price the convention was designed to remove, for no finding.

Four open pull requests are still holding that bill (#1722, #1110, #1087, #1000). This fix cancels it: because the workflow definition comes from the merge commit, it takes effect on already-open stale branches with **no rebase and no push**.

## Root cause

The workflow conflated two trees that coincide only by accident: *the tree under review* and *the tree the script is read from*.

They do not need to coincide, because the script reads **no file from the working tree**. `file_at` is `git show <rev>:<path>` and `deleted_fragments` is `git diff <a>..<b>`, so every input comes from the object database and only reachability can affect the answer. The script already accepts `--head` for exactly this and says so: "CI passes the pull request's *head* commit".

## The change

Check out the base branch, where a gate's own script is guaranteed to exist; fetch `refs/pull/<n>/head` so a fork's commit is reachable; name the commit under test with `--head`. Both gates, four steps, no script logic touched.

The reasoning the old checkout-step comments carried about *not* using the `refs/pull/<n>/merge` commit is preserved, relocated to the `--head` step where that decision now lives. For the overlap check that reasoning is load-bearing -- the merge commit would drive the merge base to the base tip and the overlap to the empty set -- and `--head` is still the branch tip, so the property is unchanged.

## Verification

The fixed CI steps, replayed in two clean clones against `2c98cfb6`, the commit that was red:

```
########## OLD: checkout the PR head, run the script from that tree ##########
python3: can't open file '/tmp/ci-sim/old/scripts/check_changelog_fragment.py'
EXIT=2

########## NEW: checkout the base, fetch the pull ref, name the head ##########
## Changelog fragment check

Base `main`, merge base `c46439a84154`.

No entry was added to `CHANGELOG.md`'s `## [Unreleased]` section.

EXIT=0
```

The merge base resolves correctly and the verdict is the true one, which is the point: no rebase was needed to learn that #1786 was clean. The sibling gate, same invocation, same commit: `No overlap ... diverged at c46439a8 (13 path(s) changed on main in that span)`, exit 0.

And in production, on this pull request: because a `pull_request` workflow is read from the merge commit, **this PR's own checks ran the new steps** -- `Refuse a changelog entry written outside a fragment` SUCCESS, `Detect an untested overlap with the base branch` SUCCESS. The fix is self-testing on the first run.

- `pytest tests/test_changelog_fragment_gate.py tests/test_merge_base_overlap.py tests/test_changelog_fragments.py tests/test_changelog_format.py` -- **98 passed**
- `ruff check scripts tests/...` clean; `ruff format --check` -- already formatted
- `python scripts/assemble_changelog.py --check` -- `changelog fragments OK (72 pending)`
- both workflows parse under `yaml.safe_load`; steps confirmed: `Checkout the base branch (ref: ${{ github.base_ref }})` / `Fetch the pull request head` / `Set up Python` / the check, invoked with `--head "$HEAD_SHA"`
- all five touched files are pure ASCII

## The pins

Three per gate:

- `test_the_verdict_does_not_depend_on_the_checked_out_tree` / `test_the_overlap_does_not_depend_on_the_checked_out_tree` -- the branch's change is committed, the *base* is checked out so that change is provably absent from the tree on disk (asserted), and the finding is still reported. This is the property that makes reading the script from the base sound.
- `test_a_recorded_change_still_passes_from_the_base_checkout` / `test_a_branch_with_no_overlap_still_passes_from_the_base_checkout` -- the other direction, so the pins above cannot be satisfied by a check that refuses everything.
- `test_the_workflow_reads_the_script_from_the_base_and_names_the_head` -- asserts the workflow does not check the head out and does pass `--head`, so a future edit back to the old shape is caught. **Both fail against the previous workflows** (verified by stashing the workflow changes): `AssertionError: the gate's script must come from the base branch`.

The overlap suite's `_run` helper hardcoded `--head HEAD`; it is now a thin wrapper over `_run_at(repo, head)` so a named commit can be checked, which is what CI does. All 30 existing overlap tests and 34 existing fragment-gate tests are unchanged and still pass.

## Doc drift

`check_changelog_fragment.py`'s `--head` docstring justified the head commit "because it is the tree under review", which is no longer how CI invokes it. Both scripts' `--head` entries now state that CI names the commit rather than checking it out, and why that is sound. Docstrings only -- no behaviour in either script changes, and `AGENTS.md` / `changelog.d/README.md` reference the workflows by filename only, so nothing else drifted.

## Scope

One concern: a gate must not require its own script in the tree it judges. Both gates are in because they are the same defect from the same template -- fixing one would leave a known-identical bug in the other, and the next gate written from it would inherit the same trap. The changelog gate was failing in production; the overlap gate is latent only because every currently open branch happens to postdate it.

---

## Round changelog

### Round 1

Initial submission. Body corrected after opening to record that #1786, the motivating case, was rebased and force-pushed while this was being written: the evidence rows are now pinned to commits, and the rebase is accounted for as the cost the defect imposes rather than quietly dropped.