### PR TITLE
fix(recorder): refuse a schema column-name list DatasetRecorder.create cannot honor

### DIFF
--- a/changelog.d/1851-dataset-schema-column-names-distinct.md
+++ b/changelog.d/1851-dataset-schema-column-names-distinct.md
@@ -1,0 +1,21 @@
+### Fixed: `DatasetRecorder.create` refuses schema column names it cannot honor
+
+`camera_keys`, `joint_names` and `action_names` declare the recorded dataset's
+column names, and neither way of getting that wrong was reported. A single name
+passed as a bare string is iterable per character, so `joint_names="gripper"`
+declared seven columns (`g`, `r`, `i`, `p`, `p`, `e`, `r`) and every one recorded
+`0.0` for the whole episode - `add_frame` reads each declared name out of the
+observation and none of those names is in it - while `create`, `add_frame`,
+`save_episode` and `finalize` all succeeded. A repeated name collapsed where it
+keys a dict (`camera_keys=["front", "front"]` declared one camera column for the
+two requested) and doubled where it indexes a position
+(`joint_names=["j1", "j2", "j2"]` recorded `j2` twice and the joint the caller
+meant not at all).
+
+Each list is now refused on the shared name-list domain already applied by every
+backend's `start_recording`, the plain-MP4 recorders and every provider's
+`set_robot_state_keys`. The check runs before the lazy lerobot import, so the
+same mistake reports identically with or without the dataset extra, and before
+the on-disk target is touched, so a refused `overwrite=True` call leaves an
+existing dataset intact instead of removing it first. `None` and `[]` still mean
+"not supplied" and the schema is derived as before.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -436,6 +436,35 @@ recorder.save_episode()
 recorder.finalize()
 ```
 
+### Schema column names must be distinct
+
+`camera_keys`, `joint_names` and `action_names` each declare the recorded
+dataset's **column names**, so each must be a list of distinct, non-blank names.
+`create()` refuses anything else before it touches the on-disk target, so a
+refused `overwrite=True` call leaves an existing dataset intact:
+
+```python
+DatasetRecorder.create(repo_id="user/d", joint_names="gripper")     # ValueError
+DatasetRecorder.create(repo_id="user/d", camera_keys=["front", "front"])  # ValueError
+```
+
+Both mistakes used to be accepted and only surfaced in the recorded data:
+
+- A single name passed as a **bare string** is iterable per character, so
+  `joint_names="gripper"` declared seven columns (`g`, `r`, `i`, `p`, `p`, `e`,
+  `r`). `add_frame` reads each declared name out of the observation, and none of
+  those names is in it, so every column recorded `0.0` for the whole episode -
+  `create()`, `add_frame()`, `save_episode()` and `finalize()` all succeeded.
+  Wrap a single name in a list: `joint_names=["gripper"]`.
+- A **repeated** name collapses where it keys a dict and doubles where it indexes
+  a position. `camera_keys=["front", "front"]` declared one camera column for the
+  two the caller asked for; `joint_names=["j1", "j2", "j2"]` recorded `j2` twice
+  and the joint the caller meant not at all.
+
+`None` and `[]` still mean "not supplied" - the schema is then derived from
+`robot_features` / `action_features`, or from `joint_names` for the action
+columns.
+
 ### Re-recording into an existing `repo_id`
 
 `DatasetRecorder.create()` builds a **fresh** dataset. If the resolved dataset

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -32,7 +32,7 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import lerobot_version
+from strands_robots.utils import lerobot_version, name_list_error
 
 logger = logging.getLogger(__name__)
 
@@ -767,8 +767,14 @@ class DatasetRecorder:
             robot_features: Dict of observation feature names → types
                 (from robot.observation_features or sim joint names)
             action_features: Dict of action feature names → types
-            camera_keys: List of camera names (images become video features)
-            joint_names: List of joint names (alternative to robot_features for sim)
+            camera_keys: List of DISTINCT camera names (images become video
+                features). One name per camera, in schema order; a single name
+                still has to be a one-element list.
+            joint_names: List of DISTINCT joint names (alternative to
+                robot_features for sim). These become the ``observation.state``
+                column names, and add_frame reads each one out of the
+                observation, so a name the observation does not carry records
+                0.0 for the whole episode.
             action_names: Explicit action-column names. Use when the action
                 space diverges from the joint names (e.g. actuator short-names
                 from SimEngine.robot_action_keys, where a tendon gripper is an
@@ -814,7 +820,44 @@ class DatasetRecorder:
                 cleared so ``create`` does not dead-end on its own existence
                 guard; a non-empty NON-dataset directory raises ``ValueError``
                 rather than clobbering unrelated files.
+
+        Raises:
+            ValueError: ``camera_keys``, ``joint_names`` or ``action_names`` is
+                not a list of distinct non-blank names (a bare string, a
+                mapping, or a repeated name). Refused before the on-disk target
+                is touched, so an ``overwrite=True`` call that is refused leaves
+                an existing dataset intact.
+            FileExistsError: The resolved dataset directory already holds a
+                dataset and ``overwrite`` is False.
         """
+        # ``camera_keys`` / ``joint_names`` / ``action_names`` each name an
+        # ordered list of DISTINCT schema column names, so each is refused on the
+        # shared name-list domain here - before the lerobot extra is probed, so
+        # the same caller mistake reports identically on every install, and
+        # before the on-disk target is touched, because ``overwrite=True``
+        # removes an existing dataset directory and a refusal arriving after that
+        # would already have destroyed it.
+        #
+        # Neither mistake this catches could be honored as written, and both used
+        # to be reported nowhere: the dataset was created, every frame was
+        # accepted and the episode saved. A single name passed as a bare string
+        # is iterable per character, so ``joint_names="gripper"`` declared seven
+        # columns (``g``, ``r``, ``i``, ``p``, ``p``, ``e``, ``r``) and every one
+        # recorded 0.0 - add_frame reads each declared name out of the
+        # observation, and none of those names is in it. A repeated name collapses
+        # where it keys a dict (two ``camera_keys`` entries with the same name
+        # declare ONE camera column, so the schema has fewer cameras than the
+        # caller asked for) and doubles where it indexes a position (a repeated
+        # joint name records that joint twice and the joint the caller meant not
+        # at all).
+        for value, param in (
+            (camera_keys, "camera_keys"),
+            (joint_names, "joint_names"),
+            (action_names, "action_names"),
+        ):
+            if value and (text := name_list_error(value, param, "DatasetRecorder.create")):
+                raise ValueError(text)
+
         # Lazy import - this is where we actually need lerobot
         LeRobotDatasetCls = _get_lerobot_dataset_class()
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -648,7 +648,10 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
     by ``render_all``, the two plain-MP4 recorders and every backend's
     ``start_recording``, and the ``robot_state_keys`` accepted by every
     provider's :meth:`~strands_robots.policies.base.Policy.set_robot_state_keys`
-    (the ordered joint/motor names a policy emits as its action-dict keys).
+    (the ordered joint/motor names a policy emits as its action-dict keys), and
+    the ``camera_keys`` / ``joint_names`` / ``action_names`` that
+    :meth:`~strands_robots.dataset_recorder.DatasetRecorder.create` declares as
+    the recorded dataset's column names.
     They name different vocabularies, but the shape contract is identical -
     several distinct non-blank names, in the order the caller wants them - and
     every consumer reaches the same failure when it is not met, so the rule
@@ -678,7 +681,8 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
     A repeated name is refused because it cannot be honored as written, and the
     consumers disagree on which way it fails. A duplicate collapses where the
     name keys a dict - the LeRobot feature map, or a dataset schema, which then
-    declares fewer columns than asked for - and doubles where each entry drives
+    declares fewer columns than asked for (two ``camera_keys`` entries naming one
+    camera declare a single camera column) - and doubles where each entry drives
     its own unit of work: VERA concatenates one panel per entry, so the frame
     the model sees is twice as wide; ``render_all`` renders the same view twice;
     and a plain-MP4 recorder opens a second encoder on the one output path, so

--- a/tests/test_dataset_schema_column_names_distinct.py
+++ b/tests/test_dataset_schema_column_names_distinct.py
@@ -1,0 +1,230 @@
+"""``DatasetRecorder.create`` refuses schema column names it cannot honor.
+
+``camera_keys``, ``joint_names`` and ``action_names`` declare the recorded
+dataset's column names. Each has to be a list of distinct, non-blank names, and
+neither way of getting that wrong could be honored as written:
+
+* A single name passed as a bare string is iterable per character, so
+  ``joint_names="gripper"`` declared seven columns (``g``, ``r``, ``i``, ``p``,
+  ``p``, ``e``, ``r``). ``add_frame`` reads each declared name out of the
+  observation - see the zero-fill behaviour pinned by
+  ``test_add_frame_fills_missing_keys_with_zero`` in the sibling recorder unit
+  tests - and none of those names is in it, so every column recorded 0.0 while
+  ``create``, ``add_frame``, ``save_episode`` and ``finalize`` all succeeded.
+* A repeated name collapses where it keys a dict and doubles where it indexes a
+  position: ``camera_keys=["front", "front"]`` declared ONE camera column for
+  the two the caller asked for, and ``joint_names=["j1", "j2", "j2"]`` recorded
+  ``j2`` twice and the joint the caller meant not at all.
+
+The rule is the shared name-list domain already applied by the three backends'
+``start_recording`` (its ``cameras`` subset), the plain-MP4 recorders and every
+provider's ``set_robot_state_keys``. The recorder those recording facades all
+flush through - and the documented direct API - was the last consumer of that
+vocabulary reaching it unvalidated.
+
+The refusal is placed ahead of both side effects ``create`` has, which is what
+these tests pin: ahead of the lazy lerobot import, so the same caller mistake
+reports identically whether or not the dataset extra is installed (which is also
+why every refusal test here runs without it), and ahead of the on-disk target,
+which ``overwrite=True`` removes.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots import dataset_recorder as recorder_mod
+from strands_robots.dataset_recorder import DatasetRecorder
+from strands_robots.utils import name_list_error
+
+# One list-of-names parameter per schema vocabulary that ``create`` declares.
+NAME_LIST_PARAMS = ("camera_keys", "joint_names", "action_names")
+
+# Values that cannot be honored as a list of distinct names, with the substring
+# each one's message must carry so a caller is told which mistake they made.
+UNUSABLE: list[tuple[str, Any, str]] = [
+    ("bare_string", "gripper", "not a single string"),
+    ("bare_bytes", b"gripper", "not a single string"),
+    ("mapping", {"j1": 0, "j2": 0}, "not a mapping"),
+    ("generator", (n for n in ("j1", "j2")), "must be a list of names"),
+    ("non_str_entry", ["j1", 2, "j3"], "must be a name (str)"),
+    ("blank_entry", ["j1", "", "j3"], "must be a non-blank name"),
+    ("repeated", ["j1", "j2", "j2"], "must not repeat a name"),
+]
+
+# Values that mean "not supplied" (the schema is derived instead) or are a
+# usable list of distinct names. None may be refused.
+USABLE: list[tuple[str, Any]] = [
+    ("none", None),
+    ("empty_list", []),
+    ("empty_tuple", ()),
+    ("one_name", ["gripper"]),
+    ("several_names", ["j1", "j2", "j3"]),
+    ("tuple_of_names", ("j1", "j2")),
+]
+
+
+class _FakeLeRobotDataset:
+    """Stand-in for ``LeRobotDataset``, recording whether ``create`` was reached."""
+
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, features: dict[str, Any]) -> None:
+        self.repo_id = "local/fake"
+        self.features = features
+        self.meta = None
+
+    @classmethod
+    def create(cls, **kwargs: Any) -> "_FakeLeRobotDataset":
+        cls.calls.append(kwargs)
+        return cls(kwargs.get("features", {}))
+
+
+def _create(**kwargs: Any) -> DatasetRecorder:
+    """Call ``DatasetRecorder.create`` with keywords the signature disallows.
+
+    Several tests here pass a value the parameter's annotation forbids (a bare
+    string where ``list[str] | None`` is declared) because that is precisely the
+    caller mistake the runtime guard exists for. Routing them through one
+    ``**kwargs: Any`` funnel states that intent once instead of scattering
+    per-call type suppressions.
+    """
+    return DatasetRecorder.create(**kwargs)
+
+
+@pytest.fixture
+def fake_lerobot(monkeypatch: pytest.MonkeyPatch) -> type[_FakeLeRobotDataset]:
+    """Route ``create`` onto a fake dataset class, so no lerobot extra is needed."""
+    _FakeLeRobotDataset.calls = []
+    monkeypatch.setattr(recorder_mod, "_get_lerobot_dataset_class", lambda: _FakeLeRobotDataset)
+    return _FakeLeRobotDataset
+
+
+@pytest.fixture
+def no_lerobot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make reaching the lazy lerobot import fatal.
+
+    A refusal must be decided before ``create`` probes the dataset extra, so the
+    same caller mistake is reported the same way on a minimal install.
+    """
+
+    def _fatal() -> Any:
+        raise AssertionError("the lerobot extra was probed before the name lists were checked")
+
+    monkeypatch.setattr(recorder_mod, "_get_lerobot_dataset_class", _fatal)
+
+
+class TestUnusableNameListsAreRefused:
+    """Every schema name list is refused on the shared domain, before any work."""
+
+    @pytest.mark.parametrize("param", NAME_LIST_PARAMS)
+    @pytest.mark.parametrize(("label", "value", "expected"), UNUSABLE, ids=[c[0] for c in UNUSABLE])
+    def test_refused_with_the_mistake_named(
+        self, no_lerobot: None, param: str, label: str, value: Any, expected: str
+    ) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _create(repo_id="local/probe", **{param: value})
+        text = str(excinfo.value)
+        assert expected in text, text
+        assert param in text, text
+        assert "DatasetRecorder.create" in text, text
+
+    @pytest.mark.parametrize("param", NAME_LIST_PARAMS)
+    @pytest.mark.parametrize(("label", "value"), USABLE, ids=[c[0] for c in USABLE])
+    def test_usable_name_lists_still_reach_the_dataset(
+        self, fake_lerobot: type[_FakeLeRobotDataset], param: str, label: str, value: Any
+    ) -> None:
+        """``None`` / ``[]`` still mean "not supplied"; distinct names are accepted."""
+        _create(repo_id="local/probe", **{param: value})
+        assert len(fake_lerobot.calls) == 1
+
+
+class TestARefusedCreateLeavesTheTargetAlone:
+    """The refusal precedes the on-disk work, so nothing is destroyed by it."""
+
+    def test_overwrite_does_not_remove_an_existing_dataset(
+        self, tmp_path: Path, fake_lerobot: type[_FakeLeRobotDataset]
+    ) -> None:
+        """``overwrite=True`` removes the target directory - a refusal must not."""
+        root = tmp_path / "ds"
+        (root / "meta").mkdir(parents=True)
+        (root / "meta" / "info.json").write_text('{"fps": 30}')
+
+        raised: Exception | None = None
+        try:
+            _create(repo_id="local/probe", root=str(root), joint_names="gripper", overwrite=True)
+        except ValueError as exc:
+            raised = exc
+
+        # Assert the surviving target first: that is the consequence that matters,
+        # and it is what a refusal arriving after ``_prepare_create_target`` would
+        # already have destroyed.
+        assert (root / "meta" / "info.json").is_file(), "the refused call deleted the dataset"
+        assert fake_lerobot.calls == [], "the refused call still built a dataset"
+        assert raised is not None, "the unusable joint_names was not refused"
+        assert "not a single string" in str(raised), str(raised)
+
+    def test_a_usable_call_does_reach_the_dataset_target(
+        self, tmp_path: Path, fake_lerobot: type[_FakeLeRobotDataset]
+    ) -> None:
+        """The control: the same call with a real name list is not refused."""
+        _create(repo_id="local/probe", root=str(tmp_path / "fresh"), joint_names=["gripper"])
+        assert len(fake_lerobot.calls) == 1
+
+
+class TestTheDomainCannotDriftFromTheSharedRule:
+    """``create`` delegates to the shared domain rather than restating it."""
+
+    @pytest.mark.parametrize("param", NAME_LIST_PARAMS)
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        [(lbl, val) for lbl, val, _ in UNUSABLE if lbl != "generator"] + USABLE,
+        ids=[lbl for lbl, _, _ in UNUSABLE if lbl != "generator"] + [lbl for lbl, _ in USABLE],
+    )
+    def test_verdict_matches_name_list_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_lerobot: type[_FakeLeRobotDataset],
+        param: str,
+        label: str,
+        value: Any,
+    ) -> None:
+        """A value the shared domain refuses is refused here, and vice versa."""
+        shared_refuses = bool(value) and name_list_error(value, param, "x") is not None
+        try:
+            _create(repo_id="local/probe", **{param: value})
+            create_refuses = False
+        except ValueError:
+            create_refuses = True
+        assert create_refuses is shared_refuses, f"verdicts differ for {param}={value!r}"
+
+    def test_every_name_list_parameter_of_create_is_guarded(self) -> None:
+        """A new list-of-names parameter cannot join ``create`` unguarded."""
+        source = inspect.getsource(DatasetRecorder.create)
+        tree = ast.parse(inspect.cleandoc(source).replace("@classmethod\n", "", 1))
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+
+        declared = {
+            arg.arg
+            for arg in func.args.args + func.args.kwonlyargs
+            if arg.annotation is not None and ast.unparse(arg.annotation) == "list[str] | None"
+        }
+        assert declared == set(NAME_LIST_PARAMS), declared
+
+        # The guard iterates ``(value, "param_name")`` pairs; collect the value
+        # each pair names so a parameter added to the signature but not to the
+        # loop is reported by name.
+        guarded: set[str] = set()
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Tuple) or len(node.elts) != 2:
+                continue
+            value_node, name_node = node.elts
+            if not isinstance(value_node, ast.Name) or not isinstance(name_node, ast.Constant):
+                continue
+            if name_node.value == value_node.id:
+                guarded.add(value_node.id)
+        assert declared <= guarded, f"unguarded name-list parameter(s): {sorted(declared - guarded)}"


### PR DESCRIPTION
`camera_keys`, `joint_names` and `action_names` declare the recorded dataset's **column names**. Neither way of getting that list wrong was reported anywhere: the dataset was created, every frame was accepted, the episode was saved, `finalize()` succeeded, and the mistake existed only in the recorded data.

![schema column-name verdicts and the honored-path round trip](https://raw.githubusercontent.com/cagataycali/robots/artifacts/dataset-schema-names/schema_names.png)

## What each call produced on main

Measured with one real LeRobotDataset write per case (`create` -> `add_frame` -> `save_episode` -> `finalize`) against the observation `{shoulder: 0.30, elbow: -0.20, gripper: 0.05}`:

| call | on main | schema it declared | values it recorded |
|---|---|---|---|
| `joint_names=['shoulder','elbow','gripper']` | accepted | `observation.state (3,)` | `[0.3, -0.2, 0.05]` |
| `joint_names='gripper'` | **accepted** | `(7,)` = `['g','r','i','p','p','e','r']` | **`[0.0] * 7`** |
| `joint_names=['shoulder','elbow','elbow']` | **accepted** | `(3,)`, `elbow` twice | **`[0.3, -0.2, -0.2]`** - `gripper` absent |
| `camera_keys=['front','front']` | **accepted** | 2 requested, **1** declared | the second camera column never existed |
| `action_names='grip'` | **accepted** | 4 action columns | **all 0.0** |

A single name passed as a bare string is iterable per character, so `joint_names="gripper"` declared seven columns. `add_frame` reads each declared name out of the observation and none of those names is in it, so every column recorded 0.0 for the whole episode - the zero-fill behaviour `test_add_frame_fills_missing_keys_with_zero` already pins. A repeated name **collapses** where it keys a dict (two `camera_keys` entries naming one camera declare one camera column) and **doubles** where it indexes a position (a repeated joint records that joint twice and the joint the caller meant not at all).

## The change

Each list is refused on the shared name-list domain in `strands_robots.utils`, already applied by every backend's `start_recording` (its `cameras` subset), the two plain-MP4 recorders and every provider's `set_robot_state_keys`. `DatasetRecorder.create` - the recorder those recording facades all flush through, and a documented direct API - was the last consumer of that vocabulary reaching it unvalidated. That domain's own docstring already named the case:

> A duplicate collapses where the name keys a dict - the LeRobot feature map, or **a dataset schema, which then declares fewer columns than asked for**

The check runs ahead of both side effects `create` has:

- **ahead of the lazy lerobot import**, so the same caller mistake reports identically with or without the dataset extra (which is also why every refusal test runs without it);
- **ahead of the on-disk target**, because `overwrite=True` calls `shutil.rmtree` on an existing dataset directory. A refusal arriving after that would already have destroyed it - pinned by `test_overwrite_does_not_remove_an_existing_dataset`, whose pre-fix failure is `AssertionError: the refused call deleted the dataset`.

No new helper and no new message shape: `name_list_error` is called with `context="DatasetRecorder.create"`, so the wording matches every sibling surface.

## Purely additive

`None` and `[]` still mean "not supplied" and the schema is derived from `robot_features` / `action_features` exactly as before - the guard is gated on a truthy value, like every other caller of the shared domain. All three internal callers (`start_recording` in the MuJoCo, Newton and Isaac backends) derive these names from unique dicts, the compiled model's camera table, or `robot_action_keys`, and prefix them per robot in a multi-robot scene, so none of them can produce a value the guard refuses. **No existing test changed.**

## Visual artifact

The figure above is measured, not drawn: every cell is read from two JSON dumps produced by one script run against `main` and against this branch. The bottom half is the honored path end to end - `start_recording(fps=30)` -> `run_policy(45 steps @ 30 Hz)` -> `stop_recording` on a headless MuJoCo (EGL) arm - with frame 22 decoded back out of the dataset's own MP4. Both trees record 45 frames in parquet, decode 45 frames from the MP4, declare the same `observation.state` columns, and **the two decoded frames are byte-identical (max per-pixel difference 0)**, so the recording path itself is unchanged.

## Tests

`tests/test_dataset_schema_column_names_distinct.py`, 78 tests, GL-free and lerobot-free (0.14s):

- every unusable value (bare string, bytes, mapping, one-shot generator, non-str entry, blank entry, repeat) x each of the three parameters is refused, with the message naming the mistake, the parameter and the surface - and with the lazy lerobot import monkeypatched to be fatal, so the refusal provably precedes it;
- every usable value (`None`, `[]`, `()`, one name, several names, a tuple) still reaches the dataset;
- a refused `overwrite=True` call leaves an existing dataset on disk and never builds a dataset, with the accepted-value control alongside it;
- a parity test asserting `create`'s verdict equals `name_list_error`'s over the whole probe set, so the two cannot drift;
- an AST test asserting every `list[str] | None` parameter of `create` appears in the guard loop, so a fourth name list cannot join the signature unguarded.

**Pre-fix proof** (source file reverted, tests kept), at base `c1acf21d`: **41 failed / 37 passed** -> **78 passed**. The 37 that pass pre-fix are the usable-value controls and the signature premise - they are what stops the guard over-reaching.

## Gate

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **16836 passed, 258 skipped, 0 failed** (499.92s)
- `ruff check strands_robots tests tests_integ`: clean; `ruff format --check`: 1023 files already formatted
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1020 source files`
- `scripts/assemble_changelog.py --check`: OK; `scripts/check_merge_base_overlap.py`: no overlap with `upstream/main`

## Out of scope

`extra_state_specs` carries `(source_key, [component_suffixes])` pairs rather than a flat name list, and a wrong component count already surfaces loudly as a shape mismatch on the first `add_frame`, so it keeps its own shape and is not folded in here.