### PR TITLE
fix(utils): a name list is read once, and a read that cannot finish is refused (closes #1897)

### DIFF
--- a/changelog.d/1897-name-list-single-guarded-read.md
+++ b/changelog.d/1897-name-list-single-guarded-read.md
@@ -1,0 +1,53 @@
+### Fixed: a name list is read once, and a read that cannot finish is refused
+
+`utils.name_list_error` tested `isinstance(value, Sequence)` and then read the
+value on every branch that needed it, guarding none of them - the per-entry walk,
+the duplicate walk, and the duplicate refusal's own `list(value)`. An acceptable
+value was therefore read **twice** and a repeated one **three times**, and a
+`Sequence` whose item access raises escaped from any of them:
+
+```
+name_list_error(HostileSeq(), "cameras", "render_all")  ->  RuntimeError: seq item exploded
+```
+
+A registered `Sequence` is not an exotic shape - `collections.abc.Sequence` is
+what a proxy or a lazily-backed name list subclasses in order to be accepted here
+at all - so the type check passing said nothing about the read succeeding. This is
+the same defect as #1873, #1874, #1875, #1878, #1888 and #1889, on the one guard
+those fixes could not reach: it refuses their probes on the `Sequence` check
+before arriving at a walk.
+
+The value is now read once, entry by entry, and a read that cannot finish is a
+verdict:
+
+```
+render_all: cameras[2] could not be read: RuntimeError: backing store unavailable
+  (got <FailsPartWay object ...>). Pass a list or tuple of names.
+```
+
+Both stems are the ones `finite_vector_error` already uses, with this guard's own
+unquoted `{param}[{i}]` index and a remedy worded for names. A read that never
+began is reported without an index, because there is no entry to name - the index
+is what says two names were read and found usable.
+
+Reading once also corrects a verdict that involved no exception at all. The reads
+were independent, so nothing obliged them to agree, and a two-entry `Sequence`
+answering `["top", "wrist"]` and then `["top", "top"]` cleared the per-entry
+checks against its first read and was refused as a repeat against its second, in
+a message rendering a third - a verdict, a check and a quotation describing three
+different lists. It is now accepted, on the one read that was examined.
+
+The read stays entry by entry rather than `list(value)` for the reason #1889
+declined to materialise, reached from the opposite direction: this guard collects
+the whole value either way, since a repeat cannot be ruled out without reading
+every entry, so laziness buys it no earlier verdict - only the index.
+
+Every existing verdict is unchanged, and the read count is pinned, being the one
+property no refusal text would reveal.
+
+One route in the same guard is measured and left open as #1903: the mapping
+refusal quotes the mapping's own keys as its remedy, and that read can raise too.
+It is a different question - the verdict there is never in doubt, since a mapping
+is refused whatever its keys say, so only the *advice* is unmeasurable - and what
+a refusal should say when it cannot compute its own remedy has no precedent here
+to follow.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1084,6 +1084,81 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
     return None
 
 
+def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any], str | None]:
+    """Read ``value`` into a list once, or return why the read could not finish.
+
+    The single read every verdict in :func:`name_list_error` is then computed
+    from. It exists because that guard used to read the caller's value on each
+    branch that needed it - the entry walk, the duplicate walk, and the
+    duplicate message's own ``list(value)`` - and none of those reads was
+    guarded. An acceptable value was read twice and a repeated one three times,
+    so a value that answers a read at all could break the guard on any of them.
+
+    Reading once is not only about the escape. The reads were independent, so
+    nothing required them to agree, and a value whose contents differ between
+    two of them was refused on the strength of a list no check had examined: a
+    two-entry ``Sequence`` yielding ``["top", "wrist"]`` and then ``["top",
+    "top"]`` cleared the per-entry domain checks against the first and was
+    refused as a repeat against the second, in a message rendering a third. One
+    read makes the verdict and the text it quotes the same list by construction.
+
+    The read is still element by element rather than ``list(value)``, which
+    matters for the same reason it does in :func:`finite_vector_error`: a
+    materialising call raises before any element has been examined, so its
+    verdict could not name how far the read got. Here the whole value is
+    collected either way - a repeat cannot be ruled out without reading every
+    entry, so there is no verdict this guard could reach by stopping early -
+    but the *index* is what distinguishes a value that produced two good names
+    from one that produced none, and that is worth keeping.
+
+    Both stems are the ones :func:`finite_vector_error` already uses, with this
+    guard's own unquoted ``{param}[{i}]`` index style and a remedy worded for
+    names rather than numbers. A read that never began is reported without an
+    index, because there is no element to name; the index is the measurement.
+
+    ``exc`` goes through :func:`_refusal_str` rather than being interpolated: a
+    value hostile enough to raise from its own read is not one whose exception is
+    assumed to have a working ``__str__``, which would be the #1873 escape
+    reintroduced inside the fix for this one.
+
+    Args:
+        value: The caller-supplied value, already known to be a
+            :class:`~collections.abc.Sequence` by the check above the call.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        The entries read and ``None``, or the entries read so far and the
+        message naming why the read stopped.
+    """
+    try:
+        elements = iter(value)  # type: ignore[call-overload]
+    except Exception as exc:
+        return [], (
+            f"{context}: {param} could not be iterated: "
+            f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(value)}). "
+            f"Pass a list or tuple of names."
+        )
+    entries: list[Any] = []
+    while True:
+        # ``next()`` is called explicitly because a ``for`` cannot guard the call
+        # it makes, so an exception raised while *producing* an entry would escape
+        # this guard exactly as one from ``__iter__`` would. ``StopIteration`` is
+        # the read finishing normally; an empty value is accepted as before,
+        # emptiness meaning "not supplied" to every caller of this function.
+        try:
+            entry = next(elements)
+        except StopIteration:
+            return entries, None
+        except Exception as exc:
+            return entries, (
+                f"{context}: {param}[{len(entries)}] could not be read: "
+                f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(value)}). "
+                f"Pass a list or tuple of names."
+            )
+        entries.append(entry)
+
+
 def name_list_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable list of distinct key names.
 
