### PR TITLE
feat(sim/isaac): GR00T action actuation on Isaac - delta-EEF differential-IK controller (closes #1812)

### DIFF
--- a/changelog.d/1812-isaac-delta-eef-action-controller.md
+++ b/changelog.d/1812-isaac-delta-eef-action-controller.md
@@ -1,0 +1,51 @@
+### Added: Isaac-side GR00T action actuation - delta-EEF differential-IK controller
+
+With the observation pipeline fixed (#1811), `examples/libero/run_isaac.py
+--policy groot` ran end-to-end but scored `success_rate 0.00` against the
+MuJoCo baseline's 1.00: `LiberoAdapter._install_action_controller` builds
+robosuite's `OSC_POSE` controller against the compiled MuJoCo model, so on
+Isaac no controller was ever installed, GR00T's task-space delta-EEF keys
+(`{x, y, z, roll, pitch, yaw, gripper}`) resolved to no joint, and every
+action landed in `send_action`'s `unresolved_keys` - a 946-second video of a
+perfectly still Franka (#1812).
+
+`strands_robots.simulation.isaac.delta_eef.IsaacDeltaEEFController` now
+converts each task-space delta into joint position targets via a
+damped-least-squares differential-IK solve on the end-effector's world-frame
+spatial Jacobian, preserving the trained action semantics (#168): inputs
+clipped to `[-1, 1]` then scaled by robosuite `OSC_POSE`'s `output_max`
+(0.05 m / 0.5 rad per 20 Hz control step), RLDS gripper convention
+(`0 = close`, `1 = open`, `0.5 = hold`). The engine side gained the seams the
+controller needs: `IsaacSimulation.install_action_controller` /
+`uninstall_action_controller` (dict actions route through
+`compute_joint_targets` before name resolution; conversion failures are error
+envelopes, never a silent fall-through), `get_jacobian` (MuJoCo-envelope
+signature parity; fixed-base articulation links only, loud rejection of
+`site_name` / `geom_name` and unverified layouts), and a `physics_timestep`
+override so `PolicyRunner` steps a full control period per action
+(`physics_dt=1/120` at 20 Hz -> 6 substeps).
+
+`LiberoAdapter._install_action_controller` tries the Isaac path when the
+MuJoCo OSC path reports its dependencies unavailable: a duck-typed probe of
+the engine's public seams installs the delta-EEF controller bound to the
+LIBERO Franka layout (`panda_joint1..7`, `panda_finger_joint1/2`,
+`panda_hand`), with a Jacobian probe at install time so broken kinematics
+surface at episode start under the existing strict/non-strict policy. Setup
+breakage on a genuine Isaac engine stays loud; engines with neither path keep
+the pre-existing warn-and-degrade behaviour, and the warning now names both
+unavailable paths. `run_isaac.py` passes `control_frequency=20.0` (the rate
+GR00T-N1.7-LIBERO was trained at) instead of inheriting the 50 Hz default.
+
+Validation status (4x L4, Isaac Sim 6.0): the controller is GPU-verified at
+the engine level - scripted saturated deltas displace `panda_hand` in the
+commanded world direction and the gripper channel drives both fingers
+(`tests_integ/simulation/test_isaac_delta_eef_gpu.py`). The full
+`--policy groot` eval installs the controller (the per-episode no-op warning
+is gone) but still measures `success_rate 0.00`, because a distinct,
+pre-existing `IsaacSimulation.load_scene` defect leaves the Isaac timeline
+stopped for the rest of the episode - `world.step()` then renders without
+integrating physics, so every action (this controller's or anyone else's)
+lands on frozen physics - and restarting the timeline exposes the scene's
+placeholder-posed objects interpenetrating the robot base and exploding the
+articulation. That defect predates this change and is tracked as its own
+issue rather than folded in here.

--- a/examples/libero/run_isaac.py
+++ b/examples/libero/run_isaac.py
@@ -894,6 +894,13 @@ def main() -> None:
                 n_episodes=args.n_episodes,
                 seed=args.seed,
                 on_frame=on_frame,
+                # GR00T-N1.7-LIBERO was trained at 20 Hz control (#168).
+                # On MuJoCo the OSC controller owns its 25-substep loop, so
+                # the runner's rate never mattered there; on Isaac the
+                # delta-EEF controller (#1812) relies on the runner to step
+                # a full 1/20 s per action (physics_dt=1/120 -> 6 substeps)
+                # so the PD drives actually track each joint target.
+                control_frequency=20.0,
                 **policy_kwargs,
             )
         finally:

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -53,6 +53,7 @@ from strands_robots.benchmarks.libero.bddl_parser import (
     parse_bddl_file,
 )
 from strands_robots.simulation.benchmark import BenchmarkProtocol, StepInfo
+from strands_robots.simulation.isaac.delta_eef import IsaacDeltaEEFController
 from strands_robots.simulation.models import SimCamera, SimRobot
 from strands_robots.utils import get_base_dir, require_optional
 
@@ -60,6 +61,17 @@ if TYPE_CHECKING:
     from strands_robots.simulation.base import SimEngine
 
 logger = logging.getLogger(__name__)
+
+# #1812 - LIBERO-on-Isaac Franka joint/link names. The Isaac eval path
+# (``examples/libero/run_isaac.py``) loads Isaac Sim's bundled Franka USD,
+# whose articulation DOFs are named ``panda_joint1..7`` (arm) plus
+# ``panda_finger_joint1/2`` (0..0.04 m prismatic fingers), with the
+# end-effector link ``panda_hand``. LIBERO is a Franka-only benchmark, so
+# these are constants rather than constructor knobs; a robot that lacks
+# them is a setup error surfaced through ``_ControllerInstallError``.
+_ISAAC_FRANKA_ARM_JOINTS: tuple[str, ...] = tuple(f"panda_joint{i}" for i in range(1, 8))
+_ISAAC_FRANKA_GRIPPER_JOINTS: tuple[str, ...] = ("panda_finger_joint1", "panda_finger_joint2")
+_ISAAC_FRANKA_EEF_LINK = "panda_hand"
 
 
 class LiberoAdapter(BenchmarkProtocol):
@@ -563,6 +575,13 @@ class LiberoAdapter(BenchmarkProtocol):
         # clears the tag.
         self._strict_action_controller = bool(strict_action_controller)
         self._action_controller_error: str | None = None
+        # #1812 - name of the robot an Isaac-side delta-EEF action
+        # controller was installed for (via
+        # ``IsaacSimulation.install_action_controller``), or ``None`` when
+        # the MuJoCo OSC path (or no path) is active. Used by the
+        # post-install settle step in :meth:`on_episode_start`, which
+        # otherwise only fires for the MuJoCo ``backend_state`` seam.
+        self._isaac_action_controller_robot: str | None = None
 
         # #168 - diagnostic logging gate for the STATE side
         # of the policy interface. Set ``STRANDS_LIBERO_STATE_LOG=1`` to
@@ -1048,20 +1067,23 @@ class LiberoAdapter(BenchmarkProtocol):
         # settle to avoid raising - the eval will still run, just at
         # the un-settled init pose.
         if scene_was_loaded:
-            world = getattr(sim, "_world", None)
-            if world is not None:
-                backend_state = getattr(world, "_backend_state", None)
-                if isinstance(backend_state, dict) and "action_controller" in backend_state:
-                    send_action = getattr(sim, "send_action", None)
-                    if callable(send_action):
-                        try:
-                            send_action({})
-                        except Exception as e:  # noqa: BLE001 - never abort eval on settle failure
-                            logger.warning(
-                                "LiberoAdapter.on_episode_start: settle send_action({}) raised %s; "
-                                "first observation will be at raw init_state instead of init_state+1step",
-                                e,
-                            )
+            controller_installed = self._isaac_action_controller_robot is not None
+            if not controller_installed:
+                world = getattr(sim, "_world", None)
+                if world is not None:
+                    backend_state = getattr(world, "_backend_state", None)
+                    controller_installed = isinstance(backend_state, dict) and "action_controller" in backend_state
+            if controller_installed:
+                send_action = getattr(sim, "send_action", None)
+                if callable(send_action):
+                    try:
+                        send_action({})
+                    except Exception as e:  # noqa: BLE001 - never abort eval on settle failure
+                        logger.warning(
+                            "LiberoAdapter.on_episode_start: settle send_action({}) raised %s; "
+                            "first observation will be at raw init_state instead of init_state+1step",
+                            e,
+                        )
 
         # #168 - reset per-episode state-log counter so each
         # episode emits its own first N STATE_LOG lines (matches the
@@ -2551,8 +2573,10 @@ class LiberoAdapter(BenchmarkProtocol):
         ``prewarm`` or another ``on_episode_start`` cycle.
         """
         # Clear any prior-episode failure tag - a re-install that now
-        # succeeds must not leave a stale error around.
+        # succeeds must not leave a stale error around. Same for the
+        # Isaac-path marker: it is re-set below if that path installs.
         self._action_controller_error = None
+        self._isaac_action_controller_robot = None
         try:
             controller = _LiberoOSCController.from_sim(
                 sim,
@@ -2579,13 +2603,34 @@ class LiberoAdapter(BenchmarkProtocol):
             logger.warning("LiberoAdapter._install_action_controller: %s", msg)
             return
         except _ControllerDependencyMissing as e:
-            # An optional dep (mujoco / robosuite) is genuinely absent.
-            # This is environmental, not a fixable setup bug, so degrade
-            # gracefully even in strict mode: requiring robosuite as a
-            # hard dep would break installs without the optional extras.
+            # The MuJoCo OSC path is unavailable - either an optional dep
+            # (mujoco / robosuite) is genuinely absent or the engine has no
+            # compiled MuJoCo model (e.g. the Isaac backend). Before
+            # degrading to the no-op name-lookup path, try the Isaac-side
+            # delta-EEF differential-IK controller (#1812); the duck-typed
+            # probe returns False on engines that expose no Isaac action
+            # seam, so non-Isaac environments keep the pre-existing
+            # warn-and-degrade behaviour.
+            try:
+                if self._try_install_isaac_action_controller(sim):
+                    return
+            except _ControllerInstallError as isaac_err:
+                msg = f"{isaac_err}. GR00T actions would no-op without the Isaac delta-EEF action controller."
+                self._action_controller_error = msg
+                if self._strict_action_controller:
+                    logger.error("LiberoAdapter._install_action_controller: %s", msg)
+                    raise _ControllerInstallError(msg) from isaac_err
+                logger.warning(
+                    "LiberoAdapter._install_action_controller: %s "
+                    "Running in non-strict mode: GR00T actions will no-op until this is resolved "
+                    "(set strict_action_controller=True to surface this as an eval error).",
+                    msg,
+                )
+                return
             msg = (
-                f"{e}. GR00T actions will no-op: the OSC controller's optional "
-                "dependencies (robosuite + mujoco) are not available in this environment."
+                f"{e}. GR00T actions will no-op: neither the MuJoCo OSC controller's "
+                "optional dependencies (robosuite + mujoco) nor an Isaac-side action "
+                "path are available in this environment."
             )
             self._action_controller_error = msg
             logger.warning("LiberoAdapter._install_action_controller: %s", msg)
@@ -2635,6 +2680,122 @@ class LiberoAdapter(BenchmarkProtocol):
             len(controller.arm_actuator_ids),
             len(controller.gripper_actuator_ids),
         )
+
+    def _try_install_isaac_action_controller(self, sim: SimEngine) -> bool:
+        """Install the Isaac delta-EEF differential-IK action controller.
+
+        Isaac counterpart of the robosuite ``OSC_POSE`` install (#1812): the
+        Isaac backend has no compiled MuJoCo model, so GR00T's task-space
+        delta-EEF action keys resolve to no joint and every action lands in
+        ``send_action``'s ``unresolved_keys`` - a 946-second video of a
+        perfectly still Franka. This builds an
+        :class:`~strands_robots.simulation.isaac.delta_eef.IsaacDeltaEEFController`
+        over the engine's public seams (``get_jacobian`` /
+        ``get_observation`` / ``install_action_controller``) so
+        ``send_action`` converts each delta into joint position targets.
+
+        Duck-typed engine probe, mirroring how the MuJoCo path probes
+        ``sim._world._model``: an engine that lacks any of the required
+        callables is simply not an Isaac engine and gets ``False`` back (the
+        caller then keeps the pre-existing warn-and-degrade behaviour).
+
+        Returns:
+            ``True`` when the controller was installed, ``False`` when the
+            engine exposes no Isaac action seam.
+
+        Raises:
+            _ControllerInstallError: The engine IS an Isaac engine but the
+                setup is broken - zero or multiple robots, missing Franka
+                joints, unreadable Jacobian, or a rejected install. These are
+                fixable setup bugs, so the caller applies the same
+                strict/non-strict policy as the MuJoCo path.
+        """
+        # Typed ``Any``: SimEngine's base surface declares none of these
+        # backend-specific seams, so ``getattr`` would otherwise narrow the
+        # results to ``None`` and mypy would reject the calls below.
+        install: Any = getattr(sim, "install_action_controller", None)
+        get_jacobian: Any = getattr(sim, "get_jacobian", None)
+        list_robots: Any = getattr(sim, "list_robots", None)
+        robot_joint_names: Any = getattr(sim, "robot_joint_names", None)
+        get_observation: Any = getattr(sim, "get_observation", None)
+        if not all(callable(f) for f in (install, get_jacobian, list_robots, robot_joint_names, get_observation)):
+            return False
+
+        robots = list(list_robots())
+        if len(robots) != 1:
+            raise _ControllerInstallError(
+                f"Isaac delta-EEF controller needs exactly one robot to bind to, found {robots!r}"
+            )
+        robot_name = robots[0]
+        joint_names = list(robot_joint_names(robot_name))
+        required = list(_ISAAC_FRANKA_ARM_JOINTS) + list(_ISAAC_FRANKA_GRIPPER_JOINTS)
+        missing = [j for j in required if j not in joint_names]
+        if missing:
+            raise _ControllerInstallError(
+                f"Isaac robot '{robot_name}' lacks the LIBERO Franka joints {missing}; "
+                f"articulation DOFs present: {joint_names}"
+            )
+
+        arm_joints = list(_ISAAC_FRANKA_ARM_JOINTS)
+        arm_indices = [joint_names.index(j) for j in arm_joints]
+
+        def jacobian_fn() -> np.ndarray:
+            result = get_jacobian(body_name=_ISAAC_FRANKA_EEF_LINK, robot_name=robot_name)
+            if result.get("status") != "success":
+                raise RuntimeError(result["content"][0]["text"])
+            payload = result["content"][1]["json"]
+            jac = np.asarray(payload["jacp"] + payload["jacr"], dtype=np.float64)
+            return jac[:, arm_indices]
+
+        def joint_positions_fn() -> np.ndarray:
+            obs = get_observation(robot_name, skip_images=True)
+            try:
+                return np.array([float(obs[j]) for j in arm_joints], dtype=np.float64)
+            except KeyError as missing_joint:
+                raise RuntimeError(
+                    f"Observation for robot '{robot_name}' is missing arm joint {missing_joint}; "
+                    f"observation keys: {sorted(obs)}"
+                ) from missing_joint
+
+        # Probe the Jacobian once at install time so a broken kinematics
+        # read surfaces as a loud install error at episode start (where the
+        # strict/non-strict policy applies) instead of as one error
+        # envelope per action mid-eval. The physics tensor view exists by
+        # now: the runner's warm-up and the scene load have stepped the
+        # world.
+        try:
+            probe = jacobian_fn()
+        except RuntimeError as e:
+            raise _ControllerInstallError(
+                f"Isaac delta-EEF controller cannot read the '{_ISAAC_FRANKA_EEF_LINK}' Jacobian: {e}"
+            ) from e
+        if probe.shape != (6, len(arm_joints)):
+            raise _ControllerInstallError(
+                f"Isaac Jacobian probe returned shape {probe.shape}; expected (6, {len(arm_joints)})"
+            )
+
+        controller = IsaacDeltaEEFController(
+            arm_joint_names=arm_joints,
+            gripper_joint_names=list(_ISAAC_FRANKA_GRIPPER_JOINTS),
+            joint_positions_fn=joint_positions_fn,
+            jacobian_fn=jacobian_fn,
+        )
+        result = install(robot_name, controller)
+        if result.get("status") != "success":
+            raise _ControllerInstallError(
+                f"IsaacSimulation.install_action_controller refused the controller: {result['content'][0]['text']}"
+            )
+        controller.reset()
+        self._isaac_action_controller_robot = robot_name
+        logger.info(
+            "LiberoAdapter: installed Isaac delta-EEF action controller for robot '%s' "
+            "(eef_link=%r, arm_joints=%d, gripper_joints=%d)",
+            robot_name,
+            _ISAAC_FRANKA_EEF_LINK,
+            len(arm_joints),
+            len(_ISAAC_FRANKA_GRIPPER_JOINTS),
+        )
+        return True
 
     @staticmethod
     def _action_controller_remediation(error: BaseException) -> str:

--- a/strands_robots/simulation/isaac/__init__.py
+++ b/strands_robots/simulation/isaac/__init__.py
@@ -26,9 +26,10 @@ if TYPE_CHECKING:
     # omni/Isaac import cost) while statically defining the names promised by
     # ``__all__`` for type checkers and static analysis.
     from strands_robots.simulation.isaac.config import IsaacConfig
+    from strands_robots.simulation.isaac.delta_eef import IsaacDeltaEEFController
     from strands_robots.simulation.isaac.simulation import IsaacSimulation
 
-__all__ = ["IsaacSimulation", "IsaacConfig"]
+__all__ = ["IsaacSimulation", "IsaacConfig", "IsaacDeltaEEFController"]
 
 
 def _lazy_isaac_simulation() -> type[IsaacSimulation]:
@@ -45,10 +46,19 @@ def _lazy_isaac_config() -> type[IsaacConfig]:
     return IsaacConfig
 
 
+def _lazy_delta_eef_controller() -> type[IsaacDeltaEEFController]:
+    """Lazy import for the delta-EEF controller (numpy-only, no Isaac dep)."""
+    from strands_robots.simulation.isaac.delta_eef import IsaacDeltaEEFController
+
+    return IsaacDeltaEEFController
+
+
 def __getattr__(name: str) -> Any:
     """PEP 562 lazy attribute access."""
     if name == "IsaacSimulation":
         return _lazy_isaac_simulation()
     if name == "IsaacConfig":
         return _lazy_isaac_config()
+    if name == "IsaacDeltaEEFController":
+        return _lazy_delta_eef_controller()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/strands_robots/simulation/isaac/delta_eef.py
+++ b/strands_robots/simulation/isaac/delta_eef.py
@@ -1,0 +1,275 @@
+"""Task-space delta-EEF to joint-position-target controller for Isaac.
+
+:class:`IsaacDeltaEEFController` is the Isaac-side counterpart of the
+MuJoCo/robosuite ``OSC_POSE`` controller that
+``LiberoAdapter._install_action_controller`` builds against a compiled
+MuJoCo model. GR00T-LIBERO checkpoints emit 7-dim Cartesian **delta-EEF**
+actions (``{x, y, z, roll, pitch, yaw, gripper}``); on Isaac there is no
+compiled MuJoCo model, so without this controller every action key lands in
+``send_action``'s ``unresolved_keys`` and the robot never moves (#1812).
+
+The controller converts each task-space delta into **joint position
+targets** via a damped-least-squares (DLS) differential-IK solve on the
+end-effector's world-frame spatial Jacobian:
+
+    dq = J^T (J J^T + lambda^2 I)^{-1} * twist
+
+and returns ``{joint_name: q_current + dq}`` for
+:meth:`IsaacSimulation.send_action` to drive through the articulation's PD
+position targets. This is issue #1812's option 1 (position-level
+differential IK); a torque-level OSC re-implementation (option 2, closest
+to what the checkpoint was trained under) is a follow-up.
+
+Action semantics (must match the MuJoCo baseline, #168):
+
+* ``x/y/z/roll/pitch/yaw`` are **normalized** per-step deltas. robosuite's
+  ``OSC_POSE`` clips each input to ``[-1, 1]`` and scales by ``output_max``
+  (``0.05`` m for position, ``0.5`` rad for rotation) per 20 Hz control
+  step -- see ``robosuite/controllers/config/osc_pose.json``. The same
+  clip-then-scale is applied here.
+* Rotation deltas are applied in the **world frame** (robosuite's
+  ``set_goal_orientation`` premultiplies the delta rotation), which matches
+  the world-frame angular rows of PhysX's spatial Jacobian.
+* ``gripper`` is in the RLDS convention (``0 = close``, ``1 = open``,
+  ``0.5`` = no command). The RLDS-to-LIBERO conversion is
+  ``-sign(2*v - 1)`` (``+1`` close / ``-1`` open); here that maps onto the
+  Isaac Franka USD's position-driven fingers as ``gripper_close`` /
+  ``gripper_open`` joint targets.
+
+Dependency-free by construction: current joint positions and the Jacobian
+are injected as callables, so unit tests exercise the full conversion with
+a mocked articulation and the class imports without Isaac Sim installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["IsaacDeltaEEFController", "TASK_SPACE_ACTION_KEYS"]
+
+#: Action-dict keys this controller consumes. Anything else in the action
+#: dict is passed through untouched so ``send_action``'s unresolved-key
+#: reporting stays honest (a key this controller does not understand must
+#: surface in the envelope, never vanish).
+TASK_SPACE_ACTION_KEYS: frozenset[str] = frozenset({"x", "y", "z", "roll", "pitch", "yaw", "gripper"})
+
+_POS_KEYS = ("x", "y", "z")
+_ROT_KEYS = ("roll", "pitch", "yaw")
+
+#: robosuite OSC_POSE ``output_max`` -- metres of translation per control
+#: step for a saturated (+/-1) input. From
+#: ``robosuite/controllers/config/osc_pose.json``; the GR00T-N1.7-LIBERO
+#: checkpoint was trained against these bounds at 20 Hz (#168).
+DEFAULT_POS_SCALE = 0.05
+#: robosuite OSC_POSE rotational ``output_max`` -- radians per control step
+#: for a saturated input.
+DEFAULT_ROT_SCALE = 0.5
+
+
+def _to_scalar(value: Any, default: float = 0.0) -> float:
+    """Coerce a GR00T action channel to a scalar float.
+
+    GR00T-LIBERO packs every action channel list-shaped (2-element list /
+    ndarray) to match the training-data shape -- the same convention
+    ``_LiberoOSCController._to_scalar`` handles on the MuJoCo path (#168).
+
+    * Scalar input -> ``float(value)``
+    * Non-empty list / tuple / ndarray -> ``float(value[0])``
+    * Everything else (None, empty list, dict, ...) -> ``default`` after a
+      WARNING log.
+    """
+    try:
+        if isinstance(value, (list, tuple, np.ndarray)) and len(value) > 0:
+            return float(value[0])
+        return float(value)
+    except (TypeError, ValueError, IndexError) as e:
+        logger.warning(
+            "IsaacDeltaEEFController: could not coerce action value %r to float (%s); using %s for this step",
+            value,
+            e,
+            default,
+        )
+        return default
+
+
+class IsaacDeltaEEFController:
+    """Convert GR00T task-space delta-EEF dicts to joint position targets.
+
+    Parameters
+    ----------
+    arm_joint_names : sequence of str
+        Ordered arm joint names (e.g. ``panda_joint1..7``). Must match the
+        column order of the Jacobian returned by ``jacobian_fn`` and the
+        element order of ``joint_positions_fn``.
+    gripper_joint_names : sequence of str
+        Position-driven gripper joint names (e.g.
+        ``panda_finger_joint1/2``). Each receives ``gripper_open`` /
+        ``gripper_close`` as its target.
+    joint_positions_fn : callable
+        Zero-arg callable returning the current arm joint positions as an
+        array-like of ``len(arm_joint_names)`` floats.
+    jacobian_fn : callable
+        Zero-arg callable returning the end-effector's world-frame spatial
+        Jacobian as a ``(6, len(arm_joint_names))`` array-like -- rows are
+        ``[linear(3); angular(3)]``, columns are the arm joints in
+        ``arm_joint_names`` order (PhysX row convention).
+    joint_limits : array-like or None
+        Optional ``(len(arm_joint_names), 2)`` lower/upper position limits;
+        targets are clipped into them. ``None`` disables clipping.
+    pos_scale, rot_scale : float
+        Metres / radians of task-space delta for a saturated (+/-1) input
+        channel. Defaults match robosuite ``OSC_POSE`` (#168).
+    damping : float
+        DLS damping ``lambda`` (> 0). Keeps the solve bounded near
+        singularities.
+    gripper_open, gripper_close : float
+        Joint position target written to every gripper joint for an
+        open / close command. Defaults match the Franka USD's 0..0.04 m
+        prismatic fingers.
+
+    Concurrency: stateless between calls and does not touch the stage;
+    safe to call from the thread driving ``send_action`` (which holds the
+    engine lock). Not safe to share across robots.
+    """
+
+    def __init__(
+        self,
+        *,
+        arm_joint_names: Sequence[str],
+        gripper_joint_names: Sequence[str],
+        joint_positions_fn: Callable[[], Any],
+        jacobian_fn: Callable[[], Any],
+        joint_limits: Any = None,
+        pos_scale: float = DEFAULT_POS_SCALE,
+        rot_scale: float = DEFAULT_ROT_SCALE,
+        damping: float = 0.05,
+        gripper_open: float = 0.04,
+        gripper_close: float = 0.0,
+    ) -> None:
+        arm = [str(n) for n in arm_joint_names]
+        if not arm:
+            raise ValueError("arm_joint_names must be a non-empty sequence of joint names.")
+        if len(set(arm)) != len(arm):
+            raise ValueError(f"arm_joint_names contains duplicates: {arm}.")
+        grip = [str(n) for n in gripper_joint_names]
+        overlap = set(arm) & set(grip)
+        if overlap:
+            raise ValueError(f"arm and gripper joint names overlap: {sorted(overlap)}.")
+        if not callable(joint_positions_fn) or not callable(jacobian_fn):
+            raise TypeError("joint_positions_fn and jacobian_fn must be callables.")
+        if not (float(pos_scale) > 0.0 and float(rot_scale) > 0.0):
+            raise ValueError(f"pos_scale/rot_scale must be > 0, got {pos_scale!r}/{rot_scale!r}.")
+        if not float(damping) > 0.0:
+            raise ValueError(f"damping must be > 0, got {damping!r}.")
+
+        self.arm_joint_names = arm
+        self.gripper_joint_names = grip
+        self._joint_positions_fn = joint_positions_fn
+        self._jacobian_fn = jacobian_fn
+        self._pos_scale = float(pos_scale)
+        self._rot_scale = float(rot_scale)
+        self._damping = float(damping)
+        self._gripper_open = float(gripper_open)
+        self._gripper_close = float(gripper_close)
+
+        if joint_limits is None:
+            self._joint_limits: np.ndarray | None = None
+        else:
+            limits = np.asarray(joint_limits, dtype=np.float64)
+            if limits.shape != (len(arm), 2):
+                raise ValueError(
+                    f"joint_limits must have shape ({len(arm)}, 2) to match arm_joint_names, got {limits.shape}."
+                )
+            if np.any(limits[:, 0] > limits[:, 1]):
+                raise ValueError("joint_limits has a lower bound above its upper bound.")
+            self._joint_limits = limits
+
+    def reset(self) -> None:
+        """Per-episode reset hook (parity with the MuJoCo OSC controller).
+
+        The DLS solve is stateless, so there is nothing to clear today; the
+        hook exists so install sites can treat both controllers uniformly.
+        """
+
+    def compute_joint_targets(self, action: Mapping[str, Any]) -> dict[str, float]:
+        """Convert one task-space delta action into joint position targets.
+
+        Args:
+            action: GR00T-style action dict. ``x/y/z/roll/pitch/yaw``
+                default to 0 (no-op delta) when absent; ``gripper`` absent
+                means "no gripper command". Keys outside
+                :data:`TASK_SPACE_ACTION_KEYS` are passed through unchanged
+                so the engine's unresolved-key reporting still fires for
+                them.
+
+        Returns:
+            ``{joint_name: target}`` -- arm targets from the DLS solve
+            (omitted entirely for an all-zero delta, so a settle step holds
+            the current PD targets), gripper targets for an open/close
+            command, plus any passed-through keys.
+
+        Raises:
+            TypeError: If ``action`` is not a mapping.
+            RuntimeError: If the injected state callables return
+                unusable data (wrong Jacobian shape, joint-count mismatch,
+                non-finite values) -- a broken solve must surface, never
+                degrade into a silent zero-motion step (#1812).
+        """
+        if not isinstance(action, Mapping):
+            raise TypeError(f"action must be a mapping, got {type(action).__name__}.")
+
+        targets: dict[str, float] = {k: v for k, v in action.items() if k not in TASK_SPACE_ACTION_KEYS}
+
+        twist = np.zeros(6, dtype=np.float64)
+        for i, key in enumerate(_POS_KEYS):
+            twist[i] = np.clip(_to_scalar(action.get(key, 0.0)), -1.0, 1.0) * self._pos_scale
+        for i, key in enumerate(_ROT_KEYS):
+            twist[3 + i] = np.clip(_to_scalar(action.get(key, 0.0)), -1.0, 1.0) * self._rot_scale
+
+        if np.any(twist != 0.0):
+            targets.update(self._solve_arm_targets(twist))
+
+        if "gripper" in action:
+            # RLDS (0=close, 1=open, 0.5=hold) -> LIBERO sign convention
+            # (+1=close, -1=open, 0=hold); see the MuJoCo controller's
+            # derivation from NVIDIA's normalize/invert_gripper_action pair.
+            command = -float(np.sign(2.0 * _to_scalar(action.get("gripper"), 0.5) - 1.0))
+            if command != 0.0:
+                finger_target = self._gripper_close if command > 0.0 else self._gripper_open
+                for name in self.gripper_joint_names:
+                    targets[name] = finger_target
+
+        return targets
+
+    def _solve_arm_targets(self, twist: np.ndarray) -> dict[str, float]:
+        """DLS-solve ``dq`` for a world-frame twist and return arm targets."""
+        n_arm = len(self.arm_joint_names)
+
+        q = np.asarray(self._joint_positions_fn(), dtype=np.float64).reshape(-1)
+        if q.shape != (n_arm,):
+            raise RuntimeError(
+                f"joint_positions_fn returned shape {q.shape}; expected ({n_arm},) matching arm_joint_names."
+            )
+        jac = np.asarray(self._jacobian_fn(), dtype=np.float64)
+        if jac.shape != (6, n_arm):
+            raise RuntimeError(f"jacobian_fn returned shape {jac.shape}; expected (6, {n_arm}).")
+        if not (np.all(np.isfinite(q)) and np.all(np.isfinite(jac))):
+            raise RuntimeError("joint positions / Jacobian contain non-finite values; refusing to solve.")
+
+        # Damped least squares: dq = J^T (J J^T + lambda^2 I)^{-1} twist.
+        # The damping term keeps (J J^T + lambda^2 I) positive definite, so
+        # np.linalg.solve cannot raise on a singular configuration.
+        gram = jac @ jac.T + (self._damping**2) * np.eye(6)
+        dq = jac.T @ np.linalg.solve(gram, twist)
+
+        q_target = q + dq
+        if self._joint_limits is not None:
+            q_target = np.clip(q_target, self._joint_limits[:, 0], self._joint_limits[:, 1])
+
+        return {name: float(q_target[i]) for i, name in enumerate(self.arm_joint_names)}

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -646,6 +646,12 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
         # Entity tracking
         self._robots: dict[str, _RobotState] = {}
+        # Per-robot task-space action controllers (install_action_controller).
+        # When a robot has one, dict actions handed to send_action are first
+        # converted to joint-name targets via compute_joint_targets -- the
+        # Isaac counterpart of the MuJoCo backend's
+        # ``world._backend_state["action_controller"]`` seam (#1812).
+        self._action_controllers: dict[str, Any] = {}
         self._cameras: dict[str, _CameraState] = {}
         self._objects: dict[str, _ObjectState] = {}
         self._prim_registry: list[str] = []  # track all created prims for cleanup
@@ -1117,6 +1123,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
             # Clear entity tracking
             self._robots.clear()
+            self._action_controllers.clear()
             self._cameras.clear()
             self._objects.clear()
             self._prim_registry.clear()
@@ -2326,6 +2333,9 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             prim_path = self._robots[name].prim_path
             self._prim_registry = [p for p in self._prim_registry if not p.startswith(prim_path)]
             del self._robots[name]
+            # A controller closed over this robot's articulation is stale
+            # the moment the robot is gone; drop it with the robot.
+            self._action_controllers.pop(name, None)
             logger.info("Removed robot '%s' (prim=%s)", name, prim_path)
             return {
                 "status": "success",
@@ -2527,6 +2537,207 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
             return obs
 
+    def physics_timestep(self) -> float | None:
+        """Return the fixed physics integration timestep in seconds.
+
+        Isaac's ``World`` steps at :attr:`IsaacConfig.physics_dt`.
+        Reporting it lets :class:`PolicyRunner` derive the physics substeps
+        per control step (``round(1 / control_frequency / physics_dt)``) so
+        a PD position-servo arm tracks each action's target for the full
+        control period -- without this override the base class returned
+        ``None`` and every applied action got a single ~8 ms step (#1812).
+        """
+        return float(self._config.physics_dt)
+
+    def install_action_controller(self, robot_name: str, controller: Any) -> dict[str, Any]:
+        """Install a task-space action controller for a robot.
+
+        Once installed, every dict action handed to :meth:`send_action` for
+        ``robot_name`` is first converted by
+        ``controller.compute_joint_targets(action)`` into a
+        ``{joint_name: position_target}`` dict, which then flows through the
+        normal name-resolution / ``ArticulationAction`` path. This is the
+        Isaac counterpart of the MuJoCo backend's
+        ``world._backend_state["action_controller"]`` seam that
+        ``LiberoAdapter._install_action_controller`` uses to route GR00T's
+        delta-EEF actions (#1812) -- see
+        :class:`~strands_robots.simulation.isaac.delta_eef.IsaacDeltaEEFController`.
+
+        Args:
+            robot_name: Robot previously added via ``add_robot``.
+            controller: Object exposing a callable
+                ``compute_joint_targets(action: Mapping) -> dict[str, float]``.
+
+        Returns:
+            Standard ``{"status", "content": [{"text"}]}`` envelope.
+        """
+        with self._lock:
+            if robot_name not in self._robots:
+                return {
+                    "status": "error",
+                    "content": [{"text": f"Robot '{robot_name}' not found. Available: {sorted(self._robots)}"}],
+                }
+            if not callable(getattr(controller, "compute_joint_targets", None)):
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "Controller must expose a callable compute_joint_targets(action) "
+                                f"method; got {type(controller).__name__}."
+                            )
+                        }
+                    ],
+                }
+            self._action_controllers[robot_name] = controller
+            logger.info(
+                "Installed action controller %s for robot '%s'",
+                type(controller).__name__,
+                robot_name,
+            )
+            return {
+                "status": "success",
+                "content": [{"text": f"Action controller installed for '{robot_name}'."}],
+            }
+
+    def uninstall_action_controller(self, robot_name: str) -> dict[str, Any]:
+        """Remove a previously installed action controller.
+
+        Idempotent: removing a robot with no controller succeeds (the
+        post-state is the same), so per-episode re-install loops don't have
+        to track whether an install ever happened.
+        """
+        with self._lock:
+            removed = self._action_controllers.pop(robot_name, None)
+            text = (
+                f"Action controller removed from '{robot_name}'."
+                if removed is not None
+                else f"No action controller installed for '{robot_name}'."
+            )
+            return {"status": "success", "content": [{"text": text}]}
+
+    def get_jacobian(
+        self,
+        body_name: str | None = None,
+        site_name: str | None = None,
+        geom_name: str | None = None,
+        robot_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Compute the world-frame spatial Jacobian for a robot link.
+
+        Signature-parity with the MuJoCo backend's ``get_jacobian``
+        (:meth:`strands_robots.simulation.mujoco.physics.PhysicsMixin.get_jacobian`):
+        returns positional (3 x ndof) and rotational (3 x ndof) Jacobians in
+        a ``json`` content block. Isaac has no sites/geoms as Jacobian
+        targets, so ``site_name`` / ``geom_name`` are rejected loudly rather
+        than silently ignored.
+
+        Args:
+            body_name: Link (rigid body) name on the articulation, e.g.
+                ``panda_hand``.
+            site_name: Unsupported on Isaac; passing it returns an error.
+            geom_name: Unsupported on Isaac; passing it returns an error.
+            robot_name: Robot to query; auto-picked when exactly one robot
+                is loaded.
+
+        Returns:
+            ``{"status": "success", "content": [{"text"}, {"json": {"jacp",
+            "jacr", "nv"}}]}`` on success, an error envelope otherwise.
+        """
+        if site_name is not None or geom_name is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "The Isaac backend computes Jacobians for articulation links only; "
+                            "site_name/geom_name are unsupported. Pass body_name (a link name)."
+                        )
+                    }
+                ],
+            }
+        if not body_name:
+            return {"status": "error", "content": [{"text": "Specify body_name (a link name)."}]}
+        with self._lock:
+            if robot_name is None:
+                if len(self._robots) == 1:
+                    robot_name = next(iter(self._robots))
+                else:
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"Specify robot_name; available robots: {sorted(self._robots)}"}],
+                    }
+            if robot_name not in self._robots:
+                return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+            try:
+                jac = self._link_jacobian(self._robots[robot_name], body_name)
+            except (RuntimeError, ValueError) as e:
+                return {"status": "error", "content": [{"text": str(e)}]}
+        return {
+            "status": "success",
+            "content": [
+                {"text": f"Jacobian for link '{body_name}': pos=(3, {jac.shape[1]}), rot=(3, {jac.shape[1]})"},
+                {"json": {"jacp": jac[:3].tolist(), "jacr": jac[3:].tolist(), "nv": jac.shape[1]}},
+            ],
+        }
+
+    def _link_jacobian(self, robot: _RobotState, link_name: str) -> np.ndarray:
+        """Return the ``(6, num_dof)`` world-frame Jacobian for one link.
+
+        Rows are ``[linear(3); angular(3)]`` (PhysX convention), columns are
+        the articulation DOFs in ``robot.joint_names`` order. Reads the
+        PhysX tensor buffers via the articulation view --
+        ``SingleArticulation`` exposes no public Jacobian accessor in Isaac
+        Sim 6.0, only its wrapped ``Articulation`` view does
+        (``_articulation_view.get_jacobians()``), so this is the one place
+        that private attribute is touched.
+
+        Raises:
+            RuntimeError: If the articulation/physics view is not available
+                yet, the robot is floating-base (unsupported layout), or the
+                buffers cannot be read.
+            ValueError: If ``link_name`` is not a link on the articulation.
+        """
+        articulation = robot.articulation
+        if articulation is None:
+            raise RuntimeError(f"Robot '{robot.name}' has no articulation handle; was the robot fully loaded?")
+        view = getattr(articulation, "_articulation_view", None)
+        if view is None:
+            raise RuntimeError(
+                f"Robot '{robot.name}': articulation exposes no _articulation_view; "
+                "cannot read Jacobians on this Isaac Sim version."
+            )
+
+        body_names = list(getattr(view, "body_names", None) or [])
+        if link_name not in body_names:
+            raise ValueError(f"Link '{link_name}' not found on robot '{robot.name}'. Links: {body_names}")
+
+        jacobians = view.get_jacobians()
+        if jacobians is None:
+            raise RuntimeError(
+                "Articulation view returned no Jacobians (physics simulation view not created yet); "
+                "step the world at least once before reading Jacobians."
+            )
+        jac = jacobians.cpu().numpy() if hasattr(jacobians, "cpu") else np.asarray(jacobians)
+        # Shape (num_articulations, num_links, 6, num_dof). Fixed-base
+        # articulations exclude the root link from the link dimension, so a
+        # link's Jacobian row is its body index minus one. A floating base
+        # would instead carry num_bodies rows and 6 extra root DOF columns;
+        # LIBERO's Franka imports fix_base=True, so refuse the layout we
+        # have not verified instead of guessing column semantics.
+        jac = jac[0]
+        n_dof = len(robot.joint_names)
+        if jac.shape[0] == len(body_names) - 1 and jac.shape[2] == n_dof:
+            row = body_names.index(link_name) - 1
+            if row < 0:
+                raise ValueError(f"Link '{link_name}' is the articulation root; it has no Jacobian.")
+        else:
+            raise RuntimeError(
+                f"Unsupported Jacobian layout {jac.shape} for robot '{robot.name}' "
+                f"({len(body_names)} links, {n_dof} DOFs). Only fixed-base articulations are supported."
+            )
+        return np.asarray(jac[row], dtype=np.float64)
+
     def send_action(
         self,
         action: dict[str, Any] | np.ndarray | list,
@@ -2538,7 +2749,11 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         Parameters
         ----------
         action : dict or array-like
-            Joint targets. If dict, keyed by joint name.
+            Joint targets. If dict, keyed by joint name -- unless the robot
+            has a controller installed via :meth:`install_action_controller`,
+            in which case the dict is first converted by the controller
+            (e.g. GR00T task-space delta-EEF keys to joint position
+            targets) and the converted dict is what gets resolved.
         robot_name : str, optional
             Robot to control.
         n_substeps : int
@@ -2582,6 +2797,30 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
             robot = self._robots[robot_name]
+
+            # Route a dict action through the robot's installed task-space
+            # controller (install_action_controller), which converts e.g.
+            # GR00T's delta-EEF keys ({x, y, z, roll, pitch, yaw, gripper})
+            # into {joint_name: position_target}. A conversion failure is a
+            # hard error envelope, never a silent fall-through to the raw
+            # name-lookup path -- the raw path would drop every task-space
+            # key and the robot would sit still while the eval reads green
+            # (#1812).
+            controller = self._action_controllers.get(robot_name)
+            if controller is not None and isinstance(action, dict):
+                try:
+                    action = controller.compute_joint_targets(action)
+                except (RuntimeError, ValueError, TypeError) as e:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"Action controller for '{robot_name}' failed to convert the task-space action: {e}"
+                                )
+                            }
+                        ],
+                    }
 
             # Convert action to array, tracking dict keys that don't name a
             # joint so unresolved commands surface in the envelope rather than

--- a/tests/benchmarks/libero/test_isaac_action_controller_install.py
+++ b/tests/benchmarks/libero/test_isaac_action_controller_install.py
@@ -1,0 +1,183 @@
+"""LiberoAdapter action-controller install on the Isaac backend (#1812).
+
+The MuJoCo path builds robosuite's OSC_POSE controller against the compiled
+MuJoCo model; on Isaac there is no compiled model, so pre-#1812 the install
+degraded to a warning and every GR00T task-space action key landed in
+``send_action``'s ``unresolved_keys`` -- success_rate pinned at 0.00 while
+the run read green. These tests pin the new routing:
+
+* On an engine exposing the Isaac action seam (``install_action_controller``
+  / ``get_jacobian`` / ``list_robots`` / ``robot_joint_names`` /
+  ``get_observation``), ``_install_action_controller`` installs an
+  :class:`IsaacDeltaEEFController` instead of warning.
+* Setup breakage on a genuine Isaac engine (missing Franka joints, broken
+  Jacobian, ambiguous robots) stays LOUD: strict mode raises
+  ``_ControllerInstallError``; non-strict records the failure.
+* Engines with neither the MuJoCo nor the Isaac path keep the pre-existing
+  warn-and-degrade behaviour, and the warning now names both missing paths.
+
+No Isaac Sim install required -- the fake engine implements only the public
+seam the adapter probes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.benchmarks.libero.adapter import (
+    LiberoAdapter,
+    _ControllerInstallError,
+)
+from strands_robots.simulation.isaac.delta_eef import IsaacDeltaEEFController
+
+PICK_CUBE_BDDL = """
+(define (problem libero_spatial_pick_cube)
+  (:domain kitchen)
+  (:language "pick up the red cube and place it on the plate")
+  (:objects cube_1 plate_1 table_1 - object)
+  (:init (on cube_1 table_1))
+  (:goal (on cube_1 plate_1)))
+"""
+
+ARM = [f"panda_joint{i}" for i in range(1, 8)]
+GRIP = ["panda_finger_joint1", "panda_finger_joint2"]
+ALL_JOINTS = ARM + GRIP
+
+
+class _FakeIsaacSim:
+    """Duck-typed stand-in for IsaacSimulation's public action seam."""
+
+    def __init__(
+        self,
+        joint_names: list[str] | None = None,
+        robots: list[str] | None = None,
+        jacobian_status: str = "success",
+    ):
+        self.joint_names = list(joint_names or ALL_JOINTS)
+        self.robots = list(robots or ["robot"])
+        self.jacobian_status = jacobian_status
+        self.installed: dict[str, Any] = {}
+
+    def list_robots(self) -> list[str]:
+        return list(self.robots)
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:  # noqa: ARG002
+        return list(self.joint_names)
+
+    def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, Any]:  # noqa: ARG002
+        return {name: 0.1 for name in self.joint_names}
+
+    def get_jacobian(self, body_name=None, site_name=None, geom_name=None, robot_name=None):  # noqa: ARG002
+        if self.jacobian_status != "success":
+            return {"status": "error", "content": [{"text": "physics simulation view not created yet"}]}
+        nv = len(self.joint_names)
+        jacp = np.eye(3, nv).tolist()
+        jacr = np.eye(3, nv, k=3).tolist()
+        return {
+            "status": "success",
+            "content": [
+                {"text": f"Jacobian for link '{body_name}'"},
+                {"json": {"jacp": jacp, "jacr": jacr, "nv": nv}},
+            ],
+        }
+
+    def install_action_controller(self, robot_name: str, controller: Any) -> dict[str, Any]:
+        self.installed[robot_name] = controller
+        return {"status": "success", "content": [{"text": f"Action controller installed for '{robot_name}'."}]}
+
+
+def _adapter(**kwargs) -> LiberoAdapter:
+    return LiberoAdapter.from_text(PICK_CUBE_BDDL, **kwargs)
+
+
+class TestIsaacInstallPath:
+    def test_installs_delta_eef_controller_on_isaac_seam(self):
+        adapter = _adapter()
+        sim = _FakeIsaacSim()
+        adapter._install_action_controller(sim)
+        assert adapter._action_controller_error is None
+        assert adapter._isaac_action_controller_robot == "robot"
+        controller = sim.installed["robot"]
+        assert isinstance(controller, IsaacDeltaEEFController)
+        assert controller.arm_joint_names == ARM
+        assert controller.gripper_joint_names == GRIP
+
+    def test_installed_controller_converts_a_task_space_action(self):
+        """End-to-end wiring: the injected closures read the fake engine's
+        Jacobian/observation and produce joint-name targets."""
+        adapter = _adapter()
+        sim = _FakeIsaacSim()
+        adapter._install_action_controller(sim)
+        targets = sim.installed["robot"].compute_joint_targets({"x": 1.0, "gripper": 1.0})
+        assert set(targets) == set(ALL_JOINTS)
+        # q = 0.1 everywhere; identity-block Jacobian moves dof 0 for an x delta.
+        assert targets["panda_joint1"] > 0.1
+        assert targets["panda_finger_joint1"] == pytest.approx(0.04)
+
+    def test_reinstall_is_idempotent(self):
+        adapter = _adapter()
+        sim = _FakeIsaacSim()
+        adapter._install_action_controller(sim)
+        adapter._install_action_controller(sim)
+        assert adapter._isaac_action_controller_robot == "robot"
+        assert isinstance(sim.installed["robot"], IsaacDeltaEEFController)
+
+
+class TestIsaacInstallFailuresStayLoud:
+    def test_missing_franka_joints_raises_in_strict_mode(self):
+        adapter = _adapter()  # strict_action_controller defaults True
+        sim = _FakeIsaacSim(joint_names=["shoulder", "elbow"])
+        with pytest.raises(_ControllerInstallError, match="panda_joint1"):
+            adapter._install_action_controller(sim)
+        assert adapter._action_controller_error is not None
+
+    def test_missing_franka_joints_warns_in_non_strict_mode(self, caplog):
+        adapter = _adapter(strict_action_controller=False)
+        sim = _FakeIsaacSim(joint_names=["shoulder", "elbow"])
+        with caplog.at_level("WARNING"):
+            adapter._install_action_controller(sim)
+        assert adapter._action_controller_error is not None
+        assert "panda_joint1" in adapter._action_controller_error
+        assert sim.installed == {}
+
+    def test_multiple_robots_raise_in_strict_mode(self):
+        adapter = _adapter()
+        sim = _FakeIsaacSim(robots=["robot_a", "robot_b"])
+        with pytest.raises(_ControllerInstallError, match="exactly one robot"):
+            adapter._install_action_controller(sim)
+
+    def test_broken_jacobian_probe_raises_in_strict_mode(self):
+        adapter = _adapter()
+        sim = _FakeIsaacSim(jacobian_status="error")
+        with pytest.raises(_ControllerInstallError, match="Jacobian"):
+            adapter._install_action_controller(sim)
+        assert sim.installed == {}
+
+
+class TestNonIsaacEnginesKeepDegradedPath:
+    def test_engine_with_no_action_path_warns_and_names_both_paths(self, caplog):
+        """A sim with neither a compiled MuJoCo model nor the Isaac seam must
+        keep the pre-existing warn-and-degrade behaviour -- and the warning
+        must name BOTH unavailable paths so the 0.00 success_rate is
+        attributable (#1812 acceptance criterion)."""
+        adapter = _adapter()
+
+        class _BareSim:
+            pass
+
+        with caplog.at_level("WARNING"):
+            adapter._install_action_controller(_BareSim())
+        assert adapter._action_controller_error is not None
+        assert "robosuite + mujoco" in adapter._action_controller_error
+        assert "Isaac" in adapter._action_controller_error
+        assert adapter._isaac_action_controller_robot is None
+
+    def test_no_raise_even_in_strict_mode_when_no_engine_seam_exists(self):
+        """Missing optional deps / wrong engine is environmental, not a
+        fixable setup bug: strict mode must not raise (pre-#1812 contract)."""
+        adapter = _adapter()  # strict
+        adapter._install_action_controller(object())
+        assert adapter._action_controller_error is not None

--- a/tests/simulation/isaac/test_dataset_recording.py
+++ b/tests/simulation/isaac/test_dataset_recording.py
@@ -81,6 +81,7 @@ def _make_engine(
     engine._prim_registry = []
     engine._cams_rec_state = None
     engine._recording_state_dict = {}
+    engine._action_controllers = {}  # cleared by destroy() (#1812)
     engine._sim_time = 0.0
     engine._step_count = 0
     engine._replicated = False

--- a/tests/simulation/isaac/test_delta_eef_controller.py
+++ b/tests/simulation/isaac/test_delta_eef_controller.py
@@ -1,0 +1,448 @@
+"""Unit tests for the Isaac delta-EEF differential-IK action controller (#1812).
+
+Covers, with a fully mocked articulation (no Isaac Sim install needed):
+
+* The DLS delta -> joint-position-target conversion itself
+  (:class:`IsaacDeltaEEFController`): clip-then-scale input semantics
+  matching robosuite ``OSC_POSE``, gripper RLDS convention, joint-limit
+  clipping, pass-through of unknown keys, and loud failures on unusable
+  injected state.
+* The engine seam: ``IsaacSimulation.install_action_controller`` routing in
+  ``send_action`` (dict actions converted, vector actions untouched,
+  conversion failures become error envelopes), ``get_jacobian``'s envelope
+  built from a fake articulation view, and the ``physics_timestep``
+  override.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.delta_eef import (
+    DEFAULT_POS_SCALE,
+    DEFAULT_ROT_SCALE,
+    IsaacDeltaEEFController,
+)
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+
+ARM = [f"panda_joint{i}" for i in range(1, 8)]
+GRIP = ["panda_finger_joint1", "panda_finger_joint2"]
+DAMPING = 0.05
+
+
+def _controller(
+    q: np.ndarray | None = None,
+    jac: np.ndarray | None = None,
+    **kwargs,
+) -> IsaacDeltaEEFController:
+    q = np.zeros(7) if q is None else q
+    jac = np.eye(6, 7) if jac is None else jac
+    return IsaacDeltaEEFController(
+        arm_joint_names=ARM,
+        gripper_joint_names=GRIP,
+        joint_positions_fn=lambda: q,
+        jacobian_fn=lambda: jac,
+        **kwargs,
+    )
+
+
+class TestDeltaToJointTargets:
+    def test_unit_x_delta_moves_first_dof_by_scaled_dls_step(self):
+        """For J = eye(6, 7), the DLS solve has the closed form
+        dq = twist / (1 + damping^2) padded with a zero -- pin it exactly."""
+        controller = _controller()
+        targets = controller.compute_joint_targets({"x": 1.0})
+        expected_dq0 = DEFAULT_POS_SCALE / (1.0 + DAMPING**2)
+        assert set(targets) == set(ARM)
+        assert targets["panda_joint1"] == pytest.approx(expected_dq0)
+        for name in ARM[1:]:
+            assert targets[name] == pytest.approx(0.0)
+
+    def test_rotation_channel_uses_rot_scale(self):
+        controller = _controller()
+        targets = controller.compute_joint_targets({"yaw": 1.0})
+        # yaw is twist row 5 -> J = eye maps it onto dof index 5.
+        assert targets["panda_joint6"] == pytest.approx(DEFAULT_ROT_SCALE / (1.0 + DAMPING**2))
+
+    def test_input_clipped_to_unit_range(self):
+        """robosuite OSC_POSE clips inputs to [-1, 1] before scaling; a
+        saturated and an over-saturated command must produce identical
+        targets."""
+        controller = _controller()
+        assert controller.compute_joint_targets({"x": 5.0}) == controller.compute_joint_targets({"x": 1.0})
+
+    def test_half_input_scales_linearly(self):
+        controller = _controller()
+        full = controller.compute_joint_targets({"y": 1.0})["panda_joint2"]
+        half = controller.compute_joint_targets({"y": 0.5})["panda_joint2"]
+        assert half == pytest.approx(full / 2.0)
+
+    def test_achieved_twist_tracks_commanded_twist(self):
+        """Behavioral: J @ dq must approximate the commanded twist (small
+        damping bias only) on a well-conditioned Jacobian."""
+        rng = np.random.default_rng(7)
+        # Orthonormal rows -> singular values are all 1, so the DLS bias is
+        # exactly damping^2 / (1 + damping^2) ~ 0.25%.
+        jac = np.linalg.qr(rng.standard_normal((7, 6)))[0].T
+        controller = _controller(jac=jac)
+        targets = controller.compute_joint_targets({"x": 0.4, "z": -0.8, "pitch": 0.3})
+        dq = np.array([targets[n] for n in ARM])
+        twist = np.array([0.4 * DEFAULT_POS_SCALE, 0.0, -0.8 * DEFAULT_POS_SCALE, 0.0, 0.3 * DEFAULT_ROT_SCALE, 0.0])
+        assert jac @ dq == pytest.approx(twist, rel=0.01)
+
+    def test_targets_offset_from_current_joint_positions(self):
+        q = np.linspace(-0.5, 0.5, 7)
+        controller = _controller(q=q)
+        targets = controller.compute_joint_targets({"x": 1.0})
+        dq0 = DEFAULT_POS_SCALE / (1.0 + DAMPING**2)
+        assert targets["panda_joint1"] == pytest.approx(q[0] + dq0)
+        assert targets["panda_joint7"] == pytest.approx(q[6])
+
+    def test_zero_delta_returns_no_arm_targets(self):
+        """An all-zero delta (e.g. the settle step's ``send_action({})``)
+        must hold the current PD targets, not re-command them -- and must
+        not even read the Jacobian."""
+
+        def poisoned():
+            raise AssertionError("jacobian_fn must not be called for a zero delta")
+
+        controller = IsaacDeltaEEFController(
+            arm_joint_names=ARM,
+            gripper_joint_names=GRIP,
+            joint_positions_fn=poisoned,
+            jacobian_fn=poisoned,
+        )
+        assert controller.compute_joint_targets({}) == {}
+        assert controller.compute_joint_targets({"x": 0.0, "roll": 0.0}) == {}
+
+    def test_list_shaped_channels_use_first_element(self):
+        """GR00T-LIBERO packs every action channel list-shaped (#168)."""
+        controller = _controller()
+        scalar = controller.compute_joint_targets({"x": 1.0})
+        listed = controller.compute_joint_targets({"x": [1.0, 0.25]})
+        assert listed == scalar
+
+    def test_joint_limits_clip_targets(self):
+        limits = np.column_stack([np.full(7, -0.01), np.full(7, 0.01)])
+        controller = _controller(joint_limits=limits)
+        targets = controller.compute_joint_targets({"x": 1.0})
+        assert targets["panda_joint1"] == pytest.approx(0.01)
+
+    def test_unknown_keys_pass_through(self):
+        """Keys the controller does not consume must survive so the
+        engine's unresolved-key reporting still fires for them."""
+        controller = _controller()
+        targets = controller.compute_joint_targets({"x": 1.0, "unmapped.foo": 3.0})
+        assert targets["unmapped.foo"] == 3.0
+
+
+class TestGripperConvention:
+    """RLDS gripper channel: 0 = close, 1 = open, 0.5 = no command."""
+
+    def test_open_command_targets_open_position(self):
+        targets = _controller().compute_joint_targets({"gripper": 1.0})
+        assert targets == {name: pytest.approx(0.04) for name in GRIP}
+
+    def test_close_command_targets_close_position(self):
+        targets = _controller().compute_joint_targets({"gripper": 0.0})
+        assert targets == {name: pytest.approx(0.0) for name in GRIP}
+
+    def test_neutral_and_absent_gripper_hold(self):
+        controller = _controller()
+        assert controller.compute_joint_targets({"gripper": 0.5}) == {}
+        assert controller.compute_joint_targets({}) == {}
+
+    def test_list_shaped_gripper(self):
+        targets = _controller().compute_joint_targets({"gripper": [1.0, 1.0]})
+        assert targets["panda_finger_joint1"] == pytest.approx(0.04)
+
+    def test_custom_open_close_positions(self):
+        controller = _controller(gripper_open=0.03, gripper_close=0.001)
+        assert _round(controller.compute_joint_targets({"gripper": 1.0})) == {name: 0.03 for name in GRIP}
+        assert _round(controller.compute_joint_targets({"gripper": 0.0})) == {name: 0.001 for name in GRIP}
+
+
+def _round(d: dict) -> dict:
+    return {k: round(v, 9) for k, v in d.items()}
+
+
+class TestControllerErrors:
+    def test_non_mapping_action_raises_type_error(self):
+        with pytest.raises(TypeError, match="mapping"):
+            _controller().compute_joint_targets([0.1] * 7)  # type: ignore[arg-type]
+
+    def test_wrong_jacobian_shape_raises(self):
+        controller = _controller(jac=np.eye(5, 7))
+        with pytest.raises(RuntimeError, match=r"expected \(6, 7\)"):
+            controller.compute_joint_targets({"x": 1.0})
+
+    def test_wrong_joint_count_raises(self):
+        controller = _controller(q=np.zeros(6))
+        with pytest.raises(RuntimeError, match="arm_joint_names"):
+            controller.compute_joint_targets({"x": 1.0})
+
+    def test_non_finite_state_raises(self):
+        controller = _controller(q=np.full(7, np.nan))
+        with pytest.raises(RuntimeError, match="non-finite"):
+            controller.compute_joint_targets({"x": 1.0})
+
+    def test_constructor_rejects_empty_arm(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            IsaacDeltaEEFController(
+                arm_joint_names=[],
+                gripper_joint_names=GRIP,
+                joint_positions_fn=lambda: [],
+                jacobian_fn=lambda: [],
+            )
+
+    def test_constructor_rejects_arm_gripper_overlap(self):
+        with pytest.raises(ValueError, match="overlap"):
+            IsaacDeltaEEFController(
+                arm_joint_names=ARM,
+                gripper_joint_names=[ARM[0]],
+                joint_positions_fn=lambda: np.zeros(7),
+                jacobian_fn=lambda: np.eye(6, 7),
+            )
+
+    def test_constructor_rejects_bad_damping(self):
+        with pytest.raises(ValueError, match="damping"):
+            _controller(damping=0.0)
+
+    def test_constructor_rejects_bad_limits_shape(self):
+        with pytest.raises(ValueError, match="joint_limits"):
+            _controller(joint_limits=np.zeros((3, 2)))
+
+
+# --- Engine seam: send_action routing -------------------------------------
+
+
+class _FakeArticulationAction:
+    def __init__(self, joint_positions=None, joint_indices=None):
+        self.joint_positions = joint_positions
+        self.joint_indices = joint_indices
+
+
+class _FakeArticulation:
+    def __init__(self):
+        self.last_action = None
+
+    def apply_action(self, action):
+        self.last_action = action
+
+    def get_joint_positions(self):
+        return None
+
+
+class _FakeWorld:
+    def step(self, render=False):  # noqa: ARG002 - signature parity
+        return None
+
+
+@pytest.fixture
+def fake_isaacsim_types(monkeypatch):
+    """Inject a fake ``isaacsim.core.utils.types`` exposing ArticulationAction."""
+    mods = {}
+    for name in ("isaacsim", "isaacsim.core", "isaacsim.core.utils", "isaacsim.core.utils.types"):
+        mod = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, mod)
+        mods[name] = mod
+    mods["isaacsim.core.utils.types"].ArticulationAction = _FakeArticulationAction
+    mods["isaacsim"].core = mods["isaacsim.core"]
+    mods["isaacsim.core"].utils = mods["isaacsim.core.utils"]
+    mods["isaacsim.core.utils"].types = mods["isaacsim.core.utils.types"]
+    return mods
+
+
+JOINTS = ARM + GRIP
+
+
+def _seed_running_world(sim, articulation, joint_names=None):
+    sim._world = _FakeWorld()
+    sim._world_created = True
+    sim._robots = {
+        "arm": _RobotState(
+            name="arm",
+            prim_path="/World/Robots/arm",
+            joint_names=list(joint_names or JOINTS),
+            articulation=articulation,
+        )
+    }
+
+
+class TestSendActionControllerRouting:
+    def test_task_space_dict_is_converted_and_applied(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        art = _FakeArticulation()
+        _seed_running_world(sim, art)
+        r = sim.install_action_controller("arm", _controller())
+        assert r["status"] == "success", r
+
+        result = sim.send_action({"x": 1.0, "gripper": 1.0}, robot_name="arm")
+        assert result["status"] == "success", result
+
+        act = art.last_action
+        assert act is not None, "apply_action was never called"
+        commanded = dict(zip(np.asarray(act.joint_indices).tolist(), np.asarray(act.joint_positions).tolist()))
+        # Arm target on dof 0 from the DLS step, fingers open at 0.04.
+        assert commanded[0] == pytest.approx(DEFAULT_POS_SCALE / (1.0 + DAMPING**2), abs=1e-6)
+        assert commanded[7] == pytest.approx(0.04)
+        assert commanded[8] == pytest.approx(0.04)
+        assert set(commanded) == set(range(9))
+
+    def test_pre_fix_behaviour_without_controller_stays_unresolved(self, fake_isaacsim_types):
+        """Without a controller, task-space keys still surface as unresolved
+        (the honest pre-#1812 failure mode, not a silent success)."""
+        sim = IsaacSimulation()
+        _seed_running_world(sim, _FakeArticulation())
+        result = sim.send_action({"x": 1.0, "gripper": 1.0}, robot_name="arm")
+        assert result["status"] == "error"
+        payload = result["content"][1]["json"]
+        assert set(payload["unresolved_keys"]) == {"x", "gripper"}
+
+    def test_controller_failure_is_an_error_envelope(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        _seed_running_world(sim, _FakeArticulation())
+        controller = _controller(jac=np.eye(4, 7))  # wrong shape -> RuntimeError
+        assert sim.install_action_controller("arm", controller)["status"] == "success"
+        result = sim.send_action({"x": 1.0}, robot_name="arm")
+        assert result["status"] == "error"
+        assert "Action controller" in result["content"][0]["text"]
+
+    def test_vector_action_bypasses_controller(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        art = _FakeArticulation()
+        _seed_running_world(sim, art)
+
+        def poisoned(_action):
+            raise AssertionError("controller must not see vector actions")
+
+        controller = _controller()
+        controller.compute_joint_targets = poisoned  # type: ignore[method-assign]
+        sim.install_action_controller("arm", controller)
+        result = sim.send_action([0.0] * 9, robot_name="arm")
+        assert result["status"] == "success", result
+        assert art.last_action is not None
+
+    def test_empty_dict_with_controller_is_a_clean_settle(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        art = _FakeArticulation()
+        _seed_running_world(sim, art)
+        sim.install_action_controller("arm", _controller())
+        result = sim.send_action({}, robot_name="arm")
+        assert result["status"] == "success", result
+        assert art.last_action is None, "a zero delta must not command any joint"
+
+    def test_uninstall_restores_raw_path(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        _seed_running_world(sim, _FakeArticulation())
+        sim.install_action_controller("arm", _controller())
+        assert sim.uninstall_action_controller("arm")["status"] == "success"
+        result = sim.send_action({"x": 1.0}, robot_name="arm")
+        assert result["status"] == "error"
+        assert "x" in result["content"][1]["json"]["unresolved_keys"]
+
+    def test_uninstall_is_idempotent(self):
+        sim = IsaacSimulation()
+        assert sim.uninstall_action_controller("nope")["status"] == "success"
+
+    def test_install_rejects_unknown_robot(self):
+        sim = IsaacSimulation()
+        result = sim.install_action_controller("ghost", _controller())
+        assert result["status"] == "error"
+        assert "ghost" in result["content"][0]["text"]
+
+    def test_install_rejects_non_controller(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        _seed_running_world(sim, _FakeArticulation())
+        result = sim.install_action_controller("arm", object())
+        assert result["status"] == "error"
+        assert "compute_joint_targets" in result["content"][0]["text"]
+
+    def test_remove_robot_drops_controller(self, fake_isaacsim_types):
+        sim = IsaacSimulation()
+        _seed_running_world(sim, _FakeArticulation())
+        sim.install_action_controller("arm", _controller())
+        assert sim.remove_robot("arm")["status"] == "success"
+        assert sim._action_controllers == {}
+
+
+# --- Engine seam: get_jacobian ---------------------------------------------
+
+
+class _FakeView:
+    def __init__(self, body_names, jacobians):
+        self.body_names = body_names
+        self._jacobians = jacobians
+
+    def get_jacobians(self):
+        return self._jacobians
+
+
+class _FakeArticulationWithView(_FakeArticulation):
+    def __init__(self, view):
+        super().__init__()
+        self._articulation_view = view
+
+
+class TestGetJacobian:
+    BODIES = ["panda_link0", "panda_link1", "panda_hand"]
+
+    def _sim(self, jacobians):
+        sim = IsaacSimulation()
+        art = _FakeArticulationWithView(_FakeView(self.BODIES, jacobians))
+        _seed_running_world(sim, art)
+        return sim
+
+    def test_envelope_carries_link_rows(self):
+        # Fixed base: (1 articulation, num_links-1, 6, num_dof).
+        jacs = np.arange(1 * 2 * 6 * 9, dtype=np.float64).reshape(1, 2, 6, 9)
+        sim = self._sim(jacs)
+        result = sim.get_jacobian(body_name="panda_hand", robot_name="arm")
+        assert result["status"] == "success", result
+        payload = result["content"][1]["json"]
+        assert payload["nv"] == 9
+        expected = jacs[0, 1]  # body index 2, minus the excluded root
+        assert np.asarray(payload["jacp"]) == pytest.approx(expected[:3])
+        assert np.asarray(payload["jacr"]) == pytest.approx(expected[3:])
+
+    def test_unknown_link_is_an_error(self):
+        sim = self._sim(np.zeros((1, 2, 6, 9)))
+        result = sim.get_jacobian(body_name="nonexistent", robot_name="arm")
+        assert result["status"] == "error"
+        assert "nonexistent" in result["content"][0]["text"]
+
+    def test_root_link_is_an_error(self):
+        sim = self._sim(np.zeros((1, 2, 6, 9)))
+        result = sim.get_jacobian(body_name="panda_link0", robot_name="arm")
+        assert result["status"] == "error"
+        assert "root" in result["content"][0]["text"]
+
+    def test_missing_physics_view_is_an_error(self):
+        sim = self._sim(None)
+        result = sim.get_jacobian(body_name="panda_hand", robot_name="arm")
+        assert result["status"] == "error"
+        assert "physics" in result["content"][0]["text"].lower()
+
+    def test_unsupported_layout_is_an_error(self):
+        # Floating-base layout: num_links rows, num_dof + 6 columns.
+        sim = self._sim(np.zeros((1, 3, 6, 15)))
+        result = sim.get_jacobian(body_name="panda_hand", robot_name="arm")
+        assert result["status"] == "error"
+        assert "fixed-base" in result["content"][0]["text"].lower()
+
+    def test_site_and_geom_names_rejected(self):
+        sim = self._sim(np.zeros((1, 2, 6, 9)))
+        for kwargs in ({"site_name": "grip_site"}, {"geom_name": "g"}):
+            result = sim.get_jacobian(body_name="panda_hand", robot_name="arm", **kwargs)
+            assert result["status"] == "error"
+            assert "unsupported" in result["content"][0]["text"]
+
+
+class TestPhysicsTimestep:
+    def test_reports_config_physics_dt(self):
+        sim = IsaacSimulation(physics_dt=0.005)
+        assert sim.physics_timestep() == pytest.approx(0.005)

--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -105,7 +105,7 @@ class TestPackageLazyExport:
         import strands_robots.simulation.isaac as isaac_pkg
 
         # Everything promised by __all__ is resolvable through the package.
-        assert set(isaac_pkg.__all__) == {"IsaacSimulation", "IsaacConfig"}
+        assert set(isaac_pkg.__all__) == {"IsaacSimulation", "IsaacConfig", "IsaacDeltaEEFController"}
         for name in isaac_pkg.__all__:
             assert getattr(isaac_pkg, name) is not None
 

--- a/tests_integ/simulation/test_isaac_delta_eef_gpu.py
+++ b/tests_integ/simulation/test_isaac_delta_eef_gpu.py
@@ -1,0 +1,229 @@
+"""GPU integration tests for the Isaac delta-EEF action controller (#1812).
+
+Verifies, against a real Isaac Sim articulation, the acceptance criterion
+that a scripted delta sequence MOVES the robot: GR00T-style task-space
+deltas installed via ``install_action_controller`` +
+``IsaacDeltaEEFController`` must displace ``panda_hand`` in the commanded
+world direction. Pre-#1812 the same action dicts landed 100% in
+``send_action``'s ``unresolved_keys`` and the Franka never moved.
+
+Requirements match ``test_isaac_gpu.py``: NVIDIA GPU, Isaac Sim 6.0+, and
+``STRANDS_GPU_TEST=1``.
+
+Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ \\
+        tests_integ/simulation/test_isaac_delta_eef_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+pytest.importorskip("strands_robots.simulation.isaac")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+ARM_JOINTS = [f"panda_joint{i}" for i in range(1, 8)]
+GRIPPER_JOINTS = ["panda_finger_joint1", "panda_finger_joint2"]
+EEF_LINK = "panda_hand"
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+def _assets_root_path() -> str:
+    """Resolve the bundled-assets root; call AFTER ``create_world()``.
+
+    The ``isaacsim.storage.native`` extension module only joins ``sys.path``
+    once ``SimulationApp`` has booted, which happens inside the first
+    ``create_world()`` -- resolving earlier raises ``ModuleNotFoundError``
+    on a fresh process.
+    """
+    try:
+        from isaacsim.storage.native import get_assets_root_path  # type: ignore[import-not-found]
+    except ImportError:
+        from omni.isaac.nucleus import get_assets_root_path  # type: ignore[import-not-found]
+
+    assets_root = get_assets_root_path()
+    assert assets_root, "get_assets_root_path() returned empty"
+    return assets_root
+
+
+def _add_franka(sim) -> None:
+    """Load the bundled Franka, trying the 6.0 asset layout then the 4.x one.
+
+    Same dual-subpath fallback as ``examples/libero/run_isaac.py``'s
+    ``_FRANKA_USD_SUBPATHS``: the Franka moved to
+    ``Isaac/Robots/FrankaRobotics/FrankaPanda/`` in Isaac Sim 6.0.
+    """
+    assets_root = _assets_root_path()
+    result = None
+    for sub in (
+        "Isaac/Robots/FrankaRobotics/FrankaPanda/franka.usd",  # Isaac Sim 6.0+
+        "Isaac/Robots/Franka/franka.usd",  # Isaac Sim 4.x and earlier
+    ):
+        result = sim.add_robot("robot", usd_path=f"{assets_root}/{sub}")
+        if result["status"] == "success":
+            return
+    raise AssertionError(f"add_robot failed for both Franka USD layouts: {result}")
+
+
+def _panda_hand_world_position(sim) -> np.ndarray:
+    """World position of the ``panda_hand`` prim via USD (no get_body_state
+    dependency -- that lands separately in #1802/#1811)."""
+    import omni.usd  # type: ignore[import-not-found]
+    from pxr import Usd, UsdGeom  # type: ignore[import-not-found]
+
+    stage = omni.usd.get_context().get_stage()
+    for prim in stage.Traverse():
+        if prim.GetName() == EEF_LINK:
+            xform = UsdGeom.Xformable(prim).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+            row = xform.ExtractTranslation()
+            return np.array([row[0], row[1], row[2]], dtype=np.float64)
+    raise AssertionError(f"No prim named {EEF_LINK!r} found on the stage")
+
+
+def _build_controller(sim, robot_name: str):
+    """Mirror LiberoAdapter._try_install_isaac_action_controller's wiring."""
+    from strands_robots.simulation.isaac import IsaacDeltaEEFController
+
+    joint_names = sim.robot_joint_names(robot_name)
+    arm_indices = [joint_names.index(j) for j in ARM_JOINTS]
+
+    def jacobian_fn() -> np.ndarray:
+        result = sim.get_jacobian(body_name=EEF_LINK, robot_name=robot_name)
+        assert result["status"] == "success", f"get_jacobian: {result}"
+        payload = result["content"][1]["json"]
+        jac = np.asarray(payload["jacp"] + payload["jacr"], dtype=np.float64)
+        return jac[:, arm_indices]
+
+    def joint_positions_fn() -> np.ndarray:
+        obs = sim.get_observation(robot_name, skip_images=True)
+        return np.array([float(obs[j]) for j in ARM_JOINTS], dtype=np.float64)
+
+    return IsaacDeltaEEFController(
+        arm_joint_names=ARM_JOINTS,
+        gripper_joint_names=GRIPPER_JOINTS,
+        joint_positions_fn=joint_positions_fn,
+        jacobian_fn=jacobian_fn,
+    )
+
+
+class TestDeltaEEFActuationGPU:
+    def test_scripted_deltas_move_panda_hand_in_commanded_direction(self):
+        """A +x / -z delta sequence must displace panda_hand accordingly.
+
+        This is the #1812 acceptance test at the engine level: the same
+        ``{x, y, z, roll, pitch, yaw, gripper}`` dicts that previously
+        no-op'd now actuate the articulation. 20 control steps of a
+        saturated +x delta (0.05 m/step commanded) must produce clearly
+        measurable +x motion; the exact magnitude depends on PD tracking,
+        so the assertion is directional with a conservative floor.
+        """
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=True))
+        try:
+            r = sim.create_world()
+            assert r["status"] == "success", f"create_world: {r}"
+            _add_franka(sim)
+
+            # Two render-less steps create/settle the physics simulation
+            # view (joint writes and Jacobian reads need it). Deliberately
+            # NO sim.reset() here: a world.reset() after add_robot leaves
+            # the articulation's cached physics view stale on Isaac 6.0
+            # (get_joint_positions returns None) -- verified live on this
+            # exact sequence.
+            sim.step(2)
+            # Move off the fully-folded home pose so the +x direction is not
+            # near a workspace boundary, then settle.
+            ready_pose = dict(zip(ARM_JOINTS, [0.0, -0.5, 0.0, -2.0, 0.0, 1.6, 0.8]))
+            r = sim.set_joint_positions(ready_pose, robot_name="robot")
+            assert r["status"] == "success", f"set_joint_positions: {r}"
+            sim.step(20)
+
+            # Jacobian must be readable after the world has stepped.
+            jac_probe = sim.get_jacobian(body_name=EEF_LINK, robot_name="robot")
+            assert jac_probe["status"] == "success", f"get_jacobian probe: {jac_probe}"
+            assert jac_probe["content"][1]["json"]["nv"] == 9
+
+            controller = _build_controller(sim, "robot")
+            r = sim.install_action_controller("robot", controller)
+            assert r["status"] == "success", f"install_action_controller: {r}"
+
+            # physics_dt=1/120 at 20 Hz control -> 6 substeps per action,
+            # matching what PolicyRunner derives from physics_timestep().
+            n_substeps = round((1.0 / 20.0) / sim.physics_timestep())
+            assert n_substeps == 6
+
+            start = _panda_hand_world_position(sim)
+            for _ in range(20):
+                r = sim.send_action({"x": 1.0, "gripper": 1.0}, robot_name="robot", n_substeps=n_substeps)
+                assert r["status"] == "success", f"send_action(+x): {r}"
+            after_x = _panda_hand_world_position(sim)
+
+            dx = after_x - start
+            # 20 saturated steps command 1.0 m; PD tracking and IK damping
+            # eat into that, but anything above 5 cm is unambiguous motion
+            # (pre-fix displacement was exactly 0).
+            assert dx[0] > 0.05, f"panda_hand did not move in +x: displacement={dx}"
+            assert abs(dx[0]) > abs(dx[1]), f"+x command produced dominant off-axis y motion: {dx}"
+
+            for _ in range(20):
+                r = sim.send_action({"z": -1.0}, robot_name="robot", n_substeps=n_substeps)
+                assert r["status"] == "success", f"send_action(-z): {r}"
+            after_z = _panda_hand_world_position(sim)
+            dz = after_z - after_x
+            assert dz[2] < -0.05, f"panda_hand did not move in -z: displacement={dz}"
+        finally:
+            sim.destroy()
+
+    def test_gripper_channel_drives_fingers(self):
+        """RLDS gripper commands (0=close, 1=open) must move both fingers."""
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=True))
+        try:
+            assert sim.create_world()["status"] == "success"
+            _add_franka(sim)
+            sim.step(5)
+
+            controller = _build_controller(sim, "robot")
+            assert sim.install_action_controller("robot", controller)["status"] == "success"
+            n_substeps = round((1.0 / 20.0) / sim.physics_timestep())
+
+            for _ in range(10):
+                assert sim.send_action({"gripper": 1.0}, robot_name="robot", n_substeps=n_substeps)["status"] == (
+                    "success"
+                )
+            open_obs = sim.get_observation("robot", skip_images=True)
+            for _ in range(10):
+                assert sim.send_action({"gripper": 0.0}, robot_name="robot", n_substeps=n_substeps)["status"] == (
+                    "success"
+                )
+            closed_obs = sim.get_observation("robot", skip_images=True)
+
+            for finger in GRIPPER_JOINTS:
+                assert open_obs[finger] > 0.03, f"{finger} did not open: {open_obs[finger]}"
+                assert closed_obs[finger] < 0.01, f"{finger} did not close: {closed_obs[finger]}"
+        finally:
+            sim.destroy()


### PR DESCRIPTION
## What

Closes #1812. Adds the Isaac-side action path that converts GR00T's task-space delta-EEF actions (`{x, y, z, roll, pitch, yaw, gripper}`) into joint actuation - issue option 1 (differential IK), no robosuite dependency:

- **`IsaacDeltaEEFController`** (`strands_robots/simulation/isaac/delta_eef.py`): damped-least-squares differential-IK solve on the end-effector's world-frame spatial Jacobian (`dq = J^T (J J^T + lambda^2 I)^{-1} twist`), returning `{joint_name: q + dq}` position targets. Preserves the trained action semantics from #168: inputs clipped to `[-1, 1]` then scaled by robosuite `OSC_POSE`'s `output_max` (0.05 m / 0.5 rad per 20 Hz control step), rotation deltas in the world frame, RLDS gripper convention (0 = close, 1 = open, 0.5 = hold). Numpy-only; joint positions and the Jacobian are injected as callables, so the class imports and unit-tests without Isaac Sim.
- **`IsaacSimulation` seams**:
  - `install_action_controller` / `uninstall_action_controller` - the Isaac counterpart of the MuJoCo backend's `world._backend_state["action_controller"]` seam. Dict actions route through `compute_joint_targets` before name resolution; a conversion failure is a hard error envelope, never a silent fall-through to the raw name-lookup path (which would drop every task-space key while the eval reads green).
  - `get_jacobian` - signature/envelope parity with the MuJoCo backend's; articulation links only (`site_name`/`geom_name` rejected loudly), fixed-base layout verified, unverified layouts refused rather than guessed.
  - `physics_timestep` override - reports `IsaacConfig.physics_dt` so `PolicyRunner` derives the substeps per control step (1/120 physics at 20 Hz -> 6 substeps) and the PD drives track each target for a full control period.
- **`LiberoAdapter._install_action_controller`**: when the MuJoCo OSC path raises `_ControllerDependencyMissing` (which is exactly what "no compiled MuJoCo model" raises on the Isaac backend), a duck-typed probe of the engine's public seams installs the delta-EEF controller bound to the LIBERO Franka layout (`panda_joint1..7`, `panda_finger_joint1/2`, `panda_hand`). A Jacobian probe at install time makes broken kinematics a loud episode-start error under the existing strict/non-strict policy. Setup breakage on a genuine Isaac engine stays loud; engines with neither path keep the pre-existing warn-and-degrade behaviour, and that warning now names **both** unavailable paths.
- **`run_isaac.py`**: passes `control_frequency=20.0` (GR00T-N1.7-LIBERO's training rate, #168) instead of inheriting the 50 Hz default - on MuJoCo the OSC controller owns its own substep loop so the runner rate never mattered; on Isaac the runner must step a full 1/20 s per action.

## Acceptance criteria

- [x] **Controller install failure stays loud** - strict mode raises `_ControllerInstallError` on a genuine Isaac engine with broken setup; engines with neither the MuJoCo OSC nor the Isaac path keep the warn-and-degrade behaviour and the warning names both missing paths (pinned by `tests/benchmarks/libero/test_isaac_action_controller_install.py`).
- [x] **Unit tests for the delta->joint-target conversion (mocked articulation)** - 49 new unit tests across `tests/simulation/isaac/test_delta_eef_controller.py` (DLS closed-form pins, clip-then-scale semantics, gripper convention, joint-limit clipping, pass-through keys, loud failures on unusable state, `send_action` routing, `get_jacobian` envelope) and `tests/benchmarks/libero/test_isaac_action_controller_install.py` (install path, strict/non-strict failure policy, non-Isaac degradation).
- [x] **GPU-gated integ test that a scripted delta sequence moves `panda_hand` in the commanded direction** - `tests_integ/simulation/test_isaac_delta_eef_gpu.py`, both tests PASS on this host (4x L4, Isaac Sim 6.0): 20 saturated +x steps displace `panda_hand` > 5 cm in +x (pre-fix displacement was exactly 0), -z likewise, and the RLDS gripper channel opens/closes both fingers.
- [ ] **`run_isaac.py --policy groot --n-episodes 5` produces a moving robot + measured success_rate** - *partially met; blocked by a distinct pre-existing defect, see below.* The 5-episode groot eval was re-run on this branch: the controller now installs on every episode (the per-episode `GR00T actions will no-op` warning from the pre-fix log is gone) and the grep-stable line reports `success_rate=0.00`, MuJoCo baseline 1.00.

## Why the eval still reads 0.00 (and why that's out of scope)

Diagnosed live on this host with a scripted-delta policy through the full `evaluate_benchmark` path, logging `panda_hand` via `get_body_state`:

1. `IsaacSimulation.load_scene` realizes LIBERO's dynamic objects via `add_object`, whose dynamic-prim constructor **stops the Isaac timeline** (#159 deferred-physics guard) - and nothing restarts it. From that point `world.step()` renders without integrating physics, so the entire episode runs on **frozen physics**: joint reads return stale garbage, `send_action` applies targets into a dead view, and *no* controller (this one or any other) can move the robot. The eval completes green because every envelope reports success.
2. Restarting the timeline after `load_scene` immediately explodes the articulation with PhysX `Illegal BroadPhaseUpdateData - non-finite bounds`: the scene objects are realized at their MJCF *placeholder* poses (e.g. bowls at `(0, -0.1, 0.02)`, inside the robot base) because BDDL init-state application is MuJoCo-only, so live physics starts from deep interpenetration.

Both are properties of the #1802/#1811-era scene-translation path that the frozen timeline has been masking - this PR's engine-level actuation is GPU-verified independently of them (the integ tests exercise the same articulation without `load_scene`). Fixing scene init-state application on Isaac is its own work item; filed as a follow-up issue and referenced here rather than folded into this PR.

## Test surface

- `hatch run lint` - clean (ruff + mypy).
- `hatch run test` - **15508 passed**, 260 skipped, 0 failed (with `MUJOCO_GL=egl`).
- `STRANDS_GPU_TEST=1 pytest tests_integ/simulation/test_isaac_delta_eef_gpu.py -s` - 2/2 PASS on real Isaac Sim 6.0.
- Two existing tests updated for the new surface: `test_isaac_backend.py::test_public_names_match_all` (new `IsaacDeltaEEFController` lazy export) and `test_dataset_recording.py` fixture (destroy() now clears `_action_controllers`).

## Out-of-scope follow-ups

- `load_scene` timeline/physics lifecycle + LIBERO init-state application on Isaac (the two-part defect above) - follow-up issue.
- Torque-level OSC re-implementation (issue option 2, closest to the training-time controller) - noted in `delta_eef.py` as a follow-up.

> Project board: please move #1812 to "In review" (the Actions token can't see the org project; noting here per AGENTS.md).
