### PR TITLE
fix(tools): the teleop tool refuses a numeric option the lerobot CLI cannot honor

### DIFF
--- a/changelog.d/1932-teleop-cli-numeric-domain.md
+++ b/changelog.d/1932-teleop-cli-numeric-domain.md
@@ -1,0 +1,34 @@
+### Fixed: the teleop tool refuses a numeric option the lerobot CLI cannot honor
+
+`build_lerobot_command` validated only *names* - a missing `dataset_repo_id`, an
+unknown `dagger_input_device` - and interpolated every numeric option into the
+argv with a bare `str()`. That argv is handed to `subprocess.Popen(...,
+start_new_session=True)`, so the detached process is not a channel the call can
+read a failure back from: the session starts, `status="success"` is returned with
+a pid, and a value the CLI cannot parse surfaces minutes later in the session's
+log file. Measured on a `lerobot-record` argv, `dataset_fps` alone reached
+`--dataset.fps` as `0`, `-5`, `2.7`, `nan`, `inf`, `True`, `'30'`, `None` and
+`[30]`; `dataset_num_episodes=0` asked for a recording of no episodes,
+`dataset_episode_time_s=0` for episodes of no length, and `replay_episode=-1`
+put a negative episode index on a replay.
+
+Two options were read for truthiness rather than presence, which made `0` mean
+the *opposite* of what it says. `teleop_time_s=0` - the one value meaning "stop
+at once" - emitted no `--teleop_time_s` at all, leaving an unbounded teleop
+session; a replay with `dataset_fps=0` dropped the rate flag, so the caller's
+requested rate was silently replaced by lerobot's own default.
+
+Every option the requested mode emits is now checked against the shared scalar
+domain for its kind - the same `strands_robots.utils` domains every other
+recording surface in the tree already applies - before the argv is built, so no
+subprocess is launched for a call that cannot be honored. The domains follow
+lerobot's own config dataclasses: `fps` and the episode counts are declared
+`int`, so an integral float read from a config is accepted and emitted as a whole
+number (`30.0` -> `30`, which is what the CLI parses into an `int` field), while
+`teleop_time_s` is lerobot's `float | None` budget and may be fractional. The
+floor is per option rather than uniform: `dataset_reset_time_s=0` (no operator
+pause between episodes) and `replay_episode=0` (the first episode) are real
+requests and stay accepted, while a zero rate, a zero-length episode and a
+zero-episode recording are refused. Only the options a mode actually puts on the
+argv are checked, so a caller is never refused for a value the requested mode
+ignores.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -34,6 +34,28 @@ from strands_robots.tools import (
 
 Parse results via `result["content"][0]["text"]`, not custom keys like `result["ports"]`.
 
+### Numeric options are checked before the session starts
+
+A teleop session runs in a detached subprocess, so a value the lerobot CLI
+cannot parse would not be reported by the call that supplied it - the session
+would start, report a pid, and fail minutes later in its log. `lerobot_teleoperate`
+therefore refuses an unusable numeric option up front, and only for the options
+the requested action actually puts on the lerobot command line:
+
+| Option | Accepted | Why the floor is where it is |
+|--------|----------|------------------------------|
+| `dataset_fps`, `fps` | positive whole number | lerobot declares both `int`; an integral float (`30.0`) is accepted and emitted as `30` |
+| `dataset_num_episodes`, `dagger_num_episodes` | positive whole number | a recording of no episodes cannot be produced |
+| `dataset_episode_time_s` | positive whole number | an episode of no length records nothing |
+| `dataset_reset_time_s` | non-negative whole number | `0` is a real setting: no operator pause between episodes |
+| `replay_episode` | non-negative whole number | `0` is the first episode |
+| `teleop_time_s` | positive number, or `None` | lerobot declares it `float \| None`; `None` (the default) means no time limit, and a fractional budget is usable |
+
+`teleop_time_s=0` is refused rather than read as "no limit" - it is the one value
+that means "stop at once", so treating it as unset would invert the request.
+Passing a value an action ignores is never an error: `action="start"` without a
+`dataset_repo_id` teleoperates and reads no `dataset_*` option.
+
 ## Examples
 
 ```python

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -16,11 +16,18 @@ import os
 import signal
 import subprocess
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import psutil
 from strands import tool
+
+from strands_robots.utils import (
+    non_negative_whole_number_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -29,6 +36,80 @@ logger = logging.getLogger(__name__)
 # Session storage directory
 SESSION_DIR = Path.cwd() / ".strands_robots/.sessions"
 SESSION_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# The numeric knobs each command mode actually puts on the lerobot argv. Every
+# one is interpolated with ``str()`` into the command line of a DETACHED
+# subprocess, so a value the lerobot CLI cannot parse is never reported by the
+# call that supplied it: the session starts, ``status="success"`` is returned,
+# and the failure appears minutes later in that session's log. A value the CLI
+# *can* parse but should not have been given - a zero recording rate, a negative
+# episode index - is worse, because nothing reports it at all.
+#
+# Refusing a knob the requested mode never emits would be a false rejection, so
+# the scoping is driven by this table rather than by validating the whole
+# signature unconditionally.
+_MODE_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
+    "replay": ("replay_episode", "dataset_fps"),
+    "record": ("dataset_num_episodes", "dataset_fps", "dataset_episode_time_s", "dataset_reset_time_s"),
+    "teleoperate": ("fps", "teleop_time_s"),
+    "dagger": ("dagger_num_episodes", "dataset_num_episodes", "dataset_fps", "fps"),
+}
+
+# The domain each knob is checked against, in the order errors are reported.
+# The whole-number knobs are declared ``int`` by lerobot's own config
+# dataclasses (``DatasetRecordConfig.fps`` / ``.num_episodes``,
+# ``TeleoperateConfig.fps``, ``DatasetReplayConfig.episode``) and by this
+# module's own signature, so a whole number is the honest domain and an integral
+# float read from a config is still honored. ``teleop_time_s`` is lerobot's
+# ``float | None`` session budget, where a fractional value is perfectly usable.
+#
+# Two knobs take the non-negative floor instead of the positive one:
+# ``dataset_reset_time_s=0`` (no operator pause between episodes) and
+# ``replay_episode=0`` (the first episode) are both real requests, whereas a
+# zero recording rate, a zero-length episode and a zero-episode recording are
+# each a request no run can satisfy.
+_OPTION_DOMAINS: tuple[tuple[str, Callable[[Any, str, str], str | None]], ...] = (
+    ("dataset_fps", positive_whole_number_error),
+    ("dataset_num_episodes", positive_whole_number_error),
+    ("dataset_episode_time_s", positive_whole_number_error),
+    ("dataset_reset_time_s", non_negative_whole_number_error),
+    ("dagger_num_episodes", positive_whole_number_error),
+    ("fps", positive_whole_number_error),
+    ("replay_episode", non_negative_whole_number_error),
+    ("teleop_time_s", positive_finite_number_error),
+)
+
+# Knobs whose ``None`` means "omit the flag and take the lerobot default", so
+# there ``None`` is a supplied value rather than an unusable one. Every other
+# knob in the table has a non-None default, so ``None`` is a caller mistake.
+_OPTIONAL_OPTIONS: frozenset[str] = frozenset({"teleop_time_s", "dagger_num_episodes"})
+
+
+def _numeric_option_error(mode: str, supplied: dict[str, Any]) -> str | None:
+    """Error text for the first numeric knob ``mode`` emits but cannot honor.
+
+    Args:
+        mode: A key of :data:`_MODE_NUMERIC_OPTIONS`; decides which knobs are
+            effective. A mode absent from that map emits none of them and is
+            never refused here.
+        supplied: Every knob in :data:`_OPTION_DOMAINS`, as supplied by the
+            caller.
+
+    Returns:
+        An error message naming the knob and its domain, or ``None`` when every
+        knob this mode emits is usable.
+    """
+    consumed = set(_MODE_NUMERIC_OPTIONS.get(mode, ()))
+    for param, check in _OPTION_DOMAINS:
+        if param not in consumed:
+            continue
+        value = supplied[param]
+        if value is None and param in _OPTIONAL_OPTIONS:
+            continue
+        if error := check(value, param, "build_lerobot_command"):
+            return error
+    return None
 
 
 class SessionManager:
@@ -238,26 +319,44 @@ def build_lerobot_command(
         The argv list, beginning with ``["python", "-m", "lerobot.scripts...."]``.
 
     Raises:
-        ValueError: If ``action`` is unknown, or ``replay`` is requested without
-            ``dataset_repo_id``.
+        ValueError: If ``action`` is unknown, ``replay`` is requested without
+            ``dataset_repo_id``, or a numeric knob the requested mode emits
+            cannot be honored (see :data:`_OPTION_DOMAINS`). The refusal
+            precedes the argv, so no subprocess is launched.
     """
+    # Every numeric knob below is interpolated into a detached subprocess's
+    # command line, which is not a channel this call can read a failure back
+    # from. Check the ones this mode actually emits before building the argv.
+    numeric_options: dict[str, Any] = {
+        "dataset_fps": dataset_fps,
+        "dataset_num_episodes": dataset_num_episodes,
+        "dataset_episode_time_s": dataset_episode_time_s,
+        "dataset_reset_time_s": dataset_reset_time_s,
+        "dagger_num_episodes": dagger_num_episodes,
+        "fps": fps,
+        "replay_episode": replay_episode,
+        "teleop_time_s": teleop_time_s,
+    }
     if action == "replay":
         if not dataset_repo_id:
             raise ValueError("dataset_repo_id is required for replay action")
+        if error := _numeric_option_error("replay", numeric_options):
+            raise ValueError(error)
         cmd = ["python", "-m", "lerobot.scripts.lerobot_replay"]
         cmd.extend(
             _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
         )
-        cmd.extend(["--dataset.repo_id", dataset_repo_id, "--dataset.episode", str(replay_episode)])
+        cmd.extend(["--dataset.repo_id", dataset_repo_id, "--dataset.episode", str(int(replay_episode))])
         if dataset_root:
             cmd.extend(["--dataset.root", dataset_root])
-        if dataset_fps:
-            cmd.extend(["--dataset.fps", str(dataset_fps)])
+        cmd.extend(["--dataset.fps", str(int(dataset_fps))])
         return cmd
 
     if action == "start":
         if dataset_repo_id:
             # Recording mode -> lerobot-record (pure data collection via teleop).
+            if error := _numeric_option_error("record", numeric_options):
+                raise ValueError(error)
             from strands_robots.dataset_recorder import resolve_dataset_dir
 
             cmd = ["python", "-m", "lerobot.scripts.lerobot_record"]
@@ -266,12 +365,12 @@ def build_lerobot_command(
             )
             cmd.extend(_teleop_args(teleop_type, teleop_port, teleop_id, teleop_left_arm_port, teleop_right_arm_port))
             cmd.extend(["--dataset.repo_id", dataset_repo_id])
-            cmd.extend(["--dataset.num_episodes", str(dataset_num_episodes)])
+            cmd.extend(["--dataset.num_episodes", str(int(dataset_num_episodes))])
             if dataset_single_task:
                 cmd.extend(["--dataset.single_task", dataset_single_task])
-            cmd.extend(["--dataset.fps", str(dataset_fps)])
-            cmd.extend(["--dataset.episode_time_s", str(dataset_episode_time_s)])
-            cmd.extend(["--dataset.reset_time_s", str(dataset_reset_time_s)])
+            cmd.extend(["--dataset.fps", str(int(dataset_fps))])
+            cmd.extend(["--dataset.episode_time_s", str(int(dataset_episode_time_s))])
+            cmd.extend(["--dataset.reset_time_s", str(int(dataset_reset_time_s))])
             # Always pin --dataset.root to a resolved on-disk path. On a fresh
             # (non-resume) recording, lerobot-record calls
             # ``cfg.dataset.stamp_repo_id()`` which rewrites repo_id to
@@ -290,13 +389,18 @@ def build_lerobot_command(
             return cmd
 
         # Simple teleoperation mode -> lerobot-teleoperate.
+        if error := _numeric_option_error("teleoperate", numeric_options):
+            raise ValueError(error)
         cmd = ["python", "-m", "lerobot.scripts.lerobot_teleoperate"]
         cmd.extend(
             _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
         )
         cmd.extend(_teleop_args(teleop_type, teleop_port, teleop_id, teleop_left_arm_port, teleop_right_arm_port))
-        cmd.extend(["--fps", str(fps)])
-        if teleop_time_s:
+        cmd.extend(["--fps", str(int(fps))])
+        # ``is not None``, not truthiness: ``0`` is now refused above, and reading
+        # it as "unset" made the one value meaning "stop at once" emit no budget
+        # at all - an unbounded session where the caller asked for none.
+        if teleop_time_s is not None:
             cmd.extend(["--teleop_time_s", str(teleop_time_s)])
         if display_data:
             cmd.extend(["--display_data", "true"])
@@ -316,6 +420,10 @@ def build_lerobot_command(
             raise ValueError("dataset_repo_id is required for dagger action (corrections are recorded)")
         if dagger_input_device not in ("keyboard", "pedal"):
             raise ValueError(f"dagger_input_device must be 'keyboard' or 'pedal', got '{dagger_input_device}'")
+        # Before the lerobot-version preflight below, so the same caller mistake
+        # reports identically whether or not the rollout entry point is present.
+        if error := _numeric_option_error("dagger", numeric_options):
+            raise ValueError(error)
 
         # lerobot.scripts.lerobot_rollout (the DAgger entry point) landed in
         # lerobot 0.6.0; on an older install the subprocess would fail with an
@@ -339,19 +447,19 @@ def build_lerobot_command(
         if dagger_record_autonomous:
             cmd.extend(["--strategy.record_autonomous", "true"])
         if dagger_num_episodes is not None:
-            cmd.extend(["--strategy.num_episodes", str(dagger_num_episodes)])
+            cmd.extend(["--strategy.num_episodes", str(int(dagger_num_episodes))])
         cmd.extend(["--dataset.repo_id", dataset_repo_id])
         if dataset_single_task:
             cmd.extend(["--dataset.single_task", dataset_single_task])
-        cmd.extend(["--dataset.num_episodes", str(dataset_num_episodes)])
-        cmd.extend(["--dataset.fps", str(dataset_fps)])
+        cmd.extend(["--dataset.num_episodes", str(int(dataset_num_episodes))])
+        cmd.extend(["--dataset.fps", str(int(dataset_fps))])
         if dataset_root:
             cmd.extend(["--dataset.root", dataset_root])
         # push_to_hub defaults to True in lerobot's DatasetRecordConfig; make it
         # explicit so an unattended correction run never uploads by surprise.
         cmd.extend(["--dataset.push_to_hub", "true" if dataset_push_to_hub else "false"])
         cmd.extend(["--dataset.video", "true" if dataset_video else "false"])
-        cmd.extend(["--fps", str(fps)])
+        cmd.extend(["--fps", str(int(fps))])
         if display_data:
             cmd.extend(["--display_data", "true"])
         return cmd

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -870,9 +870,14 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
 def non_negative_whole_number_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable non-negative whole number.
 
-    Shared domain for the number of physics steps a caller asks a simulation to
-    advance - the ``n_steps`` of every backend's
-    :meth:`~strands_robots.simulation.base.SimEngine.step`.
+    Shared domain for two families of discrete quantity whose ``0`` is a real
+    setting rather than a degenerate one: the number of physics steps a caller
+    asks a simulation to advance - the ``n_steps`` of every backend's
+    :meth:`~strands_robots.simulation.base.SimEngine.step` - and the two
+    whole-number teleop knobs :mod:`~strands_robots.tools.lerobot_teleoperate`
+    puts on the lerobot CLI, where ``dataset_reset_time_s=0`` is "no operator
+    pause between recorded episodes" and ``replay_episode=0`` is the first
+    episode.
 
     Not the only physics-step count in the tree, and the difference is the
     floor rather than the scalar policy: the ``n_substeps`` of

--- a/tests/tools/test_lerobot_teleoperate_numeric_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_numeric_domain.py
@@ -1,0 +1,304 @@
+"""``build_lerobot_command`` must refuse a numeric knob the lerobot CLI cannot honor.
+
+Every numeric option this tool accepts is interpolated with ``str()`` into the
+command line of a subprocess launched with ``start_new_session=True``. That
+detached process is not a channel the call can read a failure back from: the
+session starts, ``status="success"`` is returned with a pid, and a value the
+lerobot CLI cannot parse surfaces minutes later in the session's log file. A
+value the CLI *can* parse but should never have been given is worse still,
+because nothing reports it at any point:
+
+* ``dataset_fps=0`` put ``--dataset.fps 0`` on a ``lerobot-record`` argv;
+* ``dataset_num_episodes=0`` asked for a recording of no episodes;
+* ``replay_episode=-1`` put ``--dataset.episode -1`` on a replay;
+* ``dataset_fps=nan`` / ``inf`` / ``None`` / ``[30]`` reached the argv as the
+  literals ``nan``, ``inf``, ``None`` and ``[30]``.
+
+Two knobs were read for truthiness rather than presence, which made ``0`` mean
+the *opposite* of what it says: ``teleop_time_s=0`` ("stop at once") emitted no
+budget at all, leaving an unbounded teleop session, and a replay with
+``dataset_fps=0`` dropped the rate flag and took lerobot's own default instead
+of the caller's.
+
+The knobs are checked against the shared scalar domains
+(:mod:`strands_robots.utils`) that every other recording surface in the tree
+already applies, and only for the knobs the requested mode actually emits -
+refusing a value a mode never puts on the argv would be a false rejection.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.lerobot_teleoperate as tele_mod
+
+build_lerobot_command = tele_mod.build_lerobot_command
+lerobot_teleoperate = tele_mod.lerobot_teleoperate
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Keep the module-level session store inside the test's temp dir."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+# A value in none of the accepted domains: no run can be given it, and the CLI
+# either rejects it minutes later or silently reads something else.
+UNUSABLE = [
+    pytest.param(0, id="zero"),
+    pytest.param(-5, id="negative"),
+    pytest.param(2.7, id="fractional"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param(True, id="bool"),
+    pytest.param("30", id="numeric-string"),
+    pytest.param(None, id="none"),
+    pytest.param([30], id="list"),
+]
+
+# Whole-number knobs accept an integral real, so a count read from a config or
+# promoted by NumPy arithmetic is still honored.
+INTEGRAL = [
+    pytest.param(30, id="int"),
+    pytest.param(30.0, id="integral-float"),
+    pytest.param(np.int64(30), id="np-int64"),
+]
+
+
+def _record(**overrides: Any) -> list[str]:
+    """A ``lerobot-record`` argv (``start`` + a dataset repo id)."""
+    kwargs: dict[str, Any] = {
+        "action": "start",
+        "robot_type": "so101_follower",
+        "robot_port": "/dev/ttyACM1",
+        "teleop_type": "so101_leader",
+        "teleop_port": "/dev/ttyACM0",
+        "dataset_repo_id": "user/pick",
+        "dataset_single_task": "pick the cube",
+    }
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def _teleop(**overrides: Any) -> list[str]:
+    """A ``lerobot-teleoperate`` argv (``start`` with no dataset)."""
+    kwargs: dict[str, Any] = {
+        "action": "start",
+        "robot_type": "so101_follower",
+        "robot_port": "/dev/ttyACM1",
+        "teleop_type": "so101_leader",
+        "teleop_port": "/dev/ttyACM0",
+    }
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def _replay(**overrides: Any) -> list[str]:
+    """A ``lerobot-replay`` argv."""
+    kwargs: dict[str, Any] = {
+        "action": "replay",
+        "robot_type": "so101_follower",
+        "robot_port": "/dev/ttyACM1",
+        "dataset_repo_id": "user/pick",
+    }
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def _flag(argv: list[str], flag: str) -> str | None:
+    """The token following ``flag``, or ``None`` when the flag is absent."""
+    return argv[argv.index(flag) + 1] if flag in argv else None
+
+
+class TestARecordingRateNoRunCanHonorIsRefused:
+    """The rate the dataset is written at is the knob with the widest blast radius."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_record_refuses_an_unusable_dataset_fps(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="dataset_fps"):
+            _record(dataset_fps=value)
+
+    @pytest.mark.parametrize("value", INTEGRAL)
+    def test_record_emits_an_integral_rate_as_a_whole_number(self, value: Any) -> None:
+        """lerobot declares ``DatasetRecordConfig.fps`` an ``int``.
+
+        A ``30.0`` read from a config is a usable rate, so it is accepted - but
+        the argv must carry ``30``, not ``30.0``, because the CLI parses that
+        token into an ``int`` field. The coercion is what makes accepting the
+        integral float honest rather than a deferred failure.
+        """
+        assert _flag(_record(dataset_fps=value), "--dataset.fps") == "30"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_dagger_refuses_an_unusable_dataset_fps(self, value: Any) -> None:
+        """The DAgger corrections it appends land in the same dataset."""
+        with pytest.raises(ValueError, match="dataset_fps"):
+            build_lerobot_command(
+                action="dagger",
+                robot_type="so101_follower",
+                robot_port="/dev/ttyACM1",
+                dataset_repo_id="user/pick",
+                policy_path="lerobot/act_so101",
+                dataset_fps=value,
+            )
+
+
+class TestZeroIsHonoredWhereItIsARealSettingAndRefusedWhereItIsNot:
+    """The floor differs per knob, and both directions are pinned here.
+
+    Making every knob strictly positive would reject two real requests; making
+    them all non-negative would accept three that no run can satisfy. Neither
+    single floor is correct, which is why the domains are chosen per knob.
+    """
+
+    def test_no_operator_pause_between_episodes_is_accepted(self) -> None:
+        assert _flag(_record(dataset_reset_time_s=0), "--dataset.reset_time_s") == "0"
+
+    def test_the_first_episode_is_accepted_for_replay(self) -> None:
+        assert _flag(_replay(replay_episode=0), "--dataset.episode") == "0"
+
+    @pytest.mark.parametrize(
+        "knob",
+        ["dataset_fps", "dataset_num_episodes", "dataset_episode_time_s"],
+    )
+    def test_a_zero_that_no_run_can_satisfy_is_refused(self, knob: str) -> None:
+        """A zero rate, a zero-episode recording and a zero-length episode."""
+        with pytest.raises(ValueError, match=knob):
+            _record(**{knob: 0})
+
+    @pytest.mark.parametrize("knob", ["dataset_reset_time_s", "replay_episode"])
+    def test_the_non_negative_knobs_still_refuse_a_negative(self, knob: str) -> None:
+        builder = _replay if knob == "replay_episode" else _record
+        with pytest.raises(ValueError, match=knob):
+            builder(**{knob: -1})
+
+
+class TestATruthinessReadNoLongerInvertsAZero:
+    """``0`` must not be read as "unset" for a knob whose zero is meaningful."""
+
+    def test_a_zero_session_budget_is_refused_rather_than_dropped(self) -> None:
+        """Pre-fix this emitted no ``--teleop_time_s`` at all.
+
+        The one value that means "stop at once" produced a session with no time
+        limit - the opposite of the request - and reported success.
+        """
+        with pytest.raises(ValueError, match="teleop_time_s"):
+            _teleop(teleop_time_s=0)
+
+    def test_an_omitted_session_budget_still_means_no_limit(self) -> None:
+        """``None`` is the documented default and stays a supplied value."""
+        assert _flag(_teleop(teleop_time_s=None), "--teleop_time_s") is None
+
+    def test_a_usable_session_budget_is_emitted_and_may_be_fractional(self) -> None:
+        """lerobot declares ``TeleoperateConfig.teleop_time_s`` a ``float``."""
+        assert _flag(_teleop(teleop_time_s=12.5), "--teleop_time_s") == "12.5"
+
+    def test_replay_always_emits_the_rate_it_was_given(self) -> None:
+        """Pre-fix a falsy rate dropped the flag and took lerobot's default."""
+        assert _flag(_replay(dataset_fps=25), "--dataset.fps") == "25"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_replay_refuses_an_unusable_rate_instead_of_dropping_it(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="dataset_fps"):
+            _replay(dataset_fps=value)
+
+
+class TestOnlyTheKnobsAModeEmitsAreChecked:
+    """A caller must never be refused for a value the requested mode ignores."""
+
+    def test_teleoperate_ignores_the_dataset_rate(self) -> None:
+        """No ``--dataset.*`` flag is emitted, so the rate is not read."""
+        argv = _teleop(dataset_fps=0)
+        assert _flag(argv, "--dataset.fps") is None
+        assert _flag(argv, "--fps") == "60"
+
+    def test_record_ignores_the_teleop_session_budget(self) -> None:
+        argv = _record(teleop_time_s=0)
+        assert _flag(argv, "--teleop_time_s") is None
+        assert _flag(argv, "--dataset.fps") == "30"
+
+    def test_record_ignores_the_replay_episode_index(self) -> None:
+        assert _flag(_record(replay_episode=-1), "--dataset.episode") is None
+
+    def test_replay_ignores_the_episode_count_and_time_budgets(self) -> None:
+        argv = _replay(dataset_num_episodes=0, dataset_episode_time_s=-1, dataset_reset_time_s=-1)
+        assert _flag(argv, "--dataset.num_episodes") is None
+        assert _flag(argv, "--dataset.episode_time_s") is None
+
+
+class TestTheRefusalPrecedesTheDetachedProcess:
+    """Nothing may be launched or persisted for a call that cannot be honored."""
+
+    def test_the_tool_reports_the_refusal_without_starting_a_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _never(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("subprocess.Popen must not be reached for a refused call")
+
+        monkeypatch.setattr(tele_mod.subprocess, "Popen", _never)
+        result = lerobot_teleoperate(
+            action="start",
+            robot_type="so101_follower",
+            robot_port="/dev/ttyACM1",
+            teleop_type="so101_leader",
+            teleop_port="/dev/ttyACM0",
+            dataset_repo_id="user/pick",
+            dataset_fps=0,
+            session_name="refused",
+        )
+        assert result["status"] == "error"
+        text = "\n".join(item.get("text", "") for item in result["content"] if "text" in item)
+        assert "dataset_fps" in text
+        assert tele_mod.SessionManager().get_session("refused") is None
+
+
+class TestTheOptionTablesCannotDriftApart:
+    """A knob added to a mode must have a domain, and vice versa."""
+
+    def test_every_knob_a_mode_emits_has_a_declared_domain(self) -> None:
+        domains = {name for name, _ in tele_mod._OPTION_DOMAINS}
+        for mode, knobs in tele_mod._MODE_NUMERIC_OPTIONS.items():
+            missing = sorted(set(knobs) - domains)
+            assert not missing, f"mode {mode!r} emits {missing} with no domain in _OPTION_DOMAINS"
+
+    def test_every_declared_domain_is_emitted_by_some_mode(self) -> None:
+        """A domain no mode reads is dead weight that will rot."""
+        emitted = {knob for knobs in tele_mod._MODE_NUMERIC_OPTIONS.values() for knob in knobs}
+        orphans = sorted({name for name, _ in tele_mod._OPTION_DOMAINS} - emitted)
+        assert not orphans, f"_OPTION_DOMAINS entries no mode emits: {orphans}"
+
+    def test_every_declared_domain_names_a_real_parameter(self) -> None:
+        params = set(inspect.signature(build_lerobot_command).parameters)
+        unknown = sorted({name for name, _ in tele_mod._OPTION_DOMAINS} - params)
+        assert not unknown, f"_OPTION_DOMAINS names non-parameters: {unknown}"
+
+    def test_the_modes_are_exactly_the_ones_the_builder_dispatches(self) -> None:
+        assert set(tele_mod._MODE_NUMERIC_OPTIONS) == {"replay", "record", "teleoperate", "dagger"}
+
+    def test_an_optional_knob_is_one_the_table_actually_declares(self) -> None:
+        domains = {name for name, _ in tele_mod._OPTION_DOMAINS}
+        assert tele_mod._OPTIONAL_OPTIONS <= domains
+
+
+class TestNoWholeNumberFlagCarriesANonIntegerToken:
+    """Each accepted whole-number knob reaches the CLI as an ``int`` literal."""
+
+    @pytest.mark.parametrize(
+        ("flag", "knob", "builder"),
+        [
+            ("--dataset.fps", "dataset_fps", _record),
+            ("--dataset.num_episodes", "dataset_num_episodes", _record),
+            ("--dataset.episode_time_s", "dataset_episode_time_s", _record),
+            ("--dataset.reset_time_s", "dataset_reset_time_s", _record),
+            ("--fps", "fps", _teleop),
+            ("--dataset.episode", "replay_episode", _replay),
+        ],
+    )
+    def test_an_integral_float_is_emitted_without_a_decimal_point(self, flag, knob, builder) -> None:
+        token = _flag(builder(**{knob: 7.0}), flag)
+        assert token == "7", f"{flag} carried {token!r}, which lerobot parses into an int field"


### PR DESCRIPTION
## Problem

`build_lerobot_command` validated only **names** — a missing `dataset_repo_id`, an unknown `dagger_input_device` — and interpolated every **numeric** option into the argv with a bare `str()`. That argv is handed to `subprocess.Popen(..., start_new_session=True)`, so the detached process is not a channel the call can read a failure back from: the session starts, `status="success"` is returned with a pid, and a value the CLI cannot parse surfaces minutes later in the session's log file. A value the CLI *can* parse but should never have been given is worse, because nothing reports it at any point.

Measured against `upstream/main` (5221459a) by calling the builder directly — 15 values no run can be given reached the lerobot command line:

| mode | option | passed | argv token handed to lerobot |
|---|---|---|---|
| record | `dataset_fps` | `0`, `-5`, `2.7`, `nan`, `inf`, `True`, `'30'`, `None`, `[30]` | `--dataset.fps 0` … `--dataset.fps [30]` |
| record | `dataset_num_episodes` | `0`, `-1`, `nan` | `--dataset.num_episodes nan` |
| record | `dataset_episode_time_s` | `0` | `--dataset.episode_time_s 0` |
| replay | `replay_episode` | `-1`, `nan` | `--dataset.episode -1` |

Two options were read for **truthiness** rather than presence, which made `0` mean the *opposite* of what it says:

- `teleop_time_s=0` — the one value meaning “stop at once” — emitted **no** `--teleop_time_s` at all, leaving an **unbounded** teleop session.
- A replay with `dataset_fps=0` **dropped** the rate flag, so lerobot's own default silently replaced the caller's requested rate.

Every other recording surface in the tree already applies a shared domain to its rate (`start_recording`, `start_cameras_recording`, `encode_clip`, `lerobot_camera`). This is the surface that records a real dataset from real arms, and it was the one left unguarded.

## Change

Each option the requested mode emits is checked against the shared scalar domain for its kind (`strands_robots.utils`) **before** the argv is built, so no subprocess is launched for a call that cannot be honored. The builder raises `ValueError`, which is what its four existing name checks already do and what its documented `Raises:` section covers, so both `@tool` entry points convert it to the structured error result unchanged.

The domains follow **lerobot 0.6.2's own config dataclasses**, read from the installed package rather than assumed:

| option | declared by lerobot | domain |
|---|---|---|
| `dataset_fps`, `fps` | `DatasetRecordConfig.fps: int`, `TeleoperateConfig.fps: int` | positive whole number |
| `dataset_num_episodes`, `dagger_num_episodes` | `DatasetRecordConfig.num_episodes: int` | positive whole number |
| `dataset_episode_time_s` | `int \| float` (this module declares `int`) | positive whole number |
| `dataset_reset_time_s` | `int \| float` (this module declares `int`) | **non-negative** whole number |
| `replay_episode` | `DatasetReplayConfig.episode: int` | **non-negative** whole number |
| `teleop_time_s` | `TeleoperateConfig.teleop_time_s: float \| None` | positive finite number, or `None` |

Three points worth calling out:

- **The floor is per option, not uniform.** `dataset_reset_time_s=0` (no operator pause between episodes) and `replay_episode=0` (the first episode) are real requests and stay accepted; a zero rate, a zero-length episode and a zero-episode recording are refused. Both directions are pinned, so neither “make them all positive” nor “make them all non-negative” passes.
- **The whole-number options are coerced with `int()` at emission.** An integral float read from a config is a usable rate, so `30.0` is accepted — but the argv must carry `30`, because the CLI parses that token into an `int` field. The coercion is what makes accepting the integral float honest rather than a deferred failure.
- **Only the options a mode actually emits are checked.** `action="start"` without a `dataset_repo_id` teleoperates and reads no `dataset_*` option, so passing one there is not an error. The dagger guard runs *before* the `lerobot-rollout` version preflight, so the same caller mistake reports identically whether or not that entry point is installed.

No new helper was needed: `non_negative_whole_number_error` already is this domain, and its docstring is widened to name the second family it now serves rather than a second name being introduced for one rule.

## Visual artifact

The value that reached the lerobot command line, measured on both trees. `measure_argv.py` runs once inside a pristine `upstream/main` worktree and once inside the branch worktree — each prints the tree it resolved and the composer asserts the two differ — and every number in the figure is re-derived from the two JSON dumps, so the figure cannot ship a stale claim.

![what reached the lerobot command line](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-cli-numeric-domain/artifact_teleop_argv.png)

The bottom panel is the no-regression ledger: **5 of 6** honored calls build a **byte-identical** argv on both trees. The single deliberate difference is `record dataset_fps=30.0`, which went from `--dataset.fps 30.0` to `--dataset.fps 30`.

## Tests

`tests/tools/test_lerobot_teleoperate_numeric_domain.py`, 57 tests, no hardware and no lerobot import (1.03 s):

- every unusable value refused per mode, with the option named in the message;
- an integral real (`30`, `30.0`, `np.int64(30)`) accepted and emitted as `30`;
- `0` accepted where it is a real setting and refused where it is not, in both directions;
- `teleop_time_s=0` refused while `None` still means no limit and `12.5` is emitted;
- a replay always emits the rate it was given, instead of dropping a falsy one;
- per-mode scoping in both directions — a value a mode ignores is never refused;
- the refusal precedes the detached process: `subprocess.Popen` is monkeypatched to raise, the tool returns the error, and no session is persisted;
- table-drift guards: every option a mode emits has a declared domain, every declared domain is emitted by some mode and names a real parameter of the signature.

**Pre-fix proof** (source tree reverted to `5221459a`, tests kept): **46 failed / 11 passed** → **57 passed**. The 11 that pass pre-fix are the over-reach controls — the four per-mode scoping tests, the accepted values, the `None`-means-no-limit case and the two legitimate zeros. They are what stops the guard from becoming too broad, so they are expected to pass on both trees.

## Gate

Rebased onto `581e9d1`; `scripts/check_merge_base_overlap.py` reports no overlap.

- `ruff check` + `ruff format --check strands_robots tests tests_integ` — clean (1057 files)
- `mypy strands_robots tests tests_integ` — 0 errors outside `examples/isaac_gs` (the 14 there are byte-identical on a pristine `upstream/main` checkout of the same working copy, i.e. environmental)
- `MUJOCO_GL=egl pytest tests` — **18938 passed, 257 skipped**, 0 failed (508.81 s)
- root guards (changelog fragments/format, docstring xrefs, internal paths, unreachable statements) — 42 passed
- `scripts/assemble_changelog.py --check` — OK
- **zero existing-test churn**: all 58 tests in `tests/tools/test_lerobot_teleoperate.py` pass unchanged

Docs: `docs/hardware/tools.md` gains the accepted domain per option and the reason each floor is where it is.