### PR TITLE
ci(codeql): stop note-severity idiom alerts gating a merge

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,56 @@
+# CodeQL configuration for strands-labs/robots.
+#
+# Wired in from .github/workflows/codeql.yml via `config-file`. It exists for
+# one reason: two note-severity *quality* rules in the `security-and-quality`
+# suite fire only on idioms this codebase is obliged to use, and a CodeQL alert
+# on a pull request is a hard merge gate here. See #1810.
+#
+# Why an alert gates a merge, when the workflow used to say it does not:
+# `github-advanced-security` opens a pull-request *review thread* per new
+# alert, and the `default` branch ruleset sets
+# `required_review_thread_resolution: true`. Severity never enters into it, so a
+# note-severity style preference gates a merge exactly as an error-severity
+# taint finding does. Nothing in the CodeQL workflow can observe that
+# interaction, which is how its own comment came to describe a policy the
+# repository does not implement.
+#
+# Scope discipline: this file excludes TWO rule ids and nothing else.
+# `tests/test_codeql_query_filters.py` pins that set, so widening it is a
+# deliberate, reviewed edit rather than a drive-by line.
+
+query-filters:
+  # py/ineffectual-statement -- 27 of 27 open alerts are `...` used as a
+  # typing-construct body, which is the only way to write one: `Protocol`
+  # method bodies (PEP 544), `@abstractmethod` bodies, `@overload` signatures,
+  # and TYPE_CHECKING cross-mixin stubs. There is no rewrite available: `pass`
+  # is contrary to the convention used consistently across the tree, and
+  # `raise NotImplementedError` changes a Protocol's runtime behaviour.
+  #
+  # The capability this gives up is a genuine no-op statement, and it is NOT
+  # given up -- it moves to ruff, which is merge-blocking here where CodeQL is
+  # advisory. `[tool.ruff.lint] select` in pyproject.toml gains B015
+  # (useless-comparison, the `x == 1` case) and B018 (useless-expression).
+  # Both are silent on all 27 sites above because ruff exempts `...`.
+  - exclude:
+      id: py/ineffectual-statement
+
+  # py/import-and-import-from -- 63 of 64 open alerts are under tests/ and are
+  # the standard monkeypatch idiom, where BOTH imports are load-bearing: the
+  # module object is the patch target, the symbol is the thing under test.
+  #
+  #     import strands_robots.mesh.rosbridge_robot as rbr_mod           # patch target
+  #     from strands_robots.mesh.rosbridge_robot import RosbridgeRobot  # under test
+  #     monkeypatch.setattr(rbr_mod, "use_rosbridge", recorder)
+  #
+  # Drop the alias and there is nothing to patch, so the suite would need a
+  # live rosbridge server; drop the `from` import and the test cannot name its
+  # subject. The single non-test instance (`strands_robots/hardware_robot.py`)
+  # is a deliberate function-local lazy import. The rule states a style
+  # preference with no bug class behind it, so nothing is relocated for it.
+  - exclude:
+      id: py/import-and-import-from
+
+# NOT excluded, deliberately: py/empty-except (88 open, the largest class). A
+# swallowed exception genuinely hides bugs, the instances are not one
+# mechanical idiom, and they need reading one at a time. #1810 names keeping it
+# as an explicit non-goal; the pin test asserts it stays absent from this file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,10 +33,23 @@ jobs:
           # surfaced in PR #85 (MJCF interpolation) and PR #90 (subprocess
           # injection / path traversal).
           queries: security-and-quality
+          # Filters out two note-severity quality rules from that suite whose
+          # every instance in this repository is an idiom the codebase is
+          # obliged to use. The file carries the per-rule reasoning and the
+          # reason a filter is needed at all; see #1810.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4
         with:
           category: "/language:python"
-          # Findings appear in the Security tab; PRs are not blocked on
-          # CodeQL alerts (false-positive rate makes hard-fail noisy).
+          # Findings appear in the Security tab. This job never fails on an
+          # alert, which is NOT the same as a pull request being free to merge
+          # with one: github-advanced-security opens a review thread per new
+          # alert and the default ruleset requires thread resolution, so any
+          # new alert is a hard merge gate whatever its severity. This comment
+          # asserted the opposite until #1810 measured it. The two
+          # note-severity rules whose every instance is an unavoidable idiom
+          # are filtered in codeql-config.yml for exactly that reason; every
+          # other rule -- py/empty-except included -- still gates a merge and
+          # still needs a human read.

