### PR TITLE
fix(sim): validate an add_object colour on every backend

### DIFF
--- a/changelog.d/1854-color-domain-across-backends.md
+++ b/changelog.d/1854-color-domain-across-backends.md
@@ -1,0 +1,36 @@
+### Fixed: every simulation backend validates an `add_object` colour
+
+`coerce_rgba` is now the single definition of the colour contract - three
+components read as RGB and completed with an opaque alpha, four read as RGBA
+verbatim, any other count refused - and lives in `strands_robots.utils` beside
+the pose domain rather than in a MuJoCo-private module. The MuJoCo backend has
+honored those counts on `add_object` and `set_geom_properties`; the Newton and
+Isaac backends read the caller's `color` directly and diverged from that domain
+in both directions.
+
+Newton tested the vector for truthiness (`color or [0.5, 0.5, 0.5, 1.0]`), so a
+NumPy colour - what a palette lookup or any colour arithmetic produces, and what
+the `Args` advertise - raised a bare `ValueError: truth value of an array with
+more than one element is ambiguous` straight through the structured envelope the
+method documents as its only failure channel, while an empty vector read as
+*omitted* and the default grey was painted under a success result. Everything
+else was stored verbatim: a 1- or 2-component colour, a `nan`/`inf` channel, a
+`bool` read as the channel `1.0`, and a bare string stored AS the colour.
+`_add_object_to_builder` then handed `tuple(obj.color[:3])` to the solver at
+rebuild time, reported nowhere near the call that supplied it. Isaac forwarded
+the colour raw and then truncated it - `_construct_shape_prim` writes
+`list(color)[:3]`, so a 5-component request was applied as its first 3 under a
+success result and `"abcd"` was split per character into the colour
+`['a', 'b', 'c']`.
+
+Both backends now refuse those values with the same message MuJoCo already
+emits, and an accepted colour reaches every backend as exactly 4 plain floats,
+which makes the `color[:3]` reads the shape builders do well-defined by
+construction rather than by the caller's discipline. A `bool` channel is now
+refused for a stated reason on every shared-vector surface instead of as a
+generic non-number. MuJoCo's own colour behaviour is unchanged: all 30
+accepted-value, refused-value and message rows are byte-identical.
+
+`size` and `mass` on those two backends keep their current contract - `size`
+counts are shape-dependent and documented differently per backend, and `mass=0`
+is documented on Newton as "make it static" - and stay pinned as out of scope.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -40,6 +40,7 @@ from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
+    coerce_rgba,
     entity_name_error,
     name_list_error,
     positive_count_error,
@@ -1734,9 +1735,12 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             Lists shorter than the convention fall back to defaults for
             the missing trailing components.
         color : list[float], optional
-            RGB color ``[r, g, b]`` in ``[0, 1]``. RGBA lists (length 4)
-            are accepted; alpha is dropped (Isaac's primitive constructors
-            take RGB only). ``None`` -> default white.
+            ``[r, g, b]`` or ``[r, g, b, a]`` in 0..1 (an RGB triple is
+            completed with an opaque alpha; the Isaac shape wrappers take
+            RGB only). Any other component count is refused rather than
+            truncated, since applying only the leading components would
+            paint a colour that was not asked for. NumPy arrays are
+            accepted. ``None`` -> default white.
         mass : float
             Mass in kg. Default 0.1. Ignored when ``is_static=True``.
         is_static : bool
@@ -1859,6 +1863,17 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             orientation, _oerr = coerce_pose_vector("add_object", "orientation", orientation, 4)
             if _oerr is not None:
                 return {"status": "error", "content": [{"text": _oerr}]}
+            # Same shared domain for the colour, whose accepted counts the
+            # 4-component rgba row it ends up in defines. Forwarding it raw
+            # validated nothing and then TRUNCATED: ``_construct_shape_prim``
+            # writes ``list(color)[:3]``, so a 5-component colour was applied as
+            # its first 3 under a success result, ``"abcd"`` was split per
+            # character into the colour ``['a', 'b', 'c']``, and a scalar reached
+            # ``np.asarray`` before failing. Normalizing to 4 components here
+            # makes that ``[:3]`` read well-defined by construction.
+            color, _cerr = coerce_rgba("add_object", "color", color)
+            if _cerr is not None:
+                return {"status": "error", "content": [{"text": _cerr}]}
             scale_alias = kwargs.pop("scale", None)
             if size is None and scale_alias is not None:
                 size = scale_alias

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -33,7 +33,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     persist_geom_properties,
     refresh_body_inertial_from_geometry,
 )
-from strands_robots.utils import is_boolean
+from strands_robots.utils import BOOLEAN_VECTOR_REASON, coerce_rgba, is_boolean
 
 logger = logging.getLogger(__name__)
 
@@ -59,20 +59,6 @@ _BOOLEAN_STATE_REASON = (
     "float(True) is 1.0, so a boolean would be written as 1 radian, 1 rad/s or "
     "1 N depending on the surface, and the call would report success. Pass the "
     "quantity in the surface's own units."
-)
-
-# The vector counterpart to _BOOLEAN_STATE_REASON. It is worded separately
-# because that one names radians, rad/s and newtons, which are the wrong units
-# for what _coerce_finite_vector guards: a coordinate, a geom extent, a friction
-# coefficient or a colour channel. The wording here is the one already recorded
-# in utils.finite_vector_error, which refuses a bool component for this reason
-# on the scene-construction side - and whose docstring then defers a colour to
-# "the rgba coercion in strands_robots.simulation.mujoco.physics", i.e. to this
-# helper. Same library, same quantity, so the same answer.
-_BOOLEAN_VECTOR_REASON = (
-    "float(True) is 1.0, so a boolean would silently write 1.0 where a "
-    "coordinate, extent or colour channel belongs, and the call would report "
-    "success. Pass the component as a number."
 )
 
 
