### PR TITLE
fix(sim/isaac): set_joint_positions applies the shared joint-state domain

### DIFF
--- a/changelog.d/1928-isaac-joint-state-domain.md
+++ b/changelog.d/1928-isaac-joint-state-domain.md
@@ -1,0 +1,28 @@
+### Fixed: `set_joint_positions` applies the same joint-state domain on every backend
+
+The kinematic state writers bypass the actuators and write joint state directly.
+The MuJoCo backend refuses a value the engine cannot honor; the Isaac backend
+accepted all of them, so the accepted domain depended on which engine the caller
+happened to be driving. On Isaac, `positions={"shoulder": True}` wrote a
+1-radian target, a `nan` / `inf` was written into the articulation (PhysX
+surfaces that only from a *later* step, as an "Illegal BroadPhaseUpdateData -
+non-finite bounds" error), an unresolvable joint name was skipped so a typo
+wrote nothing - or half a pose - while the caller was told the pose had been
+applied, and a vector of the wrong length resized the articulation's
+joint-position array instead of being refused. All eleven reported
+`status="success"`.
+
+A non-numeric value was worse still: on the main thread it raised `ValueError`
+past the structured-error contract, and from a worker thread the write is queued
+and the pump's queued-action handler swallows that failure as best-effort - so
+the same call returned `status="success"` and failed with no channel at all. The
+verdict depended on which thread called.
+
+The value half of the contract now lives on the engine base as
+`SimEngine._coerce_joint_state_map`, promoted from the MuJoCo backend with its
+message text unchanged, so the two backends cannot drift apart again. Isaac
+applies it, plus the structural checks its sibling already enforced: the list
+form's length must match the robot's joint count, every mapping key must name one
+of the robot's joints, and the mapping must not be empty. Validation runs
+synchronously, before the write is queued, so a rejected value is reported to the
+caller rather than swallowed on the pump thread. Every usable call is unaffected.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -406,6 +406,21 @@ def _boolean_action_error(label: str, value: Any) -> dict[str, Any] | None:
     }
 
 
+# Why a runtime *state* write refuses a boolean, kept in one place because three
+# surfaces quote it (set_joint_positions, set_joint_velocities, apply_force).
+#
+# The actuator-command path refuses one for a stronger reason - see
+# :data:`_BOOLEAN_ACTION_REASON`: 1.0 is re-read in each drive's own units, so the
+# same True commands a different pose on every actuator. Here 1.0 is a single
+# unambiguous quantity - 1 radian, 1 rad/s, 1 N - so a boolean is merely wrong
+# rather than ambiguous.
+_BOOLEAN_STATE_REASON = (
+    "float(True) is 1.0, so a boolean would be written as 1 radian, 1 rad/s or "
+    "1 N depending on the surface, and the call would report success. Pass the "
+    "quantity in the surface's own units."
+)
+
+
 class SimEngine(ABC):
     """Abstract base class for simulation engines.
 
@@ -1175,6 +1190,78 @@ class SimEngine(ABC):
                 return None, error
             bound[name] = value
         return bound, None
+
+    @staticmethod
+    def _coerce_joint_state_map(
+        values: dict[str, Any],
+        name: str,
+        method: str,
+    ) -> tuple[dict[str, float], dict[str, Any] | None]:
+        """Coerce a ``{joint_name: value}`` state map to finite floats before any write.
+
+        Backs the kinematic state writers on every backend
+        (:meth:`set_joint_positions` / :meth:`set_joint_velocities`), so the
+        accepted domain cannot differ by which engine the caller happens to be
+        driving.
+
+        Each value must be a real number (Python or NumPy scalar) and finite, and
+        must not be a boolean. A non-numeric value would otherwise raise
+        ``ValueError`` from ``float(value)`` past the structured-error dispatch
+        contract, and ``nan`` / ``inf`` would slip straight into the engine's
+        joint state - MuJoCo's ``mj_forward`` propagates the ``nan`` across the
+        whole kinematic state (or an ``inf`` velocity blows up the integrator),
+        and PhysX reports a non-finite articulation as an "Illegal
+        BroadPhaseUpdateData - non-finite bounds" error from a later step -
+        while the tool still reports ``status="success"``. A boolean is refused
+        for the reason in :data:`_BOOLEAN_STATE_REASON`: it survives ``float()``
+        as a silent ``1.0``, so it is the one invalid value the finiteness check
+        cannot see. Validating up front keeps the write atomic: an invalid value
+        leaves the joint state untouched.
+
+        Args:
+            values: The ``{joint_name: value}`` mapping to validate.
+            name: Parameter name (``"positions"`` / ``"velocities"``), used in error text.
+            method: Calling method name, used in error text.
+
+        Returns:
+            ``(coerced, None)`` on success, or ``({}, error_dict)`` on the first
+            invalid value -- matching the structured-error tool contract so the
+            caller never raises past dispatch.
+        """
+        out: dict[str, float] = {}
+        for jnt_name, value in values.items():
+            # Before float(): float(True) is 1.0, so the boolean is unrecoverable
+            # once coerced and the write would report success having set 1 rad /
+            # 1 rad/s. numpy.bool_ needs the .item() unwrap is_boolean applies.
+            if is_boolean(value):
+                return {}, {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": f"{method}: '{name}' value for joint '{jnt_name}' must be a number, not a bool (got {value!r}). {_BOOLEAN_STATE_REASON}"
+                        }
+                    ],
+                }
+            try:
+                f = float(value)
+            except (TypeError, ValueError):
+                return {}, {
+                    "status": "error",
+                    "content": [
+                        {"text": f"{method}: '{name}' value for joint '{jnt_name}' must be a number, got {value!r}"}
+                    ],
+                }
+            if not math.isfinite(f):
+                return {}, {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": f"{method}: '{name}' value for joint '{jnt_name}' must be finite (no nan/inf), got {value!r}"
+                        }
+                    ],
+                }
+            out[jnt_name] = f
+        return out, None
 
     @abstractmethod
     def send_action(

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -5252,6 +5252,40 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         ``positions`` may be a ``dict`` keyed by joint name (only the
         listed joints are written; others retain their current value)
         or a list/array in the robot's joint order.
+
+        Validation
+        ----------
+        The write is all-or-nothing, on the same terms the MuJoCo backend's
+        :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.set_joint_positions`
+        already enforces, so the accepted domain does not depend on which engine
+        the caller is driving:
+
+        * the list form's length must equal the robot's joint count - a shorter
+          or longer vector is refused rather than resizing the articulation's
+          joint-position array, which would otherwise be handed to PhysX at the
+          wrong width;
+        * every ``dict`` key must name one of the robot's joints, and the mapping
+          must not be empty - an unresolvable name used to be skipped silently, so
+          a typo (or a name from the wrong robot) wrote nothing, or wrote only
+          part of the requested pose, while the caller was told the pose had been
+          applied;
+        * every value must be a finite, non-boolean real number, on the shared
+          :meth:`~strands_robots.simulation.base.SimEngine._coerce_joint_state_map`
+          domain. A ``nan`` / ``inf`` is refused rather than written into the
+          articulation, where PhysX surfaces it from a *later* step as an
+          "Illegal BroadPhaseUpdateData - non-finite bounds" error; a boolean is
+          refused because ``float(True)`` is a silent 1-radian target.
+
+        Validation runs synchronously, before the write is queued for the main
+        thread, so a rejected value is reported to the caller rather than raised
+        on the pump thread - where the queued-action handler swallows it after
+        this method has already answered ``status="success"``.
+
+        Returns
+        -------
+        dict
+            Standard ``{"status", "content"}`` envelope; ``error`` for an
+            unknown/uninitialized robot or a value outside the domain above.
         """
         with self._lock:
             if not self._world_created or not self._robots:
