### PR TITLE
fix(training): make val_episodes produce a validation loss, not just a smaller train set

### DIFF
--- a/changelog.d/1796-val-episodes-evaluated-split.md
+++ b/changelog.d/1796-val-episodes-evaluated-split.md
@@ -1,0 +1,18 @@
+### Fixed: `val_episodes` now produces a validation loss instead of only a smaller training set
+
+`val_episodes=N` reserved the last N episodes by emitting
+`--dataset.episodes=[0..total-N-1]`, which restricts the TRAINING set only.
+lerobot builds its evaluation dataloader from `dataset.eval_split`, so the
+reserved episodes were used by neither half and no validation loss was ever
+computed - and adding `eval_steps` alone is refused by lerobot
+(`eval_steps > 0 requires dataset.eval_split > 0.0`). Every surface taking
+`val_episodes` (the `lerobot_train` tool, `train_policy`, and `TrainSpec` on both
+the argv and in-process paths) now emits lerobot's coupled pair: the
+`dataset.eval_split` fraction that holds out exactly N episodes, plus an
+`eval_steps` cadence taken from `save_freq` so each saved checkpoint has a
+validation loss beside it. The fraction is the midpoint of the interval that
+ceils to N rather than its `N / total` boundary, which is not float-safe
+(`25 * (7 / 25) == 7.000000000000001` reserves 8). A multi-task dataset, where a
+per-task fraction cannot express a global count, is refused with the fraction to
+pass instead. `dataset.eval_split` or `eval_steps` supplied through the
+passthrough still win.

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -28,6 +28,8 @@ import psutil
 from strands import tool
 from strands.types.tools import ToolContext
 
+from strands_robots.utils import validation_split_error, validation_split_fraction
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -306,6 +308,22 @@ class SessionManager:
         return self._load_sessions()
 
 
