### PR TITLE
fix(sim/isaac): restart the timeline in load_scene and apply LIBERO init states as object/robot poses (closes #1820)

### DIFF
--- a/changelog.d/1820-isaac-load-scene-frozen-timeline.md
+++ b/changelog.d/1820-isaac-load-scene-frozen-timeline.md
@@ -1,0 +1,41 @@
+### Fixed: Isaac `load_scene` no longer leaves the episode on frozen physics; LIBERO init states now apply on Isaac as object/robot poses
+
+Two composing defects kept every Isaac LIBERO eval motionless-but-green
+(#1820). First, `IsaacSimulation.load_scene` realized dynamic objects through
+constructors that stop the timeline (#159's deferred-physics guard) and
+nothing restarted it, so the whole episode ran on frozen physics:
+`SimulationContext.step` only integrates when `is_playing()`, joint reads
+went stale, `send_action` targeted a view that never integrates - and every
+envelope still reported success. `load_scene` now restarts the timeline after
+the physics-view rebuild via `world.play()` (a bare `timeline.play()` only
+queues the state change on 6.0.x and never lands on the headless
+`step(render=False)` path - measured live: `is_playing()` still `False`
+after `play()` + 5 steps), reads `is_playing()` back, and returns an error
+envelope rather than handing out a silently frozen episode.
+
+Second - previously *masked* by the frozen timeline - the realized objects
+sit at MJCF **placeholder** poses (LIBERO encodes real per-episode poses in
+BDDL init states, which the MuJoCo backend applies as qpos vectors and Isaac
+silently skipped): coincident dynamic bodies inside the robot base, so live
+physics starts from deep interpenetration and storms PhysX "Illegal
+BroadPhaseUpdateData - non-finite bounds" into NaN joint state.
+`LiberoAdapter._apply_canonical_state` now routes model-less backends to a
+new `_apply_object_pose_state` branch: the init state is decoded through a
+local CPU MuJoCo compile of the scene MJCF (same row-selection and
+width-validation semantics as the MuJoCo branch) and applied per named prim
+via `move_object` - composing each free body's `xpos`/`xquat` with the
+prim's body-frame collision-AABB offset, now recorded on
+`SceneObject.offset`. The robot base is aligned with the scene's
+`robot0_base` body through a new `IsaacSimulation.set_robot_pose` (on
+MuJoCo the robot is part of the scene MJCF at `(-0.66, 0, 0.912)`; on Isaac
+the USD articulation spawned at the origin, inside the scene's
+origin-anchored static fixtures). Failed teleports raise rather than
+warn-and-continue, and a settle step runs only *after* the poses are legal.
+
+A GPU integration test (`tests_integ/simulation/test_isaac_scene_physics_gpu.py`)
+pins the gate frozen physics cannot fake: after `load_scene` (twice - the
+episode-2 reload included) the timeline is playing and a joint-target
+`send_action` measurably moves the articulation, with all joints finite.
+Verified end-to-end on Isaac Sim 6.0 / L4: `run_isaac.py --policy mock
+--n-episodes 2` completes both episodes with zero PhysX broadphase errors
+(previously a storm of them).

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -550,6 +550,10 @@ class LiberoAdapter(BenchmarkProtocol):
         # episode so qpos/qvel land on the same canonical state every time.
         self._canonical_qpos: np.ndarray | None = None
         self._canonical_qvel: np.ndarray | None = None
+        # CPU-side MuJoCo decode model for the object-pose init-state branch
+        # (#1820, Isaac backend). Cached as (scene_path, model, data) so the
+        # per-episode pose decode doesn't recompile the scene MJCF.
+        self._pose_decode_cache: tuple[str, Any, Any] | None = None
         self._bddl_source = bddl_source
         self._bddl_path = bddl_path
         self._success_fn: Callable[[SimEngine], bool] = compile_goal(problem.goal)
@@ -2870,7 +2874,14 @@ class LiberoAdapter(BenchmarkProtocol):
 
         Best-effort:
 
-        * Sims without an exposed compiled MuJoCo model -> debug-log + skip.
+        * Sims without an exposed compiled MuJoCo model -> route to
+          :meth:`_apply_object_pose_state` (#1820): non-MuJoCo backends
+          (Isaac) have no ``qpos`` to write, so the init state is applied
+          as per-object *poses* decoded through a local CPU MuJoCo
+          compile of the scene MJCF. That helper debug-log + skips when
+          its own preconditions (init states, scene path, a
+          ``move_object`` method, importable ``mujoco``) are missing, so
+          arbitrary model-less sims still degrade gracefully.
         * ``scene_keyframe_index`` out of range when ``nkey > 0`` -> log
           at WARNING and skip (out-of-range is a config error).
         * ``mujoco`` not importable -> debug-log + skip.
@@ -2886,7 +2897,12 @@ class LiberoAdapter(BenchmarkProtocol):
         model = getattr(world, "_model", None) if world is not None else None
         data = getattr(world, "_data", None) if world is not None else None
         if model is None or data is None:
-            logger.debug("LiberoAdapter: sim has no compiled MuJoCo model/data; skipping canonical-state apply")
+            # Non-MuJoCo backend (e.g. Isaac): no compiled model/data to
+            # write qpos into. Apply the init state as per-object poses
+            # instead (#1820) -- without this, Isaac scene objects stay at
+            # their MJCF placeholder poses (coincident bodies at the robot
+            # base) and live physics explodes on the first step.
+            self._apply_object_pose_state(sim, rng)
             return
 
         try:
@@ -3016,6 +3032,189 @@ class LiberoAdapter(BenchmarkProtocol):
 
         # Increment after successful apply so the next call is
         # "episode 1+" and gets RNG-sampled selection.
+        self._episode_count += 1
+
+    def _apply_object_pose_state(self, sim: SimEngine, rng: random.Random | None = None) -> None:
+        """Object-pose branch of :meth:`_apply_canonical_state` (#1820).
+
+        Non-MuJoCo backends (Isaac) realize the LIBERO scene as one prim
+        per MJCF body (``IsaacSimulation.load_scene``), so the flat
+        ``[time, qpos, qvel]`` init-state vector can't be written into an
+        engine ``qpos`` -- there isn't one. Instead this branch decodes
+        the init state into per-object world poses and teleports each
+        realized prim there:
+
+        1. Compile the scene MJCF with **CPU MuJoCo** (a decode-only
+           model; nothing is stepped). ``mujoco`` is always importable on
+           the LIBERO path -- the scene MJCF itself was generated through
+           robosuite, which hard-depends on it.
+        2. Select an init-state row with the SAME semantics as
+           :meth:`_apply_init_state_branch` (episode 0 pinned to row 0,
+           episodes 1+ RNG-sampled; width validated against
+           ``1 + nq + nv``, mismatch fatal per #168 bug I).
+        3. Write ``qpos``/``qvel``, ``mj_forward``, and read each free
+           body's world pose (``data.xpos`` / ``data.xquat``).
+        4. Align the robot base with the scene's ``robot0_base`` body via
+           ``sim.set_robot_pose`` (on MuJoCo the robot is part of the
+           scene MJCF; on Isaac it is a separately-loaded USD spawned at
+           the origin, inside the footprint of the scene's
+           origin-anchored static fixtures).
+        5. Teleport each realized dynamic prim via ``sim.move_object``.
+           The prim is a box at the body's collision-AABB centre, so the
+           prim pose is ``xpos + R(xquat) @ offset`` with the body-frame
+           ``offset`` recorded by :func:`load_mjcf_scene_objects`.
+           Static fixtures keep their MJCF poses (they have no free
+           joint; ``qpos`` cannot move them on MuJoCo either).
+        6. Settle a few physics steps so PhysX resolves residual contact
+           from the teleports before the first observation. The settle
+           runs HERE, after the poses are legal -- ``load_scene`` itself
+           must not step, because its objects still sit at the MJCF
+           placeholder poses (coincident bodies at the robot base) and
+           integrating from that configuration storms PhysX "Illegal
+           BroadPhaseUpdateData - non-finite bounds" and NaNs the joint
+           state (#1820 part 2).
+
+        Failed teleports and unresolvable body names raise
+        ``RuntimeError``: an object left at its placeholder pose
+        interpenetrates the robot base and WILL explode live physics, so
+        warn-and-continue is exactly the silent-failure mode this branch
+        exists to remove.
+
+        Best-effort preconditions (debug-log + skip, preserving the
+        graceful-degradation contract for arbitrary model-less sims):
+        missing/empty init states, missing scene path, no ``move_object``
+        method on the sim, ``mujoco`` not importable.
+        """
+        if self._init_states is None or int(self._init_states.shape[0]) == 0:
+            logger.debug("LiberoAdapter: no init_states; skipping object-pose state apply")
+            return
+        init_states = self._init_states
+        scene_path = self.scene_path
+        if not scene_path or not os.path.exists(scene_path):
+            logger.debug("LiberoAdapter: no scene_path on disk; skipping object-pose state apply")
+            return
+        move_object = getattr(sim, "move_object", None)
+        if not callable(move_object):
+            logger.debug("LiberoAdapter: sim has no move_object(); skipping object-pose state apply")
+            return
+        try:
+            import mujoco as _mj
+        except ImportError:
+            logger.debug("LiberoAdapter: mujoco not importable; skipping object-pose state apply")
+            return
+
+        from strands_robots.simulation.isaac.loaders import load_mjcf_scene_objects
+
+        # Decode model: compile once per scene_path, reuse across episodes.
+        if self._pose_decode_cache is not None and self._pose_decode_cache[0] == scene_path:
+            _, model, data = self._pose_decode_cache
+        else:
+            model = _mj.MjModel.from_xml_path(scene_path)
+            data = _mj.MjData(model)
+            self._pose_decode_cache = (scene_path, model, data)
+
+        # Row selection + width validation: identical semantics to
+        # _apply_init_state_branch (episode 0 -> row 0; episodes 1+ RNG).
+        n_states = int(init_states.shape[0])
+        if self._episode_count == 0:
+            idx = 0
+        else:
+            rng_local = rng if rng is not None else random.Random()
+            idx = rng_local.randint(0, n_states - 1)
+        state = init_states[idx]
+
+        nq = int(model.nq)
+        nv = int(model.nv)
+        expected_width = 1 + nq + nv
+        actual_width = int(state.shape[0])
+        if actual_width != expected_width:
+            raise RuntimeError(
+                f"LiberoAdapter: init_state width {actual_width} does not match the scene MJCF "
+                f"compiled for pose decode (1 + nq={nq} + nv={nv} = {expected_width}). The "
+                f"cached scene diverges from upstream LIBERO's scene for this BDDL task. "
+                f"#168 bug I: silent slicing forbidden - fix the scene generator instead."
+            )
+
+        data.time = float(state[0])
+        np.copyto(data.qpos, state[1 : 1 + nq])
+        np.copyto(data.qvel, state[1 + nq :])
+        _mj.mj_forward(model, data)
+
+        # Align the robot base with the scene (#1820 part 2, robot half).
+        # On MuJoCo the robot is part of the scene MJCF, so its base lands
+        # wherever the scene put it (LIBERO: robot0_base at
+        # (-0.66, 0, 0.912)); on Isaac the robot is a separately-loaded
+        # USD articulation spawned at the ORIGIN -- inside the footprint
+        # of the scene's origin-anchored static fixtures (cabinet, stove),
+        # and live physics starting from that interpenetration is the same
+        # broadphase NaN storm as the object-pose half. Best-effort on the
+        # lookup side (a robot-less scene or a sim without set_robot_pose
+        # skips with a log); a FAILED write raises, same as the object
+        # teleports below.
+        base_body = f"{self._scene_robot_prefix}base"
+        base_id = _mj.mj_name2id(model, _mj.mjtObj.mjOBJ_BODY, base_body)
+        set_robot_pose = getattr(sim, "set_robot_pose", None)
+        if base_id >= 0 and callable(set_robot_pose):
+            base_pos = np.asarray(data.xpos[base_id], dtype=float)
+            base_quat = np.asarray(data.xquat[base_id], dtype=float)  # wxyz
+            result = set_robot_pose(position=base_pos.tolist(), orientation=base_quat.tolist())
+            if isinstance(result, dict) and result.get("status") == "error":
+                text = (result.get("content") or [{}])[0].get("text", "")
+                raise RuntimeError(
+                    f"LiberoAdapter: aligning the robot base with scene body {base_body!r} failed "
+                    f"({text}). A robot left inside the scene's origin-anchored fixtures explodes "
+                    f"live physics on the first step (#1820)."
+                )
+        elif base_id < 0:
+            logger.debug("LiberoAdapter: scene has no %r body; skipping robot base alignment", base_body)
+        else:
+            logger.debug("LiberoAdapter: sim has no set_robot_pose(); skipping robot base alignment")
+
+        moved = 0
+        for obj in load_mjcf_scene_objects(scene_path):
+            if obj.is_static:
+                continue
+            body_id = _mj.mj_name2id(model, _mj.mjtObj.mjOBJ_BODY, obj.name)
+            if body_id < 0:
+                raise RuntimeError(
+                    f"LiberoAdapter: scene object {obj.name!r} (parsed from {scene_path!r}) "
+                    f"has no body in the compiled MJCF - the scene parser and the compiled "
+                    f"model disagree, so its init pose cannot be applied and live physics "
+                    f"would start from its placeholder pose (#1820)."
+                )
+            xpos = np.asarray(data.xpos[body_id], dtype=float)
+            xmat = np.asarray(data.xmat[body_id], dtype=float).reshape(3, 3)
+            xquat = np.asarray(data.xquat[body_id], dtype=float)  # wxyz, matches Isaac
+            prim_pos = xpos + xmat @ np.asarray(obj.offset, dtype=float)
+            result = move_object(name=obj.name, position=prim_pos.tolist(), orientation=xquat.tolist())
+            if isinstance(result, dict) and result.get("status") == "error":
+                text = (result.get("content") or [{}])[0].get("text", "")
+                raise RuntimeError(
+                    f"LiberoAdapter: applying init pose to scene object {obj.name!r} failed "
+                    f"({text}). An object left at its MJCF placeholder pose interpenetrates "
+                    f"the robot base and explodes live physics on the first step (#1820)."
+                )
+            moved += 1
+
+        # Settle now that every dynamic body is at a legal pose. Uses the
+        # engine's own step() (renders per its config); a handful of ticks
+        # lets PhysX resolve residual teleport contact before the first
+        # observation. Best-effort: a sim without step() just skips.
+        step = getattr(sim, "step", None)
+        if callable(step):
+            step(5)
+
+        logger.debug(
+            "LiberoAdapter: applied init_state[%d] as object poses (ep=%d, moved=%d, n_states=%d)",
+            idx,
+            self._episode_count,
+            moved,
+            n_states,
+        )
+
+        # Increment after successful apply so the next call is
+        # "episode 1+" and gets RNG-sampled selection (parity with
+        # _apply_init_state_branch).
         self._episode_count += 1
 
     def _apply_keyframe_branch(

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -784,6 +784,14 @@ class SceneObject:
     quat : tuple[float, float, float, float]
         Orientation quaternion ``[w, x, y, z]`` from the body's ``quat``
         attribute (identity when absent).
+    offset : tuple[float, float, float]
+        Body-frame offset of the AABB centre from the MJCF body origin
+        (``position = body_pos + offset`` at load time). Needed by pose
+        appliers (#1820): LIBERO init states carry per-episode *body*
+        poses, but the realized box prim sits at the AABB centre, so a
+        new body pose maps to prim pose ``body_pos + R(body_quat) @
+        offset``. Without this field the offset is unrecoverable from
+        ``position`` alone once the body moves.
     """
 
     name: str
@@ -791,6 +799,7 @@ class SceneObject:
     size: tuple[float, float, float]
     is_static: bool
     quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
 
 
 def _parse_quat(quat_str: str | None) -> tuple[float, float, float, float]:
@@ -1005,6 +1014,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
                 size=size,  # type: ignore[arg-type]
                 is_static=not has_freejoint,
                 quat=body_quat,
+                offset=center,  # type: ignore[arg-type]
             )
         )
 

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -2119,6 +2119,19 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         so per-episode reloads don't accumulate duplicate prims or hit the
         "object already exists" guard in :meth:`add_object`.
 
+        Timeline contract (#1820): realizing dynamic objects stops the
+        timeline per prim (#159); after rebuilding the physics view this
+        method restarts it (``world.play()``, which lands the state change
+        without integrating a physics tick), so on success the episode
+        integrates physics. No settle step runs here -- the objects sit
+        at MJCF *placeholder* poses until
+        ``LiberoAdapter._apply_object_pose_state`` teleports them to the
+        episode's init poses, and integrating from the placeholder
+        configuration explodes PhysX (coincident bodies at the robot
+        base). A failed or non-landing restart returns
+        ``{"status": "error"}`` rather than leaving the episode silently
+        frozen.
+
         Parameters
         ----------
         scene_path : str
@@ -2281,6 +2294,77 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                             robot.name,
                             e,
                         )
+
+                # Restart the timeline (#1820). Every dynamic prim realized
+                # above stopped it (`_construct_shape_prim`, #159) and
+                # nothing else restarts it, so without this the ENTIRE
+                # episode runs on frozen physics: `SimulationContext.step`
+                # only integrates when `is_playing()` -- `world.step()`
+                # renders with stale joint reads, `send_action` targets a
+                # view that never integrates -- and every envelope still
+                # reports success, so the eval reads green with a
+                # motionless robot (measured: 5-episode groot evals at
+                # success_rate=0.00 with byte-similar videos).
+                #
+                # `world.play()` rather than `timeline.play()`: on 6.0.x a
+                # bare `timeline.play()` only QUEUES the state change, and
+                # the headless step path (`world.step(render=False)`) never
+                # runs the app update that would land it -- measured live
+                # (Isaac 6.0 / L4): `is_playing()` still False after
+                # play() + 5 world.steps, joints frozen. `world.play()` is
+                # play + `timeline.commit()` + one app update issued with
+                # `/app/player/playSimulations` DISABLED, so the state
+                # lands synchronously and, critically, NO physics
+                # integrates on the landing tick: the objects realized
+                # above still sit at their MJCF *placeholder* poses (LIBERO
+                # encodes real per-episode poses in BDDL init states, not
+                # in body attributes -- coincident bodies inside the robot
+                # base), and integrating even one tick from that
+                # configuration storms PhysX "Illegal BroadPhaseUpdateData
+                # - non-finite bounds" and NaNs the joint state. That is
+                # also why there is deliberately NO settle step here:
+                # `LiberoAdapter._apply_object_pose_state` teleports the
+                # objects to their episode init poses and owns the settle.
+                #
+                # Ordering: play comes AFTER the STOP-event flush +
+                # `initialize_physics()` + `articulation.initialize()`
+                # above -- the stop -> rebuild -> re-init -> play cycle was
+                # verified live (Isaac 6.0 / L4) to preserve articulation
+                # state, whereas playing before the flush lets the queued
+                # STOP handlers null the freshly-built handles.
+                #
+                # A failure is FATAL, not a warning: warn-and-continue here
+                # reproduces the exact silent-frozen-physics defect this
+                # block fixes (AGENTS.md: never warn-and-continue if the
+                # system will behave unexpectedly).
+                try:
+                    self._world.play()
+                except (AttributeError, RuntimeError, TypeError, ValueError) as e:
+                    msg = (
+                        f"load_scene: restarting the timeline after realizing scene objects "
+                        f"failed ({type(e).__name__}: {e}). The timeline was stopped by the "
+                        f"dynamic-prim constructors (#159), so physics would stay FROZEN for "
+                        f"the whole episode while every action reports success (#1820). "
+                        f"Refusing to continue."
+                    )
+                    logger.error("IsaacSimulation.load_scene: %s", msg)
+                    return {"status": "error", "content": [{"text": msg}]}
+                # Verify the play actually landed. Best-effort import: no
+                # omni.timeline means no live Kit session (the CPU unit-test
+                # skeleton), where the #159 stop never ran either.
+                try:
+                    import omni.timeline  # type: ignore[import-not-found]
+                except ImportError:
+                    logger.debug("load_scene: omni.timeline unavailable; skipping timeline-playing verification")
+                else:
+                    if not omni.timeline.get_timeline_interface().is_playing():
+                        msg = (
+                            "load_scene: timeline still stopped after world.play() -- physics "
+                            "would stay FROZEN for the whole episode while every action "
+                            "reports success (#1820). Refusing to continue."
+                        )
+                        logger.error("IsaacSimulation.load_scene: %s", msg)
+                        return {"status": "error", "content": [{"text": msg}]}
 
             logger.info("IsaacSimulation.load_scene: %s", summary)
             return {
@@ -4484,6 +4568,76 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 return {"status": "success", "content": [{"text": "Set joint positions (main)."}]}
             self._action_q.put(_apply)
             return {"status": "success", "content": [{"text": "Set joint positions (queued)."}]}
+
+    def set_robot_pose(
+        self,
+        robot_name: str | None = None,
+        position: list[float] | None = None,
+        orientation: list[float] | None = None,
+    ) -> dict[str, Any]:
+        """Teleport a robot's articulation base to ``(position, orientation)``.
+
+        The scene-alignment counterpart of :meth:`move_object` (#1820): on
+        the MuJoCo backend the robot is part of the scene MJCF, so its base
+        lands wherever the scene author placed it (LIBERO puts
+        ``robot0_base`` at ``(-0.66, 0, 0.912)``); on Isaac the robot is a
+        separately-loaded USD articulation spawned at the origin -- inside
+        the footprint of the scene's origin-anchored static fixtures.
+        ``LiberoAdapter._apply_object_pose_state`` reads the scene's robot
+        base pose and aligns the articulation through this method so live
+        physics doesn't start with the robot interpenetrating a fixture
+        (PhysX "Illegal BroadPhaseUpdateData - non-finite bounds").
+
+        Parameters
+        ----------
+        robot_name : str, optional
+            Robot to move. ``None`` resolves the single robot, mirroring
+            :meth:`send_action`; ambiguous with several robots.
+        position : list[float], optional
+            World position ``[x, y, z]``. ``None`` keeps the current one.
+        orientation : list[float], optional
+            World orientation quaternion ``[w, x, y, z]``. ``None`` keeps
+            the current one.
+
+        Returns
+        -------
+        dict
+            Standard ``{"status", "content"}`` envelope; ``error`` for an
+            unknown/uninitialized robot or a failed pose write.
+        """
+        with self._lock:
+            if not self._world_created or not self._robots:
+                return {"status": "error", "content": [{"text": "No world/robot."}]}
+            if robot_name is None:
+                if len(self._robots) != 1:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"set_robot_pose(robot_name=None) is ambiguous: {len(self._robots)} robots "
+                                    f"present ({sorted(self._robots)}). Pass robot_name explicitly."
+                                )
+                            }
+                        ],
+                    }
+                robot_name = next(iter(self._robots))
+            robot = self._robots.get(robot_name)
+            if robot is None or robot.articulation is None:
+                return {"status": "error", "content": [{"text": f"Robot {robot_name!r} not initialized."}]}
+            try:
+                pos = np.asarray(position[:3], dtype=float) if position is not None else None
+                ori = np.asarray(orientation[:4], dtype=float) if orientation is not None else None
+                robot.articulation.set_world_pose(position=pos, orientation=ori)
+            except (RuntimeError, ValueError, AttributeError, TypeError) as exc:
+                return {
+                    "status": "error",
+                    "content": [{"text": f"set_robot_pose failed: {type(exc).__name__}: {exc}"}],
+                }
+            return {
+                "status": "success",
+                "content": [{"text": f"Robot {robot_name!r} base moved to {position or 'same'}."}],
+            }
 
     def move_object(
         self,

--- a/tests/benchmarks/libero/test_isaac_object_pose_state.py
+++ b/tests/benchmarks/libero/test_isaac_object_pose_state.py
@@ -1,0 +1,250 @@
+"""Object-pose init-state branch of :class:`LiberoAdapter` (#1820, Isaac).
+
+``IsaacSimulation.load_scene`` realizes LIBERO scene objects at their MJCF
+*placeholder* body poses - LIBERO encodes the real per-episode poses in BDDL
+init states (flat ``[time, qpos, qvel]`` vectors), which the MuJoCo backend
+applies by writing ``data.qpos`` (``_apply_init_state_branch``). Isaac has
+no engine ``qpos``, so before #1820 the init state was silently skipped and
+live physics started from coincident, robot-interpenetrating placeholder
+poses - PhysX "Illegal BroadPhaseUpdateData - non-finite bounds" storms the
+moment the timeline integrates.
+
+These tests pin ``_apply_object_pose_state`` (reached through the public
+``_apply_canonical_state`` entry when the sim exposes no compiled MuJoCo
+model): the init state is decoded through a LOCAL CPU MuJoCo compile of the
+scene MJCF and applied per named object via ``sim.move_object``:
+
+* dynamic (free-jointed) objects are teleported to ``xpos + R(xquat) @
+  offset`` (the realized prim sits at the body's collision-AABB centre,
+  not the body origin);
+* static fixtures are left alone (no free joint - qpos cannot move them on
+  MuJoCo either);
+* the robot base is aligned with the scene's ``robot0_base`` body via
+  ``sim.set_robot_pose`` (Isaac spawns the USD robot at the origin, inside
+  the footprint of the scene's origin-anchored static fixtures);
+* row selection matches ``_apply_init_state_branch`` (episode 0 pinned to
+  row 0, episodes 1+ RNG-sampled; ``_episode_count`` increments);
+* width mismatches and failed teleports raise (an object left at its
+  placeholder pose WILL explode live physics - warn-and-continue is the
+  silent failure mode this branch removes);
+* missing preconditions (no init states / no scene file / no
+  ``move_object`` / no ``mujoco``) degrade to a debug-log skip, preserving
+  the graceful-degradation contract for arbitrary model-less sims.
+
+CPU-only: the decode is plain ``mujoco`` (no Isaac Sim), the sim is a stub.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from strands_robots.benchmarks.libero import LiberoAdapter
+from strands_robots.simulation.base import SimEngine
+
+pytest.importorskip("mujoco")
+
+PICK_CUBE_BDDL = """
+(define (problem libero_spatial_pick_cube)
+  (:domain kitchen)
+  (:language "pick up the red cube and place it on the plate")
+  (:objects cube_1 plate_1 table_1 - object)
+  (:init (on cube_1 table_1))
+  (:goal (on cube_1 plate_1)))
+"""
+
+# One static fixture + one free-jointed cube whose collision geom is OFFSET
+# from the body origin (pos="0 0 0.01"), so the prim-pose composition
+# ``xpos + R(xquat) @ offset`` is exercised, not just the translation.
+# The robot0_base body carries the scene's robot base pose (skipped by the
+# scene parser, but read for ``sim.set_robot_pose`` alignment).
+# nq = 7 (one free joint), nv = 6 -> init-state width 1 + 7 + 6 = 14.
+_SCENE_MJCF = """
+<mujoco model="pose_probe">
+  <worldbody>
+    <body name="robot0_base" pos="-0.66 0.0 0.912">
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <body name="fixture_table" pos="0.0 0.0 0.4">
+      <geom type="box" size="0.5 0.5 0.4"/>
+    </body>
+    <body name="cube_1_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.02 0.02 0.02" pos="0 0 0.01"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_ROBOT_BASE_POS = (-0.66, 0.0, 0.912)
+
+# Target pose for the cube's free joint: translated to (0.1, 0.2, 0.9) and
+# rotated +90 deg about x. Free-joint qpos layout: [x y z qw qx qy qz].
+_SQRT_HALF = float(np.sqrt(0.5))
+_TARGET_POS = (0.1, 0.2, 0.9)
+_TARGET_QUAT = (_SQRT_HALF, _SQRT_HALF, 0.0, 0.0)  # wxyz, +90deg about x
+# R(+90deg about x) @ (0, 0, 0.01) = (0, -0.01, 0).
+_EXPECTED_PRIM_POS = (0.1, 0.19, 0.9)
+
+
+def _init_state_row(pos=_TARGET_POS, quat=_TARGET_QUAT) -> list[float]:
+    return [0.0, *pos, *quat, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+class _PoseRecordingSim:
+    """Model-less sim stub recording ``move_object`` / ``set_robot_pose`` /
+    ``step`` calls."""
+
+    def __init__(self, move_status: str = "success", robot_pose_status: str = "success") -> None:
+        self._move_status = move_status
+        self._robot_pose_status = robot_pose_status
+        self.moves: list[tuple[str, list[float], list[float]]] = []
+        self.robot_poses: list[tuple[list[float], list[float]]] = []
+        self.step_calls: list[int] = []
+
+    def move_object(self, *, name: str, position: list[float], orientation: list[float]) -> dict[str, Any]:
+        self.moves.append((name, list(position), list(orientation)))
+        if self._move_status == "error":
+            return {"status": "error", "content": [{"text": "Object not found."}]}
+        return {"status": "success", "content": [{"text": f"'{name}' moved."}]}
+
+    def set_robot_pose(self, *, position: list[float], orientation: list[float]) -> dict[str, Any]:
+        self.robot_poses.append((list(position), list(orientation)))
+        if self._robot_pose_status == "error":
+            return {"status": "error", "content": [{"text": "Robot not initialized."}]}
+        return {"status": "success", "content": [{"text": "Robot base moved."}]}
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        self.step_calls.append(n_steps)
+        return {"status": "success", "content": [{"text": "stepped"}]}
+
+
+@pytest.fixture
+def scene_file(tmp_path):
+    p = tmp_path / "scene.xml"
+    p.write_text(_SCENE_MJCF)
+    return str(p)
+
+
+def _adapter(scene_file: str, init_states: np.ndarray | None) -> LiberoAdapter:
+    return LiberoAdapter.from_text(
+        PICK_CUBE_BDDL,
+        scene_path=scene_file,
+        auto_generate_scene=False,
+        init_states=init_states,
+    )
+
+
+class TestObjectPoseApply:
+    def test_dynamic_object_teleported_to_decoded_pose(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+
+        # Only the free-jointed cube moves; the static fixture keeps its
+        # MJCF pose (qpos cannot move it on MuJoCo either).
+        assert [m[0] for m in sim.moves] == ["cube_1_main"]
+        _, position, orientation = sim.moves[0]
+        np.testing.assert_allclose(position, _EXPECTED_PRIM_POS, atol=1e-9)
+        np.testing.assert_allclose(orientation, _TARGET_QUAT, atol=1e-9)
+        # The robot base is aligned with the scene's robot0_base body:
+        # Isaac spawns the USD robot at the origin, inside the footprint
+        # of the scene's origin-anchored static fixtures.
+        assert len(sim.robot_poses) == 1
+        np.testing.assert_allclose(sim.robot_poses[0][0], _ROBOT_BASE_POS, atol=1e-9)
+        np.testing.assert_allclose(sim.robot_poses[0][1], (1.0, 0.0, 0.0, 0.0), atol=1e-9)
+        # Settle runs AFTER the teleports (settling at placeholder poses is
+        # the part-2 explosion) and the episode counter advances so the
+        # next episode gets RNG-sampled selection.
+        assert sim.step_calls == [5]
+        assert adapter._episode_count == 1
+
+    def test_episode_zero_pins_row_zero_then_rng_samples(self, scene_file) -> None:
+        rows = np.array(
+            [_init_state_row(), _init_state_row(pos=(0.3, -0.2, 0.7), quat=(1.0, 0.0, 0.0, 0.0))],
+            dtype=np.float64,
+        )
+        adapter = _adapter(scene_file, rows)
+        sim = _PoseRecordingSim()
+
+        # Episode 0: deterministic row 0 regardless of rng.
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(7))
+        np.testing.assert_allclose(sim.moves[0][1], _EXPECTED_PRIM_POS, atol=1e-9)
+
+        # Episode 1: RNG-sampled with the same semantics as the MuJoCo
+        # init-state branch (rng.randint(0, n_states - 1)).
+        rng = random.Random(7)
+        expected_idx = random.Random(7).randint(0, 1)
+        adapter._apply_canonical_state(cast(SimEngine, sim), rng)
+        expected_pos = _EXPECTED_PRIM_POS if expected_idx == 0 else (0.3, -0.2, 0.7 + 0.01)
+        np.testing.assert_allclose(sim.moves[1][1], expected_pos, atol=1e-9)
+        assert adapter._episode_count == 2
+
+    def test_width_mismatch_raises(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.zeros((1, 5), dtype=np.float64))
+        with pytest.raises(RuntimeError, match="width"):
+            adapter._apply_canonical_state(cast(SimEngine, _PoseRecordingSim()))
+
+    def test_failed_teleport_raises(self, scene_file) -> None:
+        # An object left at its placeholder pose interpenetrates the robot
+        # base and explodes live physics - never warn-and-continue.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        with pytest.raises(RuntimeError, match="cube_1_main"):
+            adapter._apply_canonical_state(cast(SimEngine, _PoseRecordingSim(move_status="error")))
+
+    def test_failed_robot_base_alignment_raises(self, scene_file) -> None:
+        # A robot left inside the scene's origin-anchored fixtures explodes
+        # live physics just like a misplaced object - never warn-and-continue.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        with pytest.raises(RuntimeError, match="robot0_base"):
+            adapter._apply_canonical_state(cast(SimEngine, _PoseRecordingSim(robot_pose_status="error")))
+
+    def test_robotless_scene_skips_base_alignment(self, tmp_path) -> None:
+        # A scene without a robot0_base body applies object poses without
+        # attempting (or requiring) base alignment.
+        scene = _SCENE_MJCF.replace("robot0_base", "not_a_robot_base")
+        p = tmp_path / "scene.xml"
+        p.write_text(scene)
+        adapter = _adapter(str(p), np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.robot_poses == []
+        assert [m[0] for m in sim.moves] == ["cube_1_main"]
+
+
+class TestObjectPoseGracefulDegradation:
+    """Missing preconditions skip (never raise) so arbitrary model-less
+    sims keep hosting the adapter, matching the pre-#1820 contract."""
+
+    def test_skips_without_init_states(self, scene_file) -> None:
+        adapter = _adapter(scene_file, None)
+        sim = _PoseRecordingSim()
+        adapter._apply_canonical_state(cast(SimEngine, sim))
+        assert sim.moves == []
+        assert sim.step_calls == []
+
+    def test_skips_without_scene_file(self, tmp_path) -> None:
+        adapter = _adapter(str(tmp_path / "missing.xml"), np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+        adapter._apply_canonical_state(cast(SimEngine, sim))
+        assert sim.moves == []
+
+    def test_skips_when_sim_lacks_move_object(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+
+        class _NoMove:
+            pass
+
+        adapter._apply_canonical_state(cast(SimEngine, _NoMove()))
+
+    def test_skips_when_mujoco_unimportable(self, scene_file, monkeypatch) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+        monkeypatch.setitem(sys.modules, "mujoco", None)
+        adapter._apply_canonical_state(cast(SimEngine, sim))
+        assert sim.moves == []

--- a/tests/simulation/isaac/test_deferred_physics_and_warmup.py
+++ b/tests/simulation/isaac/test_deferred_physics_and_warmup.py
@@ -212,6 +212,12 @@ def _skeleton_sim(world: _WarmupWorld) -> IsaacSimulation:
     sim._world = world
     sim._sim_time = 0.0
     sim._step_count = 0
+    # _warmup_camera flushes secondary render products when more than one
+    # camera is registered (#1802); a single-camera skeleton keeps that
+    # branch out of these timeline pins.
+    sim._cameras = {}
+    # SimEngine.__del__ -> cleanup() consults _world_created at GC time.
+    sim._world_created = False
 
     def _render(camera_name: str = "default", width=None, height=None):  # noqa: ANN001, ARG001
         if world.camera_ready:

--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -95,6 +95,12 @@ class TestSceneObjectExtraction:
         assert table.position == pytest.approx((1.0, 0.0, 0.01))
         # The body-level quat is preserved as [w, x, y, z].
         assert table.quat == pytest.approx((0.707, 0.0, 0.0, 0.707))
+        # The body-frame AABB-centre offset is recorded (#1820): pose
+        # appliers recompose the prim pose from a NEW body pose as
+        # ``body_pos + R(body_quat) @ offset``, which is unrecoverable
+        # from ``position`` alone once the body moves.
+        assert table.offset == pytest.approx((0.0, 0.0, -0.39))
+        assert table.position == pytest.approx(tuple(p + o for p, o in zip((1.0, 0.0, 0.4), table.offset)))
 
     def test_freejoint_body_is_movable_with_cylinder_aabb(self, objects):
         mug = objects["porcelain_mug_1_main"]

--- a/tests/simulation/isaac/test_load_scene_physics_view.py
+++ b/tests/simulation/isaac/test_load_scene_physics_view.py
@@ -53,6 +53,9 @@ class _RecordingWorld:
     def __init__(self) -> None:
         self.reset_calls = 0
         self.step_calls = 0
+        self.play_calls = 0
+        self.play_raises: Exception | None = None
+        self.events: list[str] = []
         self.physics_sim_view = object()
 
     def reset(self) -> None:
@@ -60,6 +63,12 @@ class _RecordingWorld:
 
     def step(self, render: bool = True) -> None:
         self.step_calls += 1
+
+    def play(self) -> None:
+        self.play_calls += 1
+        self.events.append("play")
+        if self.play_raises is not None:
+            raise self.play_raises
 
 
 class _RecordingArticulation:
@@ -171,3 +180,116 @@ def test_load_scene_no_world_errors(scene_file) -> None:
     result = engine.load_scene(scene_file)
     assert result["status"] == "error"
     assert "no world" in result["content"][0]["text"].lower()
+
+
+# --- Timeline restart (#1820) ------------------------------------------------
+#
+# Every dynamic prim realized by load_scene stops the timeline (#159), and
+# before #1820 nothing restarted it: the whole episode ran on frozen physics
+# (SimulationContext.step only integrates when is_playing(); joint reads went
+# stale; send_action targeted a view that never integrates) while every
+# envelope still reported success. These pins assert the restart contract:
+# ``world.play()`` (NOT a bare ``timeline.play()``, which on 6.0.x only
+# queues the state change and never lands on the headless step path) fires
+# AFTER the articulation re-init, a failed restart is a fatal error envelope
+# (never a silent warn-and-continue), and a fake ``omni.timeline`` that
+# reports the play never landed also fails loud.
+
+
+def test_load_scene_restarts_timeline_after_articulation_reinit(scene_file) -> None:
+    """world.play() fires exactly once, and only after the articulation
+    re-init. Ordering matters: the stop -> flush -> initialize_physics ->
+    articulation.initialize -> play cycle was verified live (Isaac 6.0 / L4)
+    to preserve articulation state; playing earlier lets the queued #159
+    STOP handlers null the freshly-built physics handles."""
+    engine, _ = _make_engine()
+    world = engine._world
+    art = engine._robots["robot"].articulation
+    assert art is not None
+    original_initialize = art.initialize
+
+    def _recording_initialize(physics_sim_view=None) -> None:
+        world.events.append("articulation_initialize")
+        original_initialize(physics_sim_view)
+
+    art.initialize = _recording_initialize  # type: ignore[method-assign]
+
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    assert world.events == ["articulation_initialize", "play"]
+    assert world.play_calls == 1
+
+
+def test_load_scene_play_failure_is_a_fatal_error_envelope(scene_file) -> None:
+    """A failed restart must NOT be warn-and-continue: the timeline was
+    stopped by the dynamic-prim constructors, so continuing runs the whole
+    episode on frozen physics while every action reports success - the
+    exact defect #1820 fixes."""
+    engine, _ = _make_engine()
+    engine._world.play_raises = RuntimeError("kit session torn down")
+
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "FROZEN" in text
+    assert "timeline" in text.lower()
+
+
+def test_load_scene_nonlanding_play_is_a_fatal_error_envelope(scene_file, monkeypatch) -> None:
+    """world.play() returning is not proof the play LANDED: on 6.0.x the
+    timeline state changes on a kit update tick, so load_scene reads
+    ``is_playing()`` back and refuses to hand out a frozen episode."""
+    import sys
+    import types
+
+    fake_timeline_mod = types.SimpleNamespace(
+        get_timeline_interface=lambda: types.SimpleNamespace(is_playing=lambda: False)
+    )
+    fake_omni = types.ModuleType("omni")
+    fake_omni.timeline = fake_timeline_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "omni", fake_omni)
+    monkeypatch.setitem(sys.modules, "omni.timeline", fake_timeline_mod)  # type: ignore[arg-type]
+
+    engine, _ = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "error"
+    assert "still stopped" in result["content"][0]["text"]
+
+
+def test_load_scene_playing_verification_passes(scene_file, monkeypatch) -> None:
+    """The happy live path: play lands, is_playing() confirms, load succeeds."""
+    import sys
+    import types
+
+    fake_timeline_mod = types.SimpleNamespace(
+        get_timeline_interface=lambda: types.SimpleNamespace(is_playing=lambda: True)
+    )
+    fake_omni = types.ModuleType("omni")
+    fake_omni.timeline = fake_timeline_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "omni", fake_omni)
+    monkeypatch.setitem(sys.modules, "omni.timeline", fake_timeline_mod)  # type: ignore[arg-type]
+
+    engine, calls = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    assert engine._world.play_calls == 1
+    assert calls.added == ["fixture_table", "cube_1_main"]
+
+
+def test_load_scene_missing_omni_timeline_skips_verification(scene_file, monkeypatch) -> None:
+    """Without omni.timeline there is no live Kit session (the CPU
+    skeleton, where the #159 stop never ran either): world.play() is still
+    issued, but the is_playing() read-back is skipped."""
+    import sys
+    import types
+
+    fake_omni = types.ModuleType("omni")
+    monkeypatch.setitem(sys.modules, "omni", fake_omni)
+    # A None sys.modules entry makes ``import omni.timeline`` raise ImportError.
+    monkeypatch.setitem(sys.modules, "omni.timeline", None)  # type: ignore[arg-type]
+
+    engine, calls = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    assert engine._world.play_calls == 1
+    assert calls.added == ["fixture_table", "cube_1_main"]

--- a/tests_integ/simulation/test_isaac_scene_physics_gpu.py
+++ b/tests_integ/simulation/test_isaac_scene_physics_gpu.py
@@ -1,0 +1,181 @@
+"""GPU-gated integration: load_scene leaves physics LIVE, not frozen (#1820).
+
+The frozen-physics regression gate. ``IsaacSimulation.load_scene`` realizes
+LIBERO dynamic objects via constructors that stop the timeline (#159), and
+before #1820 nothing restarted it: the whole episode rendered without
+integrating physics - joint reads went stale, ``send_action`` targeted a
+view that never integrates, and every envelope still reported success, so a
+5-episode groot eval read green with a motionless robot. The eval-level
+signals (state keys present, no PhysX errors) were all satisfiable without
+integration, which is exactly how the defect shipped; this test asserts the
+one thing frozen physics cannot fake: a joint-target ``send_action`` after
+``load_scene`` measurably changes the joint state.
+
+Also pins part 2 of #1820: the scene MJCF places dynamic objects at
+*placeholder* poses (LIBERO's real per-episode poses live in BDDL init
+states), so the objects are teleported to legal poses via ``move_object``
+(the engine half of ``LiberoAdapter._apply_object_pose_state``) BEFORE the
+first integrating step, and the articulation must stay finite afterwards -
+no "Illegal BroadPhaseUpdateData - non-finite bounds" NaN storm.
+
+Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ tests_integ/simulation/test_isaac_scene_physics_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+# The isaac subpackage import itself is CPU-safe (heavy omni/isaacsim imports
+# are lazy, deferred to create_world()); importorskip guards against a
+# broken/partial install rather than the Isaac Kit runtime.
+pytest.importorskip("strands_robots.simulation.isaac")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+# A LIBERO-shaped scene: one static fixture plus two dynamic bodies at
+# COINCIDENT placeholder poses (the measured libero_spatial pattern - both
+# bowls at [0, -0.1, 0.02], inside the robot base footprint). Faithful to
+# the defect: integrating from this configuration is what exploded PhysX.
+_SCENE_MJCF = """
+<mujoco model="frozen_physics_probe">
+  <worldbody>
+    <body name="fixture_table" pos="0.6 0.0 0.4">
+      <geom type="box" size="0.3 0.3 0.4" group="0"/>
+    </body>
+    <body name="bowl_1_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.03 0.03 0.02" group="0"/>
+    </body>
+    <body name="bowl_2_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.03 0.03 0.02" group="0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# Where the "init state" puts the dynamic bodies: resting on the fixture,
+# clear of the robot and of each other.
+_LEGAL_POSES = {
+    "bowl_1_main": [0.55, -0.12, 0.83],
+    "bowl_2_main": [0.55, 0.12, 0.83],
+}
+
+_PROBE_JOINT = "panda_joint2"
+_PROBE_DELTA = 0.3
+_MIN_MOTION = 0.05
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+def _add_franka(sim) -> None:
+    try:
+        from isaacsim.storage.native import get_assets_root_path
+    except ImportError:
+        from omni.isaac.nucleus import get_assets_root_path
+    assets_root = get_assets_root_path()
+    if not assets_root:
+        pytest.skip("No Isaac assets root (Nucleus/CDN) reachable for the Franka USD")
+    r = sim.add_robot("robot", usd_path=f"{assets_root}/Isaac/Robots/FrankaRobotics/FrankaPanda/franka.usd")
+    if r["status"] != "success":
+        r = sim.add_robot("robot", usd_path=f"{assets_root}/Isaac/Robots/Franka/franka.usd")
+    assert r["status"] == "success", f"add_robot: {r}"
+
+
+def _joint_positions(sim) -> dict[str, float]:
+    obs = sim.get_observation("robot", skip_images=True)
+    joints = {k: v for k, v in obs.items() if isinstance(v, float)}
+    assert joints, f"observation carries no joint keys: {sorted(obs)}"
+    return joints
+
+
+def _assert_actions_integrate(sim, label: str) -> None:
+    """The frozen-physics gate: a joint-target send_action must move the
+    articulation. Under a stopped timeline this probe measures ~0 motion
+    while every envelope still reports success (the #1820 diagnosis probe).
+    """
+    q0 = _joint_positions(sim)
+    assert _PROBE_JOINT in q0, f"{label}: probe joint missing from {sorted(q0)}"
+    target = q0[_PROBE_JOINT] + _PROBE_DELTA
+    r = sim.send_action({_PROBE_JOINT: target}, robot_name="robot", n_substeps=30)
+    assert r["status"] == "success", f"{label}: send_action: {r}"
+    q1 = _joint_positions(sim)
+    moved = abs(q1[_PROBE_JOINT] - q0[_PROBE_JOINT])
+    assert moved > _MIN_MOTION, (
+        f"{label}: joint-target send_action moved {_PROBE_JOINT} by only {moved:.6f} rad "
+        f"(> {_MIN_MOTION} required). Physics is FROZEN after load_scene (#1820)."
+    )
+    for name, value in q1.items():
+        assert math.isfinite(value), f"{label}: joint {name} is non-finite ({value}) - PhysX exploded (#1820 part 2)"
+
+
+class TestIsaacScenePhysicsGPU:
+    def test_load_scene_timeline_plays_and_actions_integrate(self, tmp_path):
+        """One Kit boot covers the full per-episode cycle twice (SimulationApp
+        can only boot once per process, so the journeys share a session):
+        load_scene -> timeline playing -> pose teleport -> settle -> probe,
+        then the episode-2 reload of the same scene."""
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+        scene_file = tmp_path / "scene.xml"
+        scene_file.write_text(_SCENE_MJCF)
+
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=True))
+        try:
+            r = sim.create_world()
+            assert r["status"] == "success", f"create_world: {r}"
+            _add_franka(sim)
+            sim.step(2)
+
+            # Sanity: actuation works BEFORE the scene loads (isolates the
+            # regression to load_scene rather than the action path).
+            _assert_actions_integrate(sim, "pre-scene")
+
+            for episode in (1, 2):
+                label = f"episode {episode}"
+                r = sim.load_scene(str(scene_file))
+                assert r["status"] == "success", f"{label}: load_scene: {r}"
+
+                # The timeline must be PLAYING after load_scene: the dynamic
+                # prim constructors stopped it (#159) and load_scene owns the
+                # restart (#1820 part 1).
+                import omni.timeline
+
+                assert omni.timeline.get_timeline_interface().is_playing(), (
+                    f"{label}: timeline stopped after load_scene - the episode would run on frozen physics (#1820)"
+                )
+
+                # Part 2: the dynamic bodies sit at coincident placeholder
+                # poses inside the robot base. Teleport them to legal poses
+                # BEFORE the first integrating step (the engine half of
+                # LiberoAdapter._apply_object_pose_state), then settle.
+                for name, pos in _LEGAL_POSES.items():
+                    r = sim.move_object(name=name, position=pos, orientation=[1.0, 0.0, 0.0, 0.0])
+                    assert r["status"] == "success", f"{label}: move_object({name}): {r}"
+                r = sim.step(5)
+                assert r["status"] == "success", f"{label}: settle step: {r}"
+
+                # The frozen-physics gate + the no-NaN-explosion gate.
+                _assert_actions_integrate(sim, label)
+        finally:
+            sim.destroy()


### PR DESCRIPTION
Closes #1820.

## What changed

Two composing defects kept every Isaac LIBERO eval motionless-but-green; this PR fixes both halves plus the regression gate that lets frozen physics read as success.

### Part 1 - `load_scene` left the timeline stopped (frozen physics)

`load_scene` realizes dynamic objects through constructors that stop the timeline (the #159 deferred-physics guard) and nothing restarted it. `SimulationContext.step` only integrates when `is_playing()`, so the whole episode rendered without physics: stale joint reads, `send_action` targeting a view that never integrates, every envelope still `success`.

Fix (`IsaacSimulation.load_scene`): after the #1802 physics-view rebuild + articulation re-init, restart the timeline via **`world.play()`** - not a bare `timeline.play()`, which on 6.0.x only **queues** the state change and never lands on the headless `step(render=False)` path. Measured live (Isaac 6.0 / L4): `is_playing()` still `False` after `timeline.play()` + 5 `world.step`s; `world.play()` is play + `timeline.commit()` + one app update with `/app/player/playSimulations` disabled, so it lands synchronously **without integrating a tick** (which matters - see part 2). `load_scene` then reads `is_playing()` back; a failed or non-landing restart returns an error envelope instead of handing out a silently frozen episode (never warn-and-continue).

### Part 2 - init-state application on Isaac (previously masked by part 1)

The realized objects sit at MJCF **placeholder** poses - LIBERO encodes real per-episode poses in BDDL init states, which only the MuJoCo backend applied (qpos vectors in `_apply_canonical_state`). With the timeline actually playing, live physics started from coincident dynamic bodies inside the robot base and stormed PhysX `Illegal BroadPhaseUpdateData - non-finite bounds` into NaN joint state.

Fix (`LiberoAdapter`): `_apply_canonical_state` now routes model-less backends to a new `_apply_object_pose_state` branch:

- decode the init state through a **local CPU MuJoCo compile** of the scene MJCF (`mujoco` is always importable on the LIBERO path - the scene itself was generated through robosuite). Same row-selection (episode 0 pinned to row 0, episodes 1+ RNG-sampled) and width-validation (fatal on mismatch, #168 bug I) semantics as the MuJoCo branch;
- teleport each free-jointed prim via `move_object` to `xpos + R(xquat) @ offset` - the prim sits at the body's collision-AABB centre, so the body-frame offset is now recorded on `SceneObject.offset` (`loaders.py`);
- align the robot base with the scene's `robot0_base` body via a new **`IsaacSimulation.set_robot_pose`**: on MuJoCo the robot is part of the scene MJCF (LIBERO: base at `(-0.66, 0, 0.912)`); on Isaac the USD articulation spawns at the origin, inside the footprint of the scene's origin-anchored static fixtures (cabinet, stove) - the other half of the broadphase storm;
- failed teleports/alignment **raise** (an object left at its placeholder pose explodes live physics - warn-and-continue is exactly the silent failure mode this removes); missing preconditions (no init states / scene / `move_object` / `mujoco`) keep the graceful debug-skip contract for arbitrary model-less sims;
- the settle step runs **after** the poses are legal (settling at placeholder poses is the part-2 explosion; `load_scene` deliberately does not step).

### Part 3 - regression gate

`tests_integ/simulation/test_isaac_scene_physics_gpu.py` pins the one thing frozen physics cannot fake: after `load_scene` (twice - the episode-2 reload included) the timeline is playing and a joint-target `send_action` measurably moves the articulation, with every joint finite. The scene fixture reproduces the measured defect shape (two dynamic bodies coincident at `[0, -0.1, 0.02]`).

## Test surface

- **GPU integ (ran on this branch, Isaac Sim 6.0 / L4):** `test_isaac_scene_physics_gpu.py` **passed** - pre-scene actuation sanity, then per episode: `load_scene` -> timeline playing -> pose teleport -> settle -> joint-target probe moves `panda_joint2` > 0.05 rad, all joints finite.
- **CPU unit (new/extended):**
  - `test_load_scene_physics_view.py` +5: `world.play()` fires exactly once and only after articulation re-init; play failure and non-landing play are fatal error envelopes; missing `omni.timeline` (CPU skeleton) skips verification.
  - `test_isaac_object_pose_state.py` (new, 10 tests): decoded pose composition incl. rotation of the AABB offset, static fixtures untouched, robot base alignment, episode-0-pins-row-0 selection parity, width-mismatch/failed-teleport/failed-alignment raise, 4 graceful-degradation skips.
  - `test_description_loader_geometry.py`: `SceneObject.offset` recorded and consistent with `position`.
- **Full suite:** `hatch run lint` clean; `hatch run test` = 15623 passed, 3 failed - the 3 failures (`test_deferred_physics_and_warmup.py::TestWarmupCameraResumesTimeline`) fail **identically on unmodified `upstream/main`** in this environment (verified by running the same suite on a clean base worktree), i.e. pre-existing/environmental, not from this diff.

## End-to-end verification (Isaac Sim 6.0, 4x L4)

| run | before | after |
|---|---|---|
| `run_isaac.py --policy mock --n-episodes 2` | frozen physics, green eval; naive play() -> broadphase storm | completes both episodes, **0** `Illegal BroadPhaseUpdateData`, **0** invalid-transform warnings |
| `run_isaac.py --policy groot --n-episodes 5 --auto-server` (composed locally with #1819's controller) | motionless robot, byte-similar videos | **visibly moving robot** (sustained inter-frame motion in the rollout video), measured `success_rate=0.00`, exit 0, **0** PhysX errors |

The groot run completes #1812's last acceptance criterion at the *mechanism* level: actions actuate on live physics through the full `evaluate_benchmark` path. Task success itself is now a policy/scene-fidelity question (LIBERO objects are box-primitive approximations on Isaac), not a frozen-physics one.

Note on #1819 (merged to `main` at 2026-07-31T14:50Z, while this branch was in flight): it touches the same files (`simulation.py`, `adapter.py`). Per AGENTS.md's semantic-conflict rule I verified the composition locally BEFORE it landed: merged `feat/isaac-delta-eef-action-controller` into this branch, re-ran `tests/simulation/isaac tests/benchmarks/libero` (803 passed, same 3 pre-existing env failures), and the groot end-to-end run below was executed on that composition - i.e. on exactly the tree this PR + current `main` produce.

## Acceptance criteria (from #1820)

- [x] After `load_scene`, the timeline is playing and a joint-target `send_action` moves the articulation (GPU integ test).
- [x] Scene objects rest at their episode init poses; no interpenetration with the robot; no `Illegal BroadPhaseUpdateData` storms (mock + groot runs, 0 occurrences).
- [x] `run_isaac.py --policy groot --n-episodes 5` produces a visibly moving robot and a measured success_rate (verified on the local composition with #1819; lands fully once both PRs merge).

## Out of scope / follow-ups

- **Robot arm qpos parity**: the init-state vector also carries the LIBERO Panda "ready" arm pose; on Isaac the arm still starts at the USD default. Mapping robosuite joint names (`robot0_joint1`) to USD articulation names (`panda_joint1`) needs a robust convention - follow-up issue rather than feature creep here.
- **Static fixture poses**: LIBERO's generated scenes anchor fixtures (cabinet/stove) at the origin below the table on MuJoCo too; realized identically on Isaac. Cosmetic parity only, no physics impact after base alignment.

Project board: please move #1820 to "In review" (or it will follow the automation on merge).