@@ -5264,16 +5298,84 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             if r is None or r.articulation is None:
                 return {"status": "error", "content": [{"text": f"Robot {robot_name!r} not initialized."}]}
 
+            joint_names = list(r.joint_names)
+            # Normalize both accepted shapes to a {joint name: value} mapping so
+            # one set of checks covers them. The list form binds positionally to
+            # the robot's joint order, so its length is part of the contract: a
+            # mismatched vector used to be written straight through, resizing the
+            # articulation's joint-position array instead of being refused.
+            if isinstance(positions, dict):
+                requested: dict[str, Any] = dict(positions)
+            elif isinstance(positions, (list, tuple, np.ndarray)):
+                ordered = list(positions)
+                if len(ordered) != len(joint_names):
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"set_joint_positions: list length {len(ordered)} does not match robot "
+                                    f"{robot_name!r} joint count {len(joint_names)}. Use a dict for partial updates."
+                                )
+                            }
+                        ],
+                    }
+                requested = dict(zip(joint_names, ordered, strict=True))
+            else:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "set_joint_positions: 'positions' must be a dict or list, "
+                                f"got {type(positions).__name__}"
+                            )
+                        }
+                    ],
+                }
+
+            # Resolve every name before any write, so a partially-resolvable
+            # mapping is refused rather than applied in part and reported as a
+            # complete pose.
+            if not requested:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "set_joint_positions: 'positions' is empty, so there is nothing to write. "
+                                "Pass at least one joint (dict form) or a full ordered vector (list form); "
+                                "use action='robot_joint_names' to see one robot's joints."
+                            )
+                        }
+                    ],
+                }
+            index_of = {jn: i for i, jn in enumerate(joint_names)}
+            unresolved = [jn for jn in requested if jn not in index_of]
+            if unresolved:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"set_joint_positions: unresolved 'positions' keys {unresolved} on robot "
+                                f"{robot_name!r}. Its joints are {joint_names}; "
+                                "use action='robot_joint_names' to list them."
+                            )
+                        }
+                    ],
+                }
+
+            coerced, err = self._coerce_joint_state_map(requested, "positions", "set_joint_positions")
+            if err:
+                return err
+            targets = {index_of[jn]: value for jn, value in coerced.items()}
+
             def _apply() -> None:
