### PR TITLE
fix(policies): read a 0-d observation value as the scalar it is, not raise

### DIFF
--- a/changelog.d/1883-policies-length-probe.md
+++ b/changelog.d/1883-policies-length-probe.md
@@ -1,0 +1,23 @@
+### Fixed: a 0-d observation value is read as the scalar it is, not raised on
+
+`MockPolicy.get_actions` raised `TypeError: len() of unsized object` when
+`observation.state` was a 0-d array (`np.array(0.5)`, or the result of a
+reduction such as `np.mean(...)`), and `WBCPolicy._read_vec` raised the same for
+a 0-d `base_ang_vel` / `base_quat` entry, mid-rollout. Both already had an
+answer for a value that carries no component count - `MockPolicy` falls back to
+six joints, `_read_vec` returns `None` - and a 0-d array was the one spelling
+that never reached it, because `hasattr(value, "__len__")` is `True` for a value
+whose `__len__` raises.
+
+The three remaining sites of that idiom now read the count through
+`utils.sequence_length`, which has been the single owner of the rule since it
+answered the same question for the simulation and rendering surfaces. The third
+site, `WBCPolicy`'s flat-vector/per-joint observation discriminator, did not
+raise but split the two spellings of a scalar: a plain `float` was consumed as
+the per-joint form while a 0-d array took the flat form and wrote its single
+value into the first joint's slot. Both are now read as the per-joint form.
+
+Correctly sized states and observation vectors are accepted exactly as before,
+and the structural guard that keeps the idiom out now scans the whole package
+rather than the two subpackages named when it was written - which is why these
+three survived.

--- a/strands_robots/policies/mock.py
+++ b/strands_robots/policies/mock.py
@@ -5,7 +5,7 @@ import math
 from typing import Any
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import name_list_error
+from strands_robots.utils import name_list_error, sequence_length
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,13 @@ class MockPolicy(Policy):
         if not self.robot_state_keys:
             if "observation.state" in observation_dict:
                 state = observation_dict["observation.state"]
-                dim = len(state) if hasattr(state, "__len__") else 6
+                # ``sequence_length`` rather than a ``hasattr(state,
+                # "__len__")`` probe: a 0-d array declares ``__len__`` and
+                # raises from it, so the probe passes and ``len()`` escapes
+                # past the ``else`` written for exactly this value - a state
+                # that does not carry a width (#1883, the rule from #1844).
+                n_components = sequence_length(state)
+                dim = 6 if n_components is None else n_components
             else:
                 dim = 6
             self.robot_state_keys = [f"joint_{i}" for i in range(dim)]

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -63,7 +63,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import require_optional
+from strands_robots.utils import require_optional, sequence_length
 
 from .config import WBCConfig
 from .control import compute_targets, pd_control, projected_gravity
@@ -620,7 +620,12 @@ class WBCPolicy(Policy):
         # Flat-vector form: index into the flat array by each joint's position.
         flat_key = "observation.state" if kind == "position" else "observation.velocity"
         flat = obs.get(flat_key)
-        if flat is not None and hasattr(flat, "__len__"):
+        # The flat/per-joint discriminator asks for a component count, so it
+        # asks ``sequence_length``. A 0-d array is a scalar that declares
+        # ``__len__``, and a ``hasattr`` probe sent it down the flat branch
+        # while a plain float went down the per-joint one - two spellings of
+        # one scalar answering differently for the same observation (#1883).
+        if flat is not None and sequence_length(flat) is not None:
             arr = np.asarray(flat if not hasattr(flat, "tolist") else flat.tolist(), dtype=np.float64).ravel()
             if self._robot_state_keys:
                 # Name-resolved indexing: map each observed joint to its slot in
@@ -664,7 +669,12 @@ class WBCPolicy(Policy):
     def _read_vec(obs: dict[str, Any], keys: tuple[str, ...], n: int) -> np.ndarray | None:
         for k in keys:
             v = obs.get(k)
