### PR TITLE
fix(sim): validate an add_object mass on every backend

### DIFF
--- a/changelog.d/1858-object-mass-domain-across-backends.md
+++ b/changelog.d/1858-object-mass-domain-across-backends.md
@@ -1,0 +1,41 @@
+### Fixed: `add_object` validates its `mass` on every simulation backend
+
+`SimEngine._validate_mass` is a static method on the base class all three
+backends inherit, and its docstring already states why the domain exists: a mass
+outside `(0, inf)` "does not merely mis-size one object - it poisons the whole
+world on the next step", since the solver shares one state vector. The MuJoCo
+backend has called it from `add_object` since object mass was hardened there; the
+Newton and Isaac backends inherited it and never called it. 15 of 18 measured
+cells diverged from the domain the base class defines.
+
+Newton stored the value verbatim, so `nan` / `inf` / `True` reached
+`builder.add_body(mass=...)` unchanged. A negative mass silently took the
+`obj.mass <= 0` static path, returning an immovable body on a value only `0` is
+documented to mean. A non-number was stored and then raised
+`TypeError: '<=' not supported between instances of 'str' and 'int'` out of both
+readers of that comparison - the solver rebuild and `list_objects` - so one bad
+`add_object` left an already-registered object that made a later, unrelated scene
+query raise.
+
+Isaac read the value exactly once, at `float(mass)` while assembling the result -
+after the prim was constructed, added to the scene, appended to the cleanup
+registry and entered in `_objects`. `mass="heavy"`, `[0.1]` and `None` therefore
+raised past the envelope `add_object` documents as its only failure channel with
+the object already on the stage, and retrying under the same name with a usable
+mass was refused as a duplicate: the name was permanently taken. The check now
+precedes prim construction, so a refused mass constructs nothing and leaves the
+name reusable.
+
+Isaac's success log line formatted the caller's raw `mass` with `%.3f` while the
+result reported the resolved one. For a static object the raw value is documented
+as ignored and is never coerced, so a non-numeric mass made the logging call raise
+`TypeError: must be real number` - latent, since it only fires when INFO logging
+is enabled. It now logs the resolved value, which is always a float and is the
+number the result reports, so the two cannot disagree.
+
+One documented difference is preserved and pinned: Newton documents `mass=0` as
+an alternative spelling of `is_static=True`, so a zero mass is a mode rather than
+a small mass and is not validated as a dynamic one. Isaac documents no such
+spelling and converges on the MuJoCo contract, refusing `0` with `is_static=True`
+named as the remedy. A static object's mass is read by nobody on any backend, so
+it is not validated there either.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -170,8 +170,9 @@ Because the joint-name and observation contract matches the MuJoCo backend,
 policies and observation mappings transfer unchanged between backends.
 
 The accepted *input* domain matches too, so a call one backend refuses is
-refused by all three. For the setup methods that means the pose vectors, the
-camera `fov` and the pixel dimensions - and the entity `name`: `add_robot`,
+refused by all three. For the setup methods that means the pose vectors, an
+object's `color` and `mass`, the camera `fov` and the pixel dimensions - and the
+entity `name`: `add_robot`,
 `add_object` and `add_camera` each require a non-empty string containing no NUL.
 That matters more here than on MuJoCo because the name is interpolated into the
 USD prim path (`{stage_path}/Robots/{name}`), so an unaddressable name does not
@@ -181,6 +182,13 @@ prunes its cleanup registry by that prefix. Unlike the MuJoCo backend there is
 no "derive a label from the model" short form: `name` is also the procedural
 lookup key, so `None` / `""` are refused rather than replaced with a generated
 label.
+
+The one deliberate difference in that list is `mass=0`. The Newton backend
+documents it as an alternative spelling of `is_static=True` and honours it, so it
+stays accepted there; this backend documents no such spelling, so a zero mass is
+refused with `is_static=True` named as the remedy - the MuJoCo contract these
+docs otherwise mirror. A static object's mass is read by nobody on any backend,
+so it is not validated there.
 
 Looking an entity *up* is the other half of that contract, and it answers rather
 than refuses: a name only *addresses* an entity here, so a name that cannot be a

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -224,8 +224,10 @@ sim.add_object("crate", shape="box", size=[0.5, 0.5, 0.5])   # 50 cm crate
 
 `mass` (kg) applies to dynamic objects and must be a finite number greater than
 zero - the same domain `set_body_properties(mass=...)` enforces when it writes
