### PR TITLE
docs: a cancelled check aggregates into a FAILURE rollup, and a rapid merge batch verifies only the tip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,28 @@ hatch run format            # ruff check --fix, ruff format
      mutation returned that error and the squash was already on `main`. Confirm
      with `state`/`merged`, or `git log origin/main`, before concluding a merge
      failed and redoing the work.
+   - *And on `main` afterwards.* A rollup of `FAILURE` on a merge commit is not
+     evidence that the squash broke anything: a **cancelled** check aggregates
+     into `FAILURE`. `pr-and-push.yml` keys its concurrency group on
+     `github.event.pull_request.number || github.ref`, and on a push there is no
+     PR number, so every push to `refs/heads/main` shares one group under
+     `cancel-in-progress: true` - each merge kills the run of the merge before
+     it. Read each context's own `conclusion` before you believe the rollup.
+     Four PRs merged in the 22 minutes from 03:03:44 to 03:25:25 left three
+     consecutive commits - #1788, #1794, #1796 - each reporting rollup
+     `FAILURE` whose only non-`SUCCESS` context was
+     `call-test-lint / Test and Lint` = `CANCELLED`, killed at 1m07s, 15m00s
+     and 5m38s into their runs. Nothing had failed. See #1800.
+
+     The same timings carry a cost that is not a misread: that suite had not
+     finished in 15m00s, so merging faster than it runs leaves **only the tip
+     verified** and no intermediate commit attributable. A batch is still
+     defensible - each of those four was individually green, passed
+     `Detect an untested overlap with the base branch`, and touched a file set
+     disjoint from the others - but price it knowingly: a red tip then costs a
+     manual bisect, and an intermediate commit's green is not available to lean
+     on. Do not read the intermediate `FAILURE`s as the culprit; they are the
+     batching, not a defect.
    And before merging, `reviewDecision: APPROVED` alone is not the gate: poll
    `statusCheckRollup.state == SUCCESS` and `mergeStateStatus == CLEAN`
    together, since `reviewDecision` flips before the checks finish.

--- a/changelog.d/1800-rollup-cancelled-is-not-a-failure.md
+++ b/changelog.d/1800-rollup-cancelled-is-not-a-failure.md
@@ -1,0 +1,24 @@
+### Docs: a cancelled check aggregates into a `FAILURE` rollup, and a rapid merge batch verifies only the tip
+
+`AGENTS.md` > PR Workflow > step 8 said how to verify a pull request before and
+after merging, but not how to read `main` afterwards. The obvious reading is
+wrong in a way that invites reverting a good change: `statusCheckRollup.state`
+reports `FAILURE` when a check was merely **cancelled**, and the checks UI draws
+that the same red as a genuine failure.
+
+`pr-and-push.yml` keys its concurrency group on
+`github.event.pull_request.number || github.ref`. A push carries no pull request
+number, so every push to `refs/heads/main` collapses into one group under
+`cancel-in-progress: true` and each merge kills the run of the merge before it.
+Four PRs merged inside 22 minutes left three consecutive commits (#1788, #1794,
+#1796) each reporting rollup `FAILURE` whose only non-`SUCCESS` context was
+`call-test-lint / Test and Lint` = `CANCELLED`, killed 1m07s, 15m00s and 5m38s
+into their runs. Nothing had failed.
+
+The timings also record a real cost rather than a misread: the suite had not
+finished in 15m00s, so merging faster than it runs leaves only the tip verified
+and no intermediate commit attributable. The new sub-bullet says to read each
+context's own `conclusion` before believing the rollup, and to price a batch
+knowingly - a red tip then costs a manual bisect.
+
+Documentation only; no production code or test behaviour changes.


### PR DESCRIPTION
Closes #1800.

## The misread

`AGENTS.md` > PR Workflow > step 8 says how to verify a pull request *before* and *after* merging. It says nothing about reading `main` afterwards, and the obvious reading is wrong in a direction that costs a good change.

`statusCheckRollup.state` returns `FAILURE` when a check was merely **cancelled**. Cancellation is not a verdict, but it aggregates as one, and the checks UI draws it the same red as a real failure.

The mechanism is in `pr-and-push.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

A `push` carries no `pull_request.number`, so the key falls through to `github.ref` and every push to `refs/heads/main` collapses into a single group. Each merge therefore kills the run of the merge before it.

## Measured

Four PRs merged in the 22 minutes from 03:03:44 to 03:25:25. Three consecutive commits on `main` report rollup `FAILURE`:

| commit | PR | committed | test-lint started | cancelled | elapsed when killed |
|---|---|---|---|---|---|
| `a648a00` | #1788 | 03:03:44 | 03:03:52 | 03:04:59 | 1m07s |
| `c753a76` | #1794 | 03:04:39 | 03:05:02 | 03:20:02 | 15m00s |
| `3107c94` | #1796 | 03:19:42 | 03:20:06 | 03:25:44 | 5m38s |
| `e567473` | #1793 | 03:25:25 | 03:25:47 | - | still running |

On all three, the only non-`SUCCESS` context is `call-test-lint / Test and Lint` = `CANCELLED`. Every other context is `SUCCESS`. **Nothing failed.** The natural conclusion from the rollup alone -- that one of those squashes broke the build -- is available, cheap, and false, and the remedy it suggests is reverting a reviewed, individually-green change.

I hit this misread twice in one session before reading the contexts, which is what convinced me it belongs in the file rather than in a comment.

## The half that is not a misread

The same timings carry a real cost. `c753a76`'s run reached 15m00s without finishing, so the suite outruns the interval between merges at that cadence. Only the tip is ever verified: each intermediate merge commit's run is killed before it can report, so no intermediate commit is attributable. If the tip goes red you cannot say which of the four did it without re-running each.

The batch is still defensible -- each of the four had its own green `call-test-lint`, each passed `Detect an untested overlap with the base branch`, and their file sets were pairwise disjoint -- but the coverage that results is tip-only, and that is worth knowing before leaning on an intermediate commit's green. So the guidance is to price it knowingly, not to forbid it.

## The change

One sub-bullet under step 8, alongside the existing *Before.* / *After.* pair, covering both halves: read each context's own `conclusion` before believing the rollup, and treat a rapid batch as tip-only coverage where a red tip costs a manual bisect.

Placed there rather than in a new section because it completes a sequence that already reads *before merge -> after merge*, and the two existing bullets are the same shape: a GitHub API field whose plain reading misleads, with the measured case attached.

## Scope

Documentation and a changelog fragment. No production code, no workflow change, no test behaviour change.

I deliberately did **not** change the concurrency group to stop cancelling on `main`. Serialising the suite per-commit would make every merge wait on the previous one, and the cancellation is the right default for the pull request case that key mostly serves. The batching is a real tradeoff someone may want to revisit, but it is a separate decision from documenting how to read its output, and folding it in here would put a workflow change under a docs review.

## Verification

```
python3 scripts/assemble_changelog.py --check        changelog fragments OK (76 pending)
python3 scripts/check_changelog_fragment.py         No entry was added to CHANGELOG.md's [Unreleased]
```

Every number in the table above is read back from `statusCheckRollup.contexts` on the four commits, not reconstructed from memory. The `pr-and-push.yml` group key is quoted verbatim from `main`.