### PR TITLE
fix(utils): a numeric guard must not raise on a value too large for a float

### DIFF
--- a/changelog.d/1874-conversion-escape-is-closed.md
+++ b/changelog.d/1874-conversion-escape-is-closed.md
@@ -1,0 +1,64 @@
+### Fixed: a numeric guard no longer raises on a value too large for a float
+
+Four scalar guards in `strands_robots/utils.py` establish their domain by
+converting the caller's value with `float()`: `positive_finite_number_error`,
+`finite_number_error`, `positive_whole_number_error` and `camera_fov_error`.
+`float()` raises `OverflowError` for a real whose magnitude exceeds
+`sys.float_info.max`, so each of them raised instead of returning the structured
+refusal their callers document as the only channel a bad value is reported on.
+The conversion runs before any message is rendered, so the fix that made the
+*rendering* total could not reach it.
+
+```
+positive_finite_number_error(10**400, "hz", "teleoperate")   # OverflowError
+camera_fov_error("add_camera", "fov", 10**400)               # OverflowError
+```
+
+`int` is arbitrary-precision and `device_connect`'s `@rpc()` surfaces forward a
+remote caller's number unchanged, so such a value is one request away. Two
+properties of the escape are worth naming because they constrain the fix:
+
+- **It is not an `int` problem.** `Fraction(10**400, 3)` is a registered
+  `numbers.Real` that overflows identically, so the guard has to ask the question
+  of the conversion rather than of the type.
+- **It has two exception classes.** A `numbers.Real` registration guarantees no
+  working `__float__`, so `float()` can raise `TypeError` here too - which is not
+  a magnitude complaint and is not reported as one. Such a value is now refused
+  with the text the guard already used for a value that is not a number at all.
+
+Three of the four needed a new reason, because their own would have been a false
+statement: `10**400` *is* positive, *is* finite, and *is* a positive whole number.
+They now report that the value must be within the range of a 64-bit float. That
+is not a new boundary - each guard already accepted up to `sys.float_info.max`,
+`1e300` and `10**308` among them, and raised one step past it - so the range is
+where the accepted domain already ended and all that changes is that the edge now
+answers instead of raising.
+
+`camera_fov_error` needed no new text. Its domain is bounded above at 180
+degrees, so the interval message it already had is a true statement about a value
+past the float64 range, and the overflow alone establishes that without a
+comparison.
+
+No verdict moved and no existing message changed: every value these guards
+accepted is still accepted, every value they refused is still refused with
+byte-identical text, and the whole effect is that 24 probes which used to raise
+now return a string. That is measured against a control matrix per guard rather
+than asserted.
+
+One asymmetry is deliberate and recorded in both docstrings.
+`positive_whole_number_error` refuses an outsized value where its sibling
+`non_negative_whole_number_error` accepts one, although the two are documented as
+the same policy with the floor moved. The difference is the consumer: MuJoCo's
+`_MAX_STEPS_PER_CALL` bounds a step count with a reason of its own, while this
+domain's callers include the mesh robots' `drive(count=...)`, which repeats an
+actuation command - so an unbounded count there is an unbounded actuation loop
+against a physical robot rather than a slow call.
+
+The invariant is pinned by an AST scan of the module rather than a list of
+guards, so a fifth converting guard cannot reintroduce it silently. The scan
+reports every function whose `float()` conversion no `try` protects, and asserts
+the set exactly: it is now the four container guards, which also carry this
+escape (`finite_vector_error("raycast", "origin", [10**400])` raises
+`OverflowError`) and are tracked separately, because closing it there needs an
+elementwise message format - a whole-container fallback erases the element count
+that is often the refusal's entire reason.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -480,6 +480,35 @@ def _describe_unrenderable(value: Any) -> str:
     return f"<unrepresentable {type(value).__name__}>"
 
 
+def _beyond_float_range(value: Any) -> bool:
+    """Whether ``float(value)`` overflows, i.e. no float64 stands for ``value``.
+
+    Not a domain in its own right - a helper that names, in one place, the
+    condition the three numeric guards below need a *reason* for rather than a
+    crash. ``float()`` raises ``OverflowError`` for a real whose magnitude
+    exceeds :data:`sys.float_info.max`, and Python integers are
+    arbitrary-precision while ``device_connect``'s ``@rpc()`` surfaces forward a
+    remote caller's number unchanged, so one is a request away.
+
+    The condition is *not* limited to ``int``: ``Fraction(10**400, 3)`` is a
+    registered :class:`numbers.Real` that overflows identically, which is why
+    the guards ask this question of the conversion rather than of the type.
+
+    Returns:
+        ``True`` when the conversion overflows. ``False`` when it succeeds *or*
+        fails any other way - a :class:`numbers.Real` registration guarantees no
+        working ``__float__``, and a value no number can be read from at all is
+        not a magnitude complaint and must not be reported as one.
+    """
+    try:
+        float(value)
+    except OverflowError:
+        return True
+    except Exception:
+        return False
+    return False
+
+
 def positive_finite_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive finite number.
 
@@ -506,6 +535,16 @@ def positive_finite_number_error(value: Any, param: str, context: str) -> str | 
     array passes) and rejects ``bool`` explicitly - an ``int`` subclass whose
     ``True`` would act as a silent ``1``.
 
+    **A value past the float64 range is refused with a reason of its own.**
+    ``10**400`` is positive and finite, so ``must be > 0`` would be a false
+    statement about it, and it used to raise ``OverflowError`` out of the
+    ``float()`` this guard converts with - failing on the path that exists so it
+    does not. It is not a new boundary: this guard already accepts up to
+    ``sys.float_info.max`` (``1e300`` and ``10**308`` both pass) and stopped
+    dead one step past it, so the range is the edge the domain always had and
+    all that changes is that the guard now names it. Nothing raises out of here
+    for any real scalar; see :func:`_beyond_float_range`.
+
     Args:
         value: The caller-supplied value.
         param: The parameter it came from, used in the message.
@@ -515,14 +554,24 @@ def positive_finite_number_error(value: Any, param: str, context: str) -> str | 
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, numbers.Real)
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return f"{context}: {param} must be > 0, got {_refusal_repr(value)}."
+    if _beyond_float_range(value):
+        # A real past the float64 range is positive-or-negative and finite, so
+        # neither of this guard's own reasons is true of it - hence its own text.
+        # Refusing stays right: the value is a divisor (``1 / hz``) or a
+        # multiplier evaluated in float64, and no float64 stands for it.
+        return f"{context}: {param} must be within the range of a 64-bit float, got {_refusal_repr(value)}."
+    try:
         # ``isfinite`` before the sign test: ``nan`` is never ``<= 0``, so
         # ordering these the other way lets it through.
-        or not math.isfinite(float(value))
-        or float(value) <= 0
-    ):
+        unusable = not math.isfinite(float(value)) or float(value) <= 0
+    except Exception:
+        # A ``numbers.Real`` registration owes this guard no working
+        # ``__float__``, and a value no number can be read from is refused for
+        # the same reason a non-real one is - the message it already had.
+        unusable = True
+    if unusable:
         return f"{context}: {param} must be > 0, got {_refusal_repr(value)}."
     return None
 
@@ -550,6 +599,14 @@ def finite_number_error(value: Any, param: str, context: str) -> str | None:
     velocity read from a policy action passes) and rejects ``bool`` explicitly -
     an ``int`` subclass whose ``True`` would act as a silent ``1``.
 
+    **A value past the float64 range is refused with a reason of its own.**
+    The paragraph above is the argument for it: an accepted value goes onto the
+    wire as an IEEE-754 float64, and ``10**400`` has no float64 form to put
+    there. Its own reason is needed because ``10**400`` *is* a finite number, so
+    ``must be a finite number`` would be false of the one value class most in
+    need of an honest refusal - and before that reason existed the guard raised
+    ``OverflowError`` here instead of answering.
+
     Args:
         value: The caller-supplied value.
         param: The parameter it came from, used in the message.