-the same body. A mass outside it is rejected up front, naming the parameter,
-instead of surfacing as a recompile failure:
+the same body, and the same one the Newton and Isaac backends' `add_object`
+applies, so a mass one backend refuses is refused by all three. A mass outside it
+is rejected up front, naming the parameter, instead of surfacing as a recompile
+failure:
 
 ```python
 sim.add_object("crate", shape="box", mass=0)
@@ -238,7 +240,10 @@ This matters beyond the one object: a body's mass divides every force acting on
 it, and the solver keeps a single state vector, so an infinite mass turns the
 whole world's `qpos`/`qvel` to `nan` on the next step - every other body
 included. `is_static=True` needs no mass (MuJoCo derives it from the geom's
-density), so `mass` is ignored there.
+density), so `mass` is ignored there - and not validated, on any backend, since
+nothing reads it. The Newton backend additionally documents `mass=0` as an
+alternative spelling of `is_static=True` and keeps accepting it; MuJoCo and Isaac
+refuse a zero mass and name that flag as the remedy.
 
 Whatever the reason for a rejection - mass, `size`, an unsupported `shape`, an
 unloadable mesh - the scene is rolled back to its previous compilable state and

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -1753,7 +1753,12 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             paint a colour that was not asked for. NumPy arrays are
             accepted. ``None`` -> default white.
         mass : float
-            Mass in kg. Default 0.1. Ignored when ``is_static=True``.
+            Mass in kg for a dynamic object; a finite number > 0. Default
+            0.1. Ignored when ``is_static=True``, and not validated there
+            since nothing reads it. Unlike the Newton backend there is no
+            ``mass=0`` "make it static" spelling - ``0`` is refused with
+            ``is_static=True`` named as the remedy, which is the MuJoCo
+            contract this backend's docs otherwise mirror.
         is_static : bool
             If ``True``, the prim is constructed via ``Fixed{Cuboid,
             Sphere, Cylinder, Capsule}`` and stays pinned in space. If
@@ -1780,6 +1785,16 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         Newton backends' ``add_object`` enforce, so a pose one backend refuses
         is refused by all three. Omit a vector to take its default; an empty
         vector is a wrong-length request rather than an omission.
+
+        ``mass`` must be a finite number > 0 for a dynamic object, on the shared
+        :meth:`~strands_robots.simulation.base.SimEngine._validate_mass` domain
+        the MuJoCo backend's ``add_object`` and ``set_body_properties`` enforce,
+        so a mass one backend refuses is refused by all three. It is checked
+        before the prim is constructed, because it used to be read *after* the
+        object was registered: ``float(mass)`` while assembling the result
+        raised for a non-number once the prim was already on the stage and in
+        ``_objects``, leaving the name permanently taken. A static object's mass
+        is never read, so it is not validated - the same scope MuJoCo uses.
 
         Returns
         -------
@@ -1885,6 +1900,19 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             color, _cerr = coerce_rgba("add_object", "color", color)
             if _cerr is not None:
                 return {"status": "error", "content": [{"text": _cerr}]}
+            # Same idea for the mass, on the shared ``_validate_mass`` domain the
+            # MuJoCo backend applies to the same quantity. Position matters as
+            # much as the check: the only place the raw value was read was
+            # ``float(mass)`` while assembling the result, which is AFTER
+            # ``_construct_shape_prim``, ``scene.add``, the ``_prim_registry``
+            # append and the ``_objects`` entry. A non-number therefore raised
+            # past the envelope this method documents as its only failure
+            # channel with the prim already on the stage and the name already
+            # taken - so the obvious recovery, retrying under the same name with
+            # a usable mass, was refused as a duplicate. Checked here, a refused
+            # mass constructs nothing and leaves the name reusable.
+            if not is_static and (mass_err := self._validate_mass(mass, "add_object")) is not None:
+                return mass_err
             scale_alias = kwargs.pop("scale", None)
             if size is None and scale_alias is not None:
                 size = scale_alias
@@ -1965,12 +1993,18 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 "mass": float(mass) if not is_static else 0.0,
                 "is_static": bool(is_static),
             }
+            # ``obj_info["mass"]``, not the caller's ``mass``: for a static object
+            # the raw value is documented as ignored and is never coerced, so
+            # formatting it with ``%.3f`` raised ``TypeError: must be real number``
+            # inside the logging call - only when INFO was enabled, which is why it
+            # sat latent. The resolved value is always a float and is the number
+            # this result reports, so the log and the payload cannot disagree.
             logger.info(
                 "Added object '%s' (shape=%s, pos=%s, mass=%.3f, static=%s)",
                 name,
                 shape,
                 pos,
-                mass,
+                obj_info["mass"],
                 is_static,
             )
             return {

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import math
+import numbers
 import os
 import sys
 import threading
@@ -62,6 +63,7 @@ from strands_robots.utils import (
     coerce_pose_vector,
     coerce_rgba,
     entity_name_error,
+    is_boolean,
     positive_count_error,
     require_optional,
 )
@@ -126,6 +128,29 @@ def _quat_rotate_inverse_wxyz(quat_wxyz: list[float], vec: list[float]) -> list[
     b = np.cross(q_vec, v) * (w * 2.0)
     c = q_vec * (float(np.dot(q_vec, v)) * 2.0)
     return [float(t) for t in (a - b + c)]
+
+
+def _is_zero_mass_sentinel(mass: Any) -> bool:
+    """Whether ``mass`` is Newton's documented "make it static" spelling.
+
+    ``add_object`` documents ``mass=0`` as an alternative spelling of
+    ``is_static=True``, and :meth:`NewtonSimEngine._add_object_to_builder`
+    honours it by taking the static path. A zero mass is therefore a *mode*
+    rather than a small mass, so it is not validated as a dynamic one - which is
+    the single place this backend's accepted mass domain differs from the
+    MuJoCo backend's.
+
+    ``bool`` is excluded even though ``False == 0`` is true: a boolean is
+    refused on every backend rather than being read as a spelling of the
+    sentinel, since ``float(True)`` would otherwise mean a silent 1 kg body.
+
+    Args:
+        mass: The caller-supplied value.
+
+    Returns:
+        ``True`` only for a real, non-``bool`` number equal to zero.
+    """
+    return isinstance(mass, numbers.Real) and not is_boolean(mass) and float(mass) == 0.0
 
 
 class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine):
@@ -620,6 +645,14 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         :func:`~strands_robots.utils.coerce_pose_vector` domain, so a pose one
         backend refuses is refused by both.
 
+        ``mass`` must be a finite number > 0 for a dynamic object, the domain
+        :meth:`~strands_robots.simulation.base.SimEngine._validate_mass`
+        defines and the MuJoCo backend's ``add_object`` already enforces, so a
+        mass one backend refuses is refused by both. ``mass=0`` is the one
+        documented exception: it is this backend's alternative spelling of
+        ``is_static=True`` and stays accepted. A static object's mass is never
+        read, so it is not validated - the same scope MuJoCo uses.
+
         Args:
             name: Unique object name; a non-empty ``str`` containing no NUL, the
                 same domain the MuJoCo backend's ``add_object`` accepts
@@ -637,7 +670,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 other component count is refused rather than padded or
                 truncated, since either would paint a colour that was not
                 asked for. NumPy arrays are accepted.
-            mass: Object mass; ``0`` or ``is_static`` makes it static.
+            mass: Object mass in kg; a finite number > 0 for a dynamic
+                object. ``0`` or ``is_static`` makes it static instead, and
+                a static object's mass is not read. Any other value -
+                negative, ``nan``, ``inf``, a ``bool`` or a non-number - is
+                refused rather than handed to the solver rebuild.
             is_static: When True the object is fixed in the world.
             mesh_path: Path to a mesh asset (``.obj`` / ``.stl`` / ``.glb`` /
                 ``.usd`` -- anything ``trimesh.load`` accepts). Required and
@@ -693,6 +730,21 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         color, _cerr = coerce_rgba("add_object", "color", color)
         if _cerr is not None:
             return {"status": "error", "content": [{"text": _cerr}]}
+        # A dynamic body's mass is the divisor of every force applied to it and
+        # reaches the solver as ``builder.add_body(mass=...)``, so it goes
+        # through the same shared domain the MuJoCo backend's ``add_object``
+        # applies to the same quantity. Storing it raw was wrong in three ways.
+        # ``nan``/``inf``/``True`` reached that call verbatim. A negative mass
+        # silently took the ``obj.mass <= 0`` static path, making the body
+        # immovable on a value only ``0`` is documented to mean. And a
+        # non-number was stored, then raised
+        # ``TypeError: '<=' not supported between instances of 'str' and 'int'``
+        # out of BOTH consumers of that comparison - the rebuild and
+        # ``list_objects`` - so one bad add left an already-registered object
+        # that made a later, unrelated scene query raise.
+        if not is_static and not _is_zero_mass_sentinel(mass):
+            if (mass_err := self._validate_mass(mass, "add_object")) is not None:
+                return mass_err
         if material is not None:
             return {
                 "status": "error",

--- a/tests/simulation/newton/test_mesh_objects.py
+++ b/tests/simulation/newton/test_mesh_objects.py
@@ -20,6 +20,7 @@ import types
 import numpy as np
 import pytest
 
+from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.models import SimObject
 from strands_robots.simulation.newton.simulation import NewtonSimEngine
 
@@ -42,7 +43,12 @@ class TestAddObjectValidation:
     """Error paths return before the model rebuild, so a stub engine suffices."""
 
     def _stub(self):
-        return types.SimpleNamespace(_world=types.SimpleNamespace(objects={}))
+        # ``_validate_mass`` is inherited from SimEngine, so a real engine
+        # always has it; ``add_object`` routes its ``mass`` through it.
+        return types.SimpleNamespace(
+            _world=types.SimpleNamespace(objects={}),
+            _validate_mass=SimEngine._validate_mass,
+        )
 
     def test_mesh_without_mesh_path_is_rejected(self):
         result = NewtonSimEngine.add_object(self._stub(), name="tool", shape="mesh")

--- a/tests/simulation/test_entity_name_domain_at_creation.py
+++ b/tests/simulation/test_entity_name_domain_at_creation.py
@@ -69,6 +69,7 @@ import types
 
 import pytest
 
+from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.simulation import IsaacConfig, IsaacSimulation
 from strands_robots.simulation.newton.simulation import NewtonSimEngine
 from strands_robots.utils import entity_name_error
@@ -331,6 +332,8 @@ def _newton_stub() -> types.SimpleNamespace:
         _world=types.SimpleNamespace(objects={}, cameras={}, robots={}),
         _model=types.SimpleNamespace(body_label=["ground"]),
         _lock=threading.RLock(),
+        # Inherited from SimEngine, and read by ``add_object`` for its ``mass``.
+        _validate_mass=SimEngine._validate_mass,
     )
 
 

--- a/tests/simulation/test_object_mass_domain_across_backends.py
+++ b/tests/simulation/test_object_mass_domain_across_backends.py
@@ -1,0 +1,361 @@
+"""Regression tests: every backend validates an ``add_object`` mass.
+
+``SimEngine._validate_mass`` is a static method on the base class all three
+backends inherit, and its docstring states the invariant these tests pin: a mass
+outside ``(0, inf)`` "does not merely mis-size one object - it poisons the whole
+world on the next step", and it is "the same domain ``set_body_properties``
+already enforces when it writes the same ``body_mass`` field, so a mass cannot be
+established at creation on terms the setter would refuse". The MuJoCo backend has
+called it from ``add_object`` since object mass was hardened there. The Newton and
+Isaac backends inherited it and never called it.
+
+Measured on the 8-value probe set below, one ``add_object`` per case, with no
+``newton`` / ``warp`` / ``isaacsim`` installed - 15 of 18 cells diverged from the
+domain the base class defines:
+
+* Newton stored every value verbatim on the registry entry. ``nan`` / ``inf`` /
+  ``True`` reached ``builder.add_body(mass=...)`` unchanged. A *negative* mass
+  silently took the ``obj.mass <= 0`` static path, so a body asked for at -1 kg
+  came back immovable on a value only ``0`` is documented to mean. And a
+  non-number was stored and then raised ``TypeError: '<=' not supported between
+  instances of 'str' and 'int'`` out of BOTH readers of that comparison - the
+  solver rebuild and ``list_objects`` - so one bad ``add_object`` left an
+  already-registered object that made a later, unrelated scene query raise.
+* Isaac forwarded it raw to the prim constructor and read it exactly once, at
+  ``float(mass)`` while assembling the result. That is *after* the prim is
+  constructed, after ``world.scene.add``, after the ``_prim_registry`` append and
+  after the ``_objects`` entry - so ``mass="heavy"``, ``[0.1]`` and ``None``
+  raised past the envelope this method documents as its only failure channel with
+  the object already on the stage and registered. The obvious recovery, retrying
+  under the same name with a usable mass, was then refused as a duplicate: the
+  name was permanently taken.
+
+One documented difference survives, and is pinned here rather than left to be
+inferred: Newton documents ``mass=0`` as an alternative spelling of
+``is_static=True`` and its rebuild honours it, so a zero mass is a *mode* rather
+than a small mass and is not validated as a dynamic one. Isaac documents no such
+spelling, so it converges on the MuJoCo contract and refuses ``0`` naming
+``is_static=True`` as the remedy. A static object's mass is read by nobody on any
+backend, so it is not validated there either - the scope MuJoCo already uses.
+
+``TestNoObjectMassSurfaceDrifts`` keeps it that way structurally: every public
+method of a backend engine class that takes a ``mass`` parameter must route it
+through the shared helper.
+
+What is NOT in scope, and is asserted to be unchanged in
+``tests/simulation/test_pose_vector_domain_across_backends.py``: ``size``. Its
+component counts are shape-dependent and the Isaac ``add_object`` docstring
+promises a trailing-component fallback for a short ``size`` that neither other
+backend offers, so it needs that contract settled before it can share a domain.
+
+These tests are GL-free and need neither ``newton``/``warp`` nor ``isaacsim`` nor
+a GPU: every guard runs before its method touches a solver or a stage, so calling
+the unbound method with a small stand-in for ``self`` exercises it in every
+environment.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import textwrap
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation import base as sim_base
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.newton.simulation import NewtonSimEngine, _is_zero_mass_sentinel
+from tests.simulation.test_pose_vector_domain_across_backends import _isaac_stub, _newton_stub
+
+NAN = float("nan")
+INF = float("inf")
+
+#: Masses no dynamic object can be given. The two non-finite values (``inf``
+#: makes the first integration produce ``nan`` acceleration, and the solver
+#: shares one state vector, so every *other* body goes ``nan`` with it), a
+#: negative and a zero, a ``bool`` (an ``int`` subclass, so ``float(True)``
+#: would mean a silent 1 kg body), and three non-numbers - the classes that
+#: reached a ``<=`` comparison or a ``float()`` and raised there instead.
+UNUSABLE_MASSES: tuple[Any, ...] = (0.0, -1.0, NAN, INF, True, "heavy", [0.1], None)
+
+#: The same set minus Newton's documented ``0`` sentinel.
+UNUSABLE_DYNAMIC_MASSES: tuple[Any, ...] = tuple(m for m in UNUSABLE_MASSES if m is not UNUSABLE_MASSES[0])
+
+#: Accepted spellings of a usable mass, including the NumPy scalar a config
+#: array or a randomization draw produces.
+GOOD_MASSES: tuple[Any, ...] = (0.5, 2, 1e-9)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+def _newton() -> Any:
+    """A Newton stand-in that also carries the inherited mass validator."""
+    return _newton_stub()
+
+
+def _isaac_recording() -> tuple[Any, dict[str, int]]:
+    """An Isaac stand-in that counts what a refused call must never construct."""
+    stub = _isaac_stub()
+    calls = {"construct": 0, "scene_add": 0}
+
+    def construct(**kwargs: Any) -> tuple[Any, Any]:
+        calls["construct"] += 1
+        return object(), kwargs.get("size")
+
+    def scene_add(handle: Any) -> None:
+        calls["scene_add"] += 1
+
+    stub._construct_shape_prim = construct
+    stub._world.scene.add = scene_add
+    return stub, calls
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheSharedDomain:
+    """``SimEngine._validate_mass`` is the single definition all three share."""
+
+    @pytest.mark.parametrize("mass", UNUSABLE_MASSES)
+    def test_an_unusable_mass_is_refused(self, mass: Any) -> None:
+        result = SimEngine._validate_mass(mass, "add_object")
+        assert result is not None, mass
+        assert result["status"] == "error"
+        assert "'mass'" in _text(result)
+
+    @pytest.mark.parametrize("mass", GOOD_MASSES)
+    def test_a_usable_mass_is_accepted(self, mass: Any) -> None:
+        assert SimEngine._validate_mass(mass, "add_object") is None, mass
+
+    def test_the_zero_sentinel_predicate_excludes_bool(self) -> None:
+        """``False == 0`` is true, so the sentinel test must not accept it.
+
+        Newton's ``0`` spelling of ``is_static=True`` is the one value that skips
+        the shared domain. Reading a ``bool`` as that spelling would hand the
+        backend a boolean under a success result, which is what every backend
+        refuses.
+        """
+        assert _is_zero_mass_sentinel(0.0) is True
+        assert _is_zero_mass_sentinel(0) is True
+        assert _is_zero_mass_sentinel(False) is False
+        assert _is_zero_mass_sentinel(True) is False
+        assert _is_zero_mass_sentinel(0.5) is False
+        assert _is_zero_mass_sentinel("0") is False
+        assert _is_zero_mass_sentinel(None) is False
+
+
+# --------------------------------------------------------------------------- #
+# Newton                                                                      #
+# --------------------------------------------------------------------------- #
+class TestNewtonAddObject:
+    @pytest.mark.parametrize("mass", UNUSABLE_DYNAMIC_MASSES)
+    def test_an_unusable_mass_is_refused(self, mass: Any) -> None:
+        result = NewtonSimEngine.add_object(_newton(), "crate", mass=mass)
+        assert result["status"] == "error", (mass, result)
+        assert "'mass'" in _text(result)
+
+    @pytest.mark.parametrize("mass", UNUSABLE_DYNAMIC_MASSES)
+    def test_a_refused_mass_registers_no_object(self, mass: Any) -> None:
+        """No half-placed object, so the name stays reusable.
+
+        Pre-fix every one of these registered the crate with the value stored
+        verbatim on its :class:`SimObject`.
+        """
+        stub = _newton()
+        NewtonSimEngine.add_object(stub, "crate", mass=mass)
+        assert dict(stub._world.objects) == {}
+
+    @pytest.mark.parametrize("mass", ("heavy", [0.1], None))
+    def test_a_refused_mass_leaves_list_objects_usable(self, mass: Any) -> None:
+        """A later, unrelated scene query still answers.
+
+        ``list_objects`` and ``_add_object_to_builder`` both classify an object
+        with ``obj.is_static or obj.mass <= 0``. Pre-fix a non-numeric mass was
+        registered and that comparison then raised ``TypeError: '<=' not
+        supported between instances of 'str' and 'int'`` - so one bad
+        ``add_object`` made ``list_objects()`` raise for as long as the object
+        stayed in the registry.
+        """
+        stub = _newton()
+        NewtonSimEngine.add_object(stub, "crate", mass=mass)
+        listed = NewtonSimEngine.list_objects(stub)
+        assert listed["status"] == "success", listed
+
+    def test_the_documented_zero_sentinel_is_still_accepted(self) -> None:
+        """Documented: "``0`` or ``is_static`` makes it static"."""
+        stub = _newton()
+        assert NewtonSimEngine.add_object(stub, "crate", mass=0.0)["status"] == "success"
+        assert stub._world.objects["crate"].mass == 0.0
+
+    @pytest.mark.parametrize("mass", GOOD_MASSES)
+    def test_a_usable_mass_is_accepted_and_stored(self, mass: Any) -> None:
+        stub = _newton()
+        assert NewtonSimEngine.add_object(stub, "crate", mass=mass)["status"] == "success"
+        assert stub._world.objects["crate"].mass == mass
+
+    def test_an_omitted_mass_still_takes_the_documented_default(self) -> None:
+        stub = _newton()
+        assert NewtonSimEngine.add_object(stub, "crate")["status"] == "success"
+        assert stub._world.objects["crate"].mass == 0.1
+
+    @pytest.mark.parametrize("mass", UNUSABLE_DYNAMIC_MASSES)
+    def test_a_static_object_does_not_have_its_mass_read(self, mass: Any) -> None:
+        """Scope, deliberately matching MuJoCo's.
+
+        Both consumers of the value short-circuit on ``obj.is_static``, so a
+        static object's mass reaches nothing. Validating it would refuse a call
+        whose outcome the value cannot change.
+        """
+        stub = _newton()
+        result = NewtonSimEngine.add_object(stub, "crate", mass=mass, is_static=True)
+        assert result["status"] == "success", (mass, result)
+        assert "crate" in stub._world.objects
+
+
+# --------------------------------------------------------------------------- #
+# Isaac                                                                       #
+# --------------------------------------------------------------------------- #
+class TestIsaacAddObject:
+    @pytest.mark.parametrize("mass", UNUSABLE_MASSES)
+    def test_an_unusable_mass_is_refused(self, mass: Any) -> None:
+        stub, _ = _isaac_recording()
+        result = IsaacSimulation.add_object(stub, "crate", mass=mass)
+        assert result["status"] == "error", (mass, result)
+        assert "'mass'" in _text(result)
+
+    @pytest.mark.parametrize("mass", UNUSABLE_MASSES)
+    def test_a_refused_mass_constructs_and_registers_nothing(self, mass: Any) -> None:
+        """The property the raise used to break.
+
+        Pre-fix the value was read only at ``float(mass)`` while assembling the
+        result, so for ``"heavy"`` / ``[0.1]`` / ``None`` the prim was already
+        constructed, added to the scene, appended to ``_prim_registry`` and
+        entered in ``_objects`` before the raise escaped.
+        """
+        stub, calls = _isaac_recording()
+        IsaacSimulation.add_object(stub, "crate", mass=mass)
+        assert dict(stub._objects) == {}
+        assert stub._prim_registry == []
+        assert calls == {"construct": 0, "scene_add": 0}
+
+    @pytest.mark.parametrize("mass", UNUSABLE_MASSES)
+    def test_the_name_stays_reusable_after_a_refused_mass(self, mass: Any) -> None:
+        """Pre-fix the retry was refused with "Object 'crate' already exists."."""
+        stub, _ = _isaac_recording()
+        IsaacSimulation.add_object(stub, "crate", mass=mass)
+        retry = IsaacSimulation.add_object(stub, "crate", mass=0.5)
+        assert retry["status"] == "success", retry
+        assert "crate" in stub._objects
+
+    def test_a_zero_mass_is_refused_with_the_static_remedy(self) -> None:
+        """Isaac documents no ``mass=0`` spelling, so it takes MuJoCo's contract.
+
+        ``0`` is not a usable mass for a dynamic body on either backend, and the
+        Isaac docstring only says the value is "Ignored when ``is_static=True``"
+        - so the remedy is that flag rather than a zero.
+        """
+        stub, _ = _isaac_recording()
+        result = IsaacSimulation.add_object(stub, "crate", mass=0.0)
+        assert result["status"] == "error", result
+        assert "'mass'" in _text(result)
+
+    @pytest.mark.parametrize("mass", GOOD_MASSES)
+    def test_a_usable_mass_is_accepted_and_reported(self, mass: Any) -> None:
+        stub, calls = _isaac_recording()
+        result = IsaacSimulation.add_object(stub, "crate", mass=mass)
+        assert result["status"] == "success", (mass, result)
+        assert result["content"][0]["json"]["mass"] == pytest.approx(float(mass))
+        assert calls == {"construct": 1, "scene_add": 1}
+
+    @pytest.mark.parametrize("mass", UNUSABLE_MASSES)
+    def test_a_static_object_does_not_have_its_mass_read(self, mass: Any) -> None:
+        """Scope, matching MuJoCo's: the result reports 0.0 for a static object."""
+        stub, _ = _isaac_recording()
+        result = IsaacSimulation.add_object(stub, "crate", mass=mass, is_static=True)
+        assert result["status"] == "success", (mass, result)
+        assert result["content"][0]["json"]["mass"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Structural guard                                                            #
+# --------------------------------------------------------------------------- #
+#: Every public engine-class method that takes a ``mass``, as ``(backend,
+#: method)``. Asserted exactly, so a scan root that resolved elsewhere fails
+#: loudly instead of reporting a clean sweep over nothing.
+_KNOWN_MASS_METHODS = {
+    ("mujoco", "add_object"),
+    ("mujoco", "set_body_properties"),
+    ("newton", "add_object"),
+    ("isaac", "add_object"),
+}
+
+
+def _scan_mass_methods(root: pathlib.Path) -> tuple[set[tuple[str, str]], list[str]]:
+    """Find public engine-class methods taking ``mass``, and which skip the domain.
+
+    Scoped to class methods deliberately: ``_construct_shape_prim`` and the
+    Newton object builder also take a mass, but they are private helpers reached
+    only from an already-validated ``add_object``.
+
+    Args:
+        root: The ``strands_robots/simulation`` package directory.
+
+    Returns:
+        ``(found, adrift)`` - every ``(backend, method)`` pair, and the ones with
+        no call to ``_validate_mass``.
+    """
+    found: set[tuple[str, str]] = set()
+    adrift: list[str] = []
+    for backend in ("mujoco", "newton", "isaac"):
+        for path in sorted((root / backend).glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+                for fn in [n for n in cls.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]:
+                    if fn.name.startswith("_"):
+                        continue
+                    if "mass" not in [a.arg for a in fn.args.args + fn.args.kwonlyargs]:
+                        continue
+                    found.add((backend, fn.name))
+                    validates = any(
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr == "_validate_mass"
+                        for node in ast.walk(fn)
+                    )
+                    if not validates:
+                        adrift.append(f"{backend}/{path.name}:{fn.lineno} {cls.name}.{fn.name}")
+    return found, adrift
+
+
+class TestNoObjectMassSurfaceDrifts:
+    """A backend method taking a ``mass`` must route it through the domain."""
+
+    def test_every_public_mass_surface_validates(self) -> None:
+        root = pathlib.Path(inspect.getfile(sim_base)).parent
+        found, adrift = _scan_mass_methods(root)
+        assert found == _KNOWN_MASS_METHODS, f"the set of mass surfaces changed: {found}"
+        assert adrift == [], "these accept a mass without the shared domain: " + ", ".join(adrift)
+
+    def test_the_scanner_reports_a_planted_omission(self, tmp_path: pathlib.Path) -> None:
+        """Without this, an empty result could mean a scanner matching nothing."""
+        backend = tmp_path / "mujoco"
+        backend.mkdir()
+        (backend / "simulation.py").write_text(
+            textwrap.dedent(
+                """
+                class Engine:
+                    def add_object(self, name, mass=0.1):
+                        return {"status": "success"}
+                """
+            ),
+            encoding="utf-8",
+        )
+        found, adrift = _scan_mass_methods(tmp_path)
+        assert found == {("mujoco", "add_object")}
+        assert len(adrift) == 1
+        assert "Engine.add_object" in adrift[0]

--- a/tests/simulation/test_pose_vector_domain_across_backends.py
+++ b/tests/simulation/test_pose_vector_domain_across_backends.py
@@ -39,14 +39,15 @@ class methods deliberately - ``scene_ops.reposition_body_in_scene`` is a
 module-level spec helper reached only from the already-validated
 ``move_object``, and it returns ``bool`` rather than the agent-tool envelope.
 
-What is NOT in scope, and is asserted to be unchanged: ``size`` and ``mass``.
-``size`` component counts are shape-dependent and documented differently per
-backend (the Isaac ``add_object`` docstring promises a trailing-component
-fallback for a short ``size`` that neither other backend offers), and ``mass=0``
-is documented on Newton as "make it static" - so those need their own domain
-decision rather than riding along here. ``color`` was in that list until its
-accepted counts were settled on the shared ``coerce_rgba`` domain; it is now
-pinned in ``tests/simulation/test_color_domain_across_backends.py``.
+What is NOT in scope, and is asserted to be unchanged: ``size``. Its component
+counts are shape-dependent and documented differently per backend (the Isaac
+``add_object`` docstring promises a trailing-component fallback for a short
+``size`` that neither other backend offers), so it needs its own domain decision
+rather than riding along here. ``color`` and ``mass`` were in that list until
+their domains were settled - on the shared ``coerce_rgba`` and
+``SimEngine._validate_mass`` respectively - and are now pinned in
+``tests/simulation/test_color_domain_across_backends.py`` and
+``tests/simulation/test_object_mass_domain_across_backends.py``.
 
 These tests are GL-free and need neither ``newton``/``warp`` nor ``isaacsim``
 nor a GPU: every guard runs before its method touches a solver or a stage, so
@@ -166,6 +167,10 @@ def _newton_stub() -> Any:
         _lock=threading.RLock(),
         _robot_joint_map={},
         _rebuild=lambda: None,
+        # Inherited from SimEngine, so a real engine always has it. add_object
+        # routes its ``mass`` through it, and a stand-in that omitted it would
+        # make that guard look absent rather than unexercised.
+        _validate_mass=SimEngine._validate_mass,
     )
     return stub
 
@@ -316,6 +321,7 @@ def _isaac_stub() -> Any:
         _prim_registry=[],
         _world=types.SimpleNamespace(scene=types.SimpleNamespace(add=lambda handle: None)),
         _construct_shape_prim=lambda **kwargs: (object(), kwargs.get("size")),
+        _validate_mass=SimEngine._validate_mass,
     )
 
 
@@ -569,27 +575,29 @@ class TestEveryBackendGivesTheSameVerdict:
 # --------------------------------------------------------------------------- #
 # The out-of-scope parameters are pinned as unchanged                          #
 # --------------------------------------------------------------------------- #
-class TestSizeAndMassAreOutOfScope:
-    """This change is the pose axis only; the rest keep their current contract.
+class TestSizeIsOutOfScope:
+    """This change is the pose axis only; ``size`` keeps its current contract.
 
-    ``size`` counts are shape-dependent and documented differently per backend,
-    and ``mass=0`` is documented on Newton as "make it static", so each needs
-    its own domain decision. Pinning them here makes that scope a stated
-    property rather than an omission a later reader has to infer. ``color`` is
-    no longer among them - its counts are settled on the shared ``coerce_rgba``
-    domain, pinned in ``tests/simulation/test_color_domain_across_backends.py``.
+    Its component counts are shape-dependent and documented differently per
+    backend - the Isaac ``add_object`` docstring promises a trailing-component
+    fallback for a short ``size`` that neither other backend offers - so it needs
+    that contract settled before it can share a domain. Pinning it here makes
+    that scope a stated property rather than an omission a later reader has to
+    infer.
+
+    Two axes have since left this list. ``color`` counts are settled on the
+    shared ``coerce_rgba`` domain, pinned in
+    ``tests/simulation/test_color_domain_across_backends.py``; ``mass`` is
+    settled on the shared ``SimEngine._validate_mass`` domain, pinned in
+    ``tests/simulation/test_object_mass_domain_across_backends.py`` - including
+    the ``mass=0`` "make it static" spelling Newton documents, which is the one
+    place the three backends' accepted masses legitimately differ.
     """
 
     def test_a_short_size_still_takes_the_backend_default(self):
         stub = _newton_stub()
         assert NewtonSimEngine.add_object(stub, "crate", size=[])["status"] == "success"
         assert stub._world.objects["crate"].size == [0.05, 0.05, 0.05]
-
-    def test_a_zero_mass_is_still_accepted_on_newton(self):
-        """Documented: "``0`` or ``is_static`` makes it static"."""
-        stub = _newton_stub()
-        assert NewtonSimEngine.add_object(stub, "crate", mass=0.0)["status"] == "success"
-        assert stub._world.objects["crate"].mass == 0.0
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
`SimEngine._validate_mass` is a static method on the base class **all three backends inherit**, and its docstring already states why the domain exists: a mass outside `(0, inf)` "does not merely mis-size one object - it poisons the whole world on the next step", since the solver shares one state vector. The MuJoCo backend has called it from `add_object` since object mass was hardened there. Newton and Isaac inherited it and never called it.

Measured on an 8-value probe set, one `add_object` per case, with no `newton` / `warp` / `isaacsim` installed: **15 of 18 cells diverged** from the domain the base class defines.

![add_object mass domain across backends](https://raw.githubusercontent.com/cagataycali/robots/artifacts/object-mass-domain/mass_domain.png)

## What each backend did

**Newton** stored the value verbatim on the registry entry, so `nan` / `inf` / `True` reached `builder.add_body(mass=...)` unchanged. Two consequences beyond that:

- A **negative** mass silently took the `obj.mass <= 0` static path, so a body asked for at -1 kg came back immovable - on a value only `0` is documented to mean.
- A **non-number** was stored and then raised `TypeError: '<=' not supported between instances of 'str' and 'int'` out of *both* readers of that comparison, the solver rebuild **and** `list_objects`. One bad `add_object` therefore left an already-registered object that made a later, unrelated scene query raise.

**Isaac** forwarded it raw to the prim constructor and read it exactly once, at `float(mass)` while assembling the result - which is *after* `_construct_shape_prim`, after `world.scene.add`, after the `_prim_registry` append and after the `_objects` entry. So `mass="heavy"`, `[0.1]` and `None` raised past the envelope `add_object` documents as its only failure channel, with the object already on the stage:

```
mass="heavy": raised ValueError: could not convert string to float: 'heavy'
   _objects registered : ['crate']
   scene.add() called  : 1 time(s)
   _prim_registry      : 1 entry(ies)
   retry with a good mass -> error: Object 'crate' already exists.
