### PR TITLE
fix(training/rl): the action head is sized and named from the action keys (closes #1912)

### DIFF
--- a/changelog.d/1912-rl-action-head-binds-action-keys.md
+++ b/changelog.d/1912-rl-action-head-binds-action-keys.md
@@ -1,0 +1,33 @@
+### Fixed: the RL action head is sized and named from the robot's action keys
+
+`SimEnv` sized `num_actions` from `robot_joint_names`, but `SimEnv.step` sends a
+numeric **vector** and `SimEngine.send_action` binds a vector positionally to
+`robot_action_keys`. Both docstrings already drew that line -
+`robot_joint_names` names the `observation.state` vector and says
+"Action-vector binding ... uses `robot_action_keys` instead", and
+`robot_action_keys` warns "a caller must not assume it has the same width" -
+but the env read the joint list.
+
+The two lists coincide only when a robot's actuator set matches its joint set,
+and two shipped shapes make them disagree: a tendon-driven gripper (one
+actuator over two mimic finger joints, so the builtin MuJoCo `panda` has nine
+joints and eight action keys) and a Newton floating base (a 6-DoF free joint
+that is a joint with no commandable scalar). On both, the head was one output
+too wide, so every `send_action` was refused with a structured width error -
+and `step` does not read that result. Measured on `panda`, 60 `env.step` calls
+wrote no target, left `joint1` at exactly `0.000000`, and still banked 60.0
+reward; a rollout of any length could be collected for a robot that never
+moved. Sized from the action keys the same 60 steps drive `joint1` to 0.900.
+`action_dim` is unchanged as the explicit override, and a robot whose actuators
+match its joints is unaffected.
+
+`PpoTrainer` and `FastSacTrainer` wrote the same list into `policy_meta.json`
+as `joint_names`, beside `num_actions`. That field names what those outputs
+drive, which a joint list cannot do once the widths differ, so it is now
+`action_keys` and `len(action_keys) == num_actions` holds. `GymSimEnv`'s
+`action_space` and `VecSimEnv`'s width both derive from `SimEnv.num_actions`
+and inherit the fix.
+
+`robot_joint_names` itself is unchanged: it remains the joint list and still
+names policy state keys. Whether it should narrow on the Newton backend is a
+separate question about observation naming, tracked in #1912.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -93,7 +93,15 @@ print(result.metrics)              # mean_reward, mean_episode_return, surrogate
 - `policy.pt` - the actor-critic + observation-normalizer state (the loadable
   artifact returned by `result.exported_model`).
 - `policy_meta.json` - deployable-policy metadata: `num_actions`,
-  `actor_obs_keys`, `joint_names`, `hidden_dims`.
+  `actor_obs_keys`, `action_keys`, `hidden_dims`.
+
+`action_keys` names what the `num_actions` outputs drive, in order, and is the
+robot's `robot_action_keys` - the vocabulary `send_action` binds an action
+vector against. It is not the joint list: a tendon-driven gripper is one
+actuator over two finger joints (so a Panda has 9 joints and 8 action keys), and
+the Newton backend's floating base is a joint with no commandable scalar. `SimEnv`
+sizes `num_actions` from the same list, so `len(action_keys) == num_actions`
+always holds. Pass `action_dim` to `SimEnv` to override the width.
 
 `PpoTrainer` trains fine on CPU (its `hardware_floor` declares no GPU
 requirement); MuJoCo stepping dominates, not the network.

--- a/strands_robots/training/rl/env.py
+++ b/strands_robots/training/rl/env.py
@@ -13,6 +13,14 @@ additionally see privileged simulation-only keys via ``critic_obs_keys``
 (asymmetric actor-critic). Each key is a scalar entry of
 ``SimEngine.get_observation`` (e.g. a joint position ``"Elbow"`` or velocity
 ``"Elbow.vel"``); the vector is the keys concatenated in the given order.
+
+The action contract is the other half: ``step`` sends a numeric vector, which
+``SimEngine.send_action`` binds positionally to
+``robot_action_keys(robot_name)``. Those are the robot's *actuators*, which are
+not always its joints - a tendon-driven gripper is one actuator over two finger
+joints, and the Newton backend's floating base is a joint with no commandable
+scalar - so the action head is sized from the action keys and a checkpoint
+records them as ``action_keys``. Pass ``action_dim`` to override the width.
 """
 
 from __future__ import annotations
@@ -39,7 +47,9 @@ class SimEnv:
             float``); the step reward is their sum. Build them with the
             predicate DSL (e.g. ``_joint_progress``, ``_distance_neg``).
         action_dim: Size of the action vector sent to ``engine.send_action``.
-            Defaults to the number of joints of ``robot_name``.
+            Defaults to ``len(engine.robot_action_keys(robot_name))`` - the
+            actuator count ``send_action`` binds a vector against, which is not
+            always the robot's joint count.
         robot_name: Robot to observe / drive. Defaults to the engine's first
             registered robot.
         critic_obs_keys: Optional privileged keys appended to the critic
@@ -99,7 +109,15 @@ class SimEnv:
         if action_dim is not None:
             self.num_actions = int(action_dim)
         elif self.robot_name is not None:
-            self.num_actions = len(engine.robot_joint_names(self.robot_name))
+            # ``robot_action_keys``, not ``robot_joint_names``: ``step`` sends a
+            # numeric vector, and ``send_action`` binds a vector positionally to
+            # the action keys. The two lists coincide only when a robot's
+            # actuator set matches its joint set; a tendon gripper (one actuator
+            # driving two finger joints) or a Newton floating base (a 6-DoF free
+            # joint with no scalar target) makes the joint list wider, and a
+            # vector of that width is refused - so every step wrote no target
+            # while the reward was still collected.
+            self.num_actions = len(engine.robot_action_keys(self.robot_name))
         else:
             raise ValueError("action_dim must be given when the engine has no registered robot")
 

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -427,7 +427,12 @@ class FastSacTrainer(BaseRLAlgo):
             "num_critic_obs": self.env.num_critic_obs,
             "num_actions": self.env.num_actions,
             "actor_obs_keys": self.env.actor_obs_keys,
-            "joint_names": (self.env.engine.robot_joint_names(self.env.robot_name) if self.env.robot_name else []),
+            # ``action_keys``, not a joint list: the field names what the
+            # ``num_actions`` outputs above it drive, so it must be the same
+            # vocabulary ``send_action`` binds a vector against. A tendon
+            # gripper's actuator has no matching joint name at all, and a
+            # Newton floating base is a joint with no commandable scalar.
+            "action_keys": (self.env.engine.robot_action_keys(self.env.robot_name) if self.env.robot_name else []),
             "hidden_dims": list(self.spec.hidden_dims),
             "iteration": iteration,
         }

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -475,7 +475,12 @@ class PpoTrainer(BaseRLAlgo):
             "num_critic_obs": self.env.num_critic_obs,
             "num_actions": self.env.num_actions,
             "actor_obs_keys": self.env.actor_obs_keys,
-            "joint_names": (self.env.engine.robot_joint_names(self.env.robot_name) if self.env.robot_name else []),
+            # ``action_keys``, not a joint list: the field names what the
+            # ``num_actions`` outputs above it drive, so it must be the same
+            # vocabulary ``send_action`` binds a vector against. A tendon
+            # gripper's actuator has no matching joint name at all, and a
+            # Newton floating base is a joint with no commandable scalar.
+            "action_keys": (self.env.engine.robot_action_keys(self.env.robot_name) if self.env.robot_name else []),
             "hidden_dims": list(self.spec.hidden_dims),
             "iteration": iteration,
         }

--- a/tests/simulation/newton/test_free_base_is_not_an_actuator.py
+++ b/tests/simulation/newton/test_free_base_is_not_an_actuator.py
@@ -72,11 +72,16 @@ class TestTheFreeBaseIsNotAnActionKey:
         """The state-side vocabulary is deliberately out of scope here.
 
         ``robot_joint_names`` has the same disagreement on the state side - it
-        advertises a joint ``get_observation`` never emits - but it also sizes
-        ``training/rl/env.py``'s ``num_actions`` and names policy state keys, so
-        narrowing it is a wider change than "the free joint is not an actuator"
-        and is tracked separately. Asserted rather than left implicit so the two
-        halves cannot be conflated by a later reader.
+        advertises a joint ``get_observation`` never emits - and it still names
+        policy state keys, so narrowing it is a wider change than "the free
+        joint is not an actuator" and is tracked separately. Asserted rather
+        than left implicit so the two halves cannot be conflated by a later
+        reader.
+
+        The action-sizing consumer this docstring used to name is gone:
+        ``training/rl``'s action head and checkpoint metadata read
+        ``robot_action_keys``, so this list no longer sizes an action vector -
+        see ``tests/training/test_rl_action_head_binds_action_keys.py``.
         """
         assert _engine(free_base=True).robot_joint_names("g1") == [_BASE_JOINT] + _SCALAR_JOINTS
 

--- a/tests/training/test_rl_action_head_binds_action_keys.py
+++ b/tests/training/test_rl_action_head_binds_action_keys.py
@@ -1,0 +1,400 @@
+"""The RL action head is sized and named from the robot's action keys.
+
+``SimEnv.step`` sends a numeric **vector**, and ``SimEngine.send_action`` binds a
+vector positionally to ``robot_action_keys(robot_name)`` - not to
+``robot_joint_names``. The base class says so in both directions:
+``robot_joint_names`` is documented as naming the ``observation.state`` vector
+with "Action-vector binding ... uses :meth:`robot_action_keys` instead", and
+``robot_action_keys`` warns that "a caller must not assume it has the same width
+as :meth:`robot_joint_names`".
+
+The two lists coincide only when a robot's actuator set matches its joint set.
+Two shipped shapes make them disagree:
+
+* a **tendon-driven gripper** - one actuator over two mimic finger joints, so the
+  actuator names are not joint names at all. The builtin MuJoCo ``panda`` has
+  nine joints and eight action keys.
+* a **floating base** on the Newton backend - a 6-DoF free joint that is a joint
+  with no commandable scalar, so the action keys are the joint names minus one.
+
+Sizing the head from the joint list on either shape produced a vector one wider
+than ``send_action`` binds, which every backend refuses with a structured error.
+``SimEnv.step`` does not read that result, so the refusal was invisible: no
+target was written, the world never advanced, and the reward term was still
+evaluated and banked. A rollout of any length could be collected for a robot
+that never moved.
+
+The checkpoint metadata is the same contract on the deployment side. It carries
+``num_actions`` and, beside it, the names those outputs drive; a list of joint
+names cannot serve that purpose when the widths differ, so it names the action
+keys and ``len(action_keys) == num_actions`` holds.
+
+The unit-level engine here is a purpose-built double rather than a backend, so
+these pins run on every CI job. The behavioural half uses the real MuJoCo
+``panda`` and the narrowing half the real ``NewtonSimEngine``, built solver-free
+via ``__new__`` the way ``tests/simulation/newton/test_free_base_is_not_an_actuator.py``
+does.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+
+import strands_robots.training.rl as rl_pkg
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.models import SimRobot, SimWorld
+from strands_robots.training.rl.env import SimEnv
+
+_ARM_JOINTS = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint7"]
+_FINGER_JOINTS = ["finger_joint1", "finger_joint2"]
+_ARM_ACTUATORS = [f"actuator{i}" for i in range(1, 8)]
+_GRASP_TENDON = "actuator8"
+
+
+class _TwoVocabEngine(SimEngine):
+    """A concrete engine whose action keys are not its joint names.
+
+    Models the tendon-gripper shape: two mimic finger joints driven by one
+    tendon actuator, so the actuator vocabulary is both differently spelled and
+    one narrower than the joint list. ``send_action`` reproduces the width rule
+    every backend publishes - a vector must match the action-key count - so a
+    mis-sized head is refused here exactly as it is on a real backend, without
+    needing one.
+    """
+
+    def __init__(self, *, joints: list[str], action_keys: list[str]) -> None:
+        self._joints = list(joints)
+        self._action_keys = list(action_keys)
+        self.applied: list[list[float]] = []
+        self.refused: list[int] = []
+
+    # The action vocabulary under test.
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._joints)
+
+    def robot_action_keys(self, robot_name: str) -> list[str]:
+        return list(self._action_keys)
+
+    def list_robots(self) -> list[str]:
+        return ["arm"]
+
+    def get_observation(self, robot_name: str | None = None, skip_images: bool = False) -> dict[str, Any]:
+        return {j: 0.0 for j in self._joints} | {f"{j}.vel": 0.0 for j in self._joints}
+
+    def send_action(
+        self, action: Any, robot_name: str | None = None, n_substeps: int = 1, **kwargs: Any
+    ) -> dict[str, Any]:
+        width = len(action)
+        if width != len(self._action_keys):
+            self.refused.append(width)
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"send_action: action vector length {width} does not match robot "
+                            f"'arm' action-key count {len(self._action_keys)}."
+                        )
+                    }
+                ],
+            }
+        self.applied.append([float(v) for v in action])
+        return {"status": "success", "content": [{"text": f"Action applied to 'arm' ({width} keys)."}]}
+
+    # Inert scaffolding: present only so the class is concrete. Permissive
+    # signatures keep them Liskov-safe without restating each contract.
+    def add_object(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def add_robot(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def create_world(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def destroy(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def get_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def remove_object(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def remove_robot(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def render(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def reset(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def step(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+
+def _env(engine: SimEngine, **kwargs: Any) -> SimEnv:
+    return SimEnv(engine, actor_obs_keys=["joint1"], reward_terms=[lambda _e: 1.0], robot_name="arm", **kwargs)
+
+
+class TestTheHeadIsSizedFromTheActionKeys:
+    """``num_actions`` is the count ``send_action`` binds a vector against."""
+
+    def test_the_default_width_is_the_action_key_count(self) -> None:
+        engine = _TwoVocabEngine(joints=_ARM_JOINTS + _FINGER_JOINTS, action_keys=_ARM_ACTUATORS + [_GRASP_TENDON])
+        # Premise: the two vocabularies really do disagree, so a width taken
+        # from the wrong one is observable rather than accidentally correct.
+        assert len(engine.robot_joint_names("arm")) == 9
+        assert len(engine.robot_action_keys("arm")) == 8
+        assert _env(engine).num_actions == 8
+
+    def test_the_default_width_is_accepted_by_send_action(self) -> None:
+        engine = _TwoVocabEngine(joints=_ARM_JOINTS + _FINGER_JOINTS, action_keys=_ARM_ACTUATORS + [_GRASP_TENDON])
+        env = _env(engine)
+        env.step(torch.zeros(1, env.num_actions))
+        assert engine.refused == []
+        assert len(engine.applied) == 1
+
+    def test_a_narrower_action_list_is_honored(self) -> None:
+        """The floating-base shape: same spelling, one fewer key."""
+        engine = _TwoVocabEngine(joints=["free_base"] + _ARM_JOINTS, action_keys=list(_ARM_JOINTS))
+        env = _env(engine)
+        assert env.num_actions == len(_ARM_JOINTS)
+        env.step(torch.zeros(1, env.num_actions))
+        assert engine.refused == []
+
+    def test_an_explicit_action_dim_still_wins(self) -> None:
+        """The override is the escape hatch for a robot the default mis-sizes."""
+        engine = _TwoVocabEngine(joints=_ARM_JOINTS + _FINGER_JOINTS, action_keys=_ARM_ACTUATORS + [_GRASP_TENDON])
+        assert _env(engine, action_dim=3).num_actions == 3
+
+    def test_a_robot_whose_actuators_match_its_joints_is_unchanged(self) -> None:
+        """The overwhelmingly common shape: the two lists already agreed."""
+        engine = _TwoVocabEngine(joints=list(_ARM_JOINTS), action_keys=list(_ARM_JOINTS))
+        assert _env(engine).num_actions == len(_ARM_JOINTS)
+
+    def test_no_robot_and_no_action_dim_is_still_refused(self) -> None:
+        engine = _TwoVocabEngine(joints=[], action_keys=[])
+        engine.list_robots = lambda: []  # type: ignore[method-assign]
+        with pytest.raises(ValueError, match="action_dim must be given"):
+            SimEnv(engine, actor_obs_keys=["joint1"], reward_terms=[lambda _e: 1.0])
+
+
+class TestARefusedActionWritesNoTarget:
+    """Why the mis-sized head was silent: ``step`` does not read the result."""
+
+    def test_a_mis_sized_head_banks_reward_without_applying_anything(self) -> None:
+        engine = _TwoVocabEngine(joints=_ARM_JOINTS + _FINGER_JOINTS, action_keys=_ARM_ACTUATORS + [_GRASP_TENDON])
+        env = _env(engine, action_dim=9)  # the width the joint list would have given
+        total = 0.0
+        for _ in range(20):
+            _obs, reward, done, _info = env.step(torch.zeros(1, 9))
+            total += float(reward.item())
+            assert not bool(done.item())
+        # Every action was refused, yet a full rollout of reward was collected.
+        assert engine.applied == []
+        assert engine.refused == [9] * 20
+        assert total == 20.0
+
+
+class TestAFloatingBaseRobotOnTheNewtonBackend:
+    """The real ``NewtonSimEngine``, solver-free, excludes the free root."""
+
+    @staticmethod
+    def _engine() -> Any:
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        base, scalars = "floating_base_joint", ["hip_yaw", "hip_pitch", "knee", "ankle"]
+        world = SimWorld()
+        world.robots["g1"] = SimRobot(name="g1", urdf_path="g1.xml", data_config="g1", joint_names=[base] + scalars)
+        engine = NewtonSimEngine.__new__(NewtonSimEngine)
+        engine._world = world
+        engine._model = object()  # non-None sentinel: "world created"
+        engine.default_width, engine.default_height = 64, 48
+        engine._robot_free_base_joint = {"g1": base}
+        engine._lock = threading.RLock()
+        engine._targets = {}
+        engine._write_targets = lambda: None  # type: ignore[method-assign]
+        engine._advance = lambda n_steps: None  # type: ignore[method-assign]
+
+        def _observe(robot_name: str | None = None, skip_images: bool = False) -> dict[str, Any]:
+            # The scalar observation the backend really emits: the free joint is
+            # absent from it, which is the disagreement under test.
+            return {j: 0.0 for j in scalars}
+
+        engine.get_observation = _observe  # type: ignore[method-assign]
+        return engine, scalars
+
+    def test_the_head_excludes_the_free_joint(self) -> None:
+        engine, scalars = self._engine()
+        assert len(engine.robot_joint_names("g1")) == len(scalars) + 1
+        env = SimEnv(engine, actor_obs_keys=scalars[:1], reward_terms=[lambda _e: 1.0], robot_name="g1")
+        assert env.num_actions == len(scalars)
+
+    def test_a_default_sized_action_is_applied(self) -> None:
+        engine, scalars = self._engine()
+        env = SimEnv(engine, actor_obs_keys=scalars[:1], reward_terms=[lambda _e: 1.0], robot_name="g1", n_substeps=1)
+        env.step(torch.zeros(1, env.num_actions))
+        assert set(k[1] for k in engine._targets) == set(scalars)
+
+
+class TestATendonGripperArmIsDriven:
+    """End to end on the default backend with a builtin registry robot."""
+
+    @pytest.fixture
+    def panda(self):  # type: ignore[no-untyped-def]
+        mujoco = pytest.importorskip("mujoco")
+        assert mujoco is not None
+        from strands_robots import Simulation
+
+        sim = Simulation(backend="mujoco", tool_name="rl_action_head_sim", mesh=False)
+        sim.create_world()
+        assert sim.add_robot(name="panda", data_config="panda")["status"] == "success"
+        yield sim
+        sim.cleanup()
+
+    def test_the_two_vocabularies_disagree_on_this_robot(self, panda) -> None:  # type: ignore[no-untyped-def]
+        """Premise for the two tests below, on the shipped asset itself."""
+        assert len(panda.robot_joint_names("panda")) == 9
+        assert len(panda.robot_action_keys("panda")) == 8
+
+    def test_a_default_sized_head_drives_the_arm(self, panda) -> None:  # type: ignore[no-untyped-def]
+        obs = panda.get_observation(robot_name="panda", skip_images=True)
+        env = SimEnv(
+            panda,
+            actor_obs_keys=["joint1"],
+            reward_terms=[lambda _e: 1.0],
+            robot_name="panda",
+            n_substeps=10,
+            max_episode_steps=500,
+        )
+        assert env.num_actions == 8
+        start = float(obs["joint1"])
+        action = torch.zeros(1, env.num_actions)
+        action[0, 0] = 0.9
+        for _ in range(60):
+            env.step(action)
+        end = float(panda.get_observation(robot_name="panda", skip_images=True)["joint1"])
+        # Sized from the joint list this vector is refused and joint1 never
+        # leaves 0.0 however many steps are taken.
+        assert abs(end - start) > 0.5
+
+    def test_the_joint_list_width_moves_nothing(self, panda) -> None:  # type: ignore[no-untyped-def]
+        """The consequence, on the real backend, of the width this used to take.
+
+        Holds on either side of the fix - it characterises ``send_action``'s
+        width rule and ``step``'s silence rather than the sizing - and is the
+        reproduction the sizing test above is the fix for.
+        """
+        wide = len(panda.robot_joint_names("panda"))
+        env = SimEnv(
+            panda,
+            actor_obs_keys=["joint1"],
+            reward_terms=[lambda _e: 1.0],
+            robot_name="panda",
+            action_dim=wide,
+            n_substeps=10,
+            max_episode_steps=500,
+        )
+        start = float(panda.get_observation(robot_name="panda", skip_images=True)["joint1"])
+        action = torch.zeros(1, wide)
+        action[0, 0] = 0.9
+        banked = 0.0
+        for _ in range(60):
+            _obs, reward, done, _info = env.step(action)
+            banked += float(reward.item())
+            assert not bool(done.item())
+        end = float(panda.get_observation(robot_name="panda", skip_images=True)["joint1"])
+        # Sixty steps, every one refused, and the reward collected regardless.
+        assert end == start
+        assert banked == 60.0
+        assert panda.send_action([0.0] * wide, robot_name="panda", n_substeps=1)["status"] == "error"
+
+    def test_send_action_accepts_the_default_width(self, panda) -> None:  # type: ignore[no-untyped-def]
+        env = SimEnv(panda, actor_obs_keys=["joint1"], reward_terms=[lambda _e: 1.0], robot_name="panda")
+        result = panda.send_action([0.0] * env.num_actions, robot_name="panda", n_substeps=1)
+        assert result["status"] == "success"
+
+
+def _training_modules() -> list[Path]:
+    """Every module of the training package, rooted at an imported symbol."""
+    root = Path(inspect.getfile(rl_pkg)).resolve().parent.parent
+    return sorted(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _joint_name_reads(source: str) -> list[str]:
+    """Names of functions calling ``robot_joint_names``, at any receiver."""
+    found = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for call in ast.walk(node):
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute):
+                if call.func.attr == "robot_joint_names":
+                    found.append(node.name)
+    return found
+
+
+class TestNoTrainingModuleReadsTheJointList:
+    """A joint list cannot size or name an action, so nothing here reads one.
+
+    Stated structurally rather than left to review: the package's every use of
+    a robot's joint vocabulary was an action-shaped one, so the honest rule is
+    that it reads the action vocabulary instead. A module that genuinely needs
+    the joint list - to name an observation, say - will fail this and should
+    say why in the same change rather than reintroducing the read silently.
+    """
+
+    def test_no_training_module_reads_the_joint_list(self) -> None:
+        offenders = {
+            path.name: names
+            for path in _training_modules()
+            if (names := _joint_name_reads(path.read_text(encoding="utf-8")))
+        }
+        assert offenders == {}, (
+            f"these training functions read robot_joint_names: {offenders}; an action vector binds to robot_action_keys"
+        )
+
+    def test_the_scanner_detects_a_planted_read(self) -> None:
+        planted = "def f(self):\n    return len(self.engine.robot_joint_names('r'))\n"
+        assert _joint_name_reads(planted) == ["f"]
+
+    def test_the_scan_root_is_the_training_package(self) -> None:
+        names = {p.name for p in _training_modules()}
+        assert {"env.py", "ppo.py", "fast_sac.py", "vec_env.py", "gym_env.py"} <= names
+
+
+def _metadata_action_key_reads(source: str) -> set[str]:
+    """Functions building a metadata dict with an ``action_keys`` entry."""
+    found = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Dict):
+                continue
+            keys = {k.value for k in sub.keys if isinstance(k, ast.Constant)}
+            if {"num_actions", "action_keys"} <= keys:
+                found.add(node.name)
+    return found
+
+
+class TestTheCheckpointNamesWhatTheHeadDrives:
+    """Both trainers write the action vocabulary beside ``num_actions``."""
+
+    @pytest.mark.parametrize("module", ["ppo.py", "fast_sac.py"])
+    def test_the_metadata_carries_action_keys(self, module: str) -> None:
+        path = next(p for p in _training_modules() if p.name == module)
+        assert _metadata_action_key_reads(path.read_text(encoding="utf-8"))
+
+    def test_the_metadata_scanner_detects_a_missing_entry(self) -> None:
+        planted = 'def save(self):\n    return {"num_actions": 1, "joint_names": []}\n'
+        assert _metadata_action_key_reads(planted) == set()

--- a/tests/training/test_rl_evaluate.py
+++ b/tests/training/test_rl_evaluate.py
@@ -32,6 +32,13 @@ class _FakeEngine:
     def robot_joint_names(self, robot_name: str) -> list[str]:
         return ["J"]
 
+    def robot_action_keys(self, robot_name: str) -> list[str]:
+        # These fakes are duck-typed rather than ``SimEngine`` subclasses, so
+        # they do not inherit the default that mirrors the joint names. This
+        # robot's one joint is its one actuator, so the two vocabularies agree -
+        # which is the shape ``SimEnv`` sizes its action head from.
+        return ["J"]
+
     def reset(self) -> dict:
         self._j = 0.0
         self._vel = 0.0

--- a/tests/training/test_rl_fast_sac.py
+++ b/tests/training/test_rl_fast_sac.py
@@ -215,7 +215,11 @@ def test_fast_sac_smoke_train_produces_loadable_checkpoint(tmp_path) -> None:  #
     assert meta["provider"] == "fast_sac"
     assert meta["num_actions"] == 6
     assert meta["actor_obs_keys"] == ["Elbow", "Elbow.vel"]
-    assert meta["joint_names"]  # non-empty
+    # The field names what the ``num_actions`` outputs drive, so its width is
+    # part of the contract - a length that disagreed would mis-bind a
+    # deployment's outputs onto the robot.
+    assert meta["action_keys"]  # non-empty
+    assert len(meta["action_keys"]) == meta["num_actions"]
 
     assert trainer.latest_checkpoint(str(tmp_path)) == result.checkpoint_dir
 

--- a/tests/training/test_rl_ppo.py
+++ b/tests/training/test_rl_ppo.py
@@ -221,7 +221,11 @@ def test_ppo_smoke_train_produces_loadable_checkpoint(tmp_path) -> None:  # type
         meta = json.load(f)
     assert meta["num_actions"] == 6
     assert meta["actor_obs_keys"] == ["Elbow", "Elbow.vel"]
-    assert meta["joint_names"]  # non-empty
+    # The field names what the ``num_actions`` outputs drive, so its width is
+    # part of the contract - a length that disagreed would mis-bind a
+    # deployment's outputs onto the robot.
+    assert meta["action_keys"]  # non-empty
+    assert len(meta["action_keys"]) == meta["num_actions"]
 
     # latest_checkpoint discovers the saved artifact.
     assert trainer.latest_checkpoint(str(tmp_path)) == result.checkpoint_dir

--- a/tests/training/test_rl_ppo_vectorized.py
+++ b/tests/training/test_rl_ppo_vectorized.py
@@ -25,6 +25,13 @@ class _FakeEngine:
     def robot_joint_names(self, robot_name: str) -> list[str]:
         return ["J"]
 
+    def robot_action_keys(self, robot_name: str) -> list[str]:
+        # These fakes are duck-typed rather than ``SimEngine`` subclasses, so
+        # they do not inherit the default that mirrors the joint names. This
+        # robot's one joint is its one actuator, so the two vocabularies agree -
+        # which is the shape ``SimEnv`` sizes its action head from.
+        return ["J"]
+
     def reset(self) -> dict:
         self._j = 0.0
         self._v = 0.0

--- a/tests/training/test_rl_sim_env.py
+++ b/tests/training/test_rl_sim_env.py
@@ -30,6 +30,13 @@ class _OneJointEngine:
     def robot_joint_names(self, robot_name: str) -> list[str]:
         return ["J"]
 
+    def robot_action_keys(self, robot_name: str) -> list[str]:
+        # These fakes are duck-typed rather than ``SimEngine`` subclasses, so
+        # they do not inherit the default that mirrors the joint names. This
+        # robot's one joint is its one actuator, so the two vocabularies agree -
+        # which is the shape ``SimEnv`` sizes its action head from.
+        return ["J"]
+
     def reset(self) -> dict:
         return {"status": "success"}
 
@@ -51,8 +58,9 @@ def _engine(obj: object) -> SimEngine:
     """Present a duck-typed fake as a ``SimEngine`` for the ``SimEnv`` constructor.
 
     ``SimEngine`` is a nominal ABC, but ``SimEnv`` only touches the handful of
-    methods the fakes implement (list_robots / robot_joint_names / reset /
-    get_observation / send_action), so the cast is safe for these unit tests.
+    methods the fakes implement (list_robots / robot_joint_names /
+    robot_action_keys / reset / get_observation / send_action), so the cast is
+    safe for these unit tests.
     """
     return cast(SimEngine, obj)
 
@@ -78,8 +86,9 @@ def test_rejects_nonpositive_n_substeps() -> None:
         )
 
 
-def test_infers_action_dim_from_robot_joints() -> None:
-    # No action_dim given -> derived from the robot's joint count (one joint -> 1).
+def test_infers_action_dim_from_robot_action_keys() -> None:
+    # No action_dim given -> derived from the robot's action-key count, which
+    # send_action binds a vector against (one actuator -> 1).
     env = SimEnv(_engine(_OneJointEngine()), actor_obs_keys=["J"], reward_terms=[lambda e: 1.0])
     assert env.num_actions == 1
 


### PR DESCRIPTION
`SimEnv` sized `num_actions` from `robot_joint_names`, but `SimEnv.step` sends a numeric **vector** and `SimEngine.send_action` binds a vector positionally to `robot_action_keys`. Both base-class docstrings already drew that line:

> `robot_joint_names`: "Used by `Policy.set_robot_state_keys` to name the `observation.state` vector. **Action-vector binding (`send_action` with a numeric vector, `PolicyRunner.replay`) uses `robot_action_keys` instead**"

> `robot_action_keys`: "An override may therefore rename or narrow this list, and **a caller must not assume it has the same width** as `robot_joint_names`."

`docs/simulation/overview.md` says the same thing operationally - "keying a policy by `robot_joint_names` would emit keys that resolve to nothing and leave those DOFs unmoved". The env read the joint list anyway.

## What that costs

The two lists coincide only when a robot's actuator set matches its joint set. Two shipped shapes make them disagree, and one of them is a builtin registry robot on the default backend:

| robot | joints | action keys | why they differ |
| --- | --- | --- | --- |
| MuJoCo `panda` | 9 | 8 | one tendon actuator drives both mimic finger joints |
| Newton floating base | N+1 | N | the 6-DoF free joint has no scalar target to write |

On either, the head emitted one value too many, so every `send_action` was refused with a structured width error - and `step` does not read that result. Measured on `panda`, 60 `env.step` calls:

```
num_actions 9 (joint list)   -> send_action error, no target written,
                                joint1 0.000000, joint2 0.000000, reward banked 60.0
num_actions 8 (action keys)  -> success, 8 keys applied,
                                joint1 0.899585, joint2 -0.605407, reward banked 60.0
```

The reward is identical, which is why nothing reported it: a rollout of any length could be collected for a robot that never moved. `SimEnv` default `num_actions` on `panda` goes 9 -> 8 with this change.

## The change

- `SimEnv` sizes `num_actions` from `robot_action_keys`. This is the only sizing site: `GymSimEnv.action_space` and `VecSimEnv`'s width both derive from `SimEnv.num_actions` and inherit it.
- `PpoTrainer` and `FastSacTrainer` wrote that same list into `policy_meta.json` as `joint_names`, beside `num_actions`. The field names what those outputs drive, which a joint list cannot do once the widths differ, so it is renamed in place to `action_keys` and `len(action_keys) == num_actions` now holds. Nothing in the tree read the old field; `docs/training/rl.md` is updated.
- `action_dim` is unchanged as the explicit override, and a robot whose actuators match its joints is unaffected.

`robot_joint_names` itself is **not** touched: it remains the joint list and still names policy state keys. Whether it should narrow on the Newton backend is a separate question about observation naming, which #1912 also raised and which stays open there. That issue framed the action half as a contract decision because narrowing the joint list would change checkpoint shapes - but fixing the call site does not, and a checkpoint of the current width cannot have been trained anyway, because no action was ever applied.

## Visual

Identical rollout, identical reward signal, only the head width differs. Rendered in MuJoCo headless (EGL) on the builtin `panda`.

![RL action head width](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rl-action-head/rl-action-head.png)

Both runs start from a pixel-identical frame (`max|delta| = 1`, renderer noise) and the refused run's final frame **is** its own first frame (`max|delta| = 1`) - it never moved. The two final frames differ on 22.3% of pixels. Every number in the figure is re-derived from the run's JSON dump and asserted before the image is written.

## Tests

`tests/training/test_rl_action_head_binds_action_keys.py` (19 tests). The unit-level engine is a purpose-built `SimEngine` double reproducing the width rule every backend publishes, so most pins need no backend; the behavioural half uses the real MuJoCo `panda` and the narrowing half the real `NewtonSimEngine` built solver-free via `__new__`.

- the head width is the action-key count, is accepted by `send_action`, honors a narrower list, and `action_dim` still overrides it
- a control: a robot whose actuators match its joints is unchanged
- `TestARefusedActionWritesNoTarget` - why it was silent: 20 refused steps, nothing applied, 20.0 reward banked
- `TestATendonGripperArmIsDriven` - on the shipped asset, a default-sized head drives the arm; and a companion test pins the mechanism (the joint-list width moves nothing and banks reward anyway), which holds on either side of the fix
- a structural guard that no module under `strands_robots/training/` reads the joint vocabulary, with a planted-defect meta-test and a non-vacuity check on the scan root, plus an AST pin that both trainers write `action_keys` beside `num_actions`

Three duck-typed engine doubles gained `robot_action_keys` (they are not `SimEngine` subclasses, so they do not inherit the default that mirrors the joint names). `test_infers_action_dim_from_robot_joints` is renamed to `..._from_robot_action_keys` and the premise pin in `tests/simulation/newton/test_free_base_is_not_an_actuator.py` has its justification corrected - it cited this action-sizing consumer, which is now gone. Its assertion is unchanged: `robot_joint_names` still carries the free joint.

## Gate

Pre-fix, with only the three source files at `main` and the tests from this branch: **12 failed / 63 passed**, including `assert 9 == 8`, `assert 'error' == 'success'`, `assert set() == {'ankle', 'hip_pitch', 'hip_yaw', 'knee'}`, `KeyError: 'action_keys'`, and the structural guard naming all three adrift functions. Post-fix all 75 pass.

- `MUJOCO_GL=egl python -m pytest tests` - **18489 passed, 257 skipped**, 498s
- `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ` - clean (1046 files formatted, 1043 source files checked)
- the five repo-wide root guards - 42 passed
- `scripts/check_merge_base_overlap.py` - no overlap; rebased onto `03ea30be` for diff hygiene