### PR TITLE
fix(sim): read the engine's contact payload in success_fn="contact"

### DIFF
--- a/changelog.d/1787-success-fn-contact-reads-engine-payload.md
+++ b/changelog.d/1787-success-fn-contact-reads-engine-payload.md
@@ -1,0 +1,16 @@
+### Fixed: `success_fn="contact"` reads the payload the engine returns
+
+`PolicyRunner.evaluate(success_fn="contact")` -- the sparse-success mode
+`eval_policy`'s own docstring recommends -- indexed the `get_contacts` result as
+if the result were the payload (`result["n_contacts"]`, `result["contacts"]`).
+Backends return the agent-tool envelope, whose only top-level keys are `status`
+and `content`, so both lookups missed and every episode scored a failure no
+matter what the arm did: a cube resting on a plate under 4.9 N of solver force
+evaluated to `success_rate: 0.0`. The bare mapping a test double returns did
+satisfy that reader, so the divergence never surfaced in the suite.
+
+The mode now shares the predicate DSL's `contact_any`, whose docstring already
+claimed to match it, so there is one reader for both surfaces. `_extract_json`
+reads a result with no `content` blocks as the payload itself, keeping a minimal
+engine that returns a plain reading understood, and
+`SimEngine.get_contacts` now documents where its records actually live.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -3249,7 +3249,23 @@ class SimEngine(ABC):
         raise NotImplementedError("set_obs_noise not implemented by this backend")
 
     def get_contacts(self) -> dict[str, Any]:
-        """Get contact information. Override per backend."""
+        """Get contact information. Override per backend.
+
+        Returns:
+            The agent-tool envelope -- ``{"status": ..., "content": [...]}`` --
+            whose ``json`` content block carries ``contacts``, a list of
+            per-contact records. The payload lives in that block, not on the
+            envelope itself, so a caller reading ``result["contacts"]``
+            directly always misses. The predicate DSL's ``contact_*``
+            factories (see
+            :mod:`strands_robots.simulation.predicates`) are the supported
+            readers; ``success_fn="contact"`` on
+            :meth:`~strands_robots.simulation.policy_runner.PolicyRunner.evaluate`
+            shares them.
+
+        Raises:
+            NotImplementedError: Backends that expose no contact list.
+        """
         raise NotImplementedError("get_contacts not implemented by this backend")
 
     # Raw-frame render APIs (programmatic, not tool-envelope). Optional per

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from strands_robots.simulation.benchmark import BenchmarkProtocol
 
 from strands_robots.simulation.models import TrajectoryStep
+from strands_robots.simulation.predicates import make_predicate
 from strands_robots.simulation.safe_output import validate_output_path, video_sandbox_args
 
 logger = logging.getLogger(__name__)
@@ -2967,25 +2968,15 @@ class PolicyRunner:
             return success_fn
         if success_fn == "contact":
             sim = self.sim
+            # Share the DSL's reader instead of keeping a second one. The
+            # inline copy this replaces indexed the engine result as if it
+            # were the payload, so it never saw a real backend's envelope and
+            # scored every episode a failure - while still working against a
+            # test double that returns the bare mapping.
+            contact_any = make_predicate("contact_any")
 
             def _contact_check(_obs: dict[str, Any]) -> bool:
-                get_contacts = getattr(sim, "get_contacts", None)
-                if get_contacts is None:
-                    return False
-                try:
-                    result = get_contacts()
-                except NotImplementedError:
-                    return False
-                except Exception:
-                    return False
-                # Accept either {"contacts": [...]} or {"n_contacts": int}
-                if isinstance(result, dict):
-                    if result.get("n_contacts", 0) > 0:
-                        return True
-                    contacts = result.get("contacts")
-                    if isinstance(contacts, list) and contacts:
-                        return True
-                return False
+                return bool(contact_any(sim))
 
             return _contact_check
         raise ValueError(f"Unknown success_fn string: {success_fn!r}")

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -55,7 +55,6 @@ if TYPE_CHECKING:
     from strands_robots.simulation.benchmark import BenchmarkProtocol
 
 from strands_robots.simulation.models import TrajectoryStep
-from strands_robots.simulation.predicates import make_predicate
 from strands_robots.simulation.safe_output import validate_output_path, video_sandbox_args
 
 logger = logging.getLogger(__name__)
@@ -2973,6 +2972,17 @@ class PolicyRunner:
             # were the payload, so it never saw a real backend's envelope and
             # scored every episode a failure - while still working against a
             # test double that returns the bare mapping.