-            if v is not None and hasattr(v, "__len__") and len(v) == n:
+            # ``sequence_length`` answers ``None`` for a value with no
+            # readable length, which is never ``n``, so the width test and
+            # the has-a-width test are one expression. The ``hasattr`` +
+            # ``len()`` spelling raised on a 0-d entry instead of returning
+            # the ``None`` every caller of this method is written against.
+            if v is not None and sequence_length(v) == n:
                 return np.asarray(v if not hasattr(v, "tolist") else v.tolist(), dtype=np.float64).ravel()
         return None
 

--- a/tests/test_unsized_value_is_refused_not_raised.py
+++ b/tests/test_unsized_value_is_refused_not_raised.py
@@ -15,6 +15,13 @@ structural checks as being there "to keep the never-raises envelope", and
 :func:`strands_robots.rendering.video.mjpeg_frames` documents ``ValueError`` with
 an actionable message as its only failure mode for a malformed ``size``.
 
+Not every affected surface publishes an envelope, though, and the ``policies/``
+sites added here fail a second way: they contradict *themselves*. ``MockPolicy``
+already documents ``else 6`` for a state that carries no width, and
+``WBCPolicy._read_vec`` already returns ``None`` for every value it cannot use -
+a 0-d array is exactly that value, and it was the one spelling that never
+reached the branch written for it.
+
 :func:`strands_robots.utils.sequence_length` is the single owner of the rule -
 it answers "no readable length" for a 0-d array and for a plain scalar alike -
 and these tests pin every surface that reads a caller-supplied length through
@@ -24,13 +31,17 @@ it, plus the accepted values that must keep working.
 from __future__ import annotations
 
 import ast
+import asyncio
 import inspect
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import pytest
 
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.policies.wbc.policy import WBCPolicy
 from strands_robots.rendering.video import mjpeg_frames
 from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 from strands_robots.utils import sequence_length
@@ -277,9 +288,81 @@ class TestMjpegFrameSize:
 
 
 # --------------------------------------------------------------------------- #
-# Structural: no envelope module may probe a caller length with hasattr again.
+# policies/: the sites #1844's scan root could not see (#1883).
 # --------------------------------------------------------------------------- #
