### PR TITLE
fix(sim): refuse a boolean in the runtime state writers, not write it as 1.0

### DIFF
--- a/changelog.d/1838-state-writers-reject-boolean.md
+++ b/changelog.d/1838-state-writers-reject-boolean.md
@@ -1,0 +1,50 @@
+### Fixed: the runtime state writers refuse a boolean instead of writing it as 1.0
+
+`set_joint_positions`, `set_joint_velocities` and `apply_force` coerced their
+inputs with a bare `float()`. `bool` is an `int` subclass, so `float(True)` is
+`1.0` and each of them reported `status="success"` having written 1 radian,
+1 rad/s or 1 N:
+
+```
+set_joint_positions({"panda/joint1": True})  -> success  "Set 1/1 joint positions, FK updated"
+apply_force(body_name="panda/hand", force=[True, 0.0, 0.0]) -> success  "Force: [1.0, 0.0, 0.0] N"
+```
+
+while every scene-construction vector refused the same value
+(`add_object(position=[True, 0.0, 0.3])` -> `"'position' elements must be
+numbers"`). One library answered "is this a usable number" two ways for the same
+kind of quantity, and the writers took the permissive answer.
+
+They now refuse a python and a NumPy boolean, on all three surfaces and on
+`apply_force`'s `force`, `torque` and `point` alike. The refusal names the joint
+or vector and states the units to use instead, and because the check runs before
+any write, a refused value leaves `qpos` / `qvel` and every latched wrench
+untouched.
+
+**The decision, since the code carried the opposite one.** `apply_force` held a
+comment deferring this as "bool is intentionally accepted (subclass of int ->
+finite); rejecting it is out of scope for numeric-element validation". That note
+is retired rather than left contradicting the behaviour, and the reason now lives
+next to the check. The consequence here is genuinely milder than on the actuator
+command #1837 settled: there, `1.0` is re-read in each drive's own units, so the
+same `True` commands a different pose on every actuator; here `1.0` is one
+unambiguous quantity - 1 radian, 1 rad/s, 1 N - so a boolean is merely wrong
+rather than ambiguous. The deciding argument is therefore the consistency of the
+domain rather than the severity of the outcome: a caller who cannot place a body
+at `True` should not be able to teleport a joint to `True` either, and no caller
+can plausibly mean "1 radian" by `True`.
+
+**One predicate, not three.** `simulation/base.py` and `mesh/security.py` each
+carried their own numpy-bool unwrap, because `numpy.bool_` is not a `bool`
+subclass and `isinstance(value, bool)` alone misses the boolean a comparison
+(`gripper > 0.5`) produces. Rather than add a third, the predicate moved to
+`strands_robots.utils.is_boolean`, beside the seven scalar domains there that
+already reject a bool for the same stated reason; `send_action` now shares it.
+`mesh/security.py` keeps its own inline unwrap, which raises `ValidationError`
+rather than returning a structured dict and so answers to a different contract.
+
+The gate keys on the type, not the value: `1`, `np.uint8(1)`, a 0-d numeric
+array and the documented `force=[0, 0, 0]` stop are all still accepted, and
+`nan` / `inf` and non-numeric values keep their own distinct messages. The
+regression tests pin both directions per surface, since a gate that also
+rejected `1` would have satisfied every rejection test and broken every caller.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -108,6 +108,18 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `get_energy` | - |
 | `get_sensor_data` | `sensor_name` (optional) |
 
