### PR TITLE
fix(sim): validate a substep count on every send_action

### DIFF
--- a/changelog.d/1870-send-action-substep-domain.md
+++ b/changelog.d/1870-send-action-substep-domain.md
@@ -1,0 +1,63 @@
+### Fixed: `send_action` refuses a substep count it cannot advance, before it writes
+
+`send_action(action, robot_name, n_substeps)` is the second public stepping
+surface and the last one with an unvalidated count. It was left out of the `step`
+change deliberately, because it has a contract of its own: it *writes an actuator
+target and then advances*, so a count it cannot honor is not merely a bad number
+of steps - a refusal arriving after the write leaves the robot commanded and the
+world un-advanced.
+
+No backend validated it, and the three did not agree on what a `0` meant.
+`n_substeps=0` ran one `mj_step` on MuJoCo and one control step on Newton, and
+advanced **nothing** on Isaac, which has no floor at all. So the same call
+already meant two different things depending on the backend.
+
+MuJoCo's counter desynchronized from the physics it ran. The loop is
+`range(max(1, n_substeps))` and the counter is `step_count += n_substeps`, so the
+floored loop and the raw counter disagreed for every count below 1: a `0` ran one
+step and recorded none, and a `-5` ran one step and moved `step_count`
+**backwards**. A `nan` ran one step and left `step_count` as `nan` - not one bad
+call, but every later reader of that world's step count. On Newton's solver-free
+path the same `max(1, ...)` added a `2.7` or an `inf` straight into `step_count`.
+
+`3.0` - an integral float, the most innocuous value in the set, and what
+`duration / dt` or a config read produces - raised `TypeError` out of `range()`
+on MuJoCo and Isaac, *after* the target was written and straight past the
+documented `{status, content}` envelope. Its sibling `step(3.0)` accepts the same
+number and advances 3, so the two surfaces disagreed about one value. `"3"`,
+`None` and `[3]` raised the same way on all three.
+
+All three backends now apply the shared
+`positive_whole_number_error` domain before any target is written: the same
+scalar policy as `step`'s `non_negative_whole_number_error` with the floor moved
+to `1`. A NumPy or integral-float count is honored and coerced, so `3.0` now
+succeeds where it used to raise; a fractional, zero, negative, non-finite,
+boolean or non-numeric count is refused in the same words on every backend, and
+nothing is written when it is.
+
+**`0` is refused rather than honored as "write but do not advance"**, with
+`step` named as the surface that advances a count of its own. That was the one
+genuine decision here, and it is settled on evidence rather than taste: both
+producers of this count already refuse anything below 1 - `PolicyRunner._control_substeps`
+returns `>= 1` and raises otherwise, with a docstring recording that clamping `0`
+to 1 reinstated the exact under-integration it exists to prevent, and
+`training.rl.env.SimEnv` refuses an `n_substeps` below 1. `send_action` was the
+only member of that chain without the guarantee. Honoring `0` would instead have
+adopted Isaac's *absence* of a floor over the reference backend's explicit one.
+
+`positive_count_error` was the other candidate domain and is wrong here: it
+admits only a true `int`, so it would refuse `3.0`, `np.int64(3)` and
+`np.uint8(2)` - counts MuJoCo honors today and `step` honors by documented
+design. That choice is pinned as a measurement rather than left as a preference.
+
+The `max(1, ...)` floors in MuJoCo's `_apply_sim_action` and Newton's `_advance`
+are retained as defensive no-ops and are now unreachable from either public
+surface. The counter desynchronization needed no separate fix: it was only
+reachable with a value outside the domain.
+
+Out of scope and pinned as such: `send_action` still has **no per-call ceiling**
+on any backend, so a count `step` refuses with `_MAX_STEPS_PER_CALL` is accepted
+here. That is the resource policy tracked in #1871 - a decision about a number
+for three backends with different per-step costs - not an input domain.
+
+Closes #1870.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -93,7 +93,8 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 
 | Action | Key params |
 |--------|-----------|
-| `step` | `n_steps=1` (max 100 000/call) |
+| `step` | `n_steps=1` (max 100 000/call). Non-negative whole number; `0` is an accepted no-op |
+| `send_action` | `n_substeps=1` - **positive** whole number, no per-call ceiling (see Actions) |
 | `set_gravity` | `gravity=[x,y,z]` or a scalar z-component |
 | `set_timestep` | `timestep` |
 | `get_contacts` / `get_contact_forces` | - . `get_contacts` lists every geom pair inside the detection range (`margin` + `gap`) and marks each one `active` - MuJoCo hands only the pairs inside `margin` to the solver, so a pair between the two thresholds is a proximity report carrying no force. Contact predicates count only `active` pairs; `get_contact_forces` gives the load a touching pair carries |
