### PR TITLE
fix(policies): refuse a runtime handshake value a policy cannot honor

### DIFF
--- a/changelog.d/1818-policy-runtime-handshake-domains.md
+++ b/changelog.d/1818-policy-runtime-handshake-domains.md
@@ -1,0 +1,15 @@
+### Fixed: a policy refuses a runtime handshake value it cannot honor
+
+`Policy.set_control_frequency` and `Policy.set_rtc_observed_delay` guarded with a
+bare comparison (`hz <= 0` / `steps < 0`), so `nan` and `inf` were stored as a
+control rate (neither compares `<=` to anything) and `bool` passed as an `int`
+subclass. A stored `nan`/`inf` rate raised a bare `ValueError`/`OverflowError`
+out of the Real-Time Chunking delay estimator on the *second* inference of a
+rollout, not the first; a `True` installed a silent 1 Hz clock, and a `True` or
+`2.7` step count was coerced into a chunk-seam offset the caller never asked for.
+Both setters now delegate to the shared numeric domains, so every value they
+accept is one the provider can use. `PolicyServer` forwards the wire rate
+verbatim instead of coercing it with `float(...)`, which had re-admitted a JSON
+`true` as a 1 Hz clock. New shared domain
+`strands_robots.utils.non_negative_count_error` for a count whose `0` is a
+first-class value.

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -119,6 +119,14 @@ correct, deterministic step offset - identical to a local rollout. Per-episode
 `reset(seed)` and `set_control_frequency(hz)` are forwarded too, so seeded
 episodes stay reproducible.
 
+Both forwarded values are validated by the policy itself, so a remote caller
+reaches exactly the accepted domain an in-process one does: `hz` must be a
+finite positive number and the step count `None` or a non-negative `int`. The
+server passes them through verbatim rather than coercing them - JSON carries
+`NaN`, `Infinity` and `true`, and coercing a `true` to `1.0` would install a 1 Hz
+clock no local caller could have set. A refused value is marshalled back as the
+same `RuntimeError` as any other server-side failure, before inference runs.
+
 ## Error handling
 
 Inference failures on the server are marshalled back as an `error` message and

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -632,6 +632,15 @@ real hardware where the arm genuinely keeps moving during inference), leave the
 override unset (`None`) and the policy falls back to the wall-clock p95 estimate,
 which is the right proxy there.
 
+The override is an offset into the action chunk, so it accepts `None` or a
+non-negative `int` and nothing else. A fractional count is not a smaller offset
+and `True` is not a count of one - both used to be coerced into a neighbouring
+value, which moves the seam silently. The control rate the estimator multiplies
+by (`set_control_frequency(hz)`) is a finite positive number for the same
+reason: `nan` and `inf` survive a `hz <= 0` test but not the `int()` that turns
+a latency into a step count, so they are refused where they arrive rather than
+part-way through a rollout.
+
 ## See also
 
 - [MolmoAct2 (SO-100/101)](molmoact2.md) - action contract, units, and motion diagnostics

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -156,7 +156,12 @@ class PolicyServer:
 
         if msg_type == protocol.MSG_SET_CONTROL_FREQUENCY:
             with self._lock:
-                self.policy.set_control_frequency(float(message["hz"]))
+                # Forwarded verbatim: coercing here (``float(...)``) would let
+                # the wire accept a rate the in-process API refuses - a JSON
+                # ``true`` becomes ``1.0`` and installs a silent 1 Hz clock,
+                # and a quoted ``"50"`` becomes a rate no local caller could
+                # have set. The policy owns the accepted domain.
+                self.policy.set_control_frequency(message["hz"])
             return {"type": protocol.MSG_OK}
 
         if msg_type == protocol.MSG_RESET:

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -29,7 +29,11 @@ from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
-from strands_robots.utils import positive_count_error
+from strands_robots.utils import (
+    non_negative_count_error,
+    positive_count_error,
+    positive_finite_number_error,
+)
 
 
 class Policy(ABC):
