### PR TITLE
fix(utils): a vector guard must not raise when its value's iteration fails

### DIFF
--- a/changelog.d/1878-finite-vector-iteration-escape.md
+++ b/changelog.d/1878-finite-vector-iteration-escape.md
@@ -1,0 +1,46 @@
+### Fixed: a vector guard must not raise when the value's own iteration fails
+
+`finite_vector_error` asked whether its value was iterable with `iter(vec)`
+inside `except TypeError`. `TypeError` is what "not iterable" means in Python and
+the only exception a well-behaved `__iter__` raises, so a `__iter__` raising
+anything else propagated straight out of the guard - and out of the structured
+`{"status": "error"}` tool-result contract the guard exists to keep:
+
+```python
+class HostileIteration:
+    def __iter__(self):
+        raise RuntimeError("no iteration for you")
+
+finite_vector_error("raycast", "origin", HostileIteration())   # RuntimeError
+```
+
+This was the fourth and last escape of one shape - a guard whose entire purpose
+is to answer an unusable input with a message, raising instead - after the
+rendering escape, the scalar-conversion escape and the container
+conversion-and-rendering escape. `coerce_size_vector` inherited it, being the
+only other surface that reaches this guard's `iter()`; the other container guards
+take `len()` or test `isinstance(value, Sequence)` first and never reached an
+iteration to escape from.
+
+Such a value is now refused with its own text, naming the exception that stopped
+the iteration:
+
+```
+raycast: 'origin' could not be iterated: RuntimeError: no iteration for you
+(got <unrepresentable HostileIteration>). Pass a list or tuple of numbers.
+```
+
+The wording is new rather than reusing the existing `must be a list/tuple of
+numbers`, because the two are not the same measurement: a value whose iteration
+raised may well have held numbers, and the guard never found out, so reporting
+the domain verdict would state something it did not measure. Every verdict that
+existed before is unchanged, including the `TypeError` branch that answers a
+plain non-iterable.
+
+The exception's own text is rendered through the same `_refusal_str` helper as
+every other refusal, since a value hostile enough to raise a non-`TypeError`
+from `__iter__` is not one whose exception is assumed to have a working
+`__str__` - that would reintroduce the rendering escape inside the fix for this
+one. The probe also now binds the iterator it checked and iterates that, rather
+than calling `iter(vec)` for its exception and iterating `vec` again, so the
+`__iter__` that was checked is the one that runs.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1146,6 +1146,11 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
       either poisons the physics state on the next ``mj_forward`` or aborts the
       spec recompile with a cryptic "spec recompile refused", reporting a
       success/garbage result instead of an actionable error.
+    * A value whose ``__iter__`` raises something other than ``TypeError``
+      otherwise propagates that exception out of the guard, which is the same
+      contract break by a different route - the caller asked for a verdict and
+      got a traceback. Reported as its own "could not be iterated" refusal,
+      because whether it held numbers is precisely what could not be determined.
 
     A numpy real scalar per element is accepted (``np.float64`` and friends are
     registered as ``numbers.Real``), matching the "accept NumPy scalar
@@ -1157,11 +1162,38 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     colour, whose count the rgba row it is written into defines. Returns ``None``
     when every element is a finite real number.
     """
+    # ``TypeError`` is what "not iterable" means in Python and the only exception
+    # a well-behaved ``__iter__`` raises, but a guard whose whole purpose is to
+    # answer an unusable input with a message cannot assume good behaviour of the
+    # value it was handed: any other exception escaping here would be the same
+    # defect as the rendering (#1873), scalar-conversion (#1874) and
+    # container-conversion (#1875) escapes, on the one path that must not raise.
+    # It gets its own text because the two verdicts are not the same measurement -
+    # a value whose iteration raised may well have been a list/tuple of numbers,
+    # and this guard never found out, so reporting it as "must be a list/tuple of
+    # numbers" would state something unmeasured (#1878).
+    #
+    # The iterator is bound and then iterated, rather than ``iter(vec)`` being
+    # called for its exception and ``vec`` iterated again: one ``__iter__`` call
+    # is what the probe is asking about, and a second one is free to answer
+    # differently than the one that was checked. It stays lazy - a materialising
+    # ``list(vec)`` would answer for ``__next__`` too, but at the cost of holding
+    # a whole vector that the element loop below only ever needs one at a time.
+    # ``exc`` is rendered through ``_refusal_str`` rather than interpolated: a
+    # value hostile enough to raise a non-``TypeError`` from ``__iter__`` is not
+    # a value whose exception is assumed to have a working ``__str__``, and that
+    # is the #1873 escape reintroduced inside the fix for this one.
     try:
-        iter(vec)
+        elements = iter(vec)
     except TypeError:
         return f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(vec)}"
-    for _elem in vec:
+    except Exception as exc:
+        return (
+            f"{method}: '{param_name}' could not be iterated: "
+            f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
+            f"Pass a list or tuple of numbers."
+        )
+    for _elem in elements:
         # ``numbers.Real`` accepts a numpy scalar (``np.float32`` / ``np.int64``
         # are registered) and rejects a string, ``None`` or a nested list.
         # ``bool`` is an ``int`` subclass, so it would otherwise pass as a

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -193,9 +193,9 @@ class UniterableContainer:
 
     ``__iter__`` raises ``TypeError``, which is what "not iterable" means in
     Python and what every guard here already routes to a refusal. A ``__iter__``
-    raising something *else* is a third escape mechanism, neither rendering nor
-    conversion, and is out of this change's scope - see
-    :class:`TestTheIterationEscapeStaysOutOfScope`.
+    raising something *else* was a third escape mechanism, neither rendering nor
+    conversion; it is closed by #1878 and gets its own verdict, which is what
+    :class:`TestTheIterationIsAnsweredNotEscaped` measures against this probe.
     """
 
     def __repr__(self) -> str:
