### PR TITLE
docs: a red main cannot be cleared by re-running the PRs it blocked (closes #1830)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,45 @@ hatch run format            # ruff check --fix, ruff format
      manual bisect, and an intermediate commit's green is not available to lean
      on. Do not read the intermediate `FAILURE`s as the culprit; they are the
      batching, not a defect.
+   - *And when `main` itself is red, a re-run cannot clear the PRs it blocked.*
+     `pr-and-push.yml` checks out the PR **head commit**, not
+     `refs/pull/N/merge` - the job log reads `HEAD is now at <branch head>` - so
+     a branch's green is a statement about the branch's own tree, which is the
+     reason `Detect an untested overlap with the base branch` has to exist as a
+     separate check. It follows that a fix landing on `main` is invisible to the
+     branch until the branch absorbs it, and
+     `POST /actions/runs/{id}/rerun-failed-jobs` re-uses the head SHA the run
+     recorded, so re-running changes nothing. Measured on #1824, which fixed the
+     three `test_deferred_physics_and_warmup.py` failures open as #1823: #1827
+     and #1829, both re-run after #1824 was on `main`, reported the same single
+     failure (`1 failed, 6287 passed` and `1 failed, 6277 passed`). Merge `main`
+     into the branch and push; there is no cheaper route.
+
+     **That push is free when the merge is conflict-free.** The intuition that
+     it costs the approval is wrong, and the difference is measurable before you
+     push. Two pushes onto #1821, both merges of `main` into an approved branch:
+
+     | push | `git show --cc` | PR diff vs merge base | approval |
+     |---|---|---|---|
+     | `b365d60`, resolved a conflict | 82 lines | changed | dismissed 45s later |
+     | `79cbdad`, clean base merge | 0 lines | identical, `4 files, +158/-7` | survived, still `APPROVED` |
+
+     Dismissal keys on the **PR's own diff**, not on the head SHA changing: a
+     merge that only brings the base forward leaves the diff a reviewer read
+     byte-identical, and nothing is dismissed. A conflict resolution is new,
+     unreviewed text - a combined diff is exactly the text belonging to neither
+     parent - and that is what costs a round. So refreshing an approved branch
+     over a fixed `main` is cheap, and the expensive case is the one worth
+     avoiding structurally, which is what step 3's fragment rule already does for
+     the file every branch used to conflict on.
+
+     Two consequences remain. Merge the fix for a red `main` ahead of the queue
+     rather than alongside it: while it is red nothing on top of it can merge at
+     all, whatever its own state. And do not push the refresh onto a
+     **contributor's** branch - that is the `require_last_push_approval` identity
+     problem below, which is independent of dismissal and does not care that the
+     merge was clean. Ask the contributor to absorb `main` so they stay the last
+     pusher; #1827 was left alone for that reason.
    And before merging, `reviewDecision: APPROVED` alone is not the gate: poll
    `statusCheckRollup.state == SUCCESS` and `mergeStateStatus == CLEAN`
    together, since `reviewDecision` flips before the checks finish.

--- a/changelog.d/1830-red-main-cannot-be-cleared-by-a-rerun.md
+++ b/changelog.d/1830-red-main-cannot-be-cleared-by-a-rerun.md
@@ -1,0 +1,31 @@
+### Docs: a red `main` cannot be cleared from the PRs it blocked by re-running them
+
+A failing check on a PR whose own branch is innocent cannot be cleared by
+re-running it, and the fix that works is cheaper than it looks.
+
+Two mechanisms, both measured while landing #1824 (the fix for the three
+`test_deferred_physics_and_warmup.py` failures open on `main` as #1823).
+`pr-and-push.yml` checks out the PR **head commit**, not `refs/pull/N/merge` -
+the job log reads `HEAD is now at <branch head>` - so a branch's green is a
+statement about the branch's own tree, which is why
+`Detect an untested overlap with the base branch` exists as a separate check.
+And `POST /actions/runs/{id}/rerun-failed-jobs` re-uses the head SHA the run
+recorded, so a fix landing on `main` afterwards is invisible to the re-run:
+#1827 and #1829, both re-run after #1824 was on `main`, reported the same single
+failure (`1 failed, 6287 passed` and `1 failed, 6277 passed`). The branch has to
+absorb `main` and be pushed.
+
+That push is **free when the merge is conflict-free**, contrary to the intuition
+that it spends the approval. Two pushes onto the approved #1821: `b365d60`
+resolved a conflict, showed 82 lines of combined diff under `git show --cc`, and
+its approval was dismissed 45s later; `79cbdad` was a clean base merge, showed 0,
+left the PR's diff versus its merge base byte-identical at `4 files, +158/-7`,
+and the approval survived. Dismissal keys on the PR's own diff, not on the head
+SHA changing - a conflict resolution is new unreviewed text and is what costs a
+round.
+
+Recorded in `AGENTS.md` step 8 with the two consequences: merge a red-`main` fix
+ahead of the queue, since nothing on top of it can merge while it is red; and
+never push the refresh onto a contributor's branch, which is the separate
+`require_last_push_approval` identity problem (#1722) and does not care that the
+merge was clean.


### PR DESCRIPTION
Closes #1830.

## The defect

#1823 left three tests in `tests/simulation/isaac/test_deferred_physics_and_warmup.py` failing on a pristine `main`. Three PRs whose own branches were innocent went red on it - #1821, #1827 (both `APPROVED`) and #1829 - each reading `mergeStateStatus: BLOCKED`. That state is indistinguishable from a defect in the branch.

#1824 fixed the three and is on `main` as 8ec55fd. The instinct is then to re-run the blocked checks. It does not work, and the reason is not visible from the PR.

## Two mechanisms, both measured

**CI tests the branch head, not a merge with the base.** `pr-and-push.yml` checks out the PR head commit rather than `refs/pull/N/merge`; the job log reads `HEAD is now at 2fa82b5`. A branch's green is therefore a statement about *the branch's own tree* - which is exactly why `Detect an untested overlap with the base branch` has to exist as a separate check, a fact the tree relies on but nowhere states.

**`rerun-failed-jobs` re-uses the head SHA the run recorded,** so a fix landing on `main` afterwards is invisible to the re-run:

| PR | approved | re-run after #1824 landed | result |
|---|---|---|---|
| #1827 | yes | yes | `1 failed, 6287 passed` - the same failure |
| #1829 | no | yes | `1 failed, 6277 passed` - the same failure |

The branch has to absorb `main` and be pushed. There is no cheaper route.

## The part I got wrong, and measured instead

My first draft asserted that the refresh push spends the approval, so a red `main` would cost "a re-approval round on every approved PR it blocked". I pushed the refresh onto the approved #1821 to find out, and the approval **survived** - `reviewDecision` still `APPROVED`, no `ReviewDismissedEvent`. An earlier merge push onto that same PR *had* been dismissed 45s later, and the two cases isolate the rule:

| push onto #1821 | `git show --cc` | PR diff vs merge base | approval |
|---|---|---|---|
| `b365d60`, resolved a conflict | 82 lines | changed | dismissed 45s later |
| `79cbdad`, clean base merge | 0 lines | identical, `4 files, +158/-7` | survived, still `APPROVED` |

Dismissal keys on the **PR's own diff**, not on the head SHA changing. A merge that only brings the base forward leaves the diff a reviewer read byte-identical, and nothing is dismissed; a conflict resolution is new unreviewed text - a combined diff is precisely the text belonging to neither parent - and that is what costs a round.

So refreshing an approved branch over a fixed `main` is cheap, and the expensive case is the one already avoided structurally: step 3's fragment rule exists because every branch used to conflict on one anchor in `CHANGELOG.md`, and that rule's stated cost is exactly this dismissal.

## Consequences recorded

- Merge the fix for a red `main` **ahead of** the queue, not alongside it: while it is red nothing on top of it can merge at all, whatever its own state.
- Never push the refresh onto a **contributor's** branch. That is the separate `require_last_push_approval` identity problem (#1722, two bullets below in the same section), which does not care that the merge was clean. #1827 was left alone for the contributor to absorb `main` and stay the last pusher.

## Placement

Step 8 of the PR Workflow, as a fourth `- *And when ...*` bullet after *Before* / *After* / *And on `main` afterwards*. Those three are each "a signal you would trust does not mean what it looks like"; this is the same shape, and it composes with the `require_last_push_approval` paragraph below, which supplies the one cost that is real.

## Gate

- `scripts/assemble_changelog.py --check` - `changelog fragments OK (94 pending)`.
- `tests/test_changelog_format.py`, `tests/test_changelog_fragments.py`, `tests/test_changelog_fragment_gate.py` - 68 passed.
- `tests/test_log_strings_are_ascii.py` - passed.
- `scripts/check_merge_base_overlap.py` - "computed against a base that cannot have invalidated them".

Documentation only, no production line touched. Hyphens, not em-dashes, per #434.

## Round 1 - c2dbfe0 (pre-review correction)

Replaces the original draft's claim in place: the cost paragraph became the measured contrast table above, after the experiment contradicted it. Single commit, no review had been submitted yet.