@@ -559,7 +616,19 @@ def finite_number_error(value: Any, param: str, context: str) -> str | None:
     Returns:
         An error message, or ``None`` when the value is usable.
     """
-    if isinstance(value, bool) or not isinstance(value, numbers.Real) or not math.isfinite(float(value)):
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return f"{context}: {param} must be a finite number, got {_refusal_repr(value)}."
+    if _beyond_float_range(value):
+        # ``10**400`` *is* a finite number, so this guard's own reason would be
+        # a false statement about it. Refusing stays right: the docstring above
+        # is explicit that an accepted value is serialized onto the wire as an
+        # IEEE-754 float64, and this one has no float64 form to serialize.
+        return f"{context}: {param} must be within the range of a 64-bit float, got {_refusal_repr(value)}."
+    try:
+        unusable = not math.isfinite(float(value))
+    except Exception:
+        unusable = True
+    if unusable:
         return f"{context}: {param} must be a finite number, got {_refusal_repr(value)}."
     return None
 
@@ -580,6 +649,25 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     integral value (so a NumPy ``np.int64`` height or a ``30.0`` computed from a
     config float passes) and rejects ``bool`` explicitly - an ``int`` subclass
     whose ``True`` would act as a silent 1.
+
+    **Magnitude is part of this domain, unlike its ``non_negative`` sibling.**
+    :func:`non_negative_whole_number_error` accepts ``10**400`` as a matter of
+    documented policy, on the grounds that a per-call ceiling belongs to the
+    consumer - and for its one caller that holds, because MuJoCo's
+    ``_MAX_STEPS_PER_CALL`` is exactly such a ceiling and refuses an outsized
+    step count with a reason of its own. No consumer of *this* domain owns one.
+    Its callers are ``fps``, ``width``, ``height``, ``max_frames`` and the mesh
+    robots' ``drive(count=...)``, and that last one repeats an actuation command,
+    so an unbounded count is an unbounded actuation loop against a physical
+    robot rather than a slow call. So the two guards are the same scalar policy
+    with the floor moved *and* one deliberate difference, which is recorded here
+    rather than left for a reader to find by measuring.
+
+    Refusing is therefore the verdict, and it needs a reason of its own:
+    ``10**400`` *is* a positive whole number. As above, the float64 range is not
+    a new boundary - ``1e300`` is accepted by this guard today - it is the edge
+    the domain already had, at which the guard used to raise ``OverflowError``
+    rather than answer.
 
     Args:
         value: The caller-supplied value.
@@ -602,7 +690,16 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
 
     if isinstance(value, bool) or not isinstance(value, numbers.Real):
         return message()
-    numeric = float(value)
+    if _beyond_float_range(value):
+        # ``10**400`` is a positive whole number, so ``message()`` would state
+        # something false about it. It is refused rather than accepted, and
+        # deliberately unlike its ``non_negative`` sibling - see the docstring.
+        return f"{context}: {param} must be within the range of a 64-bit float, got {_refusal_repr(value)}."
+    try:
+        numeric = float(value)
+    except Exception:
+        # No number can be read from it at all; refused, never raised.
+        return message()
     # ``isfinite`` first: ``int(nan)`` raises, and short-circuiting keeps it
     # out of the integrality check below.
     if not math.isfinite(numeric) or numeric != int(numeric) or numeric < 1:
@@ -653,6 +750,13 @@ def non_negative_whole_number_error(value: Any, param: str, context: str) -> str
     ``_MAX_STEPS_PER_CALL``, which refuses it with a reason of its own - and a
     domain guard that quietly stopped at the float range would be exactly the
     kind of boundary-by-implementation-accident this family exists to remove.
+
+    **This is the one place the two guards differ**, and the ceiling above is
+    the whole reason: :func:`positive_whole_number_error` refuses an outsized
+    value because none of its consumers owns such a ceiling and one of them
+    repeats a command to a robot. So "the same policy with the floor moved" is
+    true of every other input and not of this one. The asymmetry is deliberate;
+    if a ceiling ever appears on that side, this is the paragraph to revisit.
 
     Args:
         value: The caller-supplied value.
@@ -1233,11 +1337,40 @@ def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:
     array is a legitimate fov); a ``bool`` is refused because ``float(True)``
     would silently mean a 1-degree lens. Returns ``None`` when ``value`` is a
     usable field of view.
+
+    Nothing raises out of here. This guard is the one member of the scalar
+    numeric family that needed no new text to make that true: a magnitude past
+    the float64 range - which used to raise ``OverflowError`` out of the
+    ``float()`` below - exceeds 180 degrees by three hundred orders of
+    magnitude, so the interval message it already had is a true statement about
+    such a value. Having a bounded interval to appeal to is what distinguishes
+    it from :func:`positive_finite_number_error` and :func:`finite_number_error`,
+    whose domains are unbounded above and so have no such reason available.
     """
-    if isinstance(value, bool) or not isinstance(value, numbers.Real) or not math.isfinite(float(value)):
+
+    def not_a_number() -> str:
         return f"{method}: '{param_name}' must be a finite number in degrees, got {_refusal_repr(value)}."
-    if not (0.0 < float(value) < 180.0):
+
+    def outside_interval() -> str:
         return f"{method}: '{param_name}' must be in the open interval (0, 180) degrees, got {_refusal_str(value)}."
+
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return not_a_number()
+    if _beyond_float_range(value):
+        # This guard is the one member of the family that needs no new text. A
+        # magnitude past the float64 range exceeds 180 by three hundred orders
+        # of magnitude, so "outside the open interval" is already a true
+        # statement about it - and no comparison is needed to establish that,
+        # which is why the overflow itself is the whole test.
+        return outside_interval()
+    try:
+        numeric = float(value)
+    except Exception:
+        return not_a_number()
+    if not math.isfinite(numeric):
+        return not_a_number()
+    if not (0.0 < numeric < 180.0):
+        return outside_interval()
     return None
 
 

--- a/tests/test_conversion_escape_is_closed.py
+++ b/tests/test_conversion_escape_is_closed.py
@@ -483,13 +483,21 @@ class TestTheAsymmetryWithTheSiblingIsDeliberate:
         assert non_negative_whole_number_error(BEYOND_FLOAT_RANGE, "n_steps", "step") is None
 
     def test_they_agree_on_every_other_probe(self) -> None:
-        """The asymmetry is exactly one input class wide, not a general drift."""
-        for value in (0.0, 1, 2.5, 30.0, NAN, INF, -1, True, "x", np.int64(7)):
+        """The asymmetry is exactly one input class wide, not a general drift.
+
+        The floor is excluded because it is the *other*, already-documented
+        difference between the two guards - ``0`` is accepted by the
+        ``non_negative`` one by definition. Everything else must match.
+        """
+        for value in (1, 2.5, 30.0, NAN, INF, -1, True, "x", np.int64(7)):
             positive = positive_whole_number_error(value, "n", "ctx") is None
             non_negative = non_negative_whole_number_error(value, "n", "ctx") is None
-            if value == 0.0 or value == 0:
-                continue  # the floor itself, which is the documented difference
             assert positive == non_negative, f"the two guards disagree on {value!r}"
+
+    def test_the_floor_is_the_other_difference_and_is_excluded_deliberately(self) -> None:
+        """So the exclusion above is a stated decision, not a probe quietly dropped."""
+        assert positive_whole_number_error(0, "n", "ctx") is not None
+        assert non_negative_whole_number_error(0, "n", "ctx") is None
 
     def test_the_reason_for_the_asymmetry_is_recorded_where_a_reader_will_look(self) -> None:
         """Both docstrings must carry it, since either is the one being read."""

