### PR TITLE
fix(sim/newton): set_timestep applies the one shared timestep domain

### DIFF
--- a/changelog.d/1931-newton-timestep-shared-domain.md
+++ b/changelog.d/1931-newton-timestep-shared-domain.md
@@ -1,0 +1,38 @@
+### Fixed: the Newton timestep setter applies the one shared timestep domain
+
+`SimEngine._validate_timestep` is the shared domain for a physics timestep, and
+its docstring names where it came from: *"This is the same contract
+`MuJoCoSimEngine.set_timestep` already enforces, so the value cannot be set at
+world creation on terms the setter would refuse."* All three backends'
+`create_world` route through it, and so does the MuJoCo setter.
+`NewtonSimEngine.set_timestep` did not. It carried a hand-rolled
+`float()`/`math.isfinite()` pair with no `bool` arm, even though its own
+docstring says it *"Mirrors the MuJoCo backend"*.
+
+So a boolean installed a one-second integration step. `set_timestep(True)`
+returned `status="success"` with the text `Timestep: 1.0s (1Hz)` and wrote
+`world.timestep = 1.0` - 500x the 0.002 default, from a value that is not a
+number - while `create_world(timestep=True)` on the *same backend* refused it.
+One field, one backend, two domains. `numpy.True_` and `numpy.bool_(True)`
+behaved the same way; `False` was refused only by the coincidence that
+`float(False) == 0.0` fails the `> 0` test, which is why the other half went
+unnoticed. Measured over fifteen values against the MuJoCo setter, the
+divergence was exactly that boolean family: three cells of fifteen.
+
+Newton advances `dt = timestep / substeps`, so with the default ten substeps
+that value makes one `step()` call cover a full second of simulated time.
+Replaying both step sizes in MuJoCo with a 1 kg 0.12 m box released 0.60 m above
+the floor: the whole 0.53 m fall spans **one** `step()` call instead of 1500, so
+there is no trajectory between two consecutive observations for a policy to act
+on, and the box settles 4.92 mm *inside* the ground plane instead of 0.11 mm - a
+45x worse contact resolution.
+
+The hand-rolled pair is replaced by the shared domain, so the setter now refuses
+a boolean, a non-finite value, zero, a negative and a non-numeric value on the
+same terms `create_world` and the MuJoCo setter already did. Values that were
+usable stay usable, including the `"0.002"` string and NumPy scalars the shared
+domain coerces, and the warn-not-reject arm above 0.1 s is unchanged.
+
+A structural test asserts every backend `set_timestep` calls the shared domain,
+with a planted-copy check so a clean result cannot be vacuous, so a future
+backend cannot ship a fourth local copy of this rule silently.

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1241,25 +1241,27 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         Args:
             timestep: Positive integration timestep in seconds.
 
+        Validation: ``timestep`` must be a finite number greater than zero.
+        ``bool`` is refused explicitly (``True`` would otherwise act as a
+        1-second step, 500x the default) and so is a non-numeric value. The
+        domain is :meth:`~strands_robots.simulation.base.SimEngine._validate_timestep`,
+        shared with :meth:`create_world` and with the MuJoCo setter, so a value
+        one surface accepts is accepted by all of them.
+
         Returns:
             Status dict reporting the timestep and equivalent control rate, or
-            an error dict when no world exists or the value is not finite and
-            positive.
+            an error dict when no world exists or the value is outside that
+            domain.
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
-        try:
-            timestep = float(timestep)
-        except (TypeError, ValueError):
-            return {
-                "status": "error",
-                "content": [{"text": f"set_timestep: must be a positive number, got {timestep!r}"}],
-            }
-        if not math.isfinite(timestep) or timestep <= 0:
-            return {
-                "status": "error",
-                "content": [{"text": f"set_timestep: must be a finite positive number, got {timestep}"}],
-            }
+        # Shared with create_world, and with the MuJoCo setter this method
+        # mirrors, so no surface can install a dt another one refuses. The
+        # hand-rolled float()/isfinite() pair this replaces had no bool arm, so
+        # ``True`` coerced to a 1-second step under status="success".
+        if err := self._validate_timestep(timestep, "set_timestep"):
+            return err
+        timestep = float(timestep)
         warn = " Warning: unusually large timestep (>0.1s); physics may be unstable" if timestep > 0.1 else ""
         with self._lock:
             self._world.timestep = timestep

