### PR TITLE
fix(utils): the vector coercions compute their floats from one guarded read (closes #1906)

### DIFF
--- a/changelog.d/1906-coercions-read-once.md
+++ b/changelog.d/1906-coercions-read-once.md
@@ -1,0 +1,67 @@
+### Fixed: the vector coercions compute their floats from the read their guard already made
+
+`coerce_pose_vector`, `coerce_rgba` and `coerce_size_vector` each validated the
+caller's value with a guard that reads it, and then read the value *again*,
+unguarded, to build the floats:
+
+```python
+if (err := finite_vector_error(method, param_name, color)) is not None:
+    return None, err
+floats = [float(component) for component in color]   # second read
+```
+
+The two reads were independent, so nothing obliged them to agree, and nothing
+guarded the second. A value that answers one read and refuses the next escaped
+all three:
+
+```
+coerce_rgba("add_object", "color", FailsOnItsSecondRead(0.1, 0.2, 0.3))  ->  RuntimeError: no second read for you
+coerce_size_vector("add_object", "size", FailsOnItsSecondRead(0.1, 0.2, 0.3))  ->  RuntimeError
+coerce_pose_vector("add_object", "position", FailsOnItsSecondRead(0.1, 0.2, 0.3), 3)  ->  RuntimeError
+```
+
+Two of those reads build the return value, so "a refusal must not raise" does not
+reach them. `coerce_rgba` is the one that breaks a stated contract: its second
+read is quoted by the wrong-length refusal (`got {length}: {floats}`), and it
+happens *before* the length is compared, so a two-component colour raised on
+exactly the path whose purpose is to answer an unusable colour with text.
+
+The element read now lives in `_read_finite_vector`, which performs the read
+`finite_vector_error` always performed - element by element inside a `try`, since
+#1889 - and returns the floats it built alongside the verdict. `_read_pose_vector`
+is the same split for the fixed-length wrapper, keeping the length probe ahead of
+any element read so a wrong-length vector is still refused without producing one.
+`finite_vector_error` and `pose_vector_error` keep their signatures and their exact
+messages, because 24 call sites across four modules want a verdict and nothing
+else: the read moved, not the guard.
+
+So each coercion now keeps a list this module built, and `coerce_rgba`'s refusal
+quotes the components its own domain checks examined:
+
+```
+add_object: 'color' must have exactly 3 or 4 component(s) (RGB, or RGBA with alpha),
+  got 2: [0.1, 0.2]. Pass every component - a partial 'color' cannot be applied
+  without inventing the missing values.
+```
+
+This is #1897's property (a guard reads the caller's value once) on the three
+guards that fix could not reach, and the last of the reads
+`TestNoGuardReadsACallerValueOutsideATry` reported when #1903 added it -
+`KNOWN_MESSAGE_READS` is now empty.
+
+Three sibling pins moved with the code rather than being deleted, since each still
+holds for a reason worth stating:
+
+- `TestTheCoercionsSecondReadIsAStatedBoundary` measured the escape while it was a
+  boundary; it becomes `TestTheCoercionsReadTheirValueOnce`, asserting the same
+  probe in the accepting direction and asserting the read *count*, which is the
+  property rather than its symptom.
+- `TestTheRemainingConversionsRunOnlyOnTheAcceptedPath` named the three coercions
+  as conversions that are safe because something upstream had already converted
+  successfully. They no longer convert at all, so the module-wide scan is empty -
+  and since an empty scan is also what a scanner matching nothing produces, the
+  replacement asserts that the floats still come from a guarded read and that the
+  scan still reports a planted conversion.
+- Both "does this guard render through the shared renderer" scans now follow a
+  guard into the read helper it delegates its verdict to; a body-only reading
+  would call a delegating guard one that names nothing it refused.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1374,6 +1374,139 @@ BOOLEAN_VECTOR_REASON = (
 )
 
 
+def _read_finite_vector(method: str, param_name: str, vec: Any) -> tuple[list[float], str | None]:
+    """Read ``vec`` into floats once, or return why it is unusable.
+
+    The single read every verdict in :func:`finite_vector_error` is computed
+    from, together with the floats that read produced.
+
+    It exists because the three coercions built on that guard validated their
+    value with it and then read the value *again*, unguarded, to build their
+    floats. Two consequences, and the second is the one that reaches a stated
+    contract. A value that answers the checked read and refuses the next one
+    raised straight out of the coercion (#1906) - including out of
+    :func:`coerce_rgba`'s wrong-length refusal, whose whole purpose is to answer
+    an unusable colour with text. And the reads were independent, so nothing
+    obliged them to agree: the components a refusal quoted need not have been
+    the components any check examined. Returning the read makes the verdict and
+    the floats the caller keeps one list by construction.
+
+    This is :func:`_read_name_list`'s shape (#1897) on the numeric guards. The
+    read moves rather than the signature: :func:`finite_vector_error` and
+    :func:`pose_vector_error` have 24 call sites across four modules that want a
+    verdict and nothing else, so they stay as they were and this is what they
+    are now computed from.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        vec: The caller-supplied value.
+
+    Returns:
+        The floats read and ``None``, or the floats read so far and the message
+        naming why the value is unusable - the same text
+        :func:`finite_vector_error` has always returned.
+    """
+    # Collected as the read proceeds, so every refusal below can report the
+    # components read before the one that stopped it, and an accepted value can
+    # be returned without a second read of it.
+    floats: list[float] = []
+    # ``TypeError`` is what "not iterable" means in Python and the only exception
+    # a well-behaved ``__iter__`` raises, but a guard whose whole purpose is to
+    # answer an unusable input with a message cannot assume good behaviour of the
+    # value it was handed: any other exception escaping here would be the same
+    # defect as the rendering (#1873), scalar-conversion (#1874) and
+    # container-conversion (#1875) escapes, on the one path that must not raise.
+    # It gets its own text because the two verdicts are not the same measurement -
+    # a value whose iteration raised may well have been a list/tuple of numbers,
+    # and this guard never found out, so reporting it as "must be a list/tuple of
+    # numbers" would state something unmeasured (#1878).
+    #
+    # The iterator is bound and then iterated, rather than ``iter(vec)`` being
+    # called for its exception and ``vec`` iterated again: one ``__iter__`` call
+    # is what the probe is asking about, and a second one is free to answer
+    # differently than the one that was checked.
+    #
+    # This clause answers for ``__iter__`` only, and a success here says nothing
+    # about the read that follows (#1889): CPython synthesises the iterator for a
+    # legacy ``__getitem__`` sequence *without* calling ``__getitem__``, and
+    # ``iter()`` of a generator cannot fail at all, so a value that fails part-way
+    # through its own iteration arrives past this line intact. The element loop
+    # below guards the call that produces each element for that reason. A
+    # materialising ``list(vec)`` would cover both in one clause and is declined
+    # for a stronger reason than the memory it holds: it raises before any element
+    # has been examined, so its verdict could not say how far the read got - the
+    # one thing that distinguishes a part-way failure from an outright refusal.
+    # ``exc`` is rendered through ``_refusal_str`` rather than interpolated: a
+    # value hostile enough to raise a non-``TypeError`` from ``__iter__`` is not
+    # a value whose exception is assumed to have a working ``__str__``, and that
+    # is the #1873 escape reintroduced inside the fix for this one.
+    try:
+        elements = iter(vec)
+    except TypeError:
+        return floats, f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(vec)}"
+    except Exception as exc:
+        return floats, (
+            f"{method}: '{param_name}' could not be iterated: "
+            f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
+            f"Pass a list or tuple of numbers."
+        )
+    while True:
+        # ``next()`` is called explicitly because a ``for`` cannot guard the call
+        # it makes: an exception raised while *producing* an element is the
+        # ``__iter__`` escape one level in, on the same path that must not raise.
+        # It is reported against the element's own index, the convention every
+        # other guard here that names one already uses (``{param}[{i}]``), so the
+        # message states both what failed and what was read before it.
+        # ``StopIteration`` is the read finishing normally; an empty ``vec`` is
+        # accepted exactly as before, a component count not being this guard's
+        # question.
+        try:
+            _elem = next(elements)
+        except StopIteration:
+            break
+        except Exception as exc:
+            return floats, (
+                f"{method}: '{param_name}[{len(floats)}]' could not be read: "
+                f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
+                f"Pass a list or tuple of numbers."
+            )
+        # ``numbers.Real`` accepts a numpy scalar (``np.float32`` / ``np.int64``
+        # are registered) and rejects a string, ``None`` or a nested list.
+        # ``bool`` is an ``int`` subclass, so it would otherwise pass as a
+        # silent ``1.0`` - a ``True`` coordinate placing a body 1 m out. The
+        # agent-tool router already refuses a bool component, so refusing it
+        # here keeps the direct API and the tool surface in step.
+        if is_boolean(_elem):
+            return floats, (
+                f"{method}: '{param_name}' elements must be numbers, not a bool "
+                f"(got {_refusal_container_repr(vec)}). {BOOLEAN_VECTOR_REASON}"
+            )
+        if not isinstance(_elem, numbers.Real):
+            return floats, f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
+        # An element past the float64 range is a *magnitude* complaint and gets
+        # its own reason, exactly as the scalar guards give one (#1874). The
+        # order matters: ``_beyond_float_range`` answers only ``OverflowError``,
+        # so a registered ``numbers.Real`` with no working ``__float__`` falls
+        # through to the not-a-number text below rather than being mis-reported
+        # as out of range.
+        if _beyond_float_range(_elem):
+            return floats, (
+                f"{method}: '{param_name}' must contain numbers within the range of a 64-bit float, "
+                f"got {_refusal_container_repr(vec)}"
+            )
+        try:
+            numeric = float(_elem)
+        except Exception:
+            return floats, f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
+        if not math.isfinite(numeric):
+            return floats, (
+                f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {_refusal_container_repr(vec)}"
+            )
+        floats.append(numeric)
+    return floats, None
+
+
 def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     """Return an error message if any element of ``vec`` is not a finite number.
 
@@ -1408,102 +1541,57 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     :func:`pose_vector_error` for a fixed length, or :func:`coerce_rgba` for a
     colour, whose count the rgba row it is written into defines. Returns ``None``
     when every element is a finite real number.
+
+    The read itself is :func:`_read_finite_vector`, which returns the floats it
+    built alongside this verdict; this is the verdict half, for the callers that
+    want only a message. Both are one read of ``vec`` (#1906).
     """
