### PR TITLE
docs(sim): name the dataset home on every start_recording

### DIFF
--- a/changelog.d/1864-start-recording-dataset-home-docs.md
+++ b/changelog.d/1864-start-recording-dataset-home-docs.md
@@ -1,0 +1,40 @@
+### Docs: `start_recording` says where the dataset lands, and names the one override that moves it
+
+Every backend's `start_recording` resolves the recording directory through
+`resolve_dataset_dir`, so `$HF_LEROBOT_HOME` is load-bearing on all three - and
+no docstring said so. A caller reading the API could not find out where a
+recording went, or that the location is configurable at all:
+
+| surface | `repo_id` | `root` |
+| --- | --- | --- |
+| `simulation/mujoco/recording.py` | *no entry at all* | "defaults to the LeRobot cache under `repo_id`" |
+| `simulation/isaac/recording.py` | id or a local path | "overrides the repo_id cache-path resolution" |
+| `simulation/newton/recording.py` | id or a local path | "overrides the repo_id cache-path resolution" |
+
+Which cache went unnamed, so the environment variable appeared only in inline
+code comments a caller never reads. The MuJoCo `Args` block documented `fps` /
+`root` / `overwrite` / `vcodec` / `cameras` and omitted the one parameter that
+names the dataset.
+
+The three now point at `resolve_dataset_dir` for the precedence rules and state
+the override where it is read - from LeRobot's own `HF_LEROBOT_HOME` constant, so
+relocating the home moves both the recording and where `LeRobotDataset` reads it
+back from. `overwrite` gets the same treatment: it cites
+`DatasetRecordingMixin._prepare_dataset_target`, whose four outcomes for an
+existing target (resume, clear-empty, wipe-on-overwrite, refuse-non-dataset) two
+backends compressed into "wipe and recreate ... instead of appending to it" -
+naming two of the four and reading as though a pre-existing empty `root` were an
+error rather than the accepted case it is.
+
+Cross-references rather than three fresh restatements, because three partial
+copies of one contract is what drifted: the rules keep one prose owner, and
+`TestStartRecordingDocumentsWhereTheDatasetLands` refuses a backend that stops
+citing it. Ten of its twelve checks fail on the previous docstrings.
+
+`docs/recording.md` carried the same gap plus one wrong path: its
+`DatasetRecorder` snippet annotated `root=None` as `~/.strands_robots/datasets/`,
+a directory no code writes a dataset to - `~/.strands_robots` is the renders,
+mesh-audit and scene-cache home. A reader following it went looking for a
+recording in a directory that never existed.
+
+No behaviour change.

--- a/docs/data/annotation.md
+++ b/docs/data/annotation.md
@@ -66,9 +66,14 @@ Then annotate it in place with the LeRobot console script:
 
 ```bash
 lerobot-annotate \
-    --root=~/.strands_robots/datasets/user/pick_place \
+    --root="$HF_LEROBOT_HOME/user/pick_place" \
     --vlm.model_id=Qwen/Qwen2.5-VL-7B-Instruct
 ```
