### PR TITLE
fix(sim): refuse a boolean actuator command instead of writing it as 1.0/0.0

### DIFF
--- a/changelog.d/1837-send-action-rejects-a-boolean-command.md
+++ b/changelog.d/1837-send-action-rejects-a-boolean-command.md
@@ -1,0 +1,29 @@
+### Fixed: `send_action` refuses a boolean actuator command instead of writing it as 1.0/0.0
+
+`bool` is an `int` subclass and `numpy.bool_` coerces identically, so
+`send_action`'s scalar-coercion check admitted both and they reached the actuator
+as a silent `1.0` / `0.0` under `status="success"`. That is not one command: 1.0
+is a 1-radian target on a joint-position drive, a full-travel command on a
+normalized or tendon drive, and an out-of-range value that is silently clamped
+where `ctrlrange` excludes 1 - so the same `True` commands a different pose on
+every actuator. Measured on the Panda's `[0, 255]` tendon gripper,
+`send_action({"gripper": True})` wrote `ctrl` 255 and swung the fingers from
+closed to fully open (0.0800 m), byte-identical to an explicit full-travel
+`1.0` - the opposite of what a binary "grasp" flag asks for, and a boolean is the
+conventional binary-gripper action rather than a typo.
+
+The teleop wire validator already refused a boolean so it could not "masquerade
+as a 1.0/0.0 command", and `InputReceiver` applies validated frames through
+`send_action` - so the remote surface was held to a stricter domain than the
+local call it delegates to. Both accepted action shapes (a mapping value and a
+vector entry) now refuse a python or numpy boolean, naming the offending key or
+vector index and the actuator's own units as the remedy. The guard lives in the
+shared `SimEngine` coercion, so every backend inherits it. Numeric spellings are
+unchanged, including the documented numeric-string form and the single-element
+`[0.05]` unwrap.
+
+A 0-d numpy array (`np.array(0.5)`, `np.mean(...)`) additionally raised a bare
+`TypeError: len() of unsized object` past `send_action`'s structured-error
+contract - it declares `__len__` but raises on `len()`, so the single-element
+unwrap could not probe it and the boolean gate could not see the 0-d boolean a
+policy comparison produces. It is now left for the value checks to read.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -126,6 +126,8 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 
 A vector lets a policy's raw action chunk drive the arm directly without first zipping it into a dict. It binds to `robot_action_keys` (not `robot_joint_names`) because those are the keys `send_action` resolves and the ordering the `LeRobotDataset` recorder writes the `action` column in; the two coincide unless a robot has passive/mimic joints or a tendon gripper. The vector length must match the robot's actuator count exactly; a mismatch (or a non-numeric / scalar / string `action`) returns a structured `status="error"` dict naming the actuator count and order, rather than crashing or silently truncating commands. Use a mapping to target a subset of actuators.
 
+Each action *value* must be a finite number, and must not be a boolean. `nan` / `inf` are refused because they are not clamped into the actuator's range - MuJoCo discards the step and resets every robot in the scene while reporting success. A `bool` (or `numpy.bool_`) is refused because `float(True)` is `1.0`, and each drive reads 1.0 in its own units: a 1-radian target on a joint-position drive, a full-travel command on a normalized or tendon drive (a `[0, 255]` tendon gripper reads it as fully open), and an out-of-range value that is silently clamped where `ctrlrange` excludes 1 - so the same `True` commands a different pose on every actuator. Send the command in the actuator's own units; for a binary gripper, its endpoint value rather than a flag. This is the domain the teleop wire validator already enforces on an input frame, and `InputReceiver` applies those frames through `send_action`.
+
 ## Policy
 
 | Action | Key params |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -272,6 +272,100 @@ def _non_finite_action_error(label: str, value: Any) -> dict[str, Any] | None:
     }
 
 
