### PR TITLE
docs(sim): say which task lands on a recorded frame

### DIFF
--- a/changelog.d/1866-start-recording-task-precedence-docs.md
+++ b/changelog.d/1866-start-recording-task-precedence-docs.md
@@ -1,0 +1,55 @@
+### Docs: `start_recording(task=)` says which frame task actually wins, and names the `"untitled"` it falls back to
+
+`add_frame` owns the whole rule - `frame["task"] = task or self.default_task or
+"untitled"` - and `start_recording(task=...)` feeds only the middle term, through
+`create(task=...)` / `resume(task=...)`. The term that wins is `add_frame`'s own,
+and every rollout hook passes the rollout instruction there:
+`simulation/{isaac,newton}/recording.py` and `simulation/mujoco/simulation.py` all
+call `add_frame(..., task=instruction)`. So the effective precedence is three
+levels deep,
+
+```
+frame["task"] = run_policy(instruction=...)  or  start_recording(task=...)  or  "untitled"
+```
+
+and which level supplies the value depends on an argument to a *different* method
+- `run_policy(instruction: str = "")` defaults to empty.
+
+Two of the three docstrings described the parameter as the value "recorded with
+every frame", which is the one thing it is not, and the third documented it not at
+all:
+
+| surface | `task` | `push_to_hub` |
+| --- | --- | --- |
+| `simulation/isaac/recording.py` | "Default task description recorded with every frame." | documented |
+| `simulation/newton/recording.py` | same wording | documented |
+| `simulation/mujoco/recording.py` | *no entry at all* | *no entry at all* |
+
+The wrong claim is quieter than the omission. A caller who reads it, sets
+`task="pick up the red cube"`, then drives the rollout with
+`run_policy(..., instruction="place the cube in the bin")` gets every frame
+annotated with the second string; both are plausible, so the dataset reads as
+correctly annotated. And the terminal level was named nowhere: set neither and
+every frame carries the literal `"untitled"`, which is the conditioning signal for
+every language-conditioned policy this repo targets (pi0/pi0.5, SmolVLA, GR00T,
+MolmoAct2) - a dataset recorded that way trains against a constant instruction.
+`start_recording`'s success text already hinted at the coupling with
+`Task: {task or '(set per policy)'}`, but only in the returned string, and it does
+not say where an unset instruction lands.
+
+All three entries now state the precedence and cite
+`DatasetRecorder.add_frame` for it, rather than restating it a fourth time - the
+same single-prose-owner arrangement #1865 established for `resolve_dataset_dir`,
+with one addition: that resolver already documented its own rules, while
+`add_frame`'s `task` entry read "uses default if None" and named neither the
+session default it meant nor the fallback. The owner is now written out, so the
+cross-references resolve. MuJoCo's `Args` block gains `task` and `push_to_hub`,
+completing it after #1865 added `repo_id`.
+
+`TestStartRecordingDocumentsTheTaskThatLandsOnAFrame` guards all of it in
+`tests/simulation/test_recording_dataset_home_across_backends.py`, beside the
+directory-resolution checks that already read these docstrings. Eleven of its
+sixteen checks fail on the previous wording - including the two backends that were
+already *complete*, since completeness is not accuracy.
+
+Docstrings and tests only - no behaviour change.

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1140,7 +1140,18 @@ class DatasetRecorder:
             observation: Raw observation dict from robot/sim
                 (joint_name → float, camera_name → np.ndarray)
             action: Action dict (joint_name → float)
-            task: Task description (uses default if None)
+            task: Task description written to this frame's ``task`` column.
+                This argument is the top of a three-level chain and the only
+                place it is stated: it falls back to the recorder's
+                ``default_task`` (set from ``create(task=...)`` /
+                ``resume(task=...)``, which is what a backend's
+                ``start_recording(task=...)`` supplies) and then to the literal
+                ``"untitled"``. Every simulation rollout hook passes
+                ``run_policy(instruction=...)`` here, so a non-empty instruction
+                overrides the recording session's task, and a rollout driven with
+                neither annotates its frames ``"untitled"`` - a constant
+                instruction for any language-conditioned policy trained on the
+                result.
             camera_keys: Which keys in observation are camera images
             required_action_keys: Action column names this frame must
                 supply a value for - typically the action keys of the robot

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -160,7 +160,15 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 is read from LeRobot's own ``HF_LEROBOT_HOME`` constant, so
                 relocating it moves both this recording and where
                 ``LeRobotDataset`` later reads the dataset back from.