@@ -208,9 +208,10 @@ class UniterableContainer:
 class HostileIteration:
     """A value whose ``repr`` fails and whose ``__iter__`` raises a non-``TypeError``.
 
-    Used only against the renderer, which recovers any ``Exception``. The guards
-    reach their own ``iter()`` before the renderer, so this does not describe what
-    they do with it; :class:`TestTheIterationEscapeStaysOutOfScope` does.
+    Used against the renderer, which recovers any ``Exception``, and against
+    ``finite_vector_error``, whose own ``iter()`` is reached before the renderer
+    and answers this value with its own refusal since #1878;
+    :class:`TestTheIterationIsAnsweredNotEscaped` states what that answer is.
     """
 
     def __repr__(self) -> str:
@@ -218,6 +219,29 @@ class HostileIteration:
 
     def __iter__(self) -> Iterator[Any]:
         raise RuntimeError("no iteration for you")
+
+
+class UnprintableFailureError(Exception):
+    """An exception whose own ``str`` raises.
+
+    The fix for #1878 reports the exception that stopped the iteration, so the
+    message now interpolates a value supplied by the same hostile type. Without
+    this probe that interpolation is the #1873 rendering escape again, one level
+    inside the fix for the iteration escape, and nothing would measure it.
+    """
+
+    def __str__(self) -> str:
+        raise RuntimeError("no str for you")
+
+
+class UnprintableFailure:
+    """A value whose ``__iter__`` raises an exception that cannot be rendered."""
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+    def __iter__(self) -> Iterator[Any]:
+        raise UnprintableFailureError
 
 
 class UnprintableName(str):
@@ -843,46 +867,90 @@ class TestEveryContainerGuardRoutesThroughTheRenderer:
 # --------------------------------------------------------------------------- #
 # The boundary of this change, stated rather than omitted                      #
 # --------------------------------------------------------------------------- #