+            #
+            # Imported inside the method, not at module level: base.py imports
+            # this module at import time and predicates.py imports base under
+            # TYPE_CHECKING, so a module-level edge from here to predicates
+            # closes a loop that CodeQL's py/unsafe-cyclic-import walks - it
+            # does not honour the guard (see the #191 note on base.py's import
+            # of this module). No runtime cycle exists either way, and base.py
+            # reaches into predicates the same way from
+            # ``_stop_when_unresolved_error``.
+            from strands_robots.simulation.predicates import make_predicate
+
             contact_any = make_predicate("contact_any")
 
             def _contact_check(_obs: dict[str, Any]) -> bool:

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -124,9 +124,21 @@ def _reset_resolution_warnings() -> None:
 
 
 def _extract_json(result: dict[str, Any] | None) -> dict[str, Any]:
-    """Return the ``json`` content block payload, or ``{}`` if absent."""
+    """Return a backend result's payload mapping, or ``{}`` if there is none.
+
+    Every in-tree backend returns the agent-tool envelope, so the payload is
+    the ``json`` content block -- see
+    :meth:`strands_robots.simulation.base.SimEngine.get_contacts` for the
+    shape. A result that carries no ``content`` at all is not an envelope, so
+    the mapping itself is the payload: a minimal engine can return a plain
+    reading without wrapping it, and every predicate reads both shapes the
+    same way instead of each one guessing.
+    """
     if not isinstance(result, dict):
         return {}
+    if "content" not in result:
+        # Not an envelope - the mapping is the payload.
+        return dict(result)
     for block in result.get("content", []) or []:
         if isinstance(block, dict):
             payload = block.get("json")

