### PR TITLE
fix(sim/isaac): report a URDF's own joint names, not USD's mangled forms (closes #1900)

### DIFF
--- a/changelog.d/1900-isaac-urdf-joint-name-demangle.md
+++ b/changelog.d/1900-isaac-urdf-joint-name-demangle.md
@@ -1,0 +1,17 @@
+### Fixed: Isaac reports a URDF's own joint names, not USD's mangled forms
+
+The Isaac URDF importer transcodes any joint name that is not a valid USD
+prim identifier - the `robotstudio_so101` URDF names its joints literally
+`"1"`..`"6"`, and since a USD identifier cannot start with a digit they
+import as `tn__1_`..`tn__6_` - and that mangled form leaked through every
+public surface keyed by joint name: `robot_joint_names`, `get_observation`
+keys, and `send_action` dict resolution. Isaac was self-consistent, but the
+same URDF on MuJoCo keeps `"1"`..`"6"`, so cross-backend consumers (e.g. a
+cuRobo planner built from the same URDF fed `scene.joint_names` from the
+Isaac sim) mismatched joint vocabularies. `add_robot(urdf_path=...)` now
+re-reads the URDF's movable joint names with stdlib XML and deterministically
+maps the importer's `dof_names` back onto them (bootstring `tn__` transcoding
+and legacy `TfMakeValidIdentifier` substitution both recognised; ambiguous
+decodes keep the USD name), so every backend reports the same vocabulary for
+the same URDF. The `usd_name -> urdf_name` map is recorded on the robot's
+bookkeeping entry for diagnostics. (#1900)

--- a/strands_robots/simulation/isaac/joint_names.py
+++ b/strands_robots/simulation/isaac/joint_names.py
@@ -1,0 +1,226 @@
+"""URDF <-> USD joint-name translation for the Isaac backend.
+
+Isaac Sim's URDF importer writes each joint as a USD prim, and a USD prim
+name must be a valid identifier - it cannot start with a digit, contain
+spaces, and so on. Joint names that violate the rules get *transcoded*: on
+Isaac Sim 6.0.x the importer applies USD's bootstring transcoding, which
+wraps the name in a ``tn__`` prefix and a delimiter/suffix (the
+``robotstudio_so101`` URDF names its joints literally ``"1"``..``"6"``,
+which import as ``tn__1_``..``tn__6_``); older toolchains applied
+``TfMakeValidIdentifier``, which substitutes ``_`` for each offending
+character. Either way the articulation's ``dof_names`` report the mangled
+form, and before #1900 that form leaked through the backend's public API:
+``robot_joint_names``, ``get_observation`` keys and ``send_action`` name
+resolution all disagreed with the MuJoCo backend - and with any planner
+built from the same URDF - about what the robot's joints are called.
+
+This module recovers the URDF vocabulary at import time. Every joint-name
+read/write on the articulation handle is positional (index into
+``dof_names`` order), so translating the names once - right where
+:meth:`~strands_robots.simulation.isaac.simulation.IsaacSimulation.add_robot`
+loads the URDF - makes the whole backend speak URDF names without touching
+any hot path:
+
+* :func:`urdf_joint_names` parses the movable joints out of the URDF with
+  stdlib XML (no kit install required), and
+* :func:`demangle_usd_joint_names` maps the importer's ``dof_names`` output
+  back onto those URDF names, deterministically, refusing any mapping that
+  is ambiguous or would collide.
+
+The resulting ``usd_name -> urdf_name`` map is recorded on the robot's
+bookkeeping entry so diagnostics can still correlate the USD prim names
+with the public vocabulary.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import xml.etree.ElementTree as ET
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["urdf_joint_names", "demangle_usd_joint_names"]
+
+# Characters USD identifiers may contain (ASCII identifier alphabet). The
+# bootstring transcoding keeps exactly these and encodes everything else in
+# the suffix after the final delimiter.
+_BASIC_CHAR_RE = re.compile(r"[A-Za-z0-9_]")
+
+# Prefix USD's bootstring transcoding stamps on every transcoded identifier
+# (Isaac Sim 6.0.x URDF importer output, e.g. ``tn__1_`` for joint ``1``).
+_TRANSCODING_PREFIX = "tn__"
+
+# URDF joint types that produce articulation DOFs on import. ``fixed`` never
+# does; ``floating``/``planar`` are multi-DOF types the Isaac importer does
+# not map onto single named DOFs, and the registry URDFs do not use them.
+_MOVABLE_URDF_JOINT_TYPES = frozenset({"revolute", "continuous", "prismatic", "spherical"})
+
+
+def urdf_joint_names(urdf_path: str) -> list[str]:
+    """Return the movable joint names declared by a URDF, in file order.
+
+    Stdlib-XML parse (no kit / importer dependency), so the mapping side of
+    the #1900 fix is testable anywhere. Only joints whose type produces an
+    articulation DOF are returned (``revolute``, ``continuous``,
+    ``prismatic``, ``spherical``) - ``fixed`` joints never surface in
+    ``dof_names``, and including them could only make a mangled-name match
+    ambiguous.
+
+    Parameters
+    ----------
+    urdf_path : str
+        Filesystem path to the URDF the Isaac importer just consumed.
+
+    Returns
+    -------
+    list[str]
+        Movable joint names in document order.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``urdf_path`` does not exist.
+    ValueError
+        If the XML is malformed, the root element is not ``<robot>``, or a
+        joint carries no ``name`` attribute - the same fail-loud contract as
+        :func:`strands_robots.simulation.isaac.loaders.load_urdf`.
+    """
+    try:
+        tree = ET.parse(urdf_path)
+    except ET.ParseError as e:
+        raise ValueError(f"URDF joint-name parse: malformed XML in {urdf_path}: {e}") from e
+    root = tree.getroot()
+    if root.tag != "robot":
+        raise ValueError(f"URDF joint-name parse: root element must be <robot>, got <{root.tag}> in {urdf_path}")
+
+    names: list[str] = []
+    for joint_el in root.findall("joint"):
+        jtype = joint_el.get("type", "fixed")
+        if jtype not in _MOVABLE_URDF_JOINT_TYPES:
+            continue
+        jname = joint_el.get("name")
+        if not jname:
+            raise ValueError(f"URDF joint-name parse: <joint> without name attribute in {urdf_path}")
+        names.append(jname)
+    return names
+
+
+def demangle_usd_joint_names(
+    dof_names: list[str],
+    urdf_names: list[str],
+) -> tuple[list[str], dict[str, str]]:
+    """Map USD-mangled ``dof_names`` back onto the URDF joint vocabulary.
+
+    For each DOF name the articulation reports, in order:
+
+    * a name the URDF declares verbatim passes through unchanged (the
+      common case - a valid identifier is never transcoded);
+    * a name exactly one unclaimed URDF joint mangles to (bootstring
+      ``tn__`` transcoding or legacy ``TfMakeValidIdentifier``
+      substitution, both deterministic - see :func:`_mangles_to`) is
+      translated to that URDF name;
+    * anything else stays as reported.
+
+    The result can never key two DOFs by one public name: a translated name
+    is drawn from ``unclaimed`` - URDF joints *not* reported verbatim by any
+    DOF - and is removed from the pool when claimed, so translated names are
+    disjoint from pass-through names and from each other. An ambiguous
+    decode (two URDF joints that mangle to the same DOF name) is refused
+    and the DOF name kept, which leaves the pre-#1900 behaviour for that
+    joint: Isaac self-consistent on its own mangled name.
+
+    Parameters
+    ----------
+    dof_names : list[str]
+        Joint names as reported by ``articulation.dof_names`` after import.
+    urdf_names : list[str]
+        Movable joint names from :func:`urdf_joint_names`.
+
+    Returns
+    -------
+    tuple[list[str], dict[str, str]]
+        ``(public_names, usd_to_urdf)`` - ``public_names`` aligns
+        one-to-one with ``dof_names`` (same order, so every positional
+        articulation read/write stays valid), and ``usd_to_urdf`` records
+        only the entries that were actually translated.
+    """
+    urdf_set = set(urdf_names)
+    verbatim = urdf_set.intersection(dof_names)
+    # URDF joints not already claimed verbatim by some DOF name are the only
+    # candidates a mangled DOF name may decode to. Drawing translations from
+    # this pool (and removing each claim) is what makes the public names
+    # collision-free by construction - see the docstring.
+    unclaimed = [u for u in urdf_names if u not in verbatim]
+
+    public: list[str] = []
+    usd_to_urdf: dict[str, str] = {}
+    for dof in dof_names:
+        if dof in urdf_set:
+            public.append(dof)
+            continue
+        candidates = [u for u in unclaimed if _mangles_to(u, dof)]
+        if len(candidates) == 1:
+            urdf_name = candidates[0]
+            unclaimed.remove(urdf_name)
+            usd_to_urdf[dof] = urdf_name
+            public.append(urdf_name)
+        else:
+            if candidates:
+                logger.warning(
+                    "USD joint name %r decodes ambiguously to URDF joints %s; keeping the USD name.",
+                    dof,
+                    sorted(candidates),
+                )
+            public.append(dof)
+    return public, usd_to_urdf
+
+
+def _mangles_to(urdf_name: str, dof_name: str) -> bool:
+    """Whether the USD importer would mangle ``urdf_name`` into ``dof_name``.
+
+    Two deterministic encodings are recognised:
+
+    * **Bootstring transcoding** (Isaac Sim 6.0.x): the output is
+      ``tn__<basic>_<suffix>``, where ``<basic>`` is the subsequence of
+      ASCII-identifier characters of the input and ``<suffix>`` encodes the
+      positions/values of everything else. A name made *entirely* of basic
+      characters (a leading digit being its only defect, e.g. ``1``)
+      transcodes with an empty suffix - exactly ``tn__1_`` - so that case
+      is matched exactly. A name with non-basic characters has a non-empty
+      suffix this module does not decode; it is matched on the
+      deterministic ``tn__<basic>_`` stem, and
+      :func:`demangle_usd_joint_names` only accepts the match when it is
+      unique.
+    * **Legacy substitution** (``TfMakeValidIdentifier``): each character
+      outside the identifier alphabet - and a leading character that is not
+      a letter or underscore - is replaced by ``_``. Fully deterministic,
+      so matched exactly.
+    """
+    if dof_name == _tf_make_valid_identifier(urdf_name):
+        return True
+    if not dof_name.startswith(_TRANSCODING_PREFIX):
+        return False
+    basic = "".join(ch for ch in urdf_name if _BASIC_CHAR_RE.match(ch))
+    stem = f"{_TRANSCODING_PREFIX}{basic}_"
+    if basic == urdf_name:
+        # Empty bootstring suffix: the only defect was the leading
+        # character, so the full transcoded form is known exactly.
+        return dof_name == stem
+    return dof_name.startswith(stem) and len(dof_name) > len(stem)
+
+
+def _tf_make_valid_identifier(name: str) -> str:
+    """Pure-Python clone of USD's ``TfMakeValidIdentifier``.
+
+    Replaces every character outside ``[A-Za-z0-9_]`` with ``_``, and a
+    first character that is not ``[A-Za-z_]`` likewise; an empty input
+    yields ``_``. This is the legacy (pre-bootstring) mangle older Isaac
+    URDF importers applied to invalid prim names.
+    """
+    if not name:
+        return "_"
+    first = name[0]
+    out = [first if (first.isascii() and (first.isalpha() or first == "_")) else "_"]
+    out.extend(ch if _BASIC_CHAR_RE.match(ch) else "_" for ch in name[1:])
+    return "".join(out)

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -35,6 +35,7 @@ import numpy as np
 
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.joint_names import demangle_usd_joint_names, urdf_joint_names
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
 from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.simulation.terrain import validate_difficulty
@@ -466,6 +467,7 @@ class _RobotState:
         articulation: Any = None,
         actual_prim_path: str | None = None,
         data_config: str | None = None,
+        usd_to_urdf_joint_names: dict[str, str] | None = None,
     ):
         self.name = name
         self.prim_path = prim_path
@@ -475,6 +477,16 @@ class _RobotState:
         # Recorded as the LeRobotDataset ``robot_type`` so datasets collected
         # on Isaac carry the same embodiment metadata as MuJoCo/Newton ones.
         self.data_config = data_config
+        # USD-mangled DOF name -> URDF joint name, for robots loaded from a
+        # URDF whose joint names are not valid USD identifiers (e.g. the
+        # ``robotstudio_so101`` URDF's ``"1"``..``"6"``, imported as
+        # ``tn__1_``..``tn__6_``). ``joint_names`` above already carries the
+        # translated (URDF) vocabulary - see
+        # :mod:`strands_robots.simulation.isaac.joint_names` (#1900) - so
+        # this map is diagnostics-only: it correlates the public names with
+        # the prim names an on-stage USD walk would encounter. Empty when
+        # nothing was mangled.
+        self.usd_to_urdf_joint_names = dict(usd_to_urdf_joint_names or {})
         # The prim path the URDF importer / USD reference actually
         # placed the robot at, which can differ from ``prim_path`` when
         # the importer ignores the requested destination (Isaac Sim 4.5
@@ -1679,6 +1691,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     articulation=articulation,
                     actual_prim_path=getattr(articulation, "_strands_actual_prim_path", None),
                     data_config=data_config,
+                    usd_to_urdf_joint_names=getattr(articulation, "_strands_usd_to_urdf_joint_names", None),
                 )
                 self._robots[name] = robot_state
 
@@ -4709,7 +4722,11 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         4. Extracts joint names from ``articulation.dof_names``,
            coercing ``None`` to ``[]`` so a URDF with no actuated
            joints surfaces as the documented empty-joint-list mode
-           rather than a ``TypeError`` on iteration.
+           rather than a ``TypeError`` on iteration, then translates
+           any USD-mangled name back to the URDF's own joint name via
+           :func:`strands_robots.simulation.isaac.joint_names.demangle_usd_joint_names`
+           (#1900) so the public joint vocabulary matches the MuJoCo
+           backend's for the same URDF.
         5. Returns ``(joint_names, articulation)`` -- same shape as
            ``_load_usd_robot`` so the ``add_robot`` URDF branch can
            reuse the same envelope shape.
@@ -4886,8 +4903,46 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         if position is not None and any(p != 0.0 for p in position):
             articulation.set_world_pose(position=np.asarray(position, dtype=float))
 
-        # Step 4-5: joint names + return.
+        # Step 4-5: joint names + return. The importer transcodes any URDF
+        # joint name that is not a valid USD identifier (a purely numeric
+        # name like the robotstudio_so101's "1" imports as "tn__1_"), and
+        # before #1900 that mangled form leaked through every public surface
+        # keyed by joint name - robot_joint_names, get_observation keys,
+        # send_action resolution - so the same URDF spoke different joint
+        # vocabularies on Isaac vs MuJoCo. Every articulation read/write is
+        # positional (index into dof_names order), so translating here, once,
+        # makes the whole backend speak the URDF names. The usd->urdf map is
+        # stashed as a sidecar (same pattern as _strands_actual_prim_path)
+        # for _RobotState diagnostics. Best-effort: a URDF the stdlib parse
+        # cannot re-read (the importer accepted it, so this is surface drift,
+        # not a bad file) keeps the importer's names - Isaac stays
+        # self-consistent, which is the pre-#1900 behaviour.
         joint_names = list(articulation.dof_names) if articulation.dof_names else []
+        usd_to_urdf: dict[str, str] = {}
+        try:
+            urdf_declared = urdf_joint_names(os.path.abspath(urdf_path))
+        except (OSError, ValueError) as e:
+            logger.warning(
+                "Could not re-parse %s for joint-name translation (%s); keeping the importer's joint names %s.",
+                urdf_path,
+                e,
+                joint_names,
+            )
+        else:
+            joint_names, usd_to_urdf = demangle_usd_joint_names(joint_names, urdf_declared)
+            if usd_to_urdf:
+                logger.info(
+                    "Translated %d USD-mangled joint names back to their URDF names: %s",
+                    len(usd_to_urdf),
+                    usd_to_urdf,
+                )
+        try:
+            articulation._strands_usd_to_urdf_joint_names = usd_to_urdf  # type: ignore[attr-defined]
+        except (AttributeError, TypeError):
+            # Same fallback as _strands_actual_prim_path above: the caller
+            # then records an empty map, and the public names still carry
+            # the translated vocabulary via the returned joint_names.
+            pass
 
         logger.info(
             "Loaded URDF robot at %s from %s (%d joints, articulation=initialized)",

--- a/tests/simulation/isaac/test_urdf_joint_name_demangle.py
+++ b/tests/simulation/isaac/test_urdf_joint_name_demangle.py
@@ -1,0 +1,368 @@
+"""The Isaac backend speaks the URDF's joint names, not USD's mangled forms.
+
+Isaac Sim's URDF importer transcodes any joint name that is not a valid USD
+prim identifier: the ``robotstudio_so101`` URDF names its joints literally
+``"1"``..``"6"``, and since a USD identifier cannot start with a digit they
+import as ``tn__1_``..``tn__6_``. Before #1900 that mangled form leaked
+through every public surface keyed by joint name - ``robot_joint_names``,
+``get_observation`` keys, ``send_action`` resolution - so the same URDF
+yielded different joint vocabularies on Isaac vs MuJoCo, and a cross-backend
+consumer (e.g. a cuRobo planner built from the same URDF) mismatched the sim.
+
+These tests need no Isaac Kit install:
+
+  * the mapping logic (:mod:`strands_robots.simulation.isaac.joint_names`)
+    is pure stdlib and tested directly;
+  * the loader boundary is exercised end-to-end through ``add_robot`` with a
+    fake ``isaacsim`` module tree (the pattern of
+    ``tests/simulation/isaac/test_backend_parity.py``), pinning that the
+    translation happens where the names enter the backend, once, and that
+    every public surface downstream agrees.
+
+The importer round-trip on a real Kit is covered by the GPU-gated
+``tests_integ/simulation/test_isaac_urdf_joint_names_gpu.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.joint_names import demangle_usd_joint_names, urdf_joint_names
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+_NUMERIC_URDF = """\
+<robot name="so101_numeric">
+  <link name="base"/>
+  <link name="l1"/>
+  <link name="l2"/>
+  <link name="l3"/>
+  <link name="l4"/>
+  <link name="l5"/>
+  <link name="l6"/>
+  <joint name="mount" type="fixed">
+    <parent link="base"/>
+    <child link="l1"/>
+  </joint>
+  <joint name="1" type="revolute">
+    <parent link="l1"/>
+    <child link="l2"/>
+    <limit lower="-1.5" upper="1.5" effort="10" velocity="1"/>
+  </joint>
+  <joint name="2" type="revolute">
+    <parent link="l2"/>
+    <child link="l3"/>
+    <limit lower="-1.5" upper="1.5" effort="10" velocity="1"/>
+  </joint>
+  <joint name="3" type="revolute">
+    <parent link="l3"/>
+    <child link="l4"/>
+    <limit lower="-1.5" upper="1.5" effort="10" velocity="1"/>
+  </joint>
+  <joint name="4" type="revolute">
+    <parent link="l4"/>
+    <child link="l5"/>
+    <limit lower="-1.5" upper="1.5" effort="10" velocity="1"/>
+  </joint>
+  <joint name="5" type="continuous">
+    <parent link="l5"/>
+    <child link="l6"/>
+  </joint>
+  <joint name="6" type="prismatic">
+    <parent link="l6"/>
+    <child link="base"/>
+    <limit lower="0" upper="0.04" effort="10" velocity="1"/>
+  </joint>
+</robot>
+"""
+
+_MANGLED = [f"tn__{i}_" for i in ("1", "2", "3", "4", "5", "6")]
+_URDF_NAMES = ["1", "2", "3", "4", "5", "6"]
+
+
+@pytest.fixture
+def numeric_urdf(tmp_path: Path) -> Path:
+    path = tmp_path / "so101_numeric.urdf"
+    path.write_text(_NUMERIC_URDF, encoding="utf-8")
+    return path
+
+
+class TestUrdfJointNames:
+    """:func:`urdf_joint_names` - the kit-free URDF side of the map."""
+
+    def test_movable_joints_in_file_order(self, numeric_urdf: Path) -> None:
+        assert urdf_joint_names(str(numeric_urdf)) == _URDF_NAMES
+
+    def test_fixed_joints_are_excluded(self, numeric_urdf: Path) -> None:
+        assert "mount" not in urdf_joint_names(str(numeric_urdf))
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises((FileNotFoundError, OSError)):
+            urdf_joint_names(str(tmp_path / "nope.urdf"))
+
+    def test_malformed_xml_raises_value_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.urdf"
+        bad.write_text("<robot><joint", encoding="utf-8")
+        with pytest.raises(ValueError, match="malformed"):
+            urdf_joint_names(str(bad))
+
+    def test_non_robot_root_raises_value_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "scene.urdf"
+        bad.write_text("<mujoco/>", encoding="utf-8")
+        with pytest.raises(ValueError, match="<robot>"):
+            urdf_joint_names(str(bad))
+
+    def test_nameless_joint_raises_value_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "anon.urdf"
+        bad.write_text(
+            '<robot name="r"><link name="a"/><link name="b"/>'
+            '<joint type="revolute"><parent link="a"/><child link="b"/></joint></robot>',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="without name"):
+            urdf_joint_names(str(bad))
+
+
+class TestDemangleUsdJointNames:
+    """:func:`demangle_usd_joint_names` - the mapping logic, no kit needed."""
+
+    def test_issue_case_numeric_names_translate(self) -> None:
+        public, mapping = demangle_usd_joint_names(_MANGLED, _URDF_NAMES)
+        assert public == _URDF_NAMES
+        assert mapping == dict(zip(_MANGLED, _URDF_NAMES))
+
+    def test_valid_names_pass_through_untouched(self) -> None:
+        names = ["shoulder", "elbow", "gripper"]
+        public, mapping = demangle_usd_joint_names(names, names)
+        assert public == names
+        assert mapping == {}
+
+    def test_mixed_vocabulary_translates_only_the_mangled(self) -> None:
+        public, mapping = demangle_usd_joint_names(
+            ["shoulder", "tn__1_", "gripper"],
+            ["shoulder", "1", "gripper"],
+        )
+        assert public == ["shoulder", "1", "gripper"]
+        assert mapping == {"tn__1_": "1"}
+
+    def test_dof_order_wins_over_urdf_file_order(self) -> None:
+        # The articulation may enumerate DOFs in tree order, not file order;
+        # positional reads/writes key off dof order, so public names must too.
+        public, _ = demangle_usd_joint_names(["tn__2_", "tn__1_"], ["1", "2"])
+        assert public == ["2", "1"]
+
+    def test_legacy_underscore_substitution_translates(self) -> None:
+        # Older importers apply TfMakeValidIdentifier: per-character "_"
+        # substitution rather than bootstring transcoding.
+        public, mapping = demangle_usd_joint_names(["joint_1"], ["joint 1"])
+        assert public == ["joint 1"]
+        assert mapping == {"joint_1": "joint 1"}
+
+    def test_non_basic_characters_match_on_the_stem(self) -> None:
+        # A name with characters outside the identifier alphabet transcodes
+        # with a non-empty bootstring suffix; the match keys on the stem.
+        public, mapping = demangle_usd_joint_names(["tn__wristroll_qA2f"], ["wrist-roll"])
+        assert public == ["wrist-roll"]
+        assert mapping == {"tn__wristroll_qA2f": "wrist-roll"}
+
+    def test_ambiguous_decode_keeps_the_usd_name(self) -> None:
+        # Both URDF names substitute to "joint_1" under the legacy mangle;
+        # neither may claim it, so the USD name is kept (self-consistent).
+        public, mapping = demangle_usd_joint_names(["joint_1"], ["joint 1", "joint-1"])
+        assert public == ["joint_1"]
+        assert mapping == {}
+
+    def test_unknown_dof_name_is_kept(self) -> None:
+        public, mapping = demangle_usd_joint_names(["mystery"], _URDF_NAMES)
+        assert public == ["mystery"]
+        assert mapping == {}
+
+    def test_verbatim_claim_blocks_a_colliding_decode(self) -> None:
+        # "tn__1_" would decode to "1", but "1" is already reported verbatim
+        # by another DOF; a translation would key two DOFs by one name, so
+        # the URDF joint is not a candidate and the USD name is kept.
+        dof = ["1", "tn__1_"]
+        public, mapping = demangle_usd_joint_names(dof, ["1"])
+        assert public == dof
+        assert mapping == {}
+
+    def test_empty_inputs(self) -> None:
+        assert demangle_usd_joint_names([], []) == ([], {})
+        assert demangle_usd_joint_names([], ["1"]) == ([], {})
+
+
+# ---------------------------------------------------------------------------
+# Loader-boundary tests: add_robot(urdf_path=...) through a fake isaacsim tree.
+# ---------------------------------------------------------------------------
+
+
+class _FakeArticulationAction:
+    """Stand-in for ``isaacsim.core.utils.types.ArticulationAction``."""
+
+    def __init__(self, joint_positions=None, joint_indices=None):
+        self.joint_positions = joint_positions
+        self.joint_indices = joint_indices
+
+
+class _FakeArticulation:
+    """Articulation whose importer-reported DOF names are USD-mangled."""
+
+    def __init__(self, prim_path: str, name: str):
+        self.prim_path = prim_path
+        self.name = name
+        self.dof_names = list(_MANGLED)
+        self.last_action = None
+
+    def initialize(self) -> None:
+        return None
+
+    def get_joint_positions(self):
+        return np.arange(len(self.dof_names), dtype=np.float32) * 0.1
+
+    def apply_action(self, action) -> None:
+        self.last_action = action
+
+    def set_world_pose(self, position=None) -> None:
+        return None
+
+
+class _FakeURDFImporterConfig:
+    """Accepts the attribute writes ``_load_urdf_robot`` probes for."""
+
+
+class _FakeURDFImporter:
+    """Isaac Sim 6.0-shaped importer: ``import_urdf()`` returns a USD path."""
+
+    def __init__(self, config=None):
+        self.config = config
+
+    def import_urdf(self) -> str:
+        return "/tmp/converted_robot.usd"
+
+
+class _FakeWorld:
+    def step(self, render: bool = False) -> None:  # noqa: ARG002 - signature parity
+        return None
+
+
+@pytest.fixture
+def fake_isaacsim(monkeypatch):
+    """Fake ``isaacsim`` module tree covering every import ``add_robot``'s URDF
+    branch performs: articulation class, 6.0 URDF importer, stage reference,
+    and the ``ArticulationAction`` that ``send_action`` builds."""
+    names = (
+        "isaacsim",
+        "isaacsim.core",
+        "isaacsim.core.api",
+        "isaacsim.core.api.articulations",
+        "isaacsim.core.utils",
+        "isaacsim.core.utils.stage",
+        "isaacsim.core.utils.types",
+        "isaacsim.asset",
+        "isaacsim.asset.importer",
+        "isaacsim.asset.importer.urdf",
+    )
+    mods = {}
+    for name in names:
+        mod = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, mod)
+        mods[name] = mod
+    mods["isaacsim.core.api.articulations"].Articulation = _FakeArticulation
+    mods["isaacsim.core.utils.stage"].add_reference_to_stage = lambda usd_path, prim_path: None
+    mods["isaacsim.core.utils.types"].ArticulationAction = _FakeArticulationAction
+    mods["isaacsim.asset.importer.urdf"].URDFImporter = _FakeURDFImporter
+    mods["isaacsim.asset.importer.urdf"].URDFImporterConfig = _FakeURDFImporterConfig
+    # Wire submodule attributes so dotted imports resolve.
+    mods["isaacsim"].core = mods["isaacsim.core"]
+    mods["isaacsim"].asset = mods["isaacsim.asset"]
+    mods["isaacsim.core"].api = mods["isaacsim.core.api"]
+    mods["isaacsim.core"].utils = mods["isaacsim.core.utils"]
+    mods["isaacsim.core.api"].articulations = mods["isaacsim.core.api.articulations"]
+    mods["isaacsim.core.utils"].stage = mods["isaacsim.core.utils.stage"]
+    mods["isaacsim.core.utils"].types = mods["isaacsim.core.utils.types"]
+    mods["isaacsim.asset"].importer = mods["isaacsim.asset.importer"]
+    mods["isaacsim.asset.importer"].urdf = mods["isaacsim.asset.importer.urdf"]
+    return mods
+
+
+def _sim_with_numeric_robot(numeric_urdf: Path) -> IsaacSimulation:
+    sim = IsaacSimulation()
+    sim._world = _FakeWorld()
+    sim._world_created = True
+    result = sim.add_robot(name="arm", urdf_path=str(numeric_urdf))
+    assert result["status"] == "success", result
+    return sim
+
+
+class TestPublicApiSpeaksUrdfNames:
+    """Acceptance criteria of #1900, at the backend's public surfaces."""
+
+    def test_add_robot_reports_urdf_joint_names(self, fake_isaacsim, numeric_urdf: Path) -> None:
+        sim = IsaacSimulation()
+        sim._world = _FakeWorld()
+        sim._world_created = True
+        result = sim.add_robot(name="arm", urdf_path=str(numeric_urdf))
+        assert result["status"] == "success", result
+        payload = result["content"][0]["json"]
+        assert payload["joint_names"] == _URDF_NAMES
+
+    def test_robot_joint_names_match_the_urdf(self, fake_isaacsim, numeric_urdf: Path) -> None:
+        sim = _sim_with_numeric_robot(numeric_urdf)
+        assert sim.robot_joint_names("arm") == _URDF_NAMES
+
+    def test_observation_keys_are_urdf_names(self, fake_isaacsim, numeric_urdf: Path) -> None:
+        sim = _sim_with_numeric_robot(numeric_urdf)
+        obs = sim.get_observation("arm")
+        assert list(obs) == _URDF_NAMES
+        assert obs["3"] == pytest.approx(0.2)
+
+    def test_send_action_resolves_urdf_names(self, fake_isaacsim, numeric_urdf: Path) -> None:
+        sim = _sim_with_numeric_robot(numeric_urdf)
+        result = sim.send_action({"3": 0.5}, robot_name="arm")
+        assert result["status"] == "success", result
+        act = sim._robots["arm"].articulation.last_action
+        assert list(np.asarray(act.joint_indices)) == [2]
+        assert list(np.asarray(act.joint_positions)) == pytest.approx([0.5])
+
+    def test_send_action_refuses_the_mangled_names(self, fake_isaacsim, numeric_urdf: Path) -> None:
+        # The USD-internal form is not part of the public vocabulary: a
+        # consumer keying actions by it (the pre-fix Isaac-only shape) gets
+        # the structured unresolved-keys envelope, same as on MuJoCo.
+        sim = _sim_with_numeric_robot(numeric_urdf)
+        result = sim.send_action({"tn__3_": 0.5}, robot_name="arm")
+        assert result["status"] == "error"
+        assert "tn__3_" in result["content"][0]["text"]
+
+    def test_usd_to_urdf_map_recorded_for_diagnostics(self, fake_isaacsim, numeric_urdf: Path) -> None:
+        sim = _sim_with_numeric_robot(numeric_urdf)
+        assert sim._robots["arm"].usd_to_urdf_joint_names == dict(zip(_MANGLED, _URDF_NAMES))
+
+    def test_already_valid_urdf_names_are_unchanged(self, fake_isaacsim, tmp_path: Path, monkeypatch) -> None:
+        # A URDF whose names are valid identifiers is never transcoded:
+        # the importer reports them verbatim and no translation happens.
+        urdf = tmp_path / "named.urdf"
+        urdf.write_text(
+            '<robot name="r"><link name="a"/><link name="b"/>'
+            '<joint name="shoulder" type="revolute"><parent link="a"/><child link="b"/>'
+            '<limit lower="-1" upper="1" effort="10" velocity="1"/></joint></robot>',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_FakeArticulation, "__init__", _valid_name_init)
+        sim = IsaacSimulation()
+        sim._world = _FakeWorld()
+        sim._world_created = True
+        result = sim.add_robot(name="arm", urdf_path=str(urdf))
+        assert result["status"] == "success", result
+        assert sim.robot_joint_names("arm") == ["shoulder"]
+        assert sim._robots["arm"].usd_to_urdf_joint_names == {}
+
+
+def _valid_name_init(self, prim_path: str, name: str) -> None:
+    self.prim_path = prim_path
+    self.name = name
+    self.dof_names = ["shoulder"]
+    self.last_action = None

