### PR TITLE
fix(tools): normalize a rosbridge port that is an int subclass (closes #1835)

### DIFF
--- a/changelog.d/1835-rosbridge-int-subclass-port.md
+++ b/changelog.d/1835-rosbridge-int-subclass-port.md
@@ -1,0 +1,24 @@
+### Fixed: a rosbridge port that is an `int` subclass dials instead of raising
+
+`use_rosbridge` passed the caller's `port` straight to the `roslibpy` client,
+whose WebSocket URL builder gates it on type *identity* rather than `isinstance`
+(`type(port) == int`, autobahn/websocket/util.py:85). Every `int` subclass was
+therefore refused at every value - including the default `9090` - and refused
+with a bare `AssertionError` carrying an empty message, raised from the client
+constructor and so outside the `try` that reports an unreachable bridge. An
+`IntEnum` port read from a settings module named neither the tool, the parameter
+nor the value, out of a function annotated `-> dict[str, Any]`. `RosbridgeRobot`
+inherited it: it accepted the port at construction and then failed on every
+call, because all of its I/O forwards through this tool.
+
+The port is now normalized to a plain `int` at the one place a client is
+constructed, ahead of the connection cache read. The value is legal and dials
+exactly as the equal plain `int` does, so it is carried rather than refused. The
+shared 16-bit port domain (`tcp_port_error`) is unchanged - it is `isinstance`
+-based on purpose, and this was a type-identity defect, not a range one.
+
+Normalizing before the cache read also removes an order dependence that made
+the defect look intermittent: the cache is keyed on `(host, port)` and an
+`IntEnum` hashes equal to its value, so any earlier plain-`int` call to the same
+host and port reused that client and never reached the URL builder. A reproducer
+that happened to dial with a plain `int` first reported that everything worked.

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -123,6 +123,25 @@ class _RosbridgeBackend:
         """
         import roslibpy
 
+        # The client builds its WebSocket URL before it dials, and that builder
+        # gates the port on type IDENTITY rather than isinstance:
+        #
+        #     assert port is None or (type(port) == int and port in range(0, 65535))
+        #         - autobahn/websocket/util.py:85 (autobahn 26.7.1)
+        #
+        # So every int SUBCLASS is refused at every value, including the default
+        # 9090 - an IntEnum read from a settings module is the realistic case -
+        # and the refusal is a bare AssertionError with an empty message, raised
+        # from the constructor below and therefore outside the try that converts
+        # a failed dial. The value is legal and dials exactly as the equal plain
+        # int does, so it is normalized here rather than refused: carrying it is
+        # a capability this tool already advertises through its ``port: int``.
+        # Ahead of the cache read on purpose - the key is then a plain int
+        # whatever flavour arrived, so one (host, port) is one connection
+        # regardless of which type reached it first, and the annotation on
+        # ``_connections`` is true rather than aspirational.
+        port = int(port)
+
         ros = self._connections.get((host, port))
         if ros is None:
             ros = roslibpy.Ros(host=host, port=port)

--- a/tests/tools/test_rosbridge_port_type_identity.py
+++ b/tests/tools/test_rosbridge_port_type_identity.py
@@ -1,0 +1,290 @@
+"""A rosbridge port that is an ``int`` subclass dials like the equal plain int.
+
+The WebSocket URL builder behind ``roslibpy`` gates the port on type identity,
+not ``isinstance``::
+
+    assert port is None or (type(port) == int and port in range(0, 65535))
+        - autobahn/websocket/util.py:85 (autobahn 26.7.1)
+
+So every ``int`` subclass was refused at every value - including the default
+9090 - with a bare ``AssertionError`` carrying an empty message, raised from the
+client constructor and therefore outside the ``try`` that converts a failed
+dial. ``use_rosbridge`` normalizes the port to a plain ``int`` at the one place
+a client is constructed, which is also the place the connection cache is keyed.
+
+Four things have to stay true together, and they are grouped that way below:
+
+1. The value dials, through the tool and through ``RosbridgeRobot``, and nothing
+   escapes the tool envelope.
+2. It dials in either call order. This is the half that makes the defect look
+   intermittent: the cache is keyed on ``(host, port)`` and an ``IntEnum``
+   hashes equal to its value, so any earlier plain-int call to the same
+   host and port reused the cached client and never reached the URL builder.
+3. The shared 16-bit domain is untouched - it is ``isinstance``-based on
+   purpose, and this is a type-identity defect, not a range one.
+4. The premise: the installed dependency really does gate on identity, and the
+   normalization really does produce a value it accepts. If a future autobahn
+   uses ``isinstance``, these say so rather than leaving an unexplained
+   ``int()`` behind.
+"""
+
+from __future__ import annotations
+
+import enum
+import sys
+import types as _types
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.use_rosbridge as rb_mod
+from strands_robots.mesh.rosbridge_robot import RosbridgeRobot
+from strands_robots.utils import tcp_port_error
+
+use_rosbridge = rb_mod.use_rosbridge
+
+
+# The realistic way an int subclass reaches the tool: a port named in a settings
+# module rather than typed at the call site.
+class _Port(enum.IntEnum):
+    ROSBRIDGE = 9090
+    ALT = 9091
+
+
+class _IntSubclass(int):
+    """A plain subclass, to show the defect is the subclassing and not the enum."""
+
+
+PORT_FLAVOURS: list[Any] = [_Port.ROSBRIDGE, _IntSubclass(9090)]
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+class _RecordingRos:
+    """Stands in for ``roslibpy.Ros``, reproducing its port gate.
+
+    The gate is the point of this double: it is what turns "the tool passed an
+    IntEnum straight through" from something invisible into a failure. Mirrors
+    the completed double in test_use_rosbridge.py.
+    """
+
+    instances: list[_RecordingRos] = []
+
+    def __init__(self, host: str | None = None, port: int | None = None) -> None:
+        if not (port is None or (type(port) is int and port in range(0, 65535))):
+            raise AssertionError
+        self.host, self.port = host, port
+        self.is_connected = False
+        self.topics: list[Any] = []
+        self.service_calls: list[Any] = []
+        _RecordingRos.instances.append(self)
+
+    def run(self, timeout: float | None = None) -> None:
+        self.is_connected = True
+
+    def terminate(self) -> None:  # pragma: no cover - never called by the tool
+        self.is_connected = False
+
+
+class _RecordingTopic:
+    """Enough of ``roslibpy.Topic`` for the echo path the bridge drives."""
+
+    def __init__(self, ros: Any, name: str, message_type: str) -> None:
+        self.ros, self.name, self.message_type = ros, name, message_type
+        ros.topics.append(self)
+
+    def subscribe(self, cb: Any) -> None:
+        cb({"pose": {"x": 1.0}})
+
+    def unsubscribe(self) -> None:
+        pass
+
+    def advertise(self) -> None:
+        pass
+
+    def unadvertise(self) -> None:
+        pass
+
+    def publish(self, msg: dict[str, Any]) -> None:
+        pass
+
+
+@pytest.fixture
+def fake_roslibpy(monkeypatch: pytest.MonkeyPatch) -> _types.ModuleType:
+    """Inject a fake ``roslibpy`` and reset the process-wide connection cache.
+
+    Resetting the cache is load-bearing here rather than hygiene: a leaked
+    connection from an earlier test is exactly the masking this file is about.
+    """
+    _RecordingRos.instances = []
+    mod = _types.ModuleType("roslibpy")
+    mod.Ros = _RecordingRos  # type: ignore[attr-defined]
+    mod.Topic = _RecordingTopic  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "roslibpy", mod)
+    monkeypatch.setattr(rb_mod._backend, "_available", True)
+    monkeypatch.setattr(rb_mod._backend, "_connections", {})
+    return mod
+
+
+class TestAnIntSubclassPortDials:
+    @pytest.mark.parametrize("port", PORT_FLAVOURS)
+    def test_status_succeeds_and_nothing_escapes_the_envelope(
+        self, port: Any, fake_roslibpy: _types.ModuleType
+    ) -> None:
+        result = use_rosbridge(action="status", host="127.0.0.1", port=port, timeout=0.05)
+
+        assert result["status"] == "success"
+        assert "connected to ws://127.0.0.1:9090" in _texts(result)
+
+    @pytest.mark.parametrize("port", PORT_FLAVOURS)
+    def test_the_client_is_constructed_with_a_plain_int(self, port: Any, fake_roslibpy: _types.ModuleType) -> None:
+        use_rosbridge(action="status", host="127.0.0.1", port=port, timeout=0.05)
+
+        (ros,) = _RecordingRos.instances
+        assert type(ros.port) is int
+        assert ros.port == 9090
+
+    @pytest.mark.parametrize("action", sorted(rb_mod._ACTIONS))
+    def test_every_action_dials_rather_than_raising(self, action: str, fake_roslibpy: _types.ModuleType) -> None:
+        """Every action begins with a dial, so every action leaked this.
+
+        The action set is read from the module rather than typed out, so a
+        seventh action cannot be added without this covering it. What is
+        asserted is narrow and uniform: the call returns a result dict rather
+        than raising, and it got far enough to build a client - which is the
+        step that used to fail. What the action then does with the connection
+        is each action's own test's business, not this file's.
+        """
+        result = use_rosbridge(
+            action=action,
+            host="127.0.0.1",
+            port=_Port.ROSBRIDGE,
+            timeout=0.05,
+            topic="/odom" if action in {"echo", "publish"} else None,
+            service="/rosapi/topics" if action == "service_call" else None,
+            type="nav_msgs/Odometry" if action in {"echo", "publish"} else None,
+            count=1,
+        )
+
+        assert isinstance(result, dict)
+        (ros,) = _RecordingRos.instances
+        assert (type(ros.port), ros.port) == (int, 9090)
+
+    def test_the_cache_holds_one_connection_per_host_and_port(self, fake_roslibpy: _types.ModuleType) -> None:
+        use_rosbridge(action="status", host="127.0.0.1", port=_Port.ROSBRIDGE, timeout=0.05)
+        use_rosbridge(action="status", host="127.0.0.1", port=9090, timeout=0.05)
+        use_rosbridge(action="status", host="127.0.0.1", port=_Port.ALT, timeout=0.05)
+
+        assert len(_RecordingRos.instances) == 2
+        assert {(r.host, r.port) for r in _RecordingRos.instances} == {("127.0.0.1", 9090), ("127.0.0.1", 9091)}
+        assert all(type(key[1]) is int for key in rb_mod._backend._connections)
+
+
+class TestNeitherCallOrderMatters:
+    """The cache made the defect order-dependent, so both orders are pinned.
+
+    Before the fix, "enum then plain" raised and "plain then enum" succeeded,
+    because the second call reused a client the first had already built. A
+    reproducer that happened to touch the port with a plain int first reported
+    that everything worked.
+    """
+
+    def test_subclass_first_then_plain(self, fake_roslibpy: _types.ModuleType) -> None:
+        first = use_rosbridge(action="status", host="127.0.0.1", port=_Port.ROSBRIDGE, timeout=0.05)
+        second = use_rosbridge(action="status", host="127.0.0.1", port=9090, timeout=0.05)
+
+        assert (first["status"], second["status"]) == ("success", "success")
+
+    def test_plain_first_then_subclass(self, fake_roslibpy: _types.ModuleType) -> None:
+        first = use_rosbridge(action="status", host="127.0.0.1", port=9090, timeout=0.05)
+        second = use_rosbridge(action="status", host="127.0.0.1", port=_Port.ROSBRIDGE, timeout=0.05)
+
+        assert (first["status"], second["status"]) == ("success", "success")
+
+
+def _rover(port: Any) -> RosbridgeRobot:
+    return RosbridgeRobot(
+        node_name="rover",
+        cmd_vel_topic="/cmd_vel",
+        odom_topic="/odom",
+        # Named so the echo path needs no rosapi type lookup - this file is
+        # about the port, and a Service double would only add surface.
+        odom_type="nav_msgs/Odometry",
+        host="127.0.0.1",
+        port=port,
+    )
+
+
+class TestRosbridgeRobotInheritsTheFix:
+    """The bridge forwards all of its I/O through the tool, so one site covers it."""
+
+    def test_it_constructs_with_an_int_subclass_port(self) -> None:
+        assert _rover(_Port.ROSBRIDGE).port == 9090
+
+    def test_its_traffic_reaches_the_client_as_a_plain_int(self, fake_roslibpy: _types.ModuleType) -> None:
+        """Drives real forwarding: ``get_pose`` calls the tool, which dials.
+
+        Before the fix this raised the bare ``AssertionError`` out of
+        ``get_pose`` - a method annotated ``-> dict[str, Any]``.
+        """
+        result = _rover(_Port.ROSBRIDGE).get_pose(timeout=0.05)
+
+        assert result["status"] == "success"
+        (ros,) = _RecordingRos.instances
+        assert type(ros.port) is int
+        assert ros.port == 9090
+
+
+class TestTheSharedPortDomainIsUnchanged:
+    """This is a type-identity defect, so the range domain must not move.
+
+    Narrowing ``tcp_port_error`` to ``type(port) is int`` would reject the very
+    values this fix makes work, and it is shared with surfaces that have no
+    WebSocket under them.
+    """
+
+    @pytest.mark.parametrize("port", PORT_FLAVOURS)
+    def test_it_still_accepts_an_int_subclass(self, port: Any) -> None:
+        assert tcp_port_error(port, "port", "status") is None
+
+    def test_it_still_rejects_bool_and_out_of_range(self) -> None:
+        assert tcp_port_error(True, "port", "status") is not None
+        assert tcp_port_error(0, "port", "status") is not None
+        assert tcp_port_error(70000, "port", "status") is not None
+
+
+class TestThePremiseTheNormalizationRestsOn:
+    """Pins the claim about the dependency that ``int(port)`` exists to satisfy.
+
+    Skipped rather than faked when the extra is not installed: a premise about
+    a dependency is worth nothing measured against a double.
+    """
+
+    def test_the_url_builder_gates_the_port_on_type_identity(self) -> None:
+        create_url = pytest.importorskip("autobahn.websocket.util").create_url
+
+        with pytest.raises(AssertionError) as excinfo:
+            create_url("127.0.0.1", port=_Port.ROSBRIDGE)
+
+        assert str(excinfo.value) == ""
+        assert create_url("127.0.0.1", port=9090)
+
+    def test_the_normalized_value_is_one_the_builder_accepts(self) -> None:
+        create_url = pytest.importorskip("autobahn.websocket.util").create_url
+
+        assert create_url("127.0.0.1", port=int(_Port.ROSBRIDGE)) == create_url("127.0.0.1", port=9090)
+
+    def test_the_client_refuses_it_at_construction_not_at_dial(self) -> None:
+        """Why the tool's ``try`` around the dial never converted this.
+
+        ``_RosbridgeBackend.connect`` wraps ``ros.run(...)`` in an ``except
+        Exception`` that reports an unreachable bridge. That would have caught
+        an ``AssertionError`` - the gate simply fires earlier, in the
+        constructor, one line above the try.
+        """
+        roslibpy = pytest.importorskip("roslibpy")
+
+        with pytest.raises(AssertionError):
+            roslibpy.Ros(host="127.0.0.1", port=_Port.ROSBRIDGE)

--- a/tests/tools/test_use_rosbridge.py
+++ b/tests/tools/test_use_rosbridge.py
@@ -68,7 +68,26 @@ class _FakeRos:
     scripted_responses: dict[str, dict[str, Any]] = {}
     scripted_messages: dict[str, list[dict[str, Any]]] = {}
 
+    # The real client builds its WebSocket URL in this constructor, before it
+    # dials, and that builder gates the port on type IDENTITY and on a range
+    # that stops one short of the 16-bit top:
+    #
+    #     assert port is None or (type(port) == int and port in range(0, 65535))
+    #         - autobahn/websocket/util.py:85 (autobahn 26.7.1)
+    #
+    # Reproducing it is what makes this double stand in for the client's
+    # contract instead of a more permissive one. Accepting any port of any type
+    # here let two values that are unusable in production look usable in the
+    # whole suite: an int subclass at EVERY value (#1835) and 65535 (#1822).
+    # The bare AssertionError is deliberate - it is the shape that escapes
+    # upstream, so a test asserting the tool no longer leaks one is asserting
+    # against what a caller would really have seen. Pinned against the
+    # installed dependency by the premise tests in
+    # tests/tools/test_rosbridge_port_type_identity.py, so this stays a
+    # statement about the client rather than a rule of our own invention.
     def __init__(self, host: str | None = None, port: int | None = None) -> None:
+        if not (port is None or (type(port) is int and port in range(0, 65535))):
+            raise AssertionError
         self.host, self.port = host, port
         self.is_connected = False
         self.terminated = False


### PR DESCRIPTION
Closes #1835.

## What happens today

```python
import enum
from strands_robots.tools import use_rosbridge

class Port(enum.IntEnum):
    ROSBRIDGE = 9090

use_rosbridge(action="status", host="127.0.0.1", port=Port.ROSBRIDGE, timeout=0.05)
```

```
AssertionError
```

The WebSocket URL builder behind `roslibpy` gates the port on type **identity**, not `isinstance`:

```python
assert port is None or (type(port) == int and port in range(0, 65535))
    # autobahn/websocket/util.py:85
```

So every `int` subclass is refused at **every** value, including the default `9090`. Measured against the installed roslibpy 1.8.1 / autobahn 26.7.1:

| port | `type(port)` | before this PR |
| --- | --- | --- |
| `9090` | `int` | `connected to ws://127.0.0.1:9090` |
| `Port.ROSBRIDGE` (== 9090) | `IntEnum` | bare `AssertionError`, `str(exc) == ""` |
| `IntSubclass(9090)` | `int` subclass | bare `AssertionError`, `str(exc) == ""` |

`str(exc)` is empty, so the exception names neither the tool nor the parameter nor the value, out of a function annotated `-> dict[str, Any]`. It escapes the tool's own `except (ImportError, KeyError, AttributeError, ValueError, TypeError, OSError)` tuple, and it also escapes the `try` that converts a failed dial - because the gate fires in the **client constructor**, one line above that `try`, not in `ros.run(...)`. `RosbridgeRobot` inherits it: it accepts the port at construction and then fails on every call, since all of its I/O forwards through this tool.

### The connection cache made it look intermittent

`use_rosbridge` caches one client per `(host, port)`, and `IntEnum(9090)` hashes equal to `9090` - so **any earlier plain-int call to the same host and port masks the defect entirely**, because the enum call reuses the cached client and never reaches the URL builder. Two cold processes differing only in call order:

| order | first call | second call |
| --- | --- | --- |
| enum, then plain | **`AssertionError`** | `success` |
| plain, then enum | `success` | `success` (cached client reused) |

Worth stating because a naive reproducer that dials with a plain `int` first reports that everything works.

## What changed

`strands_robots/tools/use_rosbridge.py`: the port is normalized with `int(port)` at the one place a client is constructed - `_RosbridgeBackend.connect` - and **ahead of the cache read**.

The value is legal and dials exactly as the equal plain `int` does, so it is *carried* rather than refused: that is a capability the tool already advertises through its `port: int`. Placing it before the cache read is the second half of the fix rather than tidiness - the key is then a plain `int` whatever flavour arrived, so one `(host, port)` is one connection regardless of which type reached it first, the order dependence above is gone, and the annotation on `_connections` (`dict[tuple[str, int], Any]`) becomes true rather than aspirational.

One site covers `RosbridgeRobot` too, which is why nothing in `strands_robots/mesh/` changes.

Deliberately **not** done:

- **Narrowing `tcp_port_error`.** It is `isinstance`-based on purpose - it rejects `bool` and accepts the 16-bit range - and this is a type-identity defect, not a range one. Tightening it to `type(port) is int` would reject the very values this fix makes work, on surfaces with no WebSocket under them.
- **Catching the dependency's `assert`.** `python -O` strips it, so the behaviour would depend on how the interpreter was launched; and any `AssertionError` from client construction would be attributed to the port.

## Test surface

`tests/tools/test_rosbridge_port_type_identity.py` (21 tests), grouped by what has to stay true together:

1. **The value dials** - through the tool and through `RosbridgeRobot.get_pose`, and the client is constructed with a plain `int`. Both an `IntEnum` and a bare `int` subclass, so the defect is attributed to the subclassing rather than to the enum. Every action is covered, and the action set is read from `rb_mod._ACTIONS` rather than typed out, so a seventh action cannot be added without this covering it.
2. **Neither call order matters** - both orders from the table above are pinned. `plain -> enum` passes pre-fix, which is exactly the point: it is the order that hid this.
3. **The shared domain is unchanged** - `tcp_port_error` still accepts both subclass flavours and still rejects `bool`, `0` and `70000`.
4. **The premise the normalization rests on** - the installed builder really does gate on identity, `int(port)` really does produce a value it accepts, and the client really does refuse at construction rather than at dial (which is why the tool's `try` never converted it). Skipped rather than faked when the extra is absent: a premise about a dependency measured against a double is worth nothing.

**Also completed the `_FakeRos` double** in `tests/tools/test_use_rosbridge.py` so it reproduces the client's gate instead of accepting any port of any type. This is the part that explains why the defect was invisible: a double more permissive than the client let two unusable values look usable across the whole suite - an `int` subclass at every value (this PR) and `65535` (#1822). It now raises the same bare `AssertionError` the client raises, with the upstream line named, and the equivalence is pinned against the installed dependency by the premise tests above rather than asserted as a rule of our own.

**Delta, run locally on this branch:**

| suite | result |
| --- | --- |
| new file, source reverted (pre-fix) | **13 failed**, 8 passed |
| new file, with the fix | 21 passed |
| `tests/tools` + `tests/mesh`, this branch | 94 failed, **3399** passed |
| `tests/tools` + `tests/mesh`, `main` (same command) | 94 failed, **3378** passed |

Read as a delta, not an absolute: the 94 are identical on both sides and pre-exist (this runner has no `lerobot` / `awsiot` / GPU), and the whole effect of the branch is **+21 passes** - exactly the tests it adds. `ruff check` / `ruff format` clean. `mypy strands_robots tests tests_integ` - the command CI runs, not a scoped subset - reports the same 11 pre-existing errors on the branch as on `main`, so zero added.

## Composed with #1834 before opening

Both PRs edit `use_rosbridge.py`, and a `CLEAN` status is a statement about text rather than meaning. Merging #1834 into this branch and running both new files plus their siblings: **275 passed, 0 failed** (`test_rosbridge_port_type_identity.py`, `test_rosbridge_transport_port_limit.py`, `test_use_rosbridge.py`, `test_rosbridge_robot.py`, `test_gr00t_numeric_option_guards.py`, `test_source_no_unreachable_statements.py`, `test_changelog_fragments.py`). The two refusals are not written against each other: #1834 refuses `65535` in the validation block ahead of the backend, this one normalizes the type at the dial. Either order of landing is fine; the completed double satisfies both.

## Scope

One concern: a rosbridge port that is an `int` subclass dials like the equal plain `int`. No behaviour change for any other port value, any other type, or any other surface.