### PR TITLE
fix(mesh): share the drive-command numeric domains across every bridge

### DIFF
--- a/changelog.d/1817-rosbridge-drive-command-domains.md
+++ b/changelog.d/1817-rosbridge-drive-command-domains.md
@@ -1,0 +1,20 @@
+### Fixed: `RosbridgeRobot` now shares the drive-command numeric domains with the other mobile-base bridges
+
+`RosbridgeRobot.drive` and its constructor validated their numeric inputs with an
+inline `math.isfinite` test instead of the domain helpers `RosBridgedRobot` and
+`RtpsRobot` both call, so the newest bridge accepted and refused a different set
+of values than the two it copies its contract from. An inline finiteness test is
+looser and less safe than the helper it stands in for: it treats `bool` as a
+number, so `drive(linear=True)` published a Twist commanding 1.0 m/s and returned
+success, and `RosbridgeRobot(publish_rate=True)` installed a silent 1 Hz command
+stream; it raises a bare `TypeError` for a value it cannot coerce, so
+`drive(linear="0.5")` escaped the structured tool-result contract of the bound
+`drive_<node>` agent tool rather than naming the parameter; and `count` was not
+checked at all, so `count=0` published nothing and `count=2.7` reported a raw
+publish-loop error attributed to a transport the caller never invoked.
+
+All three bridges now call the same `finite_number_error`,
+`positive_finite_number_error` and `positive_whole_number_error` domains, report
+byte-identical text for the same bad value, and publish nothing when a command is
+refused. A structural test pins the mechanism, so a fourth transport cannot ship
+with a hand-rolled copy.

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -29,7 +29,6 @@ Typical usage::
 
 from __future__ import annotations
 
-import math
 from typing import Any
 
 from strands import tool
@@ -37,6 +36,11 @@ from strands.types.tools import AgentTool
 
 from strands_robots.mesh.ros_bridge import _check_topic
 from strands_robots.tools.use_rosbridge import _HOST_RE, use_rosbridge