@@ -76,13 +80,23 @@ class Policy(ABC):
         chunks at any other control frequency.
 
         Args:
-            hz: Positive control frequency in Hz.
+            hz: Finite positive control frequency in Hz.
 
         Raises:
-            ValueError: If ``hz`` is not strictly positive.
+            ValueError: If ``hz`` is not a finite positive number. The rate is
+                the multiplier that converts a measured latency into a step
+                count, so it has to be checked where it arrives rather than
+                where it is read: ``nan`` and ``inf`` both survive a bare
+                ``hz <= 0`` test (neither compares ``<=`` to anything) and are
+                only discovered later, inside the provider, as a bare
+                ``ValueError``/``OverflowError`` out of the ``int()`` that
+                converts the delay - and not on the first inference, because
+                the estimator returns ``0`` until it has a latency sample.
+                ``bool`` is refused for the same reason it is everywhere else
+                in this domain: ``True`` would install a silent 1 Hz clock.
         """
-        if hz <= 0:
-            raise ValueError(f"control_frequency must be positive, got {hz}")
+        if error := positive_finite_number_error(hz, "control_frequency", "set_control_frequency"):
+            raise ValueError(error)
         self.control_frequency = float(hz)
 
     #: Number of control steps the executing loop runs between issuing an
@@ -116,11 +130,18 @@ class Policy(ABC):
                 estimate.
 
         Raises:
-            ValueError: If ``steps`` is negative.
+            ValueError: If ``steps`` is neither ``None`` nor a non-negative
+                ``int``. The count is an offset into the action chunk, so a
+                fractional value is not a smaller offset and ``bool`` is not a
+                count of one - both were previously coerced by the ``int()``
+                below into a neighbouring value the caller never asked for,
+                which moves the chunk seam silently.
         """
-        if steps is not None and steps < 0:
-            raise ValueError(f"rtc_observed_delay_steps must be >= 0, got {steps}")
-        self.rtc_observed_delay_steps = None if steps is None else int(steps)
+        if steps is not None and (
+            error := non_negative_count_error(steps, "rtc_observed_delay_steps", "set_rtc_observed_delay")
+        ):
+            raise ValueError(error)
+        self.rtc_observed_delay_steps = steps
 
     @abstractmethod
     async def get_actions(

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -498,6 +498,39 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
     return None
 
 
+def non_negative_count_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable non-negative integer count.
+
+    Shared domain for a discrete count whose ``0`` is a first-class value rather
+    than a degenerate one - the number of control steps a loop executes while an
+    inference request is in flight
+    (:attr:`~strands_robots.policies.base.Policy.rtc_observed_delay_steps`).
+    That count is exactly ``0`` in the dominant case: a synchronous eval loop
+    pauses the world during inference, so no step elapses. Refusing ``0`` here
+    would therefore reject the common configuration, which is why this is a
+    separate domain rather than a caller of :func:`positive_count_error`.
+
+    In every other respect it mirrors :func:`positive_count_error`: the value is
+    consumed as an offset into an action chunk, so only a true ``int`` can be
+    honored (an integral float raises ``TypeError`` at the slice rather than
+    being coerced), and ``bool`` is rejected explicitly because as an ``int``
+    subclass a bare ``value < 0`` test lets ``True`` through as a silent count
+    of one.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it - the
+            public method name, or the class name for a constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return f"{context}: {param} must be a non-negative integer, got {value!r}."
+    return None
+
+
 def name_list_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable list of distinct key names.
 

--- a/tests/inference/test_remote_policy_roundtrip.py
+++ b/tests/inference/test_remote_policy_roundtrip.py
@@ -156,7 +156,7 @@ def test_set_control_frequency_forwarded_and_validated(served_recording):
     _server, policy, client = served_recording
     client.set_control_frequency(50.0)
     assert policy.control_frequency == 50.0
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="control_frequency must be > 0"):
         client.set_control_frequency(0.0)
 
 

