### PR TITLE
fix(sim/newton): the recorded action schema is declared from robot_action_keys

### DIFF
--- a/changelog.d/1929-newton-action-schema-authority.md
+++ b/changelog.d/1929-newton-action-schema-authority.md
@@ -1,0 +1,32 @@
+### Fixed: Newton's recorded action schema is declared from `robot_action_keys`
+
+`DatasetRecorder` names the `action` feature's columns from the `action_names` it
+is handed, and falls back to `joint_names` when a backend passes none. Newton was
+the one backend on that fallback: Isaac and MuJoCo both declare `action_names`
+from `robot_action_keys`, Newton passed none, so its action columns were named in
+the joint vocabulary while its recording hook emits the actuator vocabulary
+`robot_action_keys` defines.
+
+The two vocabularies agreed, so no recording was miscolumned. They agreed only
+because `_collect_recording_schema` and `NewtonSimEngine.robot_action_keys` each
+excluded the floating base's 6-DoF free joint from its own copy of the rule, and
+the fallback made that agreement load-bearing. An existing pin said as much in its
+own docstring - it asserted the equality "rather than assumed from the fact that
+Newton's schema fallback happens to be the scalar joint list".
+
+Either copy drifting would have failed silently. `add_frame` reads the action dict
+by declared name, so a column declared under a name the hook never emits is not a
+mismatch the recorder can report: it takes the `0.0` fill and the frame records a
+command nobody issued under `status="success"`. Every action space reaching a
+recorded rollout is absolute position, so `PolicyRunner.replay` re-sends those
+zeros to the robot as travel-to-zero targets. That is the fabrication reported in
+#1715, reached with one robot and no narrow policy.
+
+`_collect_recording_schema` now returns `action_names` alongside `joint_names` -
+mirroring Isaac's 6-tuple and ordering - built from `robot_action_keys` with the
+same `robot__` prefixing the recording hook applies, and `start_recording` passes
+it to `create`. No recorded column changes for any robot this backend can build
+today; what changes is that the naming no longer depends on two copies of an
+exclusion rule staying in step. An AST guard asserts every backend's
+`_DatasetRecorder.create` passes `action_names`, so no backend can re-enter the
+fallback silently.

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -231,7 +231,14 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             # and wipe on overwrite. See DatasetRecordingMixin._prepare_dataset_target.
             resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
-            joint_names, camera_keys, camera_dims, robot_type, recording_cameras = self._collect_recording_schema()
+            (
+                joint_names,
+                action_names,
+                camera_keys,
+                camera_dims,
+                robot_type,
+                recording_cameras,
+            ) = self._collect_recording_schema()
 
             # Backend parity with the MuJoCo recorder: a floating-base robot
             # (humanoid / mobile) exposes full base kinematics via
@@ -320,6 +327,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                     fps=fps,
                     robot_type=robot_type,
                     joint_names=joint_names,
+                    action_names=action_names,
                     extra_state_specs=base_state_specs,
                     camera_keys=camera_keys,
                     camera_dims=camera_dims,