--- a/tests/test_conversion_escape_is_closed.py
+++ b/tests/test_conversion_escape_is_closed.py
@@ -1,0 +1,796 @@
+"""Regression tests: the ``float()`` conversion escape is closed (#1874).
+
+Four scalar guards in :mod:`strands_robots.utils` establish their domain by
+converting the caller's value with ``float()``. That conversion raises
+``OverflowError`` for a real whose magnitude exceeds ``sys.float_info.max``, and
+it runs *before* any message is rendered - so #1873, which made the rendering
+total, could not reach it. This is the other half of that pair, and with it the
+scalar numeric family answers every real scalar it is given.
+
+Measured on ``2c254c7`` (i.e. with #1873 already merged), each guard called with
+its real signature. ``R:`` is a raise:
+
+| guard | ``10**400`` | ``10**5000`` | ``Fraction(10**400, 3)`` | ``RealNoFloat()`` |
+| --- | --- | --- | --- | --- |
+| ``positive_finite_number_error`` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |
+| ``finite_number_error`` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |
+| ``positive_whole_number_error`` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |
+| ``camera_fov_error`` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |
+
+Two columns are not in #1874's description of the defect and change what the fix
+has to be:
+
+* **It is not an ``int`` problem.** ``Fraction(10**400, 3)`` is a registered
+  :class:`numbers.Real` that overflows identically, so the guard has to ask the
+  question of the *conversion* rather than of the type. A fix keyed on
+  ``isinstance(value, int)`` would have left the ``Fraction`` column raising.
+* **The escape has two exception classes.** A ``numbers.Real`` registration
+  guarantees no working ``__float__``, so ``float()`` can raise ``TypeError``
+  here as well - and that is not a magnitude complaint and must not be reported
+  as one. :class:`TestAValueNoNumberCanBeReadFromKeepsTheOldReason` pins the
+  difference.
+
+## The verdict is preserved; only the raise becomes an answer
+
+Every value these guards accepted is still accepted and every value they refused
+is still refused with byte-identical text - the whole change is that 24 probes
+that used to raise now return a string. That is measured rather than asserted:
+:class:`TestNoExistingVerdictOrMessageMoved` walks a control matrix per guard.
+
+## Why the refusal names the float64 range
+
+Three of the four needed new text, because their own reason would have been a
+false statement about the value: ``10**400`` *is* positive, *is* finite, and *is*
+a positive whole number. The new reason names the float64 range, and that is not
+a bound this change invents - it is the bound the guards already enforced. Each
+accepts ``1e300`` and ``10**308`` today and raised one step past
+``sys.float_info.max``, so the range is where the accepted domain already ended;
+all that changes is that the edge now answers instead of raising.
+:class:`TestTheRangeIsTheBoundTheGuardAlreadyHad` is that argument as a test.
+
+``camera_fov_error`` is the exception and needed no new text: its domain is
+bounded above at 180 degrees, so "outside the open interval (0, 180)" is already
+a true statement about a value past the float64 range, and the overflow alone
+establishes it without a comparison.
+
+## The one deliberate asymmetry
+
+``positive_whole_number_error`` refuses an outsized value where its sibling
+``non_negative_whole_number_error`` accepts one, and the two are documented as
+the same policy with the floor moved. The difference is the consumer: MuJoCo's
+``_MAX_STEPS_PER_CALL`` bounds a step count with a reason of its own, while this
+domain's callers include the mesh robots' ``drive(count=...)``, which repeats an
+actuation command - so an unbounded count is an unbounded actuation loop against
+a physical robot. :class:`TestTheAsymmetryWithTheSiblingIsDeliberate` pins it so
+a later reader finds a decision rather than an inconsistency.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import numbers
+import sys
+from collections.abc import Callable
+from fractions import Fraction
+from typing import Any, NamedTuple
+
+import numpy as np
+import pytest
+
+from strands_robots import utils
+from strands_robots.utils import (
+    _beyond_float_range,
+    camera_fov_error,
+    finite_number_error,
+    non_negative_whole_number_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
+
+# --------------------------------------------------------------------------- #
+# Probes                                                                      #
+# --------------------------------------------------------------------------- #
+#: Past ``sys.float_info.max`` but inside the interpreter's digit limit, so its
+#: own ``repr`` works. Isolates the conversion from #1873's rendering defect.
+BEYOND_FLOAT_RANGE = 10**400
+
+#: Past the digit limit too, so it exercises the conversion *and* #1873's
+#: fallback in one value - the two fixes have to compose.
+BEYOND_INT_STR_LIMIT = 10**5000
+
+#: The largest value the conversion still accepts. The boundary is inclusive.
+FLOAT_MAX = sys.float_info.max
+
+#: An ``int`` inside the float64 range, to show the refusal is about magnitude
+#: and not about being an ``int`` or being large.
+LARGE_BUT_CONVERTIBLE = 10**308
+
+NAN = float("nan")
+INF = float("inf")
+
+
+class RealNoFloat(numbers.Real):
+    """A registered :class:`numbers.Real` with no usable ``__float__``.
+
+    ``numbers.Real`` is a registration rather than an inheritance, so a value can
+    satisfy a guard's type test and still refuse to become a float. It is the
+    second exception class the conversion can raise, and unlike an outsized
+    magnitude it is not a range complaint: no number can be read from it at all.
+    Its ``repr`` works, so it isolates the conversion from #1873's defect.
+    """
+
+    def __float__(self) -> float:
+        raise TypeError("this value cannot become a float")
+
+    def __repr__(self) -> str:
+        return "RealNoFloat()"
+
+    # The remaining abstract methods are never reached by a guard; they exist so
+    # the class is instantiable at all.
+    def __abs__(self) -> Any:
+        return self
+
+    def __add__(self, other: Any) -> Any:
+        return self
+
+    def __ceil__(self) -> Any:
+        return self
+
+    def __eq__(self, other: object) -> bool:
+        return self is other
+
+    def __floor__(self) -> Any:
+        return self
+
+    def __floordiv__(self, other: Any) -> Any:
+        return self
+
+    def __hash__(self) -> int:
+        return 0
+
+    def __le__(self, other: Any) -> bool:
+        return False
+
+    def __lt__(self, other: Any) -> bool:
+        return False
+
+    def __mod__(self, other: Any) -> Any:
+        return self
+
+    def __mul__(self, other: Any) -> Any:
+        return self
+
+    def __neg__(self) -> Any:
+        return self
+
+    def __pos__(self) -> Any:
+        return self
+
+    def __pow__(self, other: Any) -> Any:
+        return self
+
+    def __radd__(self, other: Any) -> Any:
+        return self
+
+    def __rfloordiv__(self, other: Any) -> Any:
+        return self
+
+    def __rmod__(self, other: Any) -> Any:
+        return self
+
+    def __rmul__(self, other: Any) -> Any:
+        return self
+
+    def __round__(self, ndigits: Any = None) -> Any:
+        return self
+
+    def __rpow__(self, other: Any) -> Any:
+        return self
+
+    def __rtruediv__(self, other: Any) -> Any:
+        return self
+
+    def __truediv__(self, other: Any) -> Any:
+        return self
+
+    def __trunc__(self) -> Any:
+        return self
+
+
+#: Every value that used to raise out of a converting guard. The ``Fraction`` and
+#: the ``RealNoFloat`` are the two cells #1874's description does not cover.
+OVERFLOWING_PROBES: tuple[tuple[str, Any], ...] = (
+    ("10**400", BEYOND_FLOAT_RANGE),
+    ("-10**400", -BEYOND_FLOAT_RANGE),
+    ("10**5000", BEYOND_INT_STR_LIMIT),
+    ("-10**5000", -BEYOND_INT_STR_LIMIT),
+    ("Fraction(10**400, 3)", Fraction(BEYOND_FLOAT_RANGE, 3)),
+)
+OVERFLOWING_IDS = tuple(name for name, _ in OVERFLOWING_PROBES)
+OVERFLOWING_VALUES = tuple(value for _, value in OVERFLOWING_PROBES)
+
+
+class Converting(NamedTuple):
+    """One guard that classifies by converting with ``float()``.
+
+    Attributes:
+        name: The function's name, used as the test ID.
+        call: The guard with its label arguments bound, so a probe goes to the
+            value position - first for the numeric family, third for
+            ``camera_fov_error``.
+        range_refusal: The message the guard gives for a value past the float64
+            range, as a callable taking the value. ``camera_fov_error`` is the
+            one member that reuses a message it already had.
+        old_reason: The message the guard gives for a value no number can be read
+            from - text that predates this change on every guard.
+        controls: ``(value, expected)`` pairs, where ``expected`` is ``None`` for
+            an accepted value and the exact message otherwise. Per guard, because
+            the family does not share a domain.
+    """
+
+    name: str
+    call: Callable[[Any], str | None]
+    range_refusal: Callable[[Any], str]
+    old_reason: str
+    controls: tuple[tuple[Any, str | None], ...]
+
+
+CONVERTING: tuple[Converting, ...] = (
+    Converting(
+        "positive_finite_number_error",
+        lambda v: positive_finite_number_error(v, "hz", "teleoperate"),
+        lambda v: f"teleoperate: hz must be within the range of a 64-bit float, got {v!r}.",
+        "teleoperate: hz must be > 0, got RealNoFloat().",
+        (
+            (2.5, None),
+            (30.0, None),
+            (FLOAT_MAX, None),
+            (LARGE_BUT_CONVERTIBLE, None),
+            (np.float32(58.0), None),
+            (np.int64(30), None),
+            (0, "teleoperate: hz must be > 0, got 0."),
+            (-5, "teleoperate: hz must be > 0, got -5."),
+            (NAN, "teleoperate: hz must be > 0, got nan."),
+            (INF, "teleoperate: hz must be > 0, got inf."),
+            (-INF, "teleoperate: hz must be > 0, got -inf."),
+            (True, "teleoperate: hz must be > 0, got True."),
+            ("x", "teleoperate: hz must be > 0, got 'x'."),
+        ),
+    ),
+    Converting(
+        "finite_number_error",
+        lambda v: finite_number_error(v, "vx", "drive"),
+        lambda v: f"drive: vx must be within the range of a 64-bit float, got {v!r}.",
+        "drive: vx must be a finite number, got RealNoFloat().",
+        (
+            (2.5, None),
+            (0, None),
+            (-5, None),
+            (FLOAT_MAX, None),
+            (-FLOAT_MAX, None),
+            (LARGE_BUT_CONVERTIBLE, None),
+            (np.float32(58.0), None),
+            (NAN, "drive: vx must be a finite number, got nan."),
+            (INF, "drive: vx must be a finite number, got inf."),
+            (-INF, "drive: vx must be a finite number, got -inf."),
+            (True, "drive: vx must be a finite number, got True."),
+            ("x", "drive: vx must be a finite number, got 'x'."),
+        ),
+    ),
+    Converting(
+        "positive_whole_number_error",
+        lambda v: positive_whole_number_error(v, "fps", "video"),
+        lambda v: f"video: fps must be within the range of a 64-bit float, got {v!r}.",
+        "video: fps must be a positive whole number, got RealNoFloat().",
+        (
+            (30.0, None),
+            (FLOAT_MAX, None),
+            (LARGE_BUT_CONVERTIBLE, None),
+            (np.int64(30), None),
+            (2.5, "video: fps must be a positive whole number, got 2.5."),
+            (0, "video: fps must be a positive whole number, got 0."),
+            (-5, "video: fps must be a positive whole number, got -5."),
+            (NAN, "video: fps must be a positive whole number, got nan."),
+            (INF, "video: fps must be a positive whole number, got inf."),
+            (True, "video: fps must be a positive whole number, got True."),
+            ("x", "video: fps must be a positive whole number, got 'x'."),
+        ),
+    ),
+    Converting(
+        "camera_fov_error",
+        lambda v: camera_fov_error("add_camera", "fov", v),
+        # The one member that needed no new text: its domain is bounded above, so
+        # the interval message it already had is true of an outsized value. Note
+        # ``str`` rather than ``repr`` - that branch renders plainly, and #1873
+        # pins why converting it would change an ``np.float32`` fov's text.
+        lambda v: f"add_camera: 'fov' must be in the open interval (0, 180) degrees, got {v!s}.",
+        "add_camera: 'fov' must be a finite number in degrees, got RealNoFloat().",
+        (
+            (2.5, None),
+            (58.0, None),
+            (np.float32(58.0), None),
+            (np.int64(30), None),
+            (0, "add_camera: 'fov' must be in the open interval (0, 180) degrees, got 0."),
+            (-5, "add_camera: 'fov' must be in the open interval (0, 180) degrees, got -5."),
+            (200.0, "add_camera: 'fov' must be in the open interval (0, 180) degrees, got 200.0."),
+            (NAN, "add_camera: 'fov' must be a finite number in degrees, got nan."),
+            (INF, "add_camera: 'fov' must be a finite number in degrees, got inf."),
+            (True, "add_camera: 'fov' must be a finite number in degrees, got True."),
+            ("x", "add_camera: 'fov' must be a finite number in degrees, got 'x'."),
+        ),
+    ),
+)
+CONVERTING_IDS = tuple(guard.name for guard in CONVERTING)
+
+
+# --------------------------------------------------------------------------- #
+# The helper                                                                  #
+# --------------------------------------------------------------------------- #
+class TestTheSharedPredicate:
+    """``_beyond_float_range`` answers one question and does not widen it."""
+
+    @pytest.mark.parametrize("value", OVERFLOWING_VALUES[:4], ids=OVERFLOWING_IDS[:4])
+    def test_it_is_true_for_a_magnitude_past_the_float_range(self, value: Any) -> None:
+        assert _beyond_float_range(value) is True
+
+    def test_it_is_true_for_a_non_int_real_that_overflows(self) -> None:
+        """Keyed on the conversion, not on the type - see the module docstring."""
+        assert _beyond_float_range(Fraction(BEYOND_FLOAT_RANGE, 3)) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [0, 1, -1, 2.5, FLOAT_MAX, -FLOAT_MAX, LARGE_BUT_CONVERTIBLE, NAN, INF, -INF, np.float32(1.0), np.int64(3)],
+    )
+    def test_it_is_false_for_everything_a_float_can_hold(self, value: Any) -> None:
+        assert _beyond_float_range(value) is False
+
+    def test_it_is_false_when_the_conversion_fails_some_other_way(self) -> None:
+        """A ``TypeError`` is not a magnitude complaint, so it is not this one.
+
+        Reporting "must be within the range of a 64-bit float" for a value that
+        has no ``__float__`` at all would be as false as the reasons this change
+        exists to stop giving.
+        """
+        assert _beyond_float_range(RealNoFloat()) is False
+        assert _beyond_float_range("x") is False
+        assert _beyond_float_range(None) is False
+
+    def test_the_boundary_is_inclusive(self) -> None:
+        """``float_info.max`` itself converts; only past it overflows."""
+        assert _beyond_float_range(FLOAT_MAX) is False
+        assert _beyond_float_range(int(FLOAT_MAX) * 2) is True
+
+    def test_it_does_not_swallow_a_base_exception(self) -> None:
+        """Same boundary #1873 drew on the renderers, and for the same reason.
+
+        Swallowing a ``KeyboardInterrupt`` to classify a number would be a worse
+        failure than the one being reported.
+        """
+
+        class Interrupting(numbers.Real):  # pragma: no cover - only __float__ runs
+            def __float__(self) -> float:
+                raise KeyboardInterrupt
+
+            def __abs__(self) -> Any:
+                return self
+
+            def __add__(self, other: Any) -> Any:
+                return self
+
+            def __ceil__(self) -> Any:
+                return self
+
+            def __eq__(self, other: object) -> bool:
+                return self is other
+
+            def __floor__(self) -> Any:
+                return self
+
+            def __floordiv__(self, other: Any) -> Any:
+                return self
+
+            def __hash__(self) -> int:
+                return 0
+
+            def __le__(self, other: Any) -> bool:
+                return False
+
+            def __lt__(self, other: Any) -> bool:
+                return False
+
+            def __mod__(self, other: Any) -> Any:
+                return self
+
+            def __mul__(self, other: Any) -> Any:
+                return self
+
+            def __neg__(self) -> Any:
+                return self
+
+            def __pos__(self) -> Any:
+                return self
+
+            def __pow__(self, other: Any) -> Any:
+                return self
+
+            def __radd__(self, other: Any) -> Any:
+                return self
+
+            def __rfloordiv__(self, other: Any) -> Any:
+                return self
+
+            def __rmod__(self, other: Any) -> Any:
+                return self
+
+            def __rmul__(self, other: Any) -> Any:
+                return self
+
+            def __round__(self, ndigits: Any = None) -> Any:
+                return self
+
+            def __rpow__(self, other: Any) -> Any:
+                return self
+
+            def __rtruediv__(self, other: Any) -> Any:
+                return self
+
+            def __truediv__(self, other: Any) -> Any:
+                return self
+
+            def __trunc__(self) -> Any:
+                return self
+
+        with pytest.raises(KeyboardInterrupt):
+            _beyond_float_range(Interrupting())
+
+
+# --------------------------------------------------------------------------- #
+# The closure                                                                 #
+# --------------------------------------------------------------------------- #
+class TestEveryConvertingGuardAnswersAValueItCannotConvert:
+    """The invariant, over all four guards and every probe that used to raise."""
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    @pytest.mark.parametrize("value", OVERFLOWING_VALUES, ids=OVERFLOWING_IDS)
+    def test_it_returns_a_message_instead_of_raising(self, guard: Converting, value: Any) -> None:
+        result = guard.call(value)
+        assert isinstance(result, str)
+        assert result
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_the_message_names_the_parameter_and_the_surface(self, guard: Converting) -> None:
+        """A refusal that does not say what was refused is not an answer."""
+        assert guard.call(BEYOND_FLOAT_RANGE) == guard.range_refusal(BEYOND_FLOAT_RANGE)
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_it_composes_with_the_rendering_fix(self, guard: Converting) -> None:
+        """A value past *both* boundaries needs #1873 and #1874 at once.
+
+        ``10**5000`` overflows the conversion and cannot render itself either, so
+        the refusal is only producible if the range branch routes through the
+        shared renderer rather than interpolating the value.
+        """
+        result = guard.call(BEYOND_INT_STR_LIMIT)
+        assert isinstance(result, str)
+        assert "<int of 16610 bits>" in result
+
+
+class TestAValueNoNumberCanBeReadFromKeepsTheOldReason:
+    """The second exception class is not a range complaint (module docstring).
+
+    ``float()`` raises ``TypeError`` for a registered :class:`numbers.Real` with
+    no working ``__float__``. Such a value used to raise out of all four guards
+    too, so it is fixed here - but reporting a *range* for it would be exactly
+    the kind of false reason this change exists to remove.
+    """
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_it_is_refused_with_the_text_that_predates_this_change(self, guard: Converting) -> None:
+        assert guard.call(RealNoFloat()) == guard.old_reason
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_it_is_not_told_about_the_float_range(self, guard: Converting) -> None:
+        result = guard.call(RealNoFloat())
+        assert result is not None
+        assert "64-bit float" not in result
+
+
+# --------------------------------------------------------------------------- #
+# Why the new reason is the honest one                                        #
+# --------------------------------------------------------------------------- #
+class TestTheRangeIsTheBoundTheGuardAlreadyHad:
+    """The new message names an existing boundary rather than inventing one.
+
+    This is the argument for the wording. If these guards refused well below the
+    float64 range, naming it would be arbitrary; they do not - they accept right
+    up to ``sys.float_info.max`` and used to raise one step past it.
+    """
+
+    @pytest.mark.parametrize("guard", CONVERTING[:3], ids=CONVERTING_IDS[:3])
+    def test_the_largest_convertible_value_is_still_accepted(self, guard: Converting) -> None:
+        assert guard.call(FLOAT_MAX) is None
+
+    @pytest.mark.parametrize("guard", CONVERTING[:3], ids=CONVERTING_IDS[:3])
+    def test_a_large_int_inside_the_range_is_still_accepted(self, guard: Converting) -> None:
+        """So the refusal is about magnitude, not about being an ``int``."""
+        assert guard.call(LARGE_BUT_CONVERTIBLE) is None
+
+    @pytest.mark.parametrize("guard", CONVERTING[:3], ids=CONVERTING_IDS[:3])
+    def test_the_refusal_begins_exactly_where_the_conversion_fails(self, guard: Converting) -> None:
+        just_past = int(FLOAT_MAX) * 2
+        assert guard.call(FLOAT_MAX) is None
+        assert guard.call(just_past) == guard.range_refusal(just_past)
+
+    def test_the_reason_would_have_been_false_of_the_value(self) -> None:
+        """Why new text was needed at all, stated as three true propositions."""
+        assert BEYOND_FLOAT_RANGE > 0, "so 'must be > 0' would be false of it"
+        assert BEYOND_FLOAT_RANGE == int(BEYOND_FLOAT_RANGE), "so 'positive whole number' would be false"
+        assert not isinstance(BEYOND_FLOAT_RANGE, float), "and it is finite: no float64 is involved"
+
+
+class TestTheFovGuardNeededNoNewText:
+    """The one member with a bounded domain, so it already owned a true reason."""
+
+    @pytest.mark.parametrize("value", OVERFLOWING_VALUES, ids=OVERFLOWING_IDS)
+    def test_an_outsized_angle_is_refused_as_outside_the_interval(self, value: Any) -> None:
+        result = camera_fov_error("add_camera", "fov", value)
+        assert result is not None
+        assert "open interval (0, 180) degrees" in result
+
+    @pytest.mark.parametrize("value", OVERFLOWING_VALUES, ids=OVERFLOWING_IDS)
+    def test_it_never_mentions_the_float_range(self, value: Any) -> None:
+        """New text here would have been a worse message, not a better one."""
+        result = camera_fov_error("add_camera", "fov", value)
+        assert result is not None
+        assert "64-bit float" not in result
+
+    def test_it_is_the_same_message_an_ordinary_out_of_range_angle_gets(self) -> None:
+        """Byte-identical but for the value, so the two are one reason not two."""
+        outsized = camera_fov_error("add_camera", "fov", BEYOND_FLOAT_RANGE)
+        ordinary = camera_fov_error("add_camera", "fov", 200.0)
+        assert outsized is not None and ordinary is not None
+        prefix = "add_camera: 'fov' must be in the open interval (0, 180) degrees, got "
+        assert outsized.startswith(prefix)
+        assert ordinary.startswith(prefix)
+
+    def test_the_claim_the_reason_rests_on(self) -> None:
+        """A magnitude past the float64 range really is outside ``(0, 180)``.
+
+        The guard asserts this without comparing, so the comparison lives here.
+        """
+        assert not (0 < BEYOND_FLOAT_RANGE < 180)
+        assert not (0 < -BEYOND_FLOAT_RANGE < 180)
+        assert not (0 < Fraction(BEYOND_FLOAT_RANGE, 3) < 180)
+
+
+# --------------------------------------------------------------------------- #
+# Nothing else moved                                                          #
+# --------------------------------------------------------------------------- #
+class TestNoExistingVerdictOrMessageMoved:
+    """The change is additive: 24 raises became answers and nothing else.
+
+    Without this the class above is satisfied by a guard that started refusing
+    everything, which is why an accepted-value control sits in every row.
+    """
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_every_control_keeps_its_exact_verdict_and_text(self, guard: Converting) -> None:
+        for value, expected in guard.controls:
+            assert guard.call(value) == expected, f"{guard.name} moved on {value!r}"
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_at_least_one_control_is_accepted_and_one_refused(self, guard: Converting) -> None:
+        """Non-vacuity of the row above."""
+        verdicts = {expected is None for _, expected in guard.controls}
+        assert verdicts == {True, False}
+
+    def test_the_sibling_guards_this_change_does_not_touch_are_unmoved(self) -> None:
+        """#1873's family is wider than #1874's; the rest must be untouched."""
+        assert non_negative_whole_number_error(2.7, "n_steps", "step") == (
+            "step: n_steps must be a non-negative whole number, got 2.7."
+        )
+        assert non_negative_whole_number_error(0, "n_steps", "step") is None
+
+
+class TestTheAsymmetryWithTheSiblingIsDeliberate:
+    """``positive_`` refuses an outsized value where ``non_negative_`` accepts one.
+
+    The two are documented as the same scalar policy with the floor moved, so a
+    reader who measures this will find a contradiction unless the exception is
+    recorded. It is a decision, not an oversight: the consumer of a step count
+    owns a ceiling (MuJoCo's ``_MAX_STEPS_PER_CALL``) and no consumer of an
+    ``fps`` / ``width`` / ``drive(count=...)`` does, and that last one repeats a
+    command to a robot.
+    """
+
+    def test_the_positive_guard_refuses_an_outsized_value(self) -> None:
+        assert positive_whole_number_error(BEYOND_FLOAT_RANGE, "fps", "video") is not None
+
+    def test_the_non_negative_sibling_still_accepts_one(self) -> None:
+        assert non_negative_whole_number_error(BEYOND_FLOAT_RANGE, "n_steps", "step") is None
+
+    def test_they_agree_on_every_other_probe(self) -> None:
+        """The asymmetry is exactly one input class wide, not a general drift."""
+        for value in (0.0, 1, 2.5, 30.0, NAN, INF, -1, True, "x", np.int64(7)):
+            positive = positive_whole_number_error(value, "n", "ctx") is None
+            non_negative = non_negative_whole_number_error(value, "n", "ctx") is None
+            if value == 0.0 or value == 0:
+                continue  # the floor itself, which is the documented difference
+            assert positive == non_negative, f"the two guards disagree on {value!r}"
+
+    def test_the_reason_for_the_asymmetry_is_recorded_where_a_reader_will_look(self) -> None:
+        """Both docstrings must carry it, since either is the one being read."""
+        assert "_MAX_STEPS_PER_CALL" in (positive_whole_number_error.__doc__ or "")
+        assert "drive(count=" in (positive_whole_number_error.__doc__ or "")
+        assert "the one place the two guards differ" in (non_negative_whole_number_error.__doc__ or "")
+
+
+# --------------------------------------------------------------------------- #
+# Drift: no guard may convert without a guard                                 #
+# --------------------------------------------------------------------------- #
+def _unguarded_float_calls_in(tree: ast.AST) -> list[str]:
+    """Names converted by a ``float()`` call that no ``try`` protects.
+
+    The scan is what makes this the last pass rather than a first: a fifth guard,
+    or a later edit to one of these four, reintroduces the defect silently
+    otherwise. It reports the *argument* of each unprotected conversion so a
+    failure says which value is exposed rather than only that one is.
+
+    A call is protected when it is lexically inside a ``try`` body, or when it is
+    the argument to :func:`_beyond_float_range` - which is itself protected, and
+    is the shared spelling this change introduces.
+
+    Args:
+        tree: A parsed function, or the ``ast`` node for one.
+    """
+    protected: set[ast.AST] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for stmt in node.body:
+                for inner in ast.walk(stmt):
+                    if isinstance(inner, ast.Call):
+                        protected.add(inner)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_beyond_float_range":
+            for arg in node.args:
+                for inner in ast.walk(arg):
+                    if isinstance(inner, ast.Call):
+                        protected.add(inner)
+
+    exposed = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "float"
+            and node not in protected
+            and node.args
+        ):
+            arg = node.args[0]
+            exposed.append(arg.id if isinstance(arg, ast.Name) else ast.dump(arg))
+    return exposed
+
+
+def _unguarded_float_calls(func: Any) -> list[str]:
+    """:func:`_unguarded_float_calls_in` for a live function object."""
+    return _unguarded_float_calls_in(ast.parse(inspect.getsource(func).lstrip()))
+
+
+class TestNoConvertingGuardConvertsUnprotected:
+    """The invariant is scanned in the source, not enumerated in a list."""
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_the_guard_has_no_unprotected_conversion(self, guard: Converting) -> None:
+        func = getattr(utils, guard.name)
+        assert _unguarded_float_calls(func) == []
+
+    def test_the_helper_itself_is_protected(self) -> None:
+        """It is the one place the conversion is allowed to be attempted."""
+        assert _unguarded_float_calls(_beyond_float_range) == []
+
+    @pytest.mark.parametrize("guard", CONVERTING, ids=CONVERTING_IDS)
+    def test_the_guard_asks_the_shared_predicate(self, guard: Converting) -> None:
+        """The positive form: absence of a bare ``float()`` is also satisfied by
+        a guard that stopped classifying magnitude at all."""
+        source = inspect.getsource(getattr(utils, guard.name))
+        assert "_beyond_float_range(" in source
+
+    def test_the_scanner_reports_a_planted_unprotected_conversion(self) -> None:
+        """Control: an always-passing scan would satisfy every test above."""
+
+        def planted(value: Any) -> bool:
+            return math.isfinite(float(value))
+
+        assert _unguarded_float_calls(planted) == ["value"]
+
+    def test_the_scanner_accepts_a_conversion_inside_a_try(self) -> None:
+        """Control in the other direction, so the scan is not simply strict."""
+
+        def planted(value: Any) -> float:
+            try:
+                return float(value)
+            except OverflowError:
+                return 0.0
+
+        assert _unguarded_float_calls(planted) == []
+
+
+class TestTheModuleHasExactlyOneRemainingConversionSurface:
+    """The scan run over the whole module, not over a list of four names.
+
+    A test parametrised on ``CONVERTING`` cannot fail for a guard nobody thought
+    to add to it, so the useful assertion is the complement: which functions in
+    :mod:`strands_robots.utils` still convert unprotected. The set is asserted
+    exactly, which is what makes the remaining entries a stated boundary rather
+    than an omission, and what makes a fifth converting scalar guard fail here.
+
+    The answer is the four **container** guards, and they are #1875. That issue
+    describes the *rendering* defect - ``repr`` of a list recursing into an
+    element that cannot render itself - and this scan shows the containers carry
+    the conversion escape as well:
+    ``finite_vector_error("raycast", "origin", [10**400])`` raises
+    ``OverflowError``, as does ``pose_vector_error`` with an outsized component.
+
+    So both halves of the sweep stop at the same boundary for the same reason: an
+    elementwise message format has to be decided before either can be closed
+    there, since a whole-container fallback erases the element count that is
+    often the refusal's entire reason. Recorded on #1875.
+    """
+
+    #: Not names this change chose to skip - this is the scan's output, asserted
+    #: so it can neither grow nor be quietly narrowed.
+    EXPECTED_REMAINING = frozenset(
+        {
+            "finite_vector_error",
+            "coerce_pose_vector",
+            "coerce_rgba",
+            "coerce_size_vector",
+        }
+    )
+
+    @staticmethod
+    def _converting_unprotected() -> set[str]:
+        tree = ast.parse(inspect.getsource(utils))
+        return {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _unguarded_float_calls_in(node)
+        }
+
+    def test_the_remaining_surface_is_exactly_the_container_guards(self) -> None:
+        assert self._converting_unprotected() == set(self.EXPECTED_REMAINING)
+
+    def test_no_scalar_guard_is_among_them(self) -> None:
+        """This change's claim, stated over the module rather than over a list."""
+        assert self._converting_unprotected().isdisjoint({guard.name for guard in CONVERTING})
+
+    @pytest.mark.parametrize(
+        ("call", "exc"),
+        [
+            (lambda: utils.finite_vector_error("raycast", "origin", [BEYOND_FLOAT_RANGE]), OverflowError),
+            (lambda: utils.pose_vector_error("add_object", "position", [BEYOND_FLOAT_RANGE] * 3, 3), OverflowError),
+        ],
+        ids=["finite_vector_error", "pose_vector_error"],
+    )
+    def test_a_container_guard_does_still_raise_on_an_outsized_element(
+        self, call: Callable[[], Any], exc: type[BaseException]
+    ) -> None:
+        """Pinned so #1875's widened scope is a measurement, not a remark.
+
+        Replace this when #1875 is settled rather than deleting it, per the
+        premise-test guidance in ``AGENTS.md``.
+        """
+        with pytest.raises(exc):
+            call()
+
+    def test_two_of_the_container_guards_already_answer_it(self) -> None:
+        """So #1875 is not uniform, and its fix cannot assume that it is.
+
+        ``coerce_rgba`` and ``coerce_size_vector`` range-check each component
+        before converting it, so an outsized element is refused rather than
+        converted. Their unprotected ``float()`` is on the *accepted* path, which
+        is why the scan lists them and a probe does not.
+        """
+        assert utils.coerce_rgba([BEYOND_FLOAT_RANGE] * 4, "colour", "add_object")[1] is not None
+        assert utils.coerce_size_vector([BEYOND_FLOAT_RANGE] * 3, "size", "add_object")[1] is not None

