### PR TITLE
fix(tools): refuse a gr00t_inference numeric option the service cannot honor

### DIFF
--- a/changelog.d/1821-gr00t-numeric-option-guard.md
+++ b/changelog.d/1821-gr00t-numeric-option-guard.md
@@ -1,0 +1,18 @@
+### Fixed: `gr00t_inference` refuses a numeric option it cannot honor
+
+`port`, `denoising_steps` and `timeout` were forwarded unvalidated from the
+agent tool into a detached `docker exec` command line and a port-poll loop,
+neither of which reports a value back to the caller. `port=nan` reached the
+inference server as `--port nan` and the container mapping as `-p nan:nan`;
+`denoising_steps=0` asked a diffusion policy for zero denoising steps; and
+`timeout=0` skipped the poll loop entirely, so a service that had started and
+opened its port was reported as having "failed to start", while `timeout=inf`
+never gave up at all.
+
+Each option is now held to the shared domain for its kind before any container,
+checkpoint or socket work begins, and only for the actions that read it - `list`
+scans a fixed set of ports rather than the caller's, and `lifecycle="teardown"`
+opens no socket, so neither is refused for a value it ignores. The 16-bit TCP
+port range moves to `strands_robots.utils.tcp_port_error`, which `use_rosbridge`
+and `RosbridgeRobot` now share, so the same port cannot be refused by one
+transport onto a service and accepted by the next.

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -40,6 +40,7 @@ from strands_robots.utils import (
     finite_number_error,
     positive_finite_number_error,
     positive_whole_number_error,
+    tcp_port_error,
 )
 
 _TWIST_TYPE = "geometry_msgs/Twist"
@@ -95,8 +96,8 @@ class RosbridgeRobot:
         self.scan_topic = _check_topic("scan_topic", scan_topic) if scan_topic else None
         if not host or not _HOST_RE.match(host):
             raise ValueError(f"invalid host: {host!r}")
