### PR TITLE
fix(policies): refuse an RTC re-query horizon the consumer cannot execute

### DIFF
--- a/changelog.d/1809-rtc-execution-horizon-domain.md
+++ b/changelog.d/1809-rtc-execution-horizon-domain.md
@@ -1,0 +1,29 @@
+### Fixed: the RTC re-query horizon is refused when the consumer cannot execute it
+
+`LerobotLocalPolicy(rtc_execution_horizon=...)` was stored verbatim while its
+sibling `actions_per_step` - the count it *replaces* whenever Real-Time Chunking
+is active, in the very same `Policy.execution_horizon` property - has been
+validated on the shared `chunk_count_error` domain. So the same horizon was
+refused under one name and accepted under the other, and the read path then
+reconciled it two different ways: `execution_horizon` floors it with
+`max(1, int(...))` for the consumer, while `_predict_with_rtc` hands the model
+the raw value. Consumer and model therefore disagreed about how many actions run
+before the re-query, which is precisely the agreement RTC's cross-chunk blend
+rests on.
+
+`0` was the sharpest spelling. It is falsy, so the property fell through to the
+full trained chunk and the consumer replayed it open-loop - the regime the
+property's own docstring says "keeps that tail empty and silently collapses RTC"
+- while `_init_rtc` skipped adopting the checkpoint's own
+`rtc_config.execution_horizon` because `0` is not `None`, and the model was told
+`0`. Measured on a checkpoint with a 100-action trained chunk and a declared RTC
+horizon of 10: omitting the parameter gives 10 to both sides, `0` gave the
+consumer 100 and the model 0, all under a successful construction. `-5` gave 1
+and `-5`, `2.7` gave 2 and `2.7`, `True` a silent 1, and `nan` / `inf` / a list
+surfaced as a bare `ValueError` / `OverflowError` / `TypeError` from a property
+read inside the rollout loop.
+
+A supplied horizon is now checked where it arrives - in the constructor, before
+any checkpoint is downloaded, and in `preflight`, so a rollout entry point
+reports it as a structured error rather than a raise. `None` remains the
+documented request to adopt the checkpoint's own horizon and is unaffected.

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -491,10 +491,12 @@ def chunk_count_error(value: object, param: str, provider: str) -> str | None:
     """Error text when a per-inference chunk count is not one a policy can execute.
 
     Shared domain for the counts that describe one inference chunk - how many
-    actions a provider emits (``actions_per_chunk``) and how many of them a
-    consumer executes before re-querying (``actions_per_step``). Both are
-    consumed as slice bounds over the action chunk, so only a true positive
-    ``int`` can be honored; :func:`~strands_robots.utils.positive_count_error`
+    actions a provider emits (``actions_per_chunk``), how many of them a
+    consumer executes before re-querying (``actions_per_step``), and the
+    Real-Time Chunking override of that re-query interval
+    (``rtc_execution_horizon``, which replaces ``actions_per_step`` whenever RTC
+    is active). All are consumed as slice bounds over the action chunk, so only
+    a true positive ``int`` can be honored; :func:`~strands_robots.utils.positive_count_error`
     supplies that domain (and rejects ``bool``, which as an ``int`` subclass
     would otherwise pass as a silent count of one).
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -399,7 +399,10 @@ class LerobotLocalPolicy(Policy):
         rtc_enabled: Enable Real-Time Chunking for flow-matching policies.
             Auto-detected from model config if None.
         rtc_execution_horizon: Number of timesteps from the prefix to use for
-            guidance. Defaults to model config value or 10.
+            guidance - with RTC active this is the re-query interval
+            :attr:`~strands_robots.policies.base.Policy.execution_horizon`
+            resolves, so it must be a positive whole number. ``None`` (the
+            default) adopts the model config value, else 10.
         rtc_max_guidance_weight: Maximum guidance weight for RTC correction.
             Defaults to model config value or 10.0.
         camera_key_map: Optional explicit mapping of robot/sim camera name
@@ -566,6 +569,17 @@ class LerobotLocalPolicy(Policy):
         # RTC state
         self._rtc_requested = rtc_enabled
         self._rtc_enabled = False
+        # Same domain and the same reason as ``actions_per_step`` above: with RTC
+        # active this IS the re-query interval ``execution_horizon`` resolves,
+        # through the same ``max(1, int(...))`` floor, and a value other than
+        # ``None`` also suppresses ``_init_rtc``'s adoption of the checkpoint's
+        # own ``rtc_config.execution_horizon``. ``None`` is the documented
+        # "adopt the model's value" request rather than a count, so only a
+        # supplied one is checked. See ``chunk_count_error``.
+        if rtc_execution_horizon is not None:
+            error = chunk_count_error(rtc_execution_horizon, "rtc_execution_horizon", "lerobot_local")
+            if error:
+                raise ValueError(error)
         self._rtc_execution_horizon = rtc_execution_horizon
         self._rtc_max_guidance_weight = rtc_max_guidance_weight
         self._rtc_prev_chunk: torch.Tensor | None = None
@@ -655,7 +669,11 @@ class LerobotLocalPolicy(Policy):
         * otherwise -> ``actions_per_step`` (the trained chunk, consumed whole).
 
         Falls back to ``actions_per_step`` when RTC is enabled but the horizon
-        was never resolved (defensive; ``_init_rtc`` always sets it).
+        was never resolved (defensive; ``_init_rtc`` always sets it). A
+        ``rtc_execution_horizon`` the consumer cannot execute reached this
+        fallback too, so RTC silently collapsed to the open-loop replay the
+        paragraph above describes; the constructor now refuses such a value, so
+        the horizon read here always matches the one the model is given.
         """
         if self._rtc_enabled and self._rtc_execution_horizon:
             return max(1, int(self._rtc_execution_horizon))
