### PR TITLE
fix(utils): a container guard must not raise while rendering what it refuses

### DIFF
--- a/changelog.d/1875-container-refusals-render-elementwise.md
+++ b/changelog.d/1875-container-refusals-render-elementwise.md
@@ -1,0 +1,91 @@
+### Fixed: a container guard no longer raises while rendering the container it refuses
+
+The vector and list guards in `strands_robots/utils.py` interpolate the whole
+container into their refusal text - `finite_vector_error`, `pose_vector_error`,
+`coerce_pose_vector`, `coerce_rgba`, `coerce_size_vector` and `name_list_error`.
+`repr` of a list recurses into its elements, so a container was unrenderable
+whenever any *one* of its elements was, and the guard raised instead of returning
+the structured refusal its callers document as the only channel a bad value is
+reported on. The same guards also converted an element with a bare `float()` to
+test finiteness, so an element past `sys.float_info.max` raised before any
+message was rendered at all.
+
+```
+finite_vector_error("raycast", "origin", [10**5000])           # ValueError
+pose_vector_error("add_object", "position", [10**5000], 3)     # ValueError
+name_list_error([10**5000], "cameras", "render_all")           # ValueError
+finite_vector_error("raycast", "origin", [10**400])            # OverflowError
+coerce_rgba("add_object", "color", [10**400] * 4)              # OverflowError
+```
+
+These arrive from an agent tool call or a `device_connect` `@rpc()` payload -
+`raycast(origin=)`, `add_object(position=, size=, color=)` and the recorder /
+render `cameras` lists - where a list of JSON numbers is the normal shape and
+Python integers are arbitrary-precision, so such a value is one request away.
+
+Both escapes are now answered. Each is reported as a structured refusal:
+
+```
+raycast: 'origin' must contain numbers within the range of a 64-bit float,
+got [1.0, <int of 16610 bits>, 3.0]
+```
+
+#### Why a container needed a rendering rather than a fallback
+
+The scalar guards were made total by routing every rejected value through
+`_refusal_repr`, which answers `<unrepresentable Foo>` when `repr` fails.
+Applied to a container that is close to useless: it erases every element that
+rendered perfectly well, and the element **count** with them - and the count is
+frequently the refusal's entire reason, as in `must be a 3-element vector, got
+4`. So containers get `_refusal_container_repr`, which describes the container
+component by component and substitutes only the components that cannot print.
+
+Three decisions the change had to settle, recorded because a later reader will
+ask:
+
+- **`repr` is tried on the whole container first.** That is not an optimisation:
+  a `tuple`, a `dict` and a NumPy array have reprs no elementwise form
+  reproduces (`(1.0, 2.0)`, `{'a': 1}`, `array([1., 2.])`), so the fast path is
+  what keeps those containers reported in their own notation - and what makes the
+  change text-identical for every input that answered before.
+- **The offending component is located by position, not by an inserted index.**
+  `finite_vector_error` and `name_list_error` already report a per-element index
+  in their own text (`cameras[1] must be a name`); an index inserted by the
+  renderer as well would state it twice in two forms that could disagree.
+- **Nothing is elided, and the rendering is one level deep.** Truncating would
+  erase elements that rendered fine, which is the exact failure being avoided.
+  Recursing would need cycle detection that the interpreter's own `repr` provides
+  for the fast path, and an inner container is never what the message is about -
+  a nested list is itself the refusal's reason.
+
+A `Mapping` is rendered as a mapping rather than as the list of its keys, because
+`name_list_error` refuses one *for* discarding its values: a message showing only
+the keys would perform the discarding it is complaining about.
+
+#### No verdict and no message text moved
+
+The change is additive. Every input that produced a message before produces a
+byte-identical one now, pinned as equality rather than as a substring across all
+fourteen rendering branches, including the two quoted in the docs. The NumPy
+component types the guards advertise as accepted are still accepted, and the
+`coerce_*` guards still normalise to plain `float`.
+
+#### Two module-wide invariants, both now at their strongest form
+
+- The rendering scan in `tests/test_refusal_messages_never_raise.py` reports every
+  function in `utils.py` that renders a caller value without a shared renderer.
+  Its expected table is now **empty**: no function in the module does.
+- The conversion scan in `tests/test_conversion_escape_is_closed.py` reports every
+  unprotected `float()`. `finite_vector_error` has left it. The three names that
+  remain convert only *after* `finite_vector_error` has accepted every element -
+  so their conversion provably cannot raise - and that upstream guarantee is
+  itself pinned, structurally and behaviourally, rather than hidden behind a `try`
+  whose `except` could never run.
+
+One escape in this family is left open and pinned rather than omitted: a value
+whose `__iter__` raises something other than `TypeError` still escapes
+`finite_vector_error`. It is a third mechanism needing its own message decision,
+and it cannot be expressed in a JSON payload at all, so it is tracked separately
+as #1878.
+
+Closes #1875.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -480,6 +480,77 @@ def _describe_unrenderable(value: Any) -> str:
     return f"<unrepresentable {type(value).__name__}>"
 
 
+def _refusal_container_repr(value: Any) -> str:
+    """``repr(value)`` for a refusal that reports a whole container, elementwise if it must.
+
+    The container counterpart to :func:`_refusal_repr`, and the reason the two
+    cannot be one function. ``repr`` of a list recurses into its elements, so a
+    container is unrenderable whenever any *one* of its elements is, and
+    :func:`_refusal_repr`'s whole-value fallback would answer that with
+    ``<unrepresentable list>`` - erasing every element that rendered perfectly
+    well, and the element count with them. That count is frequently the entire
+    reason for the refusal (``must be a 3-element vector, got 4``), so a
+    container needs a *rendering* rather than a fallback.
+
+    ``repr`` is tried on the whole container first, so a container that can
+    render itself is reported in exactly the text it was before this existed -
+    including a ``tuple``, a ``dict`` and a NumPy array, whose own reprs
+    (``(1.0, 2.0)``, ``{'a': 1}``, ``array([1., 2.])``) no elementwise form
+    reproduces. Only when that raises is the container described component by
+    component, substituting just the components that cannot print::
+
+        [1.0, <int of 16610 bits>, 3.0]
+
+    The offending component is located by its **position**, not by an inserted
+    index, so the fallback keeps the shape of the ``repr`` it stands in for.
+    Every guard that names an index does so in its own text (``{param}[{i}]``),
+    which is unchanged; an index inserted here too would state it twice, in two
+    forms that could disagree.
+
+    Nothing is elided. Truncating would erase elements that rendered fine, which
+    is the exact failure of the whole-value fallback this exists to avoid, and
+    ``repr`` of a long container - the text this stands in for - is not
+    truncated either.
+
+    A :class:`~collections.abc.Mapping` is rendered as a mapping rather than as
+    the list of its keys, because :func:`name_list_error` refuses one *for*
+    discarding its values: a message showing only the keys would perform the
+    discarding it is complaining about.
+
+    The rendering is one level deep. These containers carry scalars by contract -
+    a nested list is itself a refusal reason, reported as ``elements must be
+    numbers`` - so an inner container's contents are never what the message is
+    about, and recursing would additionally have to track what it had already
+    visited to terminate on a self-referential value, which the interpreter's own
+    ``repr`` does for the fast path above and a hand-written walk would not.
+
+    Args:
+        value: The rejected container.
+
+    Returns:
+        Its ``repr``; an elementwise rendering when that raises; or a bracketed
+        description when ``value`` cannot be iterated either, which is
+        :func:`_refusal_repr`'s answer for a value that is not a container at
+        all - every one of these guards accepts ``Any``, so a scalar reaches
+        them too.
+    """
+    try:
+        return repr(value)
+    except Exception:
+        pass
+    if isinstance(value, Mapping):
+        try:
+            items = list(value.items())
+        except Exception:
+            return _describe_unrenderable(value)
+        return "{" + ", ".join(f"{_refusal_repr(key)}: {_refusal_repr(val)}" for key, val in items) + "}"
+    try:
+        elements = list(value)
+    except Exception:
+        return _describe_unrenderable(value)
+    return "[" + ", ".join(_refusal_repr(element) for element in elements) + "]"
+
+
 def _beyond_float_range(value: Any) -> bool:
     """Whether ``float(value)`` overflows, i.e. no float64 stands for ``value``.
 
@@ -1010,28 +1081,30 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
     if isinstance(value, str | bytes):
         shown = value.decode(errors="replace") if isinstance(value, bytes) else value
         return (
-            f"{context}: {param} must be a list of names, not a single string, got {value!r}. "
+            f"{context}: {param} must be a list of names, not a single string, "
+            f"got {_refusal_container_repr(value)}. "
             f"A string is iterable per character, so this would be read as "
             f"{[c for c in shown][:6]}{' ...' if len(shown) > 6 else ''} "
-            f"({len(shown)} name(s)). Wrap it in a list: [{shown!r}]."
+            f"({len(shown)} name(s)). Wrap it in a list: [{_refusal_repr(shown)}]."
         )
     if isinstance(value, Mapping):
         return (
-            f"{context}: {param} must be a list of names, not a mapping, got {value!r}. "
+            f"{context}: {param} must be a list of names, not a mapping, "
+            f"got {_refusal_container_repr(value)}. "
             f"A mapping is iterable over its keys, so its values would be discarded - "
-            f"pass the names as a list: {list(value)!r}."
+            f"pass the names as a list: {_refusal_container_repr(list(value))}."
         )
     if not isinstance(value, Sequence):
         return (
             f"{context}: {param} must be a list of names, got {type(value).__name__} "
-            f"({value!r}). Pass a list or tuple; a one-shot iterator cannot be used "
+            f"({_refusal_container_repr(value)}). Pass a list or tuple; a one-shot iterator cannot be used "
             f"because the value is read more than once."
         )
     for i, entry in enumerate(value):
         if not isinstance(entry, str):
-            return f"{context}: {param}[{i}] must be a name (str), got {type(entry).__name__} ({entry!r})."
+            return f"{context}: {param}[{i}] must be a name (str), got {type(entry).__name__} ({_refusal_repr(entry)})."
         if not entry.strip():
-            return f"{context}: {param}[{i}] must be a non-blank name, got {entry!r}."
+            return f"{context}: {param}[{i}] must be a non-blank name, got {_refusal_repr(entry)}."
     seen: set[str] = set()
     repeated: set[str] = set()
     for entry in value:
@@ -1040,8 +1113,8 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
         seen.add(entry)
     if repeated:
         return (
-            f"{context}: {param} must not repeat a name, got {list(value)!r} "
-            f"({sorted(repeated)!r} appears more than once)."
+            f"{context}: {param} must not repeat a name, got {_refusal_container_repr(list(value))} "
+            f"({_refusal_container_repr(sorted(repeated))} appears more than once)."
         )
     return None
 
@@ -1087,7 +1160,7 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     try:
         iter(vec)
     except TypeError:
-        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {vec!r}"
+        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(vec)}"
     for _elem in vec:
         # ``numbers.Real`` accepts a numpy scalar (``np.float32`` / ``np.int64``
         # are registered) and rejects a string, ``None`` or a nested list.
@@ -1097,12 +1170,30 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
         # here keeps the direct API and the tool surface in step.
         if is_boolean(_elem):
             return (
-                f"{method}: '{param_name}' elements must be numbers, not a bool (got {vec!r}). {BOOLEAN_VECTOR_REASON}"
+                f"{method}: '{param_name}' elements must be numbers, not a bool "
+                f"(got {_refusal_container_repr(vec)}). {BOOLEAN_VECTOR_REASON}"
             )
         if not isinstance(_elem, numbers.Real):
-            return f"{method}: '{param_name}' elements must be numbers, got {vec!r}"
-        if not math.isfinite(float(_elem)):
-            return f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {vec!r}"
+            return f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
+        # An element past the float64 range is a *magnitude* complaint and gets
+        # its own reason, exactly as the scalar guards give one (#1874). The
+        # order matters: ``_beyond_float_range`` answers only ``OverflowError``,
+        # so a registered ``numbers.Real`` with no working ``__float__`` falls
+        # through to the not-a-number text below rather than being mis-reported
+        # as out of range.
+        if _beyond_float_range(_elem):
+            return (
+                f"{method}: '{param_name}' must contain numbers within the range of a 64-bit float, "
+                f"got {_refusal_container_repr(vec)}"
+            )
+        try:
+            numeric = float(_elem)
+        except Exception:
+            return f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
+        if not math.isfinite(numeric):
+            return (
+                f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {_refusal_container_repr(vec)}"
+            )
     return None
 
 
@@ -1128,9 +1219,15 @@ def pose_vector_error(method: str, param_name: str, vec: Any, expected_len: int)
     try:
         length = len(vec)
     except TypeError:
-        return f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, got {vec!r}"
+        return (
+            f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, "
+            f"got {_refusal_container_repr(vec)}"
+        )
     if length != expected_len:
-        return f"{method}: '{param_name}' must be a {expected_len}-element vector, got {length} ({vec!r})"
+        return (
+            f"{method}: '{param_name}' must be a {expected_len}-element vector, "
+            f"got {length} ({_refusal_container_repr(vec)})"
+        )
     return finite_vector_error(method, param_name, vec)
 
 
@@ -1224,7 +1321,7 @@ def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] |
         return None, None
     length = sequence_length(color)
     if length is None:
-        return None, f"{method}: '{param_name}' must be a sequence of numbers, got {color!r}"
+        return None, f"{method}: '{param_name}' must be a sequence of numbers, got {_refusal_container_repr(color)}"
     if (err := finite_vector_error(method, param_name, color)) is not None:
         return None, err
     floats = [float(component) for component in color]
@@ -1303,11 +1400,11 @@ def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[fl
     if length is None:
         # Reachable only for something iterable but unsized - a generator, which
         # the check above has now consumed, so there is nothing left to store.
-        return None, f"{method}: '{param_name}' must be a list/tuple of numbers, got {size!r}"
+        return None, f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(size)}"
     if length == 0:
         return None, (
             f"{method}: '{param_name}' must have at least one component, got an empty "
-            f"vector ({size!r}). An empty '{param_name}' is a component count, not an "
+            f"vector ({_refusal_container_repr(size)}). An empty '{param_name}' is a component count, not an "
             f"omission - omit '{param_name}' to take the default extent."
         )
     return [float(component) for component in size], None

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -1,0 +1,888 @@
+"""A container guard must not raise while rendering the container it refuses (#1875).
+
+``strands_robots.utils``' scalar guards were made total in two passes: #1873 gave
+them a rendering that cannot raise (``_refusal_repr`` / ``_refusal_str``), and
+#1874 gave them a *conversion* that cannot raise. Both passes deliberately
+stopped at the container guards - ``finite_vector_error``, ``pose_vector_error``,
+``coerce_pose_vector``, ``coerce_rgba`` and ``name_list_error`` - and this module
+is the pass that finishes them.
+
+Why a container could not simply reuse the scalar fallback
+----------------------------------------------------------
+``repr`` of a list recurses into its elements, so a container is unrenderable
+whenever any *one* of its elements is. Applying ``_refusal_repr`` to the whole
+container answers that with ``<unrepresentable list>``, which erases:
+
+* every element that rendered perfectly well, and
+* the element **count** - which is frequently the refusal's entire reason, as in
+  ``must be a 3-element vector, got 4``.
+
+So a container needs a *rendering* rather than a fallback:
+``_refusal_container_repr`` describes it component by component and substitutes
+only the components that cannot print, keeping the shape legible::
+
+    raycast: 'origin' must contain finite numbers (no nan/inf), got
+    [1.0, <int of 16610 bits>, 3.0]
+
+That is the difference this module pins, in both directions: the rendering
+survives an element that cannot print, *and* it does not throw away the ones that
+can. :class:`TestTheWholeValueFallbackWouldHaveBeenWrong` states the second half
+as a measurement rather than as a claim in prose.
+
+Two escapes, one boundary
+-------------------------
+The same guards also raised on the *conversion*: ``finite_vector_error`` called
+``float(element)`` unprotected to test finiteness, so an element past
+``sys.float_info.max`` raised ``OverflowError`` before any message was rendered -
+#1874's defect, one level down. Both halves are closed here because both had to
+be: a rendering that survives an unprintable element is no use if the guard
+raises on an outsized one first, and the two arrive in the same value
+(``10**5000`` is both).
+
+Where the module-wide invariants live
+-------------------------------------
+Two scans outside this file assert that no *sixth* guard can reintroduce either
+escape silently, so they are stated over ``utils.py`` as a whole rather than over
+a list of names this file happens to know:
+
+* ``tests/test_refusal_messages_never_raise.py`` -
+  ``TestNoGuardRendersACallerValueDirectly``, whose ``KNOWN_DIRECT_RENDERS`` table
+  is now **empty**: no function in the module renders a caller value without a
+  shared renderer.
+* ``tests/test_conversion_escape_is_closed.py`` -
+  ``TestTheRemainingConversionsRunOnlyOnTheAcceptedPath``, which reports the
+  remaining unprotected conversions exactly.
+
+Reachability
+------------
+These are not hypothetical inputs. ``raycast(origin=...)``,
+``add_object(position=..., size=..., color=...)`` and the recorder / render
+``cameras`` lists all arrive from an agent tool call or a ``device_connect``
+``@rpc()`` payload, where a list of JSON numbers is the normal shape and Python
+integers are arbitrary-precision. The guards are exercised here directly, as
+their siblings' tests are, so the contract is pinned at the one place every
+backend shares rather than once per caller.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import numbers
+import pathlib
+import sys
+from collections.abc import Iterator
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots import utils
+from strands_robots.utils import (
+    _describe_unrenderable,
+    _refusal_container_repr,
+    _refusal_repr,
+    coerce_pose_vector,
+    coerce_rgba,
+    coerce_size_vector,
+    finite_vector_error,
+    name_list_error,
+    pose_vector_error,
+)
+
+# --------------------------------------------------------------------------- #
+# Probes                                                                      #
+# --------------------------------------------------------------------------- #
+#: An ``int`` too wide to render: past :func:`sys.get_int_max_str_digits` (4300
+#: digits by default), so ``repr`` raises ``ValueError`` - and so does ``repr`` of
+#: any list containing it. This is the rendering escape.
+UNRENDERABLE_INT = 10**5000
+
+#: How :func:`_describe_unrenderable` names the value above. ``bit_length``
+#: needs no decimal conversion, so the magnitude survives where the digits cannot.
+UNRENDERABLE_INT_SHOWN = f"<int of {UNRENDERABLE_INT.bit_length()} bits>"
+
+#: Past ``sys.float_info.max`` but *inside* the digit limit, so its own ``repr``
+#: works and it isolates the conversion escape from the rendering one.
+OUTSIZED_INT = 10**400
+
+#: Inside the float64 range, to show a refusal is about magnitude rather than
+#: about being an ``int`` or being large.
+LARGE_BUT_CONVERTIBLE = 10**308
+
+NAN = float("nan")
+INF = float("inf")
+
+
+class Unprintable:
+    """A plain object whose ``repr`` raises.
+
+    ``int`` past the digit limit is the case that actually arrives, but the
+    guarantee is unconditional rather than a list of today's known exceptions, so
+    an arbitrary ``__repr__`` failure is probed as well.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+
+class UnprintableReal:
+    """A registered :class:`numbers.Real` whose ``repr`` raises.
+
+    Registered with ``numbers.Real.register`` rather than subclassed, which is not
+    a shortcut - it is the property under test, and matches the double in
+    ``tests/test_conversion_escape_is_closed.py``. :class:`numbers.Real` is a
+    registration rather than an inheritance, so a component can satisfy a vector
+    guard's ``isinstance`` check while owing it nothing else - including a working
+    ``__repr__``. Subclassing the ABC would have forced two dozen operators this
+    double never uses.
+
+    ``__float__`` answers ``nan``, so the element reaches the guard's *finiteness*
+    branch - the last one a value crosses before acceptance - rather than its type
+    branch, and the message still has to render the container.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+    def __float__(self) -> float:
+        return NAN
+
+
+numbers.Real.register(UnprintableReal)
+
+
+class RealNoFloat:
+    """A registered :class:`numbers.Real` from which no float can be read.
+
+    The conversion's *second* exception class. Unlike an outsized magnitude this
+    is not a range complaint - no number can be read from the value at all - so it
+    must not be told about the float64 range. Its ``repr`` works, which isolates
+    the conversion from the rendering defect.
+    """
+
+    def __repr__(self) -> str:
+        return "RealNoFloat()"
+
+    def __float__(self) -> float:
+        raise TypeError("no float can be read from this")
+
+
+numbers.Real.register(RealNoFloat)
+
+
+class UnprintableContainer(list):  # type: ignore[type-arg]
+    """A list whose own ``repr`` raises although every element renders fine.
+
+    Separates the two reasons a container can fail to render: the container
+    itself, and one of its elements. The elementwise path has to answer both, and
+    for this one it can report every component exactly.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+
+class UniterableContainer:
+    """A value whose ``repr`` fails and which is not iterable.
+
+    The floor of the rendering: with no ``repr`` and no elements to walk, the only
+    honest answer left is the whole-value description, which is what
+    :func:`_refusal_repr` would have given.
+
+    ``__iter__`` raises ``TypeError``, which is what "not iterable" means in
+    Python and what every guard here already routes to a refusal. A ``__iter__``
+    raising something *else* is a third escape mechanism, neither rendering nor
+    conversion, and is out of this change's scope - see
+    :class:`TestTheIterationEscapeStaysOutOfScope`.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+    def __iter__(self) -> Iterator[Any]:
+        raise TypeError("not iterable")
+
+
+class HostileIteration:
+    """A value whose ``repr`` fails and whose ``__iter__`` raises a non-``TypeError``.
+
+    Used only against the renderer, which recovers any ``Exception``. The guards
+    reach their own ``iter()`` before the renderer, so this does not describe what
+    they do with it; :class:`TestTheIterationEscapeStaysOutOfScope` does.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+    def __iter__(self) -> Iterator[Any]:
+        raise RuntimeError("no iteration for you")
+
+
+class UnprintableName(str):
+    """A ``str`` subclass whose ``repr`` raises.
+
+    ``name_list_error`` reaches several of its messages only after an element has
+    passed ``isinstance(entry, str)``, so a raising ``__repr__`` on a genuine
+    ``str`` is the way those branches are reached at all.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+
+class InterruptingRepr:
+    """A value whose ``repr`` raises a :class:`BaseException`.
+
+    ``KeyboardInterrupt`` and ``SystemExit`` are not errors to recover from, and a
+    renderer that swallowed them would make a container guard uninterruptible.
+    """
+
+    def __repr__(self) -> str:
+        raise KeyboardInterrupt
+
+
+# --------------------------------------------------------------------------- #
+# The rendering escape, per guard                                             #
+# --------------------------------------------------------------------------- #
+#: Every container guard, called with a container holding one element that cannot
+#: render. Each returns its message differently - the ``*_error`` guards return a
+#: ``str | None`` and the ``coerce_*`` guards a ``(value, error)`` pair - so the
+#: probe normalises to the message and the table stays one row per guard.
+#:
+#: The value is in the **last** position for all of them, after the two ``str``
+#: labels. Passing it anywhere else is refused for the wrong reason and would
+#: look like evidence about the element; ``test_the_probes_reach_the_element``
+#: below is the control for that.
+UNRENDERABLE_PROBES: tuple[tuple[str, Any], ...] = (
+    ("finite_vector_error", lambda v: finite_vector_error("raycast", "origin", v)),
+    ("pose_vector_error", lambda v: pose_vector_error("add_object", "position", v, 1)),
+    ("coerce_pose_vector", lambda v: coerce_pose_vector("add_camera", "position", v, 1)[1]),
+    ("coerce_rgba", lambda v: coerce_rgba("add_object", "color", v)[1]),
+    ("coerce_size_vector", lambda v: coerce_size_vector("add_object", "size", v)[1]),
+    ("name_list_error", lambda v: name_list_error(v, "cameras", "render_all")),
+)
+
+PROBE_IDS = [name for name, _ in UNRENDERABLE_PROBES]
+PROBE_CALLS = [call for _, call in UNRENDERABLE_PROBES]
+
+#: A container each guard accepts, for the control that the probes above reach the
+#: element. These are not interchangeable: ``coerce_rgba`` refuses any component
+#: count but 3 or 4, and ``name_list_error`` wants names rather than numbers.
+ACCEPTABLE: dict[str, Any] = {
+    "finite_vector_error": [0.5],
+    "pose_vector_error": [0.5],
+    "coerce_pose_vector": [0.5],
+    "coerce_rgba": [0.5, 0.5, 0.5],
+    "coerce_size_vector": [0.5],
+    "name_list_error": ["wrist"],
+}
+
+
+class TestEveryContainerGuardAnswersAnUnrenderableElement:
+    """The defect, closed: a refusal already decided must be returned, not lost.
+
+    Each guard runs only on the path whose entire purpose is to answer an unusable
+    input with a structured ``{"status": "error"}`` message instead of an
+    exception. Raising while building that message fails on exactly the path that
+    exists so it does not, which is why every one of these is asserted to return
+    text rather than merely "not raise".
+    """
+
+    @pytest.mark.parametrize("call", PROBE_CALLS, ids=PROBE_IDS)
+    def test_an_int_past_the_digit_limit_is_answered(self, call: Any) -> None:
+        message = call([UNRENDERABLE_INT])
+        assert message is not None
+        assert UNRENDERABLE_INT_SHOWN in message
+
+    @pytest.mark.parametrize("call", PROBE_CALLS, ids=PROBE_IDS)
+    def test_an_element_with_an_arbitrary_repr_failure_is_answered(self, call: Any) -> None:
+        """The guarantee is unconditional, not a list of the exceptions known today."""
+        message = call([Unprintable()])
+        assert message is not None
+        assert "<unrepresentable Unprintable>" in message
+
+    @pytest.mark.parametrize("call", PROBE_CALLS, ids=PROBE_IDS)
+    def test_a_container_whose_own_repr_fails_is_answered(self, call: Any) -> None:
+        """The container, not an element, is what cannot render here."""
+        message = call(UnprintableContainer([UNRENDERABLE_INT]))
+        assert message is not None
+        assert UNRENDERABLE_INT_SHOWN in message
+
+    @pytest.mark.parametrize("call", PROBE_CALLS, ids=PROBE_IDS)
+    def test_a_value_that_can_neither_render_nor_be_walked_is_answered(self, call: Any) -> None:
+        message = call(UniterableContainer())
+        assert message is not None
+        assert "<unrepresentable UniterableContainer>" in message
+
+    def test_a_numeric_element_reaches_the_finiteness_branch_and_still_renders(self) -> None:
+        """A registered ``numbers.Real`` passes the type test and owes nothing else.
+
+        Without this the unrenderable element would only ever be probed on the
+        *type* branch, and the branch nearest acceptance - the last one a value
+        crosses before the guard returns ``None`` - would go untested.
+        """
+        message = finite_vector_error("raycast", "origin", [UnprintableReal()])
+        assert message is not None
+        assert "must contain finite numbers (no nan/inf)" in message
+        assert "<unrepresentable UnprintableReal>" in message
+
+    def test_an_unrenderable_name_is_answered_on_every_name_list_branch(self) -> None:
+        """``name_list_error`` renders its value on more branches than the others."""
+        blank = name_list_error([UnprintableName("  ")], "cameras", "render_all")
+        assert blank is not None and "must be a non-blank name" in blank
+        assert "<unrepresentable UnprintableName>" in blank
+
+        repeated = name_list_error([UnprintableName("a"), UnprintableName("a")], "cameras", "render_all")
+        assert repeated is not None and "must not repeat a name" in repeated
+        assert "<unrepresentable UnprintableName>" in repeated
+
+        mapping = name_list_error({UNRENDERABLE_INT: "camera"}, "cameras", "render_all")
+        assert mapping is not None and "not a mapping" in mapping
+        assert UNRENDERABLE_INT_SHOWN in mapping
+
+        scalar = name_list_error(UNRENDERABLE_INT, "cameras", "render_all")
+        assert scalar is not None and "must be a list of names" in scalar
+        assert UNRENDERABLE_INT_SHOWN in scalar
+
+    @pytest.mark.parametrize(
+        ("call", "acceptable"),
+        [(call, ACCEPTABLE[name]) for name, call in UNRENDERABLE_PROBES],
+        ids=PROBE_IDS,
+    )
+    def test_the_probes_reach_the_element(self, call: Any, acceptable: Any) -> None:
+        """Control: a well-formed container must be accepted by the same call.
+
+        Every guard here takes the value last, after two ``str`` labels. A probe
+        that passed the container in a label position would be refused for having
+        the wrong type *there*, which reads exactly like a verdict about the
+        element and is not one. So the same probes are run against a container each
+        guard accepts and must answer ``None``, which proves the rows above measure
+        the element rather than the shape of the call.
+
+        The accepted value differs per guard because their domains do -
+        ``coerce_rgba`` needs 3 or 4 components and ``name_list_error`` needs names
+        - and a single shared value would silently be refused for its shape by
+        those two, which is the exact confusion this control exists to rule out.
+        """
+        assert call(acceptable) is None
+
+
+class TestTheConversionEscapeIsClosedToo:
+    """The other half of #1875: an element no float64 can hold.
+
+    ``finite_vector_error`` tested finiteness with a bare ``float(element)``, so an
+    element past ``sys.float_info.max`` raised ``OverflowError`` before any message
+    was rendered. It now asks ``_beyond_float_range`` first and converts inside a
+    ``try``, which is the shape #1874 established for the scalar guards, and the
+    three ``coerce_*`` guards inherit the fix because they reach it through this
+    one.
+    """
+
+    @pytest.mark.parametrize("call", PROBE_CALLS, ids=PROBE_IDS)
+    def test_an_outsized_element_is_answered(self, call: Any) -> None:
+        message = call([OUTSIZED_INT])
+        assert message is not None
+
+    def test_the_reason_given_is_the_magnitude(self) -> None:
+        """Not "not a number": an integer past the float range *is* a number.
+
+        The wording follows the scalar guards' own range text so an agent reading
+        either is told the same thing, and is a vector's plural of it.
+        """
+        message = finite_vector_error("raycast", "origin", [1.0, OUTSIZED_INT, 3.0])
+        assert message is not None
+        assert "must contain numbers within the range of a 64-bit float" in message
+        assert f"[1.0, {OUTSIZED_INT}, 3.0]" in message
+
+    def test_an_element_no_number_can_be_read_from_keeps_the_not_a_number_reason(self) -> None:
+        """The two exception classes are two honest reasons, not one.
+
+        ``_beyond_float_range`` answers ``OverflowError`` only, so a registered
+        ``numbers.Real`` whose ``__float__`` does not work falls through to the
+        pre-existing not-a-number text rather than being mis-reported as a range
+        complaint about a magnitude nobody could read.
+        """
+        message = finite_vector_error("raycast", "origin", [RealNoFloat()])
+        assert message is not None
+        assert "elements must be numbers" in message
+        assert "range of a 64-bit float" not in message
+
+    def test_the_boundary_is_where_the_float_range_is(self) -> None:
+        """A control matrix: the refusal is about magnitude, and only about that."""
+        assert finite_vector_error("raycast", "origin", [sys.float_info.max]) is None
+        assert finite_vector_error("raycast", "origin", [LARGE_BUT_CONVERTIBLE]) is None
+        assert finite_vector_error("raycast", "origin", [-OUTSIZED_INT]) is not None
+
+    def test_the_two_escapes_compose_in_one_value(self) -> None:
+        """``10**5000`` is both outsized *and* unrenderable, and arrives as one value.
+
+        Neither fix is any use without the other here: the conversion has to be
+        recovered for a message to be reached at all, and the rendering has to be
+        elementwise for that message to be buildable.
+        """
+        message = finite_vector_error("raycast", "origin", [1.0, UNRENDERABLE_INT, 3.0])
+        assert message is not None
+        assert "must contain numbers within the range of a 64-bit float" in message
+        assert f"[1.0, {UNRENDERABLE_INT_SHOWN}, 3.0]" in message
+
+
+# --------------------------------------------------------------------------- #
+# The renderer's own contract                                                 #
+# --------------------------------------------------------------------------- #
+class TestTheElementwiseRenderer:
+    """``_refusal_container_repr``: ``repr`` where it works, elementwise where it cannot."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            [1.0, 2.0, 3.0],
+            (1.0, 2.0),
+            [],
+            ["a", None, {"k": 1}],
+            {"a": 1},
+            np.array([1.0, 2.0]),
+            0.5,
+            "wrist",
+            None,
+        ],
+        ids=["list", "tuple", "empty", "mixed", "dict", "ndarray", "scalar", "str", "none"],
+    )
+    def test_a_value_that_can_render_is_reported_exactly_as_repr(self, value: Any) -> None:
+        """The fast path, and the reason no existing message text moved.
+
+        A ``tuple``, a ``dict`` and a NumPy array all have reprs no elementwise
+        form reproduces (``(1.0, 2.0)``, ``{'a': 1}``, ``array([1., 2.])``), so
+        trying the whole container first is not merely an optimisation - it is what
+        keeps those containers reported in their own notation.
+        """
+        assert _refusal_container_repr(value) == repr(value)
+
+    def test_only_the_components_that_cannot_print_are_substituted(self) -> None:
+        assert _refusal_container_repr([1.0, UNRENDERABLE_INT, 3.0]) == f"[1.0, {UNRENDERABLE_INT_SHOWN}, 3.0]"
+
+    def test_the_offending_component_is_located_by_position_not_by_an_index(self) -> None:
+        """A decision #1875 asked to be settled, so it is stated rather than implied.
+
+        ``finite_vector_error`` and ``name_list_error`` already report a per-element
+        index in their own text (``cameras[0] must be a name``). An index inserted
+        by the renderer as well would state it twice in two forms that could
+        disagree, and would not match the ``repr`` this stands in for. Position
+        alone locates the component, so position is what is used.
+        """
+        rendered = _refusal_container_repr([1.0, UNRENDERABLE_INT])
+        assert rendered == f"[1.0, {UNRENDERABLE_INT_SHOWN}]"
+        assert "[0]" not in rendered and "[1]" not in rendered
+
+        # The guards that *do* name an index still do, unchanged.
+        message = name_list_error(["ok", UNRENDERABLE_INT], "cameras", "render_all")
+        assert message is not None and "cameras[1]" in message
+
+    def test_nothing_is_elided(self) -> None:
+        """Truncating would repeat the failure this renderer exists to avoid.
+
+        A cap would erase elements that rendered fine - exactly what
+        ``<unrepresentable list>`` does - and ``repr`` of a long container, the
+        text this stands in for, is not truncated either.
+        """
+        values: list[Any] = [float(i) for i in range(50)]
+        values[25] = UNRENDERABLE_INT
+        rendered = _refusal_container_repr(values)
+        assert rendered.count(",") == 49
+        assert rendered.startswith("[0.0, 1.0,") and rendered.endswith("49.0]")
+        assert UNRENDERABLE_INT_SHOWN in rendered
+        assert "..." not in rendered
+
+    def test_the_element_count_survives(self) -> None:
+        """The count is often the refusal's whole reason, so it may not be lost."""
+        message = pose_vector_error("add_object", "position", [1.0, UNRENDERABLE_INT], 3)
+        assert message is not None
+        assert "must be a 3-element vector, got 2" in message
+        assert _refusal_container_repr([UNRENDERABLE_INT] * 4).count(UNRENDERABLE_INT_SHOWN) == 4
+
+    def test_a_mapping_is_rendered_as_a_mapping(self) -> None:
+        """``name_list_error`` refuses a mapping *for* discarding its values.
+
+        Rendering it as the list of its keys would perform, in the message, the
+        very discarding the message is complaining about.
+        """
+        rendered = _refusal_container_repr({UNRENDERABLE_INT: "camera"})
+        assert rendered == f"{{{UNRENDERABLE_INT_SHOWN}: 'camera'}}"
+
+    def test_an_unrenderable_value_inside_a_mapping_is_substituted_too(self) -> None:
+        assert _refusal_container_repr({"k": Unprintable()}) == "{'k': <unrepresentable Unprintable>}"
+
+    def test_a_container_whose_own_repr_fails_still_reports_every_element(self) -> None:
+        assert _refusal_container_repr(UnprintableContainer([1.0, 2.0])) == "[1.0, 2.0]"
+
+    def test_a_value_that_cannot_be_walked_falls_back_to_the_whole_value_description(self) -> None:
+        """With no repr and no elements, the scalar answer is the only honest one."""
+        value = UniterableContainer()
+        assert _refusal_container_repr(value) == _describe_unrenderable(value)
+        assert _refusal_container_repr(value) == "<unrepresentable UniterableContainer>"
+
+    def test_an_arbitrary_iteration_failure_is_recovered_too(self) -> None:
+        """``TypeError`` is what "not iterable" means, but the renderer promises more.
+
+        It runs on a path that must not raise, so it recovers any ``Exception`` from
+        the walk rather than only the one a well-behaved type would raise.
+        """
+        assert _refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"
+
+    def test_a_mapping_whose_items_cannot_be_walked_is_described(self) -> None:
+        class HostileMapping(dict):  # type: ignore[type-arg]
+            def __repr__(self) -> str:
+                raise RuntimeError("no repr for you")
+
+            def items(self) -> Any:
+                raise RuntimeError("no items for you")
+
+        assert _refusal_container_repr(HostileMapping()) == "<unrepresentable HostileMapping>"
+
+    def test_a_non_container_is_answered_as_the_scalar_renderer_would(self) -> None:
+        """Every one of these guards accepts ``Any``, so a scalar reaches them."""
+        assert _refusal_container_repr(UNRENDERABLE_INT) == _refusal_repr(UNRENDERABLE_INT)
+        assert _refusal_container_repr(UNRENDERABLE_INT) == UNRENDERABLE_INT_SHOWN
+
+    def test_the_rendering_is_one_level_deep(self) -> None:
+        """A nested container is described, not recursed into, and that is deliberate.
+
+        These vectors carry *scalars* by contract - a nested list is itself the
+        refusal's reason, reported as ``elements must be numbers`` - so the inner
+        container's contents are never what the message is about, and one level is
+        exactly the depth the guards need.
+
+        Recursing would also have to detect cycles: ``a = []; a.append(a)`` is
+        renderable only because the interpreter's own ``repr`` tracks what it has
+        already visited, and a hand-written recursion without that would not
+        terminate. The whole-value description is the right answer for an inner
+        element, because at that point the element *is* the value.
+        """
+        assert _refusal_container_repr([[UNRENDERABLE_INT], 2.0]) == "[<unrepresentable list>, 2.0]"
+        assert finite_vector_error("m", "p", [[UNRENDERABLE_INT], 2.0]) == (
+            "m: 'p' elements must be numbers, got [<unrepresentable list>, 2.0]"
+        )
+
+    def test_a_self_referential_container_is_still_rendered(self) -> None:
+        """The fast path handles it, which is the other reason not to recurse."""
+        cyclic: list[Any] = []
+        cyclic.append(cyclic)
+        assert _refusal_container_repr(cyclic) == "[[...]]"
+
+    def test_it_does_not_swallow_a_base_exception(self) -> None:
+        """``KeyboardInterrupt`` is not an error to recover from."""
+        with pytest.raises(KeyboardInterrupt):
+            _refusal_container_repr([InterruptingRepr()])
+        with pytest.raises(KeyboardInterrupt):
+            _refusal_container_repr({"k": InterruptingRepr()})
+
+
+class TestTheWholeValueFallbackWouldHaveBeenWrong:
+    """Why this is a new renderer and not a call to the existing one (#1875).
+
+    Stated as a measurement rather than as a claim in the docstrings: the scalar
+    renderer is applied to the same containers and shown to erase what the
+    elementwise one keeps. Without this, "a fallback would not do" is an assertion
+    no test would notice becoming false.
+    """
+
+    def test_the_scalar_renderer_erases_the_elements_that_print(self) -> None:
+        container = [1.0, UNRENDERABLE_INT, 3.0]
+        assert _refusal_repr(container) == "<unrepresentable list>"
+        assert "1.0" not in _refusal_repr(container)
+        assert "1.0" in _refusal_container_repr(container)
+
+    def test_the_scalar_renderer_erases_the_element_count(self) -> None:
+        """And the count is frequently the entire reason for the refusal."""
+        assert _refusal_repr([UNRENDERABLE_INT] * 4) == _refusal_repr([UNRENDERABLE_INT])
+        assert _refusal_container_repr([UNRENDERABLE_INT] * 4) != _refusal_container_repr([UNRENDERABLE_INT])
+
+    def test_no_guard_message_shows_the_whole_value_form_for_a_container(self) -> None:
+        """The negative form, over every guard: none of them took the shortcut."""
+        for name, call in UNRENDERABLE_PROBES:
+            message = call([1.0, UNRENDERABLE_INT])
+            assert message is not None, name
+            assert "<unrepresentable list>" not in message, name
+
+
+# --------------------------------------------------------------------------- #
+# No verdict and no existing text moved                                       #
+# --------------------------------------------------------------------------- #
+#: Every branch of every container guard that renders a value, called with an
+#: input that renders perfectly well, paired with the exact message it produced
+#: before this change. Asserted as equality rather than as a substring: routing a
+#: message through a renderer is only safe if the text is identical, and a
+#: substring check would not notice a widened or reordered sentence.
+UNCHANGED_TEXT: tuple[tuple[str, Any, str], ...] = (
+    (
+        "finite_vector_error/not-iterable",
+        lambda: finite_vector_error("m", "size", 0.5),
+        "m: 'size' must be a list/tuple of numbers, got 0.5",
+    ),
+    (
+        "finite_vector_error/not-a-number",
+        lambda: finite_vector_error("m", "size", ["a", "b"]),
+        "m: 'size' elements must be numbers, got ['a', 'b']",
+    ),
+    (
+        "finite_vector_error/nan",
+        lambda: finite_vector_error("m", "size", [NAN, 1.0]),
+        "m: 'size' must contain finite numbers (no nan/inf), got [nan, 1.0]",
+    ),
+    (
+        "finite_vector_error/inf",
+        lambda: finite_vector_error("m", "size", [INF]),
+        "m: 'size' must contain finite numbers (no nan/inf), got [inf]",
+    ),
+    (
+        "finite_vector_error/tuple",
+        lambda: finite_vector_error("m", "size", ("a",)),
+        "m: 'size' elements must be numbers, got ('a',)",
+    ),
+    (
+        "pose_vector_error/unsized",
+        lambda: pose_vector_error("add_object", "position", 0.5, 3),
+        "add_object: 'position' must be a list/tuple of 3 numbers, got 0.5",
+    ),
+    (
+        "pose_vector_error/wrong-length",
+        lambda: pose_vector_error("add_object", "position", [0.4, 0.9], 3),
+        "add_object: 'position' must be a 3-element vector, got 2 ([0.4, 0.9])",
+    ),
+    (
+        "coerce_rgba/unsized",
+        lambda: coerce_rgba("add_object", "color", 5)[1],
+        "add_object: 'color' must be a sequence of numbers, got 5",
+    ),
+    (
+        "coerce_size_vector/empty",
+        lambda: coerce_size_vector("add_object", "size", [])[1],
+        "add_object: 'size' must have at least one component, got an empty vector ([]). "
+        "An empty 'size' is a component count, not an omission - omit 'size' to take the default extent.",
+    ),
+    (
+        "name_list_error/bare-string",
+        lambda: name_list_error("wrist", "image_keys", "Surface"),
+        "Surface: image_keys must be a list of names, not a single string, got 'wrist'. "
+        "A string is iterable per character, so this would be read as "
+        "['w', 'r', 'i', 's', 't'] (5 name(s)). Wrap it in a list: ['wrist'].",
+    ),
+    (
+        "name_list_error/mapping",
+        lambda: name_list_error({"a": 1}, "image_keys", "Surface"),
+        "Surface: image_keys must be a list of names, not a mapping, got {'a': 1}. "
+        "A mapping is iterable over its keys, so its values would be discarded - "
+        "pass the names as a list: ['a'].",
+    ),
+    (
+        "name_list_error/not-a-name",
+        lambda: name_list_error(["a", 1], "image_keys", "Surface"),
+        "Surface: image_keys[1] must be a name (str), got int (1).",
+    ),
+    (
+        "name_list_error/blank",
+        lambda: name_list_error(["a", " "], "image_keys", "Surface"),
+        "Surface: image_keys[1] must be a non-blank name, got ' '.",
+    ),
+    (
+        "name_list_error/repeated",
+        lambda: name_list_error(["a", "a"], "image_keys", "Surface"),
+        "Surface: image_keys must not repeat a name, got ['a', 'a'] (['a'] appears more than once).",
+    ),
+)
+
+
+class TestNoExistingVerdictOrMessageMoved:
+    """The change is additive: inputs that answered before answer identically.
+
+    Every message these guards produce is agent-visible, several are asserted
+    verbatim by other suites, and two are quoted in the docs. So the text is
+    pinned here as equality rather than left to those callers to discover.
+    """
+
+    @pytest.mark.parametrize(
+        ("call", "expected"),
+        [(call, expected) for _, call, expected in UNCHANGED_TEXT],
+        ids=[name for name, _, _ in UNCHANGED_TEXT],
+    )
+    def test_the_message_is_unchanged(self, call: Any, expected: str) -> None:
+        assert call() == expected
+
+    def test_the_bool_component_reason_is_unchanged(self) -> None:
+        """Kept out of the table above because it quotes a module constant."""
+        message = finite_vector_error("m", "size", [True, 1.0])
+        assert message == (
+            "m: 'size' elements must be numbers, not a bool (got [True, 1.0]). " + utils.BOOLEAN_VECTOR_REASON
+        )
+
+    def test_the_component_count_refusal_still_shows_the_coerced_floats(self) -> None:
+        """``coerce_rgba`` renders its *converted* list, which cannot fail to print."""
+        assert coerce_rgba("add_object", "color", [0.5, 0.5])[1] == (
+            "add_object: 'color' must have exactly 3 or 4 component(s) (RGB, or RGBA with alpha), "
+            "got 2: [0.5, 0.5]. Pass every component - a partial 'color' cannot be applied "
+            "without inventing the missing values."
+        )
+
+    @pytest.mark.parametrize(
+        ("call", "accepted"),
+        [
+            (lambda v: finite_vector_error("m", "p", v), [0.0, 1.0, 2.0]),
+            (lambda v: pose_vector_error("m", "p", v, 3), [0.0, 1.0, 2.0]),
+            (lambda v: coerce_pose_vector("m", "p", v, 3)[1], [0.0, 1.0, 2.0]),
+            (lambda v: coerce_rgba("m", "p", v)[1], [0.5, 0.5, 0.5]),
+            (lambda v: coerce_size_vector("m", "p", v)[1], [0.1, 0.2, 0.3]),
+            (lambda v: name_list_error(v, "p", "m"), ["wrist", "top"]),
+        ],
+        ids=PROBE_IDS,
+    )
+    def test_an_acceptable_value_is_still_accepted(self, call: Any, accepted: Any) -> None:
+        """The other direction: nothing was refused that used to pass."""
+        assert call(accepted) is None
+
+    def test_the_numpy_component_types_are_still_accepted(self) -> None:
+        """A documented acceptance that a stricter conversion could have broken."""
+        assert finite_vector_error("m", "p", np.array([0.0, 1.0])) is None
+        assert finite_vector_error("m", "p", [np.float32(1.5), np.int64(2)]) is None
+        assert coerce_pose_vector("m", "p", np.array([0.0, 1.0, 2.0]), 3)[0] == [0.0, 1.0, 2.0]
+
+    def test_the_coerced_output_is_still_plain_floats(self) -> None:
+        """Normalisation is the reason three of these guards exist at all."""
+        floats, error = coerce_pose_vector("m", "p", np.array([0.0, 1.0, 2.0]), 3)
+        assert error is None and floats is not None
+        assert all(type(component) is float for component in floats)
+
+
+# --------------------------------------------------------------------------- #
+# The invariant, not the four call sites                                      #
+# --------------------------------------------------------------------------- #
+class TestEveryContainerGuardRoutesThroughTheRenderer:
+    """A structural scan, so a new branch cannot skip the renderer silently.
+
+    The behavioural tests above cover the branches that exist today. A branch
+    added tomorrow would not be in them, so the guards' source is scanned as well:
+    a container guard may not interpolate a bare parameter name into a message.
+
+    The module-wide form of this - over *every* function in ``utils.py``, not only
+    these five - is ``TestNoGuardRendersACallerValueDirectly`` in
+    ``tests/test_refusal_messages_never_raise.py``, whose table is now empty.
+    """
+
+    #: The guards this module owns. ``coerce_pose_vector`` renders nothing itself
+    #: (every message it returns comes from ``pose_vector_error``), so it is
+    #: absent here and covered by the behavioural rows instead.
+    RENDERING_GUARDS = (
+        "coerce_rgba",
+        "coerce_size_vector",
+        "finite_vector_error",
+        "name_list_error",
+        "pose_vector_error",
+    )
+
+    @staticmethod
+    def _function(name: str) -> ast.FunctionDef:
+        source = pathlib.Path(inspect.getfile(utils)).read_text(encoding="utf-8")
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+        raise AssertionError(f"{name} not found in utils.py")
+
+    @pytest.mark.parametrize("name", RENDERING_GUARDS)
+    def test_the_guard_calls_the_elementwise_renderer(self, name: str) -> None:
+        called = {
+            node.func.id
+            for node in ast.walk(self._function(name))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "_refusal_container_repr" in called
+
+    @pytest.mark.parametrize("name", RENDERING_GUARDS)
+    def test_the_guard_renders_no_parameter_directly(self, name: str) -> None:
+        fn = self._function(name)
+        args = fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs
+        carries_value = {a.arg for a in args if a.annotation is not None and ast.unparse(a.annotation) == "Any"}
+        direct = {
+            node.value.id
+            for node in ast.walk(fn)
+            if isinstance(node, ast.FormattedValue)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in carries_value
+        }
+        assert direct == set(), f"{name} renders {sorted(direct)} without the shared renderer"
+
+    def test_the_scan_reports_a_planted_direct_render(self) -> None:
+        """Without this, a scanner that matched nothing would pass just as well."""
+        planted = ast.parse(
+            "def planted(vec: Any, method: str) -> str:\n    return f'{method}: bad, got {vec!r}'\n",
+        )
+        fn = next(n for n in ast.walk(planted) if isinstance(n, ast.FunctionDef))
+        args = fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs
+        carries_value = {a.arg for a in args if a.annotation is not None and ast.unparse(a.annotation) == "Any"}
+        direct = {
+            node.value.id
+            for node in ast.walk(fn)
+            if isinstance(node, ast.FormattedValue)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in carries_value
+        }
+        assert direct == {"vec"}
+        assert "method" not in direct, "a str label is not a caller value and must not be reported"
+
+    def test_the_digit_limit_this_module_relies_on_is_below_its_probe(self) -> None:
+        """The probes are only unrenderable while the interpreter limit holds.
+
+        ``sys.set_int_max_str_digits`` is settable, so a future default - or
+        another test - could lift it past this module's probe and quietly turn
+        every rendering assertion above into a test of nothing.
+        """
+        assert sys.get_int_max_str_digits() < UNRENDERABLE_INT.bit_length() * math.log10(2)
+        with pytest.raises(ValueError):
+            repr(UNRENDERABLE_INT)
+
+
+# --------------------------------------------------------------------------- #
+# The boundary of this change, stated rather than omitted                      #
+# --------------------------------------------------------------------------- #
+class TestTheIterationEscapeStaysOutOfScope:
+    """A pin of behaviour left unchanged, so the boundary is stated (#1878).
+
+    Replace this when the surface it describes is settled rather than deleting it,
+    per the premise-test guidance in ``AGENTS.md``.
+
+    ``finite_vector_error`` asks ``iter(vec)`` inside ``except TypeError`` - which
+    is the exception "not iterable" means, and the only one a well-behaved type
+    raises. A ``__iter__`` that raises anything else escapes the guard, before
+    either the conversion or the rendering this change fixed is reached. That is a
+    **third** mechanism, and closing it here would be a different change:
+
+    * It needs its own message decision. A value whose iteration failed is not
+      "not a list/tuple of numbers" - the guard cannot tell whether it was one -
+      so reusing that text would state something unmeasured.
+    * Its reachability is weaker than #1874's and #1875's by a wide margin. Those
+      arrive as a JSON number through a ``device_connect`` ``@rpc()`` payload,
+      where an arbitrary-precision integer is one request away. A type whose
+      ``__iter__`` raises ``RuntimeError`` cannot be expressed in JSON at all and
+      has to be hand-written by a direct API caller.
+
+    So it is recorded and pinned rather than folded in, which keeps this change one
+    concern and keeps the remaining escape a measurement instead of a remark.
+    """
+
+    def test_a_hostile_iteration_still_escapes_the_vector_guard(self) -> None:
+        with pytest.raises(RuntimeError):
+            finite_vector_error("raycast", "origin", HostileIteration())
+
+    def test_the_other_guards_answer_it_because_they_ask_for_a_length_first(self) -> None:
+        """Only one guard is exposed, which is what makes the boundary small.
+
+        ``pose_vector_error`` takes ``len()`` before iterating and
+        ``name_list_error`` tests ``isinstance(value, Sequence)``, so both refuse
+        this value on its shape and never reach an iteration. Stated here so the
+        pin above is known to cover one guard rather than assumed to.
+        """
+        assert pose_vector_error("add_object", "position", HostileIteration(), 3) is not None
+        assert name_list_error(HostileIteration(), "cameras", "render_all") is not None
+
+    def test_the_rendering_half_is_closed_even_there(self) -> None:
+        """The renderer itself is total, so it is not what leaves the escape open."""
+        assert _refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -156,17 +156,17 @@ numbers.Real.register(UnprintableReal)
 class RealNoFloat:
     """A registered :class:`numbers.Real` from which no float can be read.
 
-    The conversion's *second* exception class. Unlike an outsized magnitude this
-    is not a range complaint - no number can be read from the value at all - so it
-    must not be told about the float64 range. Its ``repr`` works, which isolates
-    the conversion from the rendering defect.
+    Registered with ``numbers.Real.register`` rather than subclassed, so a value
+    can satisfy a guard's ``isinstance`` check while owing it nothing else.
+    With no ``__float__`` at all, ``float()`` raises ``TypeError`` of its own
+    accord. That is the conversion's second exception class: unlike an outsized
+    magnitude it is not a range complaint - no number can be read from this value,
+    so it must not be told about the float64 range. Its ``repr`` works, which
+    isolates the conversion from the rendering defect.
     """
 
     def __repr__(self) -> str:
         return "RealNoFloat()"
-
-    def __float__(self) -> float:
-        raise TypeError("no float can be read from this")
 
 
 numbers.Real.register(RealNoFloat)

--- a/tests/test_conversion_escape_is_closed.py
+++ b/tests/test_conversion_escape_is_closed.py
@@ -595,37 +595,48 @@ class TestNoConvertingGuardConvertsUnprotected:
         assert _unguarded_float_calls(planted) == []
 
 
-class TestTheModuleHasExactlyOneRemainingConversionSurface:
-    """The scan run over the whole module, not over a list of four names.
+class TestTheRemainingConversionsRunOnlyOnTheAcceptedPath:
+    """The scan run over the whole module, not over a list of names.
 
-    A test parametrised on ``CONVERTING`` cannot fail for a guard nobody thought
-    to add to it, so the useful assertion is the complement: which functions in
-    :mod:`strands_robots.utils` still convert unprotected. The set is asserted
-    exactly, which is what makes the remaining entries a stated boundary rather
-    than an omission, and what makes a fifth converting scalar guard fail here.
+    Replaces ``TestTheModuleHasExactlyOneRemainingConversionSurface`` rather than
+    deleting it: the boundary that class drew is still the useful statement and
+    has simply moved. It reported the four **container** guards as the remaining
+    unprotected conversions and pinned them raising, tracked as #1875. #1875 is
+    now closed, and ``finite_vector_error`` - the one of the four that converts a
+    value it has not yet accepted - has left the set, because it asks
+    :func:`_beyond_float_range` first and then converts inside a ``try``, exactly
+    as the scalar guards do.
 
-    The answer is the four **container** guards, and they are #1875. That issue
-    describes the *rendering* defect - ``repr`` of a list recursing into an
-    element that cannot render itself - and this scan shows the containers carry
-    the conversion escape as well, uniformly: all four raise ``OverflowError`` on
-    an element past the float64 range.
+    Three names remain, and they are a different statement from the one this
+    class used to make. ``coerce_pose_vector``, ``coerce_rgba`` and
+    ``coerce_size_vector`` convert only **after** ``finite_vector_error`` has
+    accepted every element - which is to say after that guard has already
+    converted each one successfully - so their ``float()`` provably cannot raise.
+    That is a real guarantee, but it is an upstream one rather than a local
+    ``try``, so the lexical scan cannot see it and reports them.
 
-    So both halves of the sweep stop at the same boundary for the same reason: an
-    elementwise message format has to be decided before either can be closed
-    there, since a whole-container fallback erases the element count that is
-    often the refusal's entire reason. Recorded on #1875.
+    Wrapping those three in a ``try`` to empty the scan would be worse: the
+    ``except`` clause could never run, so it would be untestable dead code
+    asserting a danger that does not exist. Stating the invariant and pinning it -
+    structurally, that the validating call precedes the conversion, and
+    behaviourally, that all four guards now answer an outsized element - is the
+    honest form.
     """
 
     #: Not names this change chose to skip - this is the scan's output, asserted
     #: so it can neither grow nor be quietly narrowed.
     EXPECTED_REMAINING = frozenset(
         {
-            "finite_vector_error",
             "coerce_pose_vector",
             "coerce_rgba",
             "coerce_size_vector",
         }
     )
+
+    #: The guard whose acceptance makes the three conversions above safe. Two
+    #: spellings, because ``coerce_pose_vector`` reaches it through the
+    #: fixed-length wrapper.
+    VALIDATORS = frozenset({"finite_vector_error", "pose_vector_error"})
 
     @staticmethod
     def _converting_unprotected() -> set[str]:
@@ -636,12 +647,41 @@ class TestTheModuleHasExactlyOneRemainingConversionSurface:
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _unguarded_float_calls_in(node)
         }
 
-    def test_the_remaining_surface_is_exactly_the_container_guards(self) -> None:
+    def test_the_remaining_surface_is_exactly_the_post_validation_conversions(self) -> None:
         assert self._converting_unprotected() == set(self.EXPECTED_REMAINING)
 
     def test_no_scalar_guard_is_among_them(self) -> None:
-        """This change's claim, stated over the module rather than over a list."""
+        """#1874's claim, stated over the module rather than over a list."""
         assert self._converting_unprotected().isdisjoint({guard.name for guard in CONVERTING})
+
+    def test_the_vector_guard_no_longer_converts_unprotected(self) -> None:
+        """#1875's half of the claim: the one guard that converts a *new* value."""
+        assert "finite_vector_error" not in self._converting_unprotected()
+
+    @pytest.mark.parametrize("name", sorted(EXPECTED_REMAINING))
+    def test_each_remaining_conversion_is_preceded_by_the_validating_call(self, name: str) -> None:
+        """The structural half of the invariant the docstring above claims.
+
+        A conversion that is safe *because* something upstream already made it
+        safe is only safe while that call is still there, and still first. So the
+        validating call is asserted to appear in the function, and to appear on an
+        earlier line than any conversion the scan flagged. Reordering the two, or
+        dropping the guard, fails here rather than at a caller.
+        """
+        fn = ast.parse(inspect.getsource(getattr(utils, name)).lstrip())
+        validated = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in self.VALIDATORS
+        ]
+        converted = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "float"
+        ]
+        assert validated, f"{name} converts without calling any of {sorted(self.VALIDATORS)}"
+        assert converted, f"{name} was flagged as converting but no float() call was found"
+        assert min(validated) < min(converted), f"{name} converts before it validates"
 
     #: Each container guard called with an outsized element, through the public
     #: entry point a caller actually reaches: ``coerce_pose_vector`` is reached
@@ -659,16 +699,17 @@ class TestTheModuleHasExactlyOneRemainingConversionSurface:
         [probe for _, probe in CONTAINER_PROBES],
         ids=[name for name, _ in CONTAINER_PROBES],
     )
-    def test_every_container_guard_still_raises_on_an_outsized_element(self, call: Callable[[], Any]) -> None:
-        """Pinned so #1875's widened scope is a measurement, not a remark.
+    def test_every_container_guard_now_answers_an_outsized_element(self, call: Callable[[], Any]) -> None:
+        """The inverse of the row this replaces, which pinned all four raising.
 
-        The escape is uniform across the four: every one of them raises
-        ``OverflowError``, so a fix there can treat them as one class. Replace
-        this when #1875 is settled rather than deleting it, per the premise-test
-        guidance in ``AGENTS.md``.
+        Behaviour is what the invariant is ultimately about, so it is asserted
+        directly rather than inferred from the scan: whether a guard's conversion
+        is protected locally or upstream, no caller may see an ``OverflowError``.
         """
-        with pytest.raises(OverflowError):
-            call()
+        result = call()
+        message = result if isinstance(result, str) else result[1]
+        assert message is not None
+        assert "within the range of a 64-bit float" in message
 
     def test_the_probes_reach_the_conversion_rather_than_a_label_check(self) -> None:
         """Control: each probe must fail *on its element*, not on its own shape.

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -70,9 +70,11 @@ untouched. They were #1874 and are now closed, so what was a pin of deliberate
 scope has become :class:`TestTheConversionEscapeIsClosed`: the class is replaced
 rather than deleted, because the boundary it drew is still the useful statement
 and simply moved. The
-container guards have the same rendering defect but need a rendering rather than
-a fallback, since ``<unrepresentable list>`` erases the elements that print fine;
-they are #1875, pinned by :class:`TestTheContainerGuardsStayOutOfScope`.
+container guards had the same rendering defect but needed a rendering rather than
+a fallback, since ``<unrepresentable list>`` erases the elements that print fine.
+That was #1875 and is now closed too, so the scope pin here is likewise replaced
+by its inverse, :class:`TestTheContainerGuardsAnswerAnUnrenderableElement`; the
+rendering itself lives in ``tests/test_container_refusals_render_elementwise.py``.
 
 :class:`TestNoGuardRendersACallerValueDirectly` is what makes this the last pass
 over the question rather than a first. It keys on the parameter annotated
@@ -636,29 +638,40 @@ class TestTheConversionEscapeIsClosed:
             assert isinstance(guard.call(BEYOND_FLOAT_RANGE), str) or guard.call(BEYOND_FLOAT_RANGE) is None
 
 
-class TestTheContainerGuardsStayOutOfScope:
-    """Pins of behaviour left unchanged, so the boundary is stated not omitted (#1875).
+class TestTheContainerGuardsAnswerAnUnrenderableElement:
+    """The inverse of the scope pin this class replaces (#1875).
 
-    Replace these when the surfaces they describe are settled rather than deleting
-    them.
+    ``repr`` of a container recurses into its elements, so a container was
+    unrenderable whenever any one element was, and these guards raised out of a
+    refusal they had already decided. They now answer, through
+    ``_refusal_container_repr``: the container is rendered elementwise and only
+    the components that cannot print are substituted, so the shape and the
+    element count - often the refusal's entire reason - survive.
 
-    The vector and list guards render the whole container, so ``repr``'s recursion
-    into one unrenderable element takes down a refusal already decided. The fix is
-    not this change's fallback: ``<unrepresentable list>`` erases every element
-    that rendered fine and the element count with them, and the count is often the
-    refusal's whole reason. That needs an elementwise rendering and a message
-    format decision on each surface.
+    Kept here, in the class the scope pin occupied, so the boundary this module
+    drew is visibly *moved* rather than dropped. The rendering's own contract is
+    pinned in ``tests/test_container_refusals_render_elementwise.py``.
     """
 
-    def test_a_vector_with_an_unrenderable_element_still_raises(self) -> None:
-        with pytest.raises(OverflowError):
-            finite_vector_error("raycast", "origin", [BEYOND_INT_STR_LIMIT])
-        with pytest.raises(ValueError):
-            pose_vector_error("add_object", "position", [BEYOND_INT_STR_LIMIT], 3)
+    def test_a_vector_with_an_unrenderable_element_answers(self) -> None:
+        for message in (
+            finite_vector_error("raycast", "origin", [BEYOND_INT_STR_LIMIT]),
+            pose_vector_error("add_object", "position", [BEYOND_INT_STR_LIMIT], 3),
+        ):
+            assert message is not None
+            assert f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>" in message
 
-    def test_a_name_list_with_an_unrenderable_entry_still_raises(self) -> None:
-        with pytest.raises(ValueError):
-            name_list_error([BEYOND_INT_STR_LIMIT], "cameras", "render_all")
+    def test_a_name_list_with_an_unrenderable_entry_answers(self) -> None:
+        message = name_list_error([BEYOND_INT_STR_LIMIT], "cameras", "render_all")
+        assert message is not None
+        assert f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>" in message
+
+    def test_the_elements_that_render_are_not_erased_with_the_one_that_cannot(self) -> None:
+        """The whole reason a container needed a rendering and not a fallback."""
+        message = finite_vector_error("raycast", "origin", [1.0, BEYOND_INT_STR_LIMIT, 3.0])
+        assert message is not None
+        assert f"[1.0, <int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>, 3.0]" in message
+        assert "<unrepresentable list>" not in message
 
 
 # --------------------------------------------------------------------------- #
@@ -708,16 +721,26 @@ def _scan_direct_renders(source: str) -> dict[str, tuple[tuple[str, str], ...]]:
     return found
 
 
-#: The only functions in ``utils.py`` still rendering a caller value directly, all
-#: of them container guards tracked in #1875. Every scalar guard is absent, which
-#: is this change. A new entry is a new guard that skipped the shared renderers.
-KNOWN_DIRECT_RENDERS: dict[str, tuple[tuple[str, str], ...]] = {
-    "coerce_rgba": (("color", "!r"),),
-    "coerce_size_vector": (("size", "!r"),),
-    "finite_vector_error": (("vec", "!r"),),
-    "name_list_error": (("value", "!r"),),
-    "pose_vector_error": (("vec", "!r"),),
-}
+#: Empty, and that is the assertion: **no** function in ``utils.py`` renders a
+#: caller value directly any more. The five container guards that used to be
+#: listed here were #1875 and now route through ``_refusal_container_repr``, so
+#: the table has nothing left to hold. Any entry appearing here is a new guard
+#: that skipped the shared renderers.
+KNOWN_DIRECT_RENDERS: dict[str, tuple[tuple[str, str], ...]] = {}
+
+#: The guards that render a *container*, which need the elementwise renderer
+#: rather than the whole-value one. Named so the scan below is shown to reach
+#: them: an empty ``KNOWN_DIRECT_RENDERS`` would otherwise be satisfied just as
+#: well by a scanner that had stopped looking at them.
+CONTAINER_GUARDS = frozenset(
+    {
+        "coerce_rgba",
+        "coerce_size_vector",
+        "finite_vector_error",
+        "name_list_error",
+        "pose_vector_error",
+    }
+)
 
 
 class TestNoGuardRendersACallerValueDirectly:
@@ -746,22 +769,25 @@ class TestNoGuardRendersACallerValueDirectly:
             if any(a.annotation is not None and ast.unparse(a.annotation) == "Any" for a in args):
                 scanned.add(fn.name)
         assert set(GUARD_IDS) <= scanned, f"guards invisible to the scan: {set(GUARD_IDS) - scanned}"
-        assert set(KNOWN_DIRECT_RENDERS) <= scanned
+        assert CONTAINER_GUARDS <= scanned, f"container guards invisible to the scan: {CONTAINER_GUARDS - scanned}"
         assert "validation_split_error" in scanned
 
-    def test_every_scalar_guard_calls_a_shared_renderer(self) -> None:
+    def test_every_guard_calls_a_shared_renderer(self) -> None:
         """The positive form: absence from the table is not enough on its own.
 
         A guard that stopped naming the refused value at all would also be absent,
-        and would return a message that no longer says what was refused.
+        and would return a message that no longer says what was refused. Now that
+        the table is empty this is the whole of the load-bearing half, and it
+        covers the container guards as well as the scalar ones.
         """
         tree = ast.parse(self._source())
-        owned = set(GUARD_IDS) | {"validation_split_error"}
+        owned = set(GUARD_IDS) | CONTAINER_GUARDS | {"validation_split_error"}
+        renderers = {"_refusal_repr", "_refusal_str", "_refusal_container_repr"}
         for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name in owned]:
             called = {
                 node.func.id for node in ast.walk(fn) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
             }
-            assert called & {"_refusal_repr", "_refusal_str"}, f"{fn.name} renders no value through a shared renderer"
+            assert called & renderers, f"{fn.name} renders no value through a shared renderer"
 
     def test_the_scanner_reports_a_planted_repr_omission(self) -> None:
         """Without this, an empty result could mean a scanner matching nothing."""


### PR DESCRIPTION
## Summary

Closes the rendering escape (#1875) in the six container guards of `strands_robots/utils.py` (`finite_vector_error`, `pose_vector_error`, `coerce_pose_vector`, `coerce_rgba`, `coerce_size_vector`, `name_list_error`), and the conversion escape they carried with it.

`repr` of a list recurses into its elements, so a container was unrenderable whenever any **one** of its elements was, and the guard raised out of a refusal it had already decided to return. The same guards tested finiteness with a bare `float(element)`, so an element past `sys.float_info.max` raised before any message was rendered at all. Measured on `2c254c7`:

```python
finite_vector_error("raycast", "origin", [10**5000])         # ValueError
pose_vector_error("add_object", "position", [10**5000], 3)   # ValueError
name_list_error([10**5000], "cameras", "render_all")         # ValueError
finite_vector_error("raycast", "origin", [10**400])          # OverflowError
coerce_rgba("add_object", "color", [10**400] * 4)            # OverflowError
```

Both are now structured refusals:

```
raycast: 'origin' must contain numbers within the range of a 64-bit float,
got [1.0, <int of 16610 bits>, 3.0]
```

These are reachable: `raycast(origin=)`, `add_object(position=, size=, color=)` and the recorder / render `cameras` lists all arrive from an agent tool call or a `device_connect` `@rpc()` payload, where a list of JSON numbers is the normal shape and Python integers are arbitrary-precision.

## Why a container needed a rendering, not a fallback

#1873 routes each scalar refusal through `_refusal_repr`, which answers `<unrepresentable Foo>`. Applied to a container that fallback erases every element that rendered fine **and the element count with them** - and the count is frequently the refusal's entire reason (`must be a 3-element vector, got 4`). So containers get `_refusal_container_repr`, which describes the container component by component and substitutes only the components that cannot print.

`TestTheWholeValueFallbackWouldHaveBeenWrong` states that as a measurement rather than as prose: the scalar renderer is applied to the same containers and shown to erase what the elementwise one keeps.

## Three decisions the issue asked to be settled

| decision | choice | why |
|---|---|---|
| whole-container `repr` first? | yes | not an optimisation - a `tuple`, `dict` and NumPy array have reprs no elementwise form reproduces (`(1.0, 2.0)`, `{'a': 1}`, `array([1., 2.])`). It is also what makes every existing message byte-identical. |
| name the offending index? | no - **position** | `finite_vector_error` and `name_list_error` already report an index in their own text (`cameras[1] must be a name`). Inserting one here too would state it twice in two forms that could disagree, and would not match the `repr` it stands in for. |
| truncate / recurse? | neither | truncating erases elements that rendered fine, which is the exact failure being avoided. Recursing would need the cycle detection the interpreter's own `repr` supplies for the fast path, and an inner container is never what the message is about - a nested list is itself the refusal's reason. |

A `Mapping` renders as a mapping rather than as the list of its keys, because `name_list_error` refuses one *for* discarding its values: showing only the keys would perform the discarding it complains about.

## No verdict and no message text moved

Strictly additive. Fourteen rendering branches are pinned as **exact equality** rather than as substrings, including the two quoted in `docs/`. The NumPy component types the guards advertise as accepted are still accepted, and the `coerce_*` guards still normalise to plain `float`.

The conversion half follows the shape #1874 established: `_beyond_float_range` is asked first so an outsized element gets a magnitude reason, then the conversion happens inside a `try` so a registered `numbers.Real` with no working `__float__` keeps the pre-existing not-a-number text instead of being mis-reported as a range complaint.

## Both module-wide invariants reach their strongest form

- **Rendering scan** (`test_refusal_messages_never_raise.py`): `KNOWN_DIRECT_RENDERS` is now **empty** - no function in `utils.py` renders a caller value without a shared renderer. Because an empty table would also be satisfied by a scanner that stopped looking, the positive control now names the container guards explicitly and asserts each calls a shared renderer.
- **Conversion scan** (`test_conversion_escape_is_closed.py`): `finite_vector_error` has left the set. The three names that remain (`coerce_pose_vector`, `coerce_rgba`, `coerce_size_vector`) convert only *after* `finite_vector_error` has accepted every element, so their `float()` provably cannot raise. Wrapping them in a `try` to empty the scan would add an `except` clause that could never run - untestable dead code asserting a danger that does not exist - so the upstream guarantee is stated and pinned instead: structurally (the validating call must precede the conversion) and behaviourally (all four guards answer an outsized element).

Both scope pins are **replaced by their inverses rather than deleted**, per the premise-test guidance in `AGENTS.md`.

## One escape deliberately left open, and newly pinned

`finite_vector_error` asks `iter(vec)` inside `except TypeError`. A `__iter__` raising anything else still escapes. That is a **third** mechanism: it needs its own message decision (a value whose iteration failed is not "not a list/tuple of numbers" - the guard cannot tell), and it cannot be expressed in a JSON payload at all, so its reachability is far weaker than #1874's or #1875's. Filed as #1878 and pinned by `TestTheIterationEscapeStaysOutOfScope`, which also pins that the other four guards answer it - so the boundary covers one guard as a measurement rather than as an assumption.

## Verification

At `196d7a5`:

- 507 tests pass across the new `tests/test_container_refusals_render_elementwise.py` (107) and every suite that asserts text these guards produce.
- `ruff check` and `ruff format --check` clean on all four changed Python files; `mypy` clean on the new test file, and `utils.py` carries the same single pre-existing error it did on `main` (unchanged, only its line moved).
- The wider sim suites read as a **delta**: base and head both report `20 failed, 1186 passed, 31 skipped` - identical, every failure environmental (no `PIL`, no `device_connect_edge`, no robot assets on a hosted runner). Zero regressions.
- New files are ASCII-only and host-path-free; changelog fragment present (`changelog.d/1875-container-refusals-render-elementwise.md`).

With this the guard family is complete: #1872, #1873, #1874 and #1875 are all closed, and #1878 is the one stated remainder.

Closes #1875.

---

## §13 Review Rounds

| Round | Concern | Fix Commit | Pin Test |
|---|---|---|---|
| R1 | CodeQL false-positive: `__float__` that always raises flagged as non-standard special method | `39b9140` | N/A (test fixture restructure - no new test needed; existing 107 tests validate) |