+!!! note "Numeric domain of the state writers"
+    `set_joint_positions`, `set_joint_velocities` and the `apply_force`
+    vectors take finite real numbers - a python or NumPy scalar - and refuse a
+    boolean. `float(True)` is `1.0`, so a `True` would be written as 1 radian,
+    1 rad/s or 1 N and the call would report success; `nan` / `inf` are refused
+    because `mj_forward` propagates a `nan` across the whole kinematic state
+    and an `inf` velocity blows up the integrator. Each write is
+    all-or-nothing, so a refused value leaves `qpos` / `qvel` and every latched
+    wrench untouched. This is the same domain the scene-construction vectors
+    (`add_object`, `add_camera`) and [`send_action`](#actions) enforce - one
+    library, one answer to "is this a usable number".
+
 !!! tip "Discover the sim-state surface"
     `get_state` plus the checkpoint (`save_state` / `load_state`) and
     direct pose-setting (`set_joint_positions` / `set_joint_velocities`)

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
-from strands_robots.utils import positive_count_error, positive_finite_number_error
+from strands_robots.utils import is_boolean, positive_count_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -311,27 +311,6 @@ def _unwrap_single_element_action_value(value: Any) -> Any:
     return value[0] if length == 1 else value
 
 
-def _is_boolean(value: Any) -> bool:
-    """Return True when ``value`` is a python or a numpy boolean.
-
-    ``numpy.bool_`` is not a ``bool`` subclass, so ``isinstance(value, bool)``
-    alone misses the boolean a policy produces from a comparison
-    (``gripper > 0.5``). Unwrapping through ``.item()`` first - the mechanism
-    :func:`strands_robots.mesh.security.validate_input_frame` already uses for
-    the same gate - yields a python ``bool`` for a numpy boolean scalar or 0-d
-    array while leaving every numeric scalar reported as non-boolean.
-    """
-    if isinstance(value, bool):
-        return True
-    item = getattr(value, "item", None)
-    if callable(item):
-        try:
-            return isinstance(item(), bool)
-        except (TypeError, ValueError):  # a multi-element array has no single item
-            return False
-    return False
-
-
 def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
     """Structured error when an action value is a python or numpy boolean.
 
@@ -356,7 +335,7 @@ def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
         A structured ``{"status": "error", ...}`` dict, or ``None`` when the
         value is not a boolean and is therefore usable as a command.
     """
-    if not _is_boolean(value):
+    if not is_boolean(value):
         return None
     return {
         "status": "error",

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -33,8 +33,33 @@ from strands_robots.simulation.mujoco.scene_ops import (
     persist_geom_properties,
     refresh_body_inertial_from_geometry,
 )
+from strands_robots.utils import is_boolean
 
 logger = logging.getLogger(__name__)
+
+
+# Why a runtime state write refuses a boolean, kept in one place because three
+# surfaces quote it (set_joint_positions, set_joint_velocities, apply_force).
+#
+# The actuator-command path refuses one for a stronger reason: 1.0 is re-read in
+# each drive's own units, so the same True commands a different pose on every
+# actuator. Here 1.0 is a single unambiguous quantity - 1 radian, 1 rad/s, 1 N -
+# so a boolean is merely wrong rather than ambiguous, which is why #1837 left
+# these writers alone and #1838 settled them separately.
+#
+# They refuse it anyway, and the deciding argument is consistency of the domain
+# rather than the severity of the outcome: every scene-construction vector in
+# strands_robots.utils already rejects a bool component for exactly this reason
+# ("float(True) would silently write 1.0 where a coordinate, extent or colour
+# channel belongs"). A caller who cannot place a body at True should not be able
+# to teleport a joint to True either, and no caller can plausibly mean "1 radian"
+# by True. The alternative - accepting it here - would leave the direct API and
+# the tool surface stating different domains for the same kind of number.
+_BOOLEAN_STATE_REASON = (
+    "float(True) is 1.0, so a boolean would be written as 1 radian, 1 rad/s or "
+    "1 N depending on the surface, and the call would report success. Pass the "
+    "quantity in the surface's own units."
+)
 
 
 def _coerce_finite_vector(
@@ -172,14 +197,17 @@ def _coerce_finite_joint_map(
 ) -> tuple[dict[str, float], dict[str, Any] | None]:
     """Coerce a ``{joint_name: value}`` map to finite floats before any write.
 
-    Each value must be a real number (Python or NumPy scalar) and finite. A
+    Each value must be a real number (Python or NumPy scalar) and finite, and
+    must not be a boolean. A
     non-numeric value would otherwise raise ``ValueError`` from ``float(value)``
     past the structured-error dispatch contract, and ``nan`` / ``inf`` would
     slip straight into ``data.qpos`` / ``data.qvel`` -- ``mj_forward`` then
     propagates the ``nan`` across the whole kinematic state (or an ``inf``
     velocity blows up the integrator) while the tool still reports
-    ``status="success"``. Validating up front keeps the write atomic: an invalid
-    value leaves the model untouched.
+    ``status="success"``. A boolean is refused for the reason in
+    :data:`_BOOLEAN_STATE_REASON`: it survives ``float()`` as a silent ``1.0``,
+    so it is the one invalid value the finiteness check cannot see. Validating up
+    front keeps the write atomic: an invalid value leaves the model untouched.
 
     Args:
         values: The ``{joint_name: value}`` mapping to validate.
@@ -193,6 +221,18 @@ def _coerce_finite_joint_map(
     """
     out: dict[str, float] = {}
     for jnt_name, value in values.items():
+        # Before float(): float(True) is 1.0, so the boolean is unrecoverable
+        # once coerced and the write would report success having set 1 rad /
+        # 1 rad/s. numpy.bool_ needs the .item() unwrap is_boolean applies.
+        if is_boolean(value):
+            return {}, {
+                "status": "error",
+                "content": [
+                    {
+                        "text": f"{method}: '{name}' value for joint '{jnt_name}' must be a number, not a bool (got {value!r}). {_BOOLEAN_STATE_REASON}"
+                    }
+                ],
+            }
         try:
             f = float(value)
         except (TypeError, ValueError):
@@ -682,7 +722,9 @@ class PhysicsMixin:
         ``reset()`` clears every latched wrench in the world.
 
         Each vector may be a list, a tuple or a NumPy array (a computed wrench
-        is an array), and every element must be a finite real number.
+        is an array), and every element must be a finite real number. A boolean
+        element (python or ``numpy.bool_``) is refused rather than applied as
+        ``1.0`` N - see :data:`_BOOLEAN_STATE_REASON`.
 
         Args:
             body_name: Target body name.
@@ -725,9 +767,21 @@ class PhysicsMixin:
                 # inside np.array(dtype=float64) - escaping the structured-error
                 # contract - and nan/inf or nested lists slip silently into
                 # mj_applyFT, injecting bad state into the physics buffer.
-                # bool is intentionally accepted (subclass of int -> finite);
-                # rejecting it is out of scope for numeric-element validation.
+                # A bool element is refused rather than accepted as finite. The
+                # earlier note here deferred it as "out of scope for numeric-element
+                # validation"; that scope note is what #1838 revisited, because
+                # float(True) is 1.0 and a True force component silently applies
+                # 1 N along that axis while the call reports success.
                 for _elem in _vec:
+                    if is_boolean(_elem):
+                        return {
+                            "status": "error",
+                            "content": [
+                                {
+                                    "text": f"apply_force: '{_name}' elements must be numbers, not a bool (got {_vec!r}). {_BOOLEAN_STATE_REASON}"
+                                }
+                            ],
+                        }
                     try:
                         _f = float(_elem)
                     except (TypeError, ValueError):
@@ -1372,8 +1426,9 @@ class PhysicsMixin:
           joint count (when ``robot_name`` is given, that robot's joints; otherwise the
           world must contain exactly one robot, or the call errors).
 
-        Every value must be a finite real number (Python or NumPy scalar). A
-        ``nan`` / ``inf`` or a non-numeric value returns a structured
+        Every value must be a finite real number (Python or NumPy scalar), and
+        must not be a boolean. A
+        ``nan`` / ``inf``, a boolean or a non-numeric value returns a structured
         ``status="error"`` and leaves ``qpos`` untouched, rather than corrupting
         the kinematic state (``mj_forward`` propagates a ``nan`` everywhere) or
         raising past the tool-dispatch contract.
@@ -1491,8 +1546,9 @@ class PhysicsMixin:
         Writes to qvel. Useful for initializing dynamics. Accepts dict or list
         (see set_joint_positions for list semantics).
 
-        Every value must be a finite real number (Python or NumPy scalar). A
-        ``nan`` / ``inf`` or a non-numeric value returns a structured
+        Every value must be a finite real number (Python or NumPy scalar), and
+        must not be a boolean. A
+        ``nan`` / ``inf``, a boolean or a non-numeric value returns a structured
         ``status="error"`` and leaves ``qvel`` untouched, rather than blowing up
         the integrator on the next step or raising past the tool-dispatch contract.
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -327,6 +327,38 @@ def process_rss_mb() -> float | None:
         return None
 
 
+def is_boolean(value: Any) -> bool:
+    """Return True when ``value`` is a python or a numpy boolean.
+
+    The single boolean predicate behind every numeric domain in this module and
+    the runtime writers that reuse them. Two properties make a boolean worth its
+    own check rather than letting the numeric coercion decide:
+
+    * ``bool`` is an ``int`` subclass, so ``float(True)`` is ``1.0`` and a
+      boolean survives every ``float()`` / ``numbers.Real`` gate as a silent
+      ``1.0`` - one radian, one metre, one Newton, depending on where it landed.
+    * ``numpy.bool_`` is *not* a ``bool`` subclass, so ``isinstance(value, bool)``
+      alone misses the boolean a policy or a comparison produces
+      (``gripper > 0.5``). It is also not registered as ``numbers.Real``, which
+      is why the vector domains here reject it through their ``numbers.Real``
+      check; a writer that coerces with a bare ``float()`` has no such backstop
+      and needs this predicate.
+
+    The ``.item()`` unwrap covers a numpy boolean scalar and a 0-d boolean array
+    while leaving every numeric scalar - and every multi-element array, which
+    has no single item - reported as non-boolean.
+    """
+    if isinstance(value, bool):
+        return True
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return isinstance(item(), bool)
+        except (TypeError, ValueError):  # a multi-element array has no single item
+            return False
+    return False
+
+
 def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive finite number.
 

--- a/tests/simulation/mujoco/test_state_writers_reject_a_boolean.py
+++ b/tests/simulation/mujoco/test_state_writers_reject_a_boolean.py
@@ -1,0 +1,329 @@
+"""The runtime state writers refuse a boolean instead of writing it as 1.0 (#1838).
+
+``set_joint_positions``, ``set_joint_velocities`` and ``apply_force`` each
+coerced their inputs with a bare ``float()``. ``bool`` is an ``int`` subclass, so
+``float(True)`` is ``1.0`` and every one of them reported ``status="success"``
+having written 1 radian, 1 rad/s or 1 N::
+
+    set_joint_positions({"joint1": True})  -> success  "Set 1/1 joint positions, FK updated"
+    apply_force(body_name="base", force=[True, 0.0, 0.0])  -> success  "Force: [1.0, 0.0, 0.0] N"
+
+while every scene-construction vector refused the same value. #1837 settled the
+**actuator-command** path (``send_action``); these are the **state writers**, and
+``apply_force`` additionally carried a comment deferring the question as "out of
+scope for numeric-element validation". The decision this pins is that they refuse
+it, for consistency with the domain
+:func:`strands_robots.utils.finite_vector_error` already states - the full
+argument is in ``physics._BOOLEAN_STATE_REASON``.
+
+Every boolean assertion here fails on pre-fix code, where the call returned
+``status="success"``. The ``StillAccepted`` / ``still`` tests are the over-reach
+controls: a gate that also rejected ``1``, ``np.uint8(1)``, a 0-d numeric array or
+the documented ``force=[0, 0, 0]`` would satisfy the rejections and break every
+real caller.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco.physics import (
+    _BOOLEAN_STATE_REASON,
+    _coerce_finite_joint_map,
+)
+from strands_robots.utils import is_boolean
+
+# Every spelling of a boolean that can reach a writer: a python bool, a numpy
+# boolean scalar (what ``gripper > 0.5`` produces), and a 0-d boolean array (what
+# ``np.array(True)`` or a reduction produces). numpy.bool_ is not a bool
+# subclass, so an isinstance-only gate catches the first two and misses the rest.
+_BOOLEANS = [True, False, np.True_, np.bool_(False), np.array(True)]
+_BOOLEAN_IDS = ["True", "False", "np_true", "np_false", "zero_d_array"]
+
+# Numeric values a caller legitimately passes. ``1`` and ``np.uint8(1)`` are the
+# load-bearing entries: they coerce to the same 1.0 the boolean would have
+# written, so they separate "refuses a boolean" from "refuses anything equal to 1".
+_NUMBERS = [0, 1, -1, 0.5, -1.25, np.float64(0.3), np.int64(2), np.uint8(1), np.array(0.7)]
+_NUMBER_IDS = ["int_0", "int_1", "int_neg1", "float", "neg_float", "np_float", "np_int", "np_uint8", "zero_d_array"]
+
+
+class TestSharedJointMapCoercionRefusesABoolean:
+    """``_coerce_finite_joint_map`` backs both joint writers, so one gate covers both.
+
+    Exercised directly so the domain is pinned even where MuJoCo is unavailable;
+    the sim-level classes below prove the writers actually route through it.
+    """
+
+    @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
+    @pytest.mark.parametrize("param", ["positions", "velocities"])
+    def test_every_boolean_spelling_is_refused(self, value: Any, param: str) -> None:
+        out, err = _coerce_finite_joint_map({"j0": value}, param, f"set_joint_{param}")
+        assert err is not None, f"{value!r} was accepted as a {param} value"
+        assert err["status"] == "error"
+        assert out == {}, "a refused map must coerce nothing"
+
+    @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
+    def test_the_refusal_names_the_joint_the_parameter_and_the_units(self, value: Any) -> None:
+        _, err = _coerce_finite_joint_map({"shoulder_pan": value}, "positions", "set_joint_positions")
+        assert err is not None
+        text = err["content"][0]["text"]
+        assert "set_joint_positions" in text
+        assert "shoulder_pan" in text, "the caller cannot fix the value without knowing which joint"
+        assert "'positions'" in text
+        assert "not a bool" in text, "the message must distinguish a bool from a plain non-number"
+        assert _BOOLEAN_STATE_REASON in text, "the refusal must carry the reason, not just the rejection"
+
+    def test_a_boolean_among_valid_values_refuses_the_whole_map(self) -> None:
+        """The write is all-or-nothing: one bad value coerces none of them."""
+        out, err = _coerce_finite_joint_map({"j0": 0.5, "j1": True, "j2": -0.25}, "positions", "set_joint_positions")
+        assert err is not None
+        assert "j1" in err["content"][0]["text"]
+        assert out == {}, "a partial coercion would let a partial pose through"
+
+    @pytest.mark.parametrize("value", _NUMBERS, ids=_NUMBER_IDS)
+    def test_numbers_are_still_accepted(self, value: Any) -> None:
+        out, err = _coerce_finite_joint_map({"j0": value}, "positions", "set_joint_positions")
+        assert err is None, f"{value!r} must remain a usable position"
+        assert out == {"j0": float(value)}
+
+    def test_one_is_accepted_though_it_is_what_true_would_have_written(self) -> None:
+        """The gate keys on the type, not the value - 1.0 rad is a real request."""
+        out, err = _coerce_finite_joint_map({"j0": 1}, "positions", "set_joint_positions")
+        assert err is None
+        assert out == {"j0": 1.0}
+        _, bool_err = _coerce_finite_joint_map({"j0": True}, "positions", "set_joint_positions")
+        assert bool_err is not None, "True must not ride in on int's acceptance"
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [("nope", "must be a number"), (float("nan"), "finite"), (float("inf"), "finite")],
+        ids=["non_numeric", "nan", "inf"],
+    )
+    def test_the_pre_existing_domain_is_unchanged(self, value: Any, expected: str) -> None:
+        """The bool gate is additive: non-numeric and nan/inf keep their own messages."""
+        _, err = _coerce_finite_joint_map({"j0": value}, "positions", "set_joint_positions")
+        assert err is not None
+        text = err["content"][0]["text"]
+        assert expected in text
+        assert "not a bool" not in text, "a nan is not a bool and must not be described as one"
+
+
+class TestOneBooleanPredicateNotThree:
+    """The predicate is shared, so the writers and ``send_action`` cannot diverge.
+
+    Before this change ``simulation/base.py`` and ``mesh/security.py`` each
+    carried their own numpy-bool unwrap. A third one in ``physics.py`` would make
+    "is this a boolean" a question with three answers, so the writers reuse the
+    one in :mod:`strands_robots.utils`, next to the scalar domains that already
+    reject a bool for the same stated reason.
+    """
+
+    @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
+    def test_the_shared_predicate_reports_every_boolean_spelling(self, value: Any) -> None:
+        assert is_boolean(value) is True
+
+    @pytest.mark.parametrize("value", _NUMBERS, ids=_NUMBER_IDS)
+    def test_the_shared_predicate_reports_no_number_as_boolean(self, value: Any) -> None:
+        assert is_boolean(value) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        ["0.5", None, [1.0], np.array([1.0]), np.array([True, False])],
+        ids=["str", "None", "list", "array", "bool_array"],
+    )
+    def test_a_non_scalar_value_is_left_to_the_other_checks(self, value: Any) -> None:
+        """A multi-element array has no single item, so the predicate must not raise."""
+        assert is_boolean(value) is False
+
+    def test_the_send_action_gate_uses_the_same_predicate(self) -> None:
+        from strands_robots.simulation import base
+
+        assert base.is_boolean is is_boolean, "send_action must not shadow the shared predicate"
+        assert "is_boolean(value)" in inspect.getsource(base._boolean_action_error)
+
+    def test_the_joint_writers_and_apply_force_use_the_same_predicate(self) -> None:
+        from strands_robots.simulation.mujoco import physics
+
+        assert physics.is_boolean is is_boolean
+        assert "is_boolean(value)" in inspect.getsource(physics._coerce_finite_joint_map)
+        assert "is_boolean(_elem)" in inspect.getsource(physics.PhysicsMixin.apply_force)
+
+    def test_the_retired_scope_note_is_gone_from_apply_force(self) -> None:
+        """A comment claiming bool is intentionally accepted must not outlive the behaviour.
+
+        A stale note is worse than none: the next reader takes it as the contract
+        and re-opens a settled question.
+        """
+        from strands_robots.simulation.mujoco import physics
+
+        source = inspect.getsource(physics.PhysicsMixin.apply_force)
+        assert "bool is intentionally accepted" not in source
+        assert "out of scope for numeric-element validation" not in source
+
+
+requires_mujoco = pytest.mark.skipif(
+    importlib.util.find_spec("mujoco") is None,
+    reason="mujoco not installed",
+)
+
+# Inline robot XML - no network dependency on robot model repos, and the joint
+# and body names below are the fixture's own rather than a registry robot's.
+_ROBOT_XML = """
+<mujoco model="bool_writer_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05" rgba="0.3 0.3 0.8 1"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+      <body name="link1" pos="0 0 0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 0.2" rgba="0.8 0.3 0.3 1"/>
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="50"/>
+    <position name="elbow_act" joint="elbow" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def arm_sim(tmp_path):
+    """A simulation with one two-joint arm, reproducing #1838's surfaces."""
+    from strands_robots.simulation import Simulation
+
+    path = tmp_path / "bool_writer_arm.xml"
+    path.write_text(_ROBOT_XML)
+
+    sim = Simulation()
+    sim.create_world(timestep=0.002)
+    result = sim.add_robot("arm", urdf_path=str(path), position=[0.0, 0.0, 0.0])
+    assert result["status"] == "success", f"add_robot failed: {result}"
+    sim.step(n_steps=5)
+    yield sim
+    sim.destroy()
+
+
+@pytest.fixture
+def arm_joint(arm_sim):
+    """The first addressable joint name, resolved rather than assumed."""
+    joints = arm_sim.robot_joint_names("arm")
+    assert joints, "fixture robot must have joints"
+    return joints[0]
+
+
+@requires_mujoco
+class TestSetJointPositionsRefusesABoolean:
+    @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
+    def test_a_boolean_position_is_refused(self, arm_sim, arm_joint: str, value: Any) -> None:
+        res = arm_sim.set_joint_positions({arm_joint: value})
+        assert res["status"] == "error", f"{value!r} was written as a position"
+        assert "not a bool" in res["content"][0]["text"]
+
+    def test_a_refused_position_leaves_qpos_untouched(self, arm_sim, arm_joint: str) -> None:
+        """Pre-fix this wrote 1.0 rad and reported "Set 1/1 joint positions"."""
+        before = arm_sim._world._data.qpos.copy()
+        res = arm_sim.set_joint_positions({arm_joint: True})
+        assert res["status"] == "error"
+        np.testing.assert_array_equal(arm_sim._world._data.qpos, before)
+
+    def test_a_numeric_position_is_still_written(self, arm_sim, arm_joint: str) -> None:
+        res = arm_sim.set_joint_positions({arm_joint: 0.25})
+        assert res["status"] == "success", res
+
+    def test_a_one_radian_position_is_still_written(self, arm_sim, arm_joint: str) -> None:
+        """1.0 is a legitimate target; only the boolean spelling of it is refused."""
+        assert arm_sim.set_joint_positions({arm_joint: 1})["status"] == "success"
+
+    def test_a_numpy_position_is_still_written(self, arm_sim, arm_joint: str) -> None:
+        assert arm_sim.set_joint_positions({arm_joint: np.float64(0.4)})["status"] == "success"
+
+
+@requires_mujoco
+class TestSetJointVelocitiesRefusesABoolean:
+    @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
+    def test_a_boolean_velocity_is_refused(self, arm_sim, arm_joint: str, value: Any) -> None:
+        res = arm_sim.set_joint_velocities({arm_joint: value})
+        assert res["status"] == "error", f"{value!r} was written as a velocity"
+        assert "not a bool" in res["content"][0]["text"]
+
+    def test_a_refused_velocity_leaves_qvel_untouched(self, arm_sim, arm_joint: str) -> None:
+        before = arm_sim._world._data.qvel.copy()
+        res = arm_sim.set_joint_velocities({arm_joint: np.True_})
+        assert res["status"] == "error"
+        np.testing.assert_array_equal(arm_sim._world._data.qvel, before)
+
+    def test_a_numeric_velocity_is_still_written(self, arm_sim, arm_joint: str) -> None:
+        assert arm_sim.set_joint_velocities({arm_joint: 0.5})["status"] == "success"
+
+
+@requires_mujoco
+class TestApplyForceRefusesABooleanComponent:
+    """The surface whose comment deferred the question; the note retires with it."""
+
+    @pytest.mark.parametrize("vector", ["force", "torque", "point"])
+    @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
+    def test_a_boolean_component_is_refused_on_every_vector(self, arm_sim, vector: str, value: Any) -> None:
+        # point alone is not a wrench, so it needs a force to be reached at all.
+        kwargs: dict[str, Any] = {} if vector == "force" else {"force": [1.0, 0.0, 0.0]}
+        kwargs[vector] = [value, 0.0, 0.0]
+        res = arm_sim.apply_force(body_name="arm/base", **kwargs)
+        assert res["status"] == "error", f"{value!r} was accepted as a {vector} component"
+        text = res["content"][0]["text"]
+        assert f"'{vector}'" in text
+        assert "not a bool" in text
+        assert _BOOLEAN_STATE_REASON in text
+
+    def test_a_refused_wrench_latches_nothing(self, arm_sim) -> None:
+        """Pre-fix this reported "Force: [1.0, 0.0, 0.0] N" and latched it."""
+        before = arm_sim._world._data.xfrc_applied.copy()
+        res = arm_sim.apply_force(body_name="arm/base", force=[True, 0.0, 0.0])
+        assert res["status"] == "error"
+        np.testing.assert_array_equal(arm_sim._world._data.xfrc_applied, before)
+
+    def test_a_numeric_wrench_is_still_latched(self, arm_sim) -> None:
+        res = arm_sim.apply_force(body_name="arm/base", force=[1.0, 0.0, 0.0])
+        assert res["status"] == "success", res
+        assert arm_sim._world._data.xfrc_applied.any()
+
+    def test_a_numpy_wrench_is_still_latched(self, arm_sim) -> None:
+        """A computed wrench arrives as an array of numpy floats, not python floats."""
+        res = arm_sim.apply_force(body_name="arm/base", force=np.array([0.0, 0.0, 2.5]))
+        assert res["status"] == "success", res
+
+    def test_the_documented_way_to_clear_a_force_still_works(self, arm_sim) -> None:
+        """force=[0, 0, 0] is the documented stop; the bool gate must not catch the zeros."""
+        assert arm_sim.apply_force(body_name="arm/base", force=[10.0, 0.0, 0.0])["status"] == "success"
+        assert arm_sim.apply_force(body_name="arm/base", force=[0, 0, 0])["status"] == "success"
+
+    def test_a_torque_only_call_is_still_accepted(self, arm_sim) -> None:
+        assert arm_sim.apply_force(body_name="arm/base", torque=[0.0, 0.0, 0.1])["status"] == "success"
+
+
+@requires_mujoco
+class TestTheStateWritersAndTheSceneVectorsNowAgree:
+    """The asymmetry #1838 reported: the same value, the same answer.
+
+    A boolean was refused by ``add_object(position=...)`` and accepted by
+    ``set_joint_positions``. Whatever the domain is, one library should not answer
+    the question two ways.
+    """
+
+    def test_both_surfaces_refuse_a_boolean_component(self, arm_sim, arm_joint: str) -> None:
+        scene = arm_sim.add_object(name="b1", shape="box", position=[True, 0.0, 0.3])
+        assert scene["status"] == "error"
+        assert arm_sim.set_joint_positions({arm_joint: True})["status"] == "error"
+
+    def test_both_surfaces_accept_the_numeric_form(self, arm_sim, arm_joint: str) -> None:
+        scene = arm_sim.add_object(name="b2", shape="box", position=[1.0, 0.0, 0.3])
+        assert scene["status"] == "success", scene
+        assert arm_sim.set_joint_positions({arm_joint: 1.0})["status"] == "success"

--- a/tests/simulation/test_send_action_rejects_a_boolean_command.py
+++ b/tests/simulation/test_send_action_rejects_a_boolean_command.py
@@ -28,9 +28,9 @@ import pytest
 
 from strands_robots.simulation.base import (
     SimEngine,
-    _is_boolean,
     _unwrap_single_element_action_value,
 )
+from strands_robots.utils import is_boolean
 
 pytest.importorskip("mujoco")
 
@@ -246,7 +246,7 @@ class TestBooleanPredicate:
         "value", [True, False, np.True_, np.bool_(False), np.array(True)], ids=["True", "False", "np", "np2", "0d"]
     )
     def test_boolean_values_are_reported_as_boolean(self, value: Any) -> None:
-        assert _is_boolean(value) is True
+        assert is_boolean(value) is True
 
     @pytest.mark.parametrize(
         "value",
@@ -254,7 +254,7 @@ class TestBooleanPredicate:
         ids=["0", "1", "0.0", "1.0", "npf", "npi", "npu", "str", "list", "arr", "None"],
     )
     def test_non_boolean_values_are_not_reported_as_boolean(self, value: Any) -> None:
-        assert _is_boolean(value) is False
+        assert is_boolean(value) is False
 
 
 class TestWireAndLocalDomainsAgreeOnBooleans:


### PR DESCRIPTION
Closes #1838.

## 1. The defect

`set_joint_positions`, `set_joint_velocities` and `apply_force` coerced their inputs with a bare `float()`. `bool` is an `int` subclass, so `float(True)` is `1.0` and each reported `status="success"` having written 1 radian, 1 rad/s or 1 N:

```
set_joint_positions({"panda/joint1": True})   -> success  "Set 1/1 joint positions, FK updated"   (writes 1.0 rad)
set_joint_velocities({"panda/joint1": True})  -> success  "Set 1/1 joint velocities"              (writes 1.0 rad/s)
apply_force(body_name="panda/hand", force=[True, 0.0, 0.0])
                                              -> success  "Force: [1.0, 0.0, 0.0] N"

add_object(name="b1", shape="box", position=[True, 0.0, 0.3])
                                              -> error    "'position' elements must be numbers"
```

One library answered "is this a usable number" two ways for the same kind of quantity, and the runtime writers took the permissive answer. Measured on `origin/main` production code before and after this branch:

| value | pre-fix | post-fix |
|---|---|---|
| `True` | ACCEPTED, writes `1.0` | REFUSED |
| `np.True_` | ACCEPTED, writes `1.0` | REFUSED |
| `np.array(True)` | ACCEPTED, writes `1.0` | REFUSED |

## 2. The decision, since the code carried the opposite one

The issue asked for a recorded decision rather than a guess, because `apply_force` held an explicit note:

```python
# bool is intentionally accepted (subclass of int -> finite);
# rejecting it is out of scope for numeric-element validation.
```

That note is **retired**, not left contradicting the behaviour, and the reason now lives beside the check as `_BOOLEAN_STATE_REASON`.

The consequence here is genuinely milder than on the actuator command #1837 settled. There, `1.0` is re-read in each drive's own units, so the same `True` commands a different pose on every actuator. Here `1.0` is one unambiguous quantity - 1 radian, 1 rad/s, 1 N - so a boolean is merely *wrong* rather than *ambiguous*. That is why #1837 deliberately left these writers alone.

They refuse it anyway, and the deciding argument is **consistency of the domain rather than severity of the outcome**: `utils.finite_vector_error` already rejects a bool component because "`float(True)` would silently write `1.0` where a coordinate, extent or colour channel belongs", and seven scalar domains in `utils.py` do the same. A caller who cannot place a body at `True` should not be able to teleport a joint to `True` either, and no caller can plausibly mean "1 radian" by `True`.

## 3. One predicate, not three

`simulation/base.py` and `mesh/security.py` each already carried their own numpy-bool unwrap - necessary because `numpy.bool_` is **not** a `bool` subclass, so `isinstance(value, bool)` misses the boolean a comparison (`gripper > 0.5`) produces. Adding a third in `physics.py` would have made "is this a boolean" a question with three answers.

The predicate therefore moved to `strands_robots.utils.is_boolean`, beside the seven scalar domains that already reject a bool for the same stated reason; `send_action` now shares it instead of defining its own. `mesh/security.py` keeps its inline unwrap deliberately - it raises `ValidationError` rather than returning a structured dict, so it answers to a different contract, and folding it in would have widened this PR into the mesh error surface.

## 4. Over-reach is pinned as hard as the fix

The gate keys on the **type, not the value**. All of these remain accepted, each with its own test:

- `1` and `np.uint8(1)` - they coerce to the same `1.0` the boolean would have written, so they separate "refuses a boolean" from "refuses anything equal to 1"
- a 0-d numeric array (`np.array(0.7)`), `np.float64`, `np.int64`
- `force=[0, 0, 0]`, the documented way to clear a latched wrench
- a torque-only `apply_force`, and a NumPy computed wrench

`nan` / `inf` and non-numeric values keep their own distinct messages - the bool gate is additive, and a `nan` is explicitly asserted *not* to be described as a bool.

Because the check runs before any write, a refused value leaves state untouched - asserted directly against `qpos`, `qvel` and `xfrc_applied` rather than inferred from the status field.

## 5. Verification

Run as a **delta**, since this runner has no GPU, no `torch` and no `mujoco`, and a partial environment fails tests for reasons unrelated to the diff:

| suite | base (`origin/main`) | this branch |
|---|---|---|
| `tests/simulation/ tests/mesh/ tests/policies/ tests/test_utils.py` | **157 failed, 6156 passed**, 608 skipped, 503 errors | **157 failed, 6207 passed**, 646 skipped, 503 errors |
| `mypy` on the 3 changed modules | 7 errors in 5 files | 7 errors in 5 files |

Identical 157 failures and 503 errors on both sides; the entire effect is **+51 passes and +38 mujoco-gated skips = the 89 tests this PR adds**. `ruff check` / `ruff format` clean. No non-ASCII character in any added line.

The 38 skips are the sim-level classes. They are gated with a `skipif` marker rather than a module-level `pytest.importorskip`, which would have skipped the coercion and predicate tests that need no simulator at all - and did, on the first draft. The fixture uses an inline arm XML rather than a registry robot, so it downloads no asset.

## 6. Files

| file | why |
|---|---|
| `strands_robots/utils.py` | `is_boolean` - the one predicate |
| `strands_robots/simulation/base.py` | local copy deleted, `send_action` routed to the shared one |
| `strands_robots/simulation/mujoco/physics.py` | the gate on `_coerce_finite_joint_map` (both joint writers) and the `apply_force` element loop; retired scope note; `_BOOLEAN_STATE_REASON`; 4 docstrings |
| `docs/simulation/overview.md` | the writers had **no** validation language and the bool rule was documented once, scoped to `send_action` |
| `tests/.../test_state_writers_reject_a_boolean.py` | 89 tests, both directions, per surface |
| `tests/.../test_send_action_rejects_a_boolean_command.py` | repointed at the relocated predicate |
| `changelog.d/1838-...md` | fragment, per the PR workflow |

## 13. Round changelog

**Round 1** - initial submission.