-            task: Default task description recorded with every frame.
+            task: Task description for frames that do not carry their own. It
+                is the middle of a three-level chain owned by
+                :meth:`~strands_robots.dataset_recorder.DatasetRecorder.add_frame`:
+                the task passed with a frame wins, then this value, then the
+                literal ``"untitled"``. Every rollout hook passes
+                ``run_policy(instruction=...)`` as the frame task, so a non-empty
+                instruction overrides this value; supply neither and each frame is
+                annotated ``"untitled"``, which conditions a
+                language-conditioned policy on a constant instruction.
             fps: Recording frame rate (metadata; see pacing note above).
                 Must be a positive whole number; a rate no dataset can be
                 written at is rejected up front. When an existing dataset is

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -90,6 +90,15 @@ class RecordingMixin(DatasetRecordingMixin):
                 is read from LeRobot's own ``HF_LEROBOT_HOME`` constant, so
                 relocating it moves both this recording and where
                 ``LeRobotDataset`` later reads the dataset back from.
+            task: Task description for frames that do not carry their own. It
+                is the middle of a three-level chain owned by
+                :meth:`~strands_robots.dataset_recorder.DatasetRecorder.add_frame`:
+                the task passed with a frame wins, then this value, then the
+                literal ``"untitled"``. Every rollout hook passes
+                ``run_policy(instruction=...)`` as the frame task, so a non-empty
+                instruction overrides this value; supply neither and each frame is
+                annotated ``"untitled"``, which conditions a
+                language-conditioned policy on a constant instruction.
             fps: Dataset frame rate recorded in the LeRobot metadata. Must be a
                 positive whole number - a fractional or non-numeric rate cannot
                 be written and is rejected up front rather than aborting the
@@ -109,6 +118,7 @@ class RecordingMixin(DatasetRecordingMixin):
                 the ``repo_id`` resolution above rather than being joined to it.
                 See :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
                 for the full precedence.
+            push_to_hub: Publish to the Hub at ``stop_recording``.
             overwrite: When True, wipe any existing dataset at the resolved
                 directory and record from scratch. When False (default) an
                 existing dataset is RESUMED (episodes appended), a pre-existing

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -98,7 +98,15 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 is read from LeRobot's own ``HF_LEROBOT_HOME`` constant, so
                 relocating it moves both this recording and where
                 ``LeRobotDataset`` later reads the dataset back from.
-            task: Default task description recorded with every frame.
+            task: Task description for frames that do not carry their own. It
+                is the middle of a three-level chain owned by
+                :meth:`~strands_robots.dataset_recorder.DatasetRecorder.add_frame`:
+                the task passed with a frame wins, then this value, then the
+                literal ``"untitled"``. Every rollout hook passes
+                ``run_policy(instruction=...)`` as the frame task, so a non-empty
+                instruction overrides this value; supply neither and each frame is
+                annotated ``"untitled"``, which conditions a
+                language-conditioned policy on a constant instruction.
             fps: Recording frame rate. Must be a positive whole number;
                 a rate no dataset can be written at is rejected up front. When
                 an existing dataset is RESUMED (``overwrite=False``) it must

--- a/tests/simulation/test_recording_dataset_home_across_backends.py
+++ b/tests/simulation/test_recording_dataset_home_across_backends.py
@@ -38,6 +38,19 @@ describing ``root`` as overriding "the repo_id cache-path resolution" without
 naming the cache or that it is configurable -- so the resolution had one owner in
 code and three partial restatements in prose, which is the arrangement that
 drifted in the first place.
