### PR TITLE
fix(utils): a refusal message must not raise while it is being built

### DIFF
--- a/changelog.d/1873-refusal-messages-never-raise.md
+++ b/changelog.d/1873-refusal-messages-never-raise.md
@@ -1,0 +1,70 @@
+### Fixed: a validation guard no longer raises while rendering the refusal it is returning
+
+The scalar guards in `strands_robots/utils.py` exist so a caller's bad value is
+reported through a structured `{status, content}` result - every one of their
+callers documents that result as the only channel a rejected value is reported
+on. Building the message is part of that answer, and it was not a total
+operation: the guards interpolated the caller's value directly, and rendering a
+value can raise. So a guard could fail on precisely the path whose purpose is to
+answer instead of raise.
+
+Two values reach it, neither hypothetical. Rendering an `int` wider than
+`sys.get_int_max_str_digits()` (4300 digits by default) raises `ValueError`, and
+`device_connect`'s `@rpc()` surfaces forward a remote caller's number unchanged
+while Python integers are arbitrary-precision. And a third-party type may raise
+anything at all from its own `__repr__`: `numbers.Real` is a registration rather
+than an inheritance, so a scalar that satisfies a guard's type test owes it
+nothing else.
+
+Measured across the family, the second case reached *every* guard except the one
+already rewritten for the step surface - each of them raised on a value it had
+already decided to refuse:
+
+```
+positive_count_error(-(10**5000), "n", "ctx")        # ValueError: Exceeds the limit (4300 digits)
+tcp_port_error(10**5000, "port", "ctx")              # ValueError
+entity_name_error("add_object", "name", 10**5000)    # ValueError
+positive_count_error(Unprintable(), "n", "ctx")      # RuntimeError, from the value's own __repr__
+```
+
+The outsized-integer cells are narrower than they look, which is why they read as
+clean: the guards that never convert raise only on a value they have *refused*,
+never on one they accept.
+
+Every one of them now renders through `_refusal_repr` or its new `str`
+counterpart `_refusal_str`, which defer to `repr` / `str` wherever those work and
+otherwise describe the value - by bit count for an `int`, since `int.bit_length`
+needs no decimal conversion, and by type name otherwise. No verdict and no
+agent-visible text changes: every message these guards already produced is
+reproduced byte for byte, which is pinned rather than asserted.
+`positive_whole_number_error` additionally renders on demand instead of building
+its text on the function's first line, where it raised ahead of every verdict and
+on the accept path too.
+
+Two of the sites render a value plainly rather than quoted and needed the `str`
+form rather than `repr`, because NumPy 2 reprs a scalar with its type and
+converting would have silently turned `got 200.0` into `got np.float32(200.0)` in
+text an agent reads. One of them, `camera_fov_error`'s open-interval branch,
+looks unreachable by anything unrenderable - it runs only after
+`math.isfinite(float(value))` has succeeded - but a registered `numbers.Real`
+whose `float()` is finite and outside `(0, 180)` passes that test and is refused
+there. The other, `validation_split_error`, renders a `total_tasks` read straight
+out of a dataset's `meta/info.json`, so a JSON integer of any width reaches it.
+Neither carries an `!r`, so both were invisible to a reading that looked for one.
+
+The invariant is pinned by a scan of the module rather than a list of guards, so a
+guard added later cannot reintroduce it silently. The scan keys on the parameter
+annotated `Any`, which is how every guard here spells "the caller's value" - the
+others are the `str` labels the call site supplies, which are literals and cannot
+raise - and it reports the plain `{value}` form as well as `{value!r}`.
+
+Two neighbouring escapes are deliberately left alone and pinned as out of scope.
+The `float()` conversion in `positive_finite_number_error`, `finite_number_error`,
+`camera_fov_error` and `positive_whole_number_error` raises `OverflowError` for an
+`int` wider than a float, before any message is rendered; closing it needs a
+decision this change does not, since `10**400` *is* a finite real number and "must
+be a finite number" is the wrong reason to refuse it even though refusing is
+right. And the container guards render a whole list, so one unrenderable element
+takes down a refusal already decided - but this change's fallback is not the fix
+there, because `<unrepresentable list>` erases every element that rendered fine
+along with the element count, and the count is often the refusal's whole reason.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -390,6 +390,96 @@ def sequence_length(value: Any) -> int | None:
         return None
 
 
+def _refusal_repr(value: Any) -> str:
+    """``repr(value)`` for a refusal message, or a description when it cannot be built.
+
+    Every scalar guard below renders the value it refuses through this, and none
+    of them renders one any other way. Rendering a rejected value must not be
+    able to raise: it runs only on the path whose entire purpose is to answer an
+    unusable input with a structured message instead of an exception, and every
+    caller of every one of those guards documents that ``{status, content}``
+    result as the only channel a bad value is reported on. A guard that raises
+    while building a refusal fails on exactly the path that exists so it does
+    not.
+
+    Two cases reach it, and neither is hypothetical. ``repr`` of an ``int`` wider
+    than :func:`sys.get_int_max_str_digits` (4300 digits by default) raises
+    ``ValueError``, and ``device_connect``'s ``@rpc()`` surfaces forward a remote
+    caller's number unchanged while Python integers are arbitrary-precision. And
+    a third-party type may raise anything at all from its own ``__repr__`` -
+    :class:`numbers.Real` is a registration rather than an inheritance, so a
+    scalar that satisfies a guard's type test owes it nothing else - which is why
+    the guarantee here is unconditional rather than a list of the exceptions
+    known today.
+
+    ``int.bit_length`` needs no decimal conversion, so the value most likely to
+    arrive unprintable is still described by its magnitude rather than reported
+    as an opaque type name.
+
+    Args:
+        value: The rejected value.
+
+    Returns:
+        Its ``repr``, or a bracketed description when that cannot be produced.
+    """
+    try:
+        return repr(value)
+    except Exception:
+        return _describe_unrenderable(value)
+
+
+def _refusal_str(value: Any) -> str:
+    """``str(value)`` for a refusal message, or a description when it cannot be built.
+
+    The :func:`_refusal_repr` counterpart for the two messages that report a
+    value plainly rather than quoted, where ``repr`` is not interchangeable:
+    NumPy 2 reprs a scalar with its type, so rendering an ``np.float32`` fov
+    through ``repr`` would silently turn ``got 200.0`` into
+    ``got np.float32(200.0)`` in text an agent reads.
+
+    ``str`` is exactly as able to raise as ``repr`` and for the same two reasons:
+    it falls back to ``__repr__`` when a type defines no ``__str__``, and
+    ``str`` of an ``int`` wider than :func:`sys.get_int_max_str_digits` performs
+    the same decimal conversion. So a plainly-rendered value needs the same
+    guarantee rather than a weaker one.
+
+    Args:
+        value: The rejected value.
+
+    Returns:
+        Its ``str``, or a bracketed description when that cannot be produced.
+    """
+    try:
+        return str(value)
+    except Exception:
+        return _describe_unrenderable(value)
+
+
+def _describe_unrenderable(value: Any) -> str:
+    """Describe a value whose own rendering raised.
+
+    Shared by :func:`_refusal_repr` and :func:`_refusal_str` so the two render
+    forms cannot describe the same unrenderable value differently.
+
+    ``int.bit_length`` needs no decimal conversion, so the value most likely to
+    arrive unrenderable - an ``int`` past the interpreter's digit limit - is
+    still described by its magnitude rather than reported as an opaque type
+    name. The sign is not recoverable from a bit length, which is acceptable
+    because every guard's own text states the domain the value was refused
+    against.
+
+    Args:
+        value: The value whose rendering raised.
+
+    Returns:
+        A bracketed description, which is built from the type and (for an
+        integer) a bit count, so it cannot itself raise.
+    """
+    if isinstance(value, int):
+        return f"<int of {value.bit_length()} bits>"
+    return f"<unrepresentable {type(value).__name__}>"
+
+
 def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive finite number.
 
