### PR TITLE
fix(sim): validate cameras= as a list of distinct camera names

### DIFF
--- a/changelog.d/1848-camera-subset-is-a-list-of-distinct-names.md
+++ b/changelog.d/1848-camera-subset-is-a-list-of-distinct-names.md
@@ -1,0 +1,26 @@
+### Fixed: `cameras=` is validated as a list of distinct camera names on every surface
+
+Seven public methods accept a `cameras` subset - MuJoCo's `render_all`, its two
+plain-MP4 recorders (`start_cameras_recording`,
+`start_cameras_recording_synchronous`) and every backend's `start_recording` -
+and none validated its shape, so one parameter had four failure modes and two of
+them escaped the structured `{"status": "error"}` contract these methods
+document. `cameras="wrist"` was read as five cameras, one per letter, and
+reported as five unknown cameras rather than as one mis-typed parameter;
+`cameras={"wrist": ...}` was accepted with its values silently discarded;
+`cameras=[3]` and `cameras=3` raised a bare `TypeError` out of the rendering
+surfaces and dead-ended in a generic "Dataset init failed" on the dataset ones.
+
+A repeated name failed in opposite directions depending on which surface received
+it: `render_all(["wrist", "wrist"])` returned two image blocks for one camera,
+`start_cameras_recording` reported "2 camera(s)" and opened a second encoder on
+the one output path - so the camera was rendered and appended twice per capture
+tick, and `stop_cameras_recording` reported two artifacts (25 frames each) for a
+single 25-frame file - while `start_recording` silently collapsed it and declared
+one camera column for the two requested.
+
+Every surface now resolves the value through
+`strands_robots.utils.name_list_error`, the shared domain that already governed
+the policy `image_keys` parameters, so a mistake reports the same way wherever it
+lands and names the parameter. `cameras=None` keeps its "every camera" meaning
+and an empty sequence keeps each surface's existing verdict.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -105,6 +105,27 @@ warning is logged when the implicit `default` overview camera is swept in
 alongside your real sensor cameras, so the stray view is never recorded
 silently.
 
+`cameras=` is a list of **distinct** camera names, and every surface that accepts
+one - `start_recording`, `render_all`, and the plain-MP4
+`start_cameras_recording` / `start_cameras_recording_synchronous` - enforces that
+shape up front. Two mistakes are refused rather than guessed at, because neither
+can be honored as written:
+
+- **A single name passed as a bare string.** `cameras="wrist"` is iterable per
+  character, so it would be read as five cameras, one per letter. Wrap it in a
+  list: `cameras=["wrist"]`.
+- **A repeated name.** `cameras=["wrist", "wrist"]` cannot mean one camera and
+  cannot mean two. In a dataset schema it collapses to a single column, so the
+  recording declares fewer views than were asked for; in `render_all` it renders
+  the same view twice; and in a plain-MP4 recording it opens a second encoder on
+  the one output path, so the camera is rendered and appended twice per capture
+  tick and the artifact ledger reports two files where one exists.
+
+A `Mapping` is refused for the same reason - it is iterable over its keys, so its
+values would be silently discarded. `cameras=None` keeps its "every camera"
+meaning.
+
+
 ### Where the dataset is written (`root` / `overwrite`)
 
 `root` is the on-disk directory for the dataset (defaults to the LeRobot cache

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -55,6 +55,7 @@ from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
 )
+from strands_robots.utils import name_list_error
 
 if TYPE_CHECKING:
     import threading
@@ -197,6 +198,14 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         # which optional extras this install has.
         if error := dataset_recording_option_error("start_recording", fps):
             return error
+        # ``cameras`` names an ordered list of DISTINCT camera names, so it is
+        # refused on the shared name-list domain before any dataset is created. Neither
+        # mistake this catches could be honored as written: a single name passed
+        # as a bare string is iterable per character, so it was read as one
+        # camera per letter, and a repeated name collapsed in the feature dict, declaring
+        # fewer camera columns than the caller asked for.
+        if cameras and (text := name_list_error(cameras, "cameras", "start_recording")):
+            return {"status": "error", "content": [{"text": text}]}
 
         # Reject a rate a rollout already in flight is not capturing at. The
         # rollout entry points cover the record-then-rollout ordering; this is

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -40,6 +40,7 @@ from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
     entity_name_error,
