### PR TITLE
fix(sim): validate an add_object size vector on every backend

### DIFF
--- a/changelog.d/1861-object-size-vector-domain-across-backends.md
+++ b/changelog.d/1861-object-size-vector-domain-across-backends.md
@@ -1,0 +1,42 @@
+### Fixed: an `add_object` size vector is validated on every backend
+
+`add_object(size=...)` reached the Newton and Isaac backends unvalidated, while
+the MuJoCo backend had refused the same values since its numeric inputs were
+hardened. Measured with one `add_object` per case and no `newton` / `warp` /
+`isaacsim` installed, eight values MuJoCo refuses were accepted by at least one
+of the other two: an empty vector, a `nan` or `inf` component, a `bool`, a
+`None`, a nested list, the bare string `"abc"`, and a scalar.
+
+Newton read the vector for truthiness (`size or default_size`) - the last
+surviving coalesce of that shape on that constructor, where the other four vector
+parameters all test `is None`. So `np.array([0.1, 0.1, 0.1])`, which every
+docstring there advertises as accepted, raised
+`ValueError: truth value of an array ... is ambiguous` straight through the
+structured envelope these methods document as their only failure channel, and
+`[]` is falsy so it read as *omitted*: the default 5 cm extent was applied and
+the call reported success. Everything else was stored on the registry entry and
+reached the solver at rebuild time rather than at the `add_object` a caller can
+attribute it to - `"abc"` raised
+`TypeError: can only concatenate str (not "list") to str` out of the box branch,
+and built a sphere of `radius='a'` out of the sphere one.
+
+Isaac coerced with `list(size)`, which validated nothing: the same non-finite,
+`bool` and `None` components reached the prim constructor, `"abc"` was split per
+character into the 3-component extent `['a', 'b', 'c']`, and a scalar raised
+`TypeError: 'float' object is not iterable` out of that `list()` call, past the
+envelope. A NumPy extent also survived into the agent-visible result `json` as
+`[np.float64(0.1), ...]`.
+
+All three now share one definition, `strands_robots.utils.coerce_size_vector`,
+composed of the same `finite_vector_error` component domain MuJoCo already used -
+so the refusal is identical word for word, not merely identical in verdict - plus
+the rule that an empty vector is a component count rather than an omission.
+NumPy input is accepted and normalized to plain floats, and a refused size
+constructs no prim, registers no object and leaves the name reusable.
+
+Three axes are deliberately unchanged, because each depends on the shape and
+needs one contract decision rather than a helper default: the per-shape component
+count, whether a short vector may be completed from trailing defaults (the Isaac
+`size` docstring promises this, MuJoCo refuses it outright), and whether a
+consumed extent must be positive. #1858 tracks them, and the boundary is pinned
+rather than left implicit.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -220,6 +220,42 @@ sim.add_object("crate", shape="box", size=[0.5])
 sim.add_object("crate", shape="box", size=[0.5, 0.5, 0.5])   # 50 cm crate
 ```
 
+Every component must also be a finite number, and **that** part of the domain is
+shared with the Newton and Isaac backends' `add_object` - word for word, not just
+verdict for verdict - so an extent one backend refuses is refused by all three
+with the same message. A `nan`/`inf`, boolean, `None` or otherwise non-numeric
+component is rejected by name rather than reaching the solver, a NumPy array is
+accepted and normalized to plain floats, and a value that is not a vector at all
+is refused instead of raising from whatever first tries to iterate it:
+
+```python
+sim.add_object("crate", shape="box", size=[float("nan"), 0.1, 0.1])
+# status=error: add_object: 'size' must contain finite numbers (no nan/inf),
+#               got [nan, 0.1, 0.1]
+sim.add_object("crate", shape="box", size=0.5)
+# status=error: add_object: 'size' must be a list/tuple of numbers, got 0.5
+sim.add_object("crate", shape="box", size=np.array([0.5, 0.5, 0.5]))   # accepted
+```
+
+An **empty** `size` is a component count, not an omission, so it is rejected
+rather than quietly taking the default extent - omit `size` (or pass `None`) to
+ask for the default. Here the three backends agree on the verdict but not on the
+wording, because MuJoCo reaches an empty vector through the per-shape count above
+and so names the count the shape needs:
+
+```python
+sim.add_object("crate", shape="box", size=[])
+# status=error: box needs 3 'size' component(s) [x, y, z] full edge lengths,
+#               got 0 (size=[]). ...
+```
+
+The per-shape counts in the table above remain MuJoCo's alone. Newton and Isaac
+accept a short `size` (Isaac documents completing the missing trailing components
+from defaults), and neither bounds a component to be positive, so a vector this
+backend refuses on either of those axes may still be accepted there. Converging
+the three is tracked in
+[#1858](https://github.com/strands-labs/robots/issues/1858).
+
 ## Object mass
 
 `mass` (kg) applies to dynamic objects and must be a finite number greater than

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -42,6 +42,7 @@ from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
     coerce_rgba,
+    coerce_size_vector,
     entity_name_error,
     name_list_error,
     positive_count_error,
@@ -1744,7 +1745,21 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             * ``capsule``:  ``[radius, height]`` (default ``[0.05, 0.10]``).
 
             Lists shorter than the convention fall back to defaults for
-            the missing trailing components.
+            the missing trailing components. Whether that fallback should
+            survive is the open half of #1858 - MuJoCo refuses a short
+            ``size`` outright - so it is unchanged here.
+
+            Must be a non-empty vector of finite numbers, on the shared
+            :func:`~strands_robots.utils.coerce_size_vector` domain the
+            MuJoCo and Newton backends' ``add_object`` enforce, so an extent
+            one backend refuses is refused by all three. A ``nan``/``inf``,
+            ``bool`` or non-numeric component is refused rather than reaching
+            the prim constructor, an empty vector is a component count rather
+            than an omission, and a scalar is refused by name instead of
+            raising ``TypeError: 'float' object is not iterable`` out of the
+            ``list()`` that used to coerce it. NumPy arrays are accepted and
+            normalized to plain floats, so a ``np.float64`` extent no longer
+            reaches the result ``json``.
         color : list[float], optional
             ``[r, g, b]`` or ``[r, g, b, a]`` in 0..1 (an RGB triple is
             completed with an opaque alpha; the Isaac shape wrappers take
@@ -1916,10 +1931,30 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             scale_alias = kwargs.pop("scale", None)
             if size is None and scale_alias is not None:
                 size = scale_alias
+            # The shape-independent half of the extent contract, on the shared
+            # ``coerce_size_vector`` domain the MuJoCo backend's ``add_object``
+            # composes with its own per-shape table. It runs AFTER the ``scale``
+            # alias is resolved, because the two spellings name one parameter and
+            # a domain only one of them enforced would be no domain at all. The
+            # ``list(size)`` below coerced without validating, exactly as the pose
+            # did before #1853: ``[nan, .1, .1]`` and ``[inf, .1, .1]`` reached the
+            # prim constructor verbatim, ``[True, .1, .1]`` passed ``True`` as an
+            # extent, ``[None, .1, .1]`` and ``[[0.1], .1, .1]`` passed a ``None``
+            # and a nested list, the bare string ``"abc"`` was SPLIT per character
+            # into a 3-component extent ``['a', 'b', 'c']``, ``[]`` was forwarded
+            # as a sizeless size, and a scalar ``0.5`` raised
+            # ``TypeError: 'float' object is not iterable`` out of that very
+            # ``list()`` call - past the envelope this method documents as its only
+            # failure channel. The per-shape component count, the short-vector
+            # fallback this method's ``size`` docstring promises and the positivity
+            # of a consumed extent are shape-dependent and stay with #1858.
+            size, _serr = coerce_size_vector("add_object", "size", size)
+            if _serr is not None:
+                return {"status": "error", "content": [{"text": _serr}]}
 
             pos = [0.0, 0.0, 0.5] if position is None else position
             orient = [1.0, 0.0, 0.0, 0.0] if orientation is None else orientation
-            size_in = list(size) if size is not None else None
+            size_in = size
             prim_path = f"{self._config.stage_path}/Objects/{name}"
 
             try:

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -62,6 +62,7 @@ from strands_robots.utils import (
     camera_fov_error,
     coerce_pose_vector,
     coerce_rgba,
+    coerce_size_vector,
     entity_name_error,
     is_boolean,
     positive_count_error,
@@ -645,6 +646,15 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         :func:`~strands_robots.utils.coerce_pose_vector` domain, so a pose one
         backend refuses is refused by both.
 
+        ``size`` must be a non-empty vector of finite numbers, on the shared
+        :func:`~strands_robots.utils.coerce_size_vector` domain the MuJoCo
+        backend's ``add_object`` composes with its own per-shape table, so an
+        extent one backend refuses is refused by both. An empty vector is a
+        component count rather than an omission and is rejected instead of
+        silently applying the default extent. How many components each shape
+        needs, and whether a consumed extent must be positive, are shape-
+        dependent and not yet unified across backends (#1858).
+
         ``mass`` must be a finite number > 0 for a dynamic object, the domain
         :meth:`~strands_robots.simulation.base.SimEngine._validate_mass`
         defines and the MuJoCo backend's ``add_object`` already enforces, so a
@@ -665,6 +675,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             size: Half-extents (box) or ``[radius, ...]`` (others). For
                 ``shape="mesh"`` this is the per-axis scale applied to the
                 loaded geometry (default ``[1, 1, 1]`` -- the mesh's own units).
+                Must be a non-empty vector of finite numbers; a ``nan``/``inf``,
+                ``bool`` or non-numeric component is refused rather than handed
+                to the solver rebuild, and an empty vector is refused rather
+                than read as an omission. NumPy arrays are accepted.
             color: ``[r, g, b]`` or ``[r, g, b, a]`` in 0..1 (default
                 mid-grey; alpha currently ignored by Newton shapes). Any
                 other component count is refused rather than padded or
@@ -730,6 +744,28 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         color, _cerr = coerce_rgba("add_object", "color", color)
         if _cerr is not None:
             return {"status": "error", "content": [{"text": _cerr}]}
+        # The shape-independent half of the extent contract, on the shared
+        # ``coerce_size_vector`` domain the MuJoCo backend's ``add_object``
+        # composes with its own per-shape table. ``size or default_size`` below
+        # was the LAST surviving truthiness coalesce on this constructor - the
+        # other four vector parameters all test ``is None`` - and it carried the
+        # same two defects that spelling always carries: ``np.array([.1,.1,.1])``
+        # raised ``ValueError: truth value of an array ... is ambiguous`` through
+        # this method's only documented failure channel, and ``[]`` is falsy so it
+        # read as *omitted*, applying the default 5 cm extent under a success
+        # result. Everything else was stored verbatim and reached the solver at
+        # REBUILD time rather than at the call a caller can attribute it to:
+        # ``[nan, .1, .1]`` and ``[inf, .1, .1]`` became a box half-extent,
+        # ``[True, .1, .1]`` read ``True`` as an extent, ``[None, .1, .1]`` and
+        # ``[[0.1], .1, .1]`` handed the shape builder a ``None`` and a nested
+        # list, and the bare string ``"abc"`` was stored AS the size - raising
+        # ``TypeError: can only concatenate str (not "list") to str`` from the box
+        # branch, and silently building a sphere of ``radius='a'`` from the sphere
+        # one. The per-shape component count, the short-vector question and the
+        # positivity of a consumed extent are shape-dependent and stay with #1858.
+        size, _serr = coerce_size_vector("add_object", "size", size)
+        if _serr is not None:
+            return {"status": "error", "content": [{"text": _serr}]}
         # A dynamic body's mass is the divisor of every force applied to it and
         # reaches the solver as ``builder.add_body(mass=...)``, so it goes
         # through the same shared domain the MuJoCo backend's ``add_object``
@@ -791,7 +827,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 shape=shape,
                 position=[0.0, 0.0, 0.0] if position is None else position,
                 orientation=[1.0, 0.0, 0.0, 0.0] if orientation is None else orientation,
-                size=size or default_size,
+                size=default_size if size is None else size,
                 color=[0.5, 0.5, 0.5, 1.0] if color is None else color,
                 mass=mass,
                 mesh_path=mesh_path,

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -944,6 +944,80 @@ def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] |
     return (floats if length == 4 else [*floats, 1.0]), None
 
 
+def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[float] | None, str | None]:
+    """Validate an optional object ``size`` and normalize it to plain floats.
+
+    The part of the library's extent contract that does not depend on the shape:
+    a ``size`` is a vector of finite real numbers, or it is omitted. The MuJoCo
+    backend's ``add_object`` has composed exactly this domain with its own
+    shape-aware table since its numeric inputs were hardened -
+    :func:`finite_vector_error` for the components, ``_validate_size`` for the
+    count and the consumed extents - and this is the half a backend with no such
+    table can still apply, so the same value cannot be usable on one backend and
+    unusable on another.
+
+    Membership, not truthiness: a ``size`` is "supplied" when it is not ``None``.
+    Testing the vector itself (``size or <default>``) is wrong twice over. A
+    NumPy array - what any extent arithmetic or a randomization draw produces -
+    raises a bare ``ValueError: truth value of an array ... is ambiguous``
+    through the structured tool-result contract, and an empty vector is falsy, so
+    it reads as *omitted* and the backend default extent is applied while the
+    call reports success.
+
+    An empty vector is therefore refused rather than read as an omission. That is
+    a statement about zero components only, not about how many a shape needs: no
+    shape can be built from no extents at all, so the refusal holds whatever the
+    per-shape count turns out to be.
+
+    Normalizing to a ``list[float]`` keeps the accepted NumPy input from
+    outliving this boundary - the extent is stored on :class:`SimObject`
+    (annotated ``list[float]``) and echoed in agent-visible status text, so a
+    surviving ``np.float64`` would leak ``np.float64(0.05)`` into it.
+
+    What this deliberately does NOT decide is every axis whose answer depends on
+    the shape: the component **count** each shape requires, whether a short
+    vector may be completed from defaults, and whether a component must be
+    positive (MuJoCo bounds only the components the shape actually consumes, so a
+    cylinder may legitimately pass ``size[1] == 0``). Those three differ per
+    backend today and need one contract decision rather than a helper default;
+    #1858 tracks them.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        size: The caller's extent vector, or ``None`` when it was omitted.
+
+    Returns:
+        ``(None, None)`` when ``size`` is ``None`` (omitted - the caller applies
+        its own documented default), ``(floats, None)`` for an acceptable vector,
+        or ``(None, error_message)`` for a non-numeric, ``bool`` or
+        ``nan``/``inf`` component, a value that is not a vector at all, or an
+        empty vector.
+    """
+    if size is None:
+        return None, None
+    # Component classes first, so a value that is not a vector at all is refused
+    # in the SAME words the MuJoCo backend already uses for it - one verdict
+    # should not have two spellings across backends. The empty-vector refusal is
+    # this helper's own, because MuJoCo reaches that case through its per-shape
+    # count instead and so states a count the shape needs rather than the
+    # omission the caller probably meant.
+    if (err := finite_vector_error(method, param_name, size)) is not None:
+        return None, err
+    length = sequence_length(size)
+    if length is None:
+        # Reachable only for something iterable but unsized - a generator, which
+        # the check above has now consumed, so there is nothing left to store.
+        return None, f"{method}: '{param_name}' must be a list/tuple of numbers, got {size!r}"
+    if length == 0:
+        return None, (
+            f"{method}: '{param_name}' must have at least one component, got an empty "
+            f"vector ({size!r}). An empty '{param_name}' is a component count, not an "
+            f"omission - omit '{param_name}' to take the default extent."
+        )
+    return [float(component) for component in size], None
+
+
 def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:
     """Return an error message if ``value`` is not a usable camera field of view.
 

--- a/tests/simulation/test_object_size_domain_across_backends.py
+++ b/tests/simulation/test_object_size_domain_across_backends.py
@@ -1,0 +1,502 @@
+"""Regression tests: every backend validates an ``add_object`` size vector.
+
+Third axis of the ``add_object`` numeric contract to be settled across
+backends, after ``color`` (#1856, on ``coerce_rgba``) and ``mass`` (#1859, on
+``SimEngine._validate_mass``). The MuJoCo backend has composed the whole extent
+domain since its numeric inputs were hardened - ``finite_vector_error`` for the
+components, ``_validate_size`` for the count and the consumed extents - and its
+``add_object`` docstring states the reason a short vector cannot be padded: it
+would compile "a differently-sized object while reporting success". Newton and
+Isaac applied neither half.
+
+Measured on the 8-value probe set below, one ``add_object`` per case, with no
+``newton`` / ``warp`` / ``isaacsim`` installed:
+
+* Newton read the vector for TRUTHINESS (``size or default_size``) - the LAST
+  surviving coalesce of that shape on that constructor, where the other four
+  vector parameters all test ``is None``. So ``np.array([.1, .1, .1])`` - what
+  extent arithmetic or a randomization draw produces - raised a bare
+  ``ValueError: truth value of an array with more than one element is
+  ambiguous`` straight through the structured envelope these methods document as
+  their only failure channel, and ``[]`` is falsy so it read as *omitted*: the
+  default ``[0.05, 0.05, 0.05]`` was applied and the call reported success.
+* Everything else Newton stored verbatim on the registry entry and handed to the
+  solver at REBUILD time rather than at the ``add_object`` a caller can
+  attribute it to. ``[nan, .1, .1]`` and ``[inf, .1, .1]`` became a box
+  half-extent, ``[True, .1, .1]`` read ``True`` as an extent, ``[None, .1, .1]``
+  and ``[[0.1], .1, .1]`` handed the shape builder a ``None`` and a nested list,
+  and the bare string ``"abc"`` was stored AS the size - raising
+  ``TypeError: can only concatenate str (not "list") to str`` out of the box
+  branch, and silently building a sphere of ``radius='a'`` out of the sphere one.
+  A scalar ``0.5`` reached ``TypeError: unsupported operand type(s) for +:
+  'float' and 'list'`` the same way.
+* Isaac coerced with ``list(size)``, which validated nothing - the same
+  non-finite / ``bool`` / ``None`` / nested values reached the prim constructor,
+  ``"abc"`` was SPLIT per character into the 3-component extent
+  ``['a', 'b', 'c']``, ``[]`` was forwarded as a sizeless size, and a NumPy
+  array survived as ``[np.float64(0.1), ...]`` into the result ``json``. A
+  scalar ``0.5`` raised ``TypeError: 'float' object is not iterable`` out of
+  that very ``list()`` call, past the envelope.
+
+MuJoCo refused all 8 unusable values in that set and accepted the NumPy vector.
+``TestEveryBackendGivesTheSameVerdict`` pins the parity against a real compiled
+model, in both directions.
+
+``TestNoObjectSizeSurfaceDrifts`` keeps it that way structurally: every public
+engine method taking a ``size`` must route it through a shared numeric-vector
+validator. Three spellings are accepted there and the reason is recorded with
+the set - unifying them is its own refactor, not this change.
+
+What is NOT in scope, and is asserted to be unchanged by
+``TestShapeDependentAxesStayOutOfScope``: every axis whose answer depends on the
+shape. The component **count** each shape requires, whether a short vector may
+be completed from trailing defaults (the Isaac ``size`` docstring promises it,
+MuJoCo refuses it outright, Newton stores it for a later ``size[:3]`` read - three
+behaviours, two documented, that cannot all survive), and whether a component
+must be positive (MuJoCo bounds only the components the shape actually consumes,
+so a cylinder may legitimately pass ``size[1] == 0``). #1858 tracks all three;
+they need one contract decision rather than a helper default, which is why they
+are not smuggled in behind a defect fix.
+
+These tests are GL-free apart from the MuJoCo parity class and need neither
+``newton``/``warp`` nor ``isaacsim`` nor a GPU: every guard runs before its
+method touches a solver or a stage, so calling the unbound method with a small
+stand-in for ``self`` exercises it in every environment.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import coerce_size_vector
+from tests.simulation.test_pose_vector_domain_across_backends import _isaac_stub, _newton_stub
+
+NAN = float("nan")
+INF = float("inf")
+
+#: Every value no backend can build a shape from. Each row is a measured
+#: pre-fix acceptance on at least one of Newton / Isaac (see the module
+#: docstring), and MuJoCo already refused all of them.
+UNUSABLE_SIZES: tuple[Any, ...] = (
+    [],
+    [NAN, 0.1, 0.1],
+    [INF, 0.1, 0.1],
+    [True, 0.1, 0.1],
+    [None, 0.1, 0.1],
+    [[0.1], 0.1, 0.1],
+    "abc",
+    0.5,
+)
+
+#: Accepted extents, including the NumPy vector every docstring advertises and
+#: the tuple a config literal produces. Paired with the plain floats each must
+#: normalize to, since surviving NumPy scalars leak into agent-visible output.
+GOOD_SIZES: tuple[tuple[Any, list[float]], ...] = (
+    ([0.1, 0.2, 0.3], [0.1, 0.2, 0.3]),
+    ((0.1, 0.2, 0.3), [0.1, 0.2, 0.3]),
+    (np.array([0.1, 0.2, 0.3]), [0.1, 0.2, 0.3]),
+    ([np.float64(0.1), 0.2, 0.3], [0.1, 0.2, 0.3]),
+)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+def _isaac_recording() -> tuple[Any, dict[str, Any]]:
+    """An Isaac stand-in that records what a refused call must never do."""
+    stub = _isaac_stub()
+    seen: dict[str, Any] = {"construct": 0, "scene_add": 0, "size": None}
+
+    def construct(**kwargs: Any) -> tuple[Any, Any]:
+        seen["construct"] += 1
+        seen["size"] = kwargs.get("size")
+        return object(), kwargs.get("size")
+
+    stub._construct_shape_prim = construct
+    stub._world.scene.add = lambda handle: seen.__setitem__("scene_add", seen["scene_add"] + 1)
+    return stub, seen
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheSharedDomain:
+    """``coerce_size_vector`` is the single definition the backends share."""
+
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_an_unusable_size_is_refused(self, size: Any) -> None:
+        value, err = coerce_size_vector("add_object", "size", size)
+        assert value is None, size
+        assert err is not None and "'size'" in err
+
+    @pytest.mark.parametrize(("size", "expected"), GOOD_SIZES)
+    def test_a_usable_size_normalizes_to_plain_floats(self, size: Any, expected: list[float]) -> None:
+        value, err = coerce_size_vector("add_object", "size", size)
+        assert err is None, (size, err)
+        assert value == pytest.approx(expected)
+        assert all(type(component) is float for component in value or [])
+
+    def test_an_omitted_size_is_not_an_error(self) -> None:
+        """``None`` means omitted, so the caller applies its own default."""
+        assert coerce_size_vector("add_object", "size", None) == (None, None)
+
+    def test_the_empty_vector_refusal_names_the_omission_spelling(self) -> None:
+        """The remedy has to be discoverable, since ``[]`` used to work."""
+        _, err = coerce_size_vector("add_object", "size", [])
+        assert err is not None
+        assert "omission" in err and "omit 'size'" in err.lower()
+
+    def test_a_scalar_is_refused_as_not_a_vector(self) -> None:
+        """Including a 0-d NumPy array, whose ``__len__`` exists and raises."""
+        for scalar in (0.5, np.float64(0.5), np.array(0.5)):
+            value, err = coerce_size_vector("add_object", "size", scalar)
+            assert value is None and err is not None, scalar
+            assert "must be a list/tuple of numbers" in err
+
+
+# --------------------------------------------------------------------------- #
+# Newton                                                                      #
+# --------------------------------------------------------------------------- #
+class TestNewtonAddObject:
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_an_unusable_size_is_refused(self, size: Any) -> None:
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_object(stub, "crate", size=size)
+        assert result["status"] == "error", (size, result)
+        assert "'size'" in _text(result)
+
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_a_refused_size_registers_no_object(self, size: Any) -> None:
+        """The name must stay reusable, so the obvious retry is not a duplicate."""
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", size=size)["status"] == "error"
+        assert stub._world.objects == {}
+        assert NewtonSimEngine.add_object(stub, "crate", size=[0.1, 0.1, 0.1])["status"] == "success"
+
+    @pytest.mark.parametrize(("size", "expected"), GOOD_SIZES)
+    def test_a_usable_size_is_stored_as_plain_floats(self, size: Any, expected: list[float]) -> None:
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", size=size)["status"] == "success"
+        stored = stub._world.objects["crate"].size
+        assert stored == pytest.approx(expected)
+        assert all(type(component) is float for component in stored)
+
+    def test_a_numpy_size_no_longer_raises_through_the_envelope(self) -> None:
+        """The defect the truthiness coalesce carried, pinned as a behaviour."""
+        stub = _newton_stub()
+        # Annotated ``Any`` deliberately: the parameter is declared
+        # ``list[float] | None``, and a NumPy array is the documented input the
+        # annotation does not spell, which is what this test exists to pin.
+        vector: Any = np.array([0.1, 0.1, 0.1])
+        result = NewtonSimEngine.add_object(stub, "crate", size=vector)
+        assert result["status"] == "success"
+        assert stub._world.objects["crate"].size == pytest.approx([0.1, 0.1, 0.1])
+
+    def test_an_omitted_size_still_takes_the_backend_default(self) -> None:
+        """Membership, not truthiness: only ``None`` means omitted."""
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", shape="box")["status"] == "success"
+        assert stub._world.objects["crate"].size == [0.05, 0.05, 0.05]
+
+    def test_an_omitted_mesh_size_still_takes_the_mesh_default(self, tmp_path: pathlib.Path) -> None:
+        """The default extent is per-shape, so ``is None`` must reach both branches."""
+        asset = tmp_path / "part.obj"
+        asset.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8")
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_object(stub, "part", shape="mesh", mesh_path=str(asset))
+        assert result["status"] == "success", result
+        assert stub._world.objects["part"].size == [1.0, 1.0, 1.0]
+
+    def test_an_empty_mesh_size_is_refused_too(self, tmp_path: pathlib.Path) -> None:
+        """A mesh scale is consumed like any extent, so ``[]`` is no omission there."""
+        asset = tmp_path / "part.obj"
+        asset.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8")
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_object(stub, "part", shape="mesh", mesh_path=str(asset), size=[])
+        assert result["status"] == "error"
+        assert "'size'" in _text(result)
+        assert stub._world.objects == {}
+
+    def test_an_empty_size_is_refused_rather_than_defaulted(self) -> None:
+        """Replaces the pre-fix pin: ``[]`` used to apply the default extent."""
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_object(stub, "crate", size=[])
+        assert result["status"] == "error"
+        assert "component count, not an" in _text(result)
+        assert stub._world.objects == {}
+
+
+# --------------------------------------------------------------------------- #
+# Isaac                                                                       #
+# --------------------------------------------------------------------------- #
+class TestIsaacAddObject:
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_an_unusable_size_is_refused(self, size: Any) -> None:
+        stub, _ = _isaac_recording()
+        result = IsaacSimulation.add_object(stub, "crate", size=size)
+        assert result["status"] == "error", (size, result)
+        assert "'size'" in _text(result)
+
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_a_refused_size_constructs_no_prim_and_registers_nothing(self, size: Any) -> None:
+        """Same invariant the mass fix established: no half-placed object."""
+        stub, seen = _isaac_recording()
+        assert IsaacSimulation.add_object(stub, "crate", size=size)["status"] == "error"
+        assert seen["construct"] == 0
+        assert seen["scene_add"] == 0
+        assert stub._objects == {}
+        assert stub._prim_registry == []
+        assert IsaacSimulation.add_object(stub, "crate", size=[0.1, 0.1, 0.1])["status"] == "success"
+
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_the_scale_alias_goes_through_the_same_domain(self, size: Any) -> None:
+        """``scale`` and ``size`` name one parameter, so one domain covers both."""
+        stub, seen = _isaac_recording()
+        result = IsaacSimulation.add_object(stub, "crate", scale=size)
+        assert result["status"] == "error", (size, result)
+        assert "'size'" in _text(result)
+        assert seen["construct"] == 0
+
+    @pytest.mark.parametrize(("size", "expected"), GOOD_SIZES)
+    def test_a_usable_size_reaches_the_prim_as_plain_floats(self, size: Any, expected: list[float]) -> None:
+        stub, seen = _isaac_recording()
+        assert IsaacSimulation.add_object(stub, "crate", size=size)["status"] == "success"
+        assert seen["size"] == pytest.approx(expected)
+        assert all(type(component) is float for component in seen["size"])
+
+    def test_a_numpy_size_no_longer_leaks_into_the_result_json(self) -> None:
+        """The result ``json`` is agent-visible, so ``np.float64`` cannot survive."""
+        stub, _ = _isaac_recording()
+        vector: Any = np.array([0.1, 0.2, 0.3])
+        result = IsaacSimulation.add_object(stub, "crate", size=vector)
+        assert result["status"] == "success"
+        reported = result["content"][0]["json"]["size"]
+        assert reported == pytest.approx([0.1, 0.2, 0.3])
+        assert all(type(component) is float for component in reported)
+
+    def test_a_scalar_size_is_refused_rather_than_raising(self) -> None:
+        """``list(0.5)`` used to raise ``TypeError`` past the envelope."""
+        stub, _ = _isaac_recording()
+        scalar: Any = 0.5
+        result = IsaacSimulation.add_object(stub, "crate", size=scalar)
+        assert result["status"] == "error"
+        assert "must be a list/tuple of numbers" in _text(result)
+
+
+# --------------------------------------------------------------------------- #
+# Cross-backend parity                                                        #
+# --------------------------------------------------------------------------- #
+class TestEveryBackendGivesTheSameVerdict:
+    """An extent one backend refuses is refused by all of them."""
+
+    @pytest.fixture
+    def mj_sim(self) -> Any:
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="test_object_size_domain_parity_sim", mesh=False)
+        assert sim.create_world()["status"] == "success"
+        yield sim
+        sim.cleanup()
+
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_an_unusable_size_is_refused_everywhere(self, mj_sim: Any, size: Any) -> None:
+        mj = mj_sim.add_object("crate", size=size)
+        nt = NewtonSimEngine.add_object(_newton_stub(), "crate", size=size)
+        ic = IsaacSimulation.add_object(_isaac_recording()[0], "crate", size=size)
+        assert mj["status"] == nt["status"] == ic["status"] == "error", (size, mj, nt, ic)
+        assert "'size'" in _text(mj) and "'size'" in _text(nt) and "'size'" in _text(ic)
+
+    @pytest.mark.parametrize(("size", "expected"), GOOD_SIZES)
+    def test_a_usable_size_is_accepted_everywhere(self, mj_sim: Any, size: Any, expected: list[float]) -> None:
+        """The parity is two-way: no backend refuses an extent another honors."""
+        assert mj_sim.add_object("crate", shape="box", size=size)["status"] == "success"
+        assert NewtonSimEngine.add_object(_newton_stub(), "crate", size=size)["status"] == "success"
+        assert IsaacSimulation.add_object(_isaac_recording()[0], "crate", size=size)["status"] == "success"
+
+    #: The values whose refusal is entirely the shared component domain, so all
+    #: three backends must not merely agree on the verdict but state it
+    #: identically. ``[]`` is excluded deliberately: MuJoCo reaches it through
+    #: its per-shape count and so names the count the shape needs, which is the
+    #: shape-dependent axis this change leaves alone.
+    IDENTICALLY_WORDED = tuple(s for s in UNUSABLE_SIZES if not (isinstance(s, list) and not s))
+
+    @pytest.mark.parametrize("size", IDENTICALLY_WORDED)
+    def test_the_shared_refusal_has_one_wording(self, mj_sim: Any, size: Any) -> None:
+        """Two spellings of one verdict is how backend domains start to drift."""
+        mj = mj_sim.add_object("crate", size=size)
+        nt = NewtonSimEngine.add_object(_newton_stub(), "crate", size=size)
+        ic = IsaacSimulation.add_object(_isaac_recording()[0], "crate", size=size)
+        assert {_text(mj), _text(nt), _text(ic)} == {_text(mj)}, (size, _text(mj), _text(nt), _text(ic))
+
+    @pytest.mark.parametrize("size", UNUSABLE_SIZES)
+    def test_a_refused_size_leaves_the_name_reusable_everywhere(self, mj_sim: Any, size: Any) -> None:
+        """A refusal that consumes the name makes the obvious retry impossible."""
+        assert mj_sim.add_object("crate", size=size)["status"] == "error"
+        assert mj_sim.add_object("crate", shape="box", size=[0.1, 0.1, 0.1])["status"] == "success"
+
+
+# --------------------------------------------------------------------------- #
+# Structural: no size surface drifts off a shared domain                      #
+# --------------------------------------------------------------------------- #
+#: Every public engine method taking a ``size``, and the shared validator it
+#: routes the vector through. Three spellings, because the live-geom writers in
+#: ``mujoco/physics.py`` return the tool envelope directly while ``utils.py``
+#: returns a ``(value, reason)`` pair - so ``_coerce_finite_vector`` is that
+#: module's local equivalent rather than a second domain. All three refuse the
+#: same component classes; folding them into one is its own refactor.
+_KNOWN_SIZE_SURFACES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("mujoco", "add_object"): ("finite_vector_error",),
+    ("mujoco", "set_geom_properties"): ("_coerce_finite_vector",),
+    ("newton", "add_object"): ("coerce_size_vector",),
+    ("isaac", "add_object"): ("coerce_size_vector",),
+}
+
+#: Any of these names, called on the vector, means the surface is on a shared
+#: domain rather than reading the caller's value directly.
+_SHARED_SIZE_VALIDATORS = ("coerce_size_vector", "finite_vector_error", "_coerce_finite_vector")
+
+
+def _scan_size_surfaces(root: pathlib.Path) -> tuple[dict[tuple[str, str], tuple[str, ...]], list[str]]:
+    """Find public engine-class methods taking ``size``, and which skip a domain.
+
+    Scoped to public methods of a class deliberately: ``_construct_shape_prim``
+    and the Newton object builder also take an extent, but they receive an
+    already-validated one from ``add_object`` and are not caller-facing.
+
+    Args:
+        root: The ``strands_robots/simulation`` package directory.
+
+    Returns:
+        ``(found, adrift)`` - every ``(backend, method)`` pair mapped to the
+        shared validators it calls, and the ones that call none.
+    """
+    found: dict[tuple[str, str], tuple[str, ...]] = {}
+    adrift: list[str] = []
+    for backend in ("mujoco", "newton", "isaac"):
+        for path in sorted((root / backend).glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+                for fn in [n for n in ast.iter_child_nodes(cls) if isinstance(n, ast.FunctionDef)]:
+                    if fn.name.startswith("_"):
+                        continue
+                    if "size" not in [a.arg for a in fn.args.args + fn.args.kwonlyargs]:
+                        continue
+                    called = {
+                        node.func.id
+                        for node in ast.walk(fn)
+                        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                    }
+                    validators = tuple(sorted(name for name in _SHARED_SIZE_VALIDATORS if name in called))
+                    found[(backend, fn.name)] = validators
+                    if not validators:
+                        adrift.append(f"{backend}/{path.name}:{fn.lineno} {cls.name}.{fn.name}")
+    return found, adrift
+
+
+class TestNoObjectSizeSurfaceDrifts:
+    """A backend method taking a ``size`` must route it through a shared domain."""
+
+    def test_every_public_size_surface_validates(self) -> None:
+        root = pathlib.Path(inspect.getfile(NewtonSimEngine)).parent.parent
+        found, adrift = _scan_size_surfaces(root)
+        assert adrift == [], "these accept a size without a shared domain: " + ", ".join(adrift)
+        assert found == {k: tuple(sorted(v)) for k, v in _KNOWN_SIZE_SURFACES.items()}, (
+            f"the set of size surfaces changed: {found}"
+        )
+
+    def test_the_scanner_reports_a_planted_omission(self, tmp_path: pathlib.Path) -> None:
+        """Without this, an empty result could mean a scanner matching nothing."""
+        backend = tmp_path / "newton"
+        backend.mkdir()
+        (backend / "simulation.py").write_text(
+            textwrap.dedent(
+                """
+                class Engine:
+                    def add_object(self, name, size=None):
+                        return {"status": "success"}
+                """
+            ),
+            encoding="utf-8",
+        )
+        found, adrift = _scan_size_surfaces(tmp_path)
+        assert found == {("newton", "add_object"): ()}
+        assert len(adrift) == 1
+        assert "Engine.add_object" in adrift[0]
+
+    def test_the_scanner_sees_a_planted_validator(self, tmp_path: pathlib.Path) -> None:
+        """The other direction: a routed surface must not read as adrift."""
+        backend = tmp_path / "newton"
+        backend.mkdir()
+        (backend / "simulation.py").write_text(
+            textwrap.dedent(
+                """
+                class Engine:
+                    def add_object(self, name, size=None):
+                        size, err = coerce_size_vector("add_object", "size", size)
+                        return {"status": "success"}
+                """
+            ),
+            encoding="utf-8",
+        )
+        found, adrift = _scan_size_surfaces(tmp_path)
+        assert found == {("newton", "add_object"): ("coerce_size_vector",)}
+        assert adrift == []
+
+
+# --------------------------------------------------------------------------- #
+# The boundary: what this change deliberately does not decide                  #
+# --------------------------------------------------------------------------- #
+class TestShapeDependentAxesStayOutOfScope:
+    """Counts, the short-vector fallback and positivity remain per-backend.
+
+    Asserted rather than omitted so the divergence cannot be mistaken for
+    settled, and so #1858 landing has to replace these rather than delete them.
+    """
+
+    def test_a_short_size_is_still_accepted_by_newton(self) -> None:
+        """MuJoCo refuses ``[0.1]`` on a box; Newton stores it for a later read."""
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", shape="box", size=[0.1])["status"] == "success"
+        assert stub._world.objects["crate"].size == [0.1]
+
+    def test_a_short_size_is_still_accepted_by_isaac(self) -> None:
+        """Its ``size`` docstring promises a trailing-component fallback."""
+        stub, seen = _isaac_recording()
+        assert IsaacSimulation.add_object(stub, "crate", shape="box", size=[0.1])["status"] == "success"
+        assert seen["size"] == [0.1]
+
+    def test_a_short_size_is_still_refused_by_mujoco(self) -> None:
+        """The third behaviour, and the one the other two would converge on."""
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="test_object_size_short_vector_scope_sim", mesh=False)
+        try:
+            assert sim.create_world()["status"] == "success"
+            result = sim.add_object("crate", shape="box", size=[0.1])
+            assert result["status"] == "error"
+            assert "'size' component(s)" in _text(result)
+        finally:
+            sim.cleanup()
+
+    def test_a_zero_extent_is_still_accepted_by_newton_and_isaac(self) -> None:
+        """Positivity is bounded per consumed component, so it needs the counts."""
+        stub = _newton_stub()
+        assert NewtonSimEngine.add_object(stub, "crate", size=[0.0, 0.0, 0.0])["status"] == "success"
+        isaac_stub, _ = _isaac_recording()
+        assert IsaacSimulation.add_object(isaac_stub, "crate", size=[0.0, 0.0, 0.0])["status"] == "success"
+
+    def test_the_shared_helper_takes_no_shape(self) -> None:
+        """The scope boundary in one signature: no shape means no count check."""
+        assert list(inspect.signature(coerce_size_vector).parameters) == ["method", "param_name", "size"]

--- a/tests/simulation/test_pose_vector_domain_across_backends.py
+++ b/tests/simulation/test_pose_vector_domain_across_backends.py
@@ -39,15 +39,17 @@ class methods deliberately - ``scene_ops.reposition_body_in_scene`` is a
 module-level spec helper reached only from the already-validated
 ``move_object``, and it returns ``bool`` rather than the agent-tool envelope.
 
-What is NOT in scope, and is asserted to be unchanged: ``size``. Its component
-counts are shape-dependent and documented differently per backend (the Isaac
-``add_object`` docstring promises a trailing-component fallback for a short
-``size`` that neither other backend offers), so it needs its own domain decision
-rather than riding along here. ``color`` and ``mass`` were in that list until
-their domains were settled - on the shared ``coerce_rgba`` and
-``SimEngine._validate_mass`` respectively - and are now pinned in
-``tests/simulation/test_color_domain_across_backends.py`` and
-``tests/simulation/test_object_mass_domain_across_backends.py``.
+What is NOT in scope, and is asserted to be unchanged: the shape-dependent half
+of ``size`` - the per-shape component count, the short-vector fallback the Isaac
+``add_object`` docstring promises and neither other backend offers, and the
+positivity of a consumed extent. Those need one contract decision rather than a
+helper default, and #1858 tracks them. ``color``, ``mass`` and the
+shape-independent half of ``size`` were all in that list until their domains were
+settled - on the shared ``coerce_rgba``, ``SimEngine._validate_mass`` and
+``coerce_size_vector`` respectively - and are now pinned in
+``tests/simulation/test_color_domain_across_backends.py``,
+``tests/simulation/test_object_mass_domain_across_backends.py`` and
+``tests/simulation/test_object_size_domain_across_backends.py``.
 
 These tests are GL-free and need neither ``newton``/``warp`` nor ``isaacsim``
 nor a GPU: every guard runs before its method touches a solver or a stage, so
@@ -576,27 +578,37 @@ class TestEveryBackendGivesTheSameVerdict:
 # The out-of-scope parameters are pinned as unchanged                          #
 # --------------------------------------------------------------------------- #
 class TestSizeIsOutOfScope:
-    """This change is the pose axis only; ``size`` keeps its current contract.
+    """This change is the pose axis only; ``size`` keeps its own contract.
 
-    Its component counts are shape-dependent and documented differently per
-    backend - the Isaac ``add_object`` docstring promises a trailing-component
-    fallback for a short ``size`` that neither other backend offers - so it needs
-    that contract settled before it can share a domain. Pinning it here makes
-    that scope a stated property rather than an omission a later reader has to
-    infer.
-
-    Two axes have since left this list. ``color`` counts are settled on the
+    Three axes have since left this list. ``color`` counts are settled on the
     shared ``coerce_rgba`` domain, pinned in
     ``tests/simulation/test_color_domain_across_backends.py``; ``mass`` is
     settled on the shared ``SimEngine._validate_mass`` domain, pinned in
     ``tests/simulation/test_object_mass_domain_across_backends.py`` - including
     the ``mass=0`` "make it static" spelling Newton documents, which is the one
-    place the three backends' accepted masses legitimately differ.
+    place the three backends' accepted masses legitimately differ. The
+    shape-independent half of ``size`` is settled on the shared
+    ``coerce_size_vector`` domain, pinned in
+    ``tests/simulation/test_object_size_domain_across_backends.py``.
+
+    What remains out of scope for the pose axis is the part of ``size`` that
+    depends on the shape: the per-shape component count, whether a short vector
+    may be completed from trailing defaults, and whether a consumed extent must
+    be positive. #1858 tracks those three, and
+    ``test_object_size_domain_across_backends.py`` carries their boundary pins
+    beside the domain they bound - one class, not two.
+
+    The pin that used to live here asserted that Newton read ``size=[]`` as an
+    omission and applied its default extent. That was a correct statement of the
+    behaviour at the time and is now the defect the shared domain removes, so it
+    is replaced rather than deleted: the property worth keeping is that the pose
+    change did not quietly alter what an omitted ``size`` does.
     """
 
-    def test_a_short_size_still_takes_the_backend_default(self):
+    def test_an_omitted_size_still_takes_the_backend_default(self):
+        """Membership, not truthiness - and ``None`` still means omitted."""
         stub = _newton_stub()
-        assert NewtonSimEngine.add_object(stub, "crate", size=[])["status"] == "success"
+        assert NewtonSimEngine.add_object(stub, "crate", size=None)["status"] == "success"
         assert stub._world.objects["crate"].size == [0.05, 0.05, 0.05]
 
 


### PR DESCRIPTION
`add_object(size=...)` reached the Newton and Isaac backends unvalidated. The MuJoCo backend has refused the same values since its numeric inputs were hardened, and its `add_object` docstring states the reason a short vector cannot be padded - it would compile "a differently-sized object while reporting success". This is the third axis of that constructor's numeric contract to be settled across backends, after `color` (#1856, on `coerce_rgba`) and `mass` (#1859, on `SimEngine._validate_mass`).

The axis is split deliberately. `size` carries one genuine **contract decision** - three documented behaviours for a short vector that cannot all survive - and one plain **defect**, which is that neither backend validated the components at all. This PR lands the defect. The decision stays with #1858, and the boundary between them is asserted rather than left to a later reader to infer.

## Measured

One `add_object` per cell, no `newton` / `warp` / `isaacsim` installed, on `aa5cceae`. Every guard under discussion precedes the point either backend touches a solver or a stage, which is what lets the tests run solver-free too.

| `size=` | MuJoCo | Newton | Isaac |
| --- | --- | --- | --- |
| `np.array([.1,.1,.1])` | accepted | **raised** `ValueError: truth value of an array ... is ambiguous` | accepted -> `[np.float64(0.1), ...]` |
| `[]` | refused | accepted -> **default `[0.05, 0.05, 0.05]` applied** | accepted -> `[]` |
| `[nan,.1,.1]` | refused | accepted -> stored verbatim | accepted -> forwarded verbatim |
| `[inf,.1,.1]` | refused | accepted -> stored verbatim | accepted -> forwarded verbatim |
| `[True,.1,.1]` | refused | accepted -> `True` stored as an extent | accepted |
| `[None,.1,.1]` | refused | accepted -> `None` stored as an extent | accepted |
| `[[0.1],.1,.1]` | refused | accepted -> a **nested list** stored as an extent | accepted |
| `"abc"` | refused | accepted -> the **string stored as the size** | accepted -> **`['a','b','c']`** |
| `0.5` | refused | accepted -> the **scalar stored where a vector is read** | **raised** `TypeError: 'float' object is not iterable` |

The last two rows on Newton land away from the call, as the Newton colour bug did. `_add_object_to_builder` is where the extent is finally read, so:

```
"abc", shape=box    -> REBUILD RAISED TypeError: can only concatenate str (not "list") to str
"abc", shape=sphere -> rebuilt with {'radius': 'a', ...}
0.5,  shape=box     -> REBUILD RAISED TypeError: unsupported operand type(s) for +: 'float' and 'list'
0.5,  shape=sphere  -> REBUILD RAISED TypeError: 'float' object is not subscriptable
```

So the sphere case is the worse one: no exception at all, and a sphere of `radius='a'` handed to the solver under a success result.

### The truthiness coalesce, one line from four that were fixed

`size` was the **last surviving** truthiness read on that constructor. The other four vector parameters all test `is None`:

```python
position=[0.0, 0.0, 0.0] if position is None else position,
orientation=[1.0, 0.0, 0.0, 0.0] if orientation is None else orientation,
size=size or default_size,                       # <- the last one
color=[0.5, 0.5, 0.5, 1.0] if color is None else color,
```

That spelling is wrong twice over, as `coerce_pose_vector` documents: a NumPy array - what extent arithmetic or a randomization draw produces, and what the Args advertise - raises through the structured envelope these methods document as their only failure channel, and `[]` is falsy so it reads as *omitted*, applying the default extent under a success result. The second half is a direct conflict with Key Convention 6, "No silent defaults on error": an empty `size` is a component count, not an omission.

## Shape

One shared helper, `strands_robots.utils.coerce_size_vector`, beside `coerce_pose_vector` and `coerce_rgba` and in that module's `(value, reason)` convention. It is composed of the domain MuJoCo **already** applied rather than being a new third pattern:

| axis | who decides | in scope here |
| --- | --- | --- |
| component is numeric, non-`bool`, finite | `finite_vector_error` (shared, MuJoCo already used it) | yes |
| value is a vector at all | `finite_vector_error` | yes |
| empty vector is not an omission | `coerce_size_vector` | yes |
| normalize to plain `float` | `coerce_size_vector` | yes |
| per-shape component count | per-backend | **no - #1858** |
| short vector completed from defaults | per-backend | **no - #1858** |
| consumed extent must be `> 0` | per-backend | **no - #1858** |

The split is not arbitrary; each bottom row is shape-dependent, and each has a different answer on each backend today:

- **Counts genuinely differ.** MuJoCo's `_SIZE_LAYOUT` gives `cylinder`/`capsule` **3** components (`[diameter, unused, full height]`); Newton's builder reads **2** (`radius`, `half_height`), and Isaac documents **2** (`[radius, height]`). A shared count table cannot be written without first unifying the *semantics*, which is a contract change, not a defect fix.
- **Positivity is bounded per consumed component.** `_validate_size` checks only the components the shape actually consumes, so a cylinder may legitimately pass `size[1] == 0`. A blanket `> 0` would be stricter than the reference backend, which is divergence in the other direction.
- **The short-vector question has two documented answers.** Isaac's `size` docstring promises "Lists shorter than the convention fall back to defaults for the missing trailing components"; MuJoCo refuses the same value and says why. Settling that means changing a documented promise, and #1858 argues it should change - which is worth taking on its own rather than inside a defect fix.

Refusing `[]`, by contrast, needs no count table: every shape either backend supports consumes at least one component, so zero components is unusable whatever the per-shape count turns out to be. MuJoCo's sole exception is `mesh`, whose layout is `(0, "unused")` - and MuJoCo decides that with its own table, which this change does not touch.

### One verdict, one wording

The first draft gave the non-vector case its own message (`'size' must be a sequence of numbers`) while MuJoCo said `'size' must be a list/tuple of numbers` for the identical value. Two spellings of one verdict is how backend domains start to drift, so the component checks now run **first** and the shared message is reused verbatim. `TestEveryBackendGivesTheSameVerdict::test_the_shared_refusal_has_one_wording` pins that all three backends produce a byte-identical message for all 7 non-empty unusable values. `[]` is excluded from that class deliberately and the reason is recorded with it: MuJoCo reaches an empty vector through its per-shape count, so it names the count the shape needs - the axis this change leaves alone.

On Isaac the guard runs **after** the `scale` alias is resolved, because the two spellings name one parameter and a domain only one of them enforced would be no domain at all. It also precedes `_construct_shape_prim` and `scene.add`, so a refused extent leaves no prim, no `_objects` entry and a reusable name - the invariant #1859 established for `mass`, pinned here for `size`.

## Verification

Pre-fix, with only the two backend files reverted to `aa5cceae` and the tests in place: **59 failed / 39 passed**. Representative failures quote the defect verbatim:

```
FAILED ...::TestNewtonAddObject::test_an_unusable_size_is_refused[size4]
  - AssertionError: ([None, 0.1, 0.1], {'status': 'success', ..."Added box object 'crate'."})
