### PR TITLE
fix(sim): accept one difficulty domain on every create_world

### DIFF
--- a/changelog.d/1857-create-world-difficulty-domain.md
+++ b/changelog.d/1857-create-world-difficulty-domain.md
@@ -1,0 +1,19 @@
+### Fixed: `create_world(difficulty=...)` accepts one domain on every backend
+
+`difficulty` scales a heightfield terrain's peak elevation - the curriculum knob
+a locomotion trainer ramps across resets. Every backend read it through a bare
+`float(difficulty)`, so the three disagreed on which values are numbers at all:
+`None` and `[0.5]` raised `TypeError`, which escapes the `{"status": "error"}`
+tool-result contract because the callers catch only `ValueError`; a non-numeric
+string surfaced `float()`'s own message on MuJoCo (naming neither the parameter
+nor the surface) and escaped outright on Newton and Isaac; `bool` was accepted
+asymmetrically, with `True` passing as a silent `1.0` - a full-height terrain
+indistinguishable from the default - while `False` was refused; and a numeric
+string was silently honored as a scale.
+
+The domain is now owned by `simulation.terrain.validate_difficulty`, the raising
+binding over the shared `utils.positive_finite_number_error`, and all three
+`create_world` implementations report through that one binding. A value one
+backend refuses can no longer be honored by another, and a rejected curriculum
+step is reported instead of aborting the ramp. The accepted domain is unchanged:
+a positive finite real still compiles into the heightfield exactly as before.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -160,10 +160,15 @@ sim.create_world(terrain="rough", difficulty=2.0)  # exaggerated ~16 cm bumps
 ```
 
 `difficulty=1.0` (the default) is the full-height terrain, byte-identical to
-omitting it; `<1` is gentler, `>1` harsher. It must be a finite value `> 0`,
-and it only applies with a `terrain` - setting `difficulty != 1.0` on a flat
-world (no `terrain`) is rejected with an error rather than silently having no
-effect. A locomotion curriculum ramps `difficulty` across resets to grow the
+omitting it; `<1` is gentler, `>1` harsher. It must be a finite *number*
+`> 0` - the same positive-real domain every other continuous knob accepts, so
+`0`, a negative value, `nan`/`inf`, a `bool` (`True` is not a scale, even
+though it is an `int` subclass) and a string (including a numeric one like
+`"0.5"`) are all refused with a structured error naming the parameter. Every
+backend reports through that one domain, so a scale one `create_world` refuses
+cannot be honored by another. It only applies with a `terrain` - setting
+`difficulty != 1.0` on a flat world (no `terrain`) is rejected with an error
+rather than silently having no effect. A locomotion curriculum ramps `difficulty` across resets to grow the
 terrain the policy must handle.
 
 A floating-base robot added to a terrain world (or reset in one) spawns

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -37,6 +37,7 @@ from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.config import IsaacConfig
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
 from strands_robots.simulation.models import registered, registry_entry
+from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
@@ -866,6 +867,16 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         # doubly inert - there is no heightfield terrain for it to scale (a
         # non-None terrain is already rejected above) - so any != 1.0 value is
         # meaningless here; surface that instead of a status=success no-op.
+        # The ``difficulty`` domain is owned by ``validate_difficulty`` and shared
+        # with the MuJoCo backend, which honors the value: the same scale is
+        # refused identically on every backend rather than one accepting what
+        # another rejects. It runs before the ``float(difficulty)`` test below,
+        # which raises ``TypeError`` for ``None``/a list and ``ValueError`` for a
+        # non-numeric string - escaping this method's structured-error contract.
+        try:
+            validate_difficulty(difficulty)
+        except ValueError as exc:
+            return {"status": "error", "content": [{"text": str(exc)}]}
         if float(difficulty) != 1.0:
             return {
                 "status": "error",

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -56,6 +56,7 @@ from strands_robots.simulation.models import (
 from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
 from strands_robots.simulation.newton.randomization import DomainRandomizationMixin
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
+from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
@@ -292,6 +293,16 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         # doubly inert - there is no heightfield terrain for it to scale (a
         # non-None terrain is already rejected above) - so any != 1.0 value is
         # meaningless here; surface that instead of a status=success no-op.
+        # The ``difficulty`` domain is owned by ``validate_difficulty`` and shared
+        # with the MuJoCo backend, which honors the value: the same scale is
+        # refused identically on every backend rather than one accepting what
+        # another rejects. It runs before the ``float(difficulty)`` test below,
+        # which raises ``TypeError`` for ``None``/a list and ``ValueError`` for a
+        # non-numeric string - escaping this method's structured-error contract.
+        try:
+            validate_difficulty(difficulty)
+        except ValueError as exc:
+            return {"status": "error", "content": [{"text": str(exc)}]}
         if float(difficulty) != 1.0:
             return {
                 "status": "error",

--- a/strands_robots/simulation/terrain.py
+++ b/strands_robots/simulation/terrain.py
@@ -27,16 +27,17 @@ magnitude across resets without changing the terrain *kind* -- a robot settles
 onto shallower bumps/steps at a lower difficulty and taller ones as it is
 raised.
 
-The generator is intentionally backend- and MuJoCo-independent (pure stdlib, no
-numpy / mujoco import) so the height data is trivially unit-testable and
+The generator is intentionally backend- and MuJoCo-independent (stdlib plus the shared
+validation domain in :mod:`strands_robots.utils`, no numpy / mujoco import) so the height data is trivially unit-testable and
 deterministic given ``(kind, resolution, seed)`` -- a benchmark that evaluates a
 policy on ``terrain="rough"`` regenerates the identical field on every reset.
 """
 
 from __future__ import annotations
 
-import math
 import random
+
+from strands_robots.utils import positive_finite_number_error
 
 # Supported terrain kinds. ``"rough"`` is smoothed value-noise bumps; ``"stairs"``
 # is a flight of discrete parallel step plateaus rising along +x; ``"pyramid"`` is
@@ -83,17 +84,33 @@ def validate_terrain(kind: str | None) -> None:
 
 
 def validate_difficulty(difficulty: float) -> None:
-    """Raise ``ValueError`` unless ``difficulty`` is a finite value ``> 0``.
+    """Raise ``ValueError`` unless ``difficulty`` is a finite number ``> 0``.
 
     ``difficulty`` scales the terrain's peak elevation (``1.0`` = full height);
     ``0`` would collapse the heightfield to a flat plane (a degenerate hfield
     with zero elevation, which MuJoCo rejects) and a negative/NaN value is
     meaningless, so both are rejected actionably rather than silently producing
     broken ground.
+
+    The accepted domain is
+    :func:`~strands_robots.utils.positive_finite_number_error` - the shared
+    positive-real domain every other continuous knob is measured against - and
+    this function is the raising binding over it. All three ``create_world``
+    implementations report through this one binding, so a scale one backend
+    refuses cannot be honored by another and the message is identical
+    everywhere.
+
+    Delegating also closes the type axis a bare ``float(difficulty)`` left
+    open. ``None`` and ``["0.5"]`` raised ``TypeError``, which escapes the
+    ``{"status": "error"}`` tool-result contract entirely because the callers
+    catch only ``ValueError``; a non-numeric string surfaced ``float()``'s own
+    message, naming neither the parameter nor the surface; and ``bool`` was
+    accepted asymmetrically - as an ``int`` subclass ``True`` passed the
+    ``<= 0`` test as a silent ``1.0`` (indistinguishable from the default full
+    height) while ``False`` was refused as a zero scale.
     """
-    d = float(difficulty)
-    if not math.isfinite(d) or d <= 0.0:
-        raise ValueError(f"terrain difficulty must be a finite value > 0 (1.0 = full height), got {difficulty!r}.")
+    if positive_finite_number_error(difficulty, "difficulty", "terrain") is not None:
+        raise ValueError(f"terrain difficulty must be a finite number > 0 (1.0 = full height), got {difficulty!r}.")
 
 
 def terrain_elevation(difficulty: float = 1.0) -> float:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -393,20 +393,23 @@ def sequence_length(value: Any) -> int | None:
 def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive finite number.
 
-    Shared domain for every CONTINUOUS knob that names a rate or a span of
-    time - a control-loop frequency in Hz, a rollout or teleop ``duration`` in
-    seconds. Unlike :func:`positive_whole_number_error` a fractional value is
-    perfectly usable here (``2.5`` seconds, ``62.5`` Hz), so only the sign and
-    the finiteness are constrained. It lives here rather than beside one of its
+    Shared domain for every CONTINUOUS knob a caller supplies as a positive
+    real: a rate or a span of time (a control-loop frequency in Hz, a rollout
+    or teleop ``duration`` in seconds), and a dimensionless multiplier (the
+    terrain curriculum ``difficulty`` that scales a heightfield's peak
+    elevation). Unlike :func:`positive_whole_number_error` a fractional value is
+    perfectly usable here (``2.5`` seconds, ``62.5`` Hz, a ``0.5`` scale), so
+    only the sign and the finiteness are constrained. It lives here rather than beside one of its
     callers because those callers sit in different layers
     (:mod:`strands_robots.teleop_mixin` must not depend on
     :mod:`strands_robots.simulation`), and the accepted domain must not diverge
     between them.
 
     Only a positive finite value can be honored. Such a knob is always a
-    divisor (the loop period is ``1 / hz``) or a horizon (``duration *
-    frequency`` steps), so ``0`` makes the period undefined or the horizon
-    empty, a negative value inverts it, ``nan`` poisons every comparison it
+    divisor (the loop period is ``1 / hz``), a horizon (``duration *
+    frequency`` steps) or a multiplier (``elevation * difficulty``), so ``0``
+    makes the period undefined, the horizon empty or the scaled quantity
+    degenerate, a negative value inverts it, ``nan`` poisons every comparison it
     reaches (``nan > 0`` and ``nan <= 0`` are both ``False``), and ``inf``
     collapses the period to ``0`` - an unthrottled loop, not a fast one.
     Accepts any real scalar (so a NumPy ``np.float32`` rate read from a config

--- a/tests/simulation/test_create_world_difficulty_domain.py
+++ b/tests/simulation/test_create_world_difficulty_domain.py
@@ -99,15 +99,32 @@ def _domain_refused(target: Any, **kwargs: Any) -> bool:
     let this value through", which is exactly the question being compared
     across backends. Raising is never a domain refusal: escaping the
     tool-result contract is the defect this file pins.
+
+    The handler catches ``Exception`` and stops there. A library failure is one
+    of the answers being collected, but an interrupt is not an answer about the
+    domain: swallowing ``BaseException`` would record an operator's Ctrl-C as
+    "this backend did not refuse the value", compare that against the other two
+    backends and carry on sweeping. ``pytest``'s own ``skip`` and ``fail``
+    outcomes derive from ``BaseException`` for the same reason, so they have to
+    reach the runner rather than becoming a verdict.
     """
     try:
         result = _create_world(target, **kwargs)
-    except BaseException:  # noqa: BLE001 - a raise is measured, not handled
+    except Exception:  # noqa: BLE001 - a library failure is a verdict, control flow is not
         return False
     if not isinstance(result, dict) or result.get("status") != "error":
         return False
     text = " ".join(block.get("text", "") for block in result.get("content", []))
     return _DOMAIN_MARKER in text
+
+
+def _raising_target(exc: BaseException) -> Any:
+    """A ``create_world`` stand-in that raises, so the handler's width is observable."""
+
+    def target(**_kwargs: Any) -> Any:
+        raise exc
+
+    return target
 
 
 def _newton_stub() -> Any:
@@ -193,6 +210,50 @@ class TestMuJoCoRefusesAScaleItCannotHonor:
             assert float(model.hfield_size[0][2]) == pytest.approx(terrain_elevation(float(value)), abs=1e-9)
         finally:
             sim.cleanup()
+
+
+class TestTheDomainClassifierCollectsFailuresWithoutSwallowingControlFlow:
+    """``_domain_refused`` must catch a library failure and only a library failure.
+
+    The classifier turns "what did this backend do with this value" into a bool
+    so the sweep below can compare the three implementations. A raise is one of
+    the answers it has to collect - the escaping ``TypeError`` is the defect
+    this file pins - so a library failure cannot be allowed to abort the sweep.
+    An interrupt is not an answer about the domain, though: recording one as
+    "this backend did not refuse the value" and then comparing it against the
+    other two backends turns an operator's Ctrl-C into a verdict. Both halves
+    are pinned here because the correct handler is the one that satisfies both.
+    """
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            TypeError("float() argument must be a string or a real number, not 'NoneType'"),
+            ValueError("could not convert string to float: 'abc'"),
+        ],
+        ids=["TypeError", "ValueError"],
+    )
+    def test_a_library_failure_is_collected_as_not_a_domain_refusal(self, exc: Exception) -> None:
+        """The two escapes this file exists to pin must reach the comparison, not the runner."""
+        assert _domain_refused(_raising_target(exc), difficulty=None) is False
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            KeyboardInterrupt(),
+            SystemExit(1),
+            pytest.skip.Exception("newton is not installed"),
+            pytest.fail.Exception("the backend stub is incomplete"),
+        ],
+        ids=["KeyboardInterrupt", "SystemExit", "pytest.skip", "pytest.fail"],
+    )
+    def test_control_flow_reaches_the_runner_instead_of_becoming_a_verdict(self, exc: BaseException) -> None:
+        # Executable premise: each of these derives from BaseException without
+        # deriving from Exception, which is the whole reason the handler width
+        # is observable at all.
+        assert not isinstance(exc, Exception), f"{type(exc).__name__} no longer tests the handler width"
+        with pytest.raises(type(exc)):
+            _domain_refused(_raising_target(exc), difficulty=None)
 
 
 class TestEveryBackendAgreesOnTheDomain:

--- a/tests/simulation/test_create_world_difficulty_domain.py
+++ b/tests/simulation/test_create_world_difficulty_domain.py
@@ -1,0 +1,303 @@
+"""``create_world(difficulty=...)`` accepts one domain on every backend.
+
+``difficulty`` is the terrain curriculum knob: it multiplies the heightfield's
+peak elevation, so ``1.0`` is the full-height terrain and ``0.5`` a gentler
+stage a trainer ramps across resets. Only the MuJoCo backend has a heightfield
+to scale; Newton and Isaac reject a non-default value as inert. All three
+therefore have to agree on which values are *numbers* in the first place, and
+they did not:
+
+* ``None`` and ``[0.5]`` reached a bare ``float(difficulty)`` and raised
+  ``TypeError``. Every caller catches ``ValueError`` only, so the exception
+  escaped the ``{"status": "error"}`` tool-result contract on all three
+  backends - and on the MuJoCo path it escaped after the previous world had
+  already been torn down.
+* A non-numeric string surfaced ``float()``'s own message
+  (``could not convert string to float: 'abc'``) on MuJoCo, naming neither the
+  parameter nor the surface, and escaped outright on Newton and Isaac.
+* ``bool`` was accepted asymmetrically. As an ``int`` subclass ``True`` passed
+  the ``<= 0`` test as a silent ``1.0`` - a full-height terrain
+  indistinguishable from the default - while ``False`` was refused as a zero
+  scale.
+* A numeric string (``"0.5"``) was silently honored as a ``0.5`` scale, a
+  spelling every other continuous knob in the library refuses.
+
+The domain is now owned by
+:func:`strands_robots.simulation.terrain.validate_difficulty`, the raising
+binding over the shared
+:func:`strands_robots.utils.positive_finite_number_error`, and every backend
+reports through that one binding.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.terrain import terrain_elevation, validate_difficulty
+from strands_robots.utils import positive_finite_number_error
+
+# The refusal text every backend must produce for an unusable scale. Matching on
+# it rather than on ``status == "error"`` is what distinguishes a domain refusal
+# from the backend-specific "this value is inert here" message, which is a
+# different (and correct) rejection.
+_DOMAIN_MARKER = "terrain difficulty must be a finite number > 0"
+
+# Values no backend can honor as an elevation scale. ``bool`` appears as both
+# members of the pair: the asymmetry (``True`` accepted, ``False`` refused) was
+# the sharpest form of the defect.
+UNUSABLE: list[tuple[str, Any]] = [
+    ("True", True),
+    ("False", False),
+    ("numeric string", "0.5"),
+    ("non-numeric string", "abc"),
+    ("None", None),
+    ("list", [0.5]),
+    ("nan", float("nan")),
+    ("inf", float("inf")),
+    ("-inf", float("-inf")),
+    ("zero", 0),
+    ("negative", -1.0),
+    ("numpy bool", np.bool_(True)),
+]
+
+# Scales that are usable as written. ``1.0`` is the default (no curriculum), the
+# others are real curriculum stages; the NumPy and ``int`` spellings are the
+# natural products of a config array and a hand-written ramp.
+USABLE: list[tuple[str, Any]] = [
+    ("half", 0.5),
+    ("default", 1.0),
+    ("double", 2.0),
+    ("numpy float32", np.float32(0.5)),
+    ("int", 2),
+]
+
+
+def _create_world(target: Any, **kwargs: Any) -> Any:
+    """Call ``create_world`` through one funnel.
+
+    The tests deliberately pass values the ``difficulty: float`` annotation does
+    not describe - that is the contract under test - so the call is splatted
+    through ``**kwargs`` rather than written out, which keeps the type checker
+    from objecting to inputs a caller must never write.
+    """
+    return target(**kwargs)
+
+
+def _domain_refused(target: Any, **kwargs: Any) -> bool:
+    """Whether the shared difficulty domain refused this call.
+
+    Returns ``True`` only for a structured error carrying the shared refusal
+    text. Anything else - a success, a different structured error, or an
+    exception from a step *past* the domain check - is reported as "the domain
+    let this value through", which is exactly the question being compared
+    across backends. Raising is never a domain refusal: escaping the
+    tool-result contract is the defect this file pins.
+    """
+    try:
+        result = _create_world(target, **kwargs)
+    except BaseException:  # noqa: BLE001 - a raise is measured, not handled
+        return False
+    if not isinstance(result, dict) or result.get("status") != "error":
+        return False
+    text = " ".join(block.get("text", "") for block in result.get("content", []))
+    return _DOMAIN_MARKER in text
+
+
+def _newton_stub() -> Any:
+    """A Newton engine with only the state ``create_world`` reads before the guard.
+
+    The domain check runs before any Newton/warp import, so a refusal is fully
+    observable with the package absent. A value that gets *past* the guard then
+    surfaces an error from this deliberately incomplete stub, which
+    :func:`_domain_refused` correctly reports as "not a domain refusal".
+    """
+    import threading
+    import types
+
+    return types.SimpleNamespace(_world=None, _lock=threading.RLock(), default_timestep=0.005)
+
+
+def _isaac_stub() -> Any:
+    """An Isaac engine with only the state ``create_world`` reads before the guard."""
+    import threading
+    import types
+
+    return types.SimpleNamespace(
+        _world=None,
+        _world_created=False,
+        _lock=threading.RLock(),
+        _config=types.SimpleNamespace(),
+        default_timestep=0.005,
+    )
+
+
+def _backend_create_world_targets() -> dict[str, Any]:
+    """The three ``create_world`` implementations, each bound to a callable target."""
+    from strands_robots.simulation.isaac.simulation import IsaacSimulation
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    return {
+        "newton": lambda **kw: NewtonSimEngine.create_world(_newton_stub(), **kw),
+        "isaac": lambda **kw: IsaacSimulation.create_world(_isaac_stub(), **kw),
+    }
+
+
+class TestMuJoCoRefusesAScaleItCannotHonor:
+    """The backend that honors ``difficulty`` reports, rather than raises."""
+
+    @pytest.mark.parametrize("value", [v for _, v in UNUSABLE], ids=[n for n, _ in UNUSABLE])
+    def test_an_unusable_scale_is_refused_through_the_tool_contract(self, value: Any) -> None:
+        sim = Simulation(tool_name="difficulty_domain", mesh=False)
+        try:
+            result = _create_world(sim.create_world, terrain="stairs", difficulty=value)
+            assert result["status"] == "error"
+            text = " ".join(block.get("text", "") for block in result["content"])
+            # Actionable: names the parameter, the domain and the offending value.
+            assert _DOMAIN_MARKER in text
+            assert repr(value) in text
+            # The refusal precedes world construction, so a rejected curriculum
+            # step leaves the caller with no half-built world to reason about.
+            assert sim._world is None
+        finally:
+            sim.cleanup()
+
+    def test_both_halves_of_the_bool_pair_are_refused(self) -> None:
+        """``True`` used to pass as a silent ``1.0`` while ``False`` was refused."""
+        verdicts = {}
+        for value in (True, False):
+            sim = Simulation(tool_name="difficulty_bool", mesh=False)
+            try:
+                verdicts[value] = _domain_refused(sim.create_world, terrain="stairs", difficulty=value)
+            finally:
+                sim.cleanup()
+        assert verdicts == {True: True, False: True}
+
+    @pytest.mark.parametrize("value", [v for _, v in USABLE], ids=[n for n, _ in USABLE])
+    def test_a_usable_scale_is_still_compiled_into_the_heightfield(self, value: Any) -> None:
+        """The accepted domain is unchanged: the scale still reaches the hfield."""
+        sim = Simulation(tool_name="difficulty_ok", mesh=False)
+        try:
+            result = _create_world(sim.create_world, terrain="stairs", difficulty=value)
+            assert result["status"] == "success", result
+            assert sim._world is not None
+            model = sim._world._model
+            # hfield_size is (radius_x, radius_y, elevation, base_depth): the
+            # third component is the peak the curriculum scales.
+            assert float(model.hfield_size[0][2]) == pytest.approx(terrain_elevation(float(value)), abs=1e-9)
+        finally:
+            sim.cleanup()
+
+
+class TestEveryBackendAgreesOnTheDomain:
+    """A scale one ``create_world`` refuses cannot be honored by another."""
+
+    @pytest.mark.parametrize("value", [v for _, v in UNUSABLE], ids=[n for n, _ in UNUSABLE])
+    def test_an_unusable_scale_is_refused_on_every_backend(self, value: Any) -> None:
+        sim = Simulation(tool_name="difficulty_parity", mesh=False)
+        try:
+            verdicts = {"mujoco": _domain_refused(sim.create_world, terrain="stairs", difficulty=value)}
+        finally:
+            sim.cleanup()
+        for name, target in _backend_create_world_targets().items():
+            verdicts[name] = _domain_refused(target, difficulty=value)
+        assert verdicts == dict.fromkeys(verdicts, True), f"backends disagree for {value!r}: {verdicts}"
+
+    @pytest.mark.parametrize("value", [v for _, v in USABLE], ids=[n for n, _ in USABLE])
+    def test_a_usable_scale_is_not_domain_refused_on_any_backend(self, value: Any) -> None:
+        """Newton/Isaac may still reject it as inert - but not as an unusable number."""
+        sim = Simulation(tool_name="difficulty_parity_ok", mesh=False)
+        try:
+            verdicts = {"mujoco": _domain_refused(sim.create_world, terrain="stairs", difficulty=value)}
+        finally:
+            sim.cleanup()
+        for name, target in _backend_create_world_targets().items():
+            verdicts[name] = _domain_refused(target, difficulty=value)
+        assert verdicts == dict.fromkeys(verdicts, False), f"backends disagree for {value!r}: {verdicts}"
+
+
+class TestValidateDifficultyIsTheBindingOverTheSharedDomain:
+    """One owner, so the backends cannot drift from the shared positive-real rule."""
+
+    @pytest.mark.parametrize("value", [v for _, v in UNUSABLE + USABLE], ids=[n for n, _ in UNUSABLE + USABLE])
+    def test_it_raises_exactly_when_the_shared_domain_reports(self, value: Any) -> None:
+        shared_rejects = positive_finite_number_error(value, "difficulty", "terrain") is not None
+        try:
+            validate_difficulty(value)
+            binding_rejects = False
+        except ValueError:
+            binding_rejects = True
+        assert binding_rejects is shared_rejects, f"verdicts differ for {value!r}"
+
+    def test_it_never_raises_a_type_error(self) -> None:
+        """``TypeError`` is what escaped the callers' ``except ValueError``."""
+        for _, value in UNUSABLE:
+            with pytest.raises(ValueError):
+                validate_difficulty(value)
+
+
+class TestEveryCreateWorldRoutesThroughTheOneBinding:
+    """A fourth backend cannot ship ``difficulty`` with a domain of its own."""
+
+    @staticmethod
+    def _backend_modules() -> dict[str, ast.Module]:
+        # Derived from a symbol, not a path literal, so a scan that resolves
+        # somewhere else fails the non-vacuity test below rather than passing
+        # over an empty tree.
+        root = pathlib.Path(inspect.getfile(validate_difficulty)).parent
+        return {
+            path.parent.name: ast.parse(path.read_text(encoding="utf-8"))
+            for path in sorted(root.glob("*/simulation.py"))
+        }
+
+    @staticmethod
+    def _difficulty_create_worlds(module: ast.Module) -> list[ast.FunctionDef]:
+        found = []
+        for node in ast.walk(module):
+            if not isinstance(node, ast.FunctionDef) or node.name != "create_world":
+                continue
+            args = [a.arg for a in node.args.args + node.args.kwonlyargs]
+            if "difficulty" in args:
+                found.append(node)
+        return found
+
+    @staticmethod
+    def _calls_the_binding(fn: ast.FunctionDef) -> bool:
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "validate_difficulty":
+                return True
+        return False
+
+    def test_the_scan_finds_every_backend(self) -> None:
+        """Non-vacuity: an empty or mis-rooted scan must not read as clean."""
+        found = {name for name, module in self._backend_modules().items() if self._difficulty_create_worlds(module)}
+        assert found == {"mujoco", "newton", "isaac"}, found
+
+    def test_every_backend_calls_it(self) -> None:
+        adrift = [
+            f"{name}.create_world"
+            for name, module in self._backend_modules().items()
+            for fn in self._difficulty_create_worlds(module)
+            if not self._calls_the_binding(fn)
+        ]
+        assert not adrift, (
+            f"{adrift} accept difficulty= without reaching validate_difficulty; "
+            "a second copy of the domain drifts from the shared one"
+        )
+
+    def test_the_scanner_detects_a_planted_omission(self) -> None:
+        """Guard the guard: a scanner that matched nothing would look clean."""
+        planted = ast.parse(
+            "class Engine:\n"
+            "    def create_world(self, terrain=None, difficulty=1.0):\n"
+            "        return {'status': 'success'}\n"
+        )
+        found = self._difficulty_create_worlds(planted)
+        assert len(found) == 1
+        assert not self._calls_the_binding(found[0])


### PR DESCRIPTION
## Problem

`difficulty` scales a heightfield terrain's peak elevation — the curriculum knob a locomotion trainer ramps across resets. All three backends expose it on `create_world`, and all three read it through a bare `float(difficulty)`, so they disagreed on which values are *numbers* in the first place.

Measured on `create_world(terrain="pyramid", difficulty=X)` (MuJoCo) and `create_world(difficulty=X)` (Newton / Isaac):

| `difficulty=` | mujoco (honors it) | newton | isaac |
|---|---|---|---|
| `None` | **raised `TypeError`** | **raised `TypeError`** | **raised `TypeError`** |
| `[0.5]` | **raised `TypeError`** | **raised `TypeError`** | **raised `TypeError`** |
| `'abc'` | refused, but with `could not convert string to float: 'abc'` | **raised `ValueError`** | **raised `ValueError`** |
| `'0.5'` | **accepted**, honored as a 0.5 scale | refused (inert here) | refused (inert here) |
| `True` | **accepted** as a silent `1.0` | **accepted** | **accepted** |
| `False` | refused | refused (inert here) | refused (inert here) |

Four separate consequences:

1. **`TypeError` escapes the tool-result contract.** Every caller catches `ValueError` only, so `None` and `[0.5]` propagated out of a method documented to return `{"status": ...}`. On the MuJoCo path a curriculum ramp destroys the previous world before building the next one, so the escape left the trainer with **no world at all** — the measured ramp completed stages `0.5` and `1.0` and then died on a `None` third stage with `world after the abort: None`.
2. **A dead-end message.** `float()`'s own text names neither the parameter nor the surface, so `difficulty='abc'` reads as an internal fault rather than a caller mistake.
3. **The `bool` pair was asymmetric.** `bool` is an `int` subclass, so `True` passed the `<= 0` test as a silent `1.0` — a full-height terrain indistinguishable from the default — while `False` was refused as a zero scale. One spelling of "not a scale", two verdicts.
4. **A numeric string was silently honored** as a `0.5` elevation scale, a spelling every other continuous knob in the library refuses.

## Change

`simulation.terrain.validate_difficulty` becomes the raising binding over the shared `utils.positive_finite_number_error` — the same positive-real domain `control_frequency`, `duration` and the other continuous knobs are measured against — and all three `create_world` implementations report through that one binding. The MuJoCo path already called it inside `except ValueError`, so it needed no new call site; Newton and Isaac now route through it before the `float(difficulty)` test that was raising.

One owner means the accepted domain cannot drift: a scale one `create_world` refuses can no longer be honored by another, and the message a caller sees for a given value is identical on all three.

`positive_finite_number_error`'s docstring gains the consumer class it now serves (a dimensionless multiplier, alongside a rate and a span of time). Dropping `math.isfinite` from `terrain.py` removed its only use of `math`, so that import goes with it.

**The accepted domain is unchanged.** A positive finite real still compiles into the heightfield exactly as before — the three curriculum renders below are byte-identical on both trees.

## Visual verification

![create_world difficulty domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/difficulty-domain/difficulty_domain.png)

MuJoCo pyramid terrain, headless EGL render, a 0.5 kg ball dropped from z=2.0 m and settled over 500 steps so the compiled elevation is directly observable.

* **Top row — the accepted domain is untouched.** `difficulty` 0.5 / 1.0 / 6.0 compile hfield peaks of 0.04 / 0.08 / 0.48 m and the ball rests at z = 0.130 / 0.170 / 0.570 m. All three renders are **byte-identical across the two trees** (`max|delta| = 0`), and 1.0 vs 6.0 differ on 30.5% of pixels, so the scale is visibly and numerically honored exactly as before.
* **Middle row — a curriculum ramp whose third stage came back `None` from a config lookup**, driven with no `try`/`except` around `create_world` because the structured error *is* the contract. On `main` the ramp aborts with `TypeError: float() argument must be a string or a real number, not 'NoneType'` escaping from `simulation/terrain.py:94`, after the previous stage was already torn down. With this change the step is refused with `terrain difficulty must be a finite number > 0 (1.0 = full height), got None.` and the ramp falls back to `1.0` and keeps training.
* **Bottom row — the verdict matrix.** `main` has the three backends disagreeing on 4 of 6 values with 3 escaping the contract outright; with this change all 18 cells agree.

Every number in the figure is re-derived from the two measurement runs inside the generator, which asserts them before saving.

## Tests

`tests/simulation/test_create_world_difficulty_domain.py` (62 tests, 0.94 s, GL-free for the parity half):

* **MuJoCo, the backend that honors the value** — every unusable spelling is refused *through* the tool contract (never raised), the message names the parameter, the domain and the offending value, and the refusal precedes world construction (`sim._world is None`, so a rejected curriculum step leaves nothing half-built).
* **Both halves of the `bool` pair** are refused, pinning the corrected symmetry directly.
* **A usable scale still reaches the heightfield** — `0.5` / `1.0` / `2.0` / `np.float32(0.5)` / `int` all compile and `model.hfield_size[0][2] == terrain_elevation(difficulty)`.
* **Cross-backend parity** — for each value, all three `create_world` implementations agree on whether the *domain* refused it (matching on the shared refusal text, so a backend-specific "inert here" rejection is correctly not counted as a domain refusal).
* **The binding matches the shared domain** — `validate_difficulty` raises exactly when `positive_finite_number_error` reports, over the whole probe set, and never raises `TypeError`.
* **The measurement instrument itself** — the classifier the parity sweep reads verdicts from collects a library failure (`TypeError`, `ValueError`) as "not a domain refusal" *and* lets `KeyboardInterrupt` / `SystemExit` / `pytest.skip` / `pytest.fail` reach the runner, so an interrupt can never be recorded as a backend's answer about the domain.
* **A structural guard** — every `create_world` declaring `difficulty` must reach `validate_difficulty`, with a non-vacuity test asserting the scan finds all three backends and a planted-omission meta-test so a scanner that matched nothing could not read as clean.

Pre-fix, re-derived against the current base `39d8b1ff` by reverting the production half only: **32 failed, 30 passed**. The passing side are the over-reach controls (usable values already accepted, `nan`/`inf`/`0`/negative already refused), the two meta-tests and the six classifier tests — keeping them is what stops the guard reaching too far.

Blast radius: **zero existing test changes**. Every `difficulty=` value in the suite is a positive real, and `test_terrain.py`'s refusal test asserts the message names the parameter, which it still does.

## Docs

`docs/simulation/world-building.md` named the domain as "a finite value `> 0`"; it now names the full accepted domain (including that a `bool` and a numeric string are refused) and that every backend reports through the one domain.

## Gate (local, Thor, `MUJOCO_GL=egl`)

* `ruff check strands_robots tests tests_integ` — All checks passed
* `ruff format --check strands_robots tests tests_integ` — 1027 files already formatted
* `mypy strands_robots tests tests_integ` — Success: no issues found in 1024 source files
* `python -m pytest tests -q --no-cov -p no:randomly` — **17259 passed, 258 skipped** in 511 s
* `scripts/assemble_changelog.py --check` — OK (117 pending); the five repo-wide root guards — 42 passed
* `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` — No overlap


## Round 2 — the verdict classifier caught more than a verdict

Code scanning flagged `except BaseException` in `_domain_refused`, the helper that turns "what did this backend do with this value" into the bool the parity sweep compares. Measuring both widths over every outcome `create_world` can produce showed the alert was pointing at a real defect in the measurement instrument, not at an idiom needing annotation:

| outcome | `except BaseException` | `except Exception` | same |
|---|---|---|---|
| `TypeError` leaked by `float(None)` | collected: not a domain refusal | collected: not a domain refusal | yes |
| `ValueError` leaked by `float('abc')` | collected: not a domain refusal | collected: not a domain refusal | yes |
| structured domain refusal | collected: **domain refusal** | collected: **domain refusal** | yes |
| structured non-domain error | collected: not a domain refusal | collected: not a domain refusal | yes |
| success envelope | collected: not a domain refusal | collected: not a domain refusal | yes |
| `KeyboardInterrupt` | collected: not a domain refusal | **propagated** | no |
| `SystemExit` | collected: not a domain refusal | **propagated** | no |
| `pytest.skip.Exception` | collected: not a domain refusal | **propagated** | no |
| `pytest.fail.Exception` | collected: not a domain refusal | **propagated** | no |

All five API-outcome rows are identical, so narrowing costs this file nothing — the two escaping exceptions it exists to pin are still collected and still compared across backends. All four control-flow rows differ, and none of them is an answer about the domain: they derive from `BaseException` without deriving from `Exception`, so the wide handler recorded an operator's Ctrl-C as `False` (“this backend did not refuse the value”), compared that against the other two backends and carried on sweeping. A `skip` or `fail` raised from a backend stub became a verdict instead of reaching the runner.

Exactly one of the three candidate handlers satisfies both halves, which is why both are now pinned rather than just the one that was wrong:

| handler | library failure collected | control flow reaches the runner |
|---|---|---|
| `except BaseException` (before) | 2 passed | **4 failed** (`DID NOT RAISE`) |
| no handler at all | **2 failed** (`TypeError`/`ValueError` escape) | 4 passed |
| `except Exception` (this round) | 2 passed | 4 passed |

The control-flow half carries an executable premise (`assert not isinstance(exc, Exception)`) so it cannot quietly stop testing the width if one of those classes is ever reparented, and the classifier's docstring now states the boundary.

**No production line moves in this round** — the diff is `+62/-1` in the one test file. The whole-PR pre-fix proof is unchanged at **32 failures** against the current base, which is what shows the contract was not weakened while restructuring.