+    name_list_error,
     positive_count_error,
     positive_whole_number_error,
 )
@@ -4017,6 +4018,14 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         # drops every captured frame.
         if error := _cameras_recording_option_error("start_cameras_recording", fps, max_frames_per_camera):
             return error
+        # ``cameras`` names an ordered list of DISTINCT camera names, so it is
+        # refused on the shared name-list domain before any filesystem or buffer work. Neither
+        # mistake this catches could be honored as written: a single name passed
+        # as a bare string is iterable per character, so it was read as one
+        # camera per letter, and a repeated name opened a second encoder on the one output
+        # path, so the artifact ledger reported two files where one exists.
+        if cameras and (text := name_list_error(cameras, "cameras", "start_cameras_recording")):
+            return {"status": "error", "content": [{"text": text}]}
 
         with self._lock:
             if not self._world_created:

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -17,6 +17,7 @@ from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
 )
+from strands_robots.utils import name_list_error
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +140,14 @@ class RecordingMixin(DatasetRecordingMixin):
         # which optional extras this install has.
         if error := dataset_recording_option_error("start_recording", fps):
             return error
+        # ``cameras`` names an ordered list of DISTINCT camera names, so it is
+        # refused on the shared name-list domain before any dataset is created. Neither
+        # mistake this catches could be honored as written: a single name passed
+        # as a bare string is iterable per character, so it was read as one
+        # camera per letter, and a repeated name collapsed in the feature dict, declaring
+        # fewer camera columns than the caller asked for.
+        if cameras and (text := name_list_error(cameras, "cameras", "start_recording")):
+            return {"status": "error", "content": [{"text": text}]}
 
         # Reject a rate a rollout already in flight is not capturing at. The
         # rollout entry points cover the record-then-rollout ordering; this is

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -27,6 +27,7 @@ from strands_robots.simulation.safe_output import (
     validate_output_path,
     video_sandbox_args,
 )
+from strands_robots.utils import name_list_error
 
 logger = logging.getLogger(__name__)
 
@@ -1795,6 +1796,13 @@ class RenderingMixin:
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        # ``cameras`` names an ordered list of DISTINCT camera names, so it is
+        # refused on the shared name-list domain before any camera is resolved. Neither
+        # mistake this catches could be honored as written: a single name passed
+        # as a bare string is iterable per character, so it was read as one
+        # camera per letter, and a repeated name rendered the same view twice.
+        if cameras and (text := name_list_error(cameras, "cameras", "render_all")):
+            return {"status": "error", "content": [{"text": text}]}
         names, unresolved = self._active_camera_list(cameras)
         if cameras is not None and unresolved:
             return {
@@ -1896,6 +1904,14 @@ class RenderingMixin:
             "start_cameras_recording", fps, width, height, max_frames_per_camera
         ):
             return error
+        # ``cameras`` names an ordered list of DISTINCT camera names, so it is
+        # refused on the shared name-list domain before any filesystem or capture-thread work. Neither
+        # mistake this catches could be honored as written: a single name passed
+        # as a bare string is iterable per character, so it was read as one
+        # camera per letter, and a repeated name opened a second encoder on the one output
+        # path, so the artifact ledger reported two files where one exists.
+        if cameras and (text := name_list_error(cameras, "cameras", "start_cameras_recording")):
+            return {"status": "error", "content": [{"text": text}]}
 
         # The guard above accepts any real scalar with an integral value, so a
         # ``640.0`` read from a config float and an ``np.int64`` probed from a
@@ -2341,6 +2357,14 @@ class RenderingMixin:
             "start_cameras_recording_synchronous", fps, width, height, max_frames_per_camera
         ):
             return error
