### PR TITLE
fix(sim): refuse a camera name render resolves past

### DIFF
--- a/changelog.d/1887-reserved-camera-name-at-creation.md
+++ b/changelog.d/1887-reserved-camera-name-at-creation.md
@@ -1,0 +1,31 @@
+### Fixed: a camera name the MuJoCo backend's own render resolves past is refused at `add_camera`
+
+`render`, `render_depth` and `get_frame` select the free camera for
+`camera_name` in `(None, "", "default", "free")` by an explicit token check, but
+`add_camera` let a caller claim two of those tokens as a camera *name*. The
+camera was registered, compiled into the model and offered by `list_cameras`,
+and every render of it silently answered with the free view instead - measured
+on MuJoCo 3.11.0, `add_camera("free", position=[8, 8, 8], target=[0, 0, 0])`
+returned `status="success"` with `mj_name2id(model, CAMERA, "free")` resolving,
+while `render(camera_name="free")` took the `cam_id = -1` branch. The camera was
+unreachable through the API that created it, with no error at any point.
+
+`"default"` was refused only as a *duplicate*, because `create_world` registers
+the built-in free view under that name, and that refusal prescribed the remedy
+that completed the defect: `remove_camera("default")` succeeded, the following
+`add_camera("default", ...)` succeeded, and the scene was left with an
+unreachable camera where the advertised free-view alias had been.
+
+Both are now refused as reserved names, ahead of the duplicate-name test, with
+the reason stated. The Newton backend already refused the whole set, so this was
+a one-backend parity gap; its refusal and MuJoCo's are now the same sentence
+from one shared `reserved_camera_name_error`. The token set itself becomes a
+single `FREE_CAMERA_TOKENS` definition, replacing eleven copies of the tuple
+literal across `mujoco/rendering.py`, `newton/simulation.py` and
+`simulation/base.py` - one of them written in a different order - so the side
+that routes a token and the side that refuses it can no longer disagree.
+
+The Isaac backend is deliberately unchanged: its `get_frame` looks the camera up
+in `self._cameras` directly with no token check, so `"default"` there is an
+ordinary addressable name and is that backend's documented signature default.
+The rule follows from routing, and a backend that does not route does not get it.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 # annotations`` (already in effect) makes that a no-op at runtime.
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 from strands_robots.utils import (
+    FREE_CAMERA_TOKENS,
     is_boolean,
     positive_count_error,
     positive_finite_number_error,
@@ -3771,7 +3772,7 @@ class SimEngine(ABC):
         # One label per camera: every free-camera token (None / "" / "free" /
         # "default") reports as "default", so the same camera never appears
         # under two names across calls.
-        camera_label = "default" if camera_name in (None, "", "free", "default") else str(camera_name)
+        camera_label = "default" if camera_name in FREE_CAMERA_TOKENS else str(camera_name)
         if not valid_points:
             return _err(
                 f"get_world_point found no valid depth at any of the {len(parsed)} requested pixels via "

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -27,7 +27,7 @@ from strands_robots.simulation.safe_output import (
     validate_output_path,
     video_sandbox_args,
 )
-from strands_robots.utils import name_list_error
+from strands_robots.utils import FREE_CAMERA_TOKENS, name_list_error
 
 logger = logging.getLogger(__name__)
 
@@ -954,11 +954,7 @@ class RenderingMixin:
         # with get_observation, which already keys off the per-camera config.
         # The free camera ("default"/"free") and model-only cameras that have no
         # SimCamera entry fall back to the engine default.
-        cam_cfg = (
-            registry_entry(self._world.cameras, camera_name)
-            if camera_name not in (None, "", "default", "free")
-            else None
-        )
+        cam_cfg = registry_entry(self._world.cameras, camera_name) if camera_name not in FREE_CAMERA_TOKENS else None
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
@@ -983,7 +979,7 @@ class RenderingMixin:
             # Special 'default' / 'free' tokens route to the free camera; any
             # other name MUST resolve or we error (prevents the LLM from
             # believing it rendered viewpoint X while actually getting free-cam).
-            if camera_name in (None, "", "default", "free"):
+            if camera_name in FREE_CAMERA_TOKENS:
                 cam_id = -1
                 label = "free (default)"
             else:
@@ -1095,11 +1091,7 @@ class RenderingMixin:
         # frame render() produces for the same camera (and with get_observation).
         # The free camera and model-only cameras with no SimCamera entry fall
         # back to the engine default.
-        cam_cfg = (
-            registry_entry(self._world.cameras, camera_name)
-            if camera_name not in (None, "", "default", "free")
-            else None
-        )
+        cam_cfg = registry_entry(self._world.cameras, camera_name) if camera_name not in FREE_CAMERA_TOKENS else None
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
@@ -1107,7 +1099,7 @@ class RenderingMixin:
 
         try:
             # strict camera validation (same policy as render())
-            if camera_name in (None, "", "default", "free"):
+            if camera_name in FREE_CAMERA_TOKENS:
                 cam_id = -1
                 label = "free (default)"
             else:
@@ -1296,11 +1288,7 @@ class RenderingMixin:
             raise RuntimeError(_NO_WORLD_MSG)
 
         mj = _ensure_mujoco()
-        cam_cfg = (
-            registry_entry(self._world.cameras, camera_name)
-            if camera_name not in (None, "", "default", "free")
-            else None
-        )
+        cam_cfg = registry_entry(self._world.cameras, camera_name) if camera_name not in FREE_CAMERA_TOKENS else None
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
         h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
@@ -1315,7 +1303,7 @@ class RenderingMixin:
                     "Rendering unavailable (no OpenGL context). "
                     "Install EGL or OSMesa for offscreen rendering: apt-get install libosmesa6-dev"
                 )
-            if camera_name in (None, "", "default", "free"):
+            if camera_name in FREE_CAMERA_TOKENS:
                 cam_id = -1
             else:
                 cam_id = mj_name_to_id(self._world._model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
@@ -1412,7 +1400,7 @@ class RenderingMixin:
         model = self._world._model
         # The free camera is not a model camera: it has no name to resolve and
         # no SimCamera entry, so its resolution and default size differ.
-        free_camera = camera_name in (None, "", "default", "free")
+        free_camera = camera_name in FREE_CAMERA_TOKENS
         cam_cfg = None if free_camera else registry_entry(self._world.cameras, camera_name)
 
         w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -116,6 +116,7 @@ from strands_robots.utils import (
     non_negative_whole_number_error,
     pose_vector_error,
     positive_whole_number_error,
+    reserved_camera_name_error,
     sequence_length,
     step_aborted_msg,
 )
@@ -3095,11 +3096,20 @@ class MuJoCoSimEngine(
         mount points before placing a camera; robot bodies are namespaced
         ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
 
-        Validation: ``name`` must be a non-empty ``str`` containing no NUL -
-        ``render``/``get_frame`` route ``camera_name`` in ``(None, "",
-        "default", "free")`` to the free camera, so a camera registered under
-        ``""`` could never be rendered from, and a non-string name is not
-        addressable through the agent-tool surface. ``position`` and ``target``
+        Validation: ``name`` must be a non-empty ``str`` containing no NUL, and
+        must not be one of the free-camera routing tokens
+        (:data:`~strands_robots.utils.FREE_CAMERA_TOKENS` - ``None``, ``""``,
+        ``"default"``, ``"free"``). ``render``/``render_depth``/``get_frame``
+        resolve every one of them to the free camera by an explicit token check,
+        so a camera created under any of them could never be rendered from even
+        though it is registered, compiled into the model and listed by
+        ``list_cameras``; a non-string name is additionally not addressable
+        through the agent-tool surface. This is the same set the Newton backend's
+        ``add_camera`` refuses, on the shared
+        :func:`~strands_robots.utils.reserved_camera_name_error` domain, because
+        that backend routes the same tokens. The Isaac backend does not route
+        them - its ``get_frame`` looks the name up directly - so ``"default"``
+        there is an ordinary camera name and stays accepted. ``position`` and ``target``
         must each be 3 finite numbers (a list, tuple or NumPy array; NumPy
         scalar elements accepted). Omit a vector to take its default - an empty
         vector is a wrong-length request and is rejected rather than silently
@@ -3125,6 +3135,26 @@ class MuJoCoSimEngine(
         # ``add_object`` - that test is partial for an unhashable name.
         if (name_err := entity_name_error("add_camera", "name", name)) is not None:
             return {"status": "error", "content": [{"text": name_err}]}
+
+        # Refuse a name this backend's own render entry points resolve past. The
+        # three of them (``render`` / ``render_depth`` / ``get_frame``) select the
+        # free camera for every ``FREE_CAMERA_TOKENS`` member by an explicit token
+        # check, so claiming one produced a camera that is registered, compiled
+        # into the model and offered by ``list_cameras`` - and that every render
+        # of silently answers with the free view instead, under a success result.
+        # ``entity_name_error`` above covers only the two falsy tokens, which is
+        # why this is a second guard rather than a widening of that domain: the
+        # other two are perfectly addressable *names* that this backend alone
+        # cannot address as *cameras*.
+        #
+        # It precedes the duplicate-name test because that test answered for
+        # ``"default"`` and answered misleadingly: ``create_world`` registers the
+        # built-in free view under that name, so the refusal was "already exists.
+        # Remove it first." - and following that prescription succeeded, leaving
+        # the scene with an unreachable camera where the advertised free-view
+        # alias had been.
+        if (reserved_err := reserved_camera_name_error("add_camera", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": reserved_err}]}
 
         # Validate position / target shape before we bake them into XML.
         # Membership, not truthiness: ``position or <default>`` raised a bare

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -59,6 +59,7 @@ from strands_robots.simulation.newton.randomization import DomainRandomizationMi
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
 from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
+    FREE_CAMERA_TOKENS,
     camera_fov_error,
     coerce_pose_vector,
     coerce_rgba,
@@ -69,6 +70,7 @@ from strands_robots.utils import (
     positive_count_error,
     positive_whole_number_error,
     require_optional,
+    reserved_camera_name_error,
     step_aborted_msg,
 )
 
@@ -1369,11 +1371,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         for _param, _value in (("width", width), ("height", height)):
             if (e := positive_count_error(_value, _param, "add_camera")) is not None:
                 return {"status": "error", "content": [{"text": e}]}
-        if name in (None, "", "default", "free"):
-            return {
-                "status": "error",
-                "content": [{"text": f"add_camera: '{name}' is reserved; pick a distinct camera name."}],
-            }
+        # Refuse a name this backend's own render entry points would resolve past.
+        # Shared with the MuJoCo sibling, which routes the same tokens and until
+        # now refused none of them, so the two cannot state the rule differently.
+        if (reserved_err := reserved_camera_name_error("add_camera", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": reserved_err}]}
         if name in self._world.cameras:
             return {
                 "status": "error",
@@ -1468,7 +1470,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
 
-        is_default = camera_name in (None, "", "default", "free")
+        is_default = camera_name in FREE_CAMERA_TOKENS
         label = "default" if is_default else camera_name
         try:
             eye, target, fov_deg, w, h = self._resolve_camera_view(camera_name, width, height)
@@ -1704,7 +1706,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         for param, value in (("width", width), ("height", height)):
             if value is not None and (text := positive_count_error(value, param, "render")) is not None:
                 raise ValueError(text)
-        if camera_name in (None, "", "default", "free"):
+        if camera_name in FREE_CAMERA_TOKENS:
             return (
                 (0.6, 0.6, 0.5),
                 (0.0, 0.0, 0.15),

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -7,7 +7,7 @@ import numbers
 import os
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 logger = logging.getLogger(__name__)
 
@@ -1500,6 +1500,83 @@ def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[fl
             f"omission - omit '{param_name}' to take the default extent."
         )
     return [float(component) for component in size], None
+
+
+#: Camera names that a backend's render entry points resolve to the FREE camera
+#: instead of looking up, by an explicit token check rather than a registry miss.
+#: ``None`` and ``""`` mean "no camera was named"; ``"default"`` and ``"free"``
+#: are spellings of the free view that :meth:`describe` advertises as always
+#: available, so ``render(camera_name="default")`` is a documented call.
+#:
+#: It lives here, beside :func:`entity_name_error` and :func:`camera_fov_error`,
+#: because it is read from two sides that must agree: the render entry points
+#: that route it, and the ``add_camera`` guard that refuses it as a *name*. Those
+#: two lived as eleven separate copies of the same tuple literal across
+#: ``mujoco/rendering.py``, ``mujoco/simulation.py``, ``newton/simulation.py`` and
+#: ``base.py`` - one of them written in a different order - and the MuJoCo
+#: ``add_camera`` had the set in a comment but not in code, which is exactly the
+#: drift that made a reserved name accepted there while Newton refused it.
+FREE_CAMERA_TOKENS: Final[tuple[str | None, ...]] = (None, "", "default", "free")
+
+
+def reserved_camera_name_error(method: str, param_name: str, name: Any) -> str | None:
+    """Return an error message if ``name`` is a free-camera routing token.
+
+    The creation-site counterpart to :data:`FREE_CAMERA_TOKENS`. A backend whose
+    ``render`` / ``render_depth`` / ``get_frame`` select the free camera for a
+    token cannot also let ``add_camera`` *claim* that token: the camera is
+    registered, compiled into the scene and advertised by ``list_cameras``, and
+    every render of it silently returns the free view instead. Nothing reports an
+    error at any point, so the caller reads a success and a plausible frame.
+
+    Measured on MuJoCo 3.11.0, one ``create_world`` then
+    ``add_camera("free", position=[8, 8, 8], target=[0, 0, 0])``:
+
+    * ``status="success"``, text ``Camera 'free' added at [8.0, 8.0, 8.0]``;
+    * ``world.cameras`` holds ``'free'`` and ``mj_name2id(model, CAMERA, "free")``
+      resolves it, so the camera really is in the compiled model;
+    * ``list_cameras()`` answers ``['default', 'free']``, offering the name as
+      renderable;
+    * and ``render(camera_name="free")`` takes the ``cam_id = -1`` branch with
+      label ``"free (default)"`` - the camera at ``[8, 8, 8]`` is unreachable
+      through the very API that created it.
+
+    ``"default"`` reached the same end by a worse route. It is refused there only
+    as a *duplicate*, because ``create_world`` registers the built-in free view
+    under that name, and the refusal prescribes a remedy that completes the
+    defect: ``remove_camera("default")`` succeeds, the following
+    ``add_camera("default", ...)`` succeeds, and the scene is left with an
+    unreachable camera where the advertised free-view alias used to be.
+
+    This guard is why the domain is stated as a name rule rather than left to the
+    duplicate-name test: a duplicate is a fact about what is registered, and a
+    reserved token is a fact about what can be addressed.
+
+    Only a backend that *routes* the tokens applies it. The Isaac backend's
+    ``get_frame`` looks its camera up in ``self._cameras`` directly with no token
+    check, so ``"default"`` there is an ordinary addressable name - and is that
+    backend's documented signature default - which is coherent and must not be
+    broken by this rule.
+
+    Returns ``None`` for every name that is not a routing token, including a
+    value that is not a string at all: an unaddressable name is
+    :func:`entity_name_error`'s domain, and that guard runs first at every call
+    site, so this one is only ever reached with a genuine ``str``.
+    """
+    if not isinstance(name, str):
+        return None
+    if name not in FREE_CAMERA_TOKENS:
+        return None
+    # Through the shared renderer like every other guard here, even though this
+    # one has narrowed to ``str`` and could interpolate safely: a ``str``
+    # subclass owes its ``__repr__`` nothing, and the rule that no guard renders
+    # a caller value directly is worth more than the exception would save.
+    rendered = _refusal_repr(name)
+    return (
+        f"{method}: {rendered} is reserved; pick a distinct camera name. "
+        f"render/get_frame resolve {param_name}={rendered} to the free camera by an "
+        f"explicit token check, so a camera created under it could never be rendered from."
+    )
 
 
 def camera_fov_error(method: str, param_name: str, value: Any) -> str | None:

--- a/tests/simulation/test_entity_name_domain_at_creation.py
+++ b/tests/simulation/test_entity_name_domain_at_creation.py
@@ -9,9 +9,11 @@ one ``create_world`` then ``add_object(<name>, shape="box", size=[0.06]*3)``):
   under MuJoCo's own sentinel for *unnamed*: ``mj_name2id(model, BODY, "")``
   returns ``-1``, so ``get_body_state(body_name="")`` answered
   ``Body '' not found``. Through ``add_camera`` it is worse - ``render`` routes
-  ``camera_name in (None, "", "default", "free")`` to the free camera by an
-  explicit token check, so a camera created as ``""`` can never be rendered
-  from.
+  ``camera_name in FREE_CAMERA_TOKENS`` to the free camera by an explicit
+  token check, so a camera created as ``""`` can never be rendered from. The
+  other two members of that set are addressable strings and so are outside this
+  domain; they are refused as reserved names, in
+  ``test_reserved_camera_name_at_creation.py``.
 * ``"a\\x00b"`` -> ``status="success"``, registry key ``'a\\x00b'``, compiled
   body ``'a'``. MuJoCo compares names only up to the NUL, so
   ``mj_name2id(..., "a\\x00b")`` and ``mj_name2id(..., "a")`` returned the SAME
@@ -72,7 +74,7 @@ import pytest
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.simulation import IsaacConfig, IsaacSimulation
 from strands_robots.simulation.newton.simulation import NewtonSimEngine
-from strands_robots.utils import entity_name_error
+from strands_robots.utils import FREE_CAMERA_TOKENS, entity_name_error
 
 # --------------------------------------------------------------------------- #
 # Probe sets                                                                  #
@@ -268,14 +270,30 @@ class TestMujocoAddCamera:
         sim.add_camera(name, position=[1.0, 1.0, 1.0])
         assert sim._world.cameras == before
 
-    def test_the_empty_name_collided_with_the_render_routing_token(self, sim):
+    def test_the_empty_name_collides_with_a_render_routing_token(self, sim):
         """Pin the premise for refusing ``""`` on a camera specifically.
 
         ``render``/``get_frame`` select the FREE camera for ``camera_name`` in
-        this token set, so a camera registered under ``""`` was unreachable by
+        this token set, so a camera registered under ``""`` is unreachable by
         construction - not merely awkward to address.
+
+        This replaces a pin that asserted only ``"" in (None, "", "default",
+        "free")`` against a copy of the tuple written here. That was true by
+        inspection and therefore vacuous, and by restating the set locally it
+        recorded the routing rule in a place that could not notice the rule
+        moving. It now reads the one definition the routing itself reads, so the
+        premise is checked rather than transcribed.
+
+        The premise is *wider* than the conclusion drawn here: ``"default"`` and
+        ``"free"`` are the same kind of unreachable and are refused as reserved
+        names, which ``entity_name_error`` cannot express because they are
+        perfectly addressable strings. That half lives in
+        ``test_reserved_camera_name_at_creation.py``; this test keeps only the
+        part that belongs to the addressability domain.
         """
-        assert "" in (None, "", "default", "free")
+        assert "" in FREE_CAMERA_TOKENS
+        # And the domain under test here is what refuses it, not the reserved rule.
+        assert entity_name_error("add_camera", "name", "") is not None
 
     def test_an_addressable_camera_still_registers(self, sim):
         assert sim.add_camera("wrist", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.0])["status"] == "success"

--- a/tests/simulation/test_reserved_camera_name_at_creation.py
+++ b/tests/simulation/test_reserved_camera_name_at_creation.py
@@ -63,7 +63,7 @@ import ast
 import pathlib
 import threading
 import types
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -228,11 +228,37 @@ class TestMujocoAddCamera:
 # Newton - the backend the rule came from                                     #
 # --------------------------------------------------------------------------- #
 def _newton_stub() -> types.SimpleNamespace:
-    """A stand-in for ``self`` carrying only what ``add_camera`` reads."""
+    """A stand-in for ``self`` carrying only what ``add_camera`` reads.
+
+    ``add_camera`` touches ``self._world`` (its ``cameras`` dict), ``self._model``
+    (its ``body_label`` list) and ``self._lock``. None of those need Newton, so a
+    namespace with the three lets the guard run without the optional
+    ``newton`` / ``warp`` packages or a GPU.
+    """
     return types.SimpleNamespace(
         _world=types.SimpleNamespace(cameras={}),
         _model=types.SimpleNamespace(body_label=("ground", "ball")),
         _lock=threading.RLock(),
+    )
+
+
+def _newton_add_camera(stub: types.SimpleNamespace, name: Any) -> dict[str, Any]:
+    """Call the unbound ``add_camera`` with the stand-in for ``self``.
+
+    The stand-in is deliberately not a ``NewtonSimEngine``: the point is to reach
+    the guard without the optional solver packages, and the guard runs before the
+    method touches one. Funnelling every call through one boundary states that
+    once - the shape the sibling
+    ``tests/simulation/newton/test_add_camera_numeric_validation.py`` uses -
+    instead of repeating it at each call site. A narrow ``cast`` rather than a
+    suppression, so the argument stays checked at every real call.
+    """
+    # Unbound, with the stand-in supplied as ``self`` - a bound call would look
+    # ``add_camera`` up on the namespace, which does not carry it. The ``cast`` is
+    # a no-op at runtime and only tells the checker what the argument stands in
+    # for, which keeps the boundary explicit without suppressing the check.
+    return NewtonSimEngine.add_camera(
+        cast(NewtonSimEngine, stub), name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0]
     )
 
 
@@ -247,7 +273,7 @@ class TestSameVerdictAsTheNewtonSibling:
     @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
     def test_newton_refuses_it(self, name: str) -> None:
         stub = _newton_stub()
-        result = NewtonSimEngine.add_camera(stub, name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        result = _newton_add_camera(stub, name)
         assert result["status"] == "error", (name, result)
         assert "reserved" in result["content"][0]["text"]
         assert stub._world.cameras == {}
@@ -255,7 +281,7 @@ class TestSameVerdictAsTheNewtonSibling:
     @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
     def test_the_two_refusals_are_the_same_sentence(self, sim, name: str) -> None:
         stub = _newton_stub()
-        newton = NewtonSimEngine.add_camera(stub, name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        newton = _newton_add_camera(stub, name)
         mujoco_result = sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
         assert newton["status"] == mujoco_result["status"] == "error"
         assert newton["content"][0]["text"] == mujoco_result["content"][0]["text"]
@@ -263,7 +289,7 @@ class TestSameVerdictAsTheNewtonSibling:
     @pytest.mark.parametrize("name", _GOOD_NAMES)
     def test_both_accept_the_same_good_names(self, sim, name: str) -> None:
         stub = _newton_stub()
-        newton = NewtonSimEngine.add_camera(stub, name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        newton = _newton_add_camera(stub, name)
         mujoco_result = sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
         assert newton["status"] == mujoco_result["status"] == "success", (name, newton, mujoco_result)
 

--- a/tests/simulation/test_reserved_camera_name_at_creation.py
+++ b/tests/simulation/test_reserved_camera_name_at_creation.py
@@ -1,0 +1,420 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: ``add_camera`` refuses a name its own ``render`` resolves past.
+
+A backend whose render entry points select the FREE camera for a token cannot
+also let ``add_camera`` claim that token as a camera *name*. Until this fix the
+MuJoCo backend did both, and the two halves disagreed silently - measured on
+MuJoCo 3.11.0, one ``create_world`` then
+``add_camera("free", position=[8, 8, 8], target=[0, 0, 0])``:
+
+* ``status="success"``, text ``Camera 'free' added at [8.0, 8.0, 8.0]``;
+* ``world.cameras`` held ``'free'`` and ``mj_name2id(model, CAMERA, "free")``
+  resolved it, so the camera really was in the compiled model;
+* ``list_cameras()`` answered ``['default', 'free']``, offering the name as
+  renderable;
+* and ``render(camera_name="free")`` took the ``cam_id = -1`` free-camera branch
+  with label ``"free (default)"``. The camera at ``[8, 8, 8]`` was unreachable
+  through the very API that created it, with no error at any point.
+
+``"default"`` reached the same end by a worse route. It was refused, but only as
+a *duplicate* - ``create_world`` registers the built-in free view under that
+name - and that refusal prescribed the remedy that completed the defect:
+
+```
+add_camera('default')       -> error | camera 'default' already exists. Remove it first.
+remove_camera('default')    -> success
+add_camera('default') again  -> success | Camera 'default' added at [9.0, 9.0, 9.0]
+   registry ['default'], compiled MJCF ['default'], list_cameras ['default']
+   render(camera_name='default') -> still the free camera
+```
+
+So following the error message's own instruction replaced the advertised
+free-view alias with an unreachable camera.
+
+The Newton backend already refused the whole set, so this was a one-backend
+parity gap against a rule that was settled and tested
+(``test_multi_camera.py::test_reserved_name_rejected``). The fix states the token
+set once, in :data:`~strands_robots.utils.FREE_CAMERA_TOKENS`, and refuses it
+through the shared :func:`~strands_robots.utils.reserved_camera_name_error`, so
+the side that *routes* a token and the side that *refuses* it read the same
+definition. Eleven copies of that tuple literal were in the tree - seven in
+``mujoco/rendering.py``, three in ``newton/simulation.py``, one in ``base.py``
+written in a different order - and MuJoCo's ``add_camera`` had the set in a
+comment but not in code, which is precisely how the two halves came to disagree.
+``TestTheTokenSetHasOneDefinition`` pins that no twelfth copy can appear.
+
+The Isaac backend deliberately stays out of the rule: its ``get_frame`` looks the
+camera up in ``self._cameras`` directly with no token check, so ``"default"``
+there is an ordinary addressable name - and is that backend's documented
+signature default. ``TestIsaacDoesNotRouteAndSoDoesNotRefuse`` pins that, so a
+later "make the backends consistent" change cannot break a documented call by
+applying a rule whose premise Isaac does not share.
+
+These tests need no GL: ``add_camera`` compiles the spec but renders nothing, and
+the Newton half needs neither ``newton``/``warp`` nor a GPU because the guard runs
+before the method touches a solver (the unbound-method stand-in pattern
+``tests/simulation/newton/test_add_camera_numeric_validation.py`` uses).
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import threading
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import FREE_CAMERA_TOKENS, reserved_camera_name_error
+
+#: The tokens that are also *addressable* strings, so only the reserved-name rule
+#: can refuse them. ``None`` and ``""`` are refused earlier by
+#: ``entity_name_error`` (they are unaddressable regardless of routing), which is
+#: why they are not the subject of these tests.
+_ADDRESSABLE_TOKENS = ("default", "free")
+
+#: Names that must keep working - none of them is a routing token.
+_GOOD_NAMES = ("wrist", "front", "defaults", "freely", "free_cam", "Free", "DEFAULT", "cam-1")
+
+
+# --------------------------------------------------------------------------- #
+# The shared domain                                                           #
+# --------------------------------------------------------------------------- #
+class TestTheDomain:
+    @pytest.mark.parametrize("name", FREE_CAMERA_TOKENS)
+    def test_every_routing_token_is_refused(self, name: Any) -> None:
+        """A non-``str`` token is not this guard's business, so ``None`` passes through."""
+        err = reserved_camera_name_error("add_camera", "name", name)
+        if name is None:
+            assert err is None, "an unaddressable name is entity_name_error's domain"
+        else:
+            assert err is not None, name
+            assert "reserved" in err
+
+    @pytest.mark.parametrize("name", _GOOD_NAMES)
+    def test_a_name_that_merely_resembles_a_token_is_accepted(self, name: str) -> None:
+        """Membership, not a prefix or a case-insensitive match.
+
+        ``"Free"`` and ``"defaults"`` are not routing tokens, so the render
+        entry points look them up like any other name and they must register.
+        """
+        assert reserved_camera_name_error("add_camera", "name", name) is None
+
+    @pytest.mark.parametrize("name", (7, 0, None, ["free"], {"default": 1}, b"free"))
+    def test_a_non_string_is_left_to_the_addressability_domain(self, name: Any) -> None:
+        """Two guards, two questions - this one must not also answer the first."""
+        assert reserved_camera_name_error("add_camera", "name", name) is None
+
+    def test_the_message_names_the_method_the_value_and_the_reason(self) -> None:
+        err = reserved_camera_name_error("add_camera", "name", "free")
+        assert err is not None
+        assert err.startswith("add_camera: 'free' is reserved")
+        assert "pick a distinct camera name" in err
+        # The reason, not just the verdict: why this name and not another.
+        assert "free camera" in err
+
+    def test_the_message_is_ascii(self) -> None:
+        """Project rule: no non-ASCII in a user-facing string."""
+        for token in FREE_CAMERA_TOKENS:
+            err = reserved_camera_name_error("add_camera", "name", token)
+            if err is not None:
+                err.encode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# MuJoCo - the backend this fix changes                                       #
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def sim():
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    s = Simulation(tool_name="test_reserved_camera_name_sim", mesh=False)
+    assert s.create_world()["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _compiled_camera_names(sim) -> list[str]:
+    import mujoco
+
+    model = sim._world._model
+    return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_CAMERA, i) for i in range(model.ncam)]
+
+
+class TestMujocoAddCamera:
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_a_routing_token_is_refused(self, sim, name: str) -> None:
+        """Pre-fix: ``"free"`` returned success, ``"default"`` said "already exists"."""
+        result = sim.add_camera(name, position=[8.0, 8.0, 8.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", (name, result)
+        assert "reserved" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_the_refusal_names_the_routing_as_the_reason(self, sim, name: str) -> None:
+        """Not a bare "invalid name": the caller is told why this name cannot work."""
+        text = sim.add_camera(name, position=[8.0, 8.0, 8.0], target=[0.0, 0.0, 0.0])["content"][0]["text"]
+        assert "free camera" in text
+        assert "pick a distinct camera name" in text
+
+    def test_the_refusal_compiles_no_camera(self, sim) -> None:
+        """The model is untouched - the pre-fix path really did inject a ``<camera>``."""
+        before = _compiled_camera_names(sim)
+        sim.add_camera("free", position=[8.0, 8.0, 8.0], target=[0.0, 0.0, 0.0])
+        assert _compiled_camera_names(sim) == before
+        assert "free" not in sim._world.cameras
+
+    def test_the_refusal_does_not_advertise_the_name(self, sim) -> None:
+        """``list_cameras`` offered ``'free'`` as renderable while render ignored it."""
+        sim.add_camera("free", position=[8.0, 8.0, 8.0], target=[0.0, 0.0, 0.0])
+        assert "free" not in [c for c in sim.list_cameras() if c != "default"]
+
+    def test_the_prescribed_remedy_no_longer_completes_the_defect(self, sim) -> None:
+        """The whole pre-fix ``"default"`` sequence, in one test.
+
+        The duplicate-name refusal said "Remove it first."; doing that and
+        retrying succeeded and left an unreachable camera at the removed
+        alias's name. Both steps must now refuse for the same stated reason.
+        """
+        first = sim.add_camera("default", position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert first["status"] == "error"
+        assert "reserved" in first["content"][0]["text"]
+        # The old message's remedy, followed literally.
+        assert sim.remove_camera("default")["status"] == "success"
+        second = sim.add_camera("default", position=[9.0, 9.0, 9.0], target=[0.0, 0.0, 0.0])
+        assert second["status"] == "error", second
+        assert "reserved" in second["content"][0]["text"]
+        assert "default" not in sim._world.cameras
+        assert _compiled_camera_names(sim) == []
+
+    def test_the_reserved_check_precedes_the_duplicate_test(self, sim) -> None:
+        """Ordering is the property: "already exists" was the misleading answer.
+
+        ``create_world`` registers the built-in free view as ``"default"``, so
+        the duplicate test can answer for that name - and its remedy is wrong.
+        The reserved rule has to win.
+        """
+        assert "default" in sim._world.cameras
+        text = sim.add_camera("default", position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])["content"][0]["text"]
+        assert "reserved" in text
+        assert "already exists" not in text
+
+    @pytest.mark.parametrize("name", _GOOD_NAMES)
+    def test_an_addressable_camera_still_registers(self, sim, name: str) -> None:
+        """The rule is membership - a name that merely resembles a token works."""
+        assert sim.add_camera(name, position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.0])["status"] == "success"
+        assert name in sim._world.cameras
+        assert name in _compiled_camera_names(sim)
+
+    def test_a_registered_camera_is_reachable_by_the_name_it_was_given(self, sim) -> None:
+        """The invariant behind the rule, stated positively and GL-free.
+
+        Every name ``add_camera`` accepts must resolve in the compiled model,
+        which is what ``render``'s non-token branch does with it. A routing
+        token could not satisfy this, because render never reaches the lookup.
+        """
+        import mujoco
+
+        assert sim.add_camera("wrist", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.0])["status"] == "success"
+        cam_id = mujoco.mj_name2id(sim._world._model, mujoco.mjtObj.mjOBJ_CAMERA, "wrist")
+        assert cam_id >= 0
+        assert "wrist" not in FREE_CAMERA_TOKENS
+
+
+# --------------------------------------------------------------------------- #
+# Newton - the backend the rule came from                                     #
+# --------------------------------------------------------------------------- #
+def _newton_stub() -> types.SimpleNamespace:
+    """A stand-in for ``self`` carrying only what ``add_camera`` reads."""
+    return types.SimpleNamespace(
+        _world=types.SimpleNamespace(cameras={}),
+        _model=types.SimpleNamespace(body_label=("ground", "ball")),
+        _lock=threading.RLock(),
+    )
+
+
+class TestSameVerdictAsTheNewtonSibling:
+    """Both backends route the tokens, so both must refuse them identically.
+
+    Newton's refusal was an inline literal and MuJoCo's did not exist. Asserting
+    the *text* rather than only the verdict is what makes the shared domain
+    load-bearing: a second copy of the rule would drift in wording first.
+    """
+
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_newton_refuses_it(self, name: str) -> None:
+        stub = _newton_stub()
+        result = NewtonSimEngine.add_camera(stub, name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", (name, result)
+        assert "reserved" in result["content"][0]["text"]
+        assert stub._world.cameras == {}
+
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_the_two_refusals_are_the_same_sentence(self, sim, name: str) -> None:
+        stub = _newton_stub()
+        newton = NewtonSimEngine.add_camera(stub, name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        mujoco_result = sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert newton["status"] == mujoco_result["status"] == "error"
+        assert newton["content"][0]["text"] == mujoco_result["content"][0]["text"]
+
+    @pytest.mark.parametrize("name", _GOOD_NAMES)
+    def test_both_accept_the_same_good_names(self, sim, name: str) -> None:
+        stub = _newton_stub()
+        newton = NewtonSimEngine.add_camera(stub, name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        mujoco_result = sim.add_camera(name, position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
+        assert newton["status"] == mujoco_result["status"] == "success", (name, newton, mujoco_result)
+
+
+# --------------------------------------------------------------------------- #
+# Isaac - deliberately out of the rule                                        #
+# --------------------------------------------------------------------------- #
+class _FakeCameraHandle:
+    """Stand-in for the Isaac ``Camera`` sensor handle."""
+
+
+def _isaac_engine():
+    from strands_robots.simulation.isaac.simulation import IsaacConfig, IsaacSimulation
+
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig()
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {}
+    engine._objects = {}
+    engine._cameras = {}
+    engine._prim_registry = []
+    engine._cam_out_size = {}
+    engine._camera_warmup_steps = 0
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._main_tid = threading.get_ident()
+
+    def _create_camera_prim(**kwargs: Any) -> tuple[Any, float]:
+        return _FakeCameraHandle(), 24.0
+
+    engine._create_camera_prim = _create_camera_prim  # type: ignore[method-assign]
+    return engine
+
+
+class TestIsaacDoesNotRouteAndSoDoesNotRefuse:
+    """The premise of the rule, pinned where it does not hold.
+
+    Applying the reserved-name rule to Isaac "for consistency" would break a
+    documented call, because ``"default"`` is Isaac's own signature default. The
+    rule follows from routing, and Isaac does not route.
+    """
+
+    def test_isaac_get_frame_looks_the_name_up_instead_of_routing_it(self) -> None:
+        """The premise: no token check on the read path, so no token is special."""
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        source = pathlib.Path(inspect_file(IsaacSimulation)).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        get_frame = _find_method(tree, "IsaacSimulation", "get_frame")
+        assert get_frame is not None, "IsaacSimulation.get_frame not found"
+        body = ast.get_source_segment(source, get_frame) or ""
+        assert "_cameras[camera_name]" in body, "Isaac resolves the name directly"
+        # No membership test against the token set anywhere on the read path.
+        # ``camera_name: str = "default"`` in the signature is the *default* this
+        # backend documents, not a route, so the scan looks for the comparison
+        # rather than for the word.
+        assert "FREE_CAMERA_TOKENS" not in body, "Isaac get_frame now routes the tokens"
+        for node in ast.walk(get_frame):
+            if isinstance(node, ast.Compare) and any(isinstance(op, (ast.In, ast.NotIn)) for op in node.ops):
+                rendered = ast.get_source_segment(source, node) or ""
+                assert "free" not in rendered, f"Isaac get_frame now routes: {rendered}"
+
+    @pytest.mark.parametrize("name", _ADDRESSABLE_TOKENS)
+    def test_isaac_still_accepts_the_name(self, name: str) -> None:
+        engine = _isaac_engine()
+        result = engine.add_camera(name, position=[2.0, 2.0, 2.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "success", (name, result)
+        assert name in engine._cameras
+
+    def test_isaacs_documented_signature_default_still_works(self) -> None:
+        """``add_camera()`` with no name is a documented call on this backend."""
+        import inspect as _inspect
+
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        assert _inspect.signature(IsaacSimulation.add_camera).parameters["name"].default == "default"
+        engine = _isaac_engine()
+        result = engine.add_camera(position=[2.0, 2.0, 2.0], target=[0.0, 0.0, 0.0])
+        assert result["status"] == "success", result
+        assert "default" in engine._cameras
+
+
+# --------------------------------------------------------------------------- #
+# Structural: the token set has exactly one definition                        #
+# --------------------------------------------------------------------------- #
+def inspect_file(obj) -> str:
+    import inspect as _inspect
+
+    return _inspect.getsourcefile(obj) or ""
+
+
+def _find_method(tree: ast.Module, class_name: str, method: str) -> ast.FunctionDef | None:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method:
+                    return item
+    return None
+
+
+def _package_root() -> pathlib.Path:
+    import strands_robots
+
+    return pathlib.Path(strands_robots.__file__).parent
+
+
+class TestTheTokenSetHasOneDefinition:
+    """A twelfth copy of the tuple is how the two halves drifted the first time.
+
+    The defect was not that the rule was wrong, but that the routing side and
+    the creation side each carried their own spelling of the set - and one of
+    them was a comment. Scanning for the literal keeps that from recurring.
+    """
+
+    def test_no_module_rewrites_the_literal(self) -> None:
+        offenders = []
+        for path in sorted(_package_root().rglob("*.py")):
+            if path.name == "utils.py" and path.parent == _package_root():
+                continue  # the one definition
+            text = path.read_text(encoding="utf-8")
+            tree = ast.parse(text)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Tuple) or len(node.elts) != 4:
+                    continue
+                values = []
+                for elt in node.elts:
+                    if isinstance(elt, ast.Constant):
+                        values.append(elt.value)
+                if set(values) == {None, "", "default", "free"}:
+                    offenders.append(f"{path.relative_to(_package_root())}:{node.lineno}")
+        assert not offenders, f"re-spelled FREE_CAMERA_TOKENS instead of importing it: {offenders}"
+
+    def test_the_definition_is_non_vacuous(self) -> None:
+        """Guard the guard: a scan for a set nobody writes would pass trivially."""
+        assert set(FREE_CAMERA_TOKENS) == {None, "", "default", "free"}
+
+    def test_both_sides_of_the_contract_read_it(self) -> None:
+        """The routing side and the refusing side, each importing the one name."""
+        routing = (_package_root() / "simulation" / "mujoco" / "rendering.py").read_text(encoding="utf-8")
+        refusing = (_package_root() / "utils.py").read_text(encoding="utf-8")
+        assert "FREE_CAMERA_TOKENS" in routing
+        assert "def reserved_camera_name_error" in refusing
+        assert "FREE_CAMERA_TOKENS" in refusing
+
+    def test_every_backend_that_routes_also_refuses(self) -> None:
+        """The invariant, stated so a fourth routing backend cannot skip the guard."""
+        sim_root = _package_root() / "simulation"
+        for backend in ("mujoco", "newton"):
+            files = list((sim_root / backend).rglob("*.py"))
+            blob = "\n".join(p.read_text(encoding="utf-8") for p in files)
+            assert "FREE_CAMERA_TOKENS" in blob, f"{backend} no longer routes the tokens"
+            assert "reserved_camera_name_error" in blob, f"{backend} routes the tokens but does not refuse them"


### PR DESCRIPTION
## The defect

MuJoCo's three render entry points -- `render`, `render_depth`, `get_frame` -- select the **free camera** for `camera_name` in `(None, "", "default", "free")` by an explicit token check. `add_camera` let a caller claim two of those tokens as a camera *name*. The camera was registered, compiled into the model and offered by `list_cameras`, and every render of it silently answered with the free view instead.

Measured on MuJoCo 3.11.0, one `create_world` then `add_camera("free", position=[8, 8, 8], target=[0, 0, 0])`:

```
status   : success
text     : "Camera 'free' added at [8.0, 8.0, 8.0]"
registry : ['default', 'free']
compiled : ['default', 'free']      mj_name2id(model, CAMERA, "free") = 1
list_cameras() -> ['default', 'free']
render(camera_name="free") -> cam_id = -1, label "free (default)"
```

The camera at `[8, 8, 8]` was unreachable through the very API that created it, with no error at any point -- the caller reads a success and a plausible frame.

### `"default"` reached the same end by a worse route

It *was* refused -- but only as a **duplicate**, because `create_world` registers the built-in free view under that name. That refusal then prescribed the remedy that completes the defect:

```
add_camera('default')        -> error | add_camera: camera 'default' already exists. Remove it first.
remove_camera('default')     -> success            <- following the message's own instruction
add_camera('default') again  -> success | Camera 'default' added at [9.0, 9.0, 9.0]
   registry ['default'], compiled MJCF ['default'], list_cameras ['default']
   render(camera_name='default') -> still the free camera
```

So doing exactly what the error message said replaced the advertised free-view alias with an unreachable camera.

## Why it drifted, and what the fix changes

This was a **one-backend parity gap against a rule that was already settled and tested.** Newton refuses the whole set (`test_multi_camera.py::test_reserved_name_rejected`). The table:

| backend | render *routes* the tokens? | `add_camera` *refuses* them? | coherent |
|---|---|---|---|
| MuJoCo | **yes** (`render` / `render_depth` / `get_frame`) | **no** -- only `""`, via `entity_name_error` | **no -- the defect** |
| Newton | yes | yes | yes |
| Isaac | no (`get_frame` looks up `self._cameras` directly) | no | yes |

The cause is legible: the token tuple existed as **eleven separate copies of the same literal** -- seven in `mujoco/rendering.py`, three in `newton/simulation.py`, one in `simulation/base.py` written in a *different order* -- and MuJoCo's `add_camera` carried the set **in a comment but not in code**. The side that routes a token and the side that refuses it had no shared definition to disagree through.

So:

1. `FREE_CAMERA_TOKENS` in `utils.py` is now the one definition; all eleven literals read it.
2. `reserved_camera_name_error` is the one refusal. Newton's inline message moves onto it, so the two backends' refusals are **the same sentence**, not merely the same verdict.
3. MuJoCo's `add_camera` applies it, **ahead of the duplicate-name test** -- which is what removes the misleading "Remove it first." remedy for `"default"`.

The guard renders the refused value through `_refusal_repr`, like every other guard in that module. `tests/test_refusal_messages_never_raise.py` caught the first version doing it directly; the message text is byte-identical either way, and the rule is worth keeping total.

## Isaac is deliberately unchanged

Isaac's `get_frame` resolves `self._cameras[camera_name]` with no token check, so `"default"` there is an ordinary addressable name -- and is that backend's **documented signature default** (`add_camera(name: str = "default")`). Applying this rule to Isaac "for consistency" would break a documented call. `TestIsaacDoesNotRouteAndSoDoesNotRefuse` pins the premise -- including an AST check that Isaac's read path grows no membership test -- so a later consistency pass cannot apply a rule whose premise Isaac does not share.

## Evidence

**The tests fail on pre-fix code.** Verified in a clean worktree at `061418f` with *only* the `utils.py` helper applied, so the guard's own contribution is isolated: **13 failed, 44 passed**, with the failures reading as the measurements above --

```
test_a_routing_token_is_refused[free]     - {'status': 'success', ... "Camera 'free' added at [8.0, 8.0, 8.0]"}
test_a_routing_token_is_refused[default]  - assert 'reserved' in "...camera 'default' already exists. Remove it first."
test_the_refusal_compiles_no_camera       - assert ['default', 'free'] == ['default']
test_the_refusal_does_not_advertise_...   - assert 'free' not in ['free']
test_no_module_rewrites_the_literal       - 11 sites
```

The Isaac and `test_newton_refuses_it` cases pass pre-fix, which is the correct signal: neither backend is being changed.

**No regression.** Per the delta guidance in AGENTS.md, the same command on both trees rather than an absolute count:

| run | result |
|---|---|
| base `061418f`, `tests/simulation --ignore=tests/simulation/mujoco` | 294 failed, 3524 passed, 149 errors |
| this branch, same command | 294 failed, **3554** passed, 176 errors |

Failures **identical at 294**; +30 passed and +27 errors sum to exactly the 57 tests this PR adds. The 27 are `eglQueryString` -- this container has no EGL -- and are the same class already carried by the sibling parity files in that directory (`test_send_action_substep_domain_across_backends` 41, `test_step_count_domain_across_backends` 35), both green in CI. The new file is **57/57 green in isolation**. A fatal MuJoCo abort in `tests/simulation/mujoco/` reproduces identically on base in the same ordering, so it is the environment, not this diff.

Targeted suites: **581 passed, 16 skipped, 0 failed** across the new file, the entity-name domain, the refusal-renderer scan, and both siblings' `add_camera` suites. `ruff check` / `ruff format --check` clean.

## Scope

One concern: a name `add_camera` accepts must be a name that backend's render can address.

Deliberately **not** here: `remove_camera("default")` still succeeds and drops the `SimCamera` entry for the built-in free view. That is now harmless -- the token still routes and `list_cameras` still advertises it, because both read the shared set -- but whether the alias should be removable at all is a separate question from this one, and bundling it would widen the diff past the defect.

Closes nothing; filed as a follow-up from the `add_object` domain series (#1853 pose, #1856 colour, #1859 mass, #1861 size), which had never covered `add_camera`'s *name*.

---

## Round 1 changelog

**`7d0cb23` -- `test(sim)`: type the unbound-call boundary in the reserved-name suite.**

The required check (`call-test-lint / Test and Lint`) failed at `b097f7c` on **mypy, not on a test** -- three call sites passed the `SimpleNamespace` stand-in for `self` straight into the unbound `NewtonSimEngine.add_camera`, an `arg-type` error at each:

```
tests/simulation/test_reserved_camera_name_at_creation.py:250: error: Argument 1 to "add_camera" of
  "NewtonSimEngine" has incompatible type "SimpleNamespace"; expected "NewtonSimEngine"  [arg-type]
... same at :258, :266
```

Every other context was `SUCCESS` at that commit (`CodeQL` `NEUTRAL`, advisory).

Funnelled through a single `_newton_add_camera` helper so the boundary is stated **once** -- the shape the sibling `tests/simulation/newton/test_add_camera_numeric_validation.py` already uses -- and narrowed with `cast` rather than a suppression, so the argument stays checked at every real call. The file's only remaining `type: ignore` is the Isaac `method-assign` its own sibling also carries.

One thing worth recording, because it is a trap rather than a typo: the `cast` belongs on the **argument**, not the receiver. `cast` is a no-op at runtime, so casting the receiver and issuing a bound `engine.add_camera(...)` looks the method up on the namespace, which does not carry it -- 12 `AttributeError` failures, caught by the suite locally before pushing. The unbound form with the cast applied to the `self` argument is the one that satisfies both the checker and the runtime.

No production code changed in this round; `mypy` clean and 406 passed across the new file plus the two suites it interacts with.