### PR TITLE
fix(policies): validate robot_state_keys as a list of distinct joint names

### DIFF
--- a/changelog.d/1850-state-key-name-list-domain.md
+++ b/changelog.d/1850-state-key-name-list-domain.md
@@ -1,0 +1,58 @@
+### Fixed: `robot_state_keys` is validated as a list of distinct joint names on every surface
+
+`robot_state_keys` is the ordered list of joint/motor names a policy emits as its
+action-dict keys - the names `send_action` resolves - so it decides which
+actuator each action value is sent to. Nine of the eleven surfaces that bind it
+validated nothing about its shape.
+
+Its two sibling setters on `Policy` did. `set_control_frequency` and
+`set_rtc_observed_delay` are concrete on the base class and each raises through a
+shared domain in `strands_robots.utils`; `set_robot_state_keys` is
+`@abstractmethod` with a `pass` body, so there was no shared implementation to
+carry one and each provider re-implemented the setter without it. On one policy
+instance, `set_control_frequency(True)` and `set_rtc_observed_delay(1.5)` raised
+while `set_robot_state_keys("wrist")` and `set_robot_state_keys([1])` were
+accepted.
+
+A single joint name passed as a bare string is the mistake that matters:
+`set_robot_state_keys("shoulder_pan.pos")` bound 16 per-character joints, and
+`get_actions` then emitted 13-key action dicts - the width silently shrinking
+from 16 to 13 as the repeated characters collapsed in the dict - so a robot would
+have been commanded on keys named `'s'`, `'h'`, `'o'` and `'.'`. A repeated name
+was bound at width 3 and emitted at width 2, the same collapse, which also
+narrows `lerobot_async`'s `{key: float for key in self.robot_state_keys}`
+hardware-feature map so it declares fewer columns than `align_action_values` is
+handed. A `Mapping` was accepted with its values silently discarded, a one-shot
+iterator was bound and exhausted by the first read, and non-string or blank
+entries were bound as given.
+
+Those nine surfaces now resolve the value through
+`strands_robots.utils.name_list_error`, the shared domain that already governed
+the policy `image_keys` parameters and the simulation `cameras` subset, so a
+mistake reports the same way wherever it lands and names the parameter. The two
+delegating wrappers (`CompositePolicy`, `PersistentPolicy`) forward to the policy
+that binds, so the verdict is identical through them.
+
+`WBCPolicy` and `MotionBricksPolicy` are unchanged: they resolve every G1 joint
+they drive by name inside the caller's list, so all five malformed shapes already
+failed that membership check with a message naming the missing joints. They also
+tolerate a repeated name on purpose - it resolves to its first occurrence, which
+`test_flat_state_name_resolved_first_occurrence_wins` pins - and wiring them to
+the shared domain would have turned that reviewed decision into a refusal. Their
+existing totality is now pinned behaviourally so the exemption cannot drift into
+a silent accept.
+
+One coercion had to go with the guards. `PolicyServer._dispatch` handled
+`MSG_SET_STATE_KEYS` as `set_robot_state_keys(list(message.get("keys", [])))`,
+and `list("wrist")` is `['w', 'r', 'i', 's', 't']` - five *distinct, non-blank*
+names that pass every shape check. The coercion therefore laundered a mis-typed
+parameter into a well-formed joint list that no guard could recognise. It now
+forwards the wire value verbatim, for the reason the neighbouring `hz` handler
+already documents: coercing on the server lets the wire through a value the
+in-process API refuses, and the policy owns the domain. `RemotePolicy` validates
+ahead of its own `list(...)` for the same reason on the outbound side.
+
+`robot_state_keys=None` and an empty list keep their existing "auto-detect"
+meaning: like every other consumer of the shared domain, the check is gated on a
+truthy value. Only inputs that previously bound a layout the caller never wrote
+now raise, so no working caller changes behaviour.

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
 from strands_robots.policies.base import Policy
+from strands_robots.utils import name_list_error
 
 if TYPE_CHECKING:
     from websockets.sync.client import ClientConnection
@@ -235,7 +236,23 @@ class RemotePolicy(Policy):
         server over the open connection so the server-side policy maps
         observations onto the same joints; when not yet connected, they are
         replayed on the next connect handshake.
