### PR TITLE
fix(sim): validate a step count on every backend

### DIFF
--- a/changelog.d/1868-step-count-domain-across-backends.md
+++ b/changelog.d/1868-step-count-domain-across-backends.md
@@ -47,9 +47,23 @@ true `int`, so it would have refused the `3.0` and `np.int64(3)` MuJoCo honors
 today (the first is pinned by an existing test), and `positive_whole_number_error`
 has the right scalar policy but would have refused the documented `0`. All three
 backends now apply it before any lock, solver or stage work and then coerce once
-with `int()`, which is safe only because the guard has established the value is
-finite and integral. The refusal is identical word for word across the three, not
-merely identical in verdict.
+with `int()`, which is safe because the guard has already performed that same
+conversion and compared the result back. The refusal is identical word for word
+across the three, not merely identical in verdict.
+
+Every real scalar gets a verdict from that guard; nothing raises out of it. That
+is the contract rather than a detail, because these methods document their
+structured result as the only channel a bad count is reported through and one of
+them takes its count from a remote process, where Python integers are
+arbitrary-precision. So the integrality test is an `int()` in a `try` rather than
+a `float()` round-trip - `float(10**400)` raises `OverflowError`, which would turn
+a refusal into a crash for the values most in need of one - and the refusal text
+is rendered only when a refusal is actually returned, since `repr` of an `int`
+past `sys.get_int_max_str_digits()` (4300 digits) raises `ValueError` and such a
+count is *accepted*. Magnitude is not part of this domain: `10**400` is a
+non-negative whole number and is accepted as one, and whether a count is too
+large to advance in a single call stays the per-call ceiling's question rather
+than becoming a silent boundary at the float range.
 
 Two neighbours are deliberately left alone and pinned as out of scope:
 `send_action(n_substeps=)`, which has the same gap on a second public surface,

--- a/changelog.d/1868-step-count-domain-across-backends.md
+++ b/changelog.d/1868-step-count-domain-across-backends.md
@@ -1,0 +1,61 @@
+### Fixed: `step` validates its count on every simulation backend
+
+`step(n_steps)` is the most-called method on the simulation surface and was the
+last public numeric input with three different domains. MuJoCo has *documented*
+one since its numeric inputs were hardened - "Non-negative step count (`0` is an
+accepted no-op)" - but implemented it by hand; Newton and Isaac validated
+nothing.
+
+A negative count was a silent success on Isaac. `range(-5)` is empty, so the call
+stepped nothing and reported `status="success"` - then divided the elapsed wall
+time by that negative count and put the result in agent-visible text:
+`Stepped -5x. sim_time=0.0000s, wall=0.0ms, -11876485 steps/sec`. `False` read
+the same way, as `Stepped Falsex`.
+
+`step(0)` advanced the world on Newton. `_advance` floors its count at
+`max(1, n_steps)`, so a zero - the value MuJoCo documents as a no-op - stepped
+once while the result said `Stepped 0 step(s).`: the report and the world
+disagreed, and one call was a no-op on one backend and a step on another. `-5`
+and `nan` reached that same floor and also advanced one step, reported as
+`Stepped -5 step(s).` and `Stepped nan step(s).`. `step` now answers its own zero
+rather than moving that floor, because `send_action(n_substeps=)` shares
+`_advance` and reads the floor as its own contract.
+
+`inf` escaped MuJoCo's own envelope: `int(float("inf"))` raises `OverflowError`,
+which the hand-rolled `except (TypeError, ValueError)` did not catch, so the one
+backend that documented this domain raised a bare exception through the
+structured result these methods document as their only failure channel. On
+Newton's solver-free path the same value left `step_count` and `sim_time` as
+`inf` permanently, so every later `get_state()` reported `t=inf`; `2.7` left the
+float `2.7` in an integer step counter. A boolean was read as a count of one on
+all three backends, and MuJoCo truncated `2.7` to two steps under a success
+result while its docstring promised an error for a non-integer.
+
+Two paths reach this from outside the process and now get a structured refusal
+instead of a raise or a false success: the mesh command router
+(`r.step(cmd.get("steps", 1))`, whose `dict(...)` call site propagates a raise)
+and the device-connect `@rpc()` `step`, which forwards a remote caller's value
+unchanged. Internal callers were already safe - `PolicyRunner._control_substeps`
+returns a true positive `int` on every path.
+
+The shared domain is `non_negative_whole_number_error`, the missing cell of an
+existing 2x2: it stands to `positive_whole_number_error` exactly as
+`non_negative_count_error` stands to `positive_count_error`, and for the same
+recorded reason - its `0` is first-class rather than degenerate. Neither existing
+helper fitted. `non_negative_count_error` has the right floor but accepts only a
+true `int`, so it would have refused the `3.0` and `np.int64(3)` MuJoCo honors
+today (the first is pinned by an existing test), and `positive_whole_number_error`
+has the right scalar policy but would have refused the documented `0`. All three
+backends now apply it before any lock, solver or stage work and then coerce once
+with `int()`, which is safe only because the guard has established the value is
+finite and integral. The refusal is identical word for word across the three, not
+merely identical in verdict.
+
+Two neighbours are deliberately left alone and pinned as out of scope:
+`send_action(n_substeps=)`, which has the same gap on a second public surface,
+and the per-call ceiling - MuJoCo refuses a count above `_MAX_STEPS_PER_CALL`
+(100_000) and releases its lock every 1000 steps so `stop_policy` can interleave,
+while Isaac accepted `100_001` and called `world.step` that many times inside one
+lock hold. That is a resource policy rather than an input domain, and choosing
+one ceiling for three backends with different per-step costs is a decision rather
+than a defect.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -45,6 +45,7 @@ from strands_robots.utils import (
     coerce_size_vector,
     entity_name_error,
     name_list_error,
+    non_negative_whole_number_error,
     positive_count_error,
     positive_whole_number_error,
 )
@@ -1237,13 +1238,26 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         Parameters
         ----------
         n_steps : int
-            Number of steps to take. Default 1.
+            Non-negative whole number of steps to take, on the shared
+            :func:`~strands_robots.utils.non_negative_whole_number_error` domain
+            every backend applies. Default 1, and ``0`` is an accepted no-op. A
+            NumPy or float count with an integral value is honored and coerced.
 
         Returns
         -------
         dict
-            Status dict with timing info.
+            Status dict with timing info. ``status`` is ``"error"`` when no
+            world exists or ``n_steps`` is outside that domain.
         """
+        # Guarded before the lock is taken and before any world tick: a
+        # negative count made ``range()`` empty, so the call reported success
+        # having stepped nothing, and divided the elapsed wall time by that
+        # negative count to report a negative steps/sec rate. Every
+        # non-integral value reached ``range()`` and raised past this method's
+        # structured envelope.
+        if error := non_negative_whole_number_error(n_steps, "n_steps", "step"):
+            return {"status": "error", "content": [{"text": error}]}
+        n_steps = int(n_steps)
         with self._lock:
             if not self._world_created:
                 return {"status": "error", "content": [{"text": "No world created."}]}

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -113,6 +113,7 @@ from strands_robots.utils import (
     coerce_pose_vector,
     entity_name_error,
     finite_vector_error,
+    non_negative_whole_number_error,
     pose_vector_error,
     sequence_length,
 )
@@ -3255,26 +3256,29 @@ class MuJoCoSimEngine(
         """Advance the simulation by ``n_steps`` physics steps.
 
         Args:
-            n_steps: Non-negative step count (``0`` is an accepted no-op).
+            n_steps: Non-negative whole step count (``0`` is an accepted no-op),
+                on the shared
+                :func:`~strands_robots.utils.non_negative_whole_number_error`
+                domain every backend applies. A NumPy or float count with an
+                integral value is honored and coerced; a fractional, negative,
+                non-finite, boolean or non-numeric count is refused.
 
         Returns:
             A ``{status, content}`` tool result reporting the elapsed sim time
             and total step count. ``status`` is ``"error"`` when no world