+def _read_total_tasks(dataset_root: str) -> int:
+    """Return ``total_tasks`` from a LeRobot v3 dataset's ``meta/info.json``.
+
+    lerobot's own field defaults to 0, and older datasets may omit it entirely;
+    both mean "no task count recorded" and are returned as 0, which callers
+    treat as single-task.
+    """
+    info_path = Path(dataset_root) / "meta" / "info.json"
+    if not info_path.exists():
+        return 0
+    with open(info_path) as f:
+        info = json.load(f)
+    total = info.get("total_tasks")
+    return total if isinstance(total, int) and not isinstance(total, bool) else 0
+
+
 def _read_total_episodes(dataset_root: str) -> int:
     """Return ``total_episodes`` from a LeRobot v3 dataset's ``meta/info.json``.
 
@@ -475,9 +493,21 @@ def build_train_command(
             raise ValueError(
                 f"val_episodes={val_episodes} leaves no training data (dataset has {total} episodes); reserve fewer."
             )
-        train_eps = list(range(total - val_episodes))
-        episodes_arg = "[" + ",".join(str(e) for e in train_eps) + "]"
-        cmd.append(f"--dataset.episodes={episodes_arg}")
+        split_err = validation_split_error(val_episodes, _read_total_tasks(dataset_root), "lerobot_train")
+        if split_err:
+            raise ValueError(split_err)
+        # Hand the split to lerobot instead of restricting --dataset.episodes
+        # ourselves: it holds out the tail AND computes an eval loss on it, where
+        # an episode restriction only shrinks the TRAINING set and leaves the
+        # reserved episodes unused by either half.
+        supplied = {key.lstrip("-") for key in (extra_flags or {})}
+        if "dataset.eval_split" not in supplied:
+            cmd.append(f"--dataset.eval_split={validation_split_fraction(val_episodes, total)}")
+        if "eval_steps" not in supplied:
+            # Validate on the caller's own checkpoint cadence, so every saved
+            # checkpoint has a validation loss recorded beside it. A non-positive
+            # save_freq disables periodic saving, so evaluate once at the end.
+            cmd.append(f"--eval_steps={save_freq if save_freq > 0 else steps}")
 
     if extra_flags:
         for key, value in extra_flags.items():
@@ -531,9 +561,15 @@ def lerobot_train(
         smolvla; sourced live so it tracks lerobot).
 
     Overfit guard:
-        ``val_episodes=N`` reserves the LAST N episodes for evaluation by training
-        only on episodes ``[0 .. total-N-1]`` via ``--dataset.episodes``. The total
-        is read from ``meta/info.json``.
+        ``val_episodes=N`` reserves the LAST N episodes as a validation set by
+        emitting ``--dataset.eval_split`` (the fraction that makes lerobot hold
+        out exactly N) together with ``--eval_steps``, so lerobot both keeps the
+        tail out of training AND logs an eval loss over it at the checkpoint
+        cadence. The episode and task counts are read from ``meta/info.json``;
+        a dataset with several tasks is refused because lerobot applies the
+        split fraction per task, where a global count is not expressible.
+        Passing ``dataset.eval_split`` or ``eval_steps`` in ``extra_flags``
+        overrides the derived value.
 
     Resume:
         ``resume=True`` emits ``--config_path=<ckpt>/train_config.json --resume=true``
@@ -571,7 +607,9 @@ def lerobot_train(
         lora_target_modules: PEFT target module spec (e.g. "all-linear").
         train_expert_only: Freeze the VLM, train only the action expert
             (policies exposing train_expert_only: pi0/pi05/smolvla).
-        val_episodes: Reserve the LAST N episodes as a held-out validation split.
+        val_episodes: Reserve the LAST N episodes as a held-out validation
+            split, evaluated every ``save_freq`` steps so each checkpoint has
+            a validation loss beside it.
         num_gpus: Number of GPUs; >1 launches via accelerate --multi_gpu.
         push_to_hub: Push the trained checkpoint to the HF Hub at the end.
         resume: Resume from the latest checkpoint under output_dir when present.

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -122,7 +122,8 @@ def train_policy(
         lora_r / lora_alpha / lora_target_modules: LoRA hyperparameters.
         tune: Fine-grained component toggles for GR00T
             (``{"llm","visual","projector","diffusion"}``).
-        val_episodes: Hold out the LAST N episodes for validation.
+        val_episodes: Hold out the LAST N episodes for validation; the run
+            logs an eval loss over them at the checkpoint cadence.
         augmentation: Backend-specific augmentation dict.
         fps: Dataset control rate (when a backend needs it).
         extra: Backend-specific passthrough. lerobot: ``policy_type``,

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -108,7 +108,10 @@ class TrainSpec:
             (GR00T: ``{"llm": bool, "visual": bool, "projector": bool,
             "diffusion": bool}``). Ignored by backends that don't.
         val_episodes: Hold out the LAST N episodes as a validation set
-            (deterministic split; lerobot ``--dataset.episodes=[0..total-N-1]``).
+            (deterministic split). A backend MUST make the reserved episodes
+            produce a validation signal, not merely shrink the training set;
+            the lerobot backend maps it onto ``--dataset.eval_split`` plus a
+            non-zero ``--eval_steps`` so an eval loss is logged periodically.
         augmentation: Backend-specific data augmentation (GR00T
             ``color_jitter_params`` / ``random_rotation_angle``; Cosmos
             dataset filter dict).

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -57,6 +57,7 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.training._inproc import call_callable, elastic_launch_callable, resume_argv
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+from strands_robots.utils import validation_split_error, validation_split_fraction
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from lerobot.configs.train import TrainPipelineConfig
@@ -453,8 +454,14 @@ class LerobotTrainer(Trainer):
             return spec.dataset_repo_id, (spec.dataset_root or None)
         return "local", spec.dataset_root
 
-    def _val_split_episodes(self, spec: TrainSpec) -> list[int] | None:
-        """Held-out validation split: train on the FIRST (total - N) episodes.
+    def _val_eval_split(self, spec: TrainSpec) -> float | None:
+        """``dataset.eval_split`` reserving the LAST ``val_episodes`` episodes.
+
+        Returns the fraction lerobot needs to hold the tail out of TRAINING and
+        run an evaluation pass over it, so ``val_episodes`` yields a validation
+        loss rather than only a smaller training set. Paired with a non-zero
+        ``eval_steps`` in :meth:`_apply_common_config`; lerobot refuses an
+        ``eval_steps`` that has no ``eval_split`` to draw held-out data from.
 
         Requires a local ``meta/info.json`` to know the episode count, so it is
         a no-op for a Hub dataset with no local cache (``dataset_repo_id`` set,
@@ -466,8 +473,22 @@ class LerobotTrainer(Trainer):
             return None
         total = self._dataset_total_episodes(spec.dataset_root)
         if total is not None and 0 < spec.val_episodes < total:
-            return list(range(0, total - spec.val_episodes))
+            return validation_split_fraction(spec.val_episodes, total)
         return None
+
+    def _dataset_total_tasks(self, dataset_root: str) -> int:
+        """``total_tasks`` from ``meta/info.json``, or 0 when not recorded."""
+        from pathlib import Path
+
+        info_path = Path(dataset_root) / "meta" / "info.json"
+        if not info_path.exists():
+            return 0
+        try:
+            with open(info_path) as f:
+                total = json.load(f).get("total_tasks")
+        except (OSError, ValueError):
+            return 0
+        return total if isinstance(total, int) and not isinstance(total, bool) else 0
 
     def _relative_actions(self, spec: TrainSpec) -> bool:
         """Whether to train with relative (delta) actions (``extra['relative_actions']``).