@@ -349,13 +357,17 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
 
     def _collect_recording_schema(
         self,
-    ) -> tuple[list[str], list[str], dict[str, tuple[int, int]], str, list[tuple[str, str, int, int]]]:
+    ) -> tuple[list[str], list[str], list[str], dict[str, tuple[int, int]], str, list[tuple[str, str, int, int]]]:
         """Build the dataset schema from the live Newton scene.
 
         Returns:
-            A 5-tuple of:
-              * ``joint_names``: ordered state/action joint ids (namespaced
+            A 6-tuple of:
+              * ``joint_names``: ordered scalar state joint ids (namespaced
                 ``robot__joint`` when more than one robot exists).
+              * ``action_names``: ordered action column ids, taken from
+                :meth:`robot_action_keys` - the same authority ``send_action``
+                and the recording hook's ``required_action_keys`` resolve, so a
+                declared column is always a key ``add_frame`` can receive.
               * ``camera_keys``: sanitized camera feature names (``/`` -> ``__``).
               * ``camera_dims``: map of camera feature name -> ``(height, width)``.
               * ``robot_type``: the dataset ``robot_type`` string.
@@ -365,6 +377,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         world = self._world
         assert world is not None  # guarded by start_recording
         joint_names: list[str] = []
+        action_names: list[str] = []
         robot_type = "unknown"
         multi_robot = len(world.robots) > 1
         free_base = getattr(self, "_robot_free_base_joint", {})
@@ -376,10 +389,23 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             # Mirrors get_observation / get_robot_state.
             free_short = free_base.get(rname)
             scalar_jn = [jn for jn in robot.joint_names if jn != free_short]
+            # Action columns come from ``robot_action_keys``, not from the
+            # scalar joint list computed above, even though the two agree for
+            # every robot this backend can build today. They agree only because
+            # both apply the free-base exclusion, and each applied it from its
+            # own copy of the rule; declaring the action schema from the joint
+            # list makes that agreement load-bearing. A column declared under a
+            # name the hook never emits is not a mismatch the recorder can
+            # report - ``add_frame`` reads the action dict by declared name, so
+            # an unmatched column takes the ``0.0`` fill and the episode records
+            # a command nobody issued under a success result (#1715).
+            act_keys = self.robot_action_keys(rname)
             if multi_robot:
                 joint_names.extend(f"{rname}__{jn}" for jn in scalar_jn)
+                action_names.extend(f"{rname}__{ak}" for ak in act_keys)
             else:
                 joint_names.extend(scalar_jn)
+                action_names.extend(act_keys)
             robot_type = robot.data_config or rname
 
         camera_keys: list[str] = []
@@ -392,7 +418,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             camera_keys.append(safe_name)
             camera_dims[safe_name] = (height, width)
             recording_cameras.append((cam_name, safe_name, width, height))
-        return joint_names, camera_keys, camera_dims, robot_type, recording_cameras
+        return joint_names, action_names, camera_keys, camera_dims, robot_type, recording_cameras
 
     def _make_run_policy_hook(self, robot_name: str, instruction: str) -> Any:
         """Build the per-step ``on_frame`` recording hook for Newton.

--- a/tests/simulation/newton/test_free_base_is_not_an_actuator.py
+++ b/tests/simulation/newton/test_free_base_is_not_an_actuator.py
@@ -133,20 +133,21 @@ class TestTheRecordedWidthRoundTrips:
     ``PolicyRunner.replay`` binds ``robot_action_keys`` against the recorded
     action vector and aborts the episode when the two widths differ, so this
     equality is the property that makes a floating-base recording replayable at
