### PR TITLE
fix(policies): refuse a service port the provider cannot dial

### DIFF
--- a/changelog.d/1839-policy-service-port-domain.md
+++ b/changelog.d/1839-policy-service-port-domain.md
@@ -1,0 +1,20 @@
+### Fixed: a policy provider refuses a service port it cannot dial
+
+The four providers that reach a policy service over TCP built the endpoint by
+interpolating a caller-supplied `port` with no validation: `groot` and `moveit2`
+into `tcp://<host>:<port>`, `cosmos3` into `ws://<host>:<port>`, and
+`lerobot_async` into a gRPC target. Every one of those transports connects
+lazily, so a port outside the 16-bit range was not refused by the socket -
+`create_policy("groot", port=99999)` returned a ready policy whose endpoint was
+`tcp://localhost:99999`, and the mistake only surfaced later as an inference
+timeout that implicated the server. `port=2.7` produced `tcp://localhost:2.7`;
+`cosmos3` and `lerobot_async` accepted `nan`, `None` and `[8000]`, yielding
+`ws://localhost:None` and `127.0.0.1:[8000]`.
+
+Each provider now validates the port against the shared
+`strands_robots.utils.tcp_port_error` domain - the same one the `gr00t_inference`
+tool that *starts* the GR00T service and the mesh bridges already use - before
+any transport is constructed. The check is scoped to the branch that dials: a
+`groot` local-mode policy, a `cosmos3` policy given an injected client or the
+diffusers backend, and a `lerobot_async` policy given `server_address` are
+unaffected.

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -65,6 +65,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
+from strands_robots.utils import tcp_port_error
 
 from .client import Cosmos3WebsocketClient
 from .embodiments import (
@@ -106,7 +107,10 @@ class Cosmos3Policy(Policy):
         embodiment: Embodiment key/alias (``"droid"``, ``"umi"``, ``"av"``,
             ``"bridge"``). Selects domain, action layout, and defaults.
         host: Policy-server hostname.
-        port: Policy-server WebSocket port.
+        port: Policy-server WebSocket port, an ``int`` in ``[1, 65535]``.
+            Read only when this constructor builds the client; an injected
+            ``client`` owns its own address. A value outside the range is
+            refused rather than interpolated into ``ws://<host>:<port>``.
         action_space: ``"joint_pos"`` or ``"midtrain"`` - must match how the
             server was launched (DROID default = ``joint_pos``).
         observation_mapping: ``{robot_obs_key: "observation/<server_key>"}``.
@@ -289,6 +293,13 @@ class Cosmos3Policy(Policy):
                 mode,
             )
         else:
+            # ``port`` addresses the RoboLab policy server this client dials, so
+            # a value that cannot name one is refused before it reaches
+            # ``ws://<host>:<port>``. An injected ``client`` owns its own
+            # address, so the port is validated only when this constructor is
+            # the one that builds the endpoint.
+            if not client and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+                raise ValueError(port_error)
             self._client = client or Cosmos3WebsocketClient(host=host, port=port, api_key=api_key, transport=transport)
             logger.info(
                 "Cosmos3Policy ready [embodiment=%s domain=%s action_space=%s chunk=%d backend=service ws://%s:%d]",

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -27,6 +27,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
+from strands_robots.utils import tcp_port_error
 
 from .client import Gr00tInferenceClient
 from .data_config import Gr00tDataConfig, load_data_config
@@ -356,7 +357,10 @@ class Gr00tPolicy(Policy):
     Args:
         data_config: Config name or :class:`Gr00tDataConfig`.
         host: Service host.
-        port: Service port.
+        port: Service port, an ``int`` in ``[1, 65535]``. Only read in
+            service mode; ``model_path`` selects local mode, which never
+            dials. A value outside the range is refused rather than
+            interpolated into ``tcp://<host>:<port>``.
         model_path: HF model ID or local path (triggers local mode).
         embodiment_tag: Embodiment tag string.
         device: ``"cuda"`` or ``"cpu"``.
@@ -435,6 +439,15 @@ class Gr00tPolicy(Policy):
             self._init_mappings()
         else:
             self._mode = "service"
+            # ``port`` addresses the inference service this client dials, so a
+            # value that cannot name one is refused here rather than
+            # interpolated into ``tcp://<host>:<port>``. ZMQ's ``connect`` is
+            # lazy, so an out-of-range or fractional port is accepted by the
+            # socket and only surfaces later as an inference timeout that
+            # implicates the server rather than the port. Local mode never
+            # dials, so the port is validated only on the branch that reads it.
+            if (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+                raise ValueError(port_error)
             logger.info("GR00T service mode, %s:%s", host, port)
             # Resolve api_token from env var if not provided as parameter
             resolved_token = api_token or os.environ.get("GROOT_API_TOKEN")

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -58,7 +58,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy, align_action_values, chunk_count_error
-from strands_robots.utils import require_optional
+from strands_robots.utils import require_optional, tcp_port_error
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +115,9 @@ class LerobotAsyncPolicy(Policy):
             takes precedence over ``host``/``port``. A ``grpc://`` scheme is
             stripped if present.
         host: Server host (used when ``server_address`` is not given).
-        port: Server port (used when ``server_address`` is not given).
+        port: Server port (used when ``server_address`` is not given), an
+            ``int`` in ``[1, 65535]``. A value outside the range is refused
+            rather than interpolated into the gRPC target.
         policy_type: lerobot policy type the server should load (one of
             :data:`SUPPORTED_POLICY_TYPES`). Required.
         pretrained_name_or_path: HuggingFace model id or path the server loads.
@@ -174,6 +176,12 @@ class LerobotAsyncPolicy(Policy):
         pad_short_actions: bool = False,
         **ignored_kwargs: Any,
     ) -> None:
+        # ``port`` addresses the lerobot PolicyServer this client dials, so a
+        # value that cannot name one is refused before it is interpolated into
+        # the gRPC target. ``server_address`` supersedes ``host``/``port``, so
+        # the port is validated only when it is the effective spelling.
+        if not server_address and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+            raise ValueError(port_error)
         address = server_address or f"{host}:{port}"
         if "://" in address:
             address = address.split("://", 1)[1]

--- a/strands_robots/policies/moveit2/policy.py
+++ b/strands_robots/policies/moveit2/policy.py
@@ -41,6 +41,7 @@ import os
 from typing import Any
 
 from strands_robots.policies.base import Policy
+from strands_robots.utils import tcp_port_error
 
 from .client import MoveIt2InferenceClient
 
@@ -64,7 +65,9 @@ class MoveIt2Policy(Policy):
     Args:
         host: Sidecar hostname. Default ``"127.0.0.1"`` (loopback only -
             users opt into network exposure).
-        port: Sidecar port.
+        port: Sidecar port, an ``int`` in ``[1, 65535]``. A value outside
+            the range is refused rather than interpolated into
+            ``tcp://<host>:<port>``.
         planning_group: Default MoveIt2 planning-group name. Per-call
             ``planning_group`` kwargs override this.
         timeout_ms: ZMQ socket timeout (send + recv) in milliseconds.
@@ -101,6 +104,13 @@ class MoveIt2Policy(Policy):
         api_token: str | None = None,
         **kwargs: Any,
     ) -> None:
+        # ``port`` addresses the moveit_py sidecar this client dials, so a
+        # value that cannot name one is refused before it reaches
+        # ``tcp://<host>:<port>``. The domain is the shared one the sibling
+        # transports use, so the same port cannot be refused onto a service by
+        # one and accepted by the next.
+        if (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+            raise ValueError(port_error)
         self.host = host
         self.port = port
         self.planning_group = planning_group

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -503,11 +503,18 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
 
     Shared domain for every caller-supplied port number: the agent tools that
     reach a service over TCP (``use_rosbridge``'s WebSocket,
-    ``gr00t_inference``'s inference service) and the mesh bridges that construct
-    one. A port is an index into the 16-bit TCP port space, so only an ``int``
-    in ``[1, 65535]`` names one: ``0`` asks the kernel for an ephemeral port
-    rather than naming a port, and a value outside the range has nothing to bind
-    or connect to.
+    ``gr00t_inference``'s inference service), the mesh bridges that construct
+    one, and the policy providers that dial one (``groot``, ``moveit2``,
+    ``cosmos3``, ``lerobot_async``). A port is an index into the 16-bit TCP port
+    space, so only an ``int`` in ``[1, 65535]`` names one: ``0`` asks the kernel
+    for an ephemeral port rather than naming a port, and a value outside the
+    range has nothing to bind or connect to.
+
+    A lazily-connecting transport makes the range load-bearing at the boundary
+    rather than at the socket: ZMQ's ``connect`` accepts ``tcp://host:99999``
+    and a WebSocket/gRPC target is only resolved on first use, so a port outside
+    the range is not refused by the transport - it fails much later as an
+    unreachable service, implicating the server rather than the port.
 
     It lives here rather than beside one of its callers for the same reason
     :func:`positive_count_error` does: those callers sit in different layers

--- a/tests/policies/test_service_port_domain.py
+++ b/tests/policies/test_service_port_domain.py
@@ -1,0 +1,296 @@
+"""A policy provider refuses a service port it cannot dial.
+
+Four providers reach a policy service over TCP and build the endpoint by
+interpolating a caller-supplied ``port``: ``groot`` and ``moveit2`` into
+``tcp://<host>:<port>`` (ZMQ), ``cosmos3`` into ``ws://<host>:<port>``, and
+``lerobot_async`` into a gRPC target. Every one of those transports connects
+lazily, so the socket does not reject a port outside the 16-bit range - it
+accepts it and the request fails much later as an unreachable service, naming
+the server rather than the port that could never have addressed it.
+
+:func:`~strands_robots.utils.tcp_port_error` is the shared domain the agent tool
+that *starts* the GR00T service (``gr00t_inference``) and the mesh bridges
+already validate against, and its docstring states the invariant these
+providers broke: the same port cannot be refused onto a service by one surface
+and accepted by the next. These tests pin the refusal per provider, pin that it
+precedes any transport construction, pin the values each provider still accepts,
+and pin the branch scoping - a port a call never dials is not validated.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies import create_policy
+from strands_robots.utils import tcp_port_error
+
+# Ports no TCP transport can address. ``0`` asks the kernel for an ephemeral
+# port instead of naming one; ``65536``/``99999`` are outside the 16-bit space;
+# ``2.7`` and ``"5555"`` are not port indices; ``True`` is an ``int`` subclass
+# that would land on privileged port 1; the rest cannot be interpolated into an
+# endpoint at all.
+UNUSABLE_PORTS: list[Any] = [
+    0,
+    -1,
+    65536,
+    99999,
+    2.7,
+    "5555",
+    True,
+    False,
+    float("nan"),
+    float("inf"),
+    None,
+    [5555],
+]
+
+#: Ports every provider must keep accepting: the range boundaries and the
+#: providers' own defaults.
+USABLE_PORTS: list[Any] = [1, 5555, 5556, 8000, 8080, 65535]
+
+#: A NumPy integer is not a Python ``int`` subclass, so the shared domain
+#: refuses it. It is listed separately because the point is agreement rather
+#: than acceptance: the providers must give the same answer as every other
+#: surface, not invent a wider or narrower one of their own.
+DOMAIN_REFUSED_NON_INT: list[Any] = [np.int64(8080), np.float64(8080.0)]
+
+
+def _groot(port: Any) -> Any:
+    return create_policy("groot", port=port, data_config="so100_dualcam")
+
+
+def _moveit2(port: Any) -> Any:
+    return create_policy("moveit2", port=port)
+
+
+def _cosmos3(port: Any) -> Any:
+    return create_policy("cosmos3", port=port, embodiment="droid")
+
+
+def _lerobot_async(port: Any) -> Any:
+    return create_policy("lerobot_async", port=port, policy_type="act", pretrained_name_or_path="org/ckpt")
+
+
+#: ``(provider label, constructor, class name, optional dependency)``. The
+#: refusal happens before any transport is built, so a rejected port needs no
+#: optional dependency; only the accepted-value controls dial and therefore
+#: import one.
+PROVIDERS: list[tuple[str, Any, str, str | None]] = [
+    ("groot", _groot, "Gr00tPolicy", "zmq"),
+    ("moveit2", _moveit2, "MoveIt2Policy", "zmq"),
+    ("cosmos3", _cosmos3, "Cosmos3Policy", None),
+    ("lerobot_async", _lerobot_async, "LerobotAsyncPolicy", None),
+]
+
+_IDS = [p[0] for p in PROVIDERS]
+
+
+class TestUnusablePortIsRefused:
+    """Every provider refuses a port it could only interpolate, not dial."""
+
+    @pytest.mark.parametrize(("label", "build", "cls_name", "dep"), PROVIDERS, ids=_IDS)
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS, ids=repr)
+    def test_provider_refuses(self, label: str, build: Any, cls_name: str, dep: str | None, port: Any) -> None:
+        """The refusal is a ValueError naming the class, the parameter and the value."""
+        with pytest.raises(ValueError) as excinfo:
+            build(port)
+        message = str(excinfo.value)
+        assert cls_name in message, message
+        assert "invalid port" in message, message
+        assert repr(port) in message, message
+        assert "1-65535" in message, message
+
+    @pytest.mark.parametrize(("label", "build", "cls_name", "dep"), PROVIDERS, ids=_IDS)
+    def test_refusal_matches_the_shared_domain(self, label: str, build: Any, cls_name: str, dep: str | None) -> None:
+        """A provider's verdict equals the shared domain's for every probe value.
+
+        The domain is what keeps the surfaces in step, so the test compares
+        against it rather than restating a range per provider.
+        """
+        for port in UNUSABLE_PORTS:
+            assert tcp_port_error(port, "port", cls_name) is not None, port
+            with pytest.raises(ValueError):
+                build(port)
+        for port in USABLE_PORTS:
+            assert tcp_port_error(port, "port", cls_name) is None, port
+        for port in DOMAIN_REFUSED_NON_INT:
+            assert tcp_port_error(port, "port", cls_name) is not None, port
+            with pytest.raises(ValueError):
+                build(port)
+
+
+class TestRefusalPrecedesTheTransport:
+    """A refused port never reaches a socket, context or channel."""
+
+    @pytest.mark.parametrize(
+        ("module_path", "transport_attr", "build"),
+        [
+            ("strands_robots.policies.groot.policy", "Gr00tInferenceClient", _groot),
+            ("strands_robots.policies.moveit2.policy", "MoveIt2InferenceClient", _moveit2),
+            ("strands_robots.policies.cosmos3.policy", "Cosmos3WebsocketClient", _cosmos3),
+        ],
+        ids=["groot", "moveit2", "cosmos3"],
+    )
+    def test_transport_is_never_constructed(
+        self, monkeypatch: pytest.MonkeyPatch, module_path: str, transport_attr: str, build: Any
+    ) -> None:
+        """Constructing the transport is made fatal, so reaching it fails the test."""
+        import importlib
+
+        module = importlib.import_module(module_path)
+
+        def explode(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError(f"{transport_attr} was constructed for a refused port")
+
+        monkeypatch.setattr(module, transport_attr, explode)
+        with pytest.raises(ValueError, match="invalid port"):
+            build(99999)
+
+
+class TestUsablePortIsAccepted:
+    """The change is additive: nothing a provider could dial is now refused."""
+
+    @pytest.mark.parametrize(("label", "build", "cls_name", "dep"), PROVIDERS, ids=_IDS)
+    @pytest.mark.parametrize("port", USABLE_PORTS, ids=repr)
+    def test_provider_accepts(self, label: str, build: Any, cls_name: str, dep: str | None, port: Any) -> None:
+        if dep is not None:
+            pytest.importorskip(dep, reason=f"{dep} not installed - the {label} transport cannot be built")
+        policy = build(port)
+        assert type(policy).__name__ == cls_name
+
+
+class TestOnlyTheDialedPortIsValidated:
+    """A port a call never reads is not refused - the guard is scoped."""
+
+    def test_groot_local_mode_ignores_the_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``model_path`` selects local inference, which dials nothing."""
+        from strands_robots.policies.groot.policy import Gr00tPolicy
+
+        monkeypatch.setattr(Gr00tPolicy, "_load_local_policy", lambda self, *a, **k: None)
+        monkeypatch.setattr(Gr00tPolicy, "_init_mappings", lambda self: None)
+        policy = Gr00tPolicy(model_path="/tmp/checkpoint", port=99999)
+        assert policy._mode == "local"
+
+    def test_cosmos3_injected_client_owns_its_address(self) -> None:
+        """An injected client already holds an endpoint, so ``port`` is inert."""
+        from strands_robots.policies.cosmos3 import Cosmos3Policy
+
+        sentinel = object()
+        # An inert stand-in: what is under test is that the port branch is
+        # skipped, not anything the client does.
+        policy = Cosmos3Policy(embodiment="droid", port=99999, client=sentinel)  # type: ignore[arg-type]
+        assert policy._client is sentinel
+
+    def test_cosmos3_diffusers_backend_dials_nothing(self) -> None:
+        """The in-process backend has no service endpoint to address."""
+        from strands_robots.policies.cosmos3 import Cosmos3Policy
+
+        sentinel = object()
+        policy = Cosmos3Policy(
+            embodiment="droid",
+            port=99999,
+            backend="diffusers",
+            diffusers_backend=sentinel,  # type: ignore[arg-type]  # inert stand-in: the port branch is what is under test
+        )
+        assert policy.backend == "diffusers"
+
+    def test_lerobot_async_server_address_supersedes_the_port(self) -> None:
+        """``server_address`` is the effective spelling when it is given."""
+        from strands_robots.policies.lerobot_async import LerobotAsyncPolicy
+
+        policy = LerobotAsyncPolicy(
+            server_address="gpu-box:8080",
+            port=99999,
+            policy_type="act",
+            pretrained_name_or_path="org/ckpt",
+        )
+        assert policy.server_address == "gpu-box:8080"
+
+
+class TestTransportDoesNotRefuseItself:
+    """Why the boundary guard is load-bearing rather than belt-and-braces."""
+
+    def test_zmq_connect_accepts_a_port_outside_the_range(self) -> None:
+        """ZMQ resolves the endpoint lazily, so the socket accepts port 99999.
+
+        This is the premise the guard rests on: without it, the value is not
+        refused anywhere - it becomes an endpoint that can never connect and
+        surfaces as an inference timeout blamed on the server.
+        """
+        zmq = pytest.importorskip("zmq", reason="zmq not installed - pip install 'strands-robots[groot-service]'")
+        context = zmq.Context()
+        socket = context.socket(zmq.REQ)
+        socket.setsockopt(zmq.LINGER, 0)
+        try:
+            socket.connect("tcp://localhost:99999")
+            assert socket.getsockopt_string(zmq.LAST_ENDPOINT) == "tcp://localhost:99999"
+        finally:
+            socket.close()
+            context.term()
+
+
+def _policy_module_paths() -> list[Path]:
+    """Every provider ``policy.py`` under the policies package."""
+    import strands_robots.policies as policies_pkg
+
+    root = Path(inspect.getfile(policies_pkg)).parent
+    return sorted(root.glob("*/policy.py"))
+
+
+def _classes_taking_a_port(tree: ast.Module) -> list[ast.ClassDef]:
+    """Class definitions whose ``__init__`` declares a ``port`` parameter."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for item in node.body:
+            if not isinstance(item, ast.FunctionDef) or item.name != "__init__":
+                continue
+            args = item.args
+            names = [a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+            if "port" in names:
+                found.append(node)
+    return found
+
+
+def _calls_the_shared_domain(cls: ast.ClassDef) -> bool:
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "tcp_port_error"
+        for node in ast.walk(cls)
+    )
+
+
+class TestNoProviderShipsAnUnguardedPort:
+    """A fifth provider cannot repeat this by copying a sibling constructor."""
+
+    def test_every_provider_taking_a_port_validates_it(self) -> None:
+        offenders = []
+        seen = []
+        for path in _policy_module_paths():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for cls in _classes_taking_a_port(tree):
+                seen.append(cls.name)
+                if not _calls_the_shared_domain(cls):
+                    offenders.append(f"{path.name}::{cls.name}")
+        assert set(_IDS) and {"Gr00tPolicy", "MoveIt2Policy", "Cosmos3Policy", "LerobotAsyncPolicy"} <= set(seen), seen
+        assert offenders == [], (
+            "these provider constructors accept a port without validating it against "
+            f"strands_robots.utils.tcp_port_error: {offenders}"
+        )
+
+    def test_the_scan_detects_an_unguarded_constructor(self) -> None:
+        """A planted omission is reported, so an empty result means clean sources."""
+        planted = ast.parse(
+            "class RoguePolicy:\n"
+            "    def __init__(self, host='h', port=1234):\n"
+            "        self.endpoint = f'tcp://{host}:{port}'\n"
+        )
+        classes = _classes_taking_a_port(planted)
+        assert [c.name for c in classes] == ["RoguePolicy"]
+        assert not _calls_the_shared_domain(classes[0])

--- a/tests/policies/test_service_port_domain.py
+++ b/tests/policies/test_service_port_domain.py
@@ -236,10 +236,16 @@ class TestTransportDoesNotRefuseItself:
 
 
 def _policy_module_paths() -> list[Path]:
-    """Every provider ``policy.py`` under the policies package."""
-    import strands_robots.policies as policies_pkg
+    """Every provider ``policy.py`` under the policies package.
 
-    root = Path(inspect.getfile(policies_pkg)).parent
+    The scan root is derived from ``create_policy`` -- the package's own factory,
+    so its defining module is inside the package by construction -- rather than
+    from a path literal or a second import of the package itself. A root that
+    resolved elsewhere would make the scan below silently empty, which is what
+    the "these four classes were seen" assertion in
+    :class:`TestNoProviderShipsAnUnguardedPort` exists to catch.
+    """
+    root = Path(inspect.getfile(create_policy)).parent
     return sorted(root.glob("*/policy.py"))
 
 


### PR DESCRIPTION
## Problem

Four policy providers reach a policy service over TCP and build the endpoint by interpolating a caller-supplied `port` with no validation:

| provider | endpoint |
|---|---|
| `groot` | `tcp://<host>:<port>` (ZMQ) |
| `moveit2` | `tcp://<host>:<port>` (ZMQ) |
| `cosmos3` | `ws://<host>:<port>` |
| `lerobot_async` | `<host>:<port>` (gRPC target) |

Every one of those transports connects **lazily**, so a port outside the 16-bit range is not refused by the socket - it is accepted and becomes the policy's endpoint. Measured on `c8964134`:

```
create_policy("groot",         port=99999) -> ready, endpoint tcp://localhost:99999
create_policy("groot",         port=0)     -> ready, endpoint tcp://localhost:0
create_policy("groot",         port=2.7)   -> ready, endpoint tcp://localhost:2.7
create_policy("moveit2",       port=65536) -> ready, endpoint tcp://127.0.0.1:65536
create_policy("cosmos3",       port=None)  -> ready, endpoint ws://localhost:None
create_policy("lerobot_async", port=nan)   -> ready, target   127.0.0.1:nan
```

All six return a policy that reports itself ready. `Gr00tInferenceClient.ping()` then returns `False` for port `99999` **and** for a valid port alike, so the mistake is indistinguishable from an unreachable server - the caller is sent to check the service rather than the port that could never have addressed it. `port=True` and `port=nan` instead escape the provider as a bare `zmq.error.ZMQError: Invalid argument (addr='tcp://localhost:True')`, which names ZMQ and an address but neither the parameter nor the provider.

## Why this is a divergence rather than a new rule

`strands_robots.utils.tcp_port_error` is the shared domain that `use_rosbridge`, the mesh bridges, and - directly relevant here - the `gr00t_inference` agent tool that **starts** the GR00T service already validate against. Its docstring states the invariant these providers broke:

> the same port cannot be refused by one transport onto a service and accepted by the next

So for one `port=99999`, the tool that starts the GR00T service refuses it and the policy that dials the same service accepts it. `moveit2`'s own package docstring describes its wire protocol as mirroring `Gr00tInferenceClient`, and the two constructors are byte-identical in this respect - which is why nothing failed: they agree with each other.

## Change

Each provider calls `tcp_port_error` **before any transport is constructed**, scoped to the branch that actually dials:

| provider | validated when |
|---|---|
| `groot` | service mode only - `model_path` selects local inference, which dials nothing |
| `moveit2` | always (it has no non-dialing mode) |
| `cosmos3` | `backend="service"` and no injected `client` - an injected client owns its own address |
| `lerobot_async` | `server_address` not given - it supersedes `host`/`port` |

The raise is `ValueError`, matching the existing validation in all four files (`policy_type`, `action_space`, `backend`, `mode`). No message text changes and no existing test changed: every port in the suite is already in range, so the change is purely additive to `[1, 65535]`.

`tcp_port_error`'s docstring gains the policy providers in its consumer list and a paragraph on why a lazily-connecting transport makes the boundary the only place the port can be named - the accuracy of that list is what makes a missing caller findable.

## Verification

On `c8964134`:

```
tests/policies/test_service_port_domain.py     56 failed, 30 passed   (pre-fix)
tests/policies/test_service_port_domain.py     86 passed              (post-fix)
```

The 30 that pass pre-fix are what stop the guard over-reaching: the accepted-value controls, the four branch-scoping tests, the ZMQ lazy-connect premise, and the planted-omission meta-test for the AST scanner.

Full gate:

```
MUJOCO_GL=egl python -m pytest tests -q --no-cov   16039 passed, 258 skipped   (508s)
ruff check strands_robots tests tests_integ        All checks passed
ruff format --check strands_robots tests tests_integ  1009 files already formatted
mypy strands_robots tests tests_integ             Success: no issues found in 1006 source files
python3 scripts/check_merge_base_overlap.py        No overlap
python3 scripts/assemble_changelog.py --check      OK
```

Tests added (`tests/policies/test_service_port_domain.py`):

* per-provider refusal over 12 unusable ports, asserting the message names the class, the parameter, the value and the range
* the provider's verdict equals the shared domain's for every probe value, in both directions - the domain is what keeps the surfaces in step, so the test compares against it rather than restating a range per provider
* the refusal precedes transport construction (the transport class is monkeypatched to be fatal, so reaching it fails the test)
* the accepted-value controls, including both range boundaries and every provider's own default
* the four scoping cases above, so a port a call never dials is not refused
* an AST guard: every class in `policies/*/policy.py` whose `__init__` takes a `port` must call `tcp_port_error`, plus a planted-omission meta-test so an empty result means clean sources rather than a scanner matching nothing

## Artifact

No rollout behaviour changes - the guard is at construction, and a policy that constructs behaves exactly as before - so the measured evidence is the endpoint each provider builds and what the caller eventually sees. Every cell is read from one probe script run against both trees; the figure generator asserts each claim before saving.

![measured endpoints and verdicts, main vs this change](https://raw.githubusercontent.com/cagataycali/robots/artifacts/policy-service-port-domain/policy_service_port_domain.png)

## Out of scope

* A port embedded in `lerobot_async(server_address="host:99999")` is a free-form address string with its own parse question; only the `port` parameter is validated here.
* `vera`'s `server_port` / `vis_port` are a different contract - they are `int | None` with environment-variable resolution and a documented `0` meaning "disabled" - so they are not folded in.
* `Gr00tInferenceClient` and `MoveIt2InferenceClient` are the transports these providers own; guarding the provider means a refused port never reaches them.

## Round 2 -- no production change

Rebased onto current `main` (`734af8cd`) and resolved the CodeQL note by dropping the redundant second import of `strands_robots.policies`.

The AST guard's path helper imported the package a second time only to read `inspect.getfile(...)`, while the module was already reached at the top of the file for `create_policy`. Since `create_policy` is defined in `strands_robots/policies/factory.py`, the symbol resolves to the same directory and globs the same eight provider modules -- so the helper derives the root from it and the package import is gone. That also matches the four sibling AST guards in the suite, which all locate their scan root from a symbol rather than a package import or a path literal.

The property that changed is where the root resolves, and it was already pinned: aiming it at a sibling package fails the "these four classes were seen" assertion with `AssertionError: []` rather than scanning nothing. The docstring now records that dependency. Collected id set unchanged at 86.

The rebase was for diff hygiene -- the overlap check was clean, but the diff was carrying 401 lines of `#1806` as removals. Gate re-run on the rebased head: **16039 passed, 258 skipped, 0 failed** (508s), lint triple clean, pre-fix proof re-derived at the new base at **56 failed / 30 passed**. Diff for this round is +10/-4 in one test file.