+
+That documentation half then generalized past the dataset directory, because
+``start_recording`` applies a second multi-level contract it does not own:
+``add_frame`` decides a frame's ``task``, and the session's ``task=`` is only the
+middle level of it. Two backends described that parameter as the value "recorded
+with every frame" -- which is what it is *not*, since every rollout hook passes
+``run_policy(instruction=...)`` as the frame task and a non-empty instruction
+wins -- and the third documented neither ``task`` nor ``push_to_hub`` at all. The
+terminal level, the literal ``"untitled"``, was named nowhere: record with neither
+set and every frame carries it, which is a constant instruction for the
+language-conditioned policies this repo targets. So the assertions below cover
+both contracts: what a caller is told about *where* a recording lands, and about
+*what* each of its frames is annotated with.
 """
 
 from __future__ import annotations
@@ -345,6 +358,31 @@ def _docstring(module: str, method: str) -> str:
     return doc
 
 
+def _arg_entry(module: str, method: str, param: str) -> str:
+    """The ``param:`` entry of ``module::method``'s Args block, or ``""`` if absent.
+
+    Read per parameter rather than over the whole docstring, because the claims
+    below are about what *this* entry says: a docstring-wide search would let a
+    correct sentence about some other parameter satisfy an assertion about
+    ``task``, and would let a wrong claim in the ``task`` entry be excused by a
+    right one elsewhere. An entry runs from its ``param:`` line to the next line
+    indented no deeper, which is how these Args blocks are already written.
+    """
+    lines = _docstring(module, method).splitlines()
+    for index, line in enumerate(lines):
+        if line.strip().startswith(f"{param}:"):
+            indent = len(line) - len(line.lstrip())
+            entry = [line.strip()]
+            for follow in lines[index + 1 :]:
+                if not follow.strip():
+                    continue
+                if len(follow) - len(follow.lstrip()) <= indent:
+                    break
+                entry.append(follow.strip())
+            return " ".join(entry)
+    return ""
+
+
 class TestStartRecordingDocumentsWhereTheDatasetLands:
     """The resolution has one owner in code; its documentation needs one too.
 
@@ -427,4 +465,118 @@ class TestStartRecordingDocumentsWhereTheDatasetLands:
         assert not offenders, (
             f"{', '.join(offenders)} names ~/.strands_robots/datasets as a dataset location; "
             "recordings land under $HF_LEROBOT_HOME (see resolve_dataset_dir)"
+        )
+
+
+_PER_FRAME_CLAIMS = (
+    "recorded with every frame",
+    "recorded with each frame",
+    "recorded on every frame",
+    "written to every frame",
+    "written with every frame",
+    "applied to every frame",
+    "used for every frame",
+)
+
+
+class TestStartRecordingDocumentsTheTaskThatLandsOnAFrame:
+    """The other multi-level contract ``start_recording`` applies and does not own.
+
+    ``add_frame`` is the whole rule -- ``task or self.default_task or "untitled"``
+    -- and ``start_recording(task=...)`` feeds only the middle term, via
+    ``create(task=...)`` / ``resume(task=...)``. Which term supplies the value a
+    dataset is annotated with therefore depends on an argument to a *different*
+    method: every rollout hook passes ``run_policy(instruction=...)`` as the frame
+    task, and that argument defaults to empty.
+
+    Two of the three backends described the parameter as the value "recorded with
+    every frame", which asserts it is the per-frame term rather than the middle
+    one. That failure mode is quiet in a way an omission is not: a caller who sets
+    ``task="pick up the red cube"`` and then runs
+    ``run_policy(..., instruction="place the cube in the bin")`` gets every frame
+    annotated with the second string, and both strings are plausible, so the
+    dataset reads as correctly annotated. The third backend documented neither
+    ``task`` nor ``push_to_hub``.
+
+    The assertions pin the two facts a caller cannot infer plus the claim that is
+    wrong, rather than the prose, so the rule keeps the single owner #1865
+    established for the directory resolution.
+    """
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    @pytest.mark.parametrize("param", ["task", "push_to_hub"])
+    def test_every_backend_documents_the_two_remaining_parameters(self, module, param):
+        """``start_recording`` takes eight parameters on all three backends.
+
+        Six were documented everywhere after #1865 completed the MuJoCo block
+        with ``repo_id``; these are the two it deferred, and MuJoCo's Args block
+        is where they were missing. Asserted across all three so the next backend
+        cannot ship a seven-of-eight block either.
+        """
+        assert _arg_entry(module, "start_recording", param), f"{module}::start_recording documents no {param} entry"
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    def test_every_task_entry_names_the_terminal_fallback(self, module):
+        """Set neither this nor an instruction and every frame reads ``"untitled"``.
+
+        That is the silent case, and it was documented nowhere: the task string is
+        the conditioning signal for every language-conditioned policy this repo
+        targets, so a dataset recorded with neither set trains against a constant
+        instruction. ``start_recording``'s own success text hints at the coupling
+        with "(set per policy)", which names the override but not where an unset
+        instruction actually lands.
+        """
+        entry = _arg_entry(module, "start_recording", "task")
+        assert "untitled" in entry, (
+            f"{module}::start_recording's task entry never names the untitled fallback, "
+            "so a dataset annotated entirely with it reads as unexplained"
+        )
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    def test_every_task_entry_names_what_overrides_it(self, module):
+        """The override is an argument to another method, so it cannot be inferred.
+
+        ``run_policy(instruction=...)`` is what every rollout hook passes as the
+        frame task; nothing about ``start_recording``'s own signature says that a
+        rollout can displace the value it was given.
+        """
+        entry = _arg_entry(module, "start_recording", "task")
+        assert "instruction" in entry, (
+            f"{module}::start_recording's task entry never names run_policy(instruction=...), "
+            "so the value it documents reads as the one that wins"
+        )
+
+    @pytest.mark.parametrize("module", _START_RECORDING_BACKENDS)
+    def test_no_task_entry_claims_it_is_the_per_frame_value(self, module):
+        """The non-vacuous one: this fails on two backends as they stood.
+
+        #1865's ``documents_both_parameters`` check passed on Isaac and Newton
+        precisely because their blocks were already complete -- completeness is
+        not accuracy, and a wording that is present but wrong needs its own
+        assertion. Phrasings rather than one literal string, so the claim cannot
+        come back reworded.
+        """
+        entry = _arg_entry(module, "start_recording", "task").lower()
+        claimed = [claim for claim in _PER_FRAME_CLAIMS if claim in entry]
+        assert not claimed, (
+            f"{module}::start_recording's task entry claims to be {claimed[0]!r}; "
+            "it is the middle of add_frame's chain, overridden by run_policy(instruction=...)"
+        )
+
+    def test_the_owner_states_the_whole_chain(self):
+        """A cross-reference is only worth following if the target answers it.
+
+        The three entries above cite
+        ``DatasetRecorder.add_frame`` for the precedence, which is the same
+        arrangement #1865 used for ``resolve_dataset_dir`` -- with one difference:
+        that resolver already documented its own rules, while ``add_frame``'s task
+        entry read "uses default if None" and named neither the session default it
+        means nor the terminal fallback. So the owner is pinned too, or the
+        cross-references point at nothing.
+        """
+        entry = _arg_entry("strands_robots/dataset_recorder.py", "add_frame", "task")
+        missing = [term for term in ("default_task", "untitled", "instruction") if term not in entry]
+        assert not missing, (
+            f"DatasetRecorder.add_frame's task entry names no {', '.join(missing)} - "
+            "the backends cite it for the precedence it is supposed to own"
         )