-                if isinstance(positions, dict):
-                    cur = list(r.articulation.get_joint_positions())
-                    idx = {jn: i for i, jn in enumerate(r.joint_names)}
-                    for jn, v in positions.items():
-                        if jn in idx:
-                            cur[idx[jn]] = float(v)
-                    r.articulation.set_joint_positions(np.array(cur, dtype=float))
-                else:
-                    r.articulation.set_joint_positions(np.array(positions, dtype=float))
+                cur = list(r.articulation.get_joint_positions())
+                for dof, value in targets.items():
+                    cur[dof] = value
+                r.articulation.set_joint_positions(np.array(cur, dtype=float))
 
             if self._on_main_thread():
                 _apply()

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
+from strands_robots.simulation.base import _BOOLEAN_STATE_REASON
 from strands_robots.simulation.mujoco.backend import (
     _NO_WORLD_MSG,
     _ensure_mujoco,
@@ -36,30 +37,6 @@ from strands_robots.simulation.mujoco.scene_ops import (
 from strands_robots.utils import BOOLEAN_VECTOR_REASON, coerce_rgba, is_boolean
 
 logger = logging.getLogger(__name__)
-
-
-# Why a runtime state write refuses a boolean, kept in one place because three
-# surfaces quote it (set_joint_positions, set_joint_velocities, apply_force).
-#
-# The actuator-command path refuses one for a stronger reason: 1.0 is re-read in
-# each drive's own units, so the same True commands a different pose on every
-# actuator. Here 1.0 is a single unambiguous quantity - 1 radian, 1 rad/s, 1 N -
-# so a boolean is merely wrong rather than ambiguous, which is why #1837 left
-# these writers alone and #1838 settled them separately.
-#
-# They refuse it anyway, and the deciding argument is consistency of the domain
-# rather than the severity of the outcome: every scene-construction vector in
-# strands_robots.utils already rejects a bool component for exactly this reason
-# ("float(True) would silently write 1.0 where a coordinate, extent or colour
-# channel belongs"). A caller who cannot place a body at True should not be able
-# to teleport a joint to True either, and no caller can plausibly mean "1 radian"
-# by True. The alternative - accepting it here - would leave the direct API and
-# the tool surface stating different domains for the same kind of number.
-_BOOLEAN_STATE_REASON = (
-    "float(True) is 1.0, so a boolean would be written as 1 radian, 1 rad/s or "
-    "1 N depending on the surface, and the call would report success. Pass the "
-    "quantity in the surface's own units."
-)
 
 
 def _coerce_finite_vector(
@@ -189,71 +166,6 @@ def _coerce_rgba(color: Any, method: str, name: str = "color") -> tuple[list[flo
     if reason is not None:
         return None, {"status": "error", "content": [{"text": reason}]}
     return rgba, None
-
-
-def _coerce_finite_joint_map(
-    values: dict[str, Any],
-    name: str,
-    method: str,
-) -> tuple[dict[str, float], dict[str, Any] | None]:
-    """Coerce a ``{joint_name: value}`` map to finite floats before any write.
-
-    Each value must be a real number (Python or NumPy scalar) and finite, and
-    must not be a boolean. A
-    non-numeric value would otherwise raise ``ValueError`` from ``float(value)``
-    past the structured-error dispatch contract, and ``nan`` / ``inf`` would
-    slip straight into ``data.qpos`` / ``data.qvel`` -- ``mj_forward`` then
-    propagates the ``nan`` across the whole kinematic state (or an ``inf``
-    velocity blows up the integrator) while the tool still reports
-    ``status="success"``. A boolean is refused for the reason in
-    :data:`_BOOLEAN_STATE_REASON`: it survives ``float()`` as a silent ``1.0``,
-    so it is the one invalid value the finiteness check cannot see. Validating up
-    front keeps the write atomic: an invalid value leaves the model untouched.
-
-    Args:
-        values: The ``{joint_name: value}`` mapping to validate.
-        name: Parameter name (``"positions"`` / ``"velocities"``), used in error text.
-        method: Calling method name, used in error text.
-
-    Returns:
-        ``(coerced, None)`` on success, or ``({}, error_dict)`` on the first
-        invalid value -- matching the structured-error tool contract so the
-        caller never raises past dispatch.
-    """
-    out: dict[str, float] = {}
-    for jnt_name, value in values.items():
-        # Before float(): float(True) is 1.0, so the boolean is unrecoverable
-        # once coerced and the write would report success having set 1 rad /
-        # 1 rad/s. numpy.bool_ needs the .item() unwrap is_boolean applies.
-        if is_boolean(value):
-            return {}, {
-                "status": "error",
-                "content": [
-                    {
-                        "text": f"{method}: '{name}' value for joint '{jnt_name}' must be a number, not a bool (got {value!r}). {_BOOLEAN_STATE_REASON}"
-                    }
-                ],
-            }
-        try:
-            f = float(value)
-        except (TypeError, ValueError):
-            return {}, {
-                "status": "error",
-                "content": [
-                    {"text": f"{method}: '{name}' value for joint '{jnt_name}' must be a number, got {value!r}"}
-                ],
-            }
-        if not math.isfinite(f):
-            return {}, {
-                "status": "error",
-                "content": [
-                    {
-                        "text": f"{method}: '{name}' value for joint '{jnt_name}' must be finite (no nan/inf), got {value!r}"
-                    }
-                ],
-            }
-        out[jnt_name] = f
-    return out, None
 
 
 # A ray batch is a sequence of 3-component direction vectors. Spelling it out in
@@ -564,6 +476,11 @@ class PhysicsMixin:
 
         def _validate_mass(self, mass: Any, method: str, param: str = "mass") -> dict[str, Any] | None:
             """Reject a body mass the physics engine cannot honor."""
+
+        def _coerce_joint_state_map(
+            self, values: dict[str, Any], name: str, method: str
+        ) -> tuple[dict[str, float], dict[str, Any] | None]:
+            """Coerce a joint-state map to finite floats before any write."""
 
     # State Checkpointing
 
@@ -1516,7 +1433,7 @@ class PhysicsMixin:
         # this a non-numeric entry raises ValueError past the structured-error
         # contract, and a nan/inf lands in data.qpos where mj_forward propagates
         # it across the whole kinematic state while the tool still reports success.
-        positions, err = _coerce_finite_joint_map(positions, "positions", "set_joint_positions")
+        positions, err = self._coerce_joint_state_map(positions, "positions", "set_joint_positions")
         if err:
             return err
 
@@ -1626,7 +1543,7 @@ class PhysicsMixin:
         # Validate every value is a finite number before any qvel write (see
         # set_joint_positions): a nan/inf velocity blows up the integrator on the
         # next step and a non-numeric entry escapes the structured-error contract.
-        velocities, err = _coerce_finite_joint_map(velocities, "velocities", "set_joint_velocities")
+        velocities, err = self._coerce_joint_state_map(velocities, "velocities", "set_joint_velocities")
         if err:
             return err
 

--- a/tests/simulation/mujoco/test_state_writers_reject_a_boolean.py
+++ b/tests/simulation/mujoco/test_state_writers_reject_a_boolean.py
@@ -14,7 +14,7 @@ while every scene-construction vector refused the same value. #1837 settled the
 scope for numeric-element validation". The decision this pins is that they refuse
 it, for consistency with the domain
 :func:`strands_robots.utils.finite_vector_error` already states - the full
-argument is in ``physics._BOOLEAN_STATE_REASON``.
+argument is in ``simulation.base._BOOLEAN_STATE_REASON``.
 
 Every boolean assertion here fails on pre-fix code, where the call returned
 ``status="success"``. The ``StillAccepted`` / ``still`` tests are the over-reach
@@ -32,10 +32,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-from strands_robots.simulation.mujoco.physics import (
-    _BOOLEAN_STATE_REASON,
-    _coerce_finite_joint_map,
-)
+from strands_robots.simulation.base import _BOOLEAN_STATE_REASON, SimEngine
 from strands_robots.utils import is_boolean
 
 # Every spelling of a boolean that can reach a writer: a python bool, a numpy
@@ -53,7 +50,7 @@ _NUMBER_IDS = ["int_0", "int_1", "int_neg1", "float", "neg_float", "np_float", "
 
 
 class TestSharedJointMapCoercionRefusesABoolean:
-    """``_coerce_finite_joint_map`` backs both joint writers, so one gate covers both.
+    """``SimEngine._coerce_joint_state_map`` backs both joint writers, so one gate covers both.
 
     Exercised directly so the domain is pinned even where MuJoCo is unavailable;
     the sim-level classes below prove the writers actually route through it.
@@ -62,14 +59,14 @@ class TestSharedJointMapCoercionRefusesABoolean:
     @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
     @pytest.mark.parametrize("param", ["positions", "velocities"])
     def test_every_boolean_spelling_is_refused(self, value: Any, param: str) -> None:
-        out, err = _coerce_finite_joint_map({"j0": value}, param, f"set_joint_{param}")
+        out, err = SimEngine._coerce_joint_state_map({"j0": value}, param, f"set_joint_{param}")
         assert err is not None, f"{value!r} was accepted as a {param} value"
         assert err["status"] == "error"
         assert out == {}, "a refused map must coerce nothing"
 
     @pytest.mark.parametrize("value", _BOOLEANS, ids=_BOOLEAN_IDS)
     def test_the_refusal_names_the_joint_the_parameter_and_the_units(self, value: Any) -> None:
-        _, err = _coerce_finite_joint_map({"shoulder_pan": value}, "positions", "set_joint_positions")
+        _, err = SimEngine._coerce_joint_state_map({"shoulder_pan": value}, "positions", "set_joint_positions")
         assert err is not None
         text = err["content"][0]["text"]
         assert "set_joint_positions" in text
@@ -80,23 +77,25 @@ class TestSharedJointMapCoercionRefusesABoolean:
 
     def test_a_boolean_among_valid_values_refuses_the_whole_map(self) -> None:
         """The write is all-or-nothing: one bad value coerces none of them."""
-        out, err = _coerce_finite_joint_map({"j0": 0.5, "j1": True, "j2": -0.25}, "positions", "set_joint_positions")
+        out, err = SimEngine._coerce_joint_state_map(
+            {"j0": 0.5, "j1": True, "j2": -0.25}, "positions", "set_joint_positions"
+        )
         assert err is not None
         assert "j1" in err["content"][0]["text"]
         assert out == {}, "a partial coercion would let a partial pose through"
 
     @pytest.mark.parametrize("value", _NUMBERS, ids=_NUMBER_IDS)
     def test_numbers_are_still_accepted(self, value: Any) -> None:
-        out, err = _coerce_finite_joint_map({"j0": value}, "positions", "set_joint_positions")
+        out, err = SimEngine._coerce_joint_state_map({"j0": value}, "positions", "set_joint_positions")
         assert err is None, f"{value!r} must remain a usable position"
         assert out == {"j0": float(value)}
 
     def test_one_is_accepted_though_it_is_what_true_would_have_written(self) -> None:
         """The gate keys on the type, not the value - 1.0 rad is a real request."""
-        out, err = _coerce_finite_joint_map({"j0": 1}, "positions", "set_joint_positions")
+        out, err = SimEngine._coerce_joint_state_map({"j0": 1}, "positions", "set_joint_positions")
         assert err is None
         assert out == {"j0": 1.0}
-        _, bool_err = _coerce_finite_joint_map({"j0": True}, "positions", "set_joint_positions")
+        _, bool_err = SimEngine._coerce_joint_state_map({"j0": True}, "positions", "set_joint_positions")
         assert bool_err is not None, "True must not ride in on int's acceptance"
 
     @pytest.mark.parametrize(
@@ -106,7 +105,7 @@ class TestSharedJointMapCoercionRefusesABoolean:
     )
     def test_the_pre_existing_domain_is_unchanged(self, value: Any, expected: str) -> None:
         """The bool gate is additive: non-numeric and nan/inf keep their own messages."""
-        _, err = _coerce_finite_joint_map({"j0": value}, "positions", "set_joint_positions")
+        _, err = SimEngine._coerce_joint_state_map({"j0": value}, "positions", "set_joint_positions")
         assert err is not None
         text = err["content"][0]["text"]
         assert expected in text
@@ -150,7 +149,7 @@ class TestOneBooleanPredicateNotThree:
         from strands_robots.simulation.mujoco import physics
 
         assert physics.is_boolean is is_boolean
-        assert "is_boolean(value)" in inspect.getsource(physics._coerce_finite_joint_map)
+        assert "is_boolean(value)" in inspect.getsource(SimEngine._coerce_joint_state_map)
         assert "is_boolean(_elem)" in inspect.getsource(physics.PhysicsMixin.apply_force)
 
     def test_the_retired_scope_note_is_gone_from_apply_force(self) -> None:

--- a/tests/simulation/test_input_validators_refuse_a_boolean.py
+++ b/tests/simulation/test_input_validators_refuse_a_boolean.py
@@ -377,7 +377,7 @@ class TestTheVectorCoercionRefusesABooleanComponent:
         the units of the joint writers - not of a coordinate, an extent or a
         colour channel.
         """
-        from strands_robots.simulation.mujoco.physics import _BOOLEAN_STATE_REASON
+        from strands_robots.simulation.base import _BOOLEAN_STATE_REASON
         from strands_robots.utils import BOOLEAN_VECTOR_REASON
 
         _, err = self._coerce([True, 0.0, 0.0], "origin", "raycast")

--- a/tests/simulation/test_joint_state_domain_is_shared_across_backends.py
+++ b/tests/simulation/test_joint_state_domain_is_shared_across_backends.py
@@ -1,0 +1,354 @@
+"""The kinematic state writers apply one joint-state domain on every backend.
+
+``set_joint_positions`` writes joint state directly, bypassing the actuators. The
+MuJoCo backend refuses a value the engine cannot honor - a boolean (``float(True)``
+is a silent 1-radian target), a ``nan`` / ``inf`` (``mj_forward`` propagates it
+across the whole kinematic state), a non-numeric value (it would raise past the
+structured-error contract), an unresolvable joint name (the write used to be
+skipped and reported as a complete pose) and a vector of the wrong width. The
+Isaac backend accepted all of them, so the accepted domain depended on which
+engine the caller happened to be driving.
+
+The value half of that contract now lives on the ABC as
+``SimEngine._coerce_joint_state_map``, so the two cannot drift apart again; the
+structural checks are per-backend because each engine resolves joint names
+against a different authority (MuJoCo against the compiled model, Isaac against
+the articulation's DOF order).
+
+Isaac amplifies every case: the write is queued for the main thread when the call
+arrives from a worker, and the pump's queued-action handler swallows
+``ValueError`` / ``TypeError`` as best-effort. So a value that raised on the main
+thread returned ``status="success"`` from a worker and failed with no channel at
+all. Validation therefore has to run synchronously, before the write is queued -
+which is what ``TestARefusalReachesTheCaller`` pins.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+import queue
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation import base as sim_base
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.isaac.simulation import IsaacConfig, IsaacSimulation, _RobotState
+
+JOINTS = ["shoulder", "elbow", "wrist"]
+HOME = [0.10, 0.20, 0.30]
+
+
+class FakeArticulation:
+    """Records what reaches the articulation, so a write is measurable.
+
+    Deliberately permissive: it accepts any width and any value, exactly as
+    Isaac's articulation handle does. A double that validated would hide the
+    defect this module is about.
+    """
+
+    def __init__(self) -> None:
+        self.q: list[float] = list(HOME)
+        self.writes: list[list[float]] = []
+
+    def get_joint_positions(self) -> list[float]:
+        return list(self.q)
+
+    def set_joint_positions(self, arr: Any) -> None:
+        self.writes.append(list(np.asarray(arr, dtype=float).tolist()))
+        self.q = list(np.asarray(arr, dtype=float).tolist())
+
+
+def _engine(*, queued: bool = False) -> tuple[IsaacSimulation, FakeArticulation]:
+    """A skeleton engine whose ``set_joint_positions`` reaches the real code.
+
+    ``__new__`` leaves ``_init_complete`` at its class default of ``False`` so the
+    finalizer skips a teardown this instance never set up.
+    """
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._lock = threading.RLock()
+    engine._world_created = True
+    engine._config = IsaacConfig()
+    # A worker-thread call takes the queued branch; -1 is never a real thread id.
+    engine._main_tid = -1 if queued else threading.get_ident()
+    engine._action_q = queue.Queue()
+    articulation = FakeArticulation()
+    engine._robots = {
+        "arm": _RobotState(
+            name="arm",
+            prim_path="/World/Robots/arm",
+            joint_names=list(JOINTS),
+            articulation=articulation,
+        )
+    }
+    return engine, articulation
+
+
+def _drain(engine: IsaacSimulation) -> str | None:
+    """Apply queued work the way the production pump does, reporting what it ate.
+
+    ``_pump_once`` catches ``ValueError`` / ``TypeError`` from a queued action as
+    best-effort, so a failure there has no channel back to the caller.
+    """
+    swallowed: str | None = None
+    while not engine._action_q.empty():
+        fn = engine._action_q.get_nowait()
+        try:
+            fn()
+        except (RuntimeError, ValueError, AttributeError, TypeError, KeyError, IndexError) as exc:
+            swallowed = f"{type(exc).__name__}: {exc}"
+    return swallowed
+
+
+UNUSABLE_VALUES = [
+    pytest.param(True, "bool", id="python-true"),
+    pytest.param(False, "bool", id="python-false"),
+    pytest.param(np.bool_(True), "bool", id="numpy-true"),
+    pytest.param(float("nan"), "finite", id="nan"),
+    pytest.param(float("inf"), "finite", id="inf"),
+    pytest.param(float("-inf"), "finite", id="negative-inf"),
+    pytest.param("abc", "must be a number", id="non-numeric-string"),
+    pytest.param(None, "must be a number", id="none"),
+    pytest.param([0.5], "must be a number", id="list-value"),
+]
+
+
+class TestIsaacAppliesTheSharedValueDomain:
+    """A value the engine cannot honor is refused, and nothing is written."""
+
+    @pytest.mark.parametrize(("value", "reason"), UNUSABLE_VALUES)
+    def test_an_unusable_value_is_refused(self, value: Any, reason: str) -> None:
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions={"shoulder": value}, robot_name="arm")
+        assert result["status"] == "error", f"{value!r} was accepted as a joint position"
+        text = " ".join(c.get("text", "") for c in result["content"] if "text" in c)
+        assert reason in text, text
+        assert "shoulder" in text, "the refusal must name the joint it is about"
+        assert articulation.writes == [], "a refused value must not reach the articulation"
+        assert articulation.q == HOME
+
+    @pytest.mark.parametrize(("value", "reason"), UNUSABLE_VALUES)
+    def test_the_list_form_is_held_to_the_same_domain(self, value: Any, reason: str) -> None:
+        """The two accepted shapes must not have different value domains."""
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions=[value, 0.2, 0.3], robot_name="arm")
+        assert result["status"] == "error", f"{value!r} was accepted as a vector entry"
+        assert articulation.q == HOME
+
+    def test_a_non_finite_value_never_reaches_the_articulation(self) -> None:
+        """PhysX surfaces a non-finite articulation from a later step, not this call.
+
+        So a ``nan`` written here is reported as success and diagnosed elsewhere.
+        """
+        engine, articulation = _engine()
+        engine.set_joint_positions(positions={"elbow": float("nan")}, robot_name="arm")
+        assert all(math.isfinite(v) for v in articulation.q)
+
+    def test_a_boolean_is_not_read_as_one_radian(self) -> None:
+        engine, articulation = _engine()
+        engine.set_joint_positions(positions={"shoulder": True}, robot_name="arm")
+        assert articulation.q[0] != 1.0, "float(True) was written as a 1-radian target"
+        assert articulation.q == HOME
+
+
+class TestIsaacResolvesEveryJointNameBeforeWriting:
+    """The write is all-or-nothing: a name that does not resolve refuses the call."""
+
+    def test_a_typo_is_refused_rather_than_skipped(self) -> None:
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions={"shoudler": 0.9}, robot_name="arm")
+        assert result["status"] == "error"
+        text = " ".join(c.get("text", "") for c in result["content"] if "text" in c)
+        assert "shoudler" in text, "the refusal must name the key that did not resolve"
+        assert "shoulder" in text, "and list the joints the robot does have"
+        assert articulation.writes == []
+
+    def test_a_partly_resolvable_mapping_writes_nothing(self) -> None:
+        """The worst case: half the requested pose applied, reported as all of it."""
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions={"shoulder": 0.9, "nope": 0.5}, robot_name="arm")
+        assert result["status"] == "error"
+        assert articulation.q == HOME, "a partial pose was applied"
+
+    def test_an_empty_mapping_is_refused(self) -> None:
+        """There is no write whose success could be reported."""
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions={}, robot_name="arm")
+        assert result["status"] == "error"
+        text = " ".join(c.get("text", "") for c in result["content"] if "text" in c)
+        assert "empty" in text
+        assert articulation.writes == []
+
+
+class TestIsaacRefusesAVectorOfTheWrongWidth:
+    """The list form binds positionally, so its length is part of the contract."""
+
+    @pytest.mark.parametrize("ordered", [[0.5, 0.6], [0.5, 0.6, 0.7, 0.8], []], ids=["short", "long", "empty"])
+    def test_a_mismatched_vector_is_refused(self, ordered: list[float]) -> None:
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions=ordered, robot_name="arm")
+        assert result["status"] == "error"
+        assert articulation.writes == []
+        assert len(articulation.q) == len(JOINTS), "the articulation's joint array was resized"
+
+    def test_the_refusal_names_both_counts(self) -> None:
+        engine, _ = _engine()
+        result = engine.set_joint_positions(positions=[0.5, 0.6], robot_name="arm")
+        text = " ".join(c.get("text", "") for c in result["content"] if "text" in c)
+        assert "2" in text and "3" in text, text
+        assert "dict" in text, "and point at the shape that does support a partial update"
+
+    @pytest.mark.parametrize("value", ["abc", 0.5, {0.5}], ids=["string", "scalar", "set"])
+    def test_a_value_that_is_neither_mapping_nor_vector_is_refused(self, value: Any) -> None:
+        """A str is iterable, so it would otherwise be read as one entry per character."""
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions=value, robot_name="arm")
+        assert result["status"] == "error"
+        assert articulation.writes == []
+
+
+class TestARefusalReachesTheCaller:
+    """Validation is synchronous, so a worker-thread call is answered, not queued.
+
+    Placed after the world/robot checks and before ``_action_q.put``: the pump
+    swallows a queued failure, so a check that ran inside the queued work would
+    leave the caller holding ``status="success"`` for a write that never happened.
+    """
+
+    @pytest.mark.parametrize(
+        "positions",
+        [{"shoulder": True}, {"shoulder": float("nan")}, {"shoulder": "abc"}, {"shoudler": 0.9}, [0.5, 0.6]],
+        ids=["bool", "nan", "non-numeric", "typo", "wrong-width"],
+    )
+    def test_an_unusable_value_is_never_queued(self, positions: Any) -> None:
+        engine, articulation = _engine(queued=True)
+        result = engine.set_joint_positions(positions=positions, robot_name="arm")
+        assert result["status"] == "error", "a worker-thread call must be refused too"
+        assert engine._action_q.empty(), "the refused write was queued instead of reported"
+        assert _drain(engine) is None
+        assert articulation.q == HOME
+
+    def test_the_two_call_paths_agree(self) -> None:
+        """The same value must not be refused on one thread and accepted on another."""
+        for positions in ({"shoulder": "abc"}, {"shoulder": True}, [0.5, 0.6], {}):
+            main_engine, _ = _engine()
+            worker_engine, _ = _engine(queued=True)
+            assert (
+                main_engine.set_joint_positions(positions=positions, robot_name="arm")["status"]
+                == worker_engine.set_joint_positions(positions=positions, robot_name="arm")["status"]
+            ), f"verdicts differ by calling thread for {positions!r}"
+
+
+class TestAcceptedValuesStillWrite:
+    """The domain is additive: every usable call keeps working, on both paths."""
+
+    @pytest.mark.parametrize("queued", [False, True], ids=["main", "queued"])
+    def test_a_partial_mapping_writes_only_the_named_joints(self, queued: bool) -> None:
+        engine, articulation = _engine(queued=queued)
+        result = engine.set_joint_positions(positions={"shoulder": 0.9}, robot_name="arm")
+        assert result["status"] == "success"
+        _drain(engine)
+        assert articulation.q == pytest.approx([0.9, HOME[1], HOME[2]])
+
+    @pytest.mark.parametrize("queued", [False, True], ids=["main", "queued"])
+    def test_a_full_vector_writes_every_joint(self, queued: bool) -> None:
+        engine, articulation = _engine(queued=queued)
+        result = engine.set_joint_positions(positions=[0.5, 0.6, 0.7], robot_name="arm")
+        assert result["status"] == "success"
+        _drain(engine)
+        assert articulation.q == pytest.approx([0.5, 0.6, 0.7])
+
+    @pytest.mark.parametrize(
+        "value",
+        [0, 0.0, -1.25, np.float64(0.75), np.int64(1), "0.5"],
+        ids=["int0", "float0", "negative", "np-float", "np-int", "numeric-string"],
+    )
+    def test_a_usable_spelling_of_a_number_is_accepted(self, value: Any) -> None:
+        """The domain is finiteness, not a narrow type - a numeric string is a number."""
+        engine, articulation = _engine()
+        result = engine.set_joint_positions(positions={"elbow": value}, robot_name="arm")
+        assert result["status"] == "success", f"{value!r} was refused"
+        assert articulation.q[1] == pytest.approx(float(value))
+
+
+class TestTheSharedValueDomainIsOnTheABC:
+    """One owner for the value half, so the backends cannot diverge again."""
+
+    def test_the_domain_lives_on_the_engine_base(self) -> None:
+        assert hasattr(SimEngine, "_coerce_joint_state_map")
+
+    @pytest.mark.parametrize(("value", "reason"), UNUSABLE_VALUES)
+    def test_the_shared_domain_refuses_what_the_backends_refuse(self, value: Any, reason: str) -> None:
+        coerced, error = SimEngine._coerce_joint_state_map({"j0": value}, "positions", "set_joint_positions")
+        assert error is not None
+        assert coerced == {}, "a rejected map must not be returned half-coerced"
+        assert reason in error["content"][0]["text"]
+
+    def test_it_reports_rather_than_raises(self) -> None:
+        """The structured-error contract: a caller never has to catch."""
+        coerced, error = SimEngine._coerce_joint_state_map({"j0": "abc"}, "positions", "set_joint_positions")
+        assert error is not None and error["status"] == "error"
+        assert coerced == {}
+
+    def test_it_rejects_atomically(self) -> None:
+        """One bad entry rejects the whole map, so a write cannot be partial."""
+        coerced, error = SimEngine._coerce_joint_state_map(
+            {"j0": 0.5, "j1": float("nan"), "j2": -0.25}, "positions", "set_joint_positions"
+        )
+        assert error is not None
+        assert coerced == {}
+
+
+def _joint_state_writers() -> dict[tuple[str, str], str]:
+    """Every public joint-state writer defined by a simulation backend.
+
+    Keyed by ``(backend, method)`` so the failure message names the surface that
+    drifted rather than a line number.
+    """
+    package = pathlib.Path(inspect.getfile(sim_base)).parent
+    writers: dict[tuple[str, str], str] = {}
+    for path in sorted(package.rglob("*.py")):
+        backend = path.parent.name
+        if backend == package.name:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            for fn in ast.iter_child_nodes(cls):
+                if not isinstance(fn, ast.FunctionDef):
+                    continue
+                if fn.name not in ("set_joint_positions", "set_joint_velocities"):
+                    continue
+                writers[(backend, fn.name)] = ast.unparse(fn)
+    return writers
+
+
+class TestEveryBackendJointStateWriterAppliesTheSharedDomain:
+    """A fourth backend cannot ship a joint-state writer with its own domain."""
+
+    def test_the_scan_finds_the_known_writers(self) -> None:
+        """A scan that found nothing would pass every assertion below."""
+        assert set(_joint_state_writers()) == {
+            ("mujoco", "set_joint_positions"),
+            ("mujoco", "set_joint_velocities"),
+            ("isaac", "set_joint_positions"),
+        }
+
+    def test_every_writer_calls_the_shared_domain(self) -> None:
+        adrift = sorted(k for k, src in _joint_state_writers().items() if "_coerce_joint_state_map" not in src)
+        assert not adrift, (
+            f"these joint-state writers do not apply the shared value domain: {adrift}. "
+            "A boolean reaches the joint state as a 1-radian target and a nan/inf is "
+            "written unexamined, under status='success'."
+        )
+
+    def test_the_scanner_detects_a_planted_writer(self) -> None:
+        """Without this, a scanner that silently matched nothing would look clean."""
+        planted = ast.unparse(
+            ast.parse("class E:\n    def set_joint_positions(self, positions=None):\n        return float(positions)\n")
+        )
+        assert "_coerce_joint_state_map" not in planted