-    all. Pinned as an equality between the two producers rather than assumed
-    from the fact that Newton's schema fallback happens to be the scalar joint
-    list, so either side drifting fails here.
+    all. Pinned as an equality between the two producers rather than assumed, so
+    either side drifting fails here. The schema's action columns are now declared
+    from ``robot_action_keys`` outright rather than inherited from the recorder's
+    joint-name fallback, so these read the action slot of the schema tuple.
     """
 
     def test_the_declared_action_columns_equal_the_action_keys(self):
         engine = _engine(free_base=True)
-        declared, _cam_keys, _cam_dims, _robot_type, _rec_cams = engine._collect_recording_schema()
+        _joint_names, declared, *_rest = engine._collect_recording_schema()
         assert declared == engine.robot_action_keys("g1")
 
     def test_a_vector_action_of_the_recorded_width_is_accepted(self):
         """Pre-fix this refused: 4 recorded values against 5 advertised keys."""
         engine = _engine(free_base=True)
-        declared, *_ = engine._collect_recording_schema()
+        _joint_names, declared, *_rest = engine._collect_recording_schema()
         recorded_frame = [0.1] * len(declared)
 
         result = engine.send_action(recorded_frame, robot_name="g1", n_substeps=1)

--- a/tests/simulation/test_recording_action_schema_across_backends.py
+++ b/tests/simulation/test_recording_action_schema_across_backends.py
@@ -1,0 +1,210 @@
+"""Every backend declares its recorded action columns from ``robot_action_keys``.
+
+``DatasetRecorder`` resolves the ``action`` feature's column names from the
+``action_names`` it is handed, and falls back to ``joint_names`` when a backend
+passes none (``dataset_recorder.py``, the ``elif joint_names:`` branch). That
+fallback is silent, and a backend taking it declares its action columns under
+the *joint* vocabulary while its recording hook emits the *actuator* vocabulary
+that ``robot_action_keys`` defines.
+
+Nothing reports the mismatch. ``add_frame`` reads the action dict by declared
+name, so a declared column the hook never emits is not an error - it takes the
+``0.0`` fill and the frame records a command nobody issued, under a success
+result. That is the #1715 fabrication reached without any narrow policy and
+without a multi-robot scene: one robot, one rollout, every action column zero.
+
+Newton was the backend on that fallback. Its schema builder and
+``robot_action_keys`` both excluded the floating base's free joint, each from
+its own copy of the rule, so the two vocabularies happened to agree and the
+fallback happened to be correct - agreement by coincidence, with nothing
+holding it. These tests pin the authority rather than the coincidence.
+
+Runs solver-free: the schema builder is pure over the world model, so no
+``newton`` / ``warp`` / ``lerobot`` install is required.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.models import SimRobot, SimWorld
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+_SO100_JOINTS = ["Rotation", "Pitch", "Elbow", "Wrist_Pitch", "Wrist_Roll", "Jaw"]
+_FREE_BASE = "floating_base_joint"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _world(*robots: str, joints: list[str] | None = None) -> SimWorld:
+    world = SimWorld()
+    for name in robots:
+        world.robots[name] = SimRobot(
+            name=name,
+            urdf_path="so100.xml",
+            data_config="so100",
+            joint_names=list(joints if joints is not None else _SO100_JOINTS),
+        )
+    return world
+
+
+def _engine(world: SimWorld, free_base: dict[str, str] | None = None) -> Any:
+    """A solver-free ``NewtonSimEngine`` over ``world``.
+
+    ``__new__`` rather than ``__init__``: the schema builder is the only surface
+    under test and it reads the world model, so building a solver would add a
+    Newton/Warp dependency without adding coverage. Mirrors the harness the
+    merged Newton recording tests use.
+    """
+    engine = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._world = world
+    engine.default_width = 320
+    engine.default_height = 240
+    if free_base is not None:
+        engine._robot_free_base_joint = free_base
+    return engine
+
+
+def _schema(engine: Any) -> tuple[list[str], list[str]]:
+    """Return ``(joint_names, action_names)`` from the backend's schema builder."""
+    joint_names, action_names, *_rest = engine._collect_recording_schema()
+    return joint_names, action_names
+
+
+class TestNewtonDeclaresItsActionColumnsFromTheActionKeys:
+    """The declared action columns are ``robot_action_keys``, per robot."""
+
+    def test_a_fixed_base_robot_declares_every_joint_as_an_action_column(self):
+        engine = _engine(_world("arm"))
+        joint_names, action_names = _schema(engine)
+        assert action_names == engine.robot_action_keys("arm")
+        # A fixed-base robot has no free root, so the two vocabularies coincide
+        # here. Pinned so the floating-base case below is read as the contrast.
+        assert action_names == joint_names == _SO100_JOINTS
+
+    def test_a_floating_base_robot_omits_the_free_joint_from_the_action_columns(self):
+        """The free joint is not a commandable scalar, so it is not a column."""
+        engine = _engine(
+            _world("humanoid", joints=[_FREE_BASE, *_SO100_JOINTS]),
+            free_base={"humanoid": _FREE_BASE},
+        )
+        _joint_names, action_names = _schema(engine)
+        assert action_names == engine.robot_action_keys("humanoid")
+        assert _FREE_BASE not in action_names
+        assert action_names == _SO100_JOINTS
+
+    def test_the_free_base_exclusion_is_not_re_derived_for_the_action_schema(self):
+        """The action columns follow ``robot_action_keys``, not the joint list.
+
+        This is the regression the change closes, and it is the one assertion
+        here that fails on the pre-fix tree. Before, the action columns were the
+        recorder's ``joint_names`` fallback; they matched only because the schema
+        builder re-applied the free-base exclusion itself. A backend whose action
+        keys are a different *vocabulary* - not merely a shorter list - exposes
+        that: the declared columns must follow the keys the hook actually emits.
+        """
+
+        class _PrefixedActuators(NewtonSimEngine):
+            """A robot whose actuators are named, not merely filtered, joints."""
+
+            def robot_action_keys(self, robot_name: str) -> list[str]:
+                return [f"a_{jn}" for jn in self.robot_joint_names(robot_name)]
+
+        engine = _PrefixedActuators.__new__(_PrefixedActuators)
+        engine._world = _world("arm")
+        engine.default_width = 320
+        engine.default_height = 240
+
+        joint_names, action_names = _schema(engine)
+        assert action_names == [f"a_{jn}" for jn in _SO100_JOINTS]
+        # The state schema is unchanged - this is an action-side authority, and
+        # conflating the two is what produced the defect.
+        assert joint_names == _SO100_JOINTS
+        assert action_names != joint_names
+
+    def test_multi_robot_action_columns_are_namespaced_like_the_state_columns(self):
+        engine = _engine(_world("alice", "bob"))
+        joint_names, action_names = _schema(engine)
+        assert action_names == [f"{r}__{k}" for r in ("alice", "bob") for k in _SO100_JOINTS]
+        assert len(action_names) == 2 * len(_SO100_JOINTS)
+        # Same prefixing as the state columns, so a frame keyed by the hook's
+        # ``robot__actuator`` names resolves against the declared schema.
+        assert action_names == joint_names
+
+    def test_a_single_robot_scene_is_not_namespaced(self):
+        engine = _engine(_world("solo"))
+        _joint_names, action_names = _schema(engine)
+        assert action_names == _SO100_JOINTS
+        assert not any(name.startswith("solo__") for name in action_names)
+
+    def test_the_declared_columns_are_exactly_what_the_hook_owes(self):
+        """Declared == the hook's ``required_action_keys``, so no column is unowed.
+
+        The hook scopes its ``required_action_keys`` to the driven robot with the
+        same prefixing. In a single-robot session that set is the whole declared
+        schema, which is the property that makes the ``0.0`` fill unreachable
+        there: every declared column is one some frame owes a value for.
+        """
+        engine = _engine(_world("arm"))
+        _joint_names, action_names = _schema(engine)
+        assert action_names == list(engine.robot_action_keys("arm"))
+
+
+class TestNoBackendFallsBackToTheJointNameVocabulary:
+    """Structural guard: every ``start_recording`` declares ``action_names``.
+
+    A backend that stops passing it silently re-enters the recorder's
+    ``joint_names`` fallback, which is exactly the drift this change removed and
+    which no behavioural test on that backend would fail.
+    """
+
+    SCHEMA_MODULES = [
+        "strands_robots/simulation/isaac/recording.py",
+        "strands_robots/simulation/newton/recording.py",
+        "strands_robots/simulation/mujoco/recording.py",
+    ]
+
+    @staticmethod
+    def _recorder_create_calls(source: str) -> list[ast.Call]:
+        """Every ``_DatasetRecorder.create(...)`` call in ``source``."""
+        return [
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "create"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "_DatasetRecorder"
+        ]
+
+    @pytest.mark.parametrize("module_path", SCHEMA_MODULES)
+    def test_every_recorder_create_declares_its_action_columns(self, module_path):
+        source = (_REPO_ROOT / module_path).read_text(encoding="utf-8")
+        calls = self._recorder_create_calls(source)
+        assert calls, f"{module_path}: no _DatasetRecorder.create call found"
+        for call in calls:
+            keywords = {kw.arg for kw in call.keywords}
+            assert "action_names" in keywords, (
+                f"{module_path}: _DatasetRecorder.create at line {call.lineno} omits "
+                "action_names, so the recorder falls back to the joint-name "
+                "vocabulary for the action columns (see module docstring)"
+            )
+
+    def test_the_scan_is_not_vacuous(self):
+        """Each module really is parsed and really does contain a create call."""
+        found = {
+            path: len(self._recorder_create_calls((_REPO_ROOT / path).read_text(encoding="utf-8")))
+            for path in self.SCHEMA_MODULES
+        }
+        assert all(count >= 1 for count in found.values()), found
+
+    def test_the_guard_detects_a_backend_that_omits_action_names(self):
+        """Planted positive: the assertion is not satisfiable by an empty scan."""
+        planted = "_DatasetRecorder.create(repo_id=repo_id, fps=fps, joint_names=joint_names)\n"
+        calls = self._recorder_create_calls(planted)
+        assert len(calls) == 1
+        assert "action_names" not in {kw.arg for kw in calls[0].keywords}


