### PR TITLE
fix(tools): refuse a rosbridge numeric option that cannot be honored

### DIFF
--- a/changelog.d/1816-rosbridge-numeric-option-guard.md
+++ b/changelog.d/1816-rosbridge-numeric-option-guard.md
@@ -1,0 +1,16 @@
+### Fix: `use_rosbridge` refuses a numeric option it cannot honor
+
+`use_rosbridge` exposes an agent the same `count` / `rate` / `timeout` options as
+`use_ros` and `use_rtps` and consumes them the same way, but validated none of
+them. `rate=0`, a negative value, `nan` and `inf` all returned
+`status="success"` having published every message back-to-back - the requested
+pacing discarded, which a mobile base latches as its last command. `count=True`
+published one message and reported "published True message(s)". A non-positive
+`timeout` returned an empty `echo` result blaming the topic for being silent, and
+`timeout=inf` raised `OverflowError` out of a tool documented to return a result
+dict.
+
+All three transports now share one owner of the accepted domain instead of
+carrying per-tool copies - two copies agreed with each other while the third
+transport was written with none, which is how the domain drifted. Each keeps its
+own per-action table, so an option an action never reads is still never refused.

--- a/strands_robots/tools/_numeric_options.py
+++ b/strands_robots/tools/_numeric_options.py
@@ -1,0 +1,81 @@
+"""Shared numeric-option guard for the tools that drive a ROS graph.
+
+:mod:`~strands_robots.tools.use_ros`, :mod:`~strands_robots.tools.use_rtps` and
+:mod:`~strands_robots.tools.use_rosbridge` reach a ROS graph over three
+different transports - in-process rclpy, raw RTPS, and a rosbridge WebSocket -
+but each exposes an agent the same three numeric options and consumes them the
+same way: ``count`` is a ``range()`` bound, ``rate`` becomes an inter-message
+period ``1 / rate``, and ``timeout`` is a wait budget. Only a positive finite
+value can be honored by any of them, so this module is the single owner of that
+rule: the accepted domain cannot differ between two transports onto the same
+graph, where the same publish would otherwise be refused by one and silently
+mis-paced by the other.
+
+Each tool keeps its own per-action table of which options an action reads,
+because that is a property of the transport rather than of the domain: every
+rosbridge action is a timeout-bounded WebSocket round trip, while rclpy graph
+introspection reads no caller budget at all. Passing the table in keeps the
+scoping decision - and the "never refuse a value this action ignores" contract
+it encodes - beside the dispatch that owns it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from strands_robots.utils import positive_count_error, positive_finite_number_error
+
+# The domain each option is checked against, in the order errors are reported.
+# ``count`` is a discrete ``range()`` bound, so only a true ``int`` can be
+# honored; ``timeout`` and ``rate`` are a span of seconds and a frequency in Hz,
+# where a fractional value is perfectly usable.
+_OPTION_DOMAINS: tuple[tuple[str, Callable[[Any, str, str], str | None]], ...] = (
+    ("timeout", positive_finite_number_error),
+    ("count", positive_count_error),
+    ("rate", positive_finite_number_error),
+)
+
+
+def numeric_option_error(
+    action: str,
+    options_by_action: dict[str, tuple[str, ...]],
+    *,
+    timeout: Any,
+    count: Any,
+    rate: Any,
+) -> str | None:
+    """Error text for the first numeric option ``action`` consumes but cannot honor.
+
+    ``timeout``, ``count`` and ``rate`` are agent-supplied, so each is checked
+    against the shared domain for its kind before any transport entity is
+    created: ``count`` against
+    :func:`~strands_robots.utils.positive_count_error` and ``timeout`` / ``rate``
+    against :func:`~strands_robots.utils.positive_finite_number_error`.
+
+    Only the options ``action`` actually reads are checked. A caller must never
+    be refused for a value the requested action never looks at, so the scoping
+    is driven by ``options_by_action`` rather than by validating the whole
+    signature unconditionally.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        options_by_action: The calling tool's map of action name -> the option
+            names that action consumes. An action absent from the map reads
+            none of them and is never refused here.
+        timeout: Seconds to wait, as supplied.
+        count: Message/sample count, as supplied.
+        rate: Publish rate in Hz, as supplied.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when
+        every option this action reads is usable.
+    """
+    consumed = options_by_action.get(action, ())
+    supplied: dict[str, Any] = {"timeout": timeout, "count": count, "rate": rate}
+    for param, check in _OPTION_DOMAINS:
+        if param in consumed:
+            error = check(supplied[param], param, action)
+            if error:
+                return error
+    return None

--- a/strands_robots/tools/use_ros.py
+++ b/strands_robots/tools/use_ros.py
@@ -67,7 +67,7 @@ from typing import Any
 
 from strands import tool
 
-from strands_robots.utils import positive_count_error, positive_finite_number_error
+from strands_robots.tools._numeric_options import numeric_option_error
 
 logger = logging.getLogger(__name__)
 
@@ -192,40 +192,6 @@ def _ok(text: str) -> dict[str, Any]:
 
 def _err(text: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": f"use_ros: {text}"}]}
-
-
-def _numeric_option_error(action: str, timeout: Any, count: Any, rate: Any) -> str | None:
-    """Error text for the first numeric option ``action`` consumes but cannot honor.
-
-    ``timeout``, ``count`` and ``rate`` are agent-supplied, so each is checked
-    against the shared domain for its kind before any DDS entity is created:
-    ``count`` is a ``range()`` bound (:func:`~strands_robots.utils.positive_count_error`)
-    and ``timeout`` / ``rate`` are a span of seconds and a frequency in Hz
-    (:func:`~strands_robots.utils.positive_finite_number_error`). Reusing those
-    helpers is what keeps this tool, ``use_rtps`` and the mesh bridges from
-    accepting a value one of them refuses.
-
-    Args:
-        action: The requested action; decides which options are effective.
-        timeout: Seconds to wait, as supplied.
-        count: Message/sample count, as supplied.
-        rate: Publish rate in Hz, as supplied.
-
-    Returns:
-        An error message naming the action and the option, or ``None`` when
-        every option this action reads is usable.
-    """
-    consumed = _ACTION_NUMERIC_OPTIONS.get(action, ())
-    for param, value, check in (
-        ("timeout", timeout, positive_finite_number_error),
-        ("count", count, positive_count_error),
-        ("rate", rate, positive_finite_number_error),
-    ):
-        if param in consumed:
-            error = check(value, param, action)
-            if error:
-                return error
-    return None
 
 
 # --------------------------------------------------------------------------
@@ -503,7 +469,7 @@ def use_ros(
     # backend probe, so the same caller mistake is reported identically whether
     # or not rclpy is installed - and so a refusal happens before a publisher
     # joins the graph.
-    numeric_error = _numeric_option_error(action, timeout, count, rate)
+    numeric_error = numeric_option_error(action, _ACTION_NUMERIC_OPTIONS, timeout=timeout, count=count, rate=rate)
     if numeric_error:
         return _err(numeric_error)
 

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -50,6 +50,8 @@ from typing import Any
 
 from strands import tool
 
+from strands_robots.tools._numeric_options import numeric_option_error
+
 logger = logging.getLogger(__name__)
 
 # Graph names: same allowlist posture as use_ros. Types are ROS1 two-segment.
@@ -64,6 +66,21 @@ _INSTALL_HINT = (
 )
 
 _ACTIONS = frozenset({"status", "list_topics", "list_services", "echo", "publish", "service_call"})
+
+# Which numeric options each action actually consumes. Unlike the rclpy
+# transport, whose graph introspection reads no caller budget, EVERY action here
+# begins with a timeout-bounded WebSocket dial, so every action reads
+# ``timeout``. The guard below is driven by this table rather than validating
+# the whole signature unconditionally, so a caller is never refused for a value
+# the requested action never looks at.
+_ACTION_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
+    "status": ("timeout",),
+    "list_topics": ("timeout",),
+    "list_services": ("timeout",),
+    "echo": ("timeout", "count"),
+    "service_call": ("timeout",),
+    "publish": ("timeout", "count", "rate"),
+}
 
 
 class _RosbridgeBackend:
@@ -229,9 +246,15 @@ def use_rosbridge(
         type: ROS1 two-segment interface type, e.g. ``geometry_msgs/Twist``.
             Auto-resolved for ``echo`` when omitted.
         fields: JSON field dict (``publish`` message / ``service_call`` request).
-        timeout: Seconds for connection, sample collection, or a service call.
-        count: Messages to echo or publish.
-        rate: Publish rate in Hz.
+        timeout: Seconds for the WebSocket dial, sample collection, or a
+            service call. A positive finite number of seconds; every action
+            dials the bridge, so every action reads it.
+        count: Messages to echo or publish. A positive integer; it is consumed
+            as a ``range()`` bound, so ``0`` publishes nothing and a float or a
+            numeric string cannot be honored.
+        rate: Publish rate in Hz. A positive finite number - the inter-message
+            period is ``1 / rate``, so ``0``, a negative value, ``nan`` and
+            ``inf`` all leave the burst unthrottled rather than paced.
 
     Returns:
         A Strands tool result dict ``{"status": ..., "content": [{"text": ...}]}``.
@@ -251,6 +274,14 @@ def use_rosbridge(
 
     if action not in _ACTIONS:
         return _err(f"unknown action: {action}")
+
+    # Numeric options are checked here, alongside the names and ahead of the
+    # backend probe, so the same caller mistake is reported identically whether
+    # or not roslibpy is installed - and so a refusal happens before the
+    # WebSocket is dialed and before a publisher is advertised.
+    numeric_error = numeric_option_error(action, _ACTION_NUMERIC_OPTIONS, timeout=timeout, count=count, rate=rate)
+    if numeric_error:
+        return _err(numeric_error)
 
     if action == "status":
         if not _backend.available():
@@ -278,8 +309,6 @@ def use_rosbridge(
             if action == "echo":
                 if not topic:
                     return _err("echo requires topic")
-                if count < 1:
-                    return _err("echo requires count >= 1")
                 msg_type = type or _resolve_topic_type(ros, topic, timeout)
                 if not msg_type:
                     return _err(f"cannot resolve type for {topic}; pass type=pkg/Name")
@@ -303,8 +332,6 @@ def use_rosbridge(
             if action == "publish":
                 if not topic or not type:
                     return _err("publish requires topic and type")
-                if count < 1:
-                    return _err("publish requires count >= 1")
                 _publish(ros, topic, type, fields, count, rate)
                 return _ok(f"published {count} message(s) to {topic}")
 

--- a/strands_robots/tools/use_rtps.py
+++ b/strands_robots/tools/use_rtps.py
@@ -51,7 +51,7 @@ from typing import Any
 
 from strands import tool
 
-from strands_robots.utils import positive_count_error, positive_finite_number_error
+from strands_robots.tools._numeric_options import numeric_option_error
 
 logger = logging.getLogger(__name__)
 
@@ -147,40 +147,6 @@ def _err(text: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": f"use_rtps: {text}"}]}
 
 
-def _numeric_option_error(action: str, timeout: Any, count: Any, rate: Any) -> str | None:
-    """Error text for the first numeric option ``action`` consumes but cannot honor.
-
-    ``timeout``, ``count`` and ``rate`` are agent-supplied, so each is checked
-    against the shared domain for its kind before any DDS entity is created:
-    ``count`` is a ``range()`` bound (:func:`~strands_robots.utils.positive_count_error`)
-    and ``timeout`` / ``rate`` are a span of seconds and a frequency in Hz
-    (:func:`~strands_robots.utils.positive_finite_number_error`). Reusing those
-    helpers is what keeps this tool and ``use_ros`` - two transports onto the
-    same ROS 2 graph - from disagreeing about which values are publishable.
-
-    Args:
-        action: The requested action; decides which options are effective.
-        timeout: Seconds to wait, as supplied.
-        count: Message/sample count, as supplied.
-        rate: Publish rate in Hz, as supplied.
-
-    Returns:
-        An error message naming the action and the option, or ``None`` when
-        every option this action reads is usable.
-    """
-    consumed = _ACTION_NUMERIC_OPTIONS.get(action, ())
-    for param, value, check in (
-        ("timeout", timeout, positive_finite_number_error),
-        ("count", count, positive_count_error),
-        ("rate", rate, positive_finite_number_error),
-    ):
-        if param in consumed:
-            error = check(value, param, action)
-            if error:
-                return error
-    return None
-
-
 def _sample_to_dict(sample: Any) -> Any:
     """Recursively convert an IDL dataclass sample to a plain dict."""
     if dataclasses.is_dataclass(sample) and not isinstance(sample, type):
@@ -269,7 +235,7 @@ def use_rtps(
     # backend probe, so the same caller mistake is reported identically whether
     # or not cyclonedds is installed - and so a refusal happens before a writer
     # joins the graph.
-    numeric_error = _numeric_option_error(action, timeout, count, rate)
+    numeric_error = numeric_option_error(action, _ACTION_NUMERIC_OPTIONS, timeout=timeout, count=count, rate=rate)
     if numeric_error:
         return _err(numeric_error)
 

--- a/tests/tools/test_transport_numeric_option_guards.py
+++ b/tests/tools/test_transport_numeric_option_guards.py
@@ -1,30 +1,46 @@
-"""The ROS 2 transport tools refuse a numeric option they cannot honor.
+"""The ROS transport tools refuse a numeric option they cannot honor.
 
-``use_ros`` and ``use_rtps`` expose the same three numeric options to an agent -
-``count``, ``rate`` and ``timeout`` - and both consume them the same way: ``count``
-is a ``range()`` bound, ``rate`` becomes an inter-message period ``1 / rate``, and
-``timeout`` is a wait budget. Only positive, finite values can be honored, so a
-value outside that domain must be refused with a message naming the option,
-before any DDS entity joins the graph and before a single message is published.
+``use_ros``, ``use_rtps`` and ``use_rosbridge`` expose the same three numeric
+options to an agent - ``count``, ``rate`` and ``timeout`` - and all three consume
+them the same way: ``count`` is a ``range()`` bound, ``rate`` becomes an
+inter-message period ``1 / rate``, and ``timeout`` is a wait budget. Only
+positive, finite values can be honored, so a value outside that domain must be
+refused with a message naming the option, before any transport entity joins the
+graph and before a single message is published.
 
-These tests run with NO ROS 2 and NO cyclonedds installed: the backend
-availability probe and the rclpy-facing helpers are monkeypatched, so the guards,
-the per-action scoping, the cross-transport parity and the "nothing was
-published" contract are all exercised transport-free.
+The guard used to be duplicated per tool, and that is exactly how it drifted:
+two copies agreed while the rosbridge transport arrived with no copy at all, so
+``rate`` was accepted and then discarded (every message sent back-to-back under
+``status="success"``), a ``count`` of ``True`` published one message and reported
+"published True message(s)", a non-positive ``timeout`` returned an empty result
+blaming the topic for being silent, and ``timeout=inf`` raised ``OverflowError``
+straight out of a tool documented to return a result dict. One shared owner plus
+the structural guard at the end of this module is what keeps a fourth transport
+from repeating it.
+
+These tests run with NO ROS 2, NO cyclonedds and NO roslibpy installed: the
+backend availability probes and the transport-facing helpers are monkeypatched,
+so the guards, the per-action scoping, the cross-transport parity and the
+"nothing was published" contract are all exercised transport-free.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 import sys
 import time
 import types as _types
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 import strands_robots.tools.use_ros as ros_mod
+import strands_robots.tools.use_rosbridge as rosbridge_mod
 import strands_robots.tools.use_rtps as rtps_mod
+from strands_robots.tools._numeric_options import numeric_option_error
 
 # Values outside the accepted domain of each option, with the reason each one is
 # unusable. ``inf`` matters as much as ``0``: it passes a bare ``rate > 0`` test
@@ -39,10 +55,11 @@ def _texts(result: dict[str, Any]) -> str:
 
 
 @pytest.fixture(autouse=True)
-def _both_backends_available(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default both transports to a present backend; opt out where needed."""
+def _every_backend_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every transport to a present backend; opt out where needed."""
     monkeypatch.setattr(ros_mod._backend, "available", lambda: True)
     monkeypatch.setattr(rtps_mod._backend, "available", lambda: True)
+    monkeypatch.setattr(rosbridge_mod._backend, "available", lambda: True)
 
 
 # ---------------------------------------------------------------------------
@@ -175,10 +192,26 @@ def test_the_scoping_table_covers_every_action_that_reads_an_option() -> None:
     The table is what decides whether a value is checked at all, so a typo in it
     would silently disable a guard.
     """