+
+        Validated here rather than relying on the server: the ``list(...)``
+        below would otherwise flatten a bare string into one name per character
+        and put a well-formed - but wrong - list on the wire, where no
+        server-side check could recognise it as a mis-typed parameter.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
         """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         self._robot_state_keys = list(robot_state_keys)
         with self._lock:
             if self._ws is not None:

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -151,7 +151,14 @@ class PolicyServer:
 
         if msg_type == protocol.MSG_SET_STATE_KEYS:
             with self._lock:
-                self.policy.set_robot_state_keys(list(message.get("keys", [])))
+                # Forwarded verbatim, for the same reason as ``hz`` below:
+                # coercing here (``list(...)``) lets the wire through a value
+                # the in-process API refuses. ``list("wrist")`` is
+                # ``['w', 'r', 'i', 's', 't']`` - five distinct, non-blank
+                # names that pass every shape check, so the coercion would
+                # launder a mis-typed parameter into a well-formed joint list
+                # naming one joint per letter. The policy owns the domain.
+                self.policy.set_robot_state_keys(message.get("keys", []))
             return {"type": protocol.MSG_OK}
 
         if msg_type == protocol.MSG_SET_CONTROL_FREQUENCY:

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -221,8 +221,34 @@ class Policy(ABC):
 
     @abstractmethod
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
-        """Configure the policy with robot state keys."""
-        pass
+        """Configure the policy with robot state keys.
+
+        These are the ordered joint/motor names the policy emits as its
+        action-dict keys, so they decide which actuator each action value is
+        sent to. An implementation must refuse a malformed list rather than
+        bind it. Most do so through the shared domain
+        :func:`~strands_robots.utils.name_list_error`, gated on a truthy value
+        because an empty list already means "auto-detect" on the providers that
+        support it. :class:`~strands_robots.policies.wbc.policy.WBCPolicy` and
+        :class:`~strands_robots.policies.motionbricks.policy.MotionBricksPolicy`
+        are already total without it: they resolve every joint they drive BY
+        NAME inside the caller's list, so any malformed shape fails that
+        membership check instead - and they deliberately tolerate a repeated
+        name, which resolves to its first occurrence.
+
+        Unlike :meth:`set_control_frequency` and
+        :meth:`set_rtc_observed_delay`, this setter has no shared
+        implementation to carry the domain: each provider binds the names into
+        its own layout, so each refuses at its own entry. That parity is pinned
+        structurally by the policy state-key name-list contract tests.
+
+        Args:
+            robot_state_keys: Ordered list of distinct non-blank joint/motor
+                names.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not such a list.
+        """
 
     def reset(self, seed: int | None = None) -> None:
         """Reset per-episode policy state.

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -65,7 +65,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import tcp_port_error
+from strands_robots.utils import name_list_error, tcp_port_error
 
 from .client import Cosmos3WebsocketClient
 from .embodiments import (
@@ -327,7 +327,18 @@ class Cosmos3Policy(Policy):
         Used (a) as the fallback gripper/joint source when no explicit
         ``observation_mapping`` names them, and (b) as default action actuator
         names when no ``action_mapping`` is supplied and the layout is generic.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
         """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         self.robot_state_keys = list(robot_state_keys)
 
     def reset(self, seed: int | None = None) -> None:

--- a/strands_robots/policies/curobo/policy.py
+++ b/strands_robots/policies/curobo/policy.py
@@ -71,7 +71,7 @@ import re
 from typing import Any
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import require_optional
+from strands_robots.utils import name_list_error, require_optional
 
 logger = logging.getLogger(__name__)
 
@@ -368,7 +368,18 @@ class CuroboPolicy(Policy):
         action dicts. When unset, ``get_actions`` falls back to
         ``observation.state`` length and emits ``"joint_<i>"`` keys
         (consistent with :class:`MockPolicy` / :class:`MoveIt2Policy`).
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
         """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         self._robot_state_keys = list(robot_state_keys)
 
     def reset(self, seed: int | None = None) -> None:

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -27,7 +27,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import tcp_port_error
+from strands_robots.utils import name_list_error, tcp_port_error
 
 from .client import Gr00tInferenceClient
 from .data_config import Gr00tDataConfig, load_data_config
@@ -666,7 +666,25 @@ class Gr00tPolicy(Policy):
         return "groot"
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
-        """No-op.  Mappings handle key translation."""
+        """Validate the joint-name list; the keys themselves are unused.
+
+        Gr00t translates keys through its own mappings, so nothing is stored.
+        The shape is still checked, because the same call must reach the same
+        verdict on every provider - an operator who mis-types this parameter
+        should be told so here rather than have it depend on which policy
+        happens to be loaded.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
+        """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
 
     def reset(self, seed: int | None = None) -> None:
         """Per-episode reset.

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -58,7 +58,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy, align_action_values, chunk_count_error
-from strands_robots.utils import require_optional, tcp_port_error
+from strands_robots.utils import name_list_error, require_optional, tcp_port_error
 
 logger = logging.getLogger(__name__)
 
@@ -265,7 +265,18 @@ class LerobotAsyncPolicy(Policy):
 
         Stored as the state-vector layout sent to the async inference server on
         each observation.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
         """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         self.robot_state_keys = list(robot_state_keys)
 
     def reset(self, seed: int | None = None) -> None:

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -750,8 +750,17 @@ class LerobotLocalPolicy(Policy):
 
         Raises:
             ValueError: If keys are empty and no model features available for
-                auto-detection.
+                auto-detection, or if ``robot_state_keys`` is not an ordered
+                list of distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake the latter catches:
+                ``str`` is iterable per character, so it would bind one joint
+                per letter.
         """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         if robot_state_keys:
             self.robot_state_keys = robot_state_keys
             logger.info(

--- a/strands_robots/policies/mock.py
+++ b/strands_robots/policies/mock.py
@@ -5,6 +5,7 @@ import math
 from typing import Any
 
 from strands_robots.policies.base import Policy
+from strands_robots.utils import name_list_error
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,19 @@ class MockPolicy(Policy):
         return False
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
-        """Record the ordered joint keys used to name the sinusoidal action dict."""
+        """Record the ordered joint keys used to name the sinusoidal action dict.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
+        """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         self.robot_state_keys = robot_state_keys
 
     async def get_actions(

--- a/strands_robots/policies/moveit2/policy.py
+++ b/strands_robots/policies/moveit2/policy.py
@@ -41,7 +41,7 @@ import os
 from typing import Any
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import tcp_port_error
+from strands_robots.utils import name_list_error, tcp_port_error
 
 from .client import MoveIt2InferenceClient
 
@@ -165,7 +165,18 @@ class MoveIt2Policy(Policy):
         (``[t, q0, q1, ...]``) onto per-joint action dicts. When unset,
         ``get_actions`` falls back to ``observation.state`` length and
         emits ``"joint_<i>"`` keys.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
         """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         self._robot_state_keys = list(robot_state_keys)
 
     def reset(self, seed: int | None = None) -> None:

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -227,7 +227,19 @@ class VeraPolicy(Policy):
         return True
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
-        """Record the robot's ordered joint/state keys used to build the state vector."""
+        """Record the robot's ordered joint/state keys used to build the state vector.
+
+        Raises:
+            ValueError: If ``robot_state_keys`` is not an ordered list of
+                distinct non-blank names, per
+                :func:`~strands_robots.utils.name_list_error`. A single name
+                passed as a bare string is the mistake this catches: ``str`` is
+                iterable per character, so it would bind one joint per letter.
+        """
+        if robot_state_keys and (
+            error := name_list_error(robot_state_keys, "robot_state_keys", "set_robot_state_keys")
+        ):
+            raise ValueError(error)
         self._robot_state_keys = list(robot_state_keys)
 
     def set_ik_target(

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -644,12 +644,24 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
     Shared domain for every parameter that carries an ordered list of KEY
     NAMES: the LeRobot ``image_keys`` (model VISUAL feature keys to declare on
     the config), the VERA ``image_keys`` (observation camera keys to
-    width-concat into one frame), and the simulation ``cameras`` subset accepted
+    width-concat into one frame), the simulation ``cameras`` subset accepted
     by ``render_all``, the two plain-MP4 recorders and every backend's
-    ``start_recording``. They name different vocabularies, but the shape
-    contract is identical - several distinct non-blank names, in the order the
-    caller wants them - and every consumer reaches the same failure when it is
-    not met, so the rule lives here rather than beside any one of them.
+    ``start_recording``, and the ``robot_state_keys`` accepted by every
+    provider's :meth:`~strands_robots.policies.base.Policy.set_robot_state_keys`
+    (the ordered joint/motor names a policy emits as its action-dict keys).
+    They name different vocabularies, but the shape contract is identical -
+    several distinct non-blank names, in the order the caller wants them - and
+    every consumer reaches the same failure when it is not met, so the rule
+    lives here rather than beside any one of them.
+
+    On the ``robot_state_keys`` path the duplicate case is the dict collapse
+    above, reached twice over: the emitted action dict is keyed by these names,
+    so a three-entry list with one repeat emits two commands, and the
+    ``lerobot_async`` hardware-feature map declares fewer columns than the
+    action aligner is handed. Note that the two providers resolving these names
+    by membership rather than by position (WBC, MotionBricks) deliberately
+    tolerate a repeat - it resolves to its first occurrence - so they are not
+    callers of this function.
 
     The mistake this exists for is a single name passed as a bare string.
     ``str`` is iterable, so ``list("wrist")`` yields ``['w', 'r', 'i', 's', 't']``

--- a/tests/policies/test_state_key_name_list_contract.py
+++ b/tests/policies/test_state_key_name_list_contract.py
@@ -285,14 +285,14 @@ def test_a_one_shot_iterator_is_refused() -> None:
     """A generator would present as empty to the second read of the list."""
     policy = MockPolicy()
     with pytest.raises(ValueError, match="one-shot iterator"):
-        policy.set_robot_state_keys(iter(["elbow", "wrist"]))
+        policy.set_robot_state_keys(iter(["elbow", "wrist"]))  # type: ignore[arg-type]
 
 
 def test_the_bare_string_message_names_the_per_character_reading() -> None:
     """The message has to say what the string WOULD have bound, or it reads as pedantry."""
     policy = MockPolicy()
     with pytest.raises(ValueError) as excinfo:
-        policy.set_robot_state_keys("shoulder_pan.pos")
+        policy.set_robot_state_keys("shoulder_pan.pos")  # type: ignore[arg-type]
     message = str(excinfo.value)
     assert "not a single string" in message
     assert "16 name(s)" in message
@@ -304,7 +304,7 @@ def test_a_refused_list_binds_nothing() -> None:
     policy = MockPolicy()
     policy.set_robot_state_keys(["elbow", "wrist"])
     with pytest.raises(ValueError):
-        policy.set_robot_state_keys("gripper")
+        policy.set_robot_state_keys("gripper")  # type: ignore[arg-type]
     assert policy.robot_state_keys == ["elbow", "wrist"]
 
 
@@ -312,7 +312,7 @@ def test_a_refusal_is_raised_before_any_joint_is_bound_on_a_fresh_policy() -> No
     """A first call that is refused leaves the constructor default in place."""
     policy = MockPolicy()
     with pytest.raises(ValueError):
-        policy.set_robot_state_keys("gripper")
+        policy.set_robot_state_keys("gripper")  # type: ignore[arg-type]
     assert policy.robot_state_keys == []
 
 
@@ -358,7 +358,7 @@ def test_a_composite_refuses_through_its_children() -> None:
     lower, upper = MockPolicy(), MockPolicy()
     composite = CompositePolicy(lower, upper)
     with pytest.raises(ValueError, match="robot_state_keys"):
-        composite.set_robot_state_keys("wrist")
+        composite.set_robot_state_keys("wrist")  # type: ignore[arg-type]
     assert lower.robot_state_keys == []
     assert upper.robot_state_keys == []
 
@@ -367,7 +367,7 @@ def test_the_remote_client_refuses_before_anything_reaches_the_wire() -> None:
     """Validated on the outbound side, ahead of its own ``list(...)`` flattening."""
     client = RemotePolicy(host="127.0.0.1", port=1)
     with pytest.raises(ValueError, match="robot_state_keys"):
-        client.set_robot_state_keys("wrist")
+        client.set_robot_state_keys("wrist")  # type: ignore[arg-type]
     assert client._robot_state_keys == []
 
 
@@ -389,11 +389,11 @@ def test_the_three_configuration_setters_now_agree() -> None:
     with pytest.raises(ValueError):
         policy.set_control_frequency(True)
     with pytest.raises(ValueError):
-        policy.set_rtc_observed_delay(1.5)
+        policy.set_rtc_observed_delay(1.5)  # type: ignore[arg-type]
     with pytest.raises(ValueError):
-        policy.set_robot_state_keys("wrist")
+        policy.set_robot_state_keys("wrist")  # type: ignore[arg-type]
     with pytest.raises(ValueError):
-        policy.set_robot_state_keys([1])
+        policy.set_robot_state_keys([1])  # type: ignore[list-item]
 
 
 # --------------------------------------------------------------------------
@@ -437,7 +437,7 @@ def test_wbc_refuses_a_malformed_list_through_its_by_name_check(label: str, valu
 def test_wbc_refuses_a_one_shot_iterator_too() -> None:
     """The iterator is consumed by the ``list(...)``, then fails membership."""
     with pytest.raises(ValueError, match="missing expected G1"):
-        _wbc_policy().set_robot_state_keys(iter(["left_hip_pitch_joint"]))
+        _wbc_policy().set_robot_state_keys(iter(["left_hip_pitch_joint"]))  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/tests/policies/test_state_key_name_list_contract.py
+++ b/tests/policies/test_state_key_name_list_contract.py
@@ -1,0 +1,477 @@
+"""``robot_state_keys`` is an ordered list of distinct joint names on every surface.
+
+``robot_state_keys`` names the actuators a policy emits actions for - they are the
+keys ``send_action`` resolves - so the list decides which actuator each action
+value is sent to. Fourteen ``set_robot_state_keys`` surfaces accept it (twelve
+providers, the remote client, and the abstract declaration on ``Policy``) and
+none of them validated its shape.
+
+Its two sibling setters on the same class do. ``set_control_frequency`` and
+``set_rtc_observed_delay`` are concrete on ``Policy`` and each raises through a
+shared domain in :mod:`strands_robots.utils`; ``set_robot_state_keys`` is
+``@abstractmethod`` with a ``pass`` body, so there was no shared implementation
+to carry one and each provider re-implemented the setter without it. Measured on
+one ``MockPolicy`` instance before this change, ``set_control_frequency(True)``
+and ``set_rtc_observed_delay(1.5)`` raised while ``set_robot_state_keys("wrist")``
+and ``set_robot_state_keys([1])`` were accepted.
+
+The consequences, all measured on ``MockPolicy``:
+
+* A single joint name passed as a bare string is iterable per character, so
+  ``set_robot_state_keys("shoulder_pan.pos")`` bound 16 per-character joints and
+  ``get_actions`` then emitted 13-key action dicts - the width silently shrinking
+  from 16 to 13 as the repeated characters collapsed in the dict. Those single
+  characters are the keys a robot would have been commanded on.
+* A repeated name was bound at width 3 and emitted at width 2, because the
+  names key the emitted action dict and the duplicate collapses there. The same
+  collapse narrows ``lerobot_async``'s ``{key: float for key in
+  self.robot_state_keys}`` hardware-feature map, which then declares fewer
+  columns than ``align_action_values`` is handed.
+* A ``Mapping`` was accepted with its values silently discarded, a one-shot
+  iterator was bound and exhausted by the first read, and non-string or blank
+  entries were bound as given.
+
+The rule already existed as :func:`strands_robots.utils.name_list_error`, whose
+docstring claims to be the domain for "every parameter that carries an ordered
+list of KEY NAMES"; it was wired to the two ``image_keys`` consumers and the
+simulation ``cameras`` subset, but not to this one.
+
+One coercion had to go with it. ``PolicyServer._dispatch`` handled
+``MSG_SET_STATE_KEYS`` as ``set_robot_state_keys(list(message.get("keys", [])))``,
+and ``list("wrist")`` is ``['w', 'r', 'i', 's', 't']`` - five *distinct,
+non-blank* names that pass every shape check. So the coercion laundered a
+mis-typed parameter into a well-formed joint list, and a setter-only guard could
+not see it. The same file already states that rule for the sibling handler
+(``hz`` is "forwarded verbatim" because coercing "would let the wire accept a
+rate the in-process API refuses"), so ``MSG_SET_STATE_KEYS`` now forwards
+verbatim too. ``RemotePolicy`` validates before its own ``list(...)`` for the
+same reason, on the outbound side.
+
+Two providers needed no guard and deliberately did not get one. ``WBCPolicy``
+and ``MotionBricksPolicy`` resolve every G1 joint they drive BY NAME inside the
+caller's list, so a bare string, a mapping, a one-shot iterator, and non-string
+or blank entries all fail that membership check already - measured, all five
+refused with a message naming the missing joints. They also tolerate a repeated
+name on purpose: ``test_flat_state_name_resolved_first_occurrence_wins`` pins
+that a duplicate resolves to its FIRST occurrence and must not shift the
+resolved slot, which is a reviewed decision this change does not reopen. They
+are therefore classified as already-total rather than exempted, and the claim is
+pinned behaviourally below so the classification cannot hide a silent accept.
+
+``None`` and an empty list keep their existing "auto-detect" meaning: like every
+other consumer of the shared domain, the check is gated on a truthy value.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import pathlib
+from typing import Any
+
+import pytest
+
+import strands_robots
+from strands_robots.inference.client import RemotePolicy
+from strands_robots.policies.composite import CompositePolicy
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.policies.motionbricks.policy import MotionBricksPolicy
+from strands_robots.policies.wbc.policy import WBCConfig, WBCPolicy
+
+_PACKAGE = pathlib.Path(strands_robots.__file__).parent
+
+# The surfaces that must resolve through the shared domain themselves, as
+# "<path relative to strands_robots/>::<class>". Pinned by name so a provider
+# added later shows up as a failure of test_every_surface_is_classified rather
+# than quietly widening a count.
+_MUST_VALIDATE = {
+    "inference/client.py::RemotePolicy",
+    "policies/cosmos3/policy.py::Cosmos3Policy",
+    "policies/curobo/policy.py::CuroboPolicy",
+    "policies/groot/policy.py::Gr00tPolicy",
+    "policies/lerobot_async/policy.py::LerobotAsyncPolicy",
+    "policies/lerobot_local/policy.py::LerobotLocalPolicy",
+    "policies/mock.py::MockPolicy",
+    "policies/moveit2/policy.py::MoveIt2Policy",
+    "policies/vera/provider.py::VeraPolicy",
+}
+
+# Already total without the shared domain: every joint they drive is resolved by
+# name inside the caller's list, so a malformed shape fails that check instead.
+# They deliberately tolerate a repeated name (first occurrence wins), so wiring
+# them to the shared domain would reopen a reviewed decision.
+_TOTAL_BY_MEMBERSHIP = {
+    "policies/motionbricks/policy.py::MotionBricksPolicy",
+    "policies/wbc/policy.py::WBCPolicy",
+}
+
+# Pure delegators: they bind nothing themselves, so the wrapped policy's guard
+# is the one that fires.
+_MUST_FORWARD = {
+    "policies/composite.py::CompositePolicy",
+    "policies/persistent.py::PersistentPolicy",
+}
+
+# The abstract declaration carries the contract in its docstring, not in code.
+_ABSTRACT = {"policies/base.py::Policy"}
+
+
+def _classify(source: str) -> dict[str, dict[str, bool]]:
+    """Classify every ``set_robot_state_keys`` in ``source`` by what it does.
+
+    Returns a mapping of class name to flags: whether the body calls the shared
+    domain, whether it forwards to another ``set_robot_state_keys``, and whether
+    it is the abstract declaration.
+    """
+    out: dict[str, dict[str, bool]] = {}
+    tree = ast.parse(source)
+    for cls in ast.walk(tree):
+        if not isinstance(cls, ast.ClassDef):
+            continue
+        for fn in cls.body:
+            if not isinstance(fn, ast.FunctionDef) or fn.name != "set_robot_state_keys":
+                continue
+            validates = False
+            forwards = False
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "name_list_error":
+                    validates = True
+                elif isinstance(func, ast.Attribute) and func.attr == "name_list_error":
+                    validates = True
+                elif isinstance(func, ast.Attribute) and func.attr == "set_robot_state_keys":
+                    forwards = True
+            abstract = any(
+                (isinstance(d, ast.Name) and d.id == "abstractmethod")
+                or (isinstance(d, ast.Attribute) and d.attr == "abstractmethod")
+                for d in fn.decorator_list
+            )
+            out[cls.name] = {"validates": validates, "forwards": forwards, "abstract": abstract}
+    return out
+
+
+def _discover() -> dict[str, dict[str, bool]]:
+    """Classify every ``set_robot_state_keys`` implementation in the package."""
+    found: dict[str, dict[str, bool]] = {}
+    for path in sorted(_PACKAGE.rglob("*.py")):
+        for cls_name, flags in _classify(path.read_text(encoding="utf-8")).items():
+            found[f"{path.relative_to(_PACKAGE).as_posix()}::{cls_name}"] = flags
+    return found
+
+
+# --------------------------------------------------------------------------
+# Structural parity: no surface may bind a joint-name list it did not check
+# --------------------------------------------------------------------------
+
+
+def test_every_surface_is_classified() -> None:
+    """The set of ``set_robot_state_keys`` surfaces is exactly the pinned set.
+
+    Non-vacuity guard. If this fails because a provider was added, the fix is to
+    give it the shared domain and add it to ``_MUST_VALIDATE`` - not to relax the
+    assertion.
+    """
+    assert set(_discover()) == _MUST_VALIDATE | _TOTAL_BY_MEMBERSHIP | _MUST_FORWARD | _ABSTRACT
+
+
+def test_every_binding_surface_calls_the_shared_domain() -> None:
+    """Each provider that binds the names resolves them through the one domain."""
+    found = _discover()
+    missing = sorted(name for name in _MUST_VALIDATE if not found[name]["validates"])
+    assert not missing, f"these surfaces bind robot_state_keys without name_list_error: {missing}"
+
+
+def test_delegating_wrappers_forward_rather_than_re_validate() -> None:
+    """The two wrappers bind nothing, so they forward to the policy that does."""
+    found = _discover()
+    for name in _MUST_FORWARD:
+        assert found[name]["forwards"], f"{name} must forward to the wrapped policy"
+
+
+def test_the_base_declaration_stays_abstract() -> None:
+    """The contract lives on the abstract declaration; the domain lives per-provider."""
+    found = _discover()
+    for name in _ABSTRACT:
+        assert found[name]["abstract"]
+        assert not found[name]["validates"]
+
+
+def test_the_classifier_catches_a_provider_that_skips_the_domain() -> None:
+    """Planted defect: the structural test must fail on an unguarded provider.
+
+    Without this, a classifier that silently matched nothing would let every
+    assertion above pass vacuously.
+    """
+    guarded = _classify(
+        "class Guarded:\n"
+        "    def set_robot_state_keys(self, robot_state_keys):\n"
+        '        if robot_state_keys and (error := name_list_error(robot_state_keys, "p", "c")):\n'
+        "            raise ValueError(error)\n"
+        "        self._keys = list(robot_state_keys)\n"
+    )
+    assert guarded["Guarded"]["validates"] is True
+
+    unguarded = _classify(
+        "class Unguarded:\n"
+        "    def set_robot_state_keys(self, robot_state_keys):\n"
+        "        self._keys = list(robot_state_keys)\n"
+    )
+    assert unguarded["Unguarded"]["validates"] is False
+    assert unguarded["Unguarded"]["forwards"] is False
+
+
+# --------------------------------------------------------------------------
+# The wire must not launder the value into a shape the domain accepts
+# --------------------------------------------------------------------------
+
+
+def test_the_state_keys_handler_forwards_the_wire_value_verbatim() -> None:
+    """``MSG_SET_STATE_KEYS`` must not wrap the payload in ``list(...)``.
+
+    ``list("wrist")`` is five distinct non-blank names, so it passes the shared
+    domain: coercing on the server would launder a mis-typed parameter past every
+    guard. The policy owns the domain, exactly as the ``hz`` handler documents.
+    """
+    source = (_PACKAGE / "inference" / "server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "set_robot_state_keys"
+    ]
+    assert len(calls) == 1, "expected exactly one set_robot_state_keys forward in the server"
+    (arg,) = calls[0].args
+    assert not (isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name) and arg.func.id == "list"), (
+        "the wire value is coerced with list(...), which turns a bare string into "
+        "one name per character and passes the shared domain"
+    )
+
+
+def test_list_of_a_bare_string_would_pass_the_domain() -> None:
+    """Why the coercion had to go: its output is indistinguishable from valid input."""
+    from strands_robots.utils import name_list_error
+
+    assert name_list_error("wrist", "robot_state_keys", "c") is not None
+    assert name_list_error(list("wrist"), "robot_state_keys", "c") is None
+
+
+# --------------------------------------------------------------------------
+# Behaviour: every malformed shape is refused, and refusal binds nothing
+# --------------------------------------------------------------------------
+
+_MALFORMED: list[tuple[str, Any]] = [
+    ("bare string", "shoulder_pan.pos"),
+    ("repeated name", ["elbow", "elbow", "wrist"]),
+    ("mapping", {"elbow": 1.0, "wrist": 2.0}),
+    ("non-string entry", ["elbow", 2.5]),
+    ("blank name", ["elbow", "  "]),
+    ("one-shot iterator", None),  # built per-case below; an iterator cannot be reused
+]
+
+
+@pytest.mark.parametrize("label,value", [c for c in _MALFORMED if c[0] != "one-shot iterator"])
+def test_a_malformed_joint_name_list_is_refused(label: str, value: Any) -> None:
+    """Each shape the domain names is refused, naming the parameter and surface."""
+    policy = MockPolicy()
+    with pytest.raises(ValueError, match="robot_state_keys"):
+        policy.set_robot_state_keys(value)
+
+
+def test_a_one_shot_iterator_is_refused() -> None:
+    """A generator would present as empty to the second read of the list."""
+    policy = MockPolicy()
+    with pytest.raises(ValueError, match="one-shot iterator"):
+        policy.set_robot_state_keys(iter(["elbow", "wrist"]))
+
+
+def test_the_bare_string_message_names_the_per_character_reading() -> None:
+    """The message has to say what the string WOULD have bound, or it reads as pedantry."""
+    policy = MockPolicy()
+    with pytest.raises(ValueError) as excinfo:
+        policy.set_robot_state_keys("shoulder_pan.pos")
+    message = str(excinfo.value)
+    assert "not a single string" in message
+    assert "16 name(s)" in message
+    assert "['shoulder_pan.pos']" in message
+
+
+def test_a_refused_list_binds_nothing() -> None:
+    """Refusal leaves the policy exactly as it was - no half-applied layout."""
+    policy = MockPolicy()
+    policy.set_robot_state_keys(["elbow", "wrist"])
+    with pytest.raises(ValueError):
+        policy.set_robot_state_keys("gripper")
+    assert policy.robot_state_keys == ["elbow", "wrist"]
+
+
+def test_a_refusal_is_raised_before_any_joint_is_bound_on_a_fresh_policy() -> None:
+    """A first call that is refused leaves the constructor default in place."""
+    policy = MockPolicy()
+    with pytest.raises(ValueError):
+        policy.set_robot_state_keys("gripper")
+    assert policy.robot_state_keys == []
+
+
+# --------------------------------------------------------------------------
+# Behaviour: nothing that worked before changes
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label,value",
+    [
+        ("distinct names", ["elbow", "wrist", "shoulder_pan.pos"]),
+        ("a tuple", ("elbow", "wrist")),
+        ("empty list means auto-detect", []),
+    ],
+)
+def test_a_usable_joint_name_list_is_accepted(label: str, value: Any) -> None:
+    """The check is gated on a truthy value, so ``[]`` keeps its existing meaning."""
+    MockPolicy().set_robot_state_keys(value)
+
+
+def test_none_is_the_callers_to_skip_not_this_checks_to_reject() -> None:
+    """``None`` means "not supplied", as on every other consumer of the domain."""
+    MockPolicy().set_robot_state_keys(None)  # type: ignore[arg-type]
+
+
+def test_a_distinct_list_still_drives_the_action_dict_unchanged() -> None:
+    """End to end: the accepted path is untouched by the guard."""
+    policy = MockPolicy()
+    policy.set_robot_state_keys(["elbow", "wrist"])
+    actions = asyncio.run(policy.get_actions({"elbow": 0.0, "wrist": 0.0}, "task"))
+    assert actions
+    assert all(sorted(step) == ["elbow", "wrist"] for step in actions)
+
+
+# --------------------------------------------------------------------------
+# The wrappers and the remote client reach the same verdict
+# --------------------------------------------------------------------------
+
+
+def test_a_composite_refuses_through_its_children() -> None:
+    """The wrapper binds nothing, so the child's guard is the one that fires."""
+    lower, upper = MockPolicy(), MockPolicy()
+    composite = CompositePolicy(lower, upper)
+    with pytest.raises(ValueError, match="robot_state_keys"):
+        composite.set_robot_state_keys("wrist")
+    assert lower.robot_state_keys == []
+    assert upper.robot_state_keys == []
+
+
+def test_the_remote_client_refuses_before_anything_reaches_the_wire() -> None:
+    """Validated on the outbound side, ahead of its own ``list(...)`` flattening."""
+    client = RemotePolicy(host="127.0.0.1", port=1)
+    with pytest.raises(ValueError, match="robot_state_keys"):
+        client.set_robot_state_keys("wrist")
+    assert client._robot_state_keys == []
+
+
+def test_the_remote_client_still_accepts_a_distinct_list_while_disconnected() -> None:
+    """The keys are stored for replay on the next handshake, as before."""
+    client = RemotePolicy(host="127.0.0.1", port=1)
+    client.set_robot_state_keys(["elbow", "wrist"])
+    assert client._robot_state_keys == ["elbow", "wrist"]
+
+
+# --------------------------------------------------------------------------
+# Sibling parity on one instance: the asymmetry that motivated this
+# --------------------------------------------------------------------------
+
+
+def test_the_three_configuration_setters_now_agree() -> None:
+    """All three refuse a value they cannot honor, instead of two of three."""
+    policy = MockPolicy()
+    with pytest.raises(ValueError):
+        policy.set_control_frequency(True)
+    with pytest.raises(ValueError):
+        policy.set_rtc_observed_delay(1.5)
+    with pytest.raises(ValueError):
+        policy.set_robot_state_keys("wrist")
+    with pytest.raises(ValueError):
+        policy.set_robot_state_keys([1])
+
+
+# --------------------------------------------------------------------------
+# The two already-total providers: pinned, not merely excused
+# --------------------------------------------------------------------------
+
+
+def _wbc_policy() -> WBCPolicy:
+    """A WBC policy on the real G1 layout, with no model files on disk."""
+    return WBCPolicy(
+        config=WBCConfig(
+            policy_path="policy.onnx",
+            num_actions=15,
+            n_obs_joints=29,
+            command_dim=7,
+            single_obs_dim=86,
+            obs_history_len=1,
+            default_angles=[0.1] * 15,
+            kps=[100.0] * 15,
+            kds=[1.0] * 15,
+        ),
+        allow_missing_models=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "label,value",
+    [
+        ("bare string", "left_hip_pitch_joint"),
+        ("mapping", {"left_hip_pitch_joint": 1.0}),
+        ("non-string entry", [1, 2.5, None]),
+        ("blank name", ["", "  "]),
+    ],
+)
+def test_wbc_refuses_a_malformed_list_through_its_by_name_check(label: str, value: Any) -> None:
+    """No shared domain needed: the membership check is already total here."""
+    with pytest.raises(ValueError, match="missing expected G1"):
+        _wbc_policy().set_robot_state_keys(value)
+
+
+def test_wbc_refuses_a_one_shot_iterator_too() -> None:
+    """The iterator is consumed by the ``list(...)``, then fails membership."""
+    with pytest.raises(ValueError, match="missing expected G1"):
+        _wbc_policy().set_robot_state_keys(iter(["left_hip_pitch_joint"]))
+
+
+@pytest.mark.parametrize(
+    "label,value",
+    [
+        ("bare string", "left_hip_pitch_joint"),
+        ("mapping", {"left_hip_pitch_joint": 1.0}),
+        ("non-string entry", [1, 2.5, None]),
+        ("blank name", ["", "  "]),
+    ],
+)
+def test_motionbricks_refuses_a_malformed_list_through_its_by_name_check(label: str, value: Any) -> None:
+    """Same shape of check, same verdict, so the same exemption is justified.
+
+    ``set_robot_state_keys`` reads no constructor state before it raises - only
+    the module-level joint list - so a bare instance is enough, as the config
+    resolution tests in ``tests/policies/wbc`` already do.
+    """
+    policy = object.__new__(MotionBricksPolicy)
+    with pytest.raises(ValueError, match="missing expected G1 joints"):
+        policy.set_robot_state_keys(value)
+
+
+def test_the_by_name_providers_still_tolerate_a_repeated_name() -> None:
+    """A reviewed decision this change deliberately does not reopen.
+
+    ``test_flat_state_name_resolved_first_occurrence_wins`` pins that a
+    duplicated joint name resolves to its FIRST occurrence. Wiring these two to
+    the shared domain would have turned that into a refusal, so the exemption is
+    load-bearing rather than convenient.
+    """
+    from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS
+
+    policy = _wbc_policy()
+    keys = ["floating_base_joint", *WBC_G1_ALL_JOINTS, "left_hip_pitch_joint"]
+    policy.set_robot_state_keys(keys)
+    assert policy._robot_state_keys == keys


### PR DESCRIPTION
Closes #1849.

## Summary

`robot_state_keys` is the ordered list of joint/motor names a policy emits as its action-dict keys - the names `send_action` resolves - so it decides which actuator each action value is sent to. Nine of the eleven surfaces that bind it validated nothing about its shape. This wires them to the existing shared domain `strands_robots.utils.name_list_error`, and removes the one wire-side coercion that could launder a malformed value past any such guard.

## The asymmetry that made this a one-line argument

`Policy` has three configuration setters the runtime calls before inference. Two are concrete on the base class and each raises through a shared domain; `set_robot_state_keys` is `@abstractmethod` with a `pass` body, so there was no shared implementation to carry one and each provider re-implemented the setter without it. Measured on one `MockPolicy` instance, before this change:

| call | before | after |
|---|---|---|
| `set_control_frequency(True)` | refused, `ValueError` | refused |
| `set_rtc_observed_delay(1.5)` | refused, `ValueError` | refused |
| `set_robot_state_keys("wrist")` | **accepted** | refused |
| `set_robot_state_keys([1])` | **accepted** | refused |

`name_list_error`'s own docstring already claimed to be the domain for "every parameter that carries an ordered list of KEY NAMES" - it was wired to the two `image_keys` consumers and the simulation `cameras` subset, but not to this one.

## Measured consequences

**A single joint name as a bare string.** `set_robot_state_keys("shoulder_pan.pos")` bound 16 per-character names, and `get_actions` then emitted **13**-key action dicts - the width silently shrinking from 16 to 13 as the repeated characters collapsed in the dict:

```
stored : 'shoulder_pan.pos'   len 16
emitted: {'s':..., 'h':..., 'o':..., 'u':..., 'l':..., 'd':..., 'e':...,
          'r':..., '_':..., 'p':..., 'a':..., 'n':..., '.':...}   (13 keys)
```

Those single characters are the keys a robot would have been commanded on. `set_robot_state_keys("elbow")` yields actions keyed `['b', 'e', 'l', 'o', 'w']`.

**A repeated name.** `["elbow", "elbow", "wrist"]` bound at width 3 and emitted at width 2. The same collapse narrows `lerobot_async`'s `{key: float for key in self.robot_state_keys}` hardware-feature map, so it declares fewer columns than `align_action_values` is handed.

**Also accepted:** a `Mapping` (values silently discarded), non-string entries (`[1, 2.5, None]`), blank names (`["", "  "]`), and a one-shot iterator - which was bound and exhausted by the first read, the exact hazard the domain's docstring documents.

## The wire coercion had to go with it

`PolicyServer._dispatch` handled `MSG_SET_STATE_KEYS` as:

```python
self.policy.set_robot_state_keys(list(message.get("keys", [])))
```

`list("wrist")` is `['w', 'r', 'i', 's', 't']` - five *distinct, non-blank* strings, which pass `name_list_error` cleanly. So a setter-only guard would not have closed this path: the coercion laundered a mis-typed parameter into a well-formed joint list before any check could see it. Pinned by `test_list_of_a_bare_string_would_pass_the_domain`.

The same file already states the rule, ten lines below, for the sibling handler - `hz` is "forwarded verbatim" because coercing "would let the wire accept a rate the in-process API refuses ... The policy owns the accepted domain". `MSG_SET_STATE_KEYS` now does the same. `RemotePolicy` validates ahead of its own `list(...)` on the outbound side, so a bare string cannot be flattened before it reaches the wire either.

## Two providers deliberately left alone

This is the part the control test run changed. `WBCPolicy` and `MotionBricksPolicy` resolve every G1 joint they drive **by name** inside the caller's list, so all five malformed shapes already failed that membership check with a message naming the missing joints - measured on both. They were the two surfaces that were already total.

They also tolerate a repeated name **on purpose**: `test_flat_state_name_resolved_first_occurrence_wins` pins that a duplicate resolves to its FIRST occurrence and "must not shift the resolved slot". Wiring them to the shared domain turned that reviewed decision into a refusal and failed that test. Rather than reopen it, they keep their own check and their existing totality is now pinned behaviourally, so the classification cannot drift into a silent accept.

I had originally asserted in #1849 that a duplicate binds the *last* index on these paths. That was wrong - it binds the first, deliberately - and the issue and the shared docstring are corrected accordingly.

## Tests

New `tests/policies/test_state_key_name_list_contract.py`, 35 tests. **14 fail on pre-fix code** (verified by reverting `strands_robots/` only and re-running).

* **AST parity guard**, mirroring the `cameras=` contract test: every concrete `set_robot_state_keys` either calls the shared domain or forwards to another one. Non-vacuity pins the exact set of 14 surfaces by name, split into 9 validators, 2 already-total-by-membership, 2 forwarders and 1 abstract declaration - so a provider added later fails the classification rather than quietly widening a count.
* **Planted-defect meta-test**: the classifier must return `validates=False` for a provider that stores keys without checking them, so the assertions above cannot pass vacuously.
* **Behavioural refusals** for all six malformed shapes, that a refusal binds nothing (the layout is left exactly as it was), that the bare-string message names the per-character reading it prevented, and that `None`, `[]`, tuples and distinct lists all still work.
* **Delegation**: a `CompositePolicy` refuses through its children and neither child is bound; `RemotePolicy` refuses before anything reaches the wire.
* **The already-total pair**: both refuse all five shapes through their own check, and the duplicate-tolerance they were exempted for is asserted rather than assumed.

## Gates

* `ruff format` clean, `ruff check strands_robots tests` clean.
* `mypy strands_robots`: 59 errors with the change, **59 on clean `main`**, identical by `comm` - all `import-not-found` for optional deps absent in this sandbox. No type regression.
* `pytest tests/policies tests/inference`: 88 failed / 1639 passed with the change, against a control run on clean `main` at 102 failed / 1615 passed. **Zero failures added** (`comm -13` empty); the delta reconciles exactly as 14 pre-fix failures of the new file now passing plus the 10 by-membership pins added after the control. The residual failures are environmental in this sandbox (no `torch`, `strands`, `websockets`, `msgpack`) and reproduce on clean `main`, which is why the control run was needed to say so rather than assumed.

No API-shape or wire-format change: the guards are read-only, placed before any storage or network write, and gated on truthiness. Only inputs that previously bound a layout the caller never wrote now raise, so no working caller breaks - all 315 existing `set_robot_state_keys` call sites in `tests/` pass distinct non-blank string lists or `[]`.

Changelog fragment: `changelog.d/1850-state-key-name-list-domain.md`.

Provenance: measured in a clone of `strands-labs/robots` at `5de3558` (`git remote -v` confirmed), Python 3.13.14, numpy only - `MockPolicy`, `WBCPolicy`, `MotionBricksPolicy`, `CompositePolicy` and `RemotePolicy` all import without optional deps.