### PR TITLE
fix(tools): report a rosbridge port the WebSocket transport cannot address (closes #1822)

### DIFF
--- a/changelog.d/1822-rosbridge-transport-port-domain.md
+++ b/changelog.d/1822-rosbridge-transport-port-domain.md
@@ -1,0 +1,14 @@
+### Fixed: `use_rosbridge` reports a port its WebSocket transport cannot address
+
+The tool accepts the OS port range `1-65535`, but the client underneath gates
+the port with `type(port) == int and port in range(0, 65535)`. Two values the
+tool accepts failed that gate and left it as a bare `AssertionError`, out of a
+function whose contract is a result dict: port `65535`, and an `int` subclass
+such as an `IntEnum` at any value, including the default `9090`. Both escaped
+every action and `RosbridgeRobot.drive` with them.
+
+An `int` subclass is now normalized so it reaches the wire - it is a legal port
+and dials as the equal plain `int` does - and the residual bound failure is
+reported through the tool's error envelope, naming the transport and the
+usable range. The accepted domain is unchanged, so it still agrees with
+`RosbridgeRobot`, the inference server CLI and the mesh session checks.

--- a/docs/rosbridge-integration.md
+++ b/docs/rosbridge-integration.md
@@ -119,6 +119,13 @@ robot = RosbridgeRobot(
 
 All parameters are optional except `node_name`, `cmd_vel_topic`, and `odom_topic`.
 
+`port` accepts the OS range `1-65535`, the same domain as `use_rosbridge` and
+every other port check in this package. The WebSocket client underneath
+addresses `1-65534` - its URL builder rejects the top of the 16-bit range - so a
+call on port `65535` is refused with an error naming the transport instead of
+dialing. An `int` subclass, such as an `IntEnum` from a settings module, is
+accepted and dials exactly as the equal plain `int` does.
+
 ### Fleet drive contract
 
 The `drive()` method follows the strands fleet-standard contract:

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -120,12 +120,43 @@ class _RosbridgeBackend:
         Calling ros.terminate() is never an option: it stops the process-wide,
         non-restartable Twisted reactor and would break every connection in
         this process.
+
+        Raises:
+            TimeoutError: When the bridge does not answer within ``timeout``.
+            ValueError: When the WebSocket transport cannot address ``port``.
+                The port domain this tool accepts is the OS one (1-65535); the
+                transport underneath addresses a narrower range, and the value
+                it cannot carry is reported here rather than escaping as the
+                transport's own assertion.
         """
         import roslibpy
 
+        # The WebSocket URL builder underneath roslibpy gates the port with
+        # ``type(port) == int and port in range(0, 65535)``. Two values this
+        # tool accepts fail that gate. An ``int`` subclass - an ``IntEnum``
+        # read from a config, say - fails the identity check at *any* value,
+        # including 9090; normalising to a plain ``int`` is what lets it reach
+        # the wire, and the port then dials exactly as the equal plain int
+        # does. 65535 falls outside the exclusive range and is reported below.
+        port = int(port)
+
         ros = self._connections.get((host, port))
         if ros is None:
-            ros = roslibpy.Ros(host=host, port=port)
+            try:
+                ros = roslibpy.Ros(host=host, port=port)
+            except AssertionError as exc:
+                # The transport asserts its own port bound instead of raising,
+                # so the failure is translated here rather than escaping this
+                # tool's result contract. Keying off the transport's verdict
+                # rather than a hardcoded bound means a client that widens its
+                # range starts working with no change here - and it already
+                # dials this port when assertions are disabled.
+                raise ValueError(
+                    f"port {port} cannot be dialed by the rosbridge WebSocket transport: "
+                    f"its URL builder rejects the top of the 16-bit range. Use a port in "
+                    f"1-65534 ({port} is a legal TCP port that other surfaces accept, so "
+                    f"this limit is the transport's own)."
+                ) from exc
             self._connections[(host, port)] = ros
             try:
                 ros.run(timeout=timeout)
@@ -292,6 +323,11 @@ def use_rosbridge(
                 _backend.connect(host, port, timeout)
         except TimeoutError as exc:
             return _ok(f"backend: roslibpy; not connected - {exc}")
+        except ValueError as exc:
+            # An unusable port is the caller's mistake, not a bridge that is
+            # down, so it is reported as an error like every other rejected
+            # argument rather than as a reachability observation.
+            return _err(str(exc))
         return _ok(f"backend: roslibpy; connected to ws://{host}:{port}")
 
     if not _backend.available():

--- a/tests/tools/test_use_rosbridge.py
+++ b/tests/tools/test_use_rosbridge.py
@@ -4,11 +4,14 @@ rosbridge is a WebSocket JSON transport (roslibpy) - pure pip, no sourced ROS
 environment. These tests run roslibpy-free: a fake ``roslibpy`` module is
 injected via ``sys.modules`` (fake Ros/Topic/Service record all traffic), so
 connection caching, every action dispatch, the validation layer, and the
-structured error contract are exercised with nothing installed.
+structured error contract are exercised with nothing installed. The single
+exception is the premise test for the double's port gate, which runs against
+real roslibpy when it happens to be installed and skips otherwise.
 """
 
 from __future__ import annotations
 
+import enum
 import sys
 import types as _types
 from typing import Any
@@ -69,6 +72,14 @@ class _FakeRos:
     scripted_messages: dict[str, list[dict[str, Any]]] = {}
 
     def __init__(self, host: str | None = None, port: int | None = None) -> None:
+        # The real client gates the port in its WebSocket URL builder with this
+        # expression (spelled with ``==`` there; ``is`` is the same test for
+        # int and equivalent under ruff's E721). Reproduced so this double is
+        # not more permissive than what it stands in for: without it, a port
+        # the transport cannot address looks perfectly usable in every test
+        # that runs through the fake, which is why nothing here noticed that
+        # 65535 and any int subclass escaped as a bare AssertionError.
+        assert port is None or (type(port) is int and port in range(0, 65535))
         self.host, self.port = host, port
         self.is_connected = False
         self.terminated = False
@@ -356,3 +367,120 @@ def test_publish_rejects_nonpositive_count(fake_roslibpy: _types.ModuleType) -> 
     result = use_rosbridge(action="publish", topic="/cmd_vel", type="geometry_msgs/Twist", count=0)
     assert result["status"] == "error"
     assert "count" in _texts(result)
+
+
+# Transport port domain -------------------------------------------------------
+
+
+class _PortEnum(enum.IntEnum):
+    """An ``int`` subclass port, as a settings module would export one."""
+
+    ROSBRIDGE = 9090
+
+
+# Every action, with the arguments it needs to reach the connect step.
+_ACTION_ARGS: dict[str, dict[str, Any]] = {
+    "status": {},
+    "list_topics": {},
+    "list_services": {},
+    "echo": {"topic": "/odom", "type": "nav_msgs/Odometry"},
+    "publish": {"topic": "/cmd_vel", "type": "geometry_msgs/Twist"},
+    "service_call": {"service": "/reset", "type": "std_srvs/Empty"},
+}
+
+
+def test_every_action_is_covered_by_the_port_domain_cases() -> None:
+    # So a seventh action cannot be added without deciding how it reports a
+    # port the transport cannot address.
+    assert set(_ACTION_ARGS) == set(rb_mod._ACTIONS)
+
+
+@pytest.mark.skipif(not __debug__, reason="the transport gates its port with an assert, which -O strips")
+def test_the_doubles_port_gate_is_the_real_transports() -> None:
+    """Pin that the gate reproduced in ``_FakeRos`` is the client's own.
+
+    Without this the behavior tests below would be asserting against invented
+    limits: the point of the two refusals is that the shipped transport really
+    cannot carry those ports.
+    """
+    roslibpy = pytest.importorskip("roslibpy", reason="the rosbridge client is an optional dependency")
+
+    # Constructing a client does not dial - that is ros.run() - so this is a
+    # pure check of the URL the transport is willing to build.
+    roslibpy.Ros(host="127.0.0.1", port=65534)
+    roslibpy.Ros(host="127.0.0.1", port=int(_PortEnum.ROSBRIDGE))
+    with pytest.raises(AssertionError):
+        roslibpy.Ros(host="127.0.0.1", port=65535)
+    with pytest.raises(AssertionError):
+        roslibpy.Ros(host="127.0.0.1", port=_PortEnum.ROSBRIDGE)
+
+
+@pytest.mark.parametrize("action", sorted(_ACTION_ARGS))
+def test_unaddressable_port_reported_through_the_envelope(action: str, fake_roslibpy: _types.ModuleType) -> None:
+    # 65535 is inside this tool's accepted domain but outside the exclusive
+    # range the transport's URL builder allows, and it used to leave every one
+    # of these actions as a bare AssertionError.
+    result = use_rosbridge(action=action, host="127.0.0.1", port=65535, timeout=0.05, **_ACTION_ARGS[action])
+    assert result["status"] == "error"
+    text = _texts(result)
+    assert "65535" in text
+    assert "cannot be dialed" in text
+    assert "1-65534" in text
+
+
+def test_refusal_names_the_transport_not_a_narrowed_domain(fake_roslibpy: _types.ModuleType) -> None:
+    # The accepted port domain is deliberately still the OS one, shared with
+    # RosbridgeRobot, the inference server CLI and the mesh session checks. So
+    # the refusal must come from the transport, not from narrowing this tool's
+    # own range to 1-65534 and disagreeing with all of them.
+    text = _texts(use_rosbridge(action="status", host="127.0.0.1", port=65535, timeout=0.05))
+    assert "invalid port" not in text
+    assert "transport" in text
+
+
+def test_unaddressable_port_caches_no_connection(fake_roslibpy: _types.ModuleType) -> None:
+    # The cache is populated after the client is built, so a refused port must
+    # leave nothing behind for a later call to find.
+    assert use_rosbridge(action="status", host="127.0.0.1", port=65535, timeout=0.05)["status"] == "error"
+    assert rb_mod._backend._connections == {}
+    assert _FakeRos.instances == []
+
+    assert use_rosbridge(action="status", host="127.0.0.1", port=9090, timeout=0.05)["status"] == "success"
+
+
+def test_int_subclass_port_reaches_the_wire_as_a_plain_int(fake_roslibpy: _types.ModuleType) -> None:
+    # The transport's gate is an identity check, so an IntEnum failed it at any
+    # value - including 9090, the default rosbridge port. It is a legal port,
+    # so it is normalized and dialed rather than refused.
+    result = use_rosbridge(action="status", host="127.0.0.1", port=_PortEnum.ROSBRIDGE, timeout=0.05)
+    assert result["status"] == "success"
+    assert "connected to ws://127.0.0.1:9090" in _texts(result)
+
+    (ros,) = _FakeRos.instances
+    assert type(ros.port) is int  # equality with 9090 held before the fix too
+    assert ros.port == 9090
+
+
+def test_highest_addressable_port_still_connects(fake_roslibpy: _types.ModuleType) -> None:
+    result = use_rosbridge(action="status", host="127.0.0.1", port=65534, timeout=0.05)
+    assert result["status"] == "success"
+    assert "connected to ws://127.0.0.1:65534" in _texts(result)
+
+
+def test_mesh_bridge_inherits_the_transport_verdict(fake_roslibpy: _types.ModuleType) -> None:
+    """RosbridgeRobot dials through this tool, so it inherits the contract.
+
+    Asserted here rather than beside the bridge because the fix is this tool's
+    and this is where the transport double lives: the mesh module's own tests
+    replace ``use_rosbridge`` with a recorder, so nothing there ever reaches a
+    client at all.
+    """
+    from strands_robots.mesh.rosbridge_robot import RosbridgeRobot
+
+    refused = RosbridgeRobot("rover", "/cmd_vel", "/odom", host="127.0.0.1", port=65535)
+    result = refused.drive(linear=0.1, count=1)
+    assert result["status"] == "error"
+    assert "cannot be dialed" in _texts(result)
+
+    dialed = RosbridgeRobot("rover", "/cmd_vel", "/odom", host="127.0.0.1", port=_PortEnum.ROSBRIDGE)
+    assert dialed.drive(linear=0.1, count=1)["status"] == "success"


### PR DESCRIPTION
Closes #1822.

## Problem

`use_rosbridge` accepts the OS port domain `1-65535`. The WebSocket client underneath gates the port in its URL builder with

```python
assert port is None or (type(port) == int and port in range(0, 65535))
```

Two values this tool accepts fail that gate, and it fails with a bare `assert`, so both left the tool as an `AssertionError` — out of a function whose contract is a result dict, and past its own `except (ImportError, KeyError, AttributeError, ValueError, TypeError, OSError)` tuple:

- **port `65535`** — a legal TCP port, excluded by the range's exclusive upper bound.
- **any `int` subclass at any value**, including the default `9090`, because the check is on identity rather than `isinstance`. An `IntEnum` read from a settings module is the realistic case.

Measured against the shipped roslibpy 1.8.1 / autobahn 26.7.1, both escaped all six actions and `RosbridgeRobot.drive`, which dials through this tool. Port `65534` and a plain-int `9090` report normally, so one value inside the tool's own accepted domain — and one perfectly ordinary port spelled as an enum — behaved differently from their neighbours with no diagnosis anywhere.

## Change

Both are handled at the one place a client is constructed, so both surfaces are covered by a single site.

- **An `int` subclass is normalized to a plain `int`.** The port is legal and dials exactly as the equal plain `int` does, so it is carried rather than refused. This is load-bearing, not cosmetic: it is what lets a value the tool already accepts reach the wire.
- **The residual bound failure is translated into the tool's error envelope**, naming the transport and the usable range. Keyed off the transport's own verdict rather than a hardcoded bound, so a client that widens its range starts working with no change here.
- `status` reports it as an error rather than as a reachability observation — an unusable port is the caller's mistake, not a bridge that is down.

## Why the accepted domain is left at 1-65535 rather than narrowed to 1-65534

#1822 offered narrowing the domain as the alternative. Two measurements rule it out.

1. **The wire carries 65535.** With the transport's assertion stripped (`python -O`) its URL builder returns `'ws://127.0.0.1:65535/'` and the same call dials normally. Refusing the port would be a false claim about the transport, and would make this tool disagree with `RosbridgeRobot`, the inference server CLI and the mesh session checks, which all accept `1-65535`.
2. **Narrowing is incomplete anyway.** It does nothing for the `int` subclass, which fails the identity check at *any* value — including `9090`. That half needs normalization regardless.

## Artifact

Every cell measured against the shipped client, one isolated process per case. Before: 6 of 12 escape as a bare `AssertionError`. After: 0 escape, `65535` is refused with a message naming the transport, and `IntEnum(9090)` reaches the wire at `ws://127.0.0.1:9090` identically to the plain-int control. The `9090` and `65534` rows report identically on both trees on all three surfaces.

![rosbridge transport port domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rosbridge-port-domain/port_domain.png)

No policy, simulation, rendering, recording or asset behaviour changes, so the evidence is a transport verdict matrix rather than a rollout.

## Tests

13 tests in `tests/tools/test_use_rosbridge.py`, and the double is completed in the same change.

`_FakeRos` accepted **any** port — more permissive than the client it stands in for — which is why nothing here noticed. It now reproduces the client's gate, so a port the transport cannot address no longer looks usable in any test that runs through the fake. That is pinned as a premise against real roslibpy when it is installed (skipped otherwise, and under `-O`, where the gate is stripped), so the two refusals are the shipped transport's own limits rather than invented ones.

On top of that: every action reports through the envelope (parametrized over all six, with an exhaustiveness check so a seventh cannot be added without deciding this); the refusal names the transport and not a narrowed domain; a refused port caches no connection and a later good call still connects; an `int` subclass arrives at the client as a plain `int` (`type(ros.port) is int` — equality with `9090` held before the fix too); `65534` still connects; and `RosbridgeRobot.drive` inherits the verdict, which nothing covered before because the mesh module's own tests replace `use_rosbridge` with a recorder.

**Pre-fix proof** — source reverted to the branch base `c8964134`, tests kept: `10 failed, 36 passed`, each failure the defect verbatim (`AssertionError: assert (65535 is None or (<class 'int'> is int and 65535 in range(0, 65535)))`). Zero pre-existing tests changed. The three new tests that pass pre-fix are the exhaustiveness check, the transport premise, and the `65534` over-reach control — they are what stop the change reaching too far.

## Gate

Based on `c8964134`.

- `MUJOCO_GL=egl pytest tests` — **15964 passed, 257 skipped**, 470s
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` — clean (1005 source files)
- `scripts/check_merge_base_overlap.py` — no overlap
- `scripts/assemble_changelog.py --check` — OK

Rebased onto `c8964134` after #1821 merged, which touched the same module: its hunks are the import block and the port guard, mine are the connect body and the `status` handler, so the two applied cleanly. Verified both survive — `tcp_port_error` is still imported and still gates the port at the top of the tool, and the new `1-65534` refusal is below it.