-            exists or ``n_steps`` is negative / not an integer.
+            exists, ``n_steps`` is outside that domain, or the count exceeds
+            :attr:`_MAX_STEPS_PER_CALL`.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
-        # reject negative, accept zero as no-op
-        if not isinstance(n_steps, int):
-            try:
-                n_steps = int(n_steps)
-            except (TypeError, ValueError):
-                return {
-                    "status": "error",
-                    "content": [{"text": f"step: n_steps must be an integer, got {type(n_steps).__name__}"}],
-                }
-        if n_steps < 0:
-            return {"status": "error", "content": [{"text": f"step: n_steps must be >= 0, got {n_steps}"}]}
+        # Refuse before coercing: ``int()`` alone truncates a fractional count
+        # to a different number of steps under a success result, reads a
+        # boolean as one step, and raises ``OverflowError`` on ``inf`` - which
+        # the previous ``except (TypeError, ValueError)`` did not catch, so an
+        # infinite count escaped this method's structured envelope entirely.
+        if error := non_negative_whole_number_error(n_steps, "n_steps", "step"):
+            return {"status": "error", "content": [{"text": error}]}
+        n_steps = int(n_steps)
         if n_steps == 0:
             return {
                 "status": "success",

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -65,6 +65,7 @@ from strands_robots.utils import (
     coerce_size_vector,
     entity_name_error,
     is_boolean,
+    non_negative_whole_number_error,
     positive_count_error,
     require_optional,
 )
@@ -397,9 +398,31 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         return {"status": "success", "content": [{"text": "Newton world reset."}]}
 
     def step(self, n_steps: int = 1) -> dict[str, Any]:
-        """Advance the simulation by ``n_steps`` control steps."""
+        """Advance the simulation by ``n_steps`` control steps.
+
+        Args:
+            n_steps: Non-negative whole control-step count, on the shared
+                :func:`~strands_robots.utils.non_negative_whole_number_error`
+                domain every backend applies. ``0`` is an accepted no-op, as it
+                is on MuJoCo. A NumPy or float count with an integral value is
+                honored and coerced.
+
+        Returns:
+            A ``{status, content}`` tool result. ``status`` is ``"error"`` when
+            no world exists or ``n_steps`` is outside that domain.
+        """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        if error := non_negative_whole_number_error(n_steps, "n_steps", "step"):
+            return {"status": "error", "content": [{"text": error}]}
+        n_steps = int(n_steps)
+        # ``_advance`` floors its count at 1 (``max(1, n_steps)``) because
+        # ``send_action`` shares it and reads that floor as its own contract, so
+        # a zero handed through would advance the world one step while this
+        # method reported stepping none. Answer it here instead of changing that
+        # floor, which would alter the ``send_action(n_substeps=0)`` path too.
+        if n_steps == 0:
+            return {"status": "success", "content": [{"text": "Stepped 0 step(s) (no-op)."}]}
         with self._lock:
             self._advance(n_steps)
         return {"status": "success", "content": [{"text": f"Stepped {n_steps} step(s)."}]}

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -512,6 +512,55 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     return None
 
 
+def non_negative_whole_number_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable non-negative whole number.
+
+    Shared domain for the number of physics steps a caller asks a simulation to
+    advance - the ``n_steps`` of every backend's
+    :meth:`~strands_robots.simulation.base.SimEngine.step`.
+
+    It stands to :func:`positive_whole_number_error` exactly as
+    :func:`non_negative_count_error` stands to :func:`positive_count_error`: the
+    same scalar policy with the floor moved to ``0``, because ``0`` is a
+    first-class value here rather than a degenerate one. The MuJoCo backend has
+    documented ``step(0)`` as "an accepted no-op" since its numeric inputs were
+    hardened, and an agent loop that computes ``n_steps`` from a remaining
+    duration reaches ``0`` on the last iteration of a rollout that has run out
+    of time. Refusing it would reject that loop's final call, which is why this
+    is a separate domain rather than a caller of the positive one.
+
+    Accepts any real scalar with an integral value, so a step count that came
+    from arithmetic - ``int(duration / dt)`` promoted to ``np.int64`` by a NumPy
+    dt, or a ``30.0`` read from a config - is honored. The caller coerces the
+    accepted value with ``int()`` before using it as a ``range()`` bound; that
+    coercion is safe only *because* this guard has already established the value
+    is finite and integral, which is the whole reason the two steps are ordered
+    this way. ``bool`` is rejected explicitly: it is an ``int`` subclass, so a
+    bare ``value < 0`` test lets ``True`` through as a silent count of one
+    physics step, and ``numpy.bool_`` is not registered as ``numbers.Real`` so
+    it is refused by the scalar check.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it - the
+            public method name, or the class name for a constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    message = f"{context}: {param} must be a non-negative whole number, got {value!r}."
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return message
+    numeric = float(value)
+    # ``isfinite`` first: ``int(nan)`` raises ``ValueError`` and ``int(inf)``
+    # raises ``OverflowError``, and short-circuiting keeps both out of the
+    # integrality check below.
+    if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 0:
+        return message
+    return None
+
+
 def positive_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive integer count.
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -515,6 +515,35 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     return None
 
 
+def _refusal_repr(value: Any) -> str:
+    """``repr(value)`` for a refusal message, or a description when it cannot be built.
+
+    Rendering a rejected value must not be able to raise: it runs only on the
+    path whose entire purpose is to answer an unusable input with a structured
+    message instead of an exception. Two cases reach it. ``repr`` of an ``int``
+    wider than :func:`sys.get_int_max_str_digits` (4300 digits by default)
+    raises ``ValueError``, and a caller can send one - ``sim_driver``'s
+    ``@rpc()`` ``step`` forwards a remote integer unchanged and Python integers
+    are arbitrary-precision. And a third-party :class:`numbers.Real`
+    implementation may raise anything at all from its own ``__repr__``, so the
+    guarantee here has to be unconditional rather than a list of the exceptions
+    known today. ``int.bit_length`` needs no decimal conversion, so the integer
+    that could not be printed can still be described.
+
+    Args:
+        value: The rejected value.
+
+    Returns:
+        Its ``repr``, or a bracketed description when that cannot be produced.
+    """
+    try:
+        return repr(value)
+    except Exception:
+        if isinstance(value, int):
+            return f"<int of {value.bit_length()} bits>"
+        return f"<unrepresentable {type(value).__name__}>"
+
+
 def non_negative_whole_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable non-negative whole number.
 
@@ -536,12 +565,28 @@ def non_negative_whole_number_error(value: Any, param: str, context: str) -> str
     from arithmetic - ``int(duration / dt)`` promoted to ``np.int64`` by a NumPy
     dt, or a ``30.0`` read from a config - is honored. The caller coerces the
     accepted value with ``int()`` before using it as a ``range()`` bound; that
-    coercion is safe only *because* this guard has already established the value
-    is finite and integral, which is the whole reason the two steps are ordered
-    this way. ``bool`` is rejected explicitly: it is an ``int`` subclass, so a
-    bare ``value < 0`` test lets ``True`` through as a silent count of one
-    physics step, and ``numpy.bool_`` is not registered as ``numbers.Real`` so
-    it is refused by the scalar check.
+    coercion is safe *because* this guard has already performed it and compared
+    the result back, which is the whole reason the two steps are ordered this
+    way. ``bool`` is rejected explicitly: it is an ``int`` subclass, so a bare
+    ``value < 0`` test lets ``True`` through as a silent count of one physics
+    step, and ``numpy.bool_`` is not registered as ``numbers.Real`` so it is
+    refused by the scalar check.
+
+    Every real scalar gets a verdict; nothing raises out of here. That is the
+    contract, not a detail, because the callers document their structured
+    ``{status, content}`` result as the only channel a bad count is reported
+    through, and one of them takes its count from a remote process. It is why
+    the integrality test is an ``int()`` in a ``try`` rather than a ``float()``
+    round-trip: ``float`` raises ``OverflowError`` for an ``int`` wider than a
+    float, which turned a refusal into a crash for the very values most in need
+    of one.
+
+    **Magnitude is not part of this domain.** ``10**400`` is a non-negative
+    whole number and is accepted as one. Whether a count is too large to advance
+    in a single call is a per-call resource policy - MuJoCo's
+    ``_MAX_STEPS_PER_CALL``, which refuses it with a reason of its own - and a
+    domain guard that quietly stopped at the float range would be exactly the
+    kind of boundary-by-implementation-accident this family exists to remove.
 
     Args:
         value: The caller-supplied value.
@@ -552,18 +597,43 @@ def non_negative_whole_number_error(value: Any, param: str, context: str) -> str
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    message = f"{context}: {param} must be a non-negative whole number, got {value!r}."
+
+    def message() -> str:
+        # Rendered on demand, not up front: an accepted count must neither pay
+        # for nor be refused by a message it never receives. A count wider than
+        # ``sys.get_int_max_str_digits()`` is accepted here, and building the
+        # text eagerly made ``repr`` raise on it - the guard failing on the
+        # accept path, doing work only the refuse path needs.
+        return f"{context}: {param} must be a non-negative whole number, got {_refusal_repr(value)}."
+
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        return message
+        return message()
     try:
-        numeric = float(value)
-    except (OverflowError, ValueError):
-        return message
-    # ``isfinite`` first: ``int(nan)`` raises ``ValueError`` and ``int(inf)``
-    # raises ``OverflowError``, and short-circuiting keeps both out of the
-    # integrality check below.
-    if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 0:
-        return message
+        integral = int(value)
+    except (OverflowError, TypeError, ValueError):
+        # The one conversion answers every value no count can be read from:
+        # ``int(nan)`` raises ``ValueError`` and ``int(+-inf)``
+        # ``OverflowError``, so no separate ``isfinite`` check is needed - and
+        # none is possible, because ``isfinite`` needs a ``float()`` whose own
+        # ``OverflowError`` on an ``int`` wider than a float is the escape this
+        # form exists to remove. ``TypeError`` covers a ``numbers.Real``
+        # registered without an ``__int__``: refused, never raised.
+        return message()
+
+    # ``int`` rather than ``math.trunc``, which looks like the conversion the
+    # ABC guarantees and is not usable here: NumPy scalars implement
+    # ``__int__`` but not ``__trunc__``, so ``math.trunc(np.int64(3))`` raises
+    # ``TypeError`` and the NumPy rows this domain must honor would be refused.
+    #
+    # The sign is read off the coerced ``int`` rather than the original: an
+    # ``int``-to-``int`` comparison is total, where ``value < 0`` would defer to
+    # a ``__lt__`` a ``numbers.Real`` registration does not actually guarantee.
+    # ``integral != value`` is what establishes integrality - exactly, and with
+    # no float round-trip, so a large-but-usable count is neither rounded nor
+    # refused - and it falls back to Python's default inequality rather than
+    # raising when a type supplies no ``__eq__``.
+    if integral < 0 or integral != value:
+        return message()
     return None
 
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -504,7 +504,10 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     message = f"{context}: {param} must be a positive whole number, got {value!r}."
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
-    numeric = float(value)
+    try:
+        numeric = float(value)
+    except (OverflowError, ValueError):
+        return message
     # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
     # out of the integrality check below.
     if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
@@ -552,7 +555,10 @@ def non_negative_whole_number_error(value: Any, param: str, context: str) -> str
     message = f"{context}: {param} must be a non-negative whole number, got {value!r}."
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
-    numeric = float(value)
+    try:
+        numeric = float(value)
+    except (OverflowError, ValueError):
+        return message
     # ``isfinite`` first: ``int(nan)`` raises ``ValueError`` and ``int(inf)``
     # raises ``OverflowError``, and short-circuiting keeps both out of the
     # integrality check below.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -504,10 +504,7 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     message = f"{context}: {param} must be a positive whole number, got {value!r}."
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message
-    try:
-        numeric = float(value)
-    except (OverflowError, ValueError):
-        return message
+    numeric = float(value)
     # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
     # out of the integrality check below.
     if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -47,11 +47,19 @@ def sim_with_robot():
 
 class TestStepValidation:
     def test_step_negative_errors(self, sim_with_world):
-        """step(n_steps=-5) must error and NOT decrement step_count."""
+        """step(n_steps=-5) must error and NOT decrement step_count.
+
+        The wording is the shared cross-backend one
+        (:func:`~strands_robots.utils.non_negative_whole_number_error`) rather
+        than this backend's own: Newton and Isaac state the same refusal
+        verbatim, which is what
+        ``tests/simulation/test_step_count_domain_across_backends.py`` pins. The
+        refusal itself, and the untouched ``step_count``, are unchanged.
+        """
         initial = sim_with_world._world.step_count
         res = sim_with_world.step(n_steps=-5)
         assert res["status"] == "error"
-        assert "n_steps must be >= 0" in res["content"][0]["text"]
+        assert "n_steps must be a non-negative whole number" in res["content"][0]["text"]
         assert sim_with_world._world.step_count == initial, "step_count must not change on rejected call"
 
     def test_step_zero_is_noop(self, sim_with_world):
@@ -75,13 +83,18 @@ class TestStepValidation:
         assert sim_with_world._world.step_count == 3
 
     def test_step_non_coercible_type_errors(self, sim_with_world):
-        """A non-int n_steps that cannot be coerced errors and names the type."""
+        """A non-numeric n_steps errors and names the value it was given.
+
+        Names the VALUE rather than its type name, which is the convention of
+        every helper in this family (``got {value!r}``) and the more actionable
+        half: a caller who passed the wrong variable learns which one it was.
+        """
         initial = sim_with_world._world.step_count
         res = sim_with_world.step(n_steps="not-a-number")
         assert res["status"] == "error"
         msg = res["content"][0]["text"]
-        assert "n_steps must be an integer" in msg
-        assert "str" in msg
+        assert "n_steps must be a non-negative whole number" in msg
+        assert "'not-a-number'" in msg
         assert sim_with_world._world.step_count == initial, "step_count must not change on rejected call"
 
     def test_step_exceeds_max_per_call_errors(self, sim_with_world):

--- a/tests/simulation/test_step_count_domain_across_backends.py
+++ b/tests/simulation/test_step_count_domain_across_backends.py
@@ -120,6 +120,7 @@ UNUSABLE_COUNTS: tuple[Any, ...] = (
     None,
     [3],
     np.array([3]),
+    10**400,  # OverflowError from float() on a Python int too large for IEEE 754
 )
 
 #: Counts every backend must honor, paired with the number of steps each must

--- a/tests/simulation/test_step_count_domain_across_backends.py
+++ b/tests/simulation/test_step_count_domain_across_backends.py
@@ -236,7 +236,7 @@ def _newton_stub() -> tuple[Any, SimWorld]:
     out would make that guard look absent rather than exercised.
     """
     world = SimWorld()
-    stub = types.SimpleNamespace(
+    stub: Any = types.SimpleNamespace(
         _world=world,
         _model=types.SimpleNamespace(body_label=["ground"]),
         _lock=threading.RLock(),
@@ -276,14 +276,16 @@ class TestMuJoCoStep:
     def test_an_infinite_count_is_refused_rather_than_raising_overflow(self) -> None:
         """``int(inf)`` raises ``OverflowError``, which the old guard let through."""
         stub, calls = _mujoco_stub()
-        result = MuJoCoSimEngine.step(stub, INF)
+        infinite: Any = INF
+        result = MuJoCoSimEngine.step(stub, infinite)
         assert result["status"] == "error"
         assert calls["n"] == 0
 
     def test_a_fractional_count_is_refused_rather_than_truncated(self) -> None:
         """``int(2.7)`` stepped twice and called it success."""
         stub, calls = _mujoco_stub()
-        assert MuJoCoSimEngine.step(stub, 2.7)["status"] == "error"
+        fractional: Any = 2.7
+        assert MuJoCoSimEngine.step(stub, fractional)["status"] == "error"
         assert calls["n"] == 0
 
     def test_the_documented_zero_no_op_still_holds(self) -> None:
@@ -339,7 +341,8 @@ class TestNewtonStep:
     def test_the_step_counter_stays_an_integer(self) -> None:
         """``step_count`` took the float ``2.7`` and the ``inf`` verbatim."""
         stub, world = _newton_stub()
-        for count in (2.7, INF, NAN):
+        non_integral: tuple[Any, ...] = (2.7, INF, NAN)
+        for count in non_integral:
             assert NewtonSimEngine.step(stub, count)["status"] == "error"
         assert type(world.step_count) is int
         assert world.step_count == 0
@@ -355,7 +358,7 @@ class TestNewtonStep:
 
     def test_a_no_world_engine_still_reports_that_first(self) -> None:
         """The world check precedes the domain, so the actionable error wins."""
-        stub = types.SimpleNamespace(_world=None, _model=None)
+        stub: Any = types.SimpleNamespace(_world=None, _model=None)
         result = NewtonSimEngine.step(stub, -5)
         assert result["status"] == "error"
         assert "create_world" in _text(result)
@@ -404,7 +407,8 @@ class TestIsaacStep:
 
     def test_a_non_integral_count_is_refused_rather_than_raising(self) -> None:
         """``range(2.7)`` raised ``TypeError`` past the structured envelope."""
-        for count in (2.7, "3", NAN, INF, None, [3]):
+        non_integral: tuple[Any, ...] = (2.7, "3", NAN, INF, None, [3])
+        for count in non_integral:
             stub, _calls = _isaac_stub()
             result = IsaacSimulation.step(stub, count)
             assert result["status"] == "error", count

--- a/tests/simulation/test_step_count_domain_across_backends.py
+++ b/tests/simulation/test_step_count_domain_across_backends.py
@@ -54,8 +54,22 @@ Five findings, in the order they cost something:
   ``step_count``, and with a solver it raised out of ``range()``.
 
 The fix is the shared :func:`~strands_robots.utils.non_negative_whole_number_error`
-domain applied by all three, then a single ``int()`` coercion that is safe only
-because the guard has already established the value is finite and integral.
+domain applied by all three, then a single ``int()`` coercion that is safe
+because the guard has already performed that same conversion and compared the
+result back.
+
+That guard returns a verdict for every real scalar and raises for none, which is
+the contract rather than a detail: all three ``step`` docstrings name the
+structured result as the only channel an out-of-domain count is reported on, and
+one caller takes its count from a remote process. Two values are the reason the
+implementation looks the way it does, and both are pinned by
+``TestEveryRealGetsAVerdictAndNothingRaises``. ``float(10**400)`` raises
+``OverflowError``, so integrality is tested with an ``int()`` in a ``try`` rather
+than a ``float()`` round-trip. And ``repr`` of an ``int`` past
+:func:`sys.get_int_max_str_digits` raises ``ValueError`` while that same count is
+*accepted*, so the refusal text is rendered only when a refusal is returned -
+work on the accept path that only the refuse path needs is the same shape as the
+defects above.
 That helper is the missing cell of an existing 2x2 - the same scalar policy as
 :func:`~strands_robots.utils.positive_whole_number_error` with the floor at
 ``0``, standing to it exactly as
@@ -73,6 +87,12 @@ What is NOT in scope, and is asserted to be unchanged by
   read here - which is why ``step`` answers its own zero rather than changing
   that floor. It is a second public surface with its own contract, so it is a
   separate change.
+* The magnitude of a count, which belongs to that ceiling and not to this
+  domain. ``10**400`` is a non-negative whole number, so the domain accepts it
+  and MuJoCo refuses it with its own ceiling error - exactly as it did before
+  this change, where a true ``int`` skipped its ``int()`` coercion. Refusing it
+  in the guard would have put a silent boundary at the float range while still
+  accepting ``10**300``, which no backend can advance either.
 * The per-call ceiling. MuJoCo refuses ``n_steps > _MAX_STEPS_PER_CALL``
   (100_000) with a stated reason - an unbounded lock hold - and batches its
   loop to release the lock every 1000 steps so ``stop_policy`` can interleave.
@@ -86,6 +106,8 @@ from __future__ import annotations
 
 import ast
 import inspect
+import math
+import numbers
 import pathlib
 import textwrap
 import threading
@@ -105,6 +127,15 @@ from strands_robots.utils import non_negative_whole_number_error
 NAN = float("nan")
 INF = float("inf")
 
+#: An ``int`` wider than the float range: ``float(10**400)`` raises
+#: ``OverflowError``, which is how the guard's own integrality test used to
+#: crash on it.
+BEYOND_FLOAT_RANGE = 10**400
+#: An ``int`` whose own ``repr`` raises: wider than
+#: :func:`sys.get_int_max_str_digits` (4300 digits by default), so *rendering*
+#: the refusal crashed before the value was even classified.
+BEYOND_INT_STR_LIMIT = 10**5000
+
 #: Every count no backend can advance by. Each row is a measured pre-fix
 #: acceptance or a bare raise on at least one backend (see the module docstring).
 UNUSABLE_COUNTS: tuple[Any, ...] = (
@@ -120,8 +151,30 @@ UNUSABLE_COUNTS: tuple[Any, ...] = (
     None,
     [3],
     np.array([3]),
-    10**400,  # OverflowError from float() on a Python int too large for IEEE 754
+    -BEYOND_FLOAT_RANGE,
+    -BEYOND_INT_STR_LIMIT,
 )
+
+
+def _count_id(value: Any) -> str | None:
+    """Test ID for a probe count, or ``None`` to let pytest name it.
+
+    Only the outsized integers need naming, and they need it to keep the module
+    runnable: pytest derives an ID for an ``int`` parameter with ``str()``, which
+    raises for one wider than :func:`sys.get_int_max_str_digits`. That is a
+    collection error, not a test failure - it takes down every class in this
+    file, the parity matrix included, and reports as an error rather than as
+    coverage silently lost. The defect this module documents on the guard
+    (rendering a value it was only asked to classify) has the same shape in the
+    harness.
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value == -BEYOND_FLOAT_RANGE:
+            return "negative_beyond_float_range"
+        if value == -BEYOND_INT_STR_LIMIT:
+            return "negative_beyond_int_str_limit"
+    return None
+
 
 #: Counts every backend must honor, paired with the number of steps each must
 #: advance. ``3.0`` and ``np.int64(3)`` are the load-bearing rows: MuJoCo
@@ -150,7 +203,7 @@ def _text(result: dict[str, Any]) -> str:
 class TestTheSharedDomain:
     """``non_negative_whole_number_error`` is the single definition all three share."""
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_an_unusable_count_is_refused(self, count: Any) -> None:
         error = non_negative_whole_number_error(count, "n_steps", "step")
         assert error is not None, count
@@ -185,6 +238,116 @@ class TestTheSharedDomain:
             error = non_negative_whole_number_error(count, "n_steps", "step")
             assert error is not None
             error.encode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain: every real scalar gets a verdict, nothing raises         #
+# --------------------------------------------------------------------------- #
+@numbers.Real.register
+class _RealWithoutAnInt:
+    """A registered ``numbers.Real`` that cannot be converted to an ``int``.
+
+    Registration makes ``isinstance(x, numbers.Real)`` true without inheriting
+    the ABC's implementations, so this is what reaches the guard's ``TypeError``
+    branch: ``int()`` has nothing to call. It is the one probe in this module
+    with no real-world counterpart, and it is here so that branch is a covered
+    decision rather than an unreachable line a later reader deletes.
+    """
+
+
+@numbers.Real.register
+class _RealWithAnUnprintableRepr:
+    """A registered ``numbers.Real`` whose ``repr`` raises.
+
+    ``int()`` yields a negative count, so it is refused - and rendering that
+    refusal has to survive its ``__repr__``. The real case is an outsized
+    ``int``, whose ``repr`` raises ``ValueError``; a third-party scalar can
+    raise anything, which is why the renderer's guarantee is unconditional
+    rather than a list of the exceptions known today.
+    """
+
+    def __int__(self) -> int:
+        return -1
+
+    def __repr__(self) -> str:
+        raise RuntimeError("this type cannot render itself")
+
+
+#: Every probe in this module, plus the two synthetic scalars above.
+ALL_PROBES: tuple[Any, ...] = (
+    *UNUSABLE_COUNTS,
+    *(count for count, _expected in USABLE_COUNTS),
+    _RealWithoutAnInt(),
+    _RealWithAnUnprintableRepr(),
+)
+
+
+class TestEveryRealGetsAVerdictAndNothingRaises:
+    """The guard reports through its return value, never through an exception.
+
+    All three ``step`` docstrings name the structured ``{status, content}``
+    result as the only channel an out-of-domain count is reported on, and
+    ``device_connect/sim_driver.py``'s ``@rpc()`` ``step`` forwards a remote
+    caller's count unchanged - Python integers are arbitrary-precision, so an
+    ``int`` of any width is one request away and has to be answered rather than
+    raised on.
+    """
+
+    def test_a_count_wider_than_a_float_is_answered(self) -> None:
+        """``float(10**400)`` raises ``OverflowError``, so the guard cannot use it.
+
+        Accepted, because it *is* a non-negative whole number - magnitude is the
+        per-call ceiling's question, pinned in
+        ``TestNeighbouringStepSurfacesStayOutOfScope``.
+        """
+        assert non_negative_whole_number_error(BEYOND_FLOAT_RANGE, "n_steps", "step") is None
+        error = non_negative_whole_number_error(-BEYOND_FLOAT_RANGE, "n_steps", "step")
+        assert error is not None
+        assert "n_steps" in error
+
+    def test_a_count_whose_repr_raises_is_still_refusable(self) -> None:
+        """Rendering happens on demand, so an accepted count is never rendered.
+
+        ``repr`` of an ``int`` past ``sys.get_int_max_str_digits()`` raises
+        ``ValueError``, and the message used to be built before the value was
+        classified - so the guard failed on the accept path, doing work only the
+        refuse path needs.
+        """
+        assert non_negative_whole_number_error(BEYOND_INT_STR_LIMIT, "n_steps", "step") is None
+        error = non_negative_whole_number_error(-BEYOND_INT_STR_LIMIT, "n_steps", "step")
+        assert error is not None
+        assert f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>" in error
+        assert "n_steps" in error
+        error.encode("ascii")
+
+    def test_a_real_that_cannot_be_converted_is_refused_rather_than_raising(self) -> None:
+        assert non_negative_whole_number_error(_RealWithoutAnInt(), "n_steps", "step") is not None
+
+    def test_a_real_that_cannot_render_itself_is_refused_rather_than_raising(self) -> None:
+        error = non_negative_whole_number_error(_RealWithAnUnprintableRepr(), "n_steps", "step")
+        assert error is not None
+        assert "_RealWithAnUnprintableRepr" in error
+
+    @pytest.mark.parametrize("count", ALL_PROBES, ids=_count_id)
+    def test_the_verdict_is_a_string_or_none_for_every_probe(self, count: Any) -> None:
+        """The contract as one assertion, over every value this module names."""
+        verdict = non_negative_whole_number_error(count, "n_steps", "step")
+        assert verdict is None or isinstance(verdict, str)
+
+    def test_the_count_is_coerced_with_int_because_numpy_has_no_trunc(self) -> None:
+        """``math.trunc`` is the conversion the ABC guarantees and is unusable here.
+
+        Measured, so that a later "use the abstract method" refactor fails here
+        rather than in the field: ``np.int64`` and ``np.uint8`` are load-bearing
+        rows of ``USABLE_COUNTS`` - MuJoCo honors both today - and they implement
+        ``__int__`` but not ``__trunc__``.
+        """
+        numpy_rows: tuple[tuple[Any, int], ...] = ((np.int64(3), 3), (np.uint8(2), 2))
+        for count, expected in numpy_rows:
+            with pytest.raises(TypeError):
+                math.trunc(count)
+            assert int(count) == expected
+            assert non_negative_whole_number_error(count, "n_steps", "step") is None
 
 
 # --------------------------------------------------------------------------- #
@@ -253,14 +416,14 @@ def _newton_stub() -> tuple[Any, SimWorld]:
 # MuJoCo                                                                      #
 # --------------------------------------------------------------------------- #
 class TestMuJoCoStep:
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_an_unusable_count_is_refused(self, count: Any) -> None:
         stub, _calls = _mujoco_stub()
         result = MuJoCoSimEngine.step(stub, count)
         assert result["status"] == "error", (count, result)
         assert "n_steps" in _text(result)
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_a_refused_count_advances_nothing(self, count: Any) -> None:
         stub, calls = _mujoco_stub()
         assert MuJoCoSimEngine.step(stub, count)["status"] == "error"
@@ -309,14 +472,14 @@ class TestMuJoCoStep:
 # Newton                                                                      #
 # --------------------------------------------------------------------------- #
 class TestNewtonStep:
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_an_unusable_count_is_refused(self, count: Any) -> None:
         stub, _world = _newton_stub()
         result = NewtonSimEngine.step(stub, count)
         assert result["status"] == "error", (count, result)
         assert "n_steps" in _text(result)
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_a_refused_count_advances_nothing(self, count: Any) -> None:
         """Pre-fix, ``-5`` / ``nan`` / ``True`` each advanced one step."""
         stub, world = _newton_stub()
@@ -369,14 +532,14 @@ class TestNewtonStep:
 # Isaac                                                                       #
 # --------------------------------------------------------------------------- #
 class TestIsaacStep:
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_an_unusable_count_is_refused(self, count: Any) -> None:
         stub, _calls = _isaac_stub()
         result = IsaacSimulation.step(stub, count)
         assert result["status"] == "error", (count, result)
         assert "n_steps" in _text(result)
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_a_refused_count_advances_nothing(self, count: Any) -> None:
         stub, calls = _isaac_stub()
         assert IsaacSimulation.step(stub, count)["status"] == "error"
@@ -436,12 +599,12 @@ class TestEveryBackendGivesTheSameVerdict:
             IsaacSimulation.step(_isaac_stub()[0], count),
         )
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_an_unusable_count_is_refused_everywhere(self, count: Any) -> None:
         mj, nt, ic = self._all_three(count)
         assert mj["status"] == nt["status"] == ic["status"] == "error", (count, mj, nt, ic)
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_the_shared_refusal_has_one_wording(self, count: Any) -> None:
         """Two spellings of one verdict is how backend domains start to drift."""
         mj, nt, ic = self._all_three(count)
