### PR TITLE
fix(utils): a length probe must not raise when len() refuses

### DIFF
--- a/changelog.d/1888-length-probe-refusals.md
+++ b/changelog.d/1888-length-probe-refusals.md
@@ -1,0 +1,62 @@
+### Fixed: a length a validator cannot read is reported, whatever refused it
+
+Every validator that accepts a vector first asks "how many components is this?",
+and `utils.sequence_length` is the single owner of that question so it cannot be
+answered two ways. It reported only a `TypeError` `__len__` as "no length", and
+documented that as "the narrowest superset". It is not a superset. `len()` does
+not return whatever `__len__` returned - it converts it to an index, and that
+conversion has refusals of its own:
+
+| `__len__` returns | `len()` raises | reached before |
+|---|---|---|
+| `3.5` | `TypeError` | yes |
+| `-1` | `ValueError: __len__() should return >= 0` | no |
+| `sys.maxsize + 1` | `OverflowError: cannot fit 'int' into an index-sized integer` | no |
+| (raises itself) | that exception | no |
+
+The two middle rows are the ones that matter: **the value raises nothing at
+all.** Its `__len__` is ordinary Python returning an ordinary `int`, and CPython
+refuses to convert it - so a length that is computed rather than stored, such as
+`self._end - self._start` on a proxy whose window is inverted, escaped the probe
+without anything being hostile. The last row is the argument that closed the
+rendering escape, applied to `__len__`: it is a method like any other and owes
+its caller nothing.
+
+Every reader of the shared probe inherited the escape, and it landed past the
+exact envelopes the probe exists to keep - the MuJoCo agent-tool router's
+structured error for a rejected parameter, and `get_world_point`'s pixel checks,
+which are documented as being there "to keep the never-raises envelope":
+
+```
+add_object(position=<length CPython cannot convert>)   # OverflowError, past dispatch
+get_world_point(pixels=<__len__ that refuses>)         # the value's own exception
+```
+
+Such a value now reports as carrying no readable component count, which is what
+the probe already answered for a 0-d array and a plain scalar alike. No caller
+changed and no message changed: all of these answer the caller's question
+identically, so one branch covers them and `None` needed no new vocabulary. Only
+`len(value)` runs inside the clause, so widening it masks no logic of this
+library's own, and `Exception` rather than `BaseException` keeps
+`KeyboardInterrupt` and `SystemExit` propagating.
+
+`pose_vector_error` had to be fixed separately, because it was not reading the
+shared probe at all - it carried its own `try: len(vec) / except TypeError`, so
+the rule had two implementations and widening the owner left the duplicate
+untouched. It now reads through the owner, with both of its verdicts and their
+wording unchanged. That the module has exactly one function asking `len()` of a
+caller value is now scanned rather than assumed, keyed on the parameter annotated
+`Any` - the same key the rendering scan uses for "the caller's value" - so a
+second owner cannot be added beside the first again.
+
+`coerce_size_vector` was never affected: its iteration guard runs first and
+refuses a value with no iteration before any length is read.
+
+One escape of this shape is deliberately left open and pinned rather than
+silent. `finite_vector_error` guards `iter(vec)` and walks the iterator in an
+unguarded loop, so an exception raised while producing an element still escapes -
+`iter()` cannot fail for a generator, and for a value with `__getitem__` and no
+`__iter__` CPython builds the iterator without calling it. Closing that trades
+away the laziness the guard's comment defends, and its refusal cannot reuse the
+existing "could not be iterated" text, since a vector that failed at element 4 of
+7 had four components read and found fine. It is tracked separately.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -372,11 +372,28 @@ def sequence_length(value: Any) -> int | None:
     parameter nor the method - past agent-tool dispatch, which is documented
     never to raise.
 