@@ -1138,7 +1213,10 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
     Only a :class:`~collections.abc.Sequence` is accepted, which excludes
     one-shot iterators. That matters on the LeRobot path, where the value is
     read twice - once by the pre-flight check and again at load - so a generator
-    exhausted by the first read would present as empty to the second.
+    exhausted by the first read would present as empty to the second. That is a
+    statement about the *consumers*: this function itself reads the value once,
+    through :func:`_read_name_list`, and a read that cannot finish is answered
+    with a message rather than raising out of the guard.
 
     Callers gate this check on a truthy value, because in both consumers a falsy
     ``image_keys`` (``None``, or an empty list) already means "not supplied" and
@@ -1177,20 +1255,27 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
             f"({_refusal_container_repr(value)}). Pass a list or tuple; a one-shot iterator cannot be used "
             f"because the value is read more than once."
         )
-    for i, entry in enumerate(value):
+    # One read, and every verdict below is about the list it produced. A
+    # ``Sequence`` is not obliged to answer two reads the same way, so the
+    # per-entry checks and the duplicate check have to see the same entries for
+    # their verdicts to be about the same value - see :func:`_read_name_list`.
+    entries, unread = _read_name_list(value, param, context)
+    if unread is not None:
+        return unread
+    for i, entry in enumerate(entries):
         if not isinstance(entry, str):
             return f"{context}: {param}[{i}] must be a name (str), got {type(entry).__name__} ({_refusal_repr(entry)})."
         if not entry.strip():
             return f"{context}: {param}[{i}] must be a non-blank name, got {_refusal_repr(entry)}."
     seen: set[str] = set()
     repeated: set[str] = set()
-    for entry in value:
+    for entry in entries:
         if entry in seen:
             repeated.add(entry)
         seen.add(entry)
     if repeated:
         return (
-            f"{context}: {param} must not repeat a name, got {_refusal_container_repr(list(value))} "
+            f"{context}: {param} must not repeat a name, got {_refusal_container_repr(entries)} "
             f"({_refusal_container_repr(sorted(repeated))} appears more than once)."
         )
     return None

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -72,7 +72,7 @@ import math
 import numbers
 import pathlib
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -1182,3 +1182,354 @@ class TestElementProductionIsAnsweredNotEscaped:
         vector = CountedRead(0.1, "not a number", 0.3)
         assert finite_vector_error("raycast", "origin", vector) is not None
         assert vector.produced == 2