@@ -584,6 +605,11 @@ class LerobotTrainer(Trainer):
             total = self._dataset_total_episodes(spec.dataset_root)
             if total is not None and spec.val_episodes >= total:
                 problems.append(f"val_episodes={spec.val_episodes} >= total_episodes={total}")
+            split_err = validation_split_error(
+                spec.val_episodes, self._dataset_total_tasks(spec.dataset_root), "LeRobotTrainer"
+            )
+            if split_err:
+                problems.append(split_err)
 
         # lerobot must be importable to actually train.
         try:
@@ -767,9 +793,10 @@ class LerobotTrainer(Trainer):
             cmd.append("--dataset.streaming=true")
         if spec.seed is not None:
             cmd.append(f"--seed={spec.seed}")
-        eps = self._val_split_episodes(spec)
-        if eps is not None:
-            cmd.append(f"--dataset.episodes=[{', '.join(map(str, eps))}]")
+        split = self._val_eval_split(spec)
+        if split is not None:
+            cmd.append(f"--dataset.eval_split={split}")
+            cmd.append(f"--eval_steps={spec.save_freq if spec.save_freq > 0 else spec.steps}")
         if rm is None:
             if spec.base_model:
                 cmd.append(f"--policy.pretrained_path={spec.base_model}")
@@ -924,8 +951,10 @@ class LerobotTrainer(Trainer):
         dataset_kwargs: dict[str, Any] = {
             "repo_id": repo_id,
             "root": root,
-            "episodes": self._val_split_episodes(spec),
         }
+        split = self._val_eval_split(spec)
+        if split is not None:
+            dataset_kwargs["eval_split"] = split
         if spec.streaming:
             dataset_kwargs["streaming"] = True
         return DatasetConfig(**dataset_kwargs)
@@ -938,6 +967,11 @@ class LerobotTrainer(Trainer):
             cfg.seed = spec.seed
         if hasattr(cfg, "wandb") and hasattr(cfg.wandb, "enable"):
             cfg.wandb.enable = False
+        if self._val_eval_split(spec) is not None:
+            # Validate on the caller's own checkpoint cadence so every saved
+            # checkpoint has a validation loss beside it; a non-positive
+            # save_freq disables periodic saving, so evaluate once at the end.
+            cfg.eval_steps = spec.save_freq if spec.save_freq > 0 else spec.steps
         if spec.resume:
             ckpt_cfg = self._resume_config_path(spec.output_dir)
             if ckpt_cfg:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -784,3 +784,63 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
             "and the model would disagree about the entity's name."
         )
     return None