--- a/tests/policies/test_base.py
+++ b/tests/policies/test_base.py
@@ -218,7 +218,7 @@ class TestControlFrequency:
     @pytest.mark.parametrize("bad", [0, -1, -30.0])
     def test_set_control_frequency_rejects_non_positive(self, bad):
         p = _IdentityPolicy()
-        with pytest.raises(ValueError, match="must be positive"):
+        with pytest.raises(ValueError, match="control_frequency must be > 0"):
             p.set_control_frequency(bad)
 
     def test_control_frequency_is_per_instance(self):
@@ -257,10 +257,25 @@ class TestRTCObservedDelay:
         p.set_rtc_observed_delay(None)
         assert p.rtc_observed_delay_steps is None
 
-    def test_set_observed_delay_coerces_to_int(self):
+    def test_set_observed_delay_refuses_a_bool_rather_than_counting_it_as_one(self):
+        """A ``bool`` is not a step count, and coercing it fabricated one.
+
+        This previously asserted the coercion (``True`` -> ``1``) on the grounds
+        that ``bool`` is an ``int`` subclass. That is true of the type but not of
+        the quantity: the count is the offset at which the provider slices the
+        next action chunk, so a silent ``1`` is a seam the caller never asked
+        for, not a harmless default. Being an ``int`` subclass is precisely why
+        the old bare ``steps < 0`` test could not see it.
+        """
         p = _IdentityPolicy()
-        p.set_rtc_observed_delay(True)  # bool is an int subclass
-        assert p.rtc_observed_delay_steps == 1
+        with pytest.raises(ValueError, match="rtc_observed_delay_steps must be a non-negative integer"):
+            p.set_rtc_observed_delay(True)
+        assert p.rtc_observed_delay_steps is None
+
+    def test_set_observed_delay_stores_a_true_int(self):
+        p = _IdentityPolicy()
+        p.set_rtc_observed_delay(4)
+        assert p.rtc_observed_delay_steps == 4
         assert isinstance(p.rtc_observed_delay_steps, int)
 
     def test_set_observed_delay_rejects_negative(self):

--- a/tests/policies/test_composite.py
+++ b/tests/policies/test_composite.py
@@ -266,7 +266,7 @@ class TestChildAccessAndRtcForwarding:
         # without leaving children in a half-updated state.
         lower, upper = StubPolicy([{"hip": 0.0}]), StubPolicy([{"shoulder": 0.0}])
         c = CompositePolicy(lower, upper)
-        with pytest.raises(ValueError, match="rtc_observed_delay_steps must be >= 0"):
+        with pytest.raises(ValueError, match="rtc_observed_delay_steps must be a non-negative integer"):
             c.set_rtc_observed_delay(-1)
         assert lower.rtc_observed_delay_steps is None
         assert upper.rtc_observed_delay_steps is None

