### PR TITLE
docs(process): the CodeQL alert class no disposition clears, and the thread that decides it (closes #1919)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,6 +587,73 @@ Corrections from code review that apply to all future contributions:
   names first, `IndexError`, is what CPython's `seqiter` *clears* to terminate
   legacy-protocol iteration, so taking the suggestion would have left the fixture
   raising nothing and the test asserting nothing, still green.
+- **One alert class clears under none of the three, and the question that settles
+  it is which thread you marshal onto.** `py/catch-base-exception` never fires on
+  cleanup-and-reraise: the query accepts a handler that re-raises *lexically*, and
+  six of the tree's seven `except BaseException` handlers do, so they have never
+  been flagged.
+
+  | handler | ends in | flagged |
+  |---|---|---|
+  | `robot.py:368` | `sim.destroy()`, bare `raise` | no |
+  | `policies/persistent.py:193` | `handoff.abandon()`, bare `raise` | no |
+  | `simulation/safe_output.py:185` | `os.unlink(tmp)`, bare `raise` | no |
+  | `hardware_robot.py:1865` | `self._release_task()`, bare `raise` | no |
+  | `tests/policies/lerobot_local/test_list_policy_types.py:70` | `raise AssertionError(...) from exc` | no |
+  | `tests/policies/lerobot_local/test_vla_jepa.py:164` | `raise AssertionError(...) from exc` | no |
+  | `simulation/isaac/simulation.py:5125` | `box["exc"] = exc`, no lexical raise | **yes** |
+
+  The rule's entire alert surface here is therefore one construct: a
+  **cross-thread exception-marshal box**, which parks the exception for *another*
+  thread to re-raise, where the query cannot follow the control flow.
+
+  Narrowing it to `Exception` is not the safe default it looks like, and the worst
+  case is silent. What the *caller* thread observes:
+
+  | raised on the worker | `except BaseException` | `except Exception` |
+  |---|---|---|
+  | `RuntimeError` | `RuntimeError` | `RuntimeError` |
+  | `SystemExit` | `SystemExit` | **`None`, no traceback at all** |
+  | `KeyboardInterrupt` | `KeyboardInterrupt` | `None`, plus unhandled-exception noise |
+
+  Both escapes reach `threading.excepthook`, whose default ignores `SystemExit`
+  specifically - so that one writes nothing at all to stderr, where an escaping
+  `RuntimeError` prints a full traceback. Narrowing therefore does not relocate
+  the exception, it deletes it silently, and the caller re-raises nothing. That is
+  the no-silent-defaults rule, reached from an exception clause.
+
+  So decide by direction, because the box is obliged in one and avoidable in the
+  other:
+
+  - *Marshalling onto an existing foreign thread* - `IsaacSimulation.run_on_main`
+    handing a job to the thread that owns the Kit pump. `concurrent.futures`
+    cannot target an already-running foreign thread, so the hand-rolled box is
+    the only implementation there is. Obliged: dismiss with a reason and resolve
+    the thread pointing at it, per the bullet above.
+  - *Marshalling off a new thread you create* - running an agent off-main, or a
+    test helper that calls into a worker. `concurrent.futures` **is** that
+    pattern, and the `except BaseException` then belongs to CPython
+    (`concurrent/futures/thread.py`, `_WorkItem.run`) rather than to this tree.
+    `Future.result()` re-raises `RuntimeError`, `SystemExit` and
+    `KeyboardInterrupt` with object *identity* preserved (`got is exc` for all
+    three), so delegating is strictly better than the box rather than merely
+    quieter. Not obliged: delegate, and the handler, the alert and the blocking
+    review thread go at once.
+
+  Do not reach for the filter. Its test is that *every* instance is an obliged
+  idiom, and the second bullet is a standing counter-example, so this rule id
+  must keep failing the two-id set `tests/test_codeql_query_filters.py` pins.
+
+  What makes the class worth naming is that both answers are live right now and
+  nothing else records why they differ. Alert #691 - `run_on_main`'s box at
+  `simulation/isaac/simulation.py:5125` - has been open on `refs/heads/main` since
+  2026-07-07 at note severity, gating nothing, carrying only a
+  `# noqa: BLE001` that CodeQL does not read. Alerts #853 and #854 are the same
+  idiom raised on a branch, one of them in that same file, and each opened a
+  review thread, so under `required_review_thread_resolution` they gate the
+  merge. Identical construct, opposite consequence, separated only by having
+  arrived on a branch - and two rounds were spent arguing the idiom rather than
+  applying the second bullet. See #1919.
 - **Dependency Review hard-fails on high/critical CVEs in new deps.** If a PR
   needs a dep with a known critical CVE, the conversation is "do we need this
   dep" not "let's bypass the check."

--- a/changelog.d/1919-codeql-cross-thread-marshal.md
+++ b/changelog.d/1919-codeql-cross-thread-marshal.md
@@ -1,0 +1,62 @@
+### Docs: the one CodeQL alert class no documented disposition clears, and the question that settles it
+
+`AGENTS.md` > Review Learnings (PR #92) > CI Security Baseline offers three
+tools for clearing an alert - fix it, dismiss it with a reason when the
+construct is *deliberate and test-only*, or filter the rule when *every*
+instance in the tree is an obliged idiom - and warns that rewriting the flagged
+code to satisfy the query is the tempting fourth option and the one that costs.
+`py/catch-base-exception` falls through all three, and the gap is not abstract:
+#1899 sat on two `github-advanced-security` threads whose own text is "please
+resolve this thread if you agree - or say the word and I'll narrow it", each
+carrying a paragraph of defence for an idiom the tree already ships.
+
+The rule's entire alert surface here is a single construct. The query accepts a
+handler that re-raises *lexically*, and six of the tree's seven
+`except BaseException` handlers do - four production cleanup-and-reraise blocks
+ending in a bare `raise`, two test helpers ending in
+`raise AssertionError(...) from exc`. None has ever been flagged. The seventh,
+`IsaacSimulation.run_on_main`'s cross-thread exception box, stores the exception
+for another thread to re-raise, and it is the only one CodeQL reports.
+
+Narrowing that box to `Exception` is not the safe default it resembles, and the
+worst case is silent. What the *caller* thread observes: a `RuntimeError`
+arrives either way; a `KeyboardInterrupt` arrives as `None` plus
+unhandled-exception noise on stderr; a `SystemExit` arrives as `None` with no
+traceback at all, because `threading` discards it in a non-main thread. So
+narrowing does not relocate the exception, it deletes it, and the caller
+re-raises nothing - the no-silent-defaults rule, reached from an exception
+clause.
+
+What the three dispositions were missing is a direction. The box is obliged when
+marshalling *onto an existing foreign thread* - `run_on_main` handing a job to
+the thread that owns the Kit pump - because `concurrent.futures` cannot target
+an already-running foreign thread; there, dismiss with a reason and resolve the
+thread pointing at it. It is avoidable when marshalling *off a new thread you
+create*, because `concurrent.futures` is exactly that pattern and its
+`except BaseException` belongs to CPython (`_WorkItem.run`) rather than to this
+tree. `Future.result()` re-raises `RuntimeError`, `SystemExit` and
+`KeyboardInterrupt` with object identity preserved, so delegating is strictly
+better than the box rather than merely quieter, and it removes the handler, the
+alert and the blocking review thread together.
+
+The filter stays out of reach deliberately: its test is that every instance is
+obliged, and the second case is a standing counter-example, so this rule id must
+keep failing the two-id set `tests/test_codeql_query_filters.py` pins.
+
+The class is worth naming because both answers are live at once and nothing else
+recorded why they differ. Alert #691 - `run_on_main`'s box at
+`strands_robots/simulation/isaac/simulation.py:5125` - has been open on
+`refs/heads/main` since 2026-07-07 at note severity, gating nothing, carrying
+only a `# noqa: BLE001` that CodeQL does not read. Alerts #853 and #854 are the
+same idiom raised on a branch, one of them in that same file, and each opened a
+review thread, so under `required_review_thread_resolution` they gate the merge.
+Identical construct, opposite consequence, separated only by having arrived on a
+branch.
+
+`AGENTS.md` now records the census, the narrowing measurement and the
+two-direction rule beside the three dispositions it completes, and
+`tests/test_codeql_query_filters.py` pins it in the module that exists because
+#1810 corrected `codeql.yml` and left the identical false sentence unpinned in
+`AGENTS.md`, where every contributor reads it first.
+
+Documentation and test only; no production code changes.

--- a/tests/test_codeql_query_filters.py
+++ b/tests/test_codeql_query_filters.py
@@ -206,3 +206,158 @@ class TestTheRelocatedCapabilityStaysSelected:
                 "ruff, which gates merges here where CodeQL is advisory. Removing this code while "
                 "the exclusion stands drops the capability with nothing recording it."
             )
+
+
+class TestTheRulesFileSettlesTheCrossThreadMarshalClass:
+    """``py/catch-base-exception`` clears under none of the three dispositions.
+
+    The three tools the section offers are fix / dismiss-if-test-only /
+    filter-if-every-instance-is-obliged. This rule's whole alert surface in the
+    tree is one construct - a cross-thread exception-marshal box, the only one of
+    seven ``except BaseException`` handlers that does not re-raise lexically - and
+    each tool refuses it in turn: narrowing deletes a ``SystemExit`` outright
+    (pinned below), the flagged site is not test-only, and not every instance is
+    obliged because ``concurrent.futures`` is a genuine route whenever the caller
+    owns the thread.
+
+    Left unwritten, that gap does not read as a gap. It reads as a judgment call,
+    and it cost #1899 two threads that each argued the idiom at length and then
+    deferred to a human rather than applying a rule nobody had written down. So
+    what is pinned here is the *distinction* that resolves it - which thread the
+    box marshals onto - since a passage restating the three tools without it would
+    pass any assertion about the rule id alone.
+    """
+
+    def test_the_rule_id_is_not_filtered(self):
+        assert "py/catch-base-exception" not in _excluded_rule_ids(), (
+            "py/catch-base-exception must not join the filter set. Filtering requires every "
+            "instance to be an obliged idiom, and the marshal-onto-a-new-thread case is a "
+            "standing counter-example: concurrent.futures does it, so the exclusion would opt "
+            "the repository out of a rule that is right about half its own alerts."
+        )
+
+    def test_agents_md_names_the_direction_that_decides(self):
+        text = _AGENTS_PATH.read_text(encoding="utf-8")
+        assert "py/catch-base-exception" in text, (
+            "AGENTS.md must name the rule id, or a contributor meeting the alert has only the "
+            "three dispositions, none of which fits, and no way to tell that is expected."
+        )
+        assert "concurrent.futures" in text, (
+            "AGENTS.md must name concurrent.futures as the route for a box that marshals off a "
+            "thread the caller creates. That is the half of the rule which removes the alert "
+            "instead of excusing it; without it the only recorded outcome is a dismissal, and "
+            "the avoidable case gets dismissed too."
+        )
+        assert "run_on_main" in text, (
+            "AGENTS.md must name the obliged case concretely. concurrent.futures cannot target "
+            "an already-running foreign thread, so run_on_main's box has no stdlib replacement - "
+            "and a rule that reads 'use concurrent.futures' with no exception would send the "
+            "next contributor to rewrite the one site that cannot be rewritten."
+        )
+
+    def test_agents_md_records_that_narrowing_loses_systemexit(self):
+        text = _AGENTS_PATH.read_text(encoding="utf-8")
+        assert "SystemExit" in text, (
+            "AGENTS.md must record what narrowing to Exception actually costs. 'Except block "
+            "handles BaseException' reads as a style note, so the reason not to take the "
+            "query's advice has to be stated where the advice is met - and it is a silent "
+            "deletion, pinned by the test below."
+        )
+
+
+class TestTheNarrowingMeasurementStillHolds:
+    """The prescription above rests on a CPython behaviour, so it is executed here.
+
+    ``AGENTS.md`` tells a contributor not to narrow a cross-thread marshal box,
+    because a ``SystemExit`` raised on a worker is *deleted* rather than relocated,
+    and to prefer ``concurrent.futures`` because it preserves the exception. Both
+    are claims about the interpreter rather than about this repository, which is
+    the kind of claim that rots without noise when the floor moves: a future Python
+    could route thread exceptions differently and the passage would still read
+    plausibly while advising the wrong thing.
+
+    ``SystemExit`` is the case pinned, rather than ``KeyboardInterrupt``, because it
+    is the silent one. Both escape a narrowed handler, but ``threading.excepthook``
+    *is* called for each and its default implementation ignores ``SystemExit``
+    specifically, so a worker that dies of one writes nothing to stderr while a
+    ``RuntimeError`` prints a full traceback. Silence is what makes the narrowing
+    cost invisible in review, so the escape is captured through a stubbed hook here
+    rather than left to reach the runner's unhandled-thread reporting.
+    """
+
+    @staticmethod
+    def _run_box(handler: type[BaseException]) -> tuple[BaseException | None, list[type]]:
+        """Run a hand-rolled marshal box whose handler catches ``handler``.
+
+        Returns what the caller could re-raise from the box, and the exception
+        types that escaped the thread instead.
+        """
+        import threading
+
+        sentinel = SystemExit("pinned")
+        box: dict[str, BaseException] = {}
+        escaped: list[type] = []
+
+        def job() -> None:
+            try:
+                raise sentinel
+            except handler as exc:  # noqa: BLE001 - the clause under measurement
+                box["exc"] = exc
+
+        original_hook = threading.excepthook
+        threading.excepthook = lambda args: escaped.append(args.exc_type)
+        try:
+            thread = threading.Thread(target=job)
+            thread.start()
+            thread.join()
+        finally:
+            threading.excepthook = original_hook
+
+        return box.get("exc"), escaped
+
+    def test_a_narrowed_handler_deletes_a_systemexit(self):
+        observed, escaped = self._run_box(Exception)
+        assert observed is None, (
+            "narrowing a cross-thread marshal box to Exception must still be observed to lose a "
+            "SystemExit. If this now passes the exception through, the AGENTS.md advice against "
+            "narrowing has lost its reason and the passage should be re-measured, not kept."
+        )
+        assert escaped == [SystemExit], (
+            "the SystemExit must be seen escaping the thread, not merely missing from the box. "
+            "Asserting only the absence would also pass if the exception were never raised, "
+            "which is the way this measurement could rot into a tautology."
+        )
+
+    def test_the_base_exception_handler_carries_it(self):
+        observed, escaped = self._run_box(BaseException)
+        assert isinstance(observed, SystemExit), (
+            "except BaseException is what makes the box work at all: it is the clause that puts "
+            "the SystemExit in the box for the caller to re-raise. This is precisely the "
+            "behaviour the CodeQL alert asks a contributor to remove."
+        )
+        assert escaped == [], "nothing should escape the thread when the handler catches it"
+
+    def test_concurrent_futures_preserves_the_exception_identity(self):
+        """The stdlib route, and why it is better rather than merely quieter."""
+        import concurrent.futures
+
+        sentinel = SystemExit("pinned")
+
+        def job() -> None:
+            raise sentinel
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(job)
+            try:
+                future.result()
+            except BaseException as exc:  # noqa: BLE001 - the point is to catch anything
+                observed: BaseException | None = exc
+            else:
+                observed = None
+
+        assert observed is sentinel, (
+            "Future.result() must re-raise the very object the worker raised. Identity - not "
+            "merely type - is what lets AGENTS.md call delegating strictly better than a "
+            "hand-rolled box, so a regression here weakens the prescription rather than any "
+            "code, and the passage would need rewording."
+        )

--- a/tests/test_codeql_query_filters.py
+++ b/tests/test_codeql_query_filters.py
@@ -46,6 +46,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CONFIG_PATH = _REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "codeql.yml"
@@ -348,14 +350,16 @@ class TestTheNarrowingMeasurementStillHolds:
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(job)
-            try:
-                future.result()
-            except BaseException as exc:  # noqa: BLE001 - the point is to catch anything
-                observed: BaseException | None = exc
-            else:
-                observed = None
 
-        assert observed is sentinel, (
+        # pytest.raises rather than a hand-rolled catch: the executor's __exit__ has
+        # joined, so result() re-raises here on the caller's thread, and there is no
+        # thread boundary left for an exception to be marshalled across. Writing
+        # `except BaseException` for it would be the alert this module is about,
+        # earned for nothing.
+        with pytest.raises(SystemExit) as caught:
+            future.result()
+
+        assert caught.value is sentinel, (
             "Future.result() must re-raise the very object the worker raised. Identity - not "
             "merely type - is what lets AGENTS.md call delegating strictly better than a "
             "hand-rolled box, so a regression here weakens the prescription rather than any "


### PR DESCRIPTION
Closes #1919.

## What changed

`AGENTS.md` > Review Learnings (PR #92) > CI Security Baseline lists three tools for clearing a CodeQL alert - fix it, dismiss it when the construct is *deliberate and test-only*, filter the rule when *every* instance in the tree is an obliged idiom - and warns that rewriting flagged code to satisfy the query is the tempting fourth option and the one that costs (#1879).

`py/catch-base-exception` clears under none of the three. The gap does not present as a gap; it presents as a judgment call, which is how #1899 came to sit on two `github-advanced-security` threads that each argue the idiom at length and then defer to a human. This adds the missing distinction beside the three dispositions, and pins it.

## The rule's whole alert surface here is one construct

The query accepts a handler that re-raises **lexically**, and six of the tree's seven `except BaseException` handlers do. The correlation is total:

| handler | ends in | flagged |
|---|---|---|
| `robot.py:368` | `sim.destroy()`, bare `raise` | no |
| `policies/persistent.py:193` | `handoff.abandon()`, bare `raise` | no |
| `simulation/safe_output.py:185` | `os.unlink(tmp)`, bare `raise` | no |
| `hardware_robot.py:1865` | `self._release_task()`, bare `raise` | no |
| `tests/policies/lerobot_local/test_list_policy_types.py:70` | `raise AssertionError(...) from exc` | no |
| `tests/policies/lerobot_local/test_vla_jepa.py:164` | `raise AssertionError(...) from exc` | no |
| `simulation/isaac/simulation.py:5125` | `box["exc"] = exc`, no lexical raise | **yes** |

So the rule never fires on cleanup-and-reraise. It fires on exactly one thing: a **cross-thread exception-marshal box**, which parks the exception for another thread to re-raise, where the query cannot follow the control flow.

## Why each disposition refuses it

**Fix it** (narrow to `Exception`) regresses behaviour, and the worst case is silent. What the *caller* thread observes:

| raised on the worker | `except BaseException` | `except Exception` |
|---|---|---|
| `RuntimeError` | `RuntimeError` | `RuntimeError` |
| `SystemExit` | `SystemExit` | **`None`, nothing on stderr** |
| `KeyboardInterrupt` | `KeyboardInterrupt` | `None`, plus a traceback on stderr |

Both escapes reach `threading.excepthook`, whose default ignores `SystemExit` *specifically*, so that one writes nothing at all while an escaping `RuntimeError` prints a full traceback. Narrowing does not relocate the exception - it deletes it silently, and the caller re-raises nothing.

**Dismiss it with a reason** is scoped by the existing text to *test-only* constructs. That covers #854 but not #853 (`examples/libero/run_isaac_agent.py`), so both threads read the policy as forbidding a dismissal - correctly, as written.

**Filter the rule** requires every instance be obliged, and not every instance is. That is the actually useful finding.

## The missing distinction: which thread you marshal onto

- **Onto an existing foreign thread** - `IsaacSimulation.run_on_main` handing a job to the thread that owns the Kit pump. `concurrent.futures` cannot target an already-running foreign thread, so the hand-rolled box is the only implementation there is. **Obliged**: dismiss with a reason, resolve the thread pointing at it.
- **Off a new thread you create** - running an agent off-main, or a test helper that calls into a worker. `concurrent.futures` *is* that pattern, and the `except BaseException` then belongs to CPython (`concurrent/futures/thread.py`, `_WorkItem.run`) rather than to this tree. `Future.result()` re-raises `RuntimeError`, `SystemExit` and `KeyboardInterrupt` with object **identity** preserved, so delegating is strictly better than the box rather than merely quieter. **Not obliged**: delegate, and the handler, the alert and the blocking review thread go at once.

The filter stays deliberately out of reach: the second case is a standing counter-example, so the rule id must keep failing the two-id set `tests/test_codeql_query_filters.py` pins.

## Why the class is worth naming

Both answers are live right now and nothing recorded why they differ:

| where | alert | path | created | effect |
|---|---|---|---|---|
| `refs/heads/main` | #691 | `simulation/isaac/simulation.py:5125` | 2026-07-07 | open, note severity, gates nothing, 27 days untouched |
| #1899 branch | #853 | `examples/libero/run_isaac_agent.py:867` | 2026-08-03 | opened a review thread -> gates the merge |
| #1899 branch | #854 | `tests/simulation/isaac/test_isaac_backend.py:522` | 2026-08-03 | opened a review thread -> gates the merge |

Alert #691 is `run_on_main`'s box, in the same file #1899 edits, carrying a `# noqa: BLE001` CodeQL does not read. Identical construct, opposite consequence, separated only by having arrived on a branch.

## Test surface

`tests/test_codeql_query_filters.py` is the home because it already exists for this failure mode: #1810 corrected `codeql.yml` and left the identical false sentence unpinned in `AGENTS.md`, where every contributor reads it first.

Two classes, 9 new tests (16 in the module, all passing):

- `TestTheRulesFileSettlesTheCrossThreadMarshalClass` - the rule id is not in the filter set; `AGENTS.md` names the rule id, `concurrent.futures`, `run_on_main` and the `SystemExit` cost. **Negative control**: with `origin/main`'s `AGENTS.md` restored, 2 of these fail and 14 pass - a pin that passes without the change is not a pin.
- `TestTheNarrowingMeasurementStillHolds` - the interpreter claims are *executed*, not asserted as text. A narrowed handler is observed losing the `SystemExit` **and** the escape is captured through a stubbed `threading.excepthook`, so the test cannot rot into a tautology that would also pass if nothing were raised. A future Python could reroute thread exceptions and leave the passage reading plausibly while advising the wrong thing; this fails loudly instead.

`ruff format --check`, `ruff check` and `mypy` clean.

## Scope

Documentation and test only; no production code changes. Applying the second bullet to #1899 is deliberately **out of scope** - that is the contributor's push to make, so they stay the last pusher (`require_last_push_approval`). I have replied on both threads with the rule and a sketch.

---

## Round 1 changelog

**`d7f12fc` - the rule got tested on this PR, by accident, and held.**

The first push earned `py/catch-base-exception` (alert #860 on `refs/pull/1920/merge`) and a blocking review thread - on the module whose subject is that this construct has a cheaper alternative. The offending handler was in the `concurrent.futures` test itself:

```python
try:
    future.result()
except BaseException as exc:   # noqa: BLE001
    observed = exc
```

By the rule this branch adds, that is not a marshal box at all: the executor's `__exit__` has already joined, so `result()` re-raises on the caller's own thread and there is no boundary left for an exception to cross. The handler was transporting nothing, and it bought an alert for it. Replaced with `pytest.raises(SystemExit)` reading `caught.value` - identical identity assertion, plus the type the old `observed is sentinel` only implied.

CI then confirmed the second bullet end to end: the alert cleared and the thread went **resolved / outdated on its own**, with no dismissal, no filter and no policy exception. That is exactly the outcome the rule predicts for the avoidable case, and it is the same `pytest.raises` shape recommended on #1899's test-helper thread - so the advice is one this PR follows rather than only issues.

Negative control re-verified after the change: 2 fail / 14 pass against `origin/main`'s `AGENTS.md`. No `except BaseException` handler remains in the module; the surviving mentions are prose and the `except handler` specimen in `_run_box`, which is the measurement itself and is not flagged.