### PR TITLE
docs: a clean base merge is free of dismissal, not of last-push approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,12 +270,14 @@ hatch run format            # ruff check --fix, ruff format
    #1035 is the control - same author, same fork, same `strands_robots/mesh/`
    files, one approval from the same account post-dating its head commit,
    threads clear, checks green, and no CODEOWNERS file in the tree to make
-   `require_code_owner_review` bite. It differs in exactly one input, and reads
-   `APPROVED`:
+   `require_code_owner_review` bite. It differed in exactly one input, and read
+   `APPROVED` - until a later push moved that one input and took it into the
+   blocked row as well:
 
    | PR | commit author | `triggering_actor` | approver | `reviewDecision` |
    |---|---|---|---|---|
-   | #1035 | the contributor | the contributor | the maintainer | `APPROVED` |
+   | #1035 at `2be59dad` | the contributor | the contributor | the maintainer | `APPROVED` |
+   | #1035 at `8d6a4c42` | the maintainer | the maintainer | the maintainer | `REVIEW_REQUIRED` |
    | #1722 | `strands-robots` | the maintainer | the maintainer | `REVIEW_REQUIRED` |
 
    So **pushing a fix to a contributor's branch consumes the approval of
@@ -287,6 +289,41 @@ hatch run format            # ruff check --fix, ruff format
    pusher; when the agent must push, that PR now requires a second approver,
    and saying so is the difference between a one-line request and a branch that
    never merges.
+
+   **#1035 later crossed into the second row, which makes it the whole rule
+   observed twice on one pull request.** CI triage on it correctly diagnosed a
+   stale merge base and prescribed `git merge upstream/main`; the refresh was then
+   *executed with the maintainer's token* rather than requested from the
+   contributor, so `8d6a4c42` - `Merge branch 'main' into
+   feat/ackermann-ros-robot`, authored and committed by the maintainer - became
+   the head. The prescription was right; the hand that applied it was not.
+
+   That case also pulls apart the two costs a push can carry, which the
+   conflict-free result above makes easy to read as one. The merge was clean:
+   `git show --cc` is **0 lines**, and the PR's own diff is unchanged at
+   `7 files, +900/-26`. So by the #1821 table it cost no dismissal, and the
+   pre-existing review is indeed **still `APPROVED`**, not `DISMISSED`.
+   `reviewDecision` is nonetheless `REVIEW_REQUIRED`, and a second approval from
+   that same account - on that exact head, every check `SUCCESS` - does not move
+   it. Two rules, keyed on two different things:
+
+   - `dismiss_stale_reviews_on_push` keys on the **PR's own diff**: a clean base
+     merge is free.
+   - `require_last_push_approval` keys on the **pusher's identity**: a clean base
+     merge is not free, and re-approving from that identity cannot help.
+
+   So "refreshing an approved branch over a fixed `main` is cheap" is scoped to
+   dismissal alone. On your own branch it is cheap outright; on a contributor's
+   branch it converts a pull request one maintainer could merge into one that
+   needs a second, with nothing in the PR's own fields saying so. #1035 is in that
+   state now, and needs an approver who is not the account that pushed
+   `8d6a4c42`.
+
+   Do not try to settle this from the commit metadata, which misleads in both
+   directions. #1722's author and committer are `strands-robots`, an identity
+   distinct from the approver, which reads as the rule being satisfied when it is
+   not; #1035's head names the maintainer outright. Same `REVIEW_REQUIRED`,
+   opposite metadata. Only `triggering_actor` is load-bearing.
 
    The general rule behind all three: **a decision recorded only in a PR or
    issue comment is not durable** - the next contributor will not read the same

