### PR TITLE
docs(policies/groot): Gr00tPolicy.reset docstring - drop nonexistent auto-mount claim, fix wrapper path (closes #1789)

### DIFF
--- a/changelog.d/1789-groot-reset-docstring-wrapper-path.md
+++ b/changelog.d/1789-groot-reset-docstring-wrapper-path.md
@@ -1,0 +1,14 @@
+### Docs: `Gr00tPolicy.reset` no longer claims a nonexistent auto-mounted determinism wrapper
+
+The docstring said deployments could "use the ``Robot()`` factory which
+auto-mounts the wrapper" and pointed at
+``examples/gr00t_server_deterministic_wrapper.py`` "in robots-sim". No
+auto-mount exists anywhere in this library, and the wrapper lives in this repo
+at ``examples/libero/gr00t_server_deterministic_wrapper.py`` (moved in #1282).
+A reader following the old text would forward per-episode seeds via
+``reset(options={seed})`` and believe they were getting server-side
+determinism while the server's ``reset`` remained the upstream no-op - the
+#187 success-rate-gap failure mode this docstring exists to prevent. The
+docstring now names the correct in-repo path, states that the wrapper must be
+mounted manually into the container, and cross-references #1790 (curated
+``deterministic=`` lifecycle mount) as the future no-manual-docker path.

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -668,10 +668,18 @@ class Gr00tPolicy(Policy):
         The standard ``gr00t.eval.run_gr00t_server`` registers a ``reset``
         endpoint that maps to ``policy.reset(options=...)`` (see
         ``server_client.py:94``). The default ``Gr00tPolicy.reset`` upstream
-        is a no-op; deployments that need per-episode RNG control should
-        either patch the server (see
-        ``examples/gr00t_server_deterministic_wrapper.py`` in robots-sim)
-        or use the ``Robot()`` factory which auto-mounts the wrapper.
+        is a no-op, so the forwarded seed does nothing unless the server is
+        patched. Deployments that need per-episode RNG control must run the
+        server through the determinism wrapper at
+        ``examples/libero/gr00t_server_deterministic_wrapper.py``, mounted
+        manually into the container (``docker run ...
+        -v .../gr00t_server_deterministic_wrapper.py:/srv_wrap.py ...
+        python /srv_wrap.py ...``) - see the wrapper's module docstring and
+        the "Optional server-side determinism wrapper" section of
+        ``examples/libero/run_mujoco.py``. Nothing in this library mounts
+        the wrapper automatically; a curated ``deterministic=`` mount on the
+        ``gr00t_inference`` lifecycle is tracked as a follow-up (issue
+        #1790).
 
         In LOCAL mode, applies the same client-side reseed
         ``set_eval_seed`` would (Python / NumPy / torch / cuDNN), which


### PR DESCRIPTION
Closes #1789.

## What changed

`Gr00tPolicy.reset`'s docstring (strands_robots/policies/groot/policy.py) made two false claims:

1. **"use the ``Robot()`` factory which auto-mounts the wrapper"** - no auto-mount exists anywhere in the library. The `Robot()` factory has no GR00T-server mounting logic, and the `gr00t_inference` tool deliberately does not expose volume mounts to callers (prompt-injection defense; the container reaches docker only via the curated `effective_volumes` set).
2. **"``examples/gr00t_server_deterministic_wrapper.py`` in robots-sim"** - stale path from the retired robots-sim repo. The wrapper lives in this repo at `examples/libero/gr00t_server_deterministic_wrapper.py` (landed via #1282).

The docstring now:

- Names the correct in-repo path.
- States the accurate contract: the wrapper must be **mounted manually** into the container (`docker run ... -v .../gr00t_server_deterministic_wrapper.py:/srv_wrap.py ... python /srv_wrap.py ...`), pointing at the wrapper's own module docstring and the "Optional server-side determinism wrapper" section of `examples/libero/run_mujoco.py`, which document it correctly.
- Explicitly says nothing in this library mounts the wrapper automatically, and cross-references #1790 (curated `deterministic=` mount on the `gr00t_inference` lifecycle) as the future no-manual-docker path.

## Why

A reader following the old text would forward per-episode seeds via `reset(options={seed})` and believe they were getting server-side determinism - while the server-side `reset` remained the upstream no-op and the seed silently did nothing. That is exactly the #187 success-rate-gap failure mode this docstring exists to prevent. Per AGENTS.md ("Match docstrings to semantics"): a docstring recommending a nonexistent capability is the same bug class as advertising a `_method`.

## Test surface

- Docstring-only change plus a `changelog.d/` fragment; no behavioral change.
- `hatch run lint`: clean (ruff + mypy, 977 files).
- `hatch run test` with `MUJOCO_GL=egl`: **15171 passed, 246 skipped** - no new failures.
- `python scripts/assemble_changelog.py --check`: fragments OK.

## Acceptance criteria (from #1789)

- [x] Docstring names the correct in-repo path (`examples/libero/gr00t_server_deterministic_wrapper.py`).
- [x] Docstring no longer claims any auto-mount; states the manual `docker run -v` contract instead.
- [x] Cross-references the follow-up feature issue #1790 (curated lifecycle mount flag) as the future no-manual-docker path.
- [x] No new test failures (no xref-resolution test covers this path family; full suite green).

## Out of scope / follow-ups

- #1790 - `deterministic=True` lifecycle flag on `gr00t_inference` (curated mount, no manual docker) is the feature-side follow-up, tracked separately.

Project board: please move #1789 to "In review".
