### PR TITLE
fix(sim/isaac): report an entity name the lookup cannot key, instead of raising

### DIFF
--- a/changelog.d/1846-isaac-name-lookup-is-total.md
+++ b/changelog.d/1846-isaac-name-lookup-is-total.md
@@ -1,0 +1,7 @@
+### Fixed: an Isaac entity lookup reports any name instead of raising on it
+
+Every name-taking lookup on the Isaac backend now resolves through the shared `registered()` / `registry_entry()` rule that the MuJoCo and Newton backends already use, so a name of any type gets a verdict. Previously the membership test itself raised `TypeError: unhashable type` for a list, dict, set or bytearray name, which meant the unknown-entity error path that the lookup guards was never reached and the exception escaped the `{"status", "content"}` envelope those methods document as their only failure channel. Twelve methods were affected - `remove_robot`, `remove_object`, `remove_camera`, `move_object`, `set_object_kinematic`, `set_object_collision`, `set_robot_pose`, `set_joint_positions`, `install_action_controller`, `get_body_state`, `robot_joint_names` and `get_observation` - and the escape needed no entities registered.
+
+`get_camera_params` reports a miss through an exception rather than an envelope, and its contract names `KeyError`; it now raises that for an unhashable name too, instead of a `TypeError` no caller handling the documented failure would catch.
+
+The AST check that keeps a lookup added later inside this rule now covers all three backends. It previously listed only the `SimWorld` registry attributes, so a backend that keeps its entity state on the engine itself - as Isaac does, in `_robots` / `_objects` / `_cameras` - sat outside the check while appearing to be inside it.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -182,6 +182,17 @@ no "derive a label from the model" short form: `name` is also the procedural
 lookup key, so `None` / `""` are refused rather than replaced with a generated
 label.
 