--- a/tests/simulation/mujoco/test_success_fn_contact_reads_the_engine_payload.py
+++ b/tests/simulation/mujoco/test_success_fn_contact_reads_the_engine_payload.py
@@ -1,0 +1,254 @@
+"""``success_fn="contact"`` must read the payload the engine actually returns.
+
+The string is one of exactly two values
+:meth:`~strands_robots.simulation.policy_runner.PolicyRunner.evaluate` accepts
+for sparse success, and ``eval_policy``'s own docstring recommends it. The
+reader behind it indexed the ``get_contacts`` result as if the result *were*
+the payload::
+
+    if result.get("n_contacts", 0) > 0: ...
+    contacts = result.get("contacts")
+
+Every in-tree backend returns the agent-tool envelope, whose only top-level
+keys are ``status`` and ``content``, so both lookups missed and the check
+returned ``False`` for every episode regardless of what the arm did. The bare
+mapping a test double returns *did* satisfy that reader, which is why the
+divergence never showed up in the suite: the code worked for the stub and
+failed for the engine.
+
+The mode now shares the predicate DSL's ``contact_any`` -- whose docstring
+already claimed to "match the legacy ``success_fn='contact'`` path" -- so
+there is one reader instead of two. These tests pin:
+
+* the engine consequence: a resting pair scores a success and a separated
+  pair does not, with the scene's premise measured through
+  ``get_contact_forces`` so it cannot silently drift into a no-contact scene;
+* the envelope premise: the contact list is reachable only through a ``json``
+  content block, which is why the replaced reader could not work;
+* parity: the string mode and ``make_predicate("contact_any")`` agree for
+  every payload shape either one accepts, so they cannot drift apart again;
+* the shape tolerance: an envelope and a bare payload mapping read alike, so
+  a minimal engine that returns a plain reading is still understood.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+from strands_robots.simulation import Simulation
+from strands_robots.simulation.policy_runner import PolicyRunner
+from strands_robots.simulation.predicates import _extract_json, make_predicate
+from tests.simulation.test_policy_runner import FakeSim
+
+# A one-hinge arm so ``evaluate`` has a robot to drive. The base geom is offset
+# well clear of the link capsule: a self-contact inside the arm would make the
+# separated control case report a contact and the test would pass vacuously.
+ARM_XML = """<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.40">
+      <geom name="post" type="box" size="0.03 0.03 0.03" pos="0 0 -0.14" rgba="0.3 0.3 0.35 1"/>
+      <body name="link1" pos="0 0 0">
+        <joint name="j1" type="hinge" axis="0 0 1" range="-2 2" limited="true" damping="3"/>
+        <geom name="l1" type="capsule" fromto="0 0 0 0.18 0 0" size="0.025" rgba="0.2 0.45 0.85 1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><position name="a1" joint="j1" kp="30" ctrlrange="-2 2"/></actuator>
+</mujoco>
+"""
+
+CUBE_MASS = 0.5
+_SETTLE_STEPS = 120
+
+
+def _payload(result: dict[str, Any]) -> dict[str, Any]:
+    """Read a tool result's ``json`` content block the way a caller must."""
+    return next((b["json"] for b in result.get("content", []) if "json" in b), {})
+
+
+def _build(tmp_path, *, touching: bool):
+    """A cube either resting on a static plate or floating well above it."""
+    arm = tmp_path / "arm.xml"
+    arm.write_text(ARM_XML)
+    sim = Simulation(backend="mujoco", mesh=False)
+    # No ground plane: the only contact the scene can report is the pair under
+    # test, so a verdict cannot come from the robot standing on the floor.
+    assert sim.create_world(ground_plane=False)["status"] == "success"
+    assert sim.add_robot(name="arm", urdf_path=str(arm))["status"] == "success"
+    assert (
+        sim.add_object(
+            "plate",
+            shape="box",
+            position=[0.42, 0.0, 0.10],
+            size=[0.30, 0.30, 0.04],
+            color=[0.85, 0.85, 0.88, 1.0],
+            is_static=True,
+        )["status"]
+        == "success"
+    )
+    assert (
+        sim.add_object(
+            "cube",
+            shape="box",
+            position=[0.42, 0.0, 0.19 if touching else 0.62],
+            size=[0.12, 0.12, 0.12],
+            color=[0.95, 0.45, 0.12, 1.0],
+            mass=CUBE_MASS,
+        )["status"]
+        == "success"
+    )
+    sim.step(_SETTLE_STEPS)
+    return sim
+
+
+def _normal_force(sim) -> float:
+    """Total normal force the solver reports, in newtons."""
+    contacts = _payload(sim.get_contact_forces()).get("contacts", [])
+    return sum(abs(float(c.get("normal_force", 0.0))) for c in contacts)
+
+
+def _evaluate(sim) -> dict[str, Any]:
+    result = sim.eval_policy(
+        robot_name="arm",
+        policy_provider="mock",
+        n_episodes=2,
+        max_steps=12,
+        success_fn="contact",
+        control_frequency=50.0,
+    )
+    assert result["status"] == "success"
+    return _payload(result)
+
+
+class TestAgainstTheRealEngine:
+    """The consequence a caller sees: an evaluated success rate."""
+
+    def test_a_resting_pair_scores_the_episode_a_success(self, tmp_path):
+        """A cube at rest on a plate is a contact, so every episode succeeds.
+
+        The premise is measured rather than assumed: the solver carries the
+        cube's full weight, so a scene that silently stopped touching would
+        fail here instead of turning this into a vacuous pass.
+        """
+        sim = _build(tmp_path, touching=True)
+        try:
+            assert _normal_force(sim) == pytest.approx(CUBE_MASS * 9.81, rel=0.05)
+            report = _evaluate(sim)
+            assert report["success_measured"] is True
+            assert report["success_rate"] == 1.0
+        finally:
+            sim.cleanup()
+
+    def test_a_separated_pair_scores_no_success(self, tmp_path):
+        """The same scene with the cube in free fall must score nothing.
+
+        Without this the fix could be "always report success" and the suite
+        would not notice.
+        """
+        sim = _build(tmp_path, touching=False)
+        try:
+            assert _payload(sim.get_contacts())["contacts"] == []
+            assert _normal_force(sim) == 0.0
+            assert _evaluate(sim)["success_rate"] == 0.0
+        finally:
+            sim.cleanup()
+
+    def test_the_contact_list_is_only_reachable_through_a_content_block(self, tmp_path):
+        """Why the replaced reader could not work, pinned as a premise.
+
+        ``get_contacts`` carries its records inside the envelope's ``json``
+        block; the envelope itself has neither ``contacts`` nor ``n_contacts``.
+        Any reader indexing the result directly misses both.
+        """
+        sim = _build(tmp_path, touching=True)
+        try:
+            result = sim.get_contacts()
+            assert sorted(result) == ["content", "status"]
+            assert "contacts" not in result
+            assert "n_contacts" not in result
+            assert len(_payload(result)["contacts"]) > 0
+        finally:
+            sim.cleanup()
+
+
+class _ContactSim(FakeSim):
+    """A sim whose ``get_contacts`` returns a caller-supplied result."""
+
+    def __init__(self, result: Any):
+        super().__init__()
+        self._result = result
+
+    def get_contacts(self) -> Any:
+        if isinstance(self._result, BaseException):
+            raise self._result
+        return self._result
+
+
+ENVELOPE_TOUCHING = {"status": "success", "content": [{"json": {"contacts": [{"geom1": "a", "geom2": "b"}]}}]}
+ENVELOPE_EMPTY = {"status": "success", "content": [{"text": "No contacts."}, {"json": {"contacts": []}}]}
+ENVELOPE_ERROR = {"status": "error", "content": [{"text": "No world."}]}
+
+# Payload shapes, and whether "any contact" holds for each.
+PAYLOAD_SHAPES: list[tuple[str, Any]] = [
+    ("envelope_with_contacts", ENVELOPE_TOUCHING),
+    ("envelope_empty_list", ENVELOPE_EMPTY),
+    ("envelope_error", ENVELOPE_ERROR),
+    ("bare_positive_count", {"n_contacts": 2}),
+    ("bare_zero_count", {"n_contacts": 0}),
+    ("bare_contacts_list", {"contacts": [{"geom1": "hand", "geom2": "cube"}]}),
+    ("bare_empty_mapping", {}),
+    ("malformed_contacts", {"contacts": "not-a-list", "n_contacts": 0}),
+    ("not_a_mapping", "unexpected"),
+    ("raises", NotImplementedError("backend has no contacts")),
+    ("raises_unexpectedly", RuntimeError("boom")),
+]
+
+
+class TestOneReaderForBothSurfaces:
+    """The string mode and the DSL predicate must not drift apart again."""
+
+    @pytest.mark.parametrize("label, result", PAYLOAD_SHAPES, ids=[label for label, _ in PAYLOAD_SHAPES])
+    def test_the_string_mode_agrees_with_the_contact_any_predicate(self, label, result):
+        """Both surfaces read one payload the same way, for every shape."""
+        sim = _ContactSim(result)
+        success_fn = PolicyRunner(sim)._resolve_success_fn("contact")
+        assert success_fn is not None
+        assert success_fn({}) is make_predicate("contact_any")(sim), label
+
+    def test_the_engine_envelope_is_understood_by_both(self):
+        """The shape that used to score nothing now scores a success."""
+        sim = _ContactSim(ENVELOPE_TOUCHING)
+        assert PolicyRunner(sim)._resolve_success_fn("contact")({}) is True
+        assert make_predicate("contact_any")(sim) is True
+
+    def test_a_missing_get_contacts_is_not_a_success(self):
+        """A backend with no contact list scores nothing rather than raising."""
+
+        class _NoContacts(FakeSim):
+            get_contacts = None  # type: ignore[assignment]
+
+        sim = _NoContacts()
+        assert PolicyRunner(sim)._resolve_success_fn("contact")({}) is False
+
+
+class TestPayloadShapeTolerance:
+    """``_extract_json`` reads an envelope and a bare payload mapping alike."""
+
+    def test_an_envelope_yields_its_json_block(self):
+        assert _extract_json(ENVELOPE_TOUCHING) == {"contacts": [{"geom1": "a", "geom2": "b"}]}
+
+    def test_an_envelope_without_a_json_block_yields_nothing(self):
+        assert _extract_json(ENVELOPE_ERROR) == {}
+
+    def test_a_bare_mapping_is_the_payload(self):
+        """A result with no ``content`` at all is not an envelope."""
+        assert _extract_json({"n_contacts": 2}) == {"n_contacts": 2}
+
+    def test_a_non_mapping_yields_nothing(self):
+        assert _extract_json(None) == {}