-        if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
-            raise ValueError(f"invalid port: {port!r} (expected 1-65535)")
+        if (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+            raise ValueError(port_error)
         self.host = host
         self.port = port
         self.cmd_vel_type = cmd_vel_type

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -21,7 +21,13 @@ from typing import Any
 
 from strands import tool
 
-from strands_robots.utils import get_base_dir, require_optional
+from strands_robots.utils import (
+    get_base_dir,
+    positive_count_error,
+    positive_finite_number_error,
+    require_optional,
+    tcp_port_error,
+)
 
 # Default cache layout for the lifecycle helpers. Mirrors the layout
 # documented in the Isaac-GR00T README so users moving from the manual
@@ -350,6 +356,92 @@ def _checkpoints_dir() -> Path:
     return get_base_dir() / "checkpoints"
 
 
+# Which numeric options each action actually consumes.
+#
+# ``port`` is the only one every service-touching action reads: it is written
+# into the ``docker run -p {port}:{port}`` mapping, into the inference server's
+# ``--port`` argument, and into the ``pgrep -f`` pattern that finds the process
+# to stop. ``denoising_steps`` and ``timeout`` are read only where a service is
+# actually launched and waited for.
+#
+# An action absent from this map reads none of them and is never refused for
+# one: ``list`` scans a fixed set of common ports rather than the caller's, and
+# ``find_containers`` / ``build_image`` / ``download_checkpoint`` never open a
+# socket. ``lifecycle`` is keyed by phase because the two phases are different
+# operations behind one action name - ``"full"`` builds, downloads, starts a
+# container and then starts the service, while ``"teardown"`` only removes the
+# container and reads no numeric option at all.
+_ACTION_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
+    "status": ("port",),
+    "stop": ("port",),
+    "start": ("port", "denoising_steps", "timeout"),
+    "restart": ("port", "denoising_steps", "timeout"),
+    "start_container": ("port",),
+    "lifecycle:full": ("port", "denoising_steps", "timeout"),
+}
+
+
+def _numeric_option_error(
+    action: str,
+    *,
+    port: Any,
+    denoising_steps: Any,
+    timeout: Any,
+    protocol: str,
+    lifecycle: str,
+) -> str | None:
+    """Error text for the first numeric option ``action`` reads but cannot honor.
+
+    ``port``, ``denoising_steps`` and ``timeout`` are agent-supplied and each is
+    consumed somewhere no failure is visible to the caller: ``port`` and
+    ``denoising_steps`` are interpolated into a ``docker exec`` command line that
+    runs detached, so a value the server's own argument parser rejects surfaces
+    minutes later inside the container's log rather than as this call's result;
+    ``timeout`` bounds the poll loop that waits for the port to open, where a
+    non-positive budget skips the loop entirely and reports a service that came
+    up fine as one that "failed to start", and a non-finite budget never gives up.
+    Refusing them here - before any container is built, any checkpoint is
+    downloaded, and any socket is opened - is what makes the value's rejection a
+    property of the request rather than of how far the orchestration got.
+
+    Each option is held to the shared domain for its kind:
+    :func:`~strands_robots.utils.tcp_port_error` for the port,
+    :func:`~strands_robots.utils.positive_count_error` for the discrete denoising
+    step count, and :func:`~strands_robots.utils.positive_finite_number_error`
+    for the wait budget in seconds, where a fractional value is usable.
+
+    Only the options ``action`` actually reads are checked, so a caller is never
+    refused for a value the requested action ignores. ``denoising_steps`` carries
+    one extra condition: the N1.7 entrypoint takes no ``--denoising-steps`` flag
+    (see :func:`_build_inference_command`), so under ``protocol="n1.7"`` the
+    value is genuinely inert and is left alone.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        port: The service port, as supplied.
+        denoising_steps: Diffusion denoising step count, as supplied.
+        timeout: Seconds to wait for the port to open, as supplied.
+        protocol: The server protocol; ``"n1.7"`` ignores ``denoising_steps``.
+        lifecycle: The lifecycle phase, which selects the effective option set
+            when ``action`` is ``"lifecycle"``.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when every
+        option this call reads is usable.
+    """
+    key = f"lifecycle:{lifecycle}" if action == "lifecycle" else action
+    consumed = _ACTION_NUMERIC_OPTIONS.get(key, ())
+    if "port" in consumed and (error := tcp_port_error(port, "port", action)) is not None:
+        return error
+    if "denoising_steps" in consumed and protocol != "n1.7":
+        error = positive_count_error(denoising_steps, "denoising_steps", action)
+        if error is not None:
+            return error
+    if "timeout" in consumed and (error := positive_finite_number_error(timeout, "timeout", action)) is not None:
+        return error
+    return None
+
+
 @tool
 def gr00t_inference(
     action: str,
@@ -507,16 +599,21 @@ def gr00t_inference(
         action: Action to perform (see Actions above).
         checkpoint_path: Path to model checkpoint directory (required for ``start``/``restart``).
         policy_name: Optional name for the policy service (for registration/tracking).
-        port: Port for the inference service. Defaults to 5555 (ZMQ) or auto-switches
+        port: Port for the inference service. Must be an int in 1-65535.
+            Defaults to 5555 (ZMQ) or auto-switches
             to 8000 when ``http_server=True``.
         data_config: Embodiment data config name (see Data configs above). N1.5/N1.6 only.
         embodiment_tag: Embodiment tag for the model (e.g., ``gr1``, ``so100``,
             ``libero_sim``).
         denoising_steps: Number of denoising steps for action generation (default: 4).
+            Must be a positive integer. Ignored by ``protocol="n1.7"``, whose
+            entrypoint takes no ``--denoising-steps`` flag.
             N1.5/N1.6 only - the N1.7 server reads this from the checkpoint.
         host: Host address to bind the service to (default: ``0.0.0.0``).
         container_name: Specific Docker container name. Auto-detected if omitted.
-        timeout: Seconds to wait for service startup (default: 60).
+        timeout: Seconds to wait for service startup (default: 60). Must be a
+            positive finite number - the wait is a poll loop, so a non-positive
+            budget never polls and a non-finite one never gives up.
         use_tensorrt: Enable TensorRT acceleration (default: False).
         trt_engine_path: Directory for TensorRT engine cache (default: ``gr00t_engine``).
         vit_dtype: ViT precision with TensorRT - ``fp16`` or ``fp8`` (default: ``fp8``).
@@ -669,6 +766,21 @@ def gr00t_inference(
     _hf_local_dir_reason = _check_hf_local_dir_safety(hf_local_dir)
     if _hf_local_dir_reason is not None:
         return {"status": "error", "message": _hf_local_dir_reason}
+
+    # Boundary guard: the numeric options reach a docker command line and the
+    # port-poll loop, neither of which reports back a value it cannot use. Check
+    # them here so a bad one is refused before any container, checkpoint or
+    # socket work starts - and only for the options this action reads.
+    _numeric_reason = _numeric_option_error(
+        action,
+        port=port,
+        denoising_steps=denoising_steps,
+        timeout=timeout,
+        protocol=protocol,
+        lifecycle=lifecycle,
+    )
+    if _numeric_reason is not None:
+        return {"status": "error", "message": f"gr00t_inference: {_numeric_reason}"}
 
     if action == "find_containers":
         return _find_gr00t_containers()

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -51,6 +51,7 @@ from typing import Any
 from strands import tool
 
 from strands_robots.tools._numeric_options import numeric_option_error
+from strands_robots.utils import tcp_port_error
 
 logger = logging.getLogger(__name__)
 
@@ -263,8 +264,8 @@ def use_rosbridge(
 
     if not host or not _HOST_RE.match(host):
         return _err(f"invalid host: {host!r}")
-    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
-        return _err(f"invalid port: {port!r} (expected 1-65535)")
+    if (port_error := tcp_port_error(port, "port", action)) is not None:
+        return _err(port_error)
     if topic is not None and not _NAME_RE.match(topic):
         return _err(f"invalid topic name: {topic!r}")
     if service is not None and not _NAME_RE.match(service):

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -566,7 +566,6 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         return f"{context}: {param} must be a non-negative integer, got {value!r}."
     return None
-    return None
 
 
 def name_list_error(value: Any, param: str, context: str) -> str | None:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -498,6 +498,43 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
     return None
 
 
+def tcp_port_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` cannot address a TCP port.
+
+    Shared domain for every caller-supplied port number: the agent tools that
+    reach a service over TCP (``use_rosbridge``'s WebSocket,
+    ``gr00t_inference``'s inference service) and the mesh bridges that construct
+    one. A port is an index into the 16-bit TCP port space, so only an ``int``
+    in ``[1, 65535]`` names one: ``0`` asks the kernel for an ephemeral port
+    rather than naming a port, and a value outside the range has nothing to bind
+    or connect to.
+
+    It lives here rather than beside one of its callers for the same reason
+    :func:`positive_count_error` does: those callers sit in different layers
+    (:mod:`strands_robots.tools` and :mod:`strands_robots.mesh` must not depend
+    on each other) and the accepted domain must not diverge between them - the
+    same port cannot be refused by one transport onto a service and accepted by
+    the next.
+
+    ``bool`` is rejected explicitly. It is an ``int`` subclass, so a bare
+    ``1 <= value <= 65535`` test lets ``True`` through as a silent port 1 - a
+    privileged port the caller never named.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it - the
+            requested action for an agent tool, or the class name for a
+            constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 65535:
+        return f"{context}: invalid {param}: {value!r} (expected 1-65535)"
+    return None
+
+
 def name_list_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable list of distinct key names.
 

--- a/tests/test_source_no_unreachable_statements.py
+++ b/tests/test_source_no_unreachable_statements.py
@@ -1,0 +1,109 @@
+"""Regression: no shipped statement may sit directly after an unconditional exit.
+
+A statement whose immediate predecessor in the same block is a ``return``,
+``raise``, ``continue`` or ``break`` can never execute. Unlike the unreachable
+code a type narrowing or a platform check makes dead - which is deliberate,
+defensive and correct - this shape is never intentional. It is what a
+mechanical edit leaves behind: an insertion anchored on a line that already
+ended a function, or a duplicated tail.
+
+Nothing in the local gate sees it. ``ruff`` selects ``E``, ``W``, ``F``, ``I``
+and ``UP``, none of which covers unreachable code, and the ``mypy`` run is
+configured without ``--warn-unreachable`` - for a reason this guard is careful
+not to undo. Turning that flag on reports every branch narrowing makes dead,
+including a dataclass coercing a ``str`` into its declared ``Path`` field and a
+``sys.platform != "darwin"`` guard evaluated on Linux: legitimate code that
+would have to be silenced one site at a time. This scan instead asks the one
+question with no legitimate answer, so it is clean on the package as it stands
+and stays quiet about the narrowing cases.
+
+It would have caught a duplicated ``return None`` in
+:func:`strands_robots.utils.non_negative_count_error`, left by the edit that
+inserted :func:`~strands_robots.utils.tcp_port_error` above it - a shared
+numeric-domain helper carrying a line that could never run, through a green
+lint and a green test suite.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots
+
+# A statement that transfers control out of its block unconditionally. Anything
+# the same block lists after one of these is dead by construction, with no
+# dependence on types, values or the platform.
+_TERMINATORS = (ast.Return, ast.Raise, ast.Continue, ast.Break)
+
+# The fields of an AST node that hold a statement list. ``handlers`` and the
+# bodies nested inside them are reached by ``ast.walk`` on their own nodes.
+_BLOCK_FIELDS = ("body", "orelse", "finalbody")
+
+_PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def unreachable_statements(source: str) -> list[tuple[int, str]]:
+    """Statements in ``source`` that directly follow an unconditional exit.
+
+    Args:
+        source: Python source text.
+
+    Returns:
+        One ``(line number, terminator kind)`` pair per dead statement, where
+        the line number is the dead statement's own.
+    """
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(ast.parse(source)):
+        for field in _BLOCK_FIELDS:
+            block = getattr(node, field, None)
+            if not isinstance(block, list):
+                continue
+            for statement, following in zip(block, block[1:], strict=False):
+                if isinstance(statement, _TERMINATORS):
+                    found.append((following.lineno, type(statement).__name__.lower()))
+                    break
+    return found
+
+
+def test_package_sources_discovered() -> None:
+    """Guard: the scan walked the whole package rather than one subtree."""
+    sources = _python_sources()
+    assert len(sources) > 50
+    rel_dirs = {p.relative_to(_PACKAGE_DIR).parts[0] for p in sources if p.parent != _PACKAGE_DIR}
+    assert {"simulation", "tools", "registry", "policies", "mesh"} <= rel_dirs
+
+
+def test_no_shipped_statement_follows_an_unconditional_exit() -> None:
+    """No module under ``strands_robots`` carries a statement that cannot run."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        rel = path.relative_to(_PACKAGE_DIR.parent)
+        for line, kind in unreachable_statements(path.read_text(encoding="utf-8")):
+            offenders.append(f"{rel}:{line} follows an unconditional {kind}")
+    assert not offenders, "Statements that can never execute:\n  " + "\n  ".join(offenders)
+
+
+def test_scanner_detects_a_planted_unreachable_statement() -> None:
+    """Meta: an empty result means clean sources, not a scanner that matches nothing."""
+    planted = "def f() -> int:\n    return 1\n    return 2\n"
+    assert unreachable_statements(planted) == [(3, "return")]
+
+
+def test_scanner_accepts_a_terminator_that_ends_its_block() -> None:
+    """A terminator followed only by a sibling block's code is not flagged."""
+    legitimate = (
+        "def f(x: int) -> int:\n"
+        "    for i in range(x):\n"
+        "        if i:\n"
+        "            continue\n"
+        "        break\n"
+        "    else:\n"
+        "        return 0\n"
+        "    raise ValueError(x)\n"
+    )
+    assert unreachable_statements(legitimate) == []

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -258,9 +258,18 @@ class TestStartServiceEndToEnd:
         # Wire protocol stays "ZMQ" / "HTTP" (back-compat with pre-fix callers).
         assert result["protocol"] == "ZMQ"
 
+    @patch("strands_robots.tools.gr00t_inference.time.sleep")
     @patch("strands_robots.tools.gr00t_inference._is_service_running", return_value=False)
     @patch("strands_robots.tools.gr00t_inference.subprocess.run")
-    def test_timeout_returns_error(self, mock_run, _mock_is_running):
+    def test_timeout_returns_error(self, mock_run, _mock_is_running, _mock_sleep):
+        """A budget that expires with the port still shut reports the failure.
+
+        The budget is a real (if tiny) positive one and ``time.sleep`` is patched
+        out, so this exercises the poll-then-give-up path. It used to pass
+        ``timeout=0`` as a way to avoid sleeping, which skipped the poll loop
+        entirely - the loop this test exists to cover never ran, and the value is
+        now refused at the tool boundary as one no wait can honor.
+        """
         mock_run.return_value.stdout = ""
         result = _start_service(
             checkpoint_path="/cp",
@@ -271,7 +280,7 @@ class TestStartServiceEndToEnd:
             host="0.0.0.0",
             container_name="gr00t",
             policy_name=None,
-            timeout=0,  # don't actually sleep
+            timeout=0.05,
             use_tensorrt=False,
             trt_engine_path="x",
             vit_dtype="fp8",

--- a/tests/tools/test_gr00t_numeric_option_guards.py
+++ b/tests/tools/test_gr00t_numeric_option_guards.py
@@ -1,0 +1,300 @@
+"""``gr00t_inference`` refuses a numeric option it cannot honor.
+
+Three agent-supplied numbers reach places that never report back a value they
+cannot use. ``port`` and ``denoising_steps`` are interpolated into a
+``docker exec`` command line that runs detached, so a value the inference
+server's own argument parser rejects surfaces minutes later inside the
+container's log rather than as the tool call's result. ``timeout`` bounds the
+poll loop that waits for the port to open, where a non-positive budget never
+polls once - reporting a service that came up fine as one that "failed to
+start" - and a non-finite budget never gives up at all.
+
+The port half is a cross-surface contract rather than a local one: six places
+in this package hold a caller-supplied port to ``1 <= port <= 65535``, so
+:func:`~strands_robots.utils.tcp_port_error` owns that range and the surfaces
+that take a port route through it. The parity and drift tests below are what
+keep the domain from diverging again between one transport onto a service and
+the next.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.gr00t_inference as gi
+from strands_robots.mesh.rosbridge_robot import RosbridgeRobot
+from strands_robots.tools.gr00t_inference import _ACTION_NUMERIC_OPTIONS, gr00t_inference
+from strands_robots.tools.use_rosbridge import use_rosbridge
+from strands_robots.utils import tcp_port_error
+
+# Ports outside the 16-bit TCP port space, or of a type that cannot index it.
+# ``0`` asks the kernel for an ephemeral port instead of naming one, and ``True``
+# is an ``int`` subclass that a bare range test reads as a silent port 1.
+UNUSABLE_PORTS: list[Any] = [0, -1, 70000, 2.7, True, "5555", None, float("nan"), float("inf")]
+
+# A denoising step count is consumed as a discrete ``--denoising-steps`` value,
+# so only a true positive ``int`` can be honored.
+# Ports every surface must accept. ``65535`` is a legal TCP port and the shared
+# owner accepts it, but autobahn's URL builder asserts ``port in range(0, 65535)``
+# before ``use_rosbridge`` can connect - a pre-existing quirk of that transport,
+# not of this domain - so the cross-surface list stops at 65534.
+USABLE_PORTS: list[Any] = [1, 5555, 65534]
+
+UNUSABLE_STEPS: list[Any] = [0, -1, 2.7, True, "4", None, float("nan"), float("inf")]
+
+# A wait budget in seconds. Fractional is fine (``2.5``); non-positive skips the
+# poll loop and non-finite never leaves it.
+UNUSABLE_TIMEOUTS: list[Any] = [0, -1, True, "60", None, float("nan"), float("inf")]
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with deliberately off-type values.
+
+    Routed through one ``**kwargs`` funnel because several tests pass values the
+    signature's annotations forbid on purpose - that is the input class under
+    test - and mypy does not narrow a splatted ``dict[str, Any]``.
+    """
+    return gr00t_inference(**kwargs)
+
+
+def _message(result: dict[str, Any]) -> str:
+    return str(result.get("message", ""))
+
+
+@pytest.fixture
+def no_side_effects(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Fail the test if a refused call reaches docker or a socket.
+
+    A guard that runs after the container work has already started cannot make
+    the rejection a property of the request, so every refusal test asserts the
+    counters below stayed at zero.
+    """
+    calls = {"subprocess": 0, "socket": 0}
+
+    def _no_subprocess(*_a: Any, **_kw: Any) -> Any:
+        calls["subprocess"] += 1
+        raise AssertionError("a refused call reached subprocess.run")
+
+    def _no_socket(_port: Any) -> bool:
+        calls["socket"] += 1
+        raise AssertionError("a refused call opened a socket")
+
+    monkeypatch.setattr(gi.subprocess, "run", _no_subprocess)
+    monkeypatch.setattr(gi, "_is_service_running", _no_socket)
+    return calls
+
+
+class TestPortDomain:
+    """A port that cannot address a service is refused, not sent to docker."""
+
+    @pytest.mark.parametrize("action", ["status", "stop", "start", "restart", "start_container"])
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_an_unusable_port_is_refused_by_every_action_that_reads_one(
+        self, action: str, port: Any, no_side_effects: dict[str, int]
+    ) -> None:
+        result = _call(action=action, port=port, checkpoint_path="/ckpt", hf_repo="org/model")
+        assert result["status"] == "error"
+        assert "invalid port" in _message(result)
+        assert repr(port) in _message(result)
+        assert action in _message(result)
+        assert no_side_effects == {"subprocess": 0, "socket": 0}
+
+    def test_the_message_names_the_accepted_range(self, no_side_effects: dict[str, int]) -> None:
+        message = _message(_call(action="status", port=70000))
+        assert "1-65535" in message
+
+
+class TestDenoisingStepsDomain:
+    """A denoising step count the server cannot parse is refused up front."""
+
+    @pytest.mark.parametrize("action", ["start", "restart"])
+    @pytest.mark.parametrize("steps", UNUSABLE_STEPS)
+    def test_an_unusable_step_count_is_refused(self, action: str, steps: Any, no_side_effects: dict[str, int]) -> None:
+        result = _call(action=action, checkpoint_path="/ckpt", denoising_steps=steps)
+        assert result["status"] == "error"
+        assert "denoising_steps" in _message(result)
+        assert repr(steps) in _message(result)
+        assert no_side_effects == {"subprocess": 0, "socket": 0}
+
+    @pytest.mark.parametrize("steps", UNUSABLE_STEPS)
+    def test_n17_ignores_the_step_count_so_it_is_not_refused(self, steps: Any) -> None:
+        """The N1.7 entrypoint takes no ``--denoising-steps`` flag.
+
+        Refusing a value that protocol never reads would be a false rejection,
+        so the guard leaves it alone - the call fails (or succeeds) for whatever
+        the orchestration itself decides.
+        """
+        result = _call(action="start", checkpoint_path="/ckpt", protocol="n1.7", denoising_steps=steps)
+        assert "denoising_steps must be" not in _message(result)
+
+
+class TestTimeoutDomain:
+    """A wait budget that cannot bound the poll loop is refused."""
+
+    @pytest.mark.parametrize("action", ["start", "restart"])
+    @pytest.mark.parametrize("timeout", UNUSABLE_TIMEOUTS)
+    def test_an_unusable_timeout_is_refused(self, action: str, timeout: Any, no_side_effects: dict[str, int]) -> None:
+        result = _call(action=action, checkpoint_path="/ckpt", timeout=timeout)
+        assert result["status"] == "error"
+        assert "timeout" in _message(result)
+        assert repr(timeout) in _message(result)
+        assert no_side_effects == {"subprocess": 0, "socket": 0}
+
+    def test_a_fractional_timeout_is_a_usable_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``2.5`` seconds is a perfectly good wait, so the guard must not refuse it."""
+        monkeypatch.setattr(gi, "_find_gr00t_containers", lambda: {"status": "success", "containers": []})
+        result = _call(action="start", checkpoint_path="/ckpt", timeout=2.5)
+        assert "timeout must be" not in _message(result)
+
+    def test_a_healthy_service_is_no_longer_reported_as_failed_to_start(self, no_side_effects: dict[str, int]) -> None:
+        """``timeout=0`` never polls, so the poll loop cannot see a live service.
+
+        The pre-fix result was ``status="error"`` with "failed to start" for a
+        container that had started and a port that was open. The budget is
+        refused instead, which is the only answer that does not misreport the
+        service's state.
+        """
+        result = _call(action="start", checkpoint_path="/ckpt", timeout=0)
+        assert result["status"] == "error"
+        assert "failed to start" not in _message(result)
+        assert "timeout must be > 0" in _message(result)
+
+    def test_an_unbounded_timeout_never_enters_the_poll_loop(self, no_side_effects: dict[str, int]) -> None:
+        """``inf`` satisfies ``elapsed < timeout`` forever, so it must not reach the loop.
+
+        ``no_side_effects`` is the assertion that matters here: reaching the loop
+        means calling ``_is_service_running``, which this fixture makes fatal, so
+        a regression fails instead of hanging the suite.
+        """
+        result = _call(action="start", checkpoint_path="/ckpt", timeout=math.inf)
+        assert result["status"] == "error"
+        assert "timeout must be > 0" in _message(result)
+
+
+class TestEffectiveOptionsOnly:
+    """A caller is never refused for a value the requested action ignores."""
+
+    @pytest.mark.parametrize("action", ["list", "find_containers"])
+    def test_an_action_that_reads_no_numeric_option_is_not_refused(
+        self, action: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(gi, "_is_service_running", lambda _port: False)
+        monkeypatch.setattr(gi, "_find_gr00t_containers", lambda: {"status": "success", "containers": []})
+        result = _call(action=action, port=-1, denoising_steps=0, timeout=-1)
+        assert "invalid port" not in _message(result)
+        assert "denoising_steps must be" not in _message(result)
+        assert "timeout must be" not in _message(result)
+
+    def test_lifecycle_teardown_reads_no_numeric_option(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Teardown only removes a container; refusing a port it never opens is wrong."""
+        monkeypatch.setattr(gi, "_remove_container", lambda **_kw: {"status": "success", "message": "removed"})
+        result = _call(action="lifecycle", lifecycle="teardown", port=-1, denoising_steps=0, timeout=-1)
+        assert result["status"] == "success"
+
+    def test_lifecycle_full_reads_every_numeric_option(self, no_side_effects: dict[str, int]) -> None:
+        """``lifecycle="full"`` starts a container and waits for the port."""
+        result = _call(action="lifecycle", lifecycle="full", hf_repo="org/model", denoising_steps=0)
+        assert result["status"] == "error"
+        assert "denoising_steps must be" in _message(result)
+
+    def test_the_table_only_names_actions_the_tool_dispatches(self) -> None:
+        """Every key is a real action (or ``lifecycle:<phase>``), so nothing is dead."""
+        source = Path(gi.__file__).read_text(encoding="utf-8")
+        for key in _ACTION_NUMERIC_OPTIONS:
+            action = key.split(":", 1)[0]
+            assert f'action == "{action}"' in source, f"{key} names no dispatched action"
+
+
+class TestSharedPortDomain:
+    """The owner's accepted set is exactly the 16-bit port space."""
+
+    @pytest.mark.parametrize("port", [1, 80, 5555, 65534, 65535])
+    def test_the_whole_port_space_is_accepted(self, port: int) -> None:
+        assert tcp_port_error(port, "port", "ctx") is None
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_nothing_outside_it_is(self, port: Any) -> None:
+        assert tcp_port_error(port, "port", "ctx") is not None
+
+    def test_the_message_names_the_surface_and_the_parameter(self) -> None:
+        assert tcp_port_error(0, "port", "RosbridgeRobot") == ("RosbridgeRobot: invalid port: 0 (expected 1-65535)")
+
+
+class TestPortDomainParity:
+    """Every surface that takes a caller-supplied port shares one range.
+
+    Parametrized over the shared owner's verdict rather than over a hand-written
+    expectation, so the surfaces cannot drift apart from each other or from it.
+    """
+
+    @pytest.mark.parametrize("port", [*UNUSABLE_PORTS, *USABLE_PORTS])
+    def test_the_tool_agrees_with_the_shared_owner(self, port: Any) -> None:
+        owner_refuses = tcp_port_error(port, "port", "status") is not None
+        message = _message(_call(action="status", port=port))
+        assert ("invalid port" in message) is owner_refuses
+
+    @pytest.mark.parametrize("port", [*UNUSABLE_PORTS, *USABLE_PORTS])
+    def test_the_rosbridge_tool_agrees_with_the_shared_owner(self, port: Any) -> None:
+        owner_refuses = tcp_port_error(port, "port", "status") is not None
+        result = use_rosbridge(**{"action": "status", "host": "127.0.0.1", "port": port, "timeout": 0.05})
+        texts = " ".join(block.get("text", "") for block in result["content"])
+        assert ("invalid port" in texts) is owner_refuses
+
+    @pytest.mark.parametrize("port", [*UNUSABLE_PORTS, *USABLE_PORTS])
+    def test_the_rosbridge_robot_agrees_with_the_shared_owner(self, port: Any) -> None:
+        owner_refuses = tcp_port_error(port, "port", "RosbridgeRobot") is not None
+        try:
+            RosbridgeRobot(
+                **{
+                    "node_name": "probe",
+                    "cmd_vel_topic": "/cmd_vel",
+                    "odom_topic": "/odom",
+                    "host": "127.0.0.1",
+                    "port": port,
+                }
+            )
+            refused = False
+        except ValueError as exc:
+            refused = "invalid port" in str(exc)
+        assert refused is owner_refuses
+
+
+# The surfaces where a caller or an agent supplies a port: the agent tools and
+# the mesh robot bridges. The other places this package mentions the port space
+# are a CLI ``argparse`` check and a generic env-var range helper, which have
+# their own failure channels and are not caller-facing entry points.
+_PORT_TAKING_GLOBS = ("tools/*.py", "mesh/*_robot.py")
+_ROUTED_MODULES = {"use_rosbridge.py", "rosbridge_robot.py", "gr00t_inference.py"}
+
+
+def _port_taking_sources() -> dict[Path, str]:
+    root = Path(gi.__file__).resolve().parent.parent
+    return {path: path.read_text(encoding="utf-8") for glob in _PORT_TAKING_GLOBS for path in sorted(root.glob(glob))}
+
+
+def _has_port_range_literal(source: str) -> bool:
+    """True when the module spells the 16-bit port range out for itself."""
+    return any(isinstance(node, ast.Constant) and node.value == 65535 for node in ast.walk(ast.parse(source)))
+
+
+class TestPortRangeHasOneOwner:
+    """The 16-bit range is not re-implemented beside a caller-facing port."""
+
+    def test_no_caller_facing_module_spells_the_range_out(self) -> None:
+        offenders = sorted(p.name for p, src in _port_taking_sources().items() if _has_port_range_literal(src))
+        assert offenders == [], f"these modules re-implement the port range: {offenders}"
+
+    def test_the_known_surfaces_route_through_the_shared_owner(self) -> None:
+        routed = {p.name for p, src in _port_taking_sources().items() if "tcp_port_error" in src}
+        assert _ROUTED_MODULES <= routed, f"missing: {sorted(_ROUTED_MODULES - routed)}"
+
+    def test_the_scan_detects_a_planted_copy(self, tmp_path: Path) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = "def f(port):\n    return 1 <= port <= 65535\n"
+        assert _has_port_range_literal(planted)
+        assert not _has_port_range_literal("def f(port):\n    return port > 0\n")

--- a/tests/tools/test_gr00t_numeric_option_guards.py
+++ b/tests/tools/test_gr00t_numeric_option_guards.py
@@ -26,9 +26,12 @@ from typing import Any
 
 import pytest
 
+# The module object rather than its members: the tests below reach
+# ``gi.subprocess`` to make a side effect fatal and ``gi.__file__`` to scan the
+# shipped source, so the tool's own symbols are qualified through this alias
+# instead of being imported a second time by name.
 import strands_robots.tools.gr00t_inference as gi
 from strands_robots.mesh.rosbridge_robot import RosbridgeRobot
-from strands_robots.tools.gr00t_inference import _ACTION_NUMERIC_OPTIONS, gr00t_inference
 from strands_robots.tools.use_rosbridge import use_rosbridge
 from strands_robots.utils import tcp_port_error
 
@@ -59,7 +62,7 @@ def _call(**kwargs: Any) -> dict[str, Any]:
     signature's annotations forbid on purpose - that is the input class under
     test - and mypy does not narrow a splatted ``dict[str, Any]``.
     """
-    return gr00t_inference(**kwargs)
+    return gi.gr00t_inference(**kwargs)
 
 
 def _message(result: dict[str, Any]) -> str:
@@ -205,7 +208,7 @@ class TestEffectiveOptionsOnly:
     def test_the_table_only_names_actions_the_tool_dispatches(self) -> None:
         """Every key is a real action (or ``lifecycle:<phase>``), so nothing is dead."""
         source = Path(gi.__file__).read_text(encoding="utf-8")
-        for key in _ACTION_NUMERIC_OPTIONS:
+        for key in gi._ACTION_NUMERIC_OPTIONS:
             action = key.split(":", 1)[0]
             assert f'action == "{action}"' in source, f"{key} names no dispatched action"
 


### PR DESCRIPTION
`gr00t_inference` takes three numbers from an agent — `port`, `denoising_steps`, `timeout` — and validated none of them. Each is consumed somewhere that cannot report a value back to the caller.

![measured](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gr00t-numeric-option-guard/gr00t_numeric_option_guard.png)

## What went wrong

**`port` and `denoising_steps` reach a detached command line.** `_build_inference_command` interpolates them into a `docker exec -d` invocation and `_start_container` into a `-p {port}:{port}` mapping. Measured, 7 of 8 probe values were sent verbatim:

| caller passed | token the server received |
| --- | --- |
| `port=nan` | `--port 'nan'` |
| `port=-1` | `--port '-1'` |
| `port=70000` | `--port '70000'` |
| `port=True` | `--port 'True'` |
| `denoising_steps=0` | `--denoising-steps '0'` |
| `denoising_steps=2.7` | `--denoising-steps '2.7'` |

Because the process is detached, a value the server's own argument parser rejects lands minutes later in `docker logs`, not in this call's result. `denoising_steps=0` is worse than rejected — it is a diffusion policy asked for zero denoising steps.

**`timeout` bounds a poll loop**, `while time.time() - start_time < timeout`. With a container started and the port genuinely open:

| `timeout` | main | this PR |
| --- | --- | --- |
| `60` | `success: service started on port 5555` | unchanged |
| `0` | `error: "ZMQ service failed to start within 0 seconds"` | `error: timeout must be > 0, got 0.` |
| `-1` | `error: "... within -1 seconds"` | refused |
| `nan` | `error: "... within nan seconds"` | refused |
| `True` | silent 1-second budget | refused |
| `"60"` | `error: "Unexpected error: '<' not supported between instances of 'float' and 'str'"` | refused |
| `inf` | **never returns** — still polling after 12 s | refused |

A non-positive budget makes the loop condition false on its first evaluation, so the loop never polls once and cannot see the live port: a healthy service is reported as one that failed to start, and an agent reacting to that tears down or re-starts a service that was fine.

## The port half is a cross-surface contract

Six places in this package already hold a caller-supplied port to `1 <= port <= 65535` with the `bool` exclusion — `use_rosbridge`, `RosbridgeRobot`, the inference server CLI, two mesh-session checks and the Zenoh config range helper. Two of those are byte-identical copies from the same feature, so adding a third beside this tool would institutionalize the duplication that let the gap open in the first place.

The range moves to `strands_robots.utils.tcp_port_error`, beside the other shared numeric domains and for the same layering reason they live there: `strands_robots.tools` and `strands_robots.mesh` must not depend on each other, and the same port must not be refused by one transport onto a service and accepted by the next. `use_rosbridge` and `RosbridgeRobot` now route through it — their messages keep the `invalid port` wording, gaining only the context prefix the other shared domains already emit. Panel C: 5 surface-to-surface divergences before, 0 after.

## The change

`_ACTION_NUMERIC_OPTIONS` records which options each action actually consumes, and `_numeric_option_error` checks only those, before any container is built, any checkpoint downloaded and any socket opened. Domains: `tcp_port_error` for the port, `positive_count_error` for the discrete step count, `positive_finite_number_error` for the wait budget (so `2.5` seconds stays usable).

Scoping is exact rather than blanket, because refusing a value a call ignores is its own defect:

- `list` scans a fixed set of common ports rather than the caller's; `find_containers` / `build_image` / `download_checkpoint` never open a socket. None is refused.
- `lifecycle` is keyed by phase: `"full"` starts a container and waits for the port, `"teardown"` only removes a container and reads nothing.
- `protocol="n1.7"` takes no `--denoising-steps` flag, so that value is genuinely inert there and is left alone.

One existing test changed. `test_timeout_returns_error` passed `timeout=0` with the comment "don't actually sleep" — a shortcut that skipped the poll loop entirely, so the loop it exists to cover never ran. It now uses a real `0.05 s` budget with `time.sleep` patched out, which exercises the poll-then-give-up path properly.

## Tests

`tests/tools/test_gr00t_numeric_option_guards.py`, 146 tests:

- Per-option refusal across every action that reads it, asserting the message names the action, the parameter and the value.
- A `no_side_effects` fixture that makes `subprocess.run` and `_is_service_running` fatal, so a refusal proven not to have reached docker or a socket. This is also how the `inf` case is pinned without risking a hung suite.
- Effectiveness in both directions: an action or protocol that ignores an option is not refused for it, and `2.5` seconds is accepted.
- Cross-surface parity, parametrized over the shared owner's own verdict rather than a hand-written expectation, so the three surfaces cannot drift from each other or from it.
- A drift guard: no caller-facing module spells the 16-bit range out for itself, the known surfaces route through the owner, and a planted copy is detected — so the scanner cannot pass vacuously.

**Pre-fix**: 90 failed / 40 passed. The 40 are the accepted-value controls and the "must not be refused" cases, which are what stop the guard over-reaching.

## Gate

```
ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ 1004 files already formatted
mypy strands_robots tests tests_integ               Success: no issues found in 1001 source files
python3 scripts/assemble_changelog.py --check       changelog fragments OK
MUJOCO_GL=egl pytest tests                          3 failed, 15894 passed, 257 skipped
```

The 3 failures are `tests/simulation/isaac/test_deferred_physics_and_warmup.py::TestWarmupCameraResumesTimeline`. They reproduce identically on a pristine `main` at this PR's own base - `git checkout a1d190ae -- strands_robots tests` then that file gives `3 failed, 3 passed in 0.08s`, `AttributeError: 'IsaacSimulation' object has no attribute '_world_created'`. They are what CI's `-x` stops on, and are unrelated to this branch, which touches no Isaac code (#1823, fixed by #1824).

The artifact is a measured table rather than a rollout: this is a tool-layer validation change with no policy, simulation, rendering or recording behaviour in it. Every valid configuration behaves exactly as before — panel A row 1 and panel B row 1 are the controls, and every cell in the figure is read from two JSON dumps produced by one script run against both trees, with the generator asserting each claim before it saves.

## Out of scope

- `use_rosbridge(port=65535)` raises a bare `AssertionError` out of the tool envelope: autobahn's URL builder asserts `port in range(0, 65535)`, excluding a port that is legal TCP and that every check in this package accepts. Pre-existing on `main`, a property of that transport rather than of this domain, and it needs a decision (narrow the domain, or catch it) rather than a guess. The cross-surface test list stops at `65534` with that noted.
- `_is_service_running` swallows every socket error into `return False`, so a real socket failure reads as "no service here". With the port validated at the boundary the unusable-port path no longer reaches it, which is why it is left alone here.


## Round 2 - review

Two CodeQL threads, both addressed in 798edf88. No change to the guard's behaviour or its accepted domain.

**Dead code in this PR's own diff.** The edit that inserted `tcp_port_error` left a duplicated `return None` in `non_negative_count_error` below it - `main` has one, the previous head had two. Removed. Nothing local could see it: `ruff` selects `E`/`W`/`F`/`I`/`UP`, none of which covers unreachable code, and `mypy` runs without `--warn-unreachable`. Enabling that flag is not the answer either - it reports 48 further statements that a type narrowing or a platform check makes dead (a dataclass coercing a `str` into its declared `Path` field, a `sys.platform != "darwin"` guard evaluated on Linux), all legitimate.

So `tests/test_source_no_unreachable_statements.py` asks the narrower question with no legitimate answer: a statement whose immediate predecessor **in the same block** is an unconditional `return`, `raise`, `continue` or `break`. That shape is what a mechanical edit leaves behind, never something written deliberately, so no control-flow analysis is needed and the 48 narrowing cases stay quiet. `py/unreachable-statement` had 0 open instances on `main`, and the scan agrees - 0 hits across all 1001 package modules - so the guard costs no churn and no exemption list. It ships with a planted-defect meta-test (an empty result means clean sources, not a scanner that matches nothing) and a negative control, so the rule cannot be read as "no terminator may be followed by anything".

```
Pre-fix  (utils.py at b365d603):  1 failed, 3 passed
  AssertionError: Statements that can never execute:
      strands_robots/utils.py:569 follows an unconditional return
Post-fix (798edf88):              4 passed
```

**One import of the tool module.** The alias is the load-bearing one - the tests reach `gi.subprocess` to make a side effect fatal and `gi.__file__` to scan the shipped source - so the redundant line was the `from ... import`, and the tool's two symbols are now qualified through the alias. This matches the convention already in this directory: `test_lerobot_train.py` (`as train_mod`) and `test_use_lerobot.py` (`as M`) each reach every symbol through a single alias and import nothing else from that module. A comment on the alias records why, so a later edit does not reintroduce the second import. Collected tests unchanged at 146.

No visual artifact for this round: nothing in it touches policy, simulation, rendering, recording or an asset - one deleted unreachable line, one import style, one new AST guard over the shipped package.

## Round 3 - 79cbdad, base absorption only

No file in this PR's diff changed. `79cbdad` merges `main` (8ec55fd) into the branch to pick up #1824, which fixed the three `test_deferred_physics_and_warmup.py` failures listed under **Gate** above as pre-existing on `main` (#1823). Those failures are what CI's `-x` was stopping on, so this branch could not go green until they left `main` - and because `pr-and-push.yml` checks out the branch head rather than a merge with the base, re-running the job could not see the fix either.

The merge is clean: `git show --cc 79cbdad` is empty, and the PR's diff versus its merge base is byte-identical before and after at `4 files, +158/-7`. Verified locally on the composition before pushing, since #1824 and this branch had never been compiled together: `tests/tools/test_gr00t_inference.py`, `tests/tools/test_gr00t_numeric_option_guards.py`, `tests/test_source_no_unreachable_statements.py`, `tests/tools/test_use_rosbridge.py` and `tests/simulation/isaac` give **525 passed, 0 failed** (30 collection errors from the absent GL driver in this environment, identical on the unmerged base).

The mechanism behind both halves is now written down in #1830 / #1831 so the next blocked PR is not re-diagnosed from scratch.