+Looking an entity *up* is the other half of that contract, and it answers rather
+than refuses: a name only *addresses* an entity here, so a name that cannot be a
+registry key is honestly absent. `remove_robot`, `remove_object`,
+`remove_camera`, `send_action`, `move_object`, `get_body_state` and the rest
+report it with the unknown-entity message they already had, `robot_joint_names`
+and `get_observation` keep answering empty, and `get_frame` /
+`get_camera_params` raise the `KeyError` their contract names. Previously the
+membership test itself raised `TypeError: unhashable type` for a list or dict
+name, so the miss escaped the envelope those methods document as their only
+failure channel - reachable with no entities registered at all.
+
 ## Fleet (IsaacLab-style) preview
 
 ```python

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from strands_robots.simulation.models import registered
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
@@ -470,7 +471,7 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         from strands_robots.simulation.models import TrajectoryStep
 
         state = self._recording_state()
-        if state is None or robot_name not in self._robots:
+        if state is None or not registered(self._robots, robot_name):
             return None
 
         robot = self._robots[robot_name]

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -36,6 +36,7 @@ import numpy as np
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.config import IsaacConfig
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
+from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
@@ -2231,7 +2232,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             # reloads are idempotent (no duplicate prims / no "already exists").
             removed_any = False
             for prior_name in list(self._scene_objects):
-                if prior_name in self._objects:
+                if registered(self._objects, prior_name):
                     self.remove_object(prior_name)
                     removed_any = True
                 self._scene_objects.discard(prior_name)
@@ -2268,7 +2269,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             for obj in scene_objects:
                 # ``add_object`` rejects duplicate names; if a manually-added
                 # object shadows a scene object, skip it rather than abort.
-                if obj.name in self._objects:
+                if registered(self._objects, obj.name):
                     skipped.append({"name": obj.name, "reason": "name already in use"})
                     continue
                 result = self.add_object(
@@ -2471,7 +2472,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             convention used by :meth:`get_observation` for unknown robots).
         """
         with self._lock:
-            if robot_name not in self._robots:
+            if not registered(self._robots, robot_name):
                 return []
             return list(self._robots[robot_name].joint_names)
 
@@ -2495,7 +2496,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             shape used by mutating methods on this class.
         """
         with self._lock:
-            if name not in self._robots:
+            if not registered(self._robots, name):
                 return {
                     "status": "error",
                     "content": [{"text": f"Robot '{name}' not found."}],
@@ -2537,7 +2538,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             bookkeeping that does not distinguish robots from objects.
         """
         with self._lock:
-            if name not in self._objects:
+            if not registered(self._objects, name):
                 return {
                     "status": "error",
                     "content": [{"text": f"Object '{name}' not found."}],
@@ -2630,7 +2631,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     )
                     return {}
 
-            if robot_name not in self._robots:
+            if not registered(self._robots, robot_name):
                 logger.warning(
                     "get_observation(robot_name=%r): unknown robot. Known: %s. Returning empty observation.",
                     robot_name,
@@ -2742,7 +2743,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             Standard ``{"status", "content": [{"text"}]}`` envelope.
         """
         with self._lock:
-            if robot_name not in self._robots:
+            if not registered(self._robots, robot_name):
                 return {
                     "status": "error",
                     "content": [{"text": f"Robot '{robot_name}' not found. Available: {sorted(self._robots)}"}],
@@ -2837,7 +2838,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                         "status": "error",
                         "content": [{"text": f"Specify robot_name; available robots: {sorted(self._robots)}"}],
                     }
-            if robot_name not in self._robots:
+            if not registered(self._robots, robot_name):
                 return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
             try:
                 jac = self._link_jacobian(self._robots[robot_name], body_name)
@@ -2963,7 +2964,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                         ],
                     }
 
-            if robot_name not in self._robots:
+            if not registered(self._robots, robot_name):
                 return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
             robot = self._robots[robot_name]
@@ -2976,7 +2977,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             # name-lookup path -- the raw path would drop every task-space
             # key and the robot would sit still while the eval reads green
             # (#1812).
-            controller = self._action_controllers.get(robot_name)
+            controller = registry_entry(self._action_controllers, robot_name)
             if controller is not None and isinstance(action, dict):
                 try:
                     action = controller.compute_joint_targets(action)
@@ -3224,7 +3225,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     {"text": f"Rendered (headless, no RTX): {w}x{h}"},
                 )
 
-            if camera_name not in self._cameras:
+            if not registered(self._cameras, camera_name):
                 # No camera configured - return blank. Caller probably
                 # forgot to call add_camera or typo'd the name.
                 return (
@@ -3376,7 +3377,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     "get_frame is unavailable in headless render mode (no RTX frames are produced); "
                     "use render_mode='rtx_realtime' or consume the envelope render() fallback."
                 )
-            if camera_name not in self._cameras:
+            if not registered(self._cameras, camera_name):
                 raise KeyError(f"Camera '{camera_name}' not found. Available: {sorted(self._cameras)}")
             cam = self._cameras[camera_name]
             if cam.handle is None:
@@ -3435,7 +3436,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         with self._lock:
             if not self._world_created:
                 raise RuntimeError("No world created. Call create_world first.")
-            if camera_name not in self._cameras:
+            if not registered(self._cameras, camera_name):
                 raise KeyError(f"Camera '{camera_name}' not found. Available: {sorted(self._cameras)}")
             cam = self._cameras[camera_name]
             if cam.handle is None:
@@ -3890,7 +3891,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             if the camera is unknown to ``_cameras``.
         """
         with self._lock:
-            if name not in self._cameras:
+            if not registered(self._cameras, name):
                 return {
                     "status": "error",
                     "content": [{"text": f"Camera '{name}' not found."}],
@@ -4033,7 +4034,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             if cameras is None:
                 names = list(self._cameras.keys())
             else:
-                unresolved = [c for c in cameras if c not in self._cameras]
+                unresolved = [c for c in cameras if not registered(self._cameras, c)]
                 if unresolved:
                     return {
                         "status": "error",
@@ -4893,7 +4894,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 return {"status": "error", "content": [{"text": "'positions' is required."}]}
             if robot_name is None:
                 robot_name = next(iter(self._robots))
-            r = self._robots.get(robot_name)
+            r = registry_entry(self._robots, robot_name)
             if r is None or r.articulation is None:
                 return {"status": "error", "content": [{"text": f"Robot {robot_name!r} not initialized."}]}
 
@@ -4967,7 +4968,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                         ],
                     }
                 robot_name = next(iter(self._robots))
-            robot = self._robots.get(robot_name)
+            robot = registry_entry(self._robots, robot_name)
             if robot is None or robot.articulation is None:
                 return {"status": "error", "content": [{"text": f"Robot {robot_name!r} not initialized."}]}
             try:
@@ -4997,7 +4998,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         the closing gripper fingers every frame. Velocities are zeroed
         so a teleport doesn't fling a dynamic body.
         """
-        obj = self._objects.get(name)
+        obj = registry_entry(self._objects, name)
         if obj is None or obj.handle is None:
             return {"status": "error", "content": [{"text": f"Object {name!r} not found."}]}
         try:
@@ -5060,7 +5061,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         pose exactly. Restored to dynamic on release. Toggles
         ``UsdPhysics.RigidBodyAPI.kinematicEnabled`` on the prim; best-effort.
         """
-        obj = self._objects.get(name)
+        obj = registry_entry(self._objects, name)
         if obj is None:
             return {"status": "error", "content": [{"text": f"Object {name!r} not found."}]}
         # Prefer the wrapper's own setter if present.
@@ -5107,7 +5108,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         collider lets the gripper close cleanly around it; re-enabled
         on release.
         """
-        obj = self._objects.get(name)
+        obj = registry_entry(self._objects, name)
         if obj is None:
             return {"status": "error", "content": [{"text": f"Object {name!r} not found."}]}
         if obj.handle is not None:
@@ -5137,7 +5138,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
     def _object_position(self, name: str) -> list[float] | None:
         """Return the world-frame position of ``name`` (or ``None`` if missing)."""
-        obj = self._objects.get(name)
+        obj = registry_entry(self._objects, name)
         if obj is None or obj.handle is None:
             return None
         try:
@@ -5210,7 +5211,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
     def _get_body_state_impl(self, body_name: str) -> dict[str, Any]:
         """Resolve + read ``body_name``; runs on the main thread (or pump-less)."""
-        obj = self._objects.get(body_name)
+        obj = registry_entry(self._objects, body_name)
         if obj is not None and obj.handle is not None:
             state = self._object_body_state(obj)
             if state is not None:
@@ -5292,7 +5293,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     prim = p
             elif "/" in body_name:
                 robot_name, _, link_name = body_name.partition("/")
-                r = self._robots.get(robot_name)
+                r = registry_entry(self._robots, robot_name)
                 if r is not None and link_name:
                     prim = self._find_robot_link_prim(stage, r, link_name, Sdf, Usd, UsdGeom)
             else:
@@ -5374,7 +5375,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         """
         if robot_name is None:
             robot_name = next(iter(self._robots), None)
-        r = self._robots.get(robot_name) if robot_name else None
+        r = registry_entry(self._robots, robot_name)
         if r is None:
             return None
         try:
@@ -5509,7 +5510,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         if frame is None or not getattr(frame, "size", 0):
             return None
         img = np.asarray(frame)[:, :, :3].astype("uint8")
-        out = self._cam_out_size.get(cname)
+        out = registry_entry(self._cam_out_size, cname)
         if out is not None:
             ow, oh = out
             if img.shape[1] != ow or img.shape[0] != oh:

--- a/tests/simulation/test_unhashable_entity_name_is_reported.py
+++ b/tests/simulation/test_unhashable_entity_name_is_reported.py
@@ -8,10 +8,10 @@ name that is not hashable (a list, a dict, a set) the lookup itself raises
 lookup guards is never reached and the exception escapes the agent-tool dict
 that the surrounding method documents as its only failure channel.
 
-These tests pin the lookup as total on both backends that keep such a registry:
-a name of any type resolves to a verdict, a name that cannot be a key resolves
-to "absent", and the message the method already had reports it. The AST check
-at the end is what keeps a lookup added later inside that rule.
+These tests pin the lookup as total on every backend that keeps such a
+registry: a name of any type resolves to a verdict, a name that cannot be a key
+resolves to "absent", and the message the method already had reports it. The AST
+check at the end is what keeps a lookup added later inside that rule.
 """
 
 from __future__ import annotations
@@ -291,13 +291,173 @@ def test_newton_still_resolves_a_registered_name():
 
 
 # --------------------------------------------------------------------------- #
+# Isaac keeps its registries on the engine, and answers the same way           #
+# --------------------------------------------------------------------------- #
+
+
+def _isaac_engine() -> Any:
+    """An Isaac engine holding one entity of each kind, without Isaac Sim.
+
+    Isaac does not mirror its entities onto :class:`SimWorld`; ``_robots``,
+    ``_objects`` and ``_cameras`` on the engine are the registries a name is
+    resolved against. Only that resolution is under test, so the simulator-backed
+    state each method goes on to read is left unbuilt - a call that gets past the
+    lookup fails on that state instead, which is how the tests below tell a name
+    that resolved from one that did not.
+    """
+    from strands_robots.simulation.isaac.config import IsaacConfig
+    from strands_robots.simulation.isaac.simulation import (
+        IsaacSimulation,
+        _CameraState,
+        _ObjectState,
+        _RobotState,
+    )
+
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._lock = threading.RLock()
+    engine._world_created = True
+    engine._config = IsaacConfig()
+    engine._robots = {"arm": _RobotState(name="arm", prim_path="/World/Robots/arm", joint_names=["pan"])}
+    engine._objects = {
+        "crate": _ObjectState(name="crate", prim_path="/World/Objects/crate", shape="box", is_static=False)
+    }
+    engine._cameras = {"look": _CameraState(name="look", prim_path="/World/Cameras/look", width=64, height=48)}
+    engine._prim_registry = ["/World/Robots/arm", "/World/Objects/crate", "/World/Cameras/look"]
+    # No Isaac ``World``: the prim deletion each ``remove_*`` attempts is
+    # best-effort and reports through the same envelope, so its absence does
+    # not stand in the way of the name resolution under test.
+    engine._world = None
+    engine._action_controllers = {}
+    engine._cam_out_size = {}
+    engine._cams_rec_state = None
+    engine._main_tid = threading.get_ident()
+    return engine
+
+
+# Every Isaac entry point that resolves a caller-supplied name and reports
+# through the agent-tool envelope, with the kind of entity each one addresses.
+_ISAAC_ENVELOPE_LOOKUPS: dict[str, Callable[[Any, Any], Any]] = {
+    "remove_robot": lambda e, n: e.remove_robot(n),
+    "remove_object": lambda e, n: e.remove_object(n),
+    "remove_camera": lambda e, n: e.remove_camera(n),
+    "send_action": lambda e, n: e.send_action({"pan": 0.1}, robot_name=n),
+    "get_jacobian": lambda e, n: e.get_jacobian(robot_name=n),
+    "move_object": lambda e, n: e.move_object(name=n, position=[0.2, 0.0, 0.3]),
+    "set_object_kinematic": lambda e, n: e.set_object_kinematic(n, True),
+    "set_object_collision": lambda e, n: e.set_object_collision(n, True),
+    "set_robot_pose": lambda e, n: e.set_robot_pose(robot_name=n, position=[0.0, 0.0, 0.0]),
+    "set_joint_positions": lambda e, n: e.set_joint_positions({"pan": 0.1}, robot_name=n),
+    "install_action_controller": lambda e, n: e.install_action_controller(n, object()),
+    "start_cameras_recording": lambda e, n: e.start_cameras_recording(output_dir="/tmp/isaac-name", cameras=[n]),
+    "get_body_state": lambda e, n: e.get_body_state(body_name=n),
+}
+
+
+@pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])
+def test_isaac_reports_an_unhashable_name_the_same_way(label, name):
+    """Each Isaac method returns its error envelope, not a TypeError."""
+    failures = {
+        method: miss
+        for method, call in _ISAAC_ENVELOPE_LOOKUPS.items()
+        if (miss := _envelope_miss(lambda n, _c=call: _c(_isaac_engine(), n), name)) is not None
+    }
+    assert not failures, f"a {label} name escaped or was accepted on Isaac:\n" + "\n".join(
+        f"  {k}: {v}" for k, v in sorted(failures.items())
+    )
+
+
+@pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])
+def test_isaac_best_effort_lookups_report_nothing_rather_than_raising(label, name):
+    """The two Isaac lookups with no error channel keep answering empty."""
+    engine = _isaac_engine()
+    assert engine.robot_joint_names(name) == []
+    assert engine.get_observation(robot_name=name) == {}
+
+
+@pytest.mark.parametrize(("label", "name"), UNHASHABLE, ids=[lbl for lbl, _ in UNHASHABLE])
+def test_isaac_raises_the_documented_miss_for_an_unhashable_camera(label, name):
+    """``get_camera_params`` reports through an exception, so it must be the documented one.
+
+    Its contract names ``KeyError`` for an unknown camera. A partial lookup
+    replaced that with a ``TypeError`` out of the membership test itself, which
+    no caller handling the documented failure would catch.
+    """
+    with pytest.raises(KeyError, match="not found"):
+        _isaac_engine().get_camera_params(camera_name=name)
+
+
+def test_isaac_resolves_a_registered_name_against_the_registry_alone():
+    """A name that addresses an entity is answered from the registry, unchanged.
+
+    These four need nothing but the registry, so a registered name gets the
+    same answer it always did.
+    """
+    assert _isaac_engine().remove_robot("arm")["status"] == "success"
+    assert _isaac_engine().remove_object("crate")["status"] == "success"
+    assert _isaac_engine().remove_camera("look")["status"] == "success"
+    assert _isaac_engine().robot_joint_names("arm") == ["pan"]
+    assert (
+        _isaac_engine().start_cameras_recording(output_dir="/tmp/isaac-name", cameras=["look"])["status"] == "success"
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "call"),
+    [
+        ("send_action", lambda e: e.send_action({"pan": 0.1}, robot_name="arm")),
+        ("install_action_controller", lambda e: e.install_action_controller("arm", object())),
+        ("set_robot_pose", lambda e: e.set_robot_pose(robot_name="arm", position=[0.0, 0.0, 0.0])),
+        ("set_joint_positions", lambda e: e.set_joint_positions({"pan": 0.1}, robot_name="arm")),
+    ],
+)
+def test_isaac_carries_a_registered_name_past_the_lookup(method, call):
+    """A registered name reaches the work, and fails on state, not on the name.
+
+    Each of these goes on to read simulator state this skeleton does not build,
+    so it still reports an error - but the error must no longer be the
+    unknown-entity message. That distinction is what says the guard rejects only
+    the names it should: a name the lookup turned away would have been reported
+    as absent instead of getting this far.
+    """
+    result = call(_isaac_engine())
+    assert result["status"] == "error"
+    assert "not found" not in result["content"][0]["text"], (
+        f"{method} reported a registered name as absent: {result['content'][0]['text']}"
+    )
+
+
+def test_isaac_reports_an_unknown_string_name_the_way_it_always_did():
+    """A misspelled name keeps the message the method already had."""
+    text = _isaac_engine().remove_object("crat")["content"][0]["text"]
+    assert "Object 'crat' not found" in text
+
+
+# --------------------------------------------------------------------------- #
 # no backend may re-introduce a partial lookup                                #
 # --------------------------------------------------------------------------- #
 
-# Registries keyed by an entity name. ``_policy_threads`` is the engine's own
-# per-robot map, reached before the world registries by the guard that refuses a
-# mutation while a policy runs.
-_REGISTRY_ATTRS = frozenset({"objects", "cameras", "robots", "_policy_threads"})
+# Registries keyed by an entity name. A backend keeps them either on its
+# :class:`SimWorld` (``objects`` / ``cameras`` / ``robots``) or on the engine
+# itself, and the engine-level ones are just as reachable with a caller-supplied
+# name: ``_policy_threads`` is consulted before the world registries by the guard
+# that refuses a mutation while a policy runs, ``_action_controllers`` by
+# ``send_action`` on the way to a task-space controller, and Isaac keeps its
+# whole entity state in ``_robots`` / ``_objects`` / ``_cameras``. Listing only
+# the world attributes would leave a backend that owns its registries outside
+# the check while appearing to be inside it.
+_REGISTRY_ATTRS = frozenset(
+    {
+        "objects",
+        "cameras",
+        "robots",
+        "_robots",
+        "_objects",
+        "_cameras",
+        "_policy_threads",
+        "_action_controllers",
+        "_cam_out_size",
+    }
+)
 
 # Creating an entity is a different question from looking one up: there the name
 # is not resolved but claimed, and a name that cannot be a key has to be refused
@@ -310,7 +470,7 @@ _CREATION_FUNCTIONS = frozenset({"add_robot", "add_object", "add_camera"})
 def _backend_dirs() -> list[Path]:
     """The backend packages, located from a symbol rather than a path literal."""
     simulation_dir = Path(inspect.getfile(registered)).parent
-    return [simulation_dir / "mujoco", simulation_dir / "newton"]
+    return [simulation_dir / "mujoco", simulation_dir / "newton", simulation_dir / "isaac"]
 
 
 def _is_registry(node: ast.AST) -> bool:


### PR DESCRIPTION
Closes #1846.

## Problem

Every simulation entity is addressed by name, and each backend resolves a caller-supplied name against a name-keyed registry before it does anything else. A bare `name in registry` / `registry.get(name)` is not total: for a name that is not hashable (a list, a dict, a set, a bytearray) **the lookup itself raises** `TypeError: unhashable type`, so the unknown-entity error path that the lookup guards is never reached and the exception escapes the `{"status", "content"}` envelope the surrounding method documents as its only failure channel.

The shared `registered()` / `registry_entry()` rule that makes a lookup total already exists in `strands_robots/simulation/models.py`, and its docstring spells out exactly this reasoning. It was applied to the MuJoCo and Newton backends. The Isaac backend still resolved names with a raw membership test at **25 sites**, and **13 of its 15** name-taking entry points let a `TypeError` escape - reachable with no entities registered at all:

```
remove_robot(["x"])   -> TypeError: unhashable type: 'list'
remove_object(["x"])  -> TypeError: unhashable type: 'list'
remove_camera(["x"])  -> TypeError: unhashable type: 'list'
```

`get_camera_params` reports a miss through an exception rather than an envelope, and its contract names `KeyError`. It raised `TypeError` instead, which no caller handling the documented failure would catch.

### The AST check appeared to cover this and did not

`test_every_backend_lookup_uses_the_shared_rule` is what keeps a lookup added later inside the rule. It listed only the `SimWorld` registry attributes (`objects` / `cameras` / `robots` / `_policy_threads`), so a backend that keeps its entity state **on the engine itself** sat outside the check while appearing to be inside it. Isaac keeps its whole entity state in `_robots` / `_objects` / `_cameras`, so simply adding `isaac` to the scanned directories found **zero** sites. Widening the attribute set to the engine-level maps costs the other two backends nothing (0 new offenders on either) and brings all 25 Isaac sites into the check - including one reached through a local alias in `isaac/recording.py` that a per-file grep of `simulation.py` missed.

## Change

- 26 lookups in `isaac/simulation.py` + `isaac/recording.py` now go through `registered()` / `registry_entry()`. No message text changes: each site reuses the unknown-entity message it already had.
- `_REGISTRY_ATTRS` gains the engine-level name-keyed maps (`_robots`, `_objects`, `_cameras`, `_action_controllers`, `_cam_out_size`), and `_backend_dirs()` gains `isaac`.
- Entity **creation** stays exempt as before. `load_scene`'s two duplicate-name tests are converted rather than added to the exemption, so the exemption does not grow - it still describes exactly `add_robot` / `add_object` / `add_camera`, which `test_the_creation_exemption_still_describes_real_code` pins.

Creation is a different question and is already handled: #1845 made Isaac *refuse* a name it cannot address. A lookup only *asks* whether a name addresses something, so a name that cannot be a key is honestly **absent** - which is why this half reports rather than refuses. The two are independently reachable and the contract now holds in both directions on all three backends.

## Measured

![Isaac entity-name lookup verdicts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-name-lookup/isaac_lookup.png)

`name = ["x"]` (a caller who wrapped the name in brackets) against an engine holding robot `arm`, object `crate`, camera `look`:

| | main | this change |
|---|---|---|
| lookups that let a `TypeError` escape | **13 of 15** | **0** |
| `remove_robot` / `remove_object` / `remove_camera` | `TypeError: unhashable type` | error envelope, `"Robot '...' not found."` |
| `robot_joint_names` / `get_observation` (no error channel) | `TypeError: unhashable type` | `[]` / `{}` |
| `get_camera_params` (raises by contract) | `TypeError` | `KeyError` - the documented one |

Every registered name is unchanged: `remove_object("crate")` -> `success`, `robot_joint_names("arm")` -> `["pan"]`, `start_cameras_recording(cameras=["look"])` -> `success`, and a misspelled string keeps the message it always had (`"Object 'crat' not found"`).

The render is the MuJoCo backend on the same probe, on **both** trees: `max|delta| = 1` (renderer noise). The change is Isaac-only, and the rule it routes through is the one MuJoCo and Newton already used - so the render is there to show that the reference backend, and the shared rule itself, are untouched.

## Tests

`tests/simulation/test_unhashable_entity_name_is_reported.py` gains an Isaac section next to the existing Newton one: the unhashable sweep over 12 envelope methods, the two best-effort lookups, the documented-`KeyError` contract, plus two over-reach controls (a registered name answered from the registry alone, and a registered name carried *past* the lookup so it fails on simulator state rather than on the name).

The Isaac fixture is built from the real `IsaacConfig` / `_RobotState` / `_ObjectState` / `_CameraState` types rather than stand-ins, so it cannot drift from the state the methods actually read, and it needs no Isaac Sim install.

**Pre-fix proof** (source reverted to `eed0c402`, tests kept): `14 failed, 36 passed`

```
FAILED test_isaac_reports_an_unhashable_name_the_same_way[list/dict/set/bytearray]
  -> install_action_controller: raised TypeError: unhashable type: 'list'
     move_object:               raised TypeError: unhashable type: 'list'
     remove_camera:             raised TypeError: unhashable type: 'list'  (+9 more)
FAILED test_isaac_best_effort_lookups_report_nothing_rather_than_raising[list/dict/set/bytearray]
FAILED test_isaac_raises_the_documented_miss_for_an_unhashable_camera[list/dict/set/bytearray]
FAILED test_every_backend_lookup_uses_the_shared_rule
FAILED test_the_creation_exemption_still_describes_real_code
```

Post-fix: **50 passed**. The three resolved-name tests pass on both trees by design - they are the over-reach controls.

## Gate

- `MUJOCO_GL=egl python -m pytest tests` -> **16666 passed, 258 skipped**, 504.83s (base `eed0c402`)
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (1017 source files)
- root guards (docstring xrefs, changelog fragments/format, internal paths, unreachable statements) -> 42 passed
- `scripts/check_merge_base_overlap.py` -> no overlap

## Out of scope

- `render` in `render_mode="headless"` short-circuits to a blank frame before reaching the camera lookup, so its membership test is unreachable there; it is converted anyway so the `rtx_realtime` path is covered.
- MuJoCo's unknown-entity message for a non-string name reads `"No objects in the scene"` even when objects exist. Pre-existing on that backend, unrelated to this rule, untouched here.