### PR TITLE
fix(sim): refuse a boolean at the MuJoCo runtime writers instead of writing it as 1.0/0.0 (closes #1838)

### DIFF
--- a/changelog.d/1838-runtime-writers-refuse-a-boolean.md
+++ b/changelog.d/1838-runtime-writers-refuse-a-boolean.md
@@ -1,0 +1,21 @@
+### Fixed: the MuJoCo runtime writers refuse a boolean instead of writing it as 1.0/0.0
+
+`bool` is an `int` subclass and `numpy.bool_` coerces identically, so a `try: float(value)` +
+`math.isfinite` coercion admits both. Four hand-rolled coercions in the MuJoCo path shared that
+shape, and each installed a silent `1.0` under `status="success"`: a 1 radian / 1 rad/s joint
+target (`set_joint_positions`, `set_joint_velocities`), a 1 N or 1 N*m wrench component and a
+1 m offset (`apply_force`'s `force` / `torque` / `point`), a fully saturated colour channel, a
+1 m extent and a unit friction coefficient (`set_geom_properties`), a 1 m ray origin
+(`raycast`, `multi_raycast` - which echoed `[True, 0.0, 1.0]` back in its success text), and a
+1 m/s^2 gravity axis (`set_gravity`, `create_world(gravity=...)`).
+
+Every other numeric surface in the package already refused a boolean and recorded why -
+`utils.finite_vector_error` for `add_object` / `move_object`, `send_action`, the teleop wire
+validator, and the agent-tool router, which refuses a bool component of `apply_force`'s own
+`force` / `torque` / `point`. So the same method answered differently depending on whether it
+was called directly or dispatched as a tool. The boolean predicate is now one public shared
+name (`utils.is_boolean`) applied at every coercion, so the entry points cannot diverge again.
+
+The accepted domain is otherwise unchanged: Python and NumPy reals, integers, numeric strings
+and NumPy arrays are still accepted, and `apply_force(force=[0, 0, 0])` still clears a latched
+wrench. A refusal is all-or-nothing - the model is left exactly as it was.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -108,6 +108,8 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `get_energy` | - |
 | `get_sensor_data` | `sensor_name` (optional) |
 
+Every numeric argument these writers take must be a finite number, and must not be a boolean. `nan` / `inf` are refused because they reach a MuJoCo buffer verbatim and poison the solver (a `nan` in `qpos` propagates across the whole kinematic state on the next `mj_forward`) while the call still reports success. A `bool` (or `numpy.bool_`) is refused because `float(True)` is `1.0`: a 1-radian joint target, a 1 N force component, a fully saturated colour channel, a 1 m/s^2 gravity axis - a quantity nobody asked for, reported as applied. This is the same domain the scene-construction vectors (`add_object`, `move_object`, `add_camera`) and the agent-tool router already enforce, so a value is accepted or refused identically whichever entry point it arrives through. A refusal is all-or-nothing: the model is left exactly as it was.
+
 !!! tip "Discover the sim-state surface"
     `get_state` plus the checkpoint (`save_state` / `load_state`) and
     direct pose-setting (`set_joint_positions` / `set_joint_velocities`)

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
-from strands_robots.utils import positive_count_error, positive_finite_number_error
+from strands_robots.utils import is_boolean, positive_count_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -311,27 +311,6 @@ def _unwrap_single_element_action_value(value: Any) -> Any:
     return value[0] if length == 1 else value
 
 
-def _is_boolean(value: Any) -> bool:
-    """Return True when ``value`` is a python or a numpy boolean.
-
-    ``numpy.bool_`` is not a ``bool`` subclass, so ``isinstance(value, bool)``
-    alone misses the boolean a policy produces from a comparison
-    (``gripper > 0.5``). Unwrapping through ``.item()`` first - the mechanism
-    :func:`strands_robots.mesh.security.validate_input_frame` already uses for
-    the same gate - yields a python ``bool`` for a numpy boolean scalar or 0-d
-    array while leaving every numeric scalar reported as non-boolean.
-    """
-    if isinstance(value, bool):
-        return True
-    item = getattr(value, "item", None)
-    if callable(item):
-        try:
-            return isinstance(item(), bool)
-        except (TypeError, ValueError):  # a multi-element array has no single item
-            return False
-    return False
-
-
 def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
     """Structured error when an action value is a python or numpy boolean.
 
@@ -356,7 +335,7 @@ def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
         A structured ``{"status": "error", ...}`` dict, or ``None`` when the
         value is not a boolean and is therefore usable as a command.
     """
-    if not _is_boolean(value):
+    if not is_boolean(value):
         return None
     return {
         "status": "error",
@@ -1507,6 +1486,9 @@ class SimEngine(ABC):
             gravity: A 3-element ``[x, y, z]`` sequence, or a real scalar taken
                 as the z-component (``[0, 0, z]``, matching
                 :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.set_gravity`).
+                A boolean is refused in either form: it is an ``int`` subclass, so
+                it would otherwise be installed as a 1.0/0.0 m/s^2 acceleration
+                under a success result.
             method: Public method name, used to prefix the error message.
             param: Parameter name to quote in the message.
 
@@ -1518,6 +1500,16 @@ class SimEngine(ABC):
         # computed as a NumPy scalar (np.float32 / np.int64) is treated like a
         # plain float. A NumPy array is not numbers.Real, so it still takes the
         # vector path below.
+        # A boolean is an ``int`` subclass, so it satisfies ``numbers.Real``
+        # and would be installed as a 1.0/0.0 m/s^2 acceleration. Refused for
+        # the reason :func:`strands_robots.utils.is_boolean` records: no
+        # numeric surface in this package treats a boolean as a number, and
+        # the scene-construction vectors already refuse one.
+        if is_boolean(gravity):
+            return None, {
+                "status": "error",
+                "content": [{"text": f"{method}: '{param}' must be a number, got {gravity!r}"}],
+            }
         if isinstance(gravity, numbers.Real):
             components = [0.0, 0.0, float(gravity)]
         else:
@@ -1529,6 +1521,11 @@ class SimEngine(ABC):
                         "content": [
                             {"text": f"{method}: '{param}' must be a 3-element list [x,y,z], got {len(vector)}"}
                         ],
+                    }
+                if any(is_boolean(g) for g in vector):
+                    return None, {
+                        "status": "error",
+                        "content": [{"text": f"{method}: '{param}' elements must be numbers, got {list(vector)!r}"}],
                     }
                 components = [float(g) for g in vector]
             except (TypeError, ValueError) as e:

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -33,6 +33,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     persist_geom_properties,
     refresh_body_inertial_from_geometry,
 )
+from strands_robots.utils import is_boolean
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,9 @@ def _coerce_finite_vector(
 
     Each element must be a real number (Python or NumPy scalar) and finite --
     ``nan`` / ``inf`` are rejected because they slip silently into the MuJoCo
-    model buffers and corrupt the solver while the tool still reports success.
+    model buffers and corrupt the solver while the tool still reports success. A
+    boolean is refused as non-numeric, matching every other numeric surface in
+    the package (see :func:`strands_robots.utils.is_boolean`).
     An optional lower bound enforces physics invariants (non-negative friction,
     positive geom extent).
 
@@ -87,6 +90,17 @@ def _coerce_finite_vector(
         }
     out: list[float] = []
     for elem in seq:
+        # A boolean is an ``int`` subclass and ``numpy.bool_`` coerces the
+        # same way, so ``float()`` admits both and writes a silent 1.0/0.0
+        # where a physical quantity belongs. ``utils.finite_vector_error``
+        # refuses a boolean component for exactly that reason, and the
+        # agent-tool router refuses one for every vector parameter it
+        # dispatches - so this coercion was the only entry point accepting it.
+        if is_boolean(elem):
+            return None, {
+                "status": "error",
+                "content": [{"text": f"{method}: '{name}' elements must be numbers, got {values!r}"}],
+            }
         try:
             f = float(elem)
         except (TypeError, ValueError):
@@ -172,7 +186,10 @@ def _coerce_finite_joint_map(
 ) -> tuple[dict[str, float], dict[str, Any] | None]:
     """Coerce a ``{joint_name: value}`` map to finite floats before any write.
 
-    Each value must be a real number (Python or NumPy scalar) and finite. A
+    Each value must be a real number (Python or NumPy scalar) and finite; a
+    boolean is refused as non-numeric (see
+    :func:`strands_robots.utils.is_boolean`), since ``float(True)`` would write a
+    1 radian / 1 rad/s target nobody asked for. A
     non-numeric value would otherwise raise ``ValueError`` from ``float(value)``
     past the structured-error dispatch contract, and ``nan`` / ``inf`` would
     slip straight into ``data.qpos`` / ``data.qvel`` -- ``mj_forward`` then
@@ -193,6 +210,19 @@ def _coerce_finite_joint_map(
     """
     out: dict[str, float] = {}
     for jnt_name, value in values.items():
+        # A boolean is an ``int`` subclass and ``numpy.bool_`` coerces the
+        # same way, so ``float()`` admits both and writes a silent 1.0/0.0
+        # where a physical quantity belongs. ``utils.finite_vector_error``
+        # refuses a boolean component for exactly that reason, and the
+        # agent-tool router refuses one for every vector parameter it
+        # dispatches - so this coercion was the only entry point accepting it.
+        if is_boolean(value):
+            return {}, {
+                "status": "error",
+                "content": [
+                    {"text": f"{method}: '{name}' value for joint '{jnt_name}' must be a number, got {value!r}"}
+                ],
+            }
         try:
             f = float(value)
         except (TypeError, ValueError):
@@ -682,7 +712,9 @@ class PhysicsMixin:
         ``reset()`` clears every latched wrench in the world.
 
         Each vector may be a list, a tuple or a NumPy array (a computed wrench
-        is an array), and every element must be a finite real number.
+        is an array), and every element must be a finite real number -- not a
+        boolean, which the agent-tool router already refuses for these same
+        three vectors, so both entry points now agree.
 
         Args:
             body_name: Target body name.
@@ -725,9 +757,18 @@ class PhysicsMixin:
                 # inside np.array(dtype=float64) - escaping the structured-error
                 # contract - and nan/inf or nested lists slip silently into
                 # mj_applyFT, injecting bad state into the physics buffer.
-                # bool is intentionally accepted (subclass of int -> finite);
-                # rejecting it is out of scope for numeric-element validation.
+                # A bool is refused with the non-numeric elements: it is an
+                # ``int`` subclass (and ``numpy.bool_`` coerces the same way), so
+                # ``float()`` writes it as a silent 1.0/0.0 N or N*m. The
+                # agent-tool router already refuses a bool component of this
+                # method's own force/torque/point, so the direct API was the only
+                # entry point that accepted one.
                 for _elem in _vec:
+                    if is_boolean(_elem):
+                        return {
+                            "status": "error",
+                            "content": [{"text": f"apply_force: '{_name}' elements must be numbers, got {_vec!r}"}],
+                        }
                     try:
                         _f = float(_elem)
                     except (TypeError, ValueError):
@@ -1372,8 +1413,11 @@ class PhysicsMixin:
           joint count (when ``robot_name`` is given, that robot's joints; otherwise the
           world must contain exactly one robot, or the call errors).
 
-        Every value must be a finite real number (Python or NumPy scalar). A
-        ``nan`` / ``inf`` or a non-numeric value returns a structured
+        Every value must be a finite real number (Python or NumPy scalar) and
+        must not be a boolean -- ``float(True)`` would write a 1 radian / 1 rad/s
+        target nobody asked for, the same rule the scene-construction vectors and
+        the actuator command already apply. A
+        ``nan`` / ``inf``, a boolean or a non-numeric value returns a structured
         ``status="error"`` and leaves ``qpos`` untouched, rather than corrupting
         the kinematic state (``mj_forward`` propagates a ``nan`` everywhere) or
         raising past the tool-dispatch contract.
@@ -1491,8 +1535,11 @@ class PhysicsMixin:
         Writes to qvel. Useful for initializing dynamics. Accepts dict or list
         (see set_joint_positions for list semantics).
 
-        Every value must be a finite real number (Python or NumPy scalar). A
-        ``nan`` / ``inf`` or a non-numeric value returns a structured
+        Every value must be a finite real number (Python or NumPy scalar) and
+        must not be a boolean -- ``float(True)`` would write a 1 radian / 1 rad/s
+        target nobody asked for, the same rule the scene-construction vectors and
+        the actuator command already apply. A
+        ``nan`` / ``inf``, a boolean or a non-numeric value returns a structured
         ``status="error"`` and leaves ``qvel`` untouched, rather than blowing up
         the integrator on the next step or raising past the tool-dispatch contract.
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -327,6 +327,42 @@ def process_rss_mb() -> float | None:
         return None
 
 
+def is_boolean(value: Any) -> bool:
+    """Return True when ``value`` is a python or a numpy boolean.
+
+    Shared predicate for the one rule every numeric surface in this package
+    enforces: a boolean is not a number. ``bool`` is an ``int`` subclass and
+    ``numpy.bool_`` coerces identically, so ``float(value)`` and a
+    :class:`numbers.Real` check each admit one of the two spellings - which is
+    how a ``True`` reaches a physics buffer as a silent ``1.0``. Deciding the
+    question once means the scalar domains below, the simulation writers and the
+    teleop wire validator cannot disagree about what counts as a boolean.
+
+    ``numpy.bool_`` is not a ``bool`` subclass, so ``isinstance(value, bool)``
+    alone misses the boolean a policy produces from a comparison
+    (``gripper > 0.5``). Unwrapping through ``.item()`` first - the mechanism
+    :func:`strands_robots.mesh.security.validate_input_frame` already uses for
+    the same gate - yields a python ``bool`` for a numpy boolean scalar or 0-d
+    array while leaving every numeric scalar reported as non-boolean.
+
+    Args:
+        value: Any caller-supplied value.
+
+    Returns:
+        ``True`` for ``bool``, ``numpy.bool_`` and a 0-d boolean array;
+        ``False`` for every real number and for non-numeric junk.
+    """
+    if isinstance(value, bool):
+        return True
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return isinstance(item(), bool)
+        except (TypeError, ValueError):  # a multi-element array has no single item
+            return False
+    return False
+
+
 def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive finite number.
 

--- a/tests/simulation/mujoco/test_runtime_writers_refuse_a_boolean.py
+++ b/tests/simulation/mujoco/test_runtime_writers_refuse_a_boolean.py
@@ -1,0 +1,245 @@
+"""The MuJoCo runtime writers refuse a boolean instead of writing it as 1.0/0.0.
+
+``bool`` is an ``int`` subclass and ``numpy.bool_`` coerces identically, so a
+``try: float(value)`` + ``math.isfinite`` coercion admits both and installs a
+silent ``1.0`` -- a 1 radian joint target, a 1 N force component, a fully
+saturated colour channel, a 1 m/s^2 gravity axis -- under ``status="success"``.
+
+Four hand-rolled coercions in the MuJoCo path shared that shape while every
+other numeric surface in the package refused a boolean and said why:
+:func:`strands_robots.utils.finite_vector_error` (``add_object`` / ``move_object``),
+``send_action``, the teleop wire validator, and the agent-tool router -- which
+refuses a bool component of ``apply_force``'s own ``force`` / ``torque`` /
+``point``, so the same method answered differently depending on the entry point.
+
+The tests below pin both directions: every boolean spelling is refused at every
+affected surface, and every value those surfaces accepted before (Python and
+NumPy reals, integers, numeric strings, NumPy arrays) is still accepted. A
+structural test keeps a coercion added later from reopening the hole.
+"""
+
+import ast
+import inspect
+import pathlib
+import re
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation import Simulation
+from strands_robots.utils import is_boolean
+
+# Two hinges, explicit actuators, no downloaded asset -- ``angle="radian"`` is
+# required because MJCF defaults to degrees, which would silently shrink the
+# joint ranges by a factor of ~57.
+_ARM_XML = """<mujoco model="probe_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.03" mass="1"/>
+      <body name="link" pos="0 0 0.2">
+        <joint name="pan" type="hinge" axis="0 0 1" damping="1" range="-3 3" limited="true"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.025" mass="0.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><position name="pan_act" joint="pan" kp="20" ctrlrange="-3 3"/></actuator>
+</mujoco>"""
+
+# Every spelling of "boolean" that reaches these writers in practice: a literal
+# flag, a NumPy boolean from a comparison (``gripper > 0.5``), and the 0-d array
+# an indexed comparison yields. ``numpy.bool_`` is not a ``bool`` subclass, so
+# an ``isinstance(value, bool)`` check alone misses two of the five.
+BOOLEANS = [
+    pytest.param(True, id="python-True"),
+    pytest.param(False, id="python-False"),
+    pytest.param(np.True_, id="numpy-True_"),
+    pytest.param(np.bool_(False), id="numpy-bool_-False"),
+    pytest.param(np.array(True), id="numpy-0d-array-True"),
+]
+
+
+@pytest.fixture
+def sim(tmp_path):
+    # Intentionally un-annotated: annotating this as the engine type makes mypy
+    # read ``sim._world`` as ``SimWorld | None`` at every model probe below.
+    arm = tmp_path / "arm.xml"
+    arm.write_text(_ARM_XML)
+    engine = Simulation(backend="mujoco", mesh=False)
+    engine.create_world()
+    engine.add_robot(name="arm", urdf_path=str(arm))
+    engine.add_object(name="cube", shape="box", size=[0.1, 0.1, 0.1], position=[0.4, 0.0, 0.3])
+    yield engine
+    engine.cleanup()
+
+
+def _text(result):
+    return "\n".join(c["text"] for c in result.get("content", []) if "text" in c)
+
+
+# Each entry is (surface label, call taking the offending value). Together they
+# cover all four coercions: the joint map, the shared vector coercion (directly
+# and through the rgba path), ``apply_force``'s inline loop, and the shared
+# gravity normalizer.
+def _surfaces(sim):
+    return {
+        "set_joint_positions": lambda v: sim.set_joint_positions({"pan": v}, robot_name="arm"),
+        "set_joint_velocities": lambda v: sim.set_joint_velocities({"pan": v}, robot_name="arm"),
+        "apply_force.force": lambda v: sim.apply_force(body_name="link", force=[v, 0.0, 0.0]),
+        "apply_force.torque": lambda v: sim.apply_force(body_name="link", torque=[v, 0.0, 0.0]),
+        "apply_force.point": lambda v: sim.apply_force(body_name="link", force=[1.0, 0.0, 0.0], point=[v, 0.0, 0.0]),
+        "set_geom_properties.color": lambda v: sim.set_geom_properties(geom_name="cube_geom", color=[v, 0.0, 0.0, 1.0]),
+        "set_geom_properties.size": lambda v: sim.set_geom_properties(geom_name="cube_geom", size=[v, 0.1, 0.1]),
+        "set_geom_properties.friction": lambda v: sim.set_geom_properties(
+            geom_name="cube_geom", friction=[v, 0.005, 0.0001]
+        ),
+        "raycast.origin": lambda v: sim.raycast(origin=[v, 0.0, 1.0], direction=[0.0, 0.0, -1.0]),
+        "multi_raycast.origin": lambda v: sim.multi_raycast(origin=[v, 0.0, 1.0], directions=[[0.0, 0.0, -1.0]]),
+        "set_gravity.vector": lambda v: sim.set_gravity([v, 0.0, -9.81]),
+        "set_gravity.scalar": lambda v: sim.set_gravity(v),
+    }
+
+
+class TestEveryRuntimeWriterRefusesABoolean:
+    """No affected writer accepts a boolean, in any of its spellings."""
+
+    @pytest.mark.parametrize("value", BOOLEANS)
+    def test_a_boolean_is_refused_at_every_writer(self, sim, value):
+        for label, call in _surfaces(sim).items():
+            result = call(value)
+            assert result["status"] == "error", f"{label} accepted {value!r}: {_text(result)}"
+            # A vector surface names its elements ("must be numbers"), a scalar
+            # one names the value ("must be a number") -- both must say which.
+            assert re.search(r"must be (a )?numbers?", _text(result)), f"{label}: {_text(result)}"
+
+    def test_the_refused_value_is_never_written(self, sim):
+        """A refusal leaves the model exactly as it was -- no partial write."""
+        sim.set_joint_positions({"pan": 0.4}, robot_name="arm")
+        sim.set_gravity([0.0, 0.0, -9.81])
+        model = sim._world._model
+        before_qpos = float(sim.get_observation(robot_name="arm")["pan"])
+        before_gravity = list(model.opt.gravity)
+        before_rgba = list(model.geom_rgba[model.geom("cube_geom").id])
+
+        assert sim.set_joint_positions({"pan": True}, robot_name="arm")["status"] == "error"
+        assert sim.set_gravity([True, 0.0, -9.81])["status"] == "error"
+        assert sim.set_gravity(True)["status"] == "error"
+        assert sim.set_geom_properties(geom_name="cube_geom", color=[True, 0.0, 0.0, 1.0])["status"] == "error"
+
+        assert float(sim.get_observation(robot_name="arm")["pan"]) == pytest.approx(before_qpos)
+        assert list(model.opt.gravity) == before_gravity
+        assert list(model.geom_rgba[model.geom("cube_geom").id]) == before_rgba
+
+    def test_a_boolean_wrench_leaves_no_latched_force(self, sim):
+        """``apply_force`` latches its wrench, so a refusal must latch nothing."""
+        assert sim.apply_force(body_name="link", force=[True, 0.0, 0.0])["status"] == "error"
+        assert not np.any(sim._world._data.xfrc_applied)
+
+
+class TestTheAcceptedDomainIsUnchanged:
+    """Every value these writers accepted before is still accepted."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(0.4, id="python-float"),
+            pytest.param(np.float64(0.4), id="numpy-float64"),
+            pytest.param(np.float32(0.25), id="numpy-float32"),
+            pytest.param(1, id="python-int"),
+            pytest.param(np.int64(1), id="numpy-int64"),
+            pytest.param("0.5", id="numeric-string"),
+        ],
+    )
+    def test_a_real_scalar_is_still_accepted(self, sim, value):
+        for label, call in _surfaces(sim).items():
+            if label == "set_gravity.scalar" and isinstance(value, str):
+                # ``set_gravity`` accepts a scalar OR a 3-element vector, and a
+                # 3-character string has ``len() == 3``, so it takes the vector
+                # path and fails on the "." component. Pre-existing on main and
+                # untouched here; the vector surfaces below still accept it.
+                continue
+            result = call(value)
+            assert result["status"] == "success", f"{label} refused {value!r}: {_text(result)}"
+
+    def test_numpy_vectors_are_still_accepted(self, sim):
+        assert sim.apply_force(body_name="link", force=np.array([1.0, 0.0, 0.0]))["status"] == "success"
+        assert (
+            sim.set_geom_properties(geom_name="cube_geom", color=np.array([0.2, 0.4, 0.6, 1.0], dtype=np.float32))[
+                "status"
+            ]
+            == "success"
+        )
+        assert (
+            sim.raycast(origin=np.array([0.4, 0.0, 1.0]), direction=np.array([0.0, 0.0, -1.0]))["status"] == "success"
+        )
+        assert sim.set_gravity(np.array([0.0, 0.0, -9.81]))["status"] == "success"
+
+    def test_an_explicit_zero_wrench_still_clears_a_latched_force(self, sim):
+        """``[0, 0, 0]`` is the documented "stop this body" command, not a bool."""
+        assert sim.apply_force(body_name="link", force=[2.0, 0.0, 0.0])["status"] == "success"
+        assert np.any(sim._world._data.xfrc_applied)
+        assert sim.apply_force(body_name="link", force=[0, 0, 0])["status"] == "success"
+        assert not np.any(sim._world._data.xfrc_applied)
+
+
+class TestTheEntryPointsAgree:
+    """The direct API and the surfaces that already refused a boolean agree."""
+
+    @pytest.mark.parametrize("value", BOOLEANS)
+    def test_a_runtime_writer_agrees_with_the_scene_construction_vectors(self, sim, value):
+        """``add_object``/``move_object`` already refused; the writers now match."""
+        construction = sim.add_object(name=f"probe_{id(value)}", shape="box", position=[value, 0.0, 0.3])
+        writer = sim.set_geom_properties(geom_name="cube_geom", color=[value, 0.0, 0.0, 1.0])
+        assert construction["status"] == writer["status"] == "error"
+
+    @pytest.mark.parametrize("value", BOOLEANS)
+    def test_apply_force_agrees_with_the_agent_tool_router(self, sim, value):
+        """The router refuses a bool component of this method's own vectors."""
+        fn = getattr(type(sim), "apply_force")
+        _, router_error = sim._validate_and_build_kwargs(
+            "apply_force", "apply_force", inspect.signature(fn), {"body_name": "link", "force": [value, 0.0, 0.0]}
+        )
+        direct = sim.apply_force(body_name="link", force=[value, 0.0, 0.0])
+        assert router_error is not None
+        assert direct["status"] == "error"
+
+
+class TestTheBooleanPredicateIsShared:
+    """One predicate owns the rule, and every coercion applies it."""
+
+    @pytest.mark.parametrize("value", BOOLEANS)
+    def test_every_boolean_spelling_is_recognised(self, value):
+        assert is_boolean(value) is True
+
+    @pytest.mark.parametrize(
+        "value", [0.0, 1.0, -2.5, 0, 1, np.float64(1.0), np.int64(0), np.float32(1.0), "x", None, np.array([1, 2])]
+    )
+    def test_a_non_boolean_is_not_recognised(self, value):
+        assert is_boolean(value) is False
+
+    def test_no_numeric_coercion_in_the_mujoco_physics_path_omits_the_predicate(self):
+        """A coercion added later cannot silently reopen the hole.
+
+        Each of these helpers turns caller-supplied values into the floats that
+        reach a MuJoCo buffer. Without the shared predicate, ``float()`` accepts
+        a boolean and the writer reports success for a value nobody asked for.
+        """
+        from strands_robots.simulation.mujoco import physics
+
+        source = pathlib.Path(inspect.getfile(physics)).read_text()
+        tree = ast.parse(source)
+        coercions = {"_coerce_finite_vector", "_coerce_finite_joint_map"}
+        seen = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in coercions:
+                seen.add(node.name)
+                calls = {c.func.id for c in ast.walk(node) if isinstance(c, ast.Call) and isinstance(c.func, ast.Name)}
+                assert "is_boolean" in calls, f"{node.name} does not apply the shared boolean predicate"
+        assert seen == coercions, f"expected coercions not found: {coercions - seen}"
+
+    def test_the_apply_force_element_loop_applies_the_predicate(self):
+        """``apply_force`` validates inline rather than through a helper."""
+        from strands_robots.simulation.mujoco import physics
+
+        body = inspect.getsource(physics.PhysicsMixin.apply_force)
+        assert "is_boolean(_elem)" in body

--- a/tests/simulation/mujoco/test_setter_input_type_validation.py
+++ b/tests/simulation/mujoco/test_setter_input_type_validation.py
@@ -93,14 +93,25 @@ class TestSetGravityNumpyScalar:
         assert res["status"] == "success"
         assert list(sim_with_world._world._model.opt.gravity) == [0.0, 0.0, -3.7]
 
-    def test_numpy_bool_scalar_still_rejected(self, sim_with_world):
-        """``np.bool_`` is not ``numbers.Real`` and has no ``len()`` -- it stays
-        refused with a structured error rather than becoming a 1.0 z-gravity."""
+    def test_a_boolean_scalar_is_rejected_in_either_spelling(self, sim_with_world):
+        """A boolean never becomes a 1.0 z-gravity, whichever spelling it arrives as.
+
+        ``np.bool_`` used to be refused only by accident: it is not
+        ``numbers.Real``, so it missed the scalar branch and then failed on
+        ``len()`` with a message about a 3-element list. That accident covered
+        one spelling and not the other -- a Python ``bool`` *is* an ``int``
+        subclass, so it satisfied ``numbers.Real`` and was installed as a
+        1.0 m/s^2 z-gravity under a success result. Both are now refused for the
+        stated reason, so the message names the value rather than an incidental
+        missing ``len()``.
+        """
         import numpy as np
 
-        res = sim_with_world.set_gravity(np.bool_(True))
-        assert res["status"] == "error"
-        assert "numbers" in res["content"][0]["text"]
+        for value in (np.bool_(True), True, np.True_, np.array(True)):
+            res = sim_with_world.set_gravity(value)
+            assert res["status"] == "error", f"{value!r} was accepted"
+            assert "must be a number" in res["content"][0]["text"]
+            assert list(sim_with_world._world._model.opt.gravity) != [0.0, 0.0, 1.0]
 
 
 class TestSetGeomPropertiesRejectsInvalid:

--- a/tests/simulation/test_send_action_rejects_a_boolean_command.py
+++ b/tests/simulation/test_send_action_rejects_a_boolean_command.py
@@ -28,9 +28,9 @@ import pytest
 
 from strands_robots.simulation.base import (
     SimEngine,
-    _is_boolean,
     _unwrap_single_element_action_value,
 )
+from strands_robots.utils import is_boolean
 
 pytest.importorskip("mujoco")
 
@@ -246,7 +246,7 @@ class TestBooleanPredicate:
         "value", [True, False, np.True_, np.bool_(False), np.array(True)], ids=["True", "False", "np", "np2", "0d"]
     )
     def test_boolean_values_are_reported_as_boolean(self, value: Any) -> None:
-        assert _is_boolean(value) is True
+        assert is_boolean(value) is True
 
     @pytest.mark.parametrize(
         "value",
@@ -254,7 +254,7 @@ class TestBooleanPredicate:
         ids=["0", "1", "0.0", "1.0", "npf", "npi", "npu", "str", "list", "arr", "None"],
     )
     def test_non_boolean_values_are_not_reported_as_boolean(self, value: Any) -> None:
-        assert _is_boolean(value) is False
+        assert is_boolean(value) is False
 
 
 class TestWireAndLocalDomainsAgreeOnBooleans:


### PR DESCRIPTION
Closes #1838.

## The defect

`bool` is an `int` subclass and `numpy.bool_` coerces identically, so a `try: float(value)` + `math.isfinite` coercion admits both. Four hand-rolled coercions in the MuJoCo path shared that shape, and each installed a silent `1.0` under `status="success"`. Measured on `47a4506e` (Panda + a 0.6 kg crate, MuJoCo headless):

| surface | value | main | what was installed |
|---|---|---|---|
| `set_joint_positions({'panda/joint1': True})` | `True` | `success` "Set 1/1 joint positions, FK updated" | `qpos` = 1.0 rad (57.3 deg) |
| `set_joint_velocities({'pan': True})` | `True` | `success` | `qvel` = 1.0 rad/s |
| `apply_force(force=[True, 0, 0])` | `True` | `success` "Force: [1.0, 0.0, 0.0] N" | 1 N latched |
| `apply_force(torque=...)` / `(point=...)` | `True` | `success` | 1 N*m / a 1 m application point |
| `set_geom_properties(color=[True, .18, .18, 1])` | `True` | `success` "color -> [1.0, ...]" | a saturated channel |
| `set_geom_properties(size=...)` / `(friction=...)` | `True` | `success` | a 1 m extent / unit friction |
| `raycast(origin=[True, 0, 1])` | `True` | `success` "Ray hit ... dist=0.6000m" | a 1 m ray origin |
| `multi_raycast(origin=[True, 0, 1])` | `True` | `success` "1/1 hits from [True, 0.0, 1.0]" | the boolean echoed back in the result |
| `set_gravity([True, 0, -9.81])` | `True` | `success` "Gravity: [1.0, 0.0, -9.81]" | 1 m/s^2 on x |
| `set_gravity(True)` | `True` | `success` "Gravity: [0.0, 0.0, 1.0]" | 1 m/s^2 up |
| `create_world(gravity=[True, 0, -9.81])` | `True` | `success` | the world built with 1 m/s^2 on x |

All five spellings behaved the same: `True`, `False`, `numpy.bool_`, `numpy.True_` and a 0-d boolean array. A `numpy.bool_` is the boolean a policy produces from a comparison (`gripper > 0.5`), and it is not a `bool` subclass, so an `isinstance(value, bool)` check alone misses it.

## Why this is a divergence rather than a contract choice

Every other numeric surface in the package already refused a boolean **and recorded why**:

* `utils.finite_vector_error` (`add_object`, `move_object`) - *"a `bool` is refused because `float(True)` would silently write `1.0` where a coordinate, extent or colour channel belongs. The agent-tool router already refuses a bool component, so refusing it here keeps the direct API and the tool surface in step."*
* `send_action` and the teleop wire validator, for the same reason.
* The **agent-tool router**, which refuses a bool component of every vector parameter it dispatches - including `apply_force`'s own `force` / `torque` / `point`:

```
# via the router          apply_force(force=[True, 0, 0]) -> error "Parameter 'force'[0] must be numeric, got bool."
# via the direct API      apply_force(force=[True, 0, 0]) -> success "Force: [1.0, 0.0, 0.0] N"
```

So one method answered differently depending on the entry point, and `apply_force` carried the opposite note eight lines from its own loop:

```python
# bool is intentionally accepted (subclass of int -> finite);
# rejecting it is out of scope for numeric-element validation.
```

That reads as a scope note from a finiteness change rather than a decision about booleans, and it is contradicted by the router dispatching the same method. #1838 asked for the contract to be recorded; the router had already recorded it.

## The change

The boolean predicate is now one public shared name, `utils.is_boolean` - promoted from the private copy `send_action` introduced in #1837, so there is one owner instead of a private cross-module dependency - and applied at all four coercions:

| coercion | file | surfaces |
|---|---|---|
| `_coerce_finite_joint_map` | `simulation/mujoco/physics.py` | `set_joint_positions`, `set_joint_velocities` |
| inline element loop | `simulation/mujoco/physics.py` | `apply_force` `force` / `torque` / `point` |
| `_coerce_finite_vector` | `simulation/mujoco/physics.py` | `set_geom_properties` color / size / friction, `raycast`, `multi_raycast` |
| `_normalize_gravity` | `simulation/base.py` | `set_gravity`, `create_world(gravity=...)` |

Each reuses its own existing "must be a number(s)" message, so there is **no new message shape** and a boolean component is now reported identically to `add_object`'s, which the issue quotes. A structural test fails if a coercion added later omits the predicate.

**The accepted domain is otherwise unchanged.** Python and NumPy reals, integers, numeric strings and NumPy arrays are all still accepted (18 control calls verified), and `apply_force(force=[0, 0, 0])` still clears a latched wrench. A refusal is all-or-nothing: `qpos`, `model.opt.gravity`, `geom_rgba` and `xfrc_applied` are left exactly as they were.

### Blast radius: zero

No test passed a boolean as a numeric element. One existing test needed correcting, and its docstring explains why it had been passing for the wrong reason: `test_numpy_bool_scalar_still_rejected` refused a `numpy.bool_` gravity only **by accident** - `numpy.bool_` is not `numbers.Real`, so it missed the scalar branch and then failed on `len()` with a message about a 3-element list. That accident covered one spelling and not the other, since a Python `bool` *is* an `int` subclass and was installed as a 1.0 m/s^2 z-gravity under a success result. It is now `test_a_boolean_scalar_is_rejected_in_either_spelling` and pins both.

## Visual artifact

One agent-style script of four real calls against both trees. The scene both trees build is byte-identical (max pixel delta 1 = renderer noise); after the calls the frames differ on **12.4% of pixels**.

![a boolean at the MuJoCo runtime writers](https://raw.githubusercontent.com/cagataycali/robots/artifacts/boolean-runtime-writers/boolean_runtime_writers.png)

| quantity | main | this change |
|---|---|---|
| `panda/joint1` | 1.00 rad (57.3 deg) | 0.00 rad |
| gravity x | 1.00 m/s^2 | 0.00 m/s^2 |
| crate red channel | 1.00 | 0.16 (as built) |
| latched force x | 1.00 N | 0.00 N |
| calls reported ok | 4 of 4 | 0 of 4 |

## Verification

Rebased onto `47a4506e`; `scripts/check_merge_base_overlap.py` reports no overlap (the `utils.py` hunks are disjoint - #1839 at L503, this change at L327 - and both symbols are present after the rebase).

* **Pre-fix** (`strands_robots/simulation/` reverted to `47a4506e`, keeping `utils.is_boolean` so the module still imports): **20 failed / 41 passed**. Sample: `set_joint_positions accepted True: Set 1/1 joint positions, FK updated`; `set_gravity: 'gravity' must be a 3-element list of numbers (object of type 'numpy.bool' has no len())`. The 41 that pass are the over-reach controls, the predicate unit tests and the router half of the parity tests - they are what stop the guard over-reaching.
* **Post-fix**: 61 passed across the two files.
* **Full suite**: `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **16229 passed, 258 skipped**, 520s.
* `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (1015 source files).
* `scripts/assemble_changelog.py --check` -> OK; the five repo-wide root guards -> 42 passed.

## Docs

`docs/simulation/overview.md` states the domain beside the Physics table, mirroring the paragraph that already documents it for `send_action`. The `set_joint_positions` / `set_joint_velocities` / `apply_force` / `_normalize_gravity` docstrings name the boolean rule where they state their accepted domain, and `apply_force`'s contradicting comment is replaced with the reason.

## Out of scope

These coercions accept a **numeric string** (`'0.5'`) where `add_object` / `move_object` refuse one. That is a second axis with its own blast radius and no measured silent-failure claim behind it, so it is untouched here and the controls above pin the current behaviour.