### PR DESCRIPTION
## Problem

`set_joint_positions` bypasses the actuators and writes joint state directly. The MuJoCo backend refuses a value the engine cannot honor. The Isaac backend accepted **every one of them**, so the accepted domain depended on which engine the caller happened to be driving.

Measured against a 3-joint articulation (`shoulder`, `elbow`, `wrist`) at `[0.10, 0.20, 0.30]`:

| `positions=` | main | what main left |
| --- | --- | --- |
| `{"shoulder": True}` | `success` | `[1.0, 0.2, 0.3]` — a 1-radian target |
| `{"shoulder": np.True_}` | `success` | `[1.0, 0.2, 0.3]` |
| `{"shoulder": nan}` | `success` | non-finite joint state |
| `{"shoulder": inf}` | `success` | non-finite joint state |
| `{"shoudler": 0.9}` (typo) | `success` | nothing written |
| `{"shoulder": 0.9, "nope": 0.5}` | `success` | half the pose written |
| `{}` | `success` | nothing written |
| `{"shoulder": "abc"}` | **raised** `ValueError` | nothing written |
| `[0.5, 0.6]` (3 joints) | `success` | articulation resized to width 2 |
| `[0.5, 0.6, 0.7, 0.8]` | `success` | articulation resized to width 4 |
| `"abc"` | **raised** `ValueError` | nothing written |

