### PR TITLE
fix(sim/isaac): send_action applies the shared action-value domain

### DIFF
--- a/changelog.d/1926-isaac-action-value-domain.md
+++ b/changelog.d/1926-isaac-action-value-domain.md
@@ -1,0 +1,14 @@
+### Fixed: the Isaac backend applies the shared action-value domain
+
+`IsaacSimulation.send_action` hand-rolled its own action conversion instead of
+routing through `SimEngine._coerce_action`, the shared coercion every backend
+applies. On the Isaac backend alone a boolean reached the articulation as a
+`1.0`/`0.0` PD position target, `nan`/`inf` reached it as a target no solver can
+honor, a vector whose width did not match `robot_action_keys` was handed to the
+articulation anyway, and a multi-element value, a non-numeric value, `None` or
+the single-element row a 1-DoF key carries under the
+`Policy.get_actions -> list[dict]` contract raised `TypeError`/`ValueError`
+straight past `send_action`'s structured envelope -- so a policy emitting the
+documented shape could not drive this backend at all. `send_action` now applies
+the shared domain, and the structural guard that asserts no backend can ship
+without it covers all three backends rather than two.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -29,6 +29,7 @@ import os
 import queue
 import threading
 import time
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
@@ -3136,7 +3137,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
     def send_action(
         self,
-        action: dict[str, Any] | np.ndarray | list,
+        action: dict[str, Any] | Sequence[float],
         robot_name: str | None = None,
         n_substeps: int = 1,
     ) -> dict[str, Any]:
@@ -3150,6 +3151,17 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             in which case the dict is first converted by the controller
             (e.g. GR00T task-space delta-EEF keys to joint position
             targets) and the converted dict is what gets resolved.
+            Values are on the shared action-value domain
+            (:meth:`~strands_robots.simulation.base.SimEngine._coerce_action`)
+            every backend applies: a value must coerce to a finite scalar
+            number, a boolean is refused rather than written as a 1.0/0.0
+            target, and a single-element sequence -- the ``list[float]`` a 1-DoF
+            key carries under the ``Policy.get_actions`` contract -- is
+            unwrapped to its scalar. An ordered vector is bound positionally to
+            :meth:`robot_action_keys` and its width must match that list
+            exactly; a mismatch is refused rather than applied to whichever DOFs
+            it covers. The controller conversion above runs first, so it is the
+            controller's output that is checked.
         robot_name : str, optional
             Robot to control.
         n_substeps : int
@@ -3241,34 +3253,47 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                         ],
                     }
 
-            # Convert action to array, tracking dict keys that don't name a
-            # joint so unresolved commands surface in the envelope rather than
-            # being silently dropped (parity with the MuJoCo backend).
-            unresolved: list[str] = []
-            action_array: np.ndarray
+            # Every value that reaches an actuator clears the shared
+            # action-value domain first (:meth:`SimEngine._coerce_action`),
+            # which is also what binds an ordered action *vector* positionally
+            # to ``robot_action_keys`` and refuses a width that does not match
+            # it. This backend hand-rolled its own conversion instead, so it
+            # wrote a boolean as a 1.0/0.0 target, wrote a non-finite target no
+            # solver can honor, applied a mismatched vector to whichever DOFs it
+            # happened to cover, and raised ``TypeError`` straight past this
+            # envelope for the single-element rows the
+            # ``Policy.get_actions -> list[dict]`` contract emits for a 1-DoF
+            # key. The coercion runs here rather than before the lock (where the
+            # MuJoCo and Newton backends call it) because the task-space
+            # controller above may rewrite the action and it is the controller's
+            # *output* that is applied; ``self._lock`` is an ``RLock``, so the
+            # ``robot_action_keys`` read inside the coercion re-enters safely.
+            action_map, coerce_error = self._coerce_action(action, robot_name)
+            if coerce_error is not None:
+                return coerce_error
+            assert action_map is not None  # narrow for mypy: no error implies a mapping
+
+            # Track keys that don't name a joint so unresolved commands surface
+            # in the envelope rather than being silently dropped (parity with
+            # the MuJoCo backend).
+            joint_set = set(robot.joint_names)
+            unresolved = [k for k in action_map if k not in joint_set]
             # ``joint_indices`` restricts an ``ArticulationAction`` to a subset