--- a/tests_integ/simulation/test_isaac_urdf_joint_names_gpu.py
+++ b/tests_integ/simulation/test_isaac_urdf_joint_names_gpu.py
@@ -1,0 +1,131 @@
+"""GPU-gated integration: URDF joint names survive the Isaac importer (#1900).
+
+The Isaac URDF importer transcodes any joint name that is not a valid USD
+prim identifier (a purely numeric name like the ``robotstudio_so101``'s
+``"1"`` imports as ``tn__1_``), and before #1900 that mangled form leaked
+through the backend's public API - so the same URDF yielded different joint
+vocabularies on Isaac vs MuJoCo. The mapping logic is pinned kit-free in
+``tests/simulation/isaac/test_urdf_joint_name_demangle.py``; this test is
+the importer round-trip the acceptance criteria call for: a real Kit import
+of a numeric-joint URDF must report the URDF's own names on
+``robot_joint_names``, key ``get_observation`` by them, and resolve
+``send_action`` dict actions by them.
+
+Run with::
+
+    STRANDS_GPU_TEST=1 hatch run test-integ \\
+        tests_integ/simulation/test_isaac_urdf_joint_names_gpu.py -m gpu -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("strands_robots.simulation.isaac")
+
+_GPU_ENABLED = os.environ.get("STRANDS_GPU_TEST", "0") == "1"
+
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not _GPU_ENABLED,
+        reason="Requires an NVIDIA GPU + Isaac Sim 6.0. Set STRANDS_GPU_TEST=1 to enable.",
+    ),
+]
+
+_URDF_NAMES = ["1", "2", "3", "4", "5", "6"]
+
+# A minimal fixed-base arm whose six revolute joints carry the numeric names
+# the robotstudio_so101 URDF uses. Inertials are required for the importer to
+# build real rigid bodies; geometry is a small box per link.
+_NUMERIC_URDF = """\
+<robot name="numeric_arm">
+  <link name="base_link">
+    <inertial><mass value="1.0"/><inertia ixx="0.01" iyy="0.01" izz="0.01" ixy="0" ixz="0" iyz="0"/></inertial>
+    <collision><geometry><box size="0.05 0.05 0.05"/></geometry></collision>
+  </link>
+  {links}
+</robot>
+"""
+
+_LINK_TMPL = """\
+  <link name="link{i}">
+    <inertial><mass value="0.2"/><inertia ixx="0.001" iyy="0.001" izz="0.001" ixy="0" ixz="0" iyz="0"/></inertial>
+    <collision><geometry><box size="0.04 0.04 0.04"/></geometry></collision>
+  </link>
+  <joint name="{name}" type="revolute">
+    <parent link="{parent}"/>
+    <child link="link{i}"/>
+    <origin xyz="0 0 0.06"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1.57" upper="1.57" effort="10" velocity="1"/>
+  </joint>
+"""
+
+
+def _write_numeric_urdf(tmp_path) -> str:
+    chunks = []
+    parent = "base_link"
+    for i, name in enumerate(_URDF_NAMES, start=1):
+        chunks.append(_LINK_TMPL.format(i=i, name=name, parent=parent))
+        parent = f"link{i}"
+    path = tmp_path / "numeric_arm.urdf"
+    path.write_text(_NUMERIC_URDF.format(links="".join(chunks)), encoding="utf-8")
+    return str(path)
+
+
+def _skip_if_isaac_unavailable() -> None:
+    from strands_robots.simulation.isaac import IsaacSimulation
+
+    available, reason = IsaacSimulation.is_available()
+    if not available:
+        pytest.skip(f"Isaac Sim not available: {reason}")
+
+
+def test_numeric_urdf_joint_names_round_trip(tmp_path) -> None:
+    """Import, then read/write the articulation by the URDF's own names."""
+    from strands_robots.simulation.isaac import IsaacConfig, IsaacSimulation
+
+    _skip_if_isaac_unavailable()
+    urdf_path = _write_numeric_urdf(tmp_path)
+
+    sim = IsaacSimulation(IsaacConfig(num_envs=1, headless=True))
+    try:
+        r = sim.create_world()
+        assert r["status"] == "success", f"create_world: {r}"
+
+        r = sim.add_robot(name="arm", urdf_path=urdf_path)
+        assert r["status"] == "success", f"add_robot: {r}"
+
+        # Acceptance #1: the public vocabulary is the URDF's, exactly - the
+        # same list MuJoCo reports for the same file. Set-compare then
+        # order-check against the reported order, since the importer may
+        # enumerate DOFs in tree order.
+        names = sim.robot_joint_names("arm")
+        assert sorted(names) == sorted(_URDF_NAMES), names
+        assert all(not n.startswith("tn__") for n in names), names
+
+        # Acceptance #2: observation keys are the URDF names.
+        obs = sim.get_observation("arm", skip_images=True)
+        assert set(_URDF_NAMES) <= set(obs), sorted(obs)
+
+        # Acceptance #3: send_action resolves the URDF names - a dict action
+        # keyed by them must fully resolve (no unresolved_keys envelope) and
+        # land on the right joint. The PD servo needs a settle budget to
+        # track the target (measured: ~0.17 rad of a 0.3 rad step after 20
+        # substeps), so give it a generous one and assert the commanded
+        # joint moved most of the way while every other joint stayed put.
+        r = sim.send_action({"3": 0.3}, robot_name="arm", n_substeps=120)
+        assert r["status"] == "success", f"send_action: {r}"
+        obs = sim.get_observation("arm", skip_images=True)
+        assert abs(obs["3"] - 0.3) < 0.15, obs["3"]
+        for other in ("1", "2", "4", "5", "6"):
+            assert abs(obs[other]) < 0.05, (other, obs[other])
+
+        # The mangled forms are NOT part of the public vocabulary.
+        r = sim.send_action({"tn__3_": 0.3}, robot_name="arm")
+        assert r["status"] == "error", r
+    finally:
+        sim.destroy()


