### PR TITLE
fix(sim): report a vector parameter with no readable length, not raise

### DIFF
--- a/changelog.d/1844-unsized-length-probe.md
+++ b/changelog.d/1844-unsized-length-probe.md
@@ -1,0 +1,23 @@
+### Fixed: a vector parameter with no readable length is reported, not raised
+
+Every validator that accepts a vector first asks "how many components is this?",
+and the `hasattr(value, "__len__")` then `len(value)` spelling is unsafe for a
+value class the library receives routinely: a 0-d NumPy array (`np.array(0.5)`,
+or the result of a reduction such as `np.mean(...)`) and a 0-d torch tensor both
+declare `__len__` and then raise from it. The `hasattr` probe passed and the
+`len()` call escaped with a bare `len() of unsized object` naming neither the
+parameter nor the method.
+
+Four surfaces that publish a no-raise contract were affected: the MuJoCo
+agent-tool router (every one of its ten vector parameters, so `position`,
+`force`, `gravity`, `orientation`, `color` and the rest escaped dispatch rather
+than returning a structured error), both length probes on `get_world_point`'s
+`pixels` (whose structural checks exist to keep that envelope), and
+`mjpeg_frames`' `size` (documented to fail only as `ValueError` with an
+actionable message). `send_action`'s ordered-vector form reported such a value
+as "action vector has a non-numeric entry: iteration over a 0-d array" and now
+names the two shapes an action may take.
+
+The length is read through one shared helper, `utils.sequence_length`, which
+answers "no readable length" for a 0-d array and for a plain scalar alike, and
+correctly sized NumPy vectors are accepted exactly as before.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -139,6 +139,19 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
     `gripper > 0.5` produces, and because `numpy.bool_` is not a `bool` subclass
     an `isinstance(x, bool)` guard silently misses it.
 