### PR DESCRIPTION
Closes #1787.

## Problem

`PolicyRunner.evaluate(success_fn="contact")` is one of exactly two values that method accepts for sparse success, and `eval_policy`'s own docstring recommends it. The reader behind it indexed the `get_contacts` result as if the result *were* the payload:

```python
if result.get("n_contacts", 0) > 0:
    return True
contacts = result.get("contacts")
```

Backends return the agent-tool envelope, whose only top-level keys are `status` and `content` — the contact records live inside the `json` block. Both lookups missed, so the check returned `False` for every episode regardless of what the arm did. On MuJoCo the payload does not even carry `n_contacts`, so that branch is unreachable there under any reading.

The bare mapping a test double returns *did* satisfy that reader. That is why the divergence never surfaced: the code worked for the stub and failed for the engine. The predicate DSL's `contact_any` — whose docstring already says it "matches the legacy `success_fn='contact'` path" — read the same payload correctly the whole time, so one contact list produced two opposite answers.

## Measured (mujoco 3.11.0, `MUJOCO_GL=egl`)

A 0.5 kg cube at rest on a static plate. The solver admits four contacts carrying 4.905 N — exactly the cube's weight.

| | `main` | this change |
|---|---|---|
| `get_contacts()` → `json` block | 4 contacts | 4 contacts |
| total normal force | 4.905 N | 4.905 N |
| `make_predicate("contact_any")` | `True` | `True` |
| `success_fn="contact"` verdict | **`False`** | **`True`** |
| `eval_policy` `success_rate` | **`0.0`** | **`1.0`** |
| episodes scored a success | **0 of 3** | **3 of 3** |