+from strands_robots.utils import (
+    finite_number_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
 
 _TWIST_TYPE = "geometry_msgs/Twist"
 
@@ -59,6 +63,13 @@ class RosbridgeRobot:
         max_duration: Longest accepted :meth:`drive` hold; longer requests are
             rejected loudly rather than silently truncated.
         publish_rate: Command publish rate (Hz) for held :meth:`drive` calls.
+
+    Raises:
+        ValueError: When a graph name, the host or the port is malformed, or
+            when any of ``max_linear``, ``max_angular``, ``max_duration`` and
+            ``publish_rate`` is not a finite number greater than zero. Each
+            bounds every later command, so an unusable one is refused at
+            construction instead of silently reshaping the robot's limits.
     """
 
     def __init__(
@@ -91,14 +102,22 @@ class RosbridgeRobot:
         self.cmd_vel_type = cmd_vel_type
         self.odom_type = odom_type
         self.scan_type = scan_type
+        # These four values bound every command this bridge will ever send, so
+        # one that cannot be honored is refused here rather than coerced. The
+        # domain is the shared one the sibling bridges use, so the three cannot
+        # diverge on what counts as a usable limit: a non-real value (a numeric
+        # string, ``None``, a list) is reported as this documented
+        # ``ValueError`` rather than escaping as a coercion error, and ``bool``
+        # is rejected because ``True`` would otherwise install a silent 1.0 m/s
+        # clamp or a 1 Hz publish rate.
         for label, value in (
             ("max_linear", max_linear),
             ("max_angular", max_angular),
             ("max_duration", max_duration),
             ("publish_rate", publish_rate),
         ):
-            if not math.isfinite(value) or value <= 0:
-                raise ValueError(f"{label} must be a positive finite number, got {value!r}")
+            if limit_err := positive_finite_number_error(value, label, type(self).__name__):
+                raise ValueError(limit_err)
         self.max_linear = float(max_linear)
         self.max_angular = float(max_angular)
         self.max_duration = float(max_duration)
@@ -157,28 +176,70 @@ class RosbridgeRobot:
     ) -> dict[str, Any]:
         """Publish a velocity command over rosbridge.
 
-        Fleet-standard contract: ``linear`` (m/s) and ``angular`` (rad/s),
-        optional ``duration`` hold (``round(duration * publish_rate)``
-        messages, precedence over ``count``). Inputs are validated before any
-        side effect; velocities are clamped to the constructor limits. Every
-        timed or multi-message non-zero command is followed by a single zero
-        Twist - even if the main publish failed - so a timed drive cannot
-        leave the robot with a live velocity. A bare single-shot command
-        latches until :meth:`stop`, like any raw cmd_vel publish.
+        Fleet-standard contract, shared with :meth:`RosBridgedRobot.drive` and
+        :meth:`RtpsRobot.drive`. Inputs are validated before any side effect;
+        velocities are then clamped to the constructor limits. Every timed or
+        multi-message non-zero command is followed by a single zero Twist -
+        even if the main publish failed - so a timed drive cannot leave the
+        robot with a live velocity. A bare single-shot command latches until
+        :meth:`stop`, like any raw cmd_vel publish.
+
+        Args:
+            linear: Forward linear velocity (m/s), mapped to ``linear.x``. Must
+                be a finite number; both signs are valid (negative reverses).
+            angular: Yaw angular velocity (rad/s), mapped to ``angular.z``. Must
+                be a finite number; both signs are valid (negative turns the
+                other way).
+            duration: When given, hold the command for this many seconds by
+                publishing ``round(duration * publish_rate)`` messages (at
+                least one). Takes precedence over ``count``, must be > 0 and
+                finite - a zero or negative hold has no message count that
+                expresses it, and publishing a single velocity command anyway
+                would start the robot moving - and may not exceed
+                ``max_duration``.
+            count: Number of messages to publish when ``duration`` is omitted.
+                Must be a positive whole number; ``0`` or a negative count
+                publishes nothing, so reporting a successful drive for it hides
+                a command that never left the process.
+
+        Returns:
+            The ``use_rosbridge`` publish result dict, or an
+            ``{"status": "error"}`` result naming the parameter when a value
+            cannot be honored - in which case nothing is published.
         """
-        for label, value in (("linear", linear), ("angular", angular)):
-            if not math.isfinite(value):
-                return self._error(f"drive: {label} must be a finite number, got {value!r}")
-        if duration is not None:
-            if not math.isfinite(duration) or duration <= 0:
-                return self._error(f"drive: duration must be a positive finite number of seconds, got {duration!r}")
-            if duration > self.max_duration:
-                return self._error(
-                    f"drive: duration {duration}s exceeds max_duration {self.max_duration}s "
-                    "- issue shorter commands instead of one long hold"
-                )
+        # A velocity command is the one call on this bridge that physically
+        # moves the robot, so every knob it carries is checked before anything
+        # reaches the wire, through the same shared domains the sibling bridges
+        # use. ``use_rosbridge`` validates the topic and interface type but
+        # never sees ``duration`` at all (it receives only the derived message
+        # count), and the ``count`` values it does refuse are reported against
+        # a transport this caller never invoked.
+        cmd_err = (
+            finite_number_error(linear, "linear", "drive")
+            or finite_number_error(angular, "angular", "drive")
+            or (
+                positive_finite_number_error(duration, "duration", "drive")
+                if duration is not None
+                # ``duration`` supersedes ``count``, so ``count`` is only the
+                # effective horizon when no duration was given; refusing a
+                # ``count`` this call never reads would reject a valid command.
+                else positive_whole_number_error(count, "count", "drive")
+            )
+        )
+        if cmd_err:
+            return self._error(cmd_err)
+        # Ordered after the finiteness guard on purpose: every comparison
+        # against ``nan`` is false, so a ceiling test cannot stand in for one.
+        if duration is not None and duration > self.max_duration:
+            return self._error(
+                f"drive: duration {duration}s exceeds max_duration {self.max_duration}s "
+                "- issue shorter commands instead of one long hold"
+            )
         v = max(-self.max_linear, min(self.max_linear, float(linear)))
         w = max(-self.max_angular, min(self.max_angular, float(angular)))
+        # ``duration`` is positive and finite here, so this floor is a rounding
+        # rule and not a substitute for validation: a hold shorter than one
+        # publish period still means "send the command once".
         n = max(1, round(duration * self.publish_rate)) if duration is not None else count
         try:
             return self._publish_twist(v, w, count=n)

--- a/tests/mesh/test_drive_command_numeric_domains.py
+++ b/tests/mesh/test_drive_command_numeric_domains.py
@@ -1,0 +1,356 @@
+"""The numeric domains a mobile-base bridge's drive command must share.
+
+Three bridges expose the same fleet-standard ``drive(linear, angular, duration,
+count)`` contract over three transports. A velocity command is the one call on
+any of them that physically moves the robot, so each knob it carries is checked
+before anything reaches the wire - and the accepted domain has to be the *same*
+on all three, because an agent that learns the contract from one bridge drives
+the others with it.
+
+Every check here therefore compares the three against each other rather than
+against a hardcoded expectation, and asserts the *reason* a value was refused
+rather than only that it was: a parity assertion on ``status == "error"`` alone
+passes when two bridges refuse one value for two unrelated causes.
+
+The structural guard at the end pins the mechanism: a bridge that re-implements
+a finiteness test inline instead of calling the shared domain helpers agrees
+with nothing, so no behavioral test fails when it drifts.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.ros_bridge as ros_bridge_mod
+import strands_robots.mesh.rosbridge_robot as rosbridge_mod
+import strands_robots.mesh.rtps_robot as rtps_mod
+from strands_robots.utils import (
+    finite_number_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
+
+
+class _Recorder:
+    """Records the kwargs of each forwarded transport call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+#: (label, module, forwarded transport symbol, robot factory). Every bridge is
+#: built with the same publish rate so a duration hold derives the same count.
+_TRANSPORTS: list[tuple[str, Any, str, Callable[[], Any]]] = [
+    (
+        "ros_bridge",
+        ros_bridge_mod,
+        "use_ros",
+        lambda: ros_bridge_mod.RosBridgedRobot("rover", "/cmd_vel", "/odom", publish_rate=10.0),
+    ),
+    ("rtps", rtps_mod, "use_rtps", lambda: rtps_mod.RtpsRobot("rover", "/cmd_vel", publish_rate=10.0)),
+    (
+        "rosbridge",
+        rosbridge_mod,
+        "use_rosbridge",
+        lambda: rosbridge_mod.RosbridgeRobot("rover", "/cmd_vel", "/odom", publish_rate=10.0),
+    ),
+]
+
+#: Values no signed velocity component can carry. ``nan``/``inf`` serialize into
+#: a Twist as valid float64s, so the transport accepts them and the receiving
+#: controller integrates them; the rest cannot be coerced at all.
+UNUSABLE_VELOCITIES: list[Any] = ["0.5", None, [0.5], True, False, float("nan"), float("inf")]
+
+#: Values no hold can express. ``None`` is absent, not invalid, so it is excluded.
+UNUSABLE_DURATIONS: list[Any] = ["2", [2.0], True, 0, 0.0, -1.5, float("nan"), float("inf")]
+
+#: Values no message count can express - a fractional or non-finite count cannot
+#: index a publish loop, and a non-positive one publishes nothing at all.
+UNUSABLE_COUNTS: list[Any] = [0, -5, 2.7, float("nan"), float("inf"), "3", True, None, [3]]
+
+
+def _drive(monkeypatch: pytest.MonkeyPatch, transport: tuple[str, Any, str, Callable[[], Any]], **kwargs: Any) -> Any:
+    """Drive one bridge with the transport recorded, returning (result, recorder)."""
+    _label, module, symbol, factory = transport
+    rec = _Recorder()
+    monkeypatch.setattr(module, symbol, rec)
+    return factory().drive(**kwargs), rec
+
+
+def _reason(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+# Cross-bridge parity ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", UNUSABLE_VELOCITIES, ids=repr)
+@pytest.mark.parametrize("param", ["linear", "angular"])
+def test_every_bridge_refuses_an_unusable_velocity_for_the_same_reason(
+    monkeypatch: pytest.MonkeyPatch, param: str, value: Any
+) -> None:
+    """A velocity no bridge can honor is refused identically by all three.
+
+    Asserting the shared helper's exact text (not merely ``status == "error"``)
+    is what makes this a parity check: a bridge whose own inline test happens to
+    reject the same value for a different reason still fails here.
+    """
+    expected = finite_number_error(value, param, "drive")
+    assert expected is not None, "probe value must be outside the domain"
+    for transport in _TRANSPORTS:
+        result, rec = _drive(monkeypatch, transport, **{param: value})
+        assert result["status"] == "error", f"{transport[0]} accepted {param}={value!r}"
+        assert _reason(result) == expected, f"{transport[0]} gave a different reason"
+        assert rec.calls == [], f"{transport[0]} reached the wire for {param}={value!r}"
+
+
+@pytest.mark.parametrize("value", UNUSABLE_DURATIONS, ids=repr)
+def test_every_bridge_refuses_an_unusable_duration_for_the_same_reason(
+    monkeypatch: pytest.MonkeyPatch, value: Any
+) -> None:
+    """A hold that no message count expresses is refused identically."""
+    expected = positive_finite_number_error(value, "duration", "drive")
+    assert expected is not None, "probe value must be outside the domain"
+    for transport in _TRANSPORTS:
+        result, rec = _drive(monkeypatch, transport, linear=0.5, duration=value)
+        assert result["status"] == "error", f"{transport[0]} accepted duration={value!r}"
+        assert _reason(result) == expected, f"{transport[0]} gave a different reason"
+        assert rec.calls == [], f"{transport[0]} reached the wire for duration={value!r}"
+
+
+@pytest.mark.parametrize("value", UNUSABLE_COUNTS, ids=repr)
+def test_every_bridge_refuses_an_unusable_count_for_the_same_reason(
+    monkeypatch: pytest.MonkeyPatch, value: Any
+) -> None:
+    """A count that publishes nothing, or cannot index a publish loop, is refused.
+
+    The refusal has to name ``drive`` rather than the transport: the caller
+    never invoked the transport, and its own count check reports a raw loop
+    error for a fractional value.
+    """
+    expected = positive_whole_number_error(value, "count", "drive")
+    assert expected is not None, "probe value must be outside the domain"
+    for transport in _TRANSPORTS:
+        result, rec = _drive(monkeypatch, transport, linear=0.5, count=value)
+        assert result["status"] == "error", f"{transport[0]} accepted count={value!r}"
+        assert _reason(result) == expected, f"{transport[0]} gave a different reason"
+        assert rec.calls == [], f"{transport[0]} reached the wire for count={value!r}"
+
+
+@pytest.mark.parametrize("value", ["10", None, True, 0, -1.0, float("nan"), float("inf")], ids=repr)
+def test_every_bridge_refuses_an_unusable_publish_rate_at_construction(value: Any) -> None:
+    """A publish rate that cannot be honored is refused before a robot exists.
+
+    ``publish_rate`` is the one constructor limit all three bridges share; it
+    converts a hold into a message count, so an unusable value silently
+    reshapes every later timed command.
+    """
+    for label, _module, _symbol, _factory in _TRANSPORTS:
+        expected = positive_finite_number_error(value, "publish_rate", "")
+        assert expected is not None, "probe value must be outside the domain"
+        with pytest.raises(ValueError, match="publish_rate must be > 0"):
+            if label == "rtps":
+                rtps_mod.RtpsRobot("rover", "/cmd_vel", publish_rate=value)
+            elif label == "rosbridge":
+                rosbridge_mod.RosbridgeRobot("rover", "/cmd_vel", "/odom", publish_rate=value)
+            else:
+                ros_bridge_mod.RosBridgedRobot("rover", "/cmd_vel", "/odom", publish_rate=value)
+
+
+def test_every_bridge_still_publishes_a_usable_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The premise: the domains above refuse only what cannot be honored.
+
+    Without this, deleting the guards entirely would satisfy every check above.
+    """
+    for transport in _TRANSPORTS:
+        result, rec = _drive(monkeypatch, transport, linear=0.5, angular=-0.25, count=3)
+        assert result["status"] == "success", f"{transport[0]} refused a usable command"
+        assert rec.calls, f"{transport[0]} published nothing"
+        assert rec.calls[0]["count"] == 3
+        assert rec.calls[0]["fields"] == {"linear": {"x": 0.5}, "angular": {"z": -0.25}}
+
+        held, rec_held = _drive(monkeypatch, transport, linear=0.5, duration=1.5)
+        assert held["status"] == "success"
+        assert rec_held.calls[0]["count"] == 15, "round(1.5 * 10.0) messages"
+
+
+# rosbridge-specific consequences --------------------------------------------
+
+
+@pytest.mark.parametrize("param", ["linear", "angular", "duration"])
+@pytest.mark.parametrize("value", ["0.5", None, [0.5]], ids=repr)
+def test_a_non_numeric_command_value_does_not_escape_the_bound_agent_tool(
+    monkeypatch: pytest.MonkeyPatch, param: str, value: Any
+) -> None:
+    """A value the caller cannot coerce is reported, not raised past dispatch.
+
+    ``drive`` is bound as an agent tool, so an exception leaving it escapes the
+    structured tool-result contract entirely - the agent sees a traceback where
+    a result dict was promised, and cannot read which parameter was at fault.
+    """
+    if param == "duration" and value is None:
+        pytest.skip("an omitted duration means no hold, which is valid")
+    rec = _Recorder()
+    monkeypatch.setattr(rosbridge_mod, "use_rosbridge", rec)
+    rover = rosbridge_mod.RosbridgeRobot("rover", "/cmd_vel", "/odom")
+    drive_tool: Any = next(t for t in rover.tools if t.tool_name == "drive_rover")
+
+    result = drive_tool(**{param: value})
+
+    assert result["status"] == "error"
+    assert param in _reason(result)
+    assert rec.calls == [], "nothing may reach the wire for a refused command"
+
+
+@pytest.mark.parametrize("value", [True, False], ids=repr)
+def test_a_boolean_velocity_is_refused_rather_than_commanded(monkeypatch: pytest.MonkeyPatch, value: bool) -> None:
+    """``bool`` is an int subclass, so ``True`` would command 1.0 m/s in silence."""
+    rec = _Recorder()
+    monkeypatch.setattr(rosbridge_mod, "use_rosbridge", rec)
+    rover = rosbridge_mod.RosbridgeRobot("rover", "/cmd_vel", "/odom")
+
+    result = rover.drive(linear=value)
+
+    assert result["status"] == "error"
+    assert _reason(result) == f"drive: linear must be a finite number, got {value!r}."
+    assert rec.calls == []
+
+
+@pytest.mark.parametrize("limit", ["max_linear", "max_angular", "max_duration", "publish_rate"])
+@pytest.mark.parametrize("value", [True, "2", None, [2.0], 0, -1.0, float("nan"), float("inf")], ids=repr)
+def test_an_unusable_velocity_or_horizon_limit_is_refused_at_construction(limit: str, value: Any) -> None:
+    """Each limit bounds every later command, so an unusable one is fatal here.
+
+    ``max_linear=True`` would otherwise install a silent 1.0 m/s clamp on a
+    rover configured for 2.0, quietly halving every command that exceeds it.
+    """
+    with pytest.raises(ValueError, match=f"{limit} must be > 0"):
+        rosbridge_mod.RosbridgeRobot("rover", "/cmd_vel", "/odom", **{limit: value})
+
+
+def test_a_refused_command_leaves_the_trailing_stop_rule_intact(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A timed drive still self-stops, and a refused one publishes nothing at all.
+
+    The zero Twist that follows a held command runs from a ``finally``, so a
+    guard placed wrongly could either skip it for a valid command or fire it
+    for a refused one.
+    """
+    rec = _Recorder()
+    monkeypatch.setattr(rosbridge_mod, "use_rosbridge", rec)
+    rover = rosbridge_mod.RosbridgeRobot("rover", "/cmd_vel", "/odom", publish_rate=10.0)
+
+    assert rover.drive(linear=0.5, duration=1.0)["status"] == "success"
+    assert [c["count"] for c in rec.calls] == [10, 1]
+    assert rec.calls[-1]["fields"] == {"linear": {"x": 0.0}, "angular": {"z": 0.0}}
+
+    rec.calls.clear()
+    assert rover.drive(linear=0.5, count=0)["status"] == "error"
+    assert rec.calls == [], "a refused command must not publish even a stop"
+
+
+# Structural guard: the shared domain is the only finiteness authority --------
+
+_SHARED_DOMAINS = ("finite_number_error", "positive_finite_number_error", "positive_whole_number_error")
+
+
+def _mesh_modules() -> list[Path]:
+    """Every module of the mesh package, located from a symbol it defines."""
+    package = Path(inspect.getfile(rosbridge_mod.RosbridgeRobot)).parent
+    return sorted(p for p in package.glob("*.py") if p.name != "__init__.py")
+
+
+def _bridge_classes_defining_drive(tree: ast.Module) -> list[ast.ClassDef]:
+    """Top-level classes that define a ``drive`` method of their own."""
+    found: list[ast.ClassDef] = []
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if any(isinstance(c, ast.FunctionDef) and c.name == "drive" for c in ast.iter_child_nodes(node)):
+            found.append(node)
+    return found
+
+
+def _called_plain_names(node: ast.AST) -> set[str]:
+    return {c.func.id for c in ast.walk(node) if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)}
+
+
+def _inline_finiteness_calls(node: ast.AST) -> list[str]:
+    return [
+        f"{c.func.value.id}.{c.func.attr}"
+        for c in ast.walk(node)
+        if isinstance(c, ast.Call)
+        and isinstance(c.func, ast.Attribute)
+        and isinstance(c.func.value, ast.Name)
+        and c.func.attr in {"isfinite", "isnan", "isinf"}
+    ]
+
+
+def _drive_owning_modules() -> list[tuple[Path, ast.Module, ast.ClassDef]]:
+    owners: list[tuple[Path, ast.Module, ast.ClassDef]] = []
+    for path in _mesh_modules():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        owners.extend((path, tree, cls) for cls in _bridge_classes_defining_drive(tree))
+    return owners
+
+
+def test_the_drive_owning_bridges_are_the_three_known_ones() -> None:
+    """Non-vacuity: the scan finds every bridge, so the guards below apply.
+
+    A fourth transport is picked up automatically - which is the point: it is
+    checked the moment it lands rather than after it has drifted.
+    """
+    names = {cls.name for _path, _tree, cls in _drive_owning_modules()}
+    assert {"RosBridgedRobot", "RtpsRobot", "RosbridgeRobot"} <= names, names
+
+
+def test_every_drive_owning_bridge_calls_the_shared_numeric_domains() -> None:
+    """A bridge that validates its own command values agrees with nothing.
+
+    The three domains live in :mod:`strands_robots.utils` precisely so the
+    bridges cannot diverge on what a velocity, a hold or a count may be.
+    """
+    for path, tree, cls in _drive_owning_modules():
+        called = _called_plain_names(tree)
+        missing = [name for name in _SHARED_DOMAINS if name not in called]
+        assert not missing, f"{path.name}:{cls.name} never calls {missing}"
+
+
+def test_no_bridge_command_path_tests_finiteness_inline() -> None:
+    """The command path must defer to the shared domain, not re-derive it.
+
+    An inline finiteness test accepts ``bool`` as a silent 1 and raises a bare
+    coercion error for a numeric string, so it is both looser and less safe
+    than the helper it stands in for.
+    """
+    for path, _tree, cls in _drive_owning_modules():
+        for member in ast.iter_child_nodes(cls):
+            if not isinstance(member, ast.FunctionDef) or member.name not in {"drive", "__init__"}:
+                continue
+            inline = _inline_finiteness_calls(member)
+            assert not inline, f"{path.name}:{cls.name}.{member.name} tests finiteness inline via {inline}"
+
+
+def test_the_structural_guard_detects_a_hand_rolled_bridge() -> None:
+    """Meta: a scanner that silently matched nothing would look like a clean tree."""
+    planted = ast.parse(
+        "import math\n"
+        "class PlantedRobot:\n"
+        "    def drive(self, linear=0.0):\n"
+        "        if not math.isfinite(linear):\n"
+        "            return {'status': 'error'}\n"
+        "        return {'status': 'success'}\n"
+    )
+    classes = _bridge_classes_defining_drive(planted)
+    assert [c.name for c in classes] == ["PlantedRobot"]
+    assert [name for name in _SHARED_DOMAINS if name not in _called_plain_names(planted)] == list(_SHARED_DOMAINS)
+    assert _inline_finiteness_calls(classes[0]) == ["math.isfinite"]


### PR DESCRIPTION
## Problem

Three mobile-base bridges expose the same fleet-standard `drive(linear, angular, duration, count)` contract over three transports. `RosBridgedRobot` and `RtpsRobot` both validate it through the shared domain helpers in `strands_robots.utils`:

```python
from strands_robots.utils import (
    finite_number_error,
    positive_finite_number_error,
    positive_whole_number_error,
)
```

`RosbridgeRobot` imported none of them and hand-rolled an inline `math.isfinite` test instead, so the newest of the three accepted and refused a **different set of values** than the two it copies its contract from. Measured over 16 probe values, it disagreed with the reference bridges on **13**.

An inline finiteness test is both looser and less safe than the helper it stands in for, and `finite_number_error`'s own docstring already names all three failure modes as the reason it exists:

| what happened | measured on `main` |
|---|---|
| `bool` reads as a number | `drive(linear=True)` published a Twist commanding **1.0 m/s** and returned `success` |
| `bool` reads as a limit | `RosbridgeRobot(publish_rate=True)` stored a silent **1 Hz** command stream; `max_linear=True` a silent **1.0 m/s** clamp on a rover configured for 2.0 |
| a value it cannot coerce raises | `drive(linear="0.5")` -> bare `TypeError: must be real number, not str`, **escaping the bound `drive_rover` agent tool** rather than naming the parameter |
| `count` was never checked | `count=0` published nothing; `count=2.7` / `nan` returned `use_rosbridge: publish failed: 'float' object cannot be interpreted as an integer` - a raw loop error attributed to a transport the caller never invoked; `count="3"` / `None` raised `TypeError: '>' not supported between instances of 'str' and 'int'` from the `finally` clause that exists to publish the trailing stop |

The divergence was invisible to the suite because two byte-identical copies of a rule agree with each other, and the third arrival was written with no copy at all. Every existing `RosbridgeRobot` test happened to use only values the inline test handled.

## Change

`strands_robots/mesh/rosbridge_robot.py` now calls the same three shared domains as its siblings, in the same order, with byte-identical message text - so all three bridges report `drive: count must be a positive whole number, got 2.7.` for the same input, and none of them publishes anything for a refused command. `import math` is gone from the module.

Two details worth calling out:

- The `max_duration` ceiling is now ordered **after** the finiteness guard on purpose: every comparison against `nan` is false, so a ceiling test cannot stand in for a domain check.
- `duration` still supersedes `count`, so `count` is validated only when it is the effective horizon. Refusing a `count` the call never reads would reject a valid command.

`tests/mesh/test_drive_command_numeric_domains.py` compares the three bridges **against each other** rather than against a hardcoded expectation, and asserts the *reason* a value was refused rather than only that it was - a parity assertion on `status == "error"` alone passes when two bridges refuse one value for two unrelated causes. A structural guard discovers every class in `strands_robots.mesh` that defines its own `drive`, asserts each calls the shared domains, and asserts no command path tests finiteness inline; a fourth transport is picked up automatically, which is the point. A planted-copy meta-test proves the scanner is not silently matching nothing.

Docs: `drive` gains the `Args`/`Returns` block its siblings already have, and the class docstring gains a `Raises` entry naming the constructor-limit domain.

## Verification

Pre-fix proof - reverting only `strands_robots/mesh/rosbridge_robot.py` to `main` and keeping the new tests:

```
79 failed, 3 passed in 1.23s
FAILED ...::test_every_drive_owning_bridge_calls_the_shared_numeric_domains
  - rosbridge_robot.py:RosbridgeRobot never calls ['finite_number_error',
    'positive_finite_number_error', 'positive_whole_number_error']
FAILED ...::test_no_bridge_command_path_tests_finiteness_inline
  - rosbridge_robot.py:RosbridgeRobot.__init__ tests finiteness inline via ['math.isfinite']
```

The 3 that pass pre-fix are exactly the controls, and they are what stop the guards over-reaching: `test_every_bridge_still_publishes_a_usable_command` (deleting the guards entirely would otherwise satisfy every other check), `test_the_drive_owning_bridges_are_the_three_known_ones` (non-vacuity of the scan) and `test_the_structural_guard_detects_a_hand_rolled_bridge` (the scanner's own meta-test).

Post-fix: **82 passed in 0.77s**, with **zero changes to any existing test** - no test pinned the old message text.

Full gate, headless with `MUJOCO_GL=egl`:

```
ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ 991 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 988 source files
pytest tests                                        15483 passed, 257 skipped in 476.54s
```

`tests/mesh tests/tools` alone: 3697 passed, 5 skipped. `scripts/assemble_changelog.py --check`: OK.

## Measured parity and the real wire

![drive-command numeric domains](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rosbridge-drive-domains/rosbridge_drive_domains.png)

This change is transport-layer, so the artifact is a measured verdict matrix and a wire trace rather than a rollout - no policy, simulation, rendering, recording or asset behaviour is touched. Every cell is read from two JSON dumps produced by one script run against both trees; the generator asserts each figure claim before saving.

Top: each bridge's verdict for the same value. Red marks a cell where the newest bridge disagrees with the two reference bridges - **13 of 16 before, 0 after**.

Bottom: the same five-command session through the real `use_rosbridge` tool against a stub rosbridge server. The two valid commands publish **byte-identically** on both trees (`0.4` x5 + stop, `0.3` x2 + stop); the only Twist that disappears is the **1.0 m/s** one that `drive(linear=True)` published on `main`. Total Twists on the wire: 10 -> 9.

## Scope

This is the robot layer only. The transport tool's own numeric options are a separate surface and are not touched here; `count` is validated at the robot layer because that is where the caller supplied it, so the refusal names `drive` and the parameter instead of a transport the caller never called.

Graph-name validation is unchanged - `RosbridgeRobot` already routed `node_name` / `cmd_vel_topic` / `odom_topic` / `scan_topic` through the shared `_check_topic`, and `host` / `port` through their own guards.