### PR TITLE
fix(sim/isaac): survive pip Isaac Sim 6.0.x - synchronous physics-view invalidation, camera warm-up under a stopped timeline, matrix parser tolerance

### DIFF
--- a/changelog.d/1798-isaac-pip-6x-deferred-physics-warmup.md
+++ b/changelog.d/1798-isaac-pip-6x-deferred-physics-warmup.md
@@ -1,0 +1,17 @@
+### Fixed: Isaac Sim 6.0.x pip wheels no longer crash LIBERO scene loads or starve fresh cameras
+
+On the pip `isaacsim` 6.0.x wheels, `timeline.stop()` invalidates the
+physics-tensor view asynchronously, so the deferred-physics guard returned
+with the view still live and `RigidPrim.__init__`'s eager velocity query
+raised the bare `Failed to get rigid body velocities from backend` on every
+LIBERO `load_scene`. The guard now also calls
+`SimulationManager.invalidate_physics()`, tearing the view down
+synchronously. Camera warm-up had the matching downstream failure: after the
+deferred-physics window the timeline stays stopped and `world.step()` does
+not resume play, so a freshly installed camera's RTX render product never
+accumulated a frame (`video.wrist_image` missing on the LIBERO GR00T path);
+`_warmup_camera` now re-asserts `timeline.play()` each iteration, because a
+queued stop can land mid-loop and undo a single pre-loop resume. The LIBERO
+backend-matrix parser also accepts drivers that add extra `key=value` fields
+(e.g. `run_isaac.py`'s `resolved_task=`), so the isaac row reports its real
+success rate instead of empty cells.

--- a/examples/libero/libero_backend_matrix.py
+++ b/examples/libero/libero_backend_matrix.py
@@ -125,9 +125,13 @@ _BACKEND_ROWS: list[tuple[str, str, list[str]]] = [
 # patterns" + the `print(...)` calls at the tail of run_mujoco.py and
 # run_isaac.py. If those drift, the parser surfaces an empty
 # ``success_rate`` rather than crashing -- the row will read ``ok``
-# with ``--`` cells and a stderr hint.
+# with ``--`` cells and a stderr hint. Drivers may add extra key=value
+# fields between the shared ones (run_isaac.py emits ``resolved_task=``
+# after ``task=`` when the placeholder task falls back), so match each
+# anchor key anywhere past the previous one rather than requiring strict
+# adjacency.
 _RE_RESULT = re.compile(
-    r"^policy=\S+\s+task=\S+\s+" r"success_rate=(?P<sr>[0-9]+\.[0-9]+)\s+" r"wall_time=(?P<wt>[0-9]+\.[0-9]+)s\b",
+    r"^policy=\S+\s+task=\S+.*?\s" r"success_rate=(?P<sr>[0-9]+\.[0-9]+)\s.*?" r"wall_time=(?P<wt>[0-9]+\.[0-9]+)s\b",
     re.MULTILINE,
 )
 

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -1863,14 +1863,33 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
     @staticmethod
     def _stop_timeline_for_deferred_physics() -> None:
-        """Stop the Isaac timeline so the physics-tensor view is cleared.
+        """Stop the Isaac timeline AND invalidate the physics-tensor view.
 
         After this returns the physics-tensor view is torn down, so
         ``RigidPrim.__init__`` skips its eager ``_on_physics_ready``
         velocity query and a freshly constructed ``Dynamic*`` prim
-        initialises only on the next ``world.reset()``. Best-effort: a
-        missing ``omni.timeline`` (partial Isaac install) is logged and
-        ignored.
+        initialises only on the next ``world.reset()``.
+
+        ``timeline.stop()`` alone is NOT sufficient on Isaac Sim 6.0.x
+        (verified on the pip ``isaacsim`` 6.0.0.1 and 6.0.1.0 wheels):
+        the view invalidation that upstream documents as happening
+        "automatically when the timeline is stopped" rides an event
+        subscription, and ``SimulationManager.get_physics_sim_view()``
+        is still non-``None`` when ``stop()`` returns - so the eager
+        velocity query in ``RigidPrim.__init__`` still fires and raises
+        the bare ``Exception("Failed to get rigid body velocities from
+        backend")`` this guard exists to prevent (#159 lineage). Upstream
+        provides :meth:`SimulationManager.invalidate_physics` as the
+        documented manual-invalidation entry point ("not intended to be
+        called directly unless a manual invalidation is desired/required"
+        - deferring a not-yet-viewed prim's physics init is exactly that
+        case), and it tears the view down synchronously. Call both: stop
+        the timeline (scene-build ordering, matches Isaac's own "build
+        rigid bodies, then reset once" flow) then invalidate the view.
+
+        Best-effort: a missing ``omni.timeline`` /
+        ``isaacsim.core.simulation_manager`` (partial Isaac install, older
+        Isaac without the manager API) is logged and ignored.
         """
         try:
             import omni.timeline  # type: ignore[import-not-found]
@@ -1878,6 +1897,21 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             omni.timeline.get_timeline_interface().stop()
         except (ImportError, AttributeError, RuntimeError) as e:
             logger.warning("Could not stop timeline to defer physics init: %s", e)
+        try:
+            from isaacsim.core.simulation_manager import (  # type: ignore[import-not-found]
+                SimulationManager,
+            )
+
+            if SimulationManager.get_physics_sim_view() is not None:
+                SimulationManager.invalidate_physics()
+                logger.info(
+                    "Invalidated live physics-tensor view after timeline stop "
+                    "(stop() alone leaves the view armed on Isaac Sim 6.0.x, "
+                    "so RigidPrim.__init__ would still run its eager velocity "
+                    "query on a prim outside the view)."
+                )
+        except (ImportError, AttributeError, RuntimeError) as e:
+            logger.warning("Could not invalidate physics-tensor view: %s", e)
 
     def _create_shape_prim(
         self,
@@ -2939,8 +2973,37 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         """
         if self._world is None:
             return False
+
+        # A stopped timeline never feeds the RTX render products, so a
+        # warm-up loop below it would step the physics scene while every
+        # render() probe keeps returning the malformed-buffer error - the
+        # exact state load_scene leaves behind after its deferred-physics
+        # window (the #159 guard stops the timeline before constructing
+        # Dynamic* prims, and ``world.step`` does not resume play). Resume
+        # inside the loop, every iteration: timeline stop/play commands
+        # land asynchronously on a kit update tick, so ``is_playing()`` can
+        # report stale ``True`` right after a queued ``stop()`` and a
+        # single pre-loop resume can be undone when that queued stop lands
+        # mid-warm-up. Re-asserting play() before each step converges even
+        # when a stop event is still in flight. Best-effort, same failure
+        # tolerance as the step loop.
+        def _ensure_timeline_playing() -> None:
+            try:
+                import omni.timeline  # type: ignore[import-not-found]
+
+                timeline = omni.timeline.get_timeline_interface()
+                if not timeline.is_playing():
+                    timeline.play()
+                    logger.debug(
+                        "Camera %r warm-up: resumed stopped timeline so the RTX render product can accumulate frames",
+                        name,
+                    )
+            except (ImportError, AttributeError, RuntimeError) as e:
+                logger.debug("Camera %r warm-up: could not query/resume timeline: %s", name, e)
+
         for i in range(max(1, n_steps)):
             try:
+                _ensure_timeline_playing()
                 self._world.step(render=True)
                 self._sim_time += self._config.physics_dt
                 self._step_count += 1

--- a/tests/simulation/isaac/test_deferred_physics_and_warmup.py
+++ b/tests/simulation/isaac/test_deferred_physics_and_warmup.py
@@ -1,0 +1,267 @@
+"""Regression pins for the Isaac Sim 6.0.x deferred-physics + camera-warmup fixes.
+
+Both defects were found running ``examples/libero/run_isaac.py`` end-to-end on
+the pip ``isaacsim`` wheels (verified on 6.0.0.1; 6.0.1.0 fails identically by
+mechanism) and each has an isolated live repro recorded in the fixing PR:
+
+1. **Deferred-physics guard defeated.** ``timeline.stop()`` invalidates the
+   physics-tensor view *asynchronously* on Isaac Sim 6.0.x:
+   ``SimulationManager.get_physics_sim_view()`` is still non-``None`` when
+   ``stop()`` returns, so ``RigidPrim.__init__``'s eager velocity query still
+   fires for a prim outside the view and raises the bare
+   ``Exception("Failed to get rigid body velocities from backend")`` the #159
+   guard exists to prevent - killing every LIBERO ``load_scene``. The fix makes
+   ``_stop_timeline_for_deferred_physics`` ALSO call
+   ``SimulationManager.invalidate_physics()`` (upstream's documented
+   manual-invalidation entry point), which tears the view down synchronously.
+
+2. **Camera warm-up under a stopped timeline.** After the deferred-physics
+   window the timeline stays stopped and ``world.step()`` does not resume
+   play, so a freshly added camera's RTX render product never accumulates a
+   frame and ``_warmup_camera`` burns its whole budget stepping a dead
+   renderer (the ``video.wrist_image``-missing failure on the LIBERO GR00T
+   path). The fix re-asserts ``timeline.play()`` before EVERY warm-up
+   iteration - per-iteration, not once, because stop/play land asynchronously
+   on kit update ticks and a queued ``stop()`` can undo a single pre-loop
+   resume.
+
+The tests drive the REAL ``IsaacSimulation`` methods on a ``__new__`` skeleton
+(the pattern of ``test_dataset_recording.py``) with fake ``omni.timeline`` /
+``isaacsim.core.simulation_manager`` module trees injected via
+``monkeypatch.setitem(sys.modules, ...)`` (the pattern of
+``test_backend_parity.py``), so they run with or without a real kit install.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+
+class _FakeTimeline:
+    """Stub ``omni.timeline`` interface with async-landing stop/play semantics.
+
+    ``stop()`` / ``play()`` only *queue* the state change; ``tick()`` applies
+    it - mirroring the kit behaviour observed live on 6.0.x where
+    ``is_playing()`` reports stale state right after a queued command.
+    """
+
+    def __init__(self, playing: bool = True) -> None:
+        self._playing = playing
+        self._queued: list[bool] = []
+        self.stop_calls = 0
+        self.play_calls = 0
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+        self._queued.append(False)
+
+    def play(self) -> None:
+        self.play_calls += 1
+        self._queued.append(True)
+
+    def is_playing(self) -> bool:
+        return self._playing
+
+    def tick(self) -> None:
+        """Land every queued state change (one kit update)."""
+        while self._queued:
+            self._playing = self._queued.pop(0)
+
+
+class _FakeSimulationManager:
+    """Stub ``SimulationManager`` whose view outlives ``timeline.stop()``.
+
+    The live 6.0.x behaviour this pins: stopping the timeline does NOT clear
+    the view synchronously; only ``invalidate_physics()`` does.
+    """
+
+    view: object | None = object()
+    invalidate_calls: int = 0
+
+    @classmethod
+    def get_physics_sim_view(cls) -> object | None:
+        return cls.view
+
+    @classmethod
+    def invalidate_physics(cls) -> None:
+        cls.invalidate_calls += 1
+        cls.view = None
+
+    @classmethod
+    def reset(cls, *, view_live: bool) -> None:
+        cls.view = object() if view_live else None
+        cls.invalidate_calls = 0
+
+
+@pytest.fixture
+def fake_timeline(monkeypatch) -> _FakeTimeline:
+    """Inject a fake ``omni.timeline`` module tree; return the timeline stub."""
+    timeline = _FakeTimeline(playing=True)
+    omni = types.ModuleType("omni")
+    omni_timeline = types.ModuleType("omni.timeline")
+    setattr(omni_timeline, "get_timeline_interface", lambda: timeline)  # noqa: B010 - ModuleType has no such attr statically
+    setattr(omni, "timeline", omni_timeline)  # noqa: B010
+    monkeypatch.setitem(sys.modules, "omni", omni)
+    monkeypatch.setitem(sys.modules, "omni.timeline", omni_timeline)
+    return timeline
+
+
+@pytest.fixture
+def fake_simulation_manager(monkeypatch) -> type[_FakeSimulationManager]:
+    """Inject a fake ``isaacsim.core.simulation_manager`` module tree."""
+    _FakeSimulationManager.reset(view_live=True)
+    mods = {}
+    for name in ("isaacsim", "isaacsim.core", "isaacsim.core.simulation_manager"):
+        mod = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, mod)
+        mods[name] = mod
+    setattr(mods["isaacsim.core.simulation_manager"], "SimulationManager", _FakeSimulationManager)  # noqa: B010
+    setattr(mods["isaacsim"], "core", mods["isaacsim.core"])  # noqa: B010
+    setattr(mods["isaacsim.core"], "simulation_manager", mods["isaacsim.core.simulation_manager"])  # noqa: B010
+    return _FakeSimulationManager
+
+
+class TestStopTimelineForDeferredPhysics:
+    """The #159 guard must tear the physics view down SYNCHRONOUSLY."""
+
+    def test_invalidates_live_view_after_timeline_stop(self, fake_timeline, fake_simulation_manager) -> None:
+        """Live view + stop() alone would leave RigidPrim's eager query armed.
+
+        Pre-fix behaviour: the guard called ``timeline.stop()`` and returned
+        with ``get_physics_sim_view()`` still non-``None`` (stop lands async),
+        so constructing a ``Dynamic*`` prim raised the bare backend Exception.
+        Post-fix: the guard calls ``invalidate_physics()`` and the view is
+        ``None`` when the guard returns - no tick needed.
+        """
+        IsaacSimulation._stop_timeline_for_deferred_physics()
+
+        assert fake_timeline.stop_calls == 1
+        assert fake_simulation_manager.invalidate_calls == 1
+        assert fake_simulation_manager.get_physics_sim_view() is None
+
+    def test_no_view_means_no_invalidate_call(self, fake_timeline, fake_simulation_manager) -> None:
+        """A dead view is left alone (scene-build path before any reset())."""
+        fake_simulation_manager.reset(view_live=False)
+
+        IsaacSimulation._stop_timeline_for_deferred_physics()
+
+        assert fake_timeline.stop_calls == 1
+        assert fake_simulation_manager.invalidate_calls == 0
+
+    def test_missing_simulation_manager_is_best_effort(self, fake_timeline, monkeypatch) -> None:
+        """Older/partial installs without the manager API must not raise."""
+        for name in ("isaacsim", "isaacsim.core", "isaacsim.core.simulation_manager"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        monkeypatch.setattr(
+            "builtins.__import__",
+            _blocking_import("isaacsim"),
+        )
+
+        IsaacSimulation._stop_timeline_for_deferred_physics()  # must not raise
+
+        assert fake_timeline.stop_calls == 1
+
+
+def _blocking_import(prefix: str):
+    """An ``__import__`` that raises ImportError for ``prefix``-rooted modules."""
+    real_import = __import__
+
+    def _import(name, *args, **kwargs):
+        if name == prefix or name.startswith(prefix + "."):
+            raise ImportError(f"blocked for test: {name}")
+        return real_import(name, *args, **kwargs)
+
+    return _import
+
+
+class _WarmupWorld:
+    """Stub Isaac ``World`` that renders only while the timeline plays.
+
+    Mirrors the live failure: with the timeline stopped, stepping never feeds
+    the RTX render product, so the camera never yields a frame.
+    """
+
+    def __init__(self, timeline: _FakeTimeline, frames_until_ready: int = 2) -> None:
+        self._timeline = timeline
+        self._remaining = frames_until_ready
+        self.render_steps_while_playing = 0
+
+    def step(self, render: bool = False) -> None:  # noqa: ARG002 - parity
+        # Kit update: queued timeline commands land on the step boundary.
+        self._timeline.tick()
+        if self._timeline.is_playing():
+            self.render_steps_while_playing += 1
+            if self._remaining > 0:
+                self._remaining -= 1
+
+    @property
+    def camera_ready(self) -> bool:
+        return self._remaining == 0
+
+
+def _skeleton_sim(world: _WarmupWorld) -> IsaacSimulation:
+    """Minimal ``__new__`` skeleton for the real ``_warmup_camera`` body."""
+    sim = IsaacSimulation.__new__(IsaacSimulation)
+    sim._config = IsaacConfig(headless=True, num_envs=1)
+    sim._world = world
+    sim._sim_time = 0.0
+    sim._step_count = 0
+
+    def _render(camera_name: str = "default", width=None, height=None):  # noqa: ANN001, ARG001
+        if world.camera_ready:
+            return {"status": "success", "content": []}
+        return {"status": "error", "content": [{"text": "render product not accumulated"}]}
+
+    sim.render = _render  # type: ignore[method-assign]
+    return sim
+
+
+class TestWarmupCameraResumesTimeline:
+    """``_warmup_camera`` must not step a dead renderer (stopped timeline)."""
+
+    def test_resumes_stopped_timeline_and_warms_up(self, fake_timeline) -> None:
+        """The load_scene aftermath: timeline stopped, camera just added.
+
+        Pre-fix behaviour: every warm-up step ran with the timeline stopped,
+        the render product never accumulated, and the loop exhausted its
+        budget (the ``video.wrist_image``-missing GR00T failure). Post-fix
+        the loop resumes play and the camera warms up within budget.
+        """
+        fake_timeline._playing = False
+        world = _WarmupWorld(fake_timeline, frames_until_ready=2)
+        sim = _skeleton_sim(world)
+
+        assert sim._warmup_camera("wrist_image", n_steps=5) is True
+        assert fake_timeline.play_calls >= 1
+        assert world.render_steps_while_playing >= 2
+
+    def test_reasserts_play_when_queued_stop_lands_mid_loop(self, fake_timeline) -> None:
+        """A stale ``is_playing() == True`` with a stop in flight.
+
+        This is the observed 6.0.x trap: right after the deferred-physics
+        guard, ``is_playing()`` still reports ``True`` while the queued
+        ``stop()`` lands on the next kit update - undoing any single pre-loop
+        resume. The per-iteration re-assert converges anyway.
+        """
+        fake_timeline._playing = True
+        fake_timeline.stop()  # queued; lands on the first world.step tick
+        world = _WarmupWorld(fake_timeline, frames_until_ready=2)
+        sim = _skeleton_sim(world)
+
+        assert sim._warmup_camera("wrist_image", n_steps=5) is True
+        assert fake_timeline.play_calls >= 1
+
+    def test_playing_timeline_needs_no_resume(self, fake_timeline) -> None:
+        """Steady-state add_camera: timeline already playing -> no play() call."""
+        fake_timeline._playing = True
+        world = _WarmupWorld(fake_timeline, frames_until_ready=1)
+        sim = _skeleton_sim(world)
+
+        assert sim._warmup_camera("front", n_steps=3) is True
+        assert fake_timeline.play_calls == 0

--- a/tests/test_examples_libero_drivers.py
+++ b/tests/test_examples_libero_drivers.py
@@ -95,6 +95,30 @@ def test_result_line_matches_backend_matrix_parser() -> None:
     assert float(match.group("wt")) == pytest.approx(wt)
 
 
+def test_result_line_with_extra_fields_matches_backend_matrix_parser() -> None:
+    """run_isaac.py's result line (extra key=value fields) must also parse.
+
+    ``run_isaac.py`` inserts ``resolved_task=`` between ``task=`` and
+    ``success_rate=`` when the placeholder default task falls back, and
+    appends ``backend=isaac`` after ``videos=``. The pre-fix ``_RE_RESULT``
+    required strict adjacency of the shared keys, so the isaac matrix row
+    ran green end-to-end yet printed ``--`` cells (empty success_rate) -
+    observed live on the first Isaac backend validation. Pin that extra
+    fields between the anchors stay tolerated.
+    """
+    matrix = _load_example("libero_backend_matrix.py")
+    sr, wt = 0.5, 64.8
+    line = (
+        "policy=mock  task=libero-spatial-pick_up_the_red_cube  "
+        "resolved_task=libero-spatial-pick_up_the_black_bowl_between_the_plate_and_the_ramekin_and_place_it_on_the_plate  "
+        f"success_rate={sr:.2f}  wall_time={wt:.1f}s  videos=rollouts/x.mp4  backend=isaac"
+    )
+    match = matrix._RE_RESULT.search(line)
+    assert match is not None, f"_RE_RESULT failed to parse run_isaac.py's result-line shape: {line!r}"
+    assert float(match.group("sr")) == pytest.approx(sr)
+    assert float(match.group("wt")) == pytest.approx(wt)
+
+
 def test_backend_matrix_has_mujoco_row() -> None:
     """The first matrix row must point at run_mujoco.py, and the file it
     references must exist (pre-migration it printed `unavailable`)."""


### PR DESCRIPTION
## Summary

Three fixes from validating `examples/libero` end-to-end on the **pip `isaacsim` 6.0.x wheels** (4x L4 host, Python 3.12, `isaacsim==6.0.0.1`; `6.0.1.0` fails identically by mechanism). Before these fixes, every LIBERO `load_scene` on Isaac crashed; after them, the backend matrix reports real per-backend numbers:

```
backend       success_rate   wall_time  status
mujoco                0.00       33.1s  ok        (mock; --policy groot = 1.00 in 32.1s)
isaac-1               0.00       64.8s  ok        (mock, RTX-rendered, MP4 written)
isaac-4096              --          --  unavailable (run_isaac_fleet.py - known, out of scope)
```

## Fix 1 - the #159 deferred-physics guard is defeated on Isaac Sim 6.0.x

`_stop_timeline_for_deferred_physics` stopped the timeline and relied on that clearing the physics-tensor view so `RigidPrim.__init__` skips its eager velocity query. On the pip 6.0.x wheels the invalidation lands **asynchronously**: `SimulationManager.get_physics_sim_view()` is still non-`None` when `stop()` returns, the eager query fires for a prim outside the view, and the bare `Exception("Failed to get rigid body velocities from backend")` kills `load_scene` (i.e. every `LiberoAdapter.on_episode_start`).

Isolated live repro (full logs in the validation session):

```
[hyp] view live after reset+steps:            True
[hyp] view after repo guard (timeline.stop):  True   <- guard defeated
[hyp] view after invalidate_physics():        False  <- synchronous teardown
```

The guard now also calls `SimulationManager.invalidate_physics()` - upstream's documented manual-invalidation entry point ("not intended to be called directly unless a manual invalidation is desired/required" - deferring a not-yet-viewed prim's physics init is exactly that case). Best-effort with the same exception hygiene as the timeline import; older installs without the manager API log and continue.

## Fix 2 - `_warmup_camera` steps a dead renderer after the deferred-physics window

After Fix 1's window the timeline is stopped and `world.step()` does **not** resume play, so a freshly installed camera's RTX render product never accumulates a frame: `_warmup_camera` burned its whole budget while `render()` kept returning the malformed-buffer error. On the LIBERO GR00T path this surfaced as `Server error: Video key 'video.wrist_image' must be in observation` (the adapter-installed wrist camera never warmed up).

The warm-up loop now re-asserts `timeline.play()` **per iteration** - per-iteration rather than once, because stop/play land asynchronously on kit update ticks: `is_playing()` reports stale `True` right after a queued `stop()`, which then lands mid-loop and would undo a single pre-loop resume (observed live). Isolated repro flips `render -> error` to `render -> success`.

## Fix 3 - matrix parser rejects `run_isaac.py`'s result line

`libero_backend_matrix._RE_RESULT` required strict adjacency of `policy= task= success_rate= wall_time=`. `run_isaac.py` inserts `resolved_task=` after `task=` (placeholder-task fallback) and appends `backend=isaac`, so the isaac row ran green yet printed `--` cells (the parser's documented soft-fail). The regex now tolerates extra `key=value` fields between the shared anchors; unit-checked against all three real line shapes (mujoco, isaac, groot).

## Regression tests (fail on pre-fix code - verified by stashing the fix)

- `tests/simulation/isaac/test_deferred_physics_and_warmup.py` (new, 6 tests): fake `omni.timeline` / `SimulationManager` module trees with **async-landing stop/play semantics** mirroring the observed kit behaviour; real `IsaacSimulation` methods on a `__new__` skeleton (the `test_dataset_recording.py` pattern). Pins: guard tears the view down synchronously; no-view path skips invalidation; missing manager API is best-effort; warm-up resumes a stopped timeline; warm-up converges when a queued stop lands mid-loop; already-playing timeline gets no `play()` call.
- `tests/test_examples_libero_drivers.py::test_result_line_with_extra_fields_matches_backend_matrix_parser` (new): the isaac-shaped line parses; existing strict-shape test still passes.

Pre-fix: `3 failed` (warm-up + view pins) / parser test `1 failed`. Post-fix: all green.

## Test surface

- `hatch run lint` - clean (ruff check, ruff format, mypy: "no issues found in 978 source files").
- `hatch run test` - **15172 passed, 246 skipped, 6 failed**; all 6 failures are video-decode/recording-env tests that fail identically on clean `main` on this box (stash-verified) - pre-existing environmental, not introduced here.
- End-to-end on real Isaac (this box): `run_isaac.py --policy mock --n-episodes 2` exits 0 with the grep-stable result line + MP4; full matrix output above; `run_mujoco.py --policy groot` re-verified at `success_rate=1.00` after the changes.

## Caveats / follow-ups (not in this PR)

- **6.0.1.0**: both fixes address the identical failure signature observed on 6.0.1.0 (`omni.physics.tensors` 110.1.13), but the post-fix end-to-end run was executed on 6.0.0.1 - flagging per review honesty rather than claiming a matrix of verified versions.
- **GR00T-on-Isaac is still blocked one layer deeper**: with both fixes, the eval proceeds past scene-load and `wrist_image` and then fails with `State key 'state.x' must be in observation` - `LiberoAdapter.augment_observation`'s EEF-pose reader is MuJoCo-shaped (direct `sim._world._model` site read, `robot0_right_hand` body fallback), neither of which resolves on the Isaac Franka USD. Scoped feature, issue to follow.
- pip-isaacsim install collateral worth documenting (separate issue): it pins `coverage==7.4.4`, which breaks numba's probe and thereby robosuite's OSC import (`module 'coverage.types' has no attribute 'Tracer'`); reinstalling `coverage>=7.6` resolves it.

Project board: PAT lacks org Projects:write - please route per convention.