+
+
+def validation_split_fraction(val_episodes: int, total_episodes: int) -> float:
+    """``dataset.eval_split`` that holds out exactly ``val_episodes`` episodes.
+
+    lerobot builds its held-out validation set by taking
+    ``ceil(n_episodes * eval_split)`` episodes from each task's tail, so every
+    fraction in ``((N - 1) / total, N / total]`` holds out exactly ``N``. This
+    returns the MIDPOINT of that interval rather than its ``N / total`` upper
+    bound, because the bound is not float-safe: ``25 * (7 / 25)`` evaluates to
+    ``7.000000000000001``, whose ceiling is 8 - one episode more than the caller
+    asked to reserve. The midpoint leaves half an episode of slack on either
+    side, so the requested count survives the round trip at every dataset size.
+
+    Args:
+        val_episodes: Number of episodes to hold out. Must be positive and
+            smaller than ``total_episodes``; callers validate that themselves so
+            they can name their own parameter in the error.
+        total_episodes: Episode count of the dataset being split.
+
+    Returns:
+        The fraction to pass as lerobot's ``--dataset.eval_split``.
+    """
+    return (val_episodes - 0.5) / total_episodes
+
+
+def validation_split_error(val_episodes: int, total_tasks: Any, context: str) -> str | None:
+    """Error text when a global episode COUNT cannot be honored as a split.
+
+    lerobot expresses a validation split as one ``eval_split`` FRACTION and
+    applies ``ceil(n_episodes * eval_split)`` to each task independently, so a
+    single fraction reproduces a global episode count only on a single-task
+    dataset. With ``T > 1`` tasks the ceiling is taken ``T`` times and the total
+    held out is generally not the requested ``N`` - reserving 1 episode of a
+    two-task dataset would hold out 2. Rather than quietly reserve a different
+    number of episodes than asked, callers refuse and point at the fraction,
+    which addresses the per-task behaviour directly.
+
+    A ``total_tasks`` of 0 or ``None`` means the dataset does not record a task
+    count (lerobot's own field defaults to 0), which is treated as single-task.
+
+    Args:
+        val_episodes: The requested held-out episode count, for the message.
+        total_tasks: ``total_tasks`` from the dataset's ``meta/info.json``.
+        context: Caller label the message is prefixed with.
+
+    Returns:
+        The error text, or None when the count can be honored exactly.
+    """
+    if not isinstance(total_tasks, int) or isinstance(total_tasks, bool) or total_tasks <= 1:
+        return None
+    return (
+        f"{context}: val_episodes={val_episodes} cannot be reserved exactly on a "
+        f"dataset with {total_tasks} tasks. A validation split is a per-task "
+        "fraction in lerobot (it holds out ceil(episodes_in_task * eval_split) "
+        "from every task), so a single global count is not expressible: the "
+        "ceiling would be applied once per task. Pass the fraction directly, "
+        "e.g. extra_flags={'dataset.eval_split': 0.1, 'eval_steps': 1000}, and "
+        "the split will hold out a tenth of each task."
+    )

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -331,16 +331,27 @@ def test_field_gating_passes_through_when_lerobot_unimportable(
     assert "--policy.gradient_checkpointing=true" in cmd
 
 
-def test_val_episodes_reserves_last_n_episodes(tmp_path: Path) -> None:
+def test_val_episodes_reserves_last_n_episodes_as_an_evaluated_split(tmp_path: Path) -> None:
+    """Reserving episodes must yield a validation loss, not only a smaller train set.
+
+    This previously asserted ``--dataset.episodes=[0..6]``, which restricts the
+    TRAINING set and leaves the reserved episodes unused by either half: lerobot
+    builds its eval dataloader from ``dataset.eval_split``, so an episode
+    restriction produces no validation signal at all. The corrected contract
+    emits the split plus the cadence that evaluates it.
+    """
     root = _write_dataset(tmp_path / "ds", total_episodes=10)
     cmd = build_train_command(
         dataset_root=str(root),
         policy_type="act",
         output_dir=str(tmp_path / "out"),
+        save_freq=500,
         val_episodes=3,
     )
-    # 10 total, reserve last 3 -> train on 0..6.
-    assert "--dataset.episodes=[0,1,2,3,4,5,6]" in cmd
+    # 10 total, reserve last 3: ceil(10 * 0.25) == 3.
+    assert "--dataset.eval_split=0.25" in cmd
+    assert "--eval_steps=500" in cmd
+    assert not [c for c in cmd if c.startswith("--dataset.episodes=")]
 
 
 def test_val_episodes_rejects_reserving_whole_dataset(tmp_path: Path) -> None:

--- a/tests/tools/test_val_episodes_yields_validation_loss.py
+++ b/tests/tools/test_val_episodes_yields_validation_loss.py
@@ -1,0 +1,159 @@
+"""``val_episodes`` must produce a validation signal, not just a smaller train set.
+
+lerobot expresses a held-out validation split as ``dataset.eval_split`` (a
+per-task fraction) and evaluates it every ``eval_steps`` training steps. The two
+are coupled in lerobot's own ``TrainPipelineConfig.validate``: an ``eval_steps``
+with no ``eval_split`` to draw held-out data from is a hard error, and an
+``eval_split`` with ``eval_steps == 0`` builds the split but never evaluates it.
+
+So a surface that reserves episodes by restricting ``dataset.episodes`` shrinks
+the TRAINING set and produces no validation loss at all, and one that emits
+``eval_steps`` alone refuses to launch. These tests pin that every surface taking
+``val_episodes`` emits the pair, that the fraction reproduces the requested
+episode COUNT exactly, and that a count which cannot be honored is refused
+rather than silently rounded.
+"""
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.lerobot_train import build_train_command
+from strands_robots.utils import validation_split_error, validation_split_fraction
+
+
+def _write_dataset(root: Path, total_episodes: int = 10, total_tasks: int = 1) -> Path:
+    """Minimal LeRobot v3 dataset stub carrying episode and task counts."""
+    meta = root / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+    (meta / "info.json").write_text(json.dumps({"total_episodes": total_episodes, "total_tasks": total_tasks}))
+    return root
+
+
+def _flag(cmd: list[str], name: str) -> str | None:
+    """The single value emitted for ``--name=``, or None when absent."""
+    hits = [c.split("=", 1)[1] for c in cmd if c.startswith(f"--{name}=")]
+    assert len(hits) <= 1, f"--{name} emitted {len(hits)} times: {hits}"
+    return hits[0] if hits else None
+
+
+class TestFractionReproducesRequestedCount:
+    """The emitted fraction must hold out exactly the requested episode count."""
+
+    # (total, N) pairs where the obvious ``N / total`` fraction is NOT float-safe:
+    # 25 * (7 / 25) == 7.000000000000001, whose ceiling is 8 - one episode more
+    # than asked. These are the cases a boundary fraction gets wrong.
+    @pytest.mark.parametrize(("total", "n"), [(25, 7), (25, 14), (29, 15), (35, 29), (38, 21), (41, 7)])
+    def test_boundary_unsafe_pairs_still_reserve_exactly_n(self, total: int, n: int) -> None:
+        assert math.ceil(total * (n / total)) != n, "fixture no longer exercises the float hazard"
+        assert math.ceil(total * validation_split_fraction(n, total)) == n
+
+    @pytest.mark.parametrize("total", [2, 3, 10, 50, 206, 397])
+    def test_every_count_reserves_exactly_n(self, total: int) -> None:
+        """Sweep every reservable count, not just the hand-picked hazards."""
+        for n in range(1, total):
+            assert math.ceil(total * validation_split_fraction(n, total)) == n, (total, n)
+
+    def test_command_fraction_reserves_exactly_n(self, tmp_path: Path) -> None:
+        root = _write_dataset(tmp_path / "ds", total_episodes=50)
+        cmd = build_train_command(dataset_root=str(root), policy_type="act", val_episodes=5)
+        assert math.ceil(50 * float(_flag(cmd, "dataset.eval_split") or "0")) == 5
+
+
+class TestEmittedFlagsCanProduceAValidationLoss:
+    """Both halves of lerobot's coupled pair must be emitted together."""
+
+    def test_val_episodes_emits_split_and_a_nonzero_eval_cadence(self, tmp_path: Path) -> None:
+        root = _write_dataset(tmp_path / "ds", total_episodes=10)
+        cmd = build_train_command(dataset_root=str(root), policy_type="act", save_freq=250, val_episodes=2)
+        assert float(_flag(cmd, "dataset.eval_split") or "0") > 0.0
+        assert int(_flag(cmd, "eval_steps") or "0") == 250
+
+    def test_eval_cadence_is_never_emitted_without_a_split_to_evaluate(self, tmp_path: Path) -> None:
+        """lerobot rejects eval_steps > 0 when eval_split is 0.0, so never pair them that way."""
+        root = _write_dataset(tmp_path / "ds", total_episodes=10)
+        # Annotated so mypy does not narrow the splat to the inferred value type.
+        cases: list[dict[str, Any]] = [{}, {"val_episodes": 3}]
+        for kwargs in cases:
+            cmd = build_train_command(dataset_root=str(root), policy_type="act", **kwargs)
+            steps = int(_flag(cmd, "eval_steps") or "0")
+            split = float(_flag(cmd, "dataset.eval_split") or "0")
+            assert (steps > 0) == (split > 0.0), f"{kwargs}: eval_steps={steps} eval_split={split}"
+
+    def test_no_val_episodes_leaves_evaluation_untouched(self, tmp_path: Path) -> None:
+        root = _write_dataset(tmp_path / "ds", total_episodes=10)
+        cmd = build_train_command(dataset_root=str(root), policy_type="act")
+        assert _flag(cmd, "dataset.eval_split") is None
+        assert _flag(cmd, "eval_steps") is None
+
+    def test_disabled_periodic_saving_still_evaluates_once(self, tmp_path: Path) -> None:
+        """save_freq <= 0 disables checkpointing, so fall back to a pass at the end."""
+        root = _write_dataset(tmp_path / "ds", total_episodes=10)
+        cmd = build_train_command(dataset_root=str(root), policy_type="act", steps=4000, save_freq=0, val_episodes=2)
+        assert int(_flag(cmd, "eval_steps") or "0") == 4000
+
+    def test_reserved_episodes_are_not_also_cut_from_training_by_hand(self, tmp_path: Path) -> None:
+        """A hand-rolled --dataset.episodes restriction would hide the split from lerobot."""
+        root = _write_dataset(tmp_path / "ds", total_episodes=10)
+        cmd = build_train_command(dataset_root=str(root), policy_type="act", val_episodes=2)
+        assert _flag(cmd, "dataset.episodes") is None
+
+
+class TestCountThatCannotBeHonoredIsRefused:
+    """A per-task fraction cannot express a global count on a multi-task dataset."""
+
+    def test_multi_task_dataset_is_refused_with_the_fraction_to_use(self, tmp_path: Path) -> None:
+        root = _write_dataset(tmp_path / "ds", total_episodes=10, total_tasks=3)
+        with pytest.raises(ValueError, match="cannot be reserved exactly"):
+            build_train_command(dataset_root=str(root), policy_type="act", val_episodes=2)
+
+    @pytest.mark.parametrize("tasks", [0, 1, None, True, "2"])
+    def test_absent_or_single_task_count_is_honored(self, tasks: object) -> None:
+        """0 / None mean 'no task count recorded', which lerobot treats as one task."""
+        assert validation_split_error(2, tasks, "ctx") is None
+
+    def test_refusal_names_the_task_count_and_the_direct_knobs(self) -> None:
+        err = validation_split_error(1, 4, "lerobot_train")
+        assert err is not None
+        assert err.startswith("lerobot_train: ")
+        assert "4 tasks" in err
+        assert "dataset.eval_split" in err and "eval_steps" in err
+
+
+class TestCallerOverridesTakePrecedence:
+    """extra_flags is the documented escape hatch; it must not be duplicated."""
+
+    @pytest.mark.parametrize("key", ["eval_steps", "dataset.eval_split"])
+    def test_explicit_value_replaces_the_derived_one(self, tmp_path: Path, key: str) -> None:
+        root = _write_dataset(tmp_path / "ds", total_episodes=10)
+        cmd = build_train_command(dataset_root=str(root), policy_type="act", val_episodes=2, extra_flags={key: 7})
+        # _flag asserts the flag appears at most once, so a duplicate fails here.
+        assert _flag(cmd, key) == "7"
+
+
+class TestEverySurfaceAgrees:
+    """The tool and the TrainSpec backend must not drift on one knob."""
+
+    def test_trainspec_path_emits_the_same_pair(self, tmp_path: Path) -> None:
+        pytest.importorskip("lerobot")
+        from strands_robots.training.base import TrainSpec
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        root = _write_dataset(tmp_path / "ds", total_episodes=50)
+        spec = TrainSpec(dataset_root=str(root), output_dir=str(tmp_path / "out"), val_episodes=5, save_freq=250)
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert math.ceil(50 * float(_flag(cmd, "dataset.eval_split") or "0")) == 5
+        assert int(_flag(cmd, "eval_steps") or "0") == 250
+        assert _flag(cmd, "dataset.episodes") is None
+
+    def test_trainspec_validate_refuses_a_multi_task_count(self, tmp_path: Path) -> None:
+        pytest.importorskip("lerobot")
+        from strands_robots.training.base import TrainSpec
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        root = _write_dataset(tmp_path / "ds", total_episodes=10, total_tasks=3)
+        spec = TrainSpec(dataset_root=str(root), output_dir=str(tmp_path / "out"), val_episodes=2)
+        assert any("cannot be reserved exactly" in p for p in LerobotTrainer().validate(spec))

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -235,12 +235,19 @@ class TestBuildCommand:
         cmd = LerobotTrainer(device="cpu").build_command(spec)
         assert "--policy.train_expert_only=true" in cmd
 
-    def test_val_split_episodes_flag(self, spec):
-        spec.val_episodes = 2  # total 10 -> train on [0..7]
+    def test_val_split_emits_an_evaluated_split_flag(self, spec):
+        """The reserved tail must be evaluated, not merely withheld from training.
+
+        This previously asserted ``--dataset.episodes=[0..7]``; lerobot draws its
+        eval dataloader from ``dataset.eval_split``, so an episode restriction
+        left the reserved episodes unused and no eval loss was ever computed.
+        """
+        spec.val_episodes = 2  # total 10 -> ceil(10 * 0.15) == 2 reserved
+        spec.save_freq = 400
         cmd = LerobotTrainer(device="cpu").build_command(spec)
-        ep_flags = [c for c in cmd if c.startswith("--dataset.episodes=")]
-        assert ep_flags
-        assert ep_flags[0] == "--dataset.episodes=[0, 1, 2, 3, 4, 5, 6, 7]"
+        assert "--dataset.eval_split=0.15" in cmd
+        assert "--eval_steps=400" in cmd
+        assert not [c for c in cmd if c.startswith("--dataset.episodes=")]
 
     def test_seed_and_jobname_and_passthrough(self, spec):
         spec.seed = 42
@@ -287,11 +294,21 @@ class TestBuildConfig:
         # base checkpoint as a PEFT adapter repo. cfg.peft alone drives wrapping.
         assert cfg.policy.use_peft is False
 
-    def test_val_split_episodes(self, spec):
+    def test_val_split_sets_eval_split_and_a_nonzero_eval_cadence(self, spec):
+        """In-process config must carry BOTH halves of lerobot's coupled pair.
+
+        This previously asserted ``cfg.dataset.episodes == [0..7]``. lerobot's own
+        validate() rejects ``eval_steps > 0`` without ``eval_split > 0``, and an
+        ``eval_split`` with ``eval_steps == 0`` is built but never evaluated - so
+        only the pair yields a validation loss.
+        """
         pytest.importorskip("lerobot")
-        spec.val_episodes = 2  # total 10 -> [0..7]
+        spec.val_episodes = 2  # total 10 -> ceil(10 * 0.15) == 2 reserved
+        spec.save_freq = 400
         cfg = LerobotTrainer(device="cpu").build_config(spec)
-        assert cfg.dataset.episodes == [0, 1, 2, 3, 4, 5, 6, 7]
+        assert cfg.dataset.episodes is None
+        assert cfg.dataset.eval_split == pytest.approx(0.15)
+        assert cfg.eval_steps == 400
 
 
 class TestParseLog:
@@ -886,7 +903,7 @@ class TestStreamingAndHubSource:
             val_episodes=2,
             extra={"policy_type": "act"},
         )