-    ``TypeError`` is the narrowest superset: CPython raises it both for a value
-    with no ``__len__`` at all (a plain ``float``, a ``numpy.float64``) and for
-    one whose ``__len__`` exists but refuses. Both answer the caller's question
-    the same way - this value does not carry a component count - so both report
-    as ``None`` and one branch covers them.
+    ``TypeError`` covers the two spellings this probe was written for - CPython
+    raises it for a value carrying no ``__len__`` at all (a plain ``float``, a
+    ``numpy.float64``) and for the 0-d array whose ``__len__`` exists and
+    refuses - but it is not the superset it was once documented as, and the gap
+    needs no hostile value to reach. ``len()`` converts whatever ``__len__``
+    returns into an index, and that conversion has refusals of its own: a
+    negative length raises ``ValueError`` and a length past ``sys.maxsize``
+    raises ``OverflowError``, both from CPython rather than from the value. A
+    ``__len__`` that computes its answer - ``self._end - self._start`` on a
+    proxy whose window is inverted - is ordinary Python returning an ordinary
+    ``int`` and reaches neither branch a ``TypeError`` probe has.
+
+    So the exception's type is not the question being asked. Every one of these
+    answers the caller's question the same way - this value does not carry a
+    readable component count - so all of them report as ``None`` and one branch
+    covers them. A probe on the path whose whole purpose is to answer an
+    unusable input with a message cannot assume good behaviour of the value it
+    was handed, which is the property #1873, #1874, #1875 and #1878 established
+    on four neighbouring guards. Only ``len(value)`` runs inside the ``try``, so
+    a broad clause here masks no logic of this library's own; ``Exception``
+    rather than ``BaseException`` keeps ``KeyboardInterrupt`` and ``SystemExit``
+    propagating.
 
     Args:
         value: Any caller-supplied value a validator needs the length of.
@@ -386,7 +403,7 @@ def sequence_length(value: Any) -> int | None:
     """
     try:
         return len(value)
-    except TypeError:
+    except Exception:
         return None
 
 
@@ -1308,9 +1325,16 @@ def pose_vector_error(method: str, param_name: str, vec: Any, expected_len: int)
     entry point refuses must be refused by the other. Returns ``None`` when
     ``vec`` is acceptable.
     """
