### PR TITLE
fix(recording): name the lerobot dependency that is missing

### DIFF
--- a/changelog.d/1799-lerobot-dataset-import-diagnosis.md
+++ b/changelog.d/1799-lerobot-dataset-import-diagnosis.md
@@ -1,0 +1,31 @@
+### Fixed: start_recording names the lerobot dependency that is missing
+
+`start_recording` gated on `has_lerobot_dataset()`, which collapses every way
+importing `lerobot.datasets.lerobot_dataset` can fail into a single `False`, and
+all three backends turned that `False` into one message: *"requires the lerobot
+extra: pip install 'strands-robots[lerobot]'"*. In a partially-provisioned
+environment - lerobot itself installed, but one of the packages its dataset
+stack needs absent - that named a package the caller already had:
+
+```python
+# lerobot 0.6.1 installed; `datasets` is not
+sim.start_recording(repo_id="user/ds", task="pick")
+# status=error, "requires the lerobot extra: pip install 'strands-robots[lerobot]'"
+# -> `pip show lerobot` says it is installed, so the advice reads as a library bug
+```
+
+The reason is now surfaced. A new `lerobot_dataset_import_error()` returns
+`None` when `LeRobotDataset` imports and otherwise the diagnosis, and
+`has_lerobot_dataset()` is a thin predicate over it so the two cannot disagree.
+Four causes get four different instructions: lerobot absent (install the extra);
+lerobot present but a dataset dependency absent (`pip install 'lerobot[dataset]'`
+- plain `pip install lerobot` does not pull those in); lerobot present but no
+longer exporting the module strands-robots imports (install an in-range
+lerobot); and an import that failed with nothing missing, typically a
+pandas/numpy binary conflict (no install fixes it). The same distinction was
+already drawn for the policy-factory import by
+`strands_robots.policies.lerobot_local.molmoact2._factory_import_error`.
+
+The three backends each keep their own plain-MP4 fallback advice and report the
+reason verbatim. A successful probe is still cached and a failed one still
+re-attempted, and a healthy install records exactly as before.

--- a/changelog.d/1799-lerobot-dataset-import-diagnosis.md
+++ b/changelog.d/1799-lerobot-dataset-import-diagnosis.md
@@ -26,6 +26,14 @@ pandas/numpy binary conflict (no install fixes it). The same distinction was
 already drawn for the policy-factory import by
 `strands_robots.policies.lerobot_local.molmoact2._factory_import_error`.
 
+The version string those messages quote comes from a new public
+`utils.lerobot_version()`, promoted out of the streaming-dataset reader so the
+two modules that name it cannot report it differently. Its handler catches
+`ImportError` alone: `PackageNotFoundError` subclasses `ModuleNotFoundError` and
+so is already one, and naming it as well bound it as a local the failing import
+never reaches - which raised `UnboundLocalError` out of a best-effort helper if
+`importlib.metadata` could not be imported.
+
 The three backends each keep their own plain-MP4 fallback advice and report the
 reason verbatim. A successful probe is still cached and a failed one still
 re-attempted, and a healthy install records exactly as before.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -157,7 +157,8 @@ from strands_robots.dataset_recorder import DatasetRecorder, has_lerobot_dataset
 | `recorder.clear_episode_buffer()` | Discard buffer. |
 | `recorder.finalize()` | Flush and close. |
 | `recorder.push_to_hub(tags=None, private=False)` | Upload to HuggingFace. |