--- a/changelog.d/1810-codeql-note-idiom-query-filters.md
+++ b/changelog.d/1810-codeql-note-idiom-query-filters.md
@@ -1,0 +1,16 @@
+### Fixed: a CodeQL note-severity idiom alert no longer blocks a merge
+
+`.github/workflows/codeql.yml` stated that pull requests are not blocked on
+CodeQL alerts. They were: `github-advanced-security` opens a review thread per
+new alert and the `default` branch ruleset requires thread resolution, so every
+new alert was a hard merge gate whatever its severity - two approved, green PRs
+sat unmergeable on note-severity style findings alone. A new
+`.github/codeql/codeql-config.yml` filters exactly two rules whose every
+instance in this repository is an idiom the codebase is obliged to use:
+`py/ineffectual-statement` (27 of 27 alerts were `...` as a `Protocol` /
+`@abstractmethod` / `@overload` body) and `py/import-and-import-from` (63 of 64
+were the pytest monkeypatch idiom, where the module alias is the patch target
+and the `from` import names the subject). The real no-op-statement class is not
+given up - ruff now selects `B015` and `B018`, moving it to a check that gates
+merges where CodeQL is advisory. `py/empty-except` is deliberately untouched
+and still requires a human read.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -526,6 +526,15 @@ select = [
     "F",     # pyflakes
     "I",     # isort
     "UP",    # pyupgrade
+    # Two flake8-bugbear codes, selected individually rather than as "B".
+    # They carry the no-op-statement capability that CodeQL's
+    # py/ineffectual-statement used to nominally provide before
+    # .github/codeql/codeql-config.yml filtered it (#1810): every one of that
+    # rule's 27 alerts was a `...` typing-construct body, which ruff exempts,
+    # so the rule reported only unavoidable idioms while the real bug class
+    # went unenforced by any merge-blocking check. Ruff is that check here.
+    "B015",  # useless comparison - `x == 1` as a statement, the real bug class
+    "B018",  # useless expression - a value computed and discarded
 ]
 ignore = [
     "E501",  # line too long - handled by formatter

--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -113,7 +113,7 @@ class TestPackageLazyExport:
         import strands_robots.simulation.isaac as isaac_pkg
 
         with pytest.raises(AttributeError, match="no attribute 'NotAName'"):
-            isaac_pkg.NotAName
+            _ = isaac_pkg.NotAName
 
 
 class TestIsaacConfig:

--- a/tests/simulation/newton/test_package_lazy_export.py
+++ b/tests/simulation/newton/test_package_lazy_export.py
@@ -49,4 +49,4 @@ class TestLazyResolution:
 class TestUnknownAttribute:
     def test_unknown_attribute_raises_standard_message(self):
         with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
-            newton_pkg.does_not_exist
+            _ = newton_pkg.does_not_exist

--- a/tests/test_codeql_query_filters.py
+++ b/tests/test_codeql_query_filters.py
@@ -1,0 +1,155 @@
+"""Contract pins for the CodeQL query filters.
+
+``.github/codeql/codeql-config.yml`` exists because a CodeQL alert on a pull
+request is a hard merge gate in this repository, and two note-severity *quality*
+rules in the ``security-and-quality`` suite fire only on idioms the codebase is
+obliged to use. The gate is not the CodeQL job, which never fails on an alert:
+``github-advanced-security`` opens a review thread per new alert and the
+``default`` branch ruleset sets ``required_review_thread_resolution: true``, so
+severity never enters into it. That interaction is invisible to the workflow,
+which is how its own comment came to describe a policy the repository does not
+implement. See #1810.
+
+A suppression is the kind of change that decays by widening: the cheapest way to
+clear any future alert is to append its rule id here, one line at a time, until
+the file quietly opts out of the whole quality suite. So the properties below are
+about *scope*, not about CodeQL working:
+
+- the filter set is **exactly two** rule ids, named individually, so adding a
+  third is a deliberate edit that fails this test until someone changes it;
+- ``py/empty-except`` is **absent**, which #1810 names as an explicit non-goal --
+  it is the largest class (88 open), a swallowed exception genuinely hides bugs,
+  and the instances need reading one at a time;
+- the config is **reachable**, i.e. the workflow actually passes it, since an
+  unreferenced config file silently filters nothing;
+- ruff still selects **B015 and B018**, which is the load-bearing one. Excluding
+  ``py/ineffectual-statement`` is only a no-loss trade because the real no-op
+  statement class moved to a check that is merge-blocking here where CodeQL is
+  advisory. Drop those two codes and the exclusion silently becomes a capability
+  loss, with nothing else in the tree recording the connection.
+
+These are text assertions rather than parsed YAML because that is the shape the
+existing CI-config pin uses (``tests/test_merge_base_overlap.py`` reads
+``.github/workflows/merge-base-overlap.yml`` the same way) and because ``pyyaml``
+is an optional dependency here -- a pin that skips when a dep is missing is not a
+pin.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CONFIG_PATH = _REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "codeql.yml"
+_PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
+
+#: The only two rule ids this repository filters, and the reason each is here.
+#:
+#: ``py/ineffectual-statement`` -- 27 of 27 open alerts were ``...`` used as a
+#: typing-construct body (``Protocol`` methods, ``@abstractmethod`` bodies,
+#: ``@overload`` signatures, ``TYPE_CHECKING`` stubs). No rewrite exists.
+#:
+#: ``py/import-and-import-from`` -- 63 of 64 open alerts were the pytest
+#: monkeypatch idiom, where the module alias is the patch target and the ``from``
+#: import names the subject, so both are load-bearing.
+_EXPECTED_EXCLUDED_RULES = frozenset(
+    {
+        "py/ineffectual-statement",
+        "py/import-and-import-from",
+    }
+)
+
+#: Ruff codes carrying the no-op-statement capability that the
+#: ``py/ineffectual-statement`` exclusion would otherwise give up.
+_RELOCATED_RUFF_CODES = ("B015", "B018")
+
+#: Matches the two-line ``- exclude:`` / ``id:`` form the config is written in.
+_EXCLUDED_ID_RE = re.compile(
+    r"^[ \t]*-[ \t]*exclude:[ \t]*\r?\n[ \t]*id:[ \t]*(?P<rule>[A-Za-z0-9/_-]+)[ \t]*$",
+    re.MULTILINE,
+)
+
+
+def _excluded_rule_ids() -> list[str]:
+    return _EXCLUDED_ID_RE.findall(_CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+class TestTheFilterSetStaysNarrow:
+    def test_the_config_file_exists(self):
+        assert _CONFIG_PATH.is_file(), (
+            f"{_CONFIG_PATH.relative_to(_REPO_ROOT)} is missing. If the CodeQL filters were "
+            "removed on purpose, delete this module in the same change so the tree does not "
+            "carry a pin for a file nobody has."
+        )
+
+    def test_exactly_the_two_documented_rules_are_excluded(self):
+        found = _excluded_rule_ids()
+        assert len(found) == len(set(found)), f"a rule id is excluded twice: {found}"
+        assert set(found) == set(_EXPECTED_EXCLUDED_RULES), (
+            "the CodeQL filter set changed. Every id here suppresses a real query for the whole "
+            "repository, so adding one is a decision that needs its own reasoning recorded next to "
+            "it in the config -- and then this expectation updated deliberately.\n"
+            f"  expected: {sorted(_EXPECTED_EXCLUDED_RULES)}\n"
+            f"  found:    {sorted(found)}"
+        )
+
+    def test_empty_except_is_not_excluded(self):
+        text = _CONFIG_PATH.read_text(encoding="utf-8")
+        assert "py/empty-except" not in _excluded_rule_ids(), (
+            "py/empty-except must keep gating merges. It is the largest alert class, a swallowed "
+            "exception genuinely hides bugs, and its instances are not one mechanical idiom - "
+            "#1810 names quieting it as an explicit non-goal."
+        )
+        assert "py/empty-except" in text, (
+            "the config should keep naming py/empty-except as the deliberate non-exclusion, so the "
+            "next reader looking for it finds the reason rather than an omission."
+        )
+
+    def test_each_exclusion_carries_its_reasoning(self):
+        """A bare rule id is how the next reader loses the argument for it."""
+        text = _CONFIG_PATH.read_text(encoding="utf-8")
+        assert "#1810" in text, "the config must link the issue that measured the cost"
+        for rule in _EXPECTED_EXCLUDED_RULES:
+            # The id appears once in a comment block explaining it and once in the
+            # filter itself; a filter with no prose above it is the decay case.
+            assert text.count(rule) >= 2, (
+                f"{rule} is excluded without a comment naming why. A suppression with no stated "
+                "reason cannot be re-litigated, only inherited."
+            )
+
+
+class TestTheConfigIsReachable:
+    def test_the_workflow_passes_the_config_file(self):
+        workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+        assert "config-file: ./.github/codeql/codeql-config.yml" in workflow, (
+            "codeql.yml must pass config-file, or the filters above are dead text: an "
+            "unreferenced CodeQL config silently filters nothing and every alert keeps gating."
+        )
+
+    def test_the_workflow_no_longer_claims_alerts_do_not_block(self):
+        """The comment that was false is the reason #1810 was filed."""
+        workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+        assert "PRs are not blocked on" not in workflow, (
+            "codeql.yml used to state that PRs are not blocked on CodeQL alerts. Thread-resolution "
+            "on bot-authored review threads makes every new alert a merge gate, so that sentence "
+            "described a policy the repository does not implement. Do not restore it."
+        )
+        assert "hard merge gate" in workflow, (
+            "codeql.yml must say what actually happens, not merely stop saying the wrong thing. A "
+            "contributor reading it needs to know an alert blocks the merge before they spend a "
+            "round wondering why an approved, green PR will not go in."
+        )
+
+
+class TestTheRelocatedCapabilityStaysSelected:
+    def test_ruff_still_selects_the_no_op_statement_codes(self):
+        pyproject = _PYPROJECT_PATH.read_text(encoding="utf-8")
+        for code in _RELOCATED_RUFF_CODES:
+            assert f'"{code}"' in pyproject, (
+                f"ruff must keep selecting {code}. Excluding py/ineffectual-statement from CodeQL "
+                "is only a no-loss trade because the real no-op-statement class is enforced by "
+                "ruff, which gates merges here where CodeQL is advisory. Removing this code while "
+                "the exclusion stands drops the capability with nothing recording it."
+            )

--- a/tests/test_package_lazy_imports.py
+++ b/tests/test_package_lazy_imports.py
@@ -65,12 +65,12 @@ class TestUnknownAttribute:
 
     def test_unknown_attribute_raises(self):
         with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
-            strands_robots.does_not_exist
+            _ = strands_robots.does_not_exist
 
     def test_dunder_attribute_raises_attributeerror(self):
         # Spurious dunder lookups (e.g. by copy/pickle) must not be swallowed.
         with pytest.raises(AttributeError):
-            strands_robots.__wrapped__
+            _ = strands_robots.__wrapped__
 
 
 class TestMissingDependencyContract:


### PR DESCRIPTION
Closes #1810.

`.github/workflows/codeql.yml` stated, on its `analyze` step:

> Findings appear in the Security tab; PRs are **not blocked** on CodeQL alerts (false-positive rate makes hard-fail noisy).

That is not what happens, and the workflow cannot see why. `github-advanced-security` opens a pull-request **review thread** per new alert, and the `default` branch ruleset sets `required_review_thread_resolution: true`. Severity never enters into it, so a note-severity style preference gates a merge exactly as an error-severity taint finding does. The comment described a policy the repository does not implement.

This is the root cause #1810 names as option **C**, and the config file is how it is reachable from a diff - see [Why not the ruleset](#why-not-the-ruleset).

## Measured

Re-counted from the code-scanning API today (`state=open`, all pages), not carried over from the issue:

| rule | open | severity | every instance is |
| --- | --- | --- | --- |
| `py/empty-except` | 88 | note | **not** one idiom - left alone, see below |
| `py/import-and-import-from` | 64 | note | the pytest monkeypatch idiom (63 of 64 under `tests/`) |
| `py/ineffectual-statement` | 27 | note | `...` as a typing-construct body (27 of 27) |

I classified every instance of the two filtered rules by reading the flagged line rather than trusting the rule name:

- **`py/ineffectual-statement`: 27 of 27** are `...` used as a `Protocol` method body (PEP 544), an `@abstractmethod` body, an `@overload` signature, or a `TYPE_CHECKING` cross-mixin stub. There is no rewrite: `pass` is contrary to the convention used consistently across the tree, and `raise NotImplementedError` changes a `Protocol`'s runtime behaviour.
- **`py/import-and-import-from`: 63 of 64** are under `tests/`, all the standard monkeypatch idiom where **both** imports are load-bearing - the module object is the patch target, the symbol is the thing under test. Drop the alias and there is nothing to patch; drop the `from` import and the test cannot name its subject. The single non-test instance (`strands_robots/hardware_robot.py`) is a deliberate function-local lazy import.

The cost is recurring, and it grew while the issue was open. Of the **28** alerts dismissed by hand on this repository, **15** are these two rules (10 `py/import-and-import-from`, 5 `py/ineffectual-statement`) - one more than #1810 recorded a day earlier, from clearing #1722. Two approved PRs with `call-test-lint` green and `mergeable: MERGEABLE` were unmergeable on these threads alone (#1110, 2 threads; #1722, 4 threads).

## Shape

A new `.github/codeql/codeql-config.yml`, wired in via `config-file`, excluding **exactly two** rule ids with the per-rule reasoning recorded beside each. `queries: security-and-quality` is unchanged, so the suite still runs and the Security tab keeps 100% of the signal for every other rule.

### `py/empty-except` is deliberately untouched

It is the largest class (88 open) and the one where the rule is right: a swallowed exception genuinely hides bugs, the instances are not a single mechanical idiom, and they need reading one at a time. #1810 names quieting it as an explicit non-goal. It stays merge-blocking, it is named in the config as the deliberate non-exclusion so the next reader finds a reason rather than an omission, and `test_empty_except_is_not_excluded` asserts both halves.

### The one real capability is relocated, not dropped

This is the part worth reviewing hardest, because it is the only place this PR gives something up. #1810's honest caveat on filtering `py/ineffectual-statement` is that the rule *can* in principle catch a real no-op (`x == 1` as a statement), so excluding it trades an unrealized capability for a measured cost.

It is not traded away here. `[tool.ruff.lint] select` gains two flake8-bugbear codes, chosen individually rather than as `"B"`:

| | `...` in a stub | `x == 1` | `obj.attr` discarded |
| --- | --- | --- | --- |
| CodeQL `py/ineffectual-statement` | flags (27x, all false) | flags | does not flag |
| ruff `B015` / `B018` | **silent** | `B015` | `B018` |

Measured with the CI-pinned ruff (`>=0.15.12,<0.16.0`, resolved 0.15.22):

- `B015,B018` across the whole tree: **4 findings**, and **zero** on the four modules carrying 22 of the 27 `py/ineffectual-statement` alerts (`simulation/base.py`, `mesh/transport/base.py`, `robot.py`, `policies/motionbricks/policy.py`) - ruff exempts `...`.
- On a synthetic probe, `B015` flags `x == 1` and `B018` flags a discarded `obj.attr`, while all of `Protocol` / `@abstractmethod` / `@overload` `...` bodies pass.

The direction of the move is the point: **ruff gates merges here, CodeQL is advisory.** So the no-op-statement class goes from being reported by a tool that only ever fired on unavoidable idioms, to being enforced by the check that actually blocks. That is a strictly better position than the status quo, not a concession.

The 4 `B018` findings are all one shape - an attribute read inside `pytest.raises`, where the access *is* the assertion:

```python
with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
    _ = strands_robots.does_not_exist
```

I made those an explicit discard rather than `# noqa: B018`: it states the intent in the language instead of in linter configuration, and it leaves no suppression to inherit. Behaviour is identical - the attribute access raises before the assignment ever happens - and all 4 tests pass unchanged.

## Why not the ruleset

#1810's option C offers two mechanisms. Neither is available:

- *Scope `required_review_thread_resolution` so bot-authored threads do not gate.* Rulesets have no author or severity scoping for that setting; it is a boolean. Turning it off wholesale would stop **human** review threads gating a merge, which is a real safety property and a strictly worse trade than this one.
- *Configure code scanning so note-severity alerts do not open PR review threads.* There is no such filter. The repository-level code-scanning severity setting governs the **check conclusion**, and the check is not what blocks - it already passes.

There is a third reason to prefer a file in the tree even if a settings toggle existed: a repository setting is invisible to a diff, untestable, and unattributable. AGENTS.md is explicit that a decision recorded only outside the tree is not durable. This config is reviewable, greppable, and pinned.

So the mechanism is #1810's option **B** (narrow `query-filters`, following the #215 / #216 / #229 / #395 precedent, which is being re-established rather than edited - the old config file and its narrowness pin are no longer in the tree), while the *outcome* is option C's: the alerts stop gating merges instead of stopping existing.

## The pin is about scope, not about CodeQL

A suppression decays by widening - the cheapest way to clear any future alert is to append its id, one line at a time, until the file has opted out of the whole quality suite. `tests/test_codeql_query_filters.py` (7 tests) pins the four properties that prevent that:

1. the filter set is **exactly** those two ids;
2. `py/empty-except` is absent, and still named in the config as the deliberate non-exclusion;
3. the workflow actually passes `config-file`, so the file cannot become dead text that filters nothing;
4. **ruff still selects `B015` and `B018`** - the coupling that keeps the exclusion a no-loss trade. Remove those codes while the exclusion stands and the capability is silently gone with nothing recording the connection.

It also pins that the workflow no longer claims alerts do not block, *and* that it says what does happen - a contributor needs to know an alert gates the merge before spending a round wondering why an approved, green PR will not go in.

I verified the pin bites rather than merely passing. Appending a third id (`py/empty-except`) to the config fails 2 of the 7 tests with the reasoning in the message; reverting restores 7 passed.

Text assertions, not parsed YAML, deliberately: that is the shape the existing CI-config pin uses (`tests/test_merge_base_overlap.py` reads `merge-base-overlap.yml` the same way) and `pyyaml` is an optional dependency here, so a parsed pin would silently **skip** in an environment without it.

## Verification

| gate | result |
| --- | --- |
| `ruff check strands_robots tests tests_integ` | clean |
| `ruff format --check strands_robots tests tests_integ` | 1031 files already formatted |
| `mypy tests/test_codeql_query_filters.py` | no issues |
| `tests/test_codeql_query_filters.py` | 7 passed |
| `tests/test_changelog_fragments.py` | 26 passed |
| `tests/test_merge_base_overlap.py` | 30 passed |
| `scripts/assemble_changelog.py --check` | OK (fragment `1810-...`) |
| `scripts/check_merge_base_overlap.py` | no overlap; 0 paths changed on `main` since `b7cd5c3a` |
| both YAML files | parse; `query-filters` resolves to the documented 2-element form |

The three test files touched by the `_ =` edits, read as a **delta not an absolute** per AGENTS.md:

| `test_package_lazy_imports.py` + newton + isaac lazy-export | failed | passed | skipped |
| --- | --- | --- | --- |
| base `b7cd5c3` | 1 | 73 | 1 |
| this branch | 1 | 73 | 1 |

Identical. The single failure is this sandbox lacking the `strands` package and is present with the diff reverted.

Ruff's 44 pre-existing `UP037` findings under `examples/` are untouched and out of CI's lint scope (`ruff check strands_robots tests tests_integ`); I confirmed the count is 44 on the base as well, so this PR adds none.

### The filter is verified pre-merge after all

I first recorded the filter's effect as unobservable before merge. That was wrong, and the correction is worth more than the caveat: the code-scanning **analyses** endpoint reports the query count for this PR's own run.

| ref | analysis | `rules_count` | `results_count` |
| --- | --- | --- | --- |
| `refs/heads/main` @ `b7cd5c3a` | 1558704237 | **172** | 290 |
| `refs/heads/main` @ `aa5cceae` | 1558615355 | 172 | 289 |
| `refs/heads/main` @ `91bed803` | 1558471257 | 172 | 289 |
| `refs/pull/1862/merge` @ `e55e6a49` | 1558813458 | **170** | 0 |

`Analyze (Python)` is `SUCCESS` and the run executed **exactly two fewer queries** than every recent `main` analysis. That settles both open halves at once:

- `query-filters` from a `config-file` **does** apply to a suite selected by the workflow's `queries:` input, so the fallback of moving `queries:` into the config file is not needed;
- it removed **2** queries - not 3, and not the suite - so the narrowness the pin test asserts against the config *text* is now also confirmed against the analysis GitHub actually ran.

`results_count` is 0 on a pull-request ref because a PR analysis reports only results *new* relative to its base. That is also why a per-ref alert query returns 0 for the untouched `py/empty-except` control, which is what makes it useless as evidence here - `rules_count` is the load-bearing number, and the three `main` rows are its control.

The post-merge read-back is still owed, since alert *counts* are the user-visible criterion in #1810 rather than query counts: `py/ineffectual-statement` 27 -> 0, `py/import-and-import-from` 64 -> 0, `py/empty-except` unchanged at 88. I will report it on this PR.

## Not in scope

`py/empty-except` (88, deliberate). Error-severity findings, which gate on their own merits - #1861 fixed `py/non-iterable-in-for-loop` rather than filtering it, and that remains the right response for anything above note severity. The 44 `examples/` ruff findings, which are a separate pre-existing cleanup.
