### PR TITLE
docs(sim/isaac): document pip-installed Isaac Sim collateral; name the coverage red herring (closes #1803)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ extras you need:
 |-------|----------|---------|
 | `sim-mujoco` | MuJoCo, robot_descriptions, imageio, mink + qpsolvers[daqp] | Simulation (recommended starting point). mink/qpsolvers are the differential-IK solver behind the `move_to` Cartesian transport primitive; `qpsolvers` ships no solver of its own, so the `[daqp]` backend extra is declared with it. |
 | `sim-newton` | Newton, Warp, MuJoCo-Warp, trimesh | GPU-native simulation (NVIDIA GPU; batched envs, headless ray-traced render) |
-| `sim-isaac` | usd-core, imageio (Isaac Sim installed out-of-band) | NVIDIA Isaac Sim backend - photorealistic RTX rendering, synthetic data, GPU-batched sensors, USD-native scenes. Isaac Sim itself is **not** pip-installable; install it via the Omniverse Launcher, Isaac Lab, or the NGC docker image. This extra pulls only the pip-installable Python helpers. (NVIDIA RTX GPU; GPU-only, not in `[all]`.) |
+| `sim-isaac` | usd-core, imageio (Isaac Sim installed separately) | NVIDIA Isaac Sim backend - photorealistic RTX rendering, synthetic data, GPU-batched sensors, USD-native scenes. Install Isaac Sim itself separately: via its pip wheels on Python 3.12 (`isaacsim[all,extscache]` from pypi.nvidia.com - see the caveats in [`docs/simulation/isaac.md`](docs/simulation/isaac.md)), the Omniverse Launcher, Isaac Lab, or the NGC docker image. This extra pulls only the pip-installable Python helpers. (NVIDIA RTX GPU; GPU-only, not in `[all]`.) |
 | `sim-gs` | gsplat, plyfile, torch | 3D Gaussian Splatting hybrid rendering (`strands_robots.rendering`): composite any sim backend's robot over a captured photoreal 3DGS scene. `gsplat` ships as a source dist that JIT-compiles CUDA kernels via `nvcc` on first use - probe with `strands_robots.rendering.gsplat_rasterizer_available()`; the zero-GPU `PanoramaBackground` works without this extra. (CUDA GPU; GPU-only, not in `[all]`.) |
 | `lerobot` | LeRobot | Real hardware, local VLA inference, dataset recording |
 | `molmoact2` | LeRobot + transformers, peft, scipy | MolmoAct2 transformers-native VLA (resolves from PyPI via lerobot >= 0.6) |
@@ -192,9 +192,12 @@ uv pip install "strands-robots[all]"
 
 The **Isaac Sim** GPU backend is a built-in, in-tree peer of `mujoco` and
 `newton` (it lives at `strands_robots.simulation.isaac`). Its pip-installable
-helpers ship in the `sim-isaac` extra, but Isaac Sim itself is a ~30 GB
-non-PyPI install you provision out-of-band (Omniverse Launcher, Isaac Lab, or
-the NGC docker image). Install the helpers with
+helpers ship in the `sim-isaac` extra, but the Isaac Sim runtime itself (~30 GB)
+is provisioned separately - via its own pip wheels on Python 3.12
+(`pip install 'isaacsim[all,extscache]==6.0.*' --extra-index-url https://pypi.nvidia.com`,
+with coverage/EULA caveats documented in
+[`docs/simulation/isaac.md`](docs/simulation/isaac.md)), the Omniverse
+Launcher, Isaac Lab, or the NGC docker image. Install the helpers with
 `pip install 'strands-robots[sim-isaac]'`, then select the backend with
 `create_simulation("isaac")` - see
 [Simulation (MuJoCo)](#simulation-mujoco) and

--- a/changelog.d/1803-isaac-pip-install-collateral.md
+++ b/changelog.d/1803-isaac-pip-install-collateral.md
@@ -1,0 +1,21 @@
+### Docs: pip-installed Isaac Sim 6.0.x collateral is documented and its red herring named
+
+Installing Isaac Sim via the cp312 pip wheels
+(`pip install 'isaacsim[all,extscache]==6.0.*' --extra-index-url
+https://pypi.nvidia.com`) silently degrades an existing dev environment in
+ways pip only warns about: `isaacsim-kernel` downgrades `coverage` to 7.4.4,
+which breaks numba's tracer probe and surfaces far from the cause as a
+robosuite OSC import failure inside the LIBERO adapter
+(`module 'coverage.types' has no attribute 'Tracer'`); the torch stack is
+bumped past lerobot's pins; and the first non-interactive import hangs on the
+EULA prompt without `OMNI_KIT_ACCEPT_EULA=YES`.
+
+`docs/simulation/isaac.md` now documents the pip route with the verified
+sequence (install isaacsim, reinstall `coverage>=7.6`, set the EULA env var),
+the torch-bump expectation, and the exit-134 atexit note.
+`IsaacSimulation.is_available()`'s guidance no longer claims Isaac Sim is
+"not via pip" - it lists the pip route first, with the caveats. The
+`_ControllerInstallError` raised for the numba/coverage clash now appends the
+one-line remedy (`pip install 'coverage>=7.6'`), and a dependency-audit test
+fails loudly at collection time when `coverage<7.6` is installed alongside
+numba and robosuite, turning the red herring into a named error.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -10,8 +10,9 @@ rendering run on the GPU through Isaac Sim.
 
 `strands-robots` has **no hard dependency** on Isaac Sim: the `sim-isaac` extra
 provides the pip-installable helpers, and `create_simulation("isaac")` resolves
-the **built-in** backend, exactly like `create_simulation("mujoco")`. Isaac Sim
-itself is a ~30 GB non-PyPI install you provision out-of-band (see below).
+the **built-in** backend, exactly like `create_simulation("mujoco")`. The Isaac
+Sim runtime itself (~30 GB) is provisioned separately - via its own pip wheels
+on Python 3.12, or out-of-band (see below).
 
 ## When to use it
 
@@ -29,11 +30,12 @@ Sim is a ~30 GB install and requires an NVIDIA GPU.
 
 ## Install
 
-Isaac Sim itself is **not on PyPI** - install it first, then the `sim-isaac`
-extra:
+Install the Isaac Sim runtime first, then the `sim-isaac` extra:
 
 ```bash
 # Step 1 - install Isaac Sim 6.0 (Python 3.12) via one of:
+#   - pip wheels (see caveats below):
+#       pip install 'isaacsim[all,extscache]==6.0.*' --extra-index-url https://pypi.nvidia.com
 #   - Omniverse Launcher -> Isaac Sim 6.0, OR
 #   - Isaac Lab: git clone IsaacLab && ./isaaclab.sh -i, OR
 #   - NGC Docker: docker pull nvcr.io/nvidia/isaac-sim:6.0
@@ -47,6 +49,53 @@ The `sim-isaac` extra lives in **`strands-robots`** (a peer of `sim-mujoco` and
 installed raises a `ValueError` whose message carries the exact install hint
 (`pip install 'strands-robots[sim-isaac]'`). Backend discovery is lazy, so
 MuJoCo-only users never pay the Isaac Sim import cost.
+
+### Installing Isaac Sim via pip - caveats
+
+Since the cp312 wheels shipped for Isaac Sim 6.0.x, the runtime itself is
+pip-installable on Python 3.12. The `extscache` extra is **required** - the
+bare `isaacsim[all]` metapackage omits the `isaacsim-extscache-*` packages, and
+`SimulationApp` aborts resolving its extension graph without them. The pip
+install also degrades an existing dev environment in ways pip only *warns*
+about, so run this exact sequence:
+
+```bash
+# 1. Install the Isaac Sim wheels (NVIDIA index required):
+pip install 'isaacsim[all,extscache]==6.0.*' --extra-index-url https://pypi.nvidia.com
+
+# 2. Repair the coverage downgrade (see below):
+pip install 'coverage>=7.6'
+
+# 3. Accept the EULA for non-interactive first import:
+export OMNI_KIT_ACCEPT_EULA=YES
+```
+
+Known collateral (observed with isaacsim 6.0.0.1 and 6.0.1.0):
+
+- **`coverage` downgrade breaks robosuite/LIBERO with a red-herring error.**
+  `isaacsim-kernel` pins `coverage==7.4.4`, silently downgrading modern
+  coverage. numba's tracer probe then fails, and the first visible symptom is
+  far from the cause - robosuite's OSC controller import dies inside the LIBERO
+  adapter with `module 'coverage.types' has no attribute 'Tracer'`. Verified
+  remedy: `pip install 'coverage>=7.6'` after the isaacsim install. The reverse
+  pip conflict warning (`isaacsim-kernel requires coverage==7.4.4`) is cosmetic:
+  coverage is test tooling for the kit, not a runtime dependency.
+- **torch stack bump vs lerobot pins.** The isaacsim install upgrades
+  `torch`/`torchvision` (and numpy/scipy/pyarrow), leaving pip conflict
+  warnings against lerobot's `torchvision` pin. Expect those warnings; they do
+  not by themselves indicate breakage. Validated combination as of 2026-07-31:
+  isaacsim 6.0.x with torch 2.11 / torchvision 0.26.0 alongside lerobot 0.5.1 -
+  GR00T-on-MuJoCo re-verified green post-install. The environment is outside
+  lerobot's declared support, so re-verify your own policy path after
+  installing.
+- **EULA prompt on first import.** Any non-interactive first import fails with
+  `Do you accept the EULA? ... EOF when reading a line` unless
+  `OMNI_KIT_ACCEPT_EULA=YES` is set.
+- **Exit code 134 after successful work.** Isaac Sim has a known atexit
+  segfault that makes otherwise-clean scripts exit 134 *after* completing
+  successfully. The drivers in this repo guard with `os._exit(...)` after
+  SimulationApp teardown (see `examples/libero/run_isaac.py`); user scripts
+  that boot SimulationApp should do the same.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,16 +255,21 @@ sim-newton = [
 # out-of-band Kit runtime).
 #
 # IMPORTANT: Isaac Sim itself is NOT installed by this extra. It is an Omniverse
-# Kit application provisioned out-of-band - via the NVIDIA Omniverse Launcher,
+# Kit application provisioned separately - via the runtime's own pip wheels
+# (`pip install 'isaacsim[all,extscache]==6.0.*' --extra-index-url
+# https://pypi.nvidia.com`, viable on Python 3.12; the `extscache` extra is
+# required, and see docs/simulation/isaac.md for the coverage-downgrade /
+# EULA / torch-bump caveats, #1803), the NVIDIA Omniverse Launcher,
 # Isaac Lab (`./isaaclab.sh -i`), or the NGC docker image
 # (`nvcr.io/nvidia/isaac-sim:6.0`; see
 # strands_robots/simulation/isaac/_install.py for the pinned image tag). Those
-# images/launchers ship a complete, bootable Kit (Python 3.12 interpreter + the
+# routes ship a complete, bootable Kit (Python 3.12 interpreter + the
 # full `isaacsim-*` / `isaacsim-extscache-*` extension set that `SimulationApp`
-# needs to boot). We do NOT pin `isaacsim` here: the PyPI `isaacsim[all]`
+# needs to boot). We still do NOT pin `isaacsim` here: the bare `isaacsim[all]`
 # metapackage is incomplete on its own (it omits the `isaacsim-extscache-*`
-# packages, so `SimulationApp` aborts resolving its extension graph), and every
-# other surface documents Isaac Sim as "installed separately".
+# packages, so `SimulationApp` aborts resolving its extension graph), it needs
+# the NVIDIA extra index, and its transitive pins (coverage==7.4.4, a
+# torch/torchvision bump) would degrade every non-Isaac install of this extra.
 #
 # This extra pulls ONLY the pip-installable Python helpers the backend uses
 # out-of-band from an Isaac Sim install:

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -2472,12 +2472,14 @@ class LiberoAdapter(BenchmarkProtocol):
         """
         if _is_numba_coverage_clash(error):
             return (
-                "This is the known numba/coverage>=7 incompatibility: numba's "
+                "This is the known numba/coverage incompatibility (#522): numba's "
                 "coverage_support module subclasses coverage.types.Tracer, which "
-                "coverage>=7 removed. Remediation: uninstall the conflicting "
-                "coverage from the eval environment ('pip uninstall coverage'), or "
-                "pin coverage<7, or upgrade numba to a release that no longer "
-                "imports coverage.types.Tracer."
+                "some coverage releases (notably the coverage==7.4.4 that a "
+                "pip-installed Isaac Sim pins via isaacsim-kernel) do not "
+                f"provide. {_COVERAGE_CLASH_REMEDY} Alternatively, uninstall "
+                "coverage from the eval environment ('pip uninstall coverage') "
+                "or upgrade numba to a release that no longer imports "
+                "coverage.types.Tracer."
             )
         return (
             "Ensure the OSC controller dependencies (robosuite and its "
@@ -3620,6 +3622,20 @@ def _is_numba_coverage_clash(error: BaseException) -> bool:
     return False
 
 
+#: One-line verified remedy for the numba/coverage clash, appended to every
+#: ``_ControllerInstallError`` raised for it so the user is not left
+#: correlating a coverage version with a robosuite import by hand (#1803).
+#: The canonical trigger today is a pip-installed Isaac Sim: its
+#: ``isaacsim-kernel`` package pins ``coverage==7.4.4``, silently
+#: downgrading modern coverage in the same environment.
+_COVERAGE_CLASH_REMEDY = (
+    "Remedy: pip install 'coverage>=7.6'. (A pip-installed Isaac Sim pins "
+    "coverage==7.4.4 via isaacsim-kernel, which numba's tracer probe cannot "
+    "handle; the resulting pip conflict warning against isaacsim-kernel is "
+    "cosmetic - coverage is kit test tooling, not a runtime dependency.)"
+)
+
+
 class _LiberoOSCController:
     """OSC_POSE controller wrapper for GR00T-LIBERO action dispatch (#168).
 
@@ -3804,7 +3820,9 @@ class _LiberoOSCController:
             raise _ControllerDependencyMissing(f"mujoco not available: {e}") from e
         except ImportError as e:
             if _is_numba_coverage_clash(e):
-                raise _ControllerInstallError(f"mujoco import hit the numba/coverage clash: {e}") from e
+                raise _ControllerInstallError(
+                    f"mujoco import hit the numba/coverage clash: {e}. {_COVERAGE_CLASH_REMEDY}"
+                ) from e
             raise _ControllerDependencyMissing(f"mujoco import failed (treated as unavailable): {e}") from e
         try:
             from robosuite.controllers import (  # type: ignore[import-not-found]
@@ -3824,7 +3842,9 @@ class _LiberoOSCController:
             #      as a hard dependency would break installs without the
             #      optional extras.
             if _is_numba_coverage_clash(e):
-                raise _ControllerInstallError(f"robosuite OSC import hit the numba/coverage clash: {e}") from e
+                raise _ControllerInstallError(
+                    f"robosuite OSC import hit the numba/coverage clash: {e}. {_COVERAGE_CLASH_REMEDY}"
+                ) from e
             raise _ControllerDependencyMissing(
                 f"robosuite OSC controller imports unavailable: {type(e).__name__}: {e}"
             ) from e

--- a/strands_robots/simulation/isaac/__init__.py
+++ b/strands_robots/simulation/isaac/__init__.py
@@ -11,9 +11,10 @@ Usage::
     sim = IsaacSimulation(config)
     ok, msg = IsaacSimulation.is_available()
 
-Requires NVIDIA Isaac Sim 2024.x+ (not pip-installable). Install via
-Omniverse Launcher, Isaac Lab, or the NGC docker image. The exact
-supported image tag and install commands live in
+Requires NVIDIA Isaac Sim 6.0+ (Python 3.12). Install via the pip wheels
+(``isaacsim[all,extscache]`` from pypi.nvidia.com; see the caveats in
+``docs/simulation/isaac.md``), Omniverse Launcher, Isaac Lab, or the NGC
+docker image. The exact supported image tag and install commands live in
 :mod:`strands_robots.simulation.isaac._install` -- update there, not here.
 """
 

--- a/strands_robots/simulation/isaac/_install.py
+++ b/strands_robots/simulation/isaac/_install.py
@@ -33,6 +33,22 @@ ISAAC_SIM_DOCKER_IMAGE: str = "nvcr.io/nvidia/isaac-sim:6.0"
 #: string so callers don't have to assemble it.
 ISAAC_LAB_BOOTSTRAP: str = "git clone IsaacLab && ./isaaclab.sh -i"
 
+#: Pip install command for the Isaac Sim runtime itself. Viable since the
+#: cp312 wheels shipped for Isaac Sim 6.0.x (#1803); the ``extscache``
+#: extra is REQUIRED - the bare ``isaacsim[all]`` metapackage omits the
+#: ``isaacsim-extscache-*`` packages and ``SimulationApp`` aborts resolving
+#: its extension graph without them.
+ISAAC_SIM_PIP_INSTALL: str = "pip install 'isaacsim[all,extscache]==6.0.*' --extra-index-url https://pypi.nvidia.com"
+
+#: Caveats that apply only to the pip route (#1803): isaacsim-kernel
+#: downgrades ``coverage`` to 7.4.4, which breaks numba (and hence
+#: robosuite/LIBERO) with a red-herring ``coverage.types.Tracer``
+#: AttributeError; and the first non-interactive import hangs on the EULA
+#: prompt without the env var.
+ISAAC_SIM_PIP_CAVEATS: str = (
+    "then reinstall 'pip install coverage>=7.6' and set OMNI_KIT_ACCEPT_EULA=YES for the first import"
+)
+
 #: Pip extra users install to pull our Python helpers alongside an
 #: out-of-band Isaac Sim install.
 PIP_EXTRA: str = "pip install 'strands-robots[sim-isaac]'"
@@ -49,6 +65,7 @@ def install_options_block(indent: str = "  - ") -> str:
     runtime error stay in lockstep.
     """
     lines = [
+        f"{indent}pip (Python 3.12): {ISAAC_SIM_PIP_INSTALL} ({ISAAC_SIM_PIP_CAVEATS})",
         f"{indent}NVIDIA Omniverse Launcher (Isaac Sim {ISAAC_SIM_MIN_VERSION}+)",
         f"{indent}Isaac Lab: {ISAAC_LAB_BOOTSTRAP}",
         f"{indent}Docker: {ISAAC_SIM_DOCKER_IMAGE}",
@@ -64,7 +81,8 @@ def install_options_inline() -> str:
     awkwardly inside a single sentence.
     """
     return (
-        "Isaac Sim must be installed via Omniverse Launcher, "
+        "Isaac Sim must be installed first - via pip "
+        "(isaacsim[all,extscache], Python 3.12), Omniverse Launcher, "
         f"Isaac Lab ({ISAAC_LAB_BOOTSTRAP.split(' && ')[-1]}), "
         f"or Docker ({ISAAC_SIM_DOCKER_IMAGE})."
     )
@@ -77,7 +95,7 @@ def not_importable_reason() -> str:
     """
     return (
         "omni.isaac.kit.SimulationApp / isaacsim.SimulationApp not importable. "
-        "Isaac Sim must be installed separately (not via pip). Options:\n"
+        f"Install Isaac Sim {ISAAC_SIM_MIN_VERSION}+ via one of:\n"
         f"{install_options_block()}\n"
         f"Then install the Python helpers: {PIP_EXTRA}"
     )
@@ -94,6 +112,8 @@ __all__ = [
     "ISAAC_SIM_MIN_VERSION",
     "ISAAC_SIM_DOCKER_IMAGE",
     "ISAAC_LAB_BOOTSTRAP",
+    "ISAAC_SIM_PIP_INSTALL",
+    "ISAAC_SIM_PIP_CAVEATS",
     "PIP_EXTRA",
     "install_options_block",
     "install_options_inline",

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -3696,6 +3696,9 @@ class TestInstallActionController:
         # Remediation hint names the numba/coverage clash.
         assert "numba" in str(excinfo.value)
         assert "coverage" in str(excinfo.value)
+        # #1803: and carries the one-line verified remedy (pip-installed Isaac
+        # Sim's isaacsim-kernel downgrades coverage to 7.4.4).
+        assert "coverage>=7.6" in str(excinfo.value)
         assert adapter._action_controller_error is not None
         assert "action_controller" not in sim._world._backend_state
 

--- a/tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py
+++ b/tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py
@@ -215,6 +215,9 @@ class TestFromSimDependencyClassification:
         # Must be the base class, not the degrade-gracefully subclass.
         assert not isinstance(exc.value, _ControllerDependencyMissing)
         assert "coverage" in str(exc.value).lower()
+        # #1803: the message carries the one-line verified remedy so the user
+        # is not left correlating a coverage version with a robosuite import.
+        assert "coverage>=7.6" in str(exc.value)
 
 
 def _force_mujoco_import_error(monkeypatch, exc: BaseException):
@@ -265,6 +268,8 @@ class TestFromSimMujocoImportClassification:
         # Must be the base class, not the degrade-gracefully subclass.
         assert not isinstance(exc.value, _ControllerDependencyMissing)
         assert "clash" in str(exc.value).lower()
+        # #1803: the clash message carries the one-line verified remedy.
+        assert "coverage>=7.6" in str(exc.value)
 
     def test_other_mujoco_import_error_degrades_as_dependency_missing(self, monkeypatch):
         """A mujoco ``ImportError`` that is NOT the clash (e.g. a broken native

--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -474,3 +474,28 @@ class TestInstallMetadata:
         reason = _install.not_importable_reason()
         assert "Omniverse" in reason
         assert _install.ISAAC_SIM_DOCKER_IMAGE in reason
+
+    def test_not_importable_reason_lists_pip_route_with_caveats(self):
+        """#1803: cp312 pip wheels made ``isaacsim`` pip-installable; the
+        availability probe's guidance must list the pip route first, with
+        the coverage-reinstall and EULA caveats that the pip route needs."""
+        from strands_robots.simulation.isaac import _install
+
+        reason = _install.not_importable_reason()
+        # The stale "not via pip" guidance must be gone.
+        assert "not via pip" not in reason
+        # Pip route present, listed before the Launcher option.
+        assert _install.ISAAC_SIM_PIP_INSTALL in reason
+        assert "isaacsim[all,extscache]" in reason
+        assert reason.index("pypi.nvidia.com") < reason.index("Omniverse")
+        # Pip-route caveats: coverage reinstall + EULA env var.
+        assert "coverage>=7.6" in reason
+        assert "OMNI_KIT_ACCEPT_EULA=YES" in reason
+
+    def test_inline_install_options_mention_pip_route(self):
+        from strands_robots.simulation.isaac import _install
+
+        inline = _install.install_options_inline()
+        assert "pip" in inline
+        assert "isaacsim[all,extscache]" in inline
+        assert _install.ISAAC_SIM_DOCKER_IMAGE in inline

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -752,3 +752,44 @@ def test_declared_qp_backends_are_real_qpsolvers_extras() -> None:
         f"declared {_QP_FRONTEND} backend(s) {unknown} are not published extras of "
         f"{_QP_FRONTEND}; pip installs nothing for an unknown extra. Published: {sorted(published)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Environment audit: a downgraded `coverage` next to numba+robosuite (#1803).
+#
+# Installing Isaac Sim via the pip wheels (`isaacsim[all,extscache]`) silently
+# downgrades `coverage` to the 7.4.4 that `isaacsim-kernel` pins. numba's
+# tracer probe then fails, and the first *visible* symptom lands far from the
+# cause: robosuite's OSC controller import dies inside the LIBERO adapter with
+#     AttributeError: module 'coverage.types' has no attribute 'Tracer'
+# The adapter already classifies that clash and appends the remedy (#522,
+# #1803), but only once an eval reaches the import. This guard turns the red
+# herring into a named error at test-collection time instead: if this
+# environment has numba and robosuite installed alongside a `coverage` old
+# enough to trip the clash, fail loudly with the remedy.
+_COVERAGE_CLASH_FLOOR = Version("7.6")
+
+
+def test_environment_coverage_is_compatible_with_numba_robosuite() -> None:
+    """coverage<7.6 + numba + robosuite is a known-broken combination (#1803)."""
+    import importlib.metadata
+
+    versions: dict[str, str] = {}
+    for dist in ("coverage", "numba", "robosuite"):
+        try:
+            versions[dist] = importlib.metadata.version(dist)
+        except importlib.metadata.PackageNotFoundError:
+            pytest.skip(f"{dist} not installed; the numba/coverage clash cannot occur here")
+
+    installed = Version(versions["coverage"])
+    assert installed >= _COVERAGE_CLASH_FLOOR, (
+        f"coverage=={versions['coverage']} is installed alongside "
+        f"numba=={versions['numba']} and robosuite=={versions['robosuite']}: numba's "
+        "tracer probe fails on this coverage (AttributeError: module "
+        "'coverage.types' has no attribute 'Tracer'), which breaks robosuite's OSC "
+        "controller import inside the LIBERO adapter with a red-herring error far "
+        "from the cause. This is the collateral of a pip-installed Isaac Sim "
+        "(isaacsim-kernel pins coverage==7.4.4). Remedy: pip install 'coverage>=7.6' "
+        "(the resulting pip conflict warning against isaacsim-kernel is cosmetic - "
+        "coverage is kit test tooling, not a runtime dependency)."
+    )


### PR DESCRIPTION
Closes #1803.

## What changed

Installing Isaac Sim via the cp312 pip wheels (`pip install 'isaacsim[all,extscache]==6.0.*' --extra-index-url https://pypi.nvidia.com`) - now a viable route on Python 3.12 and the one used to validate #1798 - silently degrades an existing strands-robots dev environment in ways pip only *warns* about. This PR documents the collateral and adds the cheap guards from the issue.

- **`docs/simulation/isaac.md`** - the Install section now lists the pip route as a first-class option, plus a new "Installing Isaac Sim via pip - caveats" subsection covering:
  - the exact sequence: install isaacsim -> `pip install 'coverage>=7.6'` -> `OMNI_KIT_ACCEPT_EULA=YES`;
  - why the coverage reinstall is needed (isaacsim-kernel pins `coverage==7.4.4`, numba's tracer probe fails, and the first visible symptom is a red-herring robosuite OSC import failure inside the LIBERO adapter) and why the reverse pip conflict warning is cosmetic;
  - the torch/torchvision bump vs lerobot's pins - expect pip conflict warnings; validated combination as of 2026-07-31 noted so users can distinguish expected warnings from real breakage;
  - the exit-134 atexit segfault note (`os._exit` guard, as the in-repo drivers already do - see `examples/libero/run_isaac.py`).
- **`is_available()` guidance** (`strands_robots/simulation/isaac/_install.py`) no longer claims Isaac Sim "must be installed separately (not via pip)": the pip route is listed *first*, with the coverage + EULA caveats, via new `ISAAC_SIM_PIP_INSTALL` / `ISAAC_SIM_PIP_CAVEATS` constants. `install_options_inline()` (the runtime `ImportError` message) and the package docstring updated to match. `_install.py` stays the single source of truth.
- **`_ControllerInstallError` message** (`strands_robots/benchmarks/libero/adapter.py`): a new module-level `_COVERAGE_CLASH_REMEDY` is appended at both `from_sim` raise sites (mujoco + robosuite) and folded into `_action_controller_remediation`, so the error the user actually sees carries the one-line verified remedy (`pip install 'coverage>=7.6'`) instead of leaving them to correlate a coverage version with a robosuite import by hand. The old remediation text ("pin coverage<7") predated the empirical finding in #1803 and is replaced.
- **Environment audit** (`tests/test_dependency_audit.py`): a new test fails loudly - with the remedy in the assertion message - when `coverage<7.6` is installed alongside numba and robosuite (the optional item from the issue's acceptance criteria). Skips cleanly when either package is absent.
- **`README.md`** sim-isaac extras row + prose, and the **`pyproject.toml`** sim-isaac design comment: the pip route for the runtime is acknowledged; the extra still deliberately does not pin `isaacsim` (NVIDIA index requirement, mandatory `extscache` extra, and the transitive coverage/torch collateral this very issue documents).
- Changelog fragment: `changelog.d/1803-isaac-pip-install-collateral.md`.

## Acceptance criteria (from #1803)

- [x] Docs section covering: pip install command, coverage reinstall, EULA env var, torch-bump expectation, exit-134 note (`docs/simulation/isaac.md`)
- [x] `is_available()` message updated (pip route included, listed first, with caveats)
- [x] `_ControllerInstallError` message includes the coverage remedy; regression-pinned (existing clash tests extended to assert the remedy text at all three surfaces: robosuite raise site, mujoco raise site, adapter remediation path)
- [x] Optional: `tests/test_dependency_audit.py` pin that fails loudly on `coverage<7.6` + numba + robosuite, turning the red herring into a named error

## Test surface

- `hatch run format` / `hatch run lint` clean (ruff + mypy).
- Full unit suite (`hatch run test` with `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl`): **15226 passed, 247 skipped, 0 failed**.
- New/extended tests:
  - `tests/simulation/isaac/test_isaac_backend.py::TestInstallMetadata::test_not_importable_reason_lists_pip_route_with_caveats` (pins pip-route-first ordering, `coverage>=7.6`, `OMNI_KIT_ACCEPT_EULA=YES`, and the absence of the stale "not via pip" text) and `::test_inline_install_options_mention_pip_route`
  - `tests/benchmarks/libero/test_libero_osc_controller_from_sim_construction.py` - both clash tests now assert the remedy text
  - `tests/benchmarks/libero/test_libero_adapter.py::test_install_dependency_clash_always_raises` - asserts the remedy text on the adapter path
  - `tests/test_dependency_audit.py::test_environment_coverage_is_compatible_with_numba_robosuite`

## Out of scope / follow-ups

- `docs/getting-started/installation.md` omits the `sim-isaac` extra from its extras matrix entirely (pre-existing gap, broader than this issue's scope) - can be filed as a follow-up docs issue if wanted.
- No change to the `sim-isaac` extra's dependencies: pinning `isaacsim` remains deliberately out (rationale expanded in the pyproject comment).

## Project board

If #1803 is on the Strands Labs - Robots board, please move it to "In review" (or it will auto-move to Done on merge via the close).
