### PR TITLE
fix(utils): a vector read that fails part-way is refused, not raised (closes #1889)

### DIFF
--- a/changelog.d/1888-length-probe-refusals.md
+++ b/changelog.d/1888-length-probe-refusals.md
@@ -52,11 +52,14 @@ second owner cannot be added beside the first again.
 `coerce_size_vector` was never affected: its iteration guard runs first and
 refuses a value with no iteration before any length is read.
 
-One escape of this shape is deliberately left open and pinned rather than
-silent. `finite_vector_error` guards `iter(vec)` and walks the iterator in an
-unguarded loop, so an exception raised while producing an element still escapes -
-`iter()` cannot fail for a generator, and for a value with `__getitem__` and no
-`__iter__` CPython builds the iterator without calling it. Closing that trades
-away the laziness the guard's comment defends, and its refusal cannot reuse the
-existing "could not be iterated" text, since a vector that failed at element 4 of
-7 had four components read and found fine. It is tracked separately.
+One escape of this shape was left open here and tracked separately, then closed
+in this same release cycle by #1898. `finite_vector_error` guarded `iter(vec)` and
+walked the iterator in an unguarded loop, so an exception raised while producing
+an element still escaped - `iter()` cannot fail for a generator, and for a value
+with `__getitem__` and no `__iter__` CPython builds the iterator without calling
+it. Its refusal indeed could not reuse the existing "could not be iterated" text,
+since a vector that failed at element 4 of 7 had four components read and found
+fine, so it names the element it stopped at instead. The laziness this paragraph
+expected it to trade away was kept: the read is still one component at a time,
+because a materialising `list(vec)` raises before any element has been examined
+and so could not report how far the read got.

--- a/changelog.d/1889-finite-vector-element-read.md
+++ b/changelog.d/1889-finite-vector-element-read.md
@@ -1,0 +1,53 @@
+### Fixed: a vector whose read fails part-way is refused, naming the element it stopped at
+
+`utils.finite_vector_error` probed `iter(vec)` inside a `try` and then walked the
+iterator with a plain `for`, which cannot guard the call it makes. So an exception
+raised while *producing* an element escaped exactly as one from `__iter__` did
+before #1878 - the same defect one level in, on a guard whose entire purpose is to
+answer an unusable input with a message rather than a traceback.
+
+Three routes reached it and none needs a hostile type:
+
+| value | why `iter()` cannot see it |
+|---|---|
+| `__getitem__` and no `__iter__` | CPython synthesises the iterator *without* calling `__getitem__`, so the raise lands on the first `next()` |
+| a generator that fails after a yield | `iter()` of a generator cannot fail at all |
+| a container mutated during its own read | the `RuntimeError` is the stdlib's; the value raises nothing |
+
+The first is the 0-d array's own shape, which `simulation/base.py` already notes
+this library receives ("declares `__len__` and `__getitem__`"), and the second is
+a generator expression over a partially readable buffer - ordinary caller code.
+
+The read is now guarded per element, and the refusal **names the element it
+stopped at**:
+
+```
+raycast: 'origin[1]' could not be read: RuntimeError: stream truncated
+  (got <generator object ...>). Pass a list or tuple of numbers.
+```
+
+That wording is not the `__iter__` verdict reworded, deliberately. A read that
+stopped at element 4 had four components read and found finite, which is a
+different measurement from a value whose iteration never began, and #1878's own
+lesson is that a refusal must not state what was never measured. `could not be
+iterated` is unchanged and still answers the value whose `__iter__` refuses.
+
+The escape reached **four** guards, not the two the issue predicted. A legacy
+sequence carries a readable `__len__`, so it clears the length check first and
+arrives at the iteration through `pose_vector_error` / `coerce_pose_vector` and
+`coerce_rgba` as well as `coerce_size_vector` - which is why the fix is in the
+shared guard rather than at a call site, and why the sibling test's rationale
+("neither ever reached an iteration") is corrected to say what it actually
+measures: that *that probe* carries no length and is no `Sequence`.
+
+The guard stays lazy, and that is now measured rather than asserted in prose - a
+component is read only until the first unusable one. A materialising `list(vec)`
+would have covered both halves in one clause and is declined for a stronger
+reason than the memory it holds: it raises before any element has been examined,
+so its verdict could not say how far the read got.
+
+One escape of this shape is left open and is filed rather than absorbed here
+(#1897): `name_list_error` tests `isinstance(value, Sequence)` and then walks the
+value, so a registered `Sequence` whose item access raises still escapes it. That
+guard refuses against a different domain - a name, not a number - and reads the
+value more than once, so its wording is a separate decision.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1223,11 +1223,15 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
       either poisons the physics state on the next ``mj_forward`` or aborts the
       spec recompile with a cryptic "spec recompile refused", reporting a
       success/garbage result instead of an actionable error.
-    * A value whose ``__iter__`` raises something other than ``TypeError``
+    * A value whose iteration raises something other than ``TypeError`` -
+      from ``__iter__``, or from ``__next__`` once the read is under way -
       otherwise propagates that exception out of the guard, which is the same
       contract break by a different route - the caller asked for a verdict and
-      got a traceback. Reported as its own "could not be iterated" refusal,
-      because whether it held numbers is precisely what could not be determined.
+      got a traceback. Both are reported, and not in the same words, because the
+      two are not the same measurement: a refusing ``__iter__`` yields "could not
+      be iterated", since whether it held numbers is precisely what could not be
+      determined, while a read that fails part-way names the element it stopped
+      at, the components before it having been read and found finite.
 
     A numpy real scalar per element is accepted (``np.float64`` and friends are
     registered as ``numbers.Real``), matching the "accept NumPy scalar
@@ -1253,9 +1257,18 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     # The iterator is bound and then iterated, rather than ``iter(vec)`` being
     # called for its exception and ``vec`` iterated again: one ``__iter__`` call
     # is what the probe is asking about, and a second one is free to answer
-    # differently than the one that was checked. It stays lazy - a materialising
-    # ``list(vec)`` would answer for ``__next__`` too, but at the cost of holding
-    # a whole vector that the element loop below only ever needs one at a time.
+    # differently than the one that was checked.
+    #
+    # This clause answers for ``__iter__`` only, and a success here says nothing
+    # about the read that follows (#1889): CPython synthesises the iterator for a
+    # legacy ``__getitem__`` sequence *without* calling ``__getitem__``, and
+    # ``iter()`` of a generator cannot fail at all, so a value that fails part-way
+    # through its own iteration arrives past this line intact. The element loop
+    # below guards the call that produces each element for that reason. A
+    # materialising ``list(vec)`` would cover both in one clause and is declined
+    # for a stronger reason than the memory it holds: it raises before any element
+    # has been examined, so its verdict could not say how far the read got - the
+    # one thing that distinguishes a part-way failure from an outright refusal.
     # ``exc`` is rendered through ``_refusal_str`` rather than interpolated: a
     # value hostile enough to raise a non-``TypeError`` from ``__iter__`` is not
     # a value whose exception is assumed to have a working ``__str__``, and that
@@ -1270,7 +1283,27 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
             f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
             f"Pass a list or tuple of numbers."
         )
-    for _elem in elements:
+    index = 0
+    while True:
+        # ``next()`` is called explicitly because a ``for`` cannot guard the call
+        # it makes: an exception raised while *producing* an element is the
+        # ``__iter__`` escape one level in, on the same path that must not raise.
+        # It is reported against the element's own index, the convention every
+        # other guard here that names one already uses (``{param}[{i}]``), so the
+        # message states both what failed and what was read before it.
+        # ``StopIteration`` is the read finishing normally; an empty ``vec`` is
+        # accepted exactly as before, a component count not being this guard's
+        # question.
+        try:
+            _elem = next(elements)
+        except StopIteration:
+            break
+        except Exception as exc:
+            return (
+                f"{method}: '{param_name}[{index}]' could not be read: "
+                f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
+                f"Pass a list or tuple of numbers."
+            )
         # ``numbers.Real`` accepts a numpy scalar (``np.float32`` / ``np.int64``
         # are registered) and rejects a string, ``None`` or a nested list.
         # ``bool`` is an ``int`` subclass, so it would otherwise pass as a
@@ -1303,6 +1336,7 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
             return (
                 f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {_refusal_container_repr(vec)}"
             )
+        index += 1
     return None
 
 

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -1152,7 +1152,8 @@ class TestElementProductionIsAnsweredNotEscaped:
         that ends the read is the read finishing, not a failure.
         """
         assert finite_vector_error("raycast", "origin", (v for v in (0.1, 0.2, 0.3))) is None
-        assert finite_vector_error("raycast", "origin", (v for v in ())) is None
+        empty: tuple[float, ...] = ()
+        assert finite_vector_error("raycast", "origin", (v for v in empty)) is None
 
     def test_the_index_is_a_position_and_not_a_constant(self) -> None:
         """Non-vacuity of the index: three values, three different positions.

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -881,12 +881,12 @@ class TestTheIterationIsAnsweredNotEscaped:
     four are the same defect - a guard whose entire purpose is to answer an
     unusable input with a structured refusal, raising instead.
 
-    It was recorded as the *last* of them, and that did not hold. The shared
-    length probe every vector guard runs first carried the same shape and was
-    closed by #1888, and the element access one level inside this guard's own loop
-    still carries it (#1889, pinned in
-    :class:`TestElementAccessStaysOutOfScope`). "Last" is an assertion about
-    everything that was not measured, so the family is named here by what it
+    It was recorded as the *last* of them, and that did not hold twice over. The
+    shared length probe every vector guard runs first carried the same shape and
+    was closed by #1888, and the element access one level inside this guard's own
+    loop carried it until #1889, now measured in
+    :class:`TestElementProductionIsAnsweredNotEscaped`. "Last" is an assertion
+    about everything that was not measured, so the family is named here by what it
     contains rather than by being finished.
     """
 
@@ -949,13 +949,19 @@ class TestTheIterationIsAnsweredNotEscaped:
         assert "could not be iterated" in message
         assert "UnprintableFailureError" in message
 
-    def test_the_other_guards_still_answer_because_they_ask_for_a_length_first(self) -> None:
-        """Unchanged, and still the reason the closed surface is one call.
+    def test_the_other_guards_answer_this_value_before_they_reach_an_iteration(self) -> None:
+        """Unchanged, and the reason the surface closed by *this* call is one ``iter()``.
 
-        ``pose_vector_error`` asks for a length before iterating - through the
-        shared probe since #1888, with its own ``len()`` before that - and
-        ``name_list_error`` tests ``isinstance(value, Sequence)``, so neither ever
-        reached an iteration to escape from.
+        ``pose_vector_error`` asks for a length first - through the shared probe
+        since #1888, with its own ``len()`` before that - and ``name_list_error``
+        tests ``isinstance(value, Sequence)``, so this probe is refused by those
+        guards before either reaches an iteration.
+
+        That is a property of the probe, not a general exemption: it carries no
+        length and is no ``Sequence``. A value that clears those first checks does
+        reach the iteration through them, which is why the element-production
+        escape had a wider surface than this one - see
+        :class:`TestElementProductionIsAnsweredNotEscaped`.
         """
         assert pose_vector_error("add_object", "position", HostileIteration(), 3) is not None
         assert name_list_error(HostileIteration(), "cameras", "render_all") is not None
@@ -1000,53 +1006,178 @@ class MutatedWhileRead:
             yield self._items[key]
 
 
-class TestElementAccessStaysOutOfScope:
-    """``__iter__`` is answered; ``__next__``, one level in, still is not (#1889).
+class UnprintableItemFailure:
+    """A legacy sequence whose item access raises an exception that cannot be rendered.
 
-    The guard probes ``iter(vec)`` inside a ``try`` and then walks the iterator in
-    a ``for`` loop that is not guarded, so an exception raised while *producing*
-    an element escapes exactly as an exception from ``__iter__`` used to. The
-    current code states this boundary and chose it - "it stays lazy - a
-    materialising ``list(vec)`` would answer for ``__next__`` too, but at the cost
-    of holding a whole vector that the element loop below only ever needs one at a
-    time" - so it is a stated limit rather than an oversight.
-
-    Left alone here deliberately. Closing it is a decision rather than a defect
-    fix: it trades away that laziness, and #1878's own lesson forbids reusing the
-    ``could not be iterated`` verdict for it, since a value that failed at element
-    4 of 7 had four components read and found fine, which is a different
-    measurement from one whose iteration never started. Tracked in #1889.
-
-    These assertions pin the defective behaviour, so they must be **replaced**
-    rather than deleted when #1889 lands, per the premise-test guidance in
-    ``AGENTS.md``.
+    The ``__next__`` counterpart of :class:`UnprintableFailure`. The refusal for a
+    failed read interpolates an exception supplied by the same hostile value, so
+    without this probe that interpolation is the #1873 rendering escape again, one
+    level inside the fix for #1889.
     """
 
-    def test_a_legacy_sequence_whose_item_access_raises_escapes(self) -> None:
-        """``iter()`` succeeds, so the guarded probe never sees this one."""
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+    def __len__(self) -> int:
+        return 3
+
+    def __getitem__(self, index: int) -> float:
+        raise UnprintableFailureError
+
+
+class CountedRead:
+    """Yields ``values`` one at a time, recording how many were produced.
+
+    The guard's laziness is a documented property - it reads a component at a
+    time rather than materialising the vector - and a property nothing measures is
+    one a later rewrite can drop without noticing.
+    """
+
+    def __init__(self, *values: Any) -> None:
+        self.values = values
+        self.produced = 0
+
+    def __iter__(self) -> Iterator[Any]:
+        for value in self.values:
+            self.produced += 1
+            yield value
+
+
+class TestElementProductionIsAnsweredNotEscaped:
+    """A read that fails part-way is refused, not raised (#1889).
+
+    Replaces ``TestElementAccessStaysOutOfScope``, which pinned the opposite while
+    the escape was a stated boundary rather than a fixed defect. ``iter(vec)`` was
+    probed inside a ``try`` and the iterator then walked by an unguarded ``for``,
+    so an exception raised while *producing* an element escaped exactly as one
+    from ``__iter__`` used to - the same defect as #1873, #1874, #1875 and #1878,
+    one level in.
+
+    Three routes reach it and none needs a hostile type. ``iter()`` of a generator
+    cannot fail, so the probe was structurally blind to a generator that fails
+    after its first yield; CPython synthesises the iterator for a legacy
+    ``__getitem__`` sequence *without* calling ``__getitem__``, which is the 0-d
+    array's own shape this library documents itself as receiving; and a container
+    mutated during its own read raises from the stdlib rather than from the value.
+
+    The verdict is not the ``__iter__`` one reworded. A read that stopped at
+    element 4 had four components read and found finite, which is a different
+    measurement from a value whose iteration never began, so it names the element
+    it stopped at - #1878's own lesson, that a refusal must not state what was
+    never measured.
+    """
+
+    def test_a_legacy_sequence_whose_item_access_raises_is_refused(self) -> None:
+        """``iter()`` succeeds on this value, so only a guarded read answers it."""
         assert iter(GetItemOnly()) is not None
-        with pytest.raises(RuntimeError, match="backing store unavailable"):
-            finite_vector_error("raycast", "origin", GetItemOnly())
+        message = finite_vector_error("raycast", "origin", GetItemOnly())
+        assert message is not None
+        assert "raycast: 'origin[0]' could not be read" in message
 
-    def test_a_generator_that_fails_after_its_first_yield_escapes(self) -> None:
-        """A generator cannot fail at ``iter()``, so the probe is blind to it."""
-        with pytest.raises(RuntimeError, match="stream truncated"):
-            finite_vector_error("raycast", "origin", failing_generator())
+    def test_the_refusal_names_the_exception_that_stopped_the_read(self) -> None:
+        """The type and text are what make it actionable, as on the ``__iter__`` half."""
+        message = finite_vector_error("raycast", "origin", GetItemOnly())
+        assert message is not None
+        assert "RuntimeError" in message
+        assert "backing store unavailable" in message
 
-    def test_a_container_mutated_during_its_own_read_escapes(self) -> None:
+    def test_a_generator_that_fails_after_its_first_yield_names_where_it_stopped(self) -> None:
+        """The index is the measurement: element 0 was read and was finite.
+
+        This is the whole reason the verdict is not the ``__iter__`` text - a
+        value that produced good components before failing is not one that held
+        nothing readable.
+        """
+        message = finite_vector_error("raycast", "origin", failing_generator())
+        assert message is not None
+        assert "'origin[1]' could not be read" in message
+        assert "stream truncated" in message
+
+    def test_a_container_mutated_during_its_own_read_is_refused(self) -> None:
         """The exception is the stdlib's; the value raises nothing of its own."""
-        with pytest.raises(RuntimeError, match="changed size during iteration"):
-            finite_vector_error("raycast", "origin", MutatedWhileRead())
+        message = finite_vector_error("raycast", "origin", MutatedWhileRead())
+        assert message is not None
+        assert "could not be read" in message
+        assert "changed size during iteration" in message
 
-    def test_coerce_size_vector_inherits_this_one_too(self) -> None:
-        """The same inheritance that carried the ``__iter__`` escape carries this."""
-        with pytest.raises(RuntimeError, match="backing store unavailable"):
-            coerce_size_vector("add_object", "size", GetItemOnly())
+    def test_it_does_not_claim_the_value_was_not_a_list_of_numbers(self) -> None:
+        """The domain check never ran on the element that could not be produced."""
+        message = finite_vector_error("raycast", "origin", GetItemOnly())
+        assert message is not None
+        assert "must be a list/tuple of numbers" not in message
+
+    def test_the_two_iteration_verdicts_are_not_the_same_text(self) -> None:
+        """Distinct measurements, so distinct messages.
+
+        A shared verdict would be the failure #1878 avoided when it declined to
+        fold itself into #1875: reporting a check that did not run.
+        """
+        part_way = finite_vector_error("raycast", "origin", GetItemOnly())
+        never_started = finite_vector_error("raycast", "origin", HostileIteration())
+        assert part_way is not None and never_started is not None
+        assert "could not be iterated" in never_started
+        assert "could not be iterated" not in part_way
+        assert part_way != never_started
+
+    def test_every_guard_reaching_this_iteration_inherits_the_answer(self) -> None:
+        """The surface is four calls, not the one ``iter()`` #1878 closed.
+
+        A legacy sequence carries a readable ``__len__``, so it clears the length
+        check that refused #1878's probe and reaches the iteration through
+        ``pose_vector_error`` and ``coerce_rgba`` as well - which is why the fix
+        belongs in the shared guard and not at a call site.
+        """
+        assert pose_vector_error("add_object", "position", GetItemOnly(), 3) is not None
+        assert coerce_pose_vector("add_object", "position", GetItemOnly(), 3)[1] is not None
+        assert coerce_rgba("add_object", "color", GetItemOnly())[1] is not None
+        assert coerce_size_vector("add_object", "size", GetItemOnly())[1] is not None
+
+    def test_an_exception_whose_own_str_raises_does_not_reescape(self) -> None:
+        """The fix must not reintroduce #1873 inside its own message."""
+        message = finite_vector_error("raycast", "origin", UnprintableItemFailure())
+        assert message is not None
+        assert "could not be read" in message
+        assert "UnprintableFailureError" in message
 
     def test_the_iter_half_still_answers(self) -> None:
-        """Non-vacuity: the boundary narrowed to ``__next__``, it did not move back.
+        """Non-vacuity: the ``__iter__`` verdict is unchanged, not absorbed."""
+        message = finite_vector_error("raycast", "origin", HostileIteration())
+        assert message is not None
+        assert "could not be iterated" in message
 
-        Without this, a regression that reopened the ``__iter__`` escape would
-        leave every assertion above passing for the wrong reason.
+    def test_an_acceptable_lazy_vector_is_still_accepted(self) -> None:
+        """The rewritten loop must not refuse what the ``for`` accepted.
+
+        A generator of finite numbers, and an empty one - the ``StopIteration``
+        that ends the read is the read finishing, not a failure.
         """
-        assert finite_vector_error("raycast", "origin", HostileIteration()) is not None
+        assert finite_vector_error("raycast", "origin", (v for v in (0.1, 0.2, 0.3))) is None
+        assert finite_vector_error("raycast", "origin", (v for v in ())) is None
+
+    def test_the_index_is_a_position_and_not_a_constant(self) -> None:
+        """Non-vacuity of the index: three values, three different positions.
+
+        Without this, a hard-coded ``[0]`` would satisfy every assertion above
+        while naming the wrong element for every value but the first.
+        """
+
+        def fails_at_element(position: int) -> Iterator[float]:
+            for _ in range(position):
+                yield 0.1
+            raise RuntimeError("halted")
+
+        for position in (0, 1, 2):
+            message = finite_vector_error("raycast", "origin", fails_at_element(position))
+            assert message is not None
+            assert f"'origin[{position}]' could not be read" in message
+
+    def test_the_read_is_still_one_component_at_a_time(self) -> None:
+        """The laziness the guard documents, measured rather than asserted in prose.
+
+        A materialising ``list(vec)`` would answer for ``__next__`` too, and would
+        read every component before examining any - so it could neither stop at the
+        first unusable one nor say how far the read got.
+        """
+        vector = CountedRead(0.1, "not a number", 0.3)
+        assert finite_vector_error("raycast", "origin", vector) is not None
+        assert vector.produced == 2


### PR DESCRIPTION
Closes #1889.

## What was wrong

`utils.finite_vector_error` probes `iter(vec)` inside a `try` - #1878's fix - and then walked the iterator with a plain `for`. **A `for` cannot guard the call it makes.** So an exception raised while *producing* an element escaped the guard exactly as one from `__iter__` did before #1878: the same defect one level in, on the one path whose entire purpose is to answer an unusable input with a message rather than a traceback.

Measured on `69cfd79`:

```
finite_vector_error("raycast", "origin", GetItemOnly())   -> RuntimeError: backing store unavailable
finite_vector_error("raycast", "origin", failing_gen())   -> RuntimeError: stream truncated
finite_vector_error("raycast", "origin", MutatingKeys())  -> RuntimeError: dictionary changed size during iteration
```

Three routes in, and **none needs a hostile type**:

| value | why the `iter()` probe cannot see it |
| --- | --- |
| `__getitem__`, no `__iter__` | CPython synthesises the sequence iterator *without* calling `__getitem__`, so the raise lands on the first `next()`. This is the 0-d array's own shape, which `simulation/base.py:361` already notes this library receives ("declares `__len__` and `__getitem__`") |
| a generator that fails after a yield | `iter()` of a generator cannot fail at all - the probe is structurally blind to it. A generator expression over a partially readable buffer is ordinary caller code |
| a container mutated during its own read | the `RuntimeError` is the stdlib's; the value raises nothing of its own |

## The three decisions the issue asked for

The issue filed this as a decision rather than a defect fix, because closing it has costs. Settled as follows.

**1. Laziness is kept.** The read is guarded per element (`next()` in a `try`) rather than materialised with `list(vec)`. The existing comment declined `list(vec)` on memory grounds, which is the weaker argument for a 3-4 component scene vector - the decisive one is that **a materialising call raises before any element has been examined**, so its verdict could not say how far the read got, and could not stop at the first unusable component either. Laziness is now *measured* (`test_the_read_is_still_one_component_at_a_time`), not asserted in prose, so a later rewrite cannot drop it silently.

**2. The verdicts differ, and the new one names the element.**

```
raycast: 'origin[1]' could not be read: RuntimeError: stream truncated
  (got <generator object ...>). Pass a list or tuple of numbers.
```

Reusing `could not be iterated` would understate it: a read that stopped at element 4 of 7 had four components read and found finite, which is not the same measurement as an iteration that never began - #1878's own lesson, that a refusal must not state what was never measured, is the reason #1878 was not folded into #1875 and the reason this is not folded into #1878.

**3. The index shape is the one already in the file.** `{param}[{i}]` is what `name_list_error` uses and what `_refusal_container_repr`'s docstring names as the convention ("every guard that names an index does so in its own text"), so this introduces no new vocabulary.

## Two corrections to the issue's own analysis

Both measured while fixing it, both now pinned:

- **The surface is four guards, not two.** The issue said `coerce_size_vector` was the only inheritor and that `pose_vector_error` "does not" inherit it because it asks for a length first. A legacy sequence *carries* a readable `__len__`, so it clears that check and arrives at the iteration anyway - `pose_vector_error`, `coerce_pose_vector`, `coerce_rgba` and `coerce_size_vector` all escaped. This is why the fix belongs in the shared guard and not at a call site.
- **The sibling test's rationale was wrong, not just narrow.** `test_the_other_guards_still_answer_because_they_ask_for_a_length_first` explained its pass with "neither ever reached an iteration to escape from". True of *that probe* (it carries no length and is no `Sequence`), false in general. Renamed and re-worded to say what it measures.

## The change

Four files.

**`strands_robots/utils.py`** - the `for` becomes an explicit guarded `next()` with an index; the docstring bullet now covers both halves of the iteration escape and states why their verdicts differ; the comment that defended the boundary is replaced by one explaining why `iter()` succeeding says nothing about the read that follows.

**`tests/test_container_refusals_render_elementwise.py`** - `TestElementAccessStaysOutOfScope` pinned the *defective* behaviour with `pytest.raises`, so per the premise-test guidance in `AGENTS.md` it is **replaced**, not deleted: `TestElementProductionIsAnsweredNotEscaped`, 12 tests for the previous 5. Beyond the three routes it covers the parts a fix can quietly get wrong - that the message does not claim `must be a list/tuple of numbers` (a domain check that never ran), that an exception whose own `__str__` raises does not reintroduce #1873 inside the new message, that the index is a position rather than a hard-coded `[0]` (positions 0, 1, 2), and that an acceptable lazy vector and an empty one are still accepted.

**`changelog.d/1889-finite-vector-element-read.md`** - behavioural change, so a fragment.

**`changelog.d/1888-length-probe-refusals.md`** - see round 1 below.

## Tests

- `tests/test_container_refusals_render_elementwise.py`: **124 passed** (was 117; 12 new for 5 replaced).
- **Non-vacuity**, by reverting `utils.py` alone: **9 of the 12 fail, each with its own escaping exception** (`RuntimeError: backing store unavailable`, `stream truncated`, `dictionary changed size during iteration`, `UnprintableFailureError: <exception str() failed>`, `halted`) - not one shared import. The 3 that pass on both are exactly the regression pins that must: the `__iter__` half still answering, an acceptable lazy vector still accepted, and the laziness that was already true.
- **Full `tests/` sweep, base vs branch: identical failure sets** (`diff` empty, 237 pre-existing failures / 573 collection errors from missing optional deps on a bare runner - `strands`, `torch`, `serial`, `PIL`, `mujoco`). Branch is **+7 passes**, exactly the test-count delta. The one non-dependency failure in the neighbouring #1888 module (`test_a_zero_dimensional_tensor_behaves_the_same_way`) reproduces identically on unmodified `utils.py` - the conftest mocks `torch` with numpy.
- `ruff check` / `ruff format --check` and `mypy` clean on both changed Python files (see round 2). `mypy strands_robots/utils.py`: **14 errors before, 14 after** - the single `utils.py` one is at line 899, untouched here.
- Fragment validated: `scripts/assemble_changelog.py --check` OK, and `test_changelog_fragments.py` / `test_changelog_format.py` / `test_changelog_fragment_gate.py` **68 passed**. The prose scans that new text can break - emoji, unicode dashes, ASCII log strings, review archaeology - **207 passed**.
- CI on `62b2d8e`: required `call-test-lint / Test and Lint` **SUCCESS** (lint and tests both), every other gating context green.

## Notes for review

- **`StopIteration` is the read finishing, not a failure**, so an empty `vec` is accepted exactly as the `for` accepted it - a component count is not this guard's question and is checked by `pose_vector_error` / `coerce_rgba` against the buffer they write into.
- `_refusal_container_repr` is safe to call after a partial read: it tries `repr` first and its `list(value)` fallback is itself guarded, so the message cannot re-raise on the value that just failed. Pinned by the unprintable-failure test.
- **One escape of this family is left open and filed rather than absorbed: #1897.** `name_list_error` tests `isinstance(value, Sequence)` and then walks the value, so a registered `Sequence` whose item access raises still escapes. It refuses against a different domain (a name, not a number) and reads the value more than once, so "how far did the read get" is not automatically its right measurement - a separate decision, not a second concern in this diff.

## 13. Round changelog

**Round 0 (opened)** - initial submission.

**Round 1** - `changelog.d/1888-length-probe-refusals.md`: one commit, no code change.

Self-review found the claim this PR falsifies living in a second, unreleased home. Both fragments are pending, so they assemble into the *same* release: #1888's says the element-production escape "is deliberately left open and pinned", mine says it is closed. Only the code comment had been updated by the fix - the exact asymmetry #1892 was about, one release cycle later.

The stale paragraph also predicted a cost this fix did not pay: it expected closing the escape to trade away the guard's laziness, which the fix kept. Corrected on both counts rather than deleted, so the reasoning that made the boundary worth recording survives into the log.

**Round 2** - `tests/test_container_refusals_render_elementwise.py`: one commit, one line.

CI caught what a local run had not: `mypy` cannot infer the element type of a generator over a bare `()` and reported `Need type annotation for "v"`, failing the required lint. My pre-push type check had covered `strands_robots/utils.py` only, while the repo's `hatch run lint` covers the test tree as well - the gap was in how I verified, not in what the assertion says. The empty tuple is now bound to a `tuple[float, ...]`, so the type comes from an annotation rather than from an empty iterable, and the assertion is unchanged.