@@ -433,7 +523,7 @@ def positive_finite_number_error(value: Any, param: str, context: str) -> str | 
         or not math.isfinite(float(value))
         or float(value) <= 0
     ):
-        return f"{context}: {param} must be > 0, got {value!r}."
+        return f"{context}: {param} must be > 0, got {_refusal_repr(value)}."
     return None
 
 
@@ -470,7 +560,7 @@ def finite_number_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, numbers.Real) or not math.isfinite(float(value)):
-        return f"{context}: {param} must be a finite number, got {value!r}."
+        return f"{context}: {param} must be a finite number, got {_refusal_repr(value)}."
     return None
 
 
@@ -501,44 +591,23 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    message = f"{context}: {param} must be a positive whole number, got {value!r}."
+
+    def message() -> str:
+        # Rendered on demand, not up front. The text used to be built on this
+        # function's first line, before the value had been classified at all, so
+        # ``repr`` raised on an outsized ``int`` ahead of every verdict - the
+        # guard failing while preparing a refusal it had not decided to return,
+        # and doing it on the accept path too.
+        return f"{context}: {param} must be a positive whole number, got {_refusal_repr(value)}."
+
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        return message
+        return message()
     numeric = float(value)
     # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
     # out of the integrality check below.
     if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
-        return message
+        return message()
     return None
-
-
-def _refusal_repr(value: Any) -> str:
-    """``repr(value)`` for a refusal message, or a description when it cannot be built.
-
-    Rendering a rejected value must not be able to raise: it runs only on the
-    path whose entire purpose is to answer an unusable input with a structured
-    message instead of an exception. Two cases reach it. ``repr`` of an ``int``
-    wider than :func:`sys.get_int_max_str_digits` (4300 digits by default)
-    raises ``ValueError``, and a caller can send one - ``sim_driver``'s
-    ``@rpc()`` ``step`` forwards a remote integer unchanged and Python integers
-    are arbitrary-precision. And a third-party :class:`numbers.Real`
-    implementation may raise anything at all from its own ``__repr__``, so the
-    guarantee here has to be unconditional rather than a list of the exceptions
-    known today. ``int.bit_length`` needs no decimal conversion, so the integer
-    that could not be printed can still be described.
-
-    Args:
-        value: The rejected value.
-
-    Returns:
-        Its ``repr``, or a bracketed description when that cannot be produced.
-    """
-    try:
-        return repr(value)
-    except Exception:
-        if isinstance(value, int):
-            return f"<int of {value.bit_length()} bits>"
-        return f"<unrepresentable {type(value).__name__}>"
 
 
 def non_negative_whole_number_error(value: Any, param: str, context: str) -> str | None:
@@ -682,7 +751,7 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        return f"{context}: {param} must be a positive integer, got {value!r}."
+        return f"{context}: {param} must be a positive integer, got {_refusal_repr(value)}."
     return None
 
 
@@ -726,7 +795,7 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 65535:
-        return f"{context}: invalid {param}: {value!r} (expected 1-65535)"
+        return f"{context}: invalid {param}: {_refusal_repr(value)} (expected 1-65535)"
     return None
 
 
@@ -759,7 +828,7 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        return f"{context}: {param} must be a non-negative integer, got {value!r}."
+        return f"{context}: {param} must be a non-negative integer, got {_refusal_repr(value)}."
     return None
 
 
@@ -1166,9 +1235,9 @@ def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:
     usable field of view.
     """
     if isinstance(value, bool) or not isinstance(value, numbers.Real) or not math.isfinite(float(value)):
-        return f"{method}: '{param_name}' must be a finite number in degrees, got {value!r}."
+        return f"{method}: '{param_name}' must be a finite number in degrees, got {_refusal_repr(value)}."
     if not (0.0 < float(value) < 180.0):
-        return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {value}."
+        return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {_refusal_str(value)}."
     return None
 
 
@@ -1237,7 +1306,7 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
     """
     if not isinstance(name, str):
         return (
-            f"{method}: '{param_name}' must be a non-empty string, got {name!r} "
+            f"{method}: '{param_name}' must be a non-empty string, got {_refusal_repr(name)} "
             f"({type(name).__name__}); an entity is addressed by name and every "
             "agent-tool call carries that name as a string."
         )
@@ -1249,7 +1318,7 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
         )
     if "\x00" in name:
         return (
-            f"{method}: '{param_name}' must not contain a NUL character, got {name!r}; "
+            f"{method}: '{param_name}' must not contain a NUL character, got {_refusal_repr(name)}; "
             "the compiled model reads a name only up to the first NUL, so the registry "
             "and the model would disagree about the entity's name."
         )