The divergence ran in both directions: on `main` the envelope shape scored nothing while the predicate scored a touch, and the bare-mapping shape scored a touch while the predicate scored nothing.

![success_fn=contact verdict on a resting pair](https://raw.githubusercontent.com/cagataycali/robots/artifacts/success-fn-contact/success-fn-contact-verdict.png)

The render is byte-identical on both trees (max pixel delta = 0). This changes what the evaluator reads, never what the physics does — so the artifact is one scene with two verdicts rather than a before/after image pair.

## Change

- `PolicyRunner._resolve_success_fn("contact")` delegates to `make_predicate("contact_any")` instead of keeping a second reader. The inline copy is deleted; the predicate's parity claim is now true by construction.
- `predicates._extract_json` reads a result that carries no `content` blocks as the payload itself. A minimal engine returning a plain reading stays understood, and every predicate accepts the same two shapes instead of each one guessing. The fallback only fires for a non-envelope mapping, so an error envelope still yields `{}` exactly as before.
- `SimEngine.get_contacts` documents where its records live and which readers are supported — the ambiguity is what let a caller write the wrong lookup.

Zero existing tests changed: the delegation is verdict-preserving for every shape the previous reader accepted, including the bare-mapping stubs in `tests/simulation/test_policy_runner_paths.py`.

## Tests

`tests/simulation/mujoco/test_success_fn_contact_reads_the_engine_payload.py`, 20 tests:

- **against the real engine** — a resting pair scores every episode a success; a separated pair scores none (so "always report success" cannot pass); the resting scene's premise is measured through `get_contact_forces` against `m·g`, so it cannot silently drift into a no-contact scene.
- **the envelope premise** — the contact list is reachable only through a `json` block and the envelope has neither `contacts` nor `n_contacts`, which is why the replaced reader could not work.
- **parity** — `success_fn="contact"` and `make_predicate("contact_any")` return the same verdict across 11 payload shapes (envelope with/without contacts, error envelope, bare count, bare list, empty, malformed, non-mapping, and two raising backends), so the two cannot drift apart again.
- **shape tolerance** — an envelope and a bare payload mapping read alike; an error envelope and a non-mapping still yield nothing.

The scene deliberately has no ground plane and an arm whose base geom is clear of its link capsule: a floor or self contact would let the separated control case report a touch and pass vacuously.

Pre-fix (source reverted, tests kept): **6 failed / 14 passed** — the resting-pair success rate, the envelope verdict, the bare-mapping payload read, and parity on `envelope_with_contacts`, `bare_positive_count`, `bare_contacts_list`. The 14 that pass are the negative controls and the shapes both readers already agreed on; they are what stops the fix over-reaching.

## Gate (Thor, aarch64, mujoco 3.11.0)

- `ruff check strands_robots tests tests_integ` — clean
- `ruff format --check strands_robots tests tests_integ` — 983 files already formatted
- `mypy strands_robots tests tests_integ` — clean, 980 source files
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` — **15235 passed, 255 skipped** in 508s
- `python scripts/assemble_changelog.py --check` — OK
- `python3 scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` — no overlap, branched at `e5674737`

## Out of scope

Whether a proximity-only record should count as a touch is #1781 / #1786, which changes what `contact_any` considers active. That is a property of the shared reader, so this path inherits whichever answer lands there — which is the point of having one reader.

---

## Round 1 changelog

**`76ecceb` — defer the `predicates` import so the static import loop stays open.** The first push added `from strands_robots.simulation.predicates import make_predicate` at module level, and the code-scanning check failed the PR on a module-level cyclic import. The loop is real in the AST and only there: `base.py` imports this module at import time (line 51) and `predicates.py` imports `base` under `TYPE_CHECKING`, a guard the rule walks without honouring, so the new edge closed the ring. At runtime `predicates` imports nothing from `base`, so no cycle exists in either shape — `import` of `predicates`, `policy_runner`, `base`, and the `simulation` package each succeed first in a fresh interpreter on both trees.

The import now lives inside `_resolve_success_fn`, which is exactly how `base.py` already reaches into `predicates` from `_stop_when_unresolved_error`, and which `base.py`'s own `#191` note describes as the way to keep this ring open. Cost is one `sys.modules` lookup per `evaluate()` call, not per step. The verdict, the payload reading, the docstrings, and all 20 new tests are untouched — `tests/simulation/mujoco/test_success_fn_contact_reads_the_engine_payload.py` + `tests/simulation/test_policy_runner_paths.py` = 48 passed against mujoco 3.11.0, `ruff check` / `ruff format --check` clean on the changed file.

Rejected alternative: dropping the `TYPE_CHECKING` import of `SimEngine` from `predicates.py` would also open the ring, but it costs the annotations `mypy` checks the whole DSL against — a worse trade for the same static-analysis outcome.

The rerun confirms it: `Analyze (Python)` is green and the `py/unsafe-cyclic-import` alert (severity `error` -- the one that fails a PR when it is new) is gone. What remains is a `py/cyclic-import` note on the deferred import line, and that is the shape this repo has already accepted for this ring six times on `main`: `base.py:2998`, `base.py:3194`, `benchmark_spec.py:70`, `builtin_benchmarks.py:38`/`:39`, `registry/robots.py:11`. The two `error`-severity alerts on the ring's actual root -- `base.py:51`, which imports this module at module level -- are open on `main` today and predate this branch. Collapsing that root is a `base.py`/`policy_runner.py` structural change with no bearing on which contact payload the evaluator reads, so it stays out of this diff.

## Round 2 changelog -- no code change

The `py/cyclic-import` thread on the deferred import is resolved. Nothing in the diff moved; the reasoning was verified independently rather than restated.

The two alerts are different rules, and that is the substance:

| alert | rule | severity | site | state |
|---|---|---|---|---|
| 836 | `py/unsafe-cyclic-import` | **error** | `policy_runner.py:58` (module level) | gone |
| 837 | `py/cyclic-import` | **note** | `policy_runner.py:2984` (deferred) | resolved |

The error-severity rule is the one reporting a name "may not be defined". Round 1 removed it and left the note that a cycle exists in the AST. The note's danger -- observing a partially-initialised module -- cannot arise for a function-local import, which is why CodeQL splits the rules. Exercising exactly that failure mode, entering the ring from the module the alert names as beginning it:

```python
import strands_robots.simulation.predicates as _first  # enter the ring here
from strands_robots.simulation.policy_runner import PolicyRunner
touch = PolicyRunner(_Sim())._resolve_success_fn("contact")   # contacts: [one record]
none  = PolicyRunner(_Empty())._resolve_success_fn("contact") # contacts: []
# VERDICTS True False
```

Exit 0, correct verdicts. Importing each of `predicates`, `policy_runner`, `base` and the `simulation` package first in a fresh interpreter also resolves `make_predicate` in all four orders.

The deferred form is this file's own convention: `policy_runner.py:2565`, 419 lines above the new import, already defers `simulation.benchmark` for this same ring with the same reasoning in its comment. `git diff cadbd567 76eccebf` is one file, `-1/+11` -- the import line relocated plus nine comment lines, no behavioural line.

Gate re-run on this head (`76eccebf`):

- `ruff check strands_robots tests tests_integ` -- clean
- `ruff format --check strands_robots tests tests_integ` -- 983 files already formatted
- `mypy strands_robots tests tests_integ` -- clean, 980 source files
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -- **15235 passed, 255 skipped** in 484.97s
- pre-fix proof re-derived at this base (the three source files reverted to `e5674737`, tests kept): **6 failed / 14 passed**, then 48 passed after
- `python3 scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -- no overlap
- `python scripts/assemble_changelog.py --check` -- OK

Round 1 was verified with a scoped 48-test run; this is the full suite on the same tree, so the quoted count now describes the head that merges.
