### PR TITLE
fix(benchmarks/libero): name a numba/coverage remedy that works

### DIFF
--- a/changelog.d/1805-numba-coverage-clash-remedy.md
+++ b/changelog.d/1805-numba-coverage-clash-remedy.md
@@ -1,0 +1,21 @@
+### Fixed: the numba/coverage clash diagnostic now names a remedy that works
+
+The LIBERO adapter recognises the `numba` / `coverage` import clash and, until
+now, told the caller to pin `coverage` *down* - the opposite of the fix.
+`coverage.types.Tracer`, which `numba.misc.coverage_support` subclasses with no
+version guard, is provided only from `coverage` 7.6.1 onward (7.4.0-7.6.0 name
+the same protocol `TracerCore`, 7.0-7.3 name it `TTracer`, and 6.x ships no
+`coverage/types.py` at all), so the clash is a coverage-too-old condition.
+Following the old advice made things worse: on `coverage<7` the failure text
+becomes `module 'coverage' has no attribute 'types'`, which the detector did not
+recognise, so the strict install error degraded into "GR00T actions will no-op" -
+the silent action-dropping the strict classification exists to prevent.
+
+The remedy now names `pip install 'coverage>=7.6.1'`, keeps removing `coverage`
+entirely as the alternative (numba guards `import coverage` with
+`except ImportError`), and no longer suggests a downgrade or a numba bump. It is
+built in one place and reaches all three raise sites - the adapter's install
+hint and both lazy-import guards in `_LiberoOSCController.from_sim`, which
+previously reported only the symptom. The detector also recognises the
+coverage-6.x failure shape, so an environment that already followed the old
+advice is still diagnosed instead of silently degrading.

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -354,7 +354,7 @@ class LiberoAdapter(BenchmarkProtocol):
                 action. ``PolicyRunner._evaluate_with_spec`` catches the
                 exception from ``on_episode_start`` and returns a
                 structured ``{"status": "error", ...}`` dict, so a broken