-    # ``TypeError`` is what "not iterable" means in Python and the only exception
-    # a well-behaved ``__iter__`` raises, but a guard whose whole purpose is to
-    # answer an unusable input with a message cannot assume good behaviour of the
-    # value it was handed: any other exception escaping here would be the same
-    # defect as the rendering (#1873), scalar-conversion (#1874) and
-    # container-conversion (#1875) escapes, on the one path that must not raise.
-    # It gets its own text because the two verdicts are not the same measurement -
-    # a value whose iteration raised may well have been a list/tuple of numbers,
-    # and this guard never found out, so reporting it as "must be a list/tuple of
-    # numbers" would state something unmeasured (#1878).
-    #
-    # The iterator is bound and then iterated, rather than ``iter(vec)`` being
-    # called for its exception and ``vec`` iterated again: one ``__iter__`` call
-    # is what the probe is asking about, and a second one is free to answer
-    # differently than the one that was checked.
-    #
-    # This clause answers for ``__iter__`` only, and a success here says nothing
-    # about the read that follows (#1889): CPython synthesises the iterator for a
-    # legacy ``__getitem__`` sequence *without* calling ``__getitem__``, and
-    # ``iter()`` of a generator cannot fail at all, so a value that fails part-way
-    # through its own iteration arrives past this line intact. The element loop
-    # below guards the call that produces each element for that reason. A
-    # materialising ``list(vec)`` would cover both in one clause and is declined
-    # for a stronger reason than the memory it holds: it raises before any element
-    # has been examined, so its verdict could not say how far the read got - the
-    # one thing that distinguishes a part-way failure from an outright refusal.
-    # ``exc`` is rendered through ``_refusal_str`` rather than interpolated: a
-    # value hostile enough to raise a non-``TypeError`` from ``__iter__`` is not
-    # a value whose exception is assumed to have a working ``__str__``, and that
-    # is the #1873 escape reintroduced inside the fix for this one.
-    try:
-        elements = iter(vec)
-    except TypeError:
-        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(vec)}"
-    except Exception as exc:
-        return (
-            f"{method}: '{param_name}' could not be iterated: "
-            f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
-            f"Pass a list or tuple of numbers."
+    return _read_finite_vector(method, param_name, vec)[1]
+
+
+def _read_pose_vector(method: str, param_name: str, vec: Any, expected_len: int) -> tuple[list[float], str | None]:
+    """Read ``vec`` into ``expected_len`` floats once, or say why it is unusable.
+
+    :func:`pose_vector_error`'s read, split out for the reason
+    :func:`_read_finite_vector` is (#1906): :func:`coerce_pose_vector` validated
+    the pose through the guard and then read it again to build the floats.
+
+    The length probe is unchanged and still runs before any element is produced,
+    so a wrong-length vector is still refused without reading one - it is
+    :func:`sequence_length`, which answers from ``__len__`` and cannot raise.
+    What this returns is therefore the *element* read, the one the coercion used
+    to duplicate.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        vec: The caller-supplied value.
+        expected_len: Component count the target buffer defines.
+
+    Returns:
+        The floats read and ``None``, or the floats read so far (none, when the
+        length was refused) and the message :func:`pose_vector_error` returns.
+    """
+    # Read through the shared probe rather than a second ``len()`` here. The
+    # rule "how many components is this?" has one owner (:func:`sequence_length`)
+    # precisely so it cannot be answered two ways, and this call site answered it
+    # a second way: an ``except TypeError`` clause, which is the gap that owner
+    # closed - a ``__len__`` refusing any other way, or returning a negative or
+    # an oversized ``int`` that CPython itself refuses to convert, escaped this
+    # guard and the structured contract its callers document. Both verdicts below
+    # are unchanged, including the text for a value carrying no readable length.
+    length = sequence_length(vec)
+    if length is None:
+        return [], (
+            f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, "
+            f"got {_refusal_container_repr(vec)}"
         )
-    index = 0
-    while True:
-        # ``next()`` is called explicitly because a ``for`` cannot guard the call
-        # it makes: an exception raised while *producing* an element is the
-        # ``__iter__`` escape one level in, on the same path that must not raise.
-        # It is reported against the element's own index, the convention every
-        # other guard here that names one already uses (``{param}[{i}]``), so the
-        # message states both what failed and what was read before it.
-        # ``StopIteration`` is the read finishing normally; an empty ``vec`` is
-        # accepted exactly as before, a component count not being this guard's
-        # question.
-        try:
-            _elem = next(elements)
-        except StopIteration:
-            break
-        except Exception as exc:
-            return (
-                f"{method}: '{param_name}[{index}]' could not be read: "
-                f"{type(exc).__name__}: {_refusal_str(exc)} (got {_refusal_container_repr(vec)}). "
-                f"Pass a list or tuple of numbers."
-            )
-        # ``numbers.Real`` accepts a numpy scalar (``np.float32`` / ``np.int64``
-        # are registered) and rejects a string, ``None`` or a nested list.
-        # ``bool`` is an ``int`` subclass, so it would otherwise pass as a
-        # silent ``1.0`` - a ``True`` coordinate placing a body 1 m out. The
-        # agent-tool router already refuses a bool component, so refusing it
-        # here keeps the direct API and the tool surface in step.
-        if is_boolean(_elem):
-            return (
-                f"{method}: '{param_name}' elements must be numbers, not a bool "
-                f"(got {_refusal_container_repr(vec)}). {BOOLEAN_VECTOR_REASON}"
-            )
-        if not isinstance(_elem, numbers.Real):
-            return f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
-        # An element past the float64 range is a *magnitude* complaint and gets
-        # its own reason, exactly as the scalar guards give one (#1874). The
-        # order matters: ``_beyond_float_range`` answers only ``OverflowError``,
-        # so a registered ``numbers.Real`` with no working ``__float__`` falls
-        # through to the not-a-number text below rather than being mis-reported
-        # as out of range.
-        if _beyond_float_range(_elem):
-            return (
-                f"{method}: '{param_name}' must contain numbers within the range of a 64-bit float, "
-                f"got {_refusal_container_repr(vec)}"
-            )
-        try:
-            numeric = float(_elem)
-        except Exception:
-            return f"{method}: '{param_name}' elements must be numbers, got {_refusal_container_repr(vec)}"
-        if not math.isfinite(numeric):
-            return (
-                f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {_refusal_container_repr(vec)}"
-            )
-        index += 1
-    return None
+    if length != expected_len:
+        return [], (
+            f"{method}: '{param_name}' must be a {expected_len}-element vector, "
+            f"got {length} ({_refusal_container_repr(vec)})"
+        )
+    return _read_finite_vector(method, param_name, vec)
 
 
 def pose_vector_error(method: str, param_name: str, vec: Any, expected_len: int) -> str | None:
@@ -1524,27 +1612,11 @@ def pose_vector_error(method: str, param_name: str, vec: Any, expected_len: int)
     model, and their accepted domain must not diverge - a pose either backend
     entry point refuses must be refused by the other. Returns ``None`` when
     ``vec`` is acceptable.
+
+    The read itself is :func:`_read_pose_vector`, for the same reason
+    :func:`finite_vector_error` defers to :func:`_read_finite_vector` (#1906).
     """
-    # Read through the shared probe rather than a second ``len()`` here. The
-    # rule "how many components is this?" has one owner (:func:`sequence_length`)
-    # precisely so it cannot be answered two ways, and this call site answered it
-    # a second way: an ``except TypeError`` clause, which is the gap that owner
-    # closed - a ``__len__`` refusing any other way, or returning a negative or
-    # an oversized ``int`` that CPython itself refuses to convert, escaped this
-    # guard and the structured contract its callers document. Both verdicts below
-    # are unchanged, including the text for a value carrying no readable length.
-    length = sequence_length(vec)
-    if length is None:
-        return (
-            f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, "
-            f"got {_refusal_container_repr(vec)}"
-        )
-    if length != expected_len:
-        return (
-            f"{method}: '{param_name}' must be a {expected_len}-element vector, "
-            f"got {length} ({_refusal_container_repr(vec)})"
-        )
-    return finite_vector_error(method, param_name, vec)
+    return _read_pose_vector(method, param_name, vec, expected_len)[1]
 
 
 def coerce_pose_vector(
@@ -1582,9 +1654,13 @@ def coerce_pose_vector(
     """
     if vec is None:
         return None, None
-    if (err := pose_vector_error(method, param_name, vec, expected_len)) is not None:
+    # One read, through the guard's own: the floats returned here are the ones the
+    # domain checks examined, rather than the product of a second read nothing
+    # required to agree with the first (#1906).
+    floats, err = _read_pose_vector(method, param_name, vec, expected_len)
+    if err is not None:
         return None, err
-    return [float(v) for v in vec], None
+    return floats, None
 
 
 #: The component counts a 4-component RGBA row can be built from. Alpha is the
@@ -1638,9 +1714,13 @@ def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] |
     length = sequence_length(color)
     if length is None:
         return None, f"{method}: '{param_name}' must be a sequence of numbers, got {_refusal_container_repr(color)}"
-    if (err := finite_vector_error(method, param_name, color)) is not None:
+    # One read: the floats quoted by the component-count refusal below are the ones
+    # the domain checks examined. They used to come from a second, unguarded read,
+    # so a colour that answered the checked read and refused this one raised out of
+    # the branch whose purpose is to answer an unusable colour with text (#1906).
+    floats, err = _read_finite_vector(method, param_name, color)
+    if err is not None:
         return None, err
-    floats = [float(component) for component in color]
     if length not in RGBA_ACCEPTED_LENGTHS:
         expected = " or ".join(str(n) for n in RGBA_ACCEPTED_LENGTHS)
         return None, (
@@ -1710,7 +1790,8 @@ def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[fl
     # this helper's own, because MuJoCo reaches that case through its per-shape
     # count instead and so states a count the shape needs rather than the
     # omission the caller probably meant.
-    if (err := finite_vector_error(method, param_name, size)) is not None:
+    floats, err = _read_finite_vector(method, param_name, size)
+    if err is not None:
         return None, err
     length = sequence_length(size)
     if length is None:
@@ -1723,7 +1804,9 @@ def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[fl
             f"vector ({_refusal_container_repr(size)}). An empty '{param_name}' is a component count, not an "
             f"omission - omit '{param_name}' to take the default extent."
         )
-    return [float(component) for component in size], None
+    # The floats the component checks above examined, not a second read of the
+    # caller's value (#1906).
+    return floats, None
 
 
 #: Camera names that a backend's render entry points resolve to the FREE camera

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -794,14 +794,21 @@ class TestEveryContainerGuardRoutesThroughTheRenderer:
 
     #: The guards this module owns. ``coerce_pose_vector`` renders nothing itself
     #: (every message it returns comes from ``pose_vector_error``), so it is
-    #: absent here and covered by the behavioural rows instead.
+    #: absent here and covered by the behavioural rows instead. The two read
+    #: helpers are here because since #1906 they are where the rendering happens:
+    #: they hold the element read the two vector guards return a verdict from.
     RENDERING_GUARDS = (
+        "_read_finite_vector",
+        "_read_pose_vector",
         "coerce_rgba",
         "coerce_size_vector",
         "finite_vector_error",
         "name_list_error",
         "pose_vector_error",
     )
+
+    #: The helpers a guard may compute its verdict from, whose own body renders.
+    READ_HELPERS = frozenset({"_read_finite_vector", "_read_pose_vector"})
 
     @staticmethod
     def _function(name: str) -> ast.FunctionDef:
@@ -811,13 +818,27 @@ class TestEveryContainerGuardRoutesThroughTheRenderer:
                 return node
         raise AssertionError(f"{name} not found in utils.py")
 
-    @pytest.mark.parametrize("name", RENDERING_GUARDS)
-    def test_the_guard_calls_the_elementwise_renderer(self, name: str) -> None:
-        called = {
+    @classmethod
+    def _calls(cls, name: str) -> set[str]:
+        return {
             node.func.id
-            for node in ast.walk(self._function(name))
+            for node in ast.walk(cls._function(name))
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
         }
+
+    @pytest.mark.parametrize("name", RENDERING_GUARDS)
+    def test_the_guard_calls_the_elementwise_renderer(self, name: str) -> None:
+        """Followed one hop into the read helper a guard delegates its verdict to.
+
+        Since #1906 ``finite_vector_error`` and ``pose_vector_error`` return the
+        message ``_read_finite_vector`` / ``_read_pose_vector`` built, so scanning
+        the guard's own body alone would read that delegation as a guard that names
+        nothing it refused. One hop is enough because the helpers are rows here in
+        their own right, so nothing is taken on trust from the hop.
+        """
+        called = self._calls(name)
+        for helper in called & self.READ_HELPERS:
+            called |= self._calls(helper)
         assert "_refusal_container_repr" in called
 
     @pytest.mark.parametrize("name", RENDERING_GUARDS)

--- a/tests/test_conversion_escape_is_closed.py
+++ b/tests/test_conversion_escape_is_closed.py
@@ -595,48 +595,45 @@ class TestNoConvertingGuardConvertsUnprotected:
         assert _unguarded_float_calls(planted) == []
 
 
-class TestTheRemainingConversionsRunOnlyOnTheAcceptedPath:
+class TestTheModuleConvertsOnlyInsideAGuardedRead:
     """The scan run over the whole module, not over a list of names.
 
-    Replaces ``TestTheModuleHasExactlyOneRemainingConversionSurface`` rather than
-    deleting it: the boundary that class drew is still the useful statement and
-    has simply moved. It reported the four **container** guards as the remaining
-    unprotected conversions and pinned them raising, tracked as #1875. #1875 is
-    now closed, and ``finite_vector_error`` - the one of the four that converts a
-    value it has not yet accepted - has left the set, because it asks
-    :func:`_beyond_float_range` first and then converts inside a ``try``, exactly
-    as the scalar guards do.
+    Replaces ``TestTheRemainingConversionsRunOnlyOnTheAcceptedPath`` rather than
+    deleting it, which is the second time this boundary has moved rather than gone:
+    that class replaced ``TestTheModuleHasExactlyOneRemainingConversionSurface``,
+    which reported the four container guards and pinned them raising (#1875).
 
-    Three names remain, and they are a different statement from the one this
-    class used to make. ``coerce_pose_vector``, ``coerce_rgba`` and
-    ``coerce_size_vector`` convert only **after** ``finite_vector_error`` has
-    accepted every element - which is to say after that guard has already
-    converted each one successfully - so their ``float()`` provably cannot raise.
-    That is a real guarantee, but it is an upstream one rather than a local
-    ``try``, so the lexical scan cannot see it and reports them.
+    Its statement was that three names remain - ``coerce_pose_vector``,
+    ``coerce_rgba`` and ``coerce_size_vector`` - whose ``float()`` the lexical scan
+    reports and whose safety is an **upstream** guarantee: ``finite_vector_error``
+    had already converted every element successfully, so theirs provably could not
+    raise. Since the scan could not see that, the three were pinned with the
+    validating call asserted to come first.
 
-    Wrapping those three in a ``try`` to empty the scan would be worse: the
-    ``except`` clause could never run, so it would be untestable dead code
-    asserting a danger that does not exist. Stating the invariant and pinning it -
-    structurally, that the validating call precedes the conversion, and
-    behaviourally, that all four guards now answer an outsized element - is the
-    honest form.
+    The three no longer convert at all. #1906 moved the element read into
+    ``_read_finite_vector``, which returns the floats it built inside its own
+    ``try``, so each coercion now keeps a list this module made instead of reading
+    the caller's value a second time - which also closed the escape that second
+    read was: a value that answered the checked read and refused the next one
+    raised out of the coercion, including out of ``coerce_rgba``'s wrong-length
+    refusal.
+
+    So the scan's output is empty, and an empty output is also what a scanner
+    matching nothing produces. Two statements below are what keep it a
+    measurement: the conversions are gone, *and* the floats still come from the
+    guarded read - a coercion that stopped producing floats would satisfy the
+    first alone.
     """
 
     #: Not names this change chose to skip - this is the scan's output, asserted
-    #: so it can neither grow nor be quietly narrowed.
-    EXPECTED_REMAINING = frozenset(
-        {
-            "coerce_pose_vector",
-            "coerce_rgba",
-            "coerce_size_vector",
-        }
-    )
+    #: so it can neither grow nor be quietly narrowed. Empty since #1906.
+    EXPECTED_REMAINING: frozenset[str] = frozenset()
 
-    #: The guard whose acceptance makes the three conversions above safe. Two
-    #: spellings, because ``coerce_pose_vector`` reaches it through the
-    #: fixed-length wrapper.
-    VALIDATORS = frozenset({"finite_vector_error", "pose_vector_error"})
+    #: The coercions that used to convert, and the guarded reads they now take
+    #: their floats from. Two spellings, because ``coerce_pose_vector`` reaches the
+    #: element read through the fixed-length wrapper.
+    COERCIONS = ("coerce_pose_vector", "coerce_rgba", "coerce_size_vector")
+    GUARDED_READS = frozenset({"_read_finite_vector", "_read_pose_vector"})
 
     @staticmethod
     def _converting_unprotected() -> set[str]:
@@ -647,7 +644,7 @@ class TestTheRemainingConversionsRunOnlyOnTheAcceptedPath:
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _unguarded_float_calls_in(node)
         }
 
-    def test_the_remaining_surface_is_exactly_the_post_validation_conversions(self) -> None:
+    def test_no_function_in_the_module_converts_unprotected(self) -> None:
         assert self._converting_unprotected() == set(self.EXPECTED_REMAINING)
 
     def test_no_scalar_guard_is_among_them(self) -> None:
@@ -655,33 +652,45 @@ class TestTheRemainingConversionsRunOnlyOnTheAcceptedPath:
         assert self._converting_unprotected().isdisjoint({guard.name for guard in CONVERTING})
 
     def test_the_vector_guard_no_longer_converts_unprotected(self) -> None:
-        """#1875's half of the claim: the one guard that converts a *new* value."""
-        assert "finite_vector_error" not in self._converting_unprotected()
+        """#1875's half of the claim, followed to where the conversion now lives.
 
-    @pytest.mark.parametrize("name", sorted(EXPECTED_REMAINING))
-    def test_each_remaining_conversion_is_preceded_by_the_validating_call(self, name: str) -> None:
-        """The structural half of the invariant the docstring above claims.
+        Asserting it of ``finite_vector_error`` alone would be vacuous since #1906:
+        that function converts nothing at all now, so the guarantee has to be
+        asserted of the helper it delegates its read to, which is the function that
+        classifies magnitude and then converts inside a ``try``.
+        """
+        converting = self._converting_unprotected()
+        assert "finite_vector_error" not in converting
+        assert "_read_finite_vector" not in converting
 
-        A conversion that is safe *because* something upstream already made it
-        safe is only safe while that call is still there, and still first. So the
-        validating call is asserted to appear in the function, and to appear on an
-        earlier line than any conversion the scan flagged. Reordering the two, or
-        dropping the guard, fails here rather than at a caller.
+    @pytest.mark.parametrize("name", COERCIONS)
+    def test_each_coercion_takes_its_floats_from_the_guarded_read(self, name: str) -> None:
+        """What replaces the ordering pin, and why the empty scan is not vacuous.
+
+        The ordering assertion said: the validating call is present, and earlier
+        than the conversion. There is no longer a conversion to order against, so
+        the two halves are stated directly - the coercion calls a guarded read, and
+        makes no ``float()`` call of its own. Dropping the read, or converting the
+        caller's value again beside it, fails here rather than at a caller.
         """
         fn = ast.parse(inspect.getsource(getattr(utils, name)).lstrip())
-        validated = [
-            node.lineno
-            for node in ast.walk(fn)
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in self.VALIDATORS
-        ]
-        converted = [
-            node.lineno
-            for node in ast.walk(fn)
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "float"
-        ]
-        assert validated, f"{name} converts without calling any of {sorted(self.VALIDATORS)}"
-        assert converted, f"{name} was flagged as converting but no float() call was found"
-        assert min(validated) < min(converted), f"{name} converts before it validates"
+        called = {
+            node.func.id for node in ast.walk(fn) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert called & self.GUARDED_READS, f"{name} builds its floats without a guarded read"
+        assert "float" not in called, f"{name} converts the caller's value itself"
+
+    def test_the_module_scan_still_reports_a_planted_conversion(self) -> None:
+        """Control for the empty output above, which no other row can supply.
+
+        The behavioural scanner controls sit on ``_unguarded_float_calls``; this is
+        the node-level form the module scan actually runs, so an
+        ``_unguarded_float_calls_in`` that had stopped matching would leave
+        ``EXPECTED_REMAINING`` empty and every assertion above passing.
+        """
+        planted = ast.parse("def planted(value: Any) -> float:\n    return float(value)\n")
+        fn = next(node for node in ast.walk(planted) if isinstance(node, ast.FunctionDef))
+        assert _unguarded_float_calls_in(fn)
 
     #: Each container guard called with an outsized element, through the public
     #: entry point a caller actually reaches: ``coerce_pose_vector`` is reached

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -779,7 +779,9 @@ GUARDED_READERS = frozenset(
     {
         "_describe_failed_read",
         "_describe_unrenderable",
+        "_read_finite_vector",
         "_read_name_list",
+        "_read_pose_vector",
         "_read_to_quote",
         "_refusal_container_repr",
         "_refusal_repr",
@@ -890,21 +892,20 @@ def _scan_unguarded_message_reads(source: str) -> dict[str, tuple[tuple[str, str
 
 
 #: The reads still outstanding, which is what this scan was written to surface.
-#: ``name_list_error`` came off the table with #1903 - five reads across two
-#: branches, one of them filed and four of them not - and the three the scan found
-#: beside it are #1906: each coercion validates its value with a guard that reads
-#: it and then reads it again to build the floats, so a value that answers one
-#: read and refuses the next escapes. Two of the three are on the *accepted* path
-#: rather than in a message, which is why they are a tracked boundary here rather
-#: than absorbed into #1903 - and why ``coerce_rgba`` is the one that breaks a
-#: stated contract, its second read being quoted by the wrong-length refusal.
-#: :class:`TestTheCoercionsSecondReadIsAStatedBoundary` measures the escape, so
-#: emptying this table and replacing that pin are one change.
-KNOWN_MESSAGE_READS: dict[str, tuple[tuple[str, str], ...]] = {
-    "coerce_pose_vector": (("vec", "comprehension"),),
-    "coerce_rgba": (("color", "comprehension"),),
-    "coerce_size_vector": (("size", "comprehension"),),
-}
+#: Empty, and both entries came off it the same way. ``name_list_error`` went with
+#: #1903 - five reads across two branches, one of them filed and four of them not -
+#: and the three coercions the scan found beside it went with #1906: each validated
+#: its value with a guard that reads it and then read it again, unguarded, to build
+#: the floats. That read now lives in ``_read_finite_vector`` / ``_read_pose_vector``,
+#: which return the floats they read, so a coercion's result and the components its
+#: refusal quotes are one list rather than two independent reads of the same value.
+#:
+#: An empty table is the load-bearing state here rather than a satisfied one: a new
+#: guard that reads a caller value outside a ``try`` shows up as an entry nobody
+#: wrote, which is why the assertion is stated over the module instead of over a
+#: list of guards. :class:`TestTheCoercionsReadTheirValueOnce` holds the behaviour
+#: this emptiness is the scan-level statement of.
+KNOWN_MESSAGE_READS: dict[str, tuple[tuple[str, str], ...]] = {}
 
 
 class TestNoGuardRendersACallerValueDirectly:
@@ -943,15 +944,36 @@ class TestNoGuardRendersACallerValueDirectly:
         and would return a message that no longer says what was refused. Now that
         the table is empty this is the whole of the load-bearing half, and it
         covers the container guards as well as the scalar ones.
+
+        Followed through the module's own calls rather than stopping at the guard's
+        body, because a guard may compute its verdict from a read helper that does
+        the rendering: since #1906 ``finite_vector_error`` and ``pose_vector_error``
+        return the message ``_read_finite_vector`` / ``_read_pose_vector`` built, and
+        a body-only reading calls that a guard naming nothing. Transitive is the
+        weaker statement of the two, so the reachable set is what the assertion is
+        over - a guard whose whole call graph renders nothing still fails.
         """
         tree = ast.parse(self._source())
+        defined = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
         owned = set(GUARD_IDS) | CONTAINER_GUARDS | {"validation_split_error"}
         renderers = {"_refusal_repr", "_refusal_str", "_refusal_container_repr"}
-        for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name in owned]:
-            called = {
-                node.func.id for node in ast.walk(fn) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-            }
-            assert called & renderers, f"{fn.name} renders no value through a shared renderer"
+        for name in sorted(owned & set(defined)):
+            reached: set[str] = set()
+            pending = [name]
+            while pending:
+                current = pending.pop()
+                if current in reached:
+                    continue
+                reached.add(current)
+                body = defined.get(current)
+                if body is None:
+                    continue
+                pending += [
+                    node.func.id
+                    for node in ast.walk(body)
+                    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                ]
+            assert reached & renderers, f"{name} renders no value through a shared renderer"
 
     def test_the_scanner_reports_a_planted_repr_omission(self) -> None:
         """Without this, an empty result could mean a scanner matching nothing."""
@@ -1184,60 +1206,87 @@ class FailsOnItsSecondNumericRead(Sequence[Any]):
         return self.values[index]
 
 
-class TestTheCoercionsSecondReadIsAStatedBoundary:
-    """Measured while closing #1903, out of scope there, and filed as #1906.
+class TestTheCoercionsReadTheirValueOnce:
+    """Each coercion's floats come from the read its guard already made (#1906).
 
-    The read-side scan's first find beyond the guard #1903 was about. Each
-    coercion validates its value with a guard that reads it - ``pose_vector_error``
-    or ``finite_vector_error``, both of which read element by element inside a
-    ``try`` since #1889 - and then reads it again, unguarded, to build the floats.
-    The reads are independent, so nothing obliges them to agree, which is #1897's
-    finding on three guards that fix could not reach.
+    Replaces ``TestTheCoercionsSecondReadIsAStatedBoundary`` rather than deleting
+    it, per the guidance that a premise test invalidated by a fix is re-pinned
+    instead of dropped: what it measured was a value read exactly once, asserted in
+    the raising direction because the second read escaped. The boundary is gone, so
+    the same probe is asserted in the accepting direction - the value it raised on
+    is the value it now returns floats for.
 
-    It is not absorbed into #1903 because two of the three reads are on the
-    **accepted** path and build the return value rather than a message, so "a
-    refusal must not raise" does not reach them and the family's usual argument
-    does not apply unchanged. ``coerce_rgba`` is the exception - its second read is
-    quoted by the wrong-length refusal - and it is why #1906 is a bug rather than a
-    hardening request. Fixing it properly means the shared numeric validators
-    return the list they read, which is a signature change on guards with many
-    callers and a decision of its own.
-
-    Pinned so the boundary is a measurement rather than a claim, and so that
-    closing #1906 has to replace this class and empty ``KNOWN_MESSAGE_READS`` in
-    one change rather than pass either silently.
+    Two of the three reads are on the **accepted** path and build the return value,
+    which is why two of these assertions are about a returned vector rather than a
+    refusal. ``coerce_rgba``'s is the one a refusal quotes, and it gets the
+    refusal-shaped assertion the contract asks for.
     """
 
-    def test_the_three_coercions_raise_on_a_value_that_refuses_a_second_read(self) -> None:
+    def test_the_three_coercions_accept_a_value_that_refuses_a_second_read(self) -> None:
         """Called one by one rather than looped over: the three signatures differ.
 
         ``coerce_pose_vector`` takes the component count the others infer, so a
         loop over ``(guard, args)`` pairs would hide that behind a ``*args`` splat
         no reader - and no static analysis - can check against either signature.
         """
-        with pytest.raises(RuntimeError, match="no second read for you"):
-            utils.coerce_pose_vector("add_object", "position", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3), 3)
-        with pytest.raises(RuntimeError, match="no second read for you"):
-            utils.coerce_rgba("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))
-        with pytest.raises(RuntimeError, match="no second read for you"):
-            utils.coerce_size_vector("add_object", "size", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3))
+        assert utils.coerce_pose_vector("add_object", "position", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3), 3) == (
+            [0.1, 0.2, 0.3],
+            None,
+        )
+        assert utils.coerce_rgba("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3)) == (
+            [0.1, 0.2, 0.3, 1.0],
+            None,
+        )
+        assert utils.coerce_size_vector("add_object", "size", FailsOnItsSecondNumericRead(0.1, 0.2, 0.3)) == (
+            [0.1, 0.2, 0.3],
+            None,
+        )
 
-    def test_coerce_rgba_escapes_on_the_path_that_exists_to_return_text(self) -> None:
-        """The one of the three that breaks a stated contract, which #1906 turns on.
+    def test_each_coercion_reads_the_value_exactly_once(self) -> None:
+        """The read count itself, which is the property rather than its symptom.
 
-        Two components is a refusal, and the value never reaches it: the second
-        read happens before the length is compared, so the guard raises on exactly
-        the path documented never to.
+        A coercion that read twice and tolerated a failing second read would
+        satisfy the assertions above while still computing its floats from a read
+        nothing obliged to agree with the checked one - the half of #1906 that is
+        about agreement rather than about the escape.
         """
+        position = FailsOnItsSecondNumericRead(0.1, 0.2, 0.3)
+        utils.coerce_pose_vector("add_object", "position", position, 3)
+        assert position.reads == 1
+        color = FailsOnItsSecondNumericRead(0.1, 0.2, 0.3)
+        utils.coerce_rgba("add_object", "color", color)
+        assert color.reads == 1
+        size = FailsOnItsSecondNumericRead(0.1, 0.2, 0.3)
+        utils.coerce_size_vector("add_object", "size", size)
+        assert size.reads == 1
+
+    def test_coerce_rgba_answers_on_the_path_that_exists_to_return_text(self) -> None:
+        """The one of the three that broke a stated contract, which #1906 turned on.
+
+        Two components is a refusal, and the value never reached it: the second read
+        happened before the length was compared, so the guard raised on exactly the
+        path documented never to. It now returns that refusal, and the components it
+        quotes are the ones the domain checks examined rather than a second read's.
+        """
+        floats, err = utils.coerce_rgba("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2))
+        assert floats is None
+        assert err is not None
+        assert "must have exactly 3 or 4 component(s)" in err
+        assert "got 2: [0.1, 0.2]" in err
+
+    def test_the_probe_still_refuses_a_second_read(self) -> None:
+        """Non-vacuity: a probe that had stopped refusing would pass everything above.
+
+        It is the same fixture #1897 used, so this also states what the read count
+        above is counting - one full read, and the next one raising.
+        """
+        probe = FailsOnItsSecondNumericRead(0.1, 0.2, 0.3)
+        assert [float(component) for component in probe] == [0.1, 0.2, 0.3]
         with pytest.raises(RuntimeError, match="no second read for you"):
-            utils.coerce_rgba("add_object", "color", FailsOnItsSecondNumericRead(0.1, 0.2))
+            [float(component) for component in probe]  # noqa: B018
 
     def test_the_guard_read_once_does_not_escape(self) -> None:
-        """Non-vacuity: the probe is answerable, and #1897's guard answers it.
-
-        Without this the three failures above could be a probe no guard could ever
-        accept rather than a read count.
-        """
+        """The family control: #1897's guard on the same probe, unchanged."""
         assert utils.name_list_error(FailsOnItsSecondNumericRead("top", "wrist"), "cameras", "render_all") is None
 
 


### PR DESCRIPTION
Closes #1906.

## What escaped

`coerce_pose_vector`, `coerce_rgba` and `coerce_size_vector` each validated the caller's value with a guard that reads it, and then read the value **again**, unguarded, to build the floats:

```python
if (err := finite_vector_error(method, param_name, color)) is not None:
    return None, err
floats = [float(component) for component in color]   # second read
```

The reads were independent, so nothing obliged them to agree, and nothing guarded the second one. Measured on `f3d96d6` with the `FailsOnItsSecondRead` shape #1897's own tests use:

| call | before | after |
|---|---|---|
| `coerce_rgba("add_object", "color", FailsOnItsSecondRead(0.1, 0.2, 0.3))` | **`RuntimeError`** | `([0.1, 0.2, 0.3, 1.0], None)` |
| `coerce_rgba("add_object", "color", FailsOnItsSecondRead(0.1, 0.2))` | **`RuntimeError`** on the *refusal* branch | the refusal, quoting `got 2: [0.1, 0.2]` |
| `coerce_size_vector("add_object", "size", FailsOnItsSecondRead(0.1, 0.2, 0.3))` | **`RuntimeError`** | `([0.1, 0.2, 0.3], None)` |
| `coerce_pose_vector("add_object", "position", FailsOnItsSecondRead(0.1, 0.2, 0.3), 3)` | **`RuntimeError`** | `([0.1, 0.2, 0.3], None)` |
| `name_list_error(FailsOnItsSecondRead("top", "wrist"), ...)` | `None` | `None` (the control, read once since #1897) |

Two of the three reads are on the **accepted** path and build the return value, so "a refusal must not raise" does not reach them. `coerce_rgba` is the one that breaks a stated contract: its second read is quoted by the wrong-length refusal (`got {length}: {floats}`) and happens *before* the length is compared, so a two-component colour raised on exactly the path whose purpose is to answer an unusable colour with text.

## The shape, and the question the issue left open

The issue named two options - have the shared validators return the floats they read (a signature change on guards with many callers), or read in the coercion and pass the read list down. This takes a third that costs neither: the **read** moves, the guards do not.

- `_read_finite_vector` performs the read `finite_vector_error` has always performed - element by element inside a `try`, since #1889 - and returns the floats it built alongside the verdict.
- `_read_pose_vector` is the same split for the fixed-length wrapper. The length probe still runs **before** any element is produced, so a wrong-length vector is refused without reading one; it is `sequence_length`, which cannot raise.
- `finite_vector_error` and `pose_vector_error` keep their signatures and their exact messages, and are now `return _read_*(...)[1]`. That matters: `git grep` counts **24 call sites across four modules** (`simulation/predicates.py`, `simulation/newton/simulation.py`, `simulation/mujoco/simulation.py`, `simulation/mujoco/scene_ops.py`) that want a verdict and nothing else.

This is `_read_name_list`'s shape (#1897) on the numeric guards, which is also the answer to "is this how it was settled last time": yes, and by a private helper the public guard defers to.

## Three sibling pins moved rather than went

Each still holds for a reason worth stating, so each is replaced per the guidance that an invalidated premise test is re-pinned rather than dropped.

1. `TestTheCoercionsSecondReadIsAStatedBoundary` measured the escape while it was a stated boundary. It becomes `TestTheCoercionsReadTheirValueOnce`: the same probe asserted in the accepting direction, plus the read **count** (`probe.reads == 1` for each of the three), which is the property rather than its symptom - a coercion that read twice and tolerated the failure would satisfy the acceptance assertions while still computing floats from a read nothing obliged to agree with the checked one.
2. `KNOWN_MESSAGE_READS` is now `{}`. Its three entries were the last reads `TestNoGuardReadsACallerValueOutsideATry` reported when #1903 added it.
3. `TestTheRemainingConversionsRunOnlyOnTheAcceptedPath` (`tests/test_conversion_escape_is_closed.py`) named those same three coercions as conversions that are safe *because* something upstream had already converted successfully. They no longer convert at all - so the module-wide scan is empty, and an empty scan is also what a scanner matching nothing produces. The replacement asserts both halves: each coercion calls a guarded read and makes no `float()` call of its own, and the node-level scanner still reports a planted conversion. #1875's guarantee is followed to where the conversion now lives, since asserting it of `finite_vector_error` alone would be vacuous.
4. Both "does this guard render through the shared renderer" scans (`tests/test_refusal_messages_never_raise.py`, `tests/test_container_refusals_render_elementwise.py`) now follow a guard one hop into the read helper it delegates its verdict to. A body-only reading calls a delegating guard one that names nothing it refused - which is exactly how it failed here first, and it is the check that caught the delegation.

## Pre-fix measurement

**13 tests fail on unpatched `utils.py`** with the test changes in place, across all three modules:

```
tests/test_refusal_messages_never_raise.py  5 failed  (3 behavioural + the emptied table and its reachability control)
tests/test_conversion_escape_is_closed.py   4 failed
tests/test_container_refusals_render_elementwise.py 4 failed
```

## Validation

- `ruff check` + `ruff format --check` over `strands_robots tests`: clean (993 files).
- `mypy` on the four touched files: clean. The 11 errors in the tree-wide run are missing optional wheels in this environment (`av`, `safetensors`, `gymnasium`) and are present on the base identically.
- Full `pytest tests` read as a **delta**, both runs in the same partial environment (`MUJOCO_GL=disable`, no EGL/GL, `-n 4`):

| | base `f3d96d6` | this branch |
|---|---|---|
| passed | 15195 | **15209** |
| failed | 695 | **688** |
| skipped / errors | 681 / 149 | 681 / 149 |

  Comparing failure **ids** rather than counts: one id appears on the branch and not on the base - `tests/simulation/test_policy_config_mapping_validation.py::TestRolloutRejectsUnsplattablePolicyMapping::test_well_formed_policy_config_still_runs` - and it passes 3/3 in isolation on **both** trees, so it is flaky under `-n 4` rather than attributable. Eight ids move the other way and flip between runs for the same reason. The environmental failures (no GL context, no asset fetch) are identical on both.
- The affected modules together: **359 passed** (`test_refusal_messages_never_raise.py` 93, up from 91).

## Measured, unchanged, out of scope - filed as #1909

One finding from this pass that this PR deliberately does not touch, because it is the *count*'s read rather than the components': the coercions still take their component count from `sequence_length` (`__len__`) while the components come from the element read, and nothing requires those two to agree either. A value whose `__len__` overstates its contents is accepted by `coerce_rgba` as a **3**-element rgba under a success result, and `coerce_rgba`'s refusal can quote a count and a component list that contradict each other in one sentence:

```
add_object: 'color' must have exactly 3 or 4 component(s) (RGB, or RGBA with alpha), got 2: [0.1, 0.2, 0.3].
```

Both outputs are **byte-identical on the base and on this branch** - the pre-fix second read produced the same list - so this is pre-existing rather than a regression, and it is the next member of the family rather than part of this one. #1909 carries the probes and the decision it needs (which read owns the count), since deciding it from the read changes a verdict and not only a message.

## Family

Rendering (#1873), scalar conversion (#1874), container conversion (#1875), `__iter__` (#1878), the shared length probe (#1888), element production (#1889), the name-list read count (#1897), a refusal that cannot quote what it refuses (#1903). This is #1897's property on the three guards that fix could not reach.

## §13 Round changelog

**Round 1 (initial)** - one commit, `85fe55a`: the element read moves into `_read_finite_vector` / `_read_pose_vector`; the three coercions take their floats from it; three sibling pins replaced; changelog fragment `changelog.d/1906-coercions-read-once.md`. No production message text changes for any value that is read consistently.