-_ENVELOPE_PACKAGES = ("simulation", "rendering")
+class TestMockPolicyStateWidth:
+    """``MockPolicy`` derives its joint count without raising on a 0-d state.
+
+    The canonical reference implementation every provider is pointed at, so the
+    idiom surviving here is also the one most likely to be copied.
+    """
+
+    def _dim(self, state: Any) -> int:
+        actions = asyncio.run(MockPolicy().get_actions({"observation.state": state}, "go"))
+        return len(actions[0])
+
+    def test_an_unsized_state_takes_the_documented_fallback(self) -> None:
+        """A 0-d state carries no width, so the ``else 6`` branch applies to it.
+
+        It used to raise ``TypeError: len() of unsized object`` instead - past the
+        branch written for a state that does not declare a width.
+        """
+        assert self._dim(UNSIZED) == 6
+
+    def test_a_scalar_state_answers_the_same_either_way(self) -> None:
+        """A plain float and a 0-d array are both scalars; both mean "no width"."""
+        assert self._dim(0.5) == self._dim(UNSIZED) == 6
+
+    def test_a_sized_state_still_sets_the_width(self) -> None:
+        """Over-reach control: a real state vector keeps deriving its own width."""
+        assert self._dim(np.zeros(4)) == 4
+        assert self._dim([0.0, 0.0, 0.0]) == 3
+
+
+class TestWBCObservationVectors:
+    """``WBCPolicy``'s two observation readers answer, rather than raise, for a 0-d entry."""
+
+    def _flat(self, state: Any, names: list[str]) -> np.ndarray:
+        """``_read_joint_vector`` over a stub carrying only the attribute it reads."""
+        stub = SimpleNamespace(_robot_state_keys=[])
+        return WBCPolicy._read_joint_vector(stub, {"observation.state": state}, "position", names)
+
+    def test_read_vec_reports_an_unsized_entry_as_absent(self) -> None:
+        """``_read_vec`` returns ``None`` for every value it cannot use, 0-d included.
+
+        Both callers (``base_ang_vel``, ``base_quat``) are written against that
+        ``None``; a 0-d entry used to raise out of ``get_actions`` mid-rollout.
+        """
+        assert WBCPolicy._read_vec({"k": UNSIZED}, ("k",), 3) is None
+
+    def test_read_vec_still_returns_a_correctly_sized_vector(self) -> None:
+        """Over-reach control: the accepted width is unchanged, and so is a wrong one."""
+        got = WBCPolicy._read_vec({"k": [1.0, 2.0, 3.0]}, ("k",), 3)
+        assert got is not None and np.allclose(got, [1.0, 2.0, 3.0])
+        assert WBCPolicy._read_vec({"k": [1.0, 2.0]}, ("k",), 3) is None
+
+    def test_a_scalar_state_reads_the_same_either_spelling(self) -> None:
+        """The flat/per-joint discriminator no longer splits the two scalars.
+
+        A ``hasattr`` probe sent a 0-d array down the flat branch and a plain
+        float down the per-joint one, so one observation produced two different
+        joint vectors depending on how the scalar was spelled. Neither carries a
+        component per joint, so both read as the per-joint form.
+        """
+        names = ["a", "b", "c"]
+        assert np.allclose(self._flat(UNSIZED, names), self._flat(0.5, names))
+        assert np.allclose(self._flat(UNSIZED, names), np.zeros(3))
+
+    def test_a_flat_state_vector_is_still_consumed_positionally(self) -> None:
+        """Over-reach control: the flat form the discriminator exists for is unchanged."""
+        names = ["a", "b", "c"]
+        assert np.allclose(self._flat([0.1, 0.2, 0.3], names), [0.1, 0.2, 0.3])
+        assert np.allclose(self._flat(np.array([0.1, 0.2, 0.3]), names), [0.1, 0.2, 0.3])
+
+
+# --------------------------------------------------------------------------- #
+# Structural: no module may probe a caller length with hasattr again.
+# --------------------------------------------------------------------------- #
 
 
 def _hasattr_len_probes(tree: ast.AST) -> list[int]:
@@ -295,13 +378,18 @@ def _hasattr_len_probes(tree: ast.AST) -> list[int]:
     return lines
 
 
-def _envelope_modules() -> list[Path]:
-    """Every module of the packages that publish a no-raise envelope."""
-    package_dir = Path(inspect.getfile(sequence_length)).parent
-    modules: list[Path] = []
-    for name in _ENVELOPE_PACKAGES:
-        modules.extend(sorted((package_dir / name).rglob("*.py")))
-    return modules
+def _package_modules() -> list[Path]:
+    """Every module of ``strands_robots``.
+
+    The scan was ``("simulation", "rendering")`` when #1844 introduced it, and
+    the sweep was therefore exactly as wide as the scan: three call sites in
+    ``policies/`` were never converted and went on raising for two more months
+    (#1883). Naming packages is what allowed that, so the root is the package -
+    a value whose length cannot be read is not a simulation concern, and a
+    module added under a new subpackage is covered on the day it lands rather
+    than when someone remembers to extend a tuple.
+    """
+    return sorted(Path(inspect.getfile(sequence_length)).parent.rglob("*.py"))
 
 
 class TestNoDirectLengthProbe:
@@ -309,11 +397,27 @@ class TestNoDirectLengthProbe:
 
     def test_the_scan_root_resolves_to_real_modules(self) -> None:
         """Non-vacuity: a mislocated root would make the scan below pass trivially."""
-        modules = _envelope_modules()
+        modules = _package_modules()
         assert len(modules) > 20, modules
         assert any(path.name == "base.py" for path in modules)
 