-    for table in (ros_mod._ACTION_NUMERIC_OPTIONS, rtps_mod._ACTION_NUMERIC_OPTIONS):
+    tables = (
+        ros_mod._ACTION_NUMERIC_OPTIONS,
+        rtps_mod._ACTION_NUMERIC_OPTIONS,
+        rosbridge_mod._ACTION_NUMERIC_OPTIONS,
+    )
+    for table in tables:
         for action, options in table.items():
             assert options, f"{action} lists no options; drop the entry instead"
             assert set(options) <= {"count", "rate", "timeout"}, action
+
+
+def test_every_rosbridge_action_declares_the_options_it_reads() -> None:
+    """rosbridge dials the bridge for every action, so every action reads ``timeout``.
+
+    An action missing from the table is silently unguarded, which is how this
+    transport shipped with none at all - so the table must stay exhaustive.
+    """
+    assert set(rosbridge_mod._ACTION_NUMERIC_OPTIONS) == set(rosbridge_mod._ACTIONS)
+    for action, options in rosbridge_mod._ACTION_NUMERIC_OPTIONS.items():
+        assert "timeout" in options, action
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +226,11 @@ _PUBLISH_CALLS: list[tuple[str, Callable[..., dict[str, Any]]]] = [
     (
         "use_rtps",
         lambda **kw: rtps_mod.use_rtps(action="publish", topic="/cmd_vel", type="geometry_msgs/msg/Twist", **kw),
+    ),
+    # rosbridge speaks the ROS1 two-segment type name for the same message.
+    (
+        "use_rosbridge",
+        lambda **kw: rosbridge_mod.use_rosbridge(action="publish", topic="/cmd_vel", type="geometry_msgs/Twist", **kw),
     ),
 ]
 