+_BOOLEAN_ACTION_REASON = (
+    "A boolean cannot express an actuator command. float(True) is 1.0, and each "
+    "drive reads 1.0 in its own units: a 1-radian target on a joint-position "
+    "drive, a full-travel command on a normalized or tendon drive (a [0, 255] "
+    "tendon gripper reads 1.0 as fully open), and an out-of-range value that is "
+    "silently clamped on a drive whose ctrlrange excludes 1. The same True "
+    "therefore commands a different pose on every actuator. Pass the command in "
+    "the actuator's own units - for a binary gripper, the endpoint value rather "
+    "than a flag."
+)
+
+
+def _unwrap_single_element_action_value(value: Any) -> Any:
+    """Unwrap a length-1 sequence action value to its scalar, else return it as-is.
+
+    The ``Policy.get_actions -> list[dict]`` contract emits ``list[float]`` for
+    vector-valued keys, which for a 1-DOF key yields a length-1 list (GR00T's
+    service unpack emits ``{"x": [0.05], ...}`` for the LIBERO delta-EEF
+    layout). Such a value carries exactly one scalar and is unambiguous, so it
+    is unwrapped rather than rejected.
+
+    A 0-d numpy array (``np.array(True)``, ``np.mean(...)``) declares
+    ``__len__`` and ``__getitem__`` but raises ``TypeError`` from ``len()``, so
+    probing the length directly escapes ``send_action``'s structured-error
+    contract with a bare ``len() of unsized object``. It already holds exactly
+    one scalar, so there is nothing to unwrap and it is returned unchanged for
+    the value checks to read.
+    """
+    if isinstance(value, (str, bytes, Mapping)):
+        return value
+    if not hasattr(value, "__len__") or not hasattr(value, "__getitem__"):
+        return value
+    try:
+        length = len(value)
+    except TypeError:
+        return value
+    return value[0] if length == 1 else value
+
+
+def _is_boolean(value: Any) -> bool:
+    """Return True when ``value`` is a python or a numpy boolean.
+
+    ``numpy.bool_`` is not a ``bool`` subclass, so ``isinstance(value, bool)``
+    alone misses the boolean a policy produces from a comparison
+    (``gripper > 0.5``). Unwrapping through ``.item()`` first - the mechanism
+    :func:`strands_robots.mesh.security.validate_input_frame` already uses for
+    the same gate - yields a python ``bool`` for a numpy boolean scalar or 0-d
+    array while leaving every numeric scalar reported as non-boolean.
+    """
+    if isinstance(value, bool):
+        return True
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return isinstance(item(), bool)
+        except (TypeError, ValueError):  # a multi-element array has no single item
+            return False
+    return False
+
+
+def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
+    """Structured error when an action value is a python or numpy boolean.
+
+    ``bool`` is an ``int`` subclass and ``numpy.bool_`` coerces the same way, so
+    a scalar-coercion check admits both and they reach the actuator command as a
+    silent ``1.0``/``0.0``. The teleop wire validator
+    (:func:`strands_robots.mesh.security.validate_input_frame`, which
+    ``InputReceiver`` applies through ``send_action``) already refuses a boolean
+    for exactly that reason, so a remote peer's frame is held to a stricter
+    domain than the local call it is applied through; this is the same rule for
+    the actuator-command path, applied to both accepted action shapes so a
+    mapping value and a vector entry cannot diverge.
+
+    Args:
+        label: How to name the offending element in the message - the caller
+            supplies it because a mapping names a key while a vector names a
+            position and the actuator key it binds to.
+        value: The raw value, before scalar coercion (``float(True)`` is 1.0, so
+            the boolean is unrecoverable once coerced).
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict, or ``None`` when the
+        value is not a boolean and is therefore usable as a command.
+    """
+    if not _is_boolean(value):
+        return None
+    return {
+        "status": "error",
+        "content": [
+            {"text": (f"send_action: {label} must be a number, not a bool (got {value!r}). {_BOOLEAN_ACTION_REASON}")}
+        ],
+    }
+
+
 class SimEngine(ABC):
     """Abstract base class for simulation engines.
 
@@ -861,10 +955,24 @@ class SimEngine(ABC):
         clamped into ``ctrlrange``, i.e. silently rewritten into a full-travel
         command. The sibling state writers (:meth:`set_joint_positions` /
         :meth:`set_joint_velocities`) already refuse a non-finite value, so this
-        holds the actuator-command path to the same rule. The domain is finiteness
-        alone: a numeric string is an accepted spelling of a scalar here, and a
-        finite magnitude outside ``ctrlrange`` is a units question already
-        surfaced by the clamp warning.
+        holds the actuator-command path to the same rule.
+
+        A value must additionally not be a **boolean**. ``bool`` is an ``int``
+        subclass and ``numpy.bool_`` coerces identically, so the scalar check
+        admits both and they reach the actuator as ``1.0``/``0.0`` - and 1.0 is
+        not one command: it is a 1-radian target on a joint-position drive, a
+        full-travel command on a normalized or tendon drive, and an out-of-range
+        value that is silently clamped where ``ctrlrange`` excludes 1. A boolean
+        is the conventional binary-gripper action, so the value arrives at this
+        surface routinely rather than as a typo. The teleop wire validator
+        (:func:`strands_robots.mesh.security.validate_input_frame`) already
+        refuses a boolean so it "can't masquerade as a 1.0/0.0 command", and it
+        applies frames through ``send_action`` - so refusing it here holds the
+        local call to the domain its own remote surface enforces.
+
+        Otherwise the domain is finiteness: a numeric string is an accepted
+        spelling of a scalar here, and a finite magnitude outside ``ctrlrange``
+        is a units question already surfaced by the clamp warning.
 
         Args:
             action: A ``{name: value}`` mapping, or an ordered numeric vector
@@ -900,13 +1008,12 @@ class SimEngine(ABC):
             # atomically.
             normalized: dict[str, Any] = {}
             for key, value in action.items():
-                if (
-                    not isinstance(value, (str, bytes, Mapping))
-                    and hasattr(value, "__len__")
-                    and hasattr(value, "__getitem__")
-                    and len(value) == 1
-                ):
-                    value = value[0]
+                value = _unwrap_single_element_action_value(value)
+                # Before the scalar coercion: ``float(True)`` succeeds, so the
+                # coercion below cannot see a boolean and the value would reach
+                # the actuator as a silent 1.0/0.0 command.
+                if error := _boolean_action_error(f"action value for key '{key}'", value):
+                    return None, error
                 try:
                     float(value)
                 except (TypeError, ValueError):
@@ -945,7 +1052,10 @@ class SimEngine(ABC):
             }
 
         try:
-            values = [float(v) for v in action]
+            # Keep the raw entries: ``float`` erases a boolean into 1.0/0.0, so
+            # the bool gate below has to see the value the caller passed.
+            raw_entries = list(action)
+            values = [float(v) for v in raw_entries]
         except (TypeError, ValueError) as exc:
             return None, {
                 "status": "error",
@@ -968,8 +1078,11 @@ class SimEngine(ABC):
                 ],
             }
         bound: dict[str, Any] = {}
-        for idx, (name, value) in enumerate(zip(action_keys, values)):
-            if error := _non_finite_action_error(f"action vector entry {idx} ('{name}')", value):
+        for idx, (name, raw, value) in enumerate(zip(action_keys, raw_entries, values, strict=True)):
+            label = f"action vector entry {idx} ('{name}')"
+            if error := _boolean_action_error(label, raw):
+                return None, error
+            if error := _non_finite_action_error(label, value):
                 return None, error
             bound[name] = value
         return bound, None

--- a/tests/simulation/test_send_action_rejects_a_boolean_command.py
+++ b/tests/simulation/test_send_action_rejects_a_boolean_command.py
@@ -1,0 +1,335 @@
+"""A boolean is not an actuator command, on either accepted action shape.
+
+``bool`` is an ``int`` subclass and ``numpy.bool_`` coerces identically, so
+``send_action``'s scalar-coercion check admitted both and they reached the
+actuator as a silent ``1.0``/``0.0``. That is not one command: 1.0 is a
+1-radian target on a joint-position drive, a full-travel command on a
+normalized or tendon drive, and an out-of-range value that is silently clamped
+where ``ctrlrange`` excludes 1 - so the same ``True`` commands a different pose
+on every actuator. A boolean is the conventional binary-gripper action, so the
+value arrives at this surface routinely rather than as a typo.
+
+The teleop wire validator in :mod:`strands_robots.mesh.security` already refuses
+a boolean so it cannot "masquerade as a 1.0/0.0 command", and it applies frames
+through ``send_action`` - so the remote surface was held to a stricter domain
+than the local call it delegates to. These tests pin the local call to the same
+rule, on both accepted action shapes, and pin the numeric spellings that must
+keep working so the guard cannot over-reach.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.base import (
+    SimEngine,
+    _is_boolean,
+    _unwrap_single_element_action_value,
+)
+
+pytest.importorskip("mujoco")
+
+# Two drives with deliberately different unit conventions, so "the same 1.0
+# means different things" is a property of the fixture rather than a claim:
+# ``lift_act`` is a joint-position drive in radians and ``grip_act`` is a fixed
+# tendon whose ctrlrange is the [0, 255] gripper convention.
+_ARM_XML = """
+<mujoco model="two_drive_arm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <joint name="lift" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="4"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+      <body name="hand" pos="0.2 0 0">
+        <joint name="finger1" type="slide" axis="0 1 0" range="0 0.04" limited="true" damping="2"/>
+        <geom type="box" size="0.01 0.005 0.02" pos="0 0.02 0"/>
+        <body name="finger2_link">
+          <joint name="finger2" type="slide" axis="0 -1 0" range="0 0.04" limited="true" damping="2"/>
+          <geom type="box" size="0.01 0.005 0.02" pos="0 -0.02 0"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="grip">
+      <joint joint="finger1" coef="1"/>
+      <joint joint="finger2" coef="1"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <position name="lift_act" joint="lift" kp="30" ctrlrange="-2 2"/>
+    <position name="grip_act" tendon="grip" kp="40" ctrlrange="0 255"/>
+  </actuator>
+</mujoco>
+"""
+
+# ``0.5`` is a plain numeric command; the string spelling is accepted by
+# ``send_action`` by documented design and is therefore excluded from the wire
+# parity check below rather than smuggled into it.
+_ACCEPTED_NUMERIC: list[tuple[str, Any]] = [
+    ("float", 1.0),
+    ("zero float", 0.0),
+    ("int", 0),
+    ("numpy float scalar", np.float64(0.5)),
+    ("numpy int scalar", np.int64(1)),
+    ("single-element list", [0.5]),
+    ("single-element array", np.array([0.5])),
+    ("0-d numpy array", np.array(0.5)),
+]
+
+_BOOLEAN_SPELLINGS: list[tuple[str, Any]] = [
+    ("python True", True),
+    ("python False", False),
+    ("numpy bool scalar", np.True_),
+    ("numpy bool false", np.bool_(False)),
+    ("0-d numpy bool array", np.array(True)),
+    ("single-element list of bool", [True]),
+    ("single-element bool array", np.array([True])),
+]
+
+
+@pytest.fixture
+def sim(tmp_path):  # noqa: ANN001, ANN201 - annotating this as the engine types _world as optional
+    """A two-drive arm loaded from an inline MJCF (no asset download)."""
+    from strands_robots.simulation import Simulation
+
+    path = tmp_path / "two_drive_arm.xml"
+    path.write_text(_ARM_XML, encoding="utf-8")
+    engine = Simulation(backend="mujoco", tool_name="bool_action_test", mesh=False)
+    engine.create_world()
+    added = engine.add_robot(name="arm", urdf_path=str(path))
+    assert added["status"] == "success", added
+    yield engine
+    engine.cleanup()
+
+
+def _text(result: dict[str, Any]) -> str:
+    return next(block["text"] for block in result["content"] if "text" in block)
+
+
+def _ctrl(engine: Any) -> list[float]:
+    data = engine._world._data
+    return [float(v) for v in data.ctrl[: engine._world._model.nu]]
+
+
+class TestBooleanMappingValueRefused:
+    """A boolean mapping value is refused, naming the key that carried it."""
+
+    @pytest.mark.parametrize(("label", "value"), _BOOLEAN_SPELLINGS, ids=[s[0] for s in _BOOLEAN_SPELLINGS])
+    def test_every_boolean_spelling_is_refused(self, sim, label: str, value: Any) -> None:
+        result = sim.send_action({"grip_act": value}, robot_name="arm")
+        assert result["status"] == "error", f"{label} was accepted as a command"
+        message = _text(result)
+        assert "not a bool" in message
+        assert "grip_act" in message
+
+    def test_the_refusal_names_the_units_the_caller_should_use(self, sim) -> None:
+        """The remedy has to say what to send instead, not merely that True is wrong."""
+        message = _text(sim.send_action({"grip_act": True}, robot_name="arm"))
+        assert "actuator's own units" in message
+        assert "binary gripper" in message
+
+    def test_a_boolean_leaves_the_actuators_and_the_clock_untouched(self, sim) -> None:
+        """The guard precedes the ctrl write and the physics step, so nothing is half-applied."""
+        applied = sim.send_action({"lift_act": 0.7, "grip_act": 12.0}, robot_name="arm")
+        assert applied["status"] == "success", applied
+        before_ctrl = _ctrl(sim)
+        before_time = float(sim._world._data.time)
+        assert before_ctrl != [0.0, 0.0], "fixture must establish a command a refusal could overwrite"
+
+        refused = sim.send_action({"lift_act": 0.9, "grip_act": True}, robot_name="arm", n_substeps=5)
+        assert refused["status"] == "error"
+        assert _ctrl(sim) == before_ctrl, "a refused action must not apply its other keys"
+        assert float(sim._world._data.time) == before_time, "a refused action must not advance physics"
+
+
+class TestBooleanVectorEntryRefused:
+    """A boolean vector entry is refused, naming its position and actuator key."""
+
+    def test_an_all_boolean_vector_is_refused(self, sim) -> None:
+        result = sim.send_action([True, True], robot_name="arm")
+        assert result["status"] == "error"
+        message = _text(result)
+        assert "action vector entry 0" in message
+        assert "lift_act" in message
+        assert "not a bool" in message
+
+    def test_one_boolean_among_floats_names_its_own_index(self, sim) -> None:
+        """The gripper axis is the realistic carrier, and it is the last entry."""
+        result = sim.send_action([0.3, True], robot_name="arm")
+        assert result["status"] == "error"
+        message = _text(result)
+        assert "action vector entry 1" in message
+        assert "grip_act" in message
+
+    def test_a_numpy_boolean_vector_is_refused(self, sim) -> None:
+        result = sim.send_action(np.array([True, False]), robot_name="arm")
+        assert result["status"] == "error"
+        assert "not a bool" in _text(result)
+
+    def test_a_refused_vector_leaves_every_actuator_untouched(self, sim) -> None:
+        assert sim.send_action([0.4, 20.0], robot_name="arm")["status"] == "success"
+        before = _ctrl(sim)
+        assert sim.send_action([0.5, True], robot_name="arm")["status"] == "error"
+        assert _ctrl(sim) == before
+
+
+class TestNumericCommandsStillAccepted:
+    """The guard must not narrow the numeric spellings ``send_action`` accepts."""
+
+    @pytest.mark.parametrize(("label", "value"), _ACCEPTED_NUMERIC, ids=[s[0] for s in _ACCEPTED_NUMERIC])
+    def test_numeric_mapping_values_are_accepted(self, sim, label: str, value: Any) -> None:
+        result = sim.send_action({"grip_act": value}, robot_name="arm")
+        assert result["status"] == "success", f"{label} was refused: {_text(result)}"
+
+    def test_a_numeric_string_remains_an_accepted_spelling(self, sim) -> None:
+        """Documented behaviour: the domain is the value, not its python type."""
+        result = sim.send_action({"grip_act": "0.5"}, robot_name="arm")
+        assert result["status"] == "success", _text(result)
+        assert _ctrl(sim)[1] == pytest.approx(127.5)
+
+    @pytest.mark.parametrize("vector", [[0.3, 0.4], (0.3, 0.4), np.array([0.3, 0.4])], ids=["list", "tuple", "array"])
+    def test_numeric_vectors_are_accepted(self, sim, vector: Any) -> None:
+        assert sim.send_action(vector, robot_name="arm")["status"] == "success"
+
+
+class TestZeroDimensionalArrayReachesTheValueChecks:
+    """A 0-d numpy array raised ``len() of unsized object`` past the tool contract.
+
+    It declares ``__len__`` and ``__getitem__`` but raises on ``len()``, so the
+    single-element unwrap could not probe it - and the boolean gate could not see
+    the 0-d boolean a policy comparison produces.
+    """
+
+    def test_a_zero_dimensional_numeric_array_is_a_usable_command(self, sim) -> None:
+        result = sim.send_action({"grip_act": np.array(0.5)}, robot_name="arm")
+        assert result["status"] == "success", _text(result)
+        assert _ctrl(sim)[1] == pytest.approx(127.5)
+
+    def test_a_zero_dimensional_boolean_array_is_refused_not_raised(self, sim) -> None:
+        result = sim.send_action({"grip_act": np.array(True)}, robot_name="arm")
+        assert result["status"] == "error"
+        assert "not a bool" in _text(result)
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ([0.05], 0.05),
+            (np.array([0.05]), 0.05),
+            ("0.5", "0.5"),
+            (0.5, 0.5),
+        ],
+        ids=["single-element list", "single-element array", "string", "scalar"],
+    )
+    def test_the_unwrap_yields_the_scalar_or_the_value_itself(self, value: Any, expected: Any) -> None:
+        assert _unwrap_single_element_action_value(value) == expected
+
+    def test_the_unwrap_returns_a_zero_dimensional_array_unchanged(self) -> None:
+        value = np.array(0.5)
+        assert _unwrap_single_element_action_value(value) is value
+
+    def test_the_unwrap_leaves_a_multi_element_sequence_for_the_length_check(self) -> None:
+        value = [0.1, 0.2]
+        assert _unwrap_single_element_action_value(value) is value
+
+
+class TestBooleanPredicate:
+    """``numpy.bool_`` is not a ``bool`` subclass, so the predicate cannot rely on isinstance."""
+
+    @pytest.mark.parametrize(
+        "value", [True, False, np.True_, np.bool_(False), np.array(True)], ids=["True", "False", "np", "np2", "0d"]
+    )
+    def test_boolean_values_are_reported_as_boolean(self, value: Any) -> None:
+        assert _is_boolean(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [0, 1, 0.0, 1.0, np.float64(1.0), np.int64(1), np.uint8(1), "0.5", [1.0], np.array([1.0]), None],
+        ids=["0", "1", "0.0", "1.0", "npf", "npi", "npu", "str", "list", "arr", "None"],
+    )
+    def test_non_boolean_values_are_not_reported_as_boolean(self, value: Any) -> None:
+        assert _is_boolean(value) is False
+
+
+class TestWireAndLocalDomainsAgreeOnBooleans:
+    """The wire validator and the call it applies frames through must not diverge.
+
+    ``validate_input_frame`` sanitises a teleop frame and ``InputReceiver``
+    applies the result via ``send_action``, so a boolean the wire refuses must
+    not be a value the local call accepts. Only the boolean question is compared:
+    ``send_action`` accepts a numeric string by documented design while the wire
+    validator requires an ``int``/``float``, and that divergence is deliberate.
+    """
+
+    def test_both_surfaces_refuse_every_boolean_spelling(self, sim) -> None:
+        from strands_robots.mesh.security import ValidationError, validate_input_frame
+
+        for label, value in _BOOLEAN_SPELLINGS:
+            if isinstance(value, (list, np.ndarray)) and getattr(value, "ndim", 1) != 0:
+                # A sequence value is not a teleop frame shape; the wire
+                # validator rejects it for its shape rather than its booleanness.
+                continue
+            with pytest.raises(ValidationError, match="not bool"):
+                validate_input_frame({"grip_act": value})
+            assert sim.send_action({"grip_act": value}, robot_name="arm")["status"] == "error", label
+
+    def test_both_surfaces_accept_a_plain_numeric_command(self, sim) -> None:
+        from strands_robots.mesh.security import validate_input_frame
+
+        assert validate_input_frame({"grip_act": 12.0}) == {"grip_act": 12.0}
+        assert sim.send_action({"grip_act": 12.0}, robot_name="arm")["status"] == "success"
+
+
+class TestTheSameOneCommandsADifferentPose:
+    """The premise the refusal message states, measured on the fixture.
+
+    ``float(True)`` is 1.0 for both drives, and 1.0 is a different physical
+    command on each: the tendon drive reads it as the normalized full-travel
+    fraction and maps it onto its own ctrlrange, while the joint drive takes it
+    as a radian target verbatim.
+    """
+
+    def test_one_means_full_travel_on_a_tendon_drive_and_a_radian_on_a_joint_drive(self, sim) -> None:
+        model = sim._world._model
+        lift_range = [float(v) for v in model.actuator_ctrlrange[0]]
+        grip_range = [float(v) for v in model.actuator_ctrlrange[1]]
+        assert lift_range != grip_range, "fixture must give the two drives different unit conventions"
+
+        assert sim.send_action({"lift_act": 1.0, "grip_act": 1.0}, robot_name="arm")["status"] == "success"
+        lift_ctrl, grip_ctrl = _ctrl(sim)
+        assert lift_ctrl == pytest.approx(1.0), "a joint drive takes 1.0 as a radian target"
+        assert grip_ctrl == pytest.approx(grip_range[1]), "a tendon drive reads 1.0 as full travel"
+
+
+class TestEveryBackendInheritsTheGuard:
+    """The guard lives in the shared coercion, so no backend can ship without it."""
+
+    def test_send_action_is_defined_once_and_routes_through_the_shared_coercion(self) -> None:
+        from strands_robots.simulation.mujoco import simulation as mujoco_simulation
+        from strands_robots.simulation.newton import simulation as newton_simulation
+
+        for module in (mujoco_simulation, newton_simulation):
+            tree = ast.parse(inspect.getsource(module))
+            sends = [
+                node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "send_action"
+            ]
+            assert sends, f"{module.__name__} defines no send_action"
+            for node in sends:
+                calls = {
+                    child.func.attr
+                    for child in ast.walk(node)
+                    if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
+                }
+                assert "_coerce_action" in calls, (
+                    f"{module.__name__}.send_action does not route through _coerce_action, "
+                    "so it does not inherit the action-value domain"
+                )
+
+    def test_the_shared_coercion_is_defined_on_the_abstract_engine(self) -> None:
+        assert "_coerce_action" in vars(SimEngine)