+!!! note "Component count of a vector parameter"
+    Every vector parameter (`position`, `target`, `origin`, `force`, `torque`,
+    `point`, `gravity`, `direction`, `orientation`, `color`, `get_world_point`'s
+    `pixels`, and `send_action`'s ordered-vector form) is checked for its
+    component count before it is read, and a value that carries no readable
+    count is refused with a structured error like any other. That includes a
+    0-d NumPy array or torch tensor - `np.mean(...)`, `np.array(0.5)`, a
+    squeezed observation slice - which *declares* `__len__` and then raises
+    from it, so it is reported as "not a vector of N numbers" rather than
+    escaping as a bare `len() of unsized object`. Correctly sized NumPy arrays
+    are accepted throughout, so an observation slice can be passed straight
+    through.
+
 !!! tip "Discover the sim-state surface"
     `get_state` plus the checkpoint (`save_state` / `load_state`) and
     direct pose-setting (`set_joint_positions` / `set_joint_velocities`)

--- a/strands_robots/rendering/video.py
+++ b/strands_robots/rendering/video.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import positive_whole_number_error, require_optional
+from strands_robots.utils import positive_whole_number_error, require_optional, sequence_length
 
 logger = logging.getLogger(__name__)
 
@@ -194,9 +194,9 @@ def _frame_size_error(size: Any) -> str | None:
     if size is None:
         return None
     message = f"mjpeg_frames: size must be a (width, height) pair of positive whole numbers, got {size!r}."
-    if isinstance(size, str | bytes | Mapping) or not (hasattr(size, "__len__") and hasattr(size, "__getitem__")):
+    if isinstance(size, str | bytes | Mapping) or not hasattr(size, "__getitem__"):
         return message
-    if len(size) != 2:
+    if sequence_length(size) != 2:
         return message
     for index, label in ((0, "size width"), (1, "size height")):
         if text := positive_whole_number_error(size[index], label, "mjpeg_frames"):

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -49,7 +49,12 @@ if TYPE_CHECKING:
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
-from strands_robots.utils import is_boolean, positive_count_error, positive_finite_number_error
+from strands_robots.utils import (
+    is_boolean,
+    positive_count_error,
+    positive_finite_number_error,
+    sequence_length,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -353,21 +358,17 @@ def _unwrap_single_element_action_value(value: Any) -> Any:
     is unwrapped rather than rejected.
 
     A 0-d numpy array (``np.array(True)``, ``np.mean(...)``) declares
-    ``__len__`` and ``__getitem__`` but raises ``TypeError`` from ``len()``, so
-    probing the length directly escapes ``send_action``'s structured-error
-    contract with a bare ``len() of unsized object``. It already holds exactly
-    one scalar, so there is nothing to unwrap and it is returned unchanged for
-    the value checks to read.
+    ``__len__`` and ``__getitem__`` but raises from ``len()``, which is why the
+    length is read through :func:`strands_robots.utils.sequence_length` rather
+    than probed here: it reports such a value as carrying no length, so the
+    value is returned unchanged for the value checks to read (it already holds
+    exactly one scalar, so there is nothing to unwrap).
     """
     if isinstance(value, (str, bytes, Mapping)):
         return value
-    if not hasattr(value, "__len__") or not hasattr(value, "__getitem__"):
+    if not hasattr(value, "__getitem__"):
         return value
-    try:
-        length = len(value)
-    except TypeError:
-        return value
-    return value[0] if length == 1 else value
+    return value[0] if sequence_length(value) == 1 else value
 
 
 def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
@@ -1092,7 +1093,7 @@ class SimEngine(ABC):
         # ``str``/``bytes`` are iterable but never a valid multi-joint action;
         # a scalar has no length. Reject both with an actionable message instead
         # of producing garbage character/positional keys downstream.
-        if isinstance(action, (str, bytes)) or not hasattr(action, "__len__"):
+        if isinstance(action, (str, bytes)) or sequence_length(action) is None:
             return None, {
                 "status": "error",
                 "content": [
@@ -3622,20 +3623,23 @@ class SimEngine(ABC):
                 f"{type(camera_name).__name__} ({camera_name!r}). Cameras are addressed by "
                 "name, not index; see add_camera / get_frame."
             )
-        if pixels is None or isinstance(pixels, (str, bytes)) or not hasattr(pixels, "__len__"):
+        n_pixels = None if pixels is None or isinstance(pixels, (str, bytes)) else sequence_length(pixels)
+        # ``pixels is None`` is retested rather than folded into ``n_pixels`` so
+        # the narrowing survives to the ``enumerate(pixels)`` walk below.
+        if pixels is None or n_pixels is None:
             return _err(
                 "get_world_point requires 'pixels': a non-empty list of [u, v] pixel coordinates, e.g. [[320, 240], [322, 238]]."
             )
-        if len(pixels) == 0:
+        if n_pixels == 0:
             return _err("get_world_point requires at least one [u, v] pixel; got an empty list.")
-        if len(pixels) > self._WORLD_POINT_MAX_PIXELS:
+        if n_pixels > self._WORLD_POINT_MAX_PIXELS:
             return _err(
                 f"get_world_point accepts at most {self._WORLD_POINT_MAX_PIXELS} pixels per call, "
-                f"got {len(pixels)}. Sample a handful of pixels on the target surface instead."
+                f"got {n_pixels}. Sample a handful of pixels on the target surface instead."
             )
         parsed: list[tuple[int, int]] = []
         for i, px in enumerate(pixels):
-            if isinstance(px, (str, bytes)) or not hasattr(px, "__len__") or len(px) != 2:
+            if isinstance(px, (str, bytes)) or sequence_length(px) != 2:
                 return _err(f"pixels[{i}] must be a [u, v] pair, got {px!r}.")
             coords: list[int] = []
             for axis, component in zip("uv", px, strict=True):

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -114,6 +114,7 @@ from strands_robots.utils import (
     entity_name_error,
     finite_vector_error,
     pose_vector_error,
+    sequence_length,
 )
 
 if TYPE_CHECKING:
@@ -4749,16 +4750,21 @@ class MuJoCoSimEngine(
             if val is None:
                 continue
             expected_len = " or ".join(str(n) for n in accepted_lens)
-            if not hasattr(val, "__len__"):
+            n_components = sequence_length(val)
+            if n_components is None:
                 return None, {
                     "status": "error",
                     "content": [{"text": f"Parameter '{vparam}' must be a list of {expected_len} numbers."}],
                 }
-            if len(val) not in accepted_lens:
+            if n_components not in accepted_lens:
                 return None, {
                     "status": "error",
                     "content": [
-                        {"text": (f"Parameter '{vparam}' must be a list of {expected_len} numbers, got {len(val)}.")}
+                        {
+                            "text": (
+                                f"Parameter '{vparam}' must be a list of {expected_len} numbers, got {n_components}."
+                            )
+                        }
                     ],
                 }
             for i, component in enumerate(val):

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -359,6 +359,37 @@ def is_boolean(value: Any) -> bool:
     return False
 
 
+def sequence_length(value: Any) -> int | None:
+    """Return the length of ``value``, or ``None`` when it does not carry one.
+
+    Every validator that accepts a vector first asks "how many components is
+    this?", and the obvious spelling - ``hasattr(value, "__len__")`` followed by
+    ``len(value)`` - is unsafe for the value class this library actually
+    receives. A 0-d numpy array (``np.array(0.5)``, or the result of a reduction
+    such as ``np.mean(...)``) and a 0-d torch tensor both *declare* ``__len__``
+    and then raise from it, so the ``hasattr`` probe passes and the ``len()``
+    call escapes with a bare ``len() of unsized object`` that names neither the
+    parameter nor the method - past agent-tool dispatch, which is documented
+    never to raise.
+
+    ``TypeError`` is the narrowest superset: CPython raises it both for a value
+    with no ``__len__`` at all (a plain ``float``, a ``numpy.float64``) and for
+    one whose ``__len__`` exists but refuses. Both answer the caller's question
+    the same way - this value does not carry a component count - so both report
+    as ``None`` and one branch covers them.
+
+    Args:
+        value: Any caller-supplied value a validator needs the length of.
+
+    Returns:
+        The component count, or ``None`` when the value has no readable length.
+    """
+    try:
+        return len(value)
+    except TypeError:
+        return None
+
+
 def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive finite number.
 

--- a/tests/test_unsized_value_is_refused_not_raised.py
+++ b/tests/test_unsized_value_is_refused_not_raised.py
@@ -1,0 +1,333 @@
+"""A caller value whose length cannot be read is reported, never raised.
+
+Every validator that accepts a vector first asks "how many components is this?".
+The obvious spelling - ``hasattr(value, "__len__")`` followed by ``len(value)`` -
+is unsafe for a value class this library receives routinely: a 0-d numpy array
+(``np.array(0.5)``, the result of a reduction such as ``np.mean(...)``) and a 0-d
+torch tensor both *declare* ``__len__`` and then raise from it. The ``hasattr``
+probe passes and the ``len()`` call escapes with a bare ``len() of unsized
+object`` naming neither the parameter nor the method.
+
+That escape matters because the surfaces doing the probing all publish a
+no-raise contract: the MuJoCo agent-tool router returns a structured error for
+every rejected parameter, :meth:`SimEngine.get_world_point` documents its
+structural checks as being there "to keep the never-raises envelope", and
+:func:`strands_robots.rendering.video.mjpeg_frames` documents ``ValueError`` with
+an actionable message as its only failure mode for a malformed ``size``.
+
+:func:`strands_robots.utils.sequence_length` is the single owner of the rule -
+it answers "no readable length" for a 0-d array and for a plain scalar alike -
+and these tests pin every surface that reads a caller-supplied length through
+it, plus the accepted values that must keep working.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering.video import mjpeg_frames
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+from strands_robots.utils import sequence_length
+
+# A 0-d array: declares ``__len__``, raises from it, holds exactly one scalar.
+UNSIZED = np.array(0.5)
+
+
+# A minimal actuated arm: enough for send_action to reach the action coercion,
+# with no downloaded asset and no rendering (the model is compiled, never drawn).
+_ARM_MJCF = """<mujoco model="unsized_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <geom type="box" size="0.05 0.05 0.05"/>
+      <body name="link" pos="0 0 0.05">
+        <joint name="pan" type="hinge" axis="0 0 1" range="-2 2" limited="true" damping="4"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.03"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><position name="pan_act" joint="pan" kp="50" ctrlrange="-2 2"/></actuator>
+</mujoco>
+"""
+
+
+def _call(target: Any, **kwargs: Any) -> Any:
+    """Invoke ``target`` with values whose *shape* is the subject of the test.
+
+    These parameters are annotated for the shapes a caller *should* pass
+    (``pixels`` as ``Sequence[Sequence[SupportsFloat]]``, ``size`` as a
+    ``tuple[int, int]``), while the point of this module is what happens for the
+    shapes a caller *does* pass - a 0-d NumPy array, and a correctly sized NumPy
+    array that those annotations do not describe either. Routing every such call
+    through one ``**kwargs: Any`` funnel states that intent once instead of
+    scattering per-call type suppressions.
+    """
+    return target(**kwargs)
+
+
+def _text(result: dict[str, Any]) -> str:
+    """Concatenate the text blocks of an agent-tool envelope."""
+    return " ".join(block["text"] for block in result.get("content", []) if "text" in block)
+
+
+# --------------------------------------------------------------------------- #
+# The engine premise the whole rule rests on.
+# --------------------------------------------------------------------------- #
+class TestUnsizedValuePremise:
+    """Pin the numpy/torch behaviour that makes the ``hasattr`` probe unsafe."""
+
+    def test_a_zero_dimensional_array_declares_a_length_then_refuses_it(self) -> None:
+        """``hasattr`` says yes and ``len()`` raises - the whole defect in two lines."""
+        assert hasattr(UNSIZED, "__len__")
+        with pytest.raises(TypeError):
+            len(UNSIZED)
+
+    def test_a_zero_dimensional_tensor_behaves_the_same_way(self) -> None:
+        """torch shares the property, so the rule is not numpy-specific."""
+        torch = pytest.importorskip("torch")
+        scalar = torch.tensor(0.5)
+        assert hasattr(scalar, "__len__")
+        with pytest.raises(TypeError):
+            len(scalar)
+
+    def test_a_numpy_scalar_declares_no_length_at_all(self) -> None:
+        """The other half of the domain: ``len()`` raises ``TypeError`` here too.
+
+        Both spellings answer a validator's question identically - this value
+        carries no component count - which is why one branch covers them.
+        """
+        assert not hasattr(np.float64(0.5), "__len__")
+        with pytest.raises(TypeError):
+            len(np.float64(0.5))  # type: ignore[arg-type]
+
+
+class TestSequenceLength:
+    """The shared owner of the rule."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ([1.0, 2.0, 3.0], 3),
+            ((1.0, 2.0), 2),
+            (np.array([1.0, 2.0, 3.0]), 3),
+            (np.zeros((2, 3)), 2),
+            ("abc", 3),
+            ({"a": 1}, 1),
+            ([], 0),
+        ],
+    )
+    def test_reports_the_component_count_of_a_sized_value(self, value: Any, expected: int) -> None:
+        """A readable length is returned unchanged."""
+        assert sequence_length(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            np.array(0.5),
+            np.array(True),
+            np.float64(0.5),
+            np.int64(3),
+            0.5,
+            None,
+            object(),
+        ],
+        ids=["zero_d_float", "zero_d_bool", "np_float64", "np_int64", "float", "none", "object"],
+    )
+    def test_reports_none_for_a_value_without_a_readable_length(self, value: Any) -> None:
+        """No readable length is ``None``, never an exception."""
+        assert sequence_length(value) is None
+
+
+# --------------------------------------------------------------------------- #
+# The agent-tool router: one structured error per rejected vector parameter.
+# --------------------------------------------------------------------------- #
+# Every router vector param, paired with a method whose signature declares it
+# (the router rejects a parameter the target method does not accept before it
+# ever reaches the dimension check).
+_VECTOR_PARAM_OWNERS: dict[str, tuple[str, dict[str, Any]]] = {
+    "position": ("add_object", {"name": "crate"}),
+    "target": ("add_camera", {"name": "cam"}),
+    "origin": ("raycast", {"direction": [0.0, 0.0, -1.0]}),
+    "force": ("apply_force", {"body_name": "crate"}),
+    "torque": ("apply_force", {"body_name": "crate"}),
+    "gravity": ("set_gravity", {}),
+    "direction": ("raycast", {"origin": [0.0, 0.0, 1.0]}),
+    "point": ("apply_force", {"body_name": "crate"}),
+    "orientation": ("add_object", {"name": "crate"}),
+    "color": ("add_object", {"name": "crate"}),
+}
+
+
+class TestAgentToolRouterVectorParams:
+    """No dispatched vector parameter may escape the envelope on a length probe."""
+
+    def test_every_router_vector_param_is_covered_here(self) -> None:
+        """Exhaustiveness: a twelfth vector param must be pinned too.
+
+        ``_FIELD_ALIASES`` entries are remapped to their canonical name before
+        the dimension check runs, so they are covered by the name they alias.
+        """
+        aliases = set(MuJoCoSimEngine._FIELD_ALIASES)
+        assert set(_VECTOR_PARAM_OWNERS) == set(MuJoCoSimEngine._VECTOR_PARAM_LENGTHS) - aliases
+
+    @pytest.mark.parametrize("param", sorted(_VECTOR_PARAM_OWNERS))
+    def test_an_unsized_vector_is_reported_through_the_envelope(self, param: str) -> None:
+        """The caller gets a structured error naming the parameter, not a raise."""
+        action, extra = _VECTOR_PARAM_OWNERS[param]
+        engine = MuJoCoSimEngine(tool_name="unsized_router", mesh=False)
+        signature = inspect.signature(getattr(MuJoCoSimEngine, action))
+        _, error = engine._validate_and_build_kwargs(action, action, signature, {**extra, param: UNSIZED})
+        assert error is not None, f"{action}({param}=<0-d array>) was accepted"
+        assert error["status"] == "error"
+        assert f"Parameter '{param}' must be a list of" in _text(error)
+
+    @pytest.mark.parametrize("param", sorted(_VECTOR_PARAM_OWNERS))
+    def test_a_correctly_sized_numpy_vector_is_still_accepted(self, param: str) -> None:
+        """Over-reach control: numpy vectors of the right width keep dispatching."""
+        action, extra = _VECTOR_PARAM_OWNERS[param]
+        width = MuJoCoSimEngine._VECTOR_PARAM_LENGTHS[param][0]
+        engine = MuJoCoSimEngine(tool_name="unsized_router_ok", mesh=False)
+        signature = inspect.signature(getattr(MuJoCoSimEngine, action))
+        _, error = engine._validate_and_build_kwargs(
+            action, action, signature, {**extra, param: np.linspace(0.1, 0.4, width)}
+        )
+        assert error is None, _text(error or {})
+
+
+# --------------------------------------------------------------------------- #
+# get_world_point: pixels, and each [u, v] pair.
+# --------------------------------------------------------------------------- #
+class TestGetWorldPointPixels:
+    """Both length probes on the pixel list keep the never-raises envelope.
+
+    These are the structural checks the method runs before any render work, so
+    they are reachable without a compiled world.
+    """
+
+    def test_an_unsized_pixels_container_is_reported(self) -> None:
+        """A 0-d array in place of the pixel list is refused with the usage hint."""
+        engine = MuJoCoSimEngine(tool_name="unsized_pixels", mesh=False)
+        result = _call(engine.get_world_point, pixels=np.array(320), camera_name="cam")
+        assert result["status"] == "error"
+        assert "get_world_point requires 'pixels'" in _text(result)
+
+    def test_an_unsized_pixel_pair_is_reported(self) -> None:
+        """A 0-d array in place of one [u, v] pair names that pair's index."""
+        engine = MuJoCoSimEngine(tool_name="unsized_pixel_pair", mesh=False)
+        result = _call(engine.get_world_point, pixels=[np.array(320)], camera_name="cam")
+        assert result["status"] == "error"
+        assert "pixels[0] must be a [u, v] pair" in _text(result)
+
+    def test_a_numpy_pixel_array_still_passes_structural_validation(self) -> None:
+        """Over-reach control: a correctly shaped numpy pixel array reaches the render.
+
+        With no world compiled the render is what fails, which is exactly the
+        evidence that the structural checks accepted the pixels.
+        """
+        engine = MuJoCoSimEngine(tool_name="sized_pixels", mesh=False)
+        result = _call(engine.get_world_point, pixels=np.array([[320, 240]]), camera_name="cam")
+        assert result["status"] == "error"
+        assert "failed to render camera frame" in _text(result)
+
+
+# --------------------------------------------------------------------------- #
+# send_action's ordered-vector form.
+# --------------------------------------------------------------------------- #
+class TestSendActionVectorForm:
+    """An unsized action reports the mapping-or-vector contract it violated."""
+
+    def test_an_unsized_action_names_the_two_accepted_shapes(self, tmp_path: Path) -> None:
+        """The caller is told what an action may be, not that a length failed."""
+        model = tmp_path / "arm.xml"
+        model.write_text(_ARM_MJCF)
+        engine = MuJoCoSimEngine(tool_name="unsized_action", mesh=False)
+        engine.create_world()
+        engine.add_robot(name="arm", urdf_path=str(model))
+        result = _call(engine.send_action, action=np.array(0.5))
+        assert result["status"] == "error"
+        message = _text(result)
+        assert "must be a mapping" in message
+        assert "ordered numeric" in message
+
+
+# --------------------------------------------------------------------------- #
+# mjpeg_frames: the documented ValueError, not a bare TypeError.
+# --------------------------------------------------------------------------- #
+class TestMjpegFrameSize:
+    """``size`` fails through the documented ``Raises: ValueError`` channel."""
+
+    def _frame(self) -> np.ndarray:
+        return np.zeros((8, 8, 3), dtype=np.uint8)
+
+    def test_an_unsized_size_raises_the_documented_valueerror(self) -> None:
+        """A 0-d array is refused by the eager validator, message included."""
+        with pytest.raises(ValueError, match="size must be a .width, height. pair"):
+            _call(mjpeg_frames, frame_fn=self._frame, size=np.array(640), max_frames=1)
+
+    def test_a_numpy_size_pair_is_still_accepted(self) -> None:
+        """Over-reach control: a 2-element numpy size keeps working."""
+        stream = _call(mjpeg_frames, frame_fn=self._frame, size=np.array([640, 480]), max_frames=1)
+        assert next(iter(stream)).startswith(b"--frame")
+
+
+# --------------------------------------------------------------------------- #
+# Structural: no envelope module may probe a caller length with hasattr again.
+# --------------------------------------------------------------------------- #
+_ENVELOPE_PACKAGES = ("simulation", "rendering")
+
+
+def _hasattr_len_probes(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``hasattr(<x>, "__len__")`` call in ``tree``."""
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or getattr(node.func, "id", "") != "hasattr":
+            continue
+        if len(node.args) != 2 or not isinstance(node.args[1], ast.Constant):
+            continue
+        if node.args[1].value == "__len__":
+            lines.append(node.lineno)
+    return lines
+
+
+def _envelope_modules() -> list[Path]:
+    """Every module of the packages that publish a no-raise envelope."""
+    package_dir = Path(inspect.getfile(sequence_length)).parent
+    modules: list[Path] = []
+    for name in _ENVELOPE_PACKAGES:
+        modules.extend(sorted((package_dir / name).rglob("*.py")))
+    return modules
+
+
+class TestNoDirectLengthProbe:
+    """The shared owner cannot be bypassed by reintroducing the unsafe idiom."""
+
+    def test_the_scan_root_resolves_to_real_modules(self) -> None:
+        """Non-vacuity: a mislocated root would make the scan below pass trivially."""
+        modules = _envelope_modules()
+        assert len(modules) > 20, modules
+        assert any(path.name == "base.py" for path in modules)
+
+    def test_no_envelope_module_probes_a_length_with_hasattr(self) -> None:
+        """``hasattr(x, "__len__")`` is never a safe stand-in for a length probe.
+
+        A 0-d array passes it and then raises from ``len()``. Ask
+        :func:`strands_robots.utils.sequence_length` for the length instead and
+        branch on ``None``; use ``__getitem__`` when indexability is the question.
+        """
+        offenders = {
+            f"{path.name}:{line}"
+            for path in _envelope_modules()
+            for line in _hasattr_len_probes(ast.parse(path.read_text()))
+        }
+        assert not offenders, f"use sequence_length() instead of a hasattr length probe: {sorted(offenders)}"
+
+    def test_the_scanner_detects_a_planted_probe(self) -> None:
+        """Meta: an empty result means clean sources, not a scanner matching nothing."""
+        planted = ast.parse('if not hasattr(value, "__len__"):\n    pass\n')
+        assert _hasattr_len_probes(planted) == [1]


### PR DESCRIPTION
## Problem

Every validator that accepts a vector first asks "how many components is this?", and the obvious spelling — `hasattr(value, "__len__")` followed by `len(value)` — is unsafe for a value class this library receives routinely. A **0-d NumPy array** (`np.asarray(scalar)`, `np.array(0.5)`, `np.squeeze` of a single-element slice) and a **0-d torch tensor** both *declare* `__len__` and then raise from it, so the `hasattr` probe passes and the `len()` call escapes with a bare `len() of unsized object` that names neither the parameter nor the method.

`send_action`'s scalar unwrap already guarded exactly this, with a docstring explaining why. Four sibling probes on surfaces publishing the same no-raise contract did not:

| Surface | Contract it publishes | On `main` |
|---|---|---|
| MuJoCo agent-tool router, all 10 vector params | returns a structured error for every rejected parameter | `TypeError` escapes dispatch |
| `get_world_point(pixels=...)` (2 probes) | structural checks exist "to keep the never-raises envelope" | `TypeError` escapes |
| `mjpeg_frames(size=...)` | documented `Raises: ValueError` with an actionable message | `TypeError` escapes |
| `send_action(<vector>)` | names the two accepted action shapes | `"action vector has a non-numeric entry: iteration over a 0-d array"` |

The router case is the widest: `position`, `target`, `origin`, `force`, `torque`, `point`, `gravity`, `direction`, `orientation` and `color` all escaped. Measured on a dispatched `add_object`:

```
sim(action="add_object", ..., position=0.38)              -> error: Parameter 'position' must be a list of 3 numbers.   # reported
sim(action="add_object", ..., position=np.asarray(0.38))  -> TypeError: len() of unsized object                        # escaped
```

The same caller mistake in two spellings: one reported, one fatal. Through `stream()` — what the agent runtime actually drives — the catch-all turned it into `"Sim error: len() of unsized object"`, which an agent cannot act on, instead of `"Parameter 'position' must be a list of 3 numbers."`

## Change

The length is read through one shared helper, `utils.sequence_length`, and every probe branches on its result:

```python
def sequence_length(value: Any) -> int | None:
    try:
        return len(value)
    except TypeError:
        return None
```

`TypeError` is the narrowest superset: CPython raises it both for a value with no `__len__` at all (a plain `float`, a `numpy.float64`) and for one whose `__len__` exists but refuses. Both answer the caller's question the same way — this value carries no component count — so one branch covers them, and both spellings of the mistake now report identically. Correctly sized NumPy vectors are accepted exactly as before.

Routed: the router's dimension check, both `get_world_point` pixel probes, `mjpeg_frames`' `size`, `send_action`'s vector form, and `send_action`'s scalar unwrap (which keeps its behaviour and drops its local `try`/`except` so there is one owner of the rule).

## Verification

Rollout in MuJoCo sim (headless EGL). One agent scene-build batch dispatched through `sim(action=...)`, reading only `status` as the envelope promises. Step 5 passes the plain scalar `0.38`; step 6 passes the 0-d array spelling of that same value.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/unsized-length-probe/unsized-length-probe.png)

| | `main` | this change |
|---|---|---|
| batch completed | **false** | true |
| steps run | 5 of 7 | 7 of 7 |
| cubes placed | 2 of 3 | 3 of 3 |
| step 5 (plain scalar `0.38`) | `Parameter 'position' must be a list of 3 numbers.` | identical |
| step 6 (`np.asarray(0.38)`) | **`TypeError: len() of unsized object`** | `Parameter 'position' must be a list of 3 numbers.` |
| what `stream()` hands the agent | `"Sim error: len() of unsized object"` | `"Parameter 'position' must be a list of 3 numbers."` |

The renders differ on 14.6% of pixels: on `main` the escape aborted the batch, so `cube_blue` was never created. Every number above is re-derived from the two runs' JSON inside the figure generator, which asserts each claim before saving.

**Pre-fix proof** (call sites reverted to `main`, shared helper kept so the module still imports): **15 failed / 32 passed**. 13 of the failures are a bare `TypeError: len() of unsized object`; the structural guard names all six sites. Post-fix: **47 passed**. The 32 that pass pre-fix are the engine premises, the helper's own unit tests and the accepted-value controls — they are what stop the guard over-reaching.

**Gate** at base `8af012bb`:
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` — clean, 1017 source files
- `MUJOCO_GL=egl pytest tests` — **16573 passed, 258 skipped, 0 failed** (477s), no existing test changed

## Tests

`tests/test_unsized_value_is_refused_not_raised.py` (47):

- the engine premise, executable rather than asserted in prose — `hasattr` says yes and `len()` raises, for NumPy and for torch
- `sequence_length` over both halves of its domain
- the router, **parametrized over every vector parameter**, plus an exhaustiveness test that fails if a twelfth is added, plus a correctly-sized-NumPy control per parameter
- both `get_world_point` probes, and a correctly shaped NumPy pixel array reaching the render
- `send_action`'s vector form, and `mjpeg_frames`' documented `ValueError`
- a structural guard that no module under `simulation/` or `rendering/` probes a length with `hasattr` again, with a planted-defect meta-test so an empty result means clean sources rather than a scanner matching nothing, and a non-vacuity test on its scan root

## Out of scope

Three `hasattr(x, "__len__")` probes remain in `policies/` (`mock.py`, `wbc/policy.py`). Those sit behind `Policy.get_actions`, which raises by design rather than returning an envelope, so the failure mode and the right fix differ; the structural guard is scoped to the two packages that publish a no-raise contract.