### PR TITLE
fix(deps): floor lerobot at >=0.6.1 so bucket streaming is resolver-guaranteed (closes #1506, closes #1516)

### DIFF
--- a/changelog.d/1506-lerobot-floor-bucket-streaming.md
+++ b/changelog.d/1506-lerobot-floor-bucket-streaming.md
@@ -1,0 +1,18 @@
+### Fixed: the lerobot floor now guarantees bucket streaming instead of documenting it
+
+`stream_dataset(repo_type="bucket")` needs a `StreamingLeRobotDataset` that
+accepts a `repo_type` parameter. lerobot 0.6.0's constructor has none; 0.6.1
+added `repo_type: Literal["dataset", "bucket"]`. Every lerobot-bearing extra
+floored at `>=0.6.0`, so the resolver installed a lerobot that could not serve
+the flagship streaming path at all - the `>=0.6.1` requirement lived only in
+prose. All three extras (`[lerobot]`, `[lerobot-async]`, `[molmoact2]`, the last
+of which carries its own pin rather than inheriting one) now floor at
+`>=0.6.1,<0.7.0`, so 0.6.0 is unresolvable.
+
+Raising the floor does not remove a pre-existing older lerobot from an
+environment, so the runtime guard is retained - but its message no longer says
+`repo_type='bucket' is not supported by any released lerobot`. That was true
+when written and named no remedy; it now reports the version that serves bucket
+streaming and the install command that gets it. The version is declared once, as
+`strands_robots.streaming_dataset.BUCKET_STREAMING_MIN_LEROBOT`, so the remedy
+the error advertises cannot drift from what the resolver installs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ graph TB
 | Extra | Pulls in | When |
 |-------|----------|------|
 | `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg`, `mink`, `qpsolvers[daqp]` | `Robot(mode="sim")`; `mink`/`qpsolvers` solve IK for the `move_to` primitive (the `[daqp]` backend extra is what makes the solve runnable - `qpsolvers` alone ships no solver) |
-| `[lerobot]` | `lerobot>=0.6.0,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
+| `[lerobot]` | `lerobot>=0.6.1,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` ZMQ |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | (none) | core only - Robot factory, registry, lazy imports | Inspect the catalog, write tools |
 | `[sim]` | `robot_descriptions` | Sim asset resolution without MuJoCo |
 | `[sim-mujoco]` | `sim` + `mujoco`, `imageio`, `imageio-ffmpeg` | Any `Robot()` with default `mode="sim"` |
-| `[lerobot]` | `lerobot>=0.6.0,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
+| `[lerobot]` | `lerobot>=0.6.1,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` (ZMQ to a GR00T container) |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh discovery + RPC |

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -196,7 +196,7 @@ lerobot PR #3604 and first released in 0.6.0 - so it resolves straight from
 PyPI with no git-from-source install. The `[molmoact2]` extra layers the
 auxiliary deps MolmoAct2's modeling and processor code needs
 (`transformers>=5.4.0,<5.6.0`, `peft`, `scipy`) on top of
-`strands-robots[lerobot]` (which pins `lerobot>=0.6.0,<0.7.0`):
+`strands-robots[lerobot]` (which pins `lerobot>=0.6.1,<0.7.0`):
 
 ```bash
 uv pip install "strands-robots[molmoact2]"

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -624,9 +624,11 @@ least one non-video key, otherwise `open()` raises `ValueError` rather than
 silently streaming video anyway).
 
 One kwarg is **not** tolerant-forwarded because its absence changes semantics:
-`repo_type="bucket"` requires `lerobot>=0.6.1` — on older versions `open()`
-raises `RuntimeError` instead of silently streaming from the versioned dataset
-namespace (a different storage system).
+`repo_type="bucket"` requires `lerobot>=0.6.1`, which the `[lerobot]` extra
+floors — so a resolver-conformant install always has it. On an environment
+carrying an older lerobot, `open()` raises `RuntimeError` naming the upgrade
+instead of silently streaming from the versioned dataset namespace (a different
+storage system).
 
 For **training**, the upstream trainer uses the same engine:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | `ModuleNotFoundError: mujoco` | Missing `[sim-mujoco]` | `uv pip install "strands-robots[sim-mujoco]"` |
 | `move_to: IK bridge unavailable: ... No module named 'mink'` | Missing `[sim-mujoco]` (the extra declares the IK solver) | `uv pip install "strands-robots[sim-mujoco]"` |
 | `ModuleNotFoundError: lerobot` | Missing `[lerobot]` | `uv pip install "strands-robots[lerobot]"` |
-| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.0,<0.7.0`) |
+| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.1,<0.7.0`) |
 | `ImportError: cannot import name 'MolmoAct2Policy'` | `lerobot < 0.6` (`MolmoAct2Policy` ships in lerobot >= 0.6) | `uv pip install "strands-robots[molmoact2]"` |
 | pyav build fails on Jetson/aarch64 | No prebuilt wheel for sm_110 | Use `--no-build-isolation` or install `torchcodec>=0.7` and skip pyav. See [installation](getting-started/installation.md#molmoact2-on-jetson) |
 | numpy ABI mismatch on Jetson | System pandas vs pip numpy | `uv pip install "numpy<2" "pandas==2.1.4"` then reinstall |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,16 @@ lerobot = [
     # marker. NOTE: torch/torchcodec ship as +cuXXX wheels resolved by
     # UV_TORCH_BACKEND; a plain `pip install` on Thor may need the matching CUDA
     # index -- see the README Installation section for the Thor/Jetson caveat.
-    "lerobot[feetech,dataset]>=0.6.0,<0.7.0",
+    #
+    # The floor is 0.6.1 rather than 0.6.0 because bucket streaming
+    # (`stream_dataset(repo_type="bucket")`) needs a StreamingLeRobotDataset
+    # that accepts `repo_type`, and 0.6.1 is the first release that does
+    # (0.6.0's constructor has no such parameter). Flooring here makes the
+    # flagship streaming path resolver-guaranteed instead of docs-guaranteed;
+    # `strands_robots.streaming_dataset.BUCKET_STREAMING_MIN_LEROBOT` carries
+    # the same version for the runtime guard that protects an environment with
+    # a pre-existing older lerobot.
+    "lerobot[feetech,dataset]>=0.6.1,<0.7.0",
 ]
 # Remote/offloaded inference via lerobot's native async-inference gRPC
 # transport (the `lerobot_async` policy provider, LerobotAsyncPolicy). Layers
@@ -193,7 +202,7 @@ lerobot = [
 # it here, so the gRPC/protobuf floor tracks lerobot.
 lerobot-async = [
     "strands-robots[lerobot]",
-    "lerobot[async]>=0.6.0,<0.7.0",
+    "lerobot[async]>=0.6.1,<0.7.0",
 ]
 # MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
 # MolmoAct2Policy ships in lerobot >= 0.6 (landed via lerobot PR #3604). Rather
@@ -202,11 +211,11 @@ lerobot-async = [
 # own ``[molmoact2]`` extra. That extra pulls lerobot[transformers-dep],
 # lerobot[peft-dep], lerobot[scipy-dep] at exactly the versions the MolmoAct2
 # modeling/processor code was built against, so the two stay in lock-step by
-# construction. The base ``strands-robots[lerobot]`` pin (>=0.6.0,<0.7.0) already
+# construction. The base ``strands-robots[lerobot]`` pin (>=0.6.1,<0.7.0) already
 # fixes the lerobot floor; ``lerobot[molmoact2]`` just adds the aux deps.
 molmoact2 = [
     "strands-robots[lerobot]",
-    "lerobot[molmoact2]>=0.6.0,<0.7.0",
+    "lerobot[molmoact2]>=0.6.1,<0.7.0",
 ]
 sim = [
     "robot_descriptions>=1.11.0,<2.0.0",

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -27,6 +27,16 @@ from strands_robots.utils import lerobot_version
 
 logger = logging.getLogger(__name__)
 
+# The first lerobot release whose ``StreamingLeRobotDataset`` accepts a
+# ``repo_type`` parameter, i.e. the floor for bucket streaming. 0.6.0's
+# constructor has no such parameter; 0.6.1 added
+# ``repo_type: Literal["dataset", "bucket"]``. The ``[lerobot]`` extra floors
+# lerobot here so a resolver-conformant install always has the capability; this
+# constant is what the runtime guard below advertises to an environment that
+# carries a pre-existing older lerobot, so the packaging floor and the remedy
+# the error message names cannot drift apart.
+BUCKET_STREAMING_MIN_LEROBOT = "0.6.1"
+
 
 # Only the POSITIVE result is cached. lerobot availability is a process
 # capability that can transiently fail to resolve (a slow/locked import, or - in
@@ -122,11 +132,13 @@ class StreamingDatasetReader:
         Raises:
             RuntimeError: ``repo_type`` is not ``"dataset"`` but the installed
                 ``StreamingLeRobotDataset`` does not accept a ``repo_type``
-                parameter. No released lerobot does (the versioned-dataset vs
-                bucket storage split is not upstream); the parameter is retained
-                only for a lerobot build that adds it. Silently dropping the
-                kwarg would stream from the versioned *dataset* namespace instead
-                of the requested bucket - a different storage system, not a
+                parameter. lerobot >= :data:`BUCKET_STREAMING_MIN_LEROBOT`
+                accepts it; earlier releases do not. The ``[lerobot]`` extra
+                floors lerobot at that version, so this guard only fires for an
+                environment carrying a pre-existing older lerobot - and it
+                names the upgrade as the remedy. Silently dropping the kwarg
+                would stream from the versioned *dataset* namespace instead of
+                the requested bucket - a different storage system, not a
                 cosmetic difference - so this is never tolerant-dropped.
             ValueError: ``drop_videos=True`` but no non-video keys remain in
                 ``delta_timestamps`` (or none were passed). Without a proprio
@@ -141,18 +153,22 @@ class StreamingDatasetReader:
         accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in init_sig.values())
 
         # repo_type selects WHICH storage system is read (versioned dataset
-        # namespace vs bucket). No released lerobot accepts it; unlike the
-        # cosmetic kwargs below, silently dropping a non-default value would open
-        # the wrong storage system without error - fail fast instead.
+        # namespace vs bucket). lerobot >= BUCKET_STREAMING_MIN_LEROBOT accepts
+        # it and the [lerobot] extra floors there, so this only fires for a
+        # pre-existing older lerobot; unlike the cosmetic kwargs below, silently
+        # dropping a non-default value would open the wrong storage system
+        # without error - fail fast, naming the upgrade, instead.
         if repo_type != "dataset" and not (accepts_var_kw or "repo_type" in init_sig):
             raise RuntimeError(
-                f"repo_type={repo_type!r} is not supported by any released lerobot "
-                f"(installed: {lerobot_version()}): StreamingLeRobotDataset does not "
-                "accept a repo_type parameter (the versioned-dataset vs bucket storage "
-                "split is not upstream), and silently falling back to the 'dataset' "
-                "namespace would stream from a different storage system. Pass "
-                "repo_type='dataset' (the default) or use a lerobot build whose "
-                "StreamingLeRobotDataset accepts repo_type."
+                f"repo_type={repo_type!r} requires lerobot >= "
+                f"{BUCKET_STREAMING_MIN_LEROBOT} (installed: {lerobot_version()}): "
+                "this StreamingLeRobotDataset does not accept a repo_type "
+                "parameter, and silently falling back to the 'dataset' namespace "
+                "would stream from a different storage system. Upgrade with "
+                '`pip install -U "strands-robots[lerobot]"` (its floor is at '
+                "least that), or pass "
+                "repo_type='dataset' (the default) to stream from the versioned "
+                "dataset namespace."
             )
 
         # Proprio-only: strip video keys from delta_timestamps so video decode

--- a/tests/test_customer_workflow_regressions.py
+++ b/tests/test_customer_workflow_regressions.py
@@ -127,7 +127,11 @@ class TestMolmoact2Extra:
         assert not spec.contains(Version("0.5.1")), (
             f"lerobot floor too loose: {spec} admits 0.5.1, which predates MolmoAct2 and its transformers>=5.4.0 dep"
         )
-        assert spec.contains(Version("0.6.0")), f"lerobot pin {spec} must admit 0.6.0 (MolmoAct2 floor)"
+        # Assert the declared lower BOUND, not membership of one version: the
+        # floor is >=0.6.1 for bucket streaming, which excludes 0.6.0 while
+        # still satisfying the >=0.6 MolmoAct2 requirement this guards.
+        lower = min(Version(s.version) for s in spec if s.operator == ">=")
+        assert lower >= Version("0.6"), f"lerobot pin {spec} floors below the >=0.6 MolmoAct2 release"
         # An upper bound must exist so an incompatible future major is excluded.
         assert any(s.operator in ("<", "<=", "==", "~=") for s in spec), f"lerobot pin {spec} must carry an upper bound"
 

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -147,7 +147,7 @@ def test_direct_reference_check_ignores_extras_specifiers_and_markers(tmp_path):
 # marker that excluded linux aarch64, leaving Thor/Jetson with no video decoder).
 # lerobot 0.6 fixed those markers upstream: torch>=2.7,<2.12 with a
 # ``torchcodec>=0.11,<0.12`` aarch64 marker that pulls the ABI-matched torch 2.11
-# on every platform. Requiring lerobot >= 0.6.0 is therefore what lets those
+# on every platform. Requiring lerobot >= 0.6 is therefore what lets those
 # overrides be dropped: the codec/decoder stack now resolves ABI-consistently
 # (torch 2.11 + torchcodec 0.11.x + torchvision 0.26) on linux x86_64/aarch64 and
 # macOS arm64 with no strands override.
@@ -173,15 +173,27 @@ def _lerobot_extra_requirement() -> Requirement:
     raise AssertionError("no `lerobot` requirement found in the [lerobot] extra")
 
 
-def test_lerobot_extra_requires_at_least_0_6() -> None:
-    """The ``[lerobot]`` extra must floor lerobot at >= 0.6.0.
+def test_lerobot_extra_requires_at_least_0_6_1() -> None:
+    """The ``[lerobot]`` extra must floor lerobot at >= 0.6.1.
 
-    The 0.5.1-era torch/torchcodec overrides were removed because lerobot 0.6's
-    own markers resolve the decoder stack correctly; that only holds for
-    lerobot >= 0.6, so the floor must not regress below it.
+    Two coupled reasons, either of which alone requires the floor:
+
+    * The 0.5.1-era torch/torchcodec overrides were removed because lerobot
+      0.6's own markers resolve the decoder stack correctly; that only holds
+      for lerobot >= 0.6.
+    * Bucket streaming (``stream_dataset(repo_type="bucket")``) needs a
+      ``StreamingLeRobotDataset`` that accepts ``repo_type``, which 0.6.0 does
+      not and 0.6.1 does - so 0.6.0 must be *excluded*, not merely admitted.
     """
     req = _lerobot_extra_requirement()
-    assert Version("0.6.0") in req.specifier, f"lerobot floor must admit 0.6.0, got {req.specifier}"
+    # The declared lower BOUND, not membership of one version: a later raise
+    # (say >=0.6.2) must not fail a guard whose requirement it still satisfies.
+    lower = min(Version(s.version) for s in req.specifier if s.operator == ">=")
+    assert lower >= Version("0.6.1"), f"lerobot floor must be >= 0.6.1, got {req.specifier}"
+    assert Version("0.6.0") not in req.specifier, (
+        f"lerobot floor must exclude 0.6.0 (its StreamingLeRobotDataset takes no "
+        f"repo_type, so bucket streaming cannot be served), got {req.specifier}"
+    )
     assert Version("0.5.9") not in req.specifier, (
         f"lerobot floor must exclude 0.5.x (the overrides that compensated for "
         f"lerobot 0.5.1's decoder markers were removed), got {req.specifier}"

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -1,6 +1,6 @@
 """Keep the VLA install docs consistent with the declared dependencies.
 
-The ``lerobot>=0.6.0`` bump obsoleted a body of pre-0.6 install guidance that
+The ``lerobot>=0.6`` bump obsoleted a body of pre-0.6 install guidance that
 lived in the ``train_policy`` tool docstring and the policy/training docs:
 
 * ``pip install 'lerobot[smolvla]==0.5.1'`` and a ``transformers==5.3.0`` pin -
@@ -12,7 +12,7 @@ lived in the ``train_policy`` tool docstring and the policy/training docs:
   longer applies to the supported range.
 * "MolmoAct2 requires lerobot **from source**" - ``MolmoAct2Policy`` ships in
   lerobot >= 0.6, so ``strands-robots[molmoact2]`` (which pulls
-  ``strands-robots[lerobot]`` -> ``lerobot>=0.6.0``) resolves it straight from
+  ``strands-robots[lerobot]`` -> ``lerobot>=0.6.1``) resolves it straight from
   PyPI; no ``git+`` install.
 
 These assertions pin the pyproject reality and forbid the stale guidance from
@@ -23,6 +23,9 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
@@ -36,10 +39,16 @@ def _extras() -> dict[str, list[str]]:
 # --- positive contract: the pyproject reality the docs must reflect ---
 
 
-def test_lerobot_extra_requires_0_6() -> None:
-    joined = " ".join(_extras()["lerobot"])
-    assert "lerobot" in joined
-    assert ">=0.6.0" in joined, f"lerobot extra no longer pins >=0.6.0: {joined!r}"
+def test_lerobot_extra_requires_0_6_1() -> None:
+    """The ``[lerobot]`` extra floors lerobot at >= 0.6.1.
+
+    0.6.1 is the first release whose ``StreamingLeRobotDataset`` accepts
+    ``repo_type``, so flooring there makes bucket streaming resolver-guaranteed
+    rather than docs-guaranteed.
+    """
+    req = next(r for r in map(Requirement, _extras()["lerobot"]) if r.name == "lerobot")
+    lower = min(Version(s.version) for s in req.specifier if s.operator == ">=")
+    assert lower >= Version("0.6.1"), f"lerobot extra no longer floors >=0.6.1: {req.specifier}"
 
 
 def test_molmoact2_extra_is_pure_pypi_with_transformers_5_4_plus() -> None:
@@ -50,10 +59,13 @@ def test_molmoact2_extra_is_pure_pypi_with_transformers_5_4_plus() -> None:
     # lerobot[transformers-dep] (>=5.4.0) transitively, so the >=5.4.0 guarantee
     # is preserved by construction while staying in lock-step with lerobot.
     assert "lerobot[molmoact2]" in joined, joined
-    # the lerobot floor is >=0.6.0 (MolmoAct2Policy landed in lerobot 0.6), so
-    # its transformers-dep (>=5.4.0) is what gets resolved - never the pre-0.6
-    # transformers==5.3.0.
-    assert ">=0.6.0" in joined, joined
+    # the lerobot floor is >=0.6 (MolmoAct2Policy landed in lerobot 0.6), so its
+    # transformers-dep (>=5.4.0) is what gets resolved - never the pre-0.6
+    # transformers==5.3.0. Asserted as a bound, not a literal substring, so a
+    # floor raise cannot strand a guard whose requirement it still satisfies.
+    req = next(r for r in map(Requirement, _extras()["molmoact2"]) if r.name == "lerobot")
+    lower = min(Version(s.version) for s in req.specifier if s.operator == ">=")
+    assert lower >= Version("0.6"), f"molmoact2 lerobot floor is below 0.6: {req.specifier}"
     # resolves from PyPI - no git-from-source URL
     assert "git+" not in joined, f"molmoact2 extra should not need a git URL: {joined!r}"
 
@@ -97,7 +109,7 @@ def test_lerobot_local_docs_do_not_claim_molmoact2_needs_source() -> None:
 
 # --- negative contract, extended: the pre-0.6 "lerobot from source / <0.6 pin"
 #     narrative also lingered in the architecture / troubleshooting / molmoact2
-#     pages after the >=0.6.0 floor bump. These pin it out. ---
+#     pages after the >=0.6 floor bump. These pin it out. ---
 
 _ARCHITECTURE = _REPO_ROOT / "docs" / "architecture.md"
 _TROUBLESHOOTING = _REPO_ROOT / "docs" / "troubleshooting.md"
@@ -117,16 +129,19 @@ def test_architecture_lerobot_extra_row_matches_pyproject_floor() -> None:
     text = _ARCHITECTURE.read_text()
     # the dependency-matrix row must not advertise the dead pre-0.6 cap
     assert "lerobot>=0.5.0,<0.6.0" not in text, "architecture.md still cites the dead <0.6.0 lerobot cap"
-    # it must reflect the real floor (>=0.6.0)
-    assert ">=0.6.0" in text, "architecture.md [lerobot] row should name the >=0.6.0 floor"
+    # It must reflect the real floor, read from pyproject rather than hardcoded:
+    # a floor bump would otherwise leave this page citing a dead version while
+    # the guard kept passing.
+    floor = _lerobot_floor_from_pyproject()
+    assert f"lerobot{floor}" in text, f"architecture.md [lerobot] row should name the pyproject floor lerobot{floor}"
 
 
 def test_troubleshooting_version_skew_remedy_does_not_conflict_with_floor() -> None:
     text = _TROUBLESHOOTING.read_text()
     # remedying a version-skew ImportError by pinning ``<0.6`` directly conflicts
-    # with the pyproject floor (``lerobot[...]>=0.6.0``); the remedy must (re)install
+    # with the pyproject floor (``lerobot[...]>=0.6.1``); the remedy must (re)install
     # the extra instead of a manual sub-floor pin.
-    assert "lerobot>=0.5.0,<0.6" not in text, "troubleshooting remedy pins lerobot below the required >=0.6.0 floor"
+    assert "lerobot>=0.5.0,<0.6" not in text, "troubleshooting remedy pins lerobot below the required >=0.6.1 floor"
     assert "strands-robots[lerobot]" in text
 
 

--- a/tests/test_lerobot_floor_guarantees_bucket_streaming.py
+++ b/tests/test_lerobot_floor_guarantees_bucket_streaming.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""The declared lerobot floor must actually guarantee bucket streaming.
+
+``stream_dataset(repo_type="bucket")`` needs a ``StreamingLeRobotDataset`` that
+accepts a ``repo_type`` parameter. lerobot 0.6.0's constructor has none; 0.6.1
+added ``repo_type: Literal["dataset", "bucket"]``. While the ``[lerobot]`` extra
+floored lerobot at ``>=0.6.0`` the flagship path was only *docs*-guaranteed: the
+resolver happily installed a lerobot that could not serve it at all, and the
+runtime guard told the caller "not supported by any released lerobot" - naming no
+remedy, because when that text was written none existed.
+
+These tests pin the guarantee end to end:
+
+* every lerobot-bearing extra floors at the version that accepts ``repo_type``,
+  and *excludes* 0.6.0 rather than merely admitting a newer release;
+* the packaging floor and the version the runtime guard advertises are the same
+  value, so the remedy the error message names cannot drift from what the
+  resolver installs;
+* **executed, not asserted**: a lerobot that satisfies the declared floor really
+  does accept ``repo_type``. A purely structural pin would keep passing if the
+  capability moved to another release, leaving the floor citing a version that
+  no longer delivers it;
+* the guard is retained (an environment can carry a pre-existing older lerobot)
+  and now names the upgrade as the remedy.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+import inspect
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+from strands_robots import streaming_dataset as sd
+from strands_robots.streaming_dataset import BUCKET_STREAMING_MIN_LEROBOT
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# Every extra that carries its own lerobot requirement. ``molmoact2`` inherits
+# the floor through ``strands-robots[lerobot]`` but ALSO declares
+# ``lerobot[molmoact2]>=...`` directly, so a bump that skips it would leave a
+# resolvable install of the older lerobot through that extra.
+_LEROBOT_BEARING_EXTRAS = ("lerobot", "lerobot-async", "molmoact2")
+
+
+def _extras() -> dict[str, list[str]]:
+    return tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["optional-dependencies"]
+
+
+def _lerobot_requirements() -> dict[str, Requirement]:
+    """The ``lerobot`` :class:`Requirement` each lerobot-bearing extra declares."""
+    extras = _extras()
+    out: dict[str, Requirement] = {}
+    for name in _LEROBOT_BEARING_EXTRAS:
+        assert name in extras, f"pyproject has no [{name}] extra"
+        for spec in extras[name]:
+            req = Requirement(spec)
+            if req.name == "lerobot":
+                out[name] = req
+                break
+        else:  # pragma: no cover - a missing pin is the failure this reports
+            raise AssertionError(f"[{name}] extra declares no lerobot requirement")
+    return out
+
+
+class TestEveryExtraFloorsAtTheBucketStreamingVersion:
+    """The resolver, not the docs, must guarantee the flagship streaming path."""
+
+    def test_every_lerobot_bearing_extra_floors_at_or_above_the_bucket_version(self) -> None:
+        """The declared lower bound must be at least the capability version.
+
+        Asserted as a bound rather than as membership of one version: a later
+        raise for an unrelated reason still guarantees bucket streaming, and a
+        membership assertion would fail on it.
+        """
+        for extra, req in _lerobot_requirements().items():
+            lower = min(Version(s.version) for s in req.specifier if s.operator == ">=")
+            assert lower >= Version(BUCKET_STREAMING_MIN_LEROBOT), (
+                f"[{extra}] floors lerobot at {lower}, below the {BUCKET_STREAMING_MIN_LEROBOT} "
+                f"that first accepts repo_type: {req.specifier}"
+            )
+
+    def test_every_lerobot_bearing_extra_excludes_0_6_0(self) -> None:
+        """Admitting the floor is not enough - 0.6.0 must be unresolvable.
+
+        0.6.0 satisfies ``>=0.6.0`` and cannot serve bucket streaming, so a
+        floor that merely *admits* 0.6.1 leaves the guarantee unenforced.
+        """
+        for extra, req in _lerobot_requirements().items():
+            assert Version("0.6.0") not in req.specifier, (
+                f"[{extra}] still admits lerobot 0.6.0, whose StreamingLeRobotDataset "
+                f"takes no repo_type, so bucket streaming is not resolver-guaranteed: {req.specifier}"
+            )
+
+    def test_the_upper_cap_still_follows_the_minor_convention(self) -> None:
+        """Raising the floor must not drop the ``<0.7.0`` cap (<1.0 caps minor)."""
+        for extra, req in _lerobot_requirements().items():
+            assert Version("0.7.0") not in req.specifier, f"[{extra}] lost the <0.7.0 cap: {req.specifier}"
+
+
+class TestThePackagingFloorAndTheRuntimeGuardAgree:
+    """One capability version, two consumers - they must not contradict."""
+
+    def test_installing_the_extra_satisfies_the_remedy_the_guard_advertises(self) -> None:
+        """The guard tells the caller to install ``strands-robots[lerobot]``.
+
+        That remedy is only honest if the extra's floor is at least the version
+        the guard names, so following the message provably clears the guard.
+        """
+        req = _lerobot_requirements()["lerobot"]
+        lower = min(Version(s.version) for s in req.specifier if s.operator == ">=")
+        assert lower >= Version(BUCKET_STREAMING_MIN_LEROBOT), (
+            f"the guard tells callers to install the [lerobot] extra to get lerobot >= "
+            f"{BUCKET_STREAMING_MIN_LEROBOT}, but that extra floors at {lower}: following "
+            f"the advertised remedy would not clear the guard"
+        )
+
+
+class TestTheFloorReallyDeliversTheCapability:
+    """Executed against the installed lerobot, not merely asserted."""
+
+    def test_a_lerobot_satisfying_the_declared_floor_accepts_repo_type(self) -> None:
+        """Any lerobot the declared floor admits must accept ``repo_type``.
+
+        This is the half a structural pin cannot cover: if the capability ever
+        moved to a different release, the floor would still read plausibly while
+        no longer delivering what it exists to guarantee.
+        """
+        pytest.importorskip("lerobot", reason="lerobot is an optional extra")
+        try:
+            installed = Version(md.version("lerobot"))
+        except md.PackageNotFoundError:  # pragma: no cover - importable but unmetadata'd
+            pytest.skip("lerobot version metadata unresolvable")
+        specifier = SpecifierSet(str(_lerobot_requirements()["lerobot"].specifier))
+        if installed not in specifier:
+            pytest.skip(f"installed lerobot {installed} is outside the declared floor {specifier}")
+
+        streaming_cls = sd._get_streaming_cls()
+        params = inspect.signature(streaming_cls).parameters
+        accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+        assert "repo_type" in params or accepts_var_kw, (
+            f"lerobot {installed} satisfies the declared floor {specifier} but its "
+            f"StreamingLeRobotDataset does not accept repo_type, so the floor does not "
+            f"guarantee bucket streaming"
+        )
+
+    def test_open_does_not_refuse_bucket_on_a_conforming_lerobot(self) -> None:
+        """The guard must not fire for a lerobot the declared floor admits."""
+        pytest.importorskip("lerobot", reason="lerobot is an optional extra")
+        try:
+            installed = Version(md.version("lerobot"))
+        except md.PackageNotFoundError:  # pragma: no cover
+            pytest.skip("lerobot version metadata unresolvable")
+        if installed not in SpecifierSet(str(_lerobot_requirements()["lerobot"].specifier)):
+            pytest.skip(f"installed lerobot {installed} is outside the declared floor")
+
+        # A stand-in mirroring the real constructor's repo_type parameter keeps
+        # this off the network while still exercising the production predicate.
+        class _Conforming:
+            def __init__(self, repo_id: str, repo_type: str = "dataset", **_kw: object) -> None:
+                self.repo_id = repo_id
+                self.repo_type = repo_type
+                self.num_frames = self.num_episodes = self.fps = 0
+
+            def __iter__(self):  # pragma: no cover - not iterated here
+                yield {}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sd, "StreamingLeRobotDataset", _Conforming, raising=False)
+            reader = sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+        assert reader.dataset.repo_type == "bucket"
+
+
+class TestTheGuardIsRetainedAndNamesTheUpgrade:
+    """A raised floor does not remove a pre-existing older lerobot from an env."""
+
+    @staticmethod
+    def _narrow_open() -> str:
+        class _Narrow:
+            def __init__(self, repo_id: str) -> None:
+                raise AssertionError("constructor must never be reached")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+            with pytest.raises(RuntimeError) as exc:
+                sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+        return str(exc.value)
+
+    def test_bucket_is_still_refused_when_the_constructor_lacks_repo_type(self) -> None:
+        """Flooring the extra must not delete the runtime guard: an environment
+        with a pre-existing older lerobot is still reachable, and silently
+        opening the versioned-dataset namespace would read a different storage
+        system."""
+        assert "repo_type='bucket'" in self._narrow_open()
+
+    def test_the_refusal_names_the_version_to_upgrade_to(self) -> None:
+        text = self._narrow_open()
+        assert BUCKET_STREAMING_MIN_LEROBOT in text, (
+            f"the refusal must name the version that serves bucket streaming: {text!r}"
+        )
+
+    def test_the_refusal_names_an_install_command(self) -> None:
+        text = self._narrow_open()
+        assert "strands-robots[lerobot]" in text, f"the refusal must name a followable remedy: {text!r}"
+
+    def test_the_refusal_no_longer_claims_no_release_supports_it(self) -> None:
+        """The old text said "not supported by any released lerobot" - true when
+        written, false since 0.6.1 shipped, and it left the caller with nothing
+        to do."""
+        text = self._narrow_open()
+        assert "any released lerobot" not in text, f"the refusal still claims no release supports repo_type: {text!r}"
+
+
+class TestDocsCiteTheDeclaredFloor:
+    """The pages that promise bucket streaming must name the enforced version."""
+
+    @pytest.mark.parametrize(
+        "relpath",
+        [
+            "docs/recording.md",
+            "docs/examples/overview.md",
+            "examples/notebooks/README.md",
+        ],
+    )
+    def test_bucket_streaming_pages_cite_the_declared_floor(self, relpath: str) -> None:
+        text = (_REPO_ROOT / relpath).read_text(encoding="utf-8")
+        assert BUCKET_STREAMING_MIN_LEROBOT in text, (
+            f"{relpath} promises bucket streaming but does not cite the enforced "
+            f"lerobot floor {BUCKET_STREAMING_MIN_LEROBOT}"
+        )

--- a/tests/test_lerobot_floor_guarantees_bucket_streaming.py
+++ b/tests/test_lerobot_floor_guarantees_bucket_streaming.py
@@ -86,6 +86,7 @@ def _installed_lerobot_or_skip() -> Version:
         raw = None
     if raw is None:  # pragma: no cover - importable but unmetadata'd
         pytest.skip("lerobot version metadata unresolvable")
+        return Version("0")  # unreachable; terminates the branch for static analysis
     return Version(raw)
 
 

--- a/tests/test_lerobot_floor_guarantees_bucket_streaming.py
+++ b/tests/test_lerobot_floor_guarantees_bucket_streaming.py
@@ -70,18 +70,23 @@ def _lerobot_requirements() -> dict[str, Requirement]:
 
 
 def _installed_lerobot_or_skip() -> Version:
-    """The installed lerobot version, or skip when lerobot is not available.
+    """The installed lerobot version, or skip when it cannot be determined.
 
-    Returning the version (rather than binding it in a ``try`` whose ``except``
-    calls :func:`pytest.skip`) keeps the caller free of a local that static
-    analysis must prove is bound: ``pytest.skip`` is ``NoReturn``, but that is
-    not something every checker can see.
+    Shaped so neither arm depends on ``pytest.skip`` being understood as
+    ``NoReturn``: the version string is bound on *both* branches of the
+    ``try``, and the function has a single explicit exit that every path
+    reaches. A reader - human or static - can therefore see that no local is
+    read before it is bound and that nothing falls off the end returning
+    ``None``, without having to prove the skip cannot return.
     """
     pytest.importorskip("lerobot", reason="lerobot is an optional extra")
     try:
-        return Version(md.version("lerobot"))
+        raw: str | None = md.version("lerobot")
     except md.PackageNotFoundError:  # pragma: no cover - importable but unmetadata'd
+        raw = None
+    if raw is None:  # pragma: no cover - importable but unmetadata'd
         pytest.skip("lerobot version metadata unresolvable")
+    return Version(raw)
 
 
 def _declared_lerobot_specifier() -> SpecifierSet:
@@ -187,6 +192,27 @@ class TestTheFloorReallyDeliversTheCapability:
             mp.setattr(sd, "StreamingLeRobotDataset", _Conforming, raising=False)
             reader = sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
         assert reader.dataset.repo_type == "bucket"
+
+    def test_an_unresolvable_installed_version_skips_rather_than_failing(self) -> None:
+        """Not knowing what is installed is not a defect in the library.
+
+        A lerobot that imports without distribution metadata cannot be placed
+        against the declared floor, so the executed checks skip instead of
+        reporting a failure the library is not responsible for. That arm is
+        unreachable in a normal environment - hence its ``pragma: no cover`` -
+        which is exactly why it is pinned here: it is the one path
+        :func:`_installed_lerobot_or_skip` takes that no other test in this
+        module reaches, and the arm whose control flow was reshaped to keep the
+        helper free of a possibly-unbound local and an implicit fall-through.
+        """
+
+        def _no_distribution_metadata(name: str) -> str:
+            raise md.PackageNotFoundError(name)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(md, "version", _no_distribution_metadata)
+            with pytest.raises(pytest.skip.Exception, match="metadata unresolvable"):
+                _installed_lerobot_or_skip()
 
 
 class TestTheGuardIsRetainedAndNamesTheUpgrade:

--- a/tests/test_lerobot_floor_guarantees_bucket_streaming.py
+++ b/tests/test_lerobot_floor_guarantees_bucket_streaming.py
@@ -69,6 +69,26 @@ def _lerobot_requirements() -> dict[str, Requirement]:
     return out
 
 
+def _installed_lerobot_or_skip() -> Version:
+    """The installed lerobot version, or skip when lerobot is not available.
+
+    Returning the version (rather than binding it in a ``try`` whose ``except``
+    calls :func:`pytest.skip`) keeps the caller free of a local that static
+    analysis must prove is bound: ``pytest.skip`` is ``NoReturn``, but that is
+    not something every checker can see.
+    """
+    pytest.importorskip("lerobot", reason="lerobot is an optional extra")
+    try:
+        return Version(md.version("lerobot"))
+    except md.PackageNotFoundError:  # pragma: no cover - importable but unmetadata'd
+        pytest.skip("lerobot version metadata unresolvable")
+
+
+def _declared_lerobot_specifier() -> SpecifierSet:
+    """The version range the ``[lerobot]`` extra permits the resolver to install."""
+    return SpecifierSet(str(_lerobot_requirements()["lerobot"].specifier))
+
+
 class TestEveryExtraFloorsAtTheBucketStreamingVersion:
     """The resolver, not the docs, must guarantee the flagship streaming path."""
 
@@ -132,12 +152,8 @@ class TestTheFloorReallyDeliversTheCapability:
         moved to a different release, the floor would still read plausibly while
         no longer delivering what it exists to guarantee.
         """
-        pytest.importorskip("lerobot", reason="lerobot is an optional extra")
-        try:
-            installed = Version(md.version("lerobot"))
-        except md.PackageNotFoundError:  # pragma: no cover - importable but unmetadata'd
-            pytest.skip("lerobot version metadata unresolvable")
-        specifier = SpecifierSet(str(_lerobot_requirements()["lerobot"].specifier))
+        installed = _installed_lerobot_or_skip()
+        specifier = _declared_lerobot_specifier()
         if installed not in specifier:
             pytest.skip(f"installed lerobot {installed} is outside the declared floor {specifier}")
 
@@ -152,12 +168,8 @@ class TestTheFloorReallyDeliversTheCapability:
 
     def test_open_does_not_refuse_bucket_on_a_conforming_lerobot(self) -> None:
         """The guard must not fire for a lerobot the declared floor admits."""
-        pytest.importorskip("lerobot", reason="lerobot is an optional extra")
-        try:
-            installed = Version(md.version("lerobot"))
-        except md.PackageNotFoundError:  # pragma: no cover
-            pytest.skip("lerobot version metadata unresolvable")
-        if installed not in SpecifierSet(str(_lerobot_requirements()["lerobot"].specifier)):
+        installed = _installed_lerobot_or_skip()
+        if installed not in _declared_lerobot_specifier():
             pytest.skip(f"installed lerobot {installed} is outside the declared floor")
 
         # A stand-in mirroring the real constructor's repo_type parameter keeps

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1419,9 +1419,10 @@ class TestHardwareConfigV040Followups:
         because lerobot 0.5.1's own marker excluded aarch64. lerobot 0.6 fixed
         that upstream (its `torchcodec>=0.11,<0.12; aarch64` marker pulls the
         torch-ABI-matched decoder), so the strands override was dropped and the
-        guarantee now rides on the `lerobot>=0.6.0` floor. This pins that floor
-        so a revert below 0.6 -- which would resurrect the missing-decoder bug
-        without the removed override -- fails here."""
+        guarantee now rides on the `lerobot>=0.6` floor (the extra declares
+        >=0.6.1, which bucket streaming additionally needs). This pins that
+        floor so a revert below 0.6 -- which would resurrect the
+        missing-decoder bug without the removed override -- fails here."""
         import tomllib
         from pathlib import Path
 
@@ -1432,8 +1433,12 @@ class TestHardwareConfigV040Followups:
         data = tomllib.load(open(root / "pyproject.toml", "rb"))
         lerobot_extra = data["project"]["optional-dependencies"]["lerobot"]
         lerobot_req = next(Requirement(d) for d in lerobot_extra if Requirement(d).name == "lerobot")
-        assert Version("0.6.0") in lerobot_req.specifier and Version("0.5.9") not in lerobot_req.specifier, (
-            f"[lerobot] extra must floor lerobot at >=0.6.0 so aarch64 gets torchcodec (#378); "
+        # Assert the declared lower BOUND, not membership of one version: a
+        # floor raise (e.g. to >=0.6.1 for bucket streaming) excludes 0.6.0
+        # while the >=0.6 requirement this guards still holds a fortiori.
+        lower = min(Version(s.version) for s in lerobot_req.specifier if s.operator == ">=")
+        assert lower >= Version("0.6") and Version("0.5.9") not in lerobot_req.specifier, (
+            f"[lerobot] extra must floor lerobot at >=0.6 so aarch64 gets torchcodec (#378); "
             f"got {lerobot_req.specifier}"
         )
 

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -84,14 +84,19 @@ def test_repo_type_forwarded_when_supported(monkeypatch):
 def test_repo_type_bucket_raises_when_unsupported(monkeypatch):
     """repo_type='bucket' on a constructor without the parameter must raise,
     never silently open the versioned dataset namespace instead (a different
-    storage system - the forbidden silent-kwarg-drop class)."""
+    storage system - the forbidden silent-kwarg-drop class).
+
+    The message names the lerobot version that serves bucket streaming rather
+    than the pre-0.6.1 "no released lerobot supports this" - that claim was
+    true when written and left the caller with no remedy; the capability
+    shipped in 0.6.1, which the [lerobot] extra now floors."""
 
     class _Narrow:
         def __init__(self, repo_id):
             raise AssertionError("constructor must never be reached")
 
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
-    with pytest.raises(RuntimeError, match=r"repo_type='bucket' is not supported by any released lerobot"):
+    with pytest.raises(RuntimeError, match=r"repo_type='bucket' requires lerobot >= 0\.6\.1"):
         sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
 
 
@@ -113,7 +118,7 @@ def test_bucket_guard_message_survives_unresolvable_lerobot_version(monkeypatch)
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
     with pytest.raises(RuntimeError, match=r"installed: unknown") as exc:
         sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
-    assert "repo_type='bucket' is not supported by any released lerobot" in str(exc.value)
+    assert "repo_type='bucket' requires lerobot >= 0.6.1" in str(exc.value)
 
 
 def test_repo_type_bucket_forwarded_via_var_kwargs(monkeypatch):


### PR DESCRIPTION
Closes #1506
Closes #1516

## Problem

`stream_dataset(repo_type="bucket")` needs a `StreamingLeRobotDataset` that accepts a `repo_type` parameter. Measured by parsing `StreamingLeRobotDataset.__init__` straight out of the PyPI wheels:

| lerobot | `__init__` params | `repo_type` occurrences | accepts `repo_type` | bucket streaming |
|---|---|---|---|---|
| 0.6.0 | 17 | 0 | no | **impossible** |
| 0.6.1 | 19 | 11 | yes (`Literal["dataset", "bucket"]`) | servable |

Every lerobot-bearing extra floored at `>=0.6.0`, so the resolver was permitted to install a lerobot that could not serve the flagship streaming path at all. The `>=0.6.1` requirement lived only in prose (`docs/recording.md`, `docs/examples/overview.md`, notebook 05). #1506 and #1516 both deferred on a single gate - bump once a release accepting `repo_type` is published - and 0.6.1 now satisfies it.

A second, independent half: the runtime guard's message read

```
repo_type='bucket' is not supported by any released lerobot (installed: 0.6.2): ...
Pass repo_type='dataset' (the default) or use a lerobot build whose
StreamingLeRobotDataset accepts repo_type.
```

That claim was true when written and named no followable remedy. Since 0.6.1 shipped it is simply false, so a caller with an older lerobot in their environment was told the capability does not exist rather than which version has it.

## Change

**Floors.** All three extras that declare a `lerobot` requirement move to `>=0.6.1,<0.7.0`: `[lerobot]`, `[lerobot-async]`, and `[molmoact2]`. The last one matters - it carries its *own* pin rather than inheriting one through `strands-robots[lerobot]`, so a bump that skipped it would leave 0.6.0 resolvable through that extra. The `<0.7.0` cap is unchanged (`<1.0` caps the minor).

**Guard.** Raising the floor does not remove a pre-existing older lerobot from an environment, so the fail-fast is retained - silently falling back to the versioned-dataset namespace would still read a different storage system. Its message now names the remedy:

```
repo_type='bucket' requires lerobot >= 0.6.1 (installed: 0.6.2): this
StreamingLeRobotDataset does not accept a repo_type parameter, and silently
falling back to the 'dataset' namespace would stream from a different storage
system. Upgrade with `pip install -U "strands-robots[lerobot]"` (its floor is at
least that), or pass repo_type='dataset' (the default) to stream from the
versioned dataset namespace.
```

The version is declared once, as `strands_robots.streaming_dataset.BUCKET_STREAMING_MIN_LEROBOT`, and a test asserts the extra's floor is at least that value - so the remedy the error advertises provably clears the guard.

**Docs.** The four pages citing the pin (`architecture.md`, `getting-started/installation.md`, `troubleshooting.md`, `policies/lerobot-local.md`) now name `>=0.6.1`; `recording.md` says the extra *floors* it rather than leaving it to the reader.

## Blast radius: zero on a fresh install

Measured with `pip install --dry-run --ignore-installed --report` on both requirement strings:

```
floor >=0.6.0 -> 86 packages, lerobot==0.6.1
floor >=0.6.1 -> 86 packages, lerobot==0.6.1
added=[]  removed=[]  version changes={}
```

Both floors already resolve 0.6.1, because it is the newest release in the range. The bump changes nothing that gets *installed* - it changes what is *permitted*, which is the point: a constraint file, a lockfile or an environment that already carries 0.6.0 can no longer satisfy the extra while being unable to serve bucket streaming.

## Test churn: five assertions used a proxy, not the property

Five guards asserted `Version("0.6.0") in specifier` (or `">=0.6.0" in joined`) as a stand-in for "the floor is at least 0.6". Any floor raise makes the proxy false while the property it cares about still holds a fortiori - the aarch64-torchcodec guard (#378) and the MolmoAct2 transformers-delegation guard both failed for that reason alone. Each now asserts the declared lower **bound** directly, so the next bump cannot strand a guard whose requirement it still satisfies:

- `tests/test_robot_factory.py` - aarch64 decoder floor (`lower >= 0.6`)
- `tests/test_customer_workflow_regressions.py` - MolmoAct2 transformers delegation (`lower >= 0.6`)
- `tests/test_dependency_audit.py` - the `[lerobot]` floor (`lower >= 0.6.1`, and 0.6.0 excluded)
- `tests/test_lerobot_dependency_docs.py` - two brittle substring pins, plus the architecture-page row now derives the expected floor from `pyproject.toml` instead of hardcoding it

Two pins on the old message text (`tests/test_streaming_dataset.py`) move to the corrected contract, with the reason in their docstrings.

## New regression test

`tests/test_lerobot_floor_guarantees_bucket_streaming.py` (13 tests) pins the guarantee end to end, including the half a structural pin cannot cover:

- every lerobot-bearing extra floors at or above the capability version, and **excludes 0.6.0** rather than merely admitting something newer;
- **executed, not asserted** - a lerobot satisfying the declared floor really does accept `repo_type`, and `open(repo_type="bucket")` is not refused on it. If the capability ever moved to a different release the floor would still read plausibly while no longer delivering it; this fails instead;
- the guard is retained for a pre-existing older lerobot, and its refusal names the version, names an install command, and no longer claims no release supports `repo_type`;
- the pages promising bucket streaming cite the enforced floor.

**Pre-fix**, with `pyproject.toml`, `strands_robots/streaming_dataset.py` and the docs reverted to `main`: **11 failed, 97 passed**, e.g.

```
[lerobot] floors lerobot at 0.6.0, below the 0.6.1 that first accepts repo_type: <0.7.0,>=0.6.0
[lerobot] still admits lerobot 0.6.0, whose StreamingLeRobotDataset takes no repo_type
the guard tells callers to install the [lerobot] extra to get lerobot >= 0.6.1, but that extra floors at 0.6.0
the refusal still claims no release supports repo_type: "...is not supported by any released lerobot..."
```

`test_architecture_lerobot_extra_row_matches_pyproject_floor` passes pre-fix - it derives the floor from `pyproject.toml`, so it tracks the pin rather than pinning a literal.

## Verification

- Full suite: **18802 passed, 257 skipped, 0 failed** (491s, `MUJOCO_GL=egl python -m pytest tests -q --no-cov`)
- `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ`: clean (1054 files formatted, 1051 source files; 0 errors outside `examples/`, verified identical on pristine `main` in the same working copy)
- Merge-base overlap check: no overlap with `main` since `f82abfee`

## Artifact

Every cell is measured - the wheels are parsed, the resolver verdicts computed from the declared specifiers, the blast radius read from `pip --dry-run --report`, and the two messages produced by running the real code on each tree (the generator asserts the two probes resolved to *different* trees, and asserts each claim before saving).

![lerobot floor guarantees bucket streaming](https://raw.githubusercontent.com/cagataycali/robots/artifacts/lerobot-floor-bucket-streaming/lerobot_floor_artifact.png)

No policy, simulation, rendering, recording or asset behaviour changes here - the change is dependency metadata, one diagnostic message, docs and tests - so the artifact is a measured verdict figure rather than a rollout.

---

## Section 13 - Review Rounds

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R2 | CodeQL `py/uninitialized-local-variable` (alerts 861, 862) | `9cfb21e` | `tests/test_lerobot_floor_guarantees_bucket_streaming.py` |
| R3 | CodeQL `py/explicit-returns-mixed-with-implicit` (alert 863) | `0a4ea49` | same file, `_installed_lerobot_or_skip` |
