### PR TITLE
fix(sim): the finalizer reports only a real cleanup failure, on every engine (closes #1826)

### DIFF
--- a/changelog.d/1826-finalizer-report-means-what-it-says.md
+++ b/changelog.d/1826-finalizer-report-means-what-it-says.md
@@ -1,0 +1,23 @@
+### Fixed: the finalizer reports only a real cleanup failure, on every engine
+
+`SimEngine.__del__` called `cleanup()` on any instance, so on one whose
+`__init__` never finished it reported whichever attribute construction had not
+reached yet as a cleanup failure. A plain caller typo reached this:
+`IsaacSimulation(headles=False)` raised the intended `TypeError` and then, on
+collection, also logged `Cleanup error during __del__: 'IsaacSimulation' object
+has no attribute '_world_created'` - a second message naming an attribute the
+failure does not turn on. `MuJoCoSimEngine` avoided that noise by overriding
+`__del__` to swallow every exception silently, which also discarded real
+failures, so the base class's own guarantee that a cleanup failure is logged did
+not hold for the default backend. Concrete engines now declare
+`self._init_complete = True` as the final statement of `__init__` and the shared
+finalizer skips an instance that never acquired anything, rather than calling
+`cleanup()` and silencing whatever it raises; the MuJoCo override is gone.
+
+`IsaacSimulation.__repr__` no longer raises on such an instance. It is what a
+traceback or a failing assertion renders, and `[AttributeError ... raised in
+repr()]` was actively misdirecting: it named `_world_created` for a failure whose
+real cause was a missing `_cameras`. It now reports the lifecycle fact and names
+no attribute. `IsaacSimulation.cleanup`'s docstring no longer claims the class
+has no `__del__` finalizer - it inherits one, and its reasons are reasons not to
+*rely* on garbage collection.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -313,7 +313,24 @@ class SimEngine(ABC):
 
         # Cleanup
         sim.destroy()
+
+    Concrete engines must set ``self._init_complete = True`` as the final
+    statement of their ``__init__``. :meth:`__del__` consults it and skips an
+    instance that never finished construction, so a half-built engine is never
+    reported as a cleanup failure.
     """
+
+    # Whether ``__init__`` ran to completion, i.e. whether this instance holds
+    # engine resources that need releasing. :meth:`__del__` reads it to tell
+    # "never acquired anything" from "failed to release something": on a
+    # ``__new__`` skeleton, or an ``__init__`` that raised part-way, the class
+    # attribute below answers False and the finalizer skips ``cleanup()``
+    # instead of reporting whichever attribute ``__init__`` had not reached yet
+    # as a cleanup failure. Declared on the class rather than assigned in an
+    # ABC ``__init__`` so the read itself can never raise, and so lightweight
+    # subclasses and test doubles need not thread ``super().__init__()``
+    # through (the same constraint :meth:`_init_ros_bridge` documents).
+    _init_complete: bool = False
 
     def _init_ros_bridge(self, *, ros2_bridge: bool = False, ros2_domain: int = 0) -> None:
         """Initialize the optional ROS 2 telemetry bridge state.
@@ -3719,7 +3736,14 @@ class SimEngine(ABC):
         }
 
     def cleanup(self) -> None:
-        """Release all resources. Called on __del__ / context exit."""
+        """Release all resources.
+
+        Called on context exit, and best-effort from :meth:`__del__` for an
+        engine whose ``__init__`` ran to completion. Implementations are
+        written against a fully-constructed instance: a caller whose
+        ``__init__`` raised part-way must release whatever it acquired itself
+        rather than relying on the finalizer.
+        """
         pass
 
     def __enter__(self) -> SimEngine:
@@ -3729,6 +3753,13 @@ class SimEngine(ABC):
         self.cleanup()
 
     def __del__(self) -> None:
+        if not self._init_complete:
+            # ``__init__`` never finished, so this instance holds no engine
+            # resources. Calling cleanup() here would raise on whichever
+            # attribute ``__init__`` had not reached yet and report that name
+            # as a cleanup failure - noise indistinguishable from a real leak,
+            # and a red herring for whoever reads it.
+            return
         try:
             self.cleanup()
         except Exception as e:

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -727,6 +727,10 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             config.headless,
         )
 
+        # Construction complete - the finalizer may now release what we hold.
+        # See SimEngine._init_complete: this must be the final statement.
+        self._init_complete = True
+
     def _on_main_thread(self) -> bool:
         return threading.get_ident() == self._main_tid
 
