### PR TITLE
docs(agents): a CodeQL alert gates the merge, the CodeQL check does not

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -507,9 +507,45 @@ Corrections from code review that apply to all future contributions:
   network exposure.
 
 ### CI Security Baseline
-- **CodeQL findings are not PR-blocking but ARE actionable** - check the Security
-  tab after pushing to a branch. False-positives get dismissed with a reason;
-  real findings get fixed.
+- **A CodeQL alert gates the merge; the CodeQL *check* does not.** These are two
+  objects and only one of them is advisory. The `CodeQL` context is not in the
+  required set (above), so it can sit at `NEUTRAL` indefinitely without blocking
+  anything - but the alert also opens a `github-advanced-security` **review
+  thread**, and the `default` ruleset sets
+  `required_review_thread_resolution: true`, so the merge waits on that thread
+  whatever the alert's severity. This file used to assert the opposite - that a
+  finding does not block a pull request - which is the half that is false and the
+  sentence #1810 was filed about; `.github/workflows/codeql.yml` carries the
+  corrected wording and `tests/test_codeql_query_filters.py` pins it for both
+  files. #1890 measured both halves at once: required check `SUCCESS`, `CodeQL`
+  `NEUTRAL`, `APPROVED` - and it sat for 53 minutes on one unresolved
+  note-severity thread, then merged 8 seconds after that thread was resolved.
+- **Clearing an alert has three tools and they are not interchangeable.**
+  - *Fix it.* The default for anything under `strands_robots/`, and the only
+    option for a real finding.
+  - *Dismiss it with a reason* when the flagged construct is deliberate and
+    test-only: the Security tab, or `PATCH /code-scanning/alerts/{n}` with
+    `dismissed_reason` and `dismissed_comment`. That comment is capped at **280
+    characters** and the endpoint needs `PAT_TOKEN`, so the argument goes in the
+    review thread and the dismissal points at it. This is the usual answer for a
+    hostile fixture, and it is a repeat: alert 590 (`_HostileRobot.__getattr__`)
+    and alert 852 (`GetItemOnly.__getitem__`, #1890) are the same rule,
+    `py/unexpected-raise-in-special-method`, dismissed for the same reason. Then
+    resolve the thread with a reply carrying the reasoning - dismissing alone
+    leaves the gate closed.
+  - *Filter the rule* in `.github/codeql/codeql-config.yml` only when **every**
+    instance in the tree is an idiom the codebase is obliged to use. The set is
+    two, `tests/test_codeql_query_filters.py` pins it, and appending a rule id is
+    otherwise the cheapest way to clear any alert - which is how a filter file
+    ends up quietly opting out of the whole suite.
+
+  Rewriting the flagged code to satisfy the query is the tempting fourth option
+  and the one that costs: #1879 spent a round removing a `__float__` from a test
+  fixture for a finding that gated nothing. It can also destroy the measurement
+  the code exists for. On #1890 the query asked for a `LookupError`; the one it
+  names first, `IndexError`, is what CPython's `seqiter` *clears* to terminate
+  legacy-protocol iteration, so taking the suggestion would have left the fixture
+  raising nothing and the test asserting nothing, still green.
 - **Dependency Review hard-fails on high/critical CVEs in new deps.** If a PR
   needs a dep with a known critical CVE, the conversation is "do we need this
   dep" not "let's bypass the check."

--- a/tests/test_codeql_query_filters.py
+++ b/tests/test_codeql_query_filters.py
@@ -22,6 +22,12 @@ about *scope*, not about CodeQL working:
   and the instances need reading one at a time;
 - the config is **reachable**, i.e. the workflow actually passes it, since an
   unreferenced config file silently filters nothing;
+- ``AGENTS.md`` states the gate the same way the workflow does. It carried the
+  same false sentence, and survived the correction for a structural reason: #1810
+  fixed and pinned only the workflow's copy, so nothing failed while the file every
+  contributor reads first still said the opposite. A claim with two homes needs the
+  pin to cover both, which is why this assertion lives here beside the workflow's
+  rather than in a module of its own;
 - ruff still selects **B015 and B018**, which is the load-bearing one. Excluding
   ``py/ineffectual-statement`` is only a no-loss trade because the real no-op
   statement class moved to a check that is merge-blocking here where CodeQL is
@@ -44,6 +50,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CONFIG_PATH = _REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "codeql.yml"
 _PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
+_AGENTS_PATH = _REPO_ROOT / "AGENTS.md"
 
 #: The only two rule ids this repository filters, and the reason each is here.
 #:
@@ -140,6 +147,52 @@ class TestTheConfigIsReachable:
             "codeql.yml must say what actually happens, not merely stop saying the wrong thing. A "
             "contributor reading it needs to know an alert blocks the merge before they spend a "
             "round wondering why an approved, green PR will not go in."
+        )
+
+
+class TestTheRulesFileStatesTheGate:
+    """``AGENTS.md`` is where a contributor looks before they read any workflow.
+
+    #1810 corrected ``codeql.yml`` and pinned it above, but the identical false
+    sentence in ``AGENTS.md`` went unpinned and survived - so the file that frames
+    every contribution told the reader an alert is advisory while the ruleset
+    blocked the merge on it. #1890 is the shape #1892 recorded: approved, required
+    check green, one unresolved note-severity thread - free to merge by that file's
+    account, and in fact not merging for 53 minutes, until the thread was resolved.
+
+    A negative assertion alone would not hold this - the claim can be restated in
+    new words and still be false - so it is paired with the two positives that make
+    the section actionable: the ruleset property that does the gating, and the
+    dismissal path that clears a deliberate finding without editing the code.
+    """
+
+    def test_it_no_longer_claims_a_finding_does_not_block(self):
+        text = _AGENTS_PATH.read_text(encoding="utf-8")
+        assert "not PR-blocking" not in text, (
+            "AGENTS.md used to state that CodeQL findings are not PR-blocking. A "
+            "`github-advanced-security` review thread on an alert is a merge gate under "
+            "`required_review_thread_resolution`, whatever the severity, so that sentence "
+            "described a policy the repository does not implement. Do not restore it - and see "
+            "the workflow assertion above, which is the same claim in its other home."
+        )
+
+    def test_it_names_the_ruleset_property_that_gates(self):
+        text = _AGENTS_PATH.read_text(encoding="utf-8")
+        assert "required_review_thread_resolution" in text, (
+            "AGENTS.md must name what actually blocks the merge, not merely stop denying it. A "
+            "contributor who knows only that 'CodeQL is advisory' - true of the check context, "
+            "which is not in the required set - has no account of an approved, green PR that "
+            "will not go in, and spends the round #1892 was filed to prevent."
+        )
+
+    def test_it_records_the_dismissal_path(self):
+        text = _AGENTS_PATH.read_text(encoding="utf-8")
+        assert "dismissed_reason" in text, (
+            "AGENTS.md must keep naming dismissal as the way to clear a deliberate, test-only "
+            "finding. Without it the only visible options are editing the flagged code - which "
+            "cost #1879 a round, and on #1890 would have left a fixture asserting nothing, since "
+            "the IndexError the query asks for is what CPython clears to end iteration - or "
+            "widening the filter set the test above pins at two."
         )
 
 