-    def test_no_envelope_module_probes_a_length_with_hasattr(self) -> None:
+    def test_the_scan_reaches_every_subpackage_not_a_named_few(self) -> None:
+        """The root covers the packages a named tuple left out, ``policies/`` included.
+
+        #1883's three unconverted sites were all in ``policies/``, which the
+        original ``("simulation", "rendering")`` root could not see. Asserting on
+        the subpackages present keeps a future narrowing of the root from
+        silently reopening that gap.
+        """
+        package_dir = Path(inspect.getfile(sequence_length)).parent
+        reached = {
+            path.relative_to(package_dir).parts[0]
+            for path in _package_modules()
+            if len(path.relative_to(package_dir).parts) > 1
+        }
+        assert {"policies", "simulation", "rendering"} <= reached, sorted(reached)
+
+    def test_no_module_probes_a_length_with_hasattr(self) -> None:
         """``hasattr(x, "__len__")`` is never a safe stand-in for a length probe.
 
         A 0-d array passes it and then raises from ``len()``. Ask
@@ -322,7 +426,7 @@ class TestNoDirectLengthProbe:
         """
         offenders = {
             f"{path.name}:{line}"
-            for path in _envelope_modules()
+            for path in _package_modules()
             for line in _hasattr_len_probes(ast.parse(path.read_text()))
         }
         assert not offenders, f"use sequence_length() instead of a hasattr length probe: {sorted(offenders)}"

--- a/tests/test_unsized_value_is_refused_not_raised.py
+++ b/tests/test_unsized_value_is_refused_not_raised.py
@@ -34,7 +34,6 @@ import ast
 import asyncio
 import inspect
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -323,9 +322,17 @@ class TestWBCObservationVectors:
     """``WBCPolicy``'s two observation readers answer, rather than raise, for a 0-d entry."""
 
     def _flat(self, state: Any, names: list[str]) -> np.ndarray:
-        """``_read_joint_vector`` over a stub carrying only the attribute it reads."""
-        stub = SimpleNamespace(_robot_state_keys=[])
-        return WBCPolicy._read_joint_vector(stub, {"observation.state": state}, "position", names)
+        """``_read_joint_vector`` on an instance carrying only the attribute it reads.
+
+        ``__new__`` rather than ``__init__``: the reader needs one attribute and
+        the constructor needs an ONNX runtime and a checkpoint, so building a
+        real policy here would make an observation-parsing test depend on
+        ``onnxruntime`` being installed. It is a genuine ``WBCPolicy``, so the
+        call is type-checked like any other caller's would be.
+        """
+        policy = WBCPolicy.__new__(WBCPolicy)
+        policy._robot_state_keys = []
+        return policy._read_joint_vector({"observation.state": state}, "position", names)
 
     def test_read_vec_reports_an_unsized_entry_as_absent(self) -> None:
         """``_read_vec`` returns ``None`` for every value it cannot use, 0-d included.


### PR DESCRIPTION
Closes #1883.

#1844 made `utils.sequence_length` the single owner of "how many components is this?" and added `TestNoDirectLengthProbe` to keep the `hasattr(value, "__len__")` + `len(value)` idiom from coming back. The guard works. Its scan root was two named subpackages:

```python
_ENVELOPE_PACKAGES = ("simulation", "rendering")
```

so the sweep was exactly as wide as the scan. Running #1844's own AST matcher over the whole package on `cb3019a` finds every site it could not see, and there are three:

```
[NOT SCANNED] policies/mock.py:[59]
[NOT SCANNED] policies/wbc/policy.py:[623, 667]
```

That is all of them - no other module carries the idiom - so this is three lines and then the scan root.

## Why these are not merely unconverted

At two of the three the code has **already decided** what to do with a value that carries no readable width, and the 0-d array is the one spelling that never reaches the branch written for it. Measured with `np.array(0.5)` (`ndim=0`; `hasattr(v, "__len__")` is `True`, `len(v)` raises, `sequence_length(v)` is `None`):

| surface | value | before | after |
|---|---|---|---|
| `MockPolicy.get_actions` | `0.5` (no `__len__`) | 6 joints, the documented `else` | unchanged |
| `MockPolicy.get_actions` | `np.array(0.5)` | **raised** `TypeError: len() of unsized object` | 6 joints |
| `WBCPolicy._read_vec` | `{}` (no key) | `None` | unchanged |
| `WBCPolicy._read_vec` | `{"k": np.array(0.5)}` | **raised** the same `TypeError` | `None` |

`MockPolicy` is the canonical reference implementation `policies/base.py` points every provider at, which makes it the worst of the three places for the idiom to survive. `_read_vec` returns `None` for every value it cannot use and both callers (`base_ang_vel` at :566, `base_quat` at :581) are written against that `None`; a 0-d entry raised out of `get_actions` mid-rollout instead.

## The third site is a behaviour change, so it is stated rather than slipped in

`policies/wbc/policy.py:623` is a *form discriminator* (flat vector vs. per-joint scalars), not a length read, and it does **not** raise: the branch it selects calls `np.asarray(...).ravel()`, which handles 0-d and yields shape `(1,)`. What it did instead was split the two spellings of a scalar:

| `observation.state` | branch | result for 3 joints |
|---|---|---|
| `0.5` | per-joint scalar form | `[0, 0, 0]` (the documented "missing values default to zero") |
| `np.array(0.5)` | flat-vector form | `[0.5, 0, 0]` |

One observation, two joint vectors, decided by how the caller spelled a scalar. Neither value carries a component per joint, so both now read as the per-joint form - which is what `sequence_length` is for: it answers "no readable width" for a 0-d array and a plain `float` alike. This is the only behaviour change on a value that did not previously raise, and it has its own pin.

## The scan root

Widened from `("simulation", "rendering")` to the whole `strands_robots` package. Naming subpackages is the mechanism that produced this drift, and the sweep is already clean everywhere else, so the wide root costs nothing today and closes the class rather than this instance of it. Two things keep it honest:

- the existing planted-defect meta-test, unchanged, so an empty result still cannot mean "scanner matches nothing";
- a new non-vacuity test asserting `policies/` is among the subpackages the root reaches, so a future narrowing cannot silently reopen the same gap.

Verified by planting `hasattr(value, "__len__")` in `policies/mock.py`: the widened scan fails with `use sequence_length() instead of a hasattr length probe: ['mock.py:85']`, where the old root passed.

## Scope and verification

Three expressions in two modules, the scan root, eight pins, one changelog fragment. No new helper, no new message, no public signature touched.

- Each site is pinned over both halves of its domain - the 0-d value **and** a correctly sized control that must keep working (`np.zeros(4)` -> 4 joints, a 3-vector `_read_vec` still returned, a flat `[0.1, 0.2, 0.3]` still consumed positionally).
- `tests/test_unsized_value_is_refused_not_raised.py`: 45 passed -> 53 passed, with the same 2 pre-existing failures both before and after (they need `torch` and `PIL`, absent in the local environment).
- `tests/policies/` (1714 tests): failure set **identical** before and after the change - 64 both times, every one a missing optional dependency (`msgpack`, `robot_descriptions`). No regression, and none fixed by accident.
- `ruff check` and `ruff format --check` clean on all three files. ASCII only.
- Doc drift checked: the only doc text about this rule is the `docs/simulation/overview.md` note on vector *parameters* of the sim surface, which this PR does not touch and which stays accurate. No doc edit needed.

## Changelog

**Second commit** - `test(policies): type the WBC observation-reader double as the class it stands in for`

The first push failed the required check on a single mypy `arg-type` error, and the complaint was correct rather than incidental: `_read_joint_vector` was called with a `SimpleNamespace` as `self`, which does not type-check the call the way a real caller's would. Replaced with `WBCPolicy.__new__(WBCPolicy)` - a genuine instance, so the call is checked like any other, and `__new__` rather than `__init__` keeps an observation-parsing test from requiring `onnxruntime` and a checkpoint for the single attribute the reader reads. No production code and no assertion changed. The local gap was running `mypy` without the project config, which is now part of the pre-push check.