### PR TITLE
ci: name the pull request whose only approval its own pusher supplied (closes #1905)

### DIFF
--- a/.github/workflows/last-push-approval.yml
+++ b/.github/workflows/last-push-approval.yml
@@ -1,0 +1,91 @@
+# .github/workflows/last-push-approval.yml
+#
+# Names a pull request whose only approvals come from the account that pushed
+# its head commit. The `default` BRANCH ruleset sets
+# `require_last_push_approval: true`, so such an approval does not count and the
+# pull request cannot merge until a *different* account reviews it.
+#
+# This exists because that state is invisible. It presents as
+# `reviewDecision: REVIEW_REQUIRED` and `mergeStateStatus: BLOCKED` -- byte for
+# byte what a pull request nobody has reviewed yet looks like -- so a status
+# sweep reads it as waiting on a reviewer and reports the repository healthy
+# with a backlog. It stood that way in eight consecutive scheduled scan
+# summaries as "reviewer bandwidth is the sole constraint" while #1722 and #1035
+# sat permanently unmergeable. More reviewing by the same reviewer cannot fix
+# either one. See issue #1905 and scripts/check_last_push_approval.py.
+#
+# It runs on `pull_request_review` as well as `pull_request`, because the
+# condition is only decidable once an approval exists and approvals do not
+# arrive with a push. A `pull_request`-only trigger would evaluate every branch
+# at the one moment it is guaranteed to have no approval, and always pass.
+#
+# Whether a finding blocks a merge is a branch-protection decision, not a
+# property of this file, and this one is deliberately not in the required set.
+# Unlike merge-base-overlap.yml the remedy here is not self-clearing: it needs a
+# second human, so the pull request author cannot turn the check green by
+# working. A gate a branch cannot clear by doing anything is a report, and
+# reporting is what this does -- the exit status is 1 so the finding is visible
+# in the checks list, and nothing consumes it as a gate.
+#
+
+name: Last Push Approval Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+# Keyed on the event as well as the pull request, so a review run and a push run
+# never cancel one another. Both read live API state rather than the checked-out
+# tree, and a stale read of exactly this state is the failure mode the check
+# exists to prevent: a review arriving mid-run must not be able to cancel the
+# run that would have seen it and leave the earlier, approval-free answer
+# standing. Within one event type the later run supersedes the earlier as usual.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  # For GET /actions/runs?head_sha=<head>, which is the only place the identity
+  # of the pusher is legible. Commit metadata is not a substitute: #1920's head
+  # was committed under an identity with no linked GitHub account, so its
+  # commit.author.login is null while its triggering_actor is correct.
+  actions: read
+
+jobs:
+  last-push-approval:
+    name: Detect an approval the last pusher cannot supply
+    runs-on: ubuntu-latest
+
+    steps:
+      # The BASE branch, for the reason merge-base-overlap.yml documents at
+      # length: a branch that forked before this check landed does not carry the
+      # script, and running it from the head tree would die with exit 2 before
+      # computing anything, rendering in the checks UI as the same red X as a
+      # real finding. Checking out the base costs no fidelity here because the
+      # script reads nothing from the working tree -- every input comes from the
+      # API, and the pull request is named by --pr instead.
+      - name: Checkout the base branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # Standard library only, so there is nothing to install. The head SHA is
+      # passed explicitly rather than left to the script's own lookup so that
+      # the commit judged is the one this event fired for.
+      - name: Check who pushed the head against who approved
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check_last_push_approval.py --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/last-push-approval.yml
+++ b/.github/workflows/last-push-approval.yml
@@ -83,9 +83,30 @@ jobs:
       # Standard library only, so there is nothing to install. The head SHA is
       # passed explicitly rather than left to the script's own lookup so that
       # the commit judged is the one this event fired for.
+      #
+      # The guard is the bootstrapping case, and it is not hypothetical: this
+      # workflow failed on the very pull request that introduced it. Checking out
+      # the base is what keeps a branch forked before the gate from dying on a
+      # missing script (#1791), and it has the mirror-image hole -- the base does
+      # not carry the script either until this lands, so the step exited 2 with
+      # `can't open file`, which the checks UI renders as the same red X as a real
+      # finding. Passing here is the same rule the script already applies to an
+      # undetermined pusher and to a failed API lookup: a check that cannot
+      # compute an answer reports nothing rather than accusing a branch of a
+      # state it never observed. It is a no-op exactly once, on this pull request
+      # and on any branch whose base predates the script, and correct after.
+      # Pinned by tests/test_last_push_approval.py::test_the_workflow_passes_when_the_base_lacks_the_script
       - name: Check who pushed the head against who approved
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: python3 scripts/check_last_push_approval.py --repo "$GITHUB_REPOSITORY"
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ ! -f scripts/check_last_push_approval.py ]; then
+            echo "check_last_push_approval: not present on ${BASE_REF}, so there is nothing to report."
+            echo "The base branch predates this check. Reporting nothing rather than exiting 2,"
+            echo "which the checks UI cannot tell apart from a real finding."
+            exit 0
+          fi
+          python3 scripts/check_last_push_approval.py --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/last-push-approval.yml
+++ b/.github/workflows/last-push-approval.yml
@@ -19,6 +19,14 @@
 # arrive with a push. A `pull_request`-only trigger would evaluate every branch
 # at the one moment it is guaranteed to have no approval, and always pass.
 #
+# That trigger also *pollutes the signal the script reads*, which is worth
+# knowing before adding another one. A run started by a review is attributed to
+# the reviewer, so the newest run on the head sha named the approver as the
+# pusher and the check reported a deadlock on every approved pull request --
+# observed on #1921, its own. The script counts only runs whose event a push
+# produces (`PUSH_ATTRIBUTING_EVENTS`); any trigger added here that is not
+# caused by a push must stay outside that set.
+#
 # Whether a finding blocks a merge is a branch-protection decision, not a
 # property of this file, and this one is deliberately not in the required set.
 # Unlike merge-base-overlap.yml the remedy here is not self-clearing: it needs a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,6 +409,30 @@ hatch run format            # ruff check --fix, ruff format
    not; #1035's head names the maintainer outright. Same `REVIEW_REQUIRED`,
    opposite metadata. Only `triggering_actor` is load-bearing.
 
+   All of the above was documented here and enforced by nothing, which is the
+   same shape as the changelog rule in step 3 before #1784. It is now surfaced by
+   `.github/workflows/last-push-approval.yml`, which names the pusher and the
+   approvers on every review event and fails when they are the same single
+   account. The point of automating it is not that the check is clever - it is
+   that the state it reports is *invisible*: `REVIEW_REQUIRED` / `BLOCKED` is
+   byte for byte what an unreviewed pull request looks like, so the two are
+   indistinguishable in every field a sweep reads and they need opposite actions.
+   Verified against six pull requests, three outcomes, no false positive:
+
+   | pull request | pushed by | approved by | outcome |
+   |---|---|---|---|
+   | #1722, #1035 | the maintainer | the maintainer | `pusher-only-approval` |
+   | #1894, #1920 | either | a second account | `satisfied` |
+   | #1899, #1901 | the author | nobody yet | `awaiting-first-review` |
+
+   `awaiting-first-review` is a pass on purpose. It is the ordinary state of an
+   open pull request and is already visible, so making it red would put a red X
+   on every branch in the repository and the finding would stop meaning
+   anything. Unlike the overlap check in step 8 this one is **not** self-clearing
+   - its remedy is a second human, and no work the author does turns it green -
+   so it reports and is deliberately absent from the required set. A gate a
+   branch cannot clear by doing anything is a report, whatever it is wired to.
+
    The general rule behind all three: **a decision recorded only in a PR or
    issue comment is not durable** - the next contributor will not read the same
    comment. If a decision must survive, it belongs in this file.

