### PR TITLE
docs(process): the merge gate is viewer-scoped, and the Actions token cannot read it (closes #1917)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,47 @@ hatch run format            # ruff check --fix, ruff format
    `BLOCKED` while the required check runs, then `UNSTABLE` - mergeable, with an
    advisory context red - or `CLEAN`.
 
+   That trust has a reader attached to it, which the sentence above does not say.
+   `mergeStateStatus` answers *can the viewer merge this pull request*, so it is
+   scoped to the token that asks - and on a pull request editing
+   `.github/workflows/**` the Actions `GITHUB_TOKEN` can never read anything but
+   `BLOCKED`, because an installation token is refused writes to workflow files
+   and therefore genuinely cannot perform that merge. **Read the gate with
+   `PAT_TOKEN`.** A control pair, both approved with no unresolved thread and
+   `call-test-lint` `SUCCESS`, read minutes apart:
+
+   | PR | edits `.github/workflows/**` | `GITHUB_TOKEN` | `PAT_TOKEN` | truth |
+   |---|---|---|---|---|
+   | #1915 | yes (`pr-and-push.yml`) | `BLOCKED` | `CLEAN` | merged clean, `f4dfde6` |
+   | #1902 | no | `CLEAN` | `CLEAN` | merged clean, `6cf0470` |
+
+   The mechanism isolates to one variable - same token, same scratch branch, same
+   instant, via `PUT /repos/{owner}/{repo}/contents/{path}`:
+
+   ```
+   zz_probe.txt                    GITHUB_TOKEN -> created
+   .github/workflows/zz_probe.yml  GITHUB_TOKEN -> Resource not accessible by integration
+   .github/workflows/zz_probe.yml  PAT_TOKEN    -> created
+   ```
+
+   So a `BLOCKED` read that way is neither a bug nor staleness; it is the honest
+   answer to the question the field asks. Staleness is separately ruled out:
+   `mergeable_state` on #1899 and #1035 reads `unknown` first and the settled
+   value second **for both tokens identically**, so the lazy first read is
+   per-PR, not per-viewer. `mergeable` agrees across tokens throughout - a text
+   conflict is viewer-independent, and only mergeability-*by-you* is not.
+
+   What makes this expensive is that the wrong answer is indistinguishable from a
+   right one. On a genuinely blocked PR both tokens read `blocked`, so their
+   agreement proves nothing, and the Actions token's answer on a
+   workflow-touching PR is always blocked-or-unknown. No reading of the field
+   separates the two cases. The agent then polls the gate exactly as documented,
+   correctly declines to merge, and reports the PR as waiting on a reviewer -
+   which is the presentation #1905 records for a different cause, and which had
+   stood in eight consecutive scheduled scan summaries as "reviewer bandwidth is
+   the sole constraint". It bites CI and process pull requests specifically,
+   because those are the ones carrying workflow edits. See #1917.
+
    This is worth the words because the failure mode is silent and expensive in the
    opposite direction from the usual one. Treating an advisory red as a merge
    blocker does not look like a mistake; it looks like diligence, and it costs a

--- a/changelog.d/1917-merge-gate-viewer-scope.md
+++ b/changelog.d/1917-merge-gate-viewer-scope.md
@@ -1,0 +1,44 @@
+### Docs: the documented merge gate is viewer-scoped, and the Actions token cannot read it
+
+`AGENTS.md` > PR Workflow > step 8 gates a merge on the required contexts plus
+`mergeStateStatus == CLEAN`, and calls `mergeStateStatus` the field "to trust".
+It is, and the instruction was still unusable as written, because the field
+answers *can the viewer merge this pull request* - so it is scoped to the token
+that asks. On a pull request editing `.github/workflows/**` the Actions
+`GITHUB_TOKEN` can never read anything but `BLOCKED`, however ready the pull
+request is, because an installation token is refused writes to workflow files
+and therefore genuinely cannot perform that merge.
+
+A control pair, both approved, no unresolved thread, `call-test-lint`
+`SUCCESS`, read minutes apart: #1915 (edits `pr-and-push.yml`) read `BLOCKED`
+with `GITHUB_TOKEN` and `CLEAN` with `PAT_TOKEN`; #1902 (no workflow edit) read
+`CLEAN` with both. Both merged clean minutes later, `f4dfde6` and `6cf0470`.
+The mechanism isolates to one variable - the same token, on the same scratch
+branch at the same instant, created `zz_probe.txt` and was refused
+`.github/workflows/zz_probe.yml` with `Resource not accessible by integration`,
+which `PAT_TOKEN` then created.
+
+Staleness is separately ruled out: `mergeable_state` on #1899 and #1035 reads
+`unknown` first and the settled value second for both tokens identically, so
+the lazy first read is per-PR, not per-viewer. `mergeable` agrees across tokens
+throughout, since a text conflict is viewer-independent and only
+mergeability-by-you is not.
+
+What made it expensive is that the wrong answer is indistinguishable from a
+right one. On a genuinely blocked pull request both tokens read `blocked`, so
+their agreement proves nothing, and no reading of the field separates the two
+cases. An agent polling the gate exactly as documented reads `BLOCKED`,
+correctly declines to merge, and reports a ready pull request as waiting on a
+reviewer - the presentation #1905 records for a different cause, which had
+stood in eight consecutive scheduled scan summaries as "reviewer bandwidth is
+the sole constraint". It bites CI and process pull requests specifically,
+because those carry the workflow edits.
+
+`AGENTS.md` now records the scoping, the control pair, the isolating probe and
+the prescription (read the gate with `PAT_TOKEN`) beside the claim it qualifies,
+and `tests/test_merge_gate_viewer_scope.py` pins the token and the
+`.github/workflows/**` exception to the same passage - a future edit tightening
+the section back down to "poll `mergeStateStatus == CLEAN`" is the regression,
+and it would look like an improvement.
+
+Documentation and test only; no production code changes.

--- a/tests/test_merge_gate_viewer_scope.py
+++ b/tests/test_merge_gate_viewer_scope.py
@@ -1,0 +1,131 @@
+"""Contract pin for the reader attached to the documented merge gate.
+
+``AGENTS.md`` > PR Workflow > step 8 tells a contributor to gate a merge on the
+required contexts' own conclusions and ``mergeStateStatus == CLEAN``, and calls
+``mergeStateStatus`` "the field that already accounts for the required set,
+which is why it is the one to trust". Both halves are true and the sentence is
+still not usable on its own, because the field answers *can the viewer merge
+this pull request* - so the answer depends on which token asked.
+
+Measured on a control pair, both approved, both with no unresolved thread and
+``call-test-lint / Test and Lint`` = ``SUCCESS``, read minutes apart:
+
+===============  ==============================  ================  =============
+pull request     edits ``.github/workflows/**``  ``GITHUB_TOKEN``  ``PAT_TOKEN``
+===============  ==============================  ================  =============
+#1915            yes (``pr-and-push.yml``)       ``BLOCKED``       ``CLEAN``
+#1902            no                              ``CLEAN``         ``CLEAN``
+===============  ==============================  ================  =============
+
+Both merged clean minutes later (``f4dfde6``, ``6cf0470``), so ``BLOCKED`` was
+the wrong answer about the pull request and the right answer to the question the
+field asks: an installation token is refused writes under
+``.github/workflows/``, so it genuinely cannot perform that merge. The same
+token, on the same branch at the same instant, created ``zz_probe.txt`` and was
+refused ``.github/workflows/zz_probe.yml`` with ``Resource not accessible by
+integration``.
+
+The pin exists because the failure is silent in both directions. On a genuinely
+blocked pull request both tokens read ``blocked``, so their agreement proves
+nothing; and an agent polling the gate exactly as documented reads ``BLOCKED``,
+correctly declines to merge, and reports a ready pull request as waiting on a
+reviewer. That presentation stood in eight consecutive scheduled scan summaries
+as "reviewer bandwidth is the sole constraint" - the same symptom #1905 records
+for a different cause. See #1917.
+
+So what is asserted here is *adjacency*, not vocabulary: the instruction to
+trust the field, the scoping that makes it readable, and the class of pull
+request it misreads have to stay in the same breath. A future edit tightening
+that section back down to "poll ``mergeStateStatus == CLEAN``" is exactly the
+regression, it looks like an improvement, and nothing else in the tree would
+notice - the same structural reason #1810's correction needed the pin in
+``tests/test_codeql_query_filters.py`` rather than trusting prose to stay fixed.
+
+Anchoring deserves a note, because the obvious way to write this pin does not
+hold. Asserting "``PAT_TOKEN`` appears within N characters of the trust claim"
+passes on the *uncorrected* file: ``PAT_TOKEN`` already occurs 1150 characters
+later, in the code-scanning paragraph about ``PAT_TOKEN``-only endpoints, so any
+window loose enough to be robust is also loose enough to be vacuous, and the
+margin to the corrected distance (625) is too thin to tune against. The assertions
+below therefore hang off the scoping sentence, which the correction introduces and
+whose absence is the regression itself.
+
+These are text assertions rather than a parsed document because that is the
+shape the existing ``AGENTS.md`` pins use (``tests/test_codeql_query_filters.py``
+reads the file the same way), and because the claim being pinned is prose: there
+is no structured artifact to read instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AGENTS_PATH = _REPO_ROOT / "AGENTS.md"
+
+#: The phrase naming ``mergeStateStatus`` as the field to gate a merge on.
+_TRUST_CLAIM = "which is why it is the one to trust"
+
+#: The scoping sentence the correction adds. Everything else is asserted relative
+#: to this, so its absence fails rather than making the other checks vacuous.
+_SCOPING = "can the viewer merge"
+
+#: How far the scoping sentence may sit from the trust claim, and the qualifiers
+#: from the scoping sentence, while still reading as one instruction. Generous
+#: enough to survive rewording, tight enough that moving either out of the gate
+#: discussion fails.
+_ADJACENCY_WINDOW = 1200
+
+
+def _agents_text() -> str:
+    return _AGENTS_PATH.read_text(encoding="utf-8")
+
+
+def _window_after(text: str, anchor: str) -> str | None:
+    """The ``_ADJACENCY_WINDOW`` characters following ``anchor``, or ``None``."""
+    position = text.find(anchor)
+    if position < 0:
+        return None
+    return text[position : position + _ADJACENCY_WINDOW]
+
+
+class TestTheGateNamesItsReader:
+    """``mergeStateStatus == CLEAN`` is only actionable with the reader named."""
+
+    def test_the_trust_claim_is_still_present(self) -> None:
+        # Context guard: the assertions below are positioned from this phrase, so
+        # a silent rewording would move the pin rather than break it.
+        assert _TRUST_CLAIM in _agents_text(), (
+            f"AGENTS.md no longer contains {_TRUST_CLAIM!r}, which this class uses to "
+            "locate the merge-gate instruction. If the claim was deliberately reworded, "
+            "update _TRUST_CLAIM to match rather than deleting these tests - the point "
+            "is that the instruction and its qualifiers stay together."
+        )
+
+    def test_the_gate_states_that_it_is_viewer_scoped(self) -> None:
+        window = _window_after(_agents_text(), _TRUST_CLAIM)
+        assert window is not None and _SCOPING in window, (
+            "AGENTS.md tells a contributor to trust mergeStateStatus without saying that "
+            "the field answers 'can the viewer merge this pull request'. Unscoped, the "
+            "instruction is unusable by an agent: the Actions GITHUB_TOKEN reads BLOCKED "
+            "on any PR editing .github/workflows/** however ready it is, because an "
+            "installation token cannot write workflow files. See #1917."
+        )
+
+    def test_the_token_that_can_read_the_gate_is_named(self) -> None:
+        window = _window_after(_agents_text(), _SCOPING)
+        assert window is not None and "PAT_TOKEN" in window, (
+            "AGENTS.md scopes the merge gate to the viewer but does not name the token "
+            "that can read it, which leaves the reader knowing the field is unreliable "
+            "and not what to do instead. See #1917."
+        )
+
+    def test_the_workflow_file_exception_is_stated(self) -> None:
+        window = _window_after(_agents_text(), _SCOPING)
+        assert window is not None and ".github/workflows" in window, (
+            "AGENTS.md must say which pull requests the gate misreads, not only which "
+            "token to use. BLOCKED is correct for the Actions token on a PR that edits "
+            ".github/workflows/** and equally correct on a PR that is really blocked, so "
+            "the two are indistinguishable from the field alone - naming the class is "
+            "what makes a BLOCKED read diagnosable. See #1917."
+        )


### PR DESCRIPTION
Closes #1917.

## What this corrects

`AGENTS.md` > PR Workflow > step 8 gates a merge on the required contexts' own conclusions plus `mergeStateStatus == CLEAN`, and calls `mergeStateStatus` "the field that already accounts for the required set, which is why it is the one to trust". Both halves are true. The instruction is still unusable as written, because the field answers *can the viewer merge this pull request* - so the answer is scoped to the token that asks.

On a pull request editing `.github/workflows/**`, the Actions `GITHUB_TOKEN` can never read anything but `BLOCKED`, however ready the pull request is: an installation token is refused writes to workflow files and therefore genuinely cannot perform that merge. The prescription added is one line - read the gate with `PAT_TOKEN` - and the reason it needs the surrounding paragraphs is that the wrong answer is indistinguishable from a right one.

## Evidence

A control pair from the repository itself, both approved, both with zero unresolved threads and `call-test-lint / Test and Lint` = `SUCCESS`, read minutes apart:

| PR | edits `.github/workflows/**` | `GITHUB_TOKEN` | `PAT_TOKEN` | truth |
|---|---|---|---|---|
| #1915 | yes (`pr-and-push.yml`) | `BLOCKED` | `CLEAN` | merged clean, `f4dfde6` |
| #1902 | no | `CLEAN` | `CLEAN` | merged clean, `6cf0470` |

On #1915 the two reads were issued back to back, and the `BLOCKED` was stable across three polls spanning several minutes, some 45 minutes after the approval landed.

Mechanism, isolated to one variable - same token, same scratch branch, same instant, via `PUT /repos/{owner}/{repo}/contents/{path}`:

```
zz_probe.txt                    GITHUB_TOKEN -> created
.github/workflows/zz_probe.yml  GITHUB_TOKEN -> Resource not accessible by integration
.github/workflows/zz_probe.yml  PAT_TOKEN    -> created
```

Two alternative explanations ruled out rather than assumed:

- **Staleness.** `mergeable_state` on #1899 and #1035 reads `unknown` on the first poll and the settled value on the second **for both tokens identically**, so the lazy first read is per-PR, not per-viewer.
- **A blanket permissions effect.** The Actions token reads `{'push': False, 'pull': False}` on this repository, yet still read #1902 as `CLEAN`. Lacking permission is not what produces `BLOCKED`; the workflow-file diff is.

`mergeable` agreed across tokens on every PR measured - a text conflict is viewer-independent, and only mergeability-*by-you* is not.

## Why it is worth the words

On a genuinely blocked pull request both tokens read `blocked`, so their agreement proves nothing, and the Actions token's answer on a workflow-touching PR is always blocked-or-unknown. No reading of the field separates the two cases. An agent polls the gate exactly as documented, reads `BLOCKED`, correctly declines to merge, and reports a ready pull request as waiting on a reviewer - which is how this presented: eight consecutive scheduled scan summaries concluded "reviewer bandwidth is the sole constraint". #1905 records the same presentation arising from a different mechanism. This one bites CI and process pull requests specifically, because those are the ones carrying workflow edits.

## Shape of the diff

| file | why |
|---|---|
| `AGENTS.md` | +41 lines, inserted immediately after the sentence it qualifies, so the correction cannot be read without the claim |
| `tests/test_merge_gate_viewer_scope.py` | pins the scoping, the token and the `.github/workflows/**` class to that passage |
| `changelog.d/1917-merge-gate-viewer-scope.md` | fragment, per step 3 |

Documentation and test only; no production code changes.

## Verification

- The pin fails on the uncorrected file: `3 failed, 1 passed` (the one pass is the context guard that locates the passage). With the correction, `4 passed`.
- `tests/test_changelog_fragments.py` and `tests/test_codeql_query_filters.py` - the other `AGENTS.md` text pin - stay green: `36 passed`.
- `ruff check` and `ruff format --check` clean on the new file; no non-ASCII in either added file.

One note on the test, since it is the part I would review hardest. The obvious pin - "`PAT_TOKEN` appears within N characters of the trust claim" - **passes on the uncorrected file**, because `PAT_TOKEN` already occurs 1150 characters later in the code-scanning paragraph, against 625 after the correction. Any window loose enough to be robust is also loose enough to be vacuous. That was the first draft of this test, and the pre-fix run is what caught it; the assertions now hang off the scoping sentence, whose absence is the regression itself.

## Round log

- **Round 0** - initial submission.