FAILED ...::TestNoObjectSizeSurfaceDrifts::test_every_public_size_surface_validates
  - + 'newton/simulation.py:624 NewtonSimEngine.add_object',
    + 'isaac/simulation.py:1684 IsaacSimulation.add_object',
```

The 39 that pass pre-fix are what stop the guard over-reaching: the accepted-value controls, the shared-domain tests, MuJoCo's own refusals in the parity class, the out-of-scope boundary pins, and the two scanner meta-tests. Post-fix: **105 passed** in the new module.

Full gate on `aa5cceae`:

- `ruff check` / `ruff format --check` -> clean (984 files)
- `mypy strands_robots tests` -> **11 errors, unchanged from the base's 11** (all pre-existing missing stubs for optional deps). Three transient errors from passing a NumPy array and a scalar where the parameter is annotated `list[float] | None` were removed by routing those values through `Any`-annotated locals, which is how the sibling domain modules already do it, rather than by `type: ignore`.
- `scripts/check_merge_base_overlap.py` -> no overlap; `assemble_changelog.py --check` -> OK (fragment `1861-...`, matching this PR number)
- The four cross-backend domain modules together (`pose`, `color`, `mass`, `size`) -> **476 passed**

The affected subtree read as a **delta, not an absolute**, per AGENTS.md - the same command on the unmerged base first:

| `pytest tests/simulation tests/test_utils.py` | failed | passed | skipped | errors |
| --- | --- | --- | --- | --- |
| base `aa5cceae` | 353 | 5524 | 291 | 34 |
| this branch | 353 | 5629 | 291 | 34 |

Identical failures and errors; the whole effect is **+105 passes**, exactly the tests this branch adds. The 353 pre-existing failures are this runner having no GPU and only software OSMesa, and are present with the diff reverted. The full `tests` run was not usable here - the environment is missing `msgpack`/`imageio` and stops on collection - which is why the affected subtree is the measured scope.

## Premise test replaced, not deleted

`test_pose_vector_domain_across_backends.py` held the old boundary:

```python
def test_a_short_size_still_takes_the_backend_default(self):
    assert NewtonSimEngine.add_object(stub, "crate", size=[])["status"] == "success"
    assert stub._world.objects["crate"].size == [0.05, 0.05, 0.05]