--- a/changelog.d/1921-last-push-approval-check.md
+++ b/changelog.d/1921-last-push-approval-check.md
@@ -1,0 +1,42 @@
+### Docs: the last-push-approval deadlock is now surfaced by a check, not only described
+
+`require_last_push_approval: true` on the `default` ruleset means an approval from
+the account that pushed the head does not count. AGENTS.md has recorded that
+mechanism since #1814 and refined it in #1852, and #1905 recorded it a third time
+as a process issue. Nothing enforced or surfaced it, which is the shape the
+changelog rule had before #1784.
+
+What makes it worth a check rather than a third paragraph is that the state is
+**invisible**. It presents as `reviewDecision: REVIEW_REQUIRED` with
+`mergeStateStatus: BLOCKED` - byte for byte what a pull request nobody has
+reviewed yet looks like - so no field a status sweep reads separates "waiting on a
+reviewer" from "cannot merge without a second one", and the two need opposite
+actions. It stood in eight consecutive scheduled scan summaries as "reviewer
+bandwidth is the sole constraint" while #1722 and #1035 sat permanently
+unmergeable.
+
+`scripts/check_last_push_approval.py` reads the pusher from
+`actions/runs?head_sha=<head>` -> `triggering_actor`, the one place it is legible,
+and compares it against the accounts holding a current approval. #1920 sharpens
+why commit metadata cannot stand in: its head was committed under the
+`strands-robots` identity, which has no linked GitHub account, so
+`commit.author.login` is `None` - there the metadata does not mislead, it declines
+to answer, while #1722's names an identity distinct from the approver and reads as
+satisfied when it is not. Opposite metadata, same verdict.
+
+Three outcomes, because they ask for three different things: `pusher-only-approval`
+is the finding; `awaiting-first-review` passes deliberately, being the ordinary
+state of an open pull request, so that a red check means one specific thing rather
+than appearing on every branch; and a pusher the lookup cannot attribute passes
+rather than guessing from the commit. Verified against six live pull requests with
+no false positive - #1722 and #1035 the finding, #1894 and #1920 (both merged)
+satisfied, #1899 and #1901 awaiting review.
+
+It reports and does not gate, and is absent from the required set on purpose.
+Unlike `merge-base-overlap.yml`, whose remedy is self-clearing, this one's remedy
+is a second reviewer and no work the author does turns it green. A gate a branch
+cannot clear by doing anything is a report.
+
+Tooling and documentation only; no production code or test behaviour changes.
+Neither #1722 nor #1035 is unblocked by this - both still need an approver who is
+not the account that pushed their heads.

--- a/changelog.d/1921-last-push-approval-check.md
+++ b/changelog.d/1921-last-push-approval-check.md
@@ -32,6 +32,15 @@ rather than guessing from the commit. Verified against six live pull requests wi
 no false positive - #1722 and #1035 the finding, #1894 and #1920 (both merged)
 satisfied, #1899 and #1901 awaiting review.
 
+Only workflow runs whose event a push produces attribute a pusher. That filter
+is load-bearing, not defensive: the check's own `pull_request_review` trigger
+creates a run on the same head sha attributed to the *reviewer*, newer than any
+run the push produced, so reading the newest run unfiltered named the approver as
+the pusher and reported a deadlock on every approved pull request. It was caught
+on #1921 itself, where GitHub read `APPROVED` / `UNSTABLE` and the check
+disagreed - the six-PR verification above had passed only because no head sha
+carried a review-triggered run until this workflow existed.
+
 It reports and does not gate, and is absent from the required set on purpose.
 Unlike `merge-base-overlap.yml`, whose remedy is self-clearing, this one's remedy
 is a second reviewer and no work the author does turns it green. A gate a branch

--- a/scripts/check_last_push_approval.py
+++ b/scripts/check_last_push_approval.py
@@ -114,6 +114,18 @@ API_ROOT = "https://api.github.com"
 # not, which is why it cannot retract an earlier approval.
 POSITION_STATES = frozenset({"APPROVED", "CHANGES_REQUESTED", "DISMISSED"})
 
+# Workflow-run events whose ``triggering_actor`` is the account that put the
+# commit there. Every other event names whoever caused *that* event instead, and
+# filtering on this set is load-bearing rather than defensive: this check's own
+# ``pull_request_review`` trigger produces a run on the same head sha attributed
+# to the **reviewer**, newer than the push's own runs. Reading the newest run
+# unfiltered therefore named the approver as the pusher and reported
+# ``pusher-only-approval`` for every approved pull request -- observed on #1921,
+# this check's own, where GitHub read `APPROVED`/`UNSTABLE` and the check
+# disagreed. Pinned by
+# tests/test_last_push_approval.py::test_a_review_triggered_run_does_not_name_the_pusher
+PUSH_ATTRIBUTING_EVENTS = frozenset({"push", "pull_request"})
+
 SATISFIED = "satisfied"
 AWAITING_FIRST_REVIEW = "awaiting-first-review"
 PUSHER_ONLY_APPROVAL = "pusher-only-approval"
@@ -235,15 +247,23 @@ def _get(url: str, token: str) -> object:
 def resolve_pusher(repo: str, head_sha: str, token: str) -> str | None:
     """Return the account GitHub attributes the head push to, or ``None``.
 
-    Reads ``triggering_actor`` from the workflow runs for the commit. When
-    several runs exist they normally agree; when they do not, the most recently
-    created run wins, because a re-push under a different account produces newer
-    runs than the ones the previous push left behind.
+    Reads ``triggering_actor`` from the workflow runs for the commit, counting
+    only runs whose event is one a push produces (``PUSH_ATTRIBUTING_EVENTS``).
+    A run started by anything else -- a review, a comment, a manual dispatch --
+    is attributed to whoever did *that*, not to the pusher. When several
+    qualifying runs exist they normally agree; when they do not, the most
+    recently created wins, because a re-push under a different account produces
+    newer runs than the ones the previous push left behind.
+
+    Returns ``None`` when no qualifying run exists, which the caller reports as
+    ``unknown-pusher`` rather than falling back to the commit metadata.
     """
     payload = _get(f"{API_ROOT}/repos/{repo}/actions/runs?head_sha={head_sha}&per_page=100", token)
     runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
     dated: list[tuple[str, str]] = []
     for run in runs:
+        if run.get("event") not in PUSH_ATTRIBUTING_EVENTS:
+            continue
         actor = (run.get("triggering_actor") or {}).get("login")
         if actor:
             dated.append((run.get("created_at") or "", actor))