@@ -1307,7 +1376,7 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str) ->
         return None
     return (
         f"{context}: val_episodes={val_episodes} cannot be reserved exactly on a "
-        f"dataset with {total_tasks} tasks. A validation split is a per-task "
+        f"dataset with {_refusal_str(total_tasks)} tasks. A validation split is a per-task "
         "fraction in lerobot (it holds out ceil(episodes_in_task * eval_split) "
         "from every task), so a single global count is not expressible: the "
         "ceiling would be applied once per task. Pass the fraction directly, "

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -1,0 +1,816 @@
+"""Regression tests: a refusal message must not raise while it is being built (#1873).
+
+The guards in :mod:`strands_robots.utils` exist so that a caller's bad value is
+reported through a structured ``{status, content}`` result - every one of their
+callers documents that result as the only channel a rejected value is reported
+on. Building the message is part of that answer, and it was not a total
+operation: the guards interpolated the caller's value directly, and rendering a
+value can raise.
+
+Two values reach it, neither hypothetical. Rendering an ``int`` wider than
+``sys.get_int_max_str_digits()`` (4300 digits by default) raises ``ValueError``,
+and ``device_connect``'s ``@rpc()`` surfaces forward a remote caller's number
+unchanged while Python integers are arbitrary-precision. And a third-party type
+may raise anything from its own ``__repr__``: ``numbers.Real`` is a registration
+rather than an inheritance, so a scalar that satisfies a guard's type test owes
+it nothing else.
+
+Measured on ``b28c911``, each guard called with its real signature. ``R:`` is a
+raise; ``Unprintable()`` is a plain object whose ``__repr__`` raises:
+
+| guard | ``10**400`` | ``-10**400`` | ``10**5000`` | ``-10**5000`` | ``Unprintable()`` |
+| --- | --- | --- | --- | --- | --- |
+| ``positive_finite_number_error`` | R:Overflow | R:Overflow | R:Overflow | R:Overflow | **R:RuntimeError** |
+| ``finite_number_error`` | R:Overflow | R:Overflow | R:Overflow | R:Overflow | **R:RuntimeError** |
+| ``positive_whole_number_error`` | R:Overflow | R:Overflow | **R:ValueError** | **R:ValueError** | **R:RuntimeError** |
+| ``non_negative_whole_number_error`` | accept | refuse | accept | refuse | refuse |
+| ``positive_count_error`` | accept | refuse | accept | **R:ValueError** | **R:RuntimeError** |
+| ``non_negative_count_error`` | accept | refuse | accept | **R:ValueError** | **R:RuntimeError** |
+| ``tcp_port_error`` | refuse | refuse | **R:ValueError** | **R:ValueError** | **R:RuntimeError** |
+| ``camera_fov_error`` | R:Overflow | R:Overflow | R:Overflow | R:Overflow | **R:RuntimeError** |
+| ``entity_name_error`` | refuse | refuse | **R:ValueError** | **R:ValueError** | **R:RuntimeError** |
+
+The last column is what makes this one uniform defect rather than a handful of
+outsized-integer curiosities: **every guard except the one #1869 rewrote raised
+on a value it had already decided to refuse.** That column is
+:class:`TestEveryScalarGuardAnswersAValueItCannotRender`, and it fails on pre-fix
+code for all eight.
+
+The ``R:ValueError`` cells are the same defect reached by a plain Python ``int``
+today, and they are narrower than they look: those guards never convert, so they
+raised only on a value they had *refused*, never on one they accepted. That is
+why they read as clean - including to #1872, which lists the count pair as out of
+scope.
+
+Two further sites render a value with ``str`` rather than ``repr`` and reach the
+same escape, since ``str`` falls back to ``__repr__`` when a type defines no
+``__str__`` and performs the same decimal conversion for an ``int``:
+
+* ``camera_fov_error``'s open-interval branch. It looks unreachable, because it
+  runs only after ``math.isfinite(float(value))`` has succeeded - but a
+  registered ``numbers.Real`` whose ``float()`` is finite and outside ``(0,
+  180)`` passes that test and is refused here. Pinned in
+  :class:`TestTheOpenIntervalBranchRendersPlainlyAndStillCannotRaise`.
+* ``validation_split_error``, which renders a ``total_tasks`` read straight out
+  of a dataset's ``meta/info.json`` - a JSON integer, so arbitrary-precision.
+  Pinned in :class:`TestValidationSplitRendersATaskCountItCannotRender`.
+
+Those two keep ``str`` rather than moving to ``repr``: NumPy 2 reprs a scalar
+with its type, so a documented-as-accepted ``np.float32`` fov would start
+reporting ``got np.float32(200.0)`` in text an agent reads.
+
+The fix routes all of them through ``_refusal_repr`` / ``_refusal_str``, which
+defer to ``repr`` / ``str`` wherever those work. So no verdict and no
+agent-visible text changes, which is what
+:class:`TestTheTextIsUnchangedForAValueThatCanBeRendered` pins.
+
+The ``R:Overflow`` cells are a *different* escape - the ``float()`` conversion,
+which happens before any message is rendered - and survive this change untouched.
+They are #1874, pinned by :class:`TestTheConversionEscapeStaysOutOfScope`. The
+container guards have the same rendering defect but need a rendering rather than
+a fallback, since ``<unrepresentable list>`` erases the elements that print fine;
+they are #1875, pinned by :class:`TestTheContainerGuardsStayOutOfScope`.
+
+:class:`TestNoGuardRendersACallerValueDirectly` is what makes this the last pass
+over the question rather than a first. It keys on the parameter annotated
+``Any``, which is how every guard in this module spells "the caller's value", and
+it reports the plain ``{value}`` form as well as ``{value!r}`` - a scanner that
+looked only for ``!r`` would have missed both ``str`` sites above, which is how
+they went unnoticed until the scan was written.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import numbers
+import pathlib
+import sys
+import textwrap
+from collections.abc import Callable
+from typing import Any, NamedTuple
+
+import numpy as np
+import pytest
+
+import strands_robots.utils as utils
+from strands_robots.utils import (
+    _describe_unrenderable,
+    _refusal_repr,
+    _refusal_str,
+    camera_fov_error,
+    entity_name_error,
+    finite_number_error,
+    finite_vector_error,
+    name_list_error,
+    non_negative_count_error,
+    non_negative_whole_number_error,
+    pose_vector_error,
+    positive_count_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+    tcp_port_error,
+    validation_split_error,
+)
+
+NAN = float("nan")
+INF = float("inf")
+
+#: An ``int`` wider than the float range. ``float(10**400)`` raises
+#: ``OverflowError`` - the conversion escape, which is #1874's and not this
+#: change's, because it fires before any message is rendered.
+BEYOND_FLOAT_RANGE = 10**400
+
+#: An ``int`` too wide to render: past :func:`sys.get_int_max_str_digits` (4300
+#: digits by default), so both ``repr`` and ``str`` raise ``ValueError``. This is
+#: the rendering escape this change closes.
+BEYOND_INT_STR_LIMIT = 10**5000
+
+#: ``BEYOND_INT_STR_LIMIT`` has this many decimal digits, by construction.
+#: Spelled out rather than measured with ``len(str(...))``, which is the very
+#: conversion that raises.
+BEYOND_INT_STR_LIMIT_DIGITS = 5001
+
+
+class Unprintable:
+    """A plain object whose ``repr`` raises.
+
+    Refused by every guard on type alone, which is why the last column of the
+    module docstring's table is uniform. An outsized ``int`` only reaches the
+    guards that do not convert first; this reaches all of them, and it is the
+    reason the renderer's guarantee is unconditional rather than a list of the
+    exceptions known today.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("this type cannot render itself")
+
+
+@numbers.Real.register
+class UnrenderableReal:
+    """A registered ``numbers.Real``, refused on its value, that cannot render itself.
+
+    ``numbers.Real`` is a registration rather than an inheritance, so this
+    satisfies the scalar type test the numeric guards lead with and still owes
+    them nothing. ``float()`` is ``nan`` so every guard in the family refuses it
+    on its value rather than its type - the path an ``Unprintable`` never takes,
+    since that one is turned away by the type test first.
+    """
+
+    def __float__(self) -> float:
+        return NAN
+
+    def __int__(self) -> int:
+        return -1
+
+    def __repr__(self) -> str:
+        raise RuntimeError("this scalar cannot render itself")
+
+
+@numbers.Real.register
+class UnrenderableFov:
+    """A registered ``numbers.Real`` that is finite and outside ``(0, 180)``.
+
+    The probe that reaches ``camera_fov_error``'s open-interval branch: it passes
+    the finiteness branch above it, which is what made that branch look
+    unreachable by anything unrenderable.
+    """
+
+    def __float__(self) -> float:
+        return 200.0
+
+    def __int__(self) -> int:
+        return 200
+
+    def __repr__(self) -> str:
+        raise RuntimeError("this fov cannot render itself")
+
+
+class UnrenderableName(str):
+    """A ``str`` subclass whose ``repr`` raises.
+
+    ``entity_name_error``'s NUL branch runs only after ``isinstance(name, str)``
+    has passed, and a subclass passes it - so "a ``str``'s ``repr`` cannot raise"
+    is true of ``str`` and not of the type test guarding that branch.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("this name cannot render itself")
+
+
+class Guard(NamedTuple):
+    """One scalar guard, with everything needed to probe it.
+
+    Attributes:
+        name: The function's name, used as the test ID.
+        param: The parameter label the message must still carry.
+        call: The guard with its non-value arguments already bound, so a probe
+            can be sent to its value position - first for the numeric family and
+            third for the two that lead with the method name.
+        refused: Values this guard refuses whose rendering cannot raise. Per
+            guard rather than shared, because the family does not agree on a
+            domain: ``finite_number_error`` accepts every negative the others
+            refuse, and ``entity_name_error`` accepts the string ``"3"``.
+    """
+
+    name: str
+    param: str
+    call: Callable[[Any], str | None]
+    refused: tuple[Any, ...]
+
+
+SCALAR_GUARDS: tuple[Guard, ...] = (
+    Guard(
+        "positive_finite_number_error",
+        "hz",
+        lambda v: positive_finite_number_error(v, "hz", "teleoperate"),
+        (0, -1.0, NAN, INF, None, "3", [3], True, np.float32(-1.0), np.int64(-1)),
+    ),
+    Guard(
+        "finite_number_error",
+        "linear",
+        lambda v: finite_number_error(v, "linear", "drive"),
+        (NAN, INF, -INF, None, "3", [3], True),
+    ),
+    Guard(
+        "positive_whole_number_error",
+        "fps",
+        lambda v: positive_whole_number_error(v, "fps", "video"),
+        (0, -1, 2.7, NAN, INF, None, "3", [3], True, np.int64(-1)),
+    ),
+    Guard(
+        "non_negative_whole_number_error",
+        "n_steps",
+        lambda v: non_negative_whole_number_error(v, "n_steps", "step"),
+        (-1, 2.7, NAN, INF, None, "3", [3], True, np.int64(-1)),
+    ),
+    Guard(
+        "positive_count_error",
+        "width",
+        lambda v: positive_count_error(v, "width", "add_camera"),
+        (0, -1, 2.7, NAN, None, "3", [3], True, np.int64(640)),
+    ),
+    Guard(
+        "non_negative_count_error",
+        "steps",
+        lambda v: non_negative_count_error(v, "steps", "handshake"),
+        (-1, 2.7, NAN, None, "3", [3], True, np.int64(0)),
+    ),
+    Guard(
+        "tcp_port_error",
+        "port",
+        lambda v: tcp_port_error(v, "port", "RosbridgeRobot"),
+        (0, -1, 70000, 2.7, NAN, None, "3", [3], True, np.int64(9090)),
+    ),
+    Guard(
+        "camera_fov_error",
+        "fov",
+        lambda v: camera_fov_error("add_camera", "fov", v),
+        (NAN, INF, None, "3", [3], True),
+    ),
+    Guard(
+        "entity_name_error",
+        "name",
+        lambda v: entity_name_error("add_object", "name", v),
+        (7, 2.7, None, [3], True, np.int64(7)),
+    ),
+)
+
+GUARD_IDS = tuple(guard.name for guard in SCALAR_GUARDS)
+
+#: The guards that reach their message for an outsized ``int``: they refuse it on
+#: type or range without converting, so the eager rendering was the only thing
+#: between them and a structured answer.
+ANSWERS_AN_OUTSIZED_INT = frozenset(
+    {
+        "non_negative_whole_number_error",
+        "positive_count_error",
+        "non_negative_count_error",
+        "tcp_port_error",
+        "entity_name_error",
+    }
+)
+
+#: The guards whose ``float()`` conversion raises before any rendering (#1874).
+#: ``positive_whole_number_error`` joins the set with this change: its eager
+#: ``repr`` used to raise first, so the conversion was never reached.
+HAS_A_CONVERSION_ESCAPE = frozenset(
+    {
+        "positive_finite_number_error",
+        "finite_number_error",
+        "positive_whole_number_error",
+        "camera_fov_error",
+    }
+)
+
+OUTSIZED_GUARDS = tuple(g for g in SCALAR_GUARDS if g.name in ANSWERS_AN_OUTSIZED_INT)
+OUTSIZED_IDS = tuple(g.name for g in OUTSIZED_GUARDS)
+CONVERTING_GUARDS = tuple(g for g in SCALAR_GUARDS if g.name in HAS_A_CONVERSION_ESCAPE)
+CONVERTING_IDS = tuple(g.name for g in CONVERTING_GUARDS)
+
+
+# --------------------------------------------------------------------------- #
+# The shared renderers                                                        #
+# --------------------------------------------------------------------------- #
+class TestTheSharedRenderers:
+    """``_refusal_repr`` / ``_refusal_str`` are the only ways a refused value is rendered."""
+
+    def test_a_renderable_value_renders_exactly_as_repr(self) -> None:
+        """The whole reason no message text changes: it defers wherever it can."""
+        for value in (-1, -1.0, None, "3", [3], True, np.float32(-1.0), np.int64(-1), NAN):
+            assert _refusal_repr(value) == repr(value)
+
+    def test_a_renderable_value_renders_exactly_as_str(self) -> None:
+        for value in (-1, -1.0, None, "3", [3], True, np.float32(200.0), np.int64(200)):
+            assert _refusal_str(value) == str(value)
+
+    def test_the_two_forms_are_not_interchangeable(self) -> None:
+        """Why the ``str`` sites keep ``str``: NumPy 2 reprs a scalar with its type."""
+        assert _refusal_str(np.float32(200.0)) == "200.0"
+        assert _refusal_repr(np.float32(200.0)) == "np.float32(200.0)"
+
+    def test_an_outsized_integer_is_described_by_its_magnitude(self) -> None:
+        """``int.bit_length`` needs no decimal conversion, so this stays possible."""
+        expected = f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>"
+        with pytest.raises(ValueError):
+            repr(BEYOND_INT_STR_LIMIT)
+        with pytest.raises(ValueError):
+            str(BEYOND_INT_STR_LIMIT)
+        assert _refusal_repr(BEYOND_INT_STR_LIMIT) == expected
+        assert _refusal_str(BEYOND_INT_STR_LIMIT) == expected
+
+    def test_both_forms_describe_an_unrenderable_value_identically(self) -> None:
+        """One describer, so the two render forms cannot disagree about one value."""
+        for value in (BEYOND_INT_STR_LIMIT, Unprintable(), UnrenderableReal()):
+            assert _refusal_repr(value) == _describe_unrenderable(value)
+            assert _refusal_str(value) == _describe_unrenderable(value)
+
+    def test_the_description_of_an_outsized_integer_does_not_carry_its_sign(self) -> None:
+        """A known limit of the description, pinned rather than left to be discovered.
+
+        ``int.bit_length`` is the magnitude, so the two spellings describe
+        identically and the message cannot say which arrived. It is not worth a
+        format change: magnitude is inside these guards' domains, so the sign is
+        the only reason left to refuse an outsized integer, and the guard's own
+        text states the domain it was refused against.
+        """
+        assert _describe_unrenderable(-BEYOND_INT_STR_LIMIT) == _describe_unrenderable(BEYOND_INT_STR_LIMIT)
+        refusal = positive_count_error(-BEYOND_INT_STR_LIMIT, "width", "add_camera")
+        assert refusal is not None
+        assert "must be a positive integer" in refusal
+
+    def test_a_value_that_cannot_render_itself_is_described_by_its_type(self) -> None:
+        assert _refusal_repr(Unprintable()) == "<unrepresentable Unprintable>"
+        assert _refusal_repr(UnrenderableReal()) == "<unrepresentable UnrenderableReal>"
+        assert _refusal_str(UnrenderableFov()) == "<unrepresentable UnrenderableFov>"
+        assert _refusal_repr(UnrenderableName("arm")) == "<unrepresentable UnrenderableName>"
+
+    def test_the_fallback_is_unconditional_rather_than_a_known_exception_list(self) -> None:
+        """A third-party type may raise anything, so the guarantee cannot enumerate."""
+
+        class RaisesUnusual:
+            def __repr__(self) -> str:
+                raise MemoryError("out of memory rendering myself")
+
+        class RaisesBaseException:
+            def __repr__(self) -> str:
+                raise KeyboardInterrupt
+
+        assert _refusal_repr(RaisesUnusual()) == "<unrepresentable RaisesUnusual>"
+        # ``except Exception`` does not cover a ``BaseException`` and must not:
+        # swallowing a ``KeyboardInterrupt`` to render an error message would be a
+        # worse failure than the one being reported. Pinned so the boundary is a
+        # decision rather than an oversight.
+        with pytest.raises(KeyboardInterrupt):
+            _refusal_repr(RaisesBaseException())
+
+    def test_every_rendering_is_ascii(self) -> None:
+        for value in (-1, NAN, None, [3], BEYOND_INT_STR_LIMIT, Unprintable()):
+            _refusal_repr(value).encode("ascii")
+            _refusal_str(value).encode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# The invariant: no guard raises while refusing                               #
+# --------------------------------------------------------------------------- #
+class TestEveryScalarGuardAnswersAValueItCannotRender:
+    """The uniform defect: eight of nine guards raised here before this change.
+
+    Every row fails on pre-fix code with the probe's own ``RuntimeError`` escaping
+    the guard, in place of the refusal string it had already decided to return.
+    """
+
+    @pytest.mark.parametrize("guard", SCALAR_GUARDS, ids=GUARD_IDS)
+    def test_an_unrenderable_value_refused_on_its_type_is_answered(self, guard: Guard) -> None:
+        refusal = guard.call(Unprintable())
+        assert refusal is not None, "an unrenderable value is not a usable one"
+        assert "<unrepresentable Unprintable>" in refusal
+        assert guard.param in refusal, "the message must still name the parameter"
+        refusal.encode("ascii")
+
+    @pytest.mark.parametrize("guard", SCALAR_GUARDS, ids=GUARD_IDS)
+    def test_an_unrenderable_value_refused_on_its_value_is_answered(self, guard: Guard) -> None:
+        """Past the type test, refused on its value - the path ``Unprintable`` skips."""
+        refusal = guard.call(UnrenderableReal())
+        assert refusal is not None
+        assert "<unrepresentable UnrenderableReal>" in refusal
+        assert guard.param in refusal
+
+    def test_an_unrenderable_name_subclass_is_answered(self) -> None:
+        """``entity_name_error``'s NUL branch runs after the ``str`` test passes."""
+        refusal = entity_name_error("add_object", "name", UnrenderableName("a\x00b"))
+        assert refusal is not None
+        assert "<unrepresentable UnrenderableName>" in refusal
+        assert "NUL" in refusal
+
+    @pytest.mark.parametrize("guard", SCALAR_GUARDS, ids=GUARD_IDS)
+    def test_the_verdict_is_a_string_or_none_for_every_probe(self, guard: Guard) -> None:
+        """The contract as one assertion, over every value this module names."""
+        probes = (*guard.refused, Unprintable(), UnrenderableReal(), UnrenderableFov(), UnrenderableName("a\x00b"))
+        for probe in probes:
+            verdict = guard.call(probe)
+            assert verdict is None or isinstance(verdict, str)
+
+
+class TestOutsizedIntegersAreAnsweredWhereTheGuardReachesItsMessage:
+    """The ``R:ValueError`` cells: reachable today with a plain Python ``int``.
+
+    These five refuse on type or range without converting, so the eager rendering
+    was the only thing between them and a structured answer. A remote caller's
+    number arrives through ``device_connect``'s ``@rpc()`` unchanged, and Python
+    integers are arbitrary-precision.
+    """
+
+    @pytest.mark.parametrize("guard", OUTSIZED_GUARDS, ids=OUTSIZED_IDS)
+    def test_an_outsized_integer_outside_the_domain_is_refused(self, guard: Guard) -> None:
+        refusal = guard.call(-BEYOND_INT_STR_LIMIT)
+        assert refusal is not None
+        assert f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>" in refusal
+        assert guard.param in refusal
+        refusal.encode("ascii")
+
+    def test_the_port_range_refuses_an_outsized_integer_of_either_sign(self) -> None:
+        """``tcp_port_error`` bounds above too, so both signs reach the message."""
+        for probe in (BEYOND_INT_STR_LIMIT, -BEYOND_INT_STR_LIMIT):
+            refusal = tcp_port_error(probe, "port", "RosbridgeRobot")
+            assert refusal is not None
+            assert "expected 1-65535" in refusal
+
+    def test_a_name_that_is_an_outsized_integer_is_refused(self) -> None:
+        refusal = entity_name_error("add_object", "name", BEYOND_INT_STR_LIMIT)
+        assert refusal is not None
+        assert f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>" in refusal
+        assert "(int)" in refusal, "the message names the type as well as the value"
+
+    def test_an_outsized_integer_inside_the_domain_is_still_accepted(self) -> None:
+        """Magnitude is not these guards' question, and this change does not make it one.
+
+        ``positive_count_error`` and ``non_negative_count_error`` accepted
+        ``10**400`` and ``10**5000`` before this change and still do, which is also
+        the evidence #1872 turns on: refusing an outsized positive in
+        ``positive_whole_number_error`` would break the documented 2x2 against both
+        of them, not only against the cell #1869 rewrote.
+        """
+        for probe in (BEYOND_FLOAT_RANGE, BEYOND_INT_STR_LIMIT):
+            assert positive_count_error(probe, "width", "add_camera") is None
+            assert non_negative_count_error(probe, "steps", "handshake") is None
+            assert non_negative_whole_number_error(probe, "n_steps", "step") is None
+
+
+class TestTheOpenIntervalBranchRendersPlainlyAndStillCannotRaise:
+    """``camera_fov_error``'s second branch renders with ``str``, and keeps doing so.
+
+    It looks unreachable by anything unrenderable, because it runs only after
+    ``math.isfinite(float(value))`` has succeeded. A registered ``numbers.Real``
+    whose ``float()`` is finite and outside the interval passes that test and is
+    refused here, so the branch needed the guarantee too - and it needed it in the
+    ``str`` form, because converting to ``repr`` would silently change
+    agent-visible text for a documented-as-accepted NumPy fov.
+    """
+
+    def test_the_interval_message_renders_a_numpy_fov_without_its_type(self) -> None:
+        refusal = camera_fov_error("add_camera", "fov", np.float32(200.0))
+        assert refusal == "add_camera: 'fov' must be in the open interval (0, 180) degrees, got 200.0."
+        assert "np.float32" not in refusal
+
+    def test_a_finite_fov_outside_the_interval_that_cannot_render_is_answered(self) -> None:
+        refusal = camera_fov_error("add_camera", "fov", UnrenderableFov())
+        assert refusal is not None
+        assert "must be in the open interval (0, 180) degrees" in refusal
+        assert "<unrepresentable UnrenderableFov>" in refusal
+
+    def test_the_finiteness_branch_is_the_one_that_takes_a_non_finite_fov(self) -> None:
+        """The two branches carry different reasons; neither may raise."""
+        refusal = camera_fov_error("add_camera", "fov", UnrenderableReal())
+        assert refusal is not None
+        assert "must be a finite number in degrees" in refusal
+
+
+class TestValidationSplitRendersATaskCountItCannotRender:
+    """``validation_split_error`` renders a task count read out of a dataset.
+
+    ``total_tasks`` comes from ``meta/info.json``, so it is a JSON integer and
+    arbitrary-precision. It is rendered plainly rather than quoted, which is the
+    other reason the drift scan had to cover the ``{value}`` form: this site
+    carries no ``!r`` and was invisible to a scan that looked for one.
+    """
+
+    def test_an_outsized_task_count_is_answered(self) -> None:
+        refusal = validation_split_error(1, BEYOND_INT_STR_LIMIT, "train")
+        assert refusal is not None
+        assert f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>" in refusal
+        refusal.encode("ascii")
+
+    def test_an_ordinary_task_count_still_renders_as_a_plain_number(self) -> None:
+        refusal = validation_split_error(1, 5, "train")
+        assert refusal is not None
+        assert "dataset with 5 tasks" in refusal
+
+    def test_a_single_task_dataset_is_still_accepted(self) -> None:
+        assert validation_split_error(1, 1, "train") is None
+        assert validation_split_error(1, None, "train") is None
+
+
+# --------------------------------------------------------------------------- #
+# No agent-visible change                                                     #
+# --------------------------------------------------------------------------- #
+class TestTheTextIsUnchangedForAValueThatCanBeRendered:
+    """The renderers defer, so every existing message is byte-identical.
+
+    This is the claim that makes the change verdict- and text-preserving, so it is
+    pinned rather than asserted in a description.
+    """
+
+    @pytest.mark.parametrize("guard", SCALAR_GUARDS, ids=GUARD_IDS)
+    def test_the_message_still_contains_the_plain_repr(self, guard: Guard) -> None:
+        for value in guard.refused:
+            refusal = guard.call(value)
+            assert refusal is not None, f"{value!r} must be refused by {guard.name}"
+            assert repr(value) in refusal, f"{guard.name} no longer renders {value!r} as repr"
+
+    def test_the_exact_text_of_one_message_per_guard(self) -> None:
+        """Spelled out, so a reworded message is a diff here rather than a surprise."""
+        assert positive_finite_number_error(0, "hz", "teleoperate") == "teleoperate: hz must be > 0, got 0."
+        assert finite_number_error("x", "linear", "drive") == "drive: linear must be a finite number, got 'x'."
+        assert positive_whole_number_error(0, "fps", "video") == "video: fps must be a positive whole number, got 0."
+        assert (
+            non_negative_whole_number_error(-5, "n_steps", "step")
+            == "step: n_steps must be a non-negative whole number, got -5."
+        )
+        assert positive_count_error(0, "width", "add_camera") == "add_camera: width must be a positive integer, got 0."
+        assert (
+            non_negative_count_error(-1, "steps", "handshake")
+            == "handshake: steps must be a non-negative integer, got -1."
+        )
+        assert tcp_port_error(0, "port", "RosbridgeRobot") == "RosbridgeRobot: invalid port: 0 (expected 1-65535)"
+        assert (
+            camera_fov_error("add_camera", "fov", NAN)
+            == "add_camera: 'fov' must be a finite number in degrees, got nan."
+        )
+
+    def test_an_accepted_value_is_still_accepted(self) -> None:
+        """The over-reach control: rendering changed, no domain did."""
+        assert positive_finite_number_error(30.0, "hz", "teleoperate") is None
+        assert finite_number_error(-1.5, "linear", "drive") is None
+        assert positive_whole_number_error(30.0, "fps", "video") is None
+        assert non_negative_whole_number_error(0, "n_steps", "step") is None
+        assert positive_count_error(640, "width", "add_camera") is None
+        assert non_negative_count_error(0, "steps", "handshake") is None
+        assert tcp_port_error(9090, "port", "RosbridgeRobot") is None
+        assert camera_fov_error("add_camera", "fov", np.float32(58.0)) is None
+        assert entity_name_error("add_object", "name", "cube") is None
+
+
+# --------------------------------------------------------------------------- #
+# Boundary: the escapes this change does not close                            #
+# --------------------------------------------------------------------------- #
+class TestTheConversionEscapeStaysOutOfScope:
+    """Pins of behaviour left unchanged, so the boundary is stated not omitted (#1874).
+
+    Replace these when the surfaces they describe are settled rather than deleting
+    them: the scope statement stays useful and simply narrows.
+
+    These four establish finiteness with ``math.isfinite(float(value))``, and
+    ``float()`` raises ``OverflowError`` for an ``int`` wider than a float - before
+    any message is rendered, so this change cannot reach it. Closing it needs a
+    decision this one does not: ``10**400`` *is* a finite real number, so "must be
+    a finite number" is the wrong reason to refuse it even though refusing is the
+    right verdict.
+    """
+
+    @pytest.mark.parametrize("guard", CONVERTING_GUARDS, ids=CONVERTING_IDS)
+    def test_an_integer_wider_than_a_float_still_raises(self, guard: Guard) -> None:
+        with pytest.raises(OverflowError):
+            guard.call(BEYOND_FLOAT_RANGE)
+
+    def test_positive_whole_number_error_now_raises_only_at_the_conversion(self) -> None:
+        """This change narrowed it to one escape, which is what #1872 asks for.
+
+        Before, the eager rendering raised ``ValueError`` on a value past the digit
+        limit *ahead of* the conversion - so the guard had two escapes and closing
+        only the conversion would have left the class open one digit-count higher.
+        Now both outsized spellings fail in the same single place.
+        """
+        for probe in (BEYOND_FLOAT_RANGE, BEYOND_INT_STR_LIMIT):
+            with pytest.raises(OverflowError):
+                positive_whole_number_error(probe, "fps", "video")
+
+    def test_the_two_escapes_partition_the_family(self) -> None:
+        """No guard has both open, which is why they can be settled separately."""
+        assert HAS_A_CONVERSION_ESCAPE.isdisjoint(ANSWERS_AN_OUTSIZED_INT)
+        assert HAS_A_CONVERSION_ESCAPE | ANSWERS_AN_OUTSIZED_INT == set(GUARD_IDS)
+
+
+class TestTheContainerGuardsStayOutOfScope:
+    """Pins of behaviour left unchanged, so the boundary is stated not omitted (#1875).
+
+    Replace these when the surfaces they describe are settled rather than deleting
+    them.
+
+    The vector and list guards render the whole container, so ``repr``'s recursion
+    into one unrenderable element takes down a refusal already decided. The fix is
+    not this change's fallback: ``<unrepresentable list>`` erases every element
+    that rendered fine and the element count with them, and the count is often the
+    refusal's whole reason. That needs an elementwise rendering and a message
+    format decision on each surface.
+    """
+
+    def test_a_vector_with_an_unrenderable_element_still_raises(self) -> None:
+        with pytest.raises(OverflowError):
+            finite_vector_error("raycast", "origin", [BEYOND_INT_STR_LIMIT])
+        with pytest.raises(ValueError):
+            pose_vector_error("add_object", "position", [BEYOND_INT_STR_LIMIT], 3)
+
+    def test_a_name_list_with_an_unrenderable_entry_still_raises(self) -> None:
+        with pytest.raises(ValueError):
+            name_list_error([BEYOND_INT_STR_LIMIT], "cameras", "render_all")
+
+
+# --------------------------------------------------------------------------- #
+# Drift: no caller value may be rendered directly                             #
+# --------------------------------------------------------------------------- #
+def _scan_direct_renders(source: str) -> dict[str, tuple[tuple[str, str], ...]]:
+    """Map each function in ``source`` to the caller values it renders directly.
+
+    "The caller's value" is spelled ``Any`` in every guard in this module - the
+    other parameters are the ``str`` labels the *call site* supplies, which are
+    literals and cannot raise. Keying on the annotation rather than on a list of
+    parameter names is what lets the scan cover a guard nobody has written yet.
+
+    Both render forms are reported. A scan for ``!r`` alone would have passed
+    ``camera_fov_error``'s interval branch and ``validation_split_error``, which
+    render plainly and reach the same escape.
+
+    Text a function *raises* is excluded: ``_safe_join`` renders an untrusted path
+    into a deliberate ``ValueError`` rather than answering a caller through a
+    return value, so it is not in this contract.
+
+    Args:
+        source: The contents of a Python module.
+
+    Returns:
+        Every function that renders a caller value directly, mapped to
+        ``(parameter, form)`` pairs where form is ``"!r"`` or ``"plain"``. A guard
+        on the shared renderers contributes nothing, because
+        ``_refusal_repr(value)`` is a call rather than a bare name.
+    """
+    tree = ast.parse(source)
+    found: dict[str, tuple[tuple[str, str], ...]] = {}
+    for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)]:
+        args = fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs
+        carries_value = {arg.arg for arg in args if arg.annotation is not None and ast.unparse(arg.annotation) == "Any"}
+        if not carries_value:
+            continue
+        raised = {id(n) for stmt in ast.walk(fn) if isinstance(stmt, ast.Raise) for n in ast.walk(stmt)}
+        rendered = set()
+        for node in ast.walk(fn):
+            if id(node) in raised or not isinstance(node, ast.FormattedValue):
+                continue
+            if isinstance(node.value, ast.Name) and node.value.id in carries_value:
+                rendered.add((node.value.id, "!r" if node.conversion == ord("r") else "plain"))
+        if rendered:
+            found[fn.name] = tuple(sorted(rendered))
+    return found
+
+
+#: The only functions in ``utils.py`` still rendering a caller value directly, all
+#: of them container guards tracked in #1875. Every scalar guard is absent, which
+#: is this change. A new entry is a new guard that skipped the shared renderers.
+KNOWN_DIRECT_RENDERS: dict[str, tuple[tuple[str, str], ...]] = {
+    "coerce_rgba": (("color", "!r"),),
+    "coerce_size_vector": (("size", "!r"),),
+    "finite_vector_error": (("vec", "!r"),),
+    "name_list_error": (("value", "!r"),),
+    "pose_vector_error": (("vec", "!r"),),
+}
+
+
+class TestNoGuardRendersACallerValueDirectly:
+    """A guard must render a refused value through a shared renderer.
+
+    A fixed list of guards would not survive a tenth being added, so this scans
+    the module instead: the assertion is over the whole file, and a new function
+    that renders a value it returns shows up as a new entry.
+    """
+
+    def _source(self) -> str:
+        return pathlib.Path(inspect.getfile(utils)).read_text(encoding="utf-8")
+
+    def test_no_scalar_guard_renders_a_caller_value_directly(self) -> None:
+        found = _scan_direct_renders(self._source())
+        adrift = {name: sites for name, sites in found.items() if name not in KNOWN_DIRECT_RENDERS}
+        assert adrift == {}, f"these render a caller value without a shared renderer: {adrift}"
+        assert found == KNOWN_DIRECT_RENDERS, f"the set of direct renders changed: {found}"
+
+    def test_the_scan_actually_reaches_the_guards_this_change_owns(self) -> None:
+        """An empty scan would satisfy the assertion above just as well."""
+        tree = ast.parse(self._source())
+        scanned = set()
+        for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]:
+            args = fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs
+            if any(a.annotation is not None and ast.unparse(a.annotation) == "Any" for a in args):
+                scanned.add(fn.name)
+        assert set(GUARD_IDS) <= scanned, f"guards invisible to the scan: {set(GUARD_IDS) - scanned}"
+        assert set(KNOWN_DIRECT_RENDERS) <= scanned
+        assert "validation_split_error" in scanned
+
+    def test_every_scalar_guard_calls_a_shared_renderer(self) -> None:
+        """The positive form: absence from the table is not enough on its own.
+
+        A guard that stopped naming the refused value at all would also be absent,
+        and would return a message that no longer says what was refused.
+        """
+        tree = ast.parse(self._source())
+        owned = set(GUARD_IDS) | {"validation_split_error"}
+        for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name in owned]:
+            called = {
+                node.func.id for node in ast.walk(fn) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            assert called & {"_refusal_repr", "_refusal_str"}, f"{fn.name} renders no value through a shared renderer"
+
+    def test_the_scanner_reports_a_planted_repr_omission(self) -> None:
+        """Without this, an empty result could mean a scanner matching nothing."""
+        planted = textwrap.dedent(
+            """
+            def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                if value < 0:
+                    return f"{context}: {param} must be positive, got {value!r}."
+                return None
+            """
+        )
+        assert _scan_direct_renders(planted) == {"new_guard_error": (("value", "!r"),)}
+
+    def test_the_scanner_reports_a_planted_plain_omission(self) -> None:
+        """The form that hid both ``str`` sites from an ``!r``-only reading."""
+        planted = textwrap.dedent(
+            """
+            def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                if value < 0:
+                    return f"{context}: {param} must be positive, got {value}."
+                return None
+            """
+        )
+        assert _scan_direct_renders(planted) == {"new_guard_error": (("value", "plain"),)}
+
+    def test_the_scanner_accepts_a_guard_on_a_shared_renderer(self) -> None:
+        """The control for the control: a converted guard must not be reported."""
+        converted = textwrap.dedent(
+            """
+            def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                if value < 0:
+                    return f"{context}: {param} must be positive, got {_refusal_repr(value)}."
+                return None
+            """
+        )
+        assert _scan_direct_renders(converted) == {}
+
+    def test_the_scanner_ignores_the_call_site_labels(self) -> None:
+        """``param`` and ``context`` are the call site's own literals, not values."""
+        labels_only = textwrap.dedent(
+            """
+            def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                return f"{context}: {param} is wrong ({context!r})."
+            """
+        )
+        assert _scan_direct_renders(labels_only) == {}
+
+    def test_the_scanner_ignores_a_value_rendered_into_a_raise(self) -> None:
+        """``_safe_join`` raises by design; this contract is about returned text."""
+        raising = textwrap.dedent(
+            """
+            def _safe_join(base: Path, untrusted: Any) -> Path:
+                raise ValueError(f"Path traversal blocked: {untrusted!r} escapes {base}")
+            """
+        )
+        assert _scan_direct_renders(raising) == {}
+        assert "_safe_join" not in KNOWN_DIRECT_RENDERS
+
+
+def test_the_digit_limit_this_module_turns_on_is_below_its_probe() -> None:
+    """``BEYOND_INT_STR_LIMIT`` is only unrenderable while the limit is below it.
+
+    ``sys.set_int_max_str_digits`` is process-global and a test elsewhere could
+    raise it, which would quietly turn every probe here into an ordinary integer
+    and every assertion above into a tautology.
+    """
+    assert 0 < sys.get_int_max_str_digits() < BEYOND_INT_STR_LIMIT_DIGITS


### PR DESCRIPTION
Closes #1873

The scalar guards in `utils.py` exist so a caller's bad value is reported through a structured `{status, content}` result - every one of their callers documents that result as the only channel a rejected value is reported on. Building the message is part of that answer, and it was not a total operation: the guards interpolated the caller's value directly, and rendering a value can raise. So a guard could fail on precisely the path whose purpose is to answer instead of raise.

This is decomposition step (1) of the #1872 sweep - the verdict-preserving half, which reaches the most surfaces and changes no agent-visible text.

## 1. Measured, before and after

Each guard called with its real signature - `value` first for the numeric family, third for the two that lead with the method name. `R:` is a raise; `Unprintable()` is a plain object whose `__repr__` raises. Bold marks a cell where the guard raises past its own return value.

| guard | `10**400` | `-10**400` | `10**5000` | `-10**5000` | `Unprintable()` |
|---|---|---|---|---|---|
| `positive_finite_number_error` | R:Overflow | R:Overflow | R:Overflow | R:Overflow | **R:RuntimeError** |
| `finite_number_error` | R:Overflow | R:Overflow | R:Overflow | R:Overflow | **R:RuntimeError** |
| `positive_whole_number_error` | R:Overflow | R:Overflow | **R:ValueError** | **R:ValueError** | **R:RuntimeError** |
| `non_negative_whole_number_error` | accept | refuse | accept | refuse | refuse |
| `positive_count_error` | accept | refuse | accept | **R:ValueError** | **R:RuntimeError** |
| `non_negative_count_error` | accept | refuse | accept | **R:ValueError** | **R:RuntimeError** |
| `tcp_port_error` | refuse | refuse | **R:ValueError** | **R:ValueError** | **R:RuntimeError** |
| `camera_fov_error` | R:Overflow | R:Overflow | R:Overflow | R:Overflow | **R:RuntimeError** |
| `entity_name_error` | refuse | refuse | **R:ValueError** | **R:ValueError** | **R:RuntimeError** |

After this change every bold cell is a structured refusal. The `R:Overflow` cells are **unchanged on purpose** - a different escape with a different owner, see §5.

## 2. Why this is one defect and not a handful of curiosities

The last column is the load-bearing one. **Every guard except the one #1869 rewrote raised on a value it had already decided to refuse**, and it did so through a value class that needs no unusual integer at all:

```python
class Unprintable:
    def __repr__(self): raise RuntimeError("no repr for you")

positive_count_error(Unprintable(), "n", "ctx")   # RuntimeError
```

`numbers.Real` is a registration rather than an inheritance, so a scalar that satisfies a guard's type test owes it nothing else. That is why the renderer's guarantee has to be unconditional rather than a list of the exceptions known today.

The outsized-integer half is reachable with a plain Python `int`:

```python
positive_count_error(-(10**5000), "n", "ctx")        # ValueError: Exceeds the limit (4300 digits)
tcp_port_error(10**5000, "port", "ctx")              # ValueError
entity_name_error("add_object", "name", 10**5000)    # ValueError
```

`device_connect`'s `@rpc()` surfaces forward a remote caller's number unchanged and Python integers are arbitrary-precision, so one is a request away. Those cells are narrower than they look, which is why they read as clean - including to #1872, which lists the count pair as out of scope: a guard that never converts raises only on a value it has *refused*, never on one it accepts. The correction is recorded on #1873.

## 3. The fix, and why no text changes

Every site now renders through `_refusal_repr` - the helper #1869 added for the step surface - or through its new `str` counterpart `_refusal_str`. Both defer to `repr` / `str` wherever those work and otherwise describe the value, so **every message these guards already produced is reproduced byte for byte**. That is pinned rather than asserted: `TestTheTextIsUnchangedForAValueThatCanBeRendered` re-derives the exact text of one message per guard and asserts `repr(value) in refusal` for every printable probe.

The fallback is factored into one `_describe_unrenderable`, so the two render forms cannot describe the same unrenderable value differently. `int.bit_length` needs no decimal conversion, so the value most likely to arrive unrenderable is still described by its magnitude.

`positive_whole_number_error` additionally renders **on demand** rather than on the function's first line, where the text was built before the value had been classified at all - so it raised ahead of every verdict, on the accept path too. The nested `message()` form is the one its sibling already uses.

`_refusal_repr` moves up in the file, unchanged in behaviour, so the renderer the whole family now routes through is defined before the family. That is the only reason the diff on it is larger than its docstring rewrite.

## 4. Two sites render plainly, and keep `str`

These carry no `!r`, so both were invisible to a reading that looked for one - and each is a real escape rather than a completeness exercise:

- **`camera_fov_error`'s open-interval branch** looks unreachable by anything unrenderable, because it runs only after `math.isfinite(float(value))` has succeeded. A registered `numbers.Real` whose `float()` is finite and outside `(0, 180)` passes that test and is refused there. My own issue body said to leave this branch alone; the measurement contradicted it, so it is fixed and the reasoning is recorded on #1873 rather than left in a comment.
- **`validation_split_error`** renders a `total_tasks` read straight out of a dataset's `meta/info.json`, so a JSON integer of any width reaches it. `validation_split_error(1, 10**5000, "train")` raised `ValueError` on `main`.

Both keep `str` rather than moving to `repr`, and that is not cosmetic: NumPy 2 reprs a scalar with its type, so converting would have silently turned `got 200.0` into `got np.float32(200.0)` in agent-visible text - and an `np.float32` fov is documented as accepted. `test_the_two_forms_are_not_interchangeable` pins the difference so the reason survives.

## 5. Deliberately out of scope, and pinned as such

Two classes are left alone, each because it needs a decision this change does not. Both are pinned so the boundary is a stated assertion rather than an omission, and both pins say to replace rather than delete them.

- **The `float()` conversion escape** (#1874) - `positive_finite_number_error`, `finite_number_error`, `camera_fov_error`, and now `positive_whole_number_error` as its only remaining escape. It fires before any message is rendered, so this change cannot reach it. Closing it needs a decision: `10**400` *is* a finite real number, so "must be a finite number" is the wrong reason to refuse it even though refusing is right - these values go onto the wire as IEEE-754 float64, which is a representability claim rather than a finiteness one. `TestTheConversionEscapeStaysOutOfScope`.
- **The container guards** (#1875) - `finite_vector_error`, `pose_vector_error`, `name_list_error`, `coerce_rgba`, `coerce_size_vector`. Same rendering defect, but this change's fallback is not the fix: `<unrepresentable list>` erases every element that rendered fine along with the element count, and the count is often the refusal's whole reason (`must be a 3-element vector, got 4`). That needs an elementwise rendering and a message-format decision per surface. `TestTheContainerGuardsStayOutOfScope`.

Note the two escapes **partition** the family - no guard has both open - which is why they can be settled separately, and is asserted by `test_the_two_escapes_partition_the_family` rather than left as a claim.

This change also narrows #1872 to exactly one mechanism: `positive_whole_number_error` now has only the conversion escape, where before it had two and closing only the conversion would have left the class open one digit-count higher.

## 6. Tests

`tests/test_refusal_messages_never_raise.py`, 79 checks:

- `TestTheSharedRenderers` - both renderers defer exactly to `repr` / `str`; one describer, so the forms cannot disagree; the fallback is unconditional, and `BaseException` is deliberately **not** swallowed (pinned, since swallowing a `KeyboardInterrupt` to render an error message would be a worse failure than the one being reported);
- `TestEveryScalarGuardAnswersAValueItCannotRender` - the invariant over all nine guards, with two probes: one refused on its *type* and one on its *value*, since those are different code paths and only the second exercises a guard's interior;
- `TestOutsizedIntegersAreAnsweredWhereTheGuardReachesItsMessage` - the five guards a plain outsized `int` reaches, plus the over-reach control that an outsized value *inside* the domain is still accepted;
- `TestTheOpenIntervalBranchRendersPlainlyAndStillCannotRaise` and `TestValidationSplitRendersATaskCountItCannotRender` - §4;
- `TestTheTextIsUnchangedForAValueThatCanBeRendered` - the no-change claim, including an accepted-value control so "rendering changed, no domain did" is measured;
- `TestNoGuardRendersACallerValueDirectly` - the drift scan, §7.

**Non-vacuity measured: 38 of the 79 fail on a faithful `main` equivalent**, spread across every class that pins the fix. The module imports the new private helpers, so pre-fix `main` cannot collect it at all; the measurement therefore reverts only the call sites, keeps the helpers importable, and restores #1869's already-merged guard so the number is exactly what this PR adds and not what #1869 already fixed.

Full suite run as a **delta**, since this environment has no GPU and no `newton` / `isaacsim`:

| | failed | passed | errors |
|---|---|---|---|
| base (`b28c911`) | 372 | 11644 | 670 |
| this branch | 372 | 11723 | 670 |

Identical failures and errors; **+79 passes, exactly the tests this module adds.** No pre-existing test changed, deleted or reworded - the sweep for exact-message assertions across `tests/` found 43 sites and all 43 are unaffected, because every probe in them is an ordinary value whose `repr` cannot raise.

`ruff check` and `ruff format --check` clean on both changed files; new files are ASCII-only. `mypy strands_robots/utils.py` reports the same single pre-existing `call-overload` on `int(value)` before and after (line 609 on base, 678 here - the function moved, the error did not); no new finding.

## 7. The invariant is scanned, not listed

A fixed list of guards would not survive a tenth being added, so `TestNoGuardRendersACallerValueDirectly` scans the module and asserts the full set of remaining direct renders. Two things make it more than a grep:

- **It keys on the parameter annotated `Any`**, which is how every guard here spells "the caller's value". The other parameters are the `str` labels the *call site* supplies - literals, which cannot raise - so keying on the annotation rather than on a list of names is what lets the scan cover a guard nobody has written yet. `test_the_scanner_ignores_the_call_site_labels` pins that distinction.
- **It reports the plain `{value}` form as well as `{value!r}`.** An `!r`-only reading is precisely what hid both §4 sites, so the scan that would have found them is the one that ships.

Text a function *raises* is excluded, so `_safe_join`'s deliberate path-traversal `ValueError` is not in this contract - pinned, so the exclusion is a decision rather than a gap. Controls: a planted `!r` omission, a planted plain omission, a correctly-converted guard, and the positive form (`test_every_scalar_guard_calls_a_shared_renderer`), because absence from the table would also be satisfied by a guard that stopped naming the refused value at all.

The scan drops from 13 entries to 5, and the 5 are exactly #1875's container guards.

---

## 8. Round changelog

| Round | Concern | Fix commit | Pin test |
| --- | --- | --- | --- |
| - | initial submission | `6b7a20b` | 79 checks, 38 non-vacuous |

Two findings during authoring are worth flagging because they changed the diff from what #1873 describes, and the issue has been corrected rather than left to disagree with the code:

1. **`camera_fov_error`'s interval branch is reachable** by an unrenderable value, so it is fixed here rather than pinned as deliberately-left. The issue body said the opposite; the probe in §4 is the measurement that settled it.
2. **`validation_split_error` has the same escape** and was not in the original survey at all. It was found by the §7 scan once the scan covered the plain render form - which is the argument for the scan being part of this PR rather than a follow-up.