+
+`$HF_LEROBOT_HOME` defaults to `~/.cache/huggingface/lerobot` - it is where
+`start_recording` wrote the dataset, resolved by `resolve_dataset_dir` (see
+[Recording & datasets](../recording.md#where-the-dataset-is-written-root-overwrite)).
+Pass the same `root=` you gave `start_recording` if you overrode it.
 
 Common flags:
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -12,7 +12,7 @@ sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=50)
 sim.run_policy(robot_name="so100", instruction="pick up the cube",
                policy_provider="mock", duration=10.0)
 sim.stop_recording()
-# LeRobot v3 dataset written to ~/.strands_robots/datasets/
+# LeRobot v3 dataset written to $HF_LEROBOT_HOME/user/my_dataset
 ```
 
 `start_recording` requires `[lerobot]`. Without it, use `start_cameras_recording` for plain MP4.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -128,9 +128,17 @@ meaning.
 
 ### Where the dataset is written (`root` / `overwrite`)
 
-`root` is the on-disk directory for the dataset (defaults to the LeRobot cache
-under `repo_id` when omitted). Passing an existing **empty** directory - for
-example one returned by `tempfile.mkdtemp()` - is accepted and recorded into:
+`root` is the on-disk directory for the dataset, used verbatim. When omitted,
+the directory is derived from `repo_id`: an `owner/name` id records into
+`$HF_LEROBOT_HOME/{repo_id}` (default `~/.cache/huggingface/lerobot`), and a
+`repo_id` that is itself a path is taken as the directory. The home is read from
+LeRobot's own `HF_LEROBOT_HOME` constant, so exporting it moves both the
+recording and where `LeRobotDataset` later reads it back from -
+`resolve_dataset_dir` is the one owner of those rules and every backend's
+`start_recording` applies it.
+
+Passing an existing **empty** directory - for example one returned by
+`tempfile.mkdtemp()` - is accepted and recorded into:
 
 ```python
 import tempfile
@@ -416,7 +424,7 @@ recorder = DatasetRecorder.create(
     camera_keys=["default"],
     joint_names=["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"],
     task="pick up the red cube",
-    # root=None → ~/.strands_robots/datasets/
+    # root=None → $HF_LEROBOT_HOME/user/my_dataset
     # vcodec="h264", streaming_encoding=True, image_writer_threads=4
 )
 

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -151,23 +151,38 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         Requires the ``lerobot`` extra for the dataset schema.
 
         Args:
-            repo_id: HuggingFace dataset id (``owner/name``) or a local path.
+            repo_id: HuggingFace dataset id (``owner/name``) or a local path. The
+                directory it records into is resolved by
+                :func:`~strands_robots.dataset_recorder.resolve_dataset_dir` -
+                the same resolver ``DatasetRecorder.create`` uses - so an
+                ``owner/name`` id lands in ``$HF_LEROBOT_HOME/{repo_id}`` while a
+                value that is itself a path is taken as the directory. That home
+                is read from LeRobot's own ``HF_LEROBOT_HOME`` constant, so
+                relocating it moves both this recording and where
+                ``LeRobotDataset`` later reads the dataset back from.
             task: Default task description recorded with every frame.
             fps: Recording frame rate (metadata; see pacing note above).
                 Must be a positive whole number; a rate no dataset can be
                 written at is rejected up front. When an existing dataset is
                 RESUMED (``overwrite=False``) it must equal that dataset's
                 on-disk rate, which a resume cannot change.
-            root: Explicit on-disk dataset directory (overrides the repo_id
-                cache-path resolution).
+            root: Explicit on-disk dataset directory, used verbatim - it replaces
+                the ``repo_id`` resolution above rather than being joined to it.
+                See :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
+                for the full precedence.
             push_to_hub: Publish to the Hub at ``stop_recording``.
             vcodec: Video codec for the per-camera MP4 streams. Defaults to
                 "h264" (H.264), universally decodable including by OpenCV's
                 VideoCapture. Use "libsvtav1" (AV1) for smaller files;
                 LeRobot read-back handles AV1 but OpenCV wheels commonly
                 cannot decode it and silently yield 0 frames.
-            overwrite: Wipe and recreate an existing dataset dir instead of
-                appending to it.
+            overwrite: When True, wipe any existing dataset at the resolved
+                directory and record from scratch. When False (default) an
+                existing dataset is RESUMED (episodes appended), a pre-existing
+                EMPTY directory (e.g. from ``tempfile.mkdtemp()``) is cleared and
+                recorded into, and a non-empty non-dataset directory is reported
+                as an error rather than clobbered - the four outcomes of
+                :meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`.
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every registered RTX camera is recorded. Pass a
                 subset to scope the dataset to exactly those views - matching

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -81,6 +81,15 @@ class RecordingMixin(DatasetRecordingMixin):
         rather than freezing on the chunk-start observation.
 
         Args:
+            repo_id: HuggingFace dataset id (``owner/name``) or a local path. The
+                directory it records into is resolved by
+                :func:`~strands_robots.dataset_recorder.resolve_dataset_dir` -
+                the same resolver ``DatasetRecorder.create`` uses - so an
+                ``owner/name`` id lands in ``$HF_LEROBOT_HOME/{repo_id}`` while a
+                value that is itself a path is taken as the directory. That home
+                is read from LeRobot's own ``HF_LEROBOT_HOME`` constant, so
+                relocating it moves both this recording and where
+                ``LeRobotDataset`` later reads the dataset back from.
             fps: Dataset frame rate recorded in the LeRobot metadata. Must be a
                 positive whole number - a fractional or non-numeric rate cannot
                 be written and is rejected up front rather than aborting the
@@ -96,14 +105,17 @@ class RecordingMixin(DatasetRecordingMixin):
                 dataset's on-disk rate: a resumed dataset keeps the rate it was
                 created at, so a differing request is refused with the on-disk
                 value rather than silently appending frames on a wrong timebase.
-            root: On-disk dataset directory (defaults to the LeRobot cache under
-                ``repo_id``). An existing EMPTY directory (e.g. from
-                ``tempfile.mkdtemp()``) is accepted and recorded into; an
-                existing dataset is resumed/appended (see ``overwrite``).
-            overwrite: When True, wipe any existing dataset at ``root`` and
-                record from scratch. When False (default) an existing dataset is
-                appended to; a non-empty, non-dataset ``root`` is reported as an
-                error rather than clobbered.
+            root: Explicit on-disk dataset directory, used verbatim - it replaces
+                the ``repo_id`` resolution above rather than being joined to it.
+                See :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
+                for the full precedence.
+            overwrite: When True, wipe any existing dataset at the resolved
+                directory and record from scratch. When False (default) an
+                existing dataset is RESUMED (episodes appended), a pre-existing
+                EMPTY directory (e.g. from ``tempfile.mkdtemp()``) is cleared and
+                recorded into, and a non-empty non-dataset directory is reported
+                as an error rather than clobbered - the four outcomes of
+                :meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`.
             vcodec: Video codec for the per-camera MP4 streams. Defaults to
                 "h264" (H.264), which decodes everywhere - including OpenCV's
                 VideoCapture, used by many downstream VLM video readers - so a

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -89,14 +89,24 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         Requires the ``lerobot`` extra for the dataset schema.
 
         Args:
-            repo_id: HuggingFace dataset id (``owner/name``) or a local path.
+            repo_id: HuggingFace dataset id (``owner/name``) or a local path. The
+                directory it records into is resolved by
+                :func:`~strands_robots.dataset_recorder.resolve_dataset_dir` -
+                the same resolver ``DatasetRecorder.create`` uses - so an
+                ``owner/name`` id lands in ``$HF_LEROBOT_HOME/{repo_id}`` while a
+                value that is itself a path is taken as the directory. That home
+                is read from LeRobot's own ``HF_LEROBOT_HOME`` constant, so
+                relocating it moves both this recording and where
+                ``LeRobotDataset`` later reads the dataset back from.
             task: Default task description recorded with every frame.
             fps: Recording frame rate. Must be a positive whole number;
                 a rate no dataset can be written at is rejected up front. When
                 an existing dataset is RESUMED (``overwrite=False``) it must
                 equal that dataset's on-disk rate, which a resume cannot change.
-            root: Explicit on-disk dataset directory (overrides the repo_id
-                cache-path resolution).
+            root: Explicit on-disk dataset directory, used verbatim - it replaces
+                the ``repo_id`` resolution above rather than being joined to it.
+                See :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
+                for the full precedence.
             push_to_hub: Publish to the Hub at ``stop_recording``.
             vcodec: Video codec for the per-camera MP4 streams. Defaults to
                 "h264" (H.264), universally decodable including by OpenCV's
@@ -104,8 +114,13 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 "libsvtav1" (AV1) for smaller files in storage-constrained
                 training pipelines; LeRobot read-back handles AV1 but OpenCV
                 wheels commonly cannot decode it and silently yield 0 frames.
-            overwrite: Wipe and recreate an existing dataset dir instead of
-                appending to it.
+            overwrite: When True, wipe any existing dataset at the resolved
+                directory and record from scratch. When False (default) an
+                existing dataset is RESUMED (episodes appended), a pre-existing
+                EMPTY directory (e.g. from ``tempfile.mkdtemp()``) is cleared and
+                recorded into, and a non-empty non-dataset directory is reported
+                as an error rather than clobbered - the four outcomes of
+                :meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`.
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every named scene camera is recorded. Pass a subset
                 (e.g. ``cameras=["camera1", "camera2"]``) to scope the dataset

--- a/tests/simulation/test_recording_dataset_home_across_backends.py
+++ b/tests/simulation/test_recording_dataset_home_across_backends.py
@@ -406,3 +406,25 @@ class TestStartRecordingDocumentsWhereTheDatasetLands:
         assert "_prepare_dataset_target" in _docstring(module, "start_recording"), (
             f"{module}::start_recording restates the create-vs-resume outcomes instead of citing their owner"
         )
+
+    def test_no_doc_page_sends_a_reader_to_a_dataset_home_nothing_writes(self):
+        """``~/.strands_robots/datasets/`` is not where a recording lands.
+
+        ``~/.strands_robots`` is the renders / mesh-audit / scene-cache home; no
+        code writes a dataset under it. Three doc passages named it as the
+        default recording location anyway - the quick-start comment, the
+        ``DatasetRecorder`` snippet, and an annotation workflow that handed
+        ``lerobot-annotate --root`` a path the preceding ``start_recording``
+        never wrote to, so the documented sequence could not work as written.
+        The three were independent copies, which is why fixing one left two, so
+        the property is asserted over the whole doc tree rather than per page.
+        """
+        offenders = [
+            path.as_posix()
+            for path in sorted(Path("docs").rglob("*.md"))
+            if "strands_robots/datasets" in path.read_text()
+        ]
+        assert not offenders, (
+            f"{', '.join(offenders)} names ~/.strands_robots/datasets as a dataset location; "
+            "recordings land under $HF_LEROBOT_HOME (see resolve_dataset_dir)"
+        )

--- a/tests/simulation/test_recording_dataset_home_across_backends.py
+++ b/tests/simulation/test_recording_dataset_home_across_backends.py
@@ -31,6 +31,13 @@ The behavioural half drives the Newton engine through a hand-built ``SimWorld``
 neither Newton nor lerobot installed. The structural half pins the property for
 the two backends whose simulators cannot be driven here, and for any backend
 added later.
+
+A third half covers the same contract's *documentation*. Making the override
+load-bearing on all three backends left every ``start_recording`` docstring
+describing ``root`` as overriding "the repo_id cache-path resolution" without
+naming the cache or that it is configurable -- so the resolution had one owner in
+code and three partial restatements in prose, which is the arrangement that
+drifted in the first place.
 """
 
 from __future__ import annotations
@@ -321,4 +328,81 @@ class TestNoDatasetRootResolutionDrifts:
         literals = _string_constants(module, "start_recording")
         assert not literals & {".cache", "huggingface", "lerobot"}, (
             f"{module}::start_recording hard-codes the dataset home instead of resolving it"
+        )
+
+
+def _docstring(module: str, method: str) -> str:
+    """The docstring of ``module::method``, or fail if it has none.
+
+    Read separately from :func:`_string_constants` because that reader answers
+    "what does the code spell" while these assertions answer "what does the
+    caller get told" - a method whose docstring were removed entirely would
+    satisfy an emptied-set check silently.
+    """
+    doc = ast.get_docstring(_method_node(module, method))
+    if not doc:
+        pytest.fail(f"{method} in {module} has no docstring")
+    return doc
+
+
+class TestStartRecordingDocumentsWhereTheDatasetLands:
+    """The resolution has one owner in code; its documentation needs one too.
+
+    The scanners above hold every backend to the shared resolver, which settles
+    *behaviour*. They say nothing about what a caller reading ``start_recording``
+    is told, and the answer was nothing: all three docstrings described ``root``
+    as overriding "the repo_id cache-path resolution" without naming which cache
+    or that it is configurable, the MuJoCo one documented no ``repo_id`` at all,
+    and ``$HF_LEROBOT_HOME`` appeared only in inline code comments a caller never
+    reads. So the override that #1863 made load-bearing on all three backends was
+    undiscoverable from the API surface, and three partial restatements of one
+    contract were free to drift apart again.
+
+    Each assertion pins the cross-reference rather than the prose, so the rules
+    keep a single owner: restating them per backend is what drifted.
+    """
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    def test_every_backend_points_at_the_shared_resolver(self, module):
+        assert "resolve_dataset_dir" in _docstring(module, "start_recording"), (
+            f"{module}::start_recording does not tell the caller which resolver decides the dataset directory"
+        )
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    def test_every_backend_names_the_home_override(self, module):
+        """The one thing a caller cannot find out any other way.
+
+        ``resolve_dataset_dir`` reads the home from lerobot's own constant, so
+        the environment variable is the only way to move a recording - and a
+        cross-reference alone leaves the reader to go find that out.
+        """
+        assert "HF_LEROBOT_HOME" in _docstring(module, "start_recording"), (
+            f"{module}::start_recording never names HF_LEROBOT_HOME, so the dataset home reads as fixed"
+        )
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    def test_every_backend_documents_both_parameters_that_select_the_directory(self, module):
+        """``repo_id`` and ``root`` are the two inputs to the resolution.
+
+        MuJoCo's Args block documented ``fps`` / ``root`` / ``overwrite`` /
+        ``vcodec`` / ``cameras`` and omitted the parameter that names the
+        dataset, so a cross-reference on ``root`` alone would still leave the
+        default path unexplained on that backend.
+        """
+        doc = _docstring(module, "start_recording")
+        missing = [param for param in ("repo_id:", "root:") if param not in doc]
+        assert not missing, f"{module}::start_recording documents no {', '.join(missing)} entry"
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    def test_every_backend_points_at_the_shared_create_vs_resume_owner(self, module):
+        """The same one-owner rule for the other contract documented only on a helper.
+
+        ``_prepare_dataset_target`` decides four outcomes for an existing target
+        (resume, clear-empty, wipe-on-overwrite, refuse-non-dataset). Two
+        backends described it as "wipe and recreate ... instead of appending",
+        which names two of the four and reads as though an empty ``root`` were
+        an error.
+        """
+        assert "_prepare_dataset_target" in _docstring(module, "start_recording"), (
+            f"{module}::start_recording restates the create-vs-resume outcomes instead of citing their owner"
         )


### PR DESCRIPTION
Closes #1864

## Why

#1863 made `$HF_LEROBOT_HOME` load-bearing on all three backends by routing Newton's recording through `resolve_dataset_dir` like MuJoCo and Isaac already did. **No backend's docstring names the variable**, so where a recording lands - and that the location is configurable at all - is undiscoverable from the API surface.

Measured on `0c07e64`, the two parameters that select the directory:

| module | `repo_id` says | `root` says | names `$HF_LEROBOT_HOME` |
| --- | --- | --- | --- |
| `simulation/mujoco/recording.py` | **no `Args` entry at all** | "defaults to the LeRobot cache under `repo_id`" | no (inline comment only) |
| `simulation/isaac/recording.py` | id or a local path | "overrides the repo_id cache-path resolution" | no (inline comment only) |
| `simulation/newton/recording.py` | id or a local path | "overrides the repo_id cache-path resolution" | no (inline comment only) |

Which cache goes unnamed in all three, and none says it is configurable. `resolve_dataset_dir` states the contract correctly - explicit `root` verbatim; a `repo_id` that is itself a path as a directory; otherwise `$HF_LEROBOT_HOME/{repo_id}` - so the rules are written down once, in the helper, and none of the three public entry points that apply them repeats or references them.

The MuJoCo `Args` block documented `fps` / `root` / `overwrite` / `vcodec` / `cameras` and omitted the one parameter that names the dataset.

## What

Docstrings, the doc pages, and the structural guard - no behaviour change.

1. **Cross-reference instead of restating.** All three `repo_id` / `root` entries point at `resolve_dataset_dir` in the same `:func:` style the pose and size params already use for `coerce_pose_vector` / `coerce_size_vector`. Three partial restatements of one contract is exactly the arrangement that drifted, so the rules keep one prose owner.
2. **The override is stated where a caller reading `start_recording` sees it**, and noted as read from LeRobot's own `HF_LEROBOT_HOME` constant - so relocating the home moves both the recording and where `LeRobotDataset` later reads it back from.
3. **`overwrite` gets the same treatment.** `_prepare_dataset_target`'s four outcomes for an existing target (resume, clear-empty, wipe-on-overwrite, refuse-non-dataset) were also documented only on the helper; two backends compressed them to "wipe and recreate ... instead of appending to it", which names two of the four and reads as though a pre-existing empty `root` were an error rather than the accepted case it is.
4. **`~/.strands_robots/datasets/` is removed from the docs.** No code writes a dataset under `~/.strands_robots` - that is the renders (`mujoco/rendering.py`), mesh-audit (`mesh/audit.py`) and scene-cache (`isaac/simulation.py`) home. Three separate passages named it as the recording location; see round 2 below.

## Tests

The issue proposed no test, on the grounds that a cross-reference plus #1863's code scanner is the guard. A docstring claim nothing asserts is how this drifted in the first place, so `TestStartRecordingDocumentsWhereTheDatasetLands` (13 checks) is added to `tests/simulation/test_recording_dataset_home_across_backends.py` - the module that already owns this property across backends, so the prose stays with one owner rather than starting a second file:

- every backend's `start_recording` docstring cites `resolve_dataset_dir`
- every one names `HF_LEROBOT_HOME` (the part a cross-reference alone leaves the reader to go find)
- every one documents **both** `repo_id` and `root` (the check that catches MuJoCo's omission, and any future one)
- every one cites `_prepare_dataset_target` rather than restating its outcomes
- no page under `docs/` names `~/.strands_robots/datasets` as a dataset location

Read via `ast.get_docstring`, deliberately separate from the existing `_string_constants` reader: that one answers "what does the code spell", these answer "what does the caller get told", and a method whose docstring were deleted outright would satisfy an emptied-set check silently - so a missing docstring fails rather than yielding an empty string.

**Non-vacuity, measured.** With the three `recording.py` files reverted to `main`: **10 failed, 2 passed** of the 12 docstring checks. The two that pass are `documents_both_parameters` on Isaac and Newton, which already documented both - that check exists for the MuJoCo omission and for the next backend. With `docs/` reverted, the doc-tree check fails naming both offending files.

**Gate.**

- `tests/simulation/test_recording_dataset_home_across_backends.py`: **30 passed** (17 before, +13)
- the five collectible `test_recording*` / `test_dataset*` modules together: **53 passed, 2 skipped**; the sixth (`test_dataset_recording_fps_contract.py`) needs `mujoco`, absent here and absent on `main` too
- `tests/simulation` failure/error set diffed against a clean `main` in the same environment: **identical** (43 collection errors both sides, all missing optional deps - `mujoco`, `torch`)
- `ruff format --check` and `ruff check` clean on all four touched Python files
- no test or doc asserted on the replaced wording: `grep -rn "cache-path|defaults to the LeRobot cache|Wipe and recreate"` now matches only the new test module's own prose describing what it replaced

## Out of scope

- **`task` and `push_to_hub` are still undocumented in the MuJoCo `Args` block.** Only `repo_id` was added, because it is part of the dataset-location contract this PR states; completing that block is a different concern and would make the diff about `Args` completeness rather than about where a recording lands. Cheap follow-up for whoever touches the file next.
- The `size` / count decision in #1858 and the `repo_id`-with-no-slash local-path branch of `resolve_dataset_dir` are unchanged - the docstrings defer to the helper for the full precedence rather than enumerating it a fourth time.

## 13. Round changelog

### Round 2 - the wrong path was three copies, not one

**One concern: `~/.strands_robots/datasets/` survived elsewhere in the docs.** Review feedback was right and my round-1 claim was wrong - I asserted `grep -rn "strands_robots/datasets"` matched nothing outside the comment I fixed. It matched two more places, and the grep output that led me to that conclusion had been truncated by a `head`, so the check meant to substantiate the claim never saw the hits. Recorded plainly, because the failure was in the verification rather than in the fix.

The two remaining copies:

| location | what it said |
| --- | --- |
| `docs/recording.md:15` | the page's **own opening snippet** annotates a `repo_id`-only recording as `# LeRobot v3 dataset written to ~/.strands_robots/datasets/` - the first thing a reader of this page sees was the same wrong path the round-1 commit fixed 400 lines lower down |
| `docs/data/annotation.md:69` | `lerobot-annotate --root=~/.strands_robots/datasets/user/pick_place`, run immediately after a `start_recording(repo_id="user/pick_place")` that wrote to `$HF_LEROBOT_HOME` |

The second is the worse of the two, and is not merely a stale annotation: the documented sequence **cannot work as written**, because `--root` names a directory the preceding recording never created. It is not a comment a reader can skip past - it is the command they run.

Both now name `$HF_LEROBOT_HOME`. The annotation page states the default (`~/.cache/huggingface/lerobot`), points at the resolution section rather than restating the rules a fourth time, and notes that a caller who overrode `root=` should pass the same value there. The section anchor was resolved with `markdown`'s `toc` slugifier rather than written by hand, since that heading does not slug to the obvious guess.

**Guarded rather than just fixed**, because three independent copies is precisely why fixing one left two: `test_no_doc_page_sends_a_reader_to_a_dataset_home_nothing_writes` scans every `docs/**/*.md` instead of the pages known to be wrong today. With `docs/` reverted it fails naming `docs/data/annotation.md, docs/recording.md` - so the guard is what would have caught the incomplete round-1 sweep.

**Verification (round 2).** `tests/simulation/test_recording_dataset_home_across_backends.py`: **30 passed**. `grep -rn "strands_robots/datasets" docs/ strands_robots/ examples/` now returns nothing. `ruff format --check` / `ruff check` clean. No production file touched by this commit.