### PR TITLE
docs: read the local semantic-conflict run as a delta, not an absolute (closes #1807)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,29 @@ hatch run format            # ruff check --fix, ruff format
    about meaning. This is cheap: the check that would have caught the above was
    one `pytest` invocation on two files.
 
+   Read that run as a **delta, not an absolute**. The environment you verify in
+   is almost never the one CI uses, and a partial one fails tests for reasons
+   that have nothing to do with the merge. Composing #1786 and #1804 - both
+   approved, both `CLEAN`, both editing `simulation/predicates.py`, neither ever
+   compiled with the other - the affected suite reported **376 failed, 34
+   errors** on the composition, which on its own reads as a broken merge and a
+   reason to stop. The same command on the unmerged base reported the same
+   **376 failed, 34 errors**, and 4185 passed against the composition's 4229:
+   every failure pre-existed (a hosted runner has no GPU and only software
+   OSMesa, so the rendering tests fail there whatever the diff), and the whole
+   effect of the merge was **+44 passes** - exactly the 24 + 20 tests the two
+   branches add. The reading matters in both directions: an absolute count can
+   invent a regression and cost a good merge, and it can equally hide a real one
+   inside the noise. Run the same command on the base *before* you read the
+   number, and compare the two.
+
+   Then confirm the tree you verified is the tree that landed -
+   `git diff --name-only <local-composition> origin/main -- strands_robots/ tests/`
+   should be empty. Squash rewrites the commits, so nothing but that equivalence
+   ties your local run to `main`; and on a batch, where only the tip's
+   `call-test-lint` survives the concurrency group above, it is the sole evidence
+   the intermediate commits were ever compiled together.
+
    Fixing forward beats reverting here - the two production changes were both
    correct, and only an assertion and its justification were stale. Prefer a
    narrow follow-up that re-pins the invalidated premise over reverting a

--- a/changelog.d/1807-semantic-conflict-run-is-a-delta.md
+++ b/changelog.d/1807-semantic-conflict-run-is-a-delta.md
@@ -1,0 +1,30 @@
+### Docs: the local semantic-conflict run must be read as a delta, not an absolute
+
+`AGENTS.md` > PR Workflow > step 8 tells you to compile two overlapping approved
+PRs locally and run the affected tests before merging, because
+`MERGEABLE`/`CLEAN`/`SUCCESS` are each evaluated against a base that does not
+contain the other PR (#1766 / #1763). It did not say how to read the result, and
+the obvious reading is wrong often enough to cost a good merge.
+
+#1786 and #1804 both edited `strands_robots/simulation/predicates.py` and
+neither one's CI had ever compiled it with the other. The composition reported
+`376 failed, 4229 passed, 34 errors` on the affected suite - on its own, a
+broken merge. The identical command on the unmerged base reported
+`376 failed, 4185 passed, 34 errors`: every failure pre-existed, because a
+hosted runner has no GPU and only software OSMesa, so the rendering-dependent
+tests fail there whatever the diff. The entire effect of the merge was **+44
+passes**, exactly the 24 + 20 tests the two branches add.
+
+The hazard is symmetric, which is why it is worth stating rather than leaving to
+judgement: an absolute count from a partial environment can invent a regression
+that stops a correct merge, and it can equally hide a real one inside the noise.
+Only the delta against the same command on the base carries signal.
+
+A second sub-bullet records that squash rewrites the commits, so
+`git diff --name-only <composition> origin/main -- strands_robots/ tests/` is
+what ties a local verification run to what actually landed - and on a batch,
+where only the tip's `call-test-lint` survives the `refs/heads/main` concurrency
+group (#1800), that equivalence is the sole evidence the intermediate commits
+were ever compiled together.
+
+Documentation only; no production code or test behaviour changes.


### PR DESCRIPTION
Closes #1807.

## The gap

`AGENTS.md` > PR Workflow > step 8 already tells you *to* compile two overlapping approved PRs locally before merging, and why: `MERGEABLE` / `CLEAN` / `SUCCESS` are each evaluated against a base that does not contain the other PR, so none of them can see a semantic conflict (#1766 / #1763).

It does not say how to **read** the result of that run. I hit the consequence merging #1786 and #1804 an hour ago, and the obvious reading would have stopped a correct merge.

## Measured

#1786 and #1804 both edit `strands_robots/simulation/predicates.py`; both were `APPROVED` + `CLEAN` + `SUCCESS`; neither one's CI had ever compiled it with the other. I built the composition (`git checkout -B compose origin/main && git merge pr1786 && git merge pr1804` - `predicates.py` auto-merged) and ran the affected suite:

| tree | passed | failed | errors |
|---|---|---|---|
| `origin/main` (unmerged base) | 4185 | **376** | 34 |
| `main` + #1786 + #1804 | **4229** | **376** | 34 |

Read on its own, `376 failed, 34 errors` is a broken merge and a reason to stop. Read as a delta it is the opposite: the counts are *identical*, every failure pre-existed - a hosted runner has no GPU and only software OSMesa, so the rendering-dependent tests fail there whatever the diff - and the entire effect of the merge is **+44 passes**, exactly the 24 + 20 tests the two branches add.

The scoped overlap run was **72 passed** (`test_contact_predicates_require_a_real_touch.py` + `test_success_fn_contact_reads_the_engine_payload.py` + `test_policy_runner_paths.py`). Both PRs then merged, and `main`'s tip `aabf1f3` is green on `call-test-lint / Test and Lint`.

## Why this is worth a rule rather than judgement

The hazard is **symmetric**, which is the part that makes it more than an anecdote:

- as an absolute, a high count **invents** a regression and costs a correct merge
- as an absolute, a low count in a partial environment **hides** a real one inside the noise

So the check step 8 already prescribes is only sound as a comparison. A contributor following the current wording gets a number with no way to interpret it, in an environment that is almost never the one CI uses.

## Second sub-bullet

Squash rewrites the commits, so nothing but a tree comparison ties a local verification run to what actually landed:

```
git diff --name-only <local-composition> origin/main -- strands_robots/ tests/
```

returned 0 files here, which is what lets the 72-passed run above be claimed of `main`'s tip rather than of a branch that no longer exists. On a batch this is load-bearing: only the tip's `call-test-lint` survives the shared `refs/heads/main` concurrency group (#1800 / #1801), so that equivalence is the *sole* evidence the intermediate commits were ever compiled together.

## Scope

Two paragraphs inserted after the existing "one `pytest` invocation on two files" sentence, plus the fragment. `AGENTS.md` +23. No production code, no test behaviour, no existing line reworded.

I deliberately did not touch the surrounding #1766 / #1763 narrative or the `#1800` sub-bullet this one leans on - both are correct as written, and this is additive to the same numbered step rather than a restructuring of it.

## Gate

```
pytest tests/test_changelog_fragments.py tests/test_changelog_format.py   30 passed
pytest tests/test_changelog_fragment_gate.py tests/test_log_strings_are_ascii.py   41 passed
pytest tests/test_no_host_paths.py                                        2 passed
python scripts/assemble_changelog.py --check                              changelog fragments OK (81 pending)
grep -nP '[^\x00-\x7F]' AGENTS.md                                         only the pre-existing tree diagram; the addition is pure ASCII
```