Eleven of eleven accepted, and `_coerce_finite_joint_map`'s own docstring already stated why each is refused on MuJoCo (`nan` propagating across the kinematic state, `float(True)` surviving as a silent `1.0`, a non-numeric value raising past the structured-error contract). `_resolve_joint_write_targets`'s docstring likewise already described the skipped-name case verbatim: "a typo … wrote nothing - or worse, wrote only part of the requested pose - while the caller was told the pose had been applied."

### The verdict depended on which thread called

Isaac queues the write for the main thread when the call arrives from a worker, and `_pump_once` catches `ValueError` / `TypeError` from a queued action as best-effort. So `{"shoulder": "abc"}` raised on the main thread and returned `status="success"` from a worker — with the failure swallowed on the pump thread, and no channel back to the caller at all.

The non-finite case is the one that surfaces furthest from its cause: `set_robot_pose`, four hundred lines below in the same file, already refuses a non-finite pose precisely because PhysX reports it only from a *later* step, as `Illegal BroadPhaseUpdateData - non-finite bounds`. The joint-state writer wrote it unexamined.

## Change

The **value** half of the contract moves to `SimEngine._coerce_joint_state_map`, promoted from the MuJoCo backend with its message text unchanged, so the two backends cannot drift apart again. `_BOOLEAN_STATE_REASON` moves with it, beside its existing siblings `_BOOLEAN_WORLD_REASON` and `_BOOLEAN_ACTION_REASON`. No new domain was invented — the rule already existed and only had one caller.