### PR DESCRIPTION
## Problem

`bool` is an `int` subclass and `numpy.bool_` coerces identically, so `send_action`'s scalar-coercion check (`try: float(value)`) admitted both and they reached the actuator as a silent `1.0` / `0.0` under `status="success"`.

**1.0 is not one command.** Each drive reads it in its own units:

| drive | `ctrlrange` | what `float(True)` = 1.0 becomes |
|---|---|---|
| Panda `actuator1` (joint position) | `[-2.897, 2.897]` | a 1-radian target (57 degrees) |
| Panda `actuator8` (fixed tendon) | `[0, 255]` | **`ctrl` 255 - fully open** |
| Panda `actuator4` (joint position) | `[-3.072, -0.070]` | out of range, silently clamped |

So the same `True` commands a different pose on every actuator. Measured on the Panda's tendon gripper, `send_action({"gripper": True})` swung the fingers from closed (0.0000 m) to fully open (0.0800 m) - the *opposite* of what a binary "grasp" flag asks for - and the resulting frame is **byte-identical** (`max|delta| = 0`) to an explicit full-travel `1.0`. A boolean is the conventional binary-gripper action in a VLA action space, and a JSON action frame's `true` decodes to a python `bool`, so the value arrives at this surface routinely rather than as a typo.