### PR DESCRIPTION
## What

Newton's recording schema now declares its `action` columns from `robot_action_keys` and passes them to `DatasetRecorder.create`, instead of passing none and letting the recorder fall back to naming them from `joint_names`.

No recorded column changes for any robot this backend can build today. What changes is that the naming no longer depends on two copies of an exclusion rule staying in step.

## Why

`DatasetRecorder` names the `action` feature's columns from the `action_names` it is handed, and falls back to `joint_names` when a backend passes none. The recorder's own comment at that branch says why an explicit list is preferred:

> Prefer an explicit `action_names` list (the actuator keys the rollout loops emit, which can diverge from the joint names - see `SimEngine.robot_action_keys`) so the recorded action columns match the keys `add_frame` receives.

Newton was the one backend on the fallback. Isaac (`isaac/recording.py`) and MuJoCo (`mujoco/recording.py`) both declare `action_names` from `robot_action_keys`; Newton passed none, so its action columns were named in the **joint** vocabulary while its recording hook emits the **actuator** vocabulary that `robot_action_keys` defines.

### The two vocabularies agreed only by coincidence

Nothing is miscolumned on `main` today. `NewtonSimEngine.robot_action_keys` is an override that removes the floating base's 6-DoF free joint from the joint list, and `_collect_recording_schema` independently removed the same joint for the state schema. Two hand-rolled copies of one rule, agreeing - and the fallback made that agreement load-bearing for the action columns.