Isaac applies it, plus the structural checks its sibling already enforced, written against Isaac's own authority (the articulation's DOF order rather than a compiled model):

- the list form's length must equal the robot's joint count — a mismatch is refused instead of resizing the joint-position array;
- every mapping key must name one of the robot's joints, and the mapping must not be empty — resolved up front, so the write is all-or-nothing;
- every value goes through the shared domain.

Validation runs **synchronously**, after the world/robot checks and before `_action_q.put`, so a rejected value is reported to the caller rather than swallowed on the pump thread. The refusal names the unresolved keys and lists the joints the robot does have.

The structural checks stay per-backend deliberately: MuJoCo resolves joint names against the compiled model (supporting namespaced names), Isaac against the articulation's DOF order. Only the value domain is genuinely shared, and that is what moved.

## Scope

Newton defines no joint-state writer, so there is nothing to align there. `set_joint_velocities` does not exist on Isaac. Both are covered by the parity test below, which enumerates the writers rather than hard-coding a list, so either arriving later is checked automatically.

## Tests

`tests/simulation/test_joint_state_domain_is_shared_across_backends.py`, 61 tests, GL-free and dependency-free (0.53 s):

- every unusable value refused on both accepted shapes, with the articulation provably untouched;
- a typo, a partly-resolvable mapping and an empty mapping refused, with the half-pose case asserting the arm did not move;
- a short, long and empty vector refused, asserting the articulation's joint array was **not resized**;
- `TestARefusalReachesTheCaller` — a refused value is never queued (`_action_q` empty), and the two call paths return the same verdict for the same value;
- `TestAcceptedValuesStillWrite` — a partial mapping, a full vector, and six usable spellings of a number (including `np.float64`, `np.int64` and a numeric string) all still write, on both paths;
- `TestEveryBackendJointStateWriterAppliesTheSharedDomain` — an AST parity guard over every backend joint-state writer, with a planted-defect meta-test and a non-vacuity test pinning the exact known writer set, so a fourth backend cannot ship its own domain.