@@ -5403,13 +5407,14 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         """Release all resources.
 
         Callers must invoke this explicitly (or use the class as a context
-        manager). There is intentionally no ``__del__`` finalizer: at
-        interpreter shutdown the ``threading`` / ``logger`` / ``omni``
-        modules can already be partially torn down, and acquiring
-        ``self._lock`` from a finalizer is unsafe. Relying on GC for
-        Isaac Sim cleanup also leaks the ``World``/USD stage on the
-        common case where the GC scheduler defers the finalizer past
-        the SimulationApp shutdown.
+        manager). Do not rely on garbage collection: at interpreter shutdown
+        the ``threading`` / ``logger`` / ``omni`` modules can already be
+        partially torn down, acquiring ``self._lock`` from a finalizer is
+        unsafe, and a GC scheduler that defers the finalizer past the
+        ``SimulationApp`` shutdown leaks the ``World``/USD stage. The
+        inherited :meth:`~strands_robots.simulation.base.SimEngine.__del__`
+        is a best-effort last resort for a fully-constructed engine, not the
+        intended path.
         """
         if self._world_created:
             self.destroy()
@@ -5421,10 +5426,23 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         self.cleanup()
 
     def __repr__(self) -> str:
-        return (
-            f"IsaacSimulation("
-            f"num_envs={self._config.num_envs}, "
-            f"device={self._config.device!r}, "
-            f"headless={self._config.headless}, "
-            f"world={'created' if self._world_created else 'none'})"
-        )
+        """Describe this engine, without ever raising.
+
+        ``repr`` is what a traceback or a failing assertion renders, so it must
+        not be the thing that hides a failure. On an instance whose ``__init__``
+        never finished, reading ``self._config`` raises and the reader is shown
+        ``[AttributeError ... raised in repr()]`` naming an attribute that has
+        nothing to do with the failure under investigation. Report the
+        lifecycle fact that *is* relevant instead, and name no attribute so
+        nobody is sent chasing one.
+        """
+        try:
+            return (
+                f"IsaacSimulation("
+                f"num_envs={self._config.num_envs}, "
+                f"device={self._config.device!r}, "
+                f"headless={self._config.headless}, "
+                f"world={'created' if self._world_created else 'none'})"
+            )
+        except AttributeError:
+            return f"IsaacSimulation(partially constructed, id=0x{id(self):x})"

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -362,6 +362,10 @@ class MuJoCoSimEngine(
         self._mj = _ensure_mujoco()
         logger.info("MuJoCo simulation tool '%s' initialized", tool_name)
 
+        # Construction complete - the finalizer may now release what we hold.
+        # See SimEngine._init_complete: this must be the final statement.
+        self._init_complete = True
+
     # Public Properties - read-only introspection.
     # WARNING: callers MUST NOT mutate the returned objects without holding
     # self._lock. Prefer using action methods which serialize automatically.
@@ -5101,12 +5105,6 @@ class MuJoCoSimEngine(
 
     def __exit__(self, *exc: object) -> None:
         self.cleanup()
-
-    def __del__(self) -> None:
-        try:
-            self.cleanup()
-        except Exception:
-            pass
 
 
 # Backward-compatible aliases (PR #85 shipped as ``Simulation``)

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -237,6 +237,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         logger.info("Newton simulation engine initialised (solver=%s)", self._solver_name)
 
+        # Construction complete - the finalizer may now release what we hold.
+        # See SimEngine._init_complete: this must be the final statement.
+        self._init_complete = True
+
     # World lifecycle
 
     def create_world(

--- a/tests/simulation/test_finalizer_reports_only_real_cleanup_failures.py
+++ b/tests/simulation/test_finalizer_reports_only_real_cleanup_failures.py
@@ -53,14 +53,25 @@ def _cleanup_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
 class _Engine(SimEngine):
     """Minimal concrete engine that records whether ``cleanup`` was reached.
 
-    Mirrors a real backend's lifecycle: ``_init_complete`` is the final
-    statement of ``__init__``, so the finalizer treats it as owning resources.
+    Mirrors a real backend's lifecycle: ``_init_complete`` is assigned as the
+    final statement of ``__init__``, so the finalizer treats a fully
+    constructed instance as owning resources.
+
+    Args:
+        cleanup_raises: Make ``cleanup`` fail, standing in for an engine that
+            acquired something and could not release it.
+        declare_complete: Assign the sentinel. ``False`` leaves it unassigned,
+            which is what a real backend looks like when ``__init__`` raises
+            before reaching its final statement: every earlier field is set and
+            the sentinel never is, so the class-level floor is what the
+            finalizer reads.
     """
 
-    def __init__(self, *, cleanup_raises: bool = False) -> None:
+    def __init__(self, *, cleanup_raises: bool = False, declare_complete: bool = True) -> None:
         self.cleanup_calls = 0
         self._cleanup_raises = cleanup_raises
-        self._init_complete = True
+        if declare_complete:
+            self._init_complete = True
 
     def cleanup(self) -> None:
         self.cleanup_calls += 1
@@ -151,21 +162,21 @@ class TestNothingIsReportedForAnEngineThatNeverAcquiredAnything:
     def test_an_engine_that_never_declares_construction_complete_is_not_finalized(self) -> None:
         """The flag is the contract, and it is opt-in.
 
-        A subclass that never sets it is treated as never having acquired
-        anything. The parity check below is what holds this package's own
-        engines to declaring it.
+        An engine that never sets it is treated as never having acquired
+        anything, however far its ``__init__`` otherwise got. The parity check
+        below is what holds this package's own engines to declaring it.
         """
         calls: list[int] = []
 
-        class _NeverComplete(_Engine):
-            def __init__(self) -> None:
-                self._cleanup_raises = False
-                self.cleanup_calls = 0
-
+        class _Recording(_Engine):
             def cleanup(self) -> None:
                 calls.append(1)
 
-        engine = _NeverComplete()
+        engine = _Recording(declare_complete=False)
+        # Never assigned, rather than assigned False: the read resolves to the
+        # class-level floor, which is the state a backend is left in when
+        # ``__init__`` raises before its final statement.
+        assert "_init_complete" not in vars(engine)
         del engine
         gc.collect()
         assert calls == []

--- a/tests/simulation/test_finalizer_reports_only_real_cleanup_failures.py
+++ b/tests/simulation/test_finalizer_reports_only_real_cleanup_failures.py
@@ -1,0 +1,374 @@
+"""The finalizer's report must mean what it says, on every engine.
+
+Two halves of one contract were already agreed in the tree, each pinned in a
+place that could not see the other:
+
+* a partially-built engine must **not** log a cleanup error during ``__del__``
+  (pinned for Newton in ``tests/simulation/newton``), and
+* a genuine cleanup failure **must** be logged (pinned for the base facade in
+  ``tests/simulation``).
+
+Neither held everywhere. ``SimEngine.__del__`` called ``cleanup()`` on any
+instance, so on one that never finished ``__init__`` it reported whichever
+attribute construction had not reached yet as a cleanup failure - noise
+indistinguishable from a real leak, and a red herring for whoever read it.
+``MuJoCoSimEngine`` avoided that noise by overriding ``__del__`` to swallow
+every exception silently, which also discarded real failures, so the base
+class's own pinned guarantee did not hold for the default backend. And
+``IsaacSimulation.__repr__`` raised on such an instance, so a traceback or a
+failing assertion rendered ``[AttributeError ... raised in repr()]`` naming an
+attribute the failure did not turn on.
+
+These tests pin the contract in both directions: nothing is reported for an
+instance that never acquired anything, everything is reported for one that
+failed to release something, and ``repr`` never raises. The parity check at the
+bottom keeps a future backend from shipping without declaring construction
+complete.
+"""
+
+from __future__ import annotations
+
+import ast
+import gc
+import inspect
+import logging
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+_BASE_LOGGER = "strands_robots.simulation.base"
+_CLEANUP_WARNING = "Cleanup error during __del__"
+
+
+def _cleanup_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Every finalizer cleanup-failure warning captured so far."""
+    return [rec.getMessage() for rec in caplog.records if _CLEANUP_WARNING in rec.getMessage()]
+
+
+class _Engine(SimEngine):
+    """Minimal concrete engine that records whether ``cleanup`` was reached.
+
+    Mirrors a real backend's lifecycle: ``_init_complete`` is the final
+    statement of ``__init__``, so the finalizer treats it as owning resources.
+    """
+
+    def __init__(self, *, cleanup_raises: bool = False) -> None:
+        self.cleanup_calls = 0
+        self._cleanup_raises = cleanup_raises
+        self._init_complete = True
+
+    def cleanup(self) -> None:
+        self.cleanup_calls += 1
+        if self._cleanup_raises:
+            raise RuntimeError("release failed")
+
+    # Abstract surface - none of it is exercised here. The four methods with a
+    # wide parameter list take ``*args``/``**kwargs`` rather than restating the
+    # ABC's signature: they exist only to make the class concrete.
+    def create_world(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def destroy(self) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def reset(self) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def get_state(self) -> dict[str, Any]:
+        return {"sim_time": 0.0, "step_count": 0}
+
+    def add_robot(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def remove_robot(self, name: str) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return []
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return []
+
+    def add_object(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def remove_object(self, name: str) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, skip_images: bool = False) -> dict[str, Any]:
+        return {}
+
+    def send_action(self, action, robot_name=None, n_substeps: int = 1) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def render(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+
+class TestNothingIsReportedForAnEngineThatNeverAcquiredAnything:
+    def test_the_class_attribute_is_the_floor_so_the_read_never_raises(self) -> None:
+        """``__del__`` reads ``_init_complete`` before anything else.
+
+        Declaring it on the class means the read resolves even on an instance
+        whose ``__init__`` never ran, so the finalizer cannot itself raise the
+        AttributeError it exists to stop reporting.
+        """
+        assert SimEngine._init_complete is False
+        assert IsaacSimulation.__new__(IsaacSimulation)._init_complete is False
+
+    def test_a_skeleton_instance_logs_no_cleanup_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        engine = _Engine.__new__(_Engine)
+        with caplog.at_level(logging.WARNING, logger=_BASE_LOGGER):
+            del engine
+            gc.collect()
+        assert _cleanup_warnings(caplog) == []
+
+    def test_a_skeleton_instance_is_not_offered_to_cleanup_at_all(self) -> None:
+        """The finalizer skips, rather than calling ``cleanup`` and silencing it.
+
+        Silencing would also discard a real failure; skipping keeps the channel
+        meaningful. Observing the call count is what tells the two apart.
+        """
+        calls: list[int] = []
+
+        class _Recording(_Engine):
+            def cleanup(self) -> None:
+                calls.append(1)
+
+        engine = _Recording.__new__(_Recording)
+        del engine
+        gc.collect()
+        assert calls == []
+
+    def test_an_engine_that_never_declares_construction_complete_is_not_finalized(self) -> None:
+        """The flag is the contract, and it is opt-in.
+
+        A subclass that never sets it is treated as never having acquired
+        anything. The parity check below is what holds this package's own
+        engines to declaring it.
+        """
+        calls: list[int] = []
+
+        class _NeverComplete(_Engine):
+            def __init__(self) -> None:
+                self._cleanup_raises = False
+                self.cleanup_calls = 0
+
+            def cleanup(self) -> None:
+                calls.append(1)
+
+        engine = _NeverComplete()
+        del engine
+        gc.collect()
+        assert calls == []
+
+
+class TestEverythingIsReportedForAnEngineThatFailedToRelease:
+    def test_a_constructed_engine_is_still_cleaned_up_on_gc(self) -> None:
+        """The safety net must survive the fix - skipping is for skeletons only."""
+        calls: list[int] = []
+
+        class _Recording(_Engine):
+            def cleanup(self) -> None:
+                calls.append(1)
+
+        engine = _Recording()
+        del engine
+        gc.collect()
+        assert calls == [1]
+
+    def test_a_failing_cleanup_on_a_constructed_engine_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        engine = _Engine(cleanup_raises=True)
+        with caplog.at_level(logging.WARNING, logger=_BASE_LOGGER):
+            del engine
+            gc.collect()
+        assert any("release failed" in message for message in _cleanup_warnings(caplog))
+
+
+class TestMuJoCoUsesTheSharedFinalizer:
+    """The default backend must obey the base class's own pinned guarantees.
+
+    It previously overrode ``__del__`` to swallow every exception, so a real
+    cleanup failure had no channel at all - the base facade's pin could not see
+    that because it exercises a direct ``SimEngine`` subclass.
+    """
+
+    def test_a_real_cleanup_failure_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        class _Exploding(MuJoCoSimEngine):
+            def cleanup(self, policy_stop_timeout: float | None = None) -> None:
+                raise RuntimeError("mujoco release failed")
+
+        engine = _Exploding(tool_name="finalizer_probe")
+        with caplog.at_level(logging.WARNING, logger=_BASE_LOGGER):
+            del engine
+            gc.collect()
+        assert any("mujoco release failed" in message for message in _cleanup_warnings(caplog))
+
+    def test_a_skeleton_logs_nothing_and_is_not_offered_to_cleanup(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Its own ``cleanup()`` does raise on a skeleton, so this is the skip.
+
+        Asserting both halves separates "skipped" from "attempted and silenced".
+        """
+        skeleton = MuJoCoSimEngine.__new__(MuJoCoSimEngine)
+        with pytest.raises(AttributeError):
+            skeleton.cleanup()
+
+        calls: list[int] = []
+
+        class _Recording(MuJoCoSimEngine):
+            def cleanup(self, policy_stop_timeout: float | None = None) -> None:
+                calls.append(1)
+
+        engine = _Recording.__new__(_Recording)
+        with caplog.at_level(logging.WARNING, logger=_BASE_LOGGER):
+            del engine
+            gc.collect()
+        assert _cleanup_warnings(caplog) == []
+        assert calls == []
+
+
+class TestIsaacReportsNoBogusCleanupFailure:
+    def test_a_rejected_kwarg_does_not_also_produce_a_cleanup_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A plain caller typo reaches this, with no test skeleton involved.
+
+        ``IsaacSimulation.__init__`` rejects an unknown kwarg deliberately, and
+        that rejection happens before the attributes ``cleanup()`` reads are
+        assigned. The TypeError is the whole story; a second warning naming an
+        unrelated attribute is not part of it.
+        """
+        with caplog.at_level(logging.WARNING, logger=_BASE_LOGGER):
+            try:
+                IsaacSimulation(headles=False)
+            except TypeError as exc:
+                assert "headles" in str(exc)
+            else:
+                pytest.fail("expected IsaacSimulation to reject the unknown kwarg")
+            # The bound exception is dropped when the except clause ends, which
+            # releases the traceback holding the half-built instance.
+            gc.collect()
+        assert _cleanup_warnings(caplog) == []
+
+    def test_a_skeleton_instance_logs_no_cleanup_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        engine = IsaacSimulation.__new__(IsaacSimulation)
+        with caplog.at_level(logging.WARNING, logger=_BASE_LOGGER):
+            del engine
+            gc.collect()
+        assert _cleanup_warnings(caplog) == []
+
+
+class TestIsaacReprNeverHidesAFailure:
+    def test_repr_of_a_half_built_instance_does_not_raise(self) -> None:
+        text = repr(IsaacSimulation.__new__(IsaacSimulation))
+        assert "partially constructed" in text
+
+    def test_repr_of_a_half_built_instance_names_no_attribute(self) -> None:
+        """Naming one sends the reader after a red herring.
+
+        The lifecycle fact is what is relevant; the attribute construction
+        happened to stop before is not.
+        """
+        text = repr(IsaacSimulation.__new__(IsaacSimulation))
+        assert "_config" not in text
+        assert "_world_created" not in text
+        assert "AttributeError" not in text
+
+    def test_repr_still_describes_an_instance_that_has_its_state(self) -> None:
+        """The tolerance must not cost the informative form."""
+        engine = IsaacSimulation.__new__(IsaacSimulation)
+        engine._config = type("_Cfg", (), {"num_envs": 4, "device": "cpu", "headless": True})()
+        engine._world_created = False
+        text = repr(engine)
+        assert "num_envs=4" in text
+        assert "device='cpu'" in text
+        assert "world=none" in text
+
+
+# Structural parity: no backend ships without declaring construction complete.
+
+_SENTINEL = "_init_complete"
+
+
+def _engines_missing_the_sentinel(source: str) -> list[str]:
+    """Names of ``SimEngine`` subclasses in ``source`` that do not declare it.
+
+    A class qualifies when its ``__init__`` does not end with
+    ``self._init_complete = True``. Requiring it *last* is the point: the flag
+    means "every statement of ``__init__`` ran", so an earlier position would
+    let a later fallible step leave it claiming more than happened.
+    """
+    offenders: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        bases = {ast.unparse(base).split(".")[-1] for base in node.bases}
+        if "SimEngine" not in bases:
+            continue
+        init = next(
+            (m for m in node.body if isinstance(m, ast.FunctionDef) and m.name == "__init__"),
+            None,
+        )
+        if init is None:
+            offenders.append(f"{node.name} (no __init__)")
+            continue
+        last = init.body[-1]
+        ok = (
+            isinstance(last, ast.Assign)
+            and len(last.targets) == 1
+            and isinstance(last.targets[0], ast.Attribute)
+            and last.targets[0].attr == _SENTINEL
+            and isinstance(last.value, ast.Constant)
+            and last.value.value is True
+        )
+        if not ok:
+            offenders.append(f"{node.name} (last statement is {ast.unparse(last)[:60]!r})")
+    return offenders
+
+
+def _engine_sources() -> dict[str, str]:
+    """Every ``<backend>/simulation.py`` beside the ABC, keyed by backend."""
+    root = pathlib.Path(inspect.getfile(SimEngine)).parent
+    return {path.parent.name: path.read_text(encoding="utf-8") for path in sorted(root.glob("*/simulation.py"))}
+
+
+class TestEveryBackendDeclaresConstructionComplete:
+    def test_the_known_backends_are_all_scanned(self) -> None:
+        """An empty scan would pass the check below vacuously."""
+        assert {"mujoco", "isaac", "newton"} <= set(_engine_sources())
+
+    @pytest.mark.parametrize("backend", sorted(_engine_sources()))
+    def test_backend_sets_the_sentinel_last_in_init(self, backend: str) -> None:
+        offenders = _engines_missing_the_sentinel(_engine_sources()[backend])
+        assert offenders == [], (
+            f"{backend}: {offenders} - set `self.{_SENTINEL} = True` as the final "
+            f"statement of __init__, or SimEngine.__del__ will treat the engine "
+            f"as holding no resources and skip its cleanup"
+        )
+
+    def test_the_scan_detects_a_planted_omission(self) -> None:
+        """A scanner that silently matches nothing would look like a clean tree."""
+        missing = "class Broken(SimEngine):\n    def __init__(self) -> None:\n        self._world = None\n"
+        not_last = (
+            "class Late(SimEngine):\n"
+            "    def __init__(self) -> None:\n"
+            "        self._init_complete = True\n"
+            "        self._world = None\n"
+        )
+        assert [name.split()[0] for name in _engines_missing_the_sentinel(missing)] == ["Broken"]
+        assert [name.split()[0] for name in _engines_missing_the_sentinel(not_last)] == ["Late"]
+
+    def test_a_compliant_engine_passes_the_scan(self) -> None:
+        compliant = (
+            "class Fine(SimEngine):\n"
+            "    def __init__(self) -> None:\n"
+            "        self._world = None\n"
+            "        self._init_complete = True\n"
+        )
+        assert _engines_missing_the_sentinel(compliant) == []

--- a/tests/simulation/test_simengine_facade_guardrails.py
+++ b/tests/simulation/test_simengine_facade_guardrails.py
@@ -9,7 +9,8 @@ concrete facades on :class:`strands_robots.simulation.base.SimEngine` promise:
 * ``register_benchmark_from_file`` validates its arguments and converts loader
   exceptions into structured error dicts rather than propagating them.
 * ``start_policy`` transparently passes through to ``run_policy``.
-* ``__del__`` swallows (and logs) cleanup failures during GC.
+* ``__del__`` swallows (and logs) cleanup failures during GC for an engine
+  whose ``__init__`` ran to completion.
 
 All run against a pure-Python fake engine - no MuJoCo, no GPU.
 """
@@ -31,6 +32,10 @@ class FakeSim(SimEngine):
     def __init__(self, robots: tuple[str, ...] = ("fake_robot",)) -> None:
         self._joint_names = ["j0", "j1", "j2"]
         self._robots = {name: self._joint_names for name in robots}
+        # A real engine declares construction complete as the final statement of
+        # its __init__, and SimEngine.__del__ skips an instance that has not, so
+        # a double whose finalizer behaviour is asserted has to declare it too.
+        self._init_complete = True
 
     def create_world(self, timestep=None, gravity=None, ground_plane=True):
         return {"status": "success"}


### PR DESCRIPTION
Closes #1826.

## The defect

`SimEngine.__del__` called `cleanup()` on any instance. On one whose `__init__` never finished, `cleanup()` raises on the first attribute construction had not reached yet, and the finalizer reported that name as a cleanup failure. A plain caller typo reaches this — no test scaffolding involved:

```python
>>> IsaacSimulation(headles=False)
TypeError: IsaacConfig.__init__() got an unexpected keyword argument 'headles'. Did you mean 'headless'?
# ... and then, on collection:
Cleanup error during __del__: 'IsaacSimulation' object has no attribute '_world_created'
```

The `TypeError` is the whole story and is exactly what the code intends. The second message names an attribute the failure does not turn on, and it is shaped identically to a genuine resource leak.

`MuJoCoSimEngine` avoided that noise by overriding `__del__` with `except Exception: pass`. That also discarded **real** failures, so the base class's own guarantee — that a cleanup failure is logged — did not hold for the default backend. Its `cleanup()` does raise on a half-built instance, so the override was silencing a symptom rather than removing a cause.

And `IsaacSimulation.__repr__` raised on such an instance, so a traceback or a failing assertion rendered `[AttributeError ... raised in repr()]`. That is not hypothetical: the three failures currently open in `tests/simulation/isaac/test_deferred_physics_and_warmup.py` are caused by a missing `_cameras`, and they render as

```
where _warmup_camera = <[AttributeError("'IsaacSimulation' object has no attribute '_world_created'") raised in repr()] IsaacSimulation object at 0x...>._warmup_camera
```

A reader who trusts the loudest thing on screen looks at `_world_created`.

## Both halves of the contract were already agreed in the tree

Each was pinned in a place that could not see the other:

| pinned | where | holds for |
| --- | --- | --- |
| a partially-built engine must **not** log a cleanup error | `tests/simulation/newton/test_partial_init_teardown.py` | Newton (via `__init__` ordering) |
| a genuine cleanup failure **must** be logged | `tests/simulation/test_simengine_facade_guardrails.py` | a direct `SimEngine` subclass |

The second pin exercises a pure-Python double, which is why it never noticed that MuJoCo's override made the guarantee false for the engine users actually run. And Newton's approach — setting teardown-relevant state first in `__init__` — cannot help an instance that never entered `__init__` at all, which is the reported case.

## The change

One finalizer contract, stated once:

- `SimEngine` declares `_init_complete: bool = False` as a **class** attribute, so `__del__`'s own read can never raise the AttributeError it exists to stop reporting.
- Each concrete engine (MuJoCo, Isaac, Newton) sets `self._init_complete = True` as the final statement of `__init__`.
- `SimEngine.__del__` returns early when it is False: an instance that never acquired anything is skipped, rather than offered to `cleanup()` and then silenced. A constructed engine is still finalized, and a real failure is still logged.
- `MuJoCoSimEngine.__del__` is deleted — the workaround's reason is gone, and keeping it would leave real MuJoCo failures unreported.
- `IsaacSimulation.__repr__` never raises. It reports the lifecycle fact and deliberately names no attribute, so nobody is sent chasing one.
- `IsaacSimulation.cleanup`'s docstring no longer claims the class has no `__del__` finalizer. It inherits one; the hazards it lists are real reasons not to *rely* on garbage collection, and it now says that.

Declared on the class rather than assigned in an ABC `__init__` because `SimEngine` deliberately imposes no base-class constructor contract (`_init_ros_bridge`'s docstring gives that reasoning), so lightweight subclasses need not thread `super().__init__()` through. A parity test holds this package's own engines to declaring it, and the class docstring states it for anyone adding a fourth.

### Rejected alternative

Reading state defensively inside `cleanup()` (`getattr(self, "_world_created", False)`): it trades a visible symptom for an invisible one — a genuinely half-constructed object becomes silently un-cleanable — and it invites the same treatment at each of the ~30 other reads of that attribute.

## Measured

![finalizer report before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/finalizer-report/finalizer_report.png)

Every cell above is read from one probe script run against both trees; the generator asserts each claim against the two JSON dumps before saving.

| scenario | main | this change |
| --- | --- | --- |
| Isaac, caller typo `IsaacSimulation(headles=False)` | `TypeError` **plus** `Cleanup error ... no attribute '_world_created'` | `TypeError` only |
| Isaac, instance that never ran `__init__`, collected | same bogus warning | no warning |
| Isaac, `repr()` of a half-built instance | raises `AttributeError: ... '_config'` | `IsaacSimulation(partially constructed, id=0x…)` |
| MuJoCo, genuine cleanup failure on a constructed engine | **not reported at all** | `Cleanup error during __del__: release failed` |
| MuJoCo, skeleton whose `cleanup()` raises | `cleanup()` called, then silenced (1 call) | skipped, not silenced (0 calls) |
| any engine, constructed + `cleanup()` raises *(control)* | logged | logged — unchanged |
| any engine, constructed + collected *(control)* | `cleanup()` called 1× | `cleanup()` called 1× — unchanged |

Benign `Cleanup error during __del__` warnings per run of `tests/simulation/isaac/`: **4 → 0**. That is the part that matters beyond tidiness — a real leak reported through this channel was already camouflaged by known-benign noise of the same shape.

## Tests

New `tests/simulation/test_finalizer_reports_only_real_cleanup_failures.py` (19 tests) pins the contract in both directions, so "delete the finalizer" does not pass:

- nothing is reported, and `cleanup()` is **not called**, for a skeleton — the call count is what separates *skipped* from *attempted and silenced*;
- a constructed engine is still cleaned up on GC, and a failing cleanup is still logged;
- the production repro (`IsaacSimulation(headles=False)`) produces the `TypeError` and no second message;
- `repr` of a half-built instance does not raise and names no attribute, while an instance that has its state still renders the informative form;
- an AST parity check that every `<backend>/simulation.py` engine sets the sentinel **last** in `__init__`, with a planted-omission meta-test so an empty scan cannot pass vacuously, and a compliant-source control.

`tests/simulation/test_simengine_facade_guardrails.py`'s `FakeSim` now declares `_init_complete` too. A double whose finalizer behaviour is asserted has to model the engine lifecycle it stands in for; the alternative would have been a defensive shim in production.

**Pre-fix proof** (source files reverted to `upstream/main`, tests kept): **13 failed, 6 passed**. The 6 are the over-reach controls and scanner meta-tests — `test_a_constructed_engine_is_still_cleaned_up_on_gc`, `test_a_failing_cleanup_on_a_constructed_engine_is_logged`, `test_repr_still_describes_an_instance_that_has_its_state`, and the three scanner premise/planted-defect tests. They must pass before and after; that they do is what shows the change is not simply removing the finalizer.

## Gate

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` — clean (1007 files formatted, 1004 source files type-checked).
- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` — **15812 passed, 257 skipped, 3 failed in 491.72s**.
- The 3 failures are `tests/simulation/isaac/test_deferred_physics_and_warmup.py::TestWarmupCameraResumesTimeline`, open on `main` (#1823) and fixed by #1824. Verified identical on a pristine tree at the same base: `3 failed in 0.12s`. This change does not affect them — it makes their message honest, which is visible in the artifact above.
- `scripts/check_merge_base_overlap.py` — no overlap; `scripts/assemble_changelog.py --check` — OK.

## Round 2 — 2fa82b59 (tests only, +24/-13 in one file)

Code scanning flagged `py/missing-call-to-init` (error severity) on the fixture for *"an engine that never declares construction complete"*. Fixed at the root rather than annotated, because it was pointing at a real defect in the fixture: `_NeverComplete` re-implemented `_Engine.__init__` minus its final statement, and so also **duplicated** the two field assignments above it. A field added to `_Engine.__init__` would have silently stopped being set in the stand-in, and the copy was the less faithful model — in the production case the sentinel assignment simply never runs while every earlier field is set exactly as usual.

`_Engine.__init__` is parameterised instead (`declare_complete: bool = True`) and the subclass is gone, so the fixture now differs from a fully constructed engine in precisely the one statement under test. The test also asserts the property it was previously only implying:

```python
engine = _Recording(declare_complete=False)
assert "_init_complete" not in vars(engine)
```

Never *assigned*, rather than assigned `False` — the read resolves to the class-level floor, which is the state a backend is left in when `__init__` raises.

Nothing was weakened. The pre-fix proof re-run on this head is **13 failed, 6 passed** — identical to the count above, same 6 controls — and the one test that changed still fails pre-fix at its contract assertion (`assert [1] == []`, line 182) while the new `vars()` assertion at line 178 passes on both trees. An AST scan for "overrides `__init__` while a base in the same file defines one, without calling `super().__init__`" now reports nothing for this file; `py/missing-call-to-init` has no open instance on `main`, so this keeps the package clean of the rule rather than adding the first exception to it.

Gate re-run: `ruff` / `mypy` clean (1007 formatted, 1004 type-checked); `MUJOCO_GL=egl python -m pytest tests -q --no-cov` → **15812 passed, 257 skipped, 3 failed in 497.87s**, the 3 still being the `main` failures above. No production line moved, so the artifact is unchanged.


## Round 3 - 8c70219, base absorption only

No file in this PR's diff changed. `8c70219` merges `main` (8ec55fd) into the branch to pick up #1824, which fixed the three `test_deferred_physics_and_warmup.py` failures this PR's **Gate** section lists as open on `main` (#1823). Those were the only red on this branch, and they could not be cleared by re-running: `pr-and-push.yml` checks out the branch head rather than a merge with the base, so `rerun-failed-jobs` re-ran the same tree and reported the same failure (`1 failed, 6277 passed`). The mechanism is written up in #1830 / #1831.

The merge is clean - `git show --cc 8c70219` is empty. Since #1824 edits `IsaacSimulation`, the same class this PR gives a non-raising `__repr__`, and the two had never been compiled together, the composition was verified locally first: `tests/simulation/isaac` plus this PR's own two test files give **314 passed** against **296 passed** on the base for the same selection, so the merge is +18 and costs nothing. The one failure in that run (`TestMuJoCoUsesTheSharedFinalizer::test_a_real_cleanup_failure_is_logged`) is the absent GL driver in this environment, not the merge: it fails identically on the unmerged branch and passes in CI, which is where the artifact table's MuJoCo row comes from.

Worth noting for the record that the honesty this PR adds is now visible on the fix that landed: with #1824 in, a failing warm-up assertion no longer renders `[AttributeError ... raised in repr()]` over the top of the real message.