+
+
+class HostileNameSeq(Sequence[Any]):
+    """A registered ``Sequence`` whose item access raises - #1897's own probe.
+
+    ``name_list_error`` tests ``isinstance(value, Sequence)`` and then walked the
+    value, so this cleared the type check and escaped from the walk.
+    ``collections.abc.Sequence`` is what a proxy or a lazily-backed name list
+    subclasses in order to be accepted here at all, which is why the type check
+    passing says nothing about the read succeeding.
+    """
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, index: Any) -> Any:
+        raise RuntimeError("seq item exploded")
+
+
+class NamesThenFailure(Sequence[Any]):
+    """Produces two usable names and then fails, so the index is a measurement."""
+
+    def __len__(self) -> int:
+        return 3
+
+    def __getitem__(self, index: Any) -> Any:
+        if index < 2:
+            return ("top", "wrist")[index]
+        raise RuntimeError("backing store unavailable")
+
+
+class HostileNameIteration(Sequence[Any]):
+    """A ``Sequence`` whose ``__iter__`` raises, so no entry is ever produced."""
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, index: Any) -> Any:
+        return "wrist"
+
+    def __iter__(self) -> Iterator[str]:
+        raise RuntimeError("no iteration for you")
+
+
+class UnprintableNameFailure(Sequence[Any]):
+    """Item access raises an exception that cannot itself be rendered.
+
+    The refusal for a failed read interpolates an exception supplied by the same
+    hostile value, so without this probe that interpolation is #1873's rendering
+    escape again, one level inside the fix for #1897.
+    """
+
+    def __repr__(self) -> str:
+        raise RuntimeError("no repr for you")
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, index: Any) -> Any:
+        raise UnprintableFailureError
+
+
+class CountedNameSeq(Sequence[Any]):
+    """A ``Sequence`` recording how many times it was read from start to end.
+
+    The read count is the invariant #1897 turns on. It is a property of the
+    guard, not of any one message, so nothing in the refusal text would reveal a
+    regression to two reads.
+    """
+
+    def __init__(self, *names: Any) -> None:
+        self.names = names
+        self.reads = 0
+
+    def __len__(self) -> int:
+        return len(self.names)
+
+    def __iter__(self) -> Iterator[Any]:
+        self.reads += 1
+        return iter(self.names)
+
+    def __getitem__(self, index: Any) -> Any:
+        return self.names[index]
+
+
+class DifferentOnItsSecondRead(Sequence[Any]):
+    """Answers its first read with distinct names and its second with a repeat.
+
+    Nothing obliges a ``Sequence`` to answer two reads the same way, and the
+    guard used to run its per-entry checks against one read and its duplicate
+    check against another.
+    """
+
+    def __init__(self) -> None:
+        self.reads = 0
+
+    def __len__(self) -> int:
+        return 2
+
+    def __iter__(self) -> Iterator[str]:
+        self.reads += 1
+        return iter(("top", "wrist") if self.reads == 1 else ("top", "top"))
+
+    def __getitem__(self, index: Any) -> Any:
+        return ("top", "wrist")[index]
+
+
+class FailsOnItsSecondRead(Sequence[Any]):
+    """One clean read, then raises - so only the duplicate walk reached it."""
+
+    def __init__(self) -> None:
+        self.reads = 0
+
+    def __len__(self) -> int:
+        return 2
+
+    def __iter__(self) -> Iterator[str]:
+        self.reads += 1
+        if self.reads > 1:
+            raise RuntimeError("second read refused")
+        return iter(("top", "wrist"))
+
+    def __getitem__(self, index: Any) -> Any:
+        return ("top", "wrist")[index]
+
+
+class RepeatedThenFailsOnItsThirdRead(Sequence[Any]):
+    """Two clean reads naming a repeat, then raises - the refusal's own read."""
+
+    def __init__(self) -> None:
+        self.reads = 0
+
+    def __len__(self) -> int:
+        return 2
+
+    def __iter__(self) -> Iterator[str]:
+        self.reads += 1
+        if self.reads > 2:
+            raise RuntimeError("third read refused")
+        return iter(("top", "top"))
+
+    def __getitem__(self, index: Any) -> Any:
+        return "top"
+
+
+class HostileKeyMapping(Mapping[str, str]):
+    """A ``Mapping`` whose key iteration raises, reached by the remedy's read."""
+
+    def __len__(self) -> int:
+        return 1
+
+    def __getitem__(self, key: str) -> str:
+        return "camera"
+
+    def __iter__(self) -> Iterator[str]:
+        raise RuntimeError("no keys for you")
+
+
+class TestTheNameListIsReadOnceAndAnsweredNotEscaped:
+    """``name_list_error`` reads the caller's value once, and answers a read that fails (#1897).
+
+    The seventh escape in the family - rendering (#1873), scalar conversion
+    (#1874), container conversion (#1875), ``__iter__`` (#1878), the shared length
+    probe (#1888), element production (#1889) - and the one member
+    :class:`TestElementProductionIsAnsweredNotEscaped` could not reach, because
+    ``name_list_error`` refuses that class's probes on ``isinstance(value,
+    Sequence)`` before arriving at a walk.
+
+    The defect was wider than a walk. The guard read the caller's value on every
+    branch that needed it and guarded none of them: the per-entry walk, the
+    duplicate walk, and the duplicate refusal's own ``list(value)``. So an
+    acceptable value was read **twice** and a repeated one **three times**, and a
+    value that answers one read could break the guard on any of the others.
+
+    Reading once also settles a verdict that had nothing to do with an exception.
+    The reads were independent, so a value whose contents differ between two of
+    them was refused against a list no check had examined - measured by
+    :meth:`test_the_duplicate_verdict_is_about_the_entries_that_were_checked`.
+
+    The read is still entry by entry rather than ``list(value)``, so the refusal
+    can name where it stopped. That is the same reason #1889 declined to
+    materialise, reached from the opposite direction: this guard collects the
+    whole value either way, because a repeat cannot be ruled out without reading
+    every entry, so laziness buys it no earlier verdict - only the index.
+    """
+
+    def test_a_registered_sequence_whose_item_access_raises_is_refused(self) -> None:
+        """The escape #1897 filed, with the probe it filed it with."""
+        assert isinstance(HostileNameSeq(), Sequence)
+        message = name_list_error(HostileNameSeq(), "cameras", "render_all")
+        assert message is not None
+        assert "render_all: cameras[0] could not be read" in message
+
+    def test_the_refusal_names_the_exception_that_stopped_the_read(self) -> None:
+        """The type and text are the diagnostic content of the traceback it replaces."""
+        message = name_list_error(HostileNameSeq(), "cameras", "render_all")
+        assert message is not None
+        assert "RuntimeError" in message
+        assert "seq item exploded" in message
+
+    def test_a_read_that_fails_part_way_names_the_entry_it_stopped_at(self) -> None:
+        """Two names were read and found usable, which the index states."""
+        message = name_list_error(NamesThenFailure(), "cameras", "render_all")
+        assert message is not None
+        assert "cameras[2] could not be read" in message
+        assert "backing store unavailable" in message
+
+    def test_the_index_is_a_position_and_not_a_constant(self) -> None:
+        """Non-vacuity of the index: a hard-coded ``[0]`` would pass everything above."""
+
+        class FailsAt(Sequence[Any]):
+            def __init__(self, position: int) -> None:
+                self.position = position
+
+            def __len__(self) -> int:
+                return self.position + 1
+
+            def __getitem__(self, index: Any) -> Any:
+                if index < self.position:
+                    return f"cam{index}"
+                raise RuntimeError("halted")
+
+        for position in (0, 1, 2):
+            message = name_list_error(FailsAt(position), "cameras", "render_all")
+            assert message is not None
+            assert f"cameras[{position}] could not be read" in message
+
+    def test_a_read_that_never_began_is_reported_without_an_index(self) -> None:
+        """No entry was produced, so there is none to name - the index is the measurement.
+
+        The two stems are ``finite_vector_error``'s own, so this introduces no
+        vocabulary; what differs is the remedy, which is worded for names.
+        """
+        message = name_list_error(HostileNameIteration(), "cameras", "render_all")
+        assert message is not None
+        assert "render_all: cameras could not be iterated" in message
+        assert "no iteration for you" in message
+        assert "could not be read" not in message
+        assert "cameras[0]" not in message
+
+    def test_it_does_not_claim_the_entry_was_not_a_name(self) -> None:
+        """The domain check never ran on an entry that could not be produced.
+
+        Reusing the per-entry text would report a check that did not run, which
+        is #1878's lesson and the reason that fix was not folded into #1875.
+        """
+        unread = name_list_error(HostileNameSeq(), "cameras", "render_all")
+        not_a_name = name_list_error([1], "cameras", "render_all")
+        assert unread is not None and not_a_name is not None
+        assert "must be a name (str)" in not_a_name
+        assert "must be a name (str)" not in unread
+        assert "must be a list of names" not in unread
+
+    def test_an_exception_whose_own_str_raises_does_not_reescape(self) -> None:
+        """The fix must not reintroduce #1873 inside its own message."""
+        message = name_list_error(UnprintableNameFailure(), "cameras", "render_all")
+        assert message is not None
+        assert "could not be read" in message
+        assert "UnprintableFailureError" in message
+
+    def test_the_value_is_read_exactly_once(self) -> None:
+        """The invariant no message would reveal, on all three of its outcomes.
+
+        An accepted value was read twice before this and a repeated one three
+        times, so a count is the only assertion that can hold the guard to one.
+        """
+        accepted = CountedNameSeq("top", "wrist")
+        assert name_list_error(accepted, "cameras", "render_all") is None
+        assert accepted.reads == 1
+
+        per_entry = CountedNameSeq("top", 1)
+        assert name_list_error(per_entry, "cameras", "render_all") is not None
+        assert per_entry.reads == 1
+
+        repeated = CountedNameSeq("top", "top")
+        assert name_list_error(repeated, "cameras", "render_all") is not None
+        assert repeated.reads == 1
+
+    def test_the_duplicate_verdict_is_about_the_entries_that_were_checked(self) -> None:
+        """A refusal must not be computed from a read no check examined.
+
+        This value has no hostile behaviour and raises nothing. It was refused as
+        a repeat on the strength of its *second* read, having cleared the
+        per-entry checks against its first, in a message rendering a third - so
+        the verdict, the check behind it and the text quoting it described three
+        different lists. One read makes them the same list by construction.
+        """
+        changing = DifferentOnItsSecondRead()
+        assert name_list_error(changing, "cameras", "render_all") is None
+        assert changing.reads == 1
+
+    def test_a_value_that_refuses_its_second_read_is_never_asked_for_one(self) -> None:
+        """The duplicate walk was a second read and could fail on its own."""
+        value = FailsOnItsSecondRead()
+        assert name_list_error(value, "cameras", "render_all") is None
+        assert value.reads == 1
+
+    def test_the_duplicate_refusal_does_not_read_the_value_again_to_quote_it(self) -> None:
+        """``list(value)`` inside the message was a third read, and the last escape.
+
+        The repeat is still reported, and still quotes the entries - from the one
+        read, so a value that cannot answer a third is refused for the repeat it
+        has rather than for the read the message wanted.
+        """
+        value = RepeatedThenFailsOnItsThirdRead()
+        message = name_list_error(value, "cameras", "render_all")
+        assert message is not None
+        assert "must not repeat a name" in message
+        assert "['top', 'top']" in message
+        assert value.reads == 1
+
+    def test_acceptable_and_empty_name_lists_are_unchanged(self) -> None:
+        """The rewritten read must not refuse what the two walks accepted.
+
+        Emptiness means "not supplied" to every caller, so it is not this
+        function's to reject - the ``StopIteration`` that ends the read is the
+        read finishing, not a failure.
+        """
+        assert name_list_error(["top", "wrist"], "cameras", "render_all") is None
+        assert name_list_error(("top", "wrist"), "cameras", "render_all") is None
+        assert name_list_error([], "cameras", "render_all") is None
+        assert name_list_error((), "cameras", "render_all") is None
+
+    def test_the_sibling_guards_verdicts_are_untouched(self) -> None:
+        """Non-vacuity in the other direction: this fix is local to one guard.
+
+        ``finite_vector_error``'s two read verdicts are the text these reuse, so a
+        change made in the wrong place would show up as one of them moving.
+        """
+        assert "could not be read" in str(finite_vector_error("raycast", "origin", GetItemOnly()))
+        assert "could not be iterated" in str(finite_vector_error("raycast", "origin", HostileIteration()))
+
+    def test_a_mapping_whose_keys_cannot_be_read_is_a_stated_boundary(self) -> None:
+        """Measured, out of scope here, and filed as #1903 rather than absorbed.
+
+        The mapping refusal quotes the mapping's own keys as its remedy ("pass
+        the names as a list: [...]"), which is a read of the caller's value and
+        escapes like the others did. It is not fixed here because it is not the
+        same question: a mapping is refused whatever its keys say, so the verdict
+        is already known and only the *remedy* is unmeasurable, and how a refusal
+        should degrade when its remedy cannot be computed has no precedent in
+        this file to follow - #1903 lays out the three candidates. Deciding
+        that inside this change would settle a message-design question in a diff
+        whose subject is a read count.
+
+        Pinned so the boundary is a measurement rather than a claim, and so that
+        closing it has to replace this test rather than pass it silently.
+        """
+        assert isinstance(HostileKeyMapping(), Mapping)
+        with pytest.raises(RuntimeError, match="no keys for you"):
+            name_list_error(HostileKeyMapping(), "cameras", "render_all")