--- a/tests/policies/test_runtime_handshake_value_domains.py
+++ b/tests/policies/test_runtime_handshake_value_domains.py
@@ -1,0 +1,321 @@
+"""A policy must refuse a runtime handshake value it cannot honor.
+
+A runtime tells a policy two things before it drives it: the control rate of the
+executing loop (:meth:`~strands_robots.policies.base.Policy.set_control_frequency`)
+and how many control steps elapse while one inference is in flight
+(:meth:`~strands_robots.policies.base.Policy.set_rtc_observed_delay`). Both are
+stored verbatim and read much later, inside a provider's Real-Time Chunking
+path, so a value the setter accepts but the provider cannot use is not
+discovered where the caller can act on it.
+
+Both setters used to guard with a bare comparison (``hz <= 0`` /
+``steps < 0``), which is the ordering :func:`strands_robots.utils.positive_finite_number_error`
+documents as the one that lets ``nan`` through - ``nan`` compares ``False`` to
+everything - and which lets ``bool`` through because it is an ``int`` subclass.
+The observable results were a stored ``nan``/``inf`` rate that raised out of the
+``int()`` in the delay estimator on the *second* inference of a rollout, and a
+``True`` that installed a silent 1 Hz clock (or a 1-step chunk seam).
+
+These tests pin the domains, the agreement between the policy-side rate guard
+and the runner-side guard for the same quantity, and the agreement between the
+in-process API and the same call arriving over the wire.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from typing import Any
+
+import pytest
+
+from strands_robots.inference import protocol
+from strands_robots.inference.server import PolicyServer
+from strands_robots.policies import MockPolicy
+from strands_robots.policies.composite import CompositePolicy
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.simulation.base import SimEngine
+from strands_robots.utils import non_negative_count_error
+
+# Rates no loop can run at, and the reason each one used to survive.
+UNUSABLE_RATES: list[Any] = [
+    0,  # already refused before this change
+    -1,
+    -30.0,
+    True,  # int subclass: a silent 1 Hz
+    float("nan"),  # nan <= 0 is False
+    float("inf"),  # inf <= 0 is False; the period collapses to 0
+    float("-inf"),
+    "50",  # leaked a TypeError from the comparison itself
+    None,
+    [50],
+]
+USABLE_RATES: list[Any] = [1, 30, 50, 30.0, 62.5, 240.0]
+
+# Step counts that are not an offset into an action chunk.
+UNUSABLE_STEPS: list[Any] = [-1, -5, True, False, 2.7, 3.0, float("nan"), float("inf"), "3", [2], {}]
+USABLE_STEPS: list[Any] = [0, 1, 3, 120]
+
+
+def _verdict(fn: Any) -> str:
+    """Classify one call as ``refused`` (the documented ValueError) or otherwise.
+
+    Any other exception type is reported by name so a test can distinguish a
+    refusal that names the parameter from a comparison or conversion internal
+    leaking out of a method documented to raise ``ValueError``. Catching
+    ``BaseException`` would fold an interrupted run into a verdict string, so
+    only ``Exception`` is collected.
+    """
+    try:
+        fn()
+    except ValueError:
+        return "refused"
+    except Exception as exc:  # noqa: BLE001 - the type IS the finding
+        return f"leaked {type(exc).__name__}"
+    return "accepted"
+
+
+class TestControlFrequencyDomain:
+    """``set_control_frequency`` accepts exactly the rates a loop can run at."""
+
+    @pytest.mark.parametrize("bad", UNUSABLE_RATES)
+    def test_an_unusable_rate_is_refused_where_it_arrives(self, bad):
+        p = MockPolicy()
+        assert _verdict(lambda: p.set_control_frequency(bad)) == "refused"
+        # Refused means not stored: a later read cannot pick up the bad value.
+        assert p.control_frequency is None
+
+    @pytest.mark.parametrize("bad", UNUSABLE_RATES)
+    def test_the_refusal_names_the_parameter_and_the_value(self, bad):
+        p = MockPolicy()
+        with pytest.raises(ValueError) as excinfo:
+            p.set_control_frequency(bad)
+        message = str(excinfo.value)
+        assert "set_control_frequency" in message
+        assert "control_frequency" in message
+        assert repr(bad) in message
+
+    @pytest.mark.parametrize("hz", USABLE_RATES)
+    def test_a_usable_rate_is_stored_as_a_float(self, hz):
+        p = MockPolicy()
+        p.set_control_frequency(hz)
+        assert isinstance(p.control_frequency, float)
+        assert p.control_frequency == float(hz)
+
+    @pytest.mark.parametrize("hz", USABLE_RATES)
+    def test_every_accepted_rate_converts_into_a_step_count(self, hz):
+        """The property the domain exists for: an accepted rate is usable downstream.
+
+        The provider multiplies a measured latency by this rate and takes
+        ``int()`` of it. A stored ``nan``/``inf`` raised there instead - and not
+        on the first inference, because the estimator returns ``0`` until it has
+        a latency sample, so the failure landed mid-rollout.
+        """
+        policy = LerobotLocalPolicy.__new__(LerobotLocalPolicy)
+        policy._rtc_latency_history = deque([0.05])
+        p = MockPolicy()
+        p.set_control_frequency(hz)
+        assert p.control_frequency is not None
+        delay = policy._estimate_inference_delay(fps=p.control_frequency)
+        assert isinstance(delay, int)
+        assert delay >= 0
+
+    def test_a_stored_non_finite_rate_would_break_the_estimator(self):
+        """Why the rate is checked at the setter rather than at the read.
+
+        Pinning the downstream failure keeps the justification honest: if this
+        ever stops raising, the guard's rationale needs revisiting rather than
+        silently becoming decoration.
+        """
+        policy = LerobotLocalPolicy.__new__(LerobotLocalPolicy)
+        policy._rtc_latency_history = deque([0.05])
+        with pytest.raises(ValueError):
+            policy._estimate_inference_delay(fps=float("nan"))
+        with pytest.raises(OverflowError):
+            policy._estimate_inference_delay(fps=float("inf"))
+
+
+class TestObservedDelayDomain:
+    """``set_rtc_observed_delay`` accepts exactly the counts a chunk can be sliced by."""
+
+    @pytest.mark.parametrize("bad", UNUSABLE_STEPS)
+    def test_an_unusable_step_count_is_refused(self, bad):
+        p = MockPolicy()
+        assert _verdict(lambda: p.set_rtc_observed_delay(bad)) == "refused"
+        assert p.rtc_observed_delay_steps is None
+
+    @pytest.mark.parametrize("bad", UNUSABLE_STEPS)
+    def test_the_refusal_names_the_parameter_and_the_value(self, bad):
+        p = MockPolicy()
+        with pytest.raises(ValueError) as excinfo:
+            p.set_rtc_observed_delay(bad)
+        message = str(excinfo.value)
+        assert "set_rtc_observed_delay" in message
+        assert "rtc_observed_delay_steps" in message
+        assert repr(bad) in message
+
+    @pytest.mark.parametrize("steps", USABLE_STEPS)
+    def test_a_usable_step_count_is_stored_verbatim(self, steps):
+        p = MockPolicy()
+        p.set_rtc_observed_delay(steps)
+        assert p.rtc_observed_delay_steps == steps
+        assert isinstance(p.rtc_observed_delay_steps, int)
+
+    def test_zero_is_the_dominant_case_and_stays_usable(self):
+        """A synchronous eval loop pauses the world, so exactly zero steps elapse.
+
+        This is why the count has its own non-negative domain instead of reusing
+        the positive-count one: refusing ``0`` would refuse the common path.
+        """
+        p = MockPolicy()
+        p.set_rtc_observed_delay(0)
+        assert p.rtc_observed_delay_steps == 0
+
+    def test_none_clears_the_override(self):
+        p = MockPolicy()
+        p.set_rtc_observed_delay(7)
+        p.set_rtc_observed_delay(None)
+        assert p.rtc_observed_delay_steps is None
+
+
+class TestPolicyAndRunnerAgreeOnTheRateDomain:
+    """The same control rate cannot be refused by one layer and accepted by the other.
+
+    ``SimEngine._validate_positive_frequency`` guards the rate the rollout loop
+    runs at; ``Policy.set_control_frequency`` receives that same rate one call
+    later. A rate the runner refuses must not be settable on a policy, and a
+    rate the runner accepts must not be refused by one.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_RATES + USABLE_RATES)
+    def test_the_two_guards_return_the_same_verdict(self, value):
+        runner_refuses = SimEngine._validate_positive_frequency(value, "run_policy") is not None
+        policy_refuses = _verdict(lambda: MockPolicy().set_control_frequency(value)) == "refused"
+        assert policy_refuses == runner_refuses, (
+            f"verdicts differ for {value!r}: runner_refuses={runner_refuses}, policy_refuses={policy_refuses}"
+        )
+
+
+class _RecordingPolicy(MockPolicy):
+    """A policy that records whether inference was reached."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inference_calls: list[str] = []
+
+    def get_actions_sync(self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any) -> Any:
+        self.inference_calls.append(instruction)
+        return super().get_actions_sync(observation_dict, instruction, **kwargs)
+
+
+class TestTheWireCannotAcceptWhatTheLocalApiRefuses:
+    """A remote caller reaches the same accepted domain as an in-process one.
+
+    ``PolicyServer`` applies both handshake values to the wrapped policy before
+    inference. It used to coerce the rate with ``float(...)`` first, which
+    re-admitted the two values the policy-side guard exists to refuse.
+    """
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), True, "50"])
+    def test_the_wire_can_really_deliver_these_values(self, value):
+        """Executable premise: the transport is JSON, which round-trips these.
+
+        ``json`` emits the non-standard ``NaN``/``Infinity`` tokens by default
+        and reads them back, and a JSON ``true`` decodes to a Python ``bool``,
+        so none of these is hypothetical for a third-party client.
+        """
+        decoded = protocol.loads(protocol.dumps({"hz": value}))["hz"]
+        if isinstance(value, float) and math.isnan(value):
+            assert isinstance(decoded, float) and math.isnan(decoded)
+        else:
+            assert decoded == value
+            assert type(decoded) is type(value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_RATES + USABLE_RATES)
+    def test_the_rate_domain_is_the_same_over_the_wire(self, value):
+        local = _verdict(lambda: MockPolicy().set_control_frequency(value))
+        server = PolicyServer(policy=MockPolicy())
+        wire = _verdict(
+            lambda: server._dispatch({"type": protocol.MSG_SET_CONTROL_FREQUENCY, "hz": value}),
+        )
+        assert wire == local, f"verdicts differ for {value!r}: local={local}, wire={wire}"
+
+    @pytest.mark.parametrize("value", UNUSABLE_STEPS)
+    def test_an_unusable_step_count_from_the_wire_never_reaches_inference(self, value):
+        policy = _RecordingPolicy()
+        server = PolicyServer(policy=policy)
+        with pytest.raises(ValueError):
+            server._dispatch(
+                {
+                    "type": protocol.MSG_GET_ACTIONS,
+                    "observation": {},
+                    "instruction": "pick up the cube",
+                    "rtc_observed_delay_steps": value,
+                }
+            )
+        assert policy.inference_calls == []
+        assert policy.rtc_observed_delay_steps is None
+
+    def test_a_usable_step_count_from_the_wire_still_reaches_inference(self):
+        policy = _RecordingPolicy()
+        server = PolicyServer(policy=policy)
+        reply = server._dispatch(
+            {
+                "type": protocol.MSG_GET_ACTIONS,
+                "observation": {},
+                "instruction": "pick up the cube",
+                "rtc_observed_delay_steps": 0,
+            }
+        )
+        assert reply["type"] == protocol.MSG_ACTIONS
+        assert policy.inference_calls == ["pick up the cube"]
+        assert policy.rtc_observed_delay_steps == 0
+
+
+class TestForwardingWrappersRefuseBeforeForwarding:
+    """A wrapper that fans a handshake value out to children refuses first.
+
+    ``CompositePolicy`` calls the base setter before forwarding, so a refused
+    value must leave no child half-updated.
+    """
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), True, "50"])
+    def test_an_unusable_rate_leaves_both_children_untouched(self, bad):
+        lower, upper = MockPolicy(), MockPolicy()
+        composite = CompositePolicy(lower, upper)
+        with pytest.raises(ValueError):
+            composite.set_control_frequency(bad)
+        assert composite.control_frequency is None
+        assert lower.control_frequency is None
+        assert upper.control_frequency is None
+
+    @pytest.mark.parametrize("bad", [True, 2.7, float("nan"), "3"])
+    def test_an_unusable_step_count_leaves_both_children_untouched(self, bad):
+        lower, upper = MockPolicy(), MockPolicy()
+        composite = CompositePolicy(lower, upper)
+        with pytest.raises(ValueError):
+            composite.set_rtc_observed_delay(bad)
+        assert composite.rtc_observed_delay_steps is None
+        assert lower.rtc_observed_delay_steps is None
+        assert upper.rtc_observed_delay_steps is None
+
+
+class TestNonNegativeCountDomain:
+    """The shared domain itself, independent of any caller."""
+
+    @pytest.mark.parametrize("good", [0, 1, 2, 1000])
+    def test_a_non_negative_int_is_accepted(self, good):
+        assert non_negative_count_error(good, "steps", "ctx") is None
+
+    @pytest.mark.parametrize("bad", [-1, True, False, 0.0, 2.7, float("nan"), "0", None, [0]])
+    def test_everything_else_is_refused(self, bad):
+        error = non_negative_count_error(bad, "steps", "ctx")
+        assert error is not None
+        assert error == f"ctx: steps must be a non-negative integer, got {bad!r}."
+
+    def test_zero_separates_it_from_the_positive_count_domain(self):
+        """The one difference from ``positive_count_error``, pinned deliberately."""
+        from strands_robots.utils import positive_count_error
+
+        assert non_negative_count_error(0, "steps", "ctx") is None
+        assert positive_count_error(0, "steps", "ctx") is not None


### PR DESCRIPTION
## Problem

A runtime tells a policy two things before it drives it: the control rate of the executing loop (`Policy.set_control_frequency`) and how many control steps elapse while one inference is in flight (`Policy.set_rtc_observed_delay`). Both values are stored verbatim and read much later, inside a provider's Real-Time Chunking path, so a value the setter accepts but the provider cannot use is not discovered where the caller can act on it.

Both guarded with a bare comparison - `hz <= 0` and `steps < 0`. That is the exact ordering `positive_finite_number_error` documents as the one that lets `nan` through ("`nan` poisons every comparison it reaches - `nan > 0` and `nan <= 0` are both `False`"), and it lets `bool` through because it is an `int` subclass - the other hole that docstring calls out ("rejects `bool` explicitly - an `int` subclass whose `True` would act as a silent `1`"). The shared domain that names both failure modes also names this exact quantity, "a control-loop frequency in Hz", and neither setter used it.

Measured on the real RTC delay estimator (`chunk seam` is the offset at which the provider slices the next action chunk):

| supplied by the runtime | main | chunk seam |
|---|---|---|
| `50.0` | accepted, stored `50.0` | `2` |
| `true` (JSON bool) | accepted, stored `1.0` | `0` - a silent 1 Hz clock |
| `nan` | accepted, stored `nan` | none - `ValueError` mid-rollout |
| `inf` | accepted, stored `inf` | none - `OverflowError` mid-rollout |

The two crashes land **mid-rollout, not on the first inference**: the estimator returns `0` until it has a latency sample, so the failure surfaces from the second inference of an episode, far from the call that set the rate.

The step count had the same shape: `set_rtc_observed_delay(True)` stored a seam offset of `1` and `(2.7)` stored `2` - counts the caller never asked for - while `nan` / `inf` / `"3"` raised `ValueError` / `OverflowError` / `TypeError` out of the `int()` and the comparison, from a method documented to raise `ValueError`.

`PolicyServer` reaches both setters with values a remote client supplied, and coerced the rate with `float(...)` first. The transport is JSON, which carries `NaN`, `Infinity` and `true`, so that coercion re-admitted the two values a policy-side guard exists to refuse: a JSON `true` became `1.0` and installed a 1 Hz clock no in-process caller could have set.

## Change

- `Policy.set_control_frequency` delegates to `positive_finite_number_error`, the shared domain whose docstring already scopes it to a control-loop frequency in Hz.
- `Policy.set_rtc_observed_delay` delegates to a new shared domain, `strands_robots.utils.non_negative_count_error`. It is a separate domain from `positive_count_error` rather than a caller of it because its `0` is the **dominant** case, not a degenerate one: a synchronous eval loop pauses the world during inference, so exactly zero steps elapse. In every other respect it mirrors `positive_count_error` - the value is an offset into an action chunk, so only a true `int` can be honored and `bool` is rejected explicitly.
- `PolicyServer._dispatch` forwards the wire rate verbatim. The policy owns the accepted domain, so a remote caller now reaches exactly the same one an in-process caller does, and the refusal is marshalled back as the same `RuntimeError` as any other server-side failure - before inference runs.

Every refusal is a `ValueError` naming the method, the parameter and the value. No value any runtime in the repo supplies changes verdict: `PolicyRunner` passes `observed_delay: int = 0`, `hardware_robot` passes a literal `0`, and both pass a validated float rate.

## Visual artifact

Headless MuJoCo (`MUJOCO_GL=egl`). Top: a real Panda rollout, 60 steps at 50 Hz, run on both trees with a valid handshake - final `joint1 -0.258106` / `joint2 +0.268309` rad, an **exact** match, render `max|delta| = 1` (renderer noise). The valid path is untouched; only values a policy could never honor change verdict. Below: the measured handshake, with the chunk seam taken from the real RTC delay estimator.

![Policy runtime handshake domains](https://raw.githubusercontent.com/cagataycali/robots/artifacts/policy-handshake-domains/policy-runtime-handshake-domains.png)

## Tests

New `tests/policies/test_runtime_handshake_value_domains.py` (131 tests, 0.14s, no GL):

- Both domains, in both directions - every unusable value refused and not stored, every usable one accepted, with the refusal naming the parameter and the value.
- **The property the domain exists for**: every rate the setter accepts converts into a step count through the real `_estimate_inference_delay`. Paired with a pin on the downstream failure for a stored `nan`/`inf`, so the justification stays honest rather than silently becoming decoration.
- **Cross-layer parity**: `Policy.set_control_frequency` returns the same verdict as `SimEngine._validate_positive_frequency` over the whole probe set. The runner guards the rate the rollout loop runs at and hands that same rate to the policy one call later; the two cannot diverge again.
- **Wire parity**: the same probe set through `PolicyServer._dispatch` returns the same verdict as the in-process call, and an unusable step count from the wire never reaches inference (asserted on a recording policy). Includes an executable premise - `protocol.dumps`/`loads` really does round-trip `NaN`, `Infinity` and `true`, so none of these is hypothetical for a third-party client.
- Forwarding wrappers (`CompositePolicy`) refuse before forwarding, leaving no child half-updated.
- The new domain in isolation, including the one deliberate difference from `positive_count_error`.

Three existing pins are corrected rather than shimmed. `test_set_observed_delay_coerces_to_int` asserted `True -> 1` on the grounds that `bool` is an `int` subclass - true of the type but not of the quantity, since the count is where the chunk is sliced - and is renamed to the corrected contract with that reasoning in its docstring; its assertion that a stored count is a true `int` is kept as a separate test. Two message pins move to the shared wording, so the same rejection now reads identically wherever a control rate is refused.

## Verification

At base `9b1a62be`:

- **Pre-fix** (call sites reverted, the new `utils` helper kept so the module still imports): `62 failed, 139 passed`. The 139 that pass are the accepted-value controls, the new domain's own unit tests and the premise pins - what stops the guard over-reaching.
- **Post-fix full suite**: `MUJOCO_GL=egl python -m pytest tests` -> **15740 passed, 257 skipped** in 481.94s.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (`Success: no issues found in 998 source files`).
- `scripts/assemble_changelog.py --check` -> OK. `scripts/check_merge_base_overlap.py` -> no overlap.

## Docs

`docs/policies/lerobot-local.md` states the accepted domain of the override and why the rate must be finite; `docs/inference/remote.md` states that a remote caller reaches the same domain and why the server does not coerce.

## Out of scope

`Policy.set_robot_state_keys` is a no-op on the ABC and each provider interprets the keys differently, so its domain belongs with the providers rather than the base handshake.