@@ -491,7 +654,7 @@ class TestTheParityHoldsOnACompiledModel:
         yield sim
         sim.cleanup()
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_an_unusable_count_is_refused_on_a_real_world(self, mj_sim: Any, count: Any) -> None:
         result = mj_sim.step(count)
         assert result["status"] == "error", (count, result)
@@ -505,7 +668,7 @@ class TestTheParityHoldsOnACompiledModel:
         assert mj_sim.step(count)["status"] == "success", count
         assert mj_sim._world.step_count - before == expected
 
-    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS, ids=_count_id)
     def test_a_refused_count_leaves_a_real_clock_untouched(self, mj_sim: Any, count: Any) -> None:
         """The ``inf`` row left Newton's clock at ``inf`` for the world's lifetime."""
         assert mj_sim.step(2)["status"] == "success"
@@ -660,6 +823,25 @@ class TestNeighbouringStepSurfacesStayOutOfScope:
         isaac_stub, isaac_calls = _isaac_stub()
         assert IsaacSimulation.step(isaac_stub, over)["status"] == "success"
         assert isaac_calls["n"] == over
+
+    def test_an_outsized_positive_count_is_left_to_the_per_call_ceiling(self) -> None:
+        """Magnitude is the ceiling's question, not this domain's.
+
+        ``10**400`` is a non-negative whole number, so the domain accepts it and
+        says so. MuJoCo then refuses it with its own ``_MAX_STEPS_PER_CALL``
+        error - exactly as it did before this change, where a true ``int``
+        skipped its ``int()`` coercion and reached the ceiling. Newton and Isaac
+        have no ceiling, so they would attempt it: unbounded work under a held
+        lock, which is #1871 and is not pinned here because pinning it means
+        running it. Refusing the value in the guard instead would have put a
+        silent boundary at the float range - accepting ``10**300``, which no
+        backend can advance either - which is the boundary-by-accident this
+        change exists to remove.
+        """
+        assert non_negative_whole_number_error(BEYOND_FLOAT_RANGE, "n_steps", "step") is None
+        result = MuJoCoSimEngine.step(_mujoco_stub()[0], BEYOND_FLOAT_RANGE)
+        assert result["status"] == "error"
+        assert "exceeds max" in _text(result)
 
     def test_a_boolean_is_refused_by_the_count_domain_not_the_shared_predicate(self) -> None:
         """``is_boolean`` covers the float writers; this domain has its own check.

--- a/tests/simulation/test_step_count_domain_across_backends.py
+++ b/tests/simulation/test_step_count_domain_across_backends.py
@@ -1,0 +1,668 @@
+"""Regression tests: every backend validates the ``step`` count it is given.
+
+``step(n_steps)`` is the most-called method on the simulation surface, and it
+was the last public numeric input with three different domains. The MuJoCo
+backend has documented one since its numeric inputs were hardened - "Non-negative
+step count (``0`` is an accepted no-op)" - but implemented it by hand, and
+Newton and Isaac validated nothing at all.
+
+Measured on the probe set below, one ``step`` per cell, with no ``newton`` /
+``warp`` / ``isaacsim`` installed. Every guard precedes the point a backend
+touches a solver, a stage or its lock, which is what lets these run solver-free.
+
+| ``n_steps=`` | MuJoCo | Newton | Isaac |
+| --- | --- | --- | --- |
+| ``0`` | success, no-op (documented) | success, **advanced 1** | success, 0 steps |
+| ``-5`` | error | success, **advanced 1** | **success, advanced 0** |
+| ``True`` | **success, advanced 1** | success, **advanced 1** | **success, advanced 1** |
+| ``np.True_`` | **success, advanced 1** | success, **advanced 1** | raised ``TypeError`` |
+| ``2.7`` | **success, advanced 2** | ``step_count`` became **2.7** / raised | raised ``TypeError`` |
+| ``"3"`` | **success, advanced 3** | raised ``TypeError`` | raised ``TypeError`` |
+| ``nan`` | error | success, **advanced 1** | raised ``TypeError`` |
+| ``inf`` | **raised ``OverflowError``** | ``step_count`` became **inf** / raised | raised ``TypeError`` |
+| ``None`` / ``[3]`` | error | raised ``TypeError`` | raised ``TypeError`` |
+
+Five findings, in the order they cost something:
+
+* **A negative count was a silent no-op on Isaac.** ``range(-5)`` is empty, so
+  the call stepped nothing and reported SUCCESS - then divided the elapsed wall
+  time by that negative count and reported the rate as
+  ``-11876485 steps/sec``. An agent reading "Stepped -5x" has been told the
+  world advanced when it did not.
+* **``step(0)`` advanced the world on Newton.** ``_advance`` floors its count at
+  ``max(1, n_steps)``, so a zero - the value MuJoCo documents as a no-op -
+  stepped once while the result text said ``Stepped 0 step(s).``. The report and
+  the world disagreed, and the same call was a no-op on one backend and a step
+  on another. ``-5`` and ``nan`` reached that same floor and also advanced 1,
+  under ``Stepped -5 step(s).`` / ``Stepped nan step(s).``.
+* **``inf`` escaped MuJoCo's own envelope.** ``int(float("inf"))`` raises
+  ``OverflowError``, which the hand-rolled ``except (TypeError, ValueError)``
+  did not catch - so the one backend that documented this domain raised a bare
+  exception through the structured result these methods document as their only
+  failure channel. On Newton's solver-free path the same value left
+  ``step_count`` and ``sim_time`` as ``inf`` PERMANENTLY, so every later
+  ``get_state()`` reported ``t=inf``.
+* **A boolean was read as a count of one on all three.** The defect the runtime
+  writers removed for their own inputs (``_ANY_NUMBERS`` in
+  ``test_input_validators_refuse_a_boolean``): ``bool`` is an ``int`` subclass,
+  so ``True`` survived every gate as one physics step.
+* **MuJoCo truncated a fractional count under a success result.** ``int(2.7)``
+  is ``2``, so a caller asking for 2.7 steps got 2 and was told it succeeded,
+  while its docstring promised an error when ``n_steps`` is "not an integer".
+  Newton's behaviour for the same value depended on whether a solver had been
+  constructed: solver-free it wrote the FLOAT ``2.7`` into the integer
+  ``step_count``, and with a solver it raised out of ``range()``.
+
+The fix is the shared :func:`~strands_robots.utils.non_negative_whole_number_error`
+domain applied by all three, then a single ``int()`` coercion that is safe only
+because the guard has already established the value is finite and integral.
+That helper is the missing cell of an existing 2x2 - the same scalar policy as
+:func:`~strands_robots.utils.positive_whole_number_error` with the floor at
+``0``, standing to it exactly as
+:func:`~strands_robots.utils.non_negative_count_error` stands to
+:func:`~strands_robots.utils.positive_count_error`. Reusing either existing
+non-negative or whole-number helper would have regressed the reference backend:
+``non_negative_count_error`` accepts only a true ``int``, and MuJoCo honors
+``3.0`` and ``np.int64(3)`` today.
+
+What is NOT in scope, and is asserted to be unchanged by
+``TestNeighbouringStepSurfacesStayOutOfScope``:
+
+* ``send_action(n_substeps=)`` on all three backends, which has the same
+  unvalidated domain and on Newton shares the very ``max(1, n_steps)`` floor
+  read here - which is why ``step`` answers its own zero rather than changing
+  that floor. It is a second public surface with its own contract, so it is a
+  separate change.
+* The per-call ceiling. MuJoCo refuses ``n_steps > _MAX_STEPS_PER_CALL``
+  (100_000) with a stated reason - an unbounded lock hold - and batches its
+  loop to release the lock every 1000 steps so ``stop_policy`` can interleave.
+  Isaac and Newton have neither: measured, Isaac accepted ``100_001`` and called
+  ``world.step`` that many times inside one ``self._lock`` hold. That is a
+  resource policy rather than an input domain, and picking one ceiling for three
+  backends with different per-step costs is a decision rather than a defect.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import textwrap
+import threading
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.models import SimWorld
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import non_negative_whole_number_error
+
+NAN = float("nan")
+INF = float("inf")
+
+#: Every count no backend can advance by. Each row is a measured pre-fix
+#: acceptance or a bare raise on at least one backend (see the module docstring).
+UNUSABLE_COUNTS: tuple[Any, ...] = (
+    -5,
+    -1,
+    True,
+    False,
+    np.bool_(True),
+    2.7,
+    "3",
+    NAN,
+    INF,
+    None,
+    [3],
+    np.array([3]),
+)
+
+#: Counts every backend must honor, paired with the number of steps each must
+#: advance. ``3.0`` and ``np.int64(3)`` are the load-bearing rows: MuJoCo
+#: accepted both before this change (its ``int()`` coercion took them), so a
+#: domain that refused them would be a regression on the reference backend, and
+#: a step count computed as ``int(duration / dt)`` is an ``np.int64`` whenever
+#: ``dt`` came from NumPy.
+USABLE_COUNTS: tuple[tuple[Any, int], ...] = (
+    (0, 0),
+    (1, 1),
+    (3, 3),
+    (3.0, 3),
+    (np.int64(3), 3),
+    (np.uint8(2), 2),
+    (np.float64(4.0), 4),
+)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheSharedDomain:
+    """``non_negative_whole_number_error`` is the single definition all three share."""
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_an_unusable_count_is_refused(self, count: Any) -> None:
+        error = non_negative_whole_number_error(count, "n_steps", "step")
+        assert error is not None, count
+        assert "n_steps" in error
+
+    @pytest.mark.parametrize(("count", "_expected"), USABLE_COUNTS)
+    def test_a_usable_count_is_accepted(self, count: Any, _expected: int) -> None:
+        assert non_negative_whole_number_error(count, "n_steps", "step") is None, count
+
+    def test_zero_is_accepted_and_one_below_it_is_not(self) -> None:
+        """The floor is the whole reason this is not ``positive_whole_number_error``."""
+        assert non_negative_whole_number_error(0, "n_steps", "step") is None
+        assert non_negative_whole_number_error(-1, "n_steps", "step") is not None
+
+    def test_an_accepted_count_survives_the_int_coercion_it_is_paired_with(self) -> None:
+        """The guard exists so the ``int()`` that follows it cannot raise."""
+        for count, expected in USABLE_COUNTS:
+            assert non_negative_whole_number_error(count, "n_steps", "step") is None
+            assert int(count) == expected
+
+    def test_a_non_finite_count_is_refused_rather_than_raising(self) -> None:
+        """``int(nan)`` raises ``ValueError`` and ``int(inf)`` ``OverflowError``."""
+        for count in (NAN, INF, -INF):
+            assert non_negative_whole_number_error(count, "n_steps", "step") is not None
+
+    def test_the_message_names_the_parameter_and_the_value(self) -> None:
+        error = non_negative_whole_number_error(-5, "n_steps", "step")
+        assert error == "step: n_steps must be a non-negative whole number, got -5."
+
+    def test_the_message_is_ascii(self) -> None:
+        for count in UNUSABLE_COUNTS:
+            error = non_negative_whole_number_error(count, "n_steps", "step")
+            assert error is not None
+            error.encode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# Backend stand-ins (the guards precede every solver, stage and lock)         #
+# --------------------------------------------------------------------------- #
+def _mujoco_stub() -> tuple[Any, dict[str, int]]:
+    """A MuJoCo stand-in counting ``mj_step`` calls, with no model compiled."""
+    calls = {"n": 0}
+
+    def mj_step(model: Any, data: Any) -> None:
+        calls["n"] += 1
+        data.time += 0.002
+
+    stub = types.SimpleNamespace(
+        _world=types.SimpleNamespace(
+            _model=object(),
+            _data=types.SimpleNamespace(time=0.0),
+            sim_time=0.0,
+            step_count=0,
+            _backend_state={},
+        ),
+        _mj=types.SimpleNamespace(mj_step=mj_step, mj_forward=lambda model, data: None),
+        _lock=threading.RLock(),
+        _MAX_STEPS_PER_CALL=MuJoCoSimEngine._MAX_STEPS_PER_CALL,
+        _STEPS_PER_BATCH=MuJoCoSimEngine._STEPS_PER_BATCH,
+        _apply_kinematic_attachments=lambda: None,
+        _publish_ros_telemetry=lambda: None,
+    )
+    return stub, calls
+
+
+def _isaac_stub() -> tuple[Any, dict[str, int]]:
+    calls = {"n": 0}
+    stub = types.SimpleNamespace(
+        _lock=threading.RLock(),
+        _world_created=True,
+        _config=IsaacConfig(),
+        _sim_time=0.0,
+        _step_count=0,
+        _world=types.SimpleNamespace(step=lambda render=False: calls.__setitem__("n", calls["n"] + 1)),
+    )
+    return stub, calls
+
+
+def _newton_stub() -> tuple[Any, SimWorld]:
+    """A Newton stand-in on the real inherited ``_advance``, solver-free.
+
+    ``_advance`` is bound genuinely rather than replaced: its ``max(1, n_steps)``
+    floor is the thing ``step`` has to answer for, so a stand-in that stubbed it
+    out would make that guard look absent rather than exercised.
+    """
+    world = SimWorld()
+    stub = types.SimpleNamespace(
+        _world=world,
+        _model=types.SimpleNamespace(body_label=["ground"]),
+        _lock=threading.RLock(),
+        _solver=None,
+        _sync_viewer=lambda: None,
+        substeps=1,
+    )
+    stub._advance = lambda n_steps: NewtonSimEngine._advance(stub, n_steps)
+    return stub, world
+
+
+# --------------------------------------------------------------------------- #
+# MuJoCo                                                                      #
+# --------------------------------------------------------------------------- #
+class TestMuJoCoStep:
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_an_unusable_count_is_refused(self, count: Any) -> None:
+        stub, _calls = _mujoco_stub()
+        result = MuJoCoSimEngine.step(stub, count)
+        assert result["status"] == "error", (count, result)
+        assert "n_steps" in _text(result)
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_a_refused_count_advances_nothing(self, count: Any) -> None:
+        stub, calls = _mujoco_stub()
+        assert MuJoCoSimEngine.step(stub, count)["status"] == "error"
+        assert calls["n"] == 0
+        assert stub._world.step_count == 0
+        assert stub._world.sim_time == 0.0
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_COUNTS)
+    def test_a_usable_count_advances_exactly_that_many(self, count: Any, expected: int) -> None:
+        stub, calls = _mujoco_stub()
+        assert MuJoCoSimEngine.step(stub, count)["status"] == "success", count
+        assert calls["n"] == expected
+
+    def test_an_infinite_count_is_refused_rather_than_raising_overflow(self) -> None:
+        """``int(inf)`` raises ``OverflowError``, which the old guard let through."""
+        stub, calls = _mujoco_stub()
+        result = MuJoCoSimEngine.step(stub, INF)
+        assert result["status"] == "error"
+        assert calls["n"] == 0
+
+    def test_a_fractional_count_is_refused_rather_than_truncated(self) -> None:
+        """``int(2.7)`` stepped twice and called it success."""
+        stub, calls = _mujoco_stub()
+        assert MuJoCoSimEngine.step(stub, 2.7)["status"] == "error"
+        assert calls["n"] == 0
+
+    def test_the_documented_zero_no_op_still_holds(self) -> None:
+        stub, calls = _mujoco_stub()
+        result = MuJoCoSimEngine.step(stub, 0)
+        assert result["status"] == "success"
+        assert calls["n"] == 0
+        assert "no-op" in _text(result)
+
+    def test_the_per_call_ceiling_still_holds(self) -> None:
+        """The ceiling is out of scope but must not be lost to the refactor."""
+        stub, calls = _mujoco_stub()
+        result = MuJoCoSimEngine.step(stub, MuJoCoSimEngine._MAX_STEPS_PER_CALL + 1)
+        assert result["status"] == "error"
+        assert "exceeds max" in _text(result)
+        assert calls["n"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Newton                                                                      #
+# --------------------------------------------------------------------------- #
+class TestNewtonStep:
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_an_unusable_count_is_refused(self, count: Any) -> None:
+        stub, _world = _newton_stub()
+        result = NewtonSimEngine.step(stub, count)
+        assert result["status"] == "error", (count, result)
+        assert "n_steps" in _text(result)
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_a_refused_count_advances_nothing(self, count: Any) -> None:
+        """Pre-fix, ``-5`` / ``nan`` / ``True`` each advanced one step."""
+        stub, world = _newton_stub()
+        assert NewtonSimEngine.step(stub, count)["status"] == "error"
+        assert world.step_count == 0
+        assert world.sim_time == 0.0
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_COUNTS)
+    def test_a_usable_count_advances_exactly_that_many(self, count: Any, expected: int) -> None:
+        stub, world = _newton_stub()
+        assert NewtonSimEngine.step(stub, count)["status"] == "success", count
+        assert world.step_count == expected
+
+    def test_zero_is_a_no_op_rather_than_one_step(self) -> None:
+        """``_advance``'s ``max(1, n_steps)`` floor stepped once for a zero."""
+        stub, world = _newton_stub()
+        result = NewtonSimEngine.step(stub, 0)
+        assert result["status"] == "success"
+        assert world.step_count == 0
+        assert world.sim_time == 0.0
+        assert "no-op" in _text(result)
+
+    def test_the_step_counter_stays_an_integer(self) -> None:
+        """``step_count`` took the float ``2.7`` and the ``inf`` verbatim."""
+        stub, world = _newton_stub()
+        for count in (2.7, INF, NAN):
+            assert NewtonSimEngine.step(stub, count)["status"] == "error"
+        assert type(world.step_count) is int
+        assert world.step_count == 0
+        assert NewtonSimEngine.step(stub, 2)["status"] == "success"
+        assert type(world.step_count) is int
+
+    def test_the_reported_count_is_the_count_advanced(self) -> None:
+        """``Stepped -5 step(s).`` was reported for a world that advanced 1."""
+        stub, world = _newton_stub()
+        assert NewtonSimEngine.step(stub, 4)["status"] == "success"
+        assert "4" in _text(NewtonSimEngine.step(_newton_stub()[0], 4))
+        assert world.step_count == 4
+
+    def test_a_no_world_engine_still_reports_that_first(self) -> None:
+        """The world check precedes the domain, so the actionable error wins."""
+        stub = types.SimpleNamespace(_world=None, _model=None)
+        result = NewtonSimEngine.step(stub, -5)
+        assert result["status"] == "error"
+        assert "create_world" in _text(result)
+
+
+# --------------------------------------------------------------------------- #
+# Isaac                                                                       #
+# --------------------------------------------------------------------------- #
+class TestIsaacStep:
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_an_unusable_count_is_refused(self, count: Any) -> None:
+        stub, _calls = _isaac_stub()
+        result = IsaacSimulation.step(stub, count)
+        assert result["status"] == "error", (count, result)
+        assert "n_steps" in _text(result)
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_a_refused_count_advances_nothing(self, count: Any) -> None:
+        stub, calls = _isaac_stub()
+        assert IsaacSimulation.step(stub, count)["status"] == "error"
+        assert calls["n"] == 0
+        assert stub._step_count == 0
+        assert stub._sim_time == 0.0
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_COUNTS)
+    def test_a_usable_count_advances_exactly_that_many(self, count: Any, expected: int) -> None:
+        stub, calls = _isaac_stub()
+        assert IsaacSimulation.step(stub, count)["status"] == "success", count
+        assert calls["n"] == expected
+        assert stub._step_count == expected
+
+    def test_a_negative_count_is_refused_rather_than_reported_as_success(self) -> None:
+        """``range(-5)`` was empty, so it reported success having stepped nothing."""
+        stub, calls = _isaac_stub()
+        result = IsaacSimulation.step(stub, -5)
+        assert result["status"] == "error"
+        assert calls["n"] == 0
+
+    def test_no_result_text_can_report_a_negative_rate(self) -> None:
+        """``-5`` divided the wall time by a negative count: ``-11876485 steps/sec``."""
+        for count in (-5, -1):
+            stub, _calls = _isaac_stub()
+            result = IsaacSimulation.step(stub, count)
+            assert result["status"] == "error"
+            assert "steps/sec" not in _text(result)
+
+    def test_a_non_integral_count_is_refused_rather_than_raising(self) -> None:
+        """``range(2.7)`` raised ``TypeError`` past the structured envelope."""
+        for count in (2.7, "3", NAN, INF, None, [3]):
+            stub, _calls = _isaac_stub()
+            result = IsaacSimulation.step(stub, count)
+            assert result["status"] == "error", count
+
+    def test_the_guard_precedes_the_world_tick_on_an_uncreated_world(self) -> None:
+        """A refused count needs no world, so the domain answers without one."""
+        stub, calls = _isaac_stub()
+        stub._world_created = False
+        assert IsaacSimulation.step(stub, -5)["status"] == "error"
+        assert calls["n"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Cross-backend parity                                                        #
+# --------------------------------------------------------------------------- #
+class TestEveryBackendGivesTheSameVerdict:
+    """A count one backend refuses is refused by all of them, in the same words."""
+
+    @staticmethod
+    def _all_three(count: Any) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        return (
+            MuJoCoSimEngine.step(_mujoco_stub()[0], count),
+            NewtonSimEngine.step(_newton_stub()[0], count),
+            IsaacSimulation.step(_isaac_stub()[0], count),
+        )
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_an_unusable_count_is_refused_everywhere(self, count: Any) -> None:
+        mj, nt, ic = self._all_three(count)
+        assert mj["status"] == nt["status"] == ic["status"] == "error", (count, mj, nt, ic)
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_the_shared_refusal_has_one_wording(self, count: Any) -> None:
+        """Two spellings of one verdict is how backend domains start to drift."""
+        mj, nt, ic = self._all_three(count)
+        assert {_text(mj), _text(nt), _text(ic)} == {_text(mj)}, (count, _text(mj), _text(nt), _text(ic))
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_COUNTS)
+    def test_a_usable_count_is_accepted_everywhere(self, count: Any, expected: int) -> None:
+        """The parity is two-way: no backend refuses a count another honors."""
+        mj, nt, ic = self._all_three(count)
+        assert mj["status"] == nt["status"] == ic["status"] == "success", (count, mj, nt, ic)
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_COUNTS)
+    def test_the_same_count_advances_the_same_number_of_steps(self, count: Any, expected: int) -> None:
+        """The verdict agreeing is not enough: the effect has to agree too."""
+        mj_stub, mj_calls = _mujoco_stub()
+        nt_stub, nt_world = _newton_stub()
+        ic_stub, ic_calls = _isaac_stub()
+        MuJoCoSimEngine.step(mj_stub, count)
+        NewtonSimEngine.step(nt_stub, count)
+        IsaacSimulation.step(ic_stub, count)
+        assert mj_calls["n"] == nt_world.step_count == ic_calls["n"] == expected, count
+
+    def test_zero_is_a_no_op_on_every_backend(self) -> None:
+        """The row that used to disagree: MuJoCo no-op, Newton one step, Isaac none."""
+        mj_stub, mj_calls = _mujoco_stub()
+        nt_stub, nt_world = _newton_stub()
+        ic_stub, ic_calls = _isaac_stub()
+        results = (
+            MuJoCoSimEngine.step(mj_stub, 0),
+            NewtonSimEngine.step(nt_stub, 0),
+            IsaacSimulation.step(ic_stub, 0),
+        )
+        assert all(result["status"] == "success" for result in results), results
+        assert mj_calls["n"] == nt_world.step_count == ic_calls["n"] == 0
+
+
+class TestTheParityHoldsOnACompiledModel:
+    """The stand-ins are only honest if a real engine agrees with them."""
+
+    @pytest.fixture
+    def mj_sim(self) -> Any:
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation(tool_name="test_step_count_domain_parity_sim", mesh=False)
+        assert sim.create_world()["status"] == "success"
+        yield sim
+        sim.cleanup()
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_an_unusable_count_is_refused_on_a_real_world(self, mj_sim: Any, count: Any) -> None:
+        result = mj_sim.step(count)
+        assert result["status"] == "error", (count, result)
+        assert "n_steps" in _text(result)
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_COUNTS)
+    def test_a_usable_count_advances_a_real_world_exactly_that_far(
+        self, mj_sim: Any, count: Any, expected: int
+    ) -> None:
+        before = mj_sim._world.step_count
+        assert mj_sim.step(count)["status"] == "success", count
+        assert mj_sim._world.step_count - before == expected
+
+    @pytest.mark.parametrize("count", UNUSABLE_COUNTS)
+    def test_a_refused_count_leaves_a_real_clock_untouched(self, mj_sim: Any, count: Any) -> None:
+        """The ``inf`` row left Newton's clock at ``inf`` for the world's lifetime."""
+        assert mj_sim.step(2)["status"] == "success"
+        steps, elapsed = mj_sim._world.step_count, mj_sim._world.sim_time
+        assert mj_sim.step(count)["status"] == "error"
+        assert mj_sim._world.step_count == steps
+        assert mj_sim._world.sim_time == elapsed
+
+
+# --------------------------------------------------------------------------- #
+# Structural: no step-count surface drifts off the shared domain              #
+# --------------------------------------------------------------------------- #
+#: Every public engine method taking an ``n_steps``, and the shared domain it
+#: routes the count through. The three MuJoCo rollout entries are a DIFFERENT
+#: domain and deliberately so: a rollout horizon has a floor of 1 (a zero-step
+#: rollout collects nothing) and is resolved through ``_resolve_horizon`` /
+#: ``_validate_action_horizon`` on ``positive_count_error``. They are listed so
+#: the count of ``n_steps`` surfaces cannot grow unnoticed, not because they
+#: share this change's floor.
+_KNOWN_STEP_COUNT_SURFACES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("mujoco", "step"): ("non_negative_whole_number_error",),
+    ("mujoco", "start_policy"): ("_resolve_horizon",),
+    ("mujoco", "run_policy"): (),
+    ("mujoco", "run_multi_policy"): ("_resolve_horizon",),
+    ("newton", "step"): ("non_negative_whole_number_error",),
+    ("isaac", "step"): ("non_negative_whole_number_error",),
+}
+
+#: The surfaces this change owns: every backend's public ``step``.
+_STEP_METHODS = {key for key in _KNOWN_STEP_COUNT_SURFACES if key[1] == "step"}
+
+#: Any of these, called on the count, means the surface is on a shared domain.
+_SHARED_STEP_VALIDATORS = ("non_negative_whole_number_error", "_resolve_horizon")
+
+
+def _scan_step_count_surfaces(
+    root: pathlib.Path,
+) -> tuple[dict[tuple[str, str], tuple[str, ...]], list[str]]:
+    """Find public engine-class methods taking ``n_steps``, and which skip a domain.
+
+    Scoped to public methods deliberately: ``_advance`` and ``_warmup_camera``
+    also take a step count, but they receive an already-validated one and are
+    not caller-facing.
+
+    Args:
+        root: The ``strands_robots/simulation`` package directory.
+
+    Returns:
+        ``(found, adrift)`` - every ``(backend, method)`` pair mapped to the
+        shared validators it calls, and the ones that call none.
+    """
+    found: dict[tuple[str, str], tuple[str, ...]] = {}
+    adrift: list[str] = []
+    for backend in ("mujoco", "newton", "isaac"):
+        for path in sorted((root / backend).glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+                for fn in [n for n in ast.iter_child_nodes(cls) if isinstance(n, ast.FunctionDef)]:
+                    if fn.name.startswith("_"):
+                        continue
+                    if "n_steps" not in [a.arg for a in fn.args.args + fn.args.kwonlyargs]:
+                        continue
+                    called = {
+                        node.func.id
+                        for node in ast.walk(fn)
+                        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                    } | {
+                        node.func.attr
+                        for node in ast.walk(fn)
+                        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    }
+                    validators = tuple(sorted(name for name in _SHARED_STEP_VALIDATORS if name in called))
+                    found[(backend, fn.name)] = validators
+                    if not validators and fn.name == "step":
+                        adrift.append(f"{backend}/{path.name}:{fn.lineno} {cls.name}.{fn.name}")
+    return found, adrift
+
+
+class TestNoStepCountSurfaceDrifts:
+    """A backend ``step`` must route its count through the shared domain."""
+
+    def test_every_backend_step_validates(self) -> None:
+        root = pathlib.Path(inspect.getfile(NewtonSimEngine)).parent.parent
+        found, adrift = _scan_step_count_surfaces(root)
+        assert adrift == [], "these advance a step count without a shared domain: " + ", ".join(adrift)
+        assert found == _KNOWN_STEP_COUNT_SURFACES, f"the set of n_steps surfaces changed: {found}"
+
+    def test_all_three_backends_are_covered(self) -> None:
+        """An empty scan would satisfy the assertion above just as well."""
+        assert {backend for backend, _method in _STEP_METHODS} == {"mujoco", "newton", "isaac"}
+
+    def test_every_step_is_on_this_changes_domain(self) -> None:
+        root = pathlib.Path(inspect.getfile(NewtonSimEngine)).parent.parent
+        found, _adrift = _scan_step_count_surfaces(root)
+        for key in _STEP_METHODS:
+            assert found[key] == ("non_negative_whole_number_error",), key
+
+    def test_the_scanner_reports_a_planted_omission(self, tmp_path: pathlib.Path) -> None:
+        """Without this, an empty result could mean a scanner matching nothing."""
+        backend = tmp_path / "newton"
+        backend.mkdir()
+        (backend / "simulation.py").write_text(
+            textwrap.dedent(
+                """
+                class Engine:
+                    def step(self, n_steps=1):
+                        return {"status": "success"}
+                """
+            ),
+            encoding="utf-8",
+        )
+        found, adrift = _scan_step_count_surfaces(tmp_path)
+        assert found == {("newton", "step"): ()}
+        assert len(adrift) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Boundary: the neighbouring surfaces this change does not settle             #
+# --------------------------------------------------------------------------- #
+class TestNeighbouringStepSurfacesStayOutOfScope:
+    """Pins of behaviour left unchanged, so the boundary is stated not omitted.
+
+    Replace these when the surfaces they describe are settled, rather than
+    deleting them: the scope statement stays useful and simply narrows.
+    """
+
+    def test_send_action_substeps_are_still_unvalidated(self) -> None:
+        """The same domain gap on a second surface, tracked separately.
+
+        ``send_action(n_substeps=)`` reaches Newton's ``_advance`` floor exactly
+        as ``step`` did, so a ``0`` still advances one substep here. ``step``
+        answers its own zero rather than changing that floor, because the floor
+        is this surface's documented contract and moving it is that surface's
+        change.
+        """
+        stub, world = _newton_stub()
+        stub._advance(0)
+        assert world.step_count == 1
+
+    def test_the_per_call_ceiling_is_still_mujoco_only(self) -> None:
+        """Isaac and Newton have no ceiling and no batched lock release.
+
+        MuJoCo refuses a count above ``_MAX_STEPS_PER_CALL`` with a stated
+        reason - an unbounded lock hold - and releases its lock every
+        ``_STEPS_PER_BATCH`` steps so ``stop_policy`` can interleave. Choosing
+        one ceiling for three backends with different per-step costs is a
+        decision rather than a defect, so it is not smuggled in here.
+        """
+        over = MuJoCoSimEngine._MAX_STEPS_PER_CALL + 1
+        assert MuJoCoSimEngine.step(_mujoco_stub()[0], over)["status"] == "error"
+
+        isaac_stub, isaac_calls = _isaac_stub()
+        assert IsaacSimulation.step(isaac_stub, over)["status"] == "success"
+        assert isaac_calls["n"] == over
+
+    def test_a_boolean_is_refused_by_the_count_domain_not_the_shared_predicate(self) -> None:
+        """``is_boolean`` covers the float writers; this domain has its own check.
+
+        Recorded because the two look interchangeable: ``numpy.bool_`` is not
+        registered as ``numbers.Real``, so it is refused here by the scalar gate
+        rather than by an explicit boolean test, and only python ``bool`` needs
+        the explicit one (it is an ``int`` subclass).
+        """
+        assert non_negative_whole_number_error(True, "n_steps", "step") is not None
+        assert non_negative_whole_number_error(np.bool_(True), "n_steps", "step") is not None


### PR DESCRIPTION
Closes #1868

`step(n_steps)` is the most-called method on the simulation surface and was the last public numeric input with three different domains. MuJoCo has *documented* one since its numeric inputs were hardened - "Non-negative step count (`0` is an accepted no-op)" - but implemented it by hand; Newton and Isaac validated nothing.

## 1. Measured, before and after

One `step` per cell, solver-free, with no `newton` / `warp` / `isaacsim` installed. Bold marks a cell that lies to the caller.

| `n_steps=` | MuJoCo (before) | Newton (before) | Isaac (before) | all three (after) |
| --- | --- | --- | --- | --- |
| `0` | success, no-op | success, **advanced 1** | success, 0 steps | success, no-op |
| `-5` | error | success, **advanced 1** | **success, advanced 0** | error |
| `True` | **advanced 1** | **advanced 1** | **advanced 1** | error |
| `np.True_` | **advanced 1** | **advanced 1** | raised `TypeError` | error |
| `2.7` | **advanced 2** | `step_count` became **2.7** / raised | raised `TypeError` | error |
| `"3"` | **advanced 3** | raised `TypeError` | raised `TypeError` | error |
| `nan` | error | success, **advanced 1** | raised `TypeError` | error |
| `inf` | **raised `OverflowError`** | `step_count` became **inf** / raised | raised `TypeError` | error |
| `None` / `[3]` | error | raised `TypeError` | raised `TypeError` | error |
| `3.0` | advanced 3 | advanced 3 | advanced 3 | advanced 3 |
| `np.int64(3)` | advanced 3 | advanced 3 | advanced 3 | advanced 3 |
| `10**400` | error (ceiling) | **unbounded loop** | **unbounded loop** | unchanged |

The last three rows are the ones that are *unchanged on purpose* - see §3 for the first two and §6 for `10**400`, whose magnitude belongs to the per-call ceiling rather than to this domain.

## 2. What each row cost

**A negative count was a silent success on Isaac.** `range(-5)` is empty, so the call stepped nothing and reported `status="success"` - then divided the elapsed wall time by that negative count and put the quotient in agent-visible text:

```
step(-5) -> success
  'Stepped -5x. sim_time=0.0000s, wall=0.0ms, -11876485 steps/sec'
  world.step called 0 time(s)
```

`False` read the same way, as `Stepped Falsex`.

**`step(0)` advanced the world on Newton.** `_advance` floors its count at `max(1, n_steps)`, so the value MuJoCo documents as a no-op stepped once while the result said `Stepped 0 step(s).` - the report and the world disagreeing, and one call being a no-op on one backend and a step on another. `-5` and `nan` reached that same floor and also advanced 1, under `Stepped -5 step(s).` / `Stepped nan step(s).`.

**`inf` escaped MuJoCo's own envelope.** `int(float("inf"))` raises `OverflowError`, which the hand-rolled `except (TypeError, ValueError)` did not catch - so the one backend that documented this domain raised a bare exception through the structured result these methods document as their only failure channel. On Newton's solver-free path the same value left the clock broken for the world's lifetime:

```
step(inf) -> success   step_count=inf   sim_time=inf     # every later get_state() reports t=inf
step(2.7) -> success   step_count=2.7                    # a float in an integer counter
```

Newton's behaviour for `2.7` also depended on whether a solver had been constructed: solver-free it wrote the float, with a solver it raised out of `range()`.

**A boolean was one step on all three** - the defect the runtime writers removed for their own inputs (#1841, #1837, #1843), since `bool` is an `int` subclass. **And MuJoCo truncated `2.7`** to two steps under a success result, while its docstring promised an error for a non-integer.

## 3. Why a new helper, and why not either existing one

The domain is the missing cell of an existing 2x2 in `utils.py`:

| floor | true `int` only | any real scalar with an integral value |
| --- | --- | --- |
| `>= 1` | `positive_count_error` | `positive_whole_number_error` |
| `>= 0` | `non_negative_count_error` | **`non_negative_whole_number_error`** (added here) |

Reusing one of the two existing candidates looks free and is not:

- **`non_negative_count_error`** has the right floor but accepts only a true `int`, so it would refuse `3.0` and `np.int64(3)` - both of which MuJoCo honors today via its `int()` coercion, and the first of which is pinned by the pre-existing `test_step_float_is_coerced_to_int`. That is a regression on the reference backend.
- **`positive_whole_number_error`** has the right scalar policy but a floor of `1`, which would refuse the `0` MuJoCo documents as a no-op.

So the new helper stands to `positive_whole_number_error` exactly as `non_negative_count_error` stands to `positive_count_error` - and for the reason that function's own docstring already records: its `0` is first-class rather than degenerate. All three backends apply it before any lock, solver or stage work, then coerce once with `int()`; that coercion is safe *because the guard has already performed it and compared the result back*, and the docstring says so. The refusal is identical word for word across the three, not merely identical in verdict.

**Every real scalar gets a verdict; nothing raises out of the guard.** That is the contract rather than a detail, because §4's two external paths document the structured result as the only channel a bad count is reported on. It is why integrality is tested with an `int()` inside a `try` rather than a `float()` round-trip, and why the refusal text is rendered only when a refusal is actually returned - see §7 R2.

**Newton's zero is answered in `step`, not in `_advance`.** `send_action(n_substeps=)` shares `_advance` and reads its `max(1, ...)` floor as its own contract, so moving the floor would change a second public surface's behaviour inside a `step` fix.

## 4. Two paths reach this from outside the process

Both now get a structured refusal instead of a raise or a false success:

- `mesh/core.py:1728` - `r.step(cmd.get("steps", 1))`, so a mesh command carrying `"steps": "3"` or `-5` hit the table above. The call site is `dict(r.step(...))`, so a raise propagated rather than becoming a result.
- `device_connect/sim_driver.py:160` - the `@rpc()` `step`, which forwards a remote caller's value unchanged.

Internal callers were already safe, and this was checked rather than assumed: `PolicyRunner._control_substeps` is annotated `-> int` and every return path is a true positive `int` (`round()` returns `int`), including the `step(n_steps=n_substeps)` on the replay path.

## 5. Tests

`tests/simulation/test_step_count_domain_across_backends.py`, 257 checks:

- the shared domain, including that every accepted value survives the `int()` it is paired with;
- per backend: every unusable count refused, and **a refused count advances nothing** (the pre-fix rows advanced 1);
- Newton specifically: `step_count` stays an `int`, and the reported count is the count advanced;
- Isaac specifically: no result text can carry a `steps/sec` rate for a refused count;
- `TestEveryBackendGivesTheSameVerdict` - same verdict, **same wording**, and the same number of steps actually advanced;
- `TestTheParityHoldsOnACompiledModel` - the same probe set against a real compiled MuJoCo model, so the stand-ins are not the only evidence;
- `TestNoStepCountSurfaceDrifts` - an AST scanner enumerating every public `n_steps` surface, with a planted-omission test so an empty scan cannot pass for a clean one;
- `TestEveryRealGetsAVerdictAndNothingRaises` - the guard's contract as one assertion over every probe in the module, including two registered `numbers.Real` stand-ins that keep the `TypeError` and unprintable-`repr` branches covered decisions rather than unreachable lines.

**Non-vacuity measured: 153 of the 257 fail with the three production guards reverted**, spread across all seven classes. The R2 halves were measured separately - see §7.

The two MuJoCo tests that pinned its own per-backend wording are **updated, not deleted** - the refusal and the untouched `step_count` they assert are unchanged; only the message converged. `test_step_float_is_coerced_to_int` and the per-call-ceiling test pass untouched.

Full validated-domain family re-run green: 1412 passed across the pose / colour / size / mass / step domain modules plus `test_input_validation.py` and `test_input_validators_refuse_a_boolean.py`. `ruff check`, `ruff format --check` and `mypy` clean.

## 6. Deliberately out of scope, and pinned as such

`TestNeighbouringStepSurfacesStayOutOfScope` asserts both are unchanged, so the boundary is a stated assertion rather than an omission:

- **`send_action(n_substeps=)`** has the same unvalidated domain on all three backends and shares Newton's `max(1, ...)` floor. Same shape, second public surface, its own change.
- **The per-call ceiling.** MuJoCo refuses `n_steps > _MAX_STEPS_PER_CALL` (100_000) with a stated reason - an unbounded lock hold - and releases its lock every 1000 steps so `stop_policy` can interleave. Isaac and Newton have neither: measured, Isaac accepted `100_001` and called `world.step` that many times inside one `self._lock` hold. That is a resource policy rather than an input domain, and choosing one ceiling for three backends with different per-step costs is a decision rather than a defect.

- **The magnitude of a count**, which belongs to that ceiling and not to this domain. `10**400` is a non-negative whole number, so the domain accepts it and MuJoCo refuses it with its own ceiling error - exactly as it did before this change, where a true `int` skipped its `int()` coercion. Refusing it inside the guard would have planted a silent boundary at the float range while still accepting `10**300`, which no backend can advance either: a boundary by implementation accident, which is the thing this change exists to remove. Pinned by `test_an_outsized_positive_count_is_left_to_the_per_call_ceiling`.
- **`positive_whole_number_error`**, the sibling helper, which shares both R2 shapes. Its callers never returned a structured error for such a value, so it is a pre-existing family issue rather than this change's regression.

Tracked as #1870 (the `n_substeps` domain, including the floor question this change had to leave alone), #1871 (the ceiling, with the measurements and why the constant cannot simply be copied across three backends), and #1872 (the sibling helper, with both reproducers and the one open decision: whether an outsized value belongs to *that* domain, given its callers have no ceiling to defer to).

---

## 7. Round changelog

| Round | Concern | Fix commit | Pin test |
| --- | --- | --- | --- |
| R1 | mypy `arg-type` in test module (literal probes outside `int` annotation) | `5a7801c` | existing 206 checks |
| R2 | The guard could raise past its own return value for an outsized `int` - two escapes, one input class | `3245ac9`, `ce05dd8` | `TestEveryRealGetsAVerdictAndNothingRaises`; two rows in `UNUSABLE_COUNTS`; `test_an_outsized_positive_count_is_left_to_the_per_call_ceiling` |

**Round 1** - `5a7801c`, one commit, lint only, no behaviour or assertion changed.

The lint job runs `mypy strands_robots tests tests_integ`, and the new test module failed it with 6 `arg-type` errors that the local per-file run had not surfaced. Two were the stand-ins' locals being inferred as `SimpleNamespace` rather than `Any` (passing one as `self` to the real inherited `_advance`); four were probe values that the `n_steps: int` annotation forbids **by design** - a bare `2.7` / `INF` literal and two heterogeneous tuple literals mypy widened to a union.

Fixed by annotating `Any` at the point each value is introduced, which is the pattern the sibling domain modules already use for every stand-in (`_newton_stub() -> Any` in `test_pose_vector_domain_across_backends.py`). No `type: ignore` was added and no assertion changed - the annotation cannot be the thing under test when the test exists precisely to cover values outside it.

**Round 2** - `3245ac9` + `ce05dd8`, addressing the review thread on `strands_robots/utils.py:555`.

The thread is right and it blocks: `float(value)` raises `OverflowError` for an `int` too large for a float, so the guard raised a bare exception through the structured result all three `step` docstrings name as the only failure channel - the same defect class this PR closes for `inf`, and a regression on the reference backend, where a true `int` previously skipped MuJoCo's `int()` coercion and was refused by the `_MAX_STEPS_PER_CALL` ceiling.

**The same input class had a second escape one line above it.** The refusal text was built before the value was classified, and `repr` of an `int` past `sys.get_int_max_str_digits()` (4300 digits) raises `ValueError`:

```
non_negative_whole_number_error(10**5000, "n_steps", "step")
  -> ValueError: Exceeds the limit (4300 digits) for integer string conversion
```

That fires *ahead* of the float conversion, so catching `OverflowError` alone leaves the class open one digit-count higher - and it fires for a count that is *accepted*, i.e. the guard failing on its accept path doing work only the refuse path needs. Both escapes are one concern, so they are one commit.

**The fix takes the thread's second option, not its first.** Integrality is now established by the `int()` the callers were already paired with, inside a `try`, and compared back - exact, no float round-trip, so a large-but-usable count is neither rounded nor refused. That one conversion also answers `nan` (`ValueError`) and `+-inf` (`OverflowError`), which is why no `isfinite` check remains and none is possible: `isfinite` needs the very `float()` this removes.

Refusing the outsized value instead - the thread's first suggestion - was measured and rejected for one reason: it plants a silent boundary at the float range. `10**400` **is** a non-negative whole number, so a guard whose message says "must be a non-negative whole number" would be refusing a value that satisfies the predicate it states, while still accepting `10**300`, which no backend can advance either. Magnitude has an owner already - the per-call ceiling - and this way MuJoCo's answer for `10**400` is the structured ceiling error it gave before this PR, i.e. the regression the thread identified is closed by *restoring* the old verdict rather than by substituting a new one. The boundary is pinned, not narrated: `test_an_outsized_positive_count_is_left_to_the_per_call_ceiling` asserts the domain accepts it and MuJoCo's ceiling refuses it, and records that Newton and Isaac would attempt it (#1871) rather than pretending otherwise.

Three things fell out of the measurement and are now pinned:

- **`math.trunc` is not usable here**, though it is the conversion `numbers.Real` actually guarantees: NumPy scalars implement `__int__` but not `__trunc__`, so `math.trunc(np.int64(3))` raises `TypeError` and the `np.int64` / `np.uint8` rows MuJoCo honors today would be refused. `test_the_count_is_coerced_with_int_because_numpy_has_no_trunc` makes a future "use the abstract method" refactor fail here rather than in the field.
- **The sign is read off the coerced `int`**, because an `int`-to-`int` comparison is total where `value < 0` defers to a `__lt__` a `numbers.Real` registration does not guarantee.
- **Refusal text is rendered on demand** by `_refusal_repr`, whose no-raise guarantee is unconditional rather than a list of today's exceptions, since a third-party scalar can raise anything from `__repr__`. An `int` it cannot print is described as `<int of N bits>` via `bit_length`.

Tests: **257 checks, up from 206.** The two outsized *negative* counts are rows in `UNUSABLE_COUNTS`, so every per-backend, parity, wording and compiled-model class covers them for free. They carry explicit `id=`s, and that is load-bearing: pytest names an `int` parameter with `str()`, so a bare row is a **collection error** that takes down all seven classes in the file rather than failing one test - the harness having the same defect as the guard. Non-vacuity was measured per mechanism, not just in aggregate: restoring the eager message fails 16 checks, restoring the float round-trip fails 32.

`ce05dd8` restores `positive_whole_number_error` to its pre-change form. The thread drew that boundary explicitly, and the partial form is worth holding out for three reasons: it leaves the second escape open on that helper (`10**5000` still raises `ValueError` there), it changes agent-visible text on about a dozen media knobs with no pinned row, and whether an outsized value belongs to that domain at all is an open decision rather than a port - its callers have no ceiling to defer to. #1872 carries both reproducers, the affected surfaces, the two measurements above that port over, and that decision.

Local verification on `ce05dd8`: 257 checks pass; 1412 pass across the whole validated-domain family (pose / colour / size / mass / step plus `test_input_validation.py`); `ruff check`, `ruff format --check` and `mypy strands_robots tests tests_integ` clean, with no new finding in either changed file. (`CodeQL` `NEUTRAL` is the note-severity idiom handling from #1862.)