-        assert LerobotTrainer()._val_split_episodes(spec) is None
+        assert LerobotTrainer()._val_eval_split(spec) is None
 
 
 class TestRelativeActions:
@@ -1489,7 +1506,7 @@ class TestRunTypeLabel:
 class TestValSplitEpisodesFallthrough:
     """The held-out split is a no-op (use the full dataset) when it can't be computed.
 
-    ``_val_split_episodes`` returns ``None`` -- meaning "train on every episode" --
+    ``_val_eval_split`` returns ``None`` -- meaning "train on every episode" --
     rather than raising or emitting a malformed ``episodes`` range when the episode
     count is unknown (no readable ``meta/info.json``) or the requested holdout is
     not strictly inside ``(0, total)``.
@@ -1498,12 +1515,12 @@ class TestValSplitEpisodesFallthrough:
     def test_no_op_when_episode_count_unknown(self, tmp_path):
         # dataset_root set but no meta/info.json -> total unknown -> no split.
         spec = TrainSpec(dataset_root=str(tmp_path), val_episodes=2)
-        assert LerobotTrainer(device="cpu")._val_split_episodes(spec) is None
+        assert LerobotTrainer(device="cpu")._val_eval_split(spec) is None
 
     def test_no_op_when_holdout_not_smaller_than_total(self, dataset_root):
         # info.json reports total_episodes=10; a holdout >= total is out of range.
         spec = TrainSpec(dataset_root=dataset_root, val_episodes=10)
-        assert LerobotTrainer(device="cpu")._val_split_episodes(spec) is None
+        assert LerobotTrainer(device="cpu")._val_eval_split(spec) is None
 
 
 class TestHardwareFloor:


### PR DESCRIPTION
## Problem

`val_episodes=N` reserved the last N episodes by emitting `--dataset.episodes=[0..total-N-1]`. That constrains the **training** set only. lerobot builds its evaluation dataloader from `dataset.eval_split` (`datasets/factory.py::make_train_eval_datasets`), so the reserved episodes were used by **neither** half — they were dropped from training and never evaluated. No validation loss was produced on any surface, so a val curve had to be reconstructed by hand from saved checkpoints.

Adding `eval_steps` on its own does not help: lerobot's own `TrainPipelineConfig.validate` refuses it.

```
ValueError: eval_steps > 0 requires dataset.eval_split > 0.0 to hold out eval data.
```

Measured on a 50-episode SO-101 dataset, reserving 5:

| argv | lerobot `validate()` | eval dataset | val loss |
|---|---|---|---|
| `--dataset.episodes=[0..44]` (before) | ok | `None` | none, ever |
| `--dataset.episodes=[0..44] --eval_steps=5` | **ValueError** | — | training never launches |
| `--dataset.eval_split=0.09 --eval_steps=5` | ok | 5 episodes | logged |

The two knobs are coupled, so both halves have to be emitted together.

## Change

Every surface taking `val_episodes` now emits lerobot's pair — the `lerobot_train` tool, `train_policy`, and `TrainSpec` on both the argv path and the in-process `DatasetConfig` path (three call sites for one knob).

**The fraction is the midpoint, not the boundary.** lerobot holds out `ceil(n_episodes * eval_split)`, so any fraction in `((N-1)/total, N/total]` yields exactly N. The obvious `N/total` upper bound is *not* float-safe — `25 * (7/25) == 7.000000000000001`, whose ceiling reserves **8** episodes instead of 7. 2981 `(total, N)` pairs below 400 are affected. `validation_split_fraction` returns `(N - 0.5)/total` instead, leaving half an episode of slack; a sweep over every reservable count for several dataset sizes is pinned.

**The cadence comes from `save_freq`**, so each saved checkpoint has a validation loss recorded beside it — the cadence this was being reconstructed at by hand. A non-positive `save_freq` disables periodic saving, so that falls back to a single pass at the end rather than silently disabling evaluation.

**A multi-task dataset is refused** rather than silently reserving a different count. lerobot applies the fraction *per task*, so a global episode count is not expressible there (reserving 1 episode of a two-task dataset holds out 2); the message names the fraction to pass directly. `dataset.eval_split` / `eval_steps` supplied through the passthrough still win, and `val_episodes=None` leaves evaluation untouched.

The shared helpers live in `strands_robots/utils.py` because `tools/` and `training/` do not import each other.

## Verification — real ACT run on one GPU

Same dataset, same 12 steps, `save_freq=6`, `val_episodes=5`. Both runs exit 0 and save 2 checkpoints; the train-loss curve is identical to 3 decimal places, so only the validation signal differs.

![val_episodes validation loss](https://raw.githubusercontent.com/cagataycali/robots/artifacts/val-episodes-eval-split/val_episodes_artifact.png)

```
before:  (no split line)                                        0 eval_loss lines
after:   Train/eval split: 45 train, 5 eval (eval_split=0.09, 1 tasks)
         step 6:  eval_loss=1.1051   ->  Checkpoint policy after step 6
         step 12: eval_loss=0.7979   ->  Checkpoint policy after step 12
```

Every figure cell is re-derived from the two run logs inside the generator, which also asserts the train losses match.

## Tests

New `tests/tools/test_val_episodes_yields_validation_loss.py` (26 tests) pins: the fraction reproduces the requested count including the float-unsafe pairs; both halves are emitted; **`eval_steps` is never emitted without an `eval_split`** (the regression that would reintroduce lerobot's ValueError); no hand-rolled `dataset.episodes`; the `save_freq <= 0` fallback; the multi-task refusal; passthrough precedence; and tool/`TrainSpec` parity.

Three existing tests pinned the old behaviour as the contract (`--dataset.episodes=[0..6]`, `cfg.dataset.episodes == [0..7]`). They are renamed to the corrected contract with the reason in their docstrings rather than the code being shimmed to keep them green.

**Pre-fix proof** (call sites reverted to `main`, new helpers kept so the module still imports): **13 failed / 205 passed**. With the change: **218 passed**.

## Gate

- `MUJOCO_GL=egl python -m pytest tests` → **15191 passed, 255 skipped** (486s)
- `ruff check` / `ruff format --check` → clean (981 files)
- `mypy strands_robots tests tests_integ` → clean (978 source files)
- `scripts/check_merge_base_overlap.py` → no overlap with `main` since `c19a19e6`

## Note on the log file

While measuring this I checked a related claim that training metrics do not reach the log file with wandb disabled. On the subprocess path these tools use, they do: `logging.info(train_tracker)` writes `step:3 ... loss:65.907 ...` and the eval pass writes `step 6: eval_loss=1.1051`, both captured in the session log. No change was needed there.