### PR TITLE
fix(tools): refuse a rosbridge port the transport cannot address (closes #1822)

### DIFF
--- a/changelog.d/1822-rosbridge-transport-port-limit.md
+++ b/changelog.d/1822-rosbridge-transport-port-limit.md
@@ -1,0 +1,24 @@
+### Fixed: the rosbridge surfaces refuse a port their transport cannot address
+
+`use_rosbridge(port=65535)` raised a bare `AssertionError` out of a function
+annotated `-> dict[str, Any]`. 65535 is a legal TCP port, so the shared 16-bit
+domain (`strands_robots.utils.tcp_port_error`) accepted it and the tool dialed -
+but the WebSocket transport behind roslibpy builds its URL with
+`assert port is None or (type(port) == int and port in range(0, 65535))`, and
+`range(0, 65535)` stops one short. The assert carries no message, so an agent
+driving the tool got an exception where every other refusal is a result dict,
+and the failure named neither the tool nor the parameter. Ports `1`, `5555` and
+`65534` were unaffected.
+
+`use_rosbridge` and `RosbridgeRobot` now refuse the port the transport cannot
+carry, with a message naming the surface, the parameter and the addressable
+range. The refusal happens before the backend probe, so it reads the same
+whether or not roslibpy is installed and no socket is dialed to discover it, and
+`RosbridgeRobot` refuses at construction rather than at first use - it forwards
+every call through `use_rosbridge`, so such a port is a dead bridge.
+
+The shared 16-bit domain is deliberately *not* narrowed to match: the bound
+belongs to one transport, not to the port space, and `gr00t_inference` still
+accepts the whole range. The divergence and the autobahn behaviour it rests on
+are pinned together, so a future release that accepts 65535 fails the premise
+test rather than leaving a silently over-strict guard behind.

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -35,7 +35,7 @@ from strands import tool
 from strands.types.tools import AgentTool
 
 from strands_robots.mesh.ros_bridge import _check_topic
-from strands_robots.tools.use_rosbridge import _HOST_RE, use_rosbridge
+from strands_robots.tools.use_rosbridge import _HOST_RE, _transport_port_error, use_rosbridge
 from strands_robots.utils import (
     finite_number_error,
     positive_finite_number_error,
@@ -98,6 +98,12 @@ class RosbridgeRobot:
             raise ValueError(f"invalid host: {host!r}")
         if (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
             raise ValueError(port_error)
+        # Refused at construction rather than at first use: this bridge forwards
+        # every call through use_rosbridge, so a port the transport cannot carry
+        # is a dead bridge, and the point the port is named is the only place a
+        # caller can act on that.
+        if (transport_error := _transport_port_error(port, "port", type(self).__name__)) is not None:
+            raise ValueError(transport_error)
         self.host = host
         self.port = port
         self.cmd_vel_type = cmd_vel_type

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -60,6 +60,58 @@ _NAME_RE = re.compile(r"^[A-Za-z0-9_/~]+$")
 _TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/[A-Za-z0-9_]+$")
 _HOST_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
+# The top of the 16-bit port space is a legal TCP port that this transport cannot
+# address. autobahn builds the WebSocket URL behind roslibpy with
+# ``assert port is None or (type(port) == int and port in range(0, 65535))``
+# (``autobahn/websocket/util.py``), and ``range(0, 65535)`` stops one short of
+# 65535 - so the shared owner accepts the port, the kernel would bind it, and the
+# transport then refuses it with a bare ``assert`` carrying an empty message,
+# raised out of a function annotated ``-> dict[str, Any]``. An agent driving the
+# tool got an exception where every other refusal is a result dict, and the
+# exception named neither the tool nor the parameter.
+#
+# The narrower domain is therefore declared here and refused ahead of the backend
+# probe, for the same reason the numeric options are: the caller learns the same
+# thing whether or not roslibpy is installed, and no socket is dialed first. It is
+# deliberately narrower than ``tcp_port_error``, which keeps the whole port space
+# because that is what a port *is* - this bound belongs to one transport, not to
+# the domain, and lives beside the transport that has it.
+#
+# Under ``python -O`` the assert is stripped and the transport carries 65535, but
+# refusing it uniformly is the honest contract: the tool cannot promise a port
+# whose acceptance depends on an interpreter flag.
+_TRANSPORT_MAX_PORT = 65534
+
+
+def _transport_port_error(port: int, param: str, context: str) -> str | None:
+    """Error text when the rosbridge transport cannot address ``port``.
+
+    Applied after :func:`strands_robots.utils.tcp_port_error`, which establishes
+    that ``port`` is an ``int`` in the 16-bit space, so this only has to place it
+    against the transport's own ceiling. Shared with
+    :class:`strands_robots.mesh.rosbridge_robot.RosbridgeRobot`, which reaches
+    this transport through this module, so the two cannot disagree about which
+    ports it can carry.
+
+    Args:
+        port: A port already accepted by the shared 16-bit domain.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it - the
+            requested action for an agent tool, or the class name for a
+            constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the transport can address the port.
+    """
+    if port > _TRANSPORT_MAX_PORT:
+        return (
+            f"{context}: port {port!r} is a legal TCP port that the rosbridge WebSocket "
+            f"transport cannot address (it addresses 1-{_TRANSPORT_MAX_PORT}; autobahn's "
+            "URL builder excludes the top of the range)"
+        )
+    return None
+
+
 _INSTALL_HINT = (
     "roslibpy is not importable - install the rosbridge extra: "
     'pip install "strands-robots[rosbridge]". The rosbridge transport is pure '
@@ -266,6 +318,8 @@ def use_rosbridge(
         return _err(f"invalid host: {host!r}")
     if (port_error := tcp_port_error(port, "port", action)) is not None:
         return _err(port_error)
+    if (transport_error := _transport_port_error(port, "port", action)) is not None:
+        return _err(transport_error)
     if topic is not None and not _NAME_RE.match(topic):
         return _err(f"invalid topic name: {topic!r}")
     if service is not None and not _NAME_RE.match(service):

--- a/tests/tools/test_gr00t_numeric_option_guards.py
+++ b/tests/tools/test_gr00t_numeric_option_guards.py
@@ -44,8 +44,12 @@ UNUSABLE_PORTS: list[Any] = [0, -1, 70000, 2.7, True, "5555", None, float("nan")
 # so only a true positive ``int`` can be honored.
 # Ports every surface must accept. ``65535`` is a legal TCP port and the shared
 # owner accepts it, but autobahn's URL builder asserts ``port in range(0, 65535)``
-# before ``use_rosbridge`` can connect - a pre-existing quirk of that transport,
-# not of this domain - so the cross-surface list stops at 65534.
+# before ``use_rosbridge`` can connect - a quirk of that transport, not of this
+# domain - so the cross-surface list stops at 65534. The rosbridge surfaces now
+# refuse 65535 up front for that reason, which is a deliberate divergence from
+# the shared owner rather than a drift: it is pinned, with the transport premise
+# it rests on, in ``test_rosbridge_transport_port_limit.py``. Adding 65535 here
+# would assert the opposite of that file and fail.
 USABLE_PORTS: list[Any] = [1, 5555, 65534]
 
 UNUSABLE_STEPS: list[Any] = [0, -1, 2.7, True, "4", None, float("nan"), float("inf")]

--- a/tests/tools/test_rosbridge_transport_port_limit.py
+++ b/tests/tools/test_rosbridge_transport_port_limit.py
@@ -1,0 +1,192 @@
+"""The rosbridge surfaces refuse a port their transport cannot address.
+
+``65535`` is a legal TCP port. The shared owner of the 16-bit domain
+(:func:`strands_robots.utils.tcp_port_error`) accepts it, the kernel binds it,
+and ``gr00t_inference`` connects to it - but the WebSocket transport behind
+roslibpy builds its URL with
+
+    assert port is None or (type(port) == int and port in range(0, 65535))
+
+in ``autobahn/websocket/util.py``, and ``range(0, 65535)`` stops one short. So a
+value inside the tool's own accepted domain used to leave ``use_rosbridge`` as a
+bare ``AssertionError`` with an empty message, raised out of a function
+annotated ``-> dict[str, Any]``: an agent got an exception where every other
+refusal is a result dict, naming neither the tool nor the parameter.
+
+The bound is a property of one transport, not of the port space, so it is
+declared beside that transport and applied ahead of the backend probe - the
+refusal reads the same whether or not roslibpy is installed, and no socket is
+dialed to discover it. These tests pin three things that have to stay true
+together: the refusal reaches the caller through the envelope, the shared 16-bit
+domain is *not* narrowed to match, and the transport still has the quirk that
+justifies the divergence. If a future autobahn accepts 65535, the premise class
+at the bottom fails and says so, which is the signal to widen
+``_TRANSPORT_MAX_PORT`` rather than to delete a test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from strands_robots.mesh.rosbridge_robot import RosbridgeRobot
+from strands_robots.tools import use_rosbridge as ur
+from strands_robots.tools.use_rosbridge import use_rosbridge
+from strands_robots.utils import tcp_port_error
+
+# The one port that the shared domain accepts and the transport cannot carry.
+UNADDRESSABLE_PORT = 65535
+
+# Its neighbour, which both accept: every assertion about the refusal is paired
+# with this control so a blanket refusal cannot pass as a targeted one.
+ADDRESSABLE_PORT = 65534
+
+_ROBOT_KWARGS = {
+    "node_name": "probe",
+    "cmd_vel_topic": "/cmd_vel",
+    "odom_topic": "/odom",
+    "host": "127.0.0.1",
+}
+
+
+def _texts(result: dict) -> str:
+    return " ".join(block.get("text", "") for block in result["content"])
+
+
+class TestTheToolReportsItThroughTheEnvelope:
+    """The failure channel is the result dict, not an exception."""
+
+    def test_the_top_of_the_range_is_an_error_result(self) -> None:
+        result = use_rosbridge(action="status", host="127.0.0.1", port=UNADDRESSABLE_PORT, timeout=0.05)
+
+        assert result["status"] == "error"
+
+    def test_the_message_names_the_parameter_the_transport_and_the_range(self) -> None:
+        text = _texts(use_rosbridge(action="status", host="127.0.0.1", port=UNADDRESSABLE_PORT, timeout=0.05))
+
+        assert "use_rosbridge" in text
+        assert str(UNADDRESSABLE_PORT) in text
+        assert "rosbridge WebSocket transport" in text
+        assert f"1-{ADDRESSABLE_PORT}" in text
+
+    @pytest.mark.parametrize("action", sorted(ur._ACTIONS))
+    def test_every_action_refuses_it(self, action: str) -> None:
+        """The port is read by whichever action dials, so none may accept it."""
+        result = use_rosbridge(
+            action=action,
+            host="127.0.0.1",
+            port=UNADDRESSABLE_PORT,
+            topic="/chatter",
+            service="/rosout/get_loggers",
+            type="std_msgs/String",
+            timeout=0.05,
+        )
+
+        assert result["status"] == "error"
+        assert "cannot address" in _texts(result)
+
+    def test_the_refusal_precedes_the_backend_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Nothing is imported, probed or dialed to learn the port is unusable."""
+
+        def fail(*args: object, **kwargs: object) -> bool:
+            raise AssertionError("the backend must not be probed for a port refused up front")
+
+        monkeypatch.setattr(ur._backend, "available", fail)
+        monkeypatch.setattr(ur._backend, "connect", fail)
+
+        result = use_rosbridge(action="status", host="127.0.0.1", port=UNADDRESSABLE_PORT, timeout=0.05)
+
+        assert result["status"] == "error"
+
+    def test_the_neighbour_below_is_not_refused(self) -> None:
+        """The control: 65534 reaches the transport, so the guard is targeted."""
+        text = _texts(use_rosbridge(action="status", host="127.0.0.1", port=ADDRESSABLE_PORT, timeout=0.05))
+
+        assert "cannot address" not in text
+
+    @pytest.mark.parametrize("port", [1, 5555, ADDRESSABLE_PORT, UNADDRESSABLE_PORT])
+    def test_no_port_in_the_accepted_domain_raises(self, port: int) -> None:
+        """The whole point: a dict-returning tool returns a dict for each of these."""
+        result = use_rosbridge(action="status", host="127.0.0.1", port=port, timeout=0.05)
+
+        assert result["status"] in {"success", "error"}
+
+
+class TestTheRobotRefusesItAtConstruction:
+    """``RosbridgeRobot`` forwards every call through the tool, so it shares the bound."""
+
+    def test_the_constructor_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="cannot address"):
+            RosbridgeRobot(**_ROBOT_KWARGS, port=UNADDRESSABLE_PORT)
+
+    def test_the_message_names_the_class(self) -> None:
+        with pytest.raises(ValueError, match="RosbridgeRobot"):
+            RosbridgeRobot(**_ROBOT_KWARGS, port=UNADDRESSABLE_PORT)
+
+    def test_the_neighbour_below_constructs(self) -> None:
+        robot = RosbridgeRobot(**_ROBOT_KWARGS, port=ADDRESSABLE_PORT)
+
+        assert robot.port == ADDRESSABLE_PORT
+
+
+class TestTheSharedDomainIsNotNarrowedToMatch:
+    """The divergence is deliberate: the bound belongs to a transport, not to TCP."""
+
+    def test_the_shared_owner_still_accepts_the_whole_port_space(self) -> None:
+        assert tcp_port_error(UNADDRESSABLE_PORT, "port", "ctx") is None
+
+    def test_the_transport_bound_is_one_below_the_shared_ceiling(self) -> None:
+        assert ur._TRANSPORT_MAX_PORT == UNADDRESSABLE_PORT - 1
+
+    def test_the_helper_accepts_everything_the_transport_can_carry(self) -> None:
+        assert ur._transport_port_error(ADDRESSABLE_PORT, "port", "ctx") is None
+        assert ur._transport_port_error(1, "port", "ctx") is None
+
+    def test_only_the_rosbridge_surfaces_carry_the_narrower_bound(self) -> None:
+        """A transport bound that leaked onto another surface would be a bug.
+
+        Same scan shape as the shared-owner check in
+        ``test_gr00t_numeric_option_guards.py``: read the caller-facing modules
+        that take a port and assert which of them apply this bound. The
+        inference-service tool talks to a plain socket and must keep the whole
+        port space.
+        """
+        root = Path(ur.__file__).resolve().parent.parent
+        sources = {
+            path.name: path.read_text(encoding="utf-8")
+            for glob in ("tools/*.py", "mesh/*_robot.py")
+            for path in sorted(root.glob(glob))
+        }
+        carriers = {name for name, text in sources.items() if "_transport_port_error" in text}
+
+        assert carriers == {"use_rosbridge.py", "rosbridge_robot.py"}
+
+
+class TestTheTransportPremise:
+    """Why the bound exists. If autobahn is fixed, these fail and say to widen it.
+
+    Constructing ``roslibpy.Ros`` builds the URL and opens no socket, so the
+    premise is checked without a rosbridge server.
+    """
+
+    def test_the_transport_still_rejects_the_top_of_the_range(self) -> None:
+        roslibpy = pytest.importorskip("roslibpy")
+
+        with pytest.raises(AssertionError):
+            roslibpy.Ros(host="127.0.0.1", port=UNADDRESSABLE_PORT)
+
+    def test_the_transport_accepts_the_neighbour_below(self) -> None:
+        """Pins that the assert is about that one value, not about the call."""
+        roslibpy = pytest.importorskip("roslibpy")
+
+        assert roslibpy.Ros(host="127.0.0.1", port=ADDRESSABLE_PORT) is not None
+
+    def test_the_rejection_carries_no_message_of_its_own(self) -> None:
+        """Why translating it is necessary: the raw failure names nothing."""
+        roslibpy = pytest.importorskip("roslibpy")
+
+        with pytest.raises(AssertionError) as excinfo:
+            roslibpy.Ros(host="127.0.0.1", port=UNADDRESSABLE_PORT)
+
+        assert str(excinfo.value) == ""

--- a/tests/tools/test_rosbridge_transport_port_limit.py
+++ b/tests/tools/test_rosbridge_transport_port_limit.py
@@ -42,12 +42,16 @@ UNADDRESSABLE_PORT = 65535
 # with this control so a blanket refusal cannot pass as a targeted one.
 ADDRESSABLE_PORT = 65534
 
-_ROBOT_KWARGS = {
-    "node_name": "probe",
-    "cmd_vel_topic": "/cmd_vel",
-    "odom_topic": "/odom",
-    "host": "127.0.0.1",
-}
+
+def _robot(port: int) -> RosbridgeRobot:
+    """A bridge that differs from a usable one only in its port."""
+    return RosbridgeRobot(
+        node_name="probe",
+        cmd_vel_topic="/cmd_vel",
+        odom_topic="/odom",
+        host="127.0.0.1",
+        port=port,
+    )
 
 
 def _texts(result: dict) -> str:
@@ -118,14 +122,14 @@ class TestTheRobotRefusesItAtConstruction:
 
     def test_the_constructor_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="cannot address"):
-            RosbridgeRobot(**_ROBOT_KWARGS, port=UNADDRESSABLE_PORT)
+            _robot(UNADDRESSABLE_PORT)
 
     def test_the_message_names_the_class(self) -> None:
         with pytest.raises(ValueError, match="RosbridgeRobot"):
-            RosbridgeRobot(**_ROBOT_KWARGS, port=UNADDRESSABLE_PORT)
+            _robot(UNADDRESSABLE_PORT)
 
     def test_the_neighbour_below_constructs(self) -> None:
-        robot = RosbridgeRobot(**_ROBOT_KWARGS, port=ADDRESSABLE_PORT)
+        robot = _robot(ADDRESSABLE_PORT)
 
         assert robot.port == ADDRESSABLE_PORT
 


### PR DESCRIPTION
Closes #1822.

## What happens today

```python
use_rosbridge(action="status", host="127.0.0.1", port=65535, timeout=0.05)
```

```
  File ".../autobahn/websocket/util.py", line 85, in create_url
    assert port is None or (type(port) == int and port in range(0, 65535))
AssertionError
```

65535 is a legal TCP port. The shared 16-bit domain (`strands_robots.utils.tcp_port_error`, given a single owner in #1821) accepts it, the kernel binds it, and `gr00t_inference` connects to it - but the WebSocket transport behind roslibpy builds its URL with `range(0, 65535)`, which stops one short. Verified against the installed autobahn 26.7.1:

| port | before this PR |
| --- | --- |
| `1` / `5555` / `65534` | `backend: roslibpy; not connected - could not connect ... within 0.05s` |
| `65535` | bare `AssertionError`, `str(exc) == ""`, out of a `-> dict[str, Any]` tool |

So exactly one value inside the tool's own accepted domain escaped its envelope, and the exception named neither the tool nor the parameter. `RosbridgeRobot` inherits it: it validated the port with the shared domain, accepted 65535, and then failed on every call, because all its I/O forwards through `use_rosbridge`.

## What changed

The issue laid out two contracts. This takes the third that keeps both of their properties: **the transport's bound is declared beside the transport and applied ahead of the dial**, and the shared port domain is left alone.

- `strands_robots/tools/use_rosbridge.py`: `_TRANSPORT_MAX_PORT` + `_transport_port_error(port, param, context)`, applied right after `tcp_port_error` in the validation block - before `_backend.available()`, before any socket. The message names the surface, the parameter, the value and the addressable range.
- `strands_robots/mesh/rosbridge_robot.py`: same check at construction, sharing the helper through the import edge that already exists for `_HOST_RE`. Refusing at construction rather than at first use is the point: a port this transport cannot carry makes the bridge dead, and the moment the port is named is the only place a caller can act on it.

Deliberately **not** done: narrowing `tcp_port_error`. The bound belongs to one transport, not to the port space - `gr00t_inference` talks to a plain socket and must keep the whole range. Nor is the dependency's `assert` caught: catching it would attribute any `AssertionError` from client construction to the port, and it would leave the behaviour dependent on an interpreter flag, since `python -O` strips the assert. A uniform refusal is the contract a tool can actually promise.

## Test surface

`tests/tools/test_rosbridge_transport_port_limit.py` (24 tests), organised around what has to stay true *together*:

1. **The failure reaches the caller through the envelope** - error result rather than an exception; the message names tool, port, transport and range; every one of the six actions refuses it; and a monkeypatched `_backend` that raises if touched pins that the refusal precedes the probe. Control: 65534 is not refused, so the guard is targeted rather than blanket. Plus a sweep asserting no port in the accepted domain can raise out of the tool.
2. **`RosbridgeRobot` refuses at construction** - `ValueError` naming the class; 65534 still constructs.
3. **The shared domain is not narrowed** - `tcp_port_error(65535)` still returns `None`, and a source scan asserts only `use_rosbridge.py` and `rosbridge_robot.py` carry the bound, so it cannot leak onto a third surface.
4. **The premise the bound rests on** - the transport still rejects 65535, still accepts 65534, and the rejection still carries an empty message. If a future autobahn fixes the off-by-one, these fail and say to widen `_TRANSPORT_MAX_PORT` instead of leaving an over-strict guard nobody can attribute.

Also updated the comment above `USABLE_PORTS` in `test_gr00t_numeric_option_guards.py`: it recorded this quirk as unhandled and explained why the cross-surface list stops at 65534. It now says the divergence is deliberate and where it is pinned, so the next reader does not add 65535 to a parity list that would assert the opposite of the new file.

**Delta, run locally on this branch:**

| suite | result |
| --- | --- |
| new file, source reverted (pre-fix) | **14 failed**, 9 passed |
| new file, with the fix | 24 passed |
| `test_use_rosbridge.py` + `test_rosbridge_robot.py` + `test_gr00t_numeric_option_guards.py` + `test_source_no_unreachable_statements.py` + `test_no_host_paths.py` | 230 passed, 0 failed |

`ruff check` / `ruff format` clean.

## Second commit: a typing error the local gate could not see

The first push failed `call-test-lint` on mypy rather than on a test. The local mypy run was scoped to the two changed *modules*, but `hatch run lint` runs `mypy strands_robots tests tests_integ`, so it also reads the new test file - where a `**kwargs` dict of four string values infers as `dict[str, str]` and cannot be unpacked into a constructor whose `port` is an `int`. Replaced with a small typed factory, which also reads closer to what those tests are about: two bridges differing only in their port. Worth stating rather than quietly fixing: scoping a type check to the files you touched is not the command CI runs, and on a diff that is mostly tests it is the weaker half of it.

## Scope

One concern: a port the rosbridge transport cannot address is refused where the port is named. No behaviour change for any other port or any other surface.