-                *setup* (e.g. the ``numba`` / ``coverage>=7`` import clash,
+                *setup* (e.g. the ``numba`` / ``coverage`` import clash,
                 missing robosuite, missing site/actuator IDs) is no longer
                 indistinguishable from a bad *policy* scoring
                 ``success_rate=0`` on a green run (#522). Set to ``False``
@@ -2362,7 +2362,7 @@ class LiberoAdapter(BenchmarkProtocol):
           the result) before falling through to the no-op name-lookup
           path - the pre-#522 best-effort behaviour.
         * Dependency-clash failures (``ImportError`` / ``AttributeError``
-          from the import chain - e.g. the ``numba`` / ``coverage>=7``
+          from the import chain - e.g. the ``numba`` / ``coverage``
           incompatibility) are ALWAYS re-raised with a remediation hint,
           regardless of the flag, because they are fixable
           environment-level breakage, not a legitimate "no controller
@@ -2389,7 +2389,7 @@ class LiberoAdapter(BenchmarkProtocol):
         except (ImportError, AttributeError) as e:
             # Defense-in-depth: an import/attribute error escaped from_sim's
             # own classification (it normally wraps these). Treat the known
-            # numba/coverage>=7 clash as fatal (surface it, #522); anything
+            # numba/coverage clash as fatal (surface it, #522); anything
             # else degrades like a missing optional dep.
             if _is_numba_coverage_clash(e):
                 remediation = self._action_controller_remediation(e)
@@ -2466,19 +2466,12 @@ class LiberoAdapter(BenchmarkProtocol):
     def _action_controller_remediation(error: BaseException) -> str:
         """Build a remediation hint for a dependency-clash install failure.
 
-        Detects the known ``numba`` / ``coverage>=7`` incompatibility
+        Detects the known ``numba`` / ``coverage`` incompatibility
         (#522) via :func:`_is_numba_coverage_clash` and surfaces a targeted
         fix; falls back to a generic hint for other failures.
         """
         if _is_numba_coverage_clash(error):
-            return (
-                "This is the known numba/coverage>=7 incompatibility: numba's "
-                "coverage_support module subclasses coverage.types.Tracer, which "
-                "coverage>=7 removed. Remediation: uninstall the conflicting "
-                "coverage from the eval environment ('pip uninstall coverage'), or "
-                "pin coverage<7, or upgrade numba to a release that no longer "
-                "imports coverage.types.Tracer."
-            )
+            return _numba_coverage_clash_remedy()
         return (
             "Ensure the OSC controller dependencies (robosuite and its "
             "transitive imports) are importable in this environment."
@@ -3578,7 +3571,7 @@ class _ControllerInstallError(RuntimeError):
     """Raised inside :meth:`_LiberoOSCController.from_sim` when the
     LIBERO action controller can't be built but the prerequisites ARE
     present (missing site / actuator IDs, wrong arm-joint count, a
-    broken-but-installed import such as the numba/coverage>=7 clash,
+    broken-but-installed import such as the numba/coverage clash,
     etc.). With ``strict_action_controller=True`` (the default),
     :meth:`LiberoAdapter._install_action_controller` re-raises this so
     ``PolicyRunner`` returns a structured eval error instead of silently
@@ -3598,14 +3591,59 @@ class _ControllerDependencyMissing(_ControllerInstallError):
     extras."""
 
 
+#: Oldest ``coverage`` release that provides ``coverage.types.Tracer`` - the
+#: symbol ``numba.misc.coverage_support`` subclasses unconditionally. The name
+#: was renamed INTO existence at this release: coverage 7.4.0-7.6.0 call the
+#: same protocol ``TracerCore``, 7.0-7.3 call it ``TTracer``, and 6.x and older
+#: ship no ``coverage/types.py`` at all. The numba clash is therefore a
+#: coverage-too-OLD condition, so every remedy must raise ``coverage`` rather
+#: than pin it down.
+_COVERAGE_TRACER_MIN_VERSION = "7.6.1"
+
+
+def _numba_coverage_clash_remedy() -> str:
+    """Return the remediation text for the ``numba`` / ``coverage`` clash (#522).
+
+    Single source of truth, so every raise site that classifies the clash
+    hands the caller the same fix. The version boundary it names is
+    :data:`_COVERAGE_TRACER_MIN_VERSION`.
+    """
+    return (
+        "This is the known numba/coverage import clash: numba's coverage_support "
+        "module subclasses coverage.types.Tracer with no version guard, and "
+        f"coverage provides that symbol only from {_COVERAGE_TRACER_MIN_VERSION} "
+        f"onward. Remediation: raise coverage (pip install "
+        f"'coverage>={_COVERAGE_TRACER_MIN_VERSION}'), or remove coverage from the "
+        "eval environment entirely ('pip uninstall coverage'), which numba's "
+        "ImportError guard tolerates. Pinning coverage DOWN does not fix it - older "
+        "releases have no coverage.types.Tracer either - and an environment held at "
+        "an older coverage (some GPU-sim wheels pin coverage==7.4.4) is the usual "
+        "cause."
+    )
+
+
 def _is_numba_coverage_clash(error: BaseException) -> bool:
-    """Recognise the ``numba`` / ``coverage>=7`` import incompatibility (#522).
+    """Recognise the ``numba`` / ``coverage`` import incompatibility (#522).
 
     ``numba/misc/coverage_support.py`` defines
-    ``class NumbaTracer(coverage.types.Tracer)``, but ``coverage>=7``
-    removed ``coverage.types.Tracer`` - so importing ``numba`` (pulled in
-    transitively by robosuite's OSC controller path) raises
-    ``AttributeError: module 'coverage.types' has no attribute 'Tracer'``.
+    ``class NumbaTracer(coverage.types.Tracer)`` with no version guard - its
+    only guard is ``except ImportError`` around ``import coverage`` - while
+    ``coverage`` provides ``coverage.types.Tracer`` only from
+    :data:`_COVERAGE_TRACER_MIN_VERSION` onward. Importing ``numba`` (pulled in
+    transitively by robosuite's OSC controller path) against an older
+    ``coverage`` therefore fails in one of two shapes:
+
+    * ``module 'coverage.types' has no attribute 'Tracer'`` - coverage
+      7.0-7.6.0, where ``coverage/types.py`` exists but names the protocol
+      ``TTracer`` (7.0-7.3) or ``TracerCore`` (7.4.0-7.6.0).
+    * ``module 'coverage' has no attribute 'types'`` - coverage 6.x and older,
+      which ship no ``coverage/types.py`` at all.
+
+    Both shapes are the same clash with the same fix, so both are recognised.
+    The second one is what a caller lands in after pinning ``coverage`` *down*;
+    not recognising it would downgrade the strict install error into the silent
+    "GR00T actions will no-op" degrade that #522 exists to prevent.
+
     Walk the exception chain so the signature is still recognised when the
     AttributeError is wrapped by a later ImportError.
     """
@@ -3615,6 +3653,8 @@ def _is_numba_coverage_clash(error: BaseException) -> bool:
         seen.add(id(cur))
         text = str(cur)
         if "coverage.types" in text and "Tracer" in text:
+            return True
+        if "coverage" in text and "has no attribute 'types'" in text:
             return True
         cur = cur.__cause__ or cur.__context__
     return False
@@ -3784,7 +3824,7 @@ class _LiberoOSCController:
         the sim has no compiled MuJoCo model - the caller degrades
         gracefully. Raises the base :class:`_ControllerInstallError` for a
         fixable setup failure (missing site / actuator IDs, wrong arm-joint
-        count, or the known numba/coverage>=7 clash) - in strict mode the
+        count, or the known numba/coverage clash) - in strict mode the
         caller re-raises so ``PolicyRunner`` returns a structured eval
         error instead of silently dropping every GR00T action (#522).
         """
@@ -3796,7 +3836,7 @@ class _LiberoOSCController:
         # caller degrades gracefully; that is an environmental / optional-
         # dep condition, not a fixable setup bug. An import that fails for
         # ANOTHER reason while the module IS importable-but-broken (e.g.
-        # the numba/coverage>=7 ``AttributeError`` clash) raises the base
+        # the numba/coverage ``AttributeError`` clash) raises the base
         # ``_ControllerInstallError`` so the caller can surface it (#522).
         try:
             import mujoco as _mj
@@ -3804,7 +3844,9 @@ class _LiberoOSCController:
             raise _ControllerDependencyMissing(f"mujoco not available: {e}") from e
         except ImportError as e:
             if _is_numba_coverage_clash(e):
-                raise _ControllerInstallError(f"mujoco import hit the numba/coverage clash: {e}") from e
+                raise _ControllerInstallError(
+                    f"mujoco import hit the numba/coverage clash: {e} {_numba_coverage_clash_remedy()}"
+                ) from e
             raise _ControllerDependencyMissing(f"mujoco import failed (treated as unavailable): {e}") from e
         try:
             from robosuite.controllers import (  # type: ignore[import-not-found]
@@ -3814,7 +3856,7 @@ class _LiberoOSCController:
             from robosuite.utils.binding_utils import MjSim  # type: ignore[import-not-found]
         except (ImportError, AttributeError) as e:
             # The robosuite OSC import chain failed. Two cases:
-            #   1. The known numba/coverage>=7 clash (#522) - a FIXABLE
+            #   1. The known numba/coverage clash (#522) - a FIXABLE
             #      environment problem - surface it strictly so the eval
             #      returns an error instead of scoring success_rate=0 with
             #      every action dropped.
@@ -3824,7 +3866,9 @@ class _LiberoOSCController:
             #      as a hard dependency would break installs without the
             #      optional extras.
             if _is_numba_coverage_clash(e):
-                raise _ControllerInstallError(f"robosuite OSC import hit the numba/coverage clash: {e}") from e
+                raise _ControllerInstallError(
+                    f"robosuite OSC import hit the numba/coverage clash: {e} {_numba_coverage_clash_remedy()}"
+                ) from e
             raise _ControllerDependencyMissing(
                 f"robosuite OSC controller imports unavailable: {type(e).__name__}: {e}"
             ) from e

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -3666,7 +3666,7 @@ class TestInstallActionController:
 
     def test_install_dependency_clash_always_raises(self, monkeypatch):
         """#522: A dependency-clash failure (ImportError / AttributeError
-        from the import chain, e.g. the numba/coverage>=7 incompatibility)
+        from the import chain, e.g. the numba/coverage incompatibility)
         is ALWAYS re-raised with a remediation hint, even in non-strict
         mode - it is fixable environment breakage, not a legitimate "no
         controller needed" condition."""
@@ -3807,7 +3807,7 @@ class TestInstallActionController:
         assert "action_controller" not in sim._world._backend_state
 
     def test_is_numba_coverage_clash_detection(self):
-        """#522: ``_is_numba_coverage_clash`` recognises the coverage>=7
+        """#522: ``_is_numba_coverage_clash`` recognises the coverage
         signature both directly and through the exception chain (the
         AttributeError is often re-wrapped by an ImportError upstream)."""
         from strands_robots.benchmarks.libero.adapter import _is_numba_coverage_clash

--- a/tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py
+++ b/tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py
@@ -15,7 +15,7 @@ without needing a real robosuite install:
 
 * robosuite genuinely missing -> ``_ControllerDependencyMissing`` (the caller
   degrades gracefully; requiring robosuite as a hard dep would break installs).
-* the known numba / coverage>=7 import clash -> the base
+* the known numba / coverage import clash -> the base
   ``_ControllerInstallError`` (a FIXABLE setup bug the caller surfaces strictly,
   never silently dropping every action).
 * a fully-formed Panda scene -> a constructed controller with the discovered
@@ -138,13 +138,15 @@ def _make_panda_sim():
     return _StubSim(_StubWorld(model, data)), model, data
 
 
-def _install_fake_robosuite(monkeypatch, *, clash: bool = False):
+def _install_fake_robosuite(monkeypatch, *, clash: bool = False, clash_message: str | None = None):
     """Register a fake ``robosuite`` package so ``from_sim`` gets past its
     lazy import.
 
-    With ``clash=True`` the ``robosuite.controllers`` from-import raises the
-    ``coverage.types`` ``Tracer`` ``AttributeError`` that models the #522
-    numba/coverage>=7 incompatibility.
+    With ``clash=True`` the ``robosuite.controllers`` from-import raises
+    ``clash_message`` (defaulting to the ``coverage.types`` ``Tracer``
+    signature) so the caller exercises the #522 numba/coverage clash branch.
+    Pass the coverage-6.x spelling to exercise the other real shape of the
+    same clash.
     """
     rs = types.ModuleType("robosuite")
     controllers = types.ModuleType("robosuite.controllers")
@@ -154,14 +156,17 @@ def _install_fake_robosuite(monkeypatch, *, clash: bool = False):
     if clash:
         # Model the #522 clash: importing the robosuite OSC path pulls in
         # numba, whose coverage-support shim references the ``coverage.types``
-        # ``Tracer`` that coverage>=7 removed. We raise on attribute access
+        # ``Tracer`` that coverage only provides from 7.6.1 onward. We raise
+        # on attribute access
         # with that signature so ``_is_numba_coverage_clash`` recognises it.
         # (CPython's IMPORT_FROM swallows an AttributeError and re-wraps it,
         # discarding the message, so we raise an ImportError - the production
         # code catches ImportError and AttributeError alike and classifies
         # purely by message.)
+        message = clash_message or "module 'coverage.types' has no attribute 'Tracer'"
+
         def _clash_getattr(name):
-            raise ImportError("module 'coverage.types' has no attribute 'Tracer'")
+            raise ImportError(message)
 
         setattr(controllers, "__getattr__", _clash_getattr)  # PEP 562 module __getattr__
     else:
@@ -204,7 +209,7 @@ class TestFromSimDependencyClassification:
             _from_sim(sim)
 
     def test_numba_coverage_clash_surfaces_as_install_error(self, monkeypatch):
-        """The numba/coverage>=7 clash is a FIXABLE setup bug: it must raise the
+        """The numba/coverage clash is a FIXABLE setup bug: it must raise the
         base _ControllerInstallError, NOT the dependency-missing subclass, so
         the caller surfaces it in strict mode (#522)."""
         _install_fake_robosuite(monkeypatch, clash=True)
@@ -240,7 +245,7 @@ def _force_mujoco_import_error(monkeypatch, exc: BaseException):
 class TestFromSimMujocoImportClassification:
     """The lazy ``import mujoco`` in from_sim runs before robosuite and must
     classify its own failures the same way (#522): a genuinely-absent mujoco
-    degrades gracefully, but the numba/coverage>=7 clash is a fixable setup bug
+    degrades gracefully, but the numba/coverage clash is a fixable setup bug
     the caller surfaces strictly rather than silently dropping every action."""
 
     def test_missing_mujoco_degrades_as_dependency_missing(self, monkeypatch):

--- a/tests/benchmarks/libero/test_numba_coverage_clash_remedy.py
+++ b/tests/benchmarks/libero/test_numba_coverage_clash_remedy.py
@@ -1,0 +1,216 @@
+"""The numba/coverage clash diagnostic must name a remedy that works.
+
+``numba.misc.coverage_support`` defines ``class NumbaTracer(coverage.types.Tracer)``
+with no version guard - its only guard is ``except ImportError`` around
+``import coverage`` - and ``coverage`` provides ``coverage.types.Tracer`` only
+from 7.6.1 onward. Measured by evaluating that class body against real coverage
+releases:
+
+===============  ============================================================
+``coverage``     result of ``class NumbaTracer(coverage.types.Tracer)``
+===============  ============================================================
+6.5.0            ``AttributeError: module 'coverage' has no attribute 'types'``
+7.3.4            ``AttributeError: module 'coverage.types' has no attribute 'Tracer'``
+7.6.0            ``AttributeError: module 'coverage.types' has no attribute 'Tracer'``
+7.6.1            defines cleanly
+===============  ============================================================
+
+So the clash is a coverage-too-OLD condition. Two contracts follow, and this
+module pins both:
+
+* The remedy must send the caller UP to ``coverage>=7.6.1`` (or remove coverage
+  entirely, which numba's ImportError guard tolerates), and must never advise
+  pinning coverage down - that does not fix the clash.
+* The coverage-6.x failure shape must be recognised as the same clash. It is
+  the state a caller lands in after pinning coverage down, and if the detector
+  misses it the strict :class:`_ControllerInstallError` degrades into
+  :class:`_ControllerDependencyMissing`, i.e. the silent "GR00T actions will
+  no-op" path that #522 exists to prevent.
+
+Every raise site that classifies the clash must carry the remedy: the adapter's
+``_action_controller_remediation`` and both lazy-import guards in
+``_LiberoOSCController.from_sim`` (mujoco and robosuite).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.benchmarks.libero.adapter import (  # noqa: E402
+    _COVERAGE_TRACER_MIN_VERSION,
+    LiberoAdapter,
+    _ControllerDependencyMissing,
+    _ControllerInstallError,
+    _is_numba_coverage_clash,
+    _numba_coverage_clash_remedy,
+)
+
+from .test_libero_osc_controller_from_sim_construction import (  # noqa: E402
+    _force_mujoco_import_error,
+    _from_sim,
+    _install_fake_robosuite,
+    _make_panda_sim,
+    _StubSim,
+)
+
+#: The clash as it surfaces on coverage 7.0-7.6.0 (``coverage/types.py`` exists
+#: but names the protocol ``TTracer`` or ``TracerCore``).
+_TRACER_MISSING = "module 'coverage.types' has no attribute 'Tracer'"
+
+#: The clash as it surfaces on coverage 6.x and older, which ship no
+#: ``coverage/types.py`` at all - the state that pinning coverage down produces.
+_TYPES_MODULE_MISSING = "module 'coverage' has no attribute 'types'"
+
+#: The one command that resolves the clash, as the remedy must spell it.
+_INSTALL_COMMAND = f"pip install 'coverage>={_COVERAGE_TRACER_MIN_VERSION}'"
+
+
+def _version_tuple(text: str) -> tuple[int, ...]:
+    """Parse the leading numeric components of a version string."""
+    parts: list[int] = []
+    for chunk in text.split("."):
+        if not chunk.isdigit():
+            break
+        parts.append(int(chunk))
+    return tuple(parts)
+
+
+class TestRemedyNamesAFixThatWorks:
+    """The remedy is the only place the library tells a user how to escape the
+    clash, so it must name the measured fix and nothing that fails."""
+
+    def test_remedy_names_the_coverage_floor_to_install(self) -> None:
+        """The copy-pasteable install command is present, floor included."""
+        assert _INSTALL_COMMAND in _numba_coverage_clash_remedy()
+
+    def test_remedy_offers_removing_coverage_as_the_alternative(self) -> None:
+        """numba guards ``import coverage`` with ``except ImportError``, so an
+        absent coverage genuinely works - keep offering it."""
+        assert "pip uninstall coverage" in _numba_coverage_clash_remedy()
+
+    @pytest.mark.parametrize(
+        "bad_advice",
+        [
+            "coverage<7",
+            "pin coverage<",
+            "coverage>=7 removed",
+            "upgrade numba",
+        ],
+    )
+    def test_remedy_never_advises_a_downgrade_or_a_numba_bump(self, bad_advice: str) -> None:
+        """Pinning coverage down leaves the clash in place (measured on 6.5.0),
+        and numba still subclasses ``coverage.types.Tracer`` unconditionally, so
+        neither is a fix."""
+        assert bad_advice not in _numba_coverage_clash_remedy()
+
+    def test_the_named_floor_provides_the_symbol_numba_needs(self) -> None:
+        """Pin the floor against the installed coverage.
+
+        If a future coverage renames ``Tracer`` again, the floor this message
+        recommends stops being a fix - and this test says so instead of the
+        message quietly becoming wrong.
+        """
+        coverage = pytest.importorskip("coverage")
+        installed = _version_tuple(coverage.__version__)
+        floor = _version_tuple(_COVERAGE_TRACER_MIN_VERSION)
+        if installed < floor:
+            pytest.skip(f"installed coverage {coverage.__version__} predates the {_COVERAGE_TRACER_MIN_VERSION} floor")
+        assert hasattr(coverage.types, "Tracer"), (
+            f"coverage {coverage.__version__} is at or above the "
+            f"{_COVERAGE_TRACER_MIN_VERSION} floor the clash remedy recommends, "
+            "but no longer provides coverage.types.Tracer - the remedy needs a new floor"
+        )
+
+
+class TestEveryClashRaiseSiteCarriesTheRemedy:
+    """Three code paths classify the clash. All three are what a caller sees,
+    so all three must hand over the fix rather than only the symptom."""
+
+    def test_install_action_controller_remediation(self) -> None:
+        """The adapter-level hint (``_install_action_controller``'s fatal path)."""
+        hint = LiberoAdapter._action_controller_remediation(AttributeError(_TRACER_MISSING))
+        assert _INSTALL_COMMAND in hint
+
+    def test_robosuite_import_guard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``from_sim``'s robosuite guard - the message users actually hit,
+        since robosuite's OSC path is what pulls numba in."""
+        _install_fake_robosuite(monkeypatch, clash=True)
+        sim, _model, _data = _make_panda_sim()
+
+        with pytest.raises(_ControllerInstallError) as exc:
+            _from_sim(sim)
+        assert _INSTALL_COMMAND in str(exc.value)
+
+    def test_mujoco_import_guard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``from_sim``'s mujoco guard, which runs before robosuite."""
+        _force_mujoco_import_error(monkeypatch, ImportError(_TRACER_MISSING))
+
+        with pytest.raises(_ControllerInstallError) as exc:
+            _from_sim(_StubSim(None))
+        assert _INSTALL_COMMAND in str(exc.value)
+
+
+class TestTheStateAPinnedDownCoverageProduces:
+    """coverage 6.x ships no ``coverage/types.py``, so the same numba class body
+    fails one attribute earlier. That shape is the same clash with the same fix
+    and must be classified the same way."""
+
+    def test_detector_recognises_the_absent_types_module(self) -> None:
+        assert _is_numba_coverage_clash(AttributeError(_TYPES_MODULE_MISSING)) is True
+
+    def test_detector_recognises_it_through_a_wrapping_import_error(self) -> None:
+        """The signature survives the ImportError CPython re-raises around it."""
+        cause = AttributeError(_TYPES_MODULE_MISSING)
+        wrapper = ImportError("cannot import name 'controller_factory'")
+        wrapper.__cause__ = cause
+        assert _is_numba_coverage_clash(wrapper) is True
+
+    def test_from_sim_surfaces_it_strictly_with_the_remedy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Not the degrade-gracefully subclass: an unrecognised clash would
+        report "GR00T actions will no-op" and score the eval at 0."""
+        _force_mujoco_import_error(monkeypatch, ImportError(_TYPES_MODULE_MISSING))
+
+        with pytest.raises(_ControllerInstallError) as exc:
+            _from_sim(_StubSim(None))
+        assert not isinstance(exc.value, _ControllerDependencyMissing)
+        assert _INSTALL_COMMAND in str(exc.value)
+
+    def test_robosuite_guard_surfaces_it_strictly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Same contract on the robosuite guard, which is the path that pulls
+        numba in and therefore the one a real eval trips over."""
+        _install_fake_robosuite(monkeypatch, clash=True, clash_message=_TYPES_MODULE_MISSING)
+        sim, _model, _data = _make_panda_sim()
+
+        with pytest.raises(_ControllerInstallError) as exc:
+            _from_sim(sim)
+        assert not isinstance(exc.value, _ControllerDependencyMissing)
+        assert _INSTALL_COMMAND in str(exc.value)
+
+    def test_adapter_remediation_covers_that_shape_too(self) -> None:
+        hint = LiberoAdapter._action_controller_remediation(AttributeError(_TYPES_MODULE_MISSING))
+        assert _INSTALL_COMMAND in hint
+
+
+class TestUnrelatedFailuresStillDegradeGracefully:
+    """Widening the detector must not swallow ordinary missing-dependency
+    failures, which are environmental rather than fixable setup bugs."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "libGL.so.1: cannot open shared object file",
+            "No module named 'robosuite'",
+            "coverage report generation failed",
+            "module 'numpy' has no attribute 'float'",
+            "module 'mujoco' has no attribute 'MjSpec'",
+        ],
+    )
+    def test_not_classified_as_the_clash(self, text: str) -> None:
+        assert _is_numba_coverage_clash(ImportError(text)) is False
+
+    def test_generic_hint_for_an_unrelated_install_failure(self) -> None:
+        hint = LiberoAdapter._action_controller_remediation(RuntimeError("unrelated failure"))
+        assert _INSTALL_COMMAND not in hint
+        assert "robosuite" in hint


### PR DESCRIPTION
## Problem

`_action_controller_remediation` is the only place the library tells a user how to escape the `numba` / `coverage` import clash, and its advice points the wrong way.

`numba.misc.coverage_support` defines `class NumbaTracer(coverage.types.Tracer)` with **no version guard** - its only guard is `except ImportError` around `import coverage` - and `coverage` provides that symbol only from **7.6.1** onward. Measured by evaluating numba's own class body against real coverage releases:

| `coverage` | result of `class NumbaTracer(coverage.types.Tracer)` |
| --- | --- |
| 6.5.0 | `AttributeError: module 'coverage' has no attribute 'types'` |
| 7.3.4 | `AttributeError: module 'coverage.types' has no attribute 'Tracer'` |
| 7.6.0 | `AttributeError: module 'coverage.types' has no attribute 'Tracer'` |
| 7.6.1 | defines cleanly |

`Tracer` was renamed *into* existence at 7.6.1: 7.4.0-7.6.0 name the same protocol `TracerCore`, 7.0-7.3 name it `TTracer`, and 6.x ships no `coverage/types.py` at all. The clash is therefore a coverage-too-**old** condition. The shipped remedy said the opposite:

> This is the known numba/coverage>=7 incompatibility: numba's coverage_support module subclasses coverage.types.Tracer, which **coverage>=7 removed**. Remediation: uninstall the conflicting coverage from the eval environment ('pip uninstall coverage'), or **pin coverage<7**, or **upgrade numba** to a release that no longer imports coverage.types.Tracer.

Three of its four claims do not hold, and the one command that resolves it is absent:

- "coverage>=7 removed it" - inverted; 7.6.1 added it.
- "pin coverage<7" - measured on 6.5.0, still clashes.
- "upgrade numba" - numba 0.66.0 still subclasses `coverage.types.Tracer` unconditionally.
- `pip install 'coverage>=7.6.1'` - never offered.

### Following the advice made it worse

On `coverage<7` the failure text becomes `module 'coverage' has no attribute 'types'`, which `_is_numba_coverage_clash` did not recognise (it required `"coverage.types"` **and** `"Tracer"` in the message). So a caller who followed the remedy went from a loudly-diagnosed fixable setup bug to `_ControllerDependencyMissing` and the caller's `"GR00T actions will no-op"` degrade - the silent action-dropping the strict classification exists to prevent. Measured on the pre-fix tree:

```
_ControllerDependencyMissing("robosuite OSC controller imports unavailable: "
                             "ImportError: module 'coverage' has no attribute 'types'")
```

And two of the three raise sites carried no remedy at all - including `from_sim`'s robosuite guard, which is the message a real eval hits, since robosuite's OSC path is what pulls numba in:

```
robosuite OSC import hit the numba/coverage clash: module 'coverage.types' has no attribute 'Tracer'
```

## Change

- `_numba_coverage_clash_remedy()` is the single source of the remedy text. It names `pip install 'coverage>=7.6.1'`, keeps `pip uninstall coverage` as the alternative (numba's `except ImportError` guard genuinely tolerates an absent coverage), states that pinning down does not fix it, and names `coverage==7.4.4` - the pin some GPU-sim wheels carry - as the usual cause.
- The measured boundary lives in one place, `_COVERAGE_TRACER_MIN_VERSION`.
- All three raise sites carry the remedy: the adapter's install hint plus both lazy-import guards in `_LiberoOSCController.from_sim` (mujoco and robosuite).
- `_is_numba_coverage_clash` also recognises the coverage-6.x shape, so an environment that already followed the old advice is still classified as the fixable clash instead of degrading silently. Ordinary missing-dependency failures still degrade - pinned.
- The inverted `coverage>=7` label is corrected in the module's docstrings and in the test prose that repeated it.

This is the `_ControllerInstallError` remedy item from #1803. The Isaac pip-install docs section and the `is_available()` message in that issue are a separate, Isaac-scoped change and are not touched here.

## Measurement

![numba/coverage clash remedy](https://raw.githubusercontent.com/cagataycali/robots/artifacts/numba-coverage-remedy/numba_coverage_remedy.png)

Every cell is produced by one script that evaluates numba's class body against four real coverage releases installed in shadow environments, reads the old remedy out of `main` and the new one out of this branch, and asserts each figure claim against that measurement before saving.

## Tests

`tests/benchmarks/libero/test_numba_coverage_clash_remedy.py` (21 tests) pins:

- the remedy names the install command with the floor, offers removing coverage, and never advises a downgrade or a numba bump;
- the named floor actually provides `coverage.types.Tracer` in the installed coverage - so if a future coverage renames it again, the floor this message recommends fails loudly instead of quietly becoming wrong;
- all three raise sites carry the remedy;
- the coverage-6.x shape is classified as the clash, surfaces strictly (not the degrade subclass) through both `from_sim` guards, and gets the remedy;
- unrelated failures (`libGL.so.1`, `No module named 'robosuite'`, a message that merely mentions coverage) are still not the clash, and an unrelated install failure still gets the generic hint.

`_install_fake_robosuite` grew a `clash_message` parameter so both real shapes of the same clash run through one helper.

Pre-fix, against `e5674737`: **13 failed, 8 passed**. The 8 that pass are the over-reach controls and the coverage-floor premise - what stops the widened detector swallowing genuine missing-dependency failures.

## Verification

- `ruff check strands_robots tests tests_integ` - clean (983 files)
- `ruff format --check strands_robots tests tests_integ` - clean
- `mypy strands_robots tests tests_integ` - `Success: no issues found in 980 source files`
- `python3 scripts/assemble_changelog.py --check` - OK
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly` - **15236 passed, 255 skipped** in 485.81s

No policy, simulation, rendering, recording or asset behaviour changes - the artifact is the dependency measurement rather than a rollout.