**The remote surface was already stricter than the local call it delegates to.** `mesh.security.validate_input_frame` refuses a boolean with the comment "reject it explicitly so a stray True/False (python- or numpy-derived) can't masquerade as a 1.0/0.0 command", and `InputReceiver` applies validated frames *through* `send_action`. `utils.finite_vector_error` states the same rule for scene-construction vectors: "a `bool` is refused because `float(True)` would silently write `1.0` where a coordinate, extent or colour channel belongs." The actuator command - the write that produces motion - was the one that did not apply it.

A related leak on the same expression: a 0-d numpy array (`np.array(0.5)`, `np.mean(...)`) declares `__len__` but raises on `len()`, so the single-element unwrap raised a bare `TypeError: len() of unsized object` past `send_action`'s structured-error contract - and the boolean gate could not see the 0-d boolean a policy comparison produces.

## Change

* `SimEngine._coerce_action` refuses a python or numpy boolean on **both** accepted action shapes (a mapping value and a vector entry), naming the offending key or vector index plus the actuator's own units as the remedy. The guard lives in the shared coercion, so MuJoCo and Newton both inherit it and no backend can ship without it.
* `_is_boolean` unwraps through `.item()` first - the mechanism `validate_input_frame` already uses for the same gate - so `numpy.bool_` and a 0-d boolean array are caught, not just a python `bool`.
* `_unwrap_single_element_action_value` extracts the single-element unwrap and tolerates a 0-d array, which already holds exactly one scalar.
* Numeric spellings are unchanged, including the documented numeric-string form, the single-element `[0.05]` unwrap, and every numpy real scalar.