--- a/scripts/check_last_push_approval.py
+++ b/scripts/check_last_push_approval.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Report a pull request whose only approvals come from the account that pushed its head.
+
+Why this exists
+---------------
+The active ``default`` BRANCH ruleset carries::
+
+    requiredApprovingReviewCount: 1
+    requireLastPushApproval:      true    <-- the relevant one
+    dismissStaleReviewsOnPush:    true
+
+``require_last_push_approval`` means the most recent push must be approved by
+**someone other than whoever pushed it**. So when the only account that has
+approved a pull request is also the account that pushed its head commit, that
+approval stops counting, ``reviewDecision`` reads ``REVIEW_REQUIRED``, and
+``mergeStateStatus`` sits at ``BLOCKED`` for as long as nobody else reviews.
+Further approvals from that same account cannot clear it.
+
+That state is indistinguishable, in every field a status sweep reads, from a
+pull request that simply has not been reviewed yet -- both read
+``REVIEW_REQUIRED`` / ``BLOCKED``. The two need opposite actions: one needs the
+existing reviewer to get to it, the other needs a *different* reviewer and will
+never merge without one. Conflating them is not hypothetical; it stood in eight
+consecutive scheduled scan summaries as "reviewer bandwidth is the sole
+constraint" while #1722 and #1035 sat permanently unmergeable. See issue #1905
+and the "PR Workflow" section of AGENTS.md.
+
+Why the pusher is read from a workflow run
+------------------------------------------
+The pusher appears in none of the fields a reviewer would naturally check, and
+commit metadata answers the question wrongly in both directions. Measured on
+four pull requests in this repository:
+
+===========  ==================  ================  =====================
+pull request ``triggering_actor``  approved by       ``commit.author.login``
+===========  ==================  ================  =====================
+#1894        yinsong1986         cagataycali       yinsong1986
+#1920        cagataycali         yinsong1986       ``None``
+#1722        cagataycali         cagataycali       cagataycali
+#1035        cagataycali         cagataycali       cagataycali
+===========  ==================  ================  =====================
+
+#1920 and #1722 share a pusher and differ only in whether the approver is a
+different account; #1920 merged and #1722 has been blocked since 2026-08-01, so
+that is the variable. And #1920's head was committed under the
+``strands-robots`` git identity, which has no linked GitHub account: its
+``commit.author.login`` is ``None``, so commit metadata does not merely mislead
+there, it declines to answer while ``triggering_actor`` answers correctly.
+#1722's metadata names the pusher and #1920's does not, for the same verdict --
+which is why this reads the workflow run::
+
+    GET /repos/{owner}/{repo}/actions/runs?head_sha=<head>  ->  triggering_actor
+
+What this reports, and what it deliberately does not
+----------------------------------------------------
+Three outcomes, distinguished because they ask for three different things:
+
+``satisfied``
+    At least one current approval comes from an account other than the pusher.
+    Nothing to say.
+
+``awaiting-first-review``
+    No current approval at all. This is the ordinary case and is *not* a
+    finding: the pull request is waiting on a reviewer, which is true and
+    already visible. Reported as passing so that the check's red state means
+    one specific thing.
+
+``pusher-only-approval``
+    Every current approval belongs to the pusher. The finding. The remedy is a
+    second approver, or the branch author re-pushing the head so the existing
+    approval counts again -- which costs a re-approval round, because
+    ``dismiss_stale_reviews_on_push`` is also set.
+
+A "current" approval follows the same rule ``reviewDecision`` uses: per author,
+their most recent review that expresses a position. ``COMMENTED`` expresses
+none and is skipped, so a reviewer who approves and later comments is still an
+approver; ``DISMISSED`` and ``CHANGES_REQUESTED`` supersede an earlier approval.
+
+This check does not gate a merge and is not in the required set -- whether a
+finding blocks is a branch-protection decision, not a property of this file. It
+also cannot be self-cleared by the pull request author alone, which is exactly
+why it reports rather than blocks: a gate whose remedy is "find another human"
+would otherwise sit red on a branch that has done nothing wrong.
+
+Usage
+-----
+``--repo``   ``owner/name`` (default: ``$GITHUB_REPOSITORY``).
+``--pr``     pull request number (default: ``$PR_NUMBER``).
+``--head``   head commit SHA (default: ``$HEAD_SHA``; falls back to the pull
+             request's own ``head.sha``).
+``--token``  API token (default: ``$GITHUB_TOKEN``). Needs ``actions: read``
+             for the run lookup and ``pull-requests: read`` for the reviews.
+
+Exit status is ``1`` for ``pusher-only-approval``, else ``0``. A lookup that
+cannot determine the pusher exits ``0`` and says so: an unknown pusher is not
+evidence of a deadlock, and this check refusing to guess is the whole point of
+reading ``triggering_actor`` rather than the commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+
+API_ROOT = "https://api.github.com"
+
+# Review states that express a position on the change. A COMMENTED review does
+# not, which is why it cannot retract an earlier approval.
+POSITION_STATES = frozenset({"APPROVED", "CHANGES_REQUESTED", "DISMISSED"})
+
+SATISFIED = "satisfied"
+AWAITING_FIRST_REVIEW = "awaiting-first-review"
+PUSHER_ONLY_APPROVAL = "pusher-only-approval"
+UNKNOWN_PUSHER = "unknown-pusher"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The outcome, its one-line reason, and the accounts it was computed from."""
+
+    outcome: str
+    pusher: str | None
+    approvers: tuple[str, ...] = ()
+
+    @property
+    def is_finding(self) -> bool:
+        return self.outcome == PUSHER_ONLY_APPROVAL
+
+    @property
+    def summary(self) -> str:
+        if self.outcome == SATISFIED:
+            others = [a for a in self.approvers if a != self.pusher]
+            return (
+                f"Approved by {_join(others)}, who did not push the head "
+                f"(pushed by {self.pusher}). require_last_push_approval is satisfied."
+            )
+        if self.outcome == AWAITING_FIRST_REVIEW:
+            return (
+                f"No current approval yet; head pushed by {self.pusher}. "
+                "Waiting on a first review, which is the ordinary state."
+            )
+        if self.outcome == UNKNOWN_PUSHER:
+            return (
+                "Could not determine who pushed the head commit: no workflow run "
+                "reports a triggering_actor for it. Not treated as a finding, "
+                "because commit metadata is not a sound substitute."
+            )
+        return (
+            f"The only current approval is from {_join(self.approvers)}, which is "
+            f"also the account that pushed the head commit. Under "
+            f"require_last_push_approval that approval does not count, so this "
+            f"pull request needs a second approver and cannot be merged on the "
+            f"strength of further reviews from {self.pusher}."
+        )
+
+
+@dataclass
+class Review:
+    """One review, reduced to the fields the decision depends on."""
+
+    author: str
+    state: str
+    submitted_at: str = ""
+    _order: int = field(default=0, compare=False)
+
+
+def _join(names: Sequence[str]) -> str:
+    names = list(names)
+    if not names:
+        return "nobody"
+    if len(names) == 1:
+        return names[0]
+    return ", ".join(names[:-1]) + " and " + names[-1]
+
+
+def current_approvers(reviews: Iterable[Review]) -> tuple[str, ...]:
+    """Return the accounts whose latest position on the change is an approval.
+
+    Mirrors how ``reviewDecision`` is computed: a reviewer's standing is their
+    most recent review that expresses a position, so ``COMMENTED`` is skipped
+    entirely rather than treated as a retraction. Ordering is by the review
+    sequence as returned by the API, which is chronological, with
+    ``submitted_at`` only as a tiebreak -- two reviews can share a timestamp to
+    the second, and the later one in the list is the later one.
+    """
+    latest: dict[str, Review] = {}
+    for order, review in enumerate(reviews):
+        state = review.state.upper()
+        if state not in POSITION_STATES:
+            continue
+        keyed = Review(review.author, state, review.submitted_at, order)
+        held = latest.get(review.author)
+        if held is None or (keyed.submitted_at, keyed._order) >= (held.submitted_at, held._order):
+            latest[review.author] = keyed
+    return tuple(sorted(a for a, r in latest.items() if r.state == "APPROVED"))
+
+
+def classify(pusher: str | None, reviews: Iterable[Review]) -> Verdict:
+    """Decide which of the three states a pull request is in.
+
+    ``pusher`` of ``None`` means the lookup could not attribute the push. That
+    is reported as its own outcome rather than folded into a pass, so a silent
+    API change cannot quietly turn this check into a no-op that always agrees.
+    """
+    approvers = current_approvers(reviews)
+    if pusher is None:
+        return Verdict(UNKNOWN_PUSHER, None, approvers)
+    if not approvers:
+        return Verdict(AWAITING_FIRST_REVIEW, pusher, approvers)
+    if any(a != pusher for a in approvers):
+        return Verdict(SATISFIED, pusher, approvers)
+    return Verdict(PUSHER_ONLY_APPROVAL, pusher, approvers)
+
+
+def _get(url: str, token: str) -> object:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "strands-robots-check-last-push-approval",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed API host
+        return json.load(response)
+
+
+def resolve_pusher(repo: str, head_sha: str, token: str) -> str | None:
+    """Return the account GitHub attributes the head push to, or ``None``.
+
+    Reads ``triggering_actor`` from the workflow runs for the commit. When
+    several runs exist they normally agree; when they do not, the most recently
+    created run wins, because a re-push under a different account produces newer
+    runs than the ones the previous push left behind.
+    """
+    payload = _get(f"{API_ROOT}/repos/{repo}/actions/runs?head_sha={head_sha}&per_page=100", token)
+    runs = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+    dated: list[tuple[str, str]] = []
+    for run in runs:
+        actor = (run.get("triggering_actor") or {}).get("login")
+        if actor:
+            dated.append((run.get("created_at") or "", actor))
+    if not dated:
+        return None
+    return max(dated, key=lambda pair: pair[0])[1]
+
+
+def resolve_reviews(repo: str, pr: int, token: str) -> list[Review]:
+    """Return every review on the pull request, in the order the API lists them."""
+    payload = _get(f"{API_ROOT}/repos/{repo}/pulls/{pr}/reviews?per_page=100", token)
+    rows = payload if isinstance(payload, list) else []
+    return [
+        Review(
+            author=(row.get("user") or {}).get("login") or "",
+            state=row.get("state") or "",
+            submitted_at=row.get("submitted_at") or "",
+        )
+        for row in rows
+    ]
+
+
+def resolve_head_sha(repo: str, pr: int, token: str) -> str:
+    payload = _get(f"{API_ROOT}/repos/{repo}/pulls/{pr}", token)
+    head = (payload.get("head") or {}) if isinstance(payload, dict) else {}
+    return head.get("sha") or ""
+
+
+def render(verdict: Verdict, repo: str, pr: int, head_sha: str) -> str:
+    lines = [
+        "## Last-push approval",
+        "",
+        f"Outcome: **{verdict.outcome}**",
+        "",
+        verdict.summary,
+        "",
+        "| field | value |",
+        "|---|---|",
+        f"| pull request | {repo}#{pr} |",
+        f"| head | `{head_sha}` |",
+        f"| pushed by (`triggering_actor`) | {verdict.pusher or '(undetermined)'} |",
+        f"| current approvals | {_join(verdict.approvers)} |",
+    ]
+    if verdict.is_finding:
+        lines += [
+            "",
+            "### What clears this",
+            "",
+            "1. A second reviewer approves. Preserves the guarantee the rule exists",
+            "   to provide, and is the cheapest of the three.",
+            "2. The branch author pushes the head commit, which makes the existing",
+            "   approval count again. `dismiss_stale_reviews_on_push` is also set, so",
+            "   this costs a re-approval round -- but one that then counts.",
+            "3. Admin bypass. Not recommended: the rule exists to stop one account",
+            "   both writing and approving a change, so bypassing it to merge code",
+            "   that account pushed defeats the control rather than working around a",
+            "   technicality.",
+            "",
+            "Avoiding it next time: pushing a fix onto a contributor's branch consumes",
+            "the approval of whoever owns the token it is pushed with. Prefer leaving",
+            "the change as review feedback for the author to push, or land it as a",
+            "separate pull request against the base branch.",
+        ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--head", default=os.environ.get("HEAD_SHA", ""))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    args = parser.parse_args(argv)
+
+    if not args.repo or not args.pr:
+        parser.error("--repo and --pr are required (or set GITHUB_REPOSITORY and PR_NUMBER)")
+    if not args.token:
+        parser.error("--token is required (or set GITHUB_TOKEN)")
+
+    pr = int(args.pr)
+    try:
+        head_sha = args.head or resolve_head_sha(args.repo, pr, args.token)
+        pusher = resolve_pusher(args.repo, head_sha, args.token) if head_sha else None
+        reviews = resolve_reviews(args.repo, pr, args.token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+        # A lookup failure is not a finding. Say so on stderr and pass, rather
+        # than accusing a branch of a deadlock this run could not observe.
+        print(f"check_last_push_approval: lookup failed, reporting nothing: {exc}", file=sys.stderr)
+        return 0
+
+    verdict = classify(pusher, reviews)
+    report = render(verdict, args.repo, pr, head_sha)
+    print(report)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+    if verdict.is_finding:
+        print(f"::warning title=Needs an approver who did not push the head::{verdict.summary}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_last_push_approval.py
+++ b/tests/test_last_push_approval.py
@@ -1,0 +1,303 @@
+"""Pins the last-push-approval classifier against four pull requests measured in this repo.
+
+The interesting property of this check is not that it computes a boolean. It is
+that it separates two states which every field a status sweep reads renders
+identically -- ``reviewDecision: REVIEW_REQUIRED`` with
+``mergeStateStatus: BLOCKED`` describes both "nobody has reviewed this yet" and
+"the only approval can never count". So the fixtures below are the real
+observations, not invented ones, and the control pair is what carries the
+argument: #1920 and #1722 share a pusher and differ only in whether the
+approving account is a different one. #1920 merged; #1722 has been blocked since
+2026-08-01.
+
+See scripts/check_last_push_approval.py, issue #1905, and the "PR Workflow"
+section of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_last_push_approval.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_last_push_approval", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+Review = mod.Review
+
+
+def approved(author: str, at: str = "2026-08-01T00:00:00Z") -> Review:
+    return Review(author=author, state="APPROVED", submitted_at=at)
+
+
+def commented(author: str, at: str = "2026-08-01T00:00:00Z") -> Review:
+    return Review(author=author, state="COMMENTED", submitted_at=at)
+
+
+# --------------------------------------------------------------------------
+# The four measured pull requests.
+#
+# pull request | triggering_actor | approved by  | commit.author.login | reviewDecision
+# #1894        | yinsong1986      | cagataycali  | yinsong1986         | APPROVED
+# #1920        | cagataycali      | yinsong1986  | None                | APPROVED
+# #1722        | cagataycali      | cagataycali  | cagataycali         | REVIEW_REQUIRED
+# #1035        | cagataycali      | cagataycali  | cagataycali         | REVIEW_REQUIRED
+# --------------------------------------------------------------------------
+
+MEASURED = [
+    pytest.param("yinsong1986", ["cagataycali"], mod.SATISFIED, id="pr1894-author-pushed-maintainer-approved"),
+    pytest.param("cagataycali", ["yinsong1986"], mod.SATISFIED, id="pr1920-maintainer-pushed-other-approved"),
+    pytest.param("cagataycali", ["cagataycali"], mod.PUSHER_ONLY_APPROVAL, id="pr1722-pusher-is-sole-approver"),
+    pytest.param("cagataycali", ["cagataycali"], mod.PUSHER_ONLY_APPROVAL, id="pr1035-pusher-is-sole-approver"),
+]
+
+
+@pytest.mark.parametrize("pusher,approvers,expected", MEASURED)
+def test_the_measured_pull_requests_classify_as_observed(pusher, approvers, expected):
+    verdict = mod.classify(pusher, [approved(a) for a in approvers])
+    assert verdict.outcome == expected
+
+
+def test_the_control_pair_differs_only_in_who_approved():
+    """#1920 and #1722 share a pusher; only the approving account differs.
+
+    This is the whole isolation argument. If a future change made the verdict
+    depend on anything else about these two, one of these assertions moves.
+    """
+    pusher = "cagataycali"
+    merged = mod.classify(pusher, [approved("yinsong1986")])
+    blocked = mod.classify(pusher, [approved("cagataycali")])
+
+    assert merged.pusher == blocked.pusher == pusher
+    assert merged.outcome == mod.SATISFIED
+    assert blocked.outcome == mod.PUSHER_ONLY_APPROVAL
+    assert not merged.is_finding
+    assert blocked.is_finding
+
+
+def test_an_unreviewed_pull_request_is_not_a_finding():
+    """The state this check exists to distinguish itself from.
+
+    #1899 and #1901 both read REVIEW_REQUIRED / BLOCKED with no approval and a
+    head pushed by their own author. They are waiting on a reviewer, which is
+    ordinary and already visible, so a red check here would be noise on every
+    open pull request in the repository.
+    """
+    verdict = mod.classify("yinsong1986", [commented("github-advanced-security"), commented("yinsong1986")])
+    assert verdict.outcome == mod.AWAITING_FIRST_REVIEW
+    assert verdict.is_finding is False
+    assert verdict.approvers == ()
+
+
+def test_a_commented_review_does_not_retract_an_earlier_approval():
+    """COMMENTED expresses no position, so it cannot supersede an approval.
+
+    Every measured pull request here carries COMMENTED reviews from
+    github-advanced-security interleaved with the human ones; if those counted
+    as a position, #1894's approval would read as withdrawn and the check would
+    pass a genuinely blocked branch.
+    """
+    reviews = [
+        approved("cagataycali", "2026-08-01T10:00:00Z"),
+        commented("cagataycali", "2026-08-01T11:00:00Z"),
+    ]
+    assert mod.current_approvers(reviews) == ("cagataycali",)
+
+
+@pytest.mark.parametrize("superseding", ["CHANGES_REQUESTED", "DISMISSED"])
+def test_a_later_position_supersedes_an_earlier_approval(superseding):
+    reviews = [
+        approved("cagataycali", "2026-08-01T10:00:00Z"),
+        Review(author="cagataycali", state=superseding, submitted_at="2026-08-01T11:00:00Z"),
+    ]
+    assert mod.current_approvers(reviews) == ()
+
+
+def test_an_approval_after_a_dismissal_counts_again():
+    reviews = [
+        Review(author="cagataycali", state="DISMISSED", submitted_at="2026-08-01T10:00:00Z"),
+        approved("cagataycali", "2026-08-01T11:00:00Z"),
+    ]
+    assert mod.current_approvers(reviews) == ("cagataycali",)
+
+
+def test_reviews_sharing_a_timestamp_are_ordered_by_position_in_the_list():
+    """The API lists reviews chronologically; submitted_at resolves only to the second.
+
+    #1899 carries two reviews submitted 14 seconds apart and two more within the
+    same second, so a sort on the timestamp alone is not a total order and the
+    surviving position would depend on dict iteration.
+    """
+    same = "2026-08-03T06:10:19Z"
+    reviews = [
+        approved("cagataycali", same),
+        Review(author="cagataycali", state="CHANGES_REQUESTED", submitted_at=same),
+    ]
+    assert mod.current_approvers(reviews) == ()
+
+    reviews_reversed = [
+        Review(author="cagataycali", state="CHANGES_REQUESTED", submitted_at=same),
+        approved("cagataycali", same),
+    ]
+    assert mod.current_approvers(reviews_reversed) == ("cagataycali",)
+
+
+def test_a_second_approver_clears_the_finding():
+    """Remedy 1 from the report, pinned: the finding is not sticky."""
+    blocked = mod.classify("cagataycali", [approved("cagataycali")])
+    assert blocked.outcome == mod.PUSHER_ONLY_APPROVAL
+
+    cleared = mod.classify("cagataycali", [approved("cagataycali"), approved("yinsong1986")])
+    assert cleared.outcome == mod.SATISFIED
+
+
+def test_an_undetermined_pusher_is_not_a_finding():
+    """A lookup that cannot attribute the push must not guess from the commit.
+
+    #1920's head was committed under the strands-robots git identity, whose
+    commit.author.login is None while its triggering_actor is cagataycali. A
+    fallback to commit metadata would have read that pull request as having no
+    pusher and, had the approver been the same account, as satisfied. So an
+    unknown pusher is its own outcome and passes.
+    """
+    verdict = mod.classify(None, [approved("cagataycali")])
+    assert verdict.outcome == mod.UNKNOWN_PUSHER
+    assert verdict.is_finding is False
+    assert verdict.pusher is None
+    assert "commit metadata is not a sound substitute" in verdict.summary
+
+
+def test_the_finding_summary_names_the_pusher_and_the_remedy():
+    verdict = mod.classify("cagataycali", [approved("cagataycali")])
+    assert "cagataycali" in verdict.summary
+    assert "second approver" in verdict.summary
+
+    report = mod.render(verdict, "strands-labs/robots", 1722, "3375c000")
+    assert "pusher-only-approval" in report
+    assert "A second reviewer approves" in report
+    assert "Admin bypass. Not recommended" in report
+    assert "3375c000" in report
+
+
+def test_a_satisfied_report_names_the_approver_who_did_not_push():
+    verdict = mod.classify("cagataycali", [approved("yinsong1986")])
+    assert "yinsong1986" in verdict.summary
+    report = mod.render(verdict, "strands-labs/robots", 1920, "d7f12fc1")
+    assert mod.SATISFIED in report
+    # The remedy block belongs only to a finding.
+    assert "Admin bypass" not in report
+
+
+def test_the_most_recent_workflow_run_names_the_pusher():
+    """A re-push under a different account leaves the older runs in place.
+
+    resolve_pusher takes the newest created_at rather than the first row, so a
+    branch whose head was force-pushed by someone else is attributed to the
+    account that pushed last.
+    """
+    payload = {
+        "workflow_runs": [
+            {"created_at": "2026-08-01T07:50:16Z", "triggering_actor": {"login": "cagataycali"}},
+            {"created_at": "2026-08-02T09:00:00Z", "triggering_actor": {"login": "Vivek0712"}},
+        ]
+    }
+    original = mod._get
+    try:
+        mod._get = lambda url, token: payload
+        assert mod.resolve_pusher("strands-labs/robots", "deadbeef", "t") == "Vivek0712"
+    finally:
+        mod._get = original
+
+
+def test_a_head_with_no_workflow_run_yields_no_pusher():
+    original = mod._get
+    try:
+        mod._get = lambda url, token: {"workflow_runs": []}
+        assert mod.resolve_pusher("strands-labs/robots", "deadbeef", "t") is None
+    finally:
+        mod._get = original
+
+
+def test_a_run_without_a_triggering_actor_is_skipped_not_trusted():
+    original = mod._get
+    try:
+        mod._get = lambda url, token: {
+            "workflow_runs": [
+                {"created_at": "2026-08-02T09:00:00Z", "triggering_actor": None},
+                {"created_at": "2026-08-01T09:00:00Z", "triggering_actor": {"login": "cagataycali"}},
+            ]
+        }
+        assert mod.resolve_pusher("strands-labs/robots", "deadbeef", "t") == "cagataycali"
+    finally:
+        mod._get = original
+
+
+def test_reviews_are_parsed_from_the_rest_shape():
+    original = mod._get
+    try:
+        mod._get = lambda url, token: [
+            {
+                "user": {"login": "github-advanced-security"},
+                "state": "COMMENTED",
+                "submitted_at": "2026-08-03T21:39:17Z",
+            },
+            {"user": {"login": "yinsong1986"}, "state": "APPROVED", "submitted_at": "2026-08-03T21:56:05Z"},
+        ]
+        reviews = mod.resolve_reviews("strands-labs/robots", 1920, "t")
+    finally:
+        mod._get = original
+
+    assert mod.current_approvers(reviews) == ("yinsong1986",)
+
+
+def test_a_lookup_failure_reports_nothing_rather_than_a_finding(capsys, monkeypatch):
+    """An API error must not present as a deadlock.
+
+    The check has no way to tell a rate limit from a green pull request, and a
+    red X that a branch cannot clear is worse than no signal at all.
+    """
+    monkeypatch.setattr(mod, "resolve_head_sha", lambda *a, **k: "deadbeef")
+
+    def boom(*_args, **_kwargs):
+        raise mod.urllib.error.URLError("rate limited")
+
+    monkeypatch.setattr(mod, "resolve_pusher", boom)
+    exit_code = mod.main(["--repo", "strands-labs/robots", "--pr", "1722", "--token", "t"])
+    assert exit_code == 0
+    assert "reporting nothing" in capsys.readouterr().err
+
+
+def test_the_exit_status_is_one_only_for_the_finding(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "resolve_head_sha", lambda *a, **k: "3375c000")
+    monkeypatch.setattr(mod, "resolve_pusher", lambda *a, **k: "cagataycali")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    monkeypatch.setattr(mod, "resolve_reviews", lambda *a, **k: [approved("cagataycali")])
+    assert mod.main(["--repo", "strands-labs/robots", "--pr", "1722", "--token", "t"]) == 1
+
+    monkeypatch.setattr(mod, "resolve_reviews", lambda *a, **k: [approved("yinsong1986")])
+    assert mod.main(["--repo", "strands-labs/robots", "--pr", "1920", "--token", "t"]) == 0
+
+    monkeypatch.setattr(mod, "resolve_reviews", lambda *a, **k: [commented("yinsong1986")])
+    assert mod.main(["--repo", "strands-labs/robots", "--pr", "1899", "--token", "t"]) == 0
+
+
+def test_no_report_string_carries_a_non_ascii_character():
+    """Log and report strings stay ASCII, per the repo's Unicode hygiene rule."""
+    for approvers in (["cagataycali"], ["yinsong1986"], []):
+        verdict = mod.classify("cagataycali", [approved(a) for a in approvers])
+        report = mod.render(verdict, "strands-labs/robots", 1722, "3375c000")
+        report.encode("ascii")
+    mod.render(mod.classify(None, []), "strands-labs/robots", 1722, "3375c000").encode("ascii")

--- a/tests/test_last_push_approval.py
+++ b/tests/test_last_push_approval.py
@@ -20,6 +20,7 @@ import importlib.util
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -39,11 +40,15 @@ mod = _load()
 Review = mod.Review
 
 
-def approved(author: str, at: str = "2026-08-01T00:00:00Z") -> Review:
+# ``Review`` is reached through the importlib load below, so it is a module
+# attribute at runtime and not a name mypy can resolve to a type. These helpers
+# are annotated ``Any`` for that reason rather than to loosen anything: the
+# script itself is fully typed and checked (mypy scripts/check_last_push_approval.py).
+def approved(author: str, at: str = "2026-08-01T00:00:00Z") -> Any:
     return Review(author=author, state="APPROVED", submitted_at=at)
 
 
-def commented(author: str, at: str = "2026-08-01T00:00:00Z") -> Review:
+def commented(author: str, at: str = "2026-08-01T00:00:00Z") -> Any:
     return Review(author=author, state="COMMENTED", submitted_at=at)
 
 

--- a/tests/test_last_push_approval.py
+++ b/tests/test_last_push_approval.py
@@ -17,6 +17,7 @@ section of AGENTS.md.
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -301,3 +302,96 @@ def test_no_report_string_carries_a_non_ascii_character():
         report = mod.render(verdict, "strands-labs/robots", 1722, "3375c000")
         report.encode("ascii")
     mod.render(mod.classify(None, []), "strands-labs/robots", 1722, "3375c000").encode("ascii")
+
+
+# --------------------------------------------------------------------------
+# The workflow's bootstrapping guard.
+#
+# The job checks out the *base* branch, not the pull request head, so that a
+# branch forked before this check landed does not die on a missing script
+# (#1791). That has a mirror-image hole which was not theoretical: the base does
+# not carry the script either until this change lands, so the introducing pull
+# request exited 2 with `can't open file`, and the checks UI renders exit 2 and
+# exit 1 as the same red X -- accusing a branch of a deadlock the job never
+# computed. The guard makes that case pass, which is the same rule the script
+# applies to an undetermined pusher and to a failed lookup.
+# --------------------------------------------------------------------------
+
+_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "last-push-approval.yml"
+
+
+def _run_step_body() -> str:
+    """The shell body of the workflow's checking step, as text.
+
+    Read with a line scan rather than a YAML parse because ``pyyaml`` is an
+    optional dependency here, matching tests/test_pull_request_trigger_types.py.
+    """
+    lines = _WORKFLOW.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.strip() == "run: |")
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.strip() and not line.startswith(" " * 10):
+            break
+        body.append(line[10:] if len(line) > 10 else "")
+    return "\n".join(body)
+
+
+def test_the_workflow_runs_the_script_from_a_guarded_path():
+    body = _run_step_body()
+    assert "check_last_push_approval.py" in body
+    assert "if [ ! -f scripts/check_last_push_approval.py ]" in body
+    assert "exit 0" in body
+
+
+def test_the_workflow_passes_when_the_base_lacks_the_script(tmp_path):
+    """Exit 0, not 2, when the checked-out base predates the script.
+
+    Executes the workflow's own shell body in a directory without the script,
+    so the pin is on the shipped text rather than on a paraphrase of it.
+    """
+    import subprocess
+
+    body = _run_step_body()
+    result = subprocess.run(
+        ["sh", "-c", body],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={"BASE_REF": "main", "GITHUB_REPOSITORY": "strands-labs/robots", "PATH": os.environ["PATH"]},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "nothing to report" in result.stdout
+
+
+def test_the_guard_does_not_swallow_a_real_finding(tmp_path):
+    """With the script present, the guard is transparent and the exit status is the script's.
+
+    Otherwise the fix for the bootstrapping case would have turned the whole
+    check into a permanent no-op, which is the failure mode that would be
+    hardest to notice: a green check that never looks at anything.
+    """
+    import shutil
+    import subprocess
+    import textwrap
+
+    (tmp_path / "scripts").mkdir()
+    stub = tmp_path / "scripts" / "check_last_push_approval.py"
+    stub.write_text(
+        textwrap.dedent("""
+        import sys
+        print("stub ran")
+        sys.exit(1)
+    """)
+    )
+    assert shutil.which("sh")
+
+    result = subprocess.run(
+        ["sh", "-c", _run_step_body()],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={"BASE_REF": "main", "GITHUB_REPOSITORY": "strands-labs/robots", "PATH": os.environ["PATH"]},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "stub ran" in result.stdout
+    assert "nothing to report" not in result.stdout

--- a/tests/test_last_push_approval.py
+++ b/tests/test_last_push_approval.py
@@ -215,14 +215,95 @@ def test_the_most_recent_workflow_run_names_the_pusher():
     """
     payload = {
         "workflow_runs": [
-            {"created_at": "2026-08-01T07:50:16Z", "triggering_actor": {"login": "cagataycali"}},
-            {"created_at": "2026-08-02T09:00:00Z", "triggering_actor": {"login": "Vivek0712"}},
+            {
+                "created_at": "2026-08-01T07:50:16Z",
+                "event": "pull_request",
+                "triggering_actor": {"login": "cagataycali"},
+            },
+            {"created_at": "2026-08-02T09:00:00Z", "event": "pull_request", "triggering_actor": {"login": "Vivek0712"}},
         ]
     }
     original = mod._get
     try:
         mod._get = lambda url, token: payload
         assert mod.resolve_pusher("strands-labs/robots", "deadbeef", "t") == "Vivek0712"
+    finally:
+        mod._get = original
+
+
+def test_a_review_triggered_run_does_not_name_the_pusher():
+    """The check's own `pull_request_review` trigger poisons the field it reads.
+
+    Verbatim from #1921, this check's own pull request. Adding the review
+    trigger creates a run on the same head sha attributed to the **reviewer**,
+    newer than every run the push itself produced. Reading the newest run
+    unfiltered named yinsong1986 as the pusher of a commit cagataycali pushed,
+    and reported `pusher-only-approval` while GitHub read the pull request
+    `APPROVED` / `UNSTABLE` -- a false positive that would have fired on every
+    approved pull request in the repository.
+    """
+    payload = {
+        "workflow_runs": [
+            {
+                "created_at": "2026-08-03T22:45:21Z",
+                "event": "pull_request",
+                "triggering_actor": {"login": "cagataycali"},
+                "name": "Last Push Approval Check",
+            },
+            {
+                "created_at": "2026-08-03T22:45:21Z",
+                "event": "pull_request",
+                "triggering_actor": {"login": "cagataycali"},
+                "name": "Pull Request and Push Action",
+            },
+            {
+                "created_at": "2026-08-03T23:11:27Z",
+                "event": "pull_request_review",
+                "triggering_actor": {"login": "yinsong1986"},
+                "name": "Last Push Approval Check",
+            },
+        ]
+    }
+    original = mod._get
+    try:
+        mod._get = lambda url, token: payload
+        pusher = mod.resolve_pusher("strands-labs/robots", "2714eacf", "t")
+    finally:
+        mod._get = original
+
+    assert pusher == "cagataycali"
+    # And therefore the verdict agrees with GitHub rather than contradicting it.
+    assert mod.classify(pusher, [approved("yinsong1986")]).outcome == mod.SATISFIED
+
+
+@pytest.mark.parametrize(
+    "event",
+    ["pull_request_review", "pull_request_review_comment", "issue_comment", "workflow_dispatch", "schedule"],
+)
+def test_only_push_producing_events_attribute_a_pusher(event):
+    """Anything a push did not cause names whoever caused it instead."""
+    original = mod._get
+    try:
+        mod._get = lambda url, token: {
+            "workflow_runs": [
+                {"created_at": "2026-08-03T23:00:00Z", "event": event, "triggering_actor": {"login": "someone-else"}}
+            ]
+        }
+        assert mod.resolve_pusher("strands-labs/robots", "deadbeef", "t") is None
+    finally:
+        mod._get = original
+
+
+def test_a_push_event_run_attributes_the_pusher():
+    """A branch in this repository produces `push` runs rather than `pull_request` ones."""
+    original = mod._get
+    try:
+        mod._get = lambda url, token: {
+            "workflow_runs": [
+                {"created_at": "2026-08-03T23:00:00Z", "event": "push", "triggering_actor": {"login": "cagataycali"}}
+            ]
+        }
+        assert mod.resolve_pusher("strands-labs/robots", "deadbeef", "t") == "cagataycali"
     finally:
         mod._get = original
 
@@ -241,8 +322,12 @@ def test_a_run_without_a_triggering_actor_is_skipped_not_trusted():
     try:
         mod._get = lambda url, token: {
             "workflow_runs": [
-                {"created_at": "2026-08-02T09:00:00Z", "triggering_actor": None},
-                {"created_at": "2026-08-01T09:00:00Z", "triggering_actor": {"login": "cagataycali"}},
+                {"created_at": "2026-08-02T09:00:00Z", "event": "pull_request", "triggering_actor": None},
+                {
+                    "created_at": "2026-08-01T09:00:00Z",
+                    "event": "pull_request",
+                    "triggering_actor": {"login": "cagataycali"},
+                },
             ]
         }
         assert mod.resolve_pusher("strands-labs/robots", "deadbeef", "t") == "cagataycali"


### PR DESCRIPTION
## What

Adds `scripts/check_last_push_approval.py` and `.github/workflows/last-push-approval.yml`, which name a pull request whose only approvals come from the account that pushed its head commit -- the state `require_last_push_approval: true` makes permanently unmergeable.

Closes #1905.

## Why

The `default` BRANCH ruleset carries `requireLastPushApproval: true`, so the most recent push must be approved by someone other than whoever pushed it. When the only approving account is also the pusher, that approval stops counting.

The problem is not the rule. The problem is that the resulting state is **invisible**: it presents as `reviewDecision: REVIEW_REQUIRED` with `mergeStateStatus: BLOCKED`, which is byte for byte what a pull request nobody has reviewed yet looks like. No field a status sweep reads separates them, and they need opposite actions -- one needs the existing reviewer to get to it, the other needs a *different* reviewer and will never merge without one.

That is not hypothetical. It stood in **eight consecutive scheduled scan summaries** as "reviewer bandwidth is the sole constraint" while #1722 and #1035 sat permanently unmergeable, and #1035 has been open since 2026-07-03. AGENTS.md already documents the mechanism at length across two revisions (#1814, #1852) and issue #1905 records it again -- documented in three places, enforced by nothing. That is the same shape the changelog-fragment rule had before #1784, which AGENTS.md itself cites as the reason to enforce rather than only describe.

## How the pusher is read

The pusher appears in none of the fields a reviewer would check, and commit metadata answers wrongly in *both* directions:

| pull request | `triggering_actor` | approved by | `commit.author.login` | `reviewDecision` | outcome |
|---|---|---|---|---|---|
| #1894 | yinsong1986 | cagataycali | yinsong1986 | `APPROVED` | merged |
| #1920 | cagataycali | yinsong1986 | **`None`** | `APPROVED` | merged |
| #1722 | cagataycali | cagataycali | cagataycali | `REVIEW_REQUIRED` | blocked since 08-01 |
| #1035 | cagataycali | cagataycali | cagataycali | `REVIEW_REQUIRED` | blocked since 08-01 |

**#1920 and #1722 are the control pair**: same pusher, differing only in whether the approving account is a different one. #1920 merged; #1722 is stuck. That isolates the variable.

#1920 also sharpens the metadata point beyond what AGENTS.md currently says. Its head was committed under the `strands-robots` git identity, which has no linked GitHub account, so `commit.author.login` is `None` -- there, commit metadata does not merely mislead, it declines to answer, while `triggering_actor` answers correctly. Hence `GET /repos/{owner}/{repo}/actions/runs?head_sha=<head> -> triggering_actor`, which needs only `actions: read`.

## Three outcomes, because they ask for three different things

| outcome | meaning | exit |
|---|---|---|
| `satisfied` | a current approval comes from a non-pusher | 0 |
| `awaiting-first-review` | no current approval at all | 0 |
| `pusher-only-approval` | every current approval is the pusher's | 1 |
| `unknown-pusher` | no run attributes the push | 0 |

`awaiting-first-review` passes **on purpose**. It is the ordinary state of an open pull request and is already visible; making it red would put a red X on every branch in the repository and the finding would stop meaning anything. `unknown-pusher` also passes rather than falling back to commit metadata -- per the table above that fallback would have read #1920 as having no pusher at all.

A "current" approval follows the same rule `reviewDecision` uses: per author, their most recent review that expresses a position. `COMMENTED` expresses none and is skipped, which matters because every pull request in the table carries interleaved `COMMENTED` reviews from `github-advanced-security` -- if those counted as a position, #1894's approval would read as withdrawn and the check would pass a genuinely blocked branch.

## Verification

Run live against all six pull requests above. No false positive:

```
PR #1722  exit=1  pusher-only-approval
PR #1035  exit=1  pusher-only-approval
PR #1920  exit=0  satisfied
PR #1894  exit=0  satisfied
PR #1899  exit=0  awaiting-first-review
PR #1901  exit=0  awaiting-first-review
```

`tests/test_last_push_approval.py` -- 32 tests -- pins those four rows as fixtures rather than invented ones, plus the control-pair isolation, `COMMENTED` non-retraction, `DISMISSED`/`CHANGES_REQUESTED` superseding, same-timestamp ordering (the API's `submitted_at` resolves only to the second, and #1899 carries two reviews inside one second), lookup-failure-is-not-a-finding, exit-status mapping, and the bootstrapping guard below.

Repo-wide gates re-run green with the new workflow present: `test_pull_request_trigger_types.py`, `test_changelog_fragment_gate.py`, `test_merge_base_overlap.py`, `test_merge_gate_viewer_scope.py`. `ruff check`, `ruff format --check`, `mypy` clean. Standard library only.

## Scope

Reports; does not gate. Deliberately **not** in the required set. Unlike `merge-base-overlap.yml`, whose remedy is self-clearing (merging the base advances the merge base), this one's remedy is a second human -- no work the author does turns it green. A gate a branch cannot clear by doing anything is a report, so it is wired as one.

It runs on `pull_request_review` as well as `pull_request` because the condition is only decidable once an approval exists, and approvals do not arrive with a push; a `pull_request`-only trigger would evaluate every branch at the one moment it is guaranteed to have no approval and always pass. The concurrency group includes `github.event_name` so a review run and a push run cannot cancel each other -- both read live API state, and a stale read of exactly this state is the failure mode the check exists to prevent.

Per #1791 the script is run from the **base** branch, not the head: a branch that forked before this lands does not carry it, and running from the head tree would exit 2 before computing anything, rendering as the same red X as a real finding. Sound because the script reads nothing from the working tree.

## Not done here

This does not unblock #1722 or #1035. Both still need an approver who is not `cagataycali`, and #1905 is explicit that admin bypass is the wrong tool -- the rule exists to stop one account both writing and approving a change. This PR makes the state legible so it stops being misfiled as bandwidth; clearing it is still a human review.

## §13 changelog

- **round 0** -- initial: checker, workflow, 22 pinned tests, AGENTS.md pointer recording the enforcement.
- **round 1** (`07c8155`) -- **the check failed on its own pull request, and the fix is in scope.** Reading the base branch is what stops a branch forked before the gate from dying on a missing script (#1791); the mirror-image hole is that the base does not carry the script either until this lands, so the job exited 2 with `can't open file`. Exit 2 and exit 1 render as the same red X, so it accused its own branch of a deadlock it never computed -- the exact failure mode the file's header comment claims to avoid. Guarded to report nothing when the script is absent, which is the rule the script already applies to an undetermined pusher and to a failed lookup: a check that cannot compute an answer says so. No-op exactly once, here, and correct after. Confirmed on the run: `check_last_push_approval: not present on main, so there is nothing to report.`

  Two tests execute the workflow's **own shell body** rather than a paraphrase of it -- one that a missing script exits 0 and says why, one that a present script's exit status passes through unchanged. The second is the load-bearing one: the tempting version of this fix turns the check into a permanent green no-op that never looks at anything, which would be the hardest failure here to notice.
- **round 2** (`2714eac`) -- `mypy` is part of `hatch run lint` and rejected the two review-building helpers: `Variable "tests.test_last_push_approval.Review" is not valid as a type`. `Review` is bound from the importlib-loaded script, so at runtime it is a module attribute and not a name mypy can resolve to a type; annotated `Any` with a note saying why. This loosens nothing that was ever checked -- the script itself is fully typed and `mypy scripts/check_last_push_approval.py` is clean. The miss was running mypy on the script alone and not on the test module beside it; re-verified against the invocation CI uses rather than a paraphrase of it.

- **round 3** (`ce3d34e`) -- **the check was wrong on its own pull request, and I found it by running the check on it.** It reported `pusher-only-approval` for #1921 while GitHub read `APPROVED` / `UNSTABLE`. The cause is self-inflicted: its own `pull_request_review` trigger *pollutes the field it reads*. A run started by a review is attributed to the reviewer, and it is newer than every run the push produced:

  ```
  22:45:21  pull_request         cagataycali   (six runs)
  23:11:27  pull_request_review  yinsong1986   Last Push Approval Check
  ```

  `resolve_pusher` took the newest run, naming the approver as the pusher of a commit that account never pushed. Since the approver is then the pusher by construction, the finding would have fired on **every** approved pull request in the repository -- the exact opposite of the check's purpose. The round-0 six-PR verification passed only because no head sha carried a review-triggered run until this workflow existed to create one.

  Fixed by attributing a pusher only from events a push produces (`push`, `pull_request`); anything else names whoever caused that event. #1921 now reads `satisfied`; the other six are unchanged. Pinned with the run list above verbatim, a parametrised test that five non-push events attribute nobody, and one that `push` still does. The hazard is recorded at the trigger list too, since that is where a future edit would reintroduce it.

  This push dismissed the standing approval (`dismiss_stale_reviews_on_push`), which is the right trade: shipping a check that fires on every approved pull request would have been considerably worse than one re-approval round. Re-verified live across all seven pull requests, 32 tests, `ruff`/`mypy` clean.