@@ -215,8 +253,8 @@ def _refusal_reasons(
 
 
 @pytest.mark.parametrize("value", UNUSABLE_RATES)
-def test_both_transports_refuse_the_same_rate(value: Any) -> None:
-    """A rate one transport refuses cannot be publishable through the other."""
+def test_every_transport_refuses_the_same_rate(value: Any) -> None:
+    """A rate one transport refuses cannot be publishable through another."""
     reasons = _refusal_reasons(_PUBLISH_CALLS, "rate", count=1, rate=value)
 
     for name, reason in reasons.items():
@@ -224,8 +262,8 @@ def test_both_transports_refuse_the_same_rate(value: Any) -> None:
 
 
 @pytest.mark.parametrize("value", UNUSABLE_COUNTS)
-def test_both_transports_refuse_the_same_count(value: Any) -> None:
-    """A count one transport refuses cannot be publishable through the other."""
+def test_every_transport_refuses_the_same_count(value: Any) -> None:
+    """A count one transport refuses cannot be publishable through another."""
     reasons = _refusal_reasons(_PUBLISH_CALLS, "count", count=value, rate=10.0)
 
     for name, reason in reasons.items():
@@ -233,8 +271,8 @@ def test_both_transports_refuse_the_same_count(value: Any) -> None:
 
 
 @pytest.mark.parametrize("value", UNUSABLE_TIMEOUTS)
-def test_both_transports_refuse_the_same_echo_timeout(value: Any) -> None:
-    """An echo wait budget one transport refuses is refused by the other too."""
+def test_every_transport_refuses_the_same_echo_timeout(value: Any) -> None:
+    """An echo wait budget one transport refuses is refused by the others too."""
     echo_calls: list[tuple[str, Callable[..., dict[str, Any]]]] = [
         (
             "use_ros",
@@ -243,6 +281,10 @@ def test_both_transports_refuse_the_same_echo_timeout(value: Any) -> None:
         (
             "use_rtps",
             lambda **kw: rtps_mod.use_rtps(action="echo", topic="/odom", type="nav_msgs/msg/Odometry", **kw),
+        ),
+        (
+            "use_rosbridge",
+            lambda **kw: rosbridge_mod.use_rosbridge(action="echo", topic="/odom", type="nav_msgs/Odometry", **kw),
         ),
     ]
     reasons = _refusal_reasons(echo_calls, "timeout", timeout=value)
@@ -262,3 +304,236 @@ def test_a_refusal_message_is_ascii_and_names_the_action() -> None:
 
     assert text.isascii(), text
     assert text.startswith("use_ros: publish: ")
+
+
+# ---------------------------------------------------------------------------
+# rosbridge: the transport that shipped with none of these guards.
+# ---------------------------------------------------------------------------
+
+_ROSBRIDGE_ACTION_ARGS: dict[str, dict[str, Any]] = {
+    "status": {},
+    "list_topics": {},
+    "list_services": {},
+    "echo": {"topic": "/odom", "type": "nav_msgs/Odometry"},
+    "service_call": {"service": "/reset", "type": "std_srvs/Empty"},
+    "publish": {"topic": "/cmd_vel", "type": "geometry_msgs/Twist"},
+}
+
+
+@pytest.fixture
+def rosbridge_published_at(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Wire ``use_rosbridge`` to a recording publisher and return its send timestamps.
+
+    The real ``_publish`` body runs - only the roslibpy module is faked - so the
+    list records exactly the messages that reached the WebSocket, and their
+    spacing is the pacing the tool actually applied.
+    """
+    stamps: list[float] = []
+
+    class FakeTopic:
+        def __init__(self, ros: Any, name: str, message_type: str) -> None:
+            ros.topics.append(self)
+
+        def advertise(self) -> None:
+            pass
+
+        def unadvertise(self) -> None:
+            pass
+
+        def publish(self, msg: Any) -> None:
+            stamps.append(time.perf_counter())
+
+        def subscribe(self, callback: Any) -> None:
+            pass
+
+        def unsubscribe(self) -> None:
+            pass
+
+    class FakeRos:
+        def __init__(self, host: str | None = None, port: int | None = None) -> None:
+            self.is_connected = False
+            self.topics: list[FakeTopic] = []
+
+        def run(self, timeout: float | None = None) -> None:
+            self.is_connected = True
+
+    module = _types.ModuleType("roslibpy")
+    module.Ros = FakeRos  # type: ignore[attr-defined]
+    module.Topic = FakeTopic  # type: ignore[attr-defined]
+    module.Message = dict  # type: ignore[attr-defined]
+    module.Service = object  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "roslibpy", module)
+    monkeypatch.setattr(rosbridge_mod._backend, "_connections", {})
+    return stamps
+
+
+def _publish_over_rosbridge(**options: Any) -> dict[str, Any]:
+    return rosbridge_mod.use_rosbridge(action="publish", topic="/cmd_vel", type="geometry_msgs/Twist", **options)
+
+
+@pytest.mark.parametrize("rate", UNUSABLE_RATES)
+def test_rosbridge_refuses_an_unusable_rate_before_publishing(rosbridge_published_at: list[float], rate: Any) -> None:
+    """A rate that cannot pace the burst is refused before anything is sent.
+
+    Pre-fix the loop fell back to ``period = 0.0`` and sent all six messages
+    back-to-back while reporting ``published 6 message(s)``: a velocity hold
+    collapsed into an instantaneous burst that the base then latches as its last
+    command. ``inf`` reached the same place through the front door - it passes
+    ``rate > 0`` and then collapses ``1 / rate`` to zero.
+    """
+    result = _publish_over_rosbridge(count=6, rate=rate)
+
+    assert result["status"] == "error"
+    assert f"rate must be > 0, got {rate!r}." in _texts(result)
+    assert rosbridge_published_at == []
+
+
+@pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+def test_rosbridge_refuses_an_unusable_count_before_publishing(rosbridge_published_at: list[float], count: Any) -> None:
+    """A count that is not a positive integer is refused, not partially absorbed.
+
+    The ad-hoc ``count < 1`` test this replaces caught ``0`` and ``-1`` only:
+    ``True`` published one message and reported "published True message(s)",
+    while ``2.7`` and a numeric string reached ``range()`` and failed with a
+    message naming neither the tool nor the option - after the WebSocket was
+    dialed and the publisher advertised.
+    """
+    result = _publish_over_rosbridge(count=count, rate=10.0)
+
+    assert result["status"] == "error"
+    assert f"count must be a positive integer, got {count!r}." in _texts(result)
+    assert rosbridge_published_at == []
+
+
+def test_rosbridge_paces_a_usable_rate(rosbridge_published_at: list[float]) -> None:
+    """The honored path still publishes ``count`` messages spaced by ``1 / rate``."""
+    result = _publish_over_rosbridge(count=4, rate=100.0)
+
+    assert result["status"] == "success"
+    assert len(rosbridge_published_at) == 4
+
+
+def test_a_non_finite_echo_timeout_is_refused_not_raised(rosbridge_published_at: list[float]) -> None:
+    """``timeout=inf`` must be refused, not escape the tool contract.
+
+    Pre-fix it reached the sample-collection wait as a deadline, which raised
+    ``OverflowError: timestamp out of range for platform time_t``. That is not in
+    the dispatch's handled-exception tuple, so it propagated out of a tool
+    documented to return a result dict - past the agent's error handling
+    entirely, rather than being reported as one.
+    """
+    result = rosbridge_mod.use_rosbridge(action="echo", topic="/odom", type="nav_msgs/Odometry", timeout=float("inf"))
+
+    assert result["status"] == "error"
+    assert "echo: timeout must be > 0, got inf." in _texts(result)
+
+
+@pytest.mark.parametrize("action", sorted(_ROSBRIDGE_ACTION_ARGS))
+def test_every_rosbridge_action_refuses_a_non_positive_timeout(
+    rosbridge_published_at: list[float], action: str
+) -> None:
+    """Every action dials the bridge with ``timeout``, so every action must check it.
+
+    A non-positive budget made the dial's wait loop expire immediately; on
+    ``echo`` that returned ``status="success"`` with an empty sample list and a
+    note blaming the topic for being silent, which sends the caller debugging a
+    robot that was never given time to answer.
+    """
+    result = rosbridge_mod.use_rosbridge(action=action, timeout=-1.0, **_ROSBRIDGE_ACTION_ARGS[action])
+
+    assert result["status"] == "error"
+    assert f"{action}: timeout must be > 0, got -1.0." in _texts(result)
+    assert rosbridge_mod._backend._connections == {}, "refused, yet the bridge was dialed"
+
+
+def test_a_rosbridge_refusal_names_the_option_with_no_roslibpy_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard runs ahead of the availability probe, so the message is stable."""
+    monkeypatch.setattr(rosbridge_mod._backend, "available", lambda: False)
+
+    result = _publish_over_rosbridge(count=6, rate=0.0)
+
+    assert result["status"] == "error"
+    assert "rate must be > 0" in _texts(result)
+
+
+def test_rosbridge_publish_reads_the_timeout_that_rclpy_publish_ignores(
+    rosbridge_published_at: list[float],
+) -> None:
+    """The per-action tables differ because the transports differ, and that is deliberate.
+
+    ``use_ros`` publishes through an already-running in-process node, so its
+    ``publish`` reads no caller budget and must not be refused for one. Every
+    rosbridge action begins by dialing the WebSocket with ``timeout``, so the
+    same value is effective there and a bad one has to be refused.
+    """
+    assert "timeout" not in ros_mod._ACTION_NUMERIC_OPTIONS["publish"]
+    assert "timeout" in rosbridge_mod._ACTION_NUMERIC_OPTIONS["publish"]
+
+    result = _publish_over_rosbridge(count=2, rate=100.0, timeout=-1.0)
+
+    assert result["status"] == "error"
+    assert "publish: timeout must be > 0, got -1.0." in _texts(result)
+    assert rosbridge_published_at == []
+
+
+# ---------------------------------------------------------------------------
+# Structural guard: one owner of the rule, and no transport may grow its own.
+# ---------------------------------------------------------------------------
+
+_TOOLS_DIR = Path(inspect.getfile(rosbridge_mod)).parent
+_ROS_FAMILY = ("use_ros", "use_rtps", "use_rosbridge")
+
+
+def _module_tree(stem: str) -> ast.Module:
+    return ast.parse((_TOOLS_DIR / f"{stem}.py").read_text(encoding="utf-8"))
+
+
+def _local_guard_definitions(tree: ast.Module) -> list[str]:
+    """Names of module-level functions that re-implement the shared guard."""
+    return [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name.endswith("numeric_option_error")
+    ]
+
+
+def _calls_the_shared_guard(tree: ast.Module) -> bool:
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "numeric_option_error"
+        for node in ast.walk(tree)
+    )
+
+
+@pytest.mark.parametrize("stem", _ROS_FAMILY)
+def test_every_ros_transport_routes_through_the_shared_guard(stem: str) -> None:
+    """No transport may carry its own copy of the accepted domain.
+
+    Two byte-identical copies is how the domain drifted in the first place: they
+    agreed with each other, so nothing failed, and the third transport was
+    written with no copy at all. A single owner makes an unguarded transport a
+    test failure rather than a silent one.
+    """
+    tree = _module_tree(stem)
+
+    assert _calls_the_shared_guard(tree), f"{stem} never calls the shared numeric-option guard"
+    assert _local_guard_definitions(tree) == [], f"{stem} re-implements the shared guard"
+
+
+def test_the_shared_guard_has_exactly_one_definition() -> None:
+    """The owning module defines the rule once, and the scan can find it."""
+    owner = ast.parse(Path(inspect.getfile(numeric_option_error)).read_text(encoding="utf-8"))
+
+    assert _local_guard_definitions(owner) == ["numeric_option_error"]
+
+
+def test_the_structural_scan_detects_a_planted_local_copy() -> None:
+    """Guard for the guard: a re-implementation must actually be caught.
+
+    Without this, a scan that silently matched nothing would report a clean tree.
+    """
+    planted = ast.parse("def _numeric_option_error(action, timeout, count, rate):\n    return None\n")
+
+    assert _local_guard_definitions(planted) == ["_numeric_option_error"]
+    assert not _calls_the_shared_guard(planted)


### PR DESCRIPTION
## Problem

`use_rosbridge` exposes an agent the same three numeric options as `use_ros` and `use_rtps` — `count`, `rate`, `timeout` — and consumes them the same way: `count` is a `range()` bound, `rate` becomes an inter-message period `1 / rate`, and `timeout` is a wait budget. It validated none of them.

Measured against a recording publisher (`publish(count=6)` on `/cmd_vel`, the honored `rate=10` paces six messages over 0.500s):

| call | main | this change |
|---|---|---|
| `publish(count=6, rate=0)` | `success` — 6 msgs, span **0.000s** | `error: publish: rate must be > 0, got 0.` |
| `publish(count=6, rate=-5)` | `success` — 6 msgs, span 0.000s | `error: ... got -5.` |
| `publish(count=6, rate=inf)` | `success` — 6 msgs, span 0.000s | `error: ... got inf.` |
| `publish(count=True)` | `success` — “published **True** message(s)” | `error: count must be a positive integer, got True.` |
| `publish(count=2.7)` | `error: 'float' object cannot be interpreted as an integer` | `error: ... got 2.7.` |
| `echo(timeout=-1)` | `success` — `[]` + “no messages within **-1s** — topic may be silent” | `error: echo: timeout must be > 0, got -1.0.` |
| `echo(timeout=inf)` | **`OverflowError` raised** | `error: echo: timeout must be > 0, got inf.` |

Four distinct failures behind one missing check:

- **`rate` is discarded, not honored.** `period = 1.0 / rate if rate > 0 else 0.0` turns “cannot compute a period” into “do not pace”, so a velocity hold collapses into an instantaneous burst that the base latches as its last command — reported as success. `inf` arrives through the front door: it passes `rate > 0`, then `1 / inf` is `0.0`.
- **`count` was only half guarded.** The ad-hoc `count < 1` test caught `0` and `-1`; `True` published one message and named a boolean as a count in the reply, while `2.7` and a numeric string reached `range()` and failed naming neither the tool nor the option — *after* the WebSocket was dialed and the publisher advertised.
- **A non-positive `timeout` blames the robot.** The dial and the sample wait expire immediately, and `echo` then returns `success` with an empty list and a note saying the topic may be silent — sending the caller to debug a robot that was never given time to answer.
- **`timeout=inf` escapes the tool contract.** It reaches the sample-collection wait as a deadline and raises `OverflowError: timestamp out of range for platform time_t`. `OverflowError` is not in the dispatch's handled-exception tuple, so it propagates out of a tool documented to return a result dict. On the reconnect path the same value spins the wait loop forever while holding the process-wide backend lock, so every later call in the process blocks too.

## Why it drifted, and the change

The guard existed twice — a byte-identical `_numeric_option_error` in `use_ros` and in `use_rtps`. Two copies agree with each other, so nothing ever failed, and the third transport was written with no copy at all. The rule now has **one owner** that all three call.

Each tool keeps its own per-action table, because which options an action reads is a property of the transport, not of the domain: every rosbridge action begins with a timeout-bounded WebSocket dial, so every action reads `timeout`, whereas rclpy graph introspection reads no caller budget and must not be refused for one. That asymmetry is pinned rather than smoothed over.

The guard runs alongside the existing name checks and ahead of the backend probe, matching the two siblings: the same caller mistake reports identically with and without `roslibpy` installed, and a refusal happens before the bridge is dialed and before a publisher is advertised. Message text is unchanged for `use_ros` / `use_rtps` — the reasons still come from `positive_count_error` / `positive_finite_number_error` — so every existing pin holds and no previously working call is refused.

## Wire trace

Same call on both trees; the honored `rate=10 Hz` staircase is identical (span 0.500s on main, 0.500s here), so only the refusals differ.

![use_rosbridge numeric-option wire trace](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rosbridge-numeric-options/rosbridge_wire.png)

This is a transport-layer change — no simulation, rendering, recording or policy behaviour — so the artifact is a wire trace rather than a rollout.

## Tests

Extended `tests/tools/test_transport_numeric_option_guards.py`, whose docstring already asserted this domain for the transport family:

- The three cross-transport parity tests now cover all three transports, so a value one refuses cannot be publishable through another.
- rosbridge behaviour: every unusable `rate` / `count` is refused with **nothing on the wire**; a usable rate still paces the burst; `timeout=inf` is refused instead of raising; every one of the six actions refuses a non-positive `timeout` **and leaves the bridge undialed**; the refusal names the option with `roslibpy` absent.
- The deliberate table difference is pinned: `use_ros`'s `publish` ignores `timeout`, rosbridge's reads it.
- A **structural** test asserts every ROS-family transport routes through the shared owner and that none re-implements it, plus a planted-copy meta-test so the scan cannot pass vacuously — a fourth transport cannot repeat this silently.

The 33 existing `use_rosbridge` tests are unchanged and pass; `test_publish_rejects_nonpositive_count` still holds against the new message.

## Verification

All on `MUJOCO_GL=egl`, branch based on `f2f7d27d`.

- **Pre-fix** (three transport modules reverted to `main`, shared module and tests kept): `44 failed, 21 passed`. None of the failures is in a `use_ros` / `use_rtps`-only test — the 21 that pass are those, plus the accepted-value controls and the scan meta-tests.
- **Post-fix**, same file: `65 passed`.
- **Full suite**: `15425 passed, 256 skipped` in 468s.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (988 source files).
- Merge-base overlap check: no overlap; branch rebased onto current `main`.