The guard precedes the `ctrl` write and the physics step, so a refused action applies none of its other keys and does not advance the clock.

## Sim rollout

Panda, `keyframe="home"`, gripper closed, then one `send_action({"gripper": True})` and 260 control steps. MuJoCo headless (`egl`), both panels from the same rig (`max|delta| = 0` on the start frame).

![boolean gripper command](https://raw.githubusercontent.com/cagataycali/robots/artifacts/boolean-gripper-command/boolean_gripper_command.png)

| | main | this change |
|---|---|---|
| reported status | `"success"` | `"error"` |
| `ctrl` written to the tendon drive | 255.00 | none - the call is refused |
| finger gap after 260 steps | 0.0800 m (fully open) | 0.0000 m (unchanged) |
| explicit `{"gripper": 1.0}` | 0.0800 m | 0.0800 m (unaffected) |

Panels 2 and 3 differ on 22.4% of pixels; panel 2 is byte-identical to an explicit full-travel command, which is the measurement behind "`True` is silently the maximum-travel command".

## Rejected alternative

Accepting a boolean and mapping it to the actuator's `ctrlrange` endpoints. It cannot be done consistently - the endpoint that means "grasp" is `lo` on a tendon gripper and unknowable on a joint-position gripper whose range is not a gripper axis at all - so it would replace a silent 1.0 with a silent guess. Naming the units and letting the caller send them is the only answer that is right on every drive.

## Out of scope

`set_joint_positions` / `set_joint_velocities` / `apply_force` also coerce a boolean to 1.0. Those are different parameters with a different consequence: 1.0 there is one unambiguous quantity (1 rad, 1 N) rather than a value re-interpreted per drive, and `apply_force` carries an explicit note that "bool is intentionally accepted ... rejecting it is out of scope for numeric-element validation". Revisiting that note is its own change; this PR holds the actuator-command path to the domain its own remote surface already enforces. Filed for follow-up rather than folded in.

## Tests

`tests/simulation/test_send_action_rejects_a_boolean_command.py`, 54 tests, GL-free (an inline two-drive MJCF: one joint-position drive in radians and one fixed tendon on the `[0, 255]` gripper convention, so "the same 1.0 means different things" is a property of the fixture rather than a claim).

* every boolean spelling refused on a mapping value and on a vector entry, naming the key / index
* a refusal leaves every `ctrl` entry and the clock untouched
* over-reach controls: float, int, numpy real scalars, the documented numeric string, single-element list/array, list/tuple/array vectors all still accepted
* the 0-d array reaches the value checks instead of raising
* `_is_boolean` over 5 boolean and 11 non-boolean spellings
* **wire/local parity**: every boolean the wire validator refuses, `send_action` refuses (the numeric-string divergence is deliberate and excluded explicitly)
* **premise**: 1.0 is full travel on the tendon drive and a radian on the joint drive, measured
* **structural**: both backends' `send_action` route through `_coerce_action`

Pre-fix (source reverted to `upstream/main`, new symbols stubbed): **17 failed, 15 passed** - the 15 are the over-reach controls, the premise pins and the structural test, which are what stop the guard over-reaching. The 0-d cases fail pre-fix as `TypeError: len() of unsized object`.

## Gate

* `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (1009 files formatted, 1006 source files, no issues)
* `MUJOCO_GL=egl pytest tests` -> **16005 passed, 257 skipped** in 490s at base `c8964134`
* zero existing tests changed - no call site in the tree passes a boolean action value
* `scripts/check_merge_base_overlap.py`: no overlap with `upstream/main`