-| `has_lerobot_dataset()` | Cached import check. |
+| `has_lerobot_dataset()` | Cached import check (True if `LeRobotDataset` imports). |
+| `lerobot_dataset_import_error()` | `None` if it imports, else why not - names the missing package and the install that supplies it. Use this when reporting to a human. |
 
 See [Recording](recording.md).
 

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -21,6 +21,7 @@ Usage:
     recorder.push_to_hub()
 """
 
+import importlib.util
 import json
 import logging
 import re
@@ -30,6 +31,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+from strands_robots.utils import lerobot_version
 
 logger = logging.getLogger(__name__)
 
@@ -326,22 +329,133 @@ def _huggingface_hub_version_error() -> str | None:
 _HAS_LEROBOT_DATASET: list[bool] = []
 
 
-def has_lerobot_dataset() -> bool:
-    """Return True if lerobot's ``LeRobotDataset`` can be imported.
+#: The packages ``lerobot[dataset]`` installs and that
+#: ``lerobot.datasets.lerobot_dataset`` imports at module scope. Named in the
+#: install hint so a single command fixes every one of them at once; the
+#: authoritative set is lerobot's own extra, so this is a hint for a human, not
+#: a second source of truth strands-robots probes against.
+_LEROBOT_DATASET_PACKAGES = "datasets, pandas, pyarrow, av, torchcodec"
+
+#: The module strands-robots imports to record a LeRobotDataset. Named in the
+#: drift diagnosis so a caller can check it against their lerobot directly.
+_LEROBOT_DATASET_MODULE = "lerobot.datasets.lerobot_dataset"
+
+
+def _lerobot_installed() -> bool:
+    """Whether the ``lerobot`` package itself is present.
+
+    Uses a spec lookup rather than an import so it has no side effects and does
+    not pay lerobot's import cost just to answer a question about an error
+    message.
+    """
+    if "lerobot" in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec("lerobot") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _describe_lerobot_import_failure(exc: BaseException) -> str:
+    """Turn an import failure into the diagnosis a caller can act on.
+
+    Four unrelated failures reach here and they need four different
+    instructions, so the message has to say which one happened:
+
+    * lerobot itself is absent -- installing the extra is the fix;
+    * lerobot is present but a package its dataset stack needs is not
+      (``datasets``, ``pandas``, ``pyarrow``, ``av``, ...). Plain ``pip install
+      lerobot`` does not pull those in, so "install lerobot" is not a usable
+      instruction here: the package it names is already installed;
+    * lerobot is present but does not provide what strands-robots imports -- an
+      out-of-range or from-source lerobot that moved or renamed the module;
+    * the import failed without any module being missing (``ValueError`` /
+      ``RuntimeError``, typically a pandas built against a different numpy).
+      Nothing is absent, so no install fixes it.
+
+    Only a non-``ImportError`` may claim that nothing is missing: an
+    ``ImportError`` whose ``name`` is unset still reports a failed import, and
+    telling that caller to reconcile binary versions would send them after a
+    conflict they may not have.
+
+    Args:
+        exc: The exception raised while importing ``LeRobotDataset``.
+
+    Returns:
+        An actionable diagnosis naming the cause and the install that fixes it.
+    """
+    detail = f"{type(exc).__name__}: {exc}"
+
+    if not _lerobot_installed():
+        return (
+            f"lerobot is not installed ({detail}). Install lerobot >= 0.6.0 with: pip install 'strands-robots[lerobot]'"
+        )
+
+    version = lerobot_version()
+
+    if not isinstance(exc, ImportError):
+        return (
+            f"lerobot {version} is installed and no module is missing, but importing its dataset "
+            f"stack failed ({detail}). That is a conflict between installed packages -- commonly a "
+            f"pandas built against a different numpy -- so no install of lerobot or its extra fixes "
+            f"it; reconcile the conflicting packages instead."
+        )
+
+    missing = getattr(exc, "name", None) or ""
+    if missing and missing.split(".")[0] != "lerobot":
+        return (
+            f"lerobot {version} is installed, but {missing!r}, which its dataset stack needs, is "
+            f"not ({detail}). Install that whole set with: pip install 'lerobot[dataset]' "
+            f"-- {_LEROBOT_DATASET_PACKAGES}. Installing lerobot without that extra does not pull "
+            f"them in, so reinstalling lerobot alone will not fix this."
+        )
+
+    return (
+        f"lerobot {version} is installed, but it does not provide "
+        f"{_LEROBOT_DATASET_MODULE} ({detail}). strands-robots supports "
+        f"lerobot >= 0.6.0,<0.7.0; an out-of-range or from-source lerobot can move or rename "
+        f"that module. Install a supported one with: pip install 'strands-robots[lerobot]'"
+    )
+
+
+def lerobot_dataset_import_error() -> str | None:
+    """Return None if lerobot's ``LeRobotDataset`` imports, else why it does not.
+
+    This is the probe :func:`has_lerobot_dataset` answers yes/no from, and the
+    one a caller should use when it has to tell a human what to do: the reason
+    is what distinguishes "install the lerobot extra" from the cases that
+    instruction cannot fix.
 
     A successful probe is cached; a failed probe is intentionally re-attempted
     on the next call so a transient import failure does not permanently disable
     recording for the process.
+
+    Returns:
+        ``None`` when ``LeRobotDataset`` is importable, otherwise a
+        ready-to-display diagnosis naming the cause and the install that fixes
+        it (see :func:`_describe_lerobot_import_failure`).
     """
     if _HAS_LEROBOT_DATASET:
-        return True
+        return None
     try:
         from lerobot.datasets.lerobot_dataset import LeRobotDataset  # noqa: F401
     except (ImportError, ValueError, RuntimeError) as exc:
-        logger.debug("lerobot not available: %s", exc)
-        return False
+        reason = _describe_lerobot_import_failure(exc)
+        logger.debug("lerobot dataset stack unavailable: %s", reason)
+        return reason
     _HAS_LEROBOT_DATASET.append(True)
-    return True
+    return None
+
+
+def has_lerobot_dataset() -> bool:
+    """Return True if lerobot's ``LeRobotDataset`` can be imported.
+
+    A thin predicate over :func:`lerobot_dataset_import_error` so the two cannot
+    disagree about whether recording is available. Callers that must explain the
+    unavailability to a human should use that function instead: a bare False
+    cannot say which of several unrelated causes applied.
+    """
+    return lerobot_dataset_import_error() is None
 
 
 def _get_lerobot_dataset_class():

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -206,24 +206,30 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
             return error
 
         _DatasetRecorder: Any = None
-        _has_lerobot = False
+        unavailable: str | None = None
         try:
             from strands_robots.dataset_recorder import DatasetRecorder as _DatasetRecorder
-            from strands_robots.dataset_recorder import has_lerobot_dataset as _check_lerobot
+            from strands_robots.dataset_recorder import lerobot_dataset_import_error
 
-            _has_lerobot = _check_lerobot()
-        except ImportError:
-            # lerobot extra not installed; handled by the _has_lerobot guard below.
-            pass
+            unavailable = lerobot_dataset_import_error()
+        except ImportError as exc:
+            # strands_robots.dataset_recorder itself did not import (a partial or
+            # drifted install); report that rather than blaming the lerobot extra.
+            unavailable = f"strands_robots.dataset_recorder is unavailable ({exc})."
+        if unavailable is None and _DatasetRecorder is None:
+            unavailable = "strands_robots.dataset_recorder did not provide DatasetRecorder."
 