Pre-fix (Isaac + MuJoCo reverted to `main`, the shared domain kept on the base so the module still imports): **37 failed, 24 passed**. The parity guard's failure names all three writers:

```
AssertionError: these joint-state writers do not apply the shared value domain:
[('isaac', 'set_joint_positions'), ('mujoco', 'set_joint_positions'), ('mujoco', 'set_joint_velocities')]
```

The 24 that pass pre-fix are the accepted-value controls, the shared-domain unit tests and the scanner's own meta-tests — they are what stop the change over-reaching.

Blast radius is one existing test file: `tests/simulation/mujoco/test_state_writers_reject_a_boolean.py` now imports the promoted symbol from `simulation.base` and points its `getsource` assertion at it. Every message-text assertion is unchanged, because the text is.

## Verification

```
MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly
  18671 passed, 257 skipped in 529.80s

ruff check strands_robots tests tests_integ            All checks passed!
ruff format --check strands_robots tests tests_integ   1051 files already formatted
mypy strands_robots tests tests_integ                  0 errors outside examples/
```

The 14 `examples/isaac_gs/*` mypy errors reproduce identically on a pristine `upstream/main` checkout in the same working copy, so they are a property of this local checkout rather than of the change.

## Artifact

Isaac cannot render on this host, so the joint state **each tree actually left in the articulation** is replayed onto a MuJoCo arm declaring the same joint names — the pictures are the measured writes, not a reconstruction. The call is `set_joint_positions({"shouldre": 1.15, "elbow": -1.30})`, where `shouldre` is a typo for `shoulder`.

![Isaac joint-state domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-joint-state-domain/isaac_joint_state_domain.png)

On `main` the typo is skipped, the elbow alone is written and the call reports `success` — the arm ends up differing from the requested pose across **73.7% of the frame**. With this change the call is refused naming the unresolved key, and the arm is byte-identical to before (**0%** of pixels differ). The reference panel is rendered by both trees and agrees to within 2/255, so the two runs share one rig and only the operation differs.

The generating scripts and the raw measured JSON for both trees are on the [same branch](https://github.com/cagataycali/robots/tree/artifacts/isaac-joint-state-domain); each measurement run prints the source tree it resolved, so every number is attributable.