@@ -138,7 +124,7 @@ def _coerce_finite_vector(
                 "status": "error",
                 "content": [
                     {
-                        "text": f"{method}: '{name}' elements must be numbers, not a bool (got {values!r}). {_BOOLEAN_VECTOR_REASON}"
+                        "text": f"{method}: '{name}' elements must be numbers, not a bool (got {values!r}). {BOOLEAN_VECTOR_REASON}"
                     }
                 ],
             }
@@ -180,24 +166,15 @@ def _coerce_finite_vector(
     return out, None
 
 
-# A MuJoCo geom stores its colour as a 4-component ``rgba`` row. Alpha is the
-# only component with a meaningful default (opaque), so an RGB triple can be
-# completed without inventing a colour, while any other count cannot.
-_RGBA_ACCEPTED_LENGTHS: tuple[int, ...] = (3, 4)
-_RGBA_LAYOUT = "RGB, or RGBA with alpha"
-
-
 def _coerce_rgba(color: Any, method: str, name: str = "color") -> tuple[list[float] | None, dict[str, Any] | None]:
     """Coerce a caller-supplied colour to the 4 components a geom's rgba stores.
 
-    Single source of the backend's colour contract, shared by the scene creator
-    (``add_object``) and the runtime mutator (``set_geom_properties``) so their
-    accepted domains cannot diverge: 3 components are read as RGB and completed
-    with an opaque alpha -- the one component MuJoCo defines a default for -- 4
-    are read as RGBA verbatim, and any other count is rejected because it can
-    only be applied by fabricating or discarding components the caller did not
-    ask about. An empty vector is rejected for the same reason: substituting the
-    backend default paints a colour nobody requested under a success result.
+    Envelope binding over :func:`strands_robots.utils.coerce_rgba`, which is the
+    single definition of the colour contract for every backend. This wrapper
+    exists only to report the shared reason in the structured-error shape the
+    MuJoCo scene creator (``add_object``) and runtime mutator
+    (``set_geom_properties``) return, so those two agreed domains stay in step
+    with Newton's and Isaac's rather than being a second copy of the rule.
 
     Args:
         color: The caller's colour sequence (list / tuple / NumPy array).
@@ -208,16 +185,10 @@ def _coerce_rgba(color: Any, method: str, name: str = "color") -> tuple[list[flo
         ``(rgba, None)`` with exactly 4 finite floats, or ``(None, error_dict)``
         matching the structured-error tool contract.
     """
-    floats, err = _coerce_finite_vector(
-        color,
-        name,
-        method,
-        accepted_lengths=_RGBA_ACCEPTED_LENGTHS,
-        layout=_RGBA_LAYOUT,
-    )
-    if floats is None:
-        return None, err
-    return (floats if len(floats) == 4 else [*floats, 1.0]), None
+    rgba, reason = coerce_rgba(method, name, color)
+    if reason is not None:
+        return None, {"status": "error", "content": [{"text": reason}]}
+    return rgba, None
 
 
 def _coerce_finite_joint_map(

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -59,6 +59,7 @@ from strands_robots.simulation.newton.recording import NewtonRecordingMixin
 from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
+    coerce_rgba,
     entity_name_error,
     positive_count_error,
     require_optional,
@@ -620,7 +621,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             size: Half-extents (box) or ``[radius, ...]`` (others). For
                 ``shape="mesh"`` this is the per-axis scale applied to the
                 loaded geometry (default ``[1, 1, 1]`` -- the mesh's own units).
-            color: RGBA in 0..1 (alpha currently ignored by Newton shapes).
+            color: ``[r, g, b]`` or ``[r, g, b, a]`` in 0..1 (default
+                mid-grey; alpha currently ignored by Newton shapes). Any
+                other component count is refused rather than padded or
+                truncated, since either would paint a colour that was not
+                asked for. NumPy arrays are accepted.
             mass: Object mass; ``0`` or ``is_static`` makes it static.
             is_static: When True the object is fixed in the world.
             mesh_path: Path to a mesh asset (``.obj`` / ``.stl`` / ``.glb`` /
@@ -665,6 +670,18 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         orientation, _oerr = coerce_pose_vector("add_object", "orientation", orientation, 4)
         if _oerr is not None:
             return {"status": "error", "content": [{"text": _oerr}]}
+        # Same shared domain for the colour, whose accepted counts the 4-component
+        # rgba row it ends up in defines. The ``color or <default>`` coalescing this
+        # replaces was wrong three ways: a NumPy colour raised
+        # ``ValueError: truth value of an array ... is ambiguous`` straight through
+        # this method's only documented failure channel, ``[]`` read as *omitted* so
+        # the default grey was painted under a success result, and a short colour was
+        # stored verbatim - ``_add_object_to_builder`` then handed
+        # ``tuple(obj.color[:3])`` a 1- or 2-component colour to the solver, at
+        # rebuild time rather than at the call the caller can attribute it to.
+        color, _cerr = coerce_rgba("add_object", "color", color)
+        if _cerr is not None:
+            return {"status": "error", "content": [{"text": _cerr}]}
         if material is not None:
             return {
                 "status": "error",
@@ -712,7 +729,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 position=[0.0, 0.0, 0.0] if position is None else position,
                 orientation=[1.0, 0.0, 0.0, 0.0] if orientation is None else orientation,
                 size=size or default_size,
-                color=color or [0.5, 0.5, 0.5, 1.0],
+                color=[0.5, 0.5, 0.5, 1.0] if color is None else color,
                 mass=mass,
                 mesh_path=mesh_path,
                 is_static=is_static,

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -748,6 +748,18 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
     return None
 
 
+#: Why a boolean is refused as a vector component. Worded for what a vector
+#: actually carries - a coordinate, a geom extent, a friction coefficient, a
+#: colour channel - rather than the radians / rad/s / newtons of the joint
+#: writers, whose reason is stated separately beside them. Lives here because
+#: every surface that coerces a vector component shares this one answer.
+BOOLEAN_VECTOR_REASON = (
+    "float(True) is 1.0, so a boolean would silently write 1.0 where a "
+    "coordinate, extent or colour channel belongs, and the call would report "
+    "success. Pass the component as a number."
+)
+
+
 def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     """Return an error message if any element of ``vec`` is not a finite number.
 
@@ -770,10 +782,9 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     because ``float(True)`` would silently write ``1.0`` where a coordinate,
     extent or colour channel belongs. Length is NOT checked here (size is shape-dependent, so
     its count is checked against the shape afterwards); use
-    :func:`pose_vector_error` for a fixed length, or the rgba coercion in
-    :mod:`strands_robots.simulation.mujoco.physics` for a colour, whose count
-    the geom's rgba row defines. Returns ``None`` when every element is a finite
-    real number.
+    :func:`pose_vector_error` for a fixed length, or :func:`coerce_rgba` for a
+    colour, whose count the rgba row it is written into defines. Returns ``None``
+    when every element is a finite real number.
     """
     try:
         iter(vec)
@@ -786,7 +797,11 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
         # silent ``1.0`` - a ``True`` coordinate placing a body 1 m out. The
         # agent-tool router already refuses a bool component, so refusing it
         # here keeps the direct API and the tool surface in step.
-        if isinstance(_elem, bool) or not isinstance(_elem, numbers.Real):
+        if is_boolean(_elem):
+            return (
+                f"{method}: '{param_name}' elements must be numbers, not a bool (got {vec!r}). {BOOLEAN_VECTOR_REASON}"
+            )
+        if not isinstance(_elem, numbers.Real):
             return f"{method}: '{param_name}' elements must be numbers, got {vec!r}"
         if not math.isfinite(float(_elem)):
             return f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {vec!r}"
@@ -859,6 +874,71 @@ def coerce_pose_vector(
     if (err := pose_vector_error(method, param_name, vec, expected_len)) is not None:
         return None, err
     return [float(v) for v in vec], None
+
+
+#: The component counts a 4-component RGBA row can be built from. Alpha is the
+#: only component with a meaningful default (opaque), so an RGB triple can be
+#: completed without inventing a colour, while any other count cannot.
+RGBA_ACCEPTED_LENGTHS: tuple[int, ...] = (3, 4)
+
+#: What those components mean, quoted in the component-count refusal.
+RGBA_LAYOUT = "RGB, or RGBA with alpha"
+
+
+def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] | None, str | None]:
+    """Validate an optional colour and normalize it to 4 RGBA components.
+
+    Single definition of the library's colour contract, shared by every backend
+    so their accepted domains cannot diverge - a colour one backend refuses is
+    refused by all of them. Three components are read as RGB and completed with
+    an opaque alpha, the one component a colour buffer defines a default for;
+    four are read as RGBA verbatim; any other count is refused, because it can
+    only be applied by fabricating the missing components or discarding the
+    extra ones - either way painting a colour the caller never asked for under a
+    success result.
+
+    Membership, not truthiness: a colour is "supplied" when it is not ``None``.
+    Testing the vector itself (``color or <default>``) is wrong twice over. A
+    NumPy array - what colour arithmetic and any palette lookup produce - raises
+    a bare ``ValueError: truth value of an array ... is ambiguous`` through the
+    structured tool-result contract, and an empty vector reads as *omitted*, so
+    the backend default is painted while the call reports success.
+
+    Normalizing to a ``list[float]`` of exactly 4 keeps the accepted NumPy input
+    from outliving this boundary - the colour is stored on :class:`SimObject`
+    (annotated ``list[float]``) and echoed in agent-visible status text, so a
+    surviving ``np.float64`` would leak ``np.float64(1.0)`` into it - and makes
+    the ``color[:3]`` reads the shape builders do well-defined by construction
+    rather than by the caller's discipline.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        color: The caller's colour, or ``None`` when the parameter was omitted.
+
+    Returns:
+        ``(None, None)`` when ``color`` is ``None`` (omitted - the caller
+        applies its own documented default), ``(rgba, None)`` with exactly 4
+        finite floats, or ``(None, error_message)`` for an unusable component
+        count, a non-numeric or ``bool`` component, or a ``nan``/``inf`` one.
+    """
+    if color is None:
+        return None, None
+    length = sequence_length(color)
+    if length is None:
+        return None, f"{method}: '{param_name}' must be a sequence of numbers, got {color!r}"
+    if (err := finite_vector_error(method, param_name, color)) is not None:
+        return None, err
+    floats = [float(component) for component in color]
+    if length not in RGBA_ACCEPTED_LENGTHS:
+        expected = " or ".join(str(n) for n in RGBA_ACCEPTED_LENGTHS)
+        return None, (
+            f"{method}: '{param_name}' must have exactly {expected} "
+            f"component(s) ({RGBA_LAYOUT}), got {length}: {floats}. Pass every "
+            f"component - a partial '{param_name}' cannot be applied "
+            "without inventing the missing values."
+        )
+    return (floats if length == 4 else [*floats, 1.0]), None
 
 
 def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:

--- a/tests/simulation/test_color_domain_across_backends.py
+++ b/tests/simulation/test_color_domain_across_backends.py
@@ -1,0 +1,375 @@
+"""Regression tests: every backend validates an ``add_object`` colour.
+
+``coerce_rgba`` is the single definition of the colour contract - three
+components read as RGB and completed with an opaque alpha, four read as RGBA
+verbatim, any other count refused - and the MuJoCo backend has honored it on
+``add_object`` and ``set_geom_properties`` since colour counts were settled
+there. The Newton and Isaac backends read the caller's colour directly.
+Measured on the probe set below, one ``add_object`` per case, with no ``newton``
+/ ``isaacsim`` installed:
+
+* Newton read the colour for TRUTHINESS (``color or [0.5, 0.5, 0.5, 1.0]``),
+  which is wrong three ways. ``np.array([1.0, 0.0, 0.0])`` - what a palette
+  lookup or any colour arithmetic produces - raised a bare
+  ``ValueError: truth value of an array with more than one element is
+  ambiguous`` straight through the structured envelope this method documents as
+  its only failure channel. ``[]`` is falsy, so it read as *omitted* and the
+  default grey was painted under a success result. And every other value was
+  stored verbatim: ``[0.1]`` and ``[0.1, 0.2]`` became 1- and 2-component
+  colours, ``[nan, 0, 0]`` a non-finite one, ``[True, 0, 0]`` read ``True`` as
+  the channel 1.0, and the bare string ``"abcd"`` was stored AS the colour.
+  ``_add_object_to_builder`` then handed ``tuple(obj.color[:3])`` to the solver
+  at rebuild time - a 1-component colour, reported nowhere near the call that
+  supplied it.
+* Isaac forwarded the colour raw and then TRUNCATED it:
+  ``_construct_shape_prim`` writes ``list(color)[:3]``, so a 5-component request
+  was applied as its first 3 under a success result, ``"abcd"`` was split per
+  character into the colour ``['a', 'b', 'c']``, ``[]`` wrote an empty colour
+  array, and a ``np.float64`` component survived into the prim. A scalar was
+  accepted by ``add_object`` and raised inside ``np.asarray`` afterwards.
+
+MuJoCo refused all 9 unusable values in that set and accepted all 3 NumPy
+colours. Every message here is the shared one, so a colour one backend refuses
+is refused by all of them, and an accepted colour reaches every backend as
+exactly 4 plain floats - which is what makes the ``color[:3]`` reads the shape
+builders do well-defined by construction rather than by the caller's discipline.
+
+``TestNoColorSurfaceDrifts`` keeps it that way structurally: every public method
+of a backend engine class that takes a ``color`` parameter must route it through
+the shared helper. The scope is public methods deliberately -
+``_construct_shape_prim`` / ``_create_shape_prim`` receive an already-validated
+colour from ``add_object`` and are not caller-facing.
+
+These tests are GL-free apart from the MuJoCo parity class and need neither
+``newton``/``warp`` nor ``isaacsim`` nor a GPU: every guard runs before its
+method touches a solver or a stage, so calling the unbound method with a small
+stand-in for ``self`` exercises it in every environment.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import RGBA_ACCEPTED_LENGTHS, coerce_rgba
+from tests.simulation.test_pose_vector_domain_across_backends import _isaac_stub, _newton_stub
+
+NAN = float("nan")
+INF = float("inf")
+
+#: Colours no ``add_object`` call can honor. An empty vector (the one a
+#: truthiness read swallowed as *omitted*), three unusable component counts, the
+#: two non-finite channels, a ``bool`` (an ``int`` subclass, so ``float(True)``
+#: would silently mean the channel 1.0), a bare string (an iterable of
+#: 1-character strings), and a non-iterable scalar.
+UNUSABLE_COLORS: tuple[Any, ...] = (
+    [],
+    [0.1],
+    [0.1, 0.2],
+    [0.1, 0.2, 0.3, 1.0, 0.5],
+    [NAN, 0.0, 0.0],
+    [INF, 0.0, 0.0],
+    [True, 0.0, 0.0],
+    "abcd",
+    0.5,
+)
+
+#: Accepted spellings, each with the 4 components it must become. The NumPy
+#: forms are the point: a palette lookup produces them and the Args advertise
+#: them.
+GOOD_COLORS: tuple[tuple[Any, list[float]], ...] = (
+    ([1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]),
+    ((1.0, 0.0, 0.0), [1.0, 0.0, 0.0, 1.0]),
+    ([0.1, 0.2, 0.3, 0.25], [0.1, 0.2, 0.3, 0.25]),
+    (np.array([1.0, 0.0, 0.0]), [1.0, 0.0, 0.0, 1.0]),
+    (np.array([0.1, 0.2, 0.3, 0.25], dtype=np.float32), [0.1, 0.2, 0.3, 0.25]),
+    ([np.float64(1.0), 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]),
+)
+
+#: The colour every backend documents for an omitted ``color``.
+DEFAULT_GREY = [0.5, 0.5, 0.5, 1.0]
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+def _isaac_recording_stub() -> tuple[Any, dict[str, Any]]:
+    """An Isaac stand-in that records what reaches the prim constructor.
+
+    The shared stub discards its kwargs; the colour a refused call must never
+    write - and the 4 plain floats an accepted one must - are only observable
+    here.
+    """
+    stub = _isaac_stub()
+    captured: dict[str, Any] = {}
+
+    def construct(**kwargs: Any) -> tuple[Any, Any]:
+        captured.update(kwargs)
+        return object(), kwargs.get("size")
+
+    stub._construct_shape_prim = construct
+    return stub, captured
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheSharedDomain:
+    """``coerce_rgba`` is the single definition every call site shares."""
+
+    @pytest.mark.parametrize("color", UNUSABLE_COLORS)
+    def test_an_unusable_color_is_refused(self, color: Any) -> None:
+        rgba, err = coerce_rgba("add_object", "color", color)
+        assert err is not None, color
+        assert rgba is None, "a refused colour must coerce nothing"
+        assert err.startswith("add_object: 'color'")
+
+    @pytest.mark.parametrize(("color", "expected"), GOOD_COLORS)
+    def test_a_usable_color_normalizes_to_four_plain_floats(self, color: Any, expected: list[float]) -> None:
+        """Accepted, completed to 4, and the NumPy scalars do not survive.
+
+        The colour is stored on :class:`SimObject` (annotated ``list[float]``)
+        and echoed in agent-visible status text, so a surviving ``np.float64``
+        would leak ``np.float64(1.0)`` into it.
+        """
+        rgba, err = coerce_rgba("add_object", "color", color)
+        assert err is None, (color, err)
+        assert rgba is not None
+        assert rgba == pytest.approx(expected)
+        assert len(rgba) == 4
+        assert all(type(component) is float for component in rgba)
+
+    def test_omitted_is_not_refused(self) -> None:
+        """``None`` means omitted - the caller applies its own documented default."""
+        assert coerce_rgba("add_object", "color", None) == (None, None)
+
+    def test_an_rgb_triple_is_completed_with_an_opaque_alpha(self) -> None:
+        """Alpha is the one component with a default; the channels are not."""
+        rgba, _ = coerce_rgba("add_object", "color", [0.2, 0.4, 0.6])
+        assert rgba == [0.2, 0.4, 0.6, 1.0]
+
+    @pytest.mark.parametrize("length", [0, 1, 2, 5, 6])
+    def test_only_the_documented_counts_are_accepted(self, length: int) -> None:
+        assert length not in RGBA_ACCEPTED_LENGTHS
+        _rgba, err = coerce_rgba("add_object", "color", [0.5] * length)
+        assert err is not None
+        assert "3 or 4" in err
+
+    def test_the_refusal_names_the_reason_for_a_boolean_channel(self) -> None:
+        """A bool is refused for a stated reason, not as a generic non-number."""
+        _rgba, err = coerce_rgba("add_object", "color", [True, 0.0, 0.0])
+        assert err is not None
+        assert "not a bool" in err
+        assert "float(True) is 1.0" in err
+
+
+# --------------------------------------------------------------------------- #
+# Newton                                                                      #
+# --------------------------------------------------------------------------- #
+class TestNewtonAddObject:
+    @pytest.mark.parametrize("color", UNUSABLE_COLORS)
+    def test_an_unusable_color_is_refused(self, color: Any) -> None:
+        result = NewtonSimEngine.add_object(_newton_stub(), "crate", color=color)
+        assert result["status"] == "error", (color, result)
+        assert "'color'" in _text(result)
+
+    @pytest.mark.parametrize("color", UNUSABLE_COLORS)
+    def test_a_refused_color_registers_no_object(self, color: Any) -> None:
+        """No half-painted object: the registry is untouched.
+
+        Pre-fix ``[]`` reported success and registered the crate with the
+        default grey, and ``[0.1]`` registered a 1-component colour that
+        ``_add_object_to_builder`` then handed to the solver.
+        """
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", color=color)["status"] == "error"
+        assert stub._world.objects == {}
+
+    @pytest.mark.parametrize(("color", "expected"), GOOD_COLORS)
+    def test_a_usable_color_is_stored_as_four_plain_floats(self, color: Any, expected: list[float]) -> None:
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", color=color)["status"] == "success"
+        stored = stub._world.objects["crate"].color
+        assert stored == pytest.approx(expected)
+        assert all(type(component) is float for component in stored)
+
+    def test_an_omitted_color_still_takes_the_documented_default(self) -> None:
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate")["status"] == "success"
+        assert stub._world.objects["crate"].color == DEFAULT_GREY
+
+    @pytest.mark.parametrize(("color", "expected"), GOOD_COLORS)
+    def test_the_builder_always_gets_three_components(self, color: Any, expected: list[float]) -> None:
+        """``tuple(obj.color[:3])`` is well-defined by construction now.
+
+        Pre-fix a stored ``[0.1]`` made that slice a 1-component colour, and the
+        solver saw it at rebuild time rather than at the call.
+        """
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", color=color)["status"] == "success"
+        assert tuple(stub._world.objects["crate"].color[:3]) == pytest.approx(tuple(expected[:3]))
+
+
+# --------------------------------------------------------------------------- #
+# Isaac                                                                       #
+# --------------------------------------------------------------------------- #
+class TestIsaacAddObject:
+    @pytest.mark.parametrize("color", UNUSABLE_COLORS)
+    def test_an_unusable_color_is_refused(self, color: Any) -> None:
+        stub, _captured = _isaac_recording_stub()
+        result = IsaacSimulation.add_object(stub, "crate", color=color)
+        assert result["status"] == "error", (color, result)
+        assert "'color'" in _text(result)
+
+    @pytest.mark.parametrize("color", UNUSABLE_COLORS)
+    def test_a_refused_color_constructs_no_prim(self, color: Any) -> None:
+        """The refusal precedes the prim constructor, so nothing is written."""
+        stub, captured = _isaac_recording_stub()
+        assert IsaacSimulation.add_object(stub, "crate", color=color)["status"] == "error"
+        assert captured == {}
+        assert stub._objects == {}
+
+    @pytest.mark.parametrize(("color", "expected"), GOOD_COLORS)
+    def test_a_usable_color_reaches_the_prim_as_four_plain_floats(self, color: Any, expected: list[float]) -> None:
+        """Which is what makes ``list(color)[:3]`` in the constructor well-defined.
+
+        Pre-fix a 5-component request was silently applied as its first 3, and a
+        ``np.float64`` component survived into the prim.
+        """
+        stub, captured = _isaac_recording_stub()
+        assert IsaacSimulation.add_object(stub, "crate", color=color)["status"] == "success"
+        assert captured["color"] == pytest.approx(expected)
+        assert all(type(component) is float for component in captured["color"])
+        assert list(captured["color"])[:3] == pytest.approx(expected[:3])
+
+    def test_an_omitted_color_is_still_forwarded_as_omitted(self) -> None:
+        """``None`` keeps meaning "let the prim constructor default it"."""
+        stub, captured = _isaac_recording_stub()
+        assert IsaacSimulation.add_object(stub, "crate")["status"] == "success"
+        assert captured["color"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Cross-backend parity                                                        #
+# --------------------------------------------------------------------------- #
+class TestEveryBackendGivesTheSameVerdict:
+    """A colour one backend refuses is refused by all of them, with one message."""
+
+    @pytest.fixture
+    def mj_sim(self) -> Any:
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="test_color_domain_parity_sim", mesh=False)
+        assert sim.create_world()["status"] == "success"
+        yield sim
+        sim.cleanup()
+
+    @pytest.mark.parametrize("color", UNUSABLE_COLORS)
+    def test_add_object_color_verdicts_match(self, mj_sim: Any, color: Any) -> None:
+        mj = mj_sim.add_object("crate", color=color)
+        nt = NewtonSimEngine.add_object(_newton_stub(), "crate", color=color)
+        ic = IsaacSimulation.add_object(_isaac_recording_stub()[0], "crate", color=color)
+        assert mj["status"] == nt["status"] == ic["status"] == "error", (color, mj, nt, ic)
+        texts = {_text(mj), _text(nt), _text(ic)}
+        assert len(texts) == 1, texts
+
+    @pytest.mark.parametrize(("color", "expected"), GOOD_COLORS)
+    def test_a_usable_color_is_accepted_everywhere(self, mj_sim: Any, color: Any, expected: list[float]) -> None:
+        """The parity is two-way: no backend refuses a colour another honors."""
+        assert mj_sim.add_object("crate", color=color)["status"] == "success"
+        assert NewtonSimEngine.add_object(_newton_stub(), "crate", color=color)["status"] == "success"
+        assert IsaacSimulation.add_object(_isaac_recording_stub()[0], "crate", color=color)["status"] == "success"
+
+    @pytest.mark.parametrize(("color", "expected"), GOOD_COLORS)
+    def test_the_same_four_components_are_applied_everywhere(
+        self, mj_sim: Any, color: Any, expected: list[float]
+    ) -> None:
+        """Accepted is not enough - each backend must apply the same colour."""
+        import mujoco as mj_module
+
+        assert mj_sim.add_object("crate", shape="box", color=color)["status"] == "success"
+        gid = mj_module.mj_name2id(mj_sim._world._model, mj_module.mjtObj.mjOBJ_GEOM, "crate_geom")
+        assert gid >= 0
+        assert list(mj_sim._world._model.geom_rgba[gid]) == pytest.approx(expected, abs=1e-6)
+
+        nt_stub = _newton_stub()
+        NewtonSimEngine.add_object(nt_stub, "crate", color=color)
+        assert nt_stub._world.objects["crate"].color == pytest.approx(expected)
+
+        ic_stub, captured = _isaac_recording_stub()
+        IsaacSimulation.add_object(ic_stub, "crate", color=color)
+        assert captured["color"] == pytest.approx(expected)
+
+
+# --------------------------------------------------------------------------- #
+# Structural: no colour surface drifts back off the shared domain             #
+# --------------------------------------------------------------------------- #
+def _backend_dir() -> pathlib.Path:
+    """Derive the scan root from a symbol rather than a path literal."""
+    return pathlib.Path(inspect.getfile(NewtonSimEngine)).parent.parent
+
+
+def _public_color_methods(root: pathlib.Path) -> dict[tuple[str, str], bool]:
+    """Map ``(module, method)`` to whether it routes ``color`` through the helper.
+
+    Scoped to public methods of a class: ``_construct_shape_prim`` and
+    ``_create_shape_prim`` take an already-validated colour from ``add_object``
+    and are not caller-facing, so they are excluded by construction rather than
+    by a name-based exemption that could go stale.
+    """
+    found: dict[tuple[str, str], bool] = {}
+    for path in sorted(root.glob("*/*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            for fn in [n for n in ast.iter_child_nodes(cls) if isinstance(n, ast.FunctionDef)]:
+                if fn.name.startswith("_"):
+                    continue
+                if "color" not in [a.arg for a in fn.args.args + fn.args.kwonlyargs]:
+                    continue
+                body = ast.unparse(fn)
+                found[(path.parent.name, fn.name)] = "coerce_rgba" in body
+    return found
+
+
+class TestNoColorSurfaceDrifts:
+    """A backend cannot ship an ``add_object`` colour off the shared domain."""
+
+    #: Every public backend method that takes a colour today.
+    EXPECTED = {
+        ("mujoco", "add_object"),
+        ("mujoco", "set_geom_properties"),
+        ("newton", "add_object"),
+        ("isaac", "add_object"),
+    }
+
+    def test_every_color_surface_routes_through_the_shared_helper(self) -> None:
+        found = _public_color_methods(_backend_dir())
+        adrift = sorted(key for key, routed in found.items() if not routed)
+        assert not adrift, f"colour parameters not routed through coerce_rgba: {adrift}"
+
+    def test_the_scan_sees_the_surfaces_it_is_meant_to_cover(self) -> None:
+        """Non-vacuity: an empty result would otherwise read as a clean sweep."""
+        found = _public_color_methods(_backend_dir())
+        assert self.EXPECTED <= set(found), f"scan missed {sorted(self.EXPECTED - set(found))}"
+
+    def test_the_scan_flags_a_planted_omission(self, tmp_path: pathlib.Path) -> None:
+        """A scanner that silently matched nothing would look like a clean suite."""
+        backend = tmp_path / "phony"
+        backend.mkdir()
+        (backend / "simulation.py").write_text(
+            "class PhonySimEngine:\n"
+            "    def add_object(self, name, color=None):\n"
+            "        return {'status': 'success', 'content': [{'text': color}]}\n",
+            encoding="utf-8",
+        )
+        found = _public_color_methods(tmp_path)
+        assert found == {("phony", "add_object"): False}

--- a/tests/simulation/test_input_validators_refuse_a_boolean.py
+++ b/tests/simulation/test_input_validators_refuse_a_boolean.py
@@ -377,16 +377,14 @@ class TestTheVectorCoercionRefusesABooleanComponent:
         the units of the joint writers - not of a coordinate, an extent or a
         colour channel.
         """
-        from strands_robots.simulation.mujoco.physics import (
-            _BOOLEAN_STATE_REASON,
-            _BOOLEAN_VECTOR_REASON,
-        )
+        from strands_robots.simulation.mujoco.physics import _BOOLEAN_STATE_REASON
+        from strands_robots.utils import BOOLEAN_VECTOR_REASON
 
         _, err = self._coerce([True, 0.0, 0.0], "origin", "raycast")
         assert err is not None
         text = _text(err)
         assert "not a bool" in text
-        assert _BOOLEAN_VECTOR_REASON in text
+        assert BOOLEAN_VECTOR_REASON in text
         assert _BOOLEAN_STATE_REASON not in text
         assert "radian" not in text, "a raycast origin is not measured in radians"
 

--- a/tests/simulation/test_pose_vector_domain_across_backends.py
+++ b/tests/simulation/test_pose_vector_domain_across_backends.py
@@ -39,12 +39,14 @@ class methods deliberately - ``scene_ops.reposition_body_in_scene`` is a
 module-level spec helper reached only from the already-validated
 ``move_object``, and it returns ``bool`` rather than the agent-tool envelope.
 
-What is NOT in scope, and is asserted to be unchanged: ``size``, ``color`` and
-``mass``. Their component counts are shape-dependent and documented differently
-per backend (the Isaac ``add_object`` docstring promises a trailing-component
+What is NOT in scope, and is asserted to be unchanged: ``size`` and ``mass``.
+``size`` component counts are shape-dependent and documented differently per
+backend (the Isaac ``add_object`` docstring promises a trailing-component
 fallback for a short ``size`` that neither other backend offers), and ``mass=0``
 is documented on Newton as "make it static" - so those need their own domain
-decision rather than riding along here.
+decision rather than riding along here. ``color`` was in that list until its
+accepted counts were settled on the shared ``coerce_rgba`` domain; it is now
+pinned in ``tests/simulation/test_color_domain_across_backends.py``.
 
 These tests are GL-free and need neither ``newton``/``warp`` nor ``isaacsim``
 nor a GPU: every guard runs before its method touches a solver or a stage, so
@@ -567,13 +569,15 @@ class TestEveryBackendGivesTheSameVerdict:
 # --------------------------------------------------------------------------- #
 # The out-of-scope parameters are pinned as unchanged                          #
 # --------------------------------------------------------------------------- #
-class TestSizeColorAndMassAreOutOfScope:
+class TestSizeAndMassAreOutOfScope:
     """This change is the pose axis only; the rest keep their current contract.
 
-    ``size`` / ``color`` counts are shape-dependent and documented differently
-    per backend, and ``mass=0`` is documented on Newton as "make it static", so
-    each needs its own domain decision. Pinning them here makes that scope a
-    stated property rather than an omission a later reader has to infer.
+    ``size`` counts are shape-dependent and documented differently per backend,
+    and ``mass=0`` is documented on Newton as "make it static", so each needs
+    its own domain decision. Pinning them here makes that scope a stated
+    property rather than an omission a later reader has to infer. ``color`` is
+    no longer among them - its counts are settled on the shared ``coerce_rgba``
+    domain, pinned in ``tests/simulation/test_color_domain_across_backends.py``.
     """
 
     def test_a_short_size_still_takes_the_backend_default(self):
@@ -586,11 +590,6 @@ class TestSizeColorAndMassAreOutOfScope:
         stub = _newton_stub()
         assert NewtonSimEngine.add_object(stub, "crate", mass=0.0)["status"] == "success"
         assert stub._world.objects["crate"].mass == 0.0
-
-    def test_an_omitted_color_still_takes_the_backend_default(self):
-        stub = _newton_stub()
-        assert NewtonSimEngine.add_object(stub, "crate")["status"] == "success"
-        assert stub._world.objects["crate"].color == [0.5, 0.5, 0.5, 1.0]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #1854.

## Problem

`utils.finite_vector_error` ends its docstring by deferring a colour to "the rgba coercion in `strands_robots.simulation.mujoco.physics`" - a **shared** helper pointing into a **backend-private** one. That inversion is why only MuJoCo had a colour domain: the other two backends could either duplicate the contract or reach into another backend's internals, so they did neither.

Measured with one `add_object` per case, no `newton` / `isaacsim` installed:

| `color=` | MuJoCo | Newton (`color or [0.5,0.5,0.5,1.0]`) | Isaac (forwarded raw) |
| --- | --- | --- | --- |
| `np.array([1.0,0.0,0.0])` | accepted | **raised** `ValueError: truth value of an array ... is ambiguous` | accepted, `np.float64` survives into the prim |
| `[]` | refused | accepted -> **default grey painted** | accepted -> writes an empty colour array |
| `[0.1]` / `[0.1,0.2]` | refused | accepted -> stored verbatim | accepted -> 1-/2-component colour |
| `[0.1,0.2,0.3,1.0,0.5]` | refused | accepted | accepted -> **silently applied as its first 3** |
| `[nan,0,0]` / `[inf,0,0]` | refused | accepted | accepted |
| `[True,0,0]` | refused | accepted -> `True` read as the channel `1.0` | accepted |
| `"abcd"` | refused | accepted -> the **string stored AS the colour** | accepted -> **`['a','b','c']`** |
| `0.5` | refused | raised | accepted, then raised inside `np.asarray` |

Two consequences worth naming separately from the silent-default class:

* On Newton the harm lands **away from the call**. `_add_object_to_builder` reads `tuple(obj.color[:3])`, so a stored `[0.1]` hands the solver a 1-component colour at *rebuild* time - not at the `add_object` the caller can attribute it to.
* On Isaac `add_object` was the only place the count could be checked, and it did not: `_construct_shape_prim` writes `list(color)[:3]`, so the truncation is unconditional and reported nowhere.

The one legitimate value that *failed* is the one the `Args` advertise - a NumPy colour, what a palette lookup or any colour arithmetic produces - and it escaped as a bare `ValueError` through the structured envelope these methods document as their only failure channel.

## Change

`coerce_rgba` becomes the single definition of the colour contract and moves to `strands_robots.utils`, beside the pose domain, in that module's own `(method, param_name, value) -> (value, reason)` convention:

* **3 components** -> RGB, completed with an opaque alpha (the one component a colour buffer defines a default for); **4** -> RGBA verbatim; **any other count refused**, since it can only be applied by fabricating or discarding components.
* **Membership, not truthiness**: `None` means omitted (each backend keeps its own documented default); `[]` is a component count, not an omission.
* Normalizes to exactly 4 plain `float`s, so the `color[:3]` reads both shape builders do are well-defined by construction, and no `np.float64` outlives the boundary into `SimObject` or agent-visible status text.

`BOOLEAN_VECTOR_REASON` moves to the same module, and `finite_vector_error` now names a `bool` channel and carries that reason instead of reporting it as a generic non-number - so every shared-vector surface gains the diagnostic MuJoCo's colour path already had.

MuJoCo's `_coerce_rgba` becomes an envelope binding over the shared coercion and its private `_RGBA_ACCEPTED_LENGTHS` / `_RGBA_LAYOUT` are deleted. **Its behaviour is unchanged** - 30 rows (every accepted value, every refused value, every message, both entry points) compared across the two trees: **0 differing**.

### Scope

`size` and `mass` on those two backends keep their current contract and stay pinned as out of scope, matching how the same axes were settled on MuJoCo as separate changes (`size` #1640, `color` #1643, `mass` #1642, pose #1665). `size` counts are shape-dependent and the Isaac docstring promises a trailing-component fallback the others do not offer; `mass=0` is documented on Newton as "make it static". `color` is the one axis with no open design question. `TestSizeColorAndMassAreOutOfScope` narrows to `TestSizeAndMassAreOutOfScope` so the boundary stays a stated assertion.

## Verification

![colour domain across backends](https://raw.githubusercontent.com/cagataycali/robots/artifacts/color-domain/color_domain.png)

Top panel is a real headless MuJoCo render of the three colours a caller can legitimately mean; the swatch grid below is what actually reached each backend's shape builder for the same call, measured from one script run against both trees. Every figure number is re-derived from the two JSON dumps inside the generator rather than typed.

* **Divergences from the reference backend: 13 of 18 cells -> 0 of 18.**
* Reference render across the two trees: `max|delta| = 2` over 12 of 403,200 pixels (renderer noise), and 3 of 9 accepted on both - MuJoCo untouched.
* Newton: 6 of 6 unusable colours applied -> 0; the NumPy colour it raised on is now accepted.

**Pre-fix proof** (call sites reverted to `upstream/main`, the shared helper kept so the module still imports): `65 failed, 38 passed` -> `103 passed`. The structural guard names exactly the two surfaces adrift:

```
AssertionError: colour parameters not routed through coerce_rgba:
  [('isaac', 'add_object'), ('newton', 'add_object')]
```

The 38 that pass pre-fix are the ones that must: the shared-domain unit tests, the MuJoCo rows for values it already refused, and the guard's own non-vacuity and planted-defect meta-tests. Keeping them is what stops the new guard over-reaching.

**Gate** at `9a09da0b` (no merge-base overlap):

| check | result |
| --- | --- |
| `MUJOCO_GL=egl pytest tests` | **17197 passed, 258 skipped** (518s), 0 failed |
| `ruff check strands_robots tests tests_integ` | clean |
| `ruff format --check ...` | 1026 files formatted |
| `mypy strands_robots tests tests_integ` | clean, 1023 source files |
| `scripts/assemble_changelog.py --check` | OK |

New tests: 103 in `tests/simulation/test_color_domain_across_backends.py` (1.5s). GL-free apart from the MuJoCo parity class, and they need neither `newton`/`warp` nor `isaacsim` - every guard runs before its method touches a solver or a stage. `TestNoColorSurfaceDrifts` keeps it structural: every **public** backend method taking a `color` must route it through the shared helper, which excludes `_construct_shape_prim` / `_create_shape_prim` (they receive an already-validated colour) by construction rather than by a name exemption that could go stale.