```

The obvious recovery - retrying under the same name with a usable mass - was refused as a duplicate. The name was permanently taken. The check now precedes prim construction, so a refused mass constructs nothing and leaves the name reusable.

Isaac's success **log line** also formatted the caller's raw `mass` with `%.3f` while the result reported the resolved one. For a static object the raw value is documented as ignored and is never coerced, so a non-numeric mass made the logging call raise `TypeError: must be real number` - latent, because it only fires when INFO logging is enabled. It now logs the resolved value, which is always a float and is the number the result reports, so the two cannot disagree.

## What is preserved, and pinned

One documented difference survives, and is asserted rather than left to be inferred:

| call | verdict |
| --- | --- |
| Newton `add_object(mass=0)` | success, static - its documented alternative spelling of `is_static=True`, honoured by the rebuild |
| Isaac / MuJoCo `add_object(mass=0)` | refused, naming `is_static=True` as the remedy - neither documents a zero spelling |
| any backend, `is_static=True` | mass not validated; nothing reads it (both Newton readers short-circuit on `is_static`, and Isaac reports `0.0`) |
| any backend, `mass` omitted | success, the backend's documented 0.1 kg default |

A zero mass on Newton is a *mode* rather than a small mass, so it is not validated as a dynamic one. `_is_zero_mass_sentinel` excludes `bool` deliberately: `False == 0` is true, and reading a boolean as that spelling would hand the backend a boolean under a success result.

## Scope

This is the `mass` axis only, mirroring how the reference backend's own contract was settled one axis at a time (`size` #1640, `mass` #1642, `color` #1643, pose #1665). `size` stays out of scope and is still asserted unchanged: its component counts are shape-dependent and the Isaac `add_object` docstring promises a trailing-component fallback for a short `size` that neither other backend offers, so that contract needs settling before it can share a domain. #1858 stays open for it.

No new helper was added - the domain already existed on the base class, so this is wiring plus the guard placement Isaac needed.

`TestNoObjectMassSurfaceDrifts` keeps it structural: every public engine-class method taking a `mass` (`mujoco.add_object`, `mujoco.set_body_properties`, `newton.add_object`, `isaac.add_object`) must route it through the shared helper. Scoped to class methods deliberately - `_construct_shape_prim` and the Newton object builder also take a mass, but they are private helpers reached only from an already-validated `add_object`. A planted-omission meta-test proves the scanner is not matching nothing.

The shared Newton and Isaac test doubles gained the inherited `_validate_mass` they were missing (three files), and the "size and mass are out of scope" pin narrows to `size`.

## Verification

Pre-fix, with only the two backend sources reverted to `29bd55df` and the tests in place: **43 failed / 35 passed**. Representative failures quote the defect verbatim:

```
FAILED ...::test_a_refused_mass_leaves_list_objects_usable[heavy]
  - TypeError: '<=' not supported between instances of 'str' and 'int'