+        # ``cameras`` names an ordered list of DISTINCT camera names, so it is
+        # refused on the shared name-list domain before any filesystem or capture-thread work. Neither
+        # mistake this catches could be honored as written: a single name passed
+        # as a bare string is iterable per character, so it was read as one
+        # camera per letter, and a repeated name opened a second encoder on the one output
+        # path, so the artifact ledger reported two files where one exists.
+        if cameras and (text := name_list_error(cameras, "cameras", "start_cameras_recording_synchronous")):
+            return {"status": "error", "content": [{"text": text}]}
 
         # The guard above accepts any real scalar with an integral value, so a
         # ``640.0`` read from a config float and an ``np.int64`` probed from a

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -32,6 +32,7 @@ from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
 )
+from strands_robots.utils import name_list_error
 
 if TYPE_CHECKING:
     from strands_robots.simulation.models import SimWorld
@@ -130,6 +131,14 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         # which optional extras this install has.
         if error := dataset_recording_option_error("start_recording", fps):
             return error
+        # ``cameras`` names an ordered list of DISTINCT camera names, so it is
+        # refused on the shared name-list domain before any dataset is created. Neither
+        # mistake this catches could be honored as written: a single name passed
+        # as a bare string is iterable per character, so it was read as one
+        # camera per letter, and a repeated name collapsed in the feature dict, declaring
+        # fewer camera columns than the caller asked for.
+        if cameras and (text := name_list_error(cameras, "cameras", "start_recording")):
+            return {"status": "error", "content": [{"text": text}]}
 
         # Reject a rate a rollout already in flight is not capturing at. The
         # rollout entry points cover the record-then-rollout ordering; this is

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -641,29 +641,37 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
 def name_list_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable list of distinct key names.
 
-    Shared domain for the parameters that carry an ordered list of KEY NAMES
-    into a policy: the LeRobot ``image_keys`` (model VISUAL feature keys to
-    declare on the config) and the VERA ``image_keys`` (observation camera keys
-    to width-concat into one frame). The two name different vocabularies, but
-    the shape contract is identical - several distinct non-blank names, in the
-    order the caller wants them - and both consumers reach the same failure when
-    it is not met, so the rule lives here rather than beside either of them.
+    Shared domain for every parameter that carries an ordered list of KEY
+    NAMES: the LeRobot ``image_keys`` (model VISUAL feature keys to declare on
+    the config), the VERA ``image_keys`` (observation camera keys to
+    width-concat into one frame), and the simulation ``cameras`` subset accepted
+    by ``render_all``, the two plain-MP4 recorders and every backend's
+    ``start_recording``. They name different vocabularies, but the shape
+    contract is identical - several distinct non-blank names, in the order the
+    caller wants them - and every consumer reaches the same failure when it is
+    not met, so the rule lives here rather than beside any one of them.
 
     The mistake this exists for is a single name passed as a bare string.
     ``str`` is iterable, so ``list("wrist")`` yields ``['w', 'r', 'i', 's', 't']``
     - five names the caller never wrote, one per character. Nothing downstream
     can tell that apart from a deliberate five-entry list, so it is accepted and
     the consequence surfaces far from the call: a model built declaring
-    per-character features, or a ``KeyError: 'w'`` raised mid-rollout when the
-    frame for a one-letter camera is looked up.
+    per-character features, a ``KeyError: 'w'`` raised mid-rollout when the
+    frame for a one-letter camera is looked up, or a recording refused as five
+    unknown cameras rather than as one mis-typed parameter.
 
     A ``Mapping`` is refused for the same reason in the other direction: it is
     iterable over its keys, so its values would be silently discarded.
 
-    A repeated name is refused because it cannot be honored as written - the
-    LeRobot side builds a feature dict, where a duplicate collapses and declares
-    fewer features than asked for, and the VERA side concatenates one panel per
-    entry, where a duplicate doubles the width of the frame the model sees.
+    A repeated name is refused because it cannot be honored as written, and the
+    consumers disagree on which way it fails. A duplicate collapses where the
+    name keys a dict - the LeRobot feature map, or a dataset schema, which then
+    declares fewer columns than asked for - and doubles where each entry drives
+    its own unit of work: VERA concatenates one panel per entry, so the frame
+    the model sees is twice as wide; ``render_all`` renders the same view twice;
+    and a plain-MP4 recorder opens a second encoder on the one output path, so
+    the same camera is rendered and appended twice per capture tick while the
+    artifact ledger reports two files where one exists.
 
     Only a :class:`~collections.abc.Sequence` is accepted, which excludes
     one-shot iterators. That matters on the LeRobot path, where the value is

