### PR TITLE
docs(sim): document the json payload run_policy/eval_policy return

### DIFF
--- a/changelog.d/1794-rollout-payload-documented.md
+++ b/changelog.d/1794-rollout-payload-documented.md
@@ -1,0 +1,20 @@
+### Docs: `run_policy` / `eval_policy` document the json payload they return
+
+The rollout facades return their facts in the result's `{"json": {...}}` content
+block, but their `Returns:` sections had drifted far behind it: 18 of
+`run_policy`'s 30 payload fields were undocumented, and all 22 of
+`eval_policy`'s (which had no `Returns:` section at all). The omissions included
+every field that detects a crippled rollout - `action_resolution_rate`,
+`partial_action_failure_rate` and the async-RTC telemetry - so a caller had no
+way to discover them and gated on the outer `status` instead. That reads clean
+on exactly the rollouts worth catching: a policy driving 1 of a Panda's 8
+actuators returns `status="success"` with `action_errors=0` (the one field that
+*was* documented) and `partial_action_failure_rate=0.875`.
+
+Both sections now enumerate every field, state that `status` reports whether the
+call ran rather than whether the rollout achieved anything, and show the
+index-free way to read the block - `next(b["json"] for b in result["content"] if
+"json" in b)`. A hardcoded `content[1]["json"]` raises `IndexError` on an early
+caller-error return, which carries a `text` block only. A new guard pins each
+documented field list to the payload a real rollout produces, so the two cannot
+drift apart again.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1762,24 +1762,91 @@ class SimEngine(ABC):
                 why the rollout ended via ``stopped_reason``.
 
         Returns:
-            Standard status dict with an agent-consumable ``{"json": {...}}``
-            content block alongside the human-readable ``text``. The json block
-            carries the rollout facts as typed fields (``n_steps``,
-            ``steps_used``, ``elapsed_s``, ``stopped_early``,
-            ``stopped_reason`` (``"predicate"`` | ``"budget"`` |
-            ``"cancelled"``; ``"error"`` on error results - so an agent
-            deciding whether to retry knows WHY the rollout ended),
-            ``action_errors``, ``video_path``,
-            ``video_frames``, ``positional_fallback_used``,
-            ``generic_state_keys_used``, ``missing_state_keys_used``, ...) so callers can self-correct
-            programmatically without parsing the text. The two routing-
-            degradation flags are True when the driving policy could not bind
-            the observation to the model's inputs by name and silently fell
-            back (a camera routed to a model image slot positionally, or
-            ``observation.state`` composed from the observation's own scalar
-            keys because none of ``robot_state_keys`` matched). A True flag on
-            an otherwise ``success`` run is the signature of the robot moving
-            on meaningless inputs. Mirrors :meth:`eval_policy`.
+            The standard agent-tool envelope
+            ``{"status": "success"|"error", "content": [{"text": ...},
+            {"json": {...}}]}``. The ``json`` block is the machine-readable
+            rollout report; ``text`` carries the same facts for humans.
+
+            Read the json block by SCANNING ``content`` for the first block
+            with a ``"json"`` key, never by a fixed index::
+
+                report = next(b["json"] for b in result["content"] if "json" in b)
+
+            An early caller-error return (a rejected ``duration``, an unknown
+            robot) carries a ``text`` block ONLY, so a hardcoded
+            ``content[1]`` raises ``IndexError`` on exactly the results a
+            caller most needs to read.
+
+            IMPORTANT - ``status`` is not the rollout verdict. It reports
+            whether the CALL was accepted and the loop ran; it does not say the
+            robot did anything useful. A rollout that drove only a SUBSET of
+            the robot's actuators is deliberately ``success`` (it is
+            operational), so ``status`` alone cannot see it: a policy driving 1
+            of a Panda's 8 actuators returns ``status="success"`` with
+            ``action_errors=0`` and ``partial_action_failure_rate=0.875``. Gate
+            on ``partial_action_failure_rate`` and the binding-degradation
+            flags below to decide whether a rollout is worth anything. A TOTAL
+            failure - no emitted key resolving to any actuator - is reported as
+            ``status="error"``.
+
+            Fields in the json block:
+
+            Identity: ``robot_name``, ``policy`` (the driving policy's class
+            name), ``instruction``.
+
+            Horizon: ``n_steps`` (control steps executed), ``steps_used``
+            (alias of ``n_steps`` under the retry-loop name), ``elapsed_s``,
+            ``sim_time_s`` (when the backend reports sim time),
+            ``stopped_early``, ``stopped_reason`` (``"predicate"`` - the
+            ``stop_when`` condition fired; ``"budget"`` - the step/duration
+            horizon was exhausted; ``"cancelled"`` - a cooperative stop, e.g.
+            ``stop_policy``; ``"error"`` on error results - so an agent
+            deciding whether to retry knows WHY the rollout ended).
+
+            Action health: ``action_errors`` (steps where at least one emitted
+            key did not resolve), ``action_resolution_rate`` (an
+            ``{actuator_name: fraction_of_steps_driven}`` map, so a joint stuck
+            at ``0.0`` names the actuator the policy never drove) and
+            ``partial_action_failure_rate`` (the mean fraction of the robot's
+            DOF never driven; ``0.0`` == every actuator moved every step,
+            ``~0.83`` == only 1 of 6 actuators ever moved).
+
+            Video: ``video_path`` (``None`` when no MP4 was written) and
+            ``video_frames``.
+
+            Episodes: ``n_episodes_requested``, ``n_episodes_completed``,
+            ``episodes_saved`` and ``dataset_episode_indices`` (the dataset
+            episode indices this call flushed, empty without a recording).
+
+            Policy binding: ``positional_fallback_used``,
+            ``generic_state_keys_used`` and ``missing_state_keys_used``. True
+            means the driving policy could not bind the observation to the
+            model's inputs by name and silently fell back (a camera routed to a
+            model image slot positionally, or ``observation.state`` composed
+            from the observation's own scalar keys because none of
+            ``robot_state_keys`` matched). A True flag on an otherwise
+            ``success`` run is the signature of a robot moving on meaningless
+            inputs.
+
+            Policy load: ``policy_load_time_s``, ``policy_load_cache_hit``
+            (``False`` on episode 2+ of a loop is a smell that the caller
+            rebuilt the policy instead of reusing ``policy_object=``) and
+            ``policy_resident_rss_mb``.
+
+            Async-RTC telemetry, so latency masking is provable from the
+            payload instead of from logs: ``rtc_async_enabled``,
+            ``rtc_chunks_acquired``, ``rtc_prefetch_hits``,
+            ``rtc_prefetch_blocks``, ``rtc_avg_inference_ms`` and
+            ``rtc_max_inference_ms``.
+
+            Fail-fast: if EVERY action step in the opening probe window drives
+            zero actuators - none of the policy's emitted keys resolve to any of
+            the robot's actuators - the rollout can never move the robot, so it
+            returns ``status="error"`` at the probe boundary instead of running
+            the full episode (and every remaining model inference call +
+            recording write). The error enumerates the unresolved keys and the
+            robot's valid actuator names. A PARTIAL failure runs to completion,
+            surfaced via ``partial_action_failure_rate``.
         """
         from strands_robots.policies import create_policy
 
@@ -2682,6 +2749,49 @@ class SimEngine(ABC):
         ``eval_ep1.mp4``, ...) so episodes never overwrite each other, and the
         written files are returned in the result json ``video_paths``. Recording
         is unsupported on the benchmark (``evaluate_benchmark``) path.
+
+        Returns:
+            The standard agent-tool envelope
+            ``{"status": "success"|"error", "content": [{"text": ...},
+            {"json": {...}}]}``, read the same way as :meth:`run_policy`'s -
+            by scanning ``content`` for the first block with a ``"json"`` key,
+            never by a fixed index (an early caller-error return carries a
+            ``text`` block only).
+
+            ``status`` reports whether the evaluation RAN, not whether the
+            policy succeeded: an evaluation in which every episode failed is
+            still ``status="success"`` with ``success_rate=0.0``. Read
+            ``success_measured`` first - it is ``False`` when no
+            ``success_fn`` / benchmark spec was supplied, in which case
+            ``success_rate`` is ``0.0`` for every policy regardless of what it
+            did and measures nothing.
+
+            Fields in the json block:
+
+            Outcome: ``success_rate``, ``n_success``, ``success_measured``,
+            ``episodes_completed``, ``episodes`` (the per-episode records) and
+            ``avg_steps``.
+
+            Horizon: ``n_episodes``, ``max_steps`` (the values the evaluation
+            ran with) and ``stopped_early``.
+
+            Video: ``video_paths`` (one MP4 per episode, empty when no
+            recording was requested).
+
+            Policy binding: ``positional_fallback_used``,
+            ``generic_state_keys_used`` and ``missing_state_keys_used`` - True
+            means the policy silently fell back to positional camera routing or
+            to observation-derived state keys, so the robot moved on
+            meaningless inputs and the success rate measures nothing about the
+            policy. See :meth:`run_policy` for the full contract.
+
+            Policy load: ``policy_load_time_s``, ``policy_load_cache_hit`` and
+            ``policy_resident_rss_mb``.
+
+            Async-RTC telemetry: ``rtc_async_enabled``,
+            ``rtc_chunks_acquired``, ``rtc_prefetch_hits``,
+            ``rtc_prefetch_blocks``, ``rtc_avg_inference_ms`` and
+            ``rtc_max_inference_ms``.
         """
         robots = self.list_robots()
         if not robots:

--- a/tests/simulation/test_rollout_payload_documented.py
+++ b/tests/simulation/test_rollout_payload_documented.py
@@ -1,0 +1,194 @@
+"""The rollout facades must document the json payload they actually return.
+
+:meth:`~strands_robots.simulation.base.SimEngine.run_policy` and
+:meth:`~strands_robots.simulation.base.SimEngine.eval_policy` return the
+agent-tool envelope, so every rollout fact a caller can act on lives in the
+result's ``{"json": {...}}`` content block rather than in the return value
+itself. The outer ``status`` reports only that the CALL was accepted and the
+loop ran: a policy that drives 1 of a Panda's 8 actuators is deliberately
+``status="success"`` with ``action_errors=0``, and the two fields that DO
+expose it - ``action_resolution_rate`` and ``partial_action_failure_rate`` -
+are readable only from that block.
+
+The docstring's ``Returns:`` section is the only place those fields are
+enumerated for a caller. A field the payload carries but the docstring omits is
+effectively invisible: a caller cannot gate on a key it has no way to discover,
+and gates on ``status`` alone instead. That is exactly how 18 of ``run_policy``'s
+30 payload fields - and all 22 of ``eval_policy``'s - came to be undocumented
+while the payload kept growing.
+
+These tests pin each facade's documented field list to the payload a real
+rollout produces, so the two can never drift apart again: adding a field to the
+payload without documenting it fails here.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+import strands_robots
+from strands_robots.policies import MockPolicy
+from strands_robots.simulation.base import SimEngine
+
+# Asset-free two-joint arm: keeps the guard independent of any downloaded robot
+# description. ``angle="radian"`` is required - MJCF defaults to degrees, which
+# would make the joint ranges ~2 degrees and the servos fight their limits.
+ARM_XML = """
+<mujoco model="guard_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <joint name="shoulder" type="hinge" axis="0 0 1" range="-2 2" limited="true" damping="4"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+      <body name="link" pos="0.2 0 0">
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="4"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_act" joint="shoulder" kp="30" ctrlrange="-2 2"/>
+    <position name="elbow_act" joint="elbow" kp="30" ctrlrange="-2 2"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def documented_fields(method_name: str) -> set[str]:
+    """Field names enumerated in a facade's ``Returns:`` docstring section.
+
+    Only ``\\`\\`name\\`\\``-quoted identifiers count: that is the repo's
+    docstring style for a payload field, and matching on the quoted form
+    prevents a shorter key passing merely because it is a substring of a longer
+    documented one (``n_episodes`` inside ``n_episodes_completed``).
+    """
+    doc = getattr(SimEngine, method_name).__doc__ or ""
+    block = re.search(r"\n\s*Returns:\n(.*?)(?=\n\s*(?:Raises|Args|Example|Note):|\Z)", doc, re.S)
+    if block is None:
+        return set()
+    return set(re.findall(r"``([a-z][a-z0-9_]*)``", block.group(1)))
+
+
+def payload_of(result: dict[str, Any]) -> dict[str, Any]:
+    """The first ``{"json": {...}}`` block, found by scanning - never by index.
+
+    A fixed ``content[1]`` raises ``IndexError`` on an early caller-error
+    return, which carries a ``text`` block only.
+    """
+    return next((b["json"] for b in result.get("content", []) if isinstance(b.get("json"), dict)), {})
+
+
+@pytest.fixture
+def sim(tmp_path):
+    """A minimal two-joint arm scene; no rendering, no downloaded assets."""
+    path = tmp_path / "arm.xml"
+    path.write_text(ARM_XML)
+    engine = strands_robots.Simulation(backend="mujoco", tool_name="payload_doc_guard", mesh=False)
+    engine.create_world()
+    engine.add_robot(name="arm", urdf_path=str(path))
+    yield engine
+    engine.cleanup()
+
+
+def _bound_policy(engine) -> MockPolicy:
+    policy = MockPolicy()
+    policy.set_robot_state_keys(engine.robot_action_keys("arm"))
+    return policy
+
+
+def run_policy_payload(engine) -> dict[str, Any]:
+    result = engine.run_policy(robot_name="arm", policy_object=_bound_policy(engine), n_steps=4, control_frequency=50.0)
+    assert result["status"] == "success", result
+    return payload_of(result)
+
+
+def eval_policy_payload(engine) -> dict[str, Any]:
+    result = engine.eval_policy(
+        robot_name="arm", policy_object=_bound_policy(engine), n_episodes=1, max_steps=4, control_frequency=50.0
+    )
+    assert result["status"] == "success", result
+    return payload_of(result)
+
+
+PAYLOAD_BUILDERS = {"run_policy": run_policy_payload, "eval_policy": eval_policy_payload}
+
+
+class TestEveryPayloadFieldIsDocumented:
+    """A field a caller can read must be a field a caller can discover."""
+
+    @pytest.mark.parametrize("method_name", sorted(PAYLOAD_BUILDERS))
+    def test_returns_section_enumerates_every_payload_field(self, sim, method_name):
+        payload = PAYLOAD_BUILDERS[method_name](sim)
+        assert payload, f"{method_name} returned no json block - the guard would pass vacuously"
+        missing = sorted(set(payload) - documented_fields(method_name))
+        assert not missing, (
+            f"SimEngine.{method_name}'s Returns: section does not document "
+            f"{len(missing)} field(s) its payload carries: {missing}. "
+            f"Add each as ``field_name`` to that section."
+        )
+
+    @pytest.mark.parametrize("method_name", sorted(PAYLOAD_BUILDERS))
+    def test_documented_fields_all_exist_in_the_payload(self, sim, method_name):
+        """The reverse direction: no documented field may be a phantom."""
+        payload = PAYLOAD_BUILDERS[method_name](sim)
+        # Only names the docstring presents as payload fields are compared, so a
+        # method name or argument mentioned in prose is not read as a field.
+        phantom = sorted(
+            f for f in documented_fields(method_name) if f.endswith(("_s", "_rate", "_used")) and f not in payload
+        )
+        assert not phantom, f"SimEngine.{method_name} documents field(s) its payload does not carry: {phantom}"
+
+
+class TestActionHealthFieldsAreDiscoverable:
+    """The fields that expose a crippled-but-'successful' rollout, by name.
+
+    A rollout driving a subset of the robot's actuators returns
+    ``status="success"`` with ``action_errors=0``. These are the only fields
+    that contradict that, so their presence in the docstring is the whole
+    difference between a caller that can detect it and one that cannot.
+    """
+
+    @pytest.mark.parametrize("field", ["action_resolution_rate", "partial_action_failure_rate", "action_errors"])
+    def test_run_policy_documents_action_health_field(self, field):
+        assert field in documented_fields("run_policy")
+
+    @pytest.mark.parametrize("field", ["success_rate", "success_measured"])
+    def test_eval_policy_documents_outcome_field(self, field):
+        assert field in documented_fields("eval_policy")
+
+
+class TestDocumentedAccessPathIsIndexFree:
+    """The docstring must not teach a fixed index into ``content``.
+
+    ``content[1]["json"]`` raises ``IndexError`` on an early caller-error
+    return, which carries a ``text`` block only - i.e. on exactly the results a
+    caller most needs to read.
+    """
+
+    @pytest.mark.parametrize("method_name", sorted(PAYLOAD_BUILDERS))
+    def test_returns_section_does_not_teach_a_fixed_index(self, method_name):
+        doc = getattr(SimEngine, method_name).__doc__ or ""
+        assert 'content[1]["json"]' not in doc.replace("'", '"') or "IndexError" in doc
+
+    def test_a_caller_error_result_has_no_json_block_to_index(self, sim):
+        """The premise of the warning above, pinned against the live engine."""
+        result = sim.run_policy(robot_name="arm", duration=-1)
+        assert result["status"] == "error"
+        assert len(result["content"]) == 1, result["content"]
+        assert payload_of(result) == {}
+
+
+class TestGuardCannotPassVacuously:
+    """A scanner that silently matched nothing would look like a clean suite."""
+
+    def test_a_planted_undocumented_field_is_detected(self, sim):
+        payload = run_policy_payload(sim)
+        payload["a_field_no_docstring_mentions"] = 1
+        assert sorted(set(payload) - documented_fields("run_policy")) == ["a_field_no_docstring_mentions"]
+
+    def test_the_extractor_finds_a_non_empty_field_list(self):
+        for method_name in PAYLOAD_BUILDERS:
+            assert len(documented_fields(method_name)) >= 10, method_name


