### PR TITLE
fix(utils): the vector coercions count the components they read (closes #1909)

### DIFF
--- a/changelog.d/1909-coercions-count-from-the-read.md
+++ b/changelog.d/1909-coercions-count-from-the-read.md
@@ -1,0 +1,59 @@
+### Fixed: the vector coercions count the components they read
+
+`coerce_rgba` and `coerce_size_vector` took their component *count* from
+`sequence_length(value)` - the value's `__len__` - and their components from the
+element read. Those are two independent reads of one value, and nothing obliges a
+`Sequence` to answer them the same way:
+
+```python
+class OverstatesItsLength(Sequence):
+    def __len__(self): return 4          # reports four components
+    def __getitem__(self, i):
+        if i >= 3: raise IndexError(i)   # the read yields three
+        return [0.1, 0.2, 0.3][i]
+```
+
+| call | before | after |
+|---|---|---|
+| `coerce_rgba("add_object", "color", OverstatesItsLength())` | `([0.1, 0.2, 0.3], None)` | `([0.1, 0.2, 0.3, 1.0], None)` |
+| `coerce_pose_vector("add_object", "position", OverstatesItsLength(), 4)` | `([0.1, 0.2, 0.3], None)` | refused |
+| `coerce_rgba("add_object", "color", UnderstatesItsLength())` | refused as `got 2: [0.1, 0.2, 0.3]` | `([0.1, 0.2, 0.3, 1.0], None)` |
+
+Row 1 breaks a documented promise. `coerce_rgba` returns "exactly 4 finite
+floats" so that the `color[:3]` reads the shape builders do are well-defined by
+construction; the alpha completion was gated on the *reported* count, so a
+`__len__` of 4 skipped it while the read had supplied three - the return value
+was short precisely because the count was believed over the components. Row 2 is
+the same defect on a buffer: a 3-component list where a wxyz quaternion is
+promised reaches `data.qpos`, which is the bare `ValueError` inside the numpy
+assignment `pose_vector_error` exists to prevent, now reached *through* the guard
+instead of around it. Row 3 is a refusal that contradicted itself in one
+sentence - it named a count of 2 and then quoted three components.
+
+The count now comes from the read that produced the components:
+
+- `coerce_rgba` counts `len(floats)`, so "exactly 4" holds for any accepted value
+  rather than only for one whose two reads agree.
+- `coerce_size_vector`'s empty-vector refusal asks whether the read produced a
+  component, not whether `__len__` reported zero. A value whose length reports
+  three extents and whose read yields none has no extent to write; one reporting
+  zero whose read yields components has one. The per-shape count remains #1858's
+  decision and is untouched here.
+- `_read_pose_vector` keeps its length gate ahead of the element read - refusing a
+  wrong *reported* length without producing a component is worth keeping - and
+  re-checks the accepted count against what the read yielded, so no accepted pose
+  vector can have the wrong component count whichever read disagrees:
+
+  ```
+  add_object: 'position' must be a 4-element vector, got 3: [0.1, 0.2, 0.3].
+    Its length reported 4, so the components it produced are not the vector its
+    length promised.
+  ```
+
+`sequence_length` stays where it answers its own question - *is this a sized
+sequence at all* - which is what refuses a generator on both coercions and is
+guarded (#1888) so it cannot raise.
+
+This is the count read beside the component read #1906 fixed, and completes the
+property that fix stated for the components alone: one read makes the verdict,
+the count, and the text it quotes.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1562,6 +1562,13 @@ def _read_pose_vector(method: str, param_name: str, vec: Any, expected_len: int)
     What this returns is therefore the *element* read, the one the coercion used
     to duplicate.
 
+    That probe answers a *reported* length, and the read below produces the
+    components, so the accepted count is checked a second time against what the
+    read actually yielded (#1909). The two are independent reads and nothing
+    obliges them to agree; the length gate keeps its position, because refusing a
+    wrong reported length without producing an element is worth keeping, and the
+    re-check is the same question asked of the components that exist.
+
     Args:
         method: Calling method name, used in error text.
         param_name: Parameter name, used in error text.
@@ -1591,7 +1598,24 @@ def _read_pose_vector(method: str, param_name: str, vec: Any, expected_len: int)
             f"{method}: '{param_name}' must be a {expected_len}-element vector, "
             f"got {length} ({_refusal_container_repr(vec)})"
         )
-    return _read_finite_vector(method, param_name, vec)
+    floats, err = _read_finite_vector(method, param_name, vec)
+    if err is not None:
+        return floats, err
+    # The gate above accepted a length the value *reported*; these are the
+    # components it *produced*. A ``__len__`` of 4 over a read yielding 3 passed
+    # that gate and returned a 3-component vector where a wxyz quaternion was
+    # promised - reaching the bare ``ValueError`` inside the ``data.qpos``
+    # assignment this guard exists to prevent, through the guard rather than
+    # around it (#1909). The refusal quotes the components, since they are what
+    # disagrees with the count; ``length`` is named too, because "got 3" alone
+    # would not say that the value's own length claimed otherwise.
+    if len(floats) != expected_len:
+        return floats, (
+            f"{method}: '{param_name}' must be a {expected_len}-element vector, "
+            f"got {len(floats)}: {floats}. Its length reported {length}, so the "
+            f"components it produced are not the vector its length promised."
+        )
+    return floats, None
 
 
 def pose_vector_error(method: str, param_name: str, vec: Any, expected_len: int) -> str | None:
@@ -1648,9 +1672,10 @@ def coerce_pose_vector(
 
     Returns:
         ``(None, None)`` when ``vec`` is ``None`` (omitted - the caller applies
-        its own default), ``(floats, None)`` for an acceptable vector, or
-        ``(None, error_message)`` for a wrong length, a non-numeric element or a
-        ``nan``/``inf`` component.
+        its own default), ``(floats, None)`` for an acceptable vector - always
+        ``expected_len`` components, whether counted from the value's length or
+        from the read - or ``(None, error_message)`` for a wrong length, a
+        non-numeric element or a ``nan``/``inf`` component.
     """
     if vec is None:
         return None, None
@@ -1696,7 +1721,9 @@ def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] |
     (annotated ``list[float]``) and echoed in agent-visible status text, so a
     surviving ``np.float64`` would leak ``np.float64(1.0)`` into it - and makes
     the ``color[:3]`` reads the shape builders do well-defined by construction
-    rather than by the caller's discipline.
+    rather than by the caller's discipline. Both counts above are counts of the
+    components this function read, so "exactly 4" holds for any value, not only
+    for one whose ``__len__`` agrees with its contents (#1909).
 
     Args:
         method: Calling method name, used in error text.
@@ -1711,8 +1738,11 @@ def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] |
     """
     if color is None:
         return None, None
-    length = sequence_length(color)
-    if length is None:
+    # Asked only as "is this a sized sequence at all", the question this probe
+    # owns and cannot raise answering (#1888). It is what refuses a generator,
+    # whose components a read would consume before anything could count them. The
+    # component count is not taken from it - see below.
+    if sequence_length(color) is None:
         return None, f"{method}: '{param_name}' must be a sequence of numbers, got {_refusal_container_repr(color)}"
     # One read: the floats quoted by the component-count refusal below are the ones
     # the domain checks examined. They used to come from a second, unguarded read,
@@ -1721,15 +1751,24 @@ def coerce_rgba(method: str, param_name: str, color: Any) -> tuple[list[float] |
     floats, err = _read_finite_vector(method, param_name, color)
     if err is not None:
         return None, err
-    if length not in RGBA_ACCEPTED_LENGTHS:
+    # The count is the read's, not the value's ``__len__``. Those were two
+    # independent reads and nothing obliged them to agree: a ``__len__`` of 4 over
+    # a read yielding 3 skipped the alpha completion below and returned a
+    # 3-component rgba under a success result - breaking this function's stated
+    # promise of exactly 4 finite floats, and with it the ``color[:3]`` reads the
+    # shape builders do - while the refusal named a count from one read beside
+    # components from the other (#1909). Counting the list that is returned makes
+    # the promise true by construction rather than by the two reads agreeing.
+    count = len(floats)
+    if count not in RGBA_ACCEPTED_LENGTHS:
         expected = " or ".join(str(n) for n in RGBA_ACCEPTED_LENGTHS)
         return None, (
             f"{method}: '{param_name}' must have exactly {expected} "
-            f"component(s) ({RGBA_LAYOUT}), got {length}: {floats}. Pass every "
+            f"component(s) ({RGBA_LAYOUT}), got {count}: {floats}. Pass every "
             f"component - a partial '{param_name}' cannot be applied "
             "without inventing the missing values."
         )
-    return (floats if length == 4 else [*floats, 1.0]), None
+    return (floats if count == 4 else [*floats, 1.0]), None
 
 
 def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[float] | None, str | None]:
@@ -1793,12 +1832,16 @@ def coerce_size_vector(method: str, param_name: str, size: Any) -> tuple[list[fl
     floats, err = _read_finite_vector(method, param_name, size)
     if err is not None:
         return None, err
-    length = sequence_length(size)
-    if length is None:
+    if sequence_length(size) is None:
         # Reachable only for something iterable but unsized - a generator, which
         # the check above has now consumed, so there is nothing left to store.
         return None, f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(size)}"
-    if length == 0:
+    # Empty means the read produced no component, not that ``__len__`` reported
+    # zero: the two are independent reads (#1909), and it is the absence of an
+    # extent to write that makes the value unusable. A value whose length reports
+    # three and whose read yields nothing has no extent, and one reporting zero
+    # whose read yields components has one.
+    if not floats:
         return None, (
             f"{method}: '{param_name}' must have at least one component, got an empty "
             f"vector ({_refusal_container_repr(size)}). An empty '{param_name}' is a component count, not an "

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -1290,6 +1290,190 @@ class TestTheCoercionsReadTheirValueOnce:
         assert utils.name_list_error(FailsOnItsSecondNumericRead("top", "wrist"), "cameras", "render_all") is None
 
 
+class OverstatesItsLength(Sequence[Any]):
+    """``__len__`` reports one more component than the read produces.
+
+    A ``Sequence`` owes its two protocols no agreement, and this is the shape the
+    coercions' two reads disagreed on (#1909): the count came from ``__len__`` and
+    the components from the element read.
+    """
+
+    def __init__(self, *values: Any) -> None:
+        self.values = list(values)
+        self.element_reads = 0
+
+    def __len__(self) -> int:
+        return len(self.values) + 1
+
+    def __getitem__(self, index: Any) -> Any:
+        self.element_reads += 1
+        return self.values[index]
+
+
+class UnderstatesItsLength(Sequence[Any]):
+    """``__len__`` reports two components; the read produces however many it holds."""
+
+    def __init__(self, *values: Any) -> None:
+        self.values = list(values)
+        self.element_reads = 0
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, index: Any) -> Any:
+        self.element_reads += 1
+        return self.values[index]
+
+
+class YieldsNoComponent(Sequence[Any]):
+    """``__len__`` reports three components and the read produces none."""
+
+    def __len__(self) -> int:
+        return 3
+
+    def __getitem__(self, index: Any) -> Any:
+        raise IndexError(index)
+
+
+class TestTheCoercionsCountTheComponentsTheyRead:
+    """A coercion's component count comes from the read that produced them (#1909).
+
+    #1906 made each coercion read its value's *components* once. The count beside
+    them was still a second, independent read - ``sequence_length(value)``, i.e.
+    ``__len__`` - and a ``Sequence`` is not obliged to answer the two the same way.
+    Two of the rows below are contract breaks rather than message defects, which is
+    why this is a change in verdict and not only in text.
+
+    :func:`~strands_robots.utils.sequence_length` stays where it answers its own
+    question - *is this a sized sequence at all*, which is what refuses a generator
+    on both coercions - and the pose path keeps its length gate ahead of the element
+    read, so a wrong reported length is still refused without producing a component.
+    """
+
+    def test_rgba_returns_four_components_for_a_value_that_overstates_its_length(self) -> None:
+        """The documented promise, previously true only of a value that agreed with itself.
+
+        ``coerce_rgba`` returns "exactly 4 finite floats" so the ``color[:3]`` reads
+        the shape builders do are well-defined by construction. The alpha completion
+        was gated on the *reported* count, so a ``__len__`` of 4 over a read yielding
+        3 skipped it and returned a 3-element rgba under a success result.
+        """
+        assert utils.coerce_rgba("add_object", "color", OverstatesItsLength(0.1, 0.2, 0.3)) == (
+            [0.1, 0.2, 0.3, 1.0],
+            None,
+        )
+
+    def test_rgba_accepts_the_components_it_read_when_the_length_understates_them(self) -> None:
+        """The other direction, and a deliberate change of verdict.
+
+        Three readable RGB components are a colour whatever the value's ``__len__``
+        says; refusing them "got 2" while quoting three was the refusal that
+        contradicted itself in one sentence.
+        """
+        assert utils.coerce_rgba("add_object", "color", UnderstatesItsLength(0.1, 0.2, 0.3)) == (
+            [0.1, 0.2, 0.3, 1.0],
+            None,
+        )
+
+    def test_every_rgba_this_guard_accepts_carries_four_components(self) -> None:
+        """The promise as a property over the disagreeing shapes, not one example."""
+        for color in (
+            [0.1, 0.2, 0.3],
+            [0.1, 0.2, 0.3, 0.5],
+            OverstatesItsLength(0.1, 0.2, 0.3),
+            OverstatesItsLength(0.1, 0.2, 0.3, 0.5),
+            UnderstatesItsLength(0.1, 0.2, 0.3),
+        ):
+            floats, err = utils.coerce_rgba("add_object", "color", color)
+            assert err is None
+            assert floats is not None
+            assert len(floats) == 4
+
+    def test_the_rgba_refusal_counts_the_components_it_quotes(self) -> None:
+        """The count named and the components quoted are one read's.
+
+        A refusal reading ``got 2: [0.1, 0.2, 0.3, 0.4, 0.5]`` names a count from
+        one read beside components from the other, and a reader cannot tell which
+        of the two the guard acted on.
+        """
+        floats, err = utils.coerce_rgba("add_object", "color", UnderstatesItsLength(0.1, 0.2, 0.3, 0.4, 0.5))
+        assert floats is None
+        assert err is not None
+        assert "got 5: [0.1, 0.2, 0.3, 0.4, 0.5]" in err
+
+    def test_a_pose_vector_shorter_than_its_reported_length_is_refused(self) -> None:
+        """A 3-component quaternion reached ``data.qpos`` through the guard.
+
+        The length gate accepted the reported 4, the read produced 3, and the
+        coercion returned them - the bare ``ValueError`` inside the numpy
+        assignment that :func:`~strands_robots.utils.pose_vector_error` exists to
+        prevent, reached through the guard rather than around it.
+        """
+        floats, err = utils.coerce_pose_vector("add_object", "position", OverstatesItsLength(0.1, 0.2, 0.3), 4)
+        assert floats is None
+        assert err is not None
+        assert "'position' must be a 4-element vector, got 3: [0.1, 0.2, 0.3]" in err
+        assert "length reported 4" in err
+
+    def test_no_accepted_pose_vector_has_the_wrong_component_count(self) -> None:
+        """The property behind the row above, over both directions of disagreement."""
+        for vec in (
+            [0.1, 0.2, 0.3],
+            OverstatesItsLength(0.1, 0.2, 0.3),
+            UnderstatesItsLength(0.1, 0.2, 0.3),
+            YieldsNoComponent(),
+        ):
+            for expected_len in (3, 4):
+                floats, err = utils.coerce_pose_vector("add_object", "position", vec, expected_len)
+                assert (floats is None) is (err is not None)
+                if floats is not None:
+                    assert len(floats) == expected_len
+
+    def test_a_wrong_reported_length_is_still_refused_before_any_element_is_read(self) -> None:
+        """The gate's position is deliberate and unchanged.
+
+        Refusing a wrong reported length without producing a component is worth
+        keeping - the re-check above is an addition to it, not a replacement, and a
+        re-check alone would read every element of a vector already known to be the
+        wrong length.
+        """
+        vec = UnderstatesItsLength(0.1, 0.2, 0.3)
+        floats, err = utils.coerce_pose_vector("add_object", "position", vec, 3)
+        assert floats is None
+        assert err is not None
+        assert "must be a 3-element vector, got 2" in err
+        assert vec.element_reads == 0
+
+    def test_size_takes_its_component_count_from_the_read(self) -> None:
+        """``size`` counts extents, and an extent it cannot read is not one it has.
+
+        The per-shape count is #1858's decision and not this one; what is decided
+        here is only which read the count comes from. A value whose length reports
+        three extents and whose read yields none has no extent to write, so it is
+        the empty-vector refusal - not an accepted ``size`` of three.
+        """
+        assert utils.coerce_size_vector("add_object", "size", OverstatesItsLength(0.1, 0.2, 0.3)) == (
+            [0.1, 0.2, 0.3],
+            None,
+        )
+        floats, err = utils.coerce_size_vector("add_object", "size", YieldsNoComponent())
+        assert floats is None
+        assert err is not None
+        assert "must have at least one component" in err
+
+    def test_the_probes_disagree_with_themselves(self) -> None:
+        """Non-vacuity: probes that had started agreeing would pass everything above."""
+        over = OverstatesItsLength(0.1, 0.2, 0.3)
+        assert len(over) == 4
+        assert [float(component) for component in over] == [0.1, 0.2, 0.3]
+        under = UnderstatesItsLength(0.1, 0.2, 0.3)
+        assert len(under) == 2
+        assert [float(component) for component in under] == [0.1, 0.2, 0.3]
+        nothing = YieldsNoComponent()
+        assert len(nothing) == 3
+        assert list(nothing) == []
+
+
 #: A guard that reads the caller's value straight into its message, appended to
 #: ``utils.py``'s own source so the scan is shown to reach a function it has never
 #: seen. Kept beside the tests that use it rather than inlined, because both the


### PR DESCRIPTION
Closes #1909. Follow-up to #1908, which made the three coercions read their **components** once; this is the other read in the same functions - the **count**.

## The defect

`coerce_rgba` and `coerce_size_vector` took their component count from `sequence_length(value)` (the value's `__len__`) and their components from the element read. Two independent reads of one value, and a `Sequence` is not obliged to answer them the same way:

```python
class OverstatesItsLength(Sequence):
    def __len__(self): return 4          # reports four components
    def __getitem__(self, i):
        if i >= 3: raise IndexError(i)   # the read yields three
        return [0.1, 0.2, 0.3][i]
```

Measured on `8783820` (main, with #1908 landed):

| call | before | after |
|---|---|---|
| `coerce_rgba("add_object", "color", OverstatesItsLength())` | `([0.1, 0.2, 0.3], None)` | `([0.1, 0.2, 0.3, 1.0], None)` |
| `coerce_pose_vector("add_object", "position", OverstatesItsLength(), 4)` | `([0.1, 0.2, 0.3], None)` | refused |
| `coerce_rgba("add_object", "color", UnderstatesItsLength())` | refused as `got 2: [0.1, 0.2, 0.3]` | `([0.1, 0.2, 0.3, 1.0], None)` |

Row 1 breaks a documented promise: `coerce_rgba` returns "exactly 4 finite floats" so the `color[:3]` reads the shape builders do are well-defined by construction, and the alpha completion was gated on the *reported* count - a `__len__` of 4 skipped it while the read had supplied three, so the return value was short precisely because the count was believed over the components. Row 2 is the same defect on a buffer: a 3-component list where a wxyz quaternion is promised reaches `data.qpos`, which is the bare `ValueError` inside the numpy assignment `pose_vector_error` exists to prevent, now reached *through* the guard instead of around it. Row 3 is a refusal that contradicted itself in one sentence - it named a count of 2 and then quoted three components.

## The decision

The count comes from the read that produced the components, which makes the promise true by construction instead of by the two reads agreeing:

- **`coerce_rgba`** counts `len(floats)`, so every accepted colour carries exactly 4 components whatever the value's `__len__` says. This is a change in **verdict** for this value class, not only in text, which is why it did not belong inside #1908.
- **`coerce_size_vector`**'s empty-vector refusal asks whether the read produced a component rather than whether `__len__` reported zero. A value whose length reports three extents and whose read yields none has no extent to write; one reporting zero whose read yields components has one. The per-shape count remains #1858's decision and is untouched.
- **`_read_pose_vector`** keeps its length gate ahead of the element read - refusing a wrong *reported* length without producing a component is worth keeping, and a re-check alone would read every element of a vector already known to be the wrong length - and re-checks the accepted count against what the read yielded:

  ```
  add_object: 'position' must be a 4-element vector, got 3: [0.1, 0.2, 0.3].
    Its length reported 4, so the components it produced are not the vector its
    length promised.
  ```

  `length` is named alongside the components because "got 3" alone would not say that the value's own length claimed otherwise.

`sequence_length` stays where it answers its own question - *is this a sized sequence at all* - which is what refuses a generator on both coercions and is guarded (#1888) so it cannot raise.

## Pins

`TestTheCoercionsCountTheComponentsTheyRead`, beside #1908's `TestTheCoercionsReadTheirValueOnce` in `tests/test_refusal_messages_never_raise.py`. Nine tests; **7 fail on pre-fix code** (`8783820`), and the two that pass are the two that must: the pin that a wrong *reported* length is still refused before any element is read (the gate's position is deliberate and unchanged, asserted via an element-read counter), and the non-vacuity pin that the probes disagree with themselves.

The property tests are the ones worth reading: every accepted rgba carries 4 components, no accepted pose vector has the wrong count in either direction of disagreement, and the rgba refusal's named count equals the number of components it quotes.

## Verification

- `tests/test_refusal_messages_never_raise.py` `tests/test_container_refusals_render_elementwise.py` `tests/test_conversion_escape_is_closed.py` `tests/test_changelog_fragments.py` `tests/simulation/test_object_size_domain_across_backends.py` plus the four MuJoCo vector-validation suites: **594 passed, 74 skipped, 1 failed**.
- Read as a delta, per the local-verification guidance: the one failure (`test_add_robot_accepts_numpy_position`, `No model found for 'panda'`) fails identically on `origin/main` with no diff applied - a missing model asset in the local environment, not a regression. Every other count is unchanged.
- `ruff check` and `ruff format --check` clean on both touched files; no non-ASCII introduced.
- Branch is `main` + this one commit (clean cherry-pick onto `8783820`), so the composition CI tests is the composition verified locally.

## Round log

**Round 1** - initial submission.