### PR TITLE
fix(sim/isaac): report an aborted camera warm-up as an abort, not a slow render product

### DIFF
--- a/changelog.d/1823-warmup-camera-honest-failure-report.md
+++ b/changelog.d/1823-warmup-camera-honest-failure-report.md
@@ -1,0 +1,23 @@
+### Fixed: an aborted Isaac camera warm-up is no longer reported as a slow render product
+
+`IsaacSimulation._warmup_camera` returned `False` two ways -- the step budget ran
+out while the RTX render product never accumulated, or the loop broke early on an
+exception -- and reported both with the same text: *"did not produce a valid frame
+after N warm-up step(s); the first render() may return an error until the RTX
+product accumulates a frame."* The exception itself was logged at DEBUG, so an
+operator at default log level saw only a message telling them to give the
+renderer more time, for a loop that had already stopped and would never
+accumulate anything.
+
+An early abort now names the step it reached, the budget it had left, and the
+exception that ended it. The exhaustion report is unchanged, and the step count
+it quotes is now the number of iterations the loop actually runs (previously the
+raw `n_steps`, which reads `0` for a call that still takes one step).
+
+The camera-warm-up regression pins never reached the code they pin: the
+`__new__` skeleton they drive omitted `_cameras`, which the loop reads to decide
+whether the secondary render products need an explicit flush, so every one of
+them aborted on its first step through exactly the path above. The skeleton now
+carries every attribute the loop reads, the two `wrist_image` cases register the
+real two-camera shape, and `_refresh_all_render_products` has coverage for the
+first time.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -3124,11 +3124,19 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         -------
         bool
             ``True`` if the camera produced a valid frame within
-            ``n_steps``; ``False`` if it never warmed up (logged at
-            WARNING so a misconfigured camera is visible). Never raises:
+            ``n_steps``; ``False`` if it never warmed up. Never raises:
             a step / render failure is caught and ends the loop, because
             the camera is already registered and render()'s own 0-D guard
             still covers a not-yet-ready product.