--- a/tests/simulation/test_camera_name_list_contract.py
+++ b/tests/simulation/test_camera_name_list_contract.py
@@ -1,0 +1,331 @@
+"""``cameras=`` is an ordered list of distinct camera names on every surface.
+
+Seven public methods accept a ``cameras`` subset - MuJoCo's ``render_all``, its
+two plain-MP4 recorders, and every backend's ``start_recording`` - and each one
+used to read whatever it was handed. Nothing validated the shape, so one
+parameter had four different failure modes and two of them escaped the
+structured ``{"status": "error"}`` contract these methods document:
+
+* A single name passed as a bare string is iterable per character, so
+  ``cameras="wrist"`` was read as five cameras, one per letter, and reported as
+  five unknown cameras rather than as one mis-typed parameter.
+* A ``Mapping`` is iterable over its keys, so ``cameras={"wrist": ...}`` was
+  accepted with its values silently discarded.
+* A repeated name failed in opposite directions depending on the surface:
+  ``render_all(["wrist", "wrist"])`` returned two image blocks for one camera,
+  ``start_cameras_recording`` reported "2 camera(s)" and opened a second encoder
+  on the one output path (two artifacts for one file, the camera rendered and
+  appended twice per capture tick), while ``start_recording`` silently collapsed
+  it and declared one camera column for the two requested.
+* A non-string element or a non-sequence raised a bare
+  ``TypeError: can only concatenate str (not "int") to str`` /
+  ``TypeError: 'int' object is not iterable`` out of the rendering surfaces, and
+  dead-ended in a generic "Dataset init failed" on the dataset surfaces.
+
+The rule these need already exists as
+:func:`strands_robots.utils.name_list_error`, the shared domain for a parameter
+carrying an ordered list of key names; it was wired only to the policy
+``image_keys`` consumers. These tests pin that every ``cameras`` surface now
+resolves through it, that the surfaces agree, and that a distinct list is
+untouched.
+
+``cameras=None`` keeps its "record/render every camera" meaning and an empty
+sequence keeps each surface's existing verdict: like every other consumer of the
+shared domain, the check is gated on a truthy value.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation import Simulation
+from strands_robots.simulation.models import SimWorld
+
+_ARM_XML = """<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base">
+      <geom type="box" size="0.05 0.05 0.05"/>
+      <body name="link1" pos="0 0 0.1">
+        <joint name="pan" type="hinge" axis="0 0 1" damping="2" range="-1.5 1.5" limited="true"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><position name="pan_act" joint="pan" kp="30" ctrlrange="-1.5 1.5"/></actuator>
+</mujoco>
+"""
+
+
+def _call(surface: Callable[..., Any], **kwargs: Any) -> dict[str, Any]:
+    """Invoke ``surface`` with keywords mypy must not narrow.
+
+    Several cases here deliberately pass a value the parameter's annotation
+    forbids - that is the caller mistake under test. Splatting a
+    ``dict[str, Any]`` keeps the type checker out of the way without a
+    suppression at each call site.
+    """
+    return surface(**kwargs)
+
+
+@pytest.fixture
+def cam_sim(tmp_path):
+    """A MuJoCo world with one robot and one named camera.
+
+    Deliberately un-annotated: the concrete ``Simulation`` symbol is a lazy
+    module attribute rather than a class, so annotating it makes every
+    ``sim._world`` read a union for mypy.
+    """
+    arm = tmp_path / "arm.xml"
+    arm.write_text(_ARM_XML)
+    sim = Simulation(backend="mujoco", tool_name="cameras_contract", mesh=False)
+    sim.create_world()
+    sim.add_robot(name="arm", urdf_path=str(arm))
+    sim.add_camera(name="wrist", position=[0.4, 0.4, 0.4], target=[0.0, 0.0, 0.1])
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+# Every value class that cannot be read as a list of distinct camera names.
+# Parametrized over FACTORIES so a one-shot iterator is not consumed by
+# whichever surface reads it first.
+_UNUSABLE: list[tuple[str, Callable[[], Any]]] = [
+    ("bare_string", lambda: "wrist"),
+    ("mapping", lambda: {"wrist": {"width": 64}}),
+    ("duplicate_name", lambda: ["wrist", "wrist"]),
+    ("non_string_element", lambda: [3]),
+    ("not_a_sequence", lambda: 3),
+    ("blank_name", lambda: [" "]),
+    ("one_shot_iterator", lambda: iter(["wrist"])),
+]
+
+_SURFACES: list[str] = [
+    "render_all",
+    "start_cameras_recording",
+    "start_cameras_recording_synchronous",
+    "start_recording",
+]
+
+
+def _invoke(sim: Any, surface: str, tmp_path: pathlib.Path, cameras: Any) -> dict[str, Any]:
+    """Call one ``cameras``-taking surface with the supplied value."""
+    if surface == "render_all":
+        return _call(sim.render_all, cameras=cameras, width=64, height=48)
+    if surface == "start_cameras_recording":
+        return _call(sim.start_cameras_recording, cameras=cameras, output_dir=str(tmp_path / "mp4"), fps=10)
+    if surface == "start_cameras_recording_synchronous":
+        return _call(
+            sim.start_cameras_recording_synchronous, cameras=cameras, output_dir=str(tmp_path / "mp4s"), fps=10
+        )
+    return _call(
+        sim.start_recording,
+        repo_id="local/cameras_contract",
+        task="t",
+        fps=30,
+        root=str(tmp_path / "ds"),
+        overwrite=True,
+        cameras=cameras,
+    )
+
+
+class TestAValueThatIsNotCameraNamesIsRefused:
+    """Each surface reports the parameter instead of guessing or raising."""
+
+    @pytest.mark.parametrize("surface", _SURFACES)
+    @pytest.mark.parametrize(("label", "make"), _UNUSABLE, ids=[c[0] for c in _UNUSABLE])
+    def test_the_parameter_is_named_in_a_structured_error(
+        self, cam_sim, tmp_path, surface: str, label: str, make: Callable[[], Any]
+    ) -> None:
+        result = _invoke(cam_sim, surface, tmp_path, make())
+        assert result["status"] == "error", (surface, label, result)
+        text = " ".join(block["text"] for block in result["content"] if "text" in block)
+        assert "cameras" in text, (surface, label, text)
+        assert surface in text, (surface, label, text)
+
+    @pytest.mark.parametrize("surface", _SURFACES)
+    @pytest.mark.parametrize(("label", "make"), [("non_string_element", lambda: [3]), ("not_a_sequence", lambda: 3)])
+    def test_a_non_name_value_does_not_escape_the_tool_envelope(
+        self, cam_sim, tmp_path, surface: str, label: str, make: Callable[[], Any]
+    ) -> None:
+        """These two used to raise a bare ``TypeError`` past the dispatch layer.
+
+        The rendering surfaces reached ``"tag__" + 3`` / ``for c in 3`` with the
+        caller's value, so a ``TypeError`` naming neither the parameter nor the
+        method left a method documented to return a result dict.
+        """
+        try:
+            result = _invoke(cam_sim, surface, tmp_path, make())
+        except Exception as exc:  # noqa: BLE001 - an escape is the regression
+            pytest.fail(f"{surface} raised {type(exc).__name__}: {exc}")
+        assert result["status"] == "error", (surface, label, result)
+
+
+class TestARefusedCallStartsNothing:
+    """The refusal precedes the work each surface would otherwise begin."""
+
+    def test_a_refused_capture_leaves_no_recording_running(self, cam_sim, tmp_path) -> None:
+        result = _call(
+            cam_sim.start_cameras_recording,
+            cameras=["wrist", "wrist"],
+            output_dir=str(tmp_path / "mp4"),
+            fps=10,
+        )
+        assert result["status"] == "error", result
+        status = cam_sim.get_cameras_recording_status()
+        text = " ".join(block["text"] for block in status["content"] if "text" in block)
+        assert "idle" in text.lower(), text
+        assert not (tmp_path / "mp4").exists(), sorted((tmp_path / "mp4").glob("*"))
+
+    def test_a_refused_dataset_call_creates_no_dataset(self, cam_sim, tmp_path) -> None:
+        root = tmp_path / "ds"
+        result = _call(
+            cam_sim.start_recording,
+            repo_id="local/cameras_contract",
+            task="t",
+            fps=30,
+            root=str(root),
+            overwrite=True,
+            cameras=["wrist", "wrist"],
+        )
+        assert result["status"] == "error", result
+        assert cam_sim._is_recording() is False
+        assert not root.exists(), sorted(root.glob("*"))
+
+    def test_a_refused_render_returns_no_image_block(self, cam_sim, tmp_path) -> None:
+        """Pre-fix a duplicate rendered the same view twice and returned both."""
+        result = _call(cam_sim.render_all, cameras=["wrist", "wrist"], width=64, height=48)
+        assert result["status"] == "error", result
+        assert [block for block in result["content"] if "image" in block] == []
+
+
+class TestDistinctNamesAreStillHonored:
+    """The guard is additive: a usable subset behaves exactly as before."""
+
+    def test_render_all_renders_one_block_per_requested_camera(self, cam_sim) -> None:
+        result = _call(cam_sim.render_all, cameras=["wrist"], width=64, height=48)
+        assert result["status"] == "success", result
+        assert len([block for block in result["content"] if "image" in block]) == 1
+
+    def test_render_all_still_defaults_to_every_camera(self, cam_sim) -> None:
+        result = _call(cam_sim.render_all, cameras=None, width=64, height=48)
+        assert result["status"] == "success", result
+        assert len([block for block in result["content"] if "image" in block]) >= 1
+
+    def test_a_plain_mp4_capture_still_starts(self, cam_sim, tmp_path) -> None:
+        result = _call(cam_sim.start_cameras_recording, cameras=["wrist"], output_dir=str(tmp_path / "mp4"), fps=10)
+        assert result["status"] == "success", result
+        cam_sim.stop_cameras_recording()
+
+    def test_a_scoped_dataset_recording_still_starts(self, cam_sim, tmp_path) -> None:
+        pytest.importorskip("lerobot")
+        result = _call(
+            cam_sim.start_recording,
+            repo_id="local/cameras_contract",
+            task="t",
+            fps=30,
+            root=str(tmp_path / "ds"),
+            overwrite=True,
+            cameras=["wrist"],
+        )
+        assert result["status"] == "success", result
+        cam_sim.stop_recording()
+
+    @pytest.mark.parametrize("surface", _SURFACES)
+    def test_an_empty_subset_keeps_each_surfaces_own_verdict(self, cam_sim, tmp_path, surface: str) -> None:
+        """An empty sequence already means "not supplied" to these callers.
+
+        Like every other consumer of the shared domain the check is gated on a
+        truthy value, so ``[]`` is not this change's to reinterpret.
+        """
+        result = _invoke(cam_sim, surface, tmp_path, [])
+        text = " ".join(block.get("text", "") for block in result["content"])
+        assert "must be a list of names" not in text, (surface, text)
+
+
+class TestEverySurfaceAgrees:
+    """One parameter, one verdict - the divergence this change removes."""
+
+    @pytest.mark.parametrize(("label", "make"), _UNUSABLE, ids=[c[0] for c in _UNUSABLE])
+    def test_the_surfaces_reach_the_same_verdict(self, cam_sim, tmp_path, label: str, make: Callable[[], Any]) -> None:
+        verdicts = {}
+        for index, surface in enumerate(_SURFACES):
+            scope = tmp_path / f"parity{index}"
+            scope.mkdir()
+            try:
+                verdicts[surface] = _invoke(cam_sim, surface, scope, make())["status"]
+            except Exception as exc:  # noqa: BLE001 - a raise is one of the verdicts
+                verdicts[surface] = f"raised {type(exc).__name__}"
+        assert len(set(verdicts.values())) == 1, (label, verdicts)
+
+
+def _backend_root() -> pathlib.Path:
+    """The simulation package directory, derived from a symbol it exports."""
+    return pathlib.Path(inspect.getfile(SimWorld)).parent
+
+
+def _cameras_surfaces(source: str) -> list[tuple[str, bool]]:
+    """Public methods in ``source`` taking ``cameras``, and whether each guards it."""
+    found: list[tuple[str, bool]] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+            continue
+        argnames = [arg.arg for arg in node.args.args + node.args.kwonlyargs]
+        if "cameras" not in argnames:
+            continue
+        guarded = any(
+            isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == "name_list_error"
+            for call in ast.walk(node)
+        )
+        found.append((node.name, guarded))
+    return found
+
+
+class TestGuardIsWiredAtEveryBackendSurface:
+    """A backend cannot add a ``cameras`` subset without the shared domain."""
+
+    def test_every_public_cameras_surface_resolves_the_shared_domain(self) -> None:
+        unguarded: list[str] = []
+        seen: list[str] = []
+        for backend in ("mujoco", "newton", "isaac"):
+            for module in sorted((_backend_root() / backend).glob("*.py")):
+                for name, guarded in _cameras_surfaces(module.read_text()):
+                    seen.append(f"{backend}/{module.name}::{name}")
+                    if not guarded:
+                        unguarded.append(f"{backend}/{module.name}::{name}")
+        assert seen, f"no cameras= surface found under {_backend_root()}"
+        assert unguarded == [], (
+            f"these public methods accept a cameras= subset without calling name_list_error: {unguarded}"
+        )
+
+    def test_the_scan_covers_the_known_surfaces(self) -> None:
+        """Non-vacuity: a scan root that resolved elsewhere would find nothing."""
+        seen = {
+            f"{backend}::{name}"
+            for backend in ("mujoco", "newton", "isaac")
+            for module in sorted((_backend_root() / backend).glob("*.py"))
+            for name, _ in _cameras_surfaces(module.read_text())
+        }
+        assert seen == {
+            "mujoco::render_all",
+            "mujoco::start_cameras_recording",
+            "mujoco::start_cameras_recording_synchronous",
+            "mujoco::start_recording",
+            "newton::start_recording",
+            "isaac::start_cameras_recording",
+            "isaac::start_recording",
+        }, seen
+
+    def test_the_scanner_detects_a_surface_that_drops_the_guard(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = (
+            "class Mixin:\n    def start_cameras_recording(self, cameras=None):\n        return {'status': 'success'}\n"
+        )
+        assert _cameras_surfaces(planted) == [("start_cameras_recording", False)]


### PR DESCRIPTION
Seven public methods accept a `cameras` subset and none validated its shape, so one parameter had four failure modes and two of them escaped the structured `{"status": "error"}` contract these methods document.

The rule they need already exists: `utils.name_list_error` is the shared domain for a parameter carrying an ordered list of key names, and its docstring already describes both consequences below. It was wired only to the policy `image_keys` consumers.

## The surfaces, and what each did with the same value

Measured on MuJoCo (the default backend) with one camera named `wrist`:

| `cameras=` | `render_all` | `start_cameras_recording` | `..._synchronous` | `start_recording` |
|---|---|---|---|---|
| `["wrist"]` | 1 image block | 1 camera | 1 camera | 1 camera column |
| `"wrist"` | error: 5 unknown cameras | error: 5 unknown | error: 5 unknown | error: 5 unknown |
| `{"wrist": ...}` | **success, values discarded** | **success** | **success** | **success** |
| `["wrist", "wrist"]` | **success, 2 image blocks for 1 camera** | **success, "2 camera(s)"** | **success, "2 camera(s)"** | **success, silently collapsed to 1** |
| `[3]` | **raised `TypeError`** | **raised `TypeError`** | **raised `TypeError`** | error "Dataset init failed" |
| `3` | **raised `TypeError`** | **raised `TypeError`** | **raised `TypeError`** | error "Dataset init failed" |

Four distinct problems in one parameter:

- **A single name passed as a bare string.** `str` is iterable per character, so `cameras="wrist"` was read as five cameras, one per letter, and reported as five unknown cameras rather than as one mis-typed parameter.
- **A `Mapping`** is iterable over its keys, so its values were silently discarded.
- **A non-string element or a non-sequence** reached `"tag__" + 3` / `for c in 3` with the caller's value and raised a bare `TypeError: can only concatenate str (not "int") to str` / `TypeError: 'int' object is not iterable` out of methods documented to return a result dict, or dead-ended in a generic "Dataset init failed" that names neither the parameter nor the surface.
- **A repeated name failed in opposite directions depending on which surface received it** - one parameter, two contracts. It collapses where the name keys a dict and doubles where each entry drives its own unit of work.

## The duplicate case, measured

`start_cameras_recording(cameras=["wrist", "wrist"], fps=10)` over 28 commanded arm poses:

| | main | this change |
|---|---|---|
| `start` | success, "Recording 2 camera(s)" | error, naming `cameras`; nothing started |
| `stop` ledger | 2 artifacts, 104 frames, **both naming the same file** | (after de-duplicating) 1 artifact, 26 frames |
| on disk | 1 file, 52 frames | 1 file, 26 frames |
| identical adjacent frames | **23 of 51** | **0 of 25** |

The two entries opened a second encoder on the one output path, so the camera was rendered and appended twice per capture tick: the 10 fps clip carries twice the frames, half of them duplicates, and the ledger reports two files where one exists. `render_all` returned two image blocks for the same view.

## Change

Every `cameras`-taking surface now resolves the value through `utils.name_list_error` - the one-line idiom its four existing `image_keys` call sites already use, so no second name is introduced. Guard placement follows each surface's existing order (world/existence check, then the numeric option guard, then this) and precedes any camera resolution, filesystem work, capture thread or dataset creation. `name_list_error`'s docstring is widened to name the new consumers and to record that a duplicate collapses on one kind of consumer and doubles on the other.

`cameras=None` keeps its "every camera" meaning, and an empty sequence keeps each surface's existing verdict: like every other consumer of this domain the check is gated on a truthy value, so `[]` is not this change's to reinterpret.

**Blast radius: zero.** No existing test changed; the values now refused appear nowhere in the suite as a sim `cameras=` argument.

## Artifact

MuJoCo headless (EGL), same scene and same 10 fps request on both trees. Left: a frame decoded back out of main's recording. Right: the refusal, then the recording produced by following the remedy the message gives. The middle panel is the per-frame change in each clip - main's touches zero on every other frame, which is the double append.

![cameras= duplicate name](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cameras-distinct-names/cameras_duplicate_name.png)

## Tests

`tests/simulation/test_camera_name_list_contract.py` - 57 tests:

- every value class refused at every surface, with the parameter named in a structured error;
- the two classes that used to raise pinned as not escaping the envelope;
- a refused call starts nothing (no capture running, no output dir, no dataset on disk, no image block);
- a distinct subset, `None`, and `[]` all behave exactly as before;
- a cross-surface parity test: one parameter, one verdict;
- an AST guard asserting every public method in `mujoco/`, `newton/` and `isaac/` that takes a `cameras` parameter calls the shared domain, plus a planted-defect meta-test and a non-vacuity test pinning the seven known surfaces (the guard runs with Newton and Isaac uninstalled).

**Pre-fix: 40 failed, 17 passed. Post-fix: 57 passed.** The 17 that pass pre-fix are the accepted-value controls, the empty-subset cases, the blank-name case that already errored, and the AST guard's own two meta-tests - they are what stop the guard over-reaching.

## Verification

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **16705 passed, 258 skipped**, 511.87s
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (1018 source files)
- `python3 scripts/assemble_changelog.py --check` -> OK; `scripts/check_merge_base_overlap.py` -> no overlap

Independent of #1847: the hunks in the two shared Isaac files are 16+ lines apart.