@@ -169,6 +170,8 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | ordered numeric vector (`list` / `tuple` / 1-D `numpy` array) | bound positionally to `robot_action_keys(robot_name)` (the robot's actuator keys) in declaration order - the same convention `replay_episode` uses |
 
 A vector lets a policy's raw action chunk drive the arm directly without first zipping it into a dict. It binds to `robot_action_keys` (not `robot_joint_names`) because those are the keys `send_action` resolves and the ordering the `LeRobotDataset` recorder writes the `action` column in; the two coincide unless a robot has passive/mimic joints or a tendon gripper. The vector length must match the robot's actuator count exactly; a mismatch (or a non-numeric / scalar / string `action`) returns a structured `status="error"` dict naming the actuator count and order, rather than crashing or silently truncating commands. Use a mapping to target a subset of actuators.
+
+`n_substeps` is the number of physics steps the written targets are held for. It must be a **positive** whole number: a NumPy or integral-float count (`np.int64(3)`, a `3.0` read from a config) is honored and coerced, and a fractional, zero, negative, non-finite, boolean or non-numeric count returns a structured `status="error"` dict. Nothing is written when it does - a refusal arriving after the write would leave the robot commanded and the world un-advanced. The floor is `1` rather than `step`'s `0` because of that write: to advance without commanding, use `step(n)`, whose `0` is an accepted no-op. It is also the floor both producers of this count already enforce (`PolicyRunner`'s `control_substeps` and the RL env's `n_substeps`).
 
 Each action *value* must be a finite number, and must not be a boolean. `nan` / `inf` are refused because they are not clamped into the actuator's range - MuJoCo discards the step and resets every robot in the scene while reporting success. A `bool` (or `numpy.bool_`) is refused because `float(True)` is `1.0`, and each drive reads 1.0 in its own units: a 1-radian target on a joint-position drive, a full-travel command on a normalized or tendon drive (a `[0, 255]` tendon gripper reads it as fully open), and an out-of-range value that is silently clamped where `ctrlrange` excludes 1 - so the same `True` commands a different pose on every actuator. Send the command in the actuator's own units; for a binary gripper, its endpoint value rather than a flag. This is the domain the teleop wire validator already enforces on an input frame, and `InputReceiver` applies those frames through `send_action`.
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1157,6 +1157,23 @@ class SimEngine(ABC):
         relies on this - it calls send_action once per control step and
         does NOT call sim.step() separately.
 
+        ``n_substeps`` is a **positive** whole number, on the shared
+        :func:`~strands_robots.utils.positive_whole_number_error` domain every
+        backend applies. A NumPy or float count with an integral value is
+        honored and coerced; a fractional, zero, negative, non-finite, boolean
+        or non-numeric count is refused as a structured error, and nothing is
+        written when it is - a refusal arriving after the write would leave the
+        robot commanded and the world un-advanced, which is the one state this
+        surface must never report an error from. The floor is ``1`` rather than
+        :meth:`step`'s ``0`` precisely because of the write: "advance nothing"
+        is ``step(0)``, an accepted no-op that commands nothing, while a
+        ``send_action`` advancing nothing leaves a target the world never
+        integrates. It is also the floor both producers of this count already
+        enforce - ``PolicyRunner._control_substeps`` returns ``>= 1`` and
+        raises otherwise, and ``training.rl.env.SimEnv`` refuses an
+        ``n_substeps`` below 1 - so this surface was the only member of that
+        chain without the guarantee.
+
         Backends are responsible for internal thread-safety (e.g.
         MuJoCo acquires self._lock here). PolicyRunner does not manage
         locks.
@@ -1164,7 +1181,8 @@ class SimEngine(ABC):
         Returns:
             Dict with ``status`` and ``content``. When action keys cannot
             be resolved, the ``content`` list includes a ``json`` block with
-            ``unresolved_keys`` so callers can self-correct.
+            ``unresolved_keys`` so callers can self-correct. ``status`` is
+            ``"error"`` when ``n_substeps`` is outside its domain.
         """
         ...
 
@@ -3778,7 +3796,10 @@ class SimEngine(ABC):
             "methods": {
                 "get_robot_state": "(robot_name: str) -> dict",
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
-                "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
+                "send_action": (
+                    "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict"
+                    "  # n_substeps must be a positive whole number; use step() to advance without commanding"
+                ),
                 "add_robot": (
                     "(name: str, urdf_path=None, data_config=None, position=None, "
                     "orientation=None) -> dict  # add a robot to the scene by "

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -3083,7 +3083,18 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         robot_name : str, optional
             Robot to control.
         n_substeps : int
-            Physics sub-steps after applying action. Default 1.
+            Physics sub-steps after applying action. Default 1. A positive whole
+            number, on the shared
+            :func:`~strands_robots.utils.positive_whole_number_error` domain
+            every backend applies: a NumPy or float count with an integral value
+            is honored and coerced, and a fractional, zero, negative,
+            non-finite, boolean or non-numeric count is refused. ``0`` is
+            refused rather than honored as "write but do not advance" -
+            :meth:`step` is the surface that advances a count of its own, and it
+            accepts ``0`` as a documented no-op. Note this backend's loop had no
+            floor at all, so pre-fix a ``0`` or a negative count applied the
+            targets and advanced nothing while reporting success - the opposite
+            of what MuJoCo and Newton did with the same call.
 
         Returns
         -------
@@ -3096,7 +3107,19 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             some keys don't name a joint on ``robot_name``, the ``content`` list
             carries a ``json`` block with ``unresolved_keys`` / ``applied`` so
             callers can self-correct -- mirroring the MuJoCo backend.
+            ``status`` is ``"error"`` when ``n_substeps`` is outside its domain,
+            and no joint target is applied when it is.
         """
+        # Guarded before the lock is taken and before any target is applied,
+        # mirroring this backend's ``step``: a refusal arriving after the write
+        # would leave the robot commanded and the world un-advanced. This
+        # backend's substep loop is a bare ``range(n_substeps)`` with no floor,
+        # so a fractional or non-numeric count raised ``TypeError`` past the
+        # structured envelope, and a zero or negative count reported success
+        # having advanced nothing.
+        if error := positive_whole_number_error(n_substeps, "n_substeps", "send_action"):
+            return {"status": "error", "content": [{"text": error}]}
+        n_substeps = int(n_substeps)
         with self._lock:
             if not self._world_created or self._world is None:
                 return {"status": "error", "content": [{"text": "No world created."}]}

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -115,6 +115,7 @@ from strands_robots.utils import (
     finite_vector_error,
     non_negative_whole_number_error,
     pose_vector_error,
+    positive_whole_number_error,
     sequence_length,
 )
 
@@ -450,15 +451,44 @@ class MuJoCoSimEngine(
         from the agent's dispatch thread and a PolicyRunner worker are
         serialized here.
 
+        Args:
+            action: Actuator command, as a mapping or an ordered vector.
+            robot_name: Robot to actuate. ``None`` resolves to the single robot
+                when exactly one exists.
+            n_substeps: Positive whole number of physics steps to advance after
+                writing the targets, on the shared
+                :func:`~strands_robots.utils.positive_whole_number_error` domain
+                every backend applies. A NumPy or float count with an integral
+                value is honored and coerced; a fractional, zero, negative,
+                non-finite, boolean or non-numeric count is refused. ``0`` is
+                refused rather than honored as "write but do not advance" -
+                :meth:`step` is the surface that advances a count of its own,
+                and it accepts ``0`` as a documented no-op.
+
         Returns:
             Dict with ``status`` ("success" or "error") and ``content``.
             When some action keys could not be resolved to actuators/joints,
             the ``content`` list includes a ``json`` block with an
             ``unresolved_keys`` list (and ``applied``) so callers can
-            self-correct instead of silently losing commands.
+            self-correct instead of silently losing commands. ``status`` is
+            ``"error"`` when ``n_substeps`` is outside that domain, and nothing
+            is written when it is.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        # Refused before a single ctrl value is written, because a refusal that
+        # arrived after the write would leave the robot commanded and the world
+        # un-advanced - the one state this surface must never report an error
+        # from. ``_apply_sim_action`` floors its loop at ``max(1, n_substeps)``
+        # but adds the raw count to ``step_count``, so pre-fix a ``0`` ran one
+        # ``mj_step`` and recorded none, a ``-5`` ran one and moved the counter
+        # *backwards*, and a ``nan`` ran one and made ``step_count`` ``nan`` for
+        # the rest of the world's life. A fractional or non-numeric count
+        # reached ``range()`` and raised ``TypeError`` straight past this
+        # method's structured envelope, after the write.
+        if error := positive_whole_number_error(n_substeps, "n_substeps", "send_action"):
+            return {"status": "error", "content": [{"text": error}]}
+        n_substeps = int(n_substeps)
         if robot_name is None:
             if not self._world.robots:
                 return {"status": "error", "content": [{"text": "No robots in the world."}]}

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -67,6 +67,7 @@ from strands_robots.utils import (
     is_boolean,
     non_negative_whole_number_error,
     positive_count_error,
+    positive_whole_number_error,
     require_optional,
 )
 
@@ -416,11 +417,14 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         if error := non_negative_whole_number_error(n_steps, "n_steps", "step"):
             return {"status": "error", "content": [{"text": error}]}
         n_steps = int(n_steps)
-        # ``_advance`` floors its count at 1 (``max(1, n_steps)``) because
-        # ``send_action`` shares it and reads that floor as its own contract, so
-        # a zero handed through would advance the world one step while this
-        # method reported stepping none. Answer it here instead of changing that
-        # floor, which would alter the ``send_action(n_substeps=0)`` path too.
+        # ``_advance`` floors its count at 1 (``max(1, n_steps)``), so a zero
+        # handed through would advance the world one step while this method
+        # reported stepping none. Answered here rather than by moving the floor.
+        # Both callers of ``_advance`` now guarantee a positive count - this
+        # branch, and ``send_action`` on the shared
+        # ``positive_whole_number_error`` domain - so the floor is unreachable
+        # from either public surface and is retained as a defensive no-op rather
+        # than as a contract anything reads.
         if n_steps == 0:
             return {"status": "success", "content": [{"text": "Stepped 0 step(s) (no-op)."}]}
         with self._lock:
@@ -1052,16 +1056,35 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             action: Mapping of short joint name to target position (radians).
             robot_name: Robot to actuate. ``None`` resolves to the single
                 robot when exactly one exists.
-            n_substeps: Number of control steps to advance after writing
-                targets.
+            n_substeps: Positive whole number of control steps to advance after
+                writing targets, on the shared
+                :func:`~strands_robots.utils.positive_whole_number_error` domain
+                every backend applies. A NumPy or float count with an integral
+                value is honored and coerced; a fractional, zero, negative,
+                non-finite, boolean or non-numeric count is refused. ``0`` is
+                refused rather than honored as "write but do not advance" -
+                :meth:`step` is the surface that advances a count of its own,
+                and it accepts ``0`` as a documented no-op.
 
         Returns:
             Status dict. When some keys cannot be resolved to joints, the
             ``content`` carries a ``json`` block with ``unresolved_keys`` and
-            ``applied`` so callers can self-correct.
+            ``applied`` so callers can self-correct. ``status`` is ``"error"``
+            when ``n_substeps`` is outside that domain, and no target is
+            written when it is.
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        # Refused before ``_write_targets``, because a refusal after the write
+        # would leave the robot commanded and the world un-advanced. Pre-fix
+        # this count reached ``_advance``'s ``max(1, n_steps)`` floor, so a
+        # ``0`` or a ``-5`` advanced one control step under a success result;
+        # on the solver-free path the same floor added a ``2.7`` or an ``inf``
+        # straight into ``step_count``, and a non-numeric count raised
+        # ``TypeError`` past this method's structured envelope.
+        if error := positive_whole_number_error(n_substeps, "n_substeps", "send_action"):
+            return {"status": "error", "content": [{"text": error}]}
+        n_substeps = int(n_substeps)
         try:
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError as exc:
@@ -2195,7 +2218,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     "robot / object / camera / body / joint / actuator counts)"
                 ),
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
-                "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
+                "send_action": (
+                    "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict"
+                    "  # n_substeps must be a positive whole number; use step() to advance without commanding"
+                ),
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, ...) -> dict",
                 "evaluate_benchmark": (
                     "(benchmark_name: str, robot_name=None, policy_provider='mock', "
@@ -2370,6 +2396,14 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """Run ``n_steps`` control steps (each ``substeps`` solver steps).
 
         Must be called with ``self._lock`` held.
+
+        The ``max(1, n_steps)`` floor is defensive only: both public callers -
+        :meth:`step` and :meth:`send_action` - refuse or answer a non-positive
+        count before reaching here, so the floor cannot be observed through
+        either. It is kept rather than removed so a future internal caller
+        cannot advance a negative count, and it is not a contract: a caller
+        wanting "advance nothing" gets it from ``step(0)``, which returns
+        without calling this method at all.
         """
         assert self._world is not None
         if self._solver is None:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -636,19 +636,30 @@ def finite_number_error(value: Any, param: str, context: str) -> str | None:
 def positive_whole_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive whole number.
 
-    Shared domain for every media knob that counts frames or pixels - the
-    recorders' ``fps``, ``width``, ``height`` and in-memory frame cap, the
-    ``run_policy(video=...)`` dict fields, and the
-    :func:`~strands_robots.rendering.encode_clip` playback rate. It lives here
-    rather than beside one of its callers because those callers sit in different
-    layers (:mod:`strands_robots.rendering` must not depend on
+    Shared domain for two families of positive discrete quantity:
+
+    * The media knobs that count frames or pixels - the recorders' ``fps``,
+      ``width``, ``height`` and in-memory frame cap, the
+      ``run_policy(video=...)`` dict fields, and the
+      :func:`~strands_robots.rendering.encode_clip` playback rate.
+    * The physics steps one applied action is held for - the ``n_substeps`` of
+      every backend's
+      :meth:`~strands_robots.simulation.base.SimEngine.send_action`.
+
+    It lives here rather than beside one of its callers because those callers sit
+    in different layers (:mod:`strands_robots.rendering` must not depend on
     :mod:`strands_robots.simulation`), and the accepted domain must not diverge
-    between them. Only a positive whole number can be honored: ``0`` makes the capture loop's ``1 / fps``
-    period undefined, a negative rate is rejected by the ffmpeg writer, and a
-    zero/negative frame cap drops every frame. Accepts any real scalar with an
-    integral value (so a NumPy ``np.int64`` height or a ``30.0`` computed from a
-    config float passes) and rejects ``bool`` explicitly - an ``int`` subclass
-    whose ``True`` would act as a silent 1.
+    between them. Only a positive whole number can be honored: ``0`` makes the
+    capture loop's ``1 / fps`` period undefined, a negative rate is rejected by
+    the ffmpeg writer, a zero/negative frame cap drops every frame, and a
+    ``send_action`` advancing no physics leaves a target written that the world
+    never integrates - which is why ``0`` is refused there rather than honored
+    as "write but do not advance", with
+    :meth:`~strands_robots.simulation.base.SimEngine.step` named as the surface
+    that advances a count of its own. Accepts any real scalar with an integral
+    value (so a NumPy ``np.int64`` height or a ``30.0`` computed from a config
+    float passes) and rejects ``bool`` explicitly - an ``int`` subclass whose
+    ``True`` would act as a silent 1.
 
     **Magnitude is part of this domain, unlike its ``non_negative`` sibling.**
     :func:`non_negative_whole_number_error` accepts ``10**400`` as a matter of
@@ -656,12 +667,21 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     consumer - and for its one caller that holds, because MuJoCo's
     ``_MAX_STEPS_PER_CALL`` is exactly such a ceiling and refuses an outsized
     step count with a reason of its own. No consumer of *this* domain owns one.
-    Its callers are ``fps``, ``width``, ``height``, ``max_frames`` and the mesh
-    robots' ``drive(count=...)``, and that last one repeats an actuation command,
-    so an unbounded count is an unbounded actuation loop against a physical
-    robot rather than a slow call. So the two guards are the same scalar policy
-    with the floor moved *and* one deliberate difference, which is recorded here
-    rather than left for a reader to find by measuring.
+    Its callers are ``fps``, ``width``, ``height``, ``max_frames``, the mesh
+    robots' ``drive(count=...)`` and ``send_action(n_substeps=)``. Two of those
+    repeat work that nothing bounds: ``drive`` repeats an actuation command, so
+    an unbounded count is an unbounded actuation loop against a physical robot
+    rather than a slow call, and ``n_substeps`` is a physics-step count that
+    ``_MAX_STEPS_PER_CALL`` does *not* reach - that ceiling is applied by
+    ``step`` alone, so a count ``step`` refuses is still accepted through
+    ``send_action`` on every backend. So the two guards are the same scalar
+    policy with the floor moved *and* one deliberate difference, which is
+    recorded here rather than left for a reader to find by measuring.
+
+    That last point is a boundary, not a claim to have closed it: refusing
+    ``10**400`` here is the float64 edge the domain already had, and choosing a
+    *resource* ceiling for a substep count is the same per-backend decision
+    tracked for ``step`` in #1871.
 
     Refusing is therefore the verdict, and it needs a reason of its own:
     ``10**400`` *is* a positive whole number. As above, the float64 range is not
@@ -713,6 +733,15 @@ def non_negative_whole_number_error(value: Any, param: str, context: str) -> str
     Shared domain for the number of physics steps a caller asks a simulation to
     advance - the ``n_steps`` of every backend's
     :meth:`~strands_robots.simulation.base.SimEngine.step`.
+
+    Not the only physics-step count in the tree, and the difference is the
+    floor rather than the scalar policy: the ``n_substeps`` of
+    :meth:`~strands_robots.simulation.base.SimEngine.send_action` is guarded by
+    :func:`positive_whole_number_error`, because that surface writes an actuator
+    target before it advances and a ``0`` there leaves the target written and
+    never integrated. ``step`` owns the honored zero; ``send_action`` refuses
+    its own and names ``step``. A reader arriving here from ``send_action``
+    would otherwise take this floor for that surface's.
 
     It stands to :func:`positive_whole_number_error` exactly as
     :func:`non_negative_count_error` stands to :func:`positive_count_error`: the

--- a/tests/simulation/test_send_action_substep_domain_across_backends.py
+++ b/tests/simulation/test_send_action_substep_domain_across_backends.py
@@ -1,0 +1,642 @@
+"""``send_action`` must refuse a substep count it cannot advance, before it writes.
+
+Companion to ``test_step_count_domain_across_backends.py``, which settled
+``step(n_steps)``. ``send_action(action, robot_name, n_substeps)`` is the second
+public stepping surface and it was left out of that change deliberately, because
+it has a contract of its own: it *writes an actuator target and then advances*,
+so a count it cannot honor is not merely a bad number of steps - a refusal that
+arrives after the write leaves the robot commanded and the world un-advanced.
+
+## What was measured on ``182fcc6``
+
+No backend validated the count, and the three did not even agree on what a
+``0`` meant. Real MuJoCo engine (mujoco 3.11.0, one position actuator), Newton
+on its real inherited ``_advance`` solver-free, Isaac on its verbatim substep
+loop:
+
+| ``n_substeps`` | MuJoCo | Newton | Isaac |
+| --- | --- | --- | --- |
+| ``0`` | 1 ``mj_step``, ``step_count`` **+0** | 1 control step | **0 steps**, success |
+| ``-5`` | 1 ``mj_step``, ``step_count`` **-5** | 1 control step | 0 steps, success |
+| ``False`` | 1 ``mj_step``, ``step_count`` +0 | 1 control step | 0 steps, success |
+| ``True`` | 1 ``mj_step`` | 1 control step | 1 step |
+| ``2.7`` | **raises ``TypeError``** | ``step_count`` = **2.7** | raises ``TypeError`` |
+| ``3.0`` | **raises ``TypeError``** | 3 steps, ``step_count`` = 3.0 | raises ``TypeError`` |
+| ``nan`` | 1 ``mj_step``, ``step_count`` = **nan** | 1 control step | raises ``TypeError`` |
+| ``inf`` | raises ``TypeError`` | ``step_count`` = **inf** | raises ``TypeError`` |
+| ``"3"`` / ``None`` / ``[3]`` | raises ``TypeError`` | raises ``TypeError`` | raises ``TypeError`` |
+
+Four findings the issue (#1870) did not have, each pinned below:
+
+1. **The counter desynchronizes from the physics.** MuJoCo floors its loop at
+   ``max(1, n_substeps)`` but adds the *raw* count to ``step_count``, so a ``0``
+   ran one ``mj_step`` and recorded none, and a ``-5`` ran one and moved the
+   counter **backwards**.
+2. **``nan`` and ``inf`` poison the counter permanently.** ``step_count`` became
+   ``nan`` on MuJoCo and ``inf`` on Newton - not one bad call, but every later
+   reader of the world's step count for the rest of its life.
+3. **``3.0`` - an integral float, the most innocuous value here - raised
+   ``TypeError``** on two backends, *after* the target was written, straight past
+   the documented ``{status, content}`` envelope. Its sibling ``step(3.0)``
+   accepts it and advances 3 (``USABLE_COUNTS``), so the two surfaces disagreed
+   about the same number.
+4. **The backends disagreed about ``0``.** MuJoCo and Newton floored it to one
+   step; Isaac, which has no floor at all, advanced none. So the same call
+   already meant two different things, and "honor 0" would have been picking
+   Isaac's *absence of a floor* over the reference backend's explicit one.
+
+## Why the floor is ``1`` here and ``0`` on ``step``
+
+The issue asked for this to be settled before code, listing "honor ``0`` (write
+but do not advance)" against "refuse ``0`` and name ``step``". It is settled as
+**refuse**, on evidence rather than taste: both producers of this count already
+refuse anything below 1, each with its own raise -
+``PolicyRunner._control_substeps`` returns ``>= 1`` and raises otherwise, with a
+docstring recording that clamping ``0`` to 1 reinstated the exact
+under-integration it exists to prevent, and ``training.rl.env.SimEnv`` refuses
+an ``n_substeps`` below 1. ``send_action`` was the only member of that chain
+without the guarantee, which is the "a sibling states the invariant and this
+caller skips it" shape. Pinned in ``TestTheFloorIsADecisionWithEvidence``.
+
+The domain is therefore ``positive_whole_number_error``: the same scalar policy
+as ``step``'s ``non_negative_whole_number_error`` with the floor moved to 1.
+``positive_count_error`` was the other candidate and is wrong here - it admits
+only a true ``int``, so it would refuse ``3.0``, ``np.int64(3)`` and
+``np.uint8(2)``, all of which the reference backend honors today and all of
+which ``step`` honors by documented design.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+import textwrap
+import threading
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.models import SimRobot, SimWorld
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.simulation.policy_runner import PolicyRunner
+from strands_robots.utils import (
+    non_negative_whole_number_error,
+    positive_count_error,
+    positive_whole_number_error,
+)
+
+pytest.importorskip("mujoco")
+
+NAN = float("nan")
+INF = float("inf")
+
+#: An ``int`` wider than the float range: ``float(10**400)`` raises
+#: ``OverflowError``. Refused by this guard, unlike ``step``'s - see the
+#: magnitude paragraph in ``positive_whole_number_error``.
+BEYOND_FLOAT_RANGE = 10**400
+#: An ``int`` whose own ``repr`` raises (wider than
+#: ``sys.get_int_max_str_digits()``), so rendering the refusal must not.
+BEYOND_INT_STR_LIMIT = 10**5000
+
+#: Every substep count no backend can honor. Each row is a measured pre-fix
+#: acceptance, a silent floor, a poisoned counter or a bare raise on at least
+#: one backend - see the table in the module docstring.
+UNUSABLE_SUBSTEPS: tuple[Any, ...] = (
+    0,
+    -5,
+    True,
+    False,
+    np.bool_(True),
+    2.7,
+    "3",
+    NAN,
+    INF,
+    -INF,
+    None,
+    [3],
+    np.array([3]),
+    BEYOND_FLOAT_RANGE,
+    BEYOND_INT_STR_LIMIT,
+)
+
+#: Counts every backend must honor, paired with the steps each must advance.
+#: ``3.0`` is the load-bearing row: MuJoCo and Isaac *raised* on it pre-fix
+#: while ``step(3.0)`` accepted it, so honoring it is what removes the
+#: disagreement between the two surfaces rather than a new liberty.
+USABLE_SUBSTEPS: tuple[tuple[Any, int], ...] = (
+    (1, 1),
+    (3, 3),
+    (3.0, 3),
+    (np.int64(3), 3),
+    (np.uint8(2), 2),
+    (np.float64(4.0), 4),
+)
+
+
+def _substep_id(value: Any) -> str | None:
+    """Test ID for a probe, or ``None`` to let pytest name it.
+
+    The outsized integers need naming to keep the module collectable: pytest
+    derives an ID for an ``int`` parameter with ``str()``, which raises for one
+    wider than ``sys.get_int_max_str_digits()``. That is a collection error
+    taking down every class in the file, which is the same defect this module
+    pins on the guard (rendering a value it was only asked to classify) reappearing
+    in the harness.
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value == BEYOND_FLOAT_RANGE:
+            return "beyond_float_range"
+        if value == BEYOND_INT_STR_LIMIT:
+            return "beyond_int_str_limit"
+    return None
+
+
+_ARM_XML = """
+<mujoco model="one_drive_arm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0" timestep="0.002"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <joint name="lift" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="4"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="lift_act" joint="lift" kp="30" ctrlrange="-2 2"/>
+  </actuator>
+</mujoco>
+"""
+
+_TIMESTEP = 0.002
+
+
+@pytest.fixture
+def sim(tmp_path):  # noqa: ANN001, ANN201 - the engine types _world as optional
+    """A one-actuator arm from an inline MJCF, so no asset is fetched."""
+    from strands_robots.simulation import Simulation
+
+    path = tmp_path / "one_drive_arm.xml"
+    path.write_text(_ARM_XML, encoding="utf-8")
+    engine = Simulation(backend="mujoco", tool_name="substep_domain_test", mesh=False)
+    engine.create_world()
+    added = engine.add_robot(name="arm", urdf_path=str(path))
+    assert added["status"] == "success", added
+    yield engine
+    engine.cleanup()
+
+
+def _text(result: dict[str, Any]) -> str:
+    return next(block["text"] for block in result["content"] if "text" in block)
+
+
+def _observed(engine: Any) -> tuple[float, Any, float]:
+    """The world state a refused call must leave untouched: time, count, ctrl."""
+    data = engine._world._data
+    return float(data.time), engine._world.step_count, float(data.ctrl[0])
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheSharedDomain:
+    """``positive_whole_number_error`` is the single definition all three share."""
+
+    @pytest.mark.parametrize("count", UNUSABLE_SUBSTEPS, ids=_substep_id)
+    def test_an_unusable_count_is_refused(self, count: Any) -> None:
+        error = positive_whole_number_error(count, "n_substeps", "send_action")
+        assert error is not None, count
+        assert "n_substeps" in error
+
+    @pytest.mark.parametrize(("count", "_expected"), USABLE_SUBSTEPS)
+    def test_a_usable_count_is_accepted(self, count: Any, _expected: int) -> None:
+        assert positive_whole_number_error(count, "n_substeps", "send_action") is None, count
+
+    def test_an_accepted_count_survives_the_int_coercion_it_is_paired_with(self) -> None:
+        """The guard exists so the ``int()`` each backend then applies cannot raise."""
+        for count, expected in USABLE_SUBSTEPS:
+            assert positive_whole_number_error(count, "n_substeps", "send_action") is None
+            assert int(count) == expected
+
+    def test_the_message_names_the_parameter_and_the_value(self) -> None:
+        error = positive_whole_number_error(0, "n_substeps", "send_action")
+        assert error == "send_action: n_substeps must be a positive whole number, got 0."
+
+    def test_the_message_is_ascii_and_never_raises_while_rendering(self) -> None:
+        for count in UNUSABLE_SUBSTEPS:
+            error = positive_whole_number_error(count, "n_substeps", "send_action")
+            assert error is not None
+            error.encode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# The floor: the one thing the issue said was a decision                      #
+# --------------------------------------------------------------------------- #
+class TestTheFloorIsADecisionWithEvidence:
+    """``0`` is refused here and honored by ``step``, and the reason is measured.
+
+    #1870 asked for this to be settled before code. The evidence is that both
+    producers of this count already refuse anything below 1, so refusing at the
+    consumer makes the chain uniform instead of introducing a new rule.
+    """
+
+    def test_the_two_surfaces_differ_only_in_the_floor(self) -> None:
+        assert positive_whole_number_error(0, "n_substeps", "send_action") is not None
+        assert non_negative_whole_number_error(0, "n_steps", "step") is None
+        for count, _expected in USABLE_SUBSTEPS:
+            assert positive_whole_number_error(count, "n_substeps", "send_action") is None
+            assert non_negative_whole_number_error(count, "n_steps", "step") is None
+
+    def test_the_runner_that_produces_this_count_already_refuses_a_non_positive(self) -> None:
+        """``_control_substeps`` is the sole producer on the rollout path.
+
+        Its docstring records that clamping with ``max(1, int(override))`` let
+        ``0``/``-5`` collapse to a single physics step, "reinstating the exact
+        under-integration this helper exists to prevent". That is this issue's
+        reasoning one layer up, and its return contract is ``>= 1``.
+        """
+        sim_double: Any = types.SimpleNamespace(physics_timestep=lambda: _TIMESTEP)
+        runner = PolicyRunner(sim_double)
+        for bad in (0, -5, 2.7, True):
+            with pytest.raises(ValueError, match="control_substeps"):
+                runner._control_substeps(30.0, bad)  # type: ignore[arg-type]
+        assert runner._control_substeps(30.0, 4) == 4
+        assert runner._control_substeps(30.0) >= 1
+
+    def test_the_rl_env_that_produces_this_count_also_refuses_a_non_positive(self) -> None:
+        """The second producer, refusing the same parameter name by its own raise.
+
+        Read from the source rather than by constructing a ``SimEnv`` (which
+        needs a live engine): the point being pinned is that the floor exists in
+        a second place, so a reader cannot conclude ``1`` was invented here.
+        """
+        from strands_robots.training.rl import env as rl_env
+
+        source = inspect.getsource(rl_env)
+        assert "n_substeps must be >= 1" in source
+
+    def test_advance_nothing_still_has_a_spelling_and_it_is_named(self) -> None:
+        """Refusing ``0`` removes nothing a caller can express, and says so.
+
+        ``step(0)`` is the documented no-op, and the refusal has to point at it -
+        otherwise the caller is told what is wrong and not what to do.
+        """
+        assert non_negative_whole_number_error(0, "n_steps", "step") is None
+        for doc in (
+            IsaacSimulation.send_action.__doc__,
+            NewtonSimEngine.send_action.__doc__,
+        ):
+            assert doc is not None
+            assert "step" in doc
+
+
+# --------------------------------------------------------------------------- #
+# MuJoCo: the reference backend, on a real engine                             #
+# --------------------------------------------------------------------------- #
+class TestMuJoCoSendAction:
+    """Measured on a real compiled model, so the ordering claim is observable."""
+
+    @pytest.mark.parametrize("count", UNUSABLE_SUBSTEPS, ids=_substep_id)
+    def test_an_unusable_count_is_refused_without_writing_or_stepping(self, sim, count: Any) -> None:
+        before = _observed(sim)
+        result = sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=count)
+        assert result["status"] == "error", count
+        assert "n_substeps" in _text(result)
+        assert _observed(sim) == before, f"{count!r} changed the world it was refused for"
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_SUBSTEPS)
+    def test_a_usable_count_advances_exactly_that_many_steps(self, sim, count: Any, expected: int) -> None:
+        t0, c0, _ctrl0 = _observed(sim)
+        result = sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=count)
+        assert result["status"] == "success", _text(result)
+        t1, c1, ctrl1 = _observed(sim)
+        assert round((t1 - t0) / _TIMESTEP) == expected
+        assert c1 - c0 == expected
+        assert ctrl1 == pytest.approx(0.5)
+
+    def test_an_integral_float_no_longer_raises_past_the_envelope(self, sim) -> None:
+        """``3.0`` raised ``TypeError`` from ``range()`` pre-fix, after the write.
+
+        The single most innocuous value in the probe set - a count read from a
+        config, or ``duration / dt`` - and the surface it reached raised rather
+        than answering, having already commanded the robot. Its sibling
+        ``step(3.0)`` accepted the same number.
+        """
+        result = sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=3.0)
+        assert result["status"] == "success"
+        assert sim._world.step_count == 3
+        assert sim.step(n_steps=3.0)["status"] == "success"
+
+
+class TestTheStepCounterCanNoLongerDesynchronizeOrBePoisoned:
+    """``step_count`` tracked the raw count while the loop tracked a floored one.
+
+    The loop was ``range(max(1, n_substeps))`` and the counter was
+    ``step_count += n_substeps``, so the two disagreed for every count below 1 -
+    and for ``nan`` the disagreement was permanent. Closed by the guard alone,
+    because it was only reachable with a value outside the domain; pinned here so
+    that stays true if either line is touched.
+    """
+
+    def test_a_zero_no_longer_steps_once_while_recording_none(self, sim) -> None:
+        assert sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=0)["status"] == "error"
+        assert sim._world.step_count == 0
+        assert float(sim._world._data.time) == 0.0
+
+    def test_a_negative_count_no_longer_moves_the_counter_backwards(self, sim) -> None:
+        sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=4)
+        assert sim._world.step_count == 4
+        assert sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=-5)["status"] == "error"
+        assert sim._world.step_count == 4
+
+    def test_a_non_finite_count_no_longer_poisons_the_counter_for_good(self, sim) -> None:
+        """``step_count`` became ``nan``, and every later reader inherited it."""
+        assert sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=NAN)["status"] == "error"
+        assert isinstance(sim._world.step_count, int)
+        assert not math.isnan(float(sim._world.step_count))
+        assert sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=2)["status"] == "success"
+        assert sim._world.step_count == 2
+
+
+# --------------------------------------------------------------------------- #
+# Newton and Isaac: the guard precedes every target write, solver and stage   #
+# --------------------------------------------------------------------------- #
+def _newton_stub() -> tuple[Any, dict[str, list[Any]]]:
+    """A Newton stand-in recording whether it was written to or advanced.
+
+    ``_write_targets`` and ``_advance`` are recorders rather than the real
+    methods, because what is being measured is that neither is *reached* - a
+    stand-in that ran them could only show the end state, not the ordering.
+    """
+    calls: dict[str, list[Any]] = {"write": [], "advance": []}
+    world = SimWorld()
+    world.robots["arm"] = SimRobot(name="arm", urdf_path="<inline>", joint_names=["lift"])
+    stub: Any = types.SimpleNamespace(
+        _world=world,
+        _model=types.SimpleNamespace(body_label=["ground"]),
+        _lock=threading.RLock(),
+        _targets={},
+        substeps=1,
+        _resolve_single_robot=lambda name: name or "arm",
+        _coerce_action=lambda action, robot: (dict(action), None),
+        _write_targets=lambda: calls["write"].append(True),
+        _advance=lambda n: calls["advance"].append(n),
+    )
+    return stub, calls
+
+
+def _isaac_stub() -> tuple[Any, dict[str, int]]:
+    """An Isaac stand-in counting world ticks, with no stage and no RTX."""
+    calls = {"n": 0}
+    stub: Any = types.SimpleNamespace(
+        _lock=threading.RLock(),
+        _world_created=True,
+        _config=IsaacConfig(),
+        _sim_time=0.0,
+        _step_count=0,
+        _robots={},
+        _action_controllers={},
+        _world=types.SimpleNamespace(step=lambda render=False: calls.__setitem__("n", calls["n"] + 1)),
+    )
+    return stub, calls
+
+
+class TestNewtonSendAction:
+    @pytest.mark.parametrize("count", UNUSABLE_SUBSTEPS, ids=_substep_id)
+    def test_an_unusable_count_is_refused_before_any_target_is_written(self, count: Any) -> None:
+        stub, calls = _newton_stub()
+        result = NewtonSimEngine.send_action(stub, {"lift": 0.5}, robot_name="arm", n_substeps=count)
+        assert result["status"] == "error", count
+        assert "n_substeps" in _text(result)
+        assert calls["write"] == [], f"{count!r} wrote targets it was refused for"
+        assert calls["advance"] == []
+        assert stub._targets == {}
+
+    @pytest.mark.parametrize(("count", "expected"), USABLE_SUBSTEPS)
+    def test_a_usable_count_reaches_advance_already_coerced(self, count: Any, expected: int) -> None:
+        """The ``int()`` is the guard's other half: ``_advance`` gets a true ``int``.
+
+        Pre-fix a ``3.0`` reached ``range(max(1, 3.0))`` and raised, and a
+        ``2.7`` was added to ``step_count`` verbatim.
+        """
+        stub, calls = _newton_stub()
+        result = NewtonSimEngine.send_action(stub, {"lift": 0.5}, robot_name="arm", n_substeps=count)
+        assert result["status"] == "success", _text(result)
+        assert calls["advance"] == [expected]
+        assert isinstance(calls["advance"][0], int)
+        assert calls["write"] == [True]
+
+
+class TestIsaacSendAction:
+    @pytest.mark.parametrize("count", UNUSABLE_SUBSTEPS, ids=_substep_id)
+    def test_an_unusable_count_is_refused_before_the_lock_and_any_tick(self, count: Any) -> None:
+        stub, calls = _isaac_stub()
+        result = IsaacSimulation.send_action(stub, {"lift": 0.5}, robot_name="arm", n_substeps=count)
+        assert result["status"] == "error", count
+        assert "n_substeps" in _text(result)
+        assert calls["n"] == 0, f"{count!r} ticked a world it was refused for"
+        assert stub._step_count == 0
+        assert stub._sim_time == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# The three backends no longer disagree                                       #
+# --------------------------------------------------------------------------- #
+class TestTheThreeBackendsAgree:
+    """One domain, one refusal - byte-identical, not merely equivalent."""
+
+    @pytest.mark.parametrize("count", UNUSABLE_SUBSTEPS, ids=_substep_id)
+    def test_the_refusal_is_the_same_text_on_every_backend(self, sim, count: Any) -> None:
+        mujoco_text = _text(sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=count))
+        newton_text = _text(
+            NewtonSimEngine.send_action(_newton_stub()[0], {"lift": 0.5}, robot_name="arm", n_substeps=count)
+        )
+        isaac_text = _text(
+            IsaacSimulation.send_action(_isaac_stub()[0], {"lift": 0.5}, robot_name="arm", n_substeps=count)
+        )
+        assert mujoco_text == newton_text == isaac_text
+
+    def test_the_zero_the_backends_used_to_disagree_about(self, sim) -> None:
+        """The clearest reason this was not merely an unvalidated input.
+
+        Pre-fix ``n_substeps=0`` advanced one step on MuJoCo and Newton and none
+        on Isaac, so the same call meant two different things depending on the
+        backend. "Honor 0" would have adopted Isaac's *missing* floor over the
+        reference backend's explicit one.
+        """
+        results = (
+            sim.send_action({"lift_act": 0.5}, robot_name="arm", n_substeps=0),
+            NewtonSimEngine.send_action(_newton_stub()[0], {"lift": 0.5}, robot_name="arm", n_substeps=0),
+            IsaacSimulation.send_action(_isaac_stub()[0], {"lift": 0.5}, robot_name="arm", n_substeps=0),
+        )
+        assert [r["status"] for r in results] == ["error"] * 3
+        assert len({_text(r) for r in results}) == 1
+        assert sim._world.step_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# Drift: no send_action surface may skip the guard                            #
+# --------------------------------------------------------------------------- #
+_BACKEND_MODULES = (
+    "strands_robots/simulation/mujoco/simulation.py",
+    "strands_robots/simulation/newton/simulation.py",
+    "strands_robots/simulation/isaac/simulation.py",
+)
+
+
+def _send_action_defs() -> list[tuple[str, ast.FunctionDef]]:
+    """Every concrete ``send_action`` definition in the backend modules."""
+    found: list[tuple[str, ast.FunctionDef]] = []
+    root = pathlib.Path(__file__).resolve().parents[2]
+    for relative in _BACKEND_MODULES:
+        tree = ast.parse((root / relative).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "send_action":
+                found.append((relative, node))
+    return found
+
+
+class TestNoSendActionSurfaceSkipsTheGuard:
+    """A fourth backend, or a rewrite of one of these three, fails here.
+
+    The scan is what makes this the last pass rather than a first: the defect was
+    not that one backend forgot the guard, it was that all three did, and each
+    diverged differently. A behavioural test proves today's three; the scan
+    states the rule.
+    """
+
+    def test_the_scan_finds_every_backend(self) -> None:
+        """A positive control: an empty scan must not read as a clean one."""
+        paths = {relative for relative, _node in _send_action_defs()}
+        assert paths == set(_BACKEND_MODULES)
+
+    @pytest.mark.parametrize("relative", _BACKEND_MODULES)
+    def test_every_send_action_validates_its_substep_count(self, relative: str) -> None:
+        defs = [node for path, node in _send_action_defs() if path == relative]
+        assert defs, relative
+        for node in defs:
+            args = [a.arg for a in node.args.args]
+            assert "n_substeps" in args, f"{relative}: send_action lost its n_substeps parameter"
+            calls = [
+                child
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "positive_whole_number_error"
+            ]
+            assert calls, f"{relative}: send_action does not call positive_whole_number_error"
+            assert any(
+                isinstance(arg, ast.Constant) and arg.value == "n_substeps" for call in calls for arg in call.args
+            ), f"{relative}: the guard is called but not for n_substeps"
+
+    @pytest.mark.parametrize("relative", _BACKEND_MODULES)
+    def test_the_guard_precedes_every_write_and_every_lock(self, relative: str) -> None:
+        """Ordering, structurally: a refusal after the write is the failure mode.
+
+        Compared by line number rather than by running the method, because the
+        property is "no path can write first" and a behavioural test only ever
+        exercises the paths it thought of.
+        """
+        for path, node in _send_action_defs():
+            if path != relative:
+                continue
+            guard_lines = [
+                child.lineno
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == "positive_whole_number_error"
+            ]
+            assert guard_lines, relative
+            first_guard = min(guard_lines)
+            withs = [child.lineno for child in ast.walk(node) if isinstance(child, ast.With)]
+            assert all(first_guard < line for line in withs), (
+                f"{relative}: the substep guard runs inside or after a lock, so a refusal "
+                f"can arrive once the world is already held"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Boundary                                                                    #
+# --------------------------------------------------------------------------- #
+class TestNeighbouringSubstepSurfacesStayOutOfScope:
+    """Pins of behaviour left unchanged, so the boundary is stated not omitted.
+
+    Replace these when the surfaces they describe are settled, rather than
+    deleting them: the scope statement stays useful and simply narrows.
+    """
+
+    def test_there_is_still_no_per_call_ceiling_on_a_substep_count(self) -> None:
+        """MuJoCo's ``_MAX_STEPS_PER_CALL`` guards ``step`` and not this surface.
+
+        So a count ``step`` refuses is still accepted here, on every backend.
+        That is the resource policy tracked as #1871 - a decision about a number,
+        not an input domain - and it is not smuggled in with the domain. Asserted
+        structurally rather than by running 100_001 physics steps.
+        """
+        from strands_robots.simulation.mujoco import rendering
+
+        source = inspect.getsource(rendering.RenderingMixin._apply_sim_action)
+        assert "_MAX_STEPS_PER_CALL" not in source
+        assert "_STEPS_PER_BATCH" not in source
+        over = 100_001
+        assert positive_whole_number_error(over, "n_substeps", "send_action") is None
+
+    def test_the_private_floors_are_retained_and_are_now_unreachable(self) -> None:
+        """Both are defensive no-ops once the public surfaces refuse.
+
+        Kept rather than deleted so a future internal caller cannot advance a
+        negative count, and pinned so the pair stays legible: removing a floor
+        and removing the guard are not independently safe.
+        """
+        from strands_robots.simulation.mujoco import rendering
+
+        mujoco_source = inspect.getsource(rendering.RenderingMixin._apply_sim_action)
+        assert "max(1, n_substeps)" in mujoco_source
+        newton_source = textwrap.dedent(inspect.getsource(NewtonSimEngine._advance))
+        assert "max(1, n_steps)" in newton_source
+
+    def test_the_magnitude_boundary_is_the_float_edge_not_a_resource_ceiling(self) -> None:
+        """``1e300`` is accepted and ``10**400`` refused, as on every caller of this guard.
+
+        Recorded because the two read alike and are not: refusing the second is
+        the float64 edge the domain already had, at which the guard used to raise
+        ``OverflowError`` rather than answer. Choosing a ceiling that would refuse
+        the first is #1871.
+        """
+        assert positive_whole_number_error(1e300, "n_substeps", "send_action") is None
+        assert positive_whole_number_error(BEYOND_FLOAT_RANGE, "n_substeps", "send_action") is not None
+
+    def test_the_narrower_candidate_domain_was_rejected_for_a_measured_reason(self) -> None:
+        """``positive_count_error`` would have regressed the reference backend.
+
+        It admits only a true ``int``, so it refuses every NumPy and integral-float
+        row of ``USABLE_SUBSTEPS`` - counts MuJoCo honors today and ``step``
+        honors by documented design. Pinned so the choice between the two guards
+        is a measurement a later reader can re-run, not a preference.
+        """
+        for count, _expected in USABLE_SUBSTEPS:
+            assert positive_whole_number_error(count, "n_substeps", "send_action") is None
+        refused_by_the_narrower_guard = [
+            count for count, _expected in USABLE_SUBSTEPS if positive_count_error(count, "n", "ctx") is not None
+        ]
+        assert refused_by_the_narrower_guard == [3.0, np.int64(3), np.uint8(2), np.float64(4.0)]
+
+    def test_the_rl_env_still_raises_rather_than_returning_a_structured_error(self) -> None:
+        """``SimEnv`` refuses the same parameter with a ``ValueError`` of its own.
+
+        Left alone: it is a gym-style constructor rather than an agent tool, so a
+        raise is its documented channel and it has no ``{status, content}`` to
+        return. Recorded because the two refusals now differ in wording for the
+        same parameter name, which is a real inconsistency and a deliberate one.
+        """
+        from strands_robots.training.rl import env as rl_env
+
+        source = inspect.getsource(rl_env)
+        assert "n_substeps must be >= 1" in source
+        assert "must be a positive whole number" not in source

--- a/tests/simulation/test_step_count_domain_across_backends.py
+++ b/tests/simulation/test_step_count_domain_across_backends.py
@@ -82,11 +82,14 @@ non-negative or whole-number helper would have regressed the reference backend:
 What is NOT in scope, and is asserted to be unchanged by
 ``TestNeighbouringStepSurfacesStayOutOfScope``:
 
-* ``send_action(n_substeps=)`` on all three backends, which has the same
-  unvalidated domain and on Newton shares the very ``max(1, n_steps)`` floor
-  read here - which is why ``step`` answers its own zero rather than changing
-  that floor. It is a second public surface with its own contract, so it is a
-  separate change.
+* The magnitude of a count on ``step`` (below). ``send_action(n_substeps=)`` is
+  no longer listed here: it was settled separately as #1870, on
+  ``positive_whole_number_error`` - the same scalar policy with the floor at
+  ``1``, because that surface writes an actuator target before it advances and a
+  ``0`` there leaves the target written and never integrated. ``step`` still
+  owns the honored zero, which is why it answers its own rather than moving
+  Newton's ``_advance`` floor; that floor is now unreachable from either public
+  surface. See ``test_send_action_substep_domain_across_backends.py``.
 * The magnitude of a count, which belongs to that ceiling and not to this
   domain. ``10**400`` is a non-negative whole number, so the domain accepts it
   and MuJoCo refuses it with its own ceiling error - exactly as it did before
@@ -122,7 +125,7 @@ from strands_robots.simulation.isaac.simulation import IsaacSimulation
 from strands_robots.simulation.models import SimWorld
 from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 from strands_robots.simulation.newton.simulation import NewtonSimEngine
-from strands_robots.utils import non_negative_whole_number_error
+from strands_robots.utils import non_negative_whole_number_error, positive_whole_number_error
 
 NAN = float("nan")
 INF = float("inf")
@@ -397,7 +400,11 @@ def _newton_stub() -> tuple[Any, SimWorld]:
 
     ``_advance`` is bound genuinely rather than replaced: its ``max(1, n_steps)``
     floor is the thing ``step`` has to answer for, so a stand-in that stubbed it
-    out would make that guard look absent rather than exercised.
+    out would make that guard look absent rather than exercised. Since #1870 the
+    floor is unreachable from either public surface - ``step`` answers ``0``
+    before calling it and ``send_action`` refuses a non-positive count - so it is
+    retained as a defensive no-op rather than as a contract, and this stub still
+    binds the real method so that stays a measurement.
     """
     world = SimWorld()
     stub: Any = types.SimpleNamespace(
@@ -795,18 +802,28 @@ class TestNeighbouringStepSurfacesStayOutOfScope:
     deleting them: the scope statement stays useful and simply narrows.
     """
 
-    def test_send_action_substeps_are_still_unvalidated(self) -> None:
-        """The same domain gap on a second surface, tracked separately.
+    def test_the_advance_floor_survives_but_no_public_surface_can_reach_it(self) -> None:
+        """Replaces the pin that ``send_action(n_substeps=)`` was unvalidated.
 
-        ``send_action(n_substeps=)`` reaches Newton's ``_advance`` floor exactly
-        as ``step`` did, so a ``0`` still advances one substep here. ``step``
-        answers its own zero rather than changing that floor, because the floor
-        is this surface's documented contract and moving it is that surface's
-        change.
+        That surface was settled as #1870 on ``positive_whole_number_error``, so
+        the boundary this class draws has moved rather than gone: the
+        ``max(1, n_steps)`` floor is still in ``_advance`` and still turns a
+        ``0`` into one control step when called directly, which is why ``step``
+        answers its own zero above instead of moving it. What changed is that
+        neither public caller can hand it a non-positive count any more -
+        ``step`` returns before calling it and ``send_action`` refuses - so the
+        floor is a defensive no-op rather than a contract either surface reads.
+
+        Both halves are asserted, because only the pair is the statement: drop
+        the first and a later reader deletes a floor believing nothing depends on
+        it; drop the second and the floor still reads as reachable behaviour.
         """
         stub, world = _newton_stub()
         stub._advance(0)
-        assert world.step_count == 1
+        assert world.step_count == 1, "the floor itself is unchanged"
+
+        assert non_negative_whole_number_error(0, "n_steps", "step") is None
+        assert positive_whole_number_error(0, "n_substeps", "send_action") is not None
 
     def test_the_per_call_ceiling_is_still_mujoco_only(self) -> None:
         """Isaac and Newton have no ceiling and no batched lock release.


### PR DESCRIPTION
## Summary

Closes the last unvalidated numeric input on the simulation stepping surface (#1870): `send_action(action, robot_name, n_substeps)` on all three backends.

It was deliberately left out of #1868/#1869, which settled `step(n_steps)`, because it has a contract of its own. `send_action` **writes an actuator target and then advances**, so a count it cannot honor is not merely a bad number of steps: a refusal arriving after the write leaves the robot commanded and the world un-advanced. That ordering is what the guard placement and half the tests are about.

## What was measured on `182fcc6`

Real MuJoCo engine (mujoco 3.11.0, one position actuator, inline MJCF), Newton on its real inherited `_advance` solver-free, Isaac on its verbatim substep loop:

| `n_substeps` | MuJoCo | Newton | Isaac |
| --- | --- | --- | --- |
| `0` | 1 `mj_step`, `step_count` **+0** | 1 control step | **0 steps**, success |
| `-5` | 1 `mj_step`, `step_count` **-5** | 1 control step | 0 steps, success |
| `False` | 1 `mj_step`, `step_count` +0 | 1 control step | 0 steps, success |
| `2.7` | **raises `TypeError`** | `step_count` = **2.7** | raises `TypeError` |
| `3.0` | **raises `TypeError`** | 3 steps, `step_count` = 3.0 | raises `TypeError` |
| `nan` | 1 `mj_step`, `step_count` = **nan** | 1 control step | raises `TypeError` |
| `inf` | raises `TypeError` | `step_count` = **inf** | raises `TypeError` |
| `"3"` / `None` / `[3]` | raises `TypeError` | raises `TypeError` | raises `TypeError` |

In every raising row the target had **already been written**, and the exception escaped the documented `{status, content}` envelope.

Four findings the issue did not have:

1. **The counter desynchronizes from the physics.** MuJoCo floors its loop at `max(1, n_substeps)` but adds the *raw* count to `step_count`, so a `0` ran one step and recorded none, and a `-5` ran one step and moved the counter **backwards**.
2. **`nan` / `inf` poison the counter permanently** - `step_count` became `nan` on MuJoCo and `inf` on Newton. Not one bad call: every later reader of that world's step count.
3. **`3.0` raised.** An integral float is the most innocuous value in the set - it is what `duration / dt` or a config read produces - and its sibling `step(3.0)` *accepts* it and advances 3. The two surfaces disagreed about one number.
4. **The backends disagreed about `0`.** MuJoCo and Newton floored it to one step; Isaac, which has no floor at all, advanced none. So the same call already meant two different things.

These are reachable: `send_action` is an agent tool method and the sole per-control-step entry point `PolicyRunner.run()` uses.

## The one thing the issue said was a decision

#1870 asked for `n_substeps=0` to be settled before code: honor it (write, do not advance) or refuse it and name `step`. **Settled as refuse**, on evidence rather than taste:

- Both **producers** of this count already refuse anything below 1. `PolicyRunner._control_substeps` returns `>= 1` and raises otherwise, with a docstring recording that clamping with `max(1, int(override))` "silently collapsed to a single physics step - reinstating the exact under-integration this helper exists to prevent". `training.rl.env.SimEnv` refuses an `n_substeps` below 1 with its own raise. `send_action` was the only member of that chain without the guarantee - the "a sibling states the invariant and this caller skips it" shape.
- `send_action`'s own base-class contract is that it writes ctrl values **and then runs `n_substeps` physics steps**, with `PolicyRunner.run()` depending on it as the only thing stepping the world.
- Honoring `0` would have adopted Isaac's *absence* of a floor over the reference backend's explicit one, since the three did not agree.
- Refusing loses nothing that exists: no caller in the tree passes a non-positive count, and `examples/so101_curobo/collector.py` writes `self.sim.step(max(1, n_substeps))` defensively on its kinematic path - precisely because the library never guaranteed this.

## Which guard, and why not the other one

`positive_whole_number_error` - `step`'s scalar policy with the floor moved to 1.

`positive_count_error` was the other candidate and is wrong here: it admits only a true `int`, so it refuses `3.0`, `np.int64(3)`, `np.uint8(2)` and `np.float64(4.0)` - counts MuJoCo honors today and `step` honors by documented design (`USABLE_COUNTS`). That would have been a regression on the reference backend. Pinned as a measurement rather than left as a preference, so the choice is re-runnable.

The magnitude asymmetry the guard documents applies here for its stated reason: `_MAX_STEPS_PER_CALL` is applied by `step` alone and is **absent** from `_apply_sim_action`, so no consumer of this count owns a ceiling.

## Ordering, structurally as well as behaviourally

The guard runs before any target write and before any lock on all three, mirroring each backend's own `step` placement. Both are asserted: behaviourally on the real MuJoCo engine (a refused call leaves `data.time`, `step_count` and `data.ctrl` **exactly** as they were), and structurally by an AST scan comparing the guard's line number against every `with` in the method - because the property is "no path can write first", and a behavioural test only exercises the paths it thought of.

## No verdict moved that was already correct

Strictly additive on the accept path. `3.0` and `np.int64(3)` now succeed where `3.0` used to raise, which removes the `step` / `send_action` disagreement rather than adding a liberty. The `max(1, ...)` floors in `_apply_sim_action` and `_advance` are **retained** as defensive no-ops and are now unreachable from either public surface - following the precedent set in #1877, where a downstream guard made provably unnecessary was left in place and the upstream guarantee stated and pinned instead of churning the downstream code. The counter desynchronization needed no separate fix: it was only reachable with a value outside the domain.

## The invalidated premise is replaced, not deleted

`test_send_action_substeps_are_still_unvalidated` in `test_step_count_domain_across_backends.py` asserted `stub._advance(0) == 1` under the name "still unvalidated". Per the premise-test guidance in `AGENTS.md` it is **replaced by its inverse**: the floor itself is unchanged and still asserted, and what changed - that no public surface can reach it - is asserted alongside. Both halves are kept deliberately, because only the pair is the statement: drop the first and a later reader deletes a floor believing nothing depends on it; drop the second and the floor still reads as reachable behaviour. The module docstring's scope bullet and the `_newton_stub` rationale are updated for the same reason.

## Boundary, stated and pinned

`send_action` still has **no per-call ceiling** on any backend, so a count `step` refuses with `_MAX_STEPS_PER_CALL` is accepted here. That is the resource policy tracked in #1871 - choosing a number for three backends with different per-step costs - not an input domain, and it is not smuggled in with the domain. Pinned structurally rather than by running 100_001 physics steps. Also pinned: `SimEnv` still refuses the same parameter with a `ValueError` of its own rather than a structured result, which is a real inconsistency and a deliberate one (a gym-style constructor has no envelope to return).

## Verification

At `7ab1d58`:

- **117 new tests pass; 77 of them fail on unpatched production code** (`77 failed, 40 passed`). Worth reading the runtime too: that pre-fix run took **484s against 1.7s** post-fix, because an outsized count spins under the lock instead of being refused.
- `ruff check` and `ruff format --check` clean across `strands_robots/` and `tests/` (994 files). `mypy` clean on the new test module; the pre-existing errors elsewhere are missing stubs for optional deps in this env.
- Wider suites read as a **delta**, not an absolute: `tests/simulation` + `tests/training` + the two refusal-invariant modules report **464 failure ids on base and 464 on head, and `comm` shows the two sets are byte-identical** - zero regressions, every failure environmental (no EGL/OSMesa, no assets, no torch/newton/isaac on a hosted runner). Head gains the new module's passes.
- `test_sim_engine_describe_discovery.py` has one failure (`so100` asset not fetched) - confirmed identical on base and head.
- Sibling suites specifically re-run green: the `describe()` schema parser, `test_control_substeps_validation.py`, `test_send_action_rejects_a_boolean_command.py`, `test_conversion_escape_is_closed.py` (whose two pinned docstring substrings survive the `positive_whole_number_error` rewrite).
- New files ASCII-only and host-path-free; every added line ASCII. Changelog fragment present (`changelog.d/1870-send-action-substep-domain.md`), not appended to `CHANGELOG.md`.

Doc drift swept for the new rule: the three backend param docs, the `SimEngine.send_action` contract, both `describe()` schemas (`base.py` is the one MuJoCo and Isaac both inherit), `docs/simulation/overview.md` (Actions prose + Physics table), Newton's now-stale `step` comment whose entire rationale was that `send_action(n_substeps=0)` depended on the floor, and the `_advance` docstring.

Closes #1870.