+
+            A ``False`` is always reported at WARNING, and the two ways of
+            getting there are reported DIFFERENTLY because they need
+            different remedies: an exhausted budget says the render product
+            never accumulated (waiting/stepping longer may help), while an
+            early abort names the step reached and the exception that ended
+            the loop (waiting cannot help). Reporting both as an exhausted
+            budget sent operators after the renderer for what was really a
+            surface/attribute error visible only at DEBUG.
         """
         if self._world is None:
             return False
@@ -3160,7 +3168,11 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             except (ImportError, AttributeError, RuntimeError) as e:
                 logger.debug("Camera %r warm-up: could not query/resume timeline: %s", name, e)
 
-        for i in range(max(1, n_steps)):
+        budget = max(1, n_steps)
+        attempted = 0
+        aborted: Exception | None = None
+        for i in range(budget):
+            attempted = i + 1
             try:
                 _ensure_timeline_playing()
                 self._world.step(render=True)
@@ -3185,12 +3197,32 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 # and stop rather than failing the already-registered
                 # camera. Programming bugs (NameError) still propagate.
                 logger.debug("Camera %r warm-up step %d failed: %s", name, i + 1, e)
+                aborted = e
                 break
+        if aborted is not None:
+            # An early abort is NOT a slow render product, and the two need
+            # different remedies: the exhaustion report below tells the
+            # operator to let the RTX product accumulate, but a loop that
+            # stopped on step 1 of 5 will never accumulate anything no matter
+            # how long they wait. The cause was DEBUG-only, so the operator
+            # saw only the exhaustion text and chased the renderer instead of
+            # the exception. Name the step reached and the cause.
+            logger.warning(
+                "Camera %r warm-up aborted on step %d of %d: %s: %s. The camera stays "
+                "registered and the first render() may return an error, but the loop "
+                "stopped early - further warm-up steps cannot help until this is resolved.",
+                name,
+                attempted,
+                budget,
+                type(aborted).__name__,
+                aborted,
+            )
+            return False
         logger.warning(
             "Camera %r did not produce a valid frame after %d warm-up step(s); "
             "the first render() may return an error until the RTX product accumulates a frame.",
             name,
-            n_steps,
+            budget,
         )
         return False
 

--- a/tests/simulation/isaac/test_deferred_physics_and_warmup.py
+++ b/tests/simulation/isaac/test_deferred_physics_and_warmup.py
@@ -34,6 +34,7 @@ The tests drive the REAL ``IsaacSimulation`` methods on a ``__new__`` skeleton
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 
@@ -205,13 +206,53 @@ class _WarmupWorld:
         return self._remaining == 0
 
 
-def _skeleton_sim(world: _WarmupWorld) -> IsaacSimulation:
-    """Minimal ``__new__`` skeleton for the real ``_warmup_camera`` body."""
+class _FakeApp:
+    """Stub ``SimulationApp`` whose ``update()`` is render-only.
+
+    ``_refresh_all_render_products`` prefers ``SimulationApp.update()`` and
+    falls back to ``world.step(render=True)``. The real ``update()`` flushes
+    the secondary render products WITHOUT advancing physics, so this double
+    only counts calls: it must not tick the timeline or advance camera
+    readiness, or a secondary flush would masquerade as a warm-up step.
+    """
+
+    def __init__(self) -> None:
+        self.update_calls = 0
+
+    def update(self) -> None:
+        self.update_calls += 1
+
+
+def _skeleton_sim(
+    world: _WarmupWorld,
+    *,
+    camera_names: tuple[str, ...] = ("front",),
+) -> IsaacSimulation:
+    """``__new__`` skeleton carrying every attribute ``_warmup_camera`` reads.
+
+    ``camera_names`` populates the camera registry, which the loop *sizes* to
+    decide whether the secondary render products need an explicit flush
+    (``len(self._cameras) > 1``). Pass the real two-camera shape - a
+    pre-existing ``image`` plus the LIBERO adapter's late ``wrist_image`` - to
+    exercise that branch; a single name keeps the primary-product-only path.
+
+    Every attribute here is one the real ``__init__`` always sets, so the
+    skeleton stays a faithful stand-in rather than a shape the production code
+    is bent to accept: the loop reads ``_cameras``, ``_refresh_all_render_products``
+    reads ``_world_created`` and ``_app``, and ``__repr__`` reads
+    ``_world_created`` (an incomplete skeleton makes every assertion failure in
+    this file carry a misleading ``AttributeError`` from ``repr()``).
+    """
     sim = IsaacSimulation.__new__(IsaacSimulation)
     sim._config = IsaacConfig(headless=True, num_envs=1)
     sim._world = world
+    sim._world_created = True
     sim._sim_time = 0.0
     sim._step_count = 0
+    # Values are irrelevant - the loop only takes len() - but the keys mirror
+    # the live registry so a reader sees which scenario is under test.
+    sim._cameras = dict.fromkeys(camera_names, None)  # type: ignore[assignment]
+    sim._app = _FakeApp()  # type: ignore[assignment]
 
     def _render(camera_name: str = "default", width=None, height=None):  # noqa: ANN001, ARG001
         if world.camera_ready:
@@ -235,11 +276,14 @@ class TestWarmupCameraResumesTimeline:
         """
         fake_timeline._playing = False
         world = _WarmupWorld(fake_timeline, frames_until_ready=2)
-        sim = _skeleton_sim(world)
+        sim = _skeleton_sim(world, camera_names=("image", "wrist_image"))
 
         assert sim._warmup_camera("wrist_image", n_steps=5) is True
         assert fake_timeline.play_calls >= 1
         assert world.render_steps_while_playing >= 2