-    try:
-        length = len(vec)
-    except TypeError:
+    # Read through the shared probe rather than a second ``len()`` here. The
+    # rule "how many components is this?" has one owner (:func:`sequence_length`)
+    # precisely so it cannot be answered two ways, and this call site answered it
+    # a second way: an ``except TypeError`` clause, which is the gap that owner
+    # closed - a ``__len__`` refusing any other way, or returning a negative or
+    # an oversized ``int`` that CPython itself refuses to convert, escaped this
+    # guard and the structured contract its callers document. Both verdicts below
+    # are unchanged, including the text for a value carrying no readable length.
+    length = sequence_length(vec)
+    if length is None:
         return (
             f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, "
             f"got {_refusal_container_repr(vec)}"

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -876,10 +876,18 @@ class TestTheIterationIsAnsweredNotEscaped:
     only one guard ever reached an iteration, so the surface this closes is one
     ``iter()`` call - but the verdict on that call is now a message.
 
-    This is the fourth and last escape in the family: rendering (#1873), scalar
-    conversion (#1874), container conversion and rendering (#1875), and iteration
-    here. All four are the same defect - a guard whose entire purpose is to answer
-    an unusable input with a structured refusal, raising instead.
+    This is the fourth escape in the family: rendering (#1873), scalar conversion
+    (#1874), container conversion and rendering (#1875), and iteration here. All
+    four are the same defect - a guard whose entire purpose is to answer an
+    unusable input with a structured refusal, raising instead.
+
+    It was recorded as the *last* of them, and that did not hold. The shared
+    length probe every vector guard runs first carried the same shape and was
+    closed by #1888, and the element access one level inside this guard's own loop
+    still carries it (#1889, pinned in
+    :class:`TestElementAccessStaysOutOfScope`). "Last" is an assertion about
+    everything that was not measured, so the family is named here by what it
+    contains rather than by being finished.
     """
 
     def test_a_hostile_iteration_is_refused_rather_than_raised(self) -> None:
@@ -944,7 +952,8 @@ class TestTheIterationIsAnsweredNotEscaped:
     def test_the_other_guards_still_answer_because_they_ask_for_a_length_first(self) -> None:
         """Unchanged, and still the reason the closed surface is one call.
 
-        ``pose_vector_error`` takes ``len()`` before iterating and
+        ``pose_vector_error`` asks for a length before iterating - through the
+        shared probe since #1888, with its own ``len()`` before that - and
         ``name_list_error`` tests ``isinstance(value, Sequence)``, so neither ever
         reached an iteration to escape from.
         """
@@ -954,3 +963,90 @@ class TestTheIterationIsAnsweredNotEscaped:
     def test_the_rendering_half_was_already_closed(self) -> None:
         """The renderer was never what left this open, and still is not."""
         assert _refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"
+
+
+class GetItemOnly:
+    """A sequence by the legacy protocol: ``__getitem__``, no ``__iter__``.
+
+    CPython synthesises an iterator for such a value *without* calling
+    ``__getitem__``, so ``iter()`` succeeds and the first ``next()`` is what
+    raises. This is the 0-d array's own shape - ``simulation/base.py`` notes such
+    a value "declares ``__len__`` and ``__getitem__``" - so it is a shape the
+    library documents itself as receiving, not an invented one.
+    """
+
+    def __len__(self) -> int:
+        return 3
+
+    def __getitem__(self, index: int) -> float:
+        raise RuntimeError("backing store unavailable")
+
+
+def failing_generator() -> Iterator[float]:
+    """Yields once, then fails. ``iter()`` on a generator cannot fail at all."""
+    yield 0.1
+    raise RuntimeError("stream truncated")
+
+
+class MutatedWhileRead:
+    """Grows during its own iteration, so the stdlib raises, not the value."""
+
+    def __init__(self) -> None:
+        self._items = {"a": 1.0, "b": 2.0}
+
+    def __iter__(self) -> Iterator[float]:
+        for key in self._items:
+            self._items[key + "x"] = 1.0
+            yield self._items[key]
+
+
+class TestElementAccessStaysOutOfScope:
+    """``__iter__`` is answered; ``__next__``, one level in, still is not (#1889).
+
+    The guard probes ``iter(vec)`` inside a ``try`` and then walks the iterator in
+    a ``for`` loop that is not guarded, so an exception raised while *producing*
+    an element escapes exactly as an exception from ``__iter__`` used to. The
+    current code states this boundary and chose it - "it stays lazy - a
+    materialising ``list(vec)`` would answer for ``__next__`` too, but at the cost
+    of holding a whole vector that the element loop below only ever needs one at a
+    time" - so it is a stated limit rather than an oversight.
+
+    Left alone here deliberately. Closing it is a decision rather than a defect
+    fix: it trades away that laziness, and #1878's own lesson forbids reusing the
+    ``could not be iterated`` verdict for it, since a value that failed at element
+    4 of 7 had four components read and found fine, which is a different
+    measurement from one whose iteration never started. Tracked in #1889.
+
+    These assertions pin the defective behaviour, so they must be **replaced**
+    rather than deleted when #1889 lands, per the premise-test guidance in
+    ``AGENTS.md``.
+    """
+
+    def test_a_legacy_sequence_whose_item_access_raises_escapes(self) -> None:
+        """``iter()`` succeeds, so the guarded probe never sees this one."""
+        assert iter(GetItemOnly()) is not None
+        with pytest.raises(RuntimeError, match="backing store unavailable"):
+            finite_vector_error("raycast", "origin", GetItemOnly())
+
+    def test_a_generator_that_fails_after_its_first_yield_escapes(self) -> None:
+        """A generator cannot fail at ``iter()``, so the probe is blind to it."""
+        with pytest.raises(RuntimeError, match="stream truncated"):
+            finite_vector_error("raycast", "origin", failing_generator())
+
+    def test_a_container_mutated_during_its_own_read_escapes(self) -> None:
+        """The exception is the stdlib's; the value raises nothing of its own."""
+        with pytest.raises(RuntimeError, match="changed size during iteration"):
+            finite_vector_error("raycast", "origin", MutatedWhileRead())
+
+    def test_coerce_size_vector_inherits_this_one_too(self) -> None:
+        """The same inheritance that carried the ``__iter__`` escape carries this."""
+        with pytest.raises(RuntimeError, match="backing store unavailable"):
+            coerce_size_vector("add_object", "size", GetItemOnly())
+
+    def test_the_iter_half_still_answers(self) -> None:
+        """Non-vacuity: the boundary narrowed to ``__next__``, it did not move back.
+
+        Without this, a regression that reopened the ``__iter__`` escape would
+        leave every assertion above passing for the wrong reason.
+        """
+        assert finite_vector_error("raycast", "origin", HostileIteration()) is not None

--- a/tests/test_unsized_value_is_refused_not_raised.py
+++ b/tests/test_unsized_value_is_refused_not_raised.py
@@ -26,6 +26,18 @@ reached the branch written for it.
 it answers "no readable length" for a 0-d array and for a plain scalar alike -
 and these tests pin every surface that reads a caller-supplied length through
 it, plus the accepted values that must keep working.
+
+Being the single owner turned out to be two claims, and both needed work
+(#1888). The owner reported only a ``TypeError`` ``__len__`` as "no length",
+which is not the superset it was documented as: ``len()`` converts whatever
+``__len__`` returns into an index, so a negative length is a ``ValueError`` and
+one past ``sys.maxsize`` an ``OverflowError`` - raised by CPython, with the value
+raising nothing at all and its ``__len__`` returning an ordinary ``int``. And
+``pose_vector_error`` answered the same question a second way, with its own
+``except TypeError``, so the rule had two implementations and the duplicate
+carried the same gap. Every unreadable length now reports as ``None`` from one
+probe, which is what the guards' callers document, and the tests below pin that
+domain at the owner rather than at each of its readers.
 """
 
 from __future__ import annotations
@@ -33,6 +45,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import inspect
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -43,10 +56,61 @@ from strands_robots.policies.mock import MockPolicy
 from strands_robots.policies.wbc.policy import WBCPolicy
 from strands_robots.rendering.video import mjpeg_frames
 from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
-from strands_robots.utils import sequence_length
+from strands_robots.utils import coerce_rgba, pose_vector_error, sequence_length
 
 # A 0-d array: declares ``__len__``, raises from it, holds exactly one scalar.
 UNSIZED = np.array(0.5)
+
+
+# The three ways a length is unreadable *without* a ``TypeError``. Each carries a
+# ``__getitem__`` as well, which is the 0-d array's own shape (``simulation/
+# base.py`` notes such a value "declares ``__len__`` and ``__getitem__`` but
+# raises from ``len()``") and is what the call sites gating on ``__getitem__``
+# before they probe a length require to be reached at all.
+class _NegativeLength:
+    """``len()`` raises ``ValueError``: a length may not be negative.
+
+    Nothing here raises. ``__len__`` returns an ordinary ``int`` and CPython
+    refuses to convert it, which is why a computed length - ``self._end -
+    self._start`` on a proxy whose window is inverted - reaches this row without
+    anything being hostile.
+    """
+
+    def __len__(self) -> int:
+        return -1
+
+    def __getitem__(self, index: int) -> float:
+        return 0.5
+
+
+class _OversizedLength:
+    """``len()`` raises ``OverflowError``: a length must fit in an index."""
+
+    def __len__(self) -> int:
+        return sys.maxsize + 1
+
+    def __getitem__(self, index: int) -> float:
+        return 0.5
+
+
+class _RefusingLength:
+    """``__len__`` refuses on its own account, as any third-party type may.
+
+    The #1873 argument applied to ``__len__``: a method like any other, owing a
+    caller nothing, on the one path whose purpose is to answer instead of raise.
+    """
+
+    def __len__(self) -> int:
+        raise RuntimeError("length unavailable")
+
+    def __getitem__(self, index: int) -> float:
+        return 0.5
+
+
+# ``UNSIZED`` first: the value the rule was written for, so a parametrization
+# over this tuple is a widening of an existing pin rather than a separate one.
+UNREADABLE_LENGTHS = (UNSIZED, _NegativeLength(), _OversizedLength(), _RefusingLength())
+UNREADABLE_IDS = ("zero_d_array", "negative_len", "oversized_len", "refusing_len")
 
 
 # A minimal actuated arm: enough for send_action to reach the action coercion,
@@ -106,6 +170,27 @@ class TestUnsizedValuePremise:
         with pytest.raises(TypeError):
             len(scalar)
 
+    @pytest.mark.parametrize(
+        ("value", "raised"),
+        [
+            (_NegativeLength(), ValueError),
+            (_OversizedLength(), OverflowError),
+            (_RefusingLength(), RuntimeError),
+        ],
+        ids=["negative_len", "oversized_len", "refusing_len"],
+    )
+    def test_len_refuses_in_more_ways_than_a_type_error(self, value: Any, raised: type[Exception]) -> None:
+        """``TypeError`` is not a superset of what ``len()`` raises (#1888).
+
+        The first two values raise nothing themselves: ``len()`` converts what
+        ``__len__`` returned into an index and CPython refuses, so a probe
+        catching only ``TypeError`` is escaped by ordinary Python returning an
+        ordinary ``int``. The third is the third-party case.
+        """
+        assert not issubclass(raised, TypeError), "the premise is that this is not the caught type"
+        with pytest.raises(raised):
+            len(value)
+
     def test_a_numpy_scalar_declares_no_length_at_all(self) -> None:
         """The other half of the domain: ``len()`` raises ``TypeError`` here too.
 
@@ -146,12 +231,83 @@ class TestSequenceLength:
             0.5,
             None,
             object(),
+            _NegativeLength(),
+            _OversizedLength(),
+            _RefusingLength(),
         ],
-        ids=["zero_d_float", "zero_d_bool", "np_float64", "np_int64", "float", "none", "object"],
+        ids=[
+            "zero_d_float",
+            "zero_d_bool",
+            "np_float64",
+            "np_int64",
+            "float",
+            "none",
+            "object",
+            "negative_len",
+            "oversized_len",
+            "refusing_len",
+        ],
     )
     def test_reports_none_for_a_value_without_a_readable_length(self, value: Any) -> None:
-        """No readable length is ``None``, never an exception."""
+        """No readable length is ``None``, never an exception.
+
+        The last three rows are #1888: a length is unreadable whether ``__len__``
+        is absent, refuses with a ``TypeError``, refuses some other way, or
+        returns an ``int`` CPython will not convert. All four answer the caller's
+        question the same way, so all four report through the one branch and the
+        exception's type is not part of the question.
+        """
         assert sequence_length(value) is None
+
+
+class TestEveryUnreadableLengthAnswersTheSameWay:
+    """The widened domain where this change is: the guards, and one live envelope.
+
+    ``UNSIZED`` is pinned at every surface further down this module, and those
+    surfaces reach the shared owner by the same route these values do - so
+    re-asserting all of them four times over would measure one branch four
+    times. What is worth pinning here is the owner's own domain (above), the
+    guard that answered the length question a *second* way and therefore had to
+    be fixed separately, and that a public envelope still closes over a value
+    whose length refuses rather than merely being absent.
+    """
+
+    @pytest.mark.parametrize("value", UNREADABLE_LENGTHS, ids=UNREADABLE_IDS)
+    def test_pose_vector_error_reports_a_value_with_no_readable_length(self, value: Any) -> None:
+        """The second probe is gone; the verdict and its wording are not.
+
+        ``pose_vector_error`` carried its own ``try: len(vec) except TypeError``,
+        so it inherited nothing when the owner was widened. It now reads through
+        the owner, and this is the text it already produced for a value carrying
+        no readable length.
+        """
+        message = pose_vector_error("add_object", "position", value, 3)
+        assert message is not None, "a value with no readable length was accepted as a pose"
+        assert "'position' must be a list/tuple of 3 numbers" in message
+
+    @pytest.mark.parametrize("value", UNREADABLE_LENGTHS, ids=UNREADABLE_IDS)
+    def test_coerce_rgba_reports_a_value_with_no_readable_length(self, value: Any) -> None:
+        """The colour guard reads the shared probe with no gate in front of it."""
+        colour, reason = coerce_rgba("add_object", "color", value)
+        assert colour is None
+        assert reason is not None and "'color' must be a sequence of numbers" in reason
+
+    @pytest.mark.parametrize("value", UNREADABLE_LENGTHS, ids=UNREADABLE_IDS)
+    def test_the_router_still_answers_through_its_envelope(self, value: Any) -> None:
+        """End to end: a dispatched vector parameter, refused rather than raised.
+
+        The router is the surface #1844 was written for and the one whose
+        contract is documented as never raising, so it is the envelope worth
+        re-measuring for a length that refuses rather than one that is absent.
+        """
+        engine = MuJoCoSimEngine(tool_name="refusing_length_router", mesh=False)
+        signature = inspect.signature(MuJoCoSimEngine.add_object)
+        _, error = engine._validate_and_build_kwargs(
+            "add_object", "add_object", signature, {"name": "crate", "position": value}
+        )
+        assert error is not None, "add_object(position=<unreadable length>) was accepted"
+        assert error["status"] == "error"
+        assert "Parameter 'position' must be a list of" in _text(error)
 
 
 # --------------------------------------------------------------------------- #
@@ -442,3 +598,94 @@ class TestNoDirectLengthProbe:
         """Meta: an empty result means clean sources, not a scanner matching nothing."""
         planted = ast.parse('if not hasattr(value, "__len__"):\n    pass\n')
         assert _hasattr_len_probes(planted) == [1]
+
+
+# --------------------------------------------------------------------------- #
+# Structural: the rule keeps exactly one owner.
+# --------------------------------------------------------------------------- #
+def _own_length_probes(tree: ast.AST) -> list[tuple[str, int]]:
+    """``(function, line)`` for every ``len(<param>)`` on a parameter annotated ``Any``.
+
+    ``Any`` is how ``utils.py`` spells "the caller's value" - its guards' other
+    parameters are the ``str`` labels a call site supplies, which are literals -
+    so it is the same key #1873's rendering scan used, for the same reason.
+
+    The scope is ``utils.py`` rather than the package. Measured package-wide the
+    same scan reports a dozen legitimate reads, all taken *after* a type check
+    has established the value is a sized container (``mesh/security.py``,
+    ``tools/use_lerobot.py``, the LIBERO parsers), so a package-wide assertion
+    would have to enumerate exceptions and would stop meaning anything. Inside
+    ``utils.py`` the question is unambiguous: this module *is* where the rule
+    lives, so a second ``len()`` on a caller value here is a second answer to it.
+    """
+    hits: list[tuple[str, int]] = []
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        arguments = function.args
+        untyped = {
+            argument.arg
+            for argument in [*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs]
+            if isinstance(argument.annotation, ast.Name) and argument.annotation.id == "Any"
+        }
+        if not untyped:
+            continue
+        for node in ast.walk(function):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "len"
+                and len(node.args) == 1
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id in untyped
+            ):
+                hits.append((function.name, node.lineno))
+    return hits
+
+
+class TestTheLengthRuleHasOneOwner:
+    """A second probe cannot reappear, having been the other half of #1888.
+
+    ``sequence_length`` exists because the rule cannot be kept in step in two
+    places, and it was in two places: ``pose_vector_error`` carried its own
+    ``except TypeError``, so widening the owner left it untouched. A list of
+    guards would not have caught that - the duplicate was added beside the owner,
+    in the same module, by someone reading the same docstring - so the invariant
+    is scanned rather than enumerated.
+    """
+
+    def test_sequence_length_is_the_only_function_asking_len_of_a_caller_value(self) -> None:
+        """One owner, by name, so the offender is named rather than merely counted."""
+        source = ast.parse(Path(inspect.getfile(sequence_length)).read_text())
+        owners = {name for name, _ in _own_length_probes(source)}
+        assert owners == {"sequence_length"}, (
+            f"ask sequence_length() for the length and branch on None, rather than a second len(): {sorted(owners)}"
+        )
+
+    def test_the_scanner_reports_the_probe_that_was_removed(self) -> None:
+        """Meta: the scan matched the duplicate it is here to prevent.
+
+        Planted in the shape ``pose_vector_error`` actually carried, so a scanner
+        rewrite that stopped matching it would fail here rather than pass
+        vacuously against clean sources.
+        """
+        planted = ast.parse(
+            "def pose_vector_error(method: str, param_name: str, vec: Any, expected_len: int) -> str | None:\n"
+            "    try:\n"
+            "        length = len(vec)\n"
+            "    except TypeError:\n"
+            "        return method\n"
+            "    return None\n"
+        )
+        assert _own_length_probes(planted) == [("pose_vector_error", 3)]
+
+    def test_the_scanner_does_not_match_a_read_of_this_modules_own_value(self) -> None:
+        """Non-over-reach: a length taken of a value the function built is fine.
+
+        ``require_optionals`` reads ``len(missing)`` and the name-list guard reads
+        ``len(shown)``; neither is a caller value and neither may be reported.
+        """
+        planted = ast.parse(
+            "def guard(value: Any) -> str:\n    missing = [value]\n    return 'is' if len(missing) == 1 else 'are'\n"
+        )
+        assert _own_length_probes(planted) == []


### PR DESCRIPTION
Closes #1888.

## What was wrong

`utils.sequence_length` is the single owner of the question every vector validator asks first - "how many components is this?" - and it reported only a `TypeError` `__len__` as "no length". Its docstring called `TypeError` "the narrowest superset". It is not a superset. `len()` does not return whatever `__len__` returned; it converts it to an index, and that conversion has refusals of its own:

| `__len__` returns | `len()` raises | reached by the old probe |
| --- | --- | --- |
| `3.5` | `TypeError` | yes |
| `-1` | `ValueError: __len__() should return >= 0` | **no** |
| `sys.maxsize + 1` | `OverflowError: cannot fit 'int' into an index-sized integer` | **no** |
| (raises itself) | that exception | **no** |

The two middle rows are the point: **the value raises nothing at all.** Its `__len__` is ordinary Python returning an ordinary `int`, and CPython refuses the conversion - so a length that is computed rather than stored (`self._end - self._start` on a proxy whose window is inverted) escaped without anything being hostile. The last row is the argument that closed the rendering escape in #1873, applied to `__len__`: a method like any other, owing its caller nothing.

Every reader of the shared probe inherited it, and it landed past the exact envelopes the probe exists to keep - the MuJoCo agent-tool router's structured error, and `get_world_point`'s pixel checks, documented as being there "to keep the never-raises envelope". Measured on `bfad4fb`:

```
sequence_length(NegativeLength())    -> ValueError: __len__() should return >= 0
sequence_length(OversizedLength())   -> OverflowError: cannot fit 'int' into an index-sized integer
sequence_length(RefusingLength())    -> RuntimeError: length unavailable
add_object(position=OversizedLength())  -> OverflowError, past dispatch
```

`coerce_size_vector` was never affected: its iteration guard runs first and refuses a value with no iteration before any length is read.

## The second half: the rule had two owners

`pose_vector_error` was not reading the shared probe at all - it carried its own `try: len(vec) / except TypeError` - so the rule had two implementations and widening the owner left the duplicate untouched. This is exactly the failure mode `sequence_length` exists to prevent, and the test module already asserted in prose that the probe "is the single owner of the rule" while the source disagreed.

## The change

Two hunks in one file:

1. `sequence_length` reports **any** exception as "no readable length". Only `len(value)` runs inside the clause, so it masks no logic of this library's own; `Exception` rather than `BaseException` keeps `KeyboardInterrupt` and `SystemExit` propagating, as the rendering fallback already established. All of these answer the caller's question identically, so `None` needed no new vocabulary and **no caller and no message changed**.
2. `pose_vector_error` reads through the owner, with both verdicts and their wording preserved byte for byte.

Plus the docstring correction - the "narrowest superset" claim is what made the gap read as settled.

## Tests

- **Premise**, so the claim is measured rather than argued: `len()` raises `ValueError` / `OverflowError` / the value's own exception, and each is asserted not to be a `TypeError` subclass.
- **The owner's widened domain**, folded into the existing `sequence_length` parametrization rather than pinned in parallel - three new rows beside the 0-d array the rule was written for.
- **The two guards this PR changes**, and one end-to-end router envelope, over all four unreadable-length values. The surfaces already pinned for the 0-d array reach the same owner by the same route, so re-asserting all of them four times over would measure one branch four times.
- **Structural**: `sequence_length` is the only function in `utils.py` asking `len()` of a caller value, keyed on the parameter annotated `Any` - the same key #1873's rendering scan uses for "the caller's value". A list of guards would not have caught the duplicate, since it was added beside the owner in the same module. Scoped to `utils.py` deliberately: package-wide the same scan reports a dozen legitimate reads taken *after* a type check, so it would have to enumerate exceptions and would stop meaning anything. Both meta-tests are included - one plants the probe that was removed, one plants a read of a value the function built and asserts it is not reported.

Non-vacuity checked by reverting the source hunks: **13 of the new tests fail without them**, all pass with them.

## Out of scope, pinned rather than left silent

#1878's fragment recorded its fix as "the fourth and last escape of one shape". That claim is why this gap read as closed, and it was wrong twice. This PR is the fifth. The sixth is element access inside `finite_vector_error`'s own loop: `iter(vec)` is guarded, the `for` below it is not, so an exception raised while *producing* an element still escapes - `iter()` cannot fail for a generator, and for a value with `__getitem__` and no `__iter__` CPython builds the iterator without calling it.

That one is left alone on purpose: closing it trades away the laziness the guard's comment defends, and #1878's own lesson forbids reusing its `could not be iterated` text, since a vector that failed at element 4 of 7 had four components read and found fine. Tracked in #1889 and pinned as current behaviour in `TestElementAccessStaysOutOfScope`, with a non-vacuity assertion that the `__iter__` half still answers - so the boundary is a stated assertion to *replace*, per the premise-test guidance in `AGENTS.md`.

The "fourth and last" wording is corrected in place, along with one docstring that described `pose_vector_error` as taking its own `len()`.

## Verification

- `ruff check` and `ruff format --check` clean across `strands_robots` and `tests`; `mypy` reports nothing on the three changed files.
- Directly affected suites green: the two modified modules plus the pose, object-size, utils and changelog-fragment suites.
- Wider sweep on a runner with no GL and no optional extras: `tests/test_*.py` 3108 passed; `tests/benchmarks` 526, `tests/registry` 541, `tests/rtps` 25 all green. The remaining failures are missing-asset and missing-optional-dependency artefacts of that environment (`lerobot`, `psutil`, `websockets`, `json5`, a torch stub, absent robot models, no OpenGL context) - `tests/simulation/mujoco` produces a **byte-identical** pass/fail/abort signature on this branch and on unmodified `main`, as does `tests/policies`.

## Notes for review

- The one judgement call is `except Exception` in the owner rather than enumerating `(TypeError, ValueError, OverflowError)`. Enumerating would still miss a `__len__` that refuses on its own account, which is the #1873 case and the one a third-party type actually produces; the narrow clause is what this PR is fixing, so re-narrowing it differently would reopen a row of the table.
- `None` is used for "the length could not be read" as well as "there is no length". These are not distinguished because the docstring's contract is already "no readable length" and a `__len__` that refuses does not carry a readable one - and distinguishing them would change the return type at twelve call sites, which is a much larger change for no caller that could act on the difference.

---

## Round 1 - review feedback

**No code change.** One thread, one CodeQL alert on a test fixture, cleared in the Security tab rather than in the diff.

`py/unexpected-raise-in-special-method` (note severity, alert 852) fired on `GetItemOnly.__getitem__` raising `RuntimeError`, suggesting a `LookupError`. Neither `LookupError` can carry what the fixture models:

| `__getitem__` raises | `list(value)` | usable here |
| --- | --- | --- |
| `IndexError` | `[]` - CPython's `seqiter` clears it to end iteration | no; the guard walks zero elements and the assertion passes vacuously |
| `KeyError` | `KeyError` | propagates, but states key-lookup semantics for an integer index into a sequence |
| `RuntimeError` | `RuntimeError` | models a backing store that cannot produce element 0 |

Dismissed as a false positive, matching alert 590 - the same rule on `_HostileRobot.__getattr__`, dismissed for the same reason. Checked first that the finding is this branch's own rather than a positional baseline artefact: no alert of this rule is open on `refs/heads/main`.

Not fixed in the fixture, and not filtered in `codeql-config.yml`, deliberately. `AGENTS.md` records the cost of the first (#1879 spent a round removing a `__float__` from a test fixture for an advisory finding), and the second is scoped to rules whose *every* instance is an obligatory idiom, with `tests/test_codeql_query_filters.py` pinning the set at two so a third is a reviewed edit rather than the cheapest way to clear an alert.