-class TestTheIterationEscapeStaysOutOfScope:
-    """A pin of behaviour left unchanged, so the boundary is stated (#1878).
+class TestTheIterationIsAnsweredNotEscaped:
+    """``finite_vector_error`` answers a hostile iteration instead of raising (#1878).
 
-    Replace this when the surface it describes is settled rather than deleting it,
-    per the premise-test guidance in ``AGENTS.md``.
+    Replaces ``TestTheIterationEscapeStaysOutOfScope``, which pinned the opposite
+    for as long as the escape was a stated boundary rather than a fixed defect.
+    The conclusion that class supported still holds and is still measured here -
+    only one guard ever reached an iteration, so the surface this closes is one
+    ``iter()`` call - but the verdict on that call is now a message.
 
-    ``finite_vector_error`` asks ``iter(vec)`` inside ``except TypeError`` - which
-    is the exception "not iterable" means, and the only one a well-behaved type
-    raises. A ``__iter__`` that raises anything else escapes the guard, before
-    either the conversion or the rendering this change fixed is reached. That is a
-    **third** mechanism, and closing it here would be a different change:
-
-    * It needs its own message decision. A value whose iteration failed is not
-      "not a list/tuple of numbers" - the guard cannot tell whether it was one -
-      so reusing that text would state something unmeasured.
-    * Its reachability is weaker than #1874's and #1875's by a wide margin. Those
-      arrive as a JSON number through a ``device_connect`` ``@rpc()`` payload,
-      where an arbitrary-precision integer is one request away. A type whose
-      ``__iter__`` raises ``RuntimeError`` cannot be expressed in JSON at all and
-      has to be hand-written by a direct API caller.
-
-    So it is recorded and pinned rather than folded in, which keeps this change one
-    concern and keeps the remaining escape a measurement instead of a remark.
+    This is the fourth and last escape in the family: rendering (#1873), scalar
+    conversion (#1874), container conversion and rendering (#1875), and iteration
+    here. All four are the same defect - a guard whose entire purpose is to answer
+    an unusable input with a structured refusal, raising instead.
     """
 
-    def test_a_hostile_iteration_still_escapes_the_vector_guard(self) -> None:
-        with pytest.raises(RuntimeError):
-            finite_vector_error("raycast", "origin", HostileIteration())
+    def test_a_hostile_iteration_is_refused_rather_than_raised(self) -> None:
+        message = finite_vector_error("raycast", "origin", HostileIteration())
+        assert message is not None
+        assert "raycast: 'origin' could not be iterated" in message
 
-    def test_the_other_guards_answer_it_because_they_ask_for_a_length_first(self) -> None:
-        """Only one guard is exposed, which is what makes the boundary small.
+    def test_the_refusal_names_the_exception_that_stopped_the_iteration(self) -> None:
+        """The type and text are what make the message actionable.
+
+        Without them the caller learns only that *something* went wrong inside a
+        value they own, which is the diagnostic content of the traceback this
+        replaces minus the traceback.
+        """
+        message = finite_vector_error("raycast", "origin", HostileIteration())
+        assert message is not None
+        assert "RuntimeError" in message
+        assert "no iteration for you" in message
+
+    def test_it_does_not_claim_the_value_was_not_a_list_of_numbers(self) -> None:
+        """The two verdicts are different measurements and must not share text.
+
+        A value whose ``__iter__`` raised may well have held numbers; this guard
+        never found out. Reusing the ``TypeError`` text would report a domain
+        check that never ran - which is why #1878 was not folded into #1875.
+        """
+        hostile = finite_vector_error("raycast", "origin", HostileIteration())
+        not_iterable = finite_vector_error("raycast", "origin", UniterableContainer())
+        assert hostile is not None and not_iterable is not None
+        assert "must be a list/tuple of numbers" in not_iterable
+        assert "must be a list/tuple of numbers" not in hostile
+        assert hostile != not_iterable
+
+    def test_a_plain_non_iterable_still_gets_the_type_error_text(self) -> None:
+        """The ``TypeError`` branch is the common case and is unchanged."""
+        message = finite_vector_error("raycast", "origin", 1.0)
+        assert message is not None
+        assert "must be a list/tuple of numbers" in message
+
+    def test_coerce_size_vector_inherits_the_answer_it_inherited_the_raise_from(self) -> None:
+        """``coerce_size_vector`` reaches this guard, so the fix reaches it too.
+
+        It was the only other exposed surface, by inheritance rather than by its
+        own ``iter()`` call, so it is the one place a fix could have been missed.
+        """
+        _value, error = coerce_size_vector("add_object", "size", HostileIteration())
+        assert error is not None
+        assert "could not be iterated" in error
+
+    def test_an_exception_whose_own_str_raises_does_not_reescape(self) -> None:
+        """The fix must not reintroduce #1873 inside its own message.
+
+        A value hostile enough to raise a non-``TypeError`` from ``__iter__`` is
+        not one whose exception is assumed to render, so the exception text goes
+        through the same safe renderer every other refusal uses.
+        """
+        message = finite_vector_error("raycast", "origin", UnprintableFailure())
+        assert message is not None
+        assert "could not be iterated" in message
+        assert "UnprintableFailureError" in message
+
+    def test_the_other_guards_still_answer_because_they_ask_for_a_length_first(self) -> None:
+        """Unchanged, and still the reason the closed surface is one call.
 
         ``pose_vector_error`` takes ``len()`` before iterating and
-        ``name_list_error`` tests ``isinstance(value, Sequence)``, so both refuse
-        this value on its shape and never reach an iteration. Stated here so the
-        pin above is known to cover one guard rather than assumed to.
+        ``name_list_error`` tests ``isinstance(value, Sequence)``, so neither ever
+        reached an iteration to escape from.
         """
         assert pose_vector_error("add_object", "position", HostileIteration(), 3) is not None
         assert name_list_error(HostileIteration(), "cameras", "render_all") is not None
 
-    def test_the_rendering_half_is_closed_even_there(self) -> None:
-        """The renderer itself is total, so it is not what leaves the escape open."""
+    def test_the_rendering_half_was_already_closed(self) -> None:
+        """The renderer was never what left this open, and still is not."""
         assert _refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"


### PR DESCRIPTION
Closes #1878.

## The defect

`finite_vector_error` asked whether its value was iterable like this:

```python
try:
    iter(vec)
except TypeError:
    return f"{method}: '{param_name}' must be a list/tuple of numbers, got ..."
for _elem in vec:
```

`TypeError` is what "not iterable" means in Python and the only exception a
well-behaved `__iter__` raises. A `__iter__` raising anything else propagated
straight out of the guard - and out of the structured `{"status": "error"}`
tool-result contract the guard exists to keep:

```python
class HostileIteration:
    def __iter__(self):
        raise RuntimeError("no iteration for you")

finite_vector_error("raycast", "origin", HostileIteration())   # RuntimeError
```

This is the **fourth and last** escape of one shape - a guard whose entire
purpose is to answer an unusable input with a message, raising instead - after
the rendering escape, the scalar-conversion escape and the container
conversion-and-rendering escape.

## Scope: one guard, plus the one that inherits it

`coerce_size_vector` reaches this guard's `iter()` and inherited the raise, so it
is the one place a fix could have been missed; it is covered and pinned. The
other container guards take `len()` or test `isinstance(value, Sequence)` first
and never reached an iteration to escape from - measured, not assumed.

| guard | reaches an iteration? | before | after |
|---|---|---|---|
| `finite_vector_error` | yes, `iter(vec)` | **raises** | refuses |
| `coerce_size_vector` | via `finite_vector_error` | **raises** | refuses |
| `pose_vector_error` | no - `len()` first | refuses | unchanged |
| `name_list_error` | no - `isinstance(..., Sequence)` | refuses | unchanged |
| `coerce_pose_vector` | via `pose_vector_error` | refuses | unchanged |
| `coerce_rgba` | `sequence_length` first | refuses | unchanged |

## The message is new rather than reused

```
raycast: 'origin' could not be iterated: RuntimeError: no iteration for you
(got <unrepresentable HostileIteration>). Pass a list or tuple of numbers.
```

Reusing the existing `must be a list/tuple of numbers` would state something the
guard did not measure: a value whose iteration raised may well have held numbers,
and the guard never found out. Pinned in both directions - the new text appears,
and the domain text does *not*.

## Two details that are the fix, not decoration

1. **The exception's own text goes through `_refusal_str`.** A value hostile
   enough to raise a non-`TypeError` from `__iter__` is not one whose exception is
   assumed to have a working `__str__`. Interpolating it raw would reintroduce the
   rendering escape *inside* the fix for this one, so there is a probe whose
   exception's `__str__` also raises.
2. **The iterator that was checked is the one that runs.** The probe binds
   `elements = iter(vec)` and iterates that, rather than calling `iter(vec)` for
   its exception and iterating `vec` again - a second `__iter__` call is free to
   answer differently than the one that was checked. It stays lazy; a
   materialising `list(vec)` would also answer for `__next__`, but at the cost of
   holding a whole vector the element loop needs one at a time.

## No behaviour moved

Every pre-existing verdict is unchanged, including the `TypeError` branch for a
plain non-iterable. Verified across accepted and refused inputs - `list`, `tuple`,
`np.ndarray`, a 0-d NumPy scalar, `nan`, `bool`, a `str` element, `None`, an `int`
past the float64 range, and a generator. All callers consume the message via
`(err := ...) is not None`, so a new message string flows identically; no caller
and no test depended on the raise.

As a side effect this also clears CodeQL alert #846
(`py/non-iterable-in-for-loop`, error severity) at this line, which had been open
on `main` since 2026-08-01 and was re-reported as a "new" finding against every PR
that shifted these lines.

## Tests

`TestTheIterationEscapeStaysOutOfScope` pinned the *opposite* while the escape was
a stated boundary. Per the premise-test guidance in `AGENTS.md` it is **replaced**,
not deleted, by `TestTheIterationIsAnsweredNotEscaped` (8 tests) - the conclusion
it supported still holds and is still measured, only the verdict changed. The two
fixture docstrings that cross-referenced it are updated in the same commit so no
stale pointer is left behind.

```
tests/test_container_refusals_render_elementwise.py  112 passed
+ test_conversion_escape_is_closed.py
+ test_refusal_messages_never_raise.py                306 passed total
ruff check / ruff format --check                      clean
mypy                                                  no new errors (14 = baseline)
```