@@ -1413,9 +1431,9 @@ class LerobotLocalPolicy(Policy):
         or when the embodiment name/spec cannot be resolved (``create_policy``
         surfaces that error authoritatively).
 
-        The parameter-shape guards below (``actions_per_step``, ``image_keys``)
-        run before that early-return, because both are honored whether or not an
-        embodiment is configured.
+        The parameter-shape guards below (``actions_per_step``, ``image_keys``,
+        ``rtc_execution_horizon``) run before that early-return, because all
+        three are honored whether or not an embodiment is configured.
 
         Args:
             observation_keys: Runtime observation keys (joint + camera names).
@@ -1423,8 +1441,9 @@ class LerobotLocalPolicy(Policy):
                 ``obs_rename_override``, ...).
 
         Raises:
-            ValueError: When ``actions_per_step`` is not a positive whole number,
-                when ``image_keys`` is not a list of distinct non-blank names,
+            ValueError: When ``actions_per_step`` or ``rtc_execution_horizon``
+                is not a positive whole number, when ``image_keys`` is not a
+                list of distinct non-blank names,
                 when a model image feature has no satisfiable source camera key
                 in ``observation_keys``, or when an explicit ``image_keys``
                 withholds a feature the embodiment feeds.
@@ -1447,6 +1466,15 @@ class LerobotLocalPolicy(Policy):
         supplied_image_keys = policy_config.get("image_keys")
         if supplied_image_keys and (err := name_list_error(supplied_image_keys, "image_keys", "preflight")):
             raise ValueError(err)
+
+        # The RTC re-query count, on the same domain as ``actions_per_step``: it
+        # replaces that horizon whenever RTC is active, which the model config
+        # decides, so it cannot be scoped to an embodiment either. Checked for a
+        # supplied value only - ``None`` asks for the checkpoint's own horizon.
+        if policy_config.get("rtc_execution_horizon") is not None:
+            error = chunk_count_error(policy_config["rtc_execution_horizon"], "rtc_execution_horizon", "lerobot_local")
+            if error:
+                raise ValueError(error)
 
         spec = policy_config.get("embodiment")
         if spec is None:

--- a/tests/policies/test_chunk_count_domain.py
+++ b/tests/policies/test_chunk_count_domain.py
@@ -19,10 +19,22 @@ have executed the trained 100. It also flipped
 :meth:`~strands_robots.policies.base.Policy.is_chunk_emitting` to ``False``,
 silently disabling the async-RTC latency masking for a chunk-emitting model.
 
+``rtc_execution_horizon`` is the same count once more. With Real-Time Chunking
+active it *is* the re-query interval, replacing ``actions_per_step`` in the very
+same property, and it was stored verbatim. ``0`` was the sharpest spelling: it is
+falsy, so the property fell through to the full trained chunk - the open-loop
+replay its own docstring says collapses RTC - while ``_init_rtc`` skipped
+adopting the checkpoint's ``rtc_config.execution_horizon`` because ``0`` is not
+``None``, and the model was handed the ``0`` verbatim. Consumer and model
+disagreed about the horizon for every unusable value, which is exactly the
+agreement RTC's cross-chunk blend rests on.
+
 These tests pin:
 
 * the degraded regime is unreachable, against a measured control showing what
   the default does with the same checkpoint;
+* the RTC re-query horizon shares that domain, and an accepted one is the same
+  number the consumer executes and the model is told;
 * every value outside the domain is refused by both providers, with parity
   between them apart from the one documented asymmetry (``None`` is
   ``lerobot_async``'s "use ``actions_per_chunk``" and not a count at all);
@@ -53,6 +65,11 @@ REJECTED: list[Any] = [0, -5, False, True, 2.7, "4", float("nan"), float("inf"),
 # The trained chunk length of the checkpoint the fixtures below emulate.
 TRAINED_CHUNK = 100
 
+# The RTC re-query horizon that same checkpoint declares in its ``rtc_config``.
+# Deliberately unequal to TRAINED_CHUNK: the RTC horizon exists to re-query
+# mid-chunk, so a fixture where they matched could not tell the two apart.
+MODEL_RTC_HORIZON = 10
+
 # Annotated ``Any`` so mypy does not narrow the splat against the mixed-type
 # signature; the two required identifiers are strings.
 ASYNC_REQUIRED: dict[str, Any] = {"policy_type": "act", "pretrained_name_or_path": "acme/act-cube"}
@@ -70,6 +87,28 @@ class _ChunkTrainedModel:
     config = _ChunkTrainedConfig()
 
 
+class _RtcConfig:
+    """The RTC block a flow-matching checkpoint (Pi0, SmolVLA) carries."""
+
+    enabled = True
+    execution_horizon = MODEL_RTC_HORIZON
+    max_guidance_weight = 10.0
+
+
+class _RtcTrainedConfig(_ChunkTrainedConfig):
+    """The same trained chunk, on a checkpoint that also enables RTC."""
+
+    rtc_config = _RtcConfig()
+
+
+class _RtcTrainedModel:
+    config = _RtcTrainedConfig()
+
+    def predict_action_chunk(self, *args: Any, **kwargs: Any) -> Any:
+        """Present so ``_init_rtc`` sees a flow-matching policy; never called."""
+        raise AssertionError("inference is out of scope for these tests")
+
+
 def _local(**config: Any) -> LerobotLocalPolicy:
     """Build a ``lerobot_local`` policy with the model load stubbed out."""
     with patch.object(LerobotLocalPolicy, "_load_model"):
@@ -81,6 +120,24 @@ def _regime(policy: LerobotLocalPolicy) -> tuple[Any, int, bool]:
     policy._policy = _ChunkTrainedModel()
     policy._auto_detect_actions_per_step()
     return policy.actions_per_step, policy.execution_horizon, policy.is_chunk_emitting()
+
+
+def _rtc_horizons(**config: Any) -> tuple[int, Any]:
+    """Resolve (what the consumer executes, what the model is told) under RTC.
+
+    Loads the RTC-enabled checkpoint emulation so ``_init_rtc`` runs its
+    adoption branch. The second element is the value
+    :mod:`strands_robots.policies.lerobot_local.policy` forwards to the model as
+    ``rtc_kwargs["execution_horizon"]``; RTC's cross-chunk blend is only correct
+    while the two agree, so the tests below compare them rather than reading
+    either alone.
+    """
+    policy = _local(**config)
+    policy._policy = _RtcTrainedModel()
+    policy._loaded = True
+    policy._init_rtc()
+    assert policy.supports_rtc, "fixture must reach the RTC path for these assertions to mean anything"
+    return policy.execution_horizon, policy._rtc_execution_horizon
 
 
 class TestTheDegradedRegimeIsUnreachable:
@@ -223,6 +280,106 @@ class TestTheAsyncChunkLength:
         """
         with pytest.raises(ValueError, match="actions_per_step must be a positive integer"):
             _local(actions_per_step=None)
+
+
+class TestTheRtcReQueryHorizon:
+    """``rtc_execution_horizon`` replaces the step count, so it shares its domain."""
+
+    def test_omitting_it_adopts_the_checkpoints_own_rtc_horizon(self) -> None:
+        """Control, and the premise the refusals below are measured against."""
+        consumer, model = _rtc_horizons()
+
+        assert consumer == MODEL_RTC_HORIZON
+        assert model == MODEL_RTC_HORIZON
+
+    def test_a_supplied_horizon_overrides_the_checkpoints(self) -> None:
+        """Control: an executable override is honored, not merely tolerated."""
+        consumer, model = _rtc_horizons(rtc_execution_horizon=8)
+
+        assert consumer == 8
+        assert model == 8
+
+    def test_a_zero_horizon_cannot_collapse_rtc_to_open_loop_replay(self) -> None:
+        """``0`` is refused rather than silently disabling the feature it configures.
+
+        Pre-fix this constructed. ``0`` is falsy, so ``execution_horizon`` fell
+        through to ``actions_per_step`` and the consumer executed the whole
+        trained chunk before re-querying - the open-loop replay that keeps the
+        blended tail empty - while ``_init_rtc`` skipped adopting the
+        checkpoint's own horizon (``0`` is not ``None``) and the model was told
+        ``0``. Measured on this fixture: consumer 100, model 0, against 10/10
+        for the same call with the parameter omitted.
+        """
+        with pytest.raises(ValueError, match="rtc_execution_horizon must be a positive integer"):
+            _local(rtc_execution_horizon=0)
+
+    @pytest.mark.parametrize("value", REJECTED, ids=repr)
+    def test_an_unusable_horizon_is_refused_where_it_arrives(self, value: Any) -> None:
+        """Not on the read path, which is a property read inside the rollout loop.
+
+        ``nan``, ``inf`` and a list surfaced there as a bare
+        ``ValueError``/``OverflowError``/``TypeError`` mid-rollout; the rest were
+        floored or truncated into a horizon the caller never asked for.
+        """
+        with pytest.raises(ValueError, match="rtc_execution_horizon must be a positive integer"):
+            _local(rtc_execution_horizon=value)
+
+    def test_none_is_the_adopt_request_and_not_a_count(self) -> None:
+        """The documented default: take the checkpoint's own horizon.
+
+        Unlike ``actions_per_step``, whose signature declares ``int = 1``, this
+        parameter declares ``int | None = None``, so ``None`` must stay valid.
+        """
+        assert _local(rtc_execution_horizon=None)._rtc_execution_horizon is None
+
+    def test_the_refusal_precedes_the_checkpoint_load(self) -> None:
+        loads: list[int] = []
+
+        def record(self: LerobotLocalPolicy) -> None:
+            loads.append(1)
+
+        with patch.object(LerobotLocalPolicy, "_load_model", record):
+            with pytest.raises(ValueError, match="rtc_execution_horizon"):
+                LerobotLocalPolicy(pretrained_name_or_path="acme/pi0-cube", rtc_execution_horizon=0)
+
+        assert loads == [], "the checkpoint load must not be reached for a refused horizon"
+
+    def test_preflight_refuses_it_with_no_embodiment_configured(self) -> None:
+        """RTC is decided by the model config, so this cannot be embodiment-scoped."""
+        with pytest.raises(ValueError, match="rtc_execution_horizon must be a positive integer"):
+            LerobotLocalPolicy.preflight(set(), rtc_execution_horizon=0)
+
+    def test_the_provider_preflight_entry_point_refuses_it(self) -> None:
+        """The structured-error path the rollout entry points run first."""
+        with pytest.raises(ValueError, match="rtc_execution_horizon must be a positive integer"):
+            preflight_policy("lerobot_local", {"joint_1", "front"}, rtc_execution_horizon=-5)
+
+    def test_preflight_passes_an_executable_horizon_and_the_adopt_request(self) -> None:
+        preflight_policy("lerobot_local", {"joint_1", "front"}, rtc_execution_horizon=10)
+        preflight_policy("lerobot_local", {"joint_1", "front"}, rtc_execution_horizon=None)
+
+    @pytest.mark.parametrize("value", REJECTED, ids=repr)
+    def test_it_shares_the_verdict_with_the_step_count_it_replaces(self, value: Any) -> None:
+        """Parity: one horizon cannot be refused under one name and accepted under the other."""
+
+        def verdict(build: Any) -> str:
+            try:
+                build()
+            except ValueError as exc:
+                return "refused" if "must be a positive integer" in str(exc) else "other-error"
+            return "accepted"
+
+        as_step_count = verdict(lambda: _local(actions_per_step=value))
+        as_rtc_horizon = verdict(lambda: _local(rtc_execution_horizon=value))
+        assert as_step_count == as_rtc_horizon, f"verdicts differ for horizon={value!r}"
+
+    @pytest.mark.parametrize("value", [1, 8, MODEL_RTC_HORIZON, TRAINED_CHUNK])
+    def test_an_accepted_horizon_is_the_one_both_sides_use(self, value: int) -> None:
+        """The invariant the unusable values broke, pinned for the whole domain."""
+        consumer, model = _rtc_horizons(rtc_execution_horizon=value)
+
+        assert consumer == value
+        assert model == value
 
 
 class TestTheDuckTypedFloorIsUntouched:


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy(rtc_execution_horizon=...)` was stored verbatim. Its sibling in the same signature, `actions_per_step`, is validated on the shared `chunk_count_error` domain -- and `rtc_execution_horizon` is the count that **replaces** it whenever Real-Time Chunking is active, in the very same `Policy.execution_horizon` property. So the same horizon was refused under one name and accepted under the other.

The read path then reconciled it two different ways:

- `execution_horizon` floors it with `max(1, int(...))` for the **consumer** (the interval `resolve_chunk_length` feeds the rollout loop);
- `_predict_with_rtc` puts it in `rtc_kwargs["execution_horizon"]` verbatim, so the **model** is handed the raw value.

RTC's cross-chunk blend is only correct while those two agree about how many actions run before the re-query. For every unusable spelling they did not.

`chunk_count_error`'s own docstring already describes this domain ("how many of them a consumer executes before re-querying"), the mechanism ("`execution_horizon` resolves the re-query interval through `max(1, int(...))`") and the consequence ("a rejected-then-floored value has already suppressed that adoption") -- this parameter simply did not call it. The `lerobot_async` provider validates *both* of its counts for exactly this reason, with a comment saying so.

## Measured

A checkpoint with a 100-action trained chunk whose `rtc_config` declares a re-query horizon of 10:

| `rtc_execution_horizon=` | constructor | consumer executes | model is told |
|---|---|---|---|
| omitted | accepted | 10 | 10 |
| `10` | accepted | 10 | 10 |
| `0` | accepted | **100** | **0** |
| `-5` | accepted | **1** | **-5** |
| `2.7` | accepted | **2** | **2.7** |
| `True` | accepted | **1** | **True** |
| `"10"` | accepted | **10** | **`'10'`** |
| `nan` | accepted | **ValueError** | `nan` |
| `inf` | accepted | **OverflowError** | `inf` |
| `[10]` | accepted | **TypeError** | `[10]` |

`0` is the sharpest spelling and is **strictly worse than omitting the parameter**. It is falsy, so the property falls through to `actions_per_step` and the consumer replays the whole trained chunk open-loop -- the regime the property's own docstring says "keeps that tail empty and silently collapses RTC to open-loop replay". Meanwhile `_init_rtc` skips adopting the checkpoint's own `rtc_config.execution_horizon` because `0` is not `None`, and the model is told `0`.

`nan` / `inf` / a list are not merely wrong values: `execution_horizon` is a property read by `resolve_chunk_length` **inside the rollout loop**, so they surfaced as a bare `ValueError` / `OverflowError` / `TypeError` mid-rollout rather than at the call that supplied them.

## Change

A supplied horizon is checked on the same domain, where it arrives:

- in `__init__`, before any checkpoint is downloaded;
- in `preflight`, which the rollout entry points run first, so the same mistake becomes a structured error instead of a raise. Placed before the embodiment early-return, because RTC is decided by the model config and cannot be embodiment-scoped.

`None` is unaffected -- it is the documented request to adopt the checkpoint's own horizon, not a count, so only a supplied value is checked. `chunk_count_error`'s docstring now names all three members of the domain it guards.

**Out of scope:** `rtc_max_guidance_weight`, the other RTC knob in the same signature. It is stored and logged only -- never forwarded to the model, never read by a consumer (`rtc_kwargs` carries `execution_horizon` alone) -- so a bad value there has no behavioural consequence beyond a log-format error, and it is a continuous weight rather than a chunk count. Different domain, different reasoning, its own change.

## Visual artifact

The observable consequence is the re-query cadence, so it is measured directly: a real MuJoCo Panda rollout (headless EGL), 120 control steps at 50 Hz, driven at each horizon the provider resolves. Both runs apply the same 120 actions and both report success; the collapsed horizon re-queries **2** times where the checkpoint's own horizon re-queries **12**.

![rtc_execution_horizon: re-query cadence and resolved horizons](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rtc-execution-horizon/rtc_horizon.png)

Every cell in the table and every number in the caption is read from the two measurement runs rather than typed; the generator asserts them (including that both runs applied the same action count, and that 8 accepted spellings diverge on `main` against 0 here) before saving.

## Tests

Added to `tests/policies/test_chunk_count_domain.py`, the established home for this domain, as `TestTheRtcReQueryHorizon` (21 cases):

- **controls / premise**: omitting adopts the checkpoint's own horizon (10 to both sides); an executable override is honored on both sides. Without these, "delete the guard" would pass.
- `0` cannot collapse RTC to open-loop replay; every value outside the domain is refused **where it arrives**, not on the read path.
- `None` stays valid -- the one asymmetry with `actions_per_step`, and it follows from the two signatures (`int | None = None` vs `int = 1`).
- the refusal precedes the checkpoint load (asserted by recording `_load_model` calls), and reaches the structured-error path through `preflight_policy`.
- **parity** with the step count it replaces, over the whole rejected set -- one horizon cannot be refused under one name and accepted under the other again.
- **the invariant the unusable values broke**: for every accepted horizon, the consumer executes the same number the model is told.

Pre-fix on this base: **22 failed, 61 passed**. All 22 are in the new class; no pre-existing test changes state, and the tests that already passed are the controls and the accepted-value cases. Post-fix: **83 passed**.

## Gate

- `MUJOCO_GL=egl python -m pytest tests` -> **15341 passed, 255 skipped** (520.89s)
- `ruff check strands_robots tests tests_integ` -> clean
- `ruff format --check strands_robots tests tests_integ` -> 986 files already formatted
- `mypy strands_robots tests tests_integ` -> no issues in 983 source files
- `python3 scripts/assemble_changelog.py --check` -> OK; `scripts/check_merge_base_overlap.py` -> no overlap

No existing test or message string changed.