FAILED ...::TestIsaacAddObject::test_an_unusable_mass_is_refused[0.0]
  - assert 'success' == 'error'
```

The 35 that pass pre-fix are the accepted-value controls, the `is_static` scope pins, the documented-default pins and the planted-defect meta-test - they are what stop the guard over-reaching. Post-fix: **79 passed**.

Full gate on the rebased tree (base `29bd55df`, which contains #1857):

- `MUJOCO_GL=egl pytest tests` -> **17337 passed, 258 skipped, 0 failed** (484s)
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (1025 source files)
- `scripts/check_merge_base_overlap.py` -> no overlap; `assemble_changelog.py --check` -> OK

Rebased onto `29bd55df` after #1857 landed in the same two files. The rebase is byte-faithful: both diffs are 779 lines and the diff-of-diffs contains **zero** content lines, not even `@@` offsets. #1857's `difficulty` content is intact (13 references in `newton/simulation.py`, 12 in `isaac/simulation.py`), and the pre-fix proof was re-run against the new base with the same 43/35 result.

The MuJoCo render in the artifact is byte-comparable across the two trees (`max|delta| = 1` over 1 px of 492,800 - renderer noise): the reference backend is untouched. It is the definition the other two now share.

Settles the `mass` axis of #1858. Deliberately *not* phrased as a closing keyword: the `size` axis of that issue is untouched by this PR, so #1858 has to survive this merge to keep tracking it.