### PR TITLE
fix(sim): refuse a benchmark horizon the evaluation cannot honor

### DIFF
--- a/changelog.d/1855-benchmark-horizon-domain.md
+++ b/changelog.d/1855-benchmark-horizon-domain.md
@@ -1,0 +1,34 @@
+### Fixed: a benchmark declaring a per-episode horizon the evaluation cannot honor is refused, not run as an empty evaluation
+
+`evaluate_benchmark` documents that `max_steps` "comes from the benchmark (not a
+parameter here)", so the benchmark object is the sole authority for the
+per-episode horizon. It was also the one bound of the evaluation's nested loop
+with no domain of its own: `n_episodes`, `action_horizon` and `control_substeps`
+are all checked at the public entry point, and `eval_policy` checks its own
+`max_steps` there too, but a benchmark's horizon was validated on only one of
+the four paths that can set it.
+
+`DeclarativeBenchmark.from_dict` (and so `register_benchmark_from_file`) rejected
+a non-positive-integer horizon. The constructor it feeds coerced with a bare
+`int()`, so `2.7` became `2` and `True` became `1`;
+`LiberoAdapter(max_steps=...)`, its `from_file` / `from_text` classmethods and
+`load_libero_suite` did the same, one line below a validated `init_jitter`; and a
+plain `BenchmarkProtocol` subclass setting the documented `max_steps` attribute -
+the extension point the base class invites - was not checked at all, nor was an
+assignment to it after construction.
+
+The result was the failure `SimEngine._validate_positive_int` already names for
+this parameter: "episodes of zero length, that fabricate a 0% success rate". A
+benchmark declaring `max_steps=0` returned `status="success"` reporting
+`success_rate: 0.0` and `Avg steps: 0/0` over episodes that applied no action -
+carrying the same `success_rate` field a genuine 0% result does - and a
+fractional or NaN horizon raised a bare `TypeError` out of `range()`, past the
+agent-tool envelope.
+
+The horizon now shares the count domain `positive_count_error` already documents
+it under. Each creation path raises `ValueError` where the value was supplied,
+and the evaluation loop checks it where it reads it, so a subclass attribute or a
+post-construction assignment - neither of which any constructor can see - is
+refused with a structured error naming the parameter and the benchmark. The check
+runs before `set_eval_seed`, so a rejected evaluation no longer reseeds the
+process-global RNG. Omitting the horizon still applies the documented default.

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -55,7 +55,7 @@ from strands_robots.benchmarks.libero.bddl_parser import (
 from strands_robots.simulation.benchmark import BenchmarkProtocol, StepInfo
 from strands_robots.simulation.isaac.delta_eef import IsaacDeltaEEFController
 from strands_robots.simulation.models import SimCamera, SimRobot
-from strands_robots.utils import get_base_dir, require_optional
+from strands_robots.utils import get_base_dir, positive_count_error, require_optional
 
 if TYPE_CHECKING:
     from strands_robots.simulation.base import SimEngine
@@ -183,7 +183,8 @@ class LiberoAdapter(BenchmarkProtocol):
             scene_path: Optional MJCF to ``sim.load_scene()`` on each
                 episode start. ``None`` triggers ``auto_generate_scene``
                 if enabled (see below).
-            max_steps: Override the class-level 300.
+            max_steps: Override the class-level default (720). Must be a
+                positive integer - it is the per-episode step cap.
             init_jitter: Per-episode ±jitter (metres) applied to xy of every
                 object referenced by ``(:init (on A B))`` clauses. Default
                 ``0.0`` matches LIBERO's deterministic-reset convention -
@@ -436,7 +437,15 @@ class LiberoAdapter(BenchmarkProtocol):
         if self._init_jitter < 0:
             raise ValueError(f"init_jitter must be >= 0, got {init_jitter}")
         if max_steps is not None:
-            self.max_steps = int(max_steps)
+            # Same shared count domain as ``init_jitter`` above and as the
+            # declarative spec path: the value becomes this benchmark's
+            # per-episode ``range(max_steps)`` bound, so ``int()`` alone
+            # silently truncated ``2.7`` to 2, read ``True`` as 1, and let a
+            # zero or negative horizon through to run episodes of zero
+            # length that still report a 0% success rate.
+            if error := positive_count_error(max_steps, "max_steps", type(self).__name__):
+                raise ValueError(error)
+            self.max_steps = max_steps
         self._install_cameras = bool(install_cameras)
         # Snapshot the camera config at construction time so subsequent
         # mutations to LIBERO_CAMERAS don't leak across instances.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -3080,7 +3080,13 @@ class SimEngine(ABC):
         Benchmark-agnostic evaluation entry point. Looks up ``benchmark_name``
         in the global benchmark registry, validates robot compatibility, and
         forwards to :meth:`PolicyRunner.evaluate` with the spec.
-        ``max_steps`` comes from the benchmark (not a parameter here).
+        ``max_steps`` comes from the benchmark (not a parameter here), so it
+        is validated where it is read rather than at this signature: a
+        benchmark declaring a horizon that is not a positive integer is
+        rejected with a structured error, for the same reason ``n_episodes``
+        is. Both are bounds of the same nested loop, and a non-positive one
+        runs episodes of zero length and then reports a 0% success rate over
+        them.
 
         Args:
             benchmark_name: Key from :func:`register_benchmark` /

--- a/strands_robots/simulation/benchmark.py
+++ b/strands_robots/simulation/benchmark.py
@@ -88,9 +88,16 @@ class BenchmarkProtocol(ABC):
     1 and returns a structured error on mismatch.
 
     Attributes:
-        max_steps: Per-episode horizon. Instance attribute (not abstract
-            property) so subclasses can set it in ``__init__`` or as a class
-            attribute. Defaults to ``300``.
+        max_steps: Per-episode horizon, a positive integer. Instance
+            attribute (not abstract property) so subclasses can set it in
+            ``__init__`` or as a class attribute. Defaults to ``300``.
+            Because it is an attribute rather than a validated parameter,
+            the evaluation loop checks it when it reads it: a subclass that
+            sets a zero, negative or non-integer horizon gets a structured
+            error from
+            :meth:`~strands_robots.simulation.base.SimEngine.evaluate_benchmark`
+            rather than an evaluation over episodes of zero length that
+            still reports a 0% success rate.
     """
 
     max_steps: int = 300

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -68,7 +68,7 @@ from strands_robots.simulation.benchmark import (
     register_benchmark,
 )
 from strands_robots.simulation.predicates import PREDICATE_REGISTRY, make_predicate, predicate_kind
-from strands_robots.utils import require_optional
+from strands_robots.utils import positive_count_error, require_optional
 
 if TYPE_CHECKING:
     import random
@@ -335,7 +335,13 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         self._name = name
         self._supported_robots = list(supported_robots)
         self._default_robot = default_robot
-        self.max_steps = int(max_steps)
+        # Mirrors the check ``from_dict`` runs on the raw spec value, so a
+        # directly constructed benchmark cannot carry a horizon the
+        # evaluation loop has to refuse later. ``int()`` alone silently
+        # truncated ``2.7`` to 2 and read ``True`` as 1.
+        if error := positive_count_error(max_steps, "max_steps", type(self).__name__):
+            raise ValueError(error)
+        self.max_steps = max_steps
         self._success_fn = success_fn
         self._failure_fn = failure_fn
         self._reward_terms = list(reward_terms)
@@ -477,8 +483,10 @@ class DeclarativeBenchmark(BenchmarkProtocol):
             )
 
         max_steps_raw = spec.get("max_steps", 300)
-        if not isinstance(max_steps_raw, int) or isinstance(max_steps_raw, bool) or max_steps_raw <= 0:
-            raise ValueError(f"spec.max_steps: must be a positive int, got {max_steps_raw!r}")
+        # Shared count domain, so the key a spec file sets and the keyword a
+        # direct construction passes cannot drift apart on what they accept.
+        if error := positive_count_error(max_steps_raw, "max_steps", "spec"):
+            raise ValueError(error)
 
         scene = spec.get("scene")
         if scene is not None and not isinstance(scene, str):

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -47,7 +47,12 @@ import numpy as np
 from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.dataset_recorder import RecordingFrameError
 from strands_robots.policies.base import resolve_chunk_length
-from strands_robots.utils import positive_whole_number_error, process_rss_mb, require_optional
+from strands_robots.utils import (
+    positive_count_error,
+    positive_whole_number_error,
+    process_rss_mb,
+    require_optional,
+)
 
 if TYPE_CHECKING:
     from strands_robots.policies.base import Policy
@@ -2563,6 +2568,31 @@ class PolicyRunner:
         # Lazy import to avoid circular reference (benchmark module imports
         # `SimEngine` from base which imports this module under TYPE_CHECKING).
         from strands_robots.simulation.benchmark import BenchmarkCompatibilityError
+
+        # The per-episode horizon is read off the benchmark, so it is the one
+        # rollout count with no parameter of its own to validate: every other
+        # bound of this nested loop (``n_episodes``, ``action_horizon``,
+        # ``control_substeps``) is checked by the public entry point before it
+        # gets here. Check it at the read instead. That covers every way a
+        # benchmark can come by its horizon - ``DeclarativeBenchmark.from_dict``,
+        # direct construction, a plain ``BenchmarkProtocol`` subclass setting the
+        # documented ``max_steps`` attribute, or an assignment to it after
+        # construction - none of which this method can see. Refuse before
+        # ``set_control_frequency`` and ``set_eval_seed``: the latter reseeds the
+        # process-global RNG, so a rejected eval must not reach it.
+        if error := positive_count_error(spec.max_steps, "max_steps", "evaluate_benchmark"):
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"{error} Benchmark {type(spec).__name__!r} declares that horizon; a "
+                            "non-positive one runs episodes of zero length and reports a 0% success "
+                            "rate over them instead of surfacing the mistake."
+                        )
+                    }
+                ],
+            }
 
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)

--- a/tests/simulation/test_benchmark_horizon_domain.py
+++ b/tests/simulation/test_benchmark_horizon_domain.py
@@ -1,0 +1,332 @@
+"""The benchmark per-episode horizon has one domain on every path that sets it.
+
+``evaluate_benchmark`` documents that ``max_steps`` "comes from the benchmark
+(not a parameter here)", so the benchmark object is the sole authority for the
+per-episode horizon. It is the one bound of the evaluation's nested loop with no
+parameter of its own to validate - ``n_episodes``, ``action_horizon`` and
+``control_substeps`` are all checked at the public entry point, and
+``eval_policy`` checks its own ``max_steps`` there too.
+
+That left the horizon reachable through four paths, only one of which checked it:
+
+* ``DeclarativeBenchmark.from_dict`` (and ``register_benchmark_from_file``)
+  rejected a non-positive-integer horizon.
+* ``DeclarativeBenchmark(...)`` coerced with a bare ``int()``, so ``2.7`` became
+  ``2``, ``True`` became ``1``, and ``0`` / ``-5`` were stored verbatim.
+* ``LiberoAdapter(max_steps=...)`` (and its ``from_file`` / ``from_text``
+  classmethods and ``load_libero_suite``) did the same, one line below a
+  validated ``init_jitter``.
+* A plain :class:`BenchmarkProtocol` subclass setting the documented
+  ``max_steps`` attribute - the extension point the base class invites - was not
+  checked at all, and neither was an assignment to it after construction.
+
+The consequence is the one
+:meth:`~strands_robots.simulation.base.SimEngine._validate_positive_int`'s
+docstring already names for this parameter: "episodes of zero length, that
+fabricate a 0% success rate". A benchmark declaring ``max_steps=0`` returned
+``status="success"`` reporting ``0.0%`` success over episodes that applied no
+action, and a fractional or NaN horizon raised a bare ``TypeError`` out of
+``range()``, past the agent-tool envelope.
+
+These tests pin the single domain (:func:`strands_robots.utils.positive_count_error`,
+whose own docstring already names ``max_steps``) on every path that sets the
+horizon, and pin that it is honored where it is read.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.benchmark import (
+    BenchmarkProtocol,
+    StepInfo,
+    register_benchmark,
+    unregister_benchmark,
+)
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.utils import positive_count_error
+
+# A horizon has to be a positive int: the value is consumed directly as a
+# ``range()`` bound, where an integral float raises rather than being coerced.
+UNUSABLE = [0, -5, 2.7, True, False, float("nan"), float("inf"), "300", None, [300]]
+USABLE = [1, 60, 300]
+
+# A minimal single-hinge arm: enough for a real rollout, no asset download.
+ARM_XML = """<mujoco model="probe_arm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 -9.81"/>
+  <worldbody>
+    <light pos="0 0 2"/>
+    <geom name="floor" type="plane" size="2 2 .05"/>
+    <body name="base" pos="0 0 0.02">
+      <geom type="box" size=".05 .05 .02"/>
+      <body name="link" pos="0 0 .04">
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="4"/>
+        <geom type="capsule" fromto="0 0 0 0 0 .25" size=".03"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a_shoulder" joint="shoulder" kp="40" ctrlrange="-2 2"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _declarative(max_steps: Any) -> DeclarativeBenchmark:
+    """Construct a ``DeclarativeBenchmark`` directly with the given horizon."""
+    return DeclarativeBenchmark(
+        name="probe",
+        supported_robots=[],
+        default_robot="probe_arm",
+        max_steps=max_steps,
+        success_fn=lambda _sim: False,
+        failure_fn=lambda _sim: False,
+        reward_terms=[],
+    )
+
+
+def _from_dict(max_steps: Any) -> DeclarativeBenchmark:
+    """Compile a spec dict with the given horizon (the already-guarded path)."""
+    return DeclarativeBenchmark.from_dict(
+        {
+            "name": "probe",
+            "supported_robots": [],
+            "default_robot": "probe_arm",
+            "max_steps": max_steps,
+        }
+    )
+
+
+class _AttributeBenchmark(BenchmarkProtocol):
+    """A plain subclass that sets the documented ``max_steps`` attribute.
+
+    This is the extension point :class:`BenchmarkProtocol` invites ("subclasses
+    can set it in ``__init__`` or as a class attribute"), and it has no
+    constructor the library can guard - which is why the horizon has to be
+    checked where the evaluation loop reads it.
+    """
+
+    def __init__(self, max_steps: Any) -> None:
+        self.max_steps = max_steps
+
+    @property
+    def supported_robots(self) -> list[str]:
+        return []
+
+    @property
+    def default_robot(self) -> str:
+        return "probe_arm"
+
+    def is_success(self, sim: Any) -> bool:
+        return False
+
+    def on_step(self, sim: Any, obs: dict[str, Any], action: dict[str, Any]) -> StepInfo:
+        return StepInfo(reward=0.0, done=False)
+
+
+@pytest.fixture
+def eval_sim(tmp_path: Path):
+    """A MuJoCo sim with one registered arm, plus a bound mock policy."""
+    from strands_robots import MockPolicy, Simulation
+
+    arm = tmp_path / "arm.xml"
+    arm.write_text(ARM_XML)
+    sim = Simulation(backend="mujoco", mesh=False)
+    try:
+        sim.create_world()
+        sim.add_robot(name="probe_arm", urdf_path=str(arm))
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_action_keys("probe_arm"))
+        yield sim, policy
+    finally:
+        try:
+            sim.cleanup()
+        except Exception:  # noqa: BLE001 - teardown is best effort
+            pass
+
+
+def _evaluate(sim: Any, policy: Any, benchmark: BenchmarkProtocol, n_episodes: int = 2) -> dict[str, Any]:
+    """Register ``benchmark`` and evaluate it, returning the result envelope."""
+    register_benchmark("horizon_probe", benchmark)
+    try:
+        return sim.evaluate_benchmark(
+            benchmark_name="horizon_probe",
+            robot_name="probe_arm",
+            policy_object=policy,
+            n_episodes=n_episodes,
+            control_frequency=50.0,
+        )
+    finally:
+        unregister_benchmark("horizon_probe")
+
+
+def _json(result: dict[str, Any]) -> dict[str, Any]:
+    return next((block["json"] for block in result.get("content", []) if "json" in block), {})
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(" ".join(block["text"] for block in result.get("content", []) if "text" in block).split())
+
+
+class TestEveryCreationPathSharesOneDomain:
+    """The horizon is refused identically however the benchmark acquires it."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_direct_construction_refuses_a_horizon_the_loop_cannot_honor(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="max_steps must be a positive integer"):
+            _declarative(value)
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_a_spec_dict_refuses_the_same_horizon(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="max_steps must be a positive integer"):
+            _from_dict(value)
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_two_declarative_paths_agree(self, value: Any) -> None:
+        """A spec file and a direct construction cannot drift on what they accept.
+
+        The dict path validated the raw value while the constructor it feeds
+        coerced with ``int()``, so the same horizon was refused as a spec key and
+        accepted as a keyword.
+        """
+
+        def verdict(build: Any) -> str:
+            try:
+                build(value)
+            except ValueError:
+                return "refused"
+            return "accepted"
+
+        assert verdict(_from_dict) == verdict(_declarative), f"verdicts differ for max_steps={value!r}"
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_usable_horizon_is_still_accepted_on_both_paths(self, value: int) -> None:
+        assert _declarative(value).max_steps == value
+        assert _from_dict(value).max_steps == value
+
+    def test_an_omitted_spec_horizon_keeps_the_documented_default(self) -> None:
+        """Omitting the key is not a caller mistake - the default still applies."""
+        assert (
+            DeclarativeBenchmark.from_dict(
+                {"name": "probe", "supported_robots": [], "default_robot": "probe_arm"}
+            ).max_steps
+            == 300
+        )
+
+    def test_a_usable_horizon_is_stored_without_coercion(self) -> None:
+        """The stored value is the caller's, not an ``int()`` of it."""
+        stored = _declarative(720).max_steps
+        assert stored == 720
+        assert isinstance(stored, int) and not isinstance(stored, bool)
+
+
+class TestTheHorizonIsCheckedWhereItIsRead:
+    """A benchmark whose constructor the library cannot guard is still refused."""
+
+    @pytest.mark.parametrize("value", [0, -5, 2.7, True, float("nan"), float("inf"), "300"])
+    def test_an_attribute_horizon_is_refused_with_a_structured_error(self, eval_sim: Any, value: Any) -> None:
+        sim, policy = eval_sim
+        result = _evaluate(sim, policy, _AttributeBenchmark(value))
+        assert result["status"] == "error", result
+        text = _text(result)
+        assert "max_steps must be a positive integer" in text
+        assert "_AttributeBenchmark" in text, text
+
+    def test_a_horizon_assigned_after_construction_is_refused(self, eval_sim: Any) -> None:
+        """Validating only the constructors would miss a later assignment."""
+        sim, policy = eval_sim
+        benchmark = _declarative(60)
+        benchmark.max_steps = 0  # type: ignore[assignment]
+        result = _evaluate(sim, policy, benchmark)
+        assert result["status"] == "error", result
+        assert "max_steps must be a positive integer" in _text(result)
+
+    def test_a_zero_horizon_no_longer_reports_a_success_rate(self, eval_sim: Any) -> None:
+        """The reported failure mode: a 0% success rate over empty episodes.
+
+        A zero horizon used to return ``status="success"`` with
+        ``Avg steps: 0/0`` and ``0.0%`` success over episodes that applied no
+        action, which is indistinguishable from a policy that genuinely failed.
+        """
+        sim, policy = eval_sim
+        result = _evaluate(sim, policy, _AttributeBenchmark(0))
+        assert result["status"] == "error"
+        payload = _json(result)
+        assert "success_rate" not in payload, payload
+        assert "0.0%" not in _text(result)
+
+    def test_a_refused_horizon_does_not_reseed_the_process_rng(self, eval_sim: Any) -> None:
+        """The guard runs before ``set_eval_seed``, which is a global side effect."""
+        import random
+
+        sim, policy = eval_sim
+        register_benchmark("horizon_probe", _AttributeBenchmark(0))
+        try:
+            random.seed(1234)
+            expected = random.random()
+            random.seed(1234)
+            result = sim.evaluate_benchmark(
+                benchmark_name="horizon_probe",
+                robot_name="probe_arm",
+                policy_object=policy,
+                n_episodes=1,
+                seed=99,
+                control_frequency=50.0,
+            )
+            assert result["status"] == "error"
+            assert random.random() == expected, "a refused evaluation reseeded the global RNG"
+        finally:
+            unregister_benchmark("horizon_probe")
+
+    def test_a_usable_horizon_still_runs_and_is_honored(self, eval_sim: Any) -> None:
+        """The control: a valid horizon evaluates and caps each episode at it."""
+        sim, policy = eval_sim
+        result = _evaluate(sim, policy, _AttributeBenchmark(12), n_episodes=2)
+        assert result["status"] == "success", _text(result)
+        payload = _json(result)
+        assert payload["max_steps"] == 12
+        assert payload["n_episodes"] == 2
+        assert payload["avg_steps"] == pytest.approx(12.0)
+
+
+class TestParityWithTheAlreadyGuardedSiblingBound:
+    """``eval_policy``'s ``max_steps`` and a benchmark's share one domain."""
+
+    @pytest.mark.parametrize("value", UNUSABLE + USABLE)  # type: ignore[operator]
+    def test_the_benchmark_horizon_matches_eval_policy_max_steps(self, value: Any) -> None:
+        """Both are the same per-episode step cap, so they cannot diverge.
+
+        ``eval_policy(max_steps=...)`` routes through
+        ``SimEngine._validate_positive_int``; a benchmark's horizon is the same
+        quantity arriving by a different route.
+        """
+        from strands_robots.simulation.base import SimEngine
+
+        sibling = SimEngine._validate_positive_int(value, "max_steps", "eval_policy")
+        assert (sibling is None) == (positive_count_error(value, "max_steps", "evaluate_benchmark") is None)
+
+    def test_the_domain_rejects_bool_and_integral_floats(self) -> None:
+        """Pins why this is the count domain and not the whole-number one."""
+        assert positive_count_error(True, "max_steps", "evaluate_benchmark") is not None
+        assert positive_count_error(300.0, "max_steps", "evaluate_benchmark") is not None
+        assert positive_count_error(300, "max_steps", "evaluate_benchmark") is None
+
+    def test_a_non_integer_horizon_no_longer_escapes_as_a_range_error(self) -> None:
+        """Pre-fix a fractional/NaN horizon raised out of ``range()``.
+
+        The premise: these values are exactly the ones ``range()`` refuses, so
+        without a guard the failure surfaced as a bare ``TypeError`` rather than
+        the tool envelope.
+        """
+        for value in (2.7, math.nan, math.inf):
+            # Typed Any so the deliberate misuse reaches the runtime, which is
+            # the behaviour under test.
+            bound: Any = value
+            with pytest.raises(TypeError):
+                range(bound)
+            assert positive_count_error(value, "max_steps", "evaluate_benchmark") is not None


### PR DESCRIPTION
## Problem

`evaluate_benchmark`'s own docstring says the per-episode horizon **comes from the benchmark, not from its signature**:

> ``max_steps`` comes from the benchmark (not a parameter here).

So the benchmark object is the sole authority for that value. It is also the one bound of the evaluation's nested loop with no domain of its own — `n_episodes`, `action_horizon` and `control_substeps` are all checked at the public entry point, and `eval_policy` checks its own `max_steps` there too.

The guard the codebase already wrote *for this parameter* names the exact failure. `SimEngine._validate_positive_int`:

> Shared guard for the rollout count knobs that must be `>= 1` — `n_episodes` (how many reset->rollout episodes to run), **`max_steps` (the per-episode step cap)** … A zero/negative/non-int value would otherwise flow into the rollout loop and produce a degenerate result that still reports `status="success"`: an eval over zero episodes, **or episodes of zero length, that fabricate a 0% success rate** … instead of surfacing the caller's mistake.

And `positive_count_error`'s docstring already lists `max_steps` in its domain. Neither was applied to the `max_steps` that actually decides a benchmark episode, so it was validated on only one of the four paths that can set it:

| path that sets `max_steps` | `max_steps=0` on `main` | guarded? |
|---|---|---|
| `DeclarativeBenchmark.from_dict` / a spec file | `ValueError` | yes |
| `DeclarativeBenchmark(max_steps=0)` | accepted, stored `0` | no |
| `LiberoAdapter(max_steps=0)` / `.from_file` / `.from_text` / `load_libero_suite` | accepted, stored `0` | no |
| a `BenchmarkProtocol` subclass setting the documented attribute | accepted, stored `0` | no |
| `spec.max_steps = 0` after construction | accepted, stored `0` | no |

The dict path validated the raw value and then handed it to a constructor that coerced with a bare `int()`, so **the same horizon was refused as a spec key and accepted as a keyword**. In `LiberoAdapter.__init__` the bare `int()` sits one line below a validated `init_jitter`.

### Measured on a real MuJoCo evaluation (2 episodes, Panda, `MockPolicy`)

| horizon | `main` | this change |
|---|---|---|
| `0` | `status=success`, `success_rate: 0.0`, `Avg steps: 0/0` | structured error |
| `-5` | `status=success`, `Avg steps: 0/-5` | structured error |
| `2.7` | bare `TypeError: 'float' object cannot be interpreted as an integer` out of `range()` | structured error |
| `True` | a silent 1-step horizon | structured error |
| `nan` / `inf` | bare `TypeError` / `OverflowError` | structured error |
| `'300'` | silently accepted | structured error |

The `0` row is the reported failure verbatim: a benchmark result carrying **the same `success_rate` field a genuine 0% run carries**, over episodes that applied no action — indistinguishable from a policy that actually failed. The `2.7` / `nan` / `inf` rows escape the agent-tool envelope.

## Change

The horizon now shares the count domain its documentation already claims (`positive_count_error` — strict `int`, rejects `bool`, `>= 1`), enforced at two layers:

- **Where the value is supplied** — `DeclarativeBenchmark.__init__` and `LiberoAdapter.__init__` raise `ValueError`, so the failure lands where the caller wrote it. `from_dict` now delegates the same domain instead of carrying its own copy, so a spec key and a keyword cannot drift again.
- **Where the value is read** — `PolicyRunner._evaluate_with_spec` checks `spec.max_steps` and returns the tool-error envelope. This is the only unbypassable point: a plain `BenchmarkProtocol` subclass setting the documented attribute, or an assignment to it after construction, has no constructor the library can guard.

The read-side check runs before `policy.set_control_frequency` and `set_eval_seed` — the latter reseeds the **process-global** RNG, so a rejected evaluation must not reach it (pinned).

Omitting the horizon still applies the documented default. The stored value is now the caller's rather than an `int()` of it.

Also corrects a stale `Args` line: `LiberoAdapter.__init__` documented `max_steps` as overriding "the class-level 300" while the class attribute is `720`.

## Visual artifact

MuJoCo headless (`MUJOCO_GL=egl`), same benchmark, same policy, both trees:

![benchmark horizon domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/benchmark-horizon/benchmark-horizon-domain.png)

Panels **B** and **C** render identically (`max|delta| = 1`, renderer noise): no episode ran either way, so nothing about the physics changes — the whole difference is what the library reported. Panel **A** is a real evaluation of the same benchmark at `max_steps=150` (`joint1 = +0.2024 rad`, `Avg steps: 150/150`) and is byte-identical across both trees (`max|delta| = 1`); it differs from the zero-horizon scene on 35.2% of pixels. Every number in the figure is re-derived from the two runs' JSON dumps and asserted before the image is written.

## Tests

`tests/simulation/test_benchmark_horizon_domain.py`, 61 tests:

- every creation path refuses the same horizon, and a **cross-path parity test** asserts the spec-dict and direct-construction verdicts agree per value (the divergence that let this through);
- the read-side guard refuses a subclass attribute and a post-construction assignment, naming the parameter and the benchmark;
- the reported failure is gone — no `success_rate` in the payload and no `0.0%` in the text;
- a refused evaluation does not reseed the global RNG;
- **parity with the already-guarded sibling bound**: the benchmark horizon's verdict equals `SimEngine._validate_positive_int(value, "max_steps", "eval_policy")`'s over the whole probe set, so the same per-episode step cap cannot be refused by one route and accepted by the other;
- controls: a usable horizon still evaluates and is honored (`avg_steps == 12`), an omitted spec key keeps the documented default, and the domain premise (`range()` refuses exactly these values) is pinned.

**Pre-fix proof** (source files reverted to `89fa36a3`, tests kept): **39 failed / 22 passed**, failing as `verdicts differ for max_steps=0`, `DID NOT RAISE ValueError`, `assert 'success' == 'error'`, and `OverflowError: cannot convert float infinity to integer` out of the bare `int()`. The 22 that pass are the already-guarded `from_dict` path, the domain unit tests, the usable-value controls and the parity test — they are what stop the guard over-reaching.

## Gate (local, base `89fa36a3`)

- `MUJOCO_GL=egl pytest tests` -> **17095 passed, 258 skipped, 0 failed** (489s)
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (1022 source files)
- benchmark + LIBERO suites (`test_benchmark`, `test_benchmark_dsl`, `test_builtin_benchmarks`, `test_policy_runner_benchmark`, `tests/benchmarks`) -> 768 passed, 28 skipped, **zero existing-test changes**
- merge-base overlap check -> no overlap

## Out of scope

`PolicyRunner.evaluate(max_steps=...)` on the legacy (non-spec) path is a different surface: it is a parameter, and its public entry point `eval_policy` already validates it. This PR is about the horizon that arrives via the benchmark object, which has no parameter to check.