### PR TITLE
docs: a push consumes the approval of whoever owns the token (closes #1814)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,50 @@ hatch run format            # ruff check --fix, ruff format
    rather than deleting it: the conclusion it supported usually still holds for a
    different reason, and that reason is what the next reader needs.
 
+   The converse happens too: every signal above satisfied, and the PR still
+   refuses to merge with no field naming the reason. #1722 carried one current
+   `APPROVED` review that post-dated its head commit, all four review threads
+   resolved, `call-test-lint` `SUCCESS` - and `reviewDecision`
+   `REVIEW_REQUIRED`. The `default` branch ruleset sets
+   `require_last_push_approval: true`, so the most recent push must be approved
+   by **someone other than whoever pushed it**, and the agent had pushed that
+   head commit with `PAT_TOKEN`. GitHub attributes a push to the token's
+   *owner*, which was the same account that then approved. No number of further
+   approvals from that account can clear it.
+
+   What makes this worth writing down is that the commit metadata asserts the
+   opposite. `d938686`'s author *and* committer are `strands-robots`, an
+   identity distinct from the approver, so reading the commit list says the rule
+   is satisfied. The pusher is in none of the fields you would check:
+   `reviewDecision` is `REVIEW_REQUIRED` and `mergeStateStatus` is `BLOCKED`,
+   which is also exactly what a PR with no approval at all looks like. The one
+   place it is legible:
+
+   ```
+   GET /repos/{owner}/{repo}/actions/runs?head_sha=<head>  ->  triggering_actor
+   ```
+
+   #1035 is the control - same author, same fork, same `strands_robots/mesh/`
+   files, one approval from the same account post-dating its head commit,
+   threads clear, checks green, and no CODEOWNERS file in the tree to make
+   `require_code_owner_review` bite. It differs in exactly one input, and reads
+   `APPROVED`:
+
+   | PR | commit author | `triggering_actor` | approver | `reviewDecision` |
+   |---|---|---|---|---|
+   | #1035 | the contributor | the contributor | the maintainer | `APPROVED` |
+   | #1722 | `strands-robots` | the maintainer | the maintainer | `REVIEW_REQUIRED` |
+
+   So **pushing a fix to a contributor's branch consumes the approval of
+   whoever owns the token you push with**, turning a PR one maintainer could
+   merge into one that needs a second. It compounds with
+   `dismiss_stale_reviews_on_push`, which drops the existing approval in the
+   same motion that disqualifies that account from re-supplying it. Prefer
+   leaving the change for the contributor to push, so they stay the last
+   pusher; when the agent must push, that PR now requires a second approver,
+   and saying so is the difference between a one-line request and a branch that
+   never merges.
+
    The general rule behind all three: **a decision recorded only in a PR or
    issue comment is not durable** - the next contributor will not read the same
    comment. If a decision must survive, it belongs in this file.

--- a/changelog.d/1814-last-push-approval-identity.md
+++ b/changelog.d/1814-last-push-approval-identity.md
@@ -1,0 +1,31 @@
+### Docs: pushing to a PR branch consumes the approval of whoever owns the token
+
+The `default` branch ruleset sets `require_last_push_approval: true`, so the most
+recent push must be approved by someone other than whoever pushed it. When this
+agent pushes to a PR branch it uses `PAT_TOKEN`, and GitHub attributes the push
+to the token's *owner* - so that account's approval stops counting, and no number
+of further approvals from it can clear the PR. #1722 is in that state: one
+current `APPROVED` review post-dating its head commit, all four review threads
+resolved, `call-test-lint` green, and `reviewDecision` still `REVIEW_REQUIRED`.
+
+The commit metadata asserts the opposite. `d938686`'s author and committer are
+both `strands-robots`, an identity distinct from the approver, so reading the
+commit list says the rule is satisfied. Nor is the pusher in the fields you would
+check - `reviewDecision` `REVIEW_REQUIRED` and `mergeStateStatus` `BLOCKED` are
+exactly what a PR with no approval at all looks like. It is legible in one place,
+`actions/runs?head_sha=<head>` -> `triggering_actor`.
+
+#1035 is the control: same author, same fork, same `strands_robots/mesh/` files,
+one approval from the same account post-dating its head commit, threads clear,
+checks green, no CODEOWNERS file in the tree. It differs in exactly one input -
+its head commit was pushed by the contributor rather than by the approver - and
+reads `APPROVED`. Every other rule in the ruleset is satisfied identically on
+both PRs, so `require_last_push_approval` is the only one that accounts for the
+difference.
+
+`AGENTS.md` > PR Workflow > step 8 now records the mechanism, the one API field
+that shows the pusher, and the consequence: prefer leaving a change for the
+contributor to push so they stay the last pusher, and when the agent must push,
+say on the PR that it now needs a second approver.
+
+Documentation only; no production code or test behaviour changes.


### PR DESCRIPTION
Closes #1814.

## The gap

`AGENTS.md` > PR Workflow > step 8 already collects the "the green signals are not the gate" failure modes: `reviewDecision` flips before the checks finish, and `MERGEABLE`/`CLEAN`/`SUCCESS` cannot see a semantic conflict. Every one of those is a case where a signal reads *better* than reality.

It has nothing on the converse - every signal satisfied and the PR still unmergeable. #1722 is in that state right now, and the mechanism is one this agent causes itself.

## Measured

#1722: one current `APPROVED` review post-dating the head commit, all four review threads resolved, `call-test-lint` `SUCCESS`, `reviewDecision` `REVIEW_REQUIRED`.

The active `default` branch ruleset:

```
required_approving_review_count   = 1
dismiss_stale_reviews_on_push     = True
require_code_owner_review         = True   (vacuous - no CODEOWNERS in tree)
require_last_push_approval        = True
required_review_thread_resolution = True
allowed_merge_methods             = ['squash']
```

`require_last_push_approval` means the most recent push must be approved by someone **other than whoever pushed it**. An agent push uses `PAT_TOKEN`; GitHub attributes the push to the token's *owner*, which is the same account that then approved. Further approvals from that account cannot clear it.

**The commit metadata asserts the opposite.** `d938686`'s author *and* committer are `strands-robots` - an identity distinct from the approver - so reading the commit list says the rule is satisfied. The pusher is in none of the fields you would check: `reviewDecision` `REVIEW_REQUIRED` and `mergeStateStatus` `BLOCKED` are indistinguishable from a PR with no approval at all. One field shows it:

```
GET /repos/{owner}/{repo}/actions/runs?head_sha=<head>  ->  triggering_actor
```

### Control

#1035 isolates the variable: same author, same fork, same `strands_robots/mesh/` files, one approving review from the same account post-dating its head commit, threads clear, checks green, no CODEOWNERS. It differs in exactly one input.

| PR | commit author | `triggering_actor` | approver | `reviewDecision` |
|---|---|---|---|---|
| #1035 | the contributor | the contributor | the maintainer | `APPROVED` |
| #1722 | `strands-robots` | the maintainer | the maintainer | `REVIEW_REQUIRED` |

Every rule in the ruleset except `require_last_push_approval` is satisfied identically on both, so it is the only one that accounts for the difference. I also checked the two candidates that could have confounded it: the approval post-dates the head commit, so `dismiss_stale_reviews_on_push` has not staled it; and there is no CODEOWNERS file in the tree, so `require_code_owner_review` has no owners to require.

## Why a rule rather than judgement

The cost is not the one-off. Pushing a fix to a contributor's branch **consumes the approval of whoever owns the token**, converting a PR one maintainer could merge into one that needs a second approver - and it compounds with `dismiss_stale_reviews_on_push`, which drops the existing approval in the same motion that disqualifies that account from re-supplying it. The failure is silent and permanent: nothing on the PR explains why more approvals do not help.

The guidance the paragraph lands on is therefore behavioural, not just diagnostic: prefer leaving a change for the contributor to push so they stay the last pusher; when the agent must push, that PR now requires a second approver, and saying so is the difference between a one-line request and a branch that never merges.

This PR is itself an instance - I pushed it, so it needs an approver other than the token owner.

## Scope

One paragraph block appended to the end of step 8's narrative, immediately before its existing closing sentence, plus the fragment. `AGENTS.md` **+44, -0** - a pure insertion; no existing line reworded, and the `#1766`/`#1763`, `#1800` and delta-reading paragraphs it sits after are untouched. "The general rule behind all three" still refers to the same three sub-bullets.

No production code, no test behaviour.

## Gate

```
pytest tests/test_changelog_fragments.py tests/test_changelog_format.py \
       tests/test_log_strings_are_ascii.py tests/test_no_host_paths.py    35 passed
pytest tests/test_changelog_fragment_gate.py                             38 passed
python3 scripts/assemble_changelog.py --check                            changelog fragments OK (84 pending)
git diff -U0 AGENTS.md | grep '^+' | grep -nP '[^\x00-\x7F]'              addition is pure ASCII
git diff --stat HEAD~1                                                   2 files, +75, -0
```

## Separately actionable

#1722 needs a second approver from an account other than the one that pushed `d938686`. It is otherwise complete.