### PR DESCRIPTION
Closes #1866

Follow-up to #1865, which named `$HF_LEROBOT_HOME` on every backend's `start_recording` and deferred the last two parameters of MuJoCo's `Args` block. These are those two, and `task` is not merely undocumented -- where it *is* documented, it is described as something it is not.

## The contract

`dataset_recorder.py:1248` is the whole rule:

```python
frame["task"] = task or self.default_task or "untitled"
```

`self.default_task` comes from `create(task=...)` / `resume(task=...)`, which is what `start_recording(task=...)` feeds -- so the session's `task` is the *middle* term. The term that wins is `add_frame`'s own, and every rollout hook passes the rollout instruction there (`isaac/recording.py:572,581`, `newton/recording.py:461,468`, `mujoco/simulation.py:4189,4196,4619`). Three levels deep:

```
frame["task"] = run_policy(instruction=...)  or  start_recording(task=...)  or  "untitled"
```

and which level supplies the value depends on an argument to a *different* method -- `run_policy(instruction: str = "")` defaults to empty.

## What the docstrings said

| surface | `task` | `push_to_hub` |
| --- | --- | --- |
| `simulation/isaac/recording.py` | "Default task description recorded with every frame." | documented |
| `simulation/newton/recording.py` | same wording | documented |
| `simulation/mujoco/recording.py` | *no entry at all* | *no entry at all* |

The wrong claim is quieter than the omission. "recorded with every frame" asserts this is the per-frame term; a caller who reads it, sets `task="pick up the red cube"`, then drives the rollout with `run_policy(..., instruction="place the cube in the bin")` gets every frame annotated with the second string. Nothing warns, and both strings are plausible, so the dataset reads as correctly annotated.