--- a/tests/simulation/test_timestep_domain_across_surfaces.py
+++ b/tests/simulation/test_timestep_domain_across_surfaces.py
@@ -1,0 +1,305 @@
+"""Every surface that installs a physics timestep applies the one shared domain.
+
+The integration timestep is the ``dt`` each physics substep advances by, so a
+value the integrator cannot honor poisons the whole world rather than one call.
+:meth:`~strands_robots.simulation.base.SimEngine._validate_timestep` is the
+shared domain that says so, and its docstring names the surface it was lifted
+from: *"This is the same contract ``MuJoCoSimEngine.set_timestep`` already
+enforces, so the value cannot be set at world creation on terms the setter would
+refuse."*
+
+All three backends' ``create_world`` route through it, and so does the MuJoCo
+setter. The Newton setter did not - it carried a hand-rolled
+``float()``/``math.isfinite()`` pair with no ``bool`` arm - even though its own
+docstring says it *"Mirrors the MuJoCo backend"* and the module that pins it
+says the same. Measured on one ``create_world()``, then ``set_timestep(<value>)``,
+comparing the two backends over fifteen values:
+
+* ``True`` / ``numpy.True_`` / ``numpy.bool_(True)`` -> Newton
+  ``status="success"``, ``Timestep: 1.0s (1Hz)``, and ``world.timestep == 1.0``:
+  a one-second step, 500x the 0.002 default, installed by a value that is not a
+  number. MuJoCo refused all three, and so did Newton's *own*
+  ``create_world(timestep=True)``, so one backend held two domains for one field.
+* ``False`` was refused by both - but on Newton only by accident, via
+  ``float(False) == 0.0`` failing the ``> 0`` test rather than by being a
+  boolean. Half-handled by coincidence is why nothing noticed the other half.
+* the twelve remaining values (``nan``, ``inf``, ``-inf``, ``0``, ``0.0``,
+  ``-0.002``, ``None``, ``[0.002]``, ``"0.002"``, ``numpy.float64(0.002)``,
+  ``0.002``) already agreed, so the divergence was exactly the boolean family:
+  three cells of fifteen.
+
+A one-second ``dt`` is not merely a coarse simulation. Newton advances
+``dt = timestep / substeps`` per solver step, so with the default ten substeps
+that value makes one ``step()`` call cover a full second of simulated time
+instead of 0.002 s. Replaying both step sizes in MuJoCo with a 1 kg 0.12 m box
+released 0.60 m above the floor:
+
+============================== ================= =================
+quantity                       dt from ``True``  dt from ``0.002``
+============================== ================= =================
+solver dt                      0.1 s             0.0002 s
+sim time per ``step()``         1.0 s            0.002 s
+control steps spanning the fall 1                1500
+settled height (rest = 0.06 m) 0.05508 m         0.05989 m
+penetration into the floor     4.92 mm           0.11 mm
+============================== ================= =================
+
+So the whole 0.54 m fall happens between two consecutive observations - there is
+no trajectory for a policy to act on - and the contact is resolved 45x worse,
+the box coming to rest almost 5 mm inside the ground plane. Both under
+``status="success"``, reported as ``Timestep: 1.0s (1Hz)``.
+
+Solver-free: ``NewtonSimEngine.set_timestep`` validates and writes before it
+touches the solver, so the engine here is built via ``__new__`` with only the
+attributes that path reads. The pre-existing Newton pins for this method live in
+``tests/simulation/newton/test_gravity_timestep.py``, which is skipped whenever
+Newton/Warp are absent and asserts only ``"positive" in text`` - a substring both
+domains satisfy - so it could not have caught this on either count.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.models import SimWorld
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+_DEFAULT_DT = 0.002
+
+# Values no integrator can honor. ``False`` is here because it is a boolean, not
+# because it is zero: the coincidence that ``float(False) == 0.0`` is what made
+# the missing bool arm invisible.
+UNUSABLE = [
+    True,
+    False,
+    np.True_,
+    np.bool_(True),
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    0,
+    0.0,
+    -0.002,
+    None,
+    [0.002],
+]
+
+# Values the domain accepts, so a refusal here would be a regression rather than
+# a fix. ``"0.002"`` and the NumPy scalar are accepted because the shared domain
+# coerces anything ``float()`` accepts - see its docstring.
+USABLE = [0.002, 0.5, np.float64(0.002), "0.002"]
+
+BOOLEANS = [True, np.True_, np.bool_(True)]
+
+
+def _newton_engine() -> NewtonSimEngine:
+    """A Newton engine holding a created world, without a Newton install.
+
+    ``__init__`` imports Newton/Warp and builds a solver. ``set_timestep``
+    validates, takes the lock and writes ``world.timestep``; none of that is
+    physics, so the engine is built via ``__new__`` with just those attributes -
+    the harness ``tests/simulation/newton/test_free_base_is_not_an_actuator.py``
+    uses. ``_model`` is the non-``None`` sentinel for "world created".
+    """
+    engine = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._world = SimWorld(timestep=_DEFAULT_DT, gravity=[0.0, 0.0, -9.81])
+    engine._model = object()
+    engine._lock = threading.RLock()
+    return engine
+
+
+def _stored_timestep(engine: NewtonSimEngine) -> float:
+    """The dt the world currently holds.
+
+    ``_world`` is declared ``SimWorld | None`` on the engine and the fixture
+    above always builds one, so the narrowing happens here once instead of at
+    every assertion.
+    """
+    world = engine._world
+    assert world is not None
+    return float(world.timestep)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block["text"] for block in result.get("content", []) if "text" in block)
+
+
+def _set(engine: NewtonSimEngine, value: Any) -> dict[str, Any]:
+    """Call the setter with a deliberately off-type value.
+
+    Routed through one funnel so the off-domain values, which the annotation
+    ``float`` does not describe, need a single documented ``Any`` rather than a
+    suppression at every call site.
+    """
+    return engine.set_timestep(value)
+
+
+class TestTheNewtonSetterRefusesWhatNoIntegratorCanHonor:
+    @pytest.mark.parametrize("value", UNUSABLE, ids=repr)
+    def test_an_unusable_timestep_is_refused(self, value: Any) -> None:
+        engine = _newton_engine()
+        result = _set(engine, value)
+        assert result["status"] == "error", f"{value!r} was accepted"
+        assert "set_timestep" in _text(result)
+
+    @pytest.mark.parametrize("value", UNUSABLE, ids=repr)
+    def test_a_refused_timestep_is_not_installed(self, value: Any) -> None:
+        """The world keeps its dt, so a refused call cannot half-apply.
+
+        The write is ``world.timestep = timestep`` under the lock, and Newton
+        reads that live on every step, so a value that reached it would be in
+        force for the rest of the session.
+        """
+        engine = _newton_engine()
+        _set(engine, value)
+        assert _stored_timestep(engine) == pytest.approx(_DEFAULT_DT)
+
+    @pytest.mark.parametrize("value", BOOLEANS, ids=repr)
+    def test_a_boolean_is_named_as_a_boolean(self, value: Any) -> None:
+        """``True`` is refused for being a boolean, not for being out of range.
+
+        ``float(True)`` is ``1.0``, which is finite and positive, so a domain
+        that only checks the number accepts it. The message has to say which
+        mistake was made or the caller reads "must be positive" against a value
+        that is.
+        """
+        result = _set(_newton_engine(), value)
+        assert result["status"] == "error"
+        assert "bool" in _text(result).lower()
+
+    @pytest.mark.parametrize("value", USABLE, ids=repr)
+    def test_a_usable_timestep_is_still_accepted(self, value: Any) -> None:
+        engine = _newton_engine()
+        result = _set(engine, value)
+        assert result["status"] == "success", _text(result)
+        assert _stored_timestep(engine) == pytest.approx(float(value))
+
+    def test_a_large_but_usable_timestep_still_warns_rather_than_refusing(self) -> None:
+        """The warn-not-reject arm above 0.1 s is unchanged by the new domain."""
+        result = _set(_newton_engine(), 0.5)
+        assert result["status"] == "success"
+        assert "unusually large" in _text(result)
+
+
+class TestTheSetterAndTheWorldBuilderAgree:
+    """A dt the world builder refuses cannot be installed afterwards.
+
+    ``create_world`` calls the shared domain directly, so its verdict is the
+    staticmethod's verdict. Comparing the setter against it is what stops the
+    two drifting again on this backend - which is the failure this module was
+    written for: ``create_world(timestep=True)`` refused while
+    ``set_timestep(True)`` installed a 1-second step.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE + USABLE, ids=repr)
+    def test_the_setter_matches_the_creation_domain(self, value: Any) -> None:
+        creation_refuses = SimEngine._validate_timestep(value, "create_world") is not None
+        setter_refuses = _set(_newton_engine(), value)["status"] == "error"
+        assert setter_refuses == creation_refuses, (
+            f"{value!r}: create_world refuses={creation_refuses}, set_timestep refuses={setter_refuses}"
+        )
+
+
+class TestBothBackendsSetTimestepAgree:
+    """The Newton setter answers as the MuJoCo setter it says it mirrors does.
+
+    Newton's docstring claims to mirror MuJoCo, and the module pinning it says
+    the same; neither claim was checked against the MuJoCo verdict, and the two
+    disagreed on three values.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE + USABLE, ids=repr)
+    def test_the_two_backends_return_the_same_verdict(self, value: Any) -> None:
+        pytest.importorskip("mujoco")
+        from strands_robots import Simulation
+
+        newton_refuses = _set(_newton_engine(), value)["status"] == "error"
+
+        sim = Simulation(backend="mujoco", mesh=False)
+        try:
+            sim.create_world()
+            mujoco_refuses = sim.set_timestep(value)["status"] == "error"
+        finally:
+            sim.cleanup()
+
+        assert newton_refuses == mujoco_refuses, (
+            f"{value!r}: newton refuses={newton_refuses}, mujoco refuses={mujoco_refuses}"
+        )
+
+
+def _backend_dir() -> pathlib.Path:
+    """The simulation package, derived from a symbol rather than a path literal."""
+    return pathlib.Path(inspect.getfile(SimEngine)).parent
+
+
+def _setters_missing_the_shared_domain(root: pathlib.Path) -> dict[str, list[str]]:
+    """Backend ``set_timestep`` methods that do not call the shared domain.
+
+    Keyed by ``<backend>/<module>.py`` so a failure names the file to fix.
+    """
+    found: dict[str, list[str]] = {}
+    for backend in ("mujoco", "newton", "isaac"):
+        for module in sorted((root / backend).glob("*.py")):
+            tree = ast.parse(module.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                for member in ast.iter_child_nodes(node):
+                    if not isinstance(member, ast.FunctionDef) or member.name != "set_timestep":
+                        continue
+                    calls = {
+                        call.func.attr
+                        for call in ast.walk(member)
+                        if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+                    }
+                    if "_validate_timestep" not in calls:
+                        found.setdefault(f"{backend}/{module.name}", []).append(node.name)
+    return found
+
+
+def _setters_present(root: pathlib.Path) -> set[str]:
+    present = set()
+    for backend in ("mujoco", "newton", "isaac"):
+        for module in sorted((root / backend).glob("*.py")):
+            if "def set_timestep(" in module.read_text(encoding="utf-8"):
+                present.add(f"{backend}/{module.name}")
+    return present
+
+
+class TestNoBackendCanShipAnUnsharedTimestepDomain:
+    def test_every_backend_setter_calls_the_shared_domain(self) -> None:
+        assert _setters_missing_the_shared_domain(_backend_dir()) == {}
+
+    def test_the_scan_sees_the_setters_it_claims_to_cover(self) -> None:
+        """Non-vacuity: name the surfaces, so a mis-rooted scan cannot pass.
+
+        Isaac exposes no ``set_timestep``; if it gains one it joins this set and
+        the guard above starts checking it.
+        """
+        assert _setters_present(_backend_dir()) == {
+            "mujoco/simulation.py",
+            "newton/simulation.py",
+        }
+
+    def test_the_scan_detects_a_setter_that_hand_rolls_the_domain(self, tmp_path: pathlib.Path) -> None:
+        """A planted copy of the defect must be found, or a clean result is luck."""
+        for backend in ("mujoco", "newton", "isaac"):
+            (tmp_path / backend).mkdir()
+        (tmp_path / "newton" / "simulation.py").write_text(
+            "import math\n"
+            "class NewtonSimEngine:\n"
+            "    def set_timestep(self, timestep):\n"
+            "        if not math.isfinite(float(timestep)) or timestep <= 0:\n"
+            '            return {"status": "error"}\n'
+            "        self._world.timestep = timestep\n",
+            encoding="utf-8",
+        )
+        assert _setters_missing_the_shared_domain(tmp_path) == {"newton/simulation.py": ["NewtonSimEngine"]}


### PR DESCRIPTION
## Problem

`SimEngine._validate_timestep` is the shared domain for a physics timestep, and its docstring names the surface it was lifted from:

> This is the same contract `MuJoCoSimEngine.set_timestep` already enforces, so the value cannot be set at world creation on terms the setter would refuse.

All three backends' `create_world` route through it, and so does the MuJoCo setter. `NewtonSimEngine.set_timestep` did not — it carried a hand-rolled `float()` / `math.isfinite()` pair with no `bool` arm:

```python
try:
    timestep = float(timestep)          # float(True) -> 1.0
except (TypeError, ValueError):
    ...
if not math.isfinite(timestep) or timestep <= 0:   # 1.0 is finite and positive
    ...
```

Its own docstring says it *"Mirrors the MuJoCo backend"*, and the module that pins it says the same (`tests/simulation/newton/test_gravity_timestep.py`: *"…that `set_gravity` / `set_timestep` mirror the MuJoCo backend's contract"*). Neither claim was checked against the MuJoCo verdict.

## Measurement

Fifteen values, one `create_world()` then `set_timestep(<value>)`, both backends:

| value | Newton (before) | MuJoCo |
|---|---|---|
| `True` | **accepted** — `Timestep: 1.0s (1Hz)`, `world.timestep == 1.0` | refused |
| `numpy.True_` | **accepted** — `world.timestep == 1.0` | refused |
| `numpy.bool_(True)` | **accepted** — `world.timestep == 1.0` | refused |
| `False` | refused | refused |
| `nan`, `inf`, `-inf`, `0`, `0.0`, `-0.002`, `None`, `[0.002]` | refused | refused |
| `0.002`, `"0.002"`, `numpy.float64(0.002)` | accepted | accepted |

**3 divergences of 15 → 0.** All three are the boolean family. `False` was refused only by the coincidence that `float(False) == 0.0` fails the `> 0` test rather than by being a boolean — half-handled by accident is why the other half went unnoticed.

The sharpest part: `create_world(timestep=True)` on the **same backend** already refused this, because it calls the shared domain. One field, one backend, two domains.

## Consequence

Newton advances `dt = timestep / substeps`, so with the default ten substeps a stored `1.0` makes one `step()` call cover a full second of simulated time. Replaying both step sizes in MuJoCo with a 1 kg 0.12 m box released 0.60 m above the floor:

| quantity | dt from `True` | dt from `0.002` |
|---|---|---|
| solver dt | 0.1 s | 0.0002 s |
| sim time per `step()` | 1.0 s | 0.002 s |
| `step()` calls spanning the 0.53 m fall | **1** | 1500 |
| settled height (exact rest 0.060 m) | 0.05508 m | 0.05989 m |
| penetration into the floor | **4.92 mm** | 0.11 mm |

So the whole fall happens between two consecutive observations — there is no trajectory for a policy to act on — and the contact resolves 45x worse, the box coming to rest almost 5 mm inside the ground plane. Both under `status="success"`.

## Visual artifact

Each frame is one `step()` call. The renders are the measured write replayed in MuJoCo, not a reconstruction: the top row uses the `dt` the pre-fix setter stored for `set_timestep(True)`, the bottom row the `dt` the world keeps once that value is refused. Yellow post marks the release height, blue post the true rest height.

![Newton set_timestep boolean domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/newton-timestep-domain/newton_set_timestep_boolean.png)

Framing audit is printed on the figure: the crate occupies 3.8–6.8% of each frame, `step()` 0→1 changes 13.7% of pixels on the top row and 0.01% on the bottom, and the two `step()`-0 frames are byte-identical (`max|delta| = 0`), so the rig is the same and only the timestep differs.

## Change

The hand-rolled pair is replaced by the shared domain, with the reason at the call site:

```python
# Shared with create_world, and with the MuJoCo setter this method
# mirrors, so no surface can install a dt another one refuses. The
# hand-rolled float()/isfinite() pair this replaces had no bool arm, so
# ``True`` coerced to a 1-second step under status="success".
if err := self._validate_timestep(timestep, "set_timestep"):
    return err
```

No new helper: the domain already existed and only the wiring was missing. Values that were usable stay usable — including the `"0.002"` string and NumPy scalars the shared domain coerces — and the warn-not-reject arm above 0.1 s is unchanged. The docstring now states the domain and points at it.

**Blast radius: zero existing tests changed.** The Newton pins assert `"positive" in text`, which the shared message satisfies.

## Tests

`tests/simulation/test_timestep_domain_across_surfaces.py`, 67 tests, 0.8 s, **solver-free** — `set_timestep` validates and writes before it touches the solver, so the engine is built via `__new__` with only the attributes that path reads. That matters here: the pre-existing pins for this method are `skipif`-gated on a Newton/Warp install, so they do not run in CI at all, and they assert only a substring both domains satisfy. They could not have caught this on either count.

- the boolean family, `nan`/`inf`/`-inf`/`0`/negative/`None`/list are refused, and each names `set_timestep`
- a boolean is refused **as a boolean** (`"bool"` in the message), not as an out-of-range number — `float(True)` is finite and positive, so a message saying "must be positive" against `True` is unactionable
- **a refused value is not installed** — the world keeps its dt, so a rejected call cannot half-apply
- usable values still accepted, and the >0.1 s warn arm still warns
- **cross-surface parity**: the setter's verdict equals `create_world`'s domain verdict over all 16 values — the drift this fixes
- **cross-backend parity**: Newton and MuJoCo return the same verdict over all 16 values
- **structural guard**: every backend `set_timestep` calls the shared domain, plus a non-vacuity test naming the two surfaces that exist (Isaac has none; if it gains one it joins the set) and a planted-copy test, so a clean result cannot be vacuous

Pre-fix, with only the source reverted: **16 failed / 51 passed**. The 51 that pass are the already-agreeing values, the usable-value controls and the guard's own meta-tests — they are what stop the change over-reaching.

## Verification

- `ruff check strands_robots tests tests_integ` — clean; `ruff format --check` — 1055 files already formatted
- `mypy strands_robots tests tests_integ` — **0 errors outside `examples/`**. The 14 `examples/isaac_gs` errors are byte-identical on a pristine `upstream/main` checkout in the same working copy (`diff` of the two error sets is empty), so they are environmental and not introduced here.
- `MUJOCO_GL=egl pytest tests` — **18867 passed, 257 skipped** in 501 s. Pristine `upstream/main` in the same environment: 18800 passed, 257 skipped — exactly the 67 tests added here.
- `scripts/assemble_changelog.py --check` OK; `scripts/check_merge_base_overlap.py` reports no overlap with `upstream/main`.

## Out of scope

- Isaac exposes no `set_timestep`, so there is nothing to route there; the structural guard picks it up automatically if that changes.
- `NewtonSimEngine.set_gravity` already routes through `_normalize_gravity` (#1927), and it was the only other physics setter on the backend — after this, `strands_robots/simulation/newton/simulation.py` contains no hand-rolled numeric validation.
