### PR TITLE
feat(sim/isaac): EEF state source for LiberoAdapter + IsaacSimulation.get_body_state

### DIFF
--- a/changelog.d/1802-isaac-get-body-state-eef-source.md
+++ b/changelog.d/1802-isaac-get-body-state-eef-source.md
@@ -1,0 +1,41 @@
+### Added: `IsaacSimulation.get_body_state` + an EEF state source for LIBERO-on-Isaac
+
+`examples/libero/run_isaac.py --policy groot` failed every inference call with
+`Server error: State key 'state.x' must be in observation`: the
+`libero_panda` GR00T data-config requires `state.x/y/z/roll/pitch/yaw/gripper`,
+and both of `LiberoAdapter`'s EEF pose sources were MuJoCo-shaped - the direct
+site/body read found no compiled model on Isaac, and the `get_body_state`
+fallback found no such method on `IsaacSimulation` (#1802).
+
+`IsaacSimulation.get_body_state(body_name)` now implements the MuJoCo
+envelope contract (`{"json": {position, quaternion (wxyz), rotation_matrix,
+...}}`, namespace-aware `<robot>/<link>` resolution, structured errors for
+unknown bodies, main-thread pump respected). This single surface also
+unblocks the predicate DSL on Isaac (`body_above_z`, `body_on`,
+`distance_less_than`, ... all read through `get_body_state`).
+
+On the adapter side, `LiberoAdapter` gained `eef_pos_offset` /
+`eef_quat_offset` (site-equivalent corrections for the body-only fallback,
+applied in the body's local frame), an observation-dict gripper source
+(`state_gripper_signs` restores RoboSuite's opposite-sign finger convention),
+and a loud, actionable ERROR - replacing a DEBUG skip - when EEF injection is
+enabled but produces no state keys. `load_libero_suite(adapter_kwargs=...)`
+forwards backend-specific state-source config to every registered task, and
+`run_isaac.py` plumbs the measured Isaac Franka calibration (`panda_hand`
++ `[0, 0, 0.097]` grip-site offset; the Isaac `panda_hand` frame was measured
+to coincide with RoboSuite's `robot0_right_hand` within 0.03 degrees, so no
+quaternion correction applies) via a new `--eef-body-name` flag.
+
+Getting the injected state to be non-empty also required fixing
+`IsaacSimulation.load_scene`'s physics-view lifecycle: realizing/removing
+scene prims on an already-stepped stage left the PhysX tensor view stale, so
+robot joint reads returned nothing (no `state.gripper`) and episode-2
+`DynamicCuboid` constructions crashed with "Failed to get rigid body
+velocities from backend". The fix invalidates the view after removals and
+rebuilds it (`SimulationManager.initialize_physics()` + per-robot
+articulation re-init) after adds - deliberately NOT `world.reset()`, which
+re-applies registered default states and was measured to blow the Franka
+articulation into a PhysX "Illegal BroadPhaseUpdateData - non-finite bounds"
+explosion within seconds. `step()`'s camera warm-up now also refreshes
+secondary render products so a post-scene-load `wrist_image` camera
+accumulates frames.

--- a/examples/libero/run_isaac.py
+++ b/examples/libero/run_isaac.py
@@ -286,6 +286,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "the Isaac URDF importer.",
     )
     p.add_argument(
+        "--eef-body-name",
+        default=_ISAAC_FRANKA_EEF_BODY_NAME,
+        help="Robot link whose pose feeds the LIBERO state.x/y/z/roll/pitch/yaw "
+        "keys via IsaacSimulation.get_body_state (the MuJoCo defaults "
+        "gripper0_grip_site / robot0_right_hand don't exist on the Isaac "
+        "Franka USD). Default 'panda_hand' resolves on the bundled Franka; "
+        "override when --robot-usd / --robot-urdf loads an asset with "
+        "different link names.",
+    )
+    p.add_argument(
         "--auto-server",
         dest="auto_server",
         action="store_true",
@@ -428,7 +438,7 @@ def _orchestrate_groot_server(args: argparse.Namespace, suite: str) -> dict | No
     return result
 
 
-def _resolve_task(suite: str, requested_task: str) -> str:
+def _resolve_task(suite: str, requested_task: str, adapter_kwargs: dict | None = None) -> str:
     """Register the LIBERO suite and resolve ``requested_task``.
 
     Identical fallback-to-first-registered semantics as the MuJoCo
@@ -437,10 +447,13 @@ def _resolve_task(suite: str, requested_task: str) -> str:
     task name; if the user passes the default and it doesn't resolve,
     fall back to the first registered task with a clear note.
     Explicitly-supplied unknown tasks still error loudly.
+
+    ``adapter_kwargs`` configures every adapter's backend-specific state
+    sources (#1802) -- see :func:`_isaac_adapter_kwargs`.
     """
     from strands_robots.benchmarks.libero import load_libero_suite
 
-    registered = load_libero_suite(suite)
+    registered = load_libero_suite(suite, adapter_kwargs=adapter_kwargs)
     if not registered:
         raise RuntimeError(
             f"load_libero_suite({suite!r}) registered 0 tasks. "
@@ -491,6 +504,60 @@ _FRANKA_USD_SUBPATHS = (
     "Isaac/Robots/FrankaRobotics/FrankaPanda/franka.usd",  # Isaac Sim 6.0+
     "Isaac/Robots/Franka/franka.usd",  # Isaac Sim 4.x and earlier
 )
+
+# --- EEF state-source calibration for the bundled Isaac Franka USD (#1802) --
+#
+# The libero_panda GR00T data-config requires state.x/y/z/roll/pitch/yaw/
+# gripper, which LiberoAdapter injects from RoboSuite's split source:
+# position from the gripper0_grip_site (gripper tip), orientation from the
+# robot0_right_hand body (wrist). Neither name exists on the Isaac Franka
+# USD, so the adapter reads the wrist body via IsaacSimulation.get_body_state
+# and applies a site-equivalent correction, configured here.
+#
+# Measured on this repo's Isaac 6.0 + MuJoCo backends (2026-07-31), both
+# robots at the episode-0 canonical init config of the first libero_spatial
+# task, poses compared base-relative (panda_link0 vs robot0_link0):
+#
+#   * Isaac's `panda_hand` frame COINCIDES with RoboSuite's
+#     `robot0_right_hand` frame: relative rotation 0.03 deg, position
+#     delta < 0.6 mm (both within position-controller settle error).
+#     No quaternion correction is therefore applied (`eef_quat_offset`
+#     omitted = identity); the residual is quantified above rather than
+#     hand-waved (#168's success rates are sensitive to exactly this).
+#   * The grip-site offset in the hand frame measured [0, 0, 0.097] m on
+#     MuJoCo (exact to 1e-15 -- it is the authored site transform) and
+#     [3.8e-5, -6.5e-6, 0.0964] via the cross-sim derivation; we use the
+#     authored value, valid on Isaac because the frames coincide.
+#
+# Gripper: the Isaac Franka USD drives BOTH fingers positive (URDF mimic
+# convention, panda_finger_joint2 in [0, 0.04]) while RoboSuite trains
+# state.gripper with opposite signs ([+q, -q]); the [1, -1] signs restore
+# the trained convention.
+_ISAAC_FRANKA_EEF_BODY_NAME = "panda_hand"
+_ISAAC_FRANKA_EEF_POS_OFFSET = [0.0, 0.0, 0.097]
+_ISAAC_FRANKA_GRIPPER_JOINT = "panda_finger_joint1"
+_ISAAC_FRANKA_STATE_GRIPPER_JOINTS = ["panda_finger_joint1", "panda_finger_joint2"]
+_ISAAC_FRANKA_STATE_GRIPPER_SIGNS = [1.0, -1.0]
+
+
+def _isaac_adapter_kwargs(args: argparse.Namespace) -> dict:
+    """LiberoAdapter kwargs that make EEF state injection work on Isaac (#1802).
+
+    Forwarded through ``load_libero_suite(adapter_kwargs=...)`` to every
+    registered task. ``eef_state_site_name=""`` is the adapter's documented
+    "no site available" sentinel -- Isaac has no MuJoCo sites, so the
+    body-fallback (``get_body_state`` + the offsets above) is the only
+    source and we say so explicitly rather than letting the site lookup
+    fail per step.
+    """
+    return {
+        "eef_body_name": args.eef_body_name,
+        "eef_state_site_name": "",
+        "eef_pos_offset": list(_ISAAC_FRANKA_EEF_POS_OFFSET),
+        "gripper_joint_name": _ISAAC_FRANKA_GRIPPER_JOINT,
+        "state_gripper_joint_names": list(_ISAAC_FRANKA_STATE_GRIPPER_JOINTS),
+        "state_gripper_signs": list(_ISAAC_FRANKA_STATE_GRIPPER_SIGNS),
+    }
 
 
 def _resolve_default_franka_usd(assets_root: str) -> str:
@@ -678,6 +745,28 @@ def main() -> None:
         if result.get("status") != "success":
             raise RuntimeError(f"add_camera failed: {result}")
 
+        # The libero_panda data-config ALSO requires a ``wrist_image`` video
+        # key. Pre-add it here -- at the same static fallback vantage
+        # ``LiberoAdapter.LIBERO_CAMERAS`` declares -- rather than letting the
+        # adapter install it inside ``on_episode_start`` (#1802): an RTX
+        # camera added AFTER the LIBERO scene prims are on the stage never
+        # accumulates a frame on Isaac 6.0 (its Replicator render product
+        # returns a 0-D buffer through 100+ step/update ticks; verified on
+        # this host), whereas the same camera added before scene-load warms
+        # in one step. The adapter's install step skips cameras that already
+        # exist, so pre-adding is the supported path.
+        wrist_camera = "wrist_image"
+        result = sim.add_camera(
+            name=wrist_camera,
+            position=[0.0, 0.0, 1.4],
+            target=[0.0, 0.0, 0.85],
+            fov=60.0,
+            width=256,
+            height=256,
+        )
+        if result.get("status") != "success":
+            raise RuntimeError(f"add_camera failed: {result}")
+
         # Warm up the RTX render product before recording. A camera added
         # after the last world step has an empty render product: its first
         # `get_rgba()` returns a malformed `(0,)` buffer and `render()`
@@ -695,21 +784,22 @@ def main() -> None:
         # render product accumulates samples each iteration. Bounded so a host
         # that never populates fails loudly instead of recording blank frames.
         _RTX_WARMUP_MAX_ITERS = 10
-        warmed_up = False
-        for _ in range(_RTX_WARMUP_MAX_ITERS):
-            sim.step(1)
-            probe = sim.render(camera_name=recording_camera)
-            if probe.get("status") == "success":
-                warmed_up = True
-                break
-        if not warmed_up:
-            raise RuntimeError(
-                f"RTX render product for camera {recording_camera!r} never "
-                f"accumulated a frame after {_RTX_WARMUP_MAX_ITERS} warm-up "
-                "step+render iterations; recording would produce a 0-frame "
-                f"(dropped) mp4. Last render probe: {probe}"
-            )
-        print(f"[setup] RTX camera {recording_camera!r} warmed up; render product populated")
+        for cam_name in (recording_camera, wrist_camera):
+            warmed_up = False
+            for _ in range(_RTX_WARMUP_MAX_ITERS):
+                sim.step(1)
+                probe = sim.render(camera_name=cam_name)
+                if probe.get("status") == "success":
+                    warmed_up = True
+                    break
+            if not warmed_up:
+                raise RuntimeError(
+                    f"RTX render product for camera {cam_name!r} never "
+                    f"accumulated a frame after {_RTX_WARMUP_MAX_ITERS} warm-up "
+                    "step+render iterations; recording would produce a 0-frame "
+                    f"(dropped) mp4. Last render probe: {probe}"
+                )
+            print(f"[setup] RTX camera {cam_name!r} warmed up; render product populated")
 
         # Keep the CLI-requested task distinct from the resolved one. The
         # default placeholder transparently falls back to the first registered
@@ -719,7 +809,7 @@ def main() -> None:
         # change behaviour (the fallback wouldn't fire). ``resolved_task`` is
         # what actually executes and what the filename / benchmark call use.
         requested_task = args.task
-        resolved_task = _resolve_task(suite, args.task)
+        resolved_task = _resolve_task(suite, args.task, adapter_kwargs=_isaac_adapter_kwargs(args))
         args.task = resolved_task
 
         # Filename convention matches run_mujoco.py so the matrix

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -34,6 +34,7 @@ import hashlib
 import importlib
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -145,8 +146,11 @@ class LiberoAdapter(BenchmarkProtocol):
         cameras: dict[str, dict[str, Any]] | None = None,
         eef_body_name: str | None = None,
         eef_state_site_name: str | None = None,
+        eef_pos_offset: list[float] | None = None,
+        eef_quat_offset: list[float] | None = None,
         gripper_joint_name: str | None = None,
         state_gripper_joint_names: list[str] | None = None,
+        state_gripper_signs: list[float] | None = None,
         inject_eef_state: bool = True,
         auto_generate_scene: bool = True,
         scene_cache_dir: str | None = None,
@@ -220,6 +224,28 @@ class LiberoAdapter(BenchmarkProtocol):
                 deltas. The site is preferred; the body is used as a
                 fallback when the site doesn't exist (non-RoboSuite
                 scenes).
+            eef_pos_offset: Optional ``[x, y, z]`` offset (metres),
+                expressed in the EEF *body's local frame*, added to the
+                position read via the ``get_body_state`` fallback path.
+                Backends without the RoboSuite grip site (e.g. Isaac,
+                whose Franka USD has no ``gripper0_grip_site``) can only
+                report the wrist-body pose, which sits ~9.7 cm behind
+                the gripper tip that ``state.x/y/z`` was trained on
+                (#168). This offset translates the body read to the
+                site-equivalent point: ``pos + R(body_quat) @ offset``.
+                ``None`` (default) applies no offset. Never applied to
+                the direct MuJoCo site read (that source IS the site).
+            eef_quat_offset: Optional ``[w, x, y, z]`` unit quaternion,
+                right-multiplied onto the orientation read via the
+                ``get_body_state`` fallback path (a constant local-frame
+                correction: ``quat = body_quat * offset``). Use when the
+                backend's EEF body frame differs from RoboSuite's
+                ``robot0_right_hand`` frame by a fixed rotation (the
+                frames are rigidly attached to the same physical link,
+                so the correction is configuration-independent). ``None``
+                (default) applies no correction. The position offset is
+                applied using the RAW body orientation, before this
+                correction.
             gripper_joint_name: Joint name whose ``qpos`` is read for the
                 LIBERO ``state.gripper`` key. ``None`` (default) triggers
                 auto-resolution from the scene at episode start using
@@ -231,6 +257,17 @@ class LiberoAdapter(BenchmarkProtocol):
                 is ``"finger_joint1"``. The Menagerie Panda's two-finger
                 MJCF equality constraint mirrors the value to the second
                 finger, so reading just one is sufficient.
+            state_gripper_signs: Optional 2-element sign/scale vector
+                multiplied elementwise onto the ``state.gripper``
+                2-vector, whatever source produced it. RoboSuite's
+                training data records the two Panda finger qpos with
+                OPPOSITE signs (``finger_joint1`` in ``[0, +0.04]``,
+                ``finger_joint2`` in ``[-0.04, 0]``); backends whose
+                gripper model drives both fingers positive (e.g. the
+                Isaac Franka USD, whose ``panda_finger_joint2`` follows
+                the URDF ``[0, 0.04]`` mimic convention) must pass
+                ``[1.0, -1.0]`` to restore the trained sign convention.
+                ``None`` (default) leaves values as read.
             inject_eef_state: When ``True`` (default), the adapter's
                 :meth:`augment_observation` injects ``x`` / ``y`` / ``z``
                 / ``roll`` / ``pitch`` / ``yaw`` / ``gripper`` keys
@@ -439,7 +476,26 @@ class LiberoAdapter(BenchmarkProtocol):
         self._user_state_gripper_joint_names: list[str] | None = (
             [str(n) for n in state_gripper_joint_names] if state_gripper_joint_names is not None else None
         )
+        # #1802 - EEF source corrections for backends without the RoboSuite
+        # grip site (Isaac). Validated eagerly: a malformed offset silently
+        # feeding GR00T garbage state is exactly the failure class #168
+        # spent 30 rounds bisecting.
+        self._eef_pos_offset: list[float] | None = _validated_float_vector(eef_pos_offset, 3, "eef_pos_offset")
+        self._eef_quat_offset: list[float] | None = _validated_float_vector(eef_quat_offset, 4, "eef_quat_offset")
+        if self._eef_quat_offset is not None:
+            norm = float(np.linalg.norm(self._eef_quat_offset))
+            if not (0.99 < norm < 1.01):
+                raise ValueError(f"eef_quat_offset must be a unit quaternion (wxyz); got norm={norm:.4f}")
+        self._state_gripper_signs: list[float] | None = _validated_float_vector(
+            state_gripper_signs, 2, "state_gripper_signs"
+        )
         self._inject_eef_state = bool(inject_eef_state)
+        # #1802 - loud-error latch for augment_observation: when EEF state
+        # injection is enabled but produces no state keys, the failure used
+        # to surface only as the GR00T server's cryptic "State key 'state.x'
+        # must be in observation" rejection. Log ERROR once per adapter
+        # instead (once: augment_observation runs per control step).
+        self._eef_state_missing_logged = False
         self._auto_generate_scene = bool(auto_generate_scene)
         self._scene_cache_dir = scene_cache_dir
         # Default camera-name alias map matches RoboSuite/LIBERO's two
@@ -555,8 +611,11 @@ class LiberoAdapter(BenchmarkProtocol):
         cameras: dict[str, dict[str, Any]] | None = None,
         eef_body_name: str | None = None,
         eef_state_site_name: str | None = None,
+        eef_pos_offset: list[float] | None = None,
+        eef_quat_offset: list[float] | None = None,
         gripper_joint_name: str | None = None,
         state_gripper_joint_names: list[str] | None = None,
+        state_gripper_signs: list[float] | None = None,
         inject_eef_state: bool = True,
         auto_generate_scene: bool = True,
         scene_cache_dir: str | None = None,
@@ -584,8 +643,11 @@ class LiberoAdapter(BenchmarkProtocol):
             cameras=cameras,
             eef_body_name=eef_body_name,
             eef_state_site_name=eef_state_site_name,
+            eef_pos_offset=eef_pos_offset,
+            eef_quat_offset=eef_quat_offset,
             gripper_joint_name=gripper_joint_name,
             state_gripper_joint_names=state_gripper_joint_names,
+            state_gripper_signs=state_gripper_signs,
             inject_eef_state=inject_eef_state,
             auto_generate_scene=auto_generate_scene,
             scene_cache_dir=scene_cache_dir,
@@ -611,8 +673,11 @@ class LiberoAdapter(BenchmarkProtocol):
         cameras: dict[str, dict[str, Any]] | None = None,
         eef_body_name: str | None = None,
         eef_state_site_name: str | None = None,
+        eef_pos_offset: list[float] | None = None,
+        eef_quat_offset: list[float] | None = None,
         gripper_joint_name: str | None = None,
         state_gripper_joint_names: list[str] | None = None,
+        state_gripper_signs: list[float] | None = None,
         inject_eef_state: bool = True,
         auto_generate_scene: bool = True,
         scene_cache_dir: str | None = None,
@@ -635,8 +700,11 @@ class LiberoAdapter(BenchmarkProtocol):
             cameras=cameras,
             eef_body_name=eef_body_name,
             eef_state_site_name=eef_state_site_name,
+            eef_pos_offset=eef_pos_offset,
+            eef_quat_offset=eef_quat_offset,
             gripper_joint_name=gripper_joint_name,
             state_gripper_joint_names=state_gripper_joint_names,
+            state_gripper_signs=state_gripper_signs,
             inject_eef_state=inject_eef_state,
             auto_generate_scene=auto_generate_scene,
             scene_cache_dir=scene_cache_dir,
@@ -1521,12 +1589,18 @@ class LiberoAdapter(BenchmarkProtocol):
         # deltas across rounds 23-32 of #168.
         #
         # Read both finger qpos directly from ``data.qpos[jnt_qposadr]``
-        # using the canonical RoboSuite joint names. Falls back to the
-        # legacy single-joint duplicate-packing for non-RoboSuite
-        # scenes that don't ship two named finger joints.
+        # using the canonical RoboSuite joint names. On backends without
+        # a direct MuJoCo model (Isaac), fall back to reading both
+        # configured finger joints from the observation dict itself
+        # (#1802), then to the legacy single-joint duplicate-packing for
+        # scenes that don't ship two named finger joints. Whatever source
+        # produced the 2-vector, ``state_gripper_signs`` restores the
+        # RoboSuite sign convention when configured.
         gripper_qpos = self._read_gripper_qpos(sim)
+        if gripper_qpos is None:
+            gripper_qpos = self._read_gripper_qpos_from_obs(obs)
         if gripper_qpos is not None:
-            merged.setdefault("gripper", gripper_qpos)
+            merged.setdefault("gripper", self._apply_gripper_signs(gripper_qpos))
         else:
             # Legacy fallback - read one joint from obs and duplicate
             # (preserves pre-#168 behaviour for non-RoboSuite
@@ -1540,7 +1614,7 @@ class LiberoAdapter(BenchmarkProtocol):
                         gripper_value = val
                         break
             if isinstance(gripper_value, (int, float)) and not isinstance(gripper_value, bool):
-                merged.setdefault("gripper", [float(gripper_value), float(gripper_value)])
+                merged.setdefault("gripper", self._apply_gripper_signs([float(gripper_value), float(gripper_value)]))
             else:
                 logger.debug(
                     "LiberoAdapter: gripper joints %s not found via direct mujoco lookup, "
@@ -1588,6 +1662,37 @@ class LiberoAdapter(BenchmarkProtocol):
             cam_value = merged.get(cam_key)
             if isinstance(cam_value, np.ndarray) and cam_value.ndim >= 2:
                 merged[cam_key] = np.ascontiguousarray(cam_value[::-1, :])
+
+        # #1802 - loud, actionable failure when injection was requested
+        # but produced nothing. Before this check the only symptom was
+        # the GR00T server's per-call rejection ("State key 'state.x'
+        # must be in observation") after a silent DEBUG skip here -
+        # useless for diagnosing WHICH source failed. Logged once per
+        # adapter (augment_observation runs every control step).
+        if self._inject_eef_state and not self._eef_state_missing_logged:
+            missing = [k for k in ("x", "y", "z", "roll", "pitch", "yaw", "gripper") if k not in merged]
+            if missing:
+                self._eef_state_missing_logged = True
+                has_body_state = getattr(sim, "get_body_state", None) is not None
+                logger.error(
+                    "LiberoAdapter.augment_observation: could not inject EEF state key(s) %s "
+                    "(sim=%s, get_body_state=%s, eef_state_site_name=%r, eef_body_name=%r, "
+                    "gripper_joint_name=%r, state_gripper_joint_names=%s). A policy data-config "
+                    "that requires 'state.*' keys (e.g. libero_panda) will reject every "
+                    "observation with \"State key 'state.x' must be in observation\". Fix: pass "
+                    "eef_body_name= / gripper joint names that resolve on this backend (for the "
+                    "bundled Isaac Franka: eef_body_name='panda_hand', state_gripper_joint_names="
+                    "['panda_finger_joint1', 'panda_finger_joint2']), or set "
+                    "inject_eef_state=False if the backend supplies these keys natively. "
+                    "This error is logged once per adapter.",
+                    missing,
+                    type(sim).__name__,
+                    "available" if has_body_state else "NOT IMPLEMENTED",
+                    self.eef_state_site_name,
+                    self._eef_body_name,
+                    self._gripper_joint_name,
+                    self.state_gripper_joint_names,
+                )
 
         # #168 - emit one structured STATE_LOG line per
         # ``augment_observation`` call when STRANDS_LIBERO_STATE_LOG=1.
@@ -1733,6 +1838,25 @@ class LiberoAdapter(BenchmarkProtocol):
                 logger.debug("LiberoAdapter: get_body_state(%r) raised: %s", self._eef_body_name, e)
                 state_result = None
             fallback_pos, fallback_quat = _extract_pose(state_result)
+            # #1802 - site-equivalent corrections for backends whose only
+            # EEF source is the wrist body (Isaac has no RoboSuite grip
+            # site). The position offset is expressed in the body's local
+            # frame and therefore rotated by the RAW body orientation -
+            # before the quaternion correction, which realigns the frame
+            # to RoboSuite's ``robot0_right_hand`` convention afterwards.
+            if self._eef_pos_offset is not None and fallback_pos is not None:
+                if fallback_quat is not None:
+                    delta = _quat_wxyz_rotate_vec(fallback_quat, self._eef_pos_offset)
+                    fallback_pos = [p + d for p, d in zip(fallback_pos, delta)]
+                else:
+                    logger.debug(
+                        "LiberoAdapter: eef_pos_offset configured but get_body_state(%r) "
+                        "reported no orientation; cannot express the body-frame offset - "
+                        "using the uncorrected position",
+                        self._eef_body_name,
+                    )
+            if self._eef_quat_offset is not None and fallback_quat is not None:
+                fallback_quat = _quat_wxyz_multiply(fallback_quat, self._eef_quat_offset)
         else:
             logger.debug("LiberoAdapter: sim has no get_body_state(); skipping EEF state injection")
 
@@ -1813,6 +1937,56 @@ class LiberoAdapter(BenchmarkProtocol):
                 )
                 return None
         return finger_qposes
+
+    def _read_gripper_qpos_from_obs(self, obs: dict[str, Any]) -> list[float] | None:
+        """Read both finger qpos from the observation dict itself (#1802).
+
+        Backends without a direct MuJoCo model (Isaac) still key their
+        observations by joint name, so the two joints named by
+        :attr:`state_gripper_joint_names` can be read straight from
+        ``obs``. Tries the bare key first, then the ``.../<name>``
+        namespaced-suffix convention (same convention as the legacy
+        single-joint fallback).
+
+        Returns the 2-element ``[finger1.qpos, finger2.qpos]`` vector, or
+        ``None`` if ANY configured joint is missing / non-numeric - whole
+        vector or nothing, same contract as :meth:`_read_gripper_qpos`.
+        """
+        joint_names = self.state_gripper_joint_names
+        if not joint_names:
+            return None
+        values: list[float] = []
+        for jname in joint_names:
+            value = obs.get(jname)
+            if value is None:
+                for key, val in obs.items():
+                    if isinstance(key, str) and key.endswith("/" + jname):
+                        value = val
+                        break
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                return None
+            values.append(float(value))
+        return values
+
+    def _apply_gripper_signs(self, gripper_qpos: list[float]) -> list[float]:
+        """Apply the configured ``state_gripper_signs`` to a gripper 2-vector.
+
+        No-op (returns the input unchanged) when signs weren't configured
+        or the vector length doesn't match - a mismatch means the caller
+        produced a shape this adapter wasn't configured for, and mangling
+        a partial application would be worse than leaving it as read.
+        """
+        if self._state_gripper_signs is None:
+            return gripper_qpos
+        if len(gripper_qpos) != len(self._state_gripper_signs):
+            logger.warning(
+                "LiberoAdapter: state_gripper_signs has %d elements but the gripper "
+                "vector has %d; leaving state.gripper unsigned",
+                len(self._state_gripper_signs),
+                len(gripper_qpos),
+            )
+            return gripper_qpos
+        return [v * s for v, s in zip(gripper_qpos, self._state_gripper_signs)]
 
     def is_success(self, sim: SimEngine) -> bool:
         """Check whether the LIBERO task goal is satisfied.
@@ -2629,6 +2803,16 @@ class LiberoAdapter(BenchmarkProtocol):
         if isinstance(cameras_attr, dict):
             names.update(cameras_attr.keys())
 
+        # Isaac registry-side (#1802): IsaacSimulation tracks cameras on
+        # ``sim._cameras`` (its ``_world`` is the Isaac ``World`` handle,
+        # which has no ``cameras`` dict). Without this check the install
+        # step re-attempts ``add_camera`` for the pre-added ``image`` /
+        # ``wrist_image`` every episode and logs a duplicate-name WARNING
+        # per camera per episode.
+        sim_cameras_attr = getattr(sim, "_cameras", None)
+        if isinstance(sim_cameras_attr, dict):
+            names.update(sim_cameras_attr.keys())
+
         # Model-side: cameras declared in a loaded scene MJCF.
         model = getattr(world, "_model", None) if world is not None else None
         if model is None:
@@ -3212,6 +3396,48 @@ def _extract_pose(state: dict[str, Any] | None) -> tuple[list[float] | None, lis
         if isinstance(raw_quat, list) and len(raw_quat) == 4 and all(isinstance(c, (int, float)) for c in raw_quat):
             quat = [float(c) for c in raw_quat]
     return (pos, quat)
+
+
+def _validated_float_vector(value: Any, n: int, param: str) -> list[float] | None:
+    """Validate an optional length-``n`` float vector constructor argument.
+
+    Returns ``None`` untouched; otherwise a fresh ``list[float]`` of exactly
+    ``n`` finite elements. Raises :class:`ValueError` on any shape / dtype
+    problem - state-side config errors must fail at construction, not feed
+    the policy silently-wrong observations (#168's failure class).
+    """
+    if value is None:
+        return None
+    try:
+        vec = [float(c) for c in value]
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"{param} must be a sequence of {n} numbers; got {value!r}") from e
+    if len(vec) != n or not all(math.isfinite(c) for c in vec):
+        raise ValueError(f"{param} must be {n} finite numbers; got {value!r}")
+    return vec
+
+
+def _quat_wxyz_multiply(a: list[float], b: list[float]) -> list[float]:
+    """Hamilton product ``a * b`` of two wxyz quaternions."""
+    aw, ax, ay, az = a
+    bw, bx, by, bz = b
+    return [
+        aw * bw - ax * bx - ay * by - az * bz,
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+    ]
+
+
+def _quat_wxyz_rotate_vec(quat_wxyz: list[float], vec: list[float]) -> list[float]:
+    """Rotate ``vec`` by the (normalized) wxyz quaternion: ``R(q) @ vec``."""
+    q = np.asarray(quat_wxyz, dtype=np.float64)
+    norm = float(np.linalg.norm(q)) or 1.0
+    w, x, y, z = q / norm
+    u = np.array([x, y, z], dtype=np.float64)
+    v = np.asarray(vec, dtype=np.float64)
+    rotated = v + 2.0 * np.cross(u, np.cross(u, v) + w * v)
+    return [float(c) for c in rotated]
 
 
 def _fmt_state_value(value: Any) -> str:

--- a/strands_robots/benchmarks/libero/suite.py
+++ b/strands_robots/benchmarks/libero/suite.py
@@ -259,6 +259,7 @@ def load_libero_suite(
     init_jitter: float = 0.0,
     key_prefix: str = "libero",
     load_init_states: bool = True,
+    adapter_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, LiberoAdapter]:
     """Register every task in ``suite_name`` under the benchmark registry.
 
@@ -293,6 +294,15 @@ def load_libero_suite(
             documents intent). When ``True`` and libero loading fails,
             registration continues with init_states=None and the
             adapter falls back to snapshot-and-restore.
+        adapter_kwargs: Extra keyword arguments forwarded verbatim to every
+            :meth:`LiberoAdapter.from_file` call - the hook backend drivers
+            use to configure backend-specific state sources (#1802:
+            ``examples/libero/run_isaac.py`` passes ``eef_body_name`` /
+            ``eef_pos_offset`` / ``eef_quat_offset`` / gripper joint names
+            that resolve on the Isaac Franka USD, where the MuJoCo defaults
+            do not exist). Unknown keys raise ``TypeError`` from the adapter
+            constructor - typos fail loudly rather than silently dropping a
+            state-source override.
 
     Returns:
         ``{registry_name: LiberoAdapter}`` for every successfully registered
@@ -336,6 +346,7 @@ def load_libero_suite(
                 max_steps=max_steps,
                 init_jitter=init_jitter,
                 init_states=task_init_states,
+                **(adapter_kwargs or {}),
             )
         except (BDDLParseError, FileNotFoundError, ValueError) as e:
             logger.warning("Skipping LIBERO task %s: %s", bddl_file.name, e)

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -103,6 +103,75 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _to_float_list(value: Any, n: int) -> list[float] | None:
+    """Coerce a torch tensor / numpy array / sequence to ``n`` floats.
+
+    Isaac core APIs return numpy arrays on the CPU pipeline and torch
+    tensors on the GPU pipeline; ``get_observation`` handles the same
+    duality with a ``hasattr(x, "cpu")`` probe, mirrored here. Returns
+    ``None`` on any shape / dtype mismatch so callers can treat the
+    read as failed rather than propagate a partial vector.
+    """
+    try:
+        if hasattr(value, "cpu"):
+            value = value.cpu().numpy()
+        arr = np.asarray(value, dtype=np.float64).reshape(-1)
+    except (RuntimeError, TypeError, ValueError):
+        return None
+    if arr.shape[0] < n or not np.all(np.isfinite(arr[:n])):
+        return None
+    return [float(x) for x in arr[:n]]
+
+
+def _rotmat_to_quat_wxyz(rotmat: np.ndarray | list[list[float]]) -> list[float]:
+    """Row-major 3x3 rotation matrix -> unit quaternion, MuJoCo order (wxyz).
+
+    Shepperd's method (branch on the largest diagonal term) for numerical
+    stability near 180-degree rotations. The result is normalized and
+    sign-canonicalized to ``w >= 0`` (quaternion double-cover: ``q`` and
+    ``-q`` encode the same rotation, so the canonical sign is safe for
+    every consumer and keeps repeated reads deterministic).
+    """
+    m = np.asarray(rotmat, dtype=np.float64)
+    t = float(np.trace(m))
+    if t > 0.0:
+        s = float(np.sqrt(t + 1.0)) * 2.0
+        w, x, y, z = 0.25 * s, (m[2, 1] - m[1, 2]) / s, (m[0, 2] - m[2, 0]) / s, (m[1, 0] - m[0, 1]) / s
+    elif m[0, 0] >= m[1, 1] and m[0, 0] >= m[2, 2]:
+        s = float(np.sqrt(1.0 + m[0, 0] - m[1, 1] - m[2, 2])) * 2.0
+        w, x, y, z = (m[2, 1] - m[1, 2]) / s, 0.25 * s, (m[0, 1] + m[1, 0]) / s, (m[0, 2] + m[2, 0]) / s
+    elif m[1, 1] >= m[2, 2]:
+        s = float(np.sqrt(1.0 + m[1, 1] - m[0, 0] - m[2, 2])) * 2.0
+        w, x, y, z = (m[0, 2] - m[2, 0]) / s, (m[0, 1] + m[1, 0]) / s, 0.25 * s, (m[1, 2] + m[2, 1]) / s
+    else:
+        s = float(np.sqrt(1.0 + m[2, 2] - m[0, 0] - m[1, 1])) * 2.0
+        w, x, y, z = (m[1, 0] - m[0, 1]) / s, (m[0, 2] + m[2, 0]) / s, (m[1, 2] + m[2, 1]) / s, 0.25 * s
+    q = np.array([w, x, y, z], dtype=np.float64)
+    norm = float(np.linalg.norm(q)) or 1.0
+    q = q / norm
+    if q[0] < 0.0:
+        q = -q
+    return [float(v) for v in q]
+
+
+# ``get_body_state`` submits its USD read to the main-thread pump when called
+# from a worker thread; the read itself is trivial, so a stuck wait means the
+# pump died -- fail with a TimeoutError instead of hanging the caller forever.
+_BODY_STATE_MAIN_THREAD_TIMEOUT_S = 30.0
+
+
+def _body_state_envelope(body_name: str, state: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a body-state payload in the MuJoCo-compatible success envelope."""
+    pos = state["position"]
+    quat = state["quaternion"]
+    text = (
+        f"Body '{body_name}' ({state.get('source', 'body')} at {state.get('prim_path', '?')}):\n"
+        f"  pos: [{pos[0]:.4f}, {pos[1]:.4f}, {pos[2]:.4f}]\n"
+        f"  quat: [{quat[0]:.4f}, {quat[1]:.4f}, {quat[2]:.4f}, {quat[3]:.4f}]"
+    )
+    return {"status": "success", "content": [{"text": text}, {"json": state}]}
+
+
 class SimulationAppLaunchConfig(TypedDict, total=False):
     """Typed shape for ``omni.isaac.kit.SimulationApp`` launch config.
 
@@ -2054,10 +2123,39 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
             # Clear any objects realized by a prior load_scene so per-episode
             # reloads are idempotent (no duplicate prims / no "already exists").
+            removed_any = False
             for prior_name in list(self._scene_objects):
                 if prior_name in self._objects:
                     self.remove_object(prior_name)
+                    removed_any = True
                 self._scene_objects.discard(prior_name)
+
+            # Deleting prims leaves PhysX's simulation view STALE but
+            # non-None: the very next ``DynamicCuboid`` construction takes
+            # ``RigidPrim.__init__``'s eager ``_on_physics_ready`` path
+            # (gated on ``SimulationManager.get_physics_sim_view() is not
+            # None``) and its velocity read against the torn-down view
+            # raises the bare ``Exception("Failed to get rigid body
+            # velocities from backend")`` -- episode 2+ of every Isaac
+            # LIBERO eval crashed here (#1802). The #159 timeline-stop
+            # guard does not cover this: ``SimulationManager``'s STOP
+            # callback is a pop-subscription that only fires on an app
+            # update tick, which never happens between ``timeline.stop()``
+            # and the prim constructor. ``invalidate_physics()`` is the
+            # public, SYNCHRONOUS form of exactly that callback (its
+            # docstring sanctions manual invalidation); with the view
+            # gone, every subsequent add takes the deferred-init path and
+            # the end-of-load ``world.step`` below rebuilds one fresh
+            # view for the new scene.
+            if removed_any:
+                try:
+                    from isaacsim.core.simulation_manager import (  # type: ignore[import-not-found]
+                        SimulationManager,
+                    )
+
+                    SimulationManager.invalidate_physics()
+                except (ImportError, RuntimeError, ValueError, AttributeError, TypeError) as e:
+                    logger.warning("load_scene: invalidating the physics view after removals failed: %s", e)
 
             realized: list[str] = []
             skipped: list[dict[str, Any]] = []
@@ -2089,6 +2187,67 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             )
             if skipped:
                 summary += f" ({len(skipped)} skipped)"
+
+            # Re-initialize physics views (#1802). Realizing new prims on a
+            # stage that has ALREADY STEPPED invalidates PhysX's simulation
+            # view (``_construct_shape_prim`` also stops the timeline per
+            # dynamic prim, #159; the removals above invalidate it
+            # explicitly): the per-robot ``SingleArticulation`` handles are
+            # left holding the torn-down view, and ``get_joint_positions``
+            # returns nothing but the "Physics Simulation View is not
+            # created yet" warning. On the LIBERO eval that surfaced as an
+            # observation with NO joint keys -> no ``state.gripper`` -> the
+            # GR00T server rejecting every call.
+            #
+            # The rebuild is ``SimulationManager.initialize_physics()``
+            # (the public warmup that creates the tensor-API simulation
+            # view; a no-op when the view is already live) + per-robot
+            # ``articulation.initialize`` against the fresh view --
+            # deliberately NOT ``world.reset()``: a full reset re-applies
+            # every registered prim's default state on ``post_reset``,
+            # which was measured (2026-07-31, Isaac 6.0 / L4) to
+            # destabilize the already-posed articulation into a PhysX
+            # "Illegal BroadPhaseUpdateData - non-finite bounds" explosion
+            # within ~2 s of stepping. Best-effort per robot: a robot
+            # without a handle (Phase-1 stub) is skipped, a failed re-init
+            # is logged loudly because joint observations WILL be empty
+            # afterwards.
+            if realized:
+                try:
+                    import omni.kit.app  # type: ignore[import-not-found]
+                    from isaacsim.core.simulation_manager import (  # type: ignore[import-not-found]
+                        SimulationManager,
+                    )
+
+                    # Flush the timeline-STOP events queued by the
+                    # per-dynamic-prim ``timeline.stop()`` calls (#159)
+                    # BEFORE rebuilding. Those events are dispatched on the
+                    # next app update, and their handlers null every
+                    # ``RigidPrim`` / ``Articulation`` physics handle -- a
+                    # rebuild done first would be silently undone by the
+                    # first rendered step of the episode (observed as
+                    # "Physics Simulation View is not created yet" on every
+                    # subsequent joint read / action apply of the eval).
+                    omni.kit.app.get_app().update()
+                    SimulationManager.initialize_physics()
+                except (ImportError, RuntimeError, ValueError, AttributeError, TypeError) as e:
+                    logger.warning(
+                        "load_scene: rebuilding the physics view after realizing scene objects failed: %s", e
+                    )
+                for robot in self._robots.values():
+                    if robot.articulation is None:
+                        continue
+                    try:
+                        robot.articulation.initialize(getattr(self._world, "physics_sim_view", None))
+                    except (RuntimeError, ValueError, AttributeError, TypeError) as e:
+                        logger.warning(
+                            "load_scene: re-initializing articulation for robot %r after scene "
+                            "realization failed (%s); joint observations for this robot will be "
+                            "EMPTY until the handle is re-initialized.",
+                            robot.name,
+                            e,
+                        )
+
             logger.info("IsaacSimulation.load_scene: %s", summary)
             return {
                 "status": "success",
@@ -2944,6 +3103,16 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 self._world.step(render=True)
                 self._sim_time += self._config.physics_dt
                 self._step_count += 1
+                # ``world.step(render=True)`` reliably refreshes only the
+                # PRIMARY render product; a camera added after the first
+                # (e.g. the LIBERO adapter's ``wrist_image``, installed at
+                # episode start next to the pre-existing ``image``) never
+                # accumulates a frame from stepping alone and the warm-up
+                # loop ran to exhaustion (#1802). Flush the secondary
+                # products the same way ``get_observation`` does before
+                # checking for a frame.
+                if len(self._cameras) > 1:
+                    self._refresh_all_render_products()
                 if self.render(camera_name=name).get("status") == "success":
                     logger.debug("Camera %r warmed up after %d step(s)", name, i + 1)
                     return True
@@ -4414,6 +4583,211 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             return [float(x) for x in pos]
         except (RuntimeError, ValueError, AttributeError, TypeError):
             return None
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        """World pose of a scene object or robot link, MuJoCo-envelope-compatible.
+
+        Implements the same duck-typed contract as
+        :meth:`strands_robots.simulation.mujoco.physics.PhysicsMixin.get_body_state`,
+        which is the read primitive under BOTH consumers this backend was
+        missing (#1802):
+
+        * the predicate DSL (:mod:`strands_robots.simulation.predicates`
+          ``_body_position`` / ``_body_quaternion``, so ``body_above_z`` /
+          ``body_on`` / ``distance_less_than`` / ... evaluate on Isaac), and
+        * :meth:`LiberoAdapter._read_eef_pose`'s body-state fallback, which
+          injects the ``state.x/y/z/roll/pitch/yaw`` keys the ``libero_panda``
+          GR00T data-config requires.
+
+        Name resolution, in order (namespace-aware, mirroring MuJoCo's
+        "unambiguous or explicit" contract):
+
+        1. **Object registry** -- an ``add_object`` / ``load_scene`` object
+           whose name matches ``body_name`` verbatim (this is how LIBERO
+           scene bodies such as ``porcelain_mug_1_main`` resolve).
+        2. **Absolute prim path** -- a ``body_name`` starting with ``/`` is
+           looked up on the stage directly.
+        3. **Namespaced robot link** -- ``"<robot>/<link>"`` searches the
+           named robot's prim subtree for an Xformable prim named
+           ``<link>`` (e.g. ``"robot/panda_hand"``).
+        4. **Bare robot link** -- searched across every robot's subtree;
+           first match wins, so multi-robot scenes with colliding link
+           names MUST use the namespaced form.
+
+        Returns:
+            ``{"status": "success", "content": [{"text": ...}, {"json":
+            {"position": [x, y, z], "quaternion": [w, x, y, z],
+            "rotation_matrix": 3x3, ...}}]}`` on success. ``linear_velocity``
+            / ``angular_velocity`` are included only when the resolved
+            object's handle exposes them (rigid-prim objects do; USD-walked
+            robot links do not -- keys are OMITTED rather than zero-filled,
+            per the no-silent-defaults rule). ``mass`` / ``center_of_mass``
+            from the MuJoCo contract are likewise not reported on Isaac.
+            Unknown bodies and a missing world return
+            ``{"status": "error", "content": [{"text": ...}]}``.
+
+        Concurrency: safe to call from any thread. Off the main thread with
+        the pump running, the USD read is submitted via :meth:`run_on_main`
+        (Kit's stage may only be queried from the thread that owns
+        ``SimulationApp``).
+        """
+        if not isinstance(body_name, str) or not body_name.strip():
+            return {
+                "status": "error",
+                "content": [{"text": "get_body_state: body_name must be a non-empty string."}],
+            }
+        if not self._world_created:
+            return {"status": "error", "content": [{"text": "No world created. Call create_world() first."}]}
+
+        if self._on_main_thread() or not self._pump_running:
+            return self._get_body_state_impl(body_name)
+        return self.run_on_main(
+            lambda: self._get_body_state_impl(body_name),
+            timeout=_BODY_STATE_MAIN_THREAD_TIMEOUT_S,
+        )
+
+    def _get_body_state_impl(self, body_name: str) -> dict[str, Any]:
+        """Resolve + read ``body_name``; runs on the main thread (or pump-less)."""
+        obj = self._objects.get(body_name)
+        if obj is not None and obj.handle is not None:
+            state = self._object_body_state(obj)
+            if state is not None:
+                return _body_state_envelope(body_name, state)
+
+        state = self._prim_body_state(body_name)
+        if state is not None:
+            return _body_state_envelope(body_name, state)
+
+        objects = sorted(self._objects)
+        shown = ", ".join(objects[:20]) + (", ..." if len(objects) > 20 else "")
+        msg = (
+            f"Body '{body_name}' not found on the Isaac stage. "
+            f"Known objects: [{shown}]. Robots: {sorted(self._robots)} -- address robot links as "
+            f"'<robot>/<link>' (e.g. 'robot/panda_hand') or pass an absolute prim path ('/World/...')."
+        )
+        return {"status": "error", "content": [{"text": msg}]}
+
+    def _object_body_state(self, obj: _ObjectState) -> dict[str, Any] | None:
+        """Pose (+ best-effort velocities) of a registered object's rigid prim."""
+        try:
+            pos, quat = obj.handle.get_world_pose()
+        except (RuntimeError, ValueError, AttributeError, TypeError) as e:
+            logger.debug("get_body_state: get_world_pose failed for object %r: %s", obj.name, e)
+            return None
+        position = _to_float_list(pos, 3)
+        quaternion = _to_float_list(quat, 4)  # Isaac core convention is scalar-first (wxyz), same as MuJoCo
+        if position is None or quaternion is None:
+            logger.debug("get_body_state: object %r returned an unusable pose (%r, %r)", obj.name, pos, quat)
+            return None
+        state: dict[str, Any] = {
+            "position": position,
+            "quaternion": quaternion,
+            "rotation_matrix": _quat_wxyz_to_rotmat(np.asarray(quaternion)).tolist(),
+            "source": "object",
+            "prim_path": obj.prim_path,
+        }
+        for key, getter in (("linear_velocity", "get_linear_velocity"), ("angular_velocity", "get_angular_velocity")):
+            fn = getattr(obj.handle, getter, None)
+            if fn is None:
+                continue
+            try:
+                vel = _to_float_list(fn(), 3)
+            except (RuntimeError, ValueError, AttributeError, TypeError) as e:
+                logger.debug("get_body_state: %s failed for object %r: %s", getter, obj.name, e)
+                continue
+            if vel is not None:
+                state[key] = vel
+        return state
+
+    def _prim_body_state(self, body_name: str) -> dict[str, Any] | None:
+        """Pose of a robot-link / absolute-path prim, read off the USD stage.
+
+        Same stage-walk + axis-normalization approach as
+        :meth:`gripper_frame_pose` (handles authored scale), generalized from
+        that method's name-heuristic gripper search to exact-name link
+        resolution. Returns ``None`` when the prim cannot be resolved.
+        """
+        try:
+            import omni.usd  # type: ignore[import-not-found]
+            from pxr import (  # type: ignore[import-not-found]
+                Gf,
+                Sdf,
+                Usd,
+                UsdGeom,
+            )
+        except ImportError as e:
+            logger.debug("get_body_state: USD runtime not importable: %s", e)
+            return None
+        try:
+            stage = omni.usd.get_context().get_stage()
+            if stage is None:
+                return None
+
+            prim = None
+            if body_name.startswith("/"):
+                p = stage.GetPrimAtPath(body_name)
+                if p and p.IsValid() and p.IsA(UsdGeom.Xformable):
+                    prim = p
+            elif "/" in body_name:
+                robot_name, _, link_name = body_name.partition("/")
+                r = self._robots.get(robot_name)
+                if r is not None and link_name:
+                    prim = self._find_robot_link_prim(stage, r, link_name, Sdf, Usd, UsdGeom)
+            else:
+                for r in self._robots.values():
+                    prim = self._find_robot_link_prim(stage, r, body_name, Sdf, Usd, UsdGeom)
+                    if prim is not None:
+                        break
+            if prim is None:
+                return None
+
+            xf = UsdGeom.Xformable(prim).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+            t = xf.ExtractTranslation()
+
+            def _axis(vx: float, vy: float, vz: float) -> list[float]:
+                d = xf.TransformDir(Gf.Vec3d(vx, vy, vz))
+                n = (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]) ** 0.5 or 1.0
+                return [d[0] / n, d[1] / n, d[2] / n]
+
+            ax, ay, az = _axis(1.0, 0.0, 0.0), _axis(0.0, 1.0, 0.0), _axis(0.0, 0.0, 1.0)
+            # Columns are the prim frame's local axes in world coords
+            # (``world = R @ local``), matching MuJoCo's ``data.xmat``.
+            rotmat = [
+                [ax[0], ay[0], az[0]],
+                [ax[1], ay[1], az[1]],
+                [ax[2], ay[2], az[2]],
+            ]
+            return {
+                "position": [float(t[0]), float(t[1]), float(t[2])],
+                "quaternion": _rotmat_to_quat_wxyz(rotmat),
+                "rotation_matrix": rotmat,
+                "source": "prim",
+                "prim_path": str(prim.GetPath()),
+            }
+        except (RuntimeError, ValueError, AttributeError, TypeError):
+            logger.debug("get_body_state: USD read failed for %r", body_name, exc_info=True)
+            return None
+
+    @staticmethod
+    def _find_robot_link_prim(stage: Any, r: _RobotState, link_name: str, Sdf: Any, Usd: Any, UsdGeom: Any) -> Any:  # noqa: N803 - pxr module objects passed by caller
+        """Exact-name Xformable prim under a robot's top-level subtree, or ``None``.
+
+        Walks up from ``r.actual_prim_path`` to the top-level robot prim
+        (the importer may have relocated the robot -- see
+        :meth:`gripper_frame_pose`) and searches the whole subtree for a
+        prim named ``link_name``.
+        """
+        sdf_path = Sdf.Path(r.actual_prim_path)
+        top = sdf_path
+        while top.GetParentPath() != Sdf.Path.absoluteRootPath and top.GetParentPath() != Sdf.Path.emptyPath:
+            top = top.GetParentPath()
+        root = stage.GetPrimAtPath(top)
+        if not root or not root.IsValid():
+            return None
+        for p in Usd.PrimRange(root):
+            if p.GetName() == link_name and p.IsA(UsdGeom.Xformable):
+                return p
+        return None
 
     def gripper_frame_pos(self, robot_name: str | None = None) -> list[float] | None:
         """World position of the robot's gripper / tool link (translation only)."""

--- a/tests/benchmarks/libero/test_isaac_eef_state_source.py
+++ b/tests/benchmarks/libero/test_isaac_eef_state_source.py
@@ -1,0 +1,333 @@
+"""Backend-agnostic EEF state source: get_body_state fallback + Isaac plumbing (#1802).
+
+On backends without a compiled MuJoCo model (Isaac), ``LiberoAdapter`` can
+only source the ``state.x/y/z/roll/pitch/yaw`` keys from the sim's
+``get_body_state`` duck-typed contract, and ``state.gripper`` from the
+observation dict itself. #1802 added:
+
+* ``eef_pos_offset`` / ``eef_quat_offset`` - site-equivalent corrections
+  applied to the body-state fallback (the wrist body sits ~9.7 cm behind
+  the gripper tip RoboSuite's ``state.x/y/z`` was trained on);
+* ``_read_gripper_qpos_from_obs`` + ``state_gripper_signs`` - both finger
+  qpos read from obs keys, with the RoboSuite opposite-sign convention
+  restorable for backends whose gripper drives both fingers positive;
+* a loud ERROR (not a DEBUG skip) when injection is enabled but produces
+  no state keys - previously the failure surfaced only as the GR00T
+  server's cryptic ``State key 'state.x' must be in observation``.
+
+These tests run against a pure-Python fake sim (no MuJoCo world, no Isaac
+Kit), pinning exactly the code paths the Isaac backend exercises.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.benchmarks.libero import LiberoAdapter
+from strands_robots.benchmarks.libero.adapter import (
+    _quat_wxyz_multiply,
+    _quat_wxyz_rotate_vec,
+    _quat_wxyz_to_rpy_xyz,
+)
+from strands_robots.simulation.base import SimEngine
+
+_PICK_CUBE_BDDL = """
+(define (problem libero_eef_probe)
+  (:language "pick up the cube")
+  (:objects cube_1 - object)
+  (:goal (on cube_1 table_1)))
+"""
+
+# 90 degrees about z - large enough that a missed rotation of the local
+# offset shows up as centimetres of position error.
+_HAND_QUAT = [0.7071067811865476, 0.0, 0.0, 0.7071067811865476]
+_HAND_POS = [0.4, -0.1, 0.9]
+
+
+class _FakeSim(SimEngine):
+    """Non-MuJoCo sim exposing only the ``get_body_state`` contract.
+
+    ``_world`` has no ``_model`` / ``_data``, so the adapter's direct-MuJoCo
+    reads no-op exactly as they do on the Isaac backend, forcing the
+    body-state fallback.
+    """
+
+    def __init__(self, body_states: dict[str, dict[str, Any]] | None = None) -> None:
+        self._world = None
+        self._body_states = body_states or {}
+        self.body_state_calls: list[str] = []
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        self.body_state_calls.append(body_name)
+        state = self._body_states.get(body_name)
+        if state is None:
+            return {"status": "error", "content": [{"text": f"Body '{body_name}' not found"}]}
+        return {"status": "success", "content": [{"text": "ok"}, {"json": state}]}
+
+    # --- SimEngine stubs ---------------------------------------------------
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):
+        return {"status": "success"}
+
+    def destroy(self):
+        return {"status": "success"}
+
+    def reset(self):
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):
+        return {"status": "success"}
+
+    def get_state(self):
+        return {}
+
+    def add_robot(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_robot(self, name):
+        return {"status": "success"}
+
+    def list_robots(self):
+        return []
+
+    def robot_joint_names(self, robot_name):
+        return []
+
+    def add_object(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_object(self, name):
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        return {}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        return {"status": "success"}
+
+    def physics_timestep(self):
+        return 0.002
+
+    def render(self, camera_name="default", width=640, height=480):
+        return {"status": "success", "content": []}
+
+
+class _NoBodyStateSim(_FakeSim):
+    """A sim WITHOUT get_body_state - the pre-#1802 Isaac situation."""
+
+    get_body_state = None  # type: ignore[assignment]
+
+    def __getattribute__(self, name):
+        if name == "get_body_state":
+            raise AttributeError(name)
+        return super().__getattribute__(name)
+
+
+def _isaac_like_sim() -> _FakeSim:
+    return _FakeSim(body_states={"panda_hand": {"position": list(_HAND_POS), "quaternion": list(_HAND_QUAT)}})
+
+
+def _make_adapter(**kwargs) -> LiberoAdapter:
+    return LiberoAdapter.from_text(
+        _PICK_CUBE_BDDL,
+        install_cameras=False,
+        auto_generate_scene=False,
+        **kwargs,
+    )
+
+
+class TestFallbackOffsets:
+    def test_pos_offset_rotated_into_body_frame(self):
+        """eef_pos_offset is expressed in the body frame: rotated by the
+        body quaternion, not added in world coordinates."""
+        adapter = _make_adapter(eef_body_name="panda_hand", eef_pos_offset=[0.0, 0.0, 0.097])
+        pos, quat = adapter._read_eef_pose(_isaac_like_sim())
+
+        expected = np.array(_HAND_POS) + np.array(_quat_wxyz_rotate_vec(_HAND_QUAT, [0.0, 0.0, 0.097]))
+        np.testing.assert_allclose(pos, expected, atol=1e-12)
+        np.testing.assert_allclose(quat, _HAND_QUAT, atol=1e-12)
+        # 90 deg about z maps the local +z offset to world +z here; the
+        # rotation matters for the general case - pin that the offset was
+        # NOT a plain world-frame add for a non-z-preserving quat too.
+        tilted_quat = [0.7071067811865476, 0.7071067811865476, 0.0, 0.0]  # 90 deg about x
+        sim = _FakeSim(body_states={"panda_hand": {"position": [0, 0, 0], "quaternion": tilted_quat}})
+        pos2, _ = adapter._read_eef_pose(sim)
+        np.testing.assert_allclose(pos2, [0.0, -0.097, 0.0], atol=1e-12)
+
+    def test_quat_offset_right_multiplied(self):
+        offset = [0.9238795325112867, 0.0, 0.0, 0.3826834323650898]  # 45 deg about z
+        adapter = _make_adapter(eef_body_name="panda_hand", eef_quat_offset=offset)
+        _, quat = adapter._read_eef_pose(_isaac_like_sim())
+        np.testing.assert_allclose(quat, _quat_wxyz_multiply(_HAND_QUAT, offset), atol=1e-12)
+
+    def test_pos_offset_uses_raw_body_quat_before_quat_offset(self):
+        """The local-frame position offset must be expressed with the RAW body
+        orientation; the quaternion correction applies afterwards."""
+        quat_offset = [0.7071067811865476, 0.0, 0.0, -0.7071067811865476]  # -90 deg about z
+        adapter = _make_adapter(
+            eef_body_name="panda_hand",
+            eef_pos_offset=[0.1, 0.0, 0.0],
+            eef_quat_offset=quat_offset,
+        )
+        pos, quat = adapter._read_eef_pose(_isaac_like_sim())
+
+        expected_pos = np.array(_HAND_POS) + np.array(_quat_wxyz_rotate_vec(_HAND_QUAT, [0.1, 0.0, 0.0]))
+        np.testing.assert_allclose(pos, expected_pos, atol=1e-12)
+        np.testing.assert_allclose(quat, _quat_wxyz_multiply(_HAND_QUAT, quat_offset), atol=1e-12)
+
+    def test_no_offsets_leaves_fallback_pose_unchanged(self):
+        adapter = _make_adapter(eef_body_name="panda_hand")
+        pos, quat = adapter._read_eef_pose(_isaac_like_sim())
+        np.testing.assert_allclose(pos, _HAND_POS, atol=1e-12)
+        np.testing.assert_allclose(quat, _HAND_QUAT, atol=1e-12)
+
+    def test_augment_observation_rpy_reflects_corrected_quat(self):
+        offset = [0.9238795325112867, 0.0, 0.0, 0.3826834323650898]
+        adapter = _make_adapter(eef_body_name="panda_hand", eef_quat_offset=offset)
+        merged = adapter.augment_observation(_isaac_like_sim(), {"panda_finger_joint1": 0.02})
+        expected_rpy = _quat_wxyz_to_rpy_xyz(_quat_wxyz_multiply(_HAND_QUAT, offset))
+        assert (merged["roll"], merged["pitch"], merged["yaw"]) == pytest.approx(expected_rpy)
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"eef_pos_offset": [1.0, 2.0]}, "eef_pos_offset"),
+            ({"eef_pos_offset": "not-a-vector"}, "eef_pos_offset"),
+            ({"eef_quat_offset": [1.0, 0.0, 0.0]}, "eef_quat_offset"),
+            ({"eef_quat_offset": [2.0, 0.0, 0.0, 0.0]}, "unit quaternion"),
+            ({"state_gripper_signs": [1.0]}, "state_gripper_signs"),
+        ],
+    )
+    def test_malformed_offsets_raise_at_construction(self, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            _make_adapter(**kwargs)
+
+
+class TestGripperFromObs:
+    def test_both_fingers_read_from_obs_with_signs(self):
+        """Isaac path: both finger qpos come from obs keys; [1, -1] restores
+        the RoboSuite opposite-sign convention."""
+        adapter = _make_adapter(
+            eef_body_name="panda_hand",
+            state_gripper_joint_names=["panda_finger_joint1", "panda_finger_joint2"],
+            state_gripper_signs=[1.0, -1.0],
+        )
+        obs = {"panda_finger_joint1": 0.021, "panda_finger_joint2": 0.019}
+        merged = adapter.augment_observation(_isaac_like_sim(), obs)
+        assert merged["gripper"] == pytest.approx([0.021, -0.019])
+
+    def test_namespaced_obs_keys_match_by_suffix(self):
+        adapter = _make_adapter(
+            eef_body_name="panda_hand",
+            state_gripper_joint_names=["panda_finger_joint1", "panda_finger_joint2"],
+        )
+        obs = {"arm/panda_finger_joint1": 0.02, "arm/panda_finger_joint2": 0.02}
+        merged = adapter.augment_observation(_isaac_like_sim(), obs)
+        assert merged["gripper"] == pytest.approx([0.02, 0.02])
+
+    def test_missing_finger_falls_back_to_single_joint_duplicate(self):
+        """Whole-vector-or-nothing: one missing finger -> the legacy
+        single-joint duplicate path (with signs still applied)."""
+        adapter = _make_adapter(
+            eef_body_name="panda_hand",
+            gripper_joint_name="panda_finger_joint1",
+            state_gripper_joint_names=["panda_finger_joint1", "panda_finger_joint2"],
+            state_gripper_signs=[1.0, -1.0],
+        )
+        obs = {"panda_finger_joint1": 0.02}  # joint2 missing
+        merged = adapter.augment_observation(_isaac_like_sim(), obs)
+        assert merged["gripper"] == pytest.approx([0.02, -0.02])
+
+    def test_signs_default_to_identity(self):
+        adapter = _make_adapter(
+            eef_body_name="panda_hand",
+            state_gripper_joint_names=["panda_finger_joint1", "panda_finger_joint2"],
+        )
+        obs = {"panda_finger_joint1": 0.021, "panda_finger_joint2": 0.019}
+        merged = adapter.augment_observation(_isaac_like_sim(), obs)
+        assert merged["gripper"] == pytest.approx([0.021, 0.019])
+
+
+class TestLoudErrorOnMissingState:
+    def test_error_logged_when_nothing_injectable(self, caplog):
+        """No get_body_state + no gripper obs keys -> ERROR naming the missing
+        keys and the backend fix, not a silent DEBUG skip."""
+        adapter = _make_adapter()
+        with caplog.at_level(logging.ERROR, logger="strands_robots.benchmarks.libero.adapter"):
+            merged = adapter.augment_observation(_NoBodyStateSim(), {})
+        assert all(k not in merged for k in ("x", "y", "z", "roll", "pitch", "yaw", "gripper"))
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        message = errors[0].getMessage()
+        assert "could not inject EEF state" in message
+        assert "state.x" in message
+        assert "eef_body_name" in message
+        assert "panda_hand" in message  # the actionable Isaac hint
+
+    def test_error_logged_once_per_adapter(self, caplog):
+        adapter = _make_adapter()
+        with caplog.at_level(logging.ERROR, logger="strands_robots.benchmarks.libero.adapter"):
+            adapter.augment_observation(_NoBodyStateSim(), {})
+            adapter.augment_observation(_NoBodyStateSim(), {})
+        assert len([r for r in caplog.records if r.levelno == logging.ERROR]) == 1
+
+    def test_no_error_when_injection_succeeds(self, caplog):
+        adapter = _make_adapter(
+            eef_body_name="panda_hand",
+            state_gripper_joint_names=["panda_finger_joint1", "panda_finger_joint2"],
+        )
+        obs = {"panda_finger_joint1": 0.02, "panda_finger_joint2": 0.02}
+        with caplog.at_level(logging.ERROR, logger="strands_robots.benchmarks.libero.adapter"):
+            merged = adapter.augment_observation(_isaac_like_sim(), obs)
+        assert all(k in merged for k in ("x", "y", "z", "roll", "pitch", "yaw", "gripper"))
+        assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+    def test_no_error_when_injection_disabled(self, caplog):
+        adapter = _make_adapter(inject_eef_state=False)
+        with caplog.at_level(logging.ERROR, logger="strands_robots.benchmarks.libero.adapter"):
+            adapter.augment_observation(_NoBodyStateSim(), {})
+        assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+
+class TestDirectMuJoCoPathUnaffected:
+    """The offsets are fallback-only: a resolving site read is never corrected."""
+
+    def test_site_read_ignores_offsets(self):
+        mujoco = pytest.importorskip("mujoco")
+
+        xml = """
+        <mujoco model="eef_probe">
+          <worldbody>
+            <body name="robot0_right_hand" pos="0.3 0.0 0.5" quat="0 1 0 0">
+              <geom type="box" size="0.02 0.02 0.02"/>
+              <body name="tip" pos="0 0 -0.097">
+                <site name="gripper0_grip_site" pos="0 0 0" size="0.005"/>
+                <geom type="box" size="0.01 0.01 0.01"/>
+              </body>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        model = mujoco.MjModel.from_xml_string(xml)
+        data = mujoco.MjData(model)
+        mujoco.mj_forward(model, data)
+
+        class _World:
+            _model = model
+            _data = data
+            robots: dict[str, object] = {}
+
+        sim = _FakeSim()
+        sim._world = _World()
+
+        adapter = _make_adapter(
+            eef_body_name="robot0_right_hand",
+            eef_state_site_name="gripper0_grip_site",
+            eef_pos_offset=[0.0, 0.0, 0.5],  # would move the pose half a metre if misapplied
+        )
+        pos, _ = adapter._read_eef_pose(sim)
+        sid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "gripper0_grip_site")
+        np.testing.assert_allclose(pos, np.array(data.site_xpos[sid]), atol=1e-9)

--- a/tests/simulation/isaac/test_get_body_state.py
+++ b/tests/simulation/isaac/test_get_body_state.py
@@ -1,0 +1,227 @@
+"""IsaacSimulation.get_body_state - MuJoCo-envelope-compatible body pose reads.
+
+The method is the read primitive under BOTH consumers #1802 unblocked on the
+Isaac backend: the predicate DSL (``_body_position`` / ``_body_quaternion``)
+and ``LiberoAdapter._read_eef_pose``'s body-state fallback (the source of the
+``state.x/y/z/roll/pitch/yaw`` keys the ``libero_panda`` GR00T data-config
+requires). These unit tests exercise it through a skeleton ``IsaacSimulation``
+built with ``__new__`` (same pattern as ``test_dataset_recording.py``) so the
+resolution order, envelope contract, quaternion conventions, and error shapes
+are pinned without the Isaac Sim Kit runtime. The USD prim-walk path (which
+needs a live Kit stage) is covered by
+``tests_integ/simulation/test_isaac_body_state_gpu.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.simulation import (
+    IsaacSimulation,
+    _ObjectState,
+    _quat_wxyz_to_rotmat,
+    _RobotState,
+    _rotmat_to_quat_wxyz,
+)
+
+
+class _FakeRigidHandle:
+    """Stub rigid-prim handle: world pose + optional velocities."""
+
+    def __init__(
+        self,
+        pos: list[float],
+        quat_wxyz: list[float],
+        linear_velocity: list[float] | None = None,
+        angular_velocity: list[float] | None = None,
+    ) -> None:
+        self._pos = np.asarray(pos, dtype=np.float64)
+        self._quat = np.asarray(quat_wxyz, dtype=np.float64)
+        self._lin = linear_velocity
+        self._ang = angular_velocity
+
+    def get_world_pose(self):
+        return self._pos, self._quat
+
+    def get_linear_velocity(self):
+        if self._lin is None:
+            raise AttributeError("no velocity on this handle")
+        return np.asarray(self._lin, dtype=np.float64)
+
+    def get_angular_velocity(self):
+        if self._ang is None:
+            raise AttributeError("no velocity on this handle")
+        return np.asarray(self._ang, dtype=np.float64)
+
+
+def _make_engine(
+    objects: dict[str, _ObjectState] | None = None,
+    robots: dict[str, _RobotState] | None = None,
+) -> IsaacSimulation:
+    """Skeleton IsaacSimulation with exactly the state get_body_state reads."""
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = robots if robots is not None else {}
+    engine._objects = objects if objects is not None else {}
+    engine._pump_running = False
+    engine._main_tid = threading.get_ident()
+    return engine
+
+
+def _object(name: str, handle: Any) -> _ObjectState:
+    obj = _ObjectState(name=name, prim_path=f"/World/Objects/{name}", shape="box", is_static=False)
+    obj.handle = handle
+    return obj
+
+
+def _json_payload(result: dict) -> dict:
+    return next(c["json"] for c in result["content"] if "json" in c)
+
+
+def test_no_world_errors() -> None:
+    engine = _make_engine()
+    engine._world_created = False
+    result = engine.get_body_state(body_name="anything")
+    assert result["status"] == "error"
+    assert "No world" in result["content"][0]["text"]
+
+
+@pytest.mark.parametrize("bad_name", ["", "   ", None, 42])
+def test_invalid_body_name_errors(bad_name) -> None:
+    engine = _make_engine()
+    result = engine.get_body_state(body_name=bad_name)
+    assert result["status"] == "error"
+    assert "non-empty string" in result["content"][0]["text"]
+
+
+def test_object_pose_success_envelope() -> None:
+    """Registered object resolves to the MuJoCo-compatible envelope shape."""
+    quat = [0.7071067811865476, 0.0, 0.0, 0.7071067811865476]  # 90 deg about z
+    handle = _FakeRigidHandle([0.1, -0.2, 0.3], quat)
+    engine = _make_engine(objects={"cube_main": _object("cube_main", handle)})
+
+    result = engine.get_body_state(body_name="cube_main")
+
+    assert result["status"] == "success"
+    assert any("text" in c for c in result["content"])
+    payload = _json_payload(result)
+    assert payload["position"] == pytest.approx([0.1, -0.2, 0.3])
+    assert payload["quaternion"] == pytest.approx(quat)
+    # rotation_matrix must agree with the quaternion (90 deg about z).
+    expected_r = [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+    assert np.asarray(payload["rotation_matrix"]) == pytest.approx(np.asarray(expected_r), abs=1e-12)
+    # No velocities were exposed -> keys OMITTED, never zero-filled.
+    assert "linear_velocity" not in payload
+    assert "angular_velocity" not in payload
+
+
+def test_object_velocities_included_when_handle_provides_them() -> None:
+    handle = _FakeRigidHandle([0, 0, 1], [1, 0, 0, 0], linear_velocity=[0.5, 0, 0], angular_velocity=[0, 0, 2.0])
+    engine = _make_engine(objects={"ball": _object("ball", handle)})
+
+    payload = _json_payload(engine.get_body_state(body_name="ball"))
+
+    assert payload["linear_velocity"] == pytest.approx([0.5, 0.0, 0.0])
+    assert payload["angular_velocity"] == pytest.approx([0.0, 0.0, 2.0])
+
+
+def test_unknown_body_error_is_actionable() -> None:
+    """The error names known objects/robots and the namespaced-link form."""
+    engine = _make_engine(
+        objects={"mug_main": _object("mug_main", _FakeRigidHandle([0, 0, 0], [1, 0, 0, 0]))},
+        robots={"robot": _RobotState(name="robot", prim_path="/World/Robots/robot", joint_names=[])},
+    )
+
+    result = engine.get_body_state(body_name="does_not_exist")
+
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "does_not_exist" in text
+    assert "mug_main" in text
+    assert "robot" in text
+    assert "<robot>/<link>" in text
+
+
+def test_broken_object_handle_falls_through_to_error() -> None:
+    """A handle whose pose read raises degrades to the structured error."""
+
+    class _BrokenHandle:
+        def get_world_pose(self):
+            raise RuntimeError("physics view torn down")
+
+    engine = _make_engine(objects={"cube": _object("cube", _BrokenHandle())})
+    result = engine.get_body_state(body_name="cube")
+    assert result["status"] == "error"
+    assert "cube" in result["content"][0]["text"]
+
+
+def test_prim_path_resolution_used_for_robot_links(monkeypatch) -> None:
+    """Non-object names route to the USD prim read (mocked: no Kit runtime)."""
+    engine = _make_engine(robots={"robot": _RobotState(name="robot", prim_path="/World/Robots/robot", joint_names=[])})
+    rotmat = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+    def _fake_prim_state(body_name: str):
+        assert body_name == "robot/panda_hand"
+        return {
+            "position": [0.4, 0.0, 0.5],
+            "quaternion": _rotmat_to_quat_wxyz(rotmat),
+            "rotation_matrix": rotmat,
+            "source": "prim",
+            "prim_path": "/World/Robots/robot/panda_hand",
+        }
+
+    monkeypatch.setattr(engine, "_prim_body_state", _fake_prim_state)
+
+    result = engine.get_body_state(body_name="robot/panda_hand")
+
+    assert result["status"] == "success"
+    payload = _json_payload(result)
+    assert payload["position"] == pytest.approx([0.4, 0.0, 0.5])
+    assert payload["quaternion"] == pytest.approx([1.0, 0.0, 0.0, 0.0])
+
+
+def test_prim_read_unavailable_without_kit_runtime() -> None:
+    """The real USD path degrades to None (-> error envelope) off-Kit.
+
+    On a host without omni.usd/pxr importable, _prim_body_state must not
+    raise; get_body_state reports the structured unknown-body error.
+    """
+    engine = _make_engine(robots={"robot": _RobotState(name="robot", prim_path="/World/Robots/robot", joint_names=[])})
+    result = engine.get_body_state(body_name="robot/panda_hand")
+    # Either the Kit runtime is present (then the stage lookup itself fails
+    # gracefully) or it is not importable; both must yield the error envelope.
+    assert result["status"] == "error"
+
+
+class TestQuaternionHelpers:
+    """The wxyz/rotation-matrix conversions get_body_state relies on."""
+
+    @pytest.mark.parametrize(
+        "quat",
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.7071067811865476, 0.7071067811865476, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],  # 180 deg about x (Shepperd branch)
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [0.5, 0.5, 0.5, 0.5],
+            [0.9238795325112867, 0.0, 0.3826834323650898, 0.0],
+        ],
+    )
+    def test_roundtrip(self, quat) -> None:
+        recovered = _rotmat_to_quat_wxyz(_quat_wxyz_to_rotmat(np.asarray(quat)))
+        q = np.asarray(quat)
+        r = np.asarray(recovered)
+        # Double cover: q and -q encode the same rotation.
+        assert min(np.linalg.norm(r - q), np.linalg.norm(r + q)) < 1e-12
+
+    def test_rotmat_to_quat_is_normalized_and_w_canonical(self) -> None:
+        q = _rotmat_to_quat_wxyz([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        assert np.linalg.norm(q) == pytest.approx(1.0)
+        assert q[0] >= 0.0

--- a/tests/simulation/isaac/test_load_scene_physics_view.py
+++ b/tests/simulation/isaac/test_load_scene_physics_view.py
@@ -1,0 +1,173 @@
+"""IsaacSimulation.load_scene physics-view lifecycle regression pins (#1802).
+
+The scene-realization step must rebuild the PhysX simulation view WITHOUT
+``world.reset()``: a full reset re-applies every registered prim's default
+state on ``post_reset``, which was measured (2026-07-31, Isaac 6.0 / L4) to
+destabilize the already-posed Franka articulation into a PhysX
+"Illegal BroadPhaseUpdateData - non-finite bounds" explosion within ~2 s of
+stepping. These tests drive ``load_scene`` through a ``__new__``-skeleton
+``IsaacSimulation`` (same pattern as ``test_dataset_recording.py``) with the
+prim-mutation surface mocked, pinning:
+
+* ``world.reset()`` is NEVER called from ``load_scene`` (the explosion pin);
+* every robot articulation handle is re-initialized after objects are
+  realized (the ``state.gripper``-missing pin: a stale handle makes
+  ``get_joint_positions`` return nothing);
+* a prior episode's scene objects are removed before the new episode's are
+  added (episode-2 ``DynamicCuboid`` constructions crash with "Failed to get
+  rigid body velocities from backend" against a stale-but-non-None view).
+
+The live-Kit halves of these behaviours are exercised by
+``tests_integ/simulation/test_isaac_body_state_gpu.py`` and the LIBERO GPU
+drivers.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+
+_SCENE_MJCF = """
+<mujoco model="scene_probe">
+  <worldbody>
+    <body name="fixture_table" pos="0.0 0.0 0.4">
+      <geom type="box" size="0.5 0.5 0.4"/>
+    </body>
+    <body name="cube_1_main" pos="0.1 0.0 0.85">
+      <joint type="free"/>
+      <geom type="box" size="0.02 0.02 0.02"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+class _RecordingWorld:
+    """World stub recording lifecycle calls; ``reset`` is the forbidden one."""
+
+    def __init__(self) -> None:
+        self.reset_calls = 0
+        self.step_calls = 0
+        self.physics_sim_view = object()
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+
+    def step(self, render: bool = True) -> None:
+        self.step_calls += 1
+
+
+class _RecordingArticulation:
+    def __init__(self) -> None:
+        self.initialize_calls: list[Any] = []
+
+    def initialize(self, physics_sim_view: Any = None) -> None:
+        self.initialize_calls.append(physics_sim_view)
+
+
+@dataclass
+class _Calls:
+    """Names passed to the mocked add_object / remove_object, in order."""
+
+    added: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+
+
+def _make_engine(with_robot: bool = True) -> tuple[IsaacSimulation, _Calls]:
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._lock = threading.RLock()
+    engine._world = _RecordingWorld()
+    engine._world_created = True
+    engine._objects = {}
+    engine._robots = {}
+    engine._scene_objects = set()
+    engine._prim_registry = []
+    calls = _Calls()
+    if with_robot:
+        robot = _RobotState(name="robot", prim_path="/World/Robots/robot", joint_names=[])
+        robot.articulation = _RecordingArticulation()
+        engine._robots["robot"] = robot
+
+    def _fake_add_object(name: str, **kwargs: Any) -> dict[str, Any]:
+        calls.added.append(name)
+        return {"status": "success", "content": [{"text": f"Object '{name}' added."}]}
+
+    def _fake_remove_object(name: str) -> dict[str, Any]:
+        calls.removed.append(name)
+        engine._objects.pop(name, None)
+        return {"status": "success", "content": [{"text": f"Object '{name}' removed."}]}
+
+    # setattr on the instance shadows the bound methods; the fakes accept the
+    # same (name, **kwargs) call shape load_scene uses.
+    setattr(engine, "add_object", _fake_add_object)  # noqa: B010 - mypy-safe method shadow
+    setattr(engine, "remove_object", _fake_remove_object)  # noqa: B010 - mypy-safe method shadow
+    return engine, calls
+
+
+@pytest.fixture
+def scene_file(tmp_path):
+    p = tmp_path / "scene.xml"
+    p.write_text(_SCENE_MJCF)
+    return str(p)
+
+
+def test_load_scene_never_calls_world_reset(scene_file) -> None:
+    """The #1802 explosion pin: scene realization must not world.reset().
+
+    ``World.reset()`` re-applies registered default states on ``post_reset``
+    and was observed to blow the Franka articulation into non-finite PhysX
+    transforms. If this assertion starts failing, re-read the view-rebuild
+    comment in ``load_scene`` before reaching for ``reset()``.
+    """
+    engine, calls = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    assert calls.added == ["fixture_table", "cube_1_main"]
+    assert engine._world.reset_calls == 0
+
+
+def test_load_scene_reinitializes_robot_articulations(scene_file) -> None:
+    """Stale articulation handles -> empty joint obs -> no state.gripper."""
+    engine, _ = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    art = engine._robots["robot"].articulation
+    assert art is not None
+    assert len(art.initialize_calls) == 1
+
+
+def test_load_scene_skips_reinit_for_handleless_robot(scene_file) -> None:
+    """Phase-1 stub robots (no articulation) don't abort the load."""
+    engine, _ = _make_engine()
+    engine._robots["stub"] = _RobotState(name="stub", prim_path="/World/Robots/stub", joint_names=[])
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+
+
+def test_load_scene_reload_removes_prior_scene_objects_first(scene_file) -> None:
+    """Episode-2 reload: prior scene objects are removed before new adds."""
+    engine, calls = _make_engine()
+    assert engine.load_scene(scene_file)["status"] == "success"
+    # Simulate the registry state load_scene leaves behind. Only membership
+    # is read on the reload path, so a bare object stands in for the state.
+    for name in calls.added:
+        engine._objects[name] = object()  # type: ignore[assignment]
+    calls.added.clear()
+
+    assert engine.load_scene(scene_file)["status"] == "success"
+    # _scene_objects is a set, so removal order is unspecified.
+    assert sorted(calls.removed) == ["cube_1_main", "fixture_table"]
+    assert calls.added == ["fixture_table", "cube_1_main"]
+
+
+def test_load_scene_no_world_errors(scene_file) -> None:
+    engine, _ = _make_engine()
+    engine._world_created = False
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "error"
+    assert "no world" in result["content"][0]["text"].lower()

--- a/tests_integ/simulation/test_isaac_body_state_gpu.py
+++ b/tests_integ/simulation/test_isaac_body_state_gpu.py
@@ -1,0 +1,116 @@
+"""GPU-gated integration: IsaacSimulation.get_body_state + predicate DSL (#1802).
+
+Pins the two consumers the new ``get_body_state`` unblocked on Isaac against a
+real Kit runtime:
+
+* the MuJoCo-envelope-compatible body pose read (object registry + USD
+  robot-link prim walk), and
+* the predicate DSL (``body_above_z`` / ``distance_less_than``), whose
+  ``_body_position`` primitive previously found no ``get_body_state`` on the
+  Isaac backend and silently degraded every body predicate to ``False``.
+
+Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ tests_integ/simulation/test_isaac_body_state_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# The isaac subpackage import itself is CPU-safe (heavy omni/isaacsim imports
+# are lazy, deferred to create_world()); importorskip guards against a
+# broken/partial install rather than the Isaac Kit runtime.
+pytest.importorskip("strands_robots.simulation.isaac")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+def _json_payload(result: dict) -> dict:
+    return next(c["json"] for c in result["content"] if "json" in c)
+
+
+class TestIsaacBodyStateGPU:
+    def test_body_state_and_predicates_end_to_end(self):
+        """One Kit boot covers the object read, the robot-link prim read, and
+        the predicate-DSL unlock (SimulationApp can only boot once per
+        process, so the journeys share a session like the other GPU tests)."""
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+        from strands_robots.simulation.predicates import PREDICATE_REGISTRY
+
+        _skip_if_isaac_unavailable()
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=True))
+        try:
+            r = sim.create_world()
+            assert r["status"] == "success", f"create_world: {r}"
+
+            # --- object registry path ---------------------------------------
+            r = sim.add_object(name="probe_cube", shape="box", position=[0.3, 0.1, 0.5], is_static=True)
+            assert r["status"] == "success", f"add_object: {r}"
+            sim.step(2)
+
+            r = sim.get_body_state(body_name="probe_cube")
+            assert r["status"] == "success", f"get_body_state(object): {r}"
+            payload = _json_payload(r)
+            assert payload["position"] == pytest.approx([0.3, 0.1, 0.5], abs=1e-3)
+            assert len(payload["quaternion"]) == 4
+            assert sum(c * c for c in payload["quaternion"]) == pytest.approx(1.0, abs=1e-6)
+
+            # --- unknown body: structured error, not an exception -----------
+            r = sim.get_body_state(body_name="no_such_body")
+            assert r["status"] == "error"
+            assert "no_such_body" in r["content"][0]["text"]
+
+            # --- robot-link prim path (bundled Franka USD) -------------------
+            try:
+                from isaacsim.storage.native import get_assets_root_path
+            except ImportError:
+                from omni.isaac.nucleus import get_assets_root_path
+            assets_root = get_assets_root_path()
+            if not assets_root:
+                pytest.skip("No Isaac assets root (Nucleus/CDN) reachable for the Franka USD")
+            usd_path = f"{assets_root}/Isaac/Robots/FrankaRobotics/FrankaPanda/franka.usd"
+            r = sim.add_robot("robot", usd_path=usd_path)
+            if r["status"] != "success":
+                usd_path = f"{assets_root}/Isaac/Robots/Franka/franka.usd"
+                r = sim.add_robot("robot", usd_path=usd_path)
+            assert r["status"] == "success", f"add_robot: {r}"
+            sim.step(2)
+
+            # Namespaced and bare link forms both resolve; #1802's LIBERO
+            # EEF source reads exactly this body.
+            for name in ("robot/panda_hand", "panda_hand"):
+                r = sim.get_body_state(body_name=name)
+                assert r["status"] == "success", f"get_body_state({name!r}): {r}"
+                hand = _json_payload(r)
+                assert len(hand["position"]) == 3
+                assert sum(c * c for c in hand["quaternion"]) == pytest.approx(1.0, abs=1e-6)
+
+            # --- predicate DSL unlock ----------------------------------------
+            above = PREDICATE_REGISTRY["body_above_z"](body="probe_cube", z=0.2)
+            below = PREDICATE_REGISTRY["body_above_z"](body="probe_cube", z=5.0)
+            assert above(sim) is True
+            assert below(sim) is False
+
+            near = PREDICATE_REGISTRY["distance_less_than"](body_a="probe_cube", body_b="panda_hand", threshold=10.0)
+            assert near(sim) is True
+        finally:
+            sim.destroy()


### PR DESCRIPTION
Closes #1802.

## What changed

With #1798's fixes in place, `run_isaac.py --policy groot` died on every inference call with `Server error: State key 'state.x' must be in observation`: the `libero_panda` GR00T data-config requires `state.x/y/z/roll/pitch/yaw/gripper`, and both of `LiberoAdapter`'s EEF pose sources were MuJoCo-shaped - the direct site/body read found no compiled model on Isaac, and the `get_body_state` fallback found no such method on `IsaacSimulation`.

### Part 1 - `IsaacSimulation.get_body_state(body_name)`

Implements the MuJoCo envelope contract (`{"json": {position, quaternion (wxyz), rotation_matrix, ...}}`). Name resolution, namespace-aware: object registry -> absolute prim path (`/World/...`) -> namespaced robot link (`robot/panda_hand`) -> bare robot link. Velocities are included only when the handle exposes them (keys omitted, never zero-filled); unknown bodies get a structured error naming the known objects/robots and the namespaced form; off-main-thread calls go through `run_on_main`. This single surface also unblocks the **predicate DSL** on Isaac (`body_above_z`, `body_on`, `distance_less_than`, ... all read through `get_body_state`).

### Part 2 - adapter EEF source for Isaac

- `eef_pos_offset` / `eef_quat_offset`: site-equivalent corrections for the body-only fallback, applied in the body's local frame (`pos + R(body_quat) @ offset`; quat correction right-multiplied afterwards). Validated eagerly at construction - a malformed offset silently feeding GR00T garbage state is exactly #168's failure class. Never applied to the direct MuJoCo site read.
- `_read_gripper_qpos_from_obs` + `state_gripper_signs`: both finger qpos read from the observation dict (Isaac has no direct-MuJoCo qpos), with `[1, -1]` restoring RoboSuite's opposite-sign finger convention (the Isaac Franka USD drives both fingers positive, URDF mimic convention).
- Loud, actionable **ERROR** (was a DEBUG skip) when injection is enabled but produces no state keys - names the missing keys, the configured sources, and the exact Isaac fix. Logged once per adapter.
- `load_libero_suite(adapter_kwargs=...)` forwards backend-specific state-source config to every registered task; `run_isaac.py` plumbs the Isaac Franka calibration via a new `--eef-body-name` flag.

**The offset decision, measured not assumed** (per the #168 sensitivity note): both backends were posed at the episode-0 canonical init config of the first libero_spatial task and compared base-relative (`panda_link0` vs `robot0_link0`). Isaac's `panda_hand` frame *coincides* with RoboSuite's `robot0_right_hand` (relative rotation 0.03 deg, position delta < 0.6 mm - within controller settle error), so **no quaternion correction** is applied. The grip-site offset is the authored `[0, 0, 0.097]` m site transform (cross-sim derivation agreed to `[3.8e-5, -6.5e-6, 0.0964]`); the authored value is used since the frames coincide.

### The fix under the fix - `load_scene` physics-view lifecycle

Getting non-empty state on Isaac surfaced two deeper backend bugs, both fixed here because the acceptance run is impossible without them:

- **Empty joint observations** (no `state.gripper`): realizing scene prims on an already-stepped stage leaves every `SingleArticulation` handle holding a torn-down PhysX view. `load_scene` now flushes the queued timeline-STOP events, calls `SimulationManager.initialize_physics()` (the public warmup that creates the tensor view), and re-initializes each robot articulation. Deliberately **NOT** `world.reset()`: a full reset re-applies registered default states on `post_reset`, which was measured (Isaac 6.0 / L4, 2026-07-31) to blow the posed Franka into a PhysX "Illegal BroadPhaseUpdateData - non-finite bounds" explosion within ~2 s of stepping. A regression test pins that `load_scene` never calls `world.reset()`.
- **Episode-2 crash**: prim removals leave the view stale-but-non-None, so the next `DynamicCuboid` construction takes `RigidPrim.__init__`'s eager `_on_physics_ready` path and dies with `Exception("Failed to get rigid body velocities from backend")`. `load_scene` now invalidates the view (`SimulationManager.invalidate_physics()`, the synchronous form of the STOP callback) after removals.
- `step()`'s camera warm-up now refreshes secondary render products, and `run_isaac.py` pre-adds the `wrist_image` camera the data-config requires (an RTX camera added after scene prims never accumulates a frame on Isaac 6.0; one added before warms in one step).

## Validation (4x L4, Isaac Sim 6.0.0.1 pip, GR00T-N1.7-LIBERO in the gr00t container)

```
OMNI_KIT_ACCEPT_EULA=YES python examples/libero/run_isaac.py --policy groot --port 8000 --n-episodes 5
policy=groot  task=...  resolved_task=libero-spatial-pick_up_the_black_bowl_...  success_rate=0.00  wall_time=946.8s  videos=rollouts/...  backend=isaac
```

- Zero `state.x`/`state.gripper`/`wrist_image` rejections across all 5 episodes (previously every call failed); zero PhysX errors; zero stale-view warnings; the once-per-adapter injection ERROR does not fire.
- Mock 2-episode runs (the episode-reload path): clean, stable articulation, rollout MP4 written.

**Measured success rate vs the MuJoCo baseline (1.00 on this task):** Isaac scores 0.00 - but not for state reasons. `_install_action_controller` warns `sim._world has no compiled MuJoCo model/data. GR00T actions will no-op`: the OSC_POSE controller that converts GR00T's task-space deltas into joint targets is robosuite/MuJoCo-only, so the policy's actions are never actuated on Isaac. That is the next (and now the only) layer of the backend-parity program - filing as a follow-up issue rather than growing this PR's scope.

## Test surface

- `tests/simulation/isaac/test_get_body_state.py` (14): envelope contract, resolution order, quaternion conventions (Shepperd round-trips), error shapes - `__new__`-skeleton pattern.
- `tests/benchmarks/libero/test_isaac_eef_state_source.py` (24): offset semantics (local-frame rotation, raw-quat-before-correction, fallback-only), obs-dict gripper + signs, loud-error latch, MuJoCo site read unaffected.
- `tests/simulation/isaac/test_load_scene_physics_view.py` (5): **`world.reset()` is never called** (the explosion pin), articulation re-init, reload removals.
- `tests_integ/simulation/test_isaac_body_state_gpu.py`: GPU-gated end-to-end - object + robot-link reads, and `body_above_z` / `distance_less_than` evaluating on Isaac (the predicate-DSL unlock pin).
- Full suite on the tree merged with latest `main`: **15406 passed, 260 skipped, 0 failed**, coverage 94.02%. `hatch run lint` clean.

## Acceptance criteria from #1802

- [x] `run_isaac.py --policy groot --n-episodes 5` emits the grep-stable `policy=groot ... success_rate=...` line (no `state.x` rejection)
- [x] Measured rate reported next to the MuJoCo baseline, with the cause of the gap identified (action-side no-op, follow-up below)
- [x] `IsaacSimulation.get_body_state` unit tests (mocked prims, `__new__`-skeleton) + GPU-gated integ assertion
- [x] Body predicates (`body_above_z`, `distance_less_than`) evaluate on Isaac in the GPU-gated test
- [x] Adapter logs a loud, actionable ERROR (not a DEBUG skip) when it can inject no EEF state

## Out of scope / follow-ups

- **GR00T action actuation on Isaac** (OSC controller is MuJoCo-only; actions no-op, success_rate pinned at 0.00) - will file as a follow-up issue on the project board.
- LIBERO object meshes are box approximations on Isaac (pre-existing `load_scene` translation layer) - success detection fidelity rides on the same follow-up program (#1550/#1552).

Project board: please move #1802 to "In review" (or I'll note it if automation handles it).