--- a/changelog.d/1852-last-push-approval-is-not-dismissal.md
+++ b/changelog.d/1852-last-push-approval-is-not-dismissal.md
@@ -1,0 +1,40 @@
+### Docs: a clean base merge is free of dismissal and not free of last-push approval
+
+`AGENTS.md` already recorded both halves of this - that refreshing an approved
+branch over a fixed `main` is cheap when the merge is conflict-free (#1821), and
+that pushing to a contributor's branch consumes the approval of whoever owns the
+token (#1722). It did not say that the first is scoped to *dismissal only*, and
+the two are easy to read as one rule, because the reassuring measurement and the
+hazard live in different paragraphs.
+
+#1035 is the case where both were observed on a single head, so the two
+mechanisms separate cleanly. CI triage on it correctly diagnosed a stale merge
+base and prescribed `git merge upstream/main`; the refresh was then executed with
+the maintainer's token rather than requested from the contributor, and
+`8d6a4c42` - `Merge branch 'main' into feat/ackermann-ros-robot`, authored and
+committed by the maintainer - became the head. The merge was clean: `git show
+--cc` is 0 lines and the PR's own diff is unchanged at `7 files, +900/-26`. The
+pre-existing review is therefore **still `APPROVED`**, not `DISMISSED`, exactly
+as the #1821 table predicts - and `reviewDecision` is nonetheless
+`REVIEW_REQUIRED`, with a second approval from that same account on that exact
+head, every check `SUCCESS`, failing to move it.
+
+So `dismiss_stale_reviews_on_push` keys on the PR's own diff and
+`require_last_push_approval` keys on the pusher's identity. A clean base merge is
+free under the first and not under the second, and no amount of re-approving from
+the pushing identity helps. On your own branch the refresh is cheap outright; on
+a contributor's it converts a pull request one maintainer could merge into one
+that needs a second, with nothing in the PR's own fields saying so.
+
+The control table in `AGENTS.md` step 8 listed #1035 as the row that reads
+`APPROVED`. That is now stale as a statement about the current pull request, so
+it is split per head - `2be59dad` `APPROVED`, `8d6a4c42` `REVIEW_REQUIRED`, one
+input changed - which also makes it a stronger control than two different pull
+requests were. A closing note records that the commit metadata cannot settle the
+question in either direction: #1722's author and committer are `strands-robots`,
+reading as satisfied when it is not, while #1035's head names the maintainer
+outright, and only
+`GET /repos/{owner}/{repo}/actions/runs?head_sha=<head> -> triggering_actor` is
+load-bearing.
+
+Documentation only; no production code or test behaviour changes.


### PR DESCRIPTION
A clean base merge onto an approved branch is free of **dismissal** and not free of **merge eligibility**. AGENTS.md already carried both halves; it did not say the first is scoped to dismissal only, and they sit in different paragraphs, so they read as one rule.

## The gap

Step 8 records two measured findings:

- from #1821 - refreshing an approved branch over a fixed `main` is cheap: `dismiss_stale_reviews_on_push` keys on the PR's own diff, so a merge that only brings the base forward leaves the reviewed diff byte-identical and the approval survives;
- from #1722 - pushing to a contributor's branch consumes the approval of whoever owns the token, because `require_last_push_approval: true` requires the last pusher to be someone other than the approver.

The first is reassuring and quantified; the second is a hazard several paragraphs away. The reading that falls out - "clean base merges are free" - is true of dismissal and false of eligibility, and nothing in the text scoped it.

## The case that separates them

#1035 is where both were observed on one head, so the two mechanisms come apart cleanly rather than by argument.

CI triage on it correctly diagnosed a stale merge base and prescribed `git merge upstream/main`. The refresh was then *executed with the maintainer's token* rather than requested from the contributor, so `8d6a4c42` - `Merge branch 'main' into feat/ackermann-ros-robot`, authored and committed by the maintainer - became the head. The prescription was right; the hand that applied it was not.

| measurement | value |
|---|---|
| `git show --cc --format="" 8d6a4c42 \| wc -l` | **0** (conflict-free) |
| PR's own diff vs merge base | `7 files, +900/-26` (unchanged) |
| pre-existing review state | **`APPROVED`**, not `DISMISSED` |
| `statusCheckRollup.state` | `SUCCESS` |
| `reviewDecision` | **`REVIEW_REQUIRED`** |
| `mergeStateStatus` | `BLOCKED` |
| `actions/runs?head_sha=8d6a4c42` -> `triggering_actor` | the maintainer |

The approval survived exactly as the #1821 table predicts, and the PR still cannot merge. A second approval from that same account, on that exact head, with every check green, does not move `reviewDecision` - I confirmed this by submitting one.

So:

- `dismiss_stale_reviews_on_push` keys on the **PR's own diff** - a clean base merge is free.
- `require_last_push_approval` keys on the **pusher's identity** - a clean base merge is not free, and re-approving from that identity cannot help.

On your own branch the refresh is cheap outright. On a contributor's branch it converts a PR one maintainer could merge into one that needs a second, with nothing in the PR's own fields saying so.

## The stale control table

Step 8's table listed #1035 as the row that reads `APPROVED`. That was accurate when written and is now stale as a statement about the current PR, which matters because the table is exactly what a future reader consults to decide whether #1035 is mergeable.

It is split per head instead of being replaced, so the historical reading is preserved:

| PR | commit author | `triggering_actor` | approver | `reviewDecision` |
|---|---|---|---|---|
| #1035 at `2be59dad` | the contributor | the contributor | the maintainer | `APPROVED` |
| #1035 at `8d6a4c42` | the maintainer | the maintainer | the maintainer | `REVIEW_REQUIRED` |
| #1722 | `strands-robots` | the maintainer | the maintainer | `REVIEW_REQUIRED` |

This is a **stronger** control than the original two-PR comparison: same PR, same fork, same author, same files, same reviewer, same absent CODEOWNERS - everything held constant by construction, one input moved, verdict flips.

## Metadata settles nothing

A closing note records that the commit metadata misleads in both directions, so it can never answer the question. #1722's author and committer are `strands-robots`, an identity distinct from the approver, which reads as the rule being satisfied when it is not. #1035's head names the maintainer outright. Same `REVIEW_REQUIRED`, opposite metadata. Only `GET /repos/{owner}/{repo}/actions/runs?head_sha=<head>` -> `triggering_actor` is load-bearing - which step 8 already said, and this is the second case proving it.

## Scope

Documentation only. No production code, no test behaviour.

- `AGENTS.md` +40/-3 - the table split and the scoping paragraphs, inserted in the section that already owns this rule rather than starting a new one.
- `changelog.d/1852-last-push-approval-is-not-dismissal.md` - news fragment per the `changelog.d/` workflow; `CHANGELOG.md` is untouched.

## Gate

- `scripts/assemble_changelog.py --check`: `changelog fragments OK (113 pending)`
- `pytest tests/test_changelog_fragments.py tests/test_changelog_format.py`: **30 passed**
- `git diff --name-only origin/main -- CHANGELOG.md`: empty, so the direct-edit gate is satisfied
- non-ASCII sweep over every added line: clean (the remaining hits in `AGENTS.md` are the pre-existing box-drawing characters in the repository-structure tree)

## Follow-up, not in scope here

#1035 itself needs an approver who is not the account that pushed `8d6a4c42`. That is a review-assignment matter, not a docs change, and pushing anything further to that branch would only re-consume the new approver.