### PR DESCRIPTION
Closes #1892.

## What was wrong

`AGENTS.md` is the file every contributor and agent reads before anything else, and its CI section stated a policy this repository does not implement:

```
AGENTS.md:510
- **CodeQL findings are not PR-blocking but ARE actionable** - check the Security
  tab after pushing to a branch. ...
```

#1810 measured the opposite and corrected `.github/workflows/codeql.yml`, which now says an alert is *"a hard merge gate whatever its severity"*, because `github-advanced-security` opens a review thread per new alert and the `default` ruleset sets `required_review_thread_resolution: true`. `tests/test_codeql_query_filters.py` pins that correction - `test_the_workflow_no_longer_claims_alerts_do_not_block`, commented "Do not restore it."

It pinned **one of the claim's two homes**. The identical sentence in `AGENTS.md` was never covered, so nothing failed while the rules file kept saying the opposite of the workflow it describes. That asymmetry is the whole bug; the wording is a symptom.

## Why both statements read as correct

There are two objects and only one is advisory:

| object | gating? |
| --- | --- |
| the `CodeQL` **check context** | advisory - not in `required_status_checks`, so it may sit at `NEUTRAL` (#1882 documents this) |
| the **review thread** the alert opens | hard gate - `required_review_thread_resolution: true`, severity irrelevant |

Line 510 conflated them and kept the false half. A reader who believes it ignores an alert and then has no account of an approved, green PR that will not merge - the exact cost `codeql.yml`'s own comment says is worth the words.

**Measured on #1890, both halves live at once:**

| | |
| --- | --- |
| required check `call-test-lint` | `SUCCESS` |
| `CodeQL` context | `NEUTRAL` |
| `reviewDecision` | `APPROVED` at 02:12:02Z |
| one note-severity thread (alert 852) | unresolved |
| merged | **03:05:43Z - 8 seconds after that thread was resolved, 53 minutes after the approval** |

## The change

Two files.

**1. `AGENTS.md`** - the `CI Security Baseline` bullet is replaced by one that separates the check from the thread, names `required_review_thread_resolution` as what gates, and records the three tools with the condition for each:

- *fix it* - the default for anything under `strands_robots/`;
- *dismiss with a reason* - for a deliberate, test-only construct. Notes the two sharp edges found the hard way: `dismissed_comment` caps at **280 characters** (so the argument goes in the review thread and the dismissal points at it) and the endpoint needs `PAT_TOKEN`. Alert 590 (`_HostileRobot.__getattr__`) and alert 852 (`GetItemOnly.__getitem__`) are the same rule dismissed the same way, so this is a recurring shape rather than a one-off;
- *filter the rule* - only when **every** instance is an obligatory idiom, which the existing two-id pin already guards.

And the fourth, tempting option is named as the one that costs: #1879 spent a round removing a `__float__` from a fixture for a finding that gated nothing. On #1890 it would have been worse than wasteful - the `LookupError` the query asks for is `IndexError`, which CPython's `seqiter` *clears* to terminate legacy-protocol iteration, so taking the suggestion would have left the fixture raising nothing and the test asserting nothing, **still green**.

**2. `tests/test_codeql_query_filters.py`** - `TestTheRulesFileStatesTheGate`, the sibling of the workflow assertion, in the module that already owns "the CodeQL gate is documented truthfully". One owner for one claim; a new module would have re-created the split that caused this.

A negative assertion alone would not hold it - the claim can be restated in new words and still be false - so it is paired with two positives that also make the section actionable: the ruleset property that gates, and the dismissal path that clears a deliberate finding without editing code.

## Tests

- 10 passed in `tests/test_codeql_query_filters.py` (7 existing + 3 new).
- **Non-vacuity** by reverting `AGENTS.md` to `main`'s copy: **3 failed, 7 passed**; restored, 10 passed. Each of the three fails for its own reason, not one shared import.
- `ruff check` and `ruff format --check` clean on the changed test module.
- Every other test module that reads `AGENTS.md` as text passes on this branch - the changelog-fragment gate, `test_log_strings_are_ascii`, `test_source_strings_no_emoji`, `test_source_strings_no_unicode_dashes` and `test_source_strings_no_review_archaeology` - which are the checks new prose can actually break. Remaining failures in that sweep are missing-optional-dependency artefacts of a bare runner (`strands`, `torch`, `serial`) and are identical in kind on the unmodified base.

## Notes for review

- **No changelog fragment**, deliberately: docs plus one pin module, no behaviour a user could observe. Same shape as #1882, which was `AGENTS.md`-only and carried none.
- The wording had to stop *quoting* the old phrase for the pin to mean anything - a substring assertion is only useful if the substring cannot appear innocently, which is the same reason the workflow assertion works. So the correction says the file "used to assert the opposite" rather than repeating the sentence.
- This does not contradict #1882. That PR established the `CodeQL` context is advisory and must not be treated as a blocker; this one adds that the *alert's thread* is not the context, and is. Both are needed - the first prevents a wasted round on a red advisory check, the second prevents a stall on an unresolved thread nobody has explained.