### PR DESCRIPTION
Closes #1897.

## What was wrong

`utils.name_list_error` tested `isinstance(value, Sequence)` and then read the caller's value on **every branch that needed it, guarding none of them**: the per-entry walk, the duplicate walk, and the duplicate refusal's own `list(value)`. So a registered `Sequence` whose item access raises escaped from any of the three, on the one path whose entire purpose is to answer an unusable input with a message rather than a traceback.

A registered `Sequence` is not an exotic shape - `collections.abc.Sequence` is what a proxy or a lazily-backed name list subclasses in order to be *accepted* here at all - so the type check passing said nothing about the read succeeding. This is the same defect as #1873, #1874, #1875, #1878, #1888 and #1889 on the one guard those fixes could not reach: it refuses their probes on the `Sequence` check before arriving at a walk, which is why nothing #1889 added covers it.

## The surface is six routes, not the one the issue predicted

The issue described one escape. Measured on `61946f6`, the guard had **six**, because the read count was the real defect:

| value | route | on `61946f6` |
|---|---|---|
| `Sequence`, item access raises | per-entry walk | `RuntimeError: seq item exploded` |
| `Sequence`, `__iter__` raises | per-entry walk | `RuntimeError: no iteration for you` |
| two good names, then raises | per-entry walk | `RuntimeError: backing store unavailable` |
| clean first read, second raises | **duplicate walk** | `RuntimeError: second read refused` |
| two clean reads, third raises | **the refusal's own `list(value)`** | `RuntimeError: third read refused` |
| `Mapping`, key iteration raises | the mapping remedy | `RuntimeError: no keys for you` |