An existing pin already recorded the unease, in its own docstring:

> Pinned as an equality between the two producers rather than assumed **from the fact that Newton's schema fallback happens to be the scalar joint list**, so either side drifting fails here.

That pin (`TestTheRecordedWidthRoundTrips`) asserted the coincidence rather than removing it, and it read the schema's *joint* slot while describing itself as checking the declared action columns - because the action columns did not exist as a separate thing to read.

### Why the drift would have been silent

`add_frame` reads the action dict **by declared name**. A column declared under a name the hook never emits is not a mismatch the recorder can report - it takes the `0.0` fill:

```python
for k in self._cached_action_keys or []:
    v = action.get(k)
    if v is None:
        action_vals.append(0.0)
```

So either copy of the exclusion drifting produces a recording whose every action column is `0.0`, under `status="success"`, with nothing raised at record time. That is the #1715 fabrication reached with **one robot and no narrow policy**, and every action space reaching a recorded rollout is absolute position - so `PolicyRunner.replay` re-sends those zeros to the hardware as travel-to-zero targets.

## Change

`_collect_recording_schema` returns `action_names` alongside `joint_names`, mirroring Isaac's 6-tuple and its ordering, built from `robot_action_keys` with the same `robot__` prefixing the hook applies. `start_recording` passes it to `create`.

Source delta is +26/-5. The free-base exclusion for the *state* schema is untouched - that one mirrors `get_observation` and is legitimately its own concern.

## Tests

New: `tests/simulation/test_recording_action_schema_across_backends.py` (11 tests).

- The declared columns equal `robot_action_keys` for fixed-base, floating-base, single-robot and multi-robot scenes, and multi-robot columns carry the same `robot__` prefixing as the state columns.
- `test_the_free_base_exclusion_is_not_re_derived_for_the_action_schema` is the regression the change closes: a subclass whose actuators are a different *vocabulary* than its joints (`a_<joint>`, not merely a shorter list) proves the schema follows the action-key authority rather than re-deriving the exclusion. A filtered-list-only test cannot distinguish the two implementations; this one can.
- `TestNoBackendFallsBackToTheJointNameVocabulary` is an AST guard asserting every backend's `_DatasetRecorder.create` passes `action_names`, so no backend can re-enter the fallback silently. It carries a non-vacuity check (each module really is parsed and really does contain a `create` call) and a planted-positive meta-test.

Updated rather than deleted, per the premise-test guidance: the two assertions in `TestTheRecordedWidthRoundTrips` now read the schema's action slot rather than its joint slot, so they pin the action columns themselves, and the stale sentence about the fallback is dropped from the class docstring.

### Read as a delta against the base

- New file on this head: **11 passed**. On the pre-fix tree: **7 failed, 4 passed** - and the AST guard fails for **Newton only**, Isaac and MuJoCo passing, which is the direct evidence that the guard is non-vacuous and correctly identifies which backend had drifted.
- `tests/simulation/newton/ tests/simulation/test_recording_action_schema_across_backends.py tests/test_recorded_action_columns_not_fabricated.py tests/test_dataset_schema_column_names_distinct.py` at head: **293 passed, 155 skipped, 0 failed**.
- Wider run including the dataset/recording contract suites: **366 passed, 156 skipped, 0 failed**.
- `ruff check strands_robots tests` clean; `ruff format --check` reports 235 files already formatted.

The skips are the optional-dependency gates (`lerobot`, `pyarrow`, `mujoco`, `huggingface_hub` absent on the review box) and are identical on both sides of the diff. The new tests deliberately need none of them: the schema builder is pure over the world model, so they run solver-free on a `__new__` engine, matching the harness the merged Newton recording tests use.

## Scope

One backend, one concern: which authority names Newton's action columns. Deliberately **not** in scope:

- The multi-robot frame contract that keeps #1715 open. That is a schema-semantics decision (scope the declared schema to the driven robots, versus a ragged action vector) with a stated breaking consequence, and it belongs in its own change. This PR does not narrow or widen it - a two-robot Newton scene still declares both robots' columns, exactly as before.
- `_verify_resume_schema` still validates state columns, cameras and fps but not action columns, on all three backends. Unchanged here.

Refs #1715