```

That was a correct pin of the behaviour at the time and is now the defect this change removes, so per the premise-test guidance in AGENTS.md it is **replaced** rather than dropped. The property still worth holding is that the pose axis did not quietly alter what an *omitted* `size` does, so the replacement asserts exactly that with `size=None`. The class docstring records what the old pin said and why it changed, and the shape-dependent pins now live in the new module beside the domain they bound - one class, not two.

## Docs

`docs/simulation/world-building.md` gains the shared half of the domain under **Object size**, with the per-shape table explicitly still marked as MuJoCo's alone and #1858 linked for the divergence.

The quoted error strings were **measured rather than assumed**: the first draft quoted `'size' must be a sequence of numbers` and a new empty-vector message on a page that documents the MuJoCo backend, and running the examples showed MuJoCo actually answers `must be a list/tuple of numbers` and reaches `[]` through its per-shape count. Both were corrected, and that measurement is what prompted the one-wording change above.

## Round 1

**CodeQL `py/non-iterable-in-for-loop`, error severity, on `utils.py:796`.** Every other check was green; this one is what held the PR at `UNSTABLE`.

The alert is a false positive, and the flagged line is *pre-existing* - `finite_vector_error`'s component loop, unchanged since #1856. What this PR added is a **call path**: `coerce_size_vector` forwards a caller's `size`, and one of the measured values is the bare scalar `0.5`, so a `float` now reaches that helper where previously the inferred operand was always a sequence. Runtime behaviour was already correct and is pinned by this PR - `finite_vector_error("m", "size", 0.5)` returns `m: 'size' must be a list/tuple of numbers, got 0.5`, and the guard `try: iter(vec) / except TypeError` returns before the loop. CodeQL simply does not model `iter()` as establishing iterability.

It was worth fixing rather than dismissing, for two reasons. It is **error** severity, so it sits outside the argument in #1810, which is scoped to note-severity idiom alerts. And left open it would attach to `finite_vector_error` on `main` - the shared component check under all four numeric domains (`pose`, `color`, `mass`, `size`) - and resurface on every later change routed through it.

The fix iterates the materialized components, so the loop's operand is unconditionally a `tuple`:

```python
try:
    _components = tuple(vec)