--- a/tests/test_conversion_escape_is_closed.py
+++ b/tests/test_conversion_escape_is_closed.py
@@ -728,9 +728,8 @@ class TestTheModuleHasExactlyOneRemainingConversionSurface:
     The answer is the four **container** guards, and they are #1875. That issue
     describes the *rendering* defect - ``repr`` of a list recursing into an
     element that cannot render itself - and this scan shows the containers carry
-    the conversion escape as well:
-    ``finite_vector_error("raycast", "origin", [10**400])`` raises
-    ``OverflowError``, as does ``pose_vector_error`` with an outsized component.
+    the conversion escape as well, uniformly: all four raise ``OverflowError`` on
+    an element past the float64 range.
 
     So both halves of the sweep stop at the same boundary for the same reason: an
     elementwise message format has to be decided before either can be closed
@@ -765,32 +764,45 @@ class TestTheModuleHasExactlyOneRemainingConversionSurface:
         """This change's claim, stated over the module rather than over a list."""
         assert self._converting_unprotected().isdisjoint({guard.name for guard in CONVERTING})
 
-    @pytest.mark.parametrize(
-        ("call", "exc"),
-        [
-            (lambda: utils.finite_vector_error("raycast", "origin", [BEYOND_FLOAT_RANGE]), OverflowError),
-            (lambda: utils.pose_vector_error("add_object", "position", [BEYOND_FLOAT_RANGE] * 3, 3), OverflowError),
-        ],
-        ids=["finite_vector_error", "pose_vector_error"],
+    #: Each container guard called with an outsized element, through the public
+    #: entry point a caller actually reaches: ``coerce_pose_vector`` is reached
+    #: via ``pose_vector_error``. Every one of them takes the value *last*, after
+    #: the method and parameter labels.
+    CONTAINER_PROBES: tuple[tuple[str, Callable[[], Any]], ...] = (
+        ("finite_vector_error", lambda: utils.finite_vector_error("raycast", "origin", [BEYOND_FLOAT_RANGE])),
+        ("pose_vector_error", lambda: utils.pose_vector_error("add_object", "position", [BEYOND_FLOAT_RANGE] * 3, 3)),
+        ("coerce_rgba", lambda: utils.coerce_rgba("add_object", "colour", [BEYOND_FLOAT_RANGE] * 4)),
+        ("coerce_size_vector", lambda: utils.coerce_size_vector("add_object", "size", [BEYOND_FLOAT_RANGE] * 3)),
     )
-    def test_a_container_guard_does_still_raise_on_an_outsized_element(
-        self, call: Callable[[], Any], exc: type[BaseException]
-    ) -> None:
+
+    @pytest.mark.parametrize(
+        "call",
+        [probe for _, probe in CONTAINER_PROBES],
+        ids=[name for name, _ in CONTAINER_PROBES],
+    )
+    def test_every_container_guard_still_raises_on_an_outsized_element(self, call: Callable[[], Any]) -> None:
         """Pinned so #1875's widened scope is a measurement, not a remark.
 
-        Replace this when #1875 is settled rather than deleting it, per the
-        premise-test guidance in ``AGENTS.md``.
+        The escape is uniform across the four: every one of them raises
+        ``OverflowError``, so a fix there can treat them as one class. Replace
+        this when #1875 is settled rather than deleting it, per the premise-test
+        guidance in ``AGENTS.md``.
         """
-        with pytest.raises(exc):
+        with pytest.raises(OverflowError):
             call()
 
-    def test_two_of_the_container_guards_already_answer_it(self) -> None:
-        """So #1875 is not uniform, and its fix cannot assume that it is.
+    def test_the_probes_reach_the_conversion_rather_than_a_label_check(self) -> None:
+        """Control: each probe must fail *on its element*, not on its own shape.
 
-        ``coerce_rgba`` and ``coerce_size_vector`` range-check each component
-        before converting it, so an outsized element is refused rather than
-        converted. Their unprotected ``float()`` is on the *accepted* path, which
-        is why the scan lists them and a probe does not.
+        These guards take the value in their last position, after two ``str``
+        labels. A probe that passed the container in a label position would be
+        refused for having the wrong type there - which looks like evidence about
+        the element and is not. So the same guards are called with a
+        well-formed container and must return an accepted result, proving the
+        argument order is right and the outsized element is what the row above
+        measures.
         """
-        assert utils.coerce_rgba([BEYOND_FLOAT_RANGE] * 4, "colour", "add_object")[1] is not None
-        assert utils.coerce_size_vector([BEYOND_FLOAT_RANGE] * 3, "size", "add_object")[1] is not None
+        assert utils.finite_vector_error("raycast", "origin", [0.0, 0.0, 1.0]) is None
+        assert utils.pose_vector_error("add_object", "position", [0.0, 0.0, 1.0], 3) is None
+        assert utils.coerce_rgba("add_object", "colour", [0.5, 0.5, 0.5, 1.0])[1] is None
+        assert utils.coerce_size_vector("add_object", "size", [1.0, 1.0, 1.0])[1] is None

--- a/tests/test_conversion_escape_is_closed.py
+++ b/tests/test_conversion_escape_is_closed.py
@@ -111,92 +111,28 @@ NAN = float("nan")
 INF = float("inf")
 
 
-class RealNoFloat(numbers.Real):
-    """A registered :class:`numbers.Real` with no usable ``__float__``.
+class RealNoFloat:
+    """A registered :class:`numbers.Real` from which no float can be read.
 
-    ``numbers.Real`` is a registration rather than an inheritance, so a value can
-    satisfy a guard's type test and still refuse to become a float. It is the
-    second exception class the conversion can raise, and unlike an outsized
-    magnitude it is not a range complaint: no number can be read from it at all.
-    Its ``repr`` works, so it isolates the conversion from #1873's defect.
+    Registered with ``numbers.Real.register`` rather than subclassed, which is
+    not a shortcut - it is the property under test. ``numbers.Real`` is a
+    registration rather than an inheritance, so a value can satisfy a guard's
+    ``isinstance`` check while owing it nothing else, and subclassing the ABC
+    would have forced this double to implement two dozen operators it never uses
+    and to supply the very ``__float__`` whose absence is the point.
+
+    With no ``__float__`` at all, ``float()`` raises ``TypeError`` of its own
+    accord. That is the conversion's second exception class, and unlike an
+    outsized magnitude it is not a range complaint: no number can be read from
+    this value, so it must not be told about the float64 range. Its ``repr``
+    works, which isolates the conversion from #1873's rendering defect.
     """
-
-    def __float__(self) -> float:
-        raise TypeError("this value cannot become a float")
 
     def __repr__(self) -> str:
         return "RealNoFloat()"
 
-    # The remaining abstract methods are never reached by a guard; they exist so
-    # the class is instantiable at all.
-    def __abs__(self) -> Any:
-        return self
 
-    def __add__(self, other: Any) -> Any:
-        return self
-
-    def __ceil__(self) -> Any:
-        return self
-
-    def __eq__(self, other: object) -> bool:
-        return self is other
-
-    def __floor__(self) -> Any:
-        return self
-
-    def __floordiv__(self, other: Any) -> Any:
-        return self
-
-    def __hash__(self) -> int:
-        return 0
-
-    def __le__(self, other: Any) -> bool:
-        return False
-
-    def __lt__(self, other: Any) -> bool:
-        return False
-
-    def __mod__(self, other: Any) -> Any:
-        return self
-
-    def __mul__(self, other: Any) -> Any:
-        return self
-
-    def __neg__(self) -> Any:
-        return self
-
-    def __pos__(self) -> Any:
-        return self
-
-    def __pow__(self, other: Any) -> Any:
-        return self
-
-    def __radd__(self, other: Any) -> Any:
-        return self
-
-    def __rfloordiv__(self, other: Any) -> Any:
-        return self
-
-    def __rmod__(self, other: Any) -> Any:
-        return self
-
-    def __rmul__(self, other: Any) -> Any:
-        return self
-
-    def __round__(self, ndigits: Any = None) -> Any:
-        return self
-
-    def __rpow__(self, other: Any) -> Any:
-        return self
-
-    def __rtruediv__(self, other: Any) -> Any:
-        return self
-
-    def __truediv__(self, other: Any) -> Any:
-        return self
-
-    def __trunc__(self) -> Any:
-        return self
+numbers.Real.register(RealNoFloat)
 
 
 #: Every value that used to raise out of a converting guard. The ``Fraction`` and
@@ -369,78 +305,13 @@ class TestTheSharedPredicate:
         failure than the one being reported.
         """
 
-        class Interrupting(numbers.Real):  # pragma: no cover - only __float__ runs
+        class Interrupting:
+            """Registered below, for the reason given on :class:`RealNoFloat`."""
+
             def __float__(self) -> float:
                 raise KeyboardInterrupt
 
-            def __abs__(self) -> Any:
-                return self
-
-            def __add__(self, other: Any) -> Any:
-                return self
-
-            def __ceil__(self) -> Any:
-                return self
-
-            def __eq__(self, other: object) -> bool:
-                return self is other
-
-            def __floor__(self) -> Any:
-                return self
-
-            def __floordiv__(self, other: Any) -> Any:
-                return self
-
-            def __hash__(self) -> int:
-                return 0
-
-            def __le__(self, other: Any) -> bool:
-                return False
-
-            def __lt__(self, other: Any) -> bool:
-                return False
-
-            def __mod__(self, other: Any) -> Any:
-                return self
-
-            def __mul__(self, other: Any) -> Any:
-                return self
-
-            def __neg__(self) -> Any:
-                return self
-
-            def __pos__(self) -> Any:
-                return self
-
-            def __pow__(self, other: Any) -> Any:
-                return self
-
-            def __radd__(self, other: Any) -> Any:
-                return self
-
-            def __rfloordiv__(self, other: Any) -> Any:
-                return self
-
-            def __rmod__(self, other: Any) -> Any:
-                return self
-
-            def __rmul__(self, other: Any) -> Any:
-                return self
-
-            def __round__(self, ndigits: Any = None) -> Any:
-                return self
-
-            def __rpow__(self, other: Any) -> Any:
-                return self
-
-            def __rtruediv__(self, other: Any) -> Any:
-                return self
-
-            def __truediv__(self, other: Any) -> Any:
-                return self
-
-            def __trunc__(self) -> Any:
-                return self
+        numbers.Real.register(Interrupting)
 
         with pytest.raises(KeyboardInterrupt):
             _beyond_float_range(Interrupting())

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -65,8 +65,11 @@ agent-visible text changes, which is what
 :class:`TestTheTextIsUnchangedForAValueThatCanBeRendered` pins.
 
 The ``R:Overflow`` cells are a *different* escape - the ``float()`` conversion,
-which happens before any message is rendered - and survive this change untouched.
-They are #1874, pinned by :class:`TestTheConversionEscapeStaysOutOfScope`. The
+which happens before any message is rendered - and survived this change
+untouched. They were #1874 and are now closed, so what was a pin of deliberate
+scope has become :class:`TestTheConversionEscapeIsClosed`: the class is replaced
+rather than deleted, because the boundary it drew is still the useful statement
+and simply moved. The
 container guards have the same rendering defect but need a rendering rather than
 a fallback, since ``<unrepresentable list>`` erases the elements that print fine;
 they are #1875, pinned by :class:`TestTheContainerGuardsStayOutOfScope`.
@@ -291,10 +294,12 @@ ANSWERS_AN_OUTSIZED_INT = frozenset(
     }
 )
 
-#: The guards whose ``float()`` conversion raises before any rendering (#1874).
-#: ``positive_whole_number_error`` joins the set with this change: its eager
-#: ``repr`` used to raise first, so the conversion was never reached.
-HAS_A_CONVERSION_ESCAPE = frozenset(
+#: The guards that establish their domain by converting with ``float()``. That
+#: conversion used to raise ``OverflowError`` before any rendering (#1874); it is
+#: now guarded, so this is a statement about *how* they classify a value rather
+#: than about an escape. The name changed with the fact: membership is still the
+#: line that divides the family, which is why the set outlived the defect.
+CONVERTS_THROUGH_FLOAT = frozenset(
     {
         "positive_finite_number_error",
         "finite_number_error",
@@ -305,7 +310,7 @@ HAS_A_CONVERSION_ESCAPE = frozenset(
 
 OUTSIZED_GUARDS = tuple(g for g in SCALAR_GUARDS if g.name in ANSWERS_AN_OUTSIZED_INT)
 OUTSIZED_IDS = tuple(g.name for g in OUTSIZED_GUARDS)
-CONVERTING_GUARDS = tuple(g for g in SCALAR_GUARDS if g.name in HAS_A_CONVERSION_ESCAPE)
+CONVERTING_GUARDS = tuple(g for g in SCALAR_GUARDS if g.name in CONVERTS_THROUGH_FLOAT)
 CONVERTING_IDS = tuple(g.name for g in CONVERTING_GUARDS)
 
 
@@ -584,41 +589,51 @@ class TestTheTextIsUnchangedForAValueThatCanBeRendered:
 # --------------------------------------------------------------------------- #
 # Boundary: the escapes this change does not close                            #
 # --------------------------------------------------------------------------- #
-class TestTheConversionEscapeStaysOutOfScope:
-    """Pins of behaviour left unchanged, so the boundary is stated not omitted (#1874).
+class TestTheConversionEscapeIsClosed:
+    """The replacement for this file's #1874 scope pin, now that #1874 has landed.
 
-    Replace these when the surfaces they describe are settled rather than deleting
-    them: the scope statement stays useful and simply narrows.
+    It is a replacement rather than a deletion, per the premise-test guidance in
+    ``AGENTS.md``: the conclusion the old pin supported - that the family divides
+    into guards that convert with ``float()`` and guards that do not - still
+    holds, and is still the line worth drawing. What changed is that converting no
+    longer means raising.
 
-    These four establish finiteness with ``math.isfinite(float(value))``, and
-    ``float()`` raises ``OverflowError`` for an ``int`` wider than a float - before
-    any message is rendered, so this change cannot reach it. Closing it needs a
-    decision this one does not: ``10**400`` *is* a finite real number, so "must be
-    a finite number" is the wrong reason to refuse it even though refusing is the
-    right verdict.
+    Where the old class asserted ``pytest.raises(OverflowError)`` for these four,
+    each assertion below is the same probe with the opposite expectation, so the
+    two classes read against each other. The detailed closure - the reason each
+    guard gives, and the fact that none of the existing reasons changed - is
+    :mod:`tests.test_conversion_escape_is_closed`; what is pinned here is only
+    that this file's stated boundary moved.
     """
 
     @pytest.mark.parametrize("guard", CONVERTING_GUARDS, ids=CONVERTING_IDS)
-    def test_an_integer_wider_than_a_float_still_raises(self, guard: Guard) -> None:
-        with pytest.raises(OverflowError):
-            guard.call(BEYOND_FLOAT_RANGE)
+    def test_an_integer_wider_than_a_float_is_answered(self, guard: Guard) -> None:
+        assert isinstance(guard.call(BEYOND_FLOAT_RANGE), str)
 
-    def test_positive_whole_number_error_now_raises_only_at_the_conversion(self) -> None:
-        """This change narrowed it to one escape, which is what #1872 asks for.
+    def test_positive_whole_number_error_has_no_escape_left(self) -> None:
+        """Both outsized spellings are answered, which is what #1872 asked for.
 
-        Before, the eager rendering raised ``ValueError`` on a value past the digit
-        limit *ahead of* the conversion - so the guard had two escapes and closing
-        only the conversion would have left the class open one digit-count higher.
-        Now both outsized spellings fail in the same single place.
+        This guard is where the two escapes met: its eager rendering raised
+        ``ValueError`` on a value past the digit limit *ahead of* the conversion,
+        so closing only one of them would have left the class open. #1873 closed
+        the rendering and #1874 the conversion, and this is the assertion that
+        neither left a residue at the other's boundary.
         """
         for probe in (BEYOND_FLOAT_RANGE, BEYOND_INT_STR_LIMIT):
-            with pytest.raises(OverflowError):
-                positive_whole_number_error(probe, "fps", "video")
+            assert isinstance(positive_whole_number_error(probe, "fps", "video"), str)
 
-    def test_the_two_escapes_partition_the_family(self) -> None:
-        """No guard has both open, which is why they can be settled separately."""
-        assert HAS_A_CONVERSION_ESCAPE.isdisjoint(ANSWERS_AN_OUTSIZED_INT)
-        assert HAS_A_CONVERSION_ESCAPE | ANSWERS_AN_OUTSIZED_INT == set(GUARD_IDS)
+    def test_the_two_halves_of_the_family_have_merged(self) -> None:
+        """The partition survives as a description; the escape it described does not.
+
+        The sets are still disjoint and still cover the family - that is a fact
+        about how each guard classifies a value, and it is why the two escapes
+        could be settled separately at all. What no longer holds is that
+        membership predicts a raise: every guard now answers.
+        """
+        assert CONVERTS_THROUGH_FLOAT.isdisjoint(ANSWERS_AN_OUTSIZED_INT)
+        assert CONVERTS_THROUGH_FLOAT | ANSWERS_AN_OUTSIZED_INT == set(GUARD_IDS)
+        for guard in SCALAR_GUARDS:
+            assert isinstance(guard.call(BEYOND_FLOAT_RANGE), str) or guard.call(BEYOND_FLOAT_RANGE) is None
 
 
 class TestTheContainerGuardsStayOutOfScope:


### PR DESCRIPTION
Closes #1874

Four scalar guards in `utils.py` establish their domain by converting the caller's value with `float()`. That conversion raises `OverflowError` for a real whose magnitude exceeds `sys.float_info.max`, and it runs *before* any message is rendered - so #1873, which made the refusal *rendering* total, could not reach it. This is the other half of that pair, and with it the scalar numeric family answers every real scalar it is given.

This is decomposition step (3) of the #1872 sweep.

## 1. Measured, before and after

Each guard called with its real signature, on `2c254c7` (i.e. with #1873 already merged). `R:` is a raise.

| guard | `10**400` | `10**5000` | `Fraction(10**400, 3)` | `RealNoFloat()` |
|---|---|---|---|---|
| `positive_finite_number_error` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |
| `finite_number_error` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |
| `positive_whole_number_error` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |
| `camera_fov_error` | R:Overflow | R:Overflow | R:Overflow | R:TypeError |

After this change every cell is a structured refusal. **24 probes that used to raise now return a string, and that is the entire behavioural difference** - see §4.

## 2. Two properties of the escape that are not in #1874's description, and that constrain the fix

- **It is not an `int` problem.** `Fraction(10**400, 3)` is a registered `numbers.Real` that overflows identically. A fix keyed on `isinstance(value, int)` - the obvious reading of "an int wider than a float" - would have left that column raising. The question has to be asked of the *conversion*, which is what `_beyond_float_range` does.
- **The escape has two exception classes.** A `numbers.Real` registration guarantees no working `__float__`, so `float()` raises `TypeError` here too. That is **not** a magnitude complaint and must not be reported as one: such a value keeps the text the guard already used for a value that is not a number at all. `_beyond_float_range` returns `False` for it, deliberately, and `TestAValueNoNumberCanBeReadFromKeepsTheOldReason` pins that it is never told about the float64 range.

Both were found by measurement rather than from the issue, which is why the probe set in the tests is wider than the issue's.

## 3. The decision #1874 asked for, resolved per guard rather than by a blanket rule

The issue flagged that the verdict and the reason disagree: `10**400` *is* a finite real number, so "must be a finite number" is the wrong reason to refuse it even though refusing is right. Resolved by asking what each guard's own domain can honestly say:

| guard | is the existing reason true of `10**400`? | outcome |
|---|---|---|
| `positive_finite_number_error` | no - it is `> 0` | new text |
| `finite_number_error` | no - it is finite | new text |
| `positive_whole_number_error` | no - it is a positive whole number | new text |
| `camera_fov_error` | **yes** - it is outside `(0, 180)` | **no text change** |

### Why the new reason names the float64 range

Because it is **not a bound this change invents - it is the bound the guards already enforced.** Measured:

| value | `positive_finite` | `finite` | `positive_whole` |
|---|---|---|---|
| `1e300` | accept | accept | accept |
| `10**308` (an `int`) | accept | accept | accept |
| `sys.float_info.max` | accept | accept | accept |
| `int(float_info.max) * 2` | R:Overflow -> refuse | R:Overflow -> refuse | R:Overflow -> refuse |

The accepted domain already ended exactly at the float64 range; the guard simply raised at that edge instead of answering. So the message names an existing boundary rather than a new one, and it is a *necessary* condition the value fails rather than a claim to be the tightest bound - the same standing `must be > 0` has. `TestTheRangeIsTheBoundTheGuardAlreadyHad` is that argument as a test, including the control that a large `int` *inside* the range is still accepted, so the refusal is demonstrably about magnitude and not about being an `int`.

"Within the range of" rather than "representable as": `0.1` has no exact float64 representation and is accepted, so the precise claim is about range, not exactness.

### Why `camera_fov_error` needed no new text

It is the one member whose domain is **bounded above**, so it already owned a true reason. A magnitude past the float64 range exceeds 180 degrees by three hundred orders of magnitude, and the overflow alone establishes that - no comparison is needed. It therefore reuses the interval message it already had, byte-identical but for the value. Inventing new text here would have produced a *worse* message, and `test_it_never_mentions_the_float_range` pins that it does not.

## 4. No verdict moved and no existing message changed

The whole diff in behaviour is 24 raises becoming answers. Measured by re-running one probe matrix per guard - 19 values covering accept, refuse-on-type, refuse-on-value, `nan`/`inf`, NumPy scalars and `bool` - before and after, then diffing:

```
24 changed cells, and every one of them was a RAISE.
Zero control cells changed.
```

`TestNoExistingVerdictOrMessageMoved` carries that matrix with the exact expected text per cell, and `test_at_least_one_control_is_accepted_and_one_refused` keeps it non-vacuous so "nothing changed" cannot be satisfied by a guard that started refusing everything. Independently, all 79 of #1873's tests still pass unmodified, including its byte-for-byte text-preservation class.

## 5. One deliberate asymmetry, recorded in both docstrings

`positive_whole_number_error` refuses an outsized value where `non_negative_whole_number_error` **accepts** one, and the two are documented as the same scalar policy with the floor moved. That contradiction would be found by the next reader who measures it, so it is recorded as a decision:

- `non_negative_whole_number_error` serves `n_steps`, whose consumer owns a per-call ceiling - MuJoCo's `_MAX_STEPS_PER_CALL` - that refuses an outsized count with a reason of its own. Magnitude really is the consumer's policy there.
- `positive_whole_number_error` serves `fps`, `width`, `height`, `max_frames` and the mesh robots' **`drive(count=...)`**. No consumer owns a ceiling, and that last one repeats an actuation command - so an unbounded count is an unbounded actuation loop against a physical robot rather than a slow call.

So accepting, which would have matched the sibling and needed no new text, is the one option ruled out on safety grounds. `TestTheAsymmetryWithTheSiblingIsDeliberate` pins the divergence, pins that it is *exactly one input class wide* rather than a general drift, and asserts the reason is present in both docstrings - since either is the one being read.

## 6. The invariant is scanned, not listed

`TestNoConvertingGuardConvertsUnprotected` and `TestTheModuleHasExactlyOneRemainingConversionSurface` walk the AST of `utils.py` and report every function whose `float()` call no `try` protects, keyed on the converted argument so a failure names the exposed value. A test parametrised over the four guards cannot fail for a fifth nobody added, so the load-bearing assertion is the complement, and the set is asserted **exactly**.

Controls, since a scan that always passes would satisfy every test above: a planted unprotected conversion is reported, a conversion inside a `try` is not, the helper itself is checked, and the positive form (`test_the_guard_asks_the_shared_predicate`) is asserted too - because absence of a bare `float()` is also satisfied by a guard that stopped classifying magnitude at all.

### That scan produced a finding worth acting on

The exact remaining set is the four **container** guards - and #1875 describes only their *rendering* defect. They carry this one as well, and uniformly: all four raise `OverflowError` on an element past the float64 range.

```python
finite_vector_error("raycast", "origin", [10**400])            # OverflowError
pose_vector_error("add_object", "position", [10**400]*3, 3)    # OverflowError
coerce_rgba("add_object", "colour", [10**400]*4)               # OverflowError
coerce_size_vector("add_object", "size", [10**400]*3)          # OverflowError
```

So both halves of the sweep stop at the same boundary for the same reason: an elementwise message format has to be decided before either can be closed there, since a whole-container fallback erases the element count that is often the refusal's entire reason. Pinned in one parametrized row, with the control that each guard also *accepts* a well-formed container - so a mis-ordered probe cannot be mistaken for evidence about the element (see round 1 below). Recorded on #1875 rather than left in this description.

## 7. #1873's scope pin is replaced, not deleted

`TestTheConversionEscapeStaysOutOfScope` asserted `pytest.raises(OverflowError)` for these four. Per the premise-test guidance in `AGENTS.md` it is **replaced** by `TestTheConversionEscapeIsClosed`, whose assertions are the same probes with the opposite expectation, so the two read against each other. The conclusion the old pin supported - that the family divides into guards that convert and guards that do not - still holds and is still the useful line, so `HAS_A_CONVERSION_ESCAPE` is renamed `CONVERTS_THROUGH_FLOAT`: the set outlived the defect, and the name now describes *how* a guard classifies rather than an escape it has. `test_the_two_halves_of_the_family_have_merged` keeps the disjointness and coverage assertions and adds what changed - membership no longer predicts a raise.

## 8. Tests

`tests/test_conversion_escape_is_closed.py`, 110 checks in 9 classes: the shared predicate (including that it does **not** swallow a `BaseException`, the same boundary #1873 drew on the renderers); the closure over all four guards and every probe; the `TypeError` path keeping its old reason; the range-is-the-existing-bound argument; the fov guard needing no new text, with the comparison its reason rests on; the no-change control matrix; the sibling asymmetry; and the AST scan (two classes - the per-function check and the exact-set assertion - which is where a count of eight comes from if the section is read as one item per clause).

**Non-vacuity measured: 62 of the 110 fail on a faithful pre-fix equivalent** (`62 failed, 48 passed`), spread across 7 of the 9 classes. Two pass on *both* revisions, and the second is worth stating rather than leaving as an unexplained gap:

- `TestNoExistingVerdictOrMessageMoved` - correct for a control class, and the signature you would want it to have.
- `TestTheSharedPredicate` - an artefact of how the measurement has to be built, not a weak test. The pre-fix equivalent must keep `_beyond_float_range` importable or the module cannot be collected, so the predicate those checks exercise is already the fixed one. They are non-vacuous against a *broken predicate*, which is what they are for, and cannot be non-vacuous against unfixed *call sites*.

Beyond keeping that helper importable the equivalent reverts only the call sites, so the number is what this PR adds. The 6 replaced pins in #1873's file fail pre-fix too (`6 failed, 73 passed`), for 68 in total.

Affected suite run as a **delta**, since this environment has no GPU and no `newton` / `isaacsim` - the 45 test files that reference any of these guards or their message text:

| | failed | passed | skipped | errors |
|---|---|---|---|---|
| base (`2c254c7`) | 265 | 2901 | 121 | 9 |
| this branch, at submission (`e1e58de`) | 265 | 3008 | 121 | 9 |
| this branch, at `740c8f0` | 265 | 3011 | 121 | 9 |

Identical failures, skips and errors; **+110 passes, exactly the tests this module adds.** No pre-existing test changed, deleted or reworded other than the replaced scope pin in §7.

The suite run itself was taken at `e1e58de`; the last row carries it forward by the `+3` round 1 adds rather than re-running, which is checkable rather than assumed: `git diff e1e58de..HEAD --stat` is `tests/test_conversion_escape_is_closed.py` alone and `strands_robots/utils.py` is byte-identical across it, so no other test's outcome can have moved, and the `+3` is measured per-file (107 -> 110 checks, all passing).

`ruff check`, `ruff format --check` and `mypy` clean on all three changed files; the new file is ASCII-only and host-path-free. `mypy strands_robots/utils.py` reports `Success: no issues found` on base and on this branch - no new finding.

Changelog fragment: `changelog.d/1874-conversion-escape-is-closed.md`.

---

## 9. Round changelog

| Round | Concern | Fix commit | Pin test |
| --- | --- | --- | --- |
| - | initial submission | `e1e58de` | 107 checks, 62 non-vacuous |
| 1 | the two `coerce_*` probes passed the container in the **method-name** position, so they were refused for a wrong type in a *label* slot rather than for the element under test - which is what made them look as though they already answered an outsized element | `a524b22` | `test_the_probes_reach_the_conversion_rather_than_a_label_check` - each guard must also *accept* a well-formed container, so the row above cannot pass for the wrong reason again |
| 1 | the test doubles subclassed `numbers.Real`, which forced a `__hash__` the ABC's own signature rejects and a `__float__` raising a non-standard exception | `c3f8262` | existing assertions unchanged; `numbers.Real.register` is also the stronger witness to the property under test, and drops 64 lines of unused operators |
| 1 | `value == 0.0 or value == 0` tested the same thing twice, so the second disjunct was always false when reached | `740c8f0` | `test_the_floor_is_the_other_difference_and_is_excluded_deliberately` - the skipped probe is now stated rather than dropped by a mid-loop condition |

**Round 1 changed a claim in §6.** The mis-ordered probe was the sole basis for saying the container guards were *non-uniform* in this escape ("two already answer it"). With the correct signature all four raise, so the surface is uniform and a fix for #1875 can treat them as one class. §6 is corrected above, and the correction is recorded on #1875 replacing what I had written there.

Worth noting which check caught it: the probe was green and self-consistent, and only `mypy` on the *test* module found it - `Argument 1 to "coerce_rgba" has incompatible type "list[int]"; expected "str"`. A passing assertion about the wrong call is invisible to the assertion itself, which is an argument for CI type-checking tests and not only the library.

Two findings from authoring, unchanged, worth flagging rather than leaving to be re-derived:

1. **The escape is wider than "an `int` wider than a float"** - a `Fraction` overflows identically and a `numbers.Real` with no `__float__` raises `TypeError` at the same call. That is why the fix keys on the conversion and splits the two exception classes to two different reasons (§2).
2. **The container guards have this escape too**, which #1875 does not mention (§6). Recorded on #1875.