### PR TITLE
feat(benchmarks/libero): apply the init-state arm qpos on Isaac - map robosuite joint names to the USD articulation (closes #1828)

### DIFF
--- a/changelog.d/1820-isaac-load-scene-frozen-timeline.md
+++ b/changelog.d/1820-isaac-load-scene-frozen-timeline.md
@@ -1,0 +1,41 @@
+### Fixed: Isaac `load_scene` no longer leaves the episode on frozen physics; LIBERO init states now apply on Isaac as object/robot poses
+
+Two composing defects kept every Isaac LIBERO eval motionless-but-green
+(#1820). First, `IsaacSimulation.load_scene` realized dynamic objects through
+constructors that stop the timeline (#159's deferred-physics guard) and
+nothing restarted it, so the whole episode ran on frozen physics:
+`SimulationContext.step` only integrates when `is_playing()`, joint reads
+went stale, `send_action` targeted a view that never integrates - and every
+envelope still reported success. `load_scene` now restarts the timeline after
+the physics-view rebuild via `world.play()` (a bare `timeline.play()` only
+queues the state change on 6.0.x and never lands on the headless
+`step(render=False)` path - measured live: `is_playing()` still `False`
+after `play()` + 5 steps), reads `is_playing()` back, and returns an error
+envelope rather than handing out a silently frozen episode.
+
+Second - previously *masked* by the frozen timeline - the realized objects
+sit at MJCF **placeholder** poses (LIBERO encodes real per-episode poses in
+BDDL init states, which the MuJoCo backend applies as qpos vectors and Isaac
+silently skipped): coincident dynamic bodies inside the robot base, so live
+physics starts from deep interpenetration and storms PhysX "Illegal
+BroadPhaseUpdateData - non-finite bounds" into NaN joint state.
+`LiberoAdapter._apply_canonical_state` now routes model-less backends to a
+new `_apply_object_pose_state` branch: the init state is decoded through a
+local CPU MuJoCo compile of the scene MJCF (same row-selection and
+width-validation semantics as the MuJoCo branch) and applied per named prim
+via `move_object` - composing each free body's `xpos`/`xquat` with the
+prim's body-frame collision-AABB offset, now recorded on
+`SceneObject.offset`. The robot base is aligned with the scene's
+`robot0_base` body through a new `IsaacSimulation.set_robot_pose` (on
+MuJoCo the robot is part of the scene MJCF at `(-0.66, 0, 0.912)`; on Isaac
+the USD articulation spawned at the origin, inside the scene's
+origin-anchored static fixtures). Failed teleports raise rather than
+warn-and-continue, and a settle step runs only *after* the poses are legal.
+
+A GPU integration test (`tests_integ/simulation/test_isaac_scene_physics_gpu.py`)
+pins the gate frozen physics cannot fake: after `load_scene` (twice - the
+episode-2 reload included) the timeline is playing and a joint-target
+`send_action` measurably moves the articulation, with all joints finite.
+Verified end-to-end on Isaac Sim 6.0 / L4: `run_isaac.py --policy mock
+--n-episodes 2` completes both episodes with zero PhysX broadphase errors
+(previously a storm of them).

--- a/changelog.d/1828-isaac-init-state-arm-qpos.md
+++ b/changelog.d/1828-isaac-init-state-arm-qpos.md
@@ -1,0 +1,39 @@
+### Added: the init-state arm qpos now lands on Isaac - robosuite joint names map onto the USD articulation
+
+#1827 (fixing #1820) applies LIBERO init states on the Isaac backend as
+per-object poses plus robot *base* alignment, decoded through a CPU MuJoCo
+compile of the scene MJCF. One slice of the init state was still unapplied:
+the robot **arm qpos** (LIBERO's Panda ready pose `[0, -0.161, 0, -2.444,
+0, 2.227, pi/4]` + gripper). On MuJoCo the full qpos vector lands in one
+write, so the arm starts every episode at the canonical pose the policy's
+training data assumes; on Isaac the USD Franka articulation started at its
+USD default (all-zero, upright), so the first observation was OOD relative
+to the LIBERO training distribution (#1828).
+
+The blocker was naming: the decode model uses robosuite prefixes
+(`robot0_joint1..7` / `gripper0_finger_joint1..2`) while the USD
+articulation names the DOFs `panda_joint1..7` / `panda_finger_joint1..2`,
+and plain suffix matching is ambiguous (`joint1` is a suffix of both
+`panda_joint1` and `panda_finger_joint1`). `LiberoAdapter` now strips its
+`_scene_robot_prefix` / `_scene_gripper_prefix` and maps the bare names
+onto articulation DOFs in the DOF -> scene direction with
+longest-suffix-wins semantics (`panda_finger_joint1` claims
+`finger_joint1` over `joint1`, so `joint1` lands uniquely on
+`panda_joint1`), then writes the mapped values through
+`IsaacSimulation.set_joint_positions` before the settle steps. Ambiguous
+or unmappable scene joints raise BEFORE anything is written - no silent
+partial writes - as do a failed engine write, several registered robots,
+and a robot reporting no DOF names. Robot-less probe scenes and sims
+without the joint-write seam (`set_joint_positions` / `robot_joint_names`
+/ `list_robots`) keep the branch's graceful debug-log skip, and the
+MuJoCo model-present path is untouched.
+
+CPU unit tests pin the mapping (suffix-trap disambiguation, whole-token
+boundary, dual-arm ambiguity) and the adapter routing with the
+recording-stub pattern of `test_isaac_object_pose_state.py`; a GPU
+integration test (`tests_integ/simulation/test_isaac_init_arm_qpos_gpu.py`)
+asserts the one thing a stub cannot fake - after `_apply_canonical_state`
+on a real Franka articulation the observed joint positions match the
+decoded init-state arm qpos within tolerance, including holding the pose
+through the settle steps (`set_joint_positions` writes both state and PD
+targets).

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -3220,13 +3220,23 @@ class LiberoAdapter(BenchmarkProtocol):
            scene MJCF; on Isaac it is a separately-loaded USD spawned at
            the origin, inside the footprint of the scene's
            origin-anchored static fixtures).
-        5. Teleport each realized dynamic prim via ``sim.move_object``.
+        5. Write the decoded arm + gripper qpos into the articulation via
+           :meth:`_apply_scene_arm_qpos` (#1828): the scene names the
+           joints with robosuite prefixes (``robot0_joint1`` /
+           ``gripper0_finger_joint1``) while the USD articulation names
+           them ``panda_joint1`` / ``panda_finger_joint1``, so the
+           prefix-stripped names are mapped onto articulation DOFs by
+           longest-suffix match (ambiguity fatal). Without this the arm
+           starts every episode at the USD default (all-zero, upright)
+           instead of LIBERO's Panda ready pose, so the policy's first
+           observation is OOD relative to its training distribution.
+        6. Teleport each realized dynamic prim via ``sim.move_object``.
            The prim is a box at the body's collision-AABB centre, so the
            prim pose is ``xpos + R(xquat) @ offset`` with the body-frame
            ``offset`` recorded by :func:`load_mjcf_scene_objects`.
            Static fixtures keep their MJCF poses (they have no free
            joint; ``qpos`` cannot move them on MuJoCo either).
-        6. Settle a few physics steps so PhysX resolves residual contact
+        7. Settle a few physics steps so PhysX resolves residual contact
            from the teleports before the first observation. The settle
            runs HERE, after the poses are legal -- ``load_scene`` itself
            must not step, because its objects still sit at the MJCF
@@ -3331,6 +3341,11 @@ class LiberoAdapter(BenchmarkProtocol):
         else:
             logger.debug("LiberoAdapter: sim has no set_robot_pose(); skipping robot base alignment")
 
+        # The robot's other half (#1828): write the decoded arm + gripper
+        # qpos into the articulation so the arm starts the episode at
+        # LIBERO's Panda ready pose rather than the USD default.
+        self._apply_scene_arm_qpos(sim, model, data, _mj)
+
         moved = 0
         for obj in load_mjcf_scene_objects(scene_path):
             if obj.is_static:
@@ -3377,6 +3392,135 @@ class LiberoAdapter(BenchmarkProtocol):
         # "episode 1+" and gets RNG-sampled selection (parity with
         # _apply_init_state_branch).
         self._episode_count += 1
+
+    def _apply_scene_arm_qpos(self, sim: SimEngine, model: Any, data: Any, mj: Any) -> None:
+        """Arm-qpos half of :meth:`_apply_object_pose_state` (#1828).
+
+        The init state's object poses and robot *base* pose land on Isaac
+        via ``move_object`` / ``set_robot_pose`` (#1820), but the arm qpos
+        slice (LIBERO's Panda ready pose ``[0, -0.161, 0, -2.444, 0,
+        2.227, pi/4]`` + gripper) stayed unapplied: the USD Franka
+        articulation started every episode at its USD default (all-zero,
+        upright), so the policy's first observation was OOD relative to
+        the LIBERO training distribution. This writes the decoded arm +
+        gripper joint values into the articulation via
+        ``sim.set_joint_positions`` (a kinematic state + PD-target write
+        on Isaac, so the pose holds through the settle steps).
+
+        The decode model names joints with robosuite prefixes
+        (``robot0_joint1..7`` / ``gripper0_finger_joint1..2``) while the
+        Isaac USD articulation names them ``panda_joint1..7`` /
+        ``panda_finger_joint1..2``. Plain suffix matching is ambiguous
+        (``joint1`` is a suffix of both ``panda_joint1`` and
+        ``panda_finger_joint1``), so the prefix-stripped scene names are
+        mapped onto articulation DOF names via
+        :func:`_map_scene_joints_to_articulation` -- each DOF claims its
+        LONGEST matching scene suffix, and any scene joint left unclaimed
+        or claimed by several DOFs raises. No silent partial writes: a
+        mapping failure raises ``RuntimeError`` BEFORE anything is
+        written, and a failed engine write raises too.
+
+        Scene-side conventions match :meth:`_write_libero_arm_home_qpos`
+        (#168): arm joints carry ``self._scene_robot_prefix``, gripper
+        joints carry ``self._scene_gripper_prefix`` and are filtered to
+        ``finger_joint`` names.
+
+        Best-effort preconditions (debug-log + skip, preserving the
+        graceful-degradation contract of the enclosing branch): a scene
+        without prefixed robot joints (robot-less probe scenes), a sim
+        that exposes no ``set_joint_positions`` / ``robot_joint_names`` /
+        ``list_robots`` seam (arbitrary model-less sims), or a sim with
+        no robot registered yet. Multiple robots raise -- the write
+        target is ambiguous, matching ``set_robot_pose``'s contract.
+        """
+        # 1. Collect prefix-stripped scene joint values from the decode
+        # model (qpos already carries the selected init-state row).
+        single_dof_types = (int(mj.mjtJoint.mjJNT_HINGE), int(mj.mjtJoint.mjJNT_SLIDE))
+        scene_values: dict[str, float] = {}
+        njnt = int(getattr(model, "njnt", 0))
+        for i in range(njnt):
+            jname = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, i)
+            if not isinstance(jname, str):
+                continue
+            if jname.startswith(self._scene_robot_prefix) and not jname.startswith(self._scene_gripper_prefix):
+                bare = jname[len(self._scene_robot_prefix) :]
+            elif jname.startswith(self._scene_gripper_prefix) and "finger_joint" in jname:
+                # Finger joints only -- matches the #168 convention used
+                # by _write_libero_arm_home_qpos.
+                bare = jname[len(self._scene_gripper_prefix) :]
+            else:
+                continue
+            if int(model.jnt_type[i]) not in single_dof_types:
+                raise RuntimeError(
+                    f"LiberoAdapter: scene robot joint {jname!r} is not a 1-DOF hinge/slide joint; "
+                    f"its qpos cannot map onto a single articulation DOF. The scene MJCF diverges "
+                    f"from the robosuite convention this mapping assumes (#1828)."
+                )
+            if bare in scene_values:
+                raise RuntimeError(
+                    f"LiberoAdapter: two scene robot joints strip to the same name {bare!r} "
+                    f"(prefixes {self._scene_robot_prefix!r} / {self._scene_gripper_prefix!r}); "
+                    f"one value would silently overwrite the other (#1828)."
+                )
+            scene_values[bare] = float(data.qpos[int(model.jnt_qposadr[i])])
+
+        if not scene_values:
+            logger.debug("LiberoAdapter: scene has no prefixed robot joints; skipping arm-qpos apply")
+            return
+
+        # 2. Duck-typed engine seam probe, mirroring
+        # _try_install_isaac_action_controller: an engine lacking any of
+        # these callables is simply not an articulated-robot engine.
+        # Typed ``Any``: SimEngine's base surface declares none of these
+        # backend-specific seams.
+        set_joint_positions: Any = getattr(sim, "set_joint_positions", None)
+        robot_joint_names: Any = getattr(sim, "robot_joint_names", None)
+        list_robots: Any = getattr(sim, "list_robots", None)
+        if not all(callable(f) for f in (set_joint_positions, robot_joint_names, list_robots)):
+            logger.debug("LiberoAdapter: sim exposes no joint-write seam; skipping arm-qpos apply")
+            return
+        robots = list(list_robots())
+        if not robots:
+            logger.debug("LiberoAdapter: no robot registered on the sim; skipping arm-qpos apply")
+            return
+        if len(robots) > 1:
+            raise RuntimeError(
+                f"LiberoAdapter: arm-qpos apply is ambiguous with {len(robots)} robots present "
+                f"({sorted(robots)}); cannot pick a write target (#1828)."
+            )
+        robot_name = robots[0]
+        dof_names = list(robot_joint_names(robot_name))
+        if not dof_names:
+            raise RuntimeError(
+                f"LiberoAdapter: robot {robot_name!r} reports no articulation DOF names; the decoded "
+                f"init-state arm qpos ({sorted(scene_values)}) has nowhere to land and the arm would "
+                f"silently start at the USD default pose (#1828)."
+            )
+
+        # 3. Map and write. Mapping failures raise BEFORE the write, so
+        # there is never a partial application.
+        try:
+            mapped = _map_scene_joints_to_articulation(scene_values, dof_names)
+        except ValueError as e:
+            raise RuntimeError(
+                f"LiberoAdapter: cannot apply the init-state arm qpos to robot {robot_name!r}: {e} "
+                f"An unmapped arm joint would leave the articulation at the USD default pose and the "
+                f"policy's first observation OOD relative to its training distribution (#1828)."
+            ) from e
+        result = set_joint_positions(mapped, robot_name=robot_name)
+        if isinstance(result, dict) and result.get("status") == "error":
+            text = (result.get("content") or [{}])[0].get("text", "")
+            raise RuntimeError(
+                f"LiberoAdapter: writing the init-state arm qpos to robot {robot_name!r} failed "
+                f"({text}). The arm would start the episode at the USD default pose instead of "
+                f"LIBERO's ready pose (#1828)."
+            )
+        logger.debug(
+            "LiberoAdapter: applied init-state arm qpos to robot %r (%d joints: %s)",
+            robot_name,
+            len(mapped),
+            sorted(mapped),
+        )
 
     def _apply_keyframe_branch(
         self,
@@ -3900,6 +4044,86 @@ def _quat_wxyz_to_rpy_xyz(quat_wxyz: list[float]) -> tuple[float, float, float]:
 
 
 # Scene-generation helpers (#164)
+
+
+def _is_joint_name_suffix(dof_name: str, bare_name: str) -> bool:
+    """True when ``bare_name`` is a whole-token suffix of ``dof_name``.
+
+    ``panda_joint1`` ends with ``joint1`` at a ``_`` boundary -> match;
+    ``arm_pjoint1`` also ends with ``joint1`` but at an alphanumeric
+    boundary -> no match (it names a different joint that merely shares
+    a tail). Exact equality matches too (an articulation converted
+    straight from the MJCF keeps the bare names).
+    """
+    if dof_name == bare_name:
+        return True
+    if not dof_name.endswith(bare_name):
+        return False
+    return not dof_name[-len(bare_name) - 1].isalnum()
+
+
+def _map_scene_joints_to_articulation(
+    scene_values: dict[str, float],
+    dof_names: list[str],
+) -> dict[str, float]:
+    """Map prefix-stripped scene joint values onto articulation DOF names.
+
+    The LIBERO scene MJCF names robot joints with robosuite prefixes
+    (``robot0_joint1``, ``gripper0_finger_joint1``) while the Isaac USD
+    Franka articulation names them ``panda_joint1`` /
+    ``panda_finger_joint1``. With the prefixes stripped, plain suffix
+    matching is still ambiguous: bare ``joint1`` is a suffix of BOTH
+    ``panda_joint1`` and ``panda_finger_joint1``. So the match runs in
+    the DOF -> scene direction with longest-suffix-wins semantics
+    (#1828): each articulation DOF claims the LONGEST bare scene name
+    that is a whole-token suffix of it (``panda_finger_joint1`` claims
+    ``finger_joint1`` over ``joint1``; equal-length suffixes of one
+    string are identical, so the per-DOF winner is always unique).
+
+    Parameters
+    ----------
+    scene_values : dict[str, float]
+        Prefix-stripped scene joint name -> decoded init-state qpos value.
+    dof_names : list[str]
+        Articulation DOF names in engine order.
+
+    Returns
+    -------
+    dict[str, float]
+        ``{dof_name: value}`` covering every entry of ``scene_values``
+        exactly once. DOFs with no matching scene joint are simply not
+        written (they keep their current value).
+
+    Raises
+    ------
+    ValueError
+        When any scene joint is claimed by zero DOFs (unmappable) or by
+        several DOFs (ambiguous, e.g. a dual-arm articulation where
+        ``left_joint1`` and ``right_joint1`` both claim ``joint1``).
+        Raised before anything is written -- no silent partial writes.
+    """
+    claims: dict[str, list[str]] = {}
+    for dof in dof_names:
+        candidates = [bare for bare in scene_values if _is_joint_name_suffix(dof, bare)]
+        if not candidates:
+            continue
+        best = max(candidates, key=len)
+        claims.setdefault(best, []).append(dof)
+
+    unmapped = sorted(bare for bare in scene_values if bare not in claims)
+    ambiguous = {bare: dofs for bare, dofs in claims.items() if len(dofs) > 1}
+    if unmapped or ambiguous:
+        problems = []
+        if unmapped:
+            problems.append(f"unmappable scene joints (no articulation DOF suffix-matches them): {unmapped}")
+        if ambiguous:
+            detail = "; ".join(f"{bare!r} -> {sorted(dofs)}" for bare, dofs in sorted(ambiguous.items()))
+            problems.append(f"ambiguous scene joints (claimed by several DOFs): {detail}")
+        raise ValueError(
+            f"cannot map scene joints onto articulation DOFs: {'; '.join(problems)}. "
+            f"Articulation DOFs present: {list(dof_names)}."
+        )
+    return {dofs[0]: scene_values[bare] for bare, dofs in claims.items()}
 
 
 def _default_scene_cache_dir() -> Path:

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -550,6 +550,10 @@ class LiberoAdapter(BenchmarkProtocol):
         # episode so qpos/qvel land on the same canonical state every time.
         self._canonical_qpos: np.ndarray | None = None
         self._canonical_qvel: np.ndarray | None = None
+        # CPU-side MuJoCo decode model for the object-pose init-state branch
+        # (#1820, Isaac backend). Cached as (scene_path, model, data) so the
+        # per-episode pose decode doesn't recompile the scene MJCF.
+        self._pose_decode_cache: tuple[str, Any, Any] | None = None
         self._bddl_source = bddl_source
         self._bddl_path = bddl_path
         self._success_fn: Callable[[SimEngine], bool] = compile_goal(problem.goal)
@@ -2870,7 +2874,14 @@ class LiberoAdapter(BenchmarkProtocol):
 
         Best-effort:
 
-        * Sims without an exposed compiled MuJoCo model -> debug-log + skip.
+        * Sims without an exposed compiled MuJoCo model -> route to
+          :meth:`_apply_object_pose_state` (#1820): non-MuJoCo backends
+          (Isaac) have no ``qpos`` to write, so the init state is applied
+          as per-object *poses* decoded through a local CPU MuJoCo
+          compile of the scene MJCF. That helper debug-log + skips when
+          its own preconditions (init states, scene path, a
+          ``move_object`` method, importable ``mujoco``) are missing, so
+          arbitrary model-less sims still degrade gracefully.
         * ``scene_keyframe_index`` out of range when ``nkey > 0`` -> log
           at WARNING and skip (out-of-range is a config error).
         * ``mujoco`` not importable -> debug-log + skip.
@@ -2886,7 +2897,12 @@ class LiberoAdapter(BenchmarkProtocol):
         model = getattr(world, "_model", None) if world is not None else None
         data = getattr(world, "_data", None) if world is not None else None
         if model is None or data is None:
-            logger.debug("LiberoAdapter: sim has no compiled MuJoCo model/data; skipping canonical-state apply")
+            # Non-MuJoCo backend (e.g. Isaac): no compiled model/data to
+            # write qpos into. Apply the init state as per-object poses
+            # instead (#1820) -- without this, Isaac scene objects stay at
+            # their MJCF placeholder poses (coincident bodies at the robot
+            # base) and live physics explodes on the first step.
+            self._apply_object_pose_state(sim, rng)
             return
 
         try:
@@ -3016,6 +3032,189 @@ class LiberoAdapter(BenchmarkProtocol):
 
         # Increment after successful apply so the next call is
         # "episode 1+" and gets RNG-sampled selection.
+        self._episode_count += 1
+
+    def _apply_object_pose_state(self, sim: SimEngine, rng: random.Random | None = None) -> None:
+        """Object-pose branch of :meth:`_apply_canonical_state` (#1820).
+
+        Non-MuJoCo backends (Isaac) realize the LIBERO scene as one prim
+        per MJCF body (``IsaacSimulation.load_scene``), so the flat
+        ``[time, qpos, qvel]`` init-state vector can't be written into an
+        engine ``qpos`` -- there isn't one. Instead this branch decodes
+        the init state into per-object world poses and teleports each
+        realized prim there:
+
+        1. Compile the scene MJCF with **CPU MuJoCo** (a decode-only
+           model; nothing is stepped). ``mujoco`` is always importable on
+           the LIBERO path -- the scene MJCF itself was generated through
+           robosuite, which hard-depends on it.
+        2. Select an init-state row with the SAME semantics as
+           :meth:`_apply_init_state_branch` (episode 0 pinned to row 0,
+           episodes 1+ RNG-sampled; width validated against
+           ``1 + nq + nv``, mismatch fatal per #168 bug I).
+        3. Write ``qpos``/``qvel``, ``mj_forward``, and read each free
+           body's world pose (``data.xpos`` / ``data.xquat``).
+        4. Align the robot base with the scene's ``robot0_base`` body via
+           ``sim.set_robot_pose`` (on MuJoCo the robot is part of the
+           scene MJCF; on Isaac it is a separately-loaded USD spawned at
+           the origin, inside the footprint of the scene's
+           origin-anchored static fixtures).
+        5. Teleport each realized dynamic prim via ``sim.move_object``.
+           The prim is a box at the body's collision-AABB centre, so the
+           prim pose is ``xpos + R(xquat) @ offset`` with the body-frame
+           ``offset`` recorded by :func:`load_mjcf_scene_objects`.
+           Static fixtures keep their MJCF poses (they have no free
+           joint; ``qpos`` cannot move them on MuJoCo either).
+        6. Settle a few physics steps so PhysX resolves residual contact
+           from the teleports before the first observation. The settle
+           runs HERE, after the poses are legal -- ``load_scene`` itself
+           must not step, because its objects still sit at the MJCF
+           placeholder poses (coincident bodies at the robot base) and
+           integrating from that configuration storms PhysX "Illegal
+           BroadPhaseUpdateData - non-finite bounds" and NaNs the joint
+           state (#1820 part 2).
+
+        Failed teleports and unresolvable body names raise
+        ``RuntimeError``: an object left at its placeholder pose
+        interpenetrates the robot base and WILL explode live physics, so
+        warn-and-continue is exactly the silent-failure mode this branch
+        exists to remove.
+
+        Best-effort preconditions (debug-log + skip, preserving the
+        graceful-degradation contract for arbitrary model-less sims):
+        missing/empty init states, missing scene path, no ``move_object``
+        method on the sim, ``mujoco`` not importable.
+        """
+        if self._init_states is None or int(self._init_states.shape[0]) == 0:
+            logger.debug("LiberoAdapter: no init_states; skipping object-pose state apply")
+            return
+        init_states = self._init_states
+        scene_path = self.scene_path
+        if not scene_path or not os.path.exists(scene_path):
+            logger.debug("LiberoAdapter: no scene_path on disk; skipping object-pose state apply")
+            return
+        move_object = getattr(sim, "move_object", None)
+        if not callable(move_object):
+            logger.debug("LiberoAdapter: sim has no move_object(); skipping object-pose state apply")
+            return
+        try:
+            import mujoco as _mj
+        except ImportError:
+            logger.debug("LiberoAdapter: mujoco not importable; skipping object-pose state apply")
+            return
+
+        from strands_robots.simulation.isaac.loaders import load_mjcf_scene_objects
+
+        # Decode model: compile once per scene_path, reuse across episodes.
+        if self._pose_decode_cache is not None and self._pose_decode_cache[0] == scene_path:
+            _, model, data = self._pose_decode_cache
+        else:
+            model = _mj.MjModel.from_xml_path(scene_path)
+            data = _mj.MjData(model)
+            self._pose_decode_cache = (scene_path, model, data)
+
+        # Row selection + width validation: identical semantics to
+        # _apply_init_state_branch (episode 0 -> row 0; episodes 1+ RNG).
+        n_states = int(init_states.shape[0])
+        if self._episode_count == 0:
+            idx = 0
+        else:
+            rng_local = rng if rng is not None else random.Random()
+            idx = rng_local.randint(0, n_states - 1)
+        state = init_states[idx]
+
+        nq = int(model.nq)
+        nv = int(model.nv)
+        expected_width = 1 + nq + nv
+        actual_width = int(state.shape[0])
+        if actual_width != expected_width:
+            raise RuntimeError(
+                f"LiberoAdapter: init_state width {actual_width} does not match the scene MJCF "
+                f"compiled for pose decode (1 + nq={nq} + nv={nv} = {expected_width}). The "
+                f"cached scene diverges from upstream LIBERO's scene for this BDDL task. "
+                f"#168 bug I: silent slicing forbidden - fix the scene generator instead."
+            )
+
+        data.time = float(state[0])
+        np.copyto(data.qpos, state[1 : 1 + nq])
+        np.copyto(data.qvel, state[1 + nq :])
+        _mj.mj_forward(model, data)
+
+        # Align the robot base with the scene (#1820 part 2, robot half).
+        # On MuJoCo the robot is part of the scene MJCF, so its base lands
+        # wherever the scene put it (LIBERO: robot0_base at
+        # (-0.66, 0, 0.912)); on Isaac the robot is a separately-loaded
+        # USD articulation spawned at the ORIGIN -- inside the footprint
+        # of the scene's origin-anchored static fixtures (cabinet, stove),
+        # and live physics starting from that interpenetration is the same
+        # broadphase NaN storm as the object-pose half. Best-effort on the
+        # lookup side (a robot-less scene or a sim without set_robot_pose
+        # skips with a log); a FAILED write raises, same as the object
+        # teleports below.
+        base_body = f"{self._scene_robot_prefix}base"
+        base_id = _mj.mj_name2id(model, _mj.mjtObj.mjOBJ_BODY, base_body)
+        set_robot_pose = getattr(sim, "set_robot_pose", None)
+        if base_id >= 0 and callable(set_robot_pose):
+            base_pos = np.asarray(data.xpos[base_id], dtype=float)
+            base_quat = np.asarray(data.xquat[base_id], dtype=float)  # wxyz
+            result = set_robot_pose(position=base_pos.tolist(), orientation=base_quat.tolist())
+            if isinstance(result, dict) and result.get("status") == "error":
+                text = (result.get("content") or [{}])[0].get("text", "")
+                raise RuntimeError(
+                    f"LiberoAdapter: aligning the robot base with scene body {base_body!r} failed "
+                    f"({text}). A robot left inside the scene's origin-anchored fixtures explodes "
+                    f"live physics on the first step (#1820)."
+                )
+        elif base_id < 0:
+            logger.debug("LiberoAdapter: scene has no %r body; skipping robot base alignment", base_body)
+        else:
+            logger.debug("LiberoAdapter: sim has no set_robot_pose(); skipping robot base alignment")
+
+        moved = 0
+        for obj in load_mjcf_scene_objects(scene_path):
+            if obj.is_static:
+                continue
+            body_id = _mj.mj_name2id(model, _mj.mjtObj.mjOBJ_BODY, obj.name)
+            if body_id < 0:
+                raise RuntimeError(
+                    f"LiberoAdapter: scene object {obj.name!r} (parsed from {scene_path!r}) "
+                    f"has no body in the compiled MJCF - the scene parser and the compiled "
+                    f"model disagree, so its init pose cannot be applied and live physics "
+                    f"would start from its placeholder pose (#1820)."
+                )
+            xpos = np.asarray(data.xpos[body_id], dtype=float)
+            xmat = np.asarray(data.xmat[body_id], dtype=float).reshape(3, 3)
+            xquat = np.asarray(data.xquat[body_id], dtype=float)  # wxyz, matches Isaac
+            prim_pos = xpos + xmat @ np.asarray(obj.offset, dtype=float)
+            result = move_object(name=obj.name, position=prim_pos.tolist(), orientation=xquat.tolist())
+            if isinstance(result, dict) and result.get("status") == "error":
+                text = (result.get("content") or [{}])[0].get("text", "")
+                raise RuntimeError(
+                    f"LiberoAdapter: applying init pose to scene object {obj.name!r} failed "
+                    f"({text}). An object left at its MJCF placeholder pose interpenetrates "
+                    f"the robot base and explodes live physics on the first step (#1820)."
+                )
+            moved += 1
+
+        # Settle now that every dynamic body is at a legal pose. Uses the
+        # engine's own step() (renders per its config); a handful of ticks
+        # lets PhysX resolve residual teleport contact before the first
+        # observation. Best-effort: a sim without step() just skips.
+        step = getattr(sim, "step", None)
+        if callable(step):
+            step(5)
+
+        logger.debug(
+            "LiberoAdapter: applied init_state[%d] as object poses (ep=%d, moved=%d, n_states=%d)",
+            idx,
+            self._episode_count,
+            moved,
+            n_states,
+        )
+
+        # Increment after successful apply so the next call is
+        # "episode 1+" and gets RNG-sampled selection (parity with
+        # _apply_init_state_branch).
         self._episode_count += 1
 
     def _apply_keyframe_branch(

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -784,6 +784,14 @@ class SceneObject:
     quat : tuple[float, float, float, float]
         Orientation quaternion ``[w, x, y, z]`` from the body's ``quat``
         attribute (identity when absent).
+    offset : tuple[float, float, float]
+        Body-frame offset of the AABB centre from the MJCF body origin
+        (``position = body_pos + offset`` at load time). Needed by pose
+        appliers (#1820): LIBERO init states carry per-episode *body*
+        poses, but the realized box prim sits at the AABB centre, so a
+        new body pose maps to prim pose ``body_pos + R(body_quat) @
+        offset``. Without this field the offset is unrecoverable from
+        ``position`` alone once the body moves.
     """
 
     name: str
@@ -791,6 +799,7 @@ class SceneObject:
     size: tuple[float, float, float]
     is_static: bool
     quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
 
 
 def _parse_quat(quat_str: str | None) -> tuple[float, float, float, float]:
@@ -1005,6 +1014,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
                 size=size,  # type: ignore[arg-type]
                 is_static=not has_freejoint,
                 quat=body_quat,
+                offset=center,  # type: ignore[arg-type]
             )
         )
 

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -2119,6 +2119,19 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         so per-episode reloads don't accumulate duplicate prims or hit the
         "object already exists" guard in :meth:`add_object`.
 
+        Timeline contract (#1820): realizing dynamic objects stops the
+        timeline per prim (#159); after rebuilding the physics view this
+        method restarts it (``world.play()``, which lands the state change
+        without integrating a physics tick), so on success the episode
+        integrates physics. No settle step runs here -- the objects sit
+        at MJCF *placeholder* poses until
+        ``LiberoAdapter._apply_object_pose_state`` teleports them to the
+        episode's init poses, and integrating from the placeholder
+        configuration explodes PhysX (coincident bodies at the robot
+        base). A failed or non-landing restart returns
+        ``{"status": "error"}`` rather than leaving the episode silently
+        frozen.
+
         Parameters
         ----------
         scene_path : str
@@ -2281,6 +2294,77 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                             robot.name,
                             e,
                         )
+
+                # Restart the timeline (#1820). Every dynamic prim realized
+                # above stopped it (`_construct_shape_prim`, #159) and
+                # nothing else restarts it, so without this the ENTIRE
+                # episode runs on frozen physics: `SimulationContext.step`
+                # only integrates when `is_playing()` -- `world.step()`
+                # renders with stale joint reads, `send_action` targets a
+                # view that never integrates -- and every envelope still
+                # reports success, so the eval reads green with a
+                # motionless robot (measured: 5-episode groot evals at
+                # success_rate=0.00 with byte-similar videos).
+                #
+                # `world.play()` rather than `timeline.play()`: on 6.0.x a
+                # bare `timeline.play()` only QUEUES the state change, and
+                # the headless step path (`world.step(render=False)`) never
+                # runs the app update that would land it -- measured live
+                # (Isaac 6.0 / L4): `is_playing()` still False after
+                # play() + 5 world.steps, joints frozen. `world.play()` is
+                # play + `timeline.commit()` + one app update issued with
+                # `/app/player/playSimulations` DISABLED, so the state
+                # lands synchronously and, critically, NO physics
+                # integrates on the landing tick: the objects realized
+                # above still sit at their MJCF *placeholder* poses (LIBERO
+                # encodes real per-episode poses in BDDL init states, not
+                # in body attributes -- coincident bodies inside the robot
+                # base), and integrating even one tick from that
+                # configuration storms PhysX "Illegal BroadPhaseUpdateData
+                # - non-finite bounds" and NaNs the joint state. That is
+                # also why there is deliberately NO settle step here:
+                # `LiberoAdapter._apply_object_pose_state` teleports the
+                # objects to their episode init poses and owns the settle.
+                #
+                # Ordering: play comes AFTER the STOP-event flush +
+                # `initialize_physics()` + `articulation.initialize()`
+                # above -- the stop -> rebuild -> re-init -> play cycle was
+                # verified live (Isaac 6.0 / L4) to preserve articulation
+                # state, whereas playing before the flush lets the queued
+                # STOP handlers null the freshly-built handles.
+                #
+                # A failure is FATAL, not a warning: warn-and-continue here
+                # reproduces the exact silent-frozen-physics defect this
+                # block fixes (AGENTS.md: never warn-and-continue if the
+                # system will behave unexpectedly).
+                try:
+                    self._world.play()
+                except (AttributeError, RuntimeError, TypeError, ValueError) as e:
+                    msg = (
+                        f"load_scene: restarting the timeline after realizing scene objects "
+                        f"failed ({type(e).__name__}: {e}). The timeline was stopped by the "
+                        f"dynamic-prim constructors (#159), so physics would stay FROZEN for "
+                        f"the whole episode while every action reports success (#1820). "
+                        f"Refusing to continue."
+                    )
+                    logger.error("IsaacSimulation.load_scene: %s", msg)
+                    return {"status": "error", "content": [{"text": msg}]}
+                # Verify the play actually landed. Best-effort import: no
+                # omni.timeline means no live Kit session (the CPU unit-test
+                # skeleton), where the #159 stop never ran either.
+                try:
+                    import omni.timeline  # type: ignore[import-not-found]
+                except ImportError:
+                    logger.debug("load_scene: omni.timeline unavailable; skipping timeline-playing verification")
+                else:
+                    if not omni.timeline.get_timeline_interface().is_playing():
+                        msg = (
+                            "load_scene: timeline still stopped after world.play() -- physics "
+                            "would stay FROZEN for the whole episode while every action "
+                            "reports success (#1820). Refusing to continue."
+                        )
+                        logger.error("IsaacSimulation.load_scene: %s", msg)
+                        return {"status": "error", "content": [{"text": msg}]}
 
             logger.info("IsaacSimulation.load_scene: %s", summary)
             return {
@@ -4484,6 +4568,76 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 return {"status": "success", "content": [{"text": "Set joint positions (main)."}]}
             self._action_q.put(_apply)
             return {"status": "success", "content": [{"text": "Set joint positions (queued)."}]}
+
+    def set_robot_pose(
+        self,
+        robot_name: str | None = None,
+        position: list[float] | None = None,
+        orientation: list[float] | None = None,
+    ) -> dict[str, Any]:
+        """Teleport a robot's articulation base to ``(position, orientation)``.
+
+        The scene-alignment counterpart of :meth:`move_object` (#1820): on
+        the MuJoCo backend the robot is part of the scene MJCF, so its base
+        lands wherever the scene author placed it (LIBERO puts
+        ``robot0_base`` at ``(-0.66, 0, 0.912)``); on Isaac the robot is a
+        separately-loaded USD articulation spawned at the origin -- inside
+        the footprint of the scene's origin-anchored static fixtures.
+        ``LiberoAdapter._apply_object_pose_state`` reads the scene's robot
+        base pose and aligns the articulation through this method so live
+        physics doesn't start with the robot interpenetrating a fixture
+        (PhysX "Illegal BroadPhaseUpdateData - non-finite bounds").
+
+        Parameters
+        ----------
+        robot_name : str, optional
+            Robot to move. ``None`` resolves the single robot, mirroring
+            :meth:`send_action`; ambiguous with several robots.
+        position : list[float], optional
+            World position ``[x, y, z]``. ``None`` keeps the current one.
+        orientation : list[float], optional
+            World orientation quaternion ``[w, x, y, z]``. ``None`` keeps
+            the current one.
+
+        Returns
+        -------
+        dict
+            Standard ``{"status", "content"}`` envelope; ``error`` for an
+            unknown/uninitialized robot or a failed pose write.
+        """
+        with self._lock:
+            if not self._world_created or not self._robots:
+                return {"status": "error", "content": [{"text": "No world/robot."}]}
+            if robot_name is None:
+                if len(self._robots) != 1:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"set_robot_pose(robot_name=None) is ambiguous: {len(self._robots)} robots "
+                                    f"present ({sorted(self._robots)}). Pass robot_name explicitly."
+                                )
+                            }
+                        ],
+                    }
+                robot_name = next(iter(self._robots))
+            robot = self._robots.get(robot_name)
+            if robot is None or robot.articulation is None:
+                return {"status": "error", "content": [{"text": f"Robot {robot_name!r} not initialized."}]}
+            try:
+                pos = np.asarray(position[:3], dtype=float) if position is not None else None
+                ori = np.asarray(orientation[:4], dtype=float) if orientation is not None else None
+                robot.articulation.set_world_pose(position=pos, orientation=ori)
+            except (RuntimeError, ValueError, AttributeError, TypeError) as exc:
+                return {
+                    "status": "error",
+                    "content": [{"text": f"set_robot_pose failed: {type(exc).__name__}: {exc}"}],
+                }
+            return {
+                "status": "success",
+                "content": [{"text": f"Robot {robot_name!r} base moved to {position or 'same'}."}],
+            }
 
     def move_object(
         self,

--- a/tests/benchmarks/libero/test_isaac_arm_qpos_state.py
+++ b/tests/benchmarks/libero/test_isaac_arm_qpos_state.py
@@ -1,0 +1,339 @@
+"""Arm-qpos half of the Isaac init-state apply (#1828).
+
+#1827 (fixing #1820) applies LIBERO init states on model-less backends
+(Isaac) as per-object poses plus robot *base* alignment, decoded through a
+CPU MuJoCo compile of the scene MJCF. One slice stayed unapplied: the robot
+**arm qpos** (LIBERO's Panda ready pose ``[0, -0.161, 0, -2.444, 0, 2.227,
+pi/4]`` + gripper). On MuJoCo the full qpos vector lands in one write; on
+Isaac the USD Franka articulation started every episode at its USD default
+(all-zero, upright), so the policy's first observation was OOD relative to
+the LIBERO training distribution.
+
+These tests pin ``LiberoAdapter._apply_scene_arm_qpos`` (reached through
+the public ``_apply_canonical_state`` entry when the sim exposes no
+compiled MuJoCo model) and the ``_map_scene_joints_to_articulation``
+name-mapping helper:
+
+* the decode model names joints with robosuite prefixes
+  (``robot0_joint1..7`` / ``gripper0_finger_joint1..2``) while the Isaac
+  USD articulation names them ``panda_joint1..7`` /
+  ``panda_finger_joint1..2``; the prefix-stripped names map onto
+  articulation DOFs by LONGEST whole-token suffix (plain suffix matching
+  is ambiguous: ``joint1`` is a suffix of both ``panda_joint1`` and
+  ``panda_finger_joint1``);
+* ambiguous / unmappable scene joints raise BEFORE anything is written --
+  no silent partial writes;
+* a failed ``set_joint_positions`` write raises;
+* missing engine seams (no ``set_joint_positions`` / ``robot_joint_names``
+  / ``list_robots``) and robot-less scenes degrade to a debug-log skip,
+  preserving the graceful-degradation contract of the enclosing branch.
+
+CPU-only: the decode is plain ``mujoco`` (no Isaac Sim), the sim is a
+recording stub (same pattern as ``test_isaac_object_pose_state.py``).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from strands_robots.benchmarks.libero import LiberoAdapter
+from strands_robots.benchmarks.libero.adapter import _map_scene_joints_to_articulation
+from strands_robots.simulation.base import SimEngine
+
+pytest.importorskip("mujoco")
+
+PICK_CUBE_BDDL = """
+(define (problem libero_spatial_pick_cube)
+  (:domain kitchen)
+  (:language "pick up the red cube and place it on the plate")
+  (:objects cube_1 plate_1 table_1 - object)
+  (:init (on cube_1 table_1))
+  (:goal (on cube_1 plate_1)))
+"""
+
+# LIBERO's Panda "ready" pose + PandaGripper init qpos -- the init-state
+# arm slice a policy's training data assumes at episode start.
+ARM_READY = (0.0, -0.161, 0.0, -2.444, 0.0, 2.227, math.pi / 4)
+GRIPPER_READY = (0.020833, -0.020833)
+
+# Real USD Franka articulation DOF names -- deliberately including the
+# suffix trap: bare ``joint1`` is a suffix of BOTH ``panda_joint1`` and
+# ``panda_finger_joint1``.
+FRANKA_DOFS = [f"panda_joint{i}" for i in range(1, 8)] + ["panda_finger_joint1", "panda_finger_joint2"]
+
+_TARGET_POS = (0.1, 0.2, 0.9)
+_TARGET_QUAT = (1.0, 0.0, 0.0, 0.0)
+
+
+def _scene_mjcf(robot_prefix: str = "robot0_", gripper_prefix: str = "gripper0_") -> str:
+    """A robosuite-shaped probe scene: a 7-hinge arm chain + 2 slide
+    fingers under ``robot0_base``, plus one free-jointed cube.
+
+    Joint declaration order (= qpos order): arm 1..7, fingers 1..2, cube
+    free joint. nq = 7 + 2 + 7 = 16, nv = 7 + 2 + 6 = 15 -> init-state
+    width 1 + 16 + 15 = 32.
+    """
+    arm = ""
+    for i in range(1, 8):
+        axis = "0 0 1" if i % 2 else "0 1 0"
+        arm += (
+            f'<body name="{robot_prefix}link{i}" pos="0 0 0.1">'
+            f'<joint name="{robot_prefix}joint{i}" type="hinge" axis="{axis}"/>'
+            f'<geom type="sphere" size="0.02"/>'
+        )
+    fingers = ""
+    for i, x in ((1, 0.03), (2, -0.03)):
+        fingers += (
+            f'<body name="{gripper_prefix}finger{i}" pos="{x} 0 0.05">'
+            f'<joint name="{gripper_prefix}finger_joint{i}" type="slide" axis="1 0 0"/>'
+            f'<geom type="box" size="0.005 0.005 0.02"/>'
+            f"</body>"
+        )
+    arm_close = "</body>" * 7
+    return f"""
+<mujoco model="arm_qpos_probe">
+  <worldbody>
+    <body name="{robot_prefix}base" pos="-0.66 0.0 0.912">
+      <geom type="box" size="0.05 0.05 0.05"/>
+      {arm}{fingers}{arm_close}
+    </body>
+    <body name="cube_1_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.02 0.02 0.02"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _init_state_row(arm=ARM_READY, gripper=GRIPPER_READY) -> list[float]:
+    return [0.0, *arm, *gripper, *_TARGET_POS, *_TARGET_QUAT, *([0.0] * 15)]
+
+
+class _ArmRecordingSim:
+    """Model-less sim stub recording ``set_joint_positions`` alongside the
+    ``move_object`` / ``set_robot_pose`` / ``step`` calls, exposing the
+    Isaac joint-write seam (``list_robots`` / ``robot_joint_names`` /
+    ``set_joint_positions``) with real Franka DOF names."""
+
+    def __init__(
+        self,
+        dof_names: list[str] | None = None,
+        robots: list[str] | None = None,
+        joint_write_status: str = "success",
+    ) -> None:
+        self._dof_names = FRANKA_DOFS if dof_names is None else dof_names
+        self._robots = ["robot"] if robots is None else robots
+        self._joint_write_status = joint_write_status
+        self.joint_writes: list[tuple[str | None, dict[str, float]]] = []
+        self.moves: list[tuple[str, list[float], list[float]]] = []
+        self.robot_poses: list[tuple[list[float], list[float]]] = []
+        self.step_calls: list[int] = []
+        self.events: list[str] = []
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots)
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        assert robot_name in self._robots
+        return list(self._dof_names)
+
+    def set_joint_positions(self, positions: Any = None, robot_name: str | None = None) -> dict[str, Any]:
+        self.joint_writes.append((robot_name, dict(positions)))
+        self.events.append("set_joint_positions")
+        if self._joint_write_status == "error":
+            return {"status": "error", "content": [{"text": "Robot 'robot' not initialized."}]}
+        return {"status": "success", "content": [{"text": "Set joint positions (main)."}]}
+
+    def move_object(self, *, name: str, position: list[float], orientation: list[float]) -> dict[str, Any]:
+        self.moves.append((name, list(position), list(orientation)))
+        self.events.append("move_object")
+        return {"status": "success", "content": [{"text": f"'{name}' moved."}]}
+
+    def set_robot_pose(self, *, position: list[float], orientation: list[float]) -> dict[str, Any]:
+        self.robot_poses.append((list(position), list(orientation)))
+        self.events.append("set_robot_pose")
+        return {"status": "success", "content": [{"text": "Robot base moved."}]}
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        self.step_calls.append(n_steps)
+        self.events.append("step")
+        return {"status": "success", "content": [{"text": "stepped"}]}
+
+
+@pytest.fixture
+def scene_file(tmp_path):
+    p = tmp_path / "scene.xml"
+    p.write_text(_scene_mjcf())
+    return str(p)
+
+
+def _adapter(scene_file: str, init_states: np.ndarray | None) -> LiberoAdapter:
+    return LiberoAdapter.from_text(
+        PICK_CUBE_BDDL,
+        scene_path=scene_file,
+        auto_generate_scene=False,
+        init_states=init_states,
+    )
+
+
+class TestJointNameMapping:
+    """The pure name-mapping helper: longest-suffix wins, loud failures."""
+
+    def test_franka_mapping_resolves_the_joint1_suffix_trap(self) -> None:
+        scene = {f"joint{i}": float(i) for i in range(1, 8)}
+        scene.update({"finger_joint1": 8.0, "finger_joint2": 9.0})
+        mapped = _map_scene_joints_to_articulation(scene, FRANKA_DOFS)
+        # panda_finger_joint1 claims finger_joint1 (longest suffix), NOT
+        # joint1 -- so joint1 lands uniquely on panda_joint1.
+        assert mapped == {
+            **{f"panda_joint{i}": float(i) for i in range(1, 8)},
+            "panda_finger_joint1": 8.0,
+            "panda_finger_joint2": 9.0,
+        }
+
+    def test_exact_names_map_identically(self) -> None:
+        mapped = _map_scene_joints_to_articulation({"joint1": 1.5}, ["joint1"])
+        assert mapped == {"joint1": 1.5}
+
+    def test_alphanumeric_boundary_is_not_a_suffix_match(self) -> None:
+        # ``arm_pjoint1`` merely shares a tail with ``joint1``; matching it
+        # would write the value into a different joint.
+        with pytest.raises(ValueError, match="unmappable"):
+            _map_scene_joints_to_articulation({"joint1": 0.5}, ["arm_pjoint1"])
+
+    def test_dual_arm_ambiguity_raises(self) -> None:
+        with pytest.raises(ValueError, match="ambiguous"):
+            _map_scene_joints_to_articulation({"joint1": 0.5}, ["left_joint1", "right_joint1"])
+
+    def test_unmappable_scene_joint_raises(self) -> None:
+        with pytest.raises(ValueError, match="joint7"):
+            _map_scene_joints_to_articulation(
+                {"joint1": 0.1, "joint7": 0.7},
+                ["panda_joint1"],
+            )
+
+
+class TestArmQposApply:
+    def test_arm_qpos_written_to_mapped_articulation_dofs(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _ArmRecordingSim()
+
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+
+        # One joint write, addressed to the resolved robot, carrying the
+        # decoded arm + gripper qpos on the USD articulation's names.
+        assert len(sim.joint_writes) == 1
+        robot_name, mapped = sim.joint_writes[0]
+        assert robot_name == "robot"
+        expected = {
+            **{f"panda_joint{i}": ARM_READY[i - 1] for i in range(1, 8)},
+            "panda_finger_joint1": GRIPPER_READY[0],
+            "panda_finger_joint2": GRIPPER_READY[1],
+        }
+        assert sorted(mapped) == sorted(expected)
+        for dof, value in expected.items():
+            assert mapped[dof] == pytest.approx(value, abs=1e-9), dof
+        # The write happens BEFORE the settle steps (a pose written after
+        # settling would never be integrated against the scene) and the
+        # object-pose half still runs.
+        assert sim.events.index("set_joint_positions") < sim.events.index("step")
+        assert [m[0] for m in sim.moves] == ["cube_1_main"]
+        assert len(sim.robot_poses) == 1
+        assert sim.step_calls == [5]
+        assert adapter._episode_count == 1
+
+    def test_unmappable_dofs_raise_with_no_partial_write(self, scene_file) -> None:
+        # An articulation missing panda_joint7 leaves bare joint7 unclaimed:
+        # fail loud BEFORE any write.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _ArmRecordingSim(dof_names=FRANKA_DOFS[:6] + ["panda_finger_joint1", "panda_finger_joint2"])
+        with pytest.raises(RuntimeError, match="joint7"):
+            adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.joint_writes == []
+
+    def test_ambiguous_dofs_raise_with_no_partial_write(self, scene_file) -> None:
+        # A dual-arm articulation: every bare name is claimed twice.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        dual = [f"left_{d}" for d in FRANKA_DOFS] + [f"right_{d}" for d in FRANKA_DOFS]
+        sim = _ArmRecordingSim(dof_names=dual)
+        with pytest.raises(RuntimeError, match="ambiguous"):
+            adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.joint_writes == []
+
+    def test_failed_joint_write_raises(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _ArmRecordingSim(joint_write_status="error")
+        with pytest.raises(RuntimeError, match="arm qpos"):
+            adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+
+    def test_multiple_robots_raise(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _ArmRecordingSim(robots=["robot_a", "robot_b"])
+        with pytest.raises(RuntimeError, match="ambiguous"):
+            adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.joint_writes == []
+
+    def test_empty_dof_list_raises(self, scene_file) -> None:
+        # A robot that reports no DOF names cannot absorb the arm qpos --
+        # skipping silently would leave the arm at the USD default pose.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _ArmRecordingSim(dof_names=[])
+        with pytest.raises(RuntimeError, match="no articulation DOF names"):
+            adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.joint_writes == []
+
+
+class TestArmQposGracefulDegradation:
+    """Missing engine seams / robot-less scenes skip (never raise) so
+    arbitrary model-less sims keep hosting the adapter, matching the
+    contract of the enclosing object-pose branch (#1820)."""
+
+    def test_sim_without_joint_write_seam_skips_arm_but_applies_objects(self, scene_file) -> None:
+        # The #1820-era stub surface (move_object / set_robot_pose / step
+        # only): the object-pose half still runs, the arm half skips.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+
+        class _NoJointSeam:
+            def __init__(self) -> None:
+                self.moves: list[str] = []
+                self.step_calls: list[int] = []
+
+            def move_object(self, *, name: str, position: list[float], orientation: list[float]) -> dict[str, Any]:
+                self.moves.append(name)
+                return {"status": "success", "content": [{"text": "moved"}]}
+
+            def set_robot_pose(self, *, position: list[float], orientation: list[float]) -> dict[str, Any]:
+                return {"status": "success", "content": [{"text": "moved"}]}
+
+            def step(self, n_steps: int = 1) -> dict[str, Any]:
+                self.step_calls.append(n_steps)
+                return {"status": "success", "content": [{"text": "stepped"}]}
+
+        sim = _NoJointSeam()
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.moves == ["cube_1_main"]
+        assert sim.step_calls == [5]
+
+    def test_no_registered_robot_skips(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _ArmRecordingSim(robots=[])
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.joint_writes == []
+        assert [m[0] for m in sim.moves] == ["cube_1_main"]
+
+    def test_robotless_scene_skips_joint_write(self, tmp_path) -> None:
+        # A scene without prefixed robot joints (the #1820 probe scenes)
+        # never reaches the engine seam.
+        scene = tmp_path / "scene.xml"
+        scene.write_text(_scene_mjcf(robot_prefix="fixture_", gripper_prefix="fixturegrip_"))
+        adapter = _adapter(str(scene), np.array([_init_state_row()], dtype=np.float64))
+        sim = _ArmRecordingSim()
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.joint_writes == []
+        assert [m[0] for m in sim.moves] == ["cube_1_main"]

--- a/tests/benchmarks/libero/test_isaac_object_pose_state.py
+++ b/tests/benchmarks/libero/test_isaac_object_pose_state.py
@@ -1,0 +1,250 @@
+"""Object-pose init-state branch of :class:`LiberoAdapter` (#1820, Isaac).
+
+``IsaacSimulation.load_scene`` realizes LIBERO scene objects at their MJCF
+*placeholder* body poses - LIBERO encodes the real per-episode poses in BDDL
+init states (flat ``[time, qpos, qvel]`` vectors), which the MuJoCo backend
+applies by writing ``data.qpos`` (``_apply_init_state_branch``). Isaac has
+no engine ``qpos``, so before #1820 the init state was silently skipped and
+live physics started from coincident, robot-interpenetrating placeholder
+poses - PhysX "Illegal BroadPhaseUpdateData - non-finite bounds" storms the
+moment the timeline integrates.
+
+These tests pin ``_apply_object_pose_state`` (reached through the public
+``_apply_canonical_state`` entry when the sim exposes no compiled MuJoCo
+model): the init state is decoded through a LOCAL CPU MuJoCo compile of the
+scene MJCF and applied per named object via ``sim.move_object``:
+
+* dynamic (free-jointed) objects are teleported to ``xpos + R(xquat) @
+  offset`` (the realized prim sits at the body's collision-AABB centre,
+  not the body origin);
+* static fixtures are left alone (no free joint - qpos cannot move them on
+  MuJoCo either);
+* the robot base is aligned with the scene's ``robot0_base`` body via
+  ``sim.set_robot_pose`` (Isaac spawns the USD robot at the origin, inside
+  the footprint of the scene's origin-anchored static fixtures);
+* row selection matches ``_apply_init_state_branch`` (episode 0 pinned to
+  row 0, episodes 1+ RNG-sampled; ``_episode_count`` increments);
+* width mismatches and failed teleports raise (an object left at its
+  placeholder pose WILL explode live physics - warn-and-continue is the
+  silent failure mode this branch removes);
+* missing preconditions (no init states / no scene file / no
+  ``move_object`` / no ``mujoco``) degrade to a debug-log skip, preserving
+  the graceful-degradation contract for arbitrary model-less sims.
+
+CPU-only: the decode is plain ``mujoco`` (no Isaac Sim), the sim is a stub.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from strands_robots.benchmarks.libero import LiberoAdapter
+from strands_robots.simulation.base import SimEngine
+
+pytest.importorskip("mujoco")
+
+PICK_CUBE_BDDL = """
+(define (problem libero_spatial_pick_cube)
+  (:domain kitchen)
+  (:language "pick up the red cube and place it on the plate")
+  (:objects cube_1 plate_1 table_1 - object)
+  (:init (on cube_1 table_1))
+  (:goal (on cube_1 plate_1)))
+"""
+
+# One static fixture + one free-jointed cube whose collision geom is OFFSET
+# from the body origin (pos="0 0 0.01"), so the prim-pose composition
+# ``xpos + R(xquat) @ offset`` is exercised, not just the translation.
+# The robot0_base body carries the scene's robot base pose (skipped by the
+# scene parser, but read for ``sim.set_robot_pose`` alignment).
+# nq = 7 (one free joint), nv = 6 -> init-state width 1 + 7 + 6 = 14.
+_SCENE_MJCF = """
+<mujoco model="pose_probe">
+  <worldbody>
+    <body name="robot0_base" pos="-0.66 0.0 0.912">
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+    <body name="fixture_table" pos="0.0 0.0 0.4">
+      <geom type="box" size="0.5 0.5 0.4"/>
+    </body>
+    <body name="cube_1_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.02 0.02 0.02" pos="0 0 0.01"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_ROBOT_BASE_POS = (-0.66, 0.0, 0.912)
+
+# Target pose for the cube's free joint: translated to (0.1, 0.2, 0.9) and
+# rotated +90 deg about x. Free-joint qpos layout: [x y z qw qx qy qz].
+_SQRT_HALF = float(np.sqrt(0.5))
+_TARGET_POS = (0.1, 0.2, 0.9)
+_TARGET_QUAT = (_SQRT_HALF, _SQRT_HALF, 0.0, 0.0)  # wxyz, +90deg about x
+# R(+90deg about x) @ (0, 0, 0.01) = (0, -0.01, 0).
+_EXPECTED_PRIM_POS = (0.1, 0.19, 0.9)
+
+
+def _init_state_row(pos=_TARGET_POS, quat=_TARGET_QUAT) -> list[float]:
+    return [0.0, *pos, *quat, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+class _PoseRecordingSim:
+    """Model-less sim stub recording ``move_object`` / ``set_robot_pose`` /
+    ``step`` calls."""
+
+    def __init__(self, move_status: str = "success", robot_pose_status: str = "success") -> None:
+        self._move_status = move_status
+        self._robot_pose_status = robot_pose_status
+        self.moves: list[tuple[str, list[float], list[float]]] = []
+        self.robot_poses: list[tuple[list[float], list[float]]] = []
+        self.step_calls: list[int] = []
+
+    def move_object(self, *, name: str, position: list[float], orientation: list[float]) -> dict[str, Any]:
+        self.moves.append((name, list(position), list(orientation)))
+        if self._move_status == "error":
+            return {"status": "error", "content": [{"text": "Object not found."}]}
+        return {"status": "success", "content": [{"text": f"'{name}' moved."}]}
+
+    def set_robot_pose(self, *, position: list[float], orientation: list[float]) -> dict[str, Any]:
+        self.robot_poses.append((list(position), list(orientation)))
+        if self._robot_pose_status == "error":
+            return {"status": "error", "content": [{"text": "Robot not initialized."}]}
+        return {"status": "success", "content": [{"text": "Robot base moved."}]}
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        self.step_calls.append(n_steps)
+        return {"status": "success", "content": [{"text": "stepped"}]}
+
+
+@pytest.fixture
+def scene_file(tmp_path):
+    p = tmp_path / "scene.xml"
+    p.write_text(_SCENE_MJCF)
+    return str(p)
+
+
+def _adapter(scene_file: str, init_states: np.ndarray | None) -> LiberoAdapter:
+    return LiberoAdapter.from_text(
+        PICK_CUBE_BDDL,
+        scene_path=scene_file,
+        auto_generate_scene=False,
+        init_states=init_states,
+    )
+
+
+class TestObjectPoseApply:
+    def test_dynamic_object_teleported_to_decoded_pose(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+
+        # Only the free-jointed cube moves; the static fixture keeps its
+        # MJCF pose (qpos cannot move it on MuJoCo either).
+        assert [m[0] for m in sim.moves] == ["cube_1_main"]
+        _, position, orientation = sim.moves[0]
+        np.testing.assert_allclose(position, _EXPECTED_PRIM_POS, atol=1e-9)
+        np.testing.assert_allclose(orientation, _TARGET_QUAT, atol=1e-9)
+        # The robot base is aligned with the scene's robot0_base body:
+        # Isaac spawns the USD robot at the origin, inside the footprint
+        # of the scene's origin-anchored static fixtures.
+        assert len(sim.robot_poses) == 1
+        np.testing.assert_allclose(sim.robot_poses[0][0], _ROBOT_BASE_POS, atol=1e-9)
+        np.testing.assert_allclose(sim.robot_poses[0][1], (1.0, 0.0, 0.0, 0.0), atol=1e-9)
+        # Settle runs AFTER the teleports (settling at placeholder poses is
+        # the part-2 explosion) and the episode counter advances so the
+        # next episode gets RNG-sampled selection.
+        assert sim.step_calls == [5]
+        assert adapter._episode_count == 1
+
+    def test_episode_zero_pins_row_zero_then_rng_samples(self, scene_file) -> None:
+        rows = np.array(
+            [_init_state_row(), _init_state_row(pos=(0.3, -0.2, 0.7), quat=(1.0, 0.0, 0.0, 0.0))],
+            dtype=np.float64,
+        )
+        adapter = _adapter(scene_file, rows)
+        sim = _PoseRecordingSim()
+
+        # Episode 0: deterministic row 0 regardless of rng.
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(7))
+        np.testing.assert_allclose(sim.moves[0][1], _EXPECTED_PRIM_POS, atol=1e-9)
+
+        # Episode 1: RNG-sampled with the same semantics as the MuJoCo
+        # init-state branch (rng.randint(0, n_states - 1)).
+        rng = random.Random(7)
+        expected_idx = random.Random(7).randint(0, 1)
+        adapter._apply_canonical_state(cast(SimEngine, sim), rng)
+        expected_pos = _EXPECTED_PRIM_POS if expected_idx == 0 else (0.3, -0.2, 0.7 + 0.01)
+        np.testing.assert_allclose(sim.moves[1][1], expected_pos, atol=1e-9)
+        assert adapter._episode_count == 2
+
+    def test_width_mismatch_raises(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.zeros((1, 5), dtype=np.float64))
+        with pytest.raises(RuntimeError, match="width"):
+            adapter._apply_canonical_state(cast(SimEngine, _PoseRecordingSim()))
+
+    def test_failed_teleport_raises(self, scene_file) -> None:
+        # An object left at its placeholder pose interpenetrates the robot
+        # base and explodes live physics - never warn-and-continue.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        with pytest.raises(RuntimeError, match="cube_1_main"):
+            adapter._apply_canonical_state(cast(SimEngine, _PoseRecordingSim(move_status="error")))
+
+    def test_failed_robot_base_alignment_raises(self, scene_file) -> None:
+        # A robot left inside the scene's origin-anchored fixtures explodes
+        # live physics just like a misplaced object - never warn-and-continue.
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        with pytest.raises(RuntimeError, match="robot0_base"):
+            adapter._apply_canonical_state(cast(SimEngine, _PoseRecordingSim(robot_pose_status="error")))
+
+    def test_robotless_scene_skips_base_alignment(self, tmp_path) -> None:
+        # A scene without a robot0_base body applies object poses without
+        # attempting (or requiring) base alignment.
+        scene = _SCENE_MJCF.replace("robot0_base", "not_a_robot_base")
+        p = tmp_path / "scene.xml"
+        p.write_text(scene)
+        adapter = _adapter(str(p), np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+        adapter._apply_canonical_state(cast(SimEngine, sim), random.Random(0))
+        assert sim.robot_poses == []
+        assert [m[0] for m in sim.moves] == ["cube_1_main"]
+
+
+class TestObjectPoseGracefulDegradation:
+    """Missing preconditions skip (never raise) so arbitrary model-less
+    sims keep hosting the adapter, matching the pre-#1820 contract."""
+
+    def test_skips_without_init_states(self, scene_file) -> None:
+        adapter = _adapter(scene_file, None)
+        sim = _PoseRecordingSim()
+        adapter._apply_canonical_state(cast(SimEngine, sim))
+        assert sim.moves == []
+        assert sim.step_calls == []
+
+    def test_skips_without_scene_file(self, tmp_path) -> None:
+        adapter = _adapter(str(tmp_path / "missing.xml"), np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+        adapter._apply_canonical_state(cast(SimEngine, sim))
+        assert sim.moves == []
+
+    def test_skips_when_sim_lacks_move_object(self, scene_file) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+
+        class _NoMove:
+            pass
+
+        adapter._apply_canonical_state(cast(SimEngine, _NoMove()))
+
+    def test_skips_when_mujoco_unimportable(self, scene_file, monkeypatch) -> None:
+        adapter = _adapter(scene_file, np.array([_init_state_row()], dtype=np.float64))
+        sim = _PoseRecordingSim()
+        monkeypatch.setitem(sys.modules, "mujoco", None)
+        adapter._apply_canonical_state(cast(SimEngine, sim))
+        assert sim.moves == []

--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -95,6 +95,12 @@ class TestSceneObjectExtraction:
         assert table.position == pytest.approx((1.0, 0.0, 0.01))
         # The body-level quat is preserved as [w, x, y, z].
         assert table.quat == pytest.approx((0.707, 0.0, 0.0, 0.707))
+        # The body-frame AABB-centre offset is recorded (#1820): pose
+        # appliers recompose the prim pose from a NEW body pose as
+        # ``body_pos + R(body_quat) @ offset``, which is unrecoverable
+        # from ``position`` alone once the body moves.
+        assert table.offset == pytest.approx((0.0, 0.0, -0.39))
+        assert table.position == pytest.approx(tuple(p + o for p, o in zip((1.0, 0.0, 0.4), table.offset)))
 
     def test_freejoint_body_is_movable_with_cylinder_aabb(self, objects):
         mug = objects["porcelain_mug_1_main"]

--- a/tests/simulation/isaac/test_load_scene_physics_view.py
+++ b/tests/simulation/isaac/test_load_scene_physics_view.py
@@ -53,6 +53,9 @@ class _RecordingWorld:
     def __init__(self) -> None:
         self.reset_calls = 0
         self.step_calls = 0
+        self.play_calls = 0
+        self.play_raises: Exception | None = None
+        self.events: list[str] = []
         self.physics_sim_view = object()
 
     def reset(self) -> None:
@@ -60,6 +63,12 @@ class _RecordingWorld:
 
     def step(self, render: bool = True) -> None:
         self.step_calls += 1
+
+    def play(self) -> None:
+        self.play_calls += 1
+        self.events.append("play")
+        if self.play_raises is not None:
+            raise self.play_raises
 
 
 class _RecordingArticulation:
@@ -171,3 +180,116 @@ def test_load_scene_no_world_errors(scene_file) -> None:
     result = engine.load_scene(scene_file)
     assert result["status"] == "error"
     assert "no world" in result["content"][0]["text"].lower()
+
+
+# --- Timeline restart (#1820) ------------------------------------------------
+#
+# Every dynamic prim realized by load_scene stops the timeline (#159), and
+# before #1820 nothing restarted it: the whole episode ran on frozen physics
+# (SimulationContext.step only integrates when is_playing(); joint reads went
+# stale; send_action targeted a view that never integrates) while every
+# envelope still reported success. These pins assert the restart contract:
+# ``world.play()`` (NOT a bare ``timeline.play()``, which on 6.0.x only
+# queues the state change and never lands on the headless step path) fires
+# AFTER the articulation re-init, a failed restart is a fatal error envelope
+# (never a silent warn-and-continue), and a fake ``omni.timeline`` that
+# reports the play never landed also fails loud.
+
+
+def test_load_scene_restarts_timeline_after_articulation_reinit(scene_file) -> None:
+    """world.play() fires exactly once, and only after the articulation
+    re-init. Ordering matters: the stop -> flush -> initialize_physics ->
+    articulation.initialize -> play cycle was verified live (Isaac 6.0 / L4)
+    to preserve articulation state; playing earlier lets the queued #159
+    STOP handlers null the freshly-built physics handles."""
+    engine, _ = _make_engine()
+    world = engine._world
+    art = engine._robots["robot"].articulation
+    assert art is not None
+    original_initialize = art.initialize
+
+    def _recording_initialize(physics_sim_view=None) -> None:
+        world.events.append("articulation_initialize")
+        original_initialize(physics_sim_view)
+
+    art.initialize = _recording_initialize  # type: ignore[method-assign]
+
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    assert world.events == ["articulation_initialize", "play"]
+    assert world.play_calls == 1
+
+
+def test_load_scene_play_failure_is_a_fatal_error_envelope(scene_file) -> None:
+    """A failed restart must NOT be warn-and-continue: the timeline was
+    stopped by the dynamic-prim constructors, so continuing runs the whole
+    episode on frozen physics while every action reports success - the
+    exact defect #1820 fixes."""
+    engine, _ = _make_engine()
+    engine._world.play_raises = RuntimeError("kit session torn down")
+
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "FROZEN" in text
+    assert "timeline" in text.lower()
+
+
+def test_load_scene_nonlanding_play_is_a_fatal_error_envelope(scene_file, monkeypatch) -> None:
+    """world.play() returning is not proof the play LANDED: on 6.0.x the
+    timeline state changes on a kit update tick, so load_scene reads
+    ``is_playing()`` back and refuses to hand out a frozen episode."""
+    import sys
+    import types
+
+    fake_timeline_mod = types.SimpleNamespace(
+        get_timeline_interface=lambda: types.SimpleNamespace(is_playing=lambda: False)
+    )
+    fake_omni = types.ModuleType("omni")
+    fake_omni.timeline = fake_timeline_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "omni", fake_omni)
+    monkeypatch.setitem(sys.modules, "omni.timeline", fake_timeline_mod)  # type: ignore[arg-type]
+
+    engine, _ = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "error"
+    assert "still stopped" in result["content"][0]["text"]
+
+
+def test_load_scene_playing_verification_passes(scene_file, monkeypatch) -> None:
+    """The happy live path: play lands, is_playing() confirms, load succeeds."""
+    import sys
+    import types
+
+    fake_timeline_mod = types.SimpleNamespace(
+        get_timeline_interface=lambda: types.SimpleNamespace(is_playing=lambda: True)
+    )
+    fake_omni = types.ModuleType("omni")
+    fake_omni.timeline = fake_timeline_mod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "omni", fake_omni)
+    monkeypatch.setitem(sys.modules, "omni.timeline", fake_timeline_mod)  # type: ignore[arg-type]
+
+    engine, calls = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    assert engine._world.play_calls == 1
+    assert calls.added == ["fixture_table", "cube_1_main"]
+
+
+def test_load_scene_missing_omni_timeline_skips_verification(scene_file, monkeypatch) -> None:
+    """Without omni.timeline there is no live Kit session (the CPU
+    skeleton, where the #159 stop never ran either): world.play() is still
+    issued, but the is_playing() read-back is skipped."""
+    import sys
+    import types
+
+    fake_omni = types.ModuleType("omni")
+    monkeypatch.setitem(sys.modules, "omni", fake_omni)
+    # A None sys.modules entry makes ``import omni.timeline`` raise ImportError.
+    monkeypatch.setitem(sys.modules, "omni.timeline", None)  # type: ignore[arg-type]
+
+    engine, calls = _make_engine()
+    result = engine.load_scene(scene_file)
+    assert result["status"] == "success"
+    assert engine._world.play_calls == 1
+    assert calls.added == ["fixture_table", "cube_1_main"]

--- a/tests_integ/simulation/test_isaac_init_arm_qpos_gpu.py
+++ b/tests_integ/simulation/test_isaac_init_arm_qpos_gpu.py
@@ -1,0 +1,184 @@
+"""GPU-gated integration: the init-state arm qpos lands on Isaac (#1828).
+
+#1827 (fixing #1820) applies LIBERO init states on Isaac as per-object
+poses plus robot *base* alignment; the arm qpos slice (LIBERO's Panda
+ready pose) stayed unapplied, so the USD Franka articulation started every
+episode at its USD default (all-zero, upright) and the policy's first
+observation was OOD relative to the LIBERO training distribution.
+
+This test drives the full adapter half against a real Isaac articulation:
+``LiberoAdapter._apply_canonical_state`` on a model-less sim decodes the
+init state through a CPU MuJoCo compile of the scene MJCF, maps the
+robosuite-prefixed joint names (``robot0_joint1..7`` /
+``gripper0_finger_joint1..2``) onto the REAL USD Franka DOF names
+(``panda_joint1..7`` / ``panda_finger_joint1..2``) by longest-suffix
+match, and writes them via ``IsaacSimulation.set_joint_positions``. The
+assertion is the one a stub cannot fake: after the apply (settle steps
+included -- ``set_joint_positions`` writes both state and PD targets, so
+the pose must HOLD through the settle), the articulation's observed joint
+positions match the decoded init-state arm qpos within tolerance.
+
+Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ \\
+        tests_integ/simulation/test_isaac_init_arm_qpos_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import random
+
+import numpy as np
+import pytest
+
+pytest.importorskip("strands_robots.simulation.isaac")
+pytest.importorskip("mujoco")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+PICK_CUBE_BDDL = """
+(define (problem libero_spatial_pick_cube)
+  (:domain kitchen)
+  (:language "pick up the red cube and place it on the plate")
+  (:objects cube_1 plate_1 table_1 - object)
+  (:init (on cube_1 table_1))
+  (:goal (on cube_1 plate_1)))
+"""
+
+# LIBERO's Panda ready pose + PandaGripper init qpos.
+ARM_READY = (0.0, -0.161, 0.0, -2.444, 0.0, 2.227, math.pi / 4)
+GRIPPER_READY = (0.020833, -0.020833)
+
+ARM_JOINTS = [f"panda_joint{i}" for i in range(1, 8)]
+GRIPPER_JOINTS = ["panda_finger_joint1", "panda_finger_joint2"]
+
+# PD tracking during the settle steps and finger drive coupling eat a few
+# hundredths of a radian/metre; the USD default pose differs from the
+# ready pose by >1 rad on several joints, so 0.05 cleanly separates
+# "applied and held" from "never applied".
+_TOL = 0.05
+
+
+def _scene_mjcf() -> str:
+    """A robosuite-shaped probe scene: 7-hinge arm + 2 slide fingers under
+    ``robot0_base`` (decode-only -- ``load_scene`` skips ``robot0``/
+    ``gripper0`` bodies) plus one free cube realized as a prim."""
+    arm = ""
+    for i in range(1, 8):
+        axis = "0 0 1" if i % 2 else "0 1 0"
+        arm += (
+            f'<body name="robot0_link{i}" pos="0 0 0.1">'
+            f'<joint name="robot0_joint{i}" type="hinge" axis="{axis}"/>'
+            f'<geom type="sphere" size="0.02"/>'
+        )
+    fingers = "".join(
+        f'<body name="gripper0_finger{i}" pos="{x} 0 0.05">'
+        f'<joint name="gripper0_finger_joint{i}" type="slide" axis="1 0 0"/>'
+        f'<geom type="box" size="0.005 0.005 0.02"/>'
+        f"</body>"
+        for i, x in ((1, 0.03), (2, -0.03))
+    )
+    return f"""
+<mujoco model="arm_qpos_probe">
+  <worldbody>
+    <body name="robot0_base" pos="-0.66 0.0 0.912">
+      <geom type="box" size="0.05 0.05 0.05"/>
+      {arm}{fingers}{"</body>" * 7}
+    </body>
+    <body name="fixture_table" pos="0.6 0.0 0.4">
+      <geom type="box" size="0.3 0.3 0.4" group="0"/>
+    </body>
+    <body name="cube_1_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.02 0.02 0.02" group="0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _init_state_row() -> list[float]:
+    # qpos order: arm(7), fingers(2), cube free(7); qvel = 7 + 2 + 6.
+    cube_pose = (0.55, 0.0, 0.85, 1.0, 0.0, 0.0, 0.0)
+    return [0.0, *ARM_READY, *GRIPPER_READY, *cube_pose, *([0.0] * 15)]
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+def _add_franka(sim) -> None:
+    try:
+        from isaacsim.storage.native import get_assets_root_path  # type: ignore[import-not-found]
+    except ImportError:
+        from omni.isaac.nucleus import get_assets_root_path  # type: ignore[import-not-found]
+
+    assets_root = get_assets_root_path()
+    if not assets_root:
+        pytest.skip("No Isaac assets root (Nucleus/CDN) reachable for the Franka USD")
+    r = sim.add_robot("robot", usd_path=f"{assets_root}/Isaac/Robots/FrankaRobotics/FrankaPanda/franka.usd")
+    if r["status"] != "success":
+        r = sim.add_robot("robot", usd_path=f"{assets_root}/Isaac/Robots/Franka/franka.usd")
+    assert r["status"] == "success", f"add_robot: {r}"
+
+
+class TestIsaacInitArmQposGPU:
+    def test_apply_canonical_state_lands_the_ready_pose(self, tmp_path):
+        from strands_robots.benchmarks.libero import LiberoAdapter
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+        scene_file = tmp_path / "scene.xml"
+        scene_file.write_text(_scene_mjcf())
+
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_path=str(scene_file),
+            auto_generate_scene=False,
+            init_states=np.array([_init_state_row()], dtype=np.float64),
+        )
+
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=True))
+        try:
+            r = sim.create_world()
+            assert r["status"] == "success", f"create_world: {r}"
+            _add_franka(sim)
+            r = sim.load_scene(str(scene_file))
+            assert r["status"] == "success", f"load_scene: {r}"
+            sim.step(2)
+
+            # Sanity: the USD default is NOT the ready pose, otherwise the
+            # assertion below would pass without the apply.
+            before = sim.get_observation("robot", skip_images=True)
+            drift = sum(abs(float(before[j]) - v) for j, v in zip(ARM_JOINTS, ARM_READY))
+            assert drift > 1.0, f"USD default already at the ready pose? total |delta|={drift}"
+
+            # The full model-less apply: decode, base align, ARM QPOS
+            # (#1828), object teleports, settle.
+            adapter._apply_canonical_state(sim, random.Random(0))
+
+            obs = sim.get_observation("robot", skip_images=True)
+            for joint, expected in zip(ARM_JOINTS + GRIPPER_JOINTS, ARM_READY + GRIPPER_READY):
+                assert joint in obs, f"{joint} missing from observation keys {sorted(obs)}"
+                actual = float(obs[joint])
+                assert math.isfinite(actual), f"{joint} is non-finite ({actual})"
+                assert abs(actual - expected) < _TOL, (
+                    f"{joint} = {actual:.4f}, expected {expected:.4f} (+/- {_TOL}): the init-state "
+                    f"arm qpos did not land (or did not HOLD through the settle) on Isaac (#1828)."
+                )
+        finally:
+            sim.destroy()

--- a/tests_integ/simulation/test_isaac_scene_physics_gpu.py
+++ b/tests_integ/simulation/test_isaac_scene_physics_gpu.py
@@ -1,0 +1,181 @@
+"""GPU-gated integration: load_scene leaves physics LIVE, not frozen (#1820).
+
+The frozen-physics regression gate. ``IsaacSimulation.load_scene`` realizes
+LIBERO dynamic objects via constructors that stop the timeline (#159), and
+before #1820 nothing restarted it: the whole episode rendered without
+integrating physics - joint reads went stale, ``send_action`` targeted a
+view that never integrates, and every envelope still reported success, so a
+5-episode groot eval read green with a motionless robot. The eval-level
+signals (state keys present, no PhysX errors) were all satisfiable without
+integration, which is exactly how the defect shipped; this test asserts the
+one thing frozen physics cannot fake: a joint-target ``send_action`` after
+``load_scene`` measurably changes the joint state.
+
+Also pins part 2 of #1820: the scene MJCF places dynamic objects at
+*placeholder* poses (LIBERO's real per-episode poses live in BDDL init
+states), so the objects are teleported to legal poses via ``move_object``
+(the engine half of ``LiberoAdapter._apply_object_pose_state``) BEFORE the
+first integrating step, and the articulation must stay finite afterwards -
+no "Illegal BroadPhaseUpdateData - non-finite bounds" NaN storm.
+
+Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ tests_integ/simulation/test_isaac_scene_physics_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+# The isaac subpackage import itself is CPU-safe (heavy omni/isaacsim imports
+# are lazy, deferred to create_world()); importorskip guards against a
+# broken/partial install rather than the Isaac Kit runtime.
+pytest.importorskip("strands_robots.simulation.isaac")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+# A LIBERO-shaped scene: one static fixture plus two dynamic bodies at
+# COINCIDENT placeholder poses (the measured libero_spatial pattern - both
+# bowls at [0, -0.1, 0.02], inside the robot base footprint). Faithful to
+# the defect: integrating from this configuration is what exploded PhysX.
+_SCENE_MJCF = """
+<mujoco model="frozen_physics_probe">
+  <worldbody>
+    <body name="fixture_table" pos="0.6 0.0 0.4">
+      <geom type="box" size="0.3 0.3 0.4" group="0"/>
+    </body>
+    <body name="bowl_1_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.03 0.03 0.02" group="0"/>
+    </body>
+    <body name="bowl_2_main" pos="0.0 -0.1 0.02">
+      <freejoint/>
+      <geom type="box" size="0.03 0.03 0.02" group="0"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# Where the "init state" puts the dynamic bodies: resting on the fixture,
+# clear of the robot and of each other.
+_LEGAL_POSES = {
+    "bowl_1_main": [0.55, -0.12, 0.83],
+    "bowl_2_main": [0.55, 0.12, 0.83],
+}
+
+_PROBE_JOINT = "panda_joint2"
+_PROBE_DELTA = 0.3
+_MIN_MOTION = 0.05
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+def _add_franka(sim) -> None:
+    try:
+        from isaacsim.storage.native import get_assets_root_path
+    except ImportError:
+        from omni.isaac.nucleus import get_assets_root_path
+    assets_root = get_assets_root_path()
+    if not assets_root:
+        pytest.skip("No Isaac assets root (Nucleus/CDN) reachable for the Franka USD")
+    r = sim.add_robot("robot", usd_path=f"{assets_root}/Isaac/Robots/FrankaRobotics/FrankaPanda/franka.usd")
+    if r["status"] != "success":
+        r = sim.add_robot("robot", usd_path=f"{assets_root}/Isaac/Robots/Franka/franka.usd")
+    assert r["status"] == "success", f"add_robot: {r}"
+
+
+def _joint_positions(sim) -> dict[str, float]:
+    obs = sim.get_observation("robot", skip_images=True)
+    joints = {k: v for k, v in obs.items() if isinstance(v, float)}
+    assert joints, f"observation carries no joint keys: {sorted(obs)}"
+    return joints
+
+
+def _assert_actions_integrate(sim, label: str) -> None:
+    """The frozen-physics gate: a joint-target send_action must move the
+    articulation. Under a stopped timeline this probe measures ~0 motion
+    while every envelope still reports success (the #1820 diagnosis probe).
+    """
+    q0 = _joint_positions(sim)
+    assert _PROBE_JOINT in q0, f"{label}: probe joint missing from {sorted(q0)}"
+    target = q0[_PROBE_JOINT] + _PROBE_DELTA
+    r = sim.send_action({_PROBE_JOINT: target}, robot_name="robot", n_substeps=30)
+    assert r["status"] == "success", f"{label}: send_action: {r}"
+    q1 = _joint_positions(sim)
+    moved = abs(q1[_PROBE_JOINT] - q0[_PROBE_JOINT])
+    assert moved > _MIN_MOTION, (
+        f"{label}: joint-target send_action moved {_PROBE_JOINT} by only {moved:.6f} rad "
+        f"(> {_MIN_MOTION} required). Physics is FROZEN after load_scene (#1820)."
+    )
+    for name, value in q1.items():
+        assert math.isfinite(value), f"{label}: joint {name} is non-finite ({value}) - PhysX exploded (#1820 part 2)"
+
+
+class TestIsaacScenePhysicsGPU:
+    def test_load_scene_timeline_plays_and_actions_integrate(self, tmp_path):
+        """One Kit boot covers the full per-episode cycle twice (SimulationApp
+        can only boot once per process, so the journeys share a session):
+        load_scene -> timeline playing -> pose teleport -> settle -> probe,
+        then the episode-2 reload of the same scene."""
+        from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+        _skip_if_isaac_unavailable()
+        scene_file = tmp_path / "scene.xml"
+        scene_file.write_text(_SCENE_MJCF)
+
+        sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=True))
+        try:
+            r = sim.create_world()
+            assert r["status"] == "success", f"create_world: {r}"
+            _add_franka(sim)
+            sim.step(2)
+
+            # Sanity: actuation works BEFORE the scene loads (isolates the
+            # regression to load_scene rather than the action path).
+            _assert_actions_integrate(sim, "pre-scene")
+
+            for episode in (1, 2):
+                label = f"episode {episode}"
+                r = sim.load_scene(str(scene_file))
+                assert r["status"] == "success", f"{label}: load_scene: {r}"
+
+                # The timeline must be PLAYING after load_scene: the dynamic
+                # prim constructors stopped it (#159) and load_scene owns the
+                # restart (#1820 part 1).
+                import omni.timeline
+
+                assert omni.timeline.get_timeline_interface().is_playing(), (
+                    f"{label}: timeline stopped after load_scene - the episode would run on frozen physics (#1820)"
+                )
+
+                # Part 2: the dynamic bodies sit at coincident placeholder
+                # poses inside the robot base. Teleport them to legal poses
+                # BEFORE the first integrating step (the engine half of
+                # LiberoAdapter._apply_object_pose_state), then settle.
+                for name, pos in _LEGAL_POSES.items():
+                    r = sim.move_object(name=name, position=pos, orientation=[1.0, 0.0, 0.0, 0.0])
+                    assert r["status"] == "success", f"{label}: move_object({name}): {r}"
+                r = sim.step(5)
+                assert r["status"] == "success", f"{label}: settle step: {r}"
+
+                # The frozen-physics gate + the no-NaN-explosion gate.
+                _assert_actions_integrate(sim, label)
+        finally:
+            sim.destroy()


### PR DESCRIPTION
Closes #1828.

> **Stacked on #1827** (`fix/isaac-load-scene-frozen-timeline`): this branch extends `_apply_object_pose_state`, which lands in #1827. The diff below includes #1827's commits until it merges; the #1828-specific change is the head commit (`f0cce0c`, +788/-2 across 4 files). Once #1827 is squash-merged, a rebase will shrink this PR to just that commit's content.

## What changed

#1827 applies LIBERO init states on Isaac as per-object poses plus robot **base** alignment. One slice stayed unapplied: the robot **arm qpos** (LIBERO's Panda ready pose `[0, -0.161, 0, -2.444, 0, 2.227, pi/4]` + gripper). On MuJoCo the full qpos vector lands in one write; on Isaac the USD Franka articulation started every episode at its USD default (all-zero, upright), so the policy's first observation was OOD relative to the LIBERO training distribution.

`LiberoAdapter._apply_object_pose_state` now runs a new `_apply_scene_arm_qpos` step (after base alignment, before the object teleports and the settle):

1. **Collect** the decoded arm + gripper qpos from the CPU decode model, keyed by prefix-stripped joint name (`robot0_joint1` -> `joint1`, `gripper0_finger_joint1` -> `finger_joint1`; gripper joints filtered to `finger_joint` names, matching the #168 convention in `_write_libero_arm_home_qpos`).
2. **Map** the bare names onto articulation DOF names via a new pure helper `_map_scene_joints_to_articulation`. This implements the issue's first proposed convention (longest unique suffix): plain suffix matching is ambiguous (`joint1` is a suffix of both `panda_joint1` and `panda_finger_joint1`), so the match runs in the **DOF -> scene** direction with longest-suffix-wins semantics — `panda_finger_joint1` claims `finger_joint1` over `joint1`, so `joint1` lands uniquely on `panda_joint1`. Whole-token boundary check (`arm_pjoint1` does not match `joint1`).
3. **Write** through `IsaacSimulation.set_joint_positions(mapped, robot_name=...)` — on Isaac this writes both joint state and PD targets, so the pose holds through the settle steps.

**Fail-loud contract** (acceptance criterion 2): a scene joint claimed by zero DOFs (unmappable) or several DOFs (ambiguous, e.g. dual-arm `left_joint1`/`right_joint1`) raises `RuntimeError` **before anything is written** — no silent partial writes. A failed engine write, several registered robots, and a robot reporting no DOF names also raise. Robot-less probe scenes and sims without the joint-write seam (`set_joint_positions` / `robot_joint_names` / `list_robots`) keep the branch's graceful debug-log skip, preserving the #1820 contract for arbitrary model-less sims.

**MuJoCo path unaffected** (acceptance criterion 3): everything lives inside the model-less branch; the model-present branch is untouched.

No `run_isaac.py` / `adapter_kwargs` plumbing needed — the suffix convention resolves the Franka mapping without per-robot configuration (the issue's option B, an explicit `scene_joint_map` kwarg, remains available as a follow-up if a robot ever defeats suffix matching).

## Test surface

- **14 new CPU unit tests** (`tests/benchmarks/libero/test_isaac_arm_qpos_state.py`, recording-stub pattern of `test_isaac_object_pose_state.py`): mapping helper (suffix-trap disambiguation, whole-token boundary, dual-arm ambiguity, unmappable), adapter routing (values within tolerance on the USD names, write ordered before the settle, object-pose half still runs), fail-loud paths (unmappable / ambiguous / failed write / multi-robot / empty DOF list, each asserting **no** partial write), graceful degradation (no joint seam, no robot, robot-less scene).
- **1 new GPU integ test** (`tests_integ/simulation/test_isaac_init_arm_qpos_gpu.py`): drives `_apply_canonical_state` against a real Franka articulation and asserts the observed joint positions match the decoded init-state arm qpos within 0.05 **after the settle** (the part a stub cannot fake: the pose must hold, i.e. `set_joint_positions` must write PD targets too).
- **Verified live on Isaac Sim 6.0 / L4** (standalone runner mirroring the integ test, since pytest+Kit segfaults in this dev environment — pre-existing, also affects #1827's GPU test):

  ```
  pre-apply total |delta| from ready pose: 5.3240 (must be > 1.0)
  PASS panda_joint1: actual=+0.0021 expected=+0.0000
  PASS panda_joint2: actual=-0.1638 expected=-0.1610
  PASS panda_joint3: actual=-0.0007 expected=+0.0000
  PASS panda_joint4: actual=-2.4440 expected=-2.4440
  PASS panda_joint5: actual=+0.0383 expected=+0.0000
  PASS panda_joint6: actual=+2.2271 expected=+2.2270
  PASS panda_joint7: actual=+0.7634 expected=+0.7854
  PASS panda_finger_joint1: actual=+0.0214 expected=+0.0208
  PASS panda_finger_joint2: actual=+0.0214 expected=-0.0208
  ALL ASSERTIONS PASSED
  ```

  Note `panda_finger_joint2`: robosuite encodes finger 2 with a negated axis (`-0.0208`), the USD Franka's joint range is `[0, 0.04]`, so PhysX clamps the write to ~0 and the observed value settles at +0.0214 — within tolerance, and the gripper *sign* convention is the delta-EEF controller's domain (#1812/#1819), not this mapping's.

- **Full suite delta**: `hatch run lint` clean; `hatch run test` on this branch = **+14 passes, zero new failures** vs the same command on the base commit (both runs: same 9 pre-existing failures — 3× `test_deferred_physics_and_warmup.py` tracked in #1823 (main is red), plus 6 environmental rendering/codec failures on this dev box; one order-dependent crash in `test_remote_policy_sim_rollout.py` reproduces identically at base and was deselected in both runs).

## Acceptance criteria (from #1828)

- [x] After the init-state apply on Isaac, arm joint positions match the decoded init-state arm qpos within tolerance — unit test with the recording-stub pattern + GPU integ assertion (verified live, log above).
- [x] Ambiguous / unmappable joint names fail loud, no silent partial writes — `RuntimeError` raised before any write, pinned by 5 dedicated tests.
- [x] MuJoCo path unaffected — model-present branch unchanged.

## Out of scope / follow-ups

- The explicit `scene_joint_map` adapter kwarg (issue option B) — only needed if a future embodiment defeats suffix matching; the fail-loud error message names the DOFs so the gap would be visible immediately.
- Gripper finger *sign* convention on the USD Franka (see note above) — belongs with the delta-EEF controller work (#1812/#1819).
- pytest+Kit segfault on this dev box (affects all Isaac GPU integ tests, not just this one).

Project board: please move #1828 to "In review" (or it will follow automatically via the board automation on this PR).