except TypeError:
    return f"{method}: '{param_name}' must be a list/tuple of numbers, got {vec!r}"
for _elem in _components:
```

**The accepted domain does not move.** `tuple(vec)` raises `TypeError` on exactly the values `iter(vec)` does. Verified byte-identical return values across 20 probes: `0.5`, `5`, `None`, `np.float64(0.5)`, `np.array(0.5)` (0-d), `"abc"`, `{"a": 1}`, `[[0.1], 0.1]`, `[True, 0.1]`, `[nan, 0.1]`, `[inf]`, `[]`, `np.array([])`, `(0.1, 0.2)`, `range(3)`, `{0.1, 0.2}`, and a `__getitem__`-only sequence.

That last probe is why the fix is not `isinstance(vec, Iterable)`, which would read more naturally: a class with only `__getitem__` is iterable by the legacy protocol but is **not** a `collections.abc.Iterable` instance, so the `isinstance` spelling would have started refusing a value both `iter()` and `tuple()` accept. That is a silent narrowing of a shared domain, not a legibility fix, so it was rejected - and the reason is recorded on the test that would have caught it.

`TestFiniteVectorIterabilityGuard` pins the property in both directions: a non-iterable returns a message instead of raising, and a `__getitem__`-only sequence is still accepted.

Because there is no behaviour change, these tests pass against the previous spelling too - they are a domain pin, not a bug regression test, and the commit says so rather than implying it caught something.

| four cross-backend domain modules + `tests/test_utils.py` | passed | skipped |
| --- | --- | --- |
| `e8a224d` (previous head) | 458 | 74 |
| `5bda004` | 470 | 74 |

No new failures; the whole effect is the 12 added tests. `ruff check` / `ruff format --check` / `mypy` clean on both touched files.

**No changelog fragment change.** The fragment documents behaviour a release-notes reader cares about, and this commit changes none - the `tuple()` spelling would be noise there.