And the read count itself was measurable: an **acceptable** value was read **twice**, a **repeated** one **three times**.

## The verdict that was wrong with no exception involved

The three reads were independent, so nothing obliged them to agree. A two-entry `Sequence` answering `["top", "wrist"]` and then `["top", "top"]` - raising nothing, hostile in no way - cleared the per-entry domain checks against its **first** read and was refused as a repeat against its **second**, in a message rendering its **third**:

```
name_list_error(DifferentOnItsSecondRead(), "cameras", "render_all")
  ->  "render_all: cameras must not repeat a name, got ['top', 'top'] (['top'] appears more than once)."
      reads = 3
```

The verdict, the check behind it and the text quoting it described three different lists. This is not a traceback escaping a guard; it is a refusal being *wrong*, and it is the reason the fix is "read once" rather than "wrap the walk in a `try`".

## The three decisions the issue asked for

The issue filed this as a decision because #1889's answers do not transfer. Settled as follows.

**1. Laziness is dropped, which is the opposite of #1889 - for #1889's own reason, reached from the other side.** That fix declined `list(vec)` because a materialising call raises before any element has been examined, so its verdict could not say how far the read got. Here the whole value is collected either way: **a repeat cannot be ruled out without reading every entry**, so there is no verdict this guard could reach by stopping early. What laziness was actually buying was the *index*, and that is kept - the read is still entry by entry through a guarded `next()`, not `list(value)`. So the property #1889 protected survives, and the three reads collapse to one.

