### PR TITLE
test(sim/isaac): give the warm-up skeleton the attribute the body reads (closes #1823)

### DIFF
--- a/tests/simulation/isaac/test_deferred_physics_and_warmup.py
+++ b/tests/simulation/isaac/test_deferred_physics_and_warmup.py
@@ -34,13 +34,14 @@ The tests drive the REAL ``IsaacSimulation`` methods on a ``__new__`` skeleton
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 
 import pytest
 
 from strands_robots.simulation.isaac.config import IsaacConfig
-from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _CameraState
 
 
 class _FakeTimeline:
@@ -205,13 +206,36 @@ class _WarmupWorld:
         return self._remaining == 0
 
 
-def _skeleton_sim(world: _WarmupWorld) -> IsaacSimulation:
-    """Minimal ``__new__`` skeleton for the real ``_warmup_camera`` body."""
+def _skeleton_sim(world: _WarmupWorld, camera: str) -> IsaacSimulation:
+    """Minimal ``__new__`` skeleton for the real ``_warmup_camera`` body.
+
+    EVERY attribute the real body reads must be set here. The warm-up loop
+    wraps its own iteration in ``except (..., AttributeError, ...): break``
+    to tolerate Isaac surface drift, so an attribute this skeleton omits does
+    not surface as an error - it is swallowed into the same bare ``False``
+    that a camera which genuinely never warmed up returns, with the missing
+    name visible only at DEBUG. ``_cameras`` (read to decide whether the
+    secondary render products need flushing) was omitted when this file
+    landed, and all three tests below broke out of the loop on iteration 1
+    without ever reaching the timeline resume they exist to pin.
+    :func:`_assert_reached_render_probe` is what stops that recurring
+    silently; ``camera`` is passed explicitly so the registered camera set
+    always matches the name the test warms up.
+    """
     sim = IsaacSimulation.__new__(IsaacSimulation)
     sim._config = IsaacConfig(headless=True, num_envs=1)
     sim._world = world
+    # Consistent with ``_world`` being set. ``_refresh_all_render_products``
+    # early-returns on a falsy ``_world_created``, so a skeleton that claims
+    # no world would silently no-op the flush a multi-camera case means to
+    # exercise rather than failing.
+    sim._world_created = True
     sim._sim_time = 0.0
     sim._step_count = 0
+    # The real registry type, not a placeholder: ``len(self._cameras)`` is what
+    # the body reads, and a mistyped stand-in would drift from the production
+    # dict the moment anything reads a field off it.
+    sim._cameras = {camera: _CameraState(name=camera, prim_path=f"/World/{camera}", width=640, height=480)}
 
     def _render(camera_name: str = "default", width=None, height=None):  # noqa: ANN001, ARG001
         if world.camera_ready:
@@ -219,13 +243,41 @@ def _skeleton_sim(world: _WarmupWorld) -> IsaacSimulation:
         return {"status": "error", "content": [{"text": "render product not accumulated"}]}
 
     sim.render = _render  # type: ignore[method-assign]
+    # ``SimEngine.__del__`` calls ``cleanup()``, which reads Isaac state this
+    # skeleton does not own; on GC that logged
+    # ``Cleanup error during __del__: ... no attribute '_world_created'`` and
+    # that teardown noise, not the swallowed ``_cameras`` lookup, is what the
+    # failure above was read as. Nothing here allocates a world to release.
+    sim.cleanup = lambda: None  # type: ignore[method-assign]
     return sim
+
+
+@pytest.fixture
+def warmup_log(caplog) -> pytest.LogCaptureFixture:
+    """Capture the warm-up loop's own DEBUG records for the guard below."""
+    caplog.set_level(logging.DEBUG, logger="strands_robots.simulation.isaac.simulation")
+    return caplog
+
+
+def _assert_reached_render_probe(caplog: pytest.LogCaptureFixture) -> None:
+    """Fail naming the attribute if the loop exited through its handler.
+
+    A ``False`` from ``_warmup_camera`` is ambiguous: it means either "this
+    camera never produced a frame" (what these tests assert against) or "an
+    exception broke the loop on its first iteration" (what a test-double gap
+    produces). Only the first is behaviour under test, so pin that the
+    exception path never ran - otherwise a future attribute added to the real
+    body turns these tests vacuous again, reported as the unrelated
+    ``_world_created`` name that ``__repr__`` raises on.
+    """
+    broke = [r.getMessage() for r in caplog.records if "warm-up step" in r.getMessage() and "failed" in r.getMessage()]
+    assert not broke, f"warm-up loop exited through its exception handler, so the loop under test never ran: {broke}"
 
 
 class TestWarmupCameraResumesTimeline:
     """``_warmup_camera`` must not step a dead renderer (stopped timeline)."""
 
-    def test_resumes_stopped_timeline_and_warms_up(self, fake_timeline) -> None:
+    def test_resumes_stopped_timeline_and_warms_up(self, fake_timeline, warmup_log) -> None:
         """The load_scene aftermath: timeline stopped, camera just added.
 
         Pre-fix behaviour: every warm-up step ran with the timeline stopped,
@@ -235,13 +287,14 @@ class TestWarmupCameraResumesTimeline:
         """
         fake_timeline._playing = False
         world = _WarmupWorld(fake_timeline, frames_until_ready=2)
-        sim = _skeleton_sim(world)
+        sim = _skeleton_sim(world, "wrist_image")
 
         assert sim._warmup_camera("wrist_image", n_steps=5) is True
+        _assert_reached_render_probe(warmup_log)
         assert fake_timeline.play_calls >= 1
         assert world.render_steps_while_playing >= 2
 
-    def test_reasserts_play_when_queued_stop_lands_mid_loop(self, fake_timeline) -> None:
+    def test_reasserts_play_when_queued_stop_lands_mid_loop(self, fake_timeline, warmup_log) -> None:
         """A stale ``is_playing() == True`` with a stop in flight.
 
         This is the observed 6.0.x trap: right after the deferred-physics
@@ -252,16 +305,44 @@ class TestWarmupCameraResumesTimeline:
         fake_timeline._playing = True
         fake_timeline.stop()  # queued; lands on the first world.step tick
         world = _WarmupWorld(fake_timeline, frames_until_ready=2)
-        sim = _skeleton_sim(world)
+        sim = _skeleton_sim(world, "wrist_image")
 
         assert sim._warmup_camera("wrist_image", n_steps=5) is True
+        _assert_reached_render_probe(warmup_log)
         assert fake_timeline.play_calls >= 1
+        assert world.render_steps_while_playing >= 2
 
-    def test_playing_timeline_needs_no_resume(self, fake_timeline) -> None:
-        """Steady-state add_camera: timeline already playing -> no play() call."""
+    def test_playing_timeline_needs_no_resume(self, fake_timeline, warmup_log) -> None:
+        """Steady-state add_camera: timeline already playing -> no play() call.
+
+        ``play_calls == 0`` is also what a loop that never ran reports, so the
+        warm-up is pinned to have actually stepped and rendered.
+        """
         fake_timeline._playing = True
         world = _WarmupWorld(fake_timeline, frames_until_ready=1)
-        sim = _skeleton_sim(world)
+        sim = _skeleton_sim(world, "front")
 
         assert sim._warmup_camera("front", n_steps=3) is True
+        _assert_reached_render_probe(warmup_log)
         assert fake_timeline.play_calls == 0
+        assert world.render_steps_while_playing >= 1
+
+    def test_skeleton_attribute_gap_is_not_read_as_a_warmup_failure(self, fake_timeline, warmup_log) -> None:
+        """The guard must be able to fail; pin it against a planted gap.
+
+        Removing an attribute the real body reads reproduces the exact state
+        this file landed in - ``_warmup_camera`` returns ``False`` for a
+        camera that would have warmed up fine. Without this case the guard in
+        the three tests above could pass by never having anything to find.
+        """
+        world = _WarmupWorld(fake_timeline, frames_until_ready=1)
+        sim = _skeleton_sim(world, "front")
+        del sim._cameras
+
+        assert sim._warmup_camera("front", n_steps=3) is False
+        # One step lands before the swallowed read (``world.step`` precedes the
+        # ``_cameras`` lookup), then the handler breaks - so the budget of 3 is
+        # abandoned after 1 and the render probe is never reached.
+        assert world.render_steps_while_playing == 1
+        with pytest.raises(AssertionError, match="the loop under test never ran"):
+            _assert_reached_render_probe(warmup_log)


### PR DESCRIPTION
`main` is red at `cc460a4d`, and has been since #1798 landed. Three tests in `tests/simulation/isaac/test_deferred_physics_and_warmup.py` fail on a pristine tree in 0.08 s with no Isaac Sim installed, so `call-test-lint` is red on **every** open pull request regardless of what that branch changed.

## The failure names the wrong attribute

The reported symptom is `AttributeError: 'IsaacSimulation' object has no attribute '_world_created'`. That attribute is a red herring: `_warmup_camera` never reads it on the path these tests take.

The attribute the body actually reads is `_cameras`, and `_skeleton_sim` did not set it:

```
DEBUG  Camera 'front' warm-up step 1 failed: 'IsaacSimulation' object has no attribute '_cameras'
```

`_world_created` surfaced instead because it is read in two places that run *around* the failure rather than in it - `__repr__`, which pytest calls to render the assertion, and `cleanup()` via `SimEngine.__del__` at GC. So the true cause was logged at DEBUG while two derived messages competed for attention:

| channel | what it reported |
| --- | --- |
| assertion repr | `[AttributeError("...no attribute '_world_created'") raised in repr()]` |
| GC teardown | `Cleanup error during __del__: ...no attribute '_world_created'` |
| the loop itself, at DEBUG | `warm-up step 1 failed: ...no attribute '_cameras'` |

## The tests were vacuous, not merely red

This is the part that matters more than the three red cells. `_warmup_camera` wraps each iteration in `except (RuntimeError, ValueError, OSError, AttributeError, TypeError, IndexError): break` to tolerate Isaac surface drift. `AttributeError` is in that tuple, so the missing attribute was **swallowed on iteration 1** and the method returned the same bare `False` that a camera which genuinely never warmed up returns.

So the loop broke before the timeline resume it exists to pin ever ran. All three cases have been testing the exception handler, not the #1798 fix. Two failed loudly on `is True`; the third's second assertion, `play_calls == 0`, is *also* what a loop that never ran reports - it would have passed vacuously on its own.

No production behaviour is at fault. `_warmup_camera`'s only caller is `add_camera`, where `_cameras` is always populated, and the broad `except` is the documented best-effort intent. The defect is entirely in the test double, which is why this diff is one test file.

## The change

`_skeleton_sim` now sets every attribute the real body reads:

- **`_cameras`**, keyed by a `camera` argument passed explicitly so the registered set always matches the name the test warms up. Typed as the real `_CameraState` rather than a placeholder - mypy rejected `object()` against `dict[str, _CameraState]`, and a mistyped stand-in would drift from the production dict the moment anything reads a field off it.
- **`_world_created = True`**, consistent with `_world` being set. `_refresh_all_render_products` early-returns on a falsy value, so a skeleton claiming no world would silently no-op the flush a multi-camera case means to exercise rather than failing.
- **`cleanup()` no-op**, so `SimEngine.__del__` stops reporting Isaac state this skeleton never allocated. With the gap re-planted the repr now reads `IsaacSimulation(num_envs=1, ..., world=created)` instead of raising, so a future diagnosis is not misdirected the way this one was.

### Keeping it from going vacuous again

A `False` return is ambiguous between the behaviour under test and a test-double gap, so `_assert_reached_render_probe` pins that the exception path never ran, failing with the missing attribute's real name. Without a negative control that guard could pass for want of anything to find, so `test_skeleton_attribute_gap_is_not_read_as_a_warmup_failure` plants the original gap back and asserts the guard fires - the budget of 3 is abandoned after 1 step and the render probe is never reached. `test_playing_timeline_needs_no_resume` also asserts render progress now.

This is the load-bearing part: the next attribute added to `_warmup_camera` turns these tests loudly red instead of silently vacuous.

## Gate

```
ruff check    All checks passed!
ruff format   1 file already formatted
mypy          Success: no issues found in 1 source file
changelog     changelog fragments OK
pytest tests/simulation/isaac/   202 passed, 31 skipped
pytest tests/simulation/isaac/test_deferred_physics_and_warmup.py   7 passed
```

Same command on both trees, so the delta is attributable (the residual failures and errors are missing optional extras in a minimal venv - `serial`, `device_connect_edge` - and are identical on both):

| tree | failed | passed |
| --- | --- | --- |
| pristine `main` at `cc460a4d` | 316 | 9547 |
| this branch | **313** | **9551** |

-3 failures are exactly the three reported; +4 passes are those three plus the new planted-gap guard.

## Out of scope

- `test_load_scene_physics_view.py` still logs `Cleanup error during __del__: ...no attribute '_cameras'` from its own skeletons. Pre-existing, teardown-only noise in a different file, and it fails nothing - a separate cleanup rather than a guess folded into a red-main fix.
- That `SimEngine.__del__` reports a partially-constructed object's missing attributes at all is a diagnosability question about production code, and it is what made this report name the wrong attribute. Worth its own issue, not a change smuggled into this one.

Tests only; no production behaviour changes, so no changelog fragment (per `changelog.d/README.md`, it is behavioural PRs that write fragments).

Closes #1823.