### PR TITLE
fix(utils): a refusal that cannot quote what it refuses degrades, not raises (closes #1903)

### DIFF
--- a/changelog.d/1903-refusal-degrades-when-it-cannot-quote.md
+++ b/changelog.d/1903-refusal-degrades-when-it-cannot-quote.md
@@ -1,0 +1,74 @@
+### Fixed: a refusal that cannot quote what it refuses degrades instead of raising
+
+`utils.name_list_error` built its refusal text by reading the caller's value, and
+those reads were unguarded. The mapping branch offered the mapping's own keys as
+its remedy:
+
+```python
+f"pass the names as a list: {_refusal_container_repr(list(value))}."
+```
+
+The render was safe; building its argument ran the caller's `__iter__`, so a
+mapping whose keys cannot be read escaped the guard whose whole purpose is to
+answer an unusable input with text:
+
+```
+name_list_error(HostileKeyMapping(), "cameras", "render_all")  ->  RuntimeError: no keys for you
+```
+
+This is the same defect as #1873, #1874, #1875, #1878, #1888, #1889 and #1897, on
+the one path where the read was never load-bearing. Everywhere else the verdict
+depended on the read, so a read that failed *became* the verdict. Here the verdict
+is settled before the read happens - a mapping is refused whatever its keys say -
+so only the advice was unmeasurable, and what a refusal says when it cannot
+compute its own remedy had no precedent in the file to follow.
+
+It now keeps the verdict and degrades the clause that wanted the quotation, which
+is the only available answer that states both what was measured and what was not:
+
+```
+render_all: cameras must be a list of names, not a mapping, got <HostileKeyMapping object ...>.
+  A mapping is iterable over its keys, so its values would be discarded - pass the names as
+  a list; its own keys could not be read to quote them here (RuntimeError: no keys for you).
+```
+
+The read failure is rendered by `_describe_failed_read`, which is the stem
+`_read_name_list` already used, so a refusal degraded here reads like every other
+read failure in the module rather than introducing a second vocabulary for one
+branch. Dropping the verdict instead would have stopped naming the mistake the
+caller actually made, and dropping the remedy silently would have omitted advice
+on one path without saying why.
+
+**#1903 described one read. There were five, across two branches.** The string
+branch was the weaker of the two and none of its four escapes had been filed
+anywhere: it produced the quoted characters with a comprehension over the
+caller's value, counted them with a second `len` the first read was not obliged
+to agree with, interpolated them with a bare f-string rather than the elementwise
+renderer - so an element that cannot print re-raised #1875 inside the clause
+quoting it - and called the overridable `bytes.decode` before any of that.
+A `str` subclass or a `bytes` subclass reaches all four:
+
+```
+name_list_error(HostileCharacterStr("wrist"), ...)  ->  RuntimeError: no characters for you
+name_list_error(HostileLengthStr("wrist"), ...)     ->  RuntimeError: no length for you
+name_list_error(UndecodableBytes(b"wrist"), ...)    ->  RuntimeError: no decoding for you
+```
+
+The characters and the count beside them now come from one read, which is #1897's
+property applied to a message rather than to a verdict: they can no longer
+describe different values.
+
+Every accepted and refused message is unchanged, asserted as exact text rather
+than as substrings.
+
+The escapes were invisible to `TestNoGuardRendersACallerValueDirectly`, which
+reports a caller value *rendered* without a shared renderer and is satisfied
+completely by `_refusal_container_repr(list(value))`. Its read-side companion,
+`TestNoGuardReadsACallerValueOutsideATry`, is added beside it: it scans `utils.py`
+for a public guard that runs the caller's own code outside a `try`, follows the
+value through assignments so a local holding it is covered too, and stops at the
+helpers that read inside a `try` and hand back an ordinary value. That scan is
+what found the four unfiled reads above, and three more it reports are recorded
+as #1906 with a pin that measures them - each `coerce_*` guard validates its value
+with a guard that reads it and then reads it again, so `coerce_rgba` raises on the
+wrong-length branch that exists to return text.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -497,6 +497,58 @@ def _describe_unrenderable(value: Any) -> str:
     return f"<unrepresentable {type(value).__name__}>"
 
 
+def _describe_failed_read(exc: Exception) -> str:
+    """``RuntimeError: no keys for you`` for a read a refusal could not complete.
+
+    The one spelling of a failed read in this module's refusal text, shared by
+    the guard that reports a read whose *verdict* it became
+    (:func:`_read_name_list`) and the read a message makes only to *quote*
+    something (:func:`_read_to_quote`). Named rather than repeated for the reason
+    :func:`_describe_unrenderable` is shared between the two render forms: a
+    refusal degraded on one path must not describe the same failure differently
+    from another.
+
+    ``exc`` goes through :func:`_refusal_str` rather than being interpolated: a
+    value hostile enough to raise from its own read is not one whose exception is
+    assumed to have a working ``__str__``, which would be the #1873 escape
+    reintroduced inside a message built to avoid it.
+
+    Args:
+        exc: The exception the read raised.
+
+    Returns:
+        Its type name and text, which cannot itself raise.
+    """
+    return f"{type(exc).__name__}: {_refusal_str(exc)}"
+
+
+def _read_to_quote(value: Any) -> tuple[list[Any] | None, str | None]:
+    """The elements of ``value`` for a refusal to quote, or why they could not be read.
+
+    The read a refusal makes for its own *text*, which is a different job from
+    :func:`_read_name_list`'s and needs the opposite answer. There the verdict
+    depends on the read, so a read that fails becomes the verdict. Here the
+    verdict is settled *before* the read happens - a mapping is refused whatever
+    its keys say, and a string whatever its characters are - so a read that fails
+    must not replace it: the caller passed a mapping, and that is the mistake
+    worth reporting even when its keys cannot be quoted. The failure is therefore
+    described for the message to carry rather than returned as a message of its
+    own (#1903).
+
+    Args:
+        value: The caller-supplied value a refusal wants to quote.
+
+    Returns:
+        ``(elements, None)`` when the read finished, or ``(None, description)``
+        when it did not. Exactly one side is ever populated, so a caller holding
+        a ``None`` description holds the elements.
+    """
+    try:
+        return list(value), None
+    except Exception as exc:
+        return None, _describe_failed_read(exc)
+
+
 def _refusal_container_repr(value: Any) -> str:
     """``repr(value)`` for a refusal that reports a whole container, elementwise if it must.
 
@@ -1116,10 +1168,9 @@ def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any],
     names rather than numbers. A read that never began is reported without an
     index, because there is no element to name; the index is the measurement.
 
-    ``exc`` goes through :func:`_refusal_str` rather than being interpolated: a
-    value hostile enough to raise from its own read is not one whose exception is
-    assumed to have a working ``__str__``, which would be the #1873 escape
-    reintroduced inside the fix for this one.
+    The exception is rendered by :func:`_describe_failed_read`, which is also what
+    a refusal that could only not *quote* something reports (#1903), so the two
+    cannot describe one failure two ways.
 
     Args:
         value: The caller-supplied value, already known to be a
@@ -1136,7 +1187,7 @@ def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any],
     except Exception as exc:
         return [], (
             f"{context}: {param} could not be iterated: "
-            f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(value)}). "
+            f"{_describe_failed_read(exc)} (got {_refusal_container_repr(value)}). "
             f"Pass a list or tuple of names."
         )
     entries: list[Any] = []
@@ -1153,7 +1204,7 @@ def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any],
         except Exception as exc:
             return entries, (
                 f"{context}: {param}[{len(entries)}] could not be read: "
-                f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(value)}). "
+                f"{_describe_failed_read(exc)} (got {_refusal_container_repr(value)}). "
                 f"Pass a list or tuple of names."
             )
         entries.append(entry)
@@ -1234,20 +1285,50 @@ def name_list_error(value: Any, param: str, context: str) -> str | None:
         An error message, or ``None`` when the value is usable.
     """
     if isinstance(value, str | bytes):
-        shown = value.decode(errors="replace") if isinstance(value, bytes) else value
+        # One read builds the whole consequence clause. ``bytes.decode`` is
+        # overridable and a ``str`` subclass owns its own ``__iter__`` and
+        # ``__len__``, so producing the characters and counting them are both
+        # reads of the caller's value - and taking the count from the same read
+        # that produced the characters is #1897's property applied to a message,
+        # rather than a second read the first is not obliged to agree with.
+        shown: Any = value
+        characters: list[Any] | None = None
+        unreadable: str | None = None
+        try:
+            shown = value.decode(errors="replace") if isinstance(value, bytes) else value
+        except Exception as exc:
+            unreadable = _describe_failed_read(exc)
+        else:
+            characters, unreadable = _read_to_quote(shown)
+        if characters is None:
+            consequence = (
+                f"A string is iterable per character, so this would be read as one name per "
+                f"character; its own characters could not be read to quote them here ({unreadable})."
+            )
+        else:
+            consequence = (
+                f"A string is iterable per character, so this would be read as "
+                f"{_refusal_container_repr(characters[:6])}{' ...' if len(characters) > 6 else ''} "
+                f"({len(characters)} name(s))."
+            )
         return (
             f"{context}: {param} must be a list of names, not a single string, "
-            f"got {_refusal_container_repr(value)}. "
-            f"A string is iterable per character, so this would be read as "
-            f"{[c for c in shown][:6]}{' ...' if len(shown) > 6 else ''} "
-            f"({len(shown)} name(s)). Wrap it in a list: [{_refusal_repr(shown)}]."
+            f"got {_refusal_container_repr(value)}. {consequence} "
+            f"Wrap it in a list: [{_refusal_repr(shown)}]."
         )
     if isinstance(value, Mapping):
+        # The verdict is not in doubt on this branch, so a key read that fails
+        # degrades the remedy and leaves the verdict standing (#1903).
+        names, unquotable = _read_to_quote(value)
+        remedy = (
+            f"pass the names as a list; its own keys could not be read to quote them here ({unquotable})."
+            if names is None
+            else f"pass the names as a list: {_refusal_container_repr(names)}."
+        )
         return (
             f"{context}: {param} must be a list of names, not a mapping, "
             f"got {_refusal_container_repr(value)}. "
-            f"A mapping is iterable over its keys, so its values would be discarded - "
-            f"pass the names as a list: {_refusal_container_repr(list(value))}."
+            f"A mapping is iterable over its keys, so its values would be discarded - {remedy}"
         )
     if not isinstance(value, Sequence):
         return (

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -1340,6 +1340,61 @@ class HostileKeyMapping(Mapping[str, str]):
         raise RuntimeError("no keys for you")
 
 
+class UnprintableKeyFailureMapping(Mapping[str, str]):
+    """A ``Mapping`` whose key read raises an exception that cannot print itself."""
+
+    def __len__(self) -> int:
+        return 1
+
+    def __getitem__(self, key: str) -> str:
+        return "camera"
+
+    def __iter__(self) -> Iterator[str]:
+        raise UnprintableFailureError
+
+
+class HostileCharacterStr(str):
+    """A ``str`` whose own iteration raises, reached by the consequence clause's read.
+
+    A ``str`` subclass is the shape a name arrives as when a caller wraps one -
+    an interned label, a path-like, an enum member's value - so overriding
+    ``__iter__`` is not the only route here, merely the clearest.
+    """
+
+    def __iter__(self) -> Iterator[str]:
+        raise RuntimeError("no characters for you")
+
+
+class HostileLengthStr(str):
+    """A ``str`` whose ``__len__`` raises, which the character count used to call."""
+
+    def __len__(self) -> int:
+        raise RuntimeError("no length for you")
+
+
+class UnprintableCharacterStr(str):
+    """A ``str`` that iterates into elements whose ``repr`` raises.
+
+    The container-renderer half of the same branch: reading the characters can
+    succeed and *quoting* them still escape, which is #1875's defect one level
+    inside the clause that quotes them.
+    """
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter([Unprintable()])
+
+
+class UndecodableBytes(bytes):
+    """``bytes`` whose ``decode`` raises, which the branch calls before any read.
+
+    ``bytes`` is the one input class this branch *transforms* before quoting it,
+    so producing the text to quote is itself a read of the caller's value.
+    """
+
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise RuntimeError("no decoding for you")
+
+
 class TestTheNameListIsReadOnceAndAnsweredNotEscaped:
     """``name_list_error`` reads the caller's value once, and answers a read that fails (#1897).
 
@@ -1514,22 +1569,167 @@ class TestTheNameListIsReadOnceAndAnsweredNotEscaped:
         assert "could not be read" in str(finite_vector_error("raycast", "origin", GetItemOnly()))
         assert "could not be iterated" in str(finite_vector_error("raycast", "origin", HostileIteration()))
 
-    def test_a_mapping_whose_keys_cannot_be_read_is_a_stated_boundary(self) -> None:
-        """Measured, out of scope here, and filed as #1903 rather than absorbed.
+    def test_a_mapping_whose_keys_cannot_be_read_keeps_its_verdict(self) -> None:
+        """Replaces the #1903 boundary this class stated: the mapping verdict survives.
 
-        The mapping refusal quotes the mapping's own keys as its remedy ("pass
-        the names as a list: [...]"), which is a read of the caller's value and
-        escapes like the others did. It is not fixed here because it is not the
-        same question: a mapping is refused whatever its keys say, so the verdict
-        is already known and only the *remedy* is unmeasurable, and how a refusal
-        should degrade when its remedy cannot be computed has no precedent in
-        this file to follow - #1903 lays out the three candidates. Deciding
-        that inside this change would settle a message-design question in a diff
-        whose subject is a read count.
+        The pin this replaces asserted the escape - ``pytest.raises`` on the
+        remedy's own ``list(value)``. What made it a boundary rather than a bug
+        to absorb was that the verdict was never in doubt on this branch, so the
+        question was what a refusal says when only its *advice* is unmeasurable,
+        and that is a message-design decision rather than a guarded read.
 
-        Pinned so the boundary is a measurement rather than a claim, and so that
-        closing it has to replace this test rather than pass it silently.
+        It is answered by keeping the verdict and degrading the remedy, which is
+        the only one of #1903's three candidates that states both what was
+        measured and what was not. Dropping the verdict would stop naming the
+        mistake the caller actually made, and dropping the remedy silently would
+        omit advice on one path without saying why.
         """
         assert isinstance(HostileKeyMapping(), Mapping)
-        with pytest.raises(RuntimeError, match="no keys for you"):
-            name_list_error(HostileKeyMapping(), "cameras", "render_all")
+        message = name_list_error(HostileKeyMapping(), "cameras", "render_all")
+        assert message is not None
+        assert "must be a list of names, not a mapping" in message
+        assert "its own keys could not be read to quote them here" in message
+        assert "RuntimeError: no keys for you" in message
+
+
+class TestARefusalDegradesWhenItCannotQuoteWhatItRefuses:
+    """``name_list_error``'s text reads the caller's value, and those reads are guarded (#1903).
+
+    The eighth and last member of the family - rendering (#1873), scalar
+    conversion (#1874), container conversion (#1875), ``__iter__`` (#1878), the
+    shared length probe (#1888), element production (#1889), the name-list read
+    count (#1897) - and the only one where the read was never load-bearing.
+
+    Every other member guarded a read the *verdict* needed, so a read that failed
+    became the verdict. Here the verdict is settled before the read happens: a
+    mapping is refused whatever its keys say, and a string whatever its
+    characters are. So the read exists only to quote something, and the decision
+    #1903 asked for is what the refusal says when it cannot. It keeps the verdict
+    and degrades the clause that wanted the quotation, naming the read failure
+    with ``_describe_failed_read`` - the stem ``_read_name_list`` already uses -
+    so a refusal degraded here reads like every other read failure in the module.
+
+    #1903 described one read, on the mapping branch. There are five, across two
+    branches, and the four the issue did not have are asserted below: the string
+    branch produced its characters with a comprehension, counted them with a
+    second ``len`` the first was not obliged to agree with, rendered them with a
+    bare f-string rather than the elementwise renderer, and decoded ``bytes``
+    with an overridable method before any of that.
+    """
+
+    def test_a_string_whose_characters_cannot_be_read_keeps_its_verdict(self) -> None:
+        """Not in #1903, and the same shape one branch up.
+
+        ``[c for c in shown]`` built the consequence clause and was as unguarded
+        as the mapping's ``list(value)``.
+        """
+        message = name_list_error(HostileCharacterStr("wrist"), "cameras", "render_all")
+        assert message is not None
+        assert "must be a list of names, not a single string" in message
+        assert "its own characters could not be read to quote them here" in message
+        assert "RuntimeError: no characters for you" in message
+
+    def test_the_character_count_comes_from_the_read_that_produced_them(self) -> None:
+        """``len(shown)`` was a second read, so a hostile ``__len__`` escaped too.
+
+        This is #1897's property applied to a message rather than to a verdict:
+        the quotation and the count beside it now come from one read, so they
+        cannot describe different values.
+        """
+        message = name_list_error(HostileLengthStr("wrist"), "cameras", "render_all")
+        assert message is not None
+        assert "RuntimeError: no length for you" in message
+
+    def test_the_quoted_characters_go_through_the_elementwise_renderer(self) -> None:
+        """Reading the characters can succeed and quoting them still escape.
+
+        The clause interpolated the list directly, so ``repr`` recursed into an
+        element that cannot print - #1875's defect, inside the fix for #1903's.
+        """
+        message = name_list_error(UnprintableCharacterStr("w"), "cameras", "render_all")
+        assert message is not None
+        assert "<unrepresentable Unprintable>" in message
+        assert "(1 name(s))" in message
+
+    def test_bytes_whose_decode_raises_keeps_its_verdict(self) -> None:
+        """``bytes`` is the one input class this branch transforms before quoting it.
+
+        So producing the text is a read of the caller's value, and it ran outside
+        the guard - the earliest of the five escapes on this branch.
+        """
+        message = name_list_error(UndecodableBytes(b"wrist"), "cameras", "render_all")
+        assert message is not None
+        assert "must be a list of names, not a single string" in message
+        assert "RuntimeError: no decoding for you" in message
+
+    def test_a_degraded_remedy_still_offers_the_remedy(self) -> None:
+        """Candidate 3 - drop the clause - is excluded by measurement, not by prose.
+
+        The advice is what the caller acts on, so the refusal keeps saying to
+        pass a list and reports only that it could not quote the names.
+        """
+        mapping = name_list_error(HostileKeyMapping(), "cameras", "render_all")
+        string = name_list_error(HostileCharacterStr("wrist"), "cameras", "render_all")
+        assert mapping is not None and string is not None
+        assert "pass the names as a list" in mapping
+        assert "Wrap it in a list: ['wrist']." in string
+
+    def test_a_degraded_refusal_does_not_claim_a_check_that_did_not_run(self) -> None:
+        """#1878's lesson: the entries were never read, so no entry verdict may appear."""
+        message = name_list_error(HostileKeyMapping(), "cameras", "render_all")
+        assert message is not None
+        assert "must be a name (str)" not in message
+        assert "must not repeat a name" not in message
+        assert "could not be iterated" not in message
+
+    def test_an_exception_whose_own_str_raises_does_not_reescape(self) -> None:
+        """The fix must not reintroduce #1873 inside its own degraded clause."""
+        message = name_list_error(UnprintableKeyFailureMapping(), "cameras", "render_all")
+        assert message is not None
+        assert "could not be read to quote them here" in message
+        assert "UnprintableFailureError" in message
+
+    def test_no_accepted_or_refused_message_moved(self) -> None:
+        """The whole point of degrading is that nothing else changes.
+
+        Asserted as exact text rather than as substrings, because a rewrite of
+        two message branches is precisely the change that moves a word nobody
+        looks at. The ``(5 name(s))`` count and the ``['top', 'wrist']`` remedy
+        are the two values now taken from the single read.
+        """
+        assert name_list_error(["top", "wrist"], "cameras", "render_all") is None
+        assert name_list_error("wrist", "cameras", "render_all") == (
+            "render_all: cameras must be a list of names, not a single string, got 'wrist'. "
+            "A string is iterable per character, so this would be read as "
+            "['w', 'r', 'i', 's', 't'] (5 name(s)). Wrap it in a list: ['wrist']."
+        )
+        assert name_list_error(b"wrist", "cameras", "render_all") == (
+            "render_all: cameras must be a list of names, not a single string, got b'wrist'. "
+            "A string is iterable per character, so this would be read as "
+            "['w', 'r', 'i', 's', 't'] (5 name(s)). Wrap it in a list: ['wrist']."
+        )
+        assert name_list_error("shoulder", "cameras", "render_all") == (
+            "render_all: cameras must be a list of names, not a single string, got 'shoulder'. "
+            "A string is iterable per character, so this would be read as "
+            "['s', 'h', 'o', 'u', 'l', 'd'] ... (8 name(s)). Wrap it in a list: ['shoulder']."
+        )
+        assert name_list_error({"top": 1, "wrist": 2}, "cameras", "render_all") == (
+            "render_all: cameras must be a list of names, not a mapping, "
+            "got {'top': 1, 'wrist': 2}. A mapping is iterable over its keys, so its values "
+            "would be discarded - pass the names as a list: ['top', 'wrist']."
+        )
+
+    def test_the_probes_are_the_types_the_branches_dispatch_on(self) -> None:
+        """Non-vacuity: a probe that missed its branch would pass every test above.
+
+        ``UnprintableCharacterStr`` is checked for the property it is *for* -
+        readable characters that cannot be quoted - since a probe that raised on
+        the read instead would satisfy this class's other assertions by accident.
+        """
+        assert isinstance(HostileCharacterStr("w"), str)
+        assert isinstance(HostileLengthStr("w"), str)
+        assert isinstance(UndecodableBytes(b"w"), bytes)
+        assert isinstance(UnprintableKeyFailureMapping(), Mapping)
+        assert len(list(UnprintableCharacterStr("w"))) == 1
+        with pytest.raises(RuntimeError, match="no repr for you"):
+            repr(list(UnprintableCharacterStr("w")))

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -92,7 +92,7 @@ import numbers
 import pathlib
 import sys
 import textwrap
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple
 
 import numpy as np
@@ -743,6 +743,170 @@ CONTAINER_GUARDS = frozenset(
 )
 
 
+#: Builtin calls that *read* the value handed to them, as opposed to inspecting it.
+#: ``isinstance`` and ``type`` ask a question of the object's class and cannot run
+#: the value's own code; every name here dispatches to a dunder the value owns.
+READING_BUILTINS = frozenset(
+    {
+        "all",
+        "any",
+        "dict",
+        "enumerate",
+        "frozenset",
+        "iter",
+        "len",
+        "list",
+        "max",
+        "min",
+        "next",
+        "repr",
+        "reversed",
+        "set",
+        "sorted",
+        "str",
+        "sum",
+        "tuple",
+    }
+)
+
+#: The helpers that perform a read *inside* a ``try`` and hand back an ordinary
+#: value. A name bound from one of these is this module's own object rather than
+#: the caller's, so reading it further cannot run caller code and the scan below
+#: stops following it. Without this the scan would report
+#: ``len(characters)`` - a plain ``list`` produced by a guarded read - as loudly
+#: as it reports ``len(value)``.
+GUARDED_READERS = frozenset(
+    {
+        "_describe_failed_read",
+        "_describe_unrenderable",
+        "_read_name_list",
+        "_read_to_quote",
+        "_refusal_container_repr",
+        "_refusal_repr",
+        "_refusal_str",
+        "sequence_length",
+    }
+)
+
+
+def _scan_unguarded_message_reads(source: str) -> dict[str, tuple[tuple[str, str], ...]]:
+    """Map each public guard in ``source`` to the caller reads it makes outside a ``try``.
+
+    The companion to :func:`_scan_direct_renders`, and the escape that scan is
+    blind to. It reports a caller value *rendered* without a shared renderer,
+    which is why ``_refusal_container_repr(list(value))`` satisfied it: the value
+    reaching the renderer is a ``list`` the guard built, and building it ran the
+    caller's ``__iter__``. So the render was guarded and the read feeding it was
+    not, and the whole of #1903 lived in that gap - as did the four escapes on
+    ``name_list_error``'s string branch that #1903 did not have.
+
+    "Reads the caller's value" is followed rather than assumed. The parameters
+    annotated ``Any`` are the caller's, and so is any local assigned from one:
+    ``name_list_error``'s ``shown`` is the caller's own ``str`` under a different
+    name, and reading *it* is what escaped. The chain stops at
+    :data:`GUARDED_READERS`, whose members read inside a ``try`` and return an
+    ordinary value - so a local bound from one is no longer the caller's object
+    and reading it cannot run their code.
+
+    Only public functions are scanned. The private helpers below them are the
+    guarded layer a guard is built from, so a read inside one is the point rather
+    than a defect, and reporting them would make the table a list of the fixes
+    instead of a list of the escapes.
+
+    Args:
+        source: The contents of a Python module.
+
+    Returns:
+        Every public guard that reads a caller value outside a ``try``, mapped to
+        ``(name, kind)`` pairs, where kind names the read form - a builtin, an
+        attribute call, a comprehension or a subscript.
+    """
+    tree = ast.parse(source)
+    found: dict[str, tuple[tuple[str, str], ...]] = {}
+    for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)]:
+        if fn.name.startswith("_"):
+            continue
+        args = fn.args.posonlyargs + fn.args.args + fn.args.kwonlyargs
+        tainted = {arg.arg for arg in args if arg.annotation is not None and ast.unparse(arg.annotation) == "Any"}
+        if not tainted:
+            continue
+
+        # Follow the caller's value through assignments until nothing new is
+        # bound. A guarded reader breaks the chain; anything else propagates,
+        # because a slice or a decode of the caller's object is still theirs.
+        for _ in range(len(list(ast.walk(fn)))):
+            grown = set(tainted)
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Assign | ast.AnnAssign) or node.value is None:
+                    continue
+                calls = {
+                    call.func.id
+                    for call in ast.walk(node.value)
+                    if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                }
+                if calls & GUARDED_READERS:
+                    continue
+                sources = {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+                if not sources & tainted:
+                    continue
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    grown |= {n.id for n in ast.walk(target) if isinstance(n, ast.Name)}
+            if grown == tainted:
+                break
+            tainted = grown
+
+        guarded = {
+            id(n) for stmt in ast.walk(fn) if isinstance(stmt, ast.Try) for body in stmt.body for n in ast.walk(body)
+        }
+        raised = {id(n) for stmt in ast.walk(fn) if isinstance(stmt, ast.Raise) for n in ast.walk(stmt)}
+        reads: set[tuple[str, str]] = set()
+        for node in ast.walk(fn):
+            if id(node) in guarded or id(node) in raised:
+                continue
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in READING_BUILTINS:
+                for arg in node.args:
+                    reads |= {
+                        (n.id, f"{node.func.id}()")
+                        for n in ast.walk(arg)
+                        if isinstance(n, ast.Name) and n.id in tainted
+                    }
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                target = node.func.value
+                if isinstance(target, ast.Name) and target.id in tainted:
+                    reads.add((target.id, f".{node.func.attr}()"))
+            elif isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp | ast.DictComp):
+                for generator in node.generators:
+                    reads |= {
+                        (n.id, "comprehension")
+                        for n in ast.walk(generator.iter)
+                        if isinstance(n, ast.Name) and n.id in tainted
+                    }
+            elif isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name) and node.value.id in tainted:
+                reads.add((node.value.id, "subscript"))
+        if reads:
+            found[fn.name] = tuple(sorted(reads))
+    return found
+
+
+#: The reads still outstanding, which is what this scan was written to surface.
+#: ``name_list_error`` came off the table with #1903 - five reads across two
+#: branches, one of them filed and four of them not - and the three the scan found
+#: beside it are #1906: each coercion validates its value with a guard that reads
+#: it and then reads it again to build the floats, so a value that answers one
+#: read and refuses the next escapes. Two of the three are on the *accepted* path
+#: rather than in a message, which is why they are a tracked boundary here rather
+#: than absorbed into #1903 - and why ``coerce_rgba`` is the one that breaks a
+#: stated contract, its second read being quoted by the wrong-length refusal.
+#: :class:`TestTheCoercionsSecondReadIsAStatedBoundary` measures the escape, so
+#: emptying this table and replacing that pin are one change.
+KNOWN_MESSAGE_READS: dict[str, tuple[tuple[str, str], ...]] = {
+    "coerce_pose_vector": (("vec", "comprehension"),),
+    "coerce_rgba": (("color", "comprehension"),),
+    "coerce_size_vector": (("size", "comprehension"),),
+}
+
+
 class TestNoGuardRendersACallerValueDirectly:
     """A guard must render a refused value through a shared renderer.
 
@@ -845,6 +1009,245 @@ class TestNoGuardRendersACallerValueDirectly:
         )
         assert _scan_direct_renders(raising) == {}
         assert "_safe_join" not in KNOWN_DIRECT_RENDERS
+
+
+class TestNoGuardReadsACallerValueOutsideATry:
+    """A guard must not run the caller's own code while building its refusal (#1903).
+
+    ``TestNoGuardRendersACallerValueDirectly`` above holds the *rendering* of a
+    refused value, and that is not the same property. Its table is empty because
+    every guard renders through a shared renderer - and
+    ``_refusal_container_repr(list(value))`` satisfied it completely, because the
+    value handed to the renderer was a ``list`` the guard had already built. The
+    render could not raise; building its argument ran the caller's ``__iter__``,
+    which could.
+
+    So this is the read-side scan, stated over the module rather than over a list
+    of guards, for the reason the sibling gives: a fixed list would not survive a
+    tenth guard being added. It is what closing #1903 needed in order not to be a
+    one-branch patch - the issue described the mapping's ``list(value)``, and the
+    scan found four more on the string branch beside it.
+    """
+
+    def _source(self) -> str:
+        return pathlib.Path(inspect.getfile(utils)).read_text(encoding="utf-8")
+
+    def test_no_public_guard_reads_a_caller_value_outside_a_try(self) -> None:
+        found = _scan_unguarded_message_reads(self._source())
+        adrift = {name: sites for name, sites in found.items() if name not in KNOWN_MESSAGE_READS}
+        assert adrift == {}, f"these run caller code outside a try: {adrift}"
+        assert found == KNOWN_MESSAGE_READS, f"the set of unguarded reads changed: {found}"
+
+    def test_the_scan_reaches_the_guards_it_is_asserted_over(self) -> None:
+        """An empty result and a scanner that looks at nothing are the same table."""
+        scanned = set(_scan_unguarded_message_reads(self._source() + _PLANTED_UNGUARDED_READ))
+        assert scanned == set(KNOWN_MESSAGE_READS) | {"new_guard_error"}, (
+            f"the planted guard was not reached: {scanned}"
+        )
+
+    def test_the_scanner_reports_the_read_1903_was_filed_for(self) -> None:
+        """The mapping remedy, verbatim, as the escape it was."""
+        assert _scan_unguarded_message_reads(
+            textwrap.dedent(
+                """
+                def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                    if isinstance(value, Mapping):
+                        return f"{param} must be a list: {_refusal_container_repr(list(value))}."
+                    return None
+                """
+            )
+        ) == {"new_guard_error": (("value", "list()"),)}
+
+    def test_the_scanner_reports_the_four_reads_1903_did_not_have(self) -> None:
+        """The string branch as it stood: a comprehension, a length, and a decode.
+
+        All four were invisible to every existing assertion - the rendering scan
+        sees a shared renderer, and no test passed a hostile ``str`` subclass.
+        """
+        assert _scan_unguarded_message_reads(
+            textwrap.dedent(
+                """
+                def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                    shown = value.decode(errors="replace") if isinstance(value, bytes) else value
+                    return (
+                        f"{param}: read as {[c for c in shown][:6]} ({len(shown)} name(s)). "
+                        f"Wrap it in a list: [{_refusal_repr(shown)}]."
+                    )
+                """
+            )
+        ) == {
+            "new_guard_error": (
+                ("shown", "comprehension"),
+                ("shown", "len()"),
+                ("value", ".decode()"),
+            )
+        }
+
+    def test_the_scanner_accepts_a_read_moved_inside_a_try(self) -> None:
+        """The control for the control: the shape this change lands must not be reported."""
+        assert (
+            _scan_unguarded_message_reads(
+                textwrap.dedent(
+                    """
+                    def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                        try:
+                            names = list(value)
+                        except Exception:
+                            return f"{param}: could not be read."
+                        return f"{param} must be a list: {_refusal_container_repr(names)}."
+                    """
+                )
+            )
+            == {}
+        )
+
+    def test_the_scanner_accepts_a_read_of_a_guarded_readers_result(self) -> None:
+        """``len(characters)`` is this module's own list, not the caller's value.
+
+        Without this the scan would report the fix as loudly as the defect, and an
+        unfollowable chain is what makes a taint scan get switched off.
+        """
+        assert (
+            _scan_unguarded_message_reads(
+                textwrap.dedent(
+                    """
+                    def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                        characters, unreadable = _read_to_quote(value)
+                        if characters is None:
+                            return f"{param}: could not be read ({unreadable})."
+                        return f"{param}: read as {characters[:6]} ({len(characters)} name(s))."
+                    """
+                )
+            )
+            == {}
+        )
+
+    def test_the_scanner_ignores_a_type_test(self) -> None:
+        """``isinstance`` asks the class, so it cannot run the value's own code.
+
+        A scan that reported it would fire on every guard in the file and be
+        deleted within a week, which is the failure mode worth a control of its own.
+        """
+        assert (
+            _scan_unguarded_message_reads(
+                textwrap.dedent(
+                    """
+                    def new_guard_error(value: Any, param: str, context: str) -> str | None:
+                        if isinstance(value, Mapping) or type(value) is dict:
+                            return f"{param} must be a list of names."
+                        return None
+                    """
+                )
+            )
+            == {}
+        )
+
+    def test_the_scanner_ignores_a_private_helper(self) -> None:
+        """A read inside the guarded layer is the point, not the defect.
+
+        ``_read_to_quote`` reads the caller's value on purpose; a scan that
+        reported it would hold the table open on the very functions that close it.
+        """
+        assert (
+            _scan_unguarded_message_reads(
+                textwrap.dedent(
+                    """
+                    def _read_to_quote(value: Any) -> tuple[list[Any] | None, str | None]:
+                        return list(value), None
+                    """
+                )
+            )
+            == {}
+        )
+
+
+class FailsOnItsSecondNumericRead(Sequence[Any]):
+    """Answers one full read and refuses the next, the #1897 probe shape.
+
+    Distinct from that module's ``FailsOnItsSecondRead`` in carrying numbers, so
+    it reaches the numeric coercions rather than being refused as a non-name
+    before the second read happens.
+    """
+
+    def __init__(self, *values: Any) -> None:
+        self.values = list(values)
+        self.reads = 0
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+    def __getitem__(self, index: Any) -> Any:
+        if index == 0:
+            self.reads += 1
+            if self.reads > 1:
+                raise RuntimeError("no second read for you")
+        return self.values[index]
+
+
+class TestTheCoercionsSecondReadIsAStatedBoundary:
+    """Measured while closing #1903, out of scope there, and filed as #1906.
+
+    The read-side scan's first find beyond the guard #1903 was about. Each
+    coercion validates its value with a guard that reads it - ``pose_vector_error``
+    or ``finite_vector_error``, both of which read element by element inside a
+    ``try`` since #1889 - and then reads it again, unguarded, to build the floats.
+    The reads are independent, so nothing obliges them to agree, which is #1897's
+    finding on three guards that fix could not reach.
+
+    It is not absorbed into #1903 because two of the three reads are on the
+    **accepted** path and build the return value rather than a message, so "a
+    refusal must not raise" does not reach them and the family's usual argument
+    does not apply unchanged. ``coerce_rgba`` is the exception - its second read is
+    quoted by the wrong-length refusal - and it is why #1906 is a bug rather than a
+    hardening request. Fixing it properly means the shared numeric validators
+    return the list they read, which is a signature change on guards with many
+    callers and a decision of its own.
+
+    Pinned so the boundary is a measurement rather than a claim, and so that
+    closing #1906 has to replace this class and empty ``KNOWN_MESSAGE_READS`` in
+    one change rather than pass either silently.
+    """
+
+    def test_the_three_coercions_raise_on_a_value_that_refuses_a_second_read(self) -> None:
+        probes = (
+            (utils.coerce_pose_vector, ("add_object", "position", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3), 3)),
+            (utils.coerce_rgba, ("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))),
+            (utils.coerce_size_vector, ("add_object", "size", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))),
+        )
+        for guard, args in probes:
+            with pytest.raises(RuntimeError, match="no second read for you"):
+                guard(*args)
+
+    def test_coerce_rgba_escapes_on_the_path_that_exists_to_return_text(self) -> None:
+        """The one of the three that breaks a stated contract, which #1906 turns on.
+
+        Two components is a refusal, and the value never reaches it: the second
+        read happens before the length is compared, so the guard raises on exactly
+        the path documented never to.
+        """
+        with pytest.raises(RuntimeError, match="no second read for you"):
+            utils.coerce_rgba("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2))
+
+    def test_the_guard_read_once_does_not_escape(self) -> None:
+        """Non-vacuity: the probe is answerable, and #1897's guard answers it.
+
+        Without this the three failures above could be a probe no guard could ever
+        accept rather than a read count.
+        """
+        assert utils.name_list_error(FailsOnItsSecondNumericRead("top", "wrist"), "cameras", "render_all") is None
+
+
+#: A guard that reads the caller's value straight into its message, appended to
+#: ``utils.py``'s own source so the scan is shown to reach a function it has never
+#: seen. Kept beside the tests that use it rather than inlined, because both the
+#: reachability check and its own report read the same planted text.
+_PLANTED_UNGUARDED_READ = textwrap.dedent(
+    """
+
+def new_guard_error(value: Any, param: str, context: str) -> str | None:
+    return f"{context}: {param} must be a list of names, got {len(value)}."
+"""
+)
 
 
 def test_the_digit_limit_this_module_turns_on_is_below_its_probe() -> None:

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -1209,14 +1209,18 @@ class TestTheCoercionsSecondReadIsAStatedBoundary:
     """
 
     def test_the_three_coercions_raise_on_a_value_that_refuses_a_second_read(self) -> None:
-        probes = (
-            (utils.coerce_pose_vector, ("add_object", "position", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3), 3)),
-            (utils.coerce_rgba, ("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))),
-            (utils.coerce_size_vector, ("add_object", "size", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))),
-        )
-        for guard, args in probes:
-            with pytest.raises(RuntimeError, match="no second read for you"):
-                guard(*args)
+        """Called one by one rather than looped over: the three signatures differ.
+
+        ``coerce_pose_vector`` takes the component count the others infer, so a
+        loop over ``(guard, args)`` pairs would hide that behind a ``*args`` splat
+        no reader - and no static analysis - can check against either signature.
+        """
+        with pytest.raises(RuntimeError, match="no second read for you"):
+            utils.coerce_pose_vector("add_object", "position", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3), 3)
+        with pytest.raises(RuntimeError, match="no second read for you"):
+            utils.coerce_rgba("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))
+        with pytest.raises(RuntimeError, match="no second read for you"):
+            utils.coerce_size_vector("add_object", "size", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))
 
     def test_coerce_rgba_escapes_on_the_path_that_exists_to_return_text(self) -> None:
         """The one of the three that breaks a stated contract, which #1906 turns on.


### PR DESCRIPTION
Closes #1903.

`utils.name_list_error` built its refusal text by reading the caller's value, and those reads were unguarded. The mapping branch offered the mapping's own keys as its remedy:

```python
f"pass the names as a list: {_refusal_container_repr(list(value))}."
```

The *render* is safe; building its argument runs the caller's `__iter__`. So the guard whose entire purpose is to answer an unusable input with a structured message raised instead:

```
name_list_error(HostileKeyMapping(), "cameras", "render_all")  ->  RuntimeError: no keys for you
```

## The decision the issue asked for

#1903 laid out three candidates and noted the file had no precedent to follow, because this is the one member of the family where the read was never load-bearing. Everywhere else — #1873, #1874, #1875, #1878, #1888, #1889, #1897 — the verdict depended on the read, so a read that failed *became* the verdict. Here the verdict is settled before the read happens: a mapping is refused whatever its keys say. Only the advice was unmeasurable.

**Candidate 2 — keep the verdict, degrade the remedy** — is taken, being the only one that states both what was measured and what was not:

```
render_all: cameras must be a list of names, not a mapping, got <HostileKeyMapping object ...>.
  A mapping is iterable over its keys, so its values would be discarded - pass the names as
  a list; its own keys could not be read to quote them here (RuntimeError: no keys for you).
```

Candidate 1 (answer with the read failure) drops the mapping verdict, which is the mistake the caller actually made. Candidate 3 (drop the remedy clause) omits advice on one path and says nothing about why. Both are excluded by tests, not by prose.

The cost the issue named — *a new message form* — is paid once rather than per branch. `_describe_failed_read` names the `type: text` stem `_read_name_list` was already spelling inline, so a refusal degraded here reads like every other read failure in the module, and the two cannot describe one failure two ways. `_read_to_quote` is the shared guarded read both branches now use.

## The issue described one read. There are five, across two branches.

The issue's §Scope asked the pass to check whether any other refusal in `utils.py` reads a caller value to build its *remedy*. The string branch one line up was the weaker of the two, and none of its four escapes had been filed anywhere. Measured on `e3e5e10`:

| probe | before |
|---|---|
| `HostileKeyMapping()` — mapping `__iter__` raises | `RuntimeError: no keys for you` (the filed defect) |
| `HostileCharacterStr("wrist")` — `str` subclass `__iter__` raises | **`RuntimeError: no characters for you`** |
| `HostileLengthStr("wrist")` — `str` subclass `__len__` raises | **`RuntimeError: no length for you`** |
| `UnprintableCharacterStr("w")` — characters read fine, cannot print | **`RuntimeError: no repr for you`** |
| `UndecodableBytes(b"wrist")` — `bytes` subclass overrides `decode` | **`RuntimeError: no decoding for you`** |

Four distinct shapes on one branch: `[c for c in shown]` produced the quoted characters, a second `len(shown)` counted them, a bare f-string interpolated them (so `repr` recursed into an element that cannot print — #1875 re-raised *inside* the clause quoting it), and the overridable `bytes.decode` ran before any of that.

They now come from **one** guarded read, so the quotation and the count beside it cannot describe different values — #1897's property applied to a message rather than to a verdict.

They are fixed together because they are one shape, on one function, and splitting them would have left a measured escape one branch away needing its own issue and its own round.

## Every existing message is unchanged

Asserted as **exact text** rather than as substrings, because rewriting two message branches is precisely the change that moves a word nobody looks at. Switching the character quotation to `_refusal_container_repr` is text-preserving by construction: `f"{['w', 'r']}"` and `_refusal_container_repr(['w', 'r'])` are the same string, and the count taken from the read equals `len(shown)` for any honest `str`.

## The scan the issue said was blind, and what it found

> `TestNoGuardRendersACallerValueDirectly` scans for unrendered values, not for reads, so an unguarded `list(...)` feeding a renderer is exactly what that scan is blind to — which is how this one survived #1873 and #1875.

That gap is closed structurally rather than by fixing five call sites. `TestNoGuardReadsACallerValueOutsideATry` is added beside its sibling: it scans `utils.py` for a public guard that runs the caller's own code outside a `try`, follows the value through assignments (so `shown` — the caller's `str` under another name — is covered), and stops at the helpers that read inside a `try` and hand back an ordinary value, so the fix is not reported as loudly as the defect. Six controls, including a planted defect appended to `utils.py`'s own source so an empty table cannot mean a scanner that looks at nothing.

Against the unfixed file it reports the whole defect, including the four reads the issue did not have:

```
{'name_list_error': (('shown', 'comprehension'), ('shown', 'len()'),
                     ('value', '.decode()'), ('value', 'list()'))}
```

**It also found three more guards, and those are filed as #1906 rather than fixed here.** Each `coerce_*` guard validates its value with a validator that reads it and then reads it again, unguarded, to build the floats:

| call | result |
|---|---|
| `coerce_rgba("add_object", "color", FailsOnItsSecondRead(0.1, 0.2, 0.3))` | `RuntimeError: no second read for you` |
| `coerce_rgba(...)` with **2** components — a refusal | `RuntimeError` — on the path that exists to return text |
| `coerce_size_vector(...)`, `coerce_pose_vector(...)` | `RuntimeError` |
| `name_list_error(FailsOnItsSecondRead("top", "wrist"), ...)` | `None` — the control, read once since #1897 |

They are not absorbed because two of the three reads are on the **accepted** path and build the return value rather than a message, so "a refusal must not raise" does not reach them; and fixing it properly means the shared numeric validators return the list they read, which is a signature change on guards with many callers. They are recorded in `KNOWN_MESSAGE_READS` pointing at #1906 and pinned by `TestTheCoercionsSecondReadIsAStatedBoundary`, so closing #1906 must replace that pin and empty the table in one change — the same shape #1897 used to hand #1903 over.

## The boundary pin this replaces

`test_a_mapping_whose_keys_cannot_be_read_is_a_stated_boundary` asserted the escape with `pytest.raises`. Per the premise-test guidance it is **replaced, not deleted**: it becomes `test_a_mapping_whose_keys_cannot_be_read_keeps_its_verdict`, which asserts the verdict survives and records why the boundary existed.

## Validation

Environment: hosted runner, Python 3.13.14, no GPU/EGL, `MUJOCO_GL=disable`. Optional deps partly absent, so **every number below is a delta against the unmodified base**, per the AGENTS.md guidance.

| gate | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | clean (ruff 0.15.22, the pinned range) |
| `ruff format --check strands_robots tests tests_integ` | 1039 files already formatted |
| `mypy strands_robots tests tests_integ` | **13 errors on base, 13 on branch — delta zero**; the only diff is a line number shifting on a pre-existing `utils.py` error |
| `pytest tests` (full) | **893 failures on base, 893 on branch, identical set by `diff`** — all environmental (no EGL, missing optional deps) |
| affected suite (6 files touching `name_list_error`) | 429 passed on base -> **449 passed** on branch; the same 2 no-OpenGL failures on both |
| new tests pre-fix | **8 of 10 fail**, each with the exact escaping exception; the 2 that pass are the text-preservation and probe-non-vacuity controls, which must pass both ways |
| scan pre-fix | reports all four `name_list_error` reads (above) |
| `scripts/assemble_changelog.py --check` | OK (138 pending) |

## Files

- `strands_robots/utils.py` — `_describe_failed_read`, `_read_to_quote`, both `name_list_error` branches; `_read_name_list` uses the named stem instead of repeating it (text-identical, already covered by its own tests).
- `tests/test_container_refusals_render_elementwise.py` — the boundary pin replaced, plus `TestARefusalDegradesWhenItCannotQuoteWhatItRefuses` (9 tests, 5 probes).
- `tests/test_refusal_messages_never_raise.py` — the read-side scan, its table, 8 tests and 6 controls, and the #1906 boundary pin.
- `changelog.d/1903-refusal-degrades-when-it-cannot-quote.md`.

---

### §13 changelog

**Round 1** — initial submission.

**Round 2** — the two CodeQL threads. The fix itself is unchanged.

- `py/call/wrong-arguments` (alert 858, error severity, and correct): the three coercions were
  exercised through a loop over `(guard, args)` pairs, so `coerce_pose_vector`'s extra
  component-count parameter reached every call through a `*args` splat that neither a reader nor
  static analysis can check against any of the three signatures. They are now called one by one,
  each with its own arguments, and the test docstring records why. Commit `ee97a48`; thread
  resolved by the fix.
- `py/unexpected-raise-in-special-method` (alert 859, note severity): dismissed as deliberate and
  test-only, which is the disposition this rule already carries on alerts 590
  (`_HostileRobot.__getattr__`) and 852 (`GetItemOnly.__getitem__`).
  `FailsOnItsSecondNumericRead.__getitem__` has to raise something outside `LookupError`: the
  `IndexError` the query names first is what CPython's `seqiter` catches and clears to terminate
  legacy-protocol iteration, so on a `Sequence` the suggested rewrite would end the read quietly
  and leave the three `pytest.raises` pins measuring the ABC's iteration protocol instead of the
  guards' read count. The argument is in the thread and the dismissal points at it;
  `.github/codeql/codeql-config.yml` is untouched and stays at its pinned two rule ids.

Nothing else moved this round — no change to `strands_robots/utils.py`, and the validation table
above still describes the head. Required check `call-test-lint / Test and Lint` is `SUCCESS` on
`ee97a48`, both review threads are resolved, and the `CodeQL` context sits at `NEUTRAL`, which is
advisory here.