**2. "How far did the read get" is the right measurement, and the index carries it.** The issue doubted this, on the grounds that the guard reads the value more than once. It no longer does, which removes the objection: there is one read, and the position it stopped at is a fact about it.

**3. The message stems are reused; only the remedy is re-worded.** The issue expected #1889's text to be unusable because this guard refuses against a different domain. The *stems* transfer - `could not be iterated` and `could not be read` name a read failure, which is domain-independent - while the domain lives in the remedy clause:

```
render_all: cameras[2] could not be read: RuntimeError: backing store unavailable
  (got <NamesThenFailure object ...>). Pass a list or tuple of names.
```

That is zero new vocabulary: both stems are `finite_vector_error`'s, the index is this guard's own unquoted `{param}[{i}]` (what `name_list_error` already uses and what `_refusal_container_repr`'s docstring names as the convention), and `Pass a list or tuple of names` echoes the `Pass a list or tuple;` already in the branch above. The per-entry domain verdicts (`must be a name (str)`, `must be a non-blank name`) are untouched.

**A read that never began carries no index**, because there is no entry to name - `cameras could not be iterated`, not `cameras[0]`. The index *is* the measurement, so its absence is meaningful rather than a formatting difference.

## The change

Three files.

**`strands_robots/utils.py`** - a new module-private `_read_name_list` performs the one guarded read and returns `(entries, message | None)`; `name_list_error` calls it once, and the per-entry walk, the duplicate walk and the duplicate refusal all read from `entries`. The docstring paragraph that justified requiring a `Sequence` ("the value is read twice") is corrected to say that this is a statement about the **consumers** - this function now reads once.

**`tests/test_container_refusals_render_elementwise.py`** - `TestTheNameListIsReadOnceAndAnsweredNotEscaped`, 14 tests. No test is replaced: nothing pinned the old behaviour, so unlike #1889 there is no premise test to rewrite.

**`changelog.d/1897-name-list-single-guarded-read.md`** - behavioural change, so a fragment.

## Tests

- `tests/test_container_refusals_render_elementwise.py`: **138 passed** (was 124; +14, none replaced).
- **Non-vacuity**, by reverting `utils.py` alone: **11 of the 14 fail, each with its own distinct escaping exception or wrong verdict** - `seq item exploded`, `backing store unavailable`, `halted`, `no iteration for you`, `second read refused`, `third read refused`, `UnprintableFailureError: <exception str() failed>`, `assert 2 == 1` for the read count, and the repeat verdict returned where `None` belongs. Not one shared import error. The 3 that pass on both are exactly the regression pins that must: acceptable/empty lists still accepted, the sibling guard's two verdicts untouched, and the #1903 boundary below.
- **Full `tests/` sweep, base vs branch: identical failure sets** (`diff` empty; 237 pre-existing failures / 573 collection errors from missing optional deps on a bare runner - `strands`, `torch`, `serial`, `device_connect_edge`, `PIL`, `mujoco`). Branch is **8600 passed vs 8586**, i.e. **+14**, exactly the test-count delta and no more.
- Neighbouring modules that own this family's other invariants: `test_refusal_messages_never_raise.py`, `test_dataset_schema_column_names_distinct.py`, `test_conversion_escape_is_closed.py` - **410 passed** together with this one, so no existing verdict moved. `TestNoExistingVerdictOrMessageMoved` covers all five `name_list_error` messages and is green.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`.
- **`mypy strands_robots tests tests_integ`: 96 errors before, 96 after.** The first draft added 9 (`Signature of "__getitem__" incompatible with supertype "typing.Sequence"` - the ABC's is overloaded for `int` and `slice`), caught locally rather than by CI this time; the probes now subclass `Sequence[Any]` / `Mapping[str, str]` explicitly and widen `__getitem__`, which also removes the `# type: ignore[type-arg]` those classes would otherwise need.
- Fragment validated: `scripts/assemble_changelog.py --check` OK (136 pending), and `test_changelog_fragments.py` / `test_changelog_format.py` / `test_changelog_fragment_gate.py` **68 passed**. The prose scans new text can break - emoji, unicode dashes, ASCII log strings, review archaeology - **passed**.

## Notes for review

- **`StopIteration` is the read finishing, not a failure**, so an empty value is accepted exactly as the two walks accepted it. Emptiness means "not supplied" to every caller of this function, which gates the call on a truthy value.
- **The duplicate refusal still quotes the entries**, now from the one read (`_refusal_container_repr(entries)` in place of `_refusal_container_repr(list(value))`). For a `list` or `tuple` input the rendered text is byte-identical, which is what `TestNoExistingVerdictOrMessageMoved` measures.
- **`_read_name_list` is called after the `Sequence` check**, so it never sees a one-shot iterator; the type check that excludes those is unchanged and still the reason the guard's contract can promise the consumers a re-readable value.
- `exc` goes through `_refusal_str`, not interpolation: a value hostile enough to raise from its own read is not one whose exception is assumed to have a working `__str__`, which would be #1873 reintroduced inside this fix. Pinned by `test_an_exception_whose_own_str_raises_does_not_reescape`.
- **One of the six routes is measured and left open as #1903, not absorbed.** The mapping refusal quotes the mapping's own keys as its remedy, and that `list(value)` is evaluated before `_refusal_container_repr` is entered, so the renderer's never-raise guarantee does not cover it. It is out of scope because it is a different question: the verdict there is never in doubt - a mapping is refused whatever its keys say - so only the *advice* is unmeasurable, and what a refusal should say when it cannot compute its own remedy has no precedent in this file. Settling that inside a diff whose subject is a read count would decide a message-design question by accident. It is **pinned as a boundary** (`test_a_mapping_whose_keys_cannot_be_read_is_a_stated_boundary`), so closing it must replace that test rather than pass it silently, and #1903 lays out the three candidate answers.
- Worth noting for #1903's sake: `TestNoGuardRendersACallerValueDirectly` scans for caller values rendered without a shared renderer, not for *reads*, so an unguarded `list(...)` feeding a renderer is exactly what that scan is blind to. That is how this route survived both #1873 and #1875.

## 13. Round changelog

**Round 0 (opened)** - initial submission.

**Round 1** - no commit: three CodeQL alerts dismissed as `used in tests`, and the reasoning posted on the thread.

`py/unexpected-raise-in-special-method` fired on the three probes whose `__getitem__` raises `RuntimeError` (alerts 855, 856, 857). A non-`LookupError` is precisely what these fixtures exist to model - a proxy whose backing store is gone raises what its transport raises - and taking the query's suggestion would break the tests while leaving them green, because `IndexError` is what CPython's `seqiter` clears to terminate legacy-protocol iteration. A probe raising it would read as a value that finished normally, so the guard would return `None` and every refusal assertion would be measuring an absence.

This is the same rule and the same reason as alert 590 and alert 852 (#1890), which `AGENTS.md` records under "CI Security Baseline" together with the `seqiter` trap. The full argument is in the review thread the dismissal points at, since the dismissal comment is capped at 280 characters. Not added to `.github/codeql/codeql-config.yml`: a real non-`LookupError` from a real `__getitem__` under `strands_robots/` would still be worth an alert.