### PR TITLE
docs(process): a review thread you already answered is not an open review comment (closes #1924)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,56 @@ hatch run format            # ruff check --fix, ruff format
    request reached `APPROVED` / `SUCCESS` / `CLEAN` having appended to the log.
 4. All tests must pass, lint must be clean
 5. Open PR from your fork, address all review comments
+
+   **Check whether you are already the thread's last author before replying.**
+   "Address all review comments" is a per-*concern* obligation, not a
+   per-*cycle* one, and an agent that rebuilds its context each run cannot tell
+   those apart from the thread alone. On #1899 a single thread collected **12
+   consecutive author replies** between 21:46 and 01:30, every one of them
+   announcing the same commit (`35ee25d2`):
+
+   | reply | posted (UTC) | thread state when posted |
+   |---|---|---|
+   | 1st | 21:46 | open, question unanswered |
+   | 2nd | 21:52 | resolved *by this reply* |
+   | 3rd - 12th | 22:28 - 01:30 | `isResolved: true`, `isOutdated: true` |
+
+   The branch's last push was 22:37, so every reply from the 3rd on described
+   work that was already complete and already announced twice - and they were
+   still arriving hourly after the PR was green and waiting on nothing but a
+   reviewer.
+
+   The loop is self-feeding, which is why it does not decay on its own:
+   replying makes the thread the most recently active thing on the PR, so it is
+   the first thing the next cycle reads, and an agent's own prior reply is
+   indistinguishable from context it has not yet acted on. The reviewer's
+   question is still sitting there verbatim in the serialised thread. Nothing
+   in the payload says "answered".
+
+   So gate on authorship and state, not on whether a question is present:
+
+   - Thread's last non-bot comment is **yours** -> do not reply. You have
+     already said it. If there is code to push, push it; the push is the
+     message.
+   - Thread is **`isResolved` or `isOutdated`** -> do not reply. Resolution is
+     terminal. Reopening it to restate a landed fix reads as noise, not
+     diligence.
+   - Last comment is **someone else's** and your existing replies do not answer
+     it -> reply once, then resolve.
+
+   The authorship check is the cheap one, and it would have prevented ten of
+   those twelve comments on its own: no semantic comparison, just the author of
+   the last comment. Both `isResolved` and the comment authors are already in
+   the context payload - they were fetched and not read.
+
+   What makes this worth writing down is that the previous rule was *satisfied*
+   by all twelve. "Address all review comments", and "reply when a thread asks
+   a direct question", are both still true of a thread you have already
+   answered, because answering does not remove the question. The cost lands on
+   the next reader: the signal that the thread was settled at 21:52 is buried
+   under ten paragraphs restating it, and a reviewer must scroll all of them to
+   learn nothing changed. Same shape as #1919 - the policy was not wrong, it
+   was silent on a case that recurs every scheduled cycle.
 6. Track follow-up items as issues on the [project board](https://github.com/orgs/strands-labs/projects/2)
 
    **Read the board with `PAT_TOKEN`, not the Actions `GITHUB_TOKEN`.** An

--- a/changelog.d/1924-review-thread-reply-gate.md
+++ b/changelog.d/1924-review-thread-reply-gate.md
@@ -1,0 +1,40 @@
+### Docs: a review thread you already answered is not an open review comment
+
+`AGENTS.md` > PR Workflow > step 5 said "address all review comments". That is
+complete for a human, who remembers replying, and incomplete for an agent that
+rebuilds its context from the GitHub payload each scheduled run: the reviewer's
+question is still sitting there verbatim, and the agent's own prior reply is
+indistinguishable from context it has not yet acted on. Nothing in the payload
+says "answered", so the instruction is satisfied by replying again - and again.
+
+On #1899 one review thread took **12 consecutive replies from the pull request's
+own author**, between 21:46 and 01:30, every one of them announcing the same
+commit (`35ee25d2`). The thread was resolved at 21:52 by the second of them and
+marked outdated; the branch's last push was 22:37. So from the third reply on,
+each described work that was already complete and already announced twice, and
+they were still arriving hourly after the pull request was green and waiting on
+nothing but a reviewer.
+
+The loop is self-feeding rather than self-limiting, which is why prose alone had
+not stopped it: replying makes the thread the most recently active thing on the
+pull request, so it is the first thing the next cycle reads, and its salience
+rises with every restatement.
+
+Step 5 now gates on authorship and thread state instead of on whether a question
+is present. If a thread's last non-bot comment is your own, no reply is owed -
+push the code if there is code to push, because the push is the message. If the
+thread is `isResolved` or `isOutdated`, resolution is terminal and reopening it
+to restate a landed fix reads as noise rather than diligence. A reply is owed
+only when the last comment is someone else's and the existing replies do not
+answer it, and then exactly once.
+
+The authorship check is the cheap half - no semantic comparison, just the author
+of the last comment - and on its own it would have prevented ten of the twelve.
+Both `isResolved` and the comment authors were already in the context payload on
+#1899; they were fetched and never read.
+
+Pinned by `tests/test_review_thread_reply_gate.py`, which asserts adjacency
+rather than vocabulary: a future edit tightening the step back to a bare "address
+all review comments" is exactly the regression, looks like a simplification, and
+nothing else in the tree would notice. Same shape as #1919 - the policy was not
+wrong, it was silent on a case that recurs every scheduled cycle.

--- a/tests/test_review_thread_reply_gate.py
+++ b/tests/test_review_thread_reply_gate.py
@@ -1,0 +1,175 @@
+"""Contract pin for the reply gate attached to the documented review-comment step.
+
+``AGENTS.md`` > PR Workflow > step 5 tells a contributor to "address all review
+comments". That instruction is complete for a human, who remembers replying, and
+incomplete for an agent that rebuilds its context from the GitHub payload each
+scheduled run: the reviewer's question is still sitting there verbatim, and the
+agent's own prior reply is indistinguishable from context it has not yet acted
+on. So the instruction is *satisfied* by replying again, and again.
+
+Measured on #1899, one review thread, replies by the pull request's own author:
+
+===========  ==============  =========================================
+reply        posted (UTC)    thread state when posted
+===========  ==============  =========================================
+1st          21:46           open, question unanswered
+2nd          21:52           resolved *by this reply*
+3rd - 12th   22:28 - 01:30   ``isResolved: true``, ``isOutdated: true``
+===========  ==============  =========================================
+
+Twelve consecutive replies, every one announcing the same commit
+(``35ee25d2``), against a branch whose last push was 22:37 - so from the 3rd on
+they described work already complete and already announced twice, and were still
+arriving hourly after the pull request was green and waiting on nothing but a
+reviewer. The loop is self-feeding rather than decaying, which is why it needs a
+written gate: replying makes the thread the most recently active thing on the
+pull request, so it is the first thing the next cycle reads.
+
+What is pinned here is *adjacency*, for the same reason as
+``tests/test_merge_gate_viewer_scope.py``: both halves of the uncorrected step 5
+are true, and a future edit tightening it back to a bare "address all review
+comments" is exactly the regression, looks like a simplification, and nothing
+else in the tree would notice. The gate has to stay in the same breath as the
+instruction it qualifies.
+
+Two anchoring notes, because the obvious ways to write this pin do not hold.
+
+First, the assertions run against **whitespace-normalised** text. ``AGENTS.md``
+is hard-wrapped near 76 columns, so any multi-word phrase can straddle a line
+break: ``the push is the message`` is present in the corrected file and a
+line-oriented ``grep`` for it returns nothing, because it wraps after "is". A
+line-based pin would therefore fail on a pure reflow that changes no meaning,
+and - worse - could pass vacuously if a phrase it searched for happened not to
+wrap. Normalising first makes the pin insensitive to wrapping and sensitive only
+to wording.
+
+Second, the directives are bounded by the **step 5 / step 6 slice** rather than a
+tuned character window. A window wide enough to be robust is also wide enough to
+be vacuous here: ``AGENTS.md`` discusses review threads in the CI Security
+Baseline section too ("resolve the thread with a reply carrying the reasoning"),
+so a loose window around step 5 can be satisfied by prose about CodeQL
+dismissals that says nothing about replying twice. Slicing to the step it belongs
+to means a directive moved out of step 5 fails, which is the intent - the gate is
+useless where a contributor addressing review comments will not read it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AGENTS_PATH = _REPO_ROOT / "AGENTS.md"
+
+#: PR Workflow step 5 - the instruction the gate qualifies. Unique in the file.
+_STEP_5 = "address all review comments"
+
+#: PR Workflow step 6 - the end of step 5's prose, used as the slice bound.
+_STEP_6 = "Track follow-up items as issues on the [project board]"
+
+#: The gate sentence. Its absence is the regression, so every other assertion
+#: hangs off it rather than off a character offset from step 5.
+_GATE = "Check whether you are already the thread's last author before replying."
+
+#: The reason the bare instruction is insufficient. Dropping this is how the
+#: rule gets "simplified" back into the loop it exists to stop.
+_PER_CONCERN = "per-*concern* obligation, not a per-*cycle* one"
+
+#: The two dispositions, each paired with its directive. The pairing is the
+#: point: naming the fields without "do not reply" documents a payload, not a
+#: rule.
+_OWN_REPLY_DIRECTIVE = "is **yours** -> do not reply"
+_TERMINAL_STATE_DIRECTIVE = "`isResolved` or `isOutdated`** -> do not reply"
+
+#: The single-reply case, so the gate cannot be read as "never reply".
+_REPLY_ONCE = "reply once, then resolve"
+
+
+def _normalised() -> str:
+    """``AGENTS.md`` with every whitespace run collapsed to one space.
+
+    See the module docstring: the file is hard-wrapped, so phrases straddle line
+    breaks and a line-oriented read is both fragile and potentially vacuous.
+    """
+    return re.sub(r"\s+", " ", _AGENTS_PATH.read_text(encoding="utf-8"))
+
+
+def _step_5_prose() -> str:
+    """The text of PR Workflow step 5, bounded by step 6."""
+    text = _normalised()
+    start = text.index(_STEP_5)
+    end = text.index(_STEP_6, start)
+    return text[start:end]
+
+
+def test_step_5_anchor_is_unique() -> None:
+    """The slice bounds must be unambiguous or every assertion below drifts."""
+    text = _normalised()
+    assert text.count(_STEP_5) == 1, (
+        f"{_STEP_5!r} is no longer a unique anchor in AGENTS.md; the step 5 slice "
+        "this module asserts against cannot be located unambiguously."
+    )
+    assert text.count(_STEP_6) == 1, (
+        f"{_STEP_6!r} is no longer a unique anchor in AGENTS.md; the step 5 slice has no reliable end bound."
+    )
+    assert text.index(_STEP_5) < text.index(_STEP_6), (
+        "PR Workflow step 6 now precedes step 5; the slice bounds are inverted."
+    )
+
+
+def test_reply_gate_is_in_the_same_breath_as_the_instruction() -> None:
+    """The gate qualifies step 5, so it has to live inside step 5."""
+    prose = _step_5_prose()
+    assert _GATE in prose, (
+        "AGENTS.md > PR Workflow step 5 no longer carries the reply gate "
+        f"({_GATE!r}). Without it, 'address all review comments' is satisfied by "
+        "replying to a thread already answered - the #1899 loop, where one "
+        "thread took 12 consecutive replies all announcing the same commit."
+    )
+    # The gate must open step 5's prose, not trail it: a contributor who stops
+    # reading after the numbered line should still hit it.
+    assert prose.index(_GATE) < 200, (
+        "The reply gate has drifted away from the head of PR Workflow step 5 "
+        f"(now {prose.index(_GATE)} characters in). It qualifies the instruction "
+        "on that line and is only read if it stays next to it."
+    )
+
+
+def test_gate_keeps_the_reason_it_exists() -> None:
+    """Per-concern vs per-cycle is what makes the gate non-obvious."""
+    prose = _step_5_prose()
+    assert _PER_CONCERN in prose, (
+        "AGENTS.md > PR Workflow step 5 no longer distinguishes a per-concern "
+        "obligation from a per-cycle one. That distinction is the whole reason "
+        "the gate is not self-evident: an agent rebuilding context each run "
+        "reads an answered question as an open one."
+    )
+
+
+def test_both_do_not_reply_dispositions_survive_with_their_directive() -> None:
+    """Naming the fields is not the rule; pairing them with a directive is."""
+    prose = _step_5_prose()
+    assert _OWN_REPLY_DIRECTIVE in prose, (
+        "AGENTS.md > PR Workflow step 5 no longer says that a thread whose last "
+        "comment is your own gets no further reply. This is the cheap, purely "
+        "mechanical half of the gate - it needs no semantic comparison, just the "
+        "author of the last comment - and on its own it would have prevented ten "
+        "of the twelve replies on #1899."
+    )
+    assert _TERMINAL_STATE_DIRECTIVE in prose, (
+        "AGENTS.md > PR Workflow step 5 no longer treats isResolved / isOutdated "
+        "as terminal. Both fields are already in the context payload; on #1899 "
+        "they were fetched and not read, and ten replies landed on a thread "
+        "carrying both."
+    )
+
+
+def test_gate_does_not_read_as_never_reply() -> None:
+    """The gate suppresses duplicates, not correspondence."""
+    prose = _step_5_prose()
+    assert _REPLY_ONCE in prose, (
+        "AGENTS.md > PR Workflow step 5 no longer states the case where a reply "
+        f"IS owed ({_REPLY_ONCE!r}). Without it the gate over-reads as 'do not "
+        "reply to review threads', and a direct question from a reviewer goes "
+        "unanswered - the opposite failure, and the more expensive one."
+    )


### PR DESCRIPTION
Closes #1924.

## What changed

`AGENTS.md` > PR Workflow > step 5 said "address all review comments". Step 5 now also says how to tell an unaddressed comment from one you already addressed, because for an agent those are not distinguishable from the thread alone.

## Why

An agent rebuilds its context from the GitHub payload each scheduled run. The reviewer's question is still sitting in that payload verbatim, and the agent's own prior reply is indistinguishable from context it has not yet acted on — nothing in the payload says "answered". So "address all review comments" is *satisfied* by replying again.

Measured on #1899, one thread, replies by that PR's own author:

| reply | posted (UTC) | thread state when posted |
|---|---|---|
| 1st | 21:46 | open, question unanswered |
| 2nd | 21:52 | resolved *by this reply* |
| 3rd - 12th | 22:28 - 01:30 | `isResolved: true`, `isOutdated: true` |

Twelve consecutive replies, every one announcing the same commit (`35ee25d2`), against a branch whose last push was 22:37. From the third on, each described work already complete and already announced twice — and they were still arriving hourly after the PR was green and waiting on nothing but a reviewer.

The loop is self-feeding rather than self-limiting, which is why prose had not stopped it: replying makes the thread the most recently active thing on the PR, so it is the first thing the next cycle reads. Salience rises with every restatement.

## The rule

Gate on authorship and thread state, not on whether a question is present:

- last non-bot comment is **yours** -> no reply owed; push the code if there is code to push, because the push is the message;
- thread is **`isResolved` or `isOutdated`** -> resolution is terminal, reopening it to restate a landed fix reads as noise rather than diligence;
- last comment is **someone else's** and your existing replies do not answer it -> reply once, then resolve.

The authorship check is the cheap half — no semantic comparison, just the author of the last comment — and alone would have prevented ten of the twelve. Both `isResolved` and the comment authors were already in the payload on #1899; they were fetched and never read.

## Test surface

`tests/test_review_thread_reply_gate.py`, 5 assertions, asserting **adjacency rather than vocabulary** — same rationale as `tests/test_merge_gate_viewer_scope.py`. Tightening step 5 back to a bare "address all review comments" is the regression, it looks like a simplification, and nothing else in the tree would notice.

Two anchoring decisions, both because the obvious pin does not hold:

- **Whitespace is normalised first.** `AGENTS.md` is hard-wrapped near 76 columns, so phrases straddle line breaks: `the push is the message` is present in the corrected file and a line-oriented `grep` for it returns **nothing**, because it wraps after "is". A line-based pin would fail on a pure reflow that changes no meaning, and could pass vacuously on a phrase that happened not to wrap.
- **Assertions are bounded by the step 5 / step 6 slice, not a character window.** `AGENTS.md` discusses review threads in the CI Security Baseline section too ("resolve the thread with a reply carrying the reasoning"), so a window loose enough to be robust is also loose enough to be satisfied by prose about CodeQL dismissals that says nothing about replying twice. Slicing to the step means a directive moved out of step 5 fails — which is the intent; the gate is useless where a contributor addressing review comments will not read it.

Verified the pin actually catches the regression: **4 of the 5 assertions fire against the uncorrected `AGENTS.md`**. The fifth (`test_step_5_anchor_is_unique`) guards the slice bounds, which exist in both files, and is meant to pass — it fails only if the anchors stop being unique, which would make the other four vacuous.

`ruff check` and `ruff format --check` clean on the new file; the 5 tests pass. No production code touched.

## Scope

Docs + pin only, one concern. Same shape as #1920 and #1922.

One thing I want to be explicit about rather than bury: the rule is written to be read by whoever is *about to* reply, and its cheap half is mechanical, but nothing in the tree enforces it at reply time — there is no in-tree code that posts review replies, so the pin can only protect the written rule from being simplified away. If maintainers would rather have this as a runtime check in the agent context builder instead of a documented gate, say so and I will close this in favour of that; I went with the documented gate because it matches where the other four process rules landed.