### PR DESCRIPTION
Closes #1900. Split from #1895's second finding: the Isaac URDF importer mangles joint names that are not legal USD prim names, and the mangled names leaked through the backend's public API - so the same URDF yielded different joint vocabularies on Isaac vs MuJoCo.

## What changed

- **New `strands_robots/simulation/isaac/joint_names.py`** (kit-free, stdlib only):
  - `urdf_joint_names(path)` - movable joint names (`revolute`/`continuous`/`prismatic`/`spherical`) parsed out of the URDF in file order, with the same fail-loud contract as `loaders.load_urdf`.
  - `demangle_usd_joint_names(dof_names, urdf_names)` - deterministically maps the importer's `dof_names` back onto the URDF vocabulary. Recognises both encodings: bootstring `tn__` transcoding (Isaac Sim 6.0.x; matched exactly when the name is all identifier characters, e.g. `"1"` -> `tn__1_`, and on the deterministic `tn__<basic>_` stem otherwise) and legacy `TfMakeValidIdentifier` `_`-substitution. An ambiguous decode keeps the USD name for that joint; translated names are collision-free by construction (candidates are drawn only from URDF joints no DOF reports verbatim, and each claim removes the joint from the pool).
- **`_load_urdf_robot`** translates once, where the names enter the backend. Every articulation read/write downstream is positional (index into `dof_names` order), so `robot_joint_names`, `get_observation` keys, `send_action` dict resolution, the pump's joint cache, `set_joint_positions`, and dataset-recording schemas all speak URDF names with no hot-path change. Best-effort: if the stdlib re-parse of a URDF the importer just accepted fails, the importer's names are kept (pre-fix, self-consistent behaviour) with a warning.
- **`_RobotState.usd_to_urdf_joint_names`** records the `usd_name -> urdf_name` map (issue's suggested bookkeeping) for diagnostics, carried via the same sidecar pattern as `_strands_actual_prim_path`.

## Acceptance criteria (from #1900)

- [x] The same URDF added on Isaac and MuJoCo reports identical `robot_joint_names` - Isaac now reports the URDF's own names (`"1"`..`"6"` for the numeric case).
- [x] `get_observation` keys and `send_action` name resolution use the URDF names on Isaac (and `send_action({"tn__3_": ...})` now returns the structured unresolved-keys envelope, same as MuJoCo would).
- [x] Regression test with a numeric-joint-name URDF: `tests/simulation/isaac/test_urdf_joint_name_demangle.py` (23 tests, no kit install required - mapping logic direct + the `add_robot` boundary through a fake `isaacsim` module tree) and GPU-gated `tests_integ/simulation/test_isaac_urdf_joint_names_gpu.py` for the importer round-trip.

## Test surface

- `hatch run lint` clean; full unit suite green: **18386 passed, 262 skipped, 0 failed** (with `MUJOCO_GL=egl`; without EGL the pre-existing GL-renderer crash in `test_remote_policy_sim_rollout` aborts the run - environmental, not touched here).
- GPU integ round-trip **executed and passing on a real Isaac Sim 6.0.0.1 pip Kit** (L4 GPU): a six-joint URDF named `"1"`..`"6"` imports (importer reports `tn__1_`..`tn__6_`), `robot_joint_names` returns the URDF names, observations are keyed by them, a dict action keyed `{"3": 0.3}` moves exactly joint 3, and the mangled key is refused.

## Out of scope / follow-ups

- The USD load path (`_load_usd_robot`) is untouched: a bare USD carries no URDF to recover names from, so its `dof_names` remain authoritative.
- `examples/so101_curobo` needs no change - it feeds `scene.joint_names` into cuRobo, which now agrees with the planner's URDF-derived names once this and #1901 (the #1895 reset fix, open separately) both land.

Project board: issue #1900 should move to "In review" (tracked on the Strands Labs - Robots board).