-        if not _has_lerobot or _DatasetRecorder is None:
+        if unavailable is not None:
             return {
                 "status": "error",
                 "content": [
                     {
                         "text": (
-                            "start_recording produces a LeRobotDataset (parquet + video) and "
-                            "requires the lerobot extra: pip install 'strands-robots[lerobot]'.\n"
+                            "start_recording produces a LeRobotDataset (parquet + video), which "
+                            "needs lerobot's dataset stack:\n"
+                            "\n"
+                            f"  {unavailable}\n"
+                            "\n"
                             "For plain MP4 video, use start_cameras_recording instead."
                         )
                     }

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -148,27 +148,32 @@ class RecordingMixin(DatasetRecordingMixin):
             return error
 
         _DatasetRecorder: Any = None
-        _has_lerobot = False
+        unavailable: str | None = None
         try:
             from strands_robots.dataset_recorder import DatasetRecorder as _DatasetRecorder
-            from strands_robots.dataset_recorder import has_lerobot_dataset as _check_lerobot
+            from strands_robots.dataset_recorder import lerobot_dataset_import_error
 
-            _has_lerobot = _check_lerobot()
-        except ImportError:
-            pass
+            unavailable = lerobot_dataset_import_error()
+        except ImportError as exc:
+            # strands_robots.dataset_recorder itself did not import (a partial or
+            # drifted install); report that rather than blaming the lerobot extra.
+            unavailable = f"strands_robots.dataset_recorder is unavailable ({exc})."
+        if unavailable is None and _DatasetRecorder is None:
+            unavailable = "strands_robots.dataset_recorder did not provide DatasetRecorder."
 
-        if not _has_lerobot or _DatasetRecorder is None:
+        if unavailable is not None:
             return {
                 "status": "error",
                 "content": [
                     {
                         "text": (
-                            "start_recording produces a LeRobotDataset (parquet + video) and "
-                            "requires the lerobot extra. For plain MP4 video under the "
-                            "[sim-mujoco] extra alone, use start_cameras_recording instead.\n"
+                            "start_recording produces a LeRobotDataset (parquet + video), which "
+                            "needs lerobot's dataset stack:\n"
                             "\n"
-                            "  - Dataset + policy training data:  pip install 'strands-robots[lerobot]'\n"
-                            "  - Plain MP4 only:                  start_cameras_recording(cameras=..., output_dir=...)"
+                            f"  {unavailable}\n"
+                            "\n"
+                            "For plain MP4 video under the [sim-mujoco] extra alone, use "
+                            "start_cameras_recording(cameras=..., output_dir=...) instead."
                         )
                     }
                 ],

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -139,24 +139,30 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             return error
 
         _DatasetRecorder: Any = None
-        _has_lerobot = False
+        unavailable: str | None = None
         try:
             from strands_robots.dataset_recorder import DatasetRecorder as _DatasetRecorder
-            from strands_robots.dataset_recorder import has_lerobot_dataset as _check_lerobot
+            from strands_robots.dataset_recorder import lerobot_dataset_import_error
 
-            _has_lerobot = _check_lerobot()
-        except ImportError:
-            # lerobot extra not installed; handled by the _has_lerobot guard below.
-            pass
+            unavailable = lerobot_dataset_import_error()
+        except ImportError as exc:
+            # strands_robots.dataset_recorder itself did not import (a partial or
+            # drifted install); report that rather than blaming the lerobot extra.
+            unavailable = f"strands_robots.dataset_recorder is unavailable ({exc})."
+        if unavailable is None and _DatasetRecorder is None:
+            unavailable = "strands_robots.dataset_recorder did not provide DatasetRecorder."
 
-        if not _has_lerobot or _DatasetRecorder is None:
+        if unavailable is not None:
             return {
                 "status": "error",
                 "content": [
                     {
                         "text": (
-                            "start_recording produces a LeRobotDataset (parquet + video) and "
-                            "requires the lerobot extra: pip install 'strands-robots[lerobot]'.\n"
+                            "start_recording produces a LeRobotDataset (parquet + video), which "
+                            "needs lerobot's dataset stack:\n"
+                            "\n"
+                            f"  {unavailable}\n"
+                            "\n"
                             "For plain MP4 video, pass video={'path': ...} to run_policy instead."
                         )
                     }

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -23,6 +23,8 @@ import sys
 from collections.abc import Callable
 from typing import Any
 
+from strands_robots.utils import lerobot_version
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,16 +77,6 @@ def _get_streaming_cls() -> Any:
             "For proprio-only streaming without torchcodec, use drop_videos=True "
             "with a delta_timestamps covering the non-video keys you need."
         ) from exc
-
-
-def _lerobot_version() -> str:
-    """Best-effort installed lerobot version string for error messages."""
-    try:
-        from importlib.metadata import PackageNotFoundError, version
-
-        return version("lerobot")
-    except (ImportError, PackageNotFoundError):
-        return "unknown"
 
 
 class StreamingDatasetReader:
@@ -155,7 +147,7 @@ class StreamingDatasetReader:
         if repo_type != "dataset" and not (accepts_var_kw or "repo_type" in init_sig):
             raise RuntimeError(
                 f"repo_type={repo_type!r} is not supported by any released lerobot "
-                f"(installed: {_lerobot_version()}): StreamingLeRobotDataset does not "
+                f"(installed: {lerobot_version()}): StreamingLeRobotDataset does not "
                 "accept a repo_type parameter (the versioned-dataset vs bucket storage "
                 "split is not upstream), and silently falling back to the 'dataset' "
                 "namespace would stream from a different storage system. Pass "
@@ -194,7 +186,7 @@ class StreamingDatasetReader:
                 "(lerobot %s) does not accept return_uint8, so frames stream as "
                 "float32 (~4x the bandwidth of uint8). Policies still normalize "
                 "correctly; upgrade lerobot for uint8 streaming.",
-                _lerobot_version(),
+                lerobot_version(),
             )
 
         kwargs: dict[str, Any] = {"repo_id": repo_id}

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -120,12 +120,20 @@ def lerobot_version() -> str:
     (:mod:`strands_robots.dataset_recorder` and
     :mod:`strands_robots.streaming_dataset`) and must not report the version
     differently.
+
+    ``except ImportError`` is deliberately the whole handler. ``version`` signals
+    an unresolvable distribution with ``PackageNotFoundError``, which subclasses
+    ``ModuleNotFoundError`` and so already *is* an ``ImportError``. Naming it in
+    the handler as well would bind it as a local that the ``import`` above may
+    never reach, and evaluating the handler would then raise
+    ``UnboundLocalError`` out of a function documented never to raise - on
+    precisely the failure the second name looked like it was covering.
     """
     try:
-        from importlib.metadata import PackageNotFoundError, version
+        from importlib.metadata import version
 
         return version("lerobot")
-    except (ImportError, PackageNotFoundError):
+    except ImportError:
         return "unknown"
 
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -110,6 +110,25 @@ def require_optionals(
     raise ImportError("\n".join(parts)) from None
 
 
+def lerobot_version() -> str:
+    """Return the installed lerobot version, or ``"unknown"`` if undeterminable.
+
+    Best-effort and never raises: it exists for error messages, where naming the
+    installed version is what distinguishes "lerobot is missing" from "lerobot
+    is present but something it needs is not". Lives here rather than beside one
+    of its callers because those callers sit in different modules
+    (:mod:`strands_robots.dataset_recorder` and
+    :mod:`strands_robots.streaming_dataset`) and must not report the version
+    differently.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("lerobot")
+    except (ImportError, PackageNotFoundError):
+        return "unknown"
+
+
 #
 # Path resolution - single source of truth for all strands-robots paths
 #

--- a/tests/simulation/mujoco/test_recording_backends.py
+++ b/tests/simulation/mujoco/test_recording_backends.py
@@ -52,12 +52,14 @@ class TestStartRecordingErrorWithoutLerobot:
     def test_extra_absent_points_to_start_cameras_recording(self, sim, monkeypatch):
         import strands_robots.dataset_recorder as dr
 
-        monkeypatch.setattr(dr, "has_lerobot_dataset", lambda: False)
+        reason = "lerobot is not installed (ModuleNotFoundError: No module named 'lerobot'). Install lerobot >= 0.6.0 with: pip install 'strands-robots[lerobot]'"
+        monkeypatch.setattr(dr, "lerobot_dataset_import_error", lambda: reason)
         result = sim.start_recording(repo_id="local/test_rec")
         assert result["status"] == "error"
         text = result["content"][0]["text"]
         assert "start_cameras_recording" in text
-        assert "lerobot" in text.lower()
+        # Surfaced verbatim, so the caller sees which dependency is missing.
+        assert reason in text
 
     def test_broken_import_falls_through_to_structured_error(self, sim, monkeypatch):
         import strands_robots.dataset_recorder as dr

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -651,12 +651,15 @@ def test_start_recording_without_lerobot_points_at_mp4_fallback(sim_with_two_rob
     returns an error that names the lerobot extra and the plain-MP4 fallback."""
     import strands_robots.dataset_recorder as dr
 
-    monkeypatch.setattr(dr, "has_lerobot_dataset", lambda: False)
+    reason = "lerobot is not installed (ModuleNotFoundError: No module named 'lerobot'). Install lerobot >= 0.6.0 with: pip install 'strands-robots[lerobot]'"
+    monkeypatch.setattr(dr, "lerobot_dataset_import_error", lambda: reason)
 
     r = sim_with_two_robots.start_recording(repo_id="local/no_lerobot", task="t")
     assert r["status"] == "error"
     text = r["content"][0]["text"]
-    assert "lerobot" in text
+    # The diagnosis is surfaced verbatim: a caller must be told WHICH
+    # dependency is missing, not just that recording is unavailable.
+    assert reason in text
     assert "start_cameras_recording" in text
 
 

--- a/tests/simulation/newton/test_recording_lifecycle_guards.py
+++ b/tests/simulation/newton/test_recording_lifecycle_guards.py
@@ -53,14 +53,16 @@ class TestStartRecordingGuards:
     def test_missing_lerobot_extra_returns_actionable_error(self, monkeypatch):
         # When the lerobot extra is absent, start_recording must not dead-end in
         # dataset creation - it returns an error that names the install extra.
-        monkeypatch.setattr(dataset_recorder, "has_lerobot_dataset", lambda: False)
+        reason = "lerobot is not installed (ModuleNotFoundError: No module named 'lerobot'). Install lerobot >= 0.6.0 with: pip install 'strands-robots[lerobot]'"
+        monkeypatch.setattr(dataset_recorder, "lerobot_dataset_import_error", lambda: reason)
         engine = _make_engine(_world_with_robot())
 
         result = engine.start_recording(repo_id="local/sim_recording")
 
         assert result["status"] == "error"
         text = result["content"][0]["text"]
-        assert "lerobot" in text
+        # Surfaced verbatim, so the caller sees which dependency is missing.
+        assert reason in text
         assert "strands-robots[lerobot]" in text
 
     def test_no_world_returns_error(self):

--- a/tests/test_lerobot_dataset_import_diagnosis.py
+++ b/tests/test_lerobot_dataset_import_diagnosis.py
@@ -1,0 +1,220 @@
+"""start_recording must say WHICH lerobot dependency is missing, not just that one is.
+
+``has_lerobot_dataset()`` collapses every way importing
+``lerobot.datasets.lerobot_dataset`` can fail into a single ``False``, and all
+three backends' ``start_recording`` turned that ``False`` into one message:
+"requires the lerobot extra: pip install 'strands-robots[lerobot]'". For a
+partially-provisioned environment -- lerobot itself installed, but one of the
+packages its dataset stack needs (``datasets``, ``pandas``, ``pyarrow``,
+``av``) absent -- that instruction names a package the caller already has, so
+they verify lerobot is installed and conclude the library is wrong about its own
+dependency.
+
+``strands_robots.policies.lerobot_local.molmoact2._factory_import_error``
+already draws exactly this distinction for the policy-factory import, and its
+docstring states the principle: "telling the caller to reinstall lerobot is a
+dead end that sends a partially-provisioned env chasing the wrong remedy". These
+pin the same distinction for the recording path.
+
+The four causes and their four different remedies:
+
+* lerobot absent                       -> install the extra;
+* lerobot present, a dataset dep absent -> ``pip install 'lerobot[dataset]'``
+  (plain ``pip install lerobot`` does not pull those in);
+* lerobot present, module moved/renamed -> install an in-range lerobot;
+* import failed with nothing missing    -> no install fixes it.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+
+import pytest
+
+from strands_robots import dataset_recorder as dr
+
+#: A representative dependency from each layer of lerobot's dataset stack.
+_DATASET_DEPS = ("datasets", "pandas", "pyarrow", "av", "torchcodec")
+
+
+@pytest.fixture
+def lerobot_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the "lerobot itself is installed" half of the diagnosis.
+
+    The three lerobot-present branches must be reachable whether or not lerobot
+    is installed in the environment running the tests, so the contract holds
+    everywhere rather than only where a real lerobot happens to be importable.
+    """
+    monkeypatch.setattr(dr, "_lerobot_installed", lambda: True)
+    monkeypatch.setattr(dr, "lerobot_version", lambda: "0.6.0")
+
+
+class TestMissingDatasetDependencyIsNamed:
+    """The regression: a missing dataset dep must not read as "install lerobot"."""
+
+    @pytest.mark.parametrize("dep", _DATASET_DEPS)
+    def test_the_missing_package_is_named(self, dep: str, lerobot_present: None) -> None:
+        exc = ModuleNotFoundError(f"No module named {dep!r}", name=dep)
+
+        text = dr._describe_lerobot_import_failure(exc)
+
+        assert dep in text, f"diagnosis does not name the missing package: {text!r}"
+
+    @pytest.mark.parametrize("dep", _DATASET_DEPS)
+    def test_the_remedy_installs_the_dataset_extra(self, dep: str, lerobot_present: None) -> None:
+        exc = ModuleNotFoundError(f"No module named {dep!r}", name=dep)
+
+        text = dr._describe_lerobot_import_failure(exc)
+
+        # One command covers the whole stack: a caller who installed lerobot
+        # without the extra is missing all of it, not just the package that
+        # happened to be imported first.
+        assert "pip install 'lerobot[dataset]'" in text
+
+    @pytest.mark.parametrize("dep", _DATASET_DEPS)
+    def test_it_does_not_say_lerobot_is_missing(self, dep: str, lerobot_present: None) -> None:
+        exc = ModuleNotFoundError(f"No module named {dep!r}", name=dep)
+
+        text = dr._describe_lerobot_import_failure(exc)
+
+        # lerobot IS installed here, so any claim that it is not, or any
+        # instruction to reinstall it on its own, is the misdiagnosis.
+        assert "lerobot is not installed" not in text
+        assert "strands-robots[lerobot]" not in text
+        assert "0.6.0 is installed" in text, "the installed version anchors the diagnosis"
+
+
+class TestEachCauseGetsItsOwnRemedy:
+    """Four causes, four instructions - none may collapse into another."""
+
+    def test_absent_lerobot_points_at_the_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dr, "_lerobot_installed", lambda: False)
+
+        text = dr._describe_lerobot_import_failure(ModuleNotFoundError("No module named 'lerobot'", name="lerobot"))
+
+        assert "lerobot is not installed" in text
+        assert "strands-robots[lerobot]" in text
+
+    def test_moved_module_points_at_the_supported_range(self, lerobot_present: None) -> None:
+        # An in-place lerobot that renamed the module reports a name INSIDE
+        # lerobot -- as does `cannot import name X from lerobot.datasets...`,
+        # whose `name` is the module, not the symbol.
+        text = dr._describe_lerobot_import_failure(
+            ImportError(
+                "cannot import name 'LeRobotDataset'",
+                name="lerobot.datasets.lerobot_dataset",
+            )
+        )
+
+        assert "lerobot.datasets.lerobot_dataset" in text
+        assert "lerobot >= 0.6.0" in text
+        # Not the transitive-dep remedy: the dataset extra cannot supply a
+        # module that lerobot itself no longer exports.
+        assert "lerobot[dataset]" not in text
+
+    def test_unnamed_import_error_is_not_called_a_binary_conflict(self, lerobot_present: None) -> None:
+        # An ImportError with no `name` still reports a failed import, so it must
+        # not be told that nothing is missing and no install will help.
+        text = dr._describe_lerobot_import_failure(ImportError("something went wrong"))
+
+        assert "no module is missing" not in text
+        assert "lerobot >= 0.6.0" in text
+
+    def test_non_import_error_says_no_install_fixes_it(self, lerobot_present: None) -> None:
+        # The numpy/pandas ABI mismatch this module's own comment describes:
+        # every package is present, so an install instruction is a dead end.
+        text = dr._describe_lerobot_import_failure(
+            ValueError("numpy.dtype size changed, may indicate binary incompatibility")
+        )
+
+        assert "no module is missing" in text
+        assert "reconcile the conflicting packages" in text
+        assert "pip install" not in text
+
+
+class TestPredicateAgreesWithReason:
+    """``has_lerobot_dataset`` must be exactly "there is no reason"."""
+
+    @pytest.mark.parametrize(
+        "reason", [None, "lerobot is not installed (...)", "lerobot 0.6.0 is installed, but 'av' ..."]
+    )
+    def test_predicate_is_the_negation_of_a_reason(self, reason: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dr, "lerobot_dataset_import_error", lambda: reason)
+
+        assert dr.has_lerobot_dataset() is (reason is None)
+
+
+class TestSuccessfulProbeIsStillCached:
+    """The caching contract the reason-bearing probe inherited."""
+
+    def test_a_cached_success_short_circuits_without_importing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dr, "_HAS_LEROBOT_DATASET", [True])
+        # A cached success must not re-probe, so a describer that would raise is
+        # never reached.
+        monkeypatch.setattr(
+            dr, "_describe_lerobot_import_failure", lambda exc: pytest.fail("re-probed a cached success")
+        )
+
+        assert dr.lerobot_dataset_import_error() is None
+
+    def test_a_failure_is_not_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A failed probe is deliberately re-attempted: caching False would
+        # disable recording for the rest of the process once anything transiently
+        # failed to import.
+        monkeypatch.setattr(dr, "_HAS_LEROBOT_DATASET", [])
+        calls: list[int] = []
+
+        def _describe(exc: BaseException) -> str:
+            calls.append(1)
+            return "nope"
+
+        monkeypatch.setattr(dr, "_describe_lerobot_import_failure", _describe)
+        monkeypatch.setitem(dr.sys.modules, "lerobot.datasets.lerobot_dataset", None)
+
+        assert dr.lerobot_dataset_import_error() == "nope"
+        assert dr.lerobot_dataset_import_error() == "nope"
+        assert len(calls) == 2, "a failed probe must be re-attempted, not cached"
+
+
+class TestRemedyActuallySuppliesTheNamedPackages:
+    """Every package the message names must really ship in ``lerobot[dataset]``.
+
+    The message tells a caller that one command supplies the whole stack. If
+    lerobot moves a package out of that extra, the instruction silently stops
+    being true - and a caller following it is back to the dead end this
+    diagnosis exists to remove.
+    """
+
+    def test_named_packages_ship_in_the_extra_the_message_recommends(self) -> None:
+        pytest.importorskip("lerobot", reason="the extra's contents are read from lerobot's metadata")
+        requirements = importlib.metadata.requires("lerobot") or []
+
+        def resolve(extra: str, seen: frozenset[str] = frozenset()) -> set[str]:
+            """Transitive closure of a lerobot extra (they reference each other)."""
+            if extra in seen:
+                return set()
+            seen = seen | {extra}
+            found: set[str] = set()
+            for raw in requirements:
+                marker = re.search(r"""extra\s*==\s*['"]([^'"]+)['"]""", raw)
+                if not marker or marker.group(1) != extra:
+                    continue
+                spec = raw.split(";")[0].strip()
+                nested = re.match(r"lerobot\[([^\]]+)\]", spec)
+                if nested:
+                    for sub in nested.group(1).split(","):
+                        found |= resolve(sub.strip(), seen)
+                else:
+                    found.add(re.split(r"[<>=!\[ ]", spec, maxsplit=1)[0].lower())
+            return found
+
+        shipped = resolve("dataset")
+        assert shipped, "could not read lerobot[dataset] from lerobot's metadata"
+
+        named = [pkg.strip() for pkg in dr._LEROBOT_DATASET_PACKAGES.split(",")]
+        assert named, "the hint names no packages"
+        assert not set(named) - shipped, (
+            f"the diagnosis names {sorted(set(named) - shipped)}, which lerobot[dataset] "
+            f"does not install (it ships {sorted(shipped)})"
+        )

--- a/tests/test_lerobot_install_hints_pypi.py
+++ b/tests/test_lerobot_install_hints_pypi.py
@@ -58,6 +58,46 @@ class TestMolmoAct2VersionHint:
         assert "git+" not in msg
 
 
+class TestDatasetRecorderHints:
+    """The recording path's hints obey the same currency contract.
+
+    ``start_recording``'s diagnosis has two branches that tell a caller to
+    install a lerobot, and those must name the >=0.6 PyPI floor like every other
+    hint here. Its other two branches deliberately do NOT recommend a lerobot
+    install - a missing dataset dependency and a binary conflict are not fixed by
+    one - so they are held to the opposite contract.
+    """
+
+    def test_absent_lerobot_hint_uses_currency_hint(self, monkeypatch) -> None:
+        from strands_robots import dataset_recorder as dr
+
+        monkeypatch.setattr(dr, "_lerobot_installed", lambda: False)
+        text = dr._describe_lerobot_import_failure(ModuleNotFoundError("nope", name="lerobot"))
+        _assert_currency(text)
+        assert "strands-robots[lerobot]" in text
+
+    def test_moved_module_hint_uses_currency_hint(self, monkeypatch) -> None:
+        from strands_robots import dataset_recorder as dr
+
+        monkeypatch.setattr(dr, "_lerobot_installed", lambda: True)
+        monkeypatch.setattr(dr, "lerobot_version", lambda: "0.6.0")
+        text = dr._describe_lerobot_import_failure(ImportError("gone", name="lerobot.datasets.lerobot_dataset"))
+        _assert_currency(text)
+        assert "strands-robots[lerobot]" in text
+
+    def test_transitive_dep_hint_does_not_send_the_caller_to_reinstall_lerobot(self, monkeypatch) -> None:
+        from strands_robots import dataset_recorder as dr
+
+        monkeypatch.setattr(dr, "_lerobot_installed", lambda: True)
+        monkeypatch.setattr(dr, "lerobot_version", lambda: "0.6.0")
+        text = dr._describe_lerobot_import_failure(ModuleNotFoundError("nope", name="pyarrow"))
+        # Remedy is the dataset extra that supplies it, not a lerobot reinstall.
+        assert "pip install 'lerobot[dataset]'" in text
+        assert "strands-robots" not in text
+        for token in _STALE:
+            assert token not in text
+
+
 class TestRewardModelHints:
     def test_load_reward_model_missing_rewards_uses_currency_hint(self, monkeypatch) -> None:
         from strands_robots.training import reward as reward_mod

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -95,20 +95,6 @@ def test_repo_type_bucket_raises_when_unsupported(monkeypatch):
         sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
 
 
-def test_lerobot_version_unknown_when_metadata_unresolvable(monkeypatch):
-    """_lerobot_version() degrades to 'unknown' instead of raising when the
-    installed-distribution metadata for lerobot cannot be resolved (e.g. a
-    source checkout without dist-info). The value only ever enriches an error
-    message, so a PackageNotFoundError here must not escape."""
-    import importlib.metadata as md
-
-    def _raise(_name):
-        raise md.PackageNotFoundError("lerobot")
-
-    monkeypatch.setattr(md, "version", _raise)
-    assert sd._lerobot_version() == "unknown"
-
-
 def test_bucket_guard_message_survives_unresolvable_lerobot_version(monkeypatch):
     """The repo_type='bucket' fail-fast must surface as the actionable
     RuntimeError even when lerobot's version metadata is unresolvable: the

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -387,3 +387,36 @@ class TestPoseVectorDomain:
         values, error = coerce_pose_vector("m", "position", bad, 3)
         assert values is None
         assert error and error.startswith("m: 'position'")
+
+
+class TestLerobotVersion:
+    """``lerobot_version`` degrades instead of raising.
+
+    Promoted out of the streaming-dataset reader so it and
+    :mod:`strands_robots.dataset_recorder` - which both name the installed
+    version in an error message - cannot report it differently.
+    """
+
+    def test_an_unresolvable_distribution_reads_as_unknown(self, monkeypatch):
+        # A source checkout without dist-info cannot resolve the version. The
+        # value only ever enriches an error message, so a PackageNotFoundError
+        # must not escape and mask the failure being reported.
+        import importlib.metadata as md
+
+        from strands_robots.utils import lerobot_version
+
+        def _raise(_name):
+            raise md.PackageNotFoundError("lerobot")
+
+        monkeypatch.setattr(md, "version", _raise)
+
+        assert lerobot_version() == "unknown"
+
+    def test_a_resolvable_distribution_reads_as_its_version(self, monkeypatch):
+        import importlib.metadata as md
+
+        from strands_robots.utils import lerobot_version
+
+        monkeypatch.setattr(md, "version", lambda _name: "0.6.1")
+
+        assert lerobot_version() == "0.6.1"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -420,3 +420,40 @@ class TestLerobotVersion:
         monkeypatch.setattr(md, "version", lambda _name: "0.6.1")
 
         assert lerobot_version() == "0.6.1"
+
+    def test_an_unimportable_metadata_module_reads_as_unknown(self, monkeypatch):
+        """The other documented failure - the import itself - must also degrade.
+
+        ``importlib.metadata`` is stdlib, so this handler is the defensive half.
+        A handler that cannot run is not a defence though: naming
+        ``PackageNotFoundError`` beside ``ImportError`` bound it as a local the
+        failing import never reaches, so evaluating the handler raised
+        ``UnboundLocalError`` - from a function documented never to raise, and
+        exactly on the branch the second name appeared to cover.
+        """
+        import builtins
+
+        from strands_robots.utils import lerobot_version
+
+        real_import = builtins.__import__
+
+        def _no_metadata(name, *args, **kwargs):
+            if name == "importlib.metadata":
+                raise ImportError(f"No module named {name!r}")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_metadata)
+
+        assert lerobot_version() == "unknown"
+
+    def test_an_unresolvable_distribution_is_already_an_import_error(self):
+        """The single handler rests on a stdlib hierarchy, so assert it.
+
+        ``version`` raises ``PackageNotFoundError`` and the one-name handler
+        catches it as an ``ImportError``. Were a future CPython to stop deriving
+        it from ``ModuleNotFoundError``, that handler would silently stop
+        catching it, so the premise is pinned here rather than left to prose.
+        """
+        import importlib.metadata as md
+
+        assert issubclass(md.PackageNotFoundError, ImportError)


### PR DESCRIPTION
## Problem

`start_recording` gates on `has_lerobot_dataset()`, which collapses **every** way importing `lerobot.datasets.lerobot_dataset` can fail into a single `False`. All three backends turn that `False` into one message:

> `start_recording produces a LeRobotDataset (parquet + video) and requires the lerobot extra: pip install 'strands-robots[lerobot]'.`

In a partially-provisioned environment — lerobot itself installed, but one of the packages its dataset stack needs absent — that instruction names a package the caller already has:

```python
# lerobot 0.6.1 installed; `datasets` is not
sim.start_recording(repo_id="user/ds", task="pick")
# status=error, "requires the lerobot extra: pip install 'strands-robots[lerobot]'"
```

`pip show lerobot` then says `Version: 0.6.1`, so the advice reads as the library being wrong about its own dependency, and the real cause is never stated. Measured on Thor by hiding one package from the import system and calling the real `start_recording`: `datasets`, `pyarrow` and `av` each produce the **identical** message, and none of them names the package that is actually missing.

The repo already draws this exact distinction one layer over, in `strands_robots.policies.lerobot_local.molmoact2._factory_import_error`, whose docstring states the principle:

> a *transitive* dependency that the factory pulls in is missing — here `exc.name` names a non-lerobot package. The fix is to install THAT package; **telling the caller to reinstall lerobot is a dead end that sends a partially-provisioned env chasing the wrong remedy.**

The recording path never got it.

## Change

New `dataset_recorder.lerobot_dataset_import_error()` returns `None` when `LeRobotDataset` imports and otherwise the diagnosis. `has_lerobot_dataset()` becomes a thin predicate over it (`... is None`) so one probe answers both questions and the two cannot disagree. All three backends call the reason-bearing probe and report it verbatim, keeping their own plain-MP4 fallback advice.

Four causes now get four different instructions — and the fourth is the one an install cannot fix:

| cause | instruction |
|---|---|
| lerobot absent | `pip install 'strands-robots[lerobot]'` |
| lerobot present, a dataset dependency absent | `pip install 'lerobot[dataset]'` — plain `pip install lerobot` does not pull those in |
| lerobot present, no longer exports the module we import | install an in-range lerobot (`>= 0.6.0,<0.7.0`) |
| import failed with **nothing** missing | no install fixes it — reconcile the conflicting packages |

Only a non-`ImportError` may claim that nothing is missing: an `ImportError` whose `name` is unset still reports a failed import, so sending that caller after a binary conflict they may not have would be a new dead end. The fourth branch is the numpy/pandas ABI mismatch this module's own comment already describes as the reason `ValueError`/`RuntimeError` are caught here.

The transitive-dep branch names the **whole** dataset set in one command rather than the single package that happened to be imported first: a caller who installed lerobot without the extra is missing all of it, so one install ends the loop instead of revealing the next missing package on the retry — the same reasoning `utils.require_optionals` documents.

`streaming_dataset._lerobot_version` is promoted to `utils.lerobot_version` (public, cycle-proof layer) so the two modules that now name the installed version in an error message cannot report it differently; its contract test moves to `tests/test_utils.py` with the code.

## Remedy verification

The message tells the caller one command supplies the whole stack, so that claim is measured rather than asserted. Resolving `lerobot[dataset]`'s transitive closure from lerobot's own metadata (it references `lerobot[av-dep]`):

```
lerobot[dataset] -> ['av', 'datasets', 'jsonlines', 'pandas', 'pyarrow', 'torchcodec']
every package the diagnosis names is in that set
```

`TestRemedyActuallySuppliesTheNamedPackages` pins it, so if lerobot moves a package out of that extra the instruction fails a test instead of silently becoming untrue.

## Artifact

Measured on Thor, MuJoCo headless (`MUJOCO_GL=egl`). Each row is a real `start_recording` call with one package hidden from the import system, run against both trees; every cell in the figure is read from the two runs' JSON and audited by the generator (which asserts main gives *one* message for all four causes and this PR gives four distinct ones).

![start_recording lerobot dependency diagnosis](https://raw.githubusercontent.com/cagataycali/robots/artifacts/lerobot-dataset-import-diagnosis/diagnosis.png)

The healthy-install control is the top-left panel: a real frame decoded back out of the recorded dataset MP4 after a 45-step rollout. `rollout=success`, `stop_recording=success`, 45 frames, 2 MP4s — and the decoded frame is **byte-identical** on main and on this branch (`max|delta| = 0`), so a working install records exactly as before.

## Tests

`tests/test_lerobot_dataset_import_diagnosis.py` (25) covers each cause's own remedy, that a missing dataset dependency is named and never reported as lerobot being absent, that the predicate is exactly "there is no reason", and that a success is still cached while a failure is still re-attempted.

`tests/test_lerobot_install_hints_pypi.py` gains `TestDatasetRecorderHints` (3), reusing that file's existing `_assert_currency` contract: the two branches that do recommend a lerobot install must name the `>= 0.6` PyPI floor, and the transitive-dep branch is held to the opposite contract (it must *not* send the caller to reinstall lerobot) — mirroring the sibling guard already there for the policy factory.

The three existing backend guard tests now patch the reason-bearing probe and additionally assert the reason is surfaced **verbatim**, which is stronger than the previous "the word lerobot appears".

**Pre-fix proof**, re-measured at the current base over the seven test files this PR touches (`strands_robots/{dataset_recorder,utils,streaming_dataset}.py` and the three backend `recording.py` reverted to `upstream/main`, tests kept): `16 failed, 137 passed, 18 errors`. The 18 errors are fixture setup — the symbols do not exist on main. Those that pass are the over-reach controls (a healthy install still records; the absent-lerobot branch keeps its existing advice) and unrelated pinned behaviour in those files; they are what stops the change over-reaching.

## Gate

Rebased onto `main` at `e5674737`. The branch was still based on `3107c942`, so #1793 read as reverted in `git diff main...HEAD` — 398 phantom content lines, now gone (1228 → 820). `scripts/check_merge_base_overlap.py` reported no overlap before and after, so the rebase was for diff hygiene rather than to repair an invalidated check; #1793's content is verified intact on the rebased tree.

```
ruff check strands_robots tests tests_integ            All checks passed!
ruff format --check strands_robots tests tests_integ   983 files already formatted
mypy strands_robots tests tests_integ                  Success: no issues found in 980 source files
MUJOCO_GL=egl pytest tests                             15246 passed, 255 skipped in 523.79s
python scripts/assemble_changelog.py --check            changelog fragments OK (76 pending)
python scripts/check_merge_base_overlap.py              No overlap
tests/test_{changelog_fragments,changelog_format,docstrings_no_dangling_doc_refs,source_strings_no_internal_file_paths}.py
                                                        38 passed
```

## Round 2 — uninitialized local in the promoted helper

CodeQL flagged `utils.lerobot_version` (alert 835, error severity). The alert is right, and the failure lands on the exact branch the flagged name looked like it was covering.

An `except` tuple is evaluated when an exception arrives, and `PackageNotFoundError` was bound by the `from importlib.metadata import ...` inside the same `try`. If that import is what fails, the name is unbound and the handler itself raises — out of a function documented never to raise:

```
UnboundLocalError: cannot access local variable 'PackageNotFoundError'
where it is not associated with a value
```

The second name is also **redundant**, which is what makes the fix a deletion rather than a shim:

```
PackageNotFoundError.__mro__ -> PackageNotFoundError, ModuleNotFoundError, ImportError, Exception, ...
issubclass(PackageNotFoundError, ImportError) = True
```

`except ImportError` alone therefore covers both an unresolvable distribution and a failed import of `importlib.metadata`, so the handler drops to one name.

The two sibling readers of the same metadata API already avoid this, in two different ways: `doctor._resolve_version` puts the import **outside** its `try`, and `tools.harness_memory._version_string` reads the exception off a module-level alias. `lerobot_version` was the only site that moved the import inside the `try` while naming one of its symbols in the handler, and `grep -rn PackageNotFoundError strands_robots/` confirms there is no third.

This also clears alert **778**, open on `main` since 2026-07-22 for the identical pattern at `streaming_dataset.py:86` — that copy is the one this PR promotes into `utils`, and the promoted version no longer carries it.

`TestLerobotVersion` gains the second documented failure mode (the import itself, `1 failed, 3 passed` against the pre-fix source — the traceback points at the handler line) and an assertion on the stdlib hierarchy the one-name handler now rests on, so a future CPython that stopped deriving `PackageNotFoundError` from `ModuleNotFoundError` would fail a test rather than silently stop being caught. The existing tests patch `version`, so the import succeeds and neither of them could reach this branch.

## Out of scope

`torchcodec` is **not** required to import `LeRobotDataset` (verified: hiding it leaves `start_recording` succeeding) — it is needed to decode video later, which is a different surface with a different failure point. It is named in the install hint because it ships in the same extra, so one command still covers it.