The terminal level was named nowhere. Set neither and every frame carries the literal `"untitled"` -- and the task string is the conditioning signal for every language-conditioned policy this repo targets (pi0/pi0.5, SmolVLA, GR00T, MolmoAct2), so such a dataset trains against a constant instruction. `start_recording`'s success text already hints at the coupling with `Task: {task or '(set per policy)'}`, but only in the returned string, and it does not say where an unset instruction actually lands.

Same defect class #1865 fixed for `repo_id`: a multi-level contract owned by one function, restated partially -- and here incorrectly -- at the three public entry points that apply it.

## Change

- All three `task` entries state the precedence and cite `DatasetRecorder.add_frame` for it rather than restating it a fourth time. Each names `"untitled"` as the terminal fallback and says plainly that a non-empty `run_policy(instruction=...)` overrides the value -- the two facts a caller cannot infer from `start_recording`'s own signature. One wording on all three, so a future divergence reads as a diff rather than as three paraphrases.
- `add_frame`'s own `task` entry is written out. #1865 could cross-reference `resolve_dataset_dir` because that resolver already documented its own rules; `add_frame`'s entry read "uses default if None" and named neither the session default it meant nor the fallback, so the cross-references would have pointed at nothing.
- MuJoCo's `Args` block gains `task` and `push_to_hub`, completing it after #1865 added `repo_id`. `push_to_hub`'s existing one-liner was accurate and is copied verbatim.

Not changed: the precedence itself. `instruction`-wins is defensible and `"untitled"` is a valid LeRobot task string. Whether an all-`"untitled"` dataset deserves a warning at `stop_recording` is a separate behavioural question, so this diff stays reviewable as documentation.

## Guard

`TestStartRecordingDocumentsTheTaskThatLandsOnAFrame`, in `tests/simulation/test_recording_dataset_home_across_backends.py` -- the module that already owns the "what does the caller get told" property across backends via `ast.get_docstring`, rather than a new one. 16 checks:

| check | asserts |
| --- | --- |
| `documents_the_two_remaining_parameters` (x6) | every backend has a `task` and a `push_to_hub` entry -- catches MuJoCo today and the next backend tomorrow |
| `names_the_terminal_fallback` (x3) | every `task` entry names `untitled` |
| `names_what_overrides_it` (x3) | every `task` entry names `instruction` |
| `no_task_entry_claims_it_is_the_per_frame_value` (x3) | no entry claims to be the value recorded on every frame |
| `the_owner_states_the_whole_chain` | `add_frame`'s entry names `default_task`, `untitled` and `instruction` |

Read per parameter, via a new `_arg_entry` beside the existing whole-docstring `_docstring`: a docstring-wide search would let a correct sentence about `repo_id` satisfy an assertion about `task`, and let a wrong claim about `task` be excused by a right one elsewhere. The fourth row is the non-vacuous one -- #1865's `documents_both_parameters` passed on Isaac and Newton precisely because their blocks were already *complete*, and completeness is not accuracy. It matches a set of phrasings rather than one literal string so the claim cannot come back reworded.

## Verification

Measured on a clean `550e7685` checkout (the #1865 squash, which is what the issue measured on).

- **Non-vacuity:** with the four production files reverted and the test file kept, **11 failed / 35 passed**. The 5 that still pass are the 4 `documents_the_two_remaining_parameters` cells Isaac and Newton already satisfied, plus MuJoCo's `no_claim` cell -- which passes vacuously on an absent entry, and is covered by the `documents` row.
- **With the change:** 46 passed (30 pre-existing + 16).
- **Delta on `tests/test_dataset_recorder.py` + `tests/simulation/`:** 57 failed / 550 errors on **both** base and branch -- all pre-existing, this env has no `mujoco` -- and 2662 -> 2678 passed, exactly the 16 new checks. No test outside the guard reads any of this wording (`grep` for `recorded with every frame` / `Default task description` across `tests/` matches nothing).
- `ruff check` and `ruff format --check` clean on all five files. `tests/test_docstring_xref_roles_resolve.py` passes, so the new `:meth:` target resolves. No non-ASCII introduced.
- `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py` pass with the fragment.

No behaviour change: docstrings and tests only.

## Round changelog

**Round 1** -- initial submission.