+        # The late second camera is exactly the #1802 shape, so the loop must
+        # also have flushed the secondary render products.
+        assert sim._app.update_calls >= 1
 
     def test_reasserts_play_when_queued_stop_lands_mid_loop(self, fake_timeline) -> None:
         """A stale ``is_playing() == True`` with a stop in flight.
@@ -252,7 +296,7 @@ class TestWarmupCameraResumesTimeline:
         fake_timeline._playing = True
         fake_timeline.stop()  # queued; lands on the first world.step tick
         world = _WarmupWorld(fake_timeline, frames_until_ready=2)
-        sim = _skeleton_sim(world)
+        sim = _skeleton_sim(world, camera_names=("image", "wrist_image"))
 
         assert sim._warmup_camera("wrist_image", n_steps=5) is True
         assert fake_timeline.play_calls >= 1
@@ -265,3 +309,110 @@ class TestWarmupCameraResumesTimeline:
 
         assert sim._warmup_camera("front", n_steps=3) is True
         assert fake_timeline.play_calls == 0
+
+
+class _RaisingWorld(_WarmupWorld):
+    """``_WarmupWorld`` whose ``step`` raises on the ``raise_on``-th call.
+
+    Models the failure the loop's own comment anticipates - "stepping /
+    rendering a partially-initialised stage can raise on surface drift" - so
+    the loop breaks with budget left over.
+    """
+
+    def __init__(self, timeline: _FakeTimeline, *, raise_on: int, exc: Exception) -> None:
+        super().__init__(timeline, frames_until_ready=10**6)
+        self._raise_on = raise_on
+        self._exc = exc
+        self.step_calls = 0
+
+    def step(self, render: bool = False) -> None:
+        self.step_calls += 1
+        if self.step_calls == self._raise_on:
+            raise self._exc
+        super().step(render=render)
+
+
+def _warnings(caplog) -> str:  # noqa: ANN001 - pytest fixture
+    """Every WARNING message the warm-up emitted, joined."""
+    return "\n".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+
+
+class TestWarmupCameraFailureReportNamesTheCause:
+    """A ``False`` must say WHICH failure happened - the remedies differ.
+
+    An exhausted budget means the render product never accumulated, so
+    stepping/waiting longer can help. An early abort means the loop stopped on
+    an exception with budget left, so waiting cannot help until that exception
+    is fixed. Reporting an abort with the exhaustion text (the pre-fix
+    behaviour, with the exception itself DEBUG-only) points the operator at
+    the renderer for what is really a surface or attribute error.
+    """
+
+    def test_an_abort_names_the_step_reached_and_the_cause(self, fake_timeline, caplog) -> None:
+        """Abort on step 1 of 5: report the step reached and the exception."""
+        fake_timeline._playing = True
+        world = _RaisingWorld(fake_timeline, raise_on=1, exc=AttributeError("no attribute '_cameras'"))
+        sim = _skeleton_sim(world)
+
+        with caplog.at_level(logging.WARNING):
+            assert sim._warmup_camera("front", n_steps=5) is False
+
+        text = _warnings(caplog)
+        assert "aborted on step 1 of 5" in text
+        assert "AttributeError" in text
+        assert "no attribute '_cameras'" in text
+        # It must NOT claim the render product was given the whole budget.
+        assert "did not produce a valid frame" not in text
+
+    def test_the_reported_step_count_is_the_steps_taken(self, fake_timeline, caplog) -> None:
+        """A mid-loop abort reports where it stopped, not the budget."""
+        fake_timeline._playing = True
+        world = _RaisingWorld(fake_timeline, raise_on=3, exc=RuntimeError("stage surface drift"))
+        sim = _skeleton_sim(world)
+
+        with caplog.at_level(logging.WARNING):
+            assert sim._warmup_camera("front", n_steps=6) is False
+
+        assert "aborted on step 3 of 6" in _warnings(caplog)
+
+    def test_an_exhausted_budget_still_points_at_the_render_product(self, fake_timeline, caplog) -> None:
+        """No exception, never ready: the original exhaustion report stands."""
+        fake_timeline._playing = True
+        world = _WarmupWorld(fake_timeline, frames_until_ready=10**6)
+        sim = _skeleton_sim(world)
+
+        with caplog.at_level(logging.WARNING):
+            assert sim._warmup_camera("front", n_steps=3) is False
+
+        text = _warnings(caplog)
+        assert "did not produce a valid frame after 3 warm-up step(s)" in text
+        assert "aborted" not in text
+        assert world.render_steps_while_playing == 3, "the whole budget must really have been spent"
+
+
+class TestWarmupCameraSecondaryRenderProducts:
+    """The ``len(self._cameras) > 1`` flush from #1802, exercised.
+
+    ``world.step(render=True)`` reliably refreshes only the PRIMARY render
+    product, so a camera added next to an existing one needs an explicit
+    secondary flush before the frame check. The registry size is what selects
+    that branch.
+    """
+
+    def test_a_second_camera_flushes_the_secondary_render_products(self, fake_timeline) -> None:
+        """Two registered cameras -> the secondary products are flushed."""
+        fake_timeline._playing = True
+        world = _WarmupWorld(fake_timeline, frames_until_ready=2)
+        sim = _skeleton_sim(world, camera_names=("image", "wrist_image"))
+
+        assert sim._warmup_camera("wrist_image", n_steps=5) is True
+        assert sim._app.update_calls >= 1
+
+    def test_a_single_camera_needs_no_secondary_flush(self, fake_timeline) -> None:
+        """One registered camera -> stepping alone refreshes it, no flush."""
+        fake_timeline._playing = True
+        world = _WarmupWorld(fake_timeline, frames_until_ready=2)
+        sim = _skeleton_sim(world, camera_names=("front",))
+
+        assert sim._warmup_camera("front", n_steps=5) is True
+        assert sim._app.update_calls == 0


### PR DESCRIPTION
Closes #1823.

## The defect

`IsaacSimulation._warmup_camera` returns `False` two ways, and reported both with the same sentence:

```
Camera 'front' did not produce a valid frame after 5 warm-up step(s); the first
render() may return an error until the RTX product accumulates a frame.
```

That text is correct for one of them (the budget ran out while the render product never accumulated) and misleading for the other (the loop broke early on an exception, with budget left). The exception was logged at DEBUG, so at default log level the two are indistinguishable — and the remedy the message implies, *give the renderer more time*, cannot work for a loop that has already stopped and will never step again.

A loop that aborted on **step 1 of 5** reported the same thing as one that spent all 5.

## The evidence that this is not hypothetical

The file's own regression pins were failing through exactly this path, and the report is why it was hard to see. On a pristine `main` at `cc460a4d`:

```
$ git status --porcelain      # clean
$ MUJOCO_GL=egl python -m pytest tests/simulation/isaac/test_deferred_physics_and_warmup.py -q --no-cov
3 failed, 3 passed in 0.12s
```

The `__new__` skeleton those tests drive sets `_config`, `_world`, `_sim_time`, `_step_count` and `render`. It does not set `_cameras`, which the loop reads to decide whether the secondary render products need an explicit flush:

```python
if len(self._cameras) > 1:
    self._refresh_all_render_products()
```

So every one of the three aborted with `AttributeError` on its **first** iteration, never reached the timeline-resume code they exist to pin, and then logged the exhaustion text above. Instrumenting `logger.debug` was the only way to see the real cause:

```
Camera 'front' warm-up step 1 failed: 'IsaacSimulation' object has no attribute '_cameras'
```

The `AttributeError: '_world_created'` that appears in the pytest output is a second red herring — it is `repr()` failing while pytest formats the assertion, not the cause.

This is a clean case of two changes that are each green alone and red together. The `len(self._cameras) > 1` block arrived in #1811 (merged 11:02). The test file arrived in #1798 (merged 12:37) but was branched from a base **11 commits behind** #1811, so its CI never saw that line, and #1811's CI never saw the test file. `git merge-base --is-ancestor bf0fbc11 c753a763` is false. Because CI runs pytest with `-x`, `main` then reports only the first of the three and reddens `call-test-lint` on every open pull request regardless of what that branch changed.

## The change

**Production** — an early abort is reported as an abort:

```
Camera 'front' warm-up aborted on step 1 of 5: AttributeError: no attribute '_cameras'.
The camera stays registered and the first render() may return an error, but the loop
stopped early - further warm-up steps cannot help until this is resolved.
```

The exhaustion message is unchanged, so anything grepping for it still matches. The step count it quotes is now the number of iterations the loop actually runs rather than the raw `n_steps` (which reads `0` for a call that still takes one step, since the range is `max(1, n_steps)`).

I deliberately did **not** narrow the `except` clause. `AttributeError` is legitimately reachable on a real install — the loop's own comment anticipates it ("stepping / rendering a partially-initialised stage can raise on surface drift") — so catching it is right and the defect was reporting it as something else.

**Tests** — the skeleton now carries every attribute the loop reads (`_cameras`, `_world_created`, `_app`), all of which the real `__init__` always sets, so it stays a faithful stand-in rather than a shape the production code is bent to accept. The two `wrist_image` cases now register the real two-camera shape (a pre-existing `image` plus the adapter's late `wrist_image`), which is the scenario #1811 added that block for, and assert the flush happened. `_refresh_all_render_products` had **no coverage anywhere in the suite** before this; it now has both branches.

## Visual artifact

Every cell below is read from two real runs of the same three scenarios, one per tree, with the second generated against a stashed source. This change alters no rendered output, no motion and no policy behaviour — it changes what the operator is told — so the artifact is the operator-visible report rather than a frame.

![warm-up failure report: main vs this change](https://raw.githubusercontent.com/cagataycali/robots/artifacts/warmup-report/warmup_report.png)

| scenario | steps taken / budget | main | this change |
| --- | --- | --- | --- |
| missing attribute | 1 of 5 | "did not produce a valid frame after 5 warm-up step(s)" | "aborted on step 1 of 5: AttributeError: …" |
| surface drift mid-loop | 3 of 6 | "did not produce a valid frame after 6 warm-up step(s)" | "aborted on step 3 of 6: RuntimeError: stage surface drift" |
| budget exhausted (control) | 3 of 3 | "did not produce a valid frame after 3 warm-up step(s)" | **byte-identical** |

The figure generator asserts each of those relations before it saves, including that the control row is byte-identical across trees and that the secondary-flush counts (`1 camera → 0`, `2 cameras → 2`) are unchanged — that branch was already correct, it was simply never executed by a test.

## Verification

Pre-fix proof, two arms, each reverting one half of the change:

| reverted | result |
| --- | --- |
| the test file (so: `main`'s skeleton) | `3 failed, 3 passed` — the red `main`, which this PR fixes |
| `simulation.py` (so: `main`'s report) | `2 failed, 9 passed` |

The second arm quotes the defect directly:

```
assert 'aborted on step 1 of 5' in "Camera 'front' did not produce a valid frame after 5
  warm-up step(s); the first render() may return an error until the RTX product accumulates a frame."
```

The 9 that pass in that arm are the exhaustion control and the two flush tests — they are what keep the new report from over-reaching, so they are expected to pass both before and after.

Gate, all on the branch head:

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` → **15620 passed, 257 skipped, 0 failed** in 482.77s
- `tests/simulation/isaac/` → 254 passed; the changed file → 11 passed (was 3 failed / 3 passed)
- `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ` → clean (998 source files)
- `scripts/assemble_changelog.py --check` → OK; `scripts/check_merge_base_overlap.py` → no overlap

The skeleton's `__del__` now logs a swallowed `Cleanup error … '_lock'` at teardown instead of `'_world_created'`, because `cleanup()` gets one attribute further before giving up. It is the same benign, already-swallowed noise every `__new__` Isaac skeleton in the suite produces; adding `_lock` would let `cleanup()` proceed into tearing down the fake world, which is worse.