-            # of the articulation's DOFs; ``None`` addresses every joint. For a
-            # dict action we command ONLY the named joints and leave the rest at
-            # their current PD targets (parity with the MuJoCo/Newton backends).
-            # A full zero-filled ``joint_positions`` vector would instead drive
-            # every unnamed joint to 0.0 -- e.g. ``send_action({"gripper": 0.04})``
-            # would slam the whole arm to its home pose.
-            joint_indices: np.ndarray | None
-            if isinstance(action, dict):
-                joint_set = set(robot.joint_names)
-                unresolved = [k for k in action if k not in joint_set]
-                named = [i for i, jname in enumerate(robot.joint_names) if jname in action]
-                action_array = np.array(
-                    [float(action[robot.joint_names[i]]) for i in named],
-                    dtype=np.float32,
-                )
-                joint_indices = np.array(named, dtype=np.int32)
-            elif isinstance(action, np.ndarray):
-                action_array = action.astype(np.float32).flatten()
-                joint_indices = None
-            else:
-                action_array = np.array(action, dtype=np.float32)
-                joint_indices = None
+            # of the articulation's DOFs. Command ONLY the named joints and
+            # leave the rest at their current PD targets (parity with the
+            # MuJoCo/Newton backends). A full zero-filled ``joint_positions``
+            # vector would instead drive every unnamed joint to 0.0 -- e.g.
+            # ``send_action({"gripper": 0.04})`` would slam the whole arm to its
+            # home pose. A full-width vector action arrives here as a mapping
+            # over every joint, so the indices then address every DOF in
+            # articulation order - what the raw vector path expressed by passing
+            # ``None``.
+            named = [i for i, jname in enumerate(robot.joint_names) if jname in action_map]
+            action_array: np.ndarray = np.array(
+                [float(action_map[robot.joint_names[i]]) for i in named],
+                dtype=np.float32,
+            )
+            joint_indices: np.ndarray = np.array(named, dtype=np.int32)
 
             # Apply to articulation. Isaac Sim 6.0's articulation
             # (``isaacsim.core.prims.SingleArticulation``) drives PD position
@@ -3310,7 +3335,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 self._step_count += 1
 
         if unresolved:
-            applied = [k for k in action if k not in unresolved]
+            applied = [k for k in action_map if k not in unresolved]
             return {
                 "status": "error",
                 "content": [

--- a/tests/simulation/isaac/test_backend_parity.py
+++ b/tests/simulation/isaac/test_backend_parity.py
@@ -122,6 +122,16 @@ class TestSendActionPartialDict:
         assert list(np.asarray(act.joint_positions)) == pytest.approx([0.1, 0.2, 0.3, 0.04])
 
     def test_vector_action_addresses_all_joints(self, fake_isaacsim_types):
+        """A full-width vector commands every joint, in order.
+
+        The assertion is on which DOFs are addressed rather than on how that is
+        spelled. It used to require ``joint_indices is None`` -- the "all DOFs"
+        shorthand the raw vector path happened to use -- which made this and
+        ``test_full_dict_commands_all_joints`` pin two different spellings of one
+        outcome. The vector is now bound to ``robot_action_keys`` by the shared
+        coercion, so both arrive as a mapping over every joint and name the DOFs
+        explicitly; ``[0, 1, 2, 3]`` and ``None`` address the same articulation.
+        """
         sim = IsaacSimulation()
         art = _FakeArticulation()
         _seed_running_world(sim, self.JOINTS, art)
@@ -129,8 +139,7 @@ class TestSendActionPartialDict:
         result = sim.send_action([0.1, 0.2, 0.3, 0.04], robot_name="arm")
         assert result["status"] == "success", result
         act = art.last_action
-        # A positional vector addresses every joint -> joint_indices None (all).
-        assert act.joint_indices is None
+        assert list(np.asarray(act.joint_indices)) == list(range(len(self.JOINTS)))
         assert list(np.asarray(act.joint_positions)) == pytest.approx([0.1, 0.2, 0.3, 0.04])
 
 

--- a/tests/simulation/isaac/test_send_action_action_value_domain.py
+++ b/tests/simulation/isaac/test_send_action_action_value_domain.py
@@ -1,0 +1,256 @@
+"""The Isaac backend applies the shared action-value domain.
+
+``SimEngine._coerce_action`` is the one place the action-value domain lives: a
+value must coerce to a finite scalar number, a boolean is refused rather than
+written as a ``1.0``/``0.0`` target, a single-element sequence -- the
+``list[float]`` a 1-DoF key carries under the ``Policy.get_actions -> list[dict]``
+contract -- is unwrapped to its scalar, and an ordered vector is bound
+positionally to ``robot_action_keys`` with its width required to match that list
+exactly. ``TestEveryBackendInheritsTheGuard`` in
+``tests/simulation/test_send_action_rejects_a_boolean_command.py`` states the
+invariant this file measures: the guard lives in the shared coercion so no
+backend can ship without it.
+
+The Isaac backend shipped its own conversion instead, so on this backend alone:
+
+  * a boolean reached the articulation as a ``1.0`` / ``0.0`` PD target;
+  * ``nan`` / ``inf`` reached it as a target no solver can honor;
+  * a vector whose width did not match the robot was handed to the articulation
+    anyway, addressed at every DOF -- so a caller error surfaced, at best, as a
+    shape complaint from the runtime rather than as the width mismatch it is;
+  * a multi-element value, a non-numeric value and ``None`` raised ``TypeError``
+    / ``ValueError`` straight past ``send_action``'s structured envelope; and
+  * the single-element row a 1-DoF key carries raised ``TypeError`` as well, so
+    a policy emitting the documented shape could not drive this backend at all.
+
+Every value is checked against the shared coercion's own verdict rather than
+against a hand-written table, so the two cannot drift apart. None of it requires
+NVIDIA Isaac Sim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+
+from .test_backend_parity import _FakeArticulation, fake_isaacsim_types  # noqa: F401 - fixture
+
+JOINTS = ["shoulder", "elbow", "wrist", "gripper"]
+
+
+class _CountingWorld:
+    """Isaac World stand-in that records how many physics steps were run."""
+
+    def __init__(self) -> None:
+        self.steps = 0
+
+    def step(self, render: bool = False) -> None:  # noqa: ARG002 - signature parity
+        self.steps += 1
+
+
+def _running_sim(articulation: Any) -> IsaacSimulation:
+    sim = IsaacSimulation()
+    sim._world = _CountingWorld()
+    sim._world_created = True
+    sim._robots = {
+        "arm": _RobotState(
+            name="arm",
+            prim_path="/World/Robots/arm",
+            joint_names=list(JOINTS),
+            articulation=articulation,
+        )
+    }
+    return sim
+
+
+def _call(sim: IsaacSimulation, action: Any) -> dict[str, Any]:
+    """Invoke send_action with a deliberately off-domain value.
+
+    Routed through one funnel so the off-type values this file exists to probe
+    are not each a separate typing suppression at the call site.
+    """
+    return sim.send_action(action, robot_name="arm")
+
+
+# Values that must be refused. Each is reachable from a policy or an agent tool
+# rather than being a typo: a boolean is the conventional binary-gripper action,
+# a non-finite value is what a diverging policy emits, and a width mismatch is
+# what an action head sized from the wrong key list produces.
+REFUSED: list[tuple[str, Any]] = [
+    ("python bool True", {"gripper": True}),
+    ("python bool False", {"gripper": False}),
+    ("numpy bool", {"gripper": np.bool_(True)}),
+    ("nan", {"gripper": float("nan")}),
+    ("inf", {"gripper": float("inf")}),
+    ("multi-element value", {"gripper": [1.0, 2.0, 3.0]}),
+    ("non-numeric value", {"gripper": "not-a-number"}),
+    ("None value", {"gripper": None}),
+    ("vector too short", [0.1, 0.2]),
+    ("vector too long", [0.1, 0.2, 0.3, 0.4, 0.5]),
+    ("ndarray too short", np.array([0.1, 0.2])),
+    ("nan in vector", [0.1, float("nan"), 0.3, 0.04]),
+    ("bool in vector", [0.1, True, 0.3, 0.04]),
+    ("non-numeric in vector", [0.1, "x", 0.3, 0.04]),
+]
+
+# Values that were already accepted and must stay accepted.
+ACCEPTED: list[tuple[str, Any, list[float]]] = [
+    ("plain float", {"gripper": 0.04}, [0.04]),
+    ("numeric string", {"gripper": "0.04"}, [0.04]),
+    ("negative float", {"gripper": -0.04}, [-0.04]),
+    ("full-width vector", [0.1, 0.2, 0.3, 0.04], [0.1, 0.2, 0.3, 0.04]),
+    ("single-element row", {"gripper": [0.04]}, [0.04]),
+    ("single-element ndarray row", {"gripper": np.array([0.04])}, [0.04]),
+]
+
+
+class TestTheDomainMatchesTheSharedContract:
+    """Isaac's verdict for a value is the shared coercion's verdict for it."""
+
+    @pytest.mark.parametrize(("label", "action"), REFUSED + [(lbl, a) for lbl, a, _ in ACCEPTED])
+    def test_the_verdicts_agree(self, fake_isaacsim_types, label, action) -> None:  # noqa: F811, ARG002
+        sim = _running_sim(_FakeArticulation())
+        _, contract_error = SimEngine._coerce_action(sim, action, "arm")
+        contract_refuses = contract_error is not None
+
+        result = _call(sim, action)
+        backend_refuses = result["status"] == "error"
+
+        assert backend_refuses is contract_refuses, (
+            f"{label}: backend says {'error' if backend_refuses else 'success'} while the shared "
+            f"contract says {'error' if contract_refuses else 'accepted'}"
+        )
+
+    @pytest.mark.parametrize(("label", "action"), REFUSED)
+    def test_a_refused_value_reports_the_contract_reason(self, fake_isaacsim_types, label, action) -> None:  # noqa: F811, ARG002
+        sim = _running_sim(_FakeArticulation())
+        _, contract_error = SimEngine._coerce_action(sim, action, "arm")
+        assert contract_error is not None, f"{label} must be off-domain for this test to mean anything"
+
+        result = _call(sim, action)
+        assert result["content"][0]["text"] == contract_error["content"][0]["text"], label
+
+
+class TestARefusalReachesNoActuator:
+    """A refusal is reported before anything is written or advanced."""
+
+    @pytest.mark.parametrize(("label", "action"), REFUSED)
+    def test_no_target_is_applied_and_no_step_is_run(self, fake_isaacsim_types, label, action) -> None:  # noqa: F811, ARG002
+        art = _FakeArticulation()
+        sim = _running_sim(art)
+
+        assert _call(sim, action)["status"] == "error", label
+        assert art.last_action is None, f"{label} reached the articulation"
+        assert sim._world.steps == 0, f"{label} advanced physics"
+
+    def test_no_off_domain_value_escapes_the_structured_envelope(self, fake_isaacsim_types) -> None:  # noqa: F811
+        """Not one of them raises: the envelope is send_action's whole contract.
+
+        A raise here is worse than a wrong value. ``PolicyRunner`` counts an
+        error result to decide whether a rollout is degrading; an exception
+        instead unwinds the rollout mid-episode.
+        """
+        for label, action in REFUSED:
+            sim = _running_sim(_FakeArticulation())
+            try:
+                result = _call(sim, action)
+            except Exception as exc:  # noqa: BLE001 - an escape past the envelope IS the finding
+                pytest.fail(f"{label} raised {type(exc).__name__} past the envelope: {exc}")
+            assert result["status"] == "error", label
+
+
+class TestTheSingleElementRowIsHonored:
+    """The shape the get_actions contract emits for a 1-DoF key is applied."""
+
+    def test_a_one_element_row_applies_its_scalar(self, fake_isaacsim_types) -> None:  # noqa: F811
+        art = _FakeArticulation()
+        sim = _running_sim(art)
+
+        assert _call(sim, {"gripper": [0.04]})["status"] == "success"
+        assert list(np.asarray(art.last_action.joint_positions)) == pytest.approx([0.04])
+        assert list(np.asarray(art.last_action.joint_indices)) == [JOINTS.index("gripper")]
+
+    def test_a_one_element_row_matches_the_bare_scalar(self, fake_isaacsim_types) -> None:  # noqa: F811
+        """The unwrap is an unwrap: the two spellings command the same target."""
+        wrapped_art, bare_art = _FakeArticulation(), _FakeArticulation()
+        assert _call(_running_sim(wrapped_art), {"gripper": [0.04]})["status"] == "success"
+        assert _call(_running_sim(bare_art), {"gripper": 0.04})["status"] == "success"
+
+        assert list(np.asarray(wrapped_art.last_action.joint_positions)) == pytest.approx(
+            list(np.asarray(bare_art.last_action.joint_positions))
+        )
+
+
+class TestAVectorWidthMustMatchTheActionKeys:
+    """A width that does not match is refused rather than partly applied."""
+
+    def test_the_fixture_makes_truncation_detectable(self, fake_isaacsim_types) -> None:  # noqa: F811
+        sim = _running_sim(_FakeArticulation())
+        assert len(sim.robot_action_keys("arm")) == len(JOINTS) > 2, (
+            "the robot needs several action keys or a dropped trailing command is invisible"
+        )
+
+    def test_a_short_vector_does_not_command_the_joints_it_covers(self, fake_isaacsim_types) -> None:  # noqa: F811
+        art = _FakeArticulation()
+        sim = _running_sim(art)
+
+        result = _call(sim, [0.1, 0.2])
+        assert result["status"] == "error"
+        assert art.last_action is None, "a partial command reached the articulation"
+
+    @pytest.mark.parametrize("action", [[0.1, 0.2], [0.1, 0.2, 0.3, 0.4, 0.5]])
+    def test_the_refusal_names_both_widths(self, fake_isaacsim_types, action) -> None:  # noqa: F811
+        text = _call(_running_sim(_FakeArticulation()), action)["content"][0]["text"]
+        assert f"length {len(action)}" in text
+        assert f"count {len(JOINTS)}" in text
+        assert "gripper" in text, "the message must show the action keys the caller should target"
+
+    def test_an_exact_width_vector_commands_every_joint_in_order(self, fake_isaacsim_types) -> None:  # noqa: F811
+        art = _FakeArticulation()
+        sim = _running_sim(art)
+
+        assert _call(sim, [0.1, 0.2, 0.3, 0.04])["status"] == "success"
+        assert list(np.asarray(art.last_action.joint_indices)) == list(range(len(JOINTS)))
+        assert list(np.asarray(art.last_action.joint_positions)) == pytest.approx([0.1, 0.2, 0.3, 0.04])
+
+
+class TestUsableValuesStayUsable:
+    """The over-reach control: nothing that worked is now refused."""
+
+    @pytest.mark.parametrize(("label", "action", "expected"), ACCEPTED)
+    def test_an_on_domain_value_is_applied_and_advances_physics(
+        self,
+        fake_isaacsim_types,  # noqa: F811
+        label,
+        action,
+        expected,
+    ) -> None:
+        art = _FakeArticulation()
+        sim = _running_sim(art)
+
+        assert _call(sim, action)["status"] == "success", label
+        assert list(np.asarray(art.last_action.joint_positions)) == pytest.approx(expected), label
+        assert sim._world.steps == 1, label
+
+    def test_a_partial_dict_still_commands_only_the_named_joint(self, fake_isaacsim_types) -> None:  # noqa: F811
+        """The coercion returns a mapping unchanged, so subset targeting survives."""
+        art = _FakeArticulation()
+        sim = _running_sim(art)
+
+        assert _call(sim, {"gripper": 0.04})["status"] == "success"
+        assert list(np.asarray(art.last_action.joint_indices)) == [JOINTS.index("gripper")]
+
+    def test_an_unresolved_key_is_still_reported_with_the_keys_it_applied(self, fake_isaacsim_types) -> None:  # noqa: F811
+        """Name resolution is a separate question from the value domain."""
+        sim = _running_sim(_FakeArticulation())
+
+        result = _call(sim, {"gripper": 0.04, "nosuchjoint": 0.1})
+        assert result["status"] == "error"
+        payload = next(block["json"] for block in result["content"] if "json" in block)
+        assert payload["unresolved_keys"] == ["nosuchjoint"]
+        assert payload["applied"] == ["gripper"], "the report must name keys, not the vector's floats"

--- a/tests/simulation/test_send_action_rejects_a_boolean_command.py
+++ b/tests/simulation/test_send_action_rejects_a_boolean_command.py
@@ -311,10 +311,15 @@ class TestEveryBackendInheritsTheGuard:
     """The guard lives in the shared coercion, so no backend can ship without it."""
 
     def test_send_action_is_defined_once_and_routes_through_the_shared_coercion(self) -> None:
+        from strands_robots.simulation.isaac import simulation as isaac_simulation
         from strands_robots.simulation.mujoco import simulation as mujoco_simulation
         from strands_robots.simulation.newton import simulation as newton_simulation
 
-        for module in (mujoco_simulation, newton_simulation):
+        # Every backend, not the two that happened to be written first: this
+        # class asserts that no backend can ship without the guard, and the
+        # Isaac backend shipped its own conversion for exactly as long as it was
+        # missing from this loop.
+        for module in (mujoco_simulation, newton_simulation, isaac_simulation):
             tree = ast.parse(inspect.getsource(module))
             sends = [
                 node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "send_action"


### PR DESCRIPTION
`IsaacSimulation.send_action` hand-rolled its own action conversion instead of routing through `SimEngine._coerce_action`, the shared coercion that owns the action-value domain.

`TestEveryBackendInheritsTheGuard` in `tests/simulation/test_send_action_rejects_a_boolean_command.py` already states the invariant — *"The guard lives in the shared coercion, so no backend can ship without it"* — and its loop named two of the three backends:

```python
for module in (mujoco_simulation, newton_simulation):
```

So this backend shipped without it, and stayed that way for as long as it was missing from that loop.

## What reached the articulation

Measured on a robot with four action keys, capturing the `ArticulationAction` `send_action` writes. None of these values is a typo: a boolean is the conventional binary-gripper action, and a one-element row is the documented `Policy.get_actions -> list[dict]` shape for a 1-DoF key.

| `send_action` call | main | this change |
| --- | --- | --- |
| `{"shoulder": True, "gripper": True}` | success — wrote `1.0` to joints 0 and 3 | error, names the bool and its units |
| `{"gripper": [0.030]}` (1-DoF policy row) | **raised `TypeError` past the envelope** | success — applied `0.030` |
| `{"shoulder": nan}` | success — wrote `nan` to joint 0 | error, names the non-finite value |
| `[0.30, -0.55, 0.45]` (4 action keys) | success — handed 3 values, addressed at every DOF | error, names both widths |
| `{"gripper": "not-a-number"}` / `None` | raised `TypeError` / `ValueError` | error, names the key |
| `{"gripper": [1.0, 2.0, 3.0]}` | raised `TypeError` | error, names the key |
| `{"gripper": 0.04}` (already usable) | success — applied `0.04` | success — applied `0.04` |

Two consequences are worth separating out.

**A well-formed command nobody asked for.** `float(True)` is `1.0`, and `1.0` is a different physical command on every drive — a 1-radian target on a joint-position drive, full travel on a normalized one. The written `ArticulationAction` is perfectly valid, so nothing downstream can notice.

**A policy could not drive this backend at all.** The shared coercion unwraps a single-element value specifically because the `get_actions` contract emits `list[float]` for a vector-valued key, which for a 1-DoF key is a length-1 list. This backend called `float()` on it and raised, before `apply_action` and outside any handler.

## The change

`send_action` now calls the shared coercion and builds its `joint_positions` from the returned mapping. It runs *after* the task-space controller, because it is the controller's output that is applied, and inside the lock — `self._lock` is an `RLock`, so the `robot_action_keys` read inside the coercion re-enters safely. The MuJoCo and Newton backends call it before their lock; neither has a conversion step in front of it.

Also in scope, both consequences of the same divergence:

- The structural guard now loops over all three backends, so a fourth cannot arrive without the domain.
- The `action` parameter annotation was `dict[str, Any] | np.ndarray | list`; the abstract method and both other backends declare `dict[str, Any] | Sequence[float]`. Aligned.

A full-width vector now arrives as a mapping over every joint, so `joint_indices` names the DOFs explicitly rather than passing `None`. Both address the same articulation, and `test_full_dict_commands_all_joints` already pinned `[0, 1, 2, 3]` for the equivalent full dict — the two spellings of "command every joint" now agree. `test_vector_action_addresses_all_joints` asserted `joint_indices is None`, an implementation spelling standing in for its own stated contract; it now asserts which DOFs are addressed, with the reason in its docstring.

Subset targeting, unresolved-key reporting and the `n_substeps` domain are unchanged. The partial-application report now iterates the coerced mapping, so it names keys rather than a raw vector's floats.

## Verification

![Isaac send_action action-value domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-action-domain/isaac-action-domain.png)

Every panel replays the exact `ArticulationAction` the backend wrote, on a MuJoCo arm carrying the same four joints, so the picture is the measured write rather than a reconstruction. Panel 2 differs from panel 1 on **97.8%** of pixels; panel 3 is **byte-identical** to panel 1 (`max|3 - 1| = 0`), i.e. the refusal wrote nothing and ran no physics step. The inset is the case main raises on.

**New tests** — `tests/simulation/isaac/test_send_action_action_value_domain.py`, 64 tests, no Isaac Sim required. Every value is checked against the shared coercion's *own* verdict rather than a hand-written table, so the two cannot drift apart, plus: the reported reason is the contract's reason; a refusal reaches neither the articulation nor a physics step; no off-domain value escapes the envelope; the one-element row applies the same target as the bare scalar; a width mismatch names both widths; and an over-reach control that every already-usable value still applies.

**Pre-fix proof** — reverting only `strands_robots/simulation/isaac/simulation.py` to `main` and keeping the tests: `53 failed, 75 passed`. The structural guard fails as `strands_robots.simulation.isaac.simulation.send_action does not route through _coerce_action, so it does not inherit the action-value domain`. Post-fix: `128 passed`. The 75 that pass pre-fix are the over-reach controls, the fixture premises and the values `main` already handled — they are what stops the guard over-reaching.

**Gate** — full suite `18605 passed, 257 skipped` (`MUJOCO_GL=egl`, 509s), `ruff check` clean, `ruff format --check` clean on 1049 files, `mypy strands_robots tests tests_integ` clean, the five repo-wide root guards `42 passed`, `assemble_changelog.py --check` OK, and the merge-base overlap check reports no overlap at `ef858bcf`. Rebased onto current `main`; hunks are disjoint from the `isaac/simulation.py` change that landed in that span (upstream at 1227-1330 / 5134-5215, this branch at 3136-3342).

## Not in scope

The backend has 23 remaining raw registry membership tests where the other two use `registered()` (#1846 covers the lookup side, a separate question from the value domain), and the per-call step ceiling asymmetry is #1871.