### PR DESCRIPTION
## Problem

`run_policy` and `eval_policy` return their rollout facts in the result's `{"json": {...}}` content block, not in the return value itself. Their `Returns:` sections had drifted far behind that payload:

| facade | payload fields | documented on main |
|---|---|---|
| `run_policy` | 30 | 12 |
| `eval_policy` | 22 | 0 (no `Returns:` section at all) |

The omissions include every field that exposes a crippled rollout - `action_resolution_rate`, `partial_action_failure_rate` and the async-RTC telemetry. A caller cannot gate on a key it has no way to discover, so it gates on the outer `status` instead, and `status` reads clean on exactly the rollouts worth catching.

Measured on a Panda over the same 110-step horizon:

| field | 8 of 8 actuators driven | 1 of 8 actuators driven |
|---|---|---|
| `status` | `success` | `success` |
| `action_errors` | `0` | `0` |
| `n_steps` | `110` | `110` |
| `partial_action_failure_rate` | `0.0` | **`0.875`** |

Every field the docstring listed is identical across the two runs. `action_errors` - the one action-health field that *was* documented - is `0` for both, because it counts steps where a key failed to resolve, not DOF the policy never addressed. The single field that separates them was undocumented.

A second, sharper problem: the natural guess for reading the block is a fixed index. `content[1]["json"]` raises `IndexError` on an early caller-error return, which carries a `text` block only:

```python
r = sim.run_policy(robot_name="panda", duration=-1)
# status=error, content blocks: ['text'], len=1
r["content"][1]["json"]   # IndexError: list index out of range
```

So the results a caller most needs to inspect are the ones a fixed index crashes on.

## Change

Both `Returns:` sections now:

- enumerate **every** field the payload carries, grouped (identity, horizon, action health, video, episodes, policy binding, policy load, async-RTC);
- state that `status` reports whether the **call** was accepted and the loop ran, not whether the rollout achieved anything, with the `0.875` example inline and the note that a *total* resolution failure **is** `status="error"`;
- show the index-free access path, `next(b["json"] for b in result["content"] if "json" in b)`, and say why a fixed index is wrong.

`eval_policy` additionally documents reading `success_measured` first: it is `False` when no `success_fn` / benchmark spec was supplied, in which case `success_rate` is `0.0` for every policy regardless of what it did.

### Why a guard, not just prose

The docs drifted because nothing held them to the payload, and the payload keeps growing. A new guard runs a real rollout of each facade and asserts every key it returns is enumerated in that facade's `Returns:` section, so adding a field without documenting it fails there. It follows the existing `test_predicate_docstring_completeness` precedent - including its planted-entry meta-test, so a scanner that silently matched nothing cannot look like a clean suite.

The guard matches only ``` ``name`` ```-quoted identifiers (the repo's docstring style for a payload field). That prevents a shorter key passing merely because it is a substring of a longer documented one - `n_episodes` inside `n_episodes_completed`. It also pins the reverse direction (no phantom fields), that the docstring does not teach a fixed index, and - against the live engine - that a caller-error result really does carry no json block to index. Fixture is an inline two-joint MJCF, so no downloaded robot description and no rendering: 14 tests in 0.83s.

No behaviour changes.

## Rejected alternative

Promoting the json fields onto the outer result dict was considered and is not viable: `AGENTS.md` requires agent-tool handlers to return the `{"status": ..., "content": [...]}` envelope, and `run_policy` / `eval_policy` are bound as agent tools. Flattening the payload into the envelope would break that contract for every consumer.

## Verification

- Pre-fix (docstrings reverted, guard kept): **8 failed, 6 passed**. The 6 that pass are the over-reach controls - the reverse-direction check, the index-free check, the planted-key meta-test and `action_errors` (already documented). They are what stop the guard over-reaching, so they are expected to pass on both trees.
- Post-fix scoped: 14 passed in 0.83s.
- Full suite on the branch: `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **15176 passed, 255 skipped** in 479.96s.
- CI-exact lint: `ruff check` clean, `ruff format --check` 981 files already formatted, `mypy strands_robots tests tests_integ` clean (978 source files).
- Root guards: `test_changelog_fragments`, `test_changelog_format`, `test_docstrings_no_dangling_doc_refs`, `test_source_strings_no_internal_file_paths` -> 38 passed.
- `scripts/assemble_changelog.py --check` OK; `scripts/check_merge_base_overlap.py` reports no overlap with `main` since `c19a19e6`.

## Artifact

Two rollouts with opposite physical outcomes, reported identically on every field the docstring listed. Renders are unchanged by this PR (documentation + guard only); the two panels differ on 14.5% of pixels.

![rollout payload documentation](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-payload-docs/payload_docs.png)