### PR TITLE
fix(tools): pose_tool honors its steps / step_delay interpolation options

### DIFF
--- a/changelog.d/1933-pose-tool-interpolation-options.md
+++ b/changelog.d/1933-pose-tool-interpolation-options.md
@@ -1,0 +1,19 @@
+### Fixed: `pose_tool` honors its `steps` / `step_delay` interpolation options instead of dropping them
+
+`pose_tool`'s documented `steps` and `step_delay` parameters never reached the
+interpolation loop that reads them. `move_multiple_motors` did not accept them and
+called `_smooth_move(positions)` with neither, so every interpolated move -
+`load_pose`, `move_multiple` and `reset_to_home` - ran the hardcoded 20 increments
+at 0.05s regardless of what the caller asked for, and reported success. An agent
+asking for a slower, finer trajectory on a real arm silently got the default one.
+
+Both options are now forwarded, and validated at the tool boundary before any pose
+file is read or the serial port is opened, because each is consumed inside the loop
+on a live servo bus: `steps` is the divisor for each motor's increment and the bound
+of the write loop (`positive_count_error`), and `step_delay` is the pause between
+goal positions (`positive_finite_number_error`). Previously unusable values would
+have raised `ZeroDivisionError`, silently skipped the loop and reported a move that
+never happened, jumped at full travel in a single increment, or - for an infinite
+delay - blocked forever with the arm stopped part-way through its trajectory and the
+port still open. Only the actions that interpolate are checked; any other action
+ignores both options and is never refused for them.

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -22,8 +22,82 @@ import serial.tools.list_ports
 from strands import tool
 
 from strands_robots.tools._path_validation import validate_save_path
+from strands_robots.utils import positive_count_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
+
+
+# Interpolation options: which actions read them, and the domain they must be in.
+#
+# ``steps`` and ``step_delay`` are only consumed on the interpolated path, so an
+# action that moves in one shot never reads them and must never be refused for
+# them. ``reset_to_home`` interpolates unconditionally; ``load_pose`` and
+# ``move_multiple`` interpolate only when the caller leaves ``smooth`` truthy.
+_INTERPOLATING_ACTIONS = frozenset({"load_pose", "move_multiple"})
+_ALWAYS_INTERPOLATING_ACTIONS = frozenset({"reset_to_home"})
+
+
+def _interpolates(action: str, smooth: bool) -> bool:
+    """Report whether ``action`` will build an interpolated trajectory.
+
+    Args:
+        action: The requested action.
+        smooth: The caller's ``smooth`` flag, which only some actions consult.
+
+    Returns:
+        True when the action reads ``steps`` / ``step_delay``.
+    """
+    if action in _ALWAYS_INTERPOLATING_ACTIONS:
+        return True
+    return action in _INTERPOLATING_ACTIONS and bool(smooth)
+
+
+def _smooth_move_option_error(action: str, *, smooth: bool, steps: Any, step_delay: Any) -> str | None:
+    """Error text for an interpolation option this action cannot honor.
+
+    Both options are consumed inside the interpolation loop, on a live servo
+    bus: ``steps`` divides the travel into increments and bounds the loop, and
+    ``step_delay`` is the pause between successive goal positions. Their product
+    is the trajectory's duration, so neither has a usable value outside its
+    domain and each fails in its own way if one is not applied.
+
+    ``steps`` is checked against
+    :func:`~strands_robots.utils.positive_count_error`: it is a divisor and a
+    ``range()`` bound, so ``0`` raises ``ZeroDivisionError``, a negative count
+    makes the loop body unreachable and reports a move that never happened, and
+    a fractional or string count raises ``TypeError`` from ``range()``. ``bool``
+    is refused with it, because ``True`` is a silent single increment - a
+    full-travel jump on exactly the path a caller asking to interpolate wanted
+    to avoid.
+
+    ``step_delay`` is checked against
+    :func:`~strands_robots.utils.positive_finite_number_error` - the same domain
+    the library's other pacing knobs use - and that includes refusing ``0``. The
+    pause *is* the smoothing: with no pause the increments are written as fast as
+    the bus accepts them (a six-motor 20-step move is ~126 short writes, on the
+    order of ten milliseconds at 1 Mbaud) instead of over the requested
+    ``steps * step_delay`` seconds, so the interpolation the caller asked for
+    cannot be honored. A caller who wants to go straight to the target already
+    has ``smooth=False`` for it. A negative or ``nan`` delay raises
+    ``ValueError`` from ``time.sleep`` and ``inf`` blocks the call forever,
+    leaving the arm stopped part-way through its trajectory with the port still
+    open.
+
+    Args:
+        action: The requested action; decides whether the options are read.
+        smooth: The caller's ``smooth`` flag.
+        steps: Interpolation step count, as supplied.
+        step_delay: Seconds between increments, as supplied.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when the
+        action reads neither option or both values are usable.
+    """
+    if not _interpolates(action, bool(smooth)):
+        return None
+    if error := positive_count_error(steps, "steps", action):
+        return error
+    return positive_finite_number_error(step_delay, "step_delay", action)
 
 
 @dataclass
@@ -300,10 +374,30 @@ class MotorController:
                 positions[motor_name] = pos
         return positions
 
-    def move_multiple_motors(self, positions: dict[str, float], smooth: bool = True) -> bool:
-        """Move multiple motors simultaneously."""
+    def move_multiple_motors(
+        self,
+        positions: dict[str, float],
+        smooth: bool = True,
+        steps: int = 20,
+        step_delay: float = 0.05,
+    ) -> bool:
+        """Move multiple motors simultaneously.
+
+        Args:
+            positions: Target position per motor name.
+            smooth: Interpolate towards the targets instead of commanding them
+                in one shot.
+            steps: Number of increments when interpolating. Forwarded to
+                :meth:`_smooth_move`, which requires a positive integer.
+            step_delay: Seconds between increments when interpolating.
+                Forwarded to :meth:`_smooth_move`, which requires a positive
+                finite value.
+
+        Returns:
+            True when every motor was commanded successfully.
+        """
         if smooth:
-            return self._smooth_move(positions)
+            return self._smooth_move(positions, steps=steps, step_delay=step_delay)
         else:
             success = True
             for motor_name, position in positions.items():
@@ -312,7 +406,22 @@ class MotorController:
             return success
 
     def _smooth_move(self, target_positions: dict[str, float], steps: int = 20, step_delay: float = 0.05) -> bool:
-        """Smoothly move to target positions."""
+        """Smoothly move to target positions.
+
+        Args:
+            target_positions: Target position per motor name.
+            steps: Number of increments; must be a positive integer, since it is
+                the divisor for each motor's per-step increment and the bound of
+                the write loop.
+            step_delay: Seconds between increments; must be positive and finite,
+                since it is passed straight to ``time.sleep``.
+                :func:`_smooth_move_option_error` is what holds both to those
+                domains for every caller that reaches here through
+                :func:`pose_tool`.
+
+        Returns:
+            True once every increment has been written.
+        """
         current_positions = self.read_all_positions()
 
         # Calculate step increments
@@ -397,12 +506,30 @@ def pose_tool(
         positions: Dictionary of motor positions {motor_name: degrees}
         description: Description for stored poses
         smooth: Use smooth interpolated movement
-        steps: Number of steps for smooth movement
-        step_delay: Delay between movement steps
+        steps: Number of increments for an interpolated move. A positive
+            integer - it divides the travel and bounds the write loop.
+        step_delay: Seconds between increments of an interpolated move. A
+            positive finite number - this pause is what makes the move smooth,
+            so ``0`` is refused; use ``smooth=False`` to go straight to the
+            target. Together with ``steps`` it sets the trajectory duration
+            (the default 20 x 0.05s = ~1s).
+
+    Both interpolation options are read only by ``load_pose`` and
+    ``move_multiple`` (when ``smooth`` is left truthy) and by
+    ``reset_to_home``, which always interpolates; any other action ignores them
+    and is never refused for them.
 
     Returns:
-        Dict containing status and response content
+        Dict containing status and response content, or an error dict when an
+        interpolation option the requested action reads cannot be honored.
     """
+
+    # Both interpolation options are consumed on a live servo bus - one as a
+    # divisor and loop bound, one as the pause between goal positions - so an
+    # unusable value is refused here, before any pose file is read or the port
+    # is opened, rather than raising part-way through a trajectory.
+    if option_error := _smooth_move_option_error(action, smooth=smooth, steps=steps, step_delay=step_delay):
+        return {"status": "error", "content": [{"text": option_error}]}
 
     # Initialize managers
     pose_manager = PoseManager(robot_id)
@@ -592,7 +719,7 @@ def pose_tool(
                 return {"status": "error", "content": [{"text": f"{error}"}]}
 
             try:
-                success = controller.move_multiple_motors(pose.positions, smooth)
+                success = controller.move_multiple_motors(pose.positions, smooth, steps=steps, step_delay=step_delay)
                 if success:
                     return {
                         "status": "success",
@@ -633,7 +760,7 @@ def pose_tool(
                 return {"status": "error", "content": [{"text": f"{error}"}]}
 
             try:
-                success = controller.move_multiple_motors(positions, smooth)
+                success = controller.move_multiple_motors(positions, smooth, steps=steps, step_delay=step_delay)
                 if success:
                     pos_text = "\n".join(
                         [
@@ -682,7 +809,9 @@ def pose_tool(
                 return {"status": "error", "content": [{"text": f"{error}"}]}
 
             try:
-                success = controller.move_multiple_motors(home_positions, smooth=True)
+                success = controller.move_multiple_motors(
+                    home_positions, smooth=True, steps=steps, step_delay=step_delay
+                )
                 if success:
                     return {
                         "status": "success",

--- a/tests/tools/test_pose_tool.py
+++ b/tests/tools/test_pose_tool.py
@@ -648,13 +648,24 @@ def test_pose_tool_reset_to_home_reports_move_failure(cwd_tmp, monkeypatch) -> N
     The home move is fault-injected at the controller boundary (the bus accepts
     the connection but the grouped move reports failure), pinning that the tool
     does not claim the arm reached home when it did not.
+
+    The double also records the interpolation options it was handed, so this
+    pins that the caller's ``steps`` / ``step_delay`` reach the controller on
+    the failure path too, not only on the successful one.
     """
+    seen: dict[str, Any] = {}
+
+    def _refuse(self, positions, smooth=True, steps=20, step_delay=0.05) -> bool:
+        seen.update(positions=positions, smooth=smooth, steps=steps, step_delay=step_delay)
+        return False
+
     monkeypatch.setattr(serial, "Serial", AlwaysReadingSerial)
-    monkeypatch.setattr(pose_mod.MotorController, "move_multiple_motors", lambda self, positions, smooth=True: False)
-    result = pose_tool(action="reset_to_home", robot_id="hw_arm", port="/dev/ttyTEST")
+    monkeypatch.setattr(pose_mod.MotorController, "move_multiple_motors", _refuse)
+    result = pose_tool(action="reset_to_home", robot_id="hw_arm", port="/dev/ttyTEST", steps=6, step_delay=0.01)
     assert result["status"] == "error"
     _assert_ascii(result)
     assert "Failed to move to home position" in _texts(result)
+    assert (seen["steps"], seen["step_delay"]) == (6, 0.01), seen
 
 
 def test_pose_tool_smooth_move_interpolates_from_current_positions(cwd_tmp, reading_serial) -> None:

--- a/tests/tools/test_pose_tool_interpolation_options.py
+++ b/tests/tools/test_pose_tool_interpolation_options.py
@@ -1,0 +1,348 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for ``pose_tool``'s ``steps`` / ``step_delay`` options.
+
+Two properties, and the first is what the second exists to make safe:
+
+1. **The options reach the loop that reads them.** They are documented
+   parameters of the tool, but ``move_multiple_motors`` did not accept them and
+   invoked ``_smooth_move(positions)`` with neither, so every interpolated move
+   ran the hardcoded 20 increments at 0.05s and reported success. The
+   observable pinned here is the *requested* pacing - the number of increments
+   written and the delay asked of ``time.sleep`` - rather than elapsed wall
+   clock, so the assertion is exact on any host.
+
+2. **A value the loop cannot honor is refused, before the port is opened.**
+   Once forwarded, both values are consumed on a live servo bus: ``steps``
+   divides each motor's travel and bounds the write loop, and ``step_delay`` is
+   the pause between goal positions. ``TestWhyTheValuesAreRefused`` measures
+   each failure directly against ``_smooth_move`` so the domain is justified by
+   what the loop does with the value, not by assertion.
+
+Every test that reaches the motor path takes ``fake_serial`` (or the reading
+variant below) and passes an explicit fake ``port``: ``pose_tool``'s ``port``
+defaults to ``/dev/ttyACM0``, so a test that omits it drives whatever arm is
+plugged into the machine running the suite.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+import serial
+
+import strands_robots.tools.pose_tool as pose_mod
+from strands_robots.tools.pose_tool import (
+    MotorController,
+    PoseManager,
+    _smooth_move_option_error,
+    pose_tool,
+)
+from strands_robots.utils import positive_count_error, positive_finite_number_error
+
+from .conftest import FakeSerial
+
+# Actions that build an interpolated trajectory, and how each one gets there.
+# ``reset_to_home`` passes ``smooth=True`` itself, so it interpolates whatever
+# the caller's flag says.
+_INTERPOLATING = ("load_pose", "move_multiple", "reset_to_home")
+
+# Counts that cannot bound the write loop or divide the travel.
+_UNUSABLE_STEPS: tuple[Any, ...] = (0, -5, 2.7, "4", None, True, False, [4], math.nan)
+
+# Delays that cannot pace the loop. ``0`` is among them: the pause is the
+# smoothing, so a zero delay writes every increment as fast as the bus accepts
+# it, which is the one-shot move ``smooth=False`` already spells.
+_UNUSABLE_DELAYS: tuple[Any, ...] = (0, 0.0, -0.01, math.nan, math.inf, "0.05", None, True, [0.05])
+
+_MOTORS = {"shoulder_pan": 5.0, "elbow_flex": -5.0}
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool through one funnel.
+
+    Several tests deliberately supply values outside the declared types (that is
+    the contract under test), and a ``**dict[str, Any]`` splat is not narrowed,
+    so routing every call through here states the intent once instead of
+    scattering per-call suppressions.
+
+    Args:
+        **kwargs: Forwarded verbatim to :func:`pose_tool`.
+
+    Returns:
+        The tool result dict.
+    """
+    return pose_tool(**kwargs)
+
+
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate every ``text`` field of a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _position_packet(raw: int = 0x0800) -> bytes:
+    """A Feetech read response encoding ``raw`` at bytes 5/6."""
+    return bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF, 0, 0, 0])
+
+
+class _ReadingSerial(FakeSerial):
+    """A ``FakeSerial`` that always answers a read with a decodable position.
+
+    ``_smooth_move`` reads the current pose before interpolating and only steps
+    the motors it could read, so a source that never answers would make the
+    interpolation vacuous.
+    """
+
+    def read(self, n: int = 1) -> bytes:
+        return _position_packet()
+
+
+@pytest.fixture
+def reading_serial(monkeypatch: pytest.MonkeyPatch) -> list[_ReadingSerial]:
+    """Patch ``serial.Serial`` with an always-answering position source."""
+    instances: list[_ReadingSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _ReadingSerial:
+        fs = _ReadingSerial(port, baudrate, timeout)
+        instances.append(fs)
+        return fs
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return instances
+
+
+@pytest.fixture
+def pacing(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    """Record the delay each ``time.sleep`` is asked for and every motor write.
+
+    The recorder replaces the sleep rather than shortening it, so a test never
+    pays the delay it is asserting about, and the assertion is on the value the
+    loop *requested* - which no amount of host load can change.
+    """
+    seen: dict[str, list[Any]] = {"sleeps": [], "moves": []}
+    real_move = MotorController.move_motor
+
+    def _sleep(seconds: Any) -> None:
+        seen["sleeps"].append(seconds)
+
+    def _move(self: MotorController, motor_name: str, position_degrees: float) -> bool:
+        seen["moves"].append((motor_name, position_degrees))
+        return bool(real_move(self, motor_name, position_degrees))
+
+    monkeypatch.setattr(pose_mod.time, "sleep", _sleep)
+    monkeypatch.setattr(MotorController, "move_motor", _move)
+    return seen
+
+
+def _stored_pose(cwd_tmp: Any) -> None:
+    """Persist a pose named ``target`` for the ``load_pose`` action to load."""
+    PoseManager("hw_arm").store_pose("target", dict(_MOTORS))
+
+
+def _smooth(controller: MotorController, **kwargs: Any) -> bool:
+    """Invoke the interpolation loop directly, through one funnel.
+
+    Same reason as :func:`_call`: some of these values are deliberately outside
+    the declared types, and a ``**dict[str, Any]`` splat is not narrowed, so the
+    intent is stated here once rather than per call.
+
+    Args:
+        controller: A connected controller.
+        **kwargs: Forwarded to ``_smooth_move`` alongside the target pose.
+
+    Returns:
+        Whatever the interpolation loop returns.
+    """
+    return bool(controller._smooth_move(dict(_MOTORS), **kwargs))
+
+
+def _drive(action: str, **extra: Any) -> dict[str, Any]:
+    """Invoke one interpolating action with the arguments it requires."""
+    kwargs: dict[str, Any] = {"action": action, "robot_id": "hw_arm", "port": "/dev/ttyTEST"}
+    if action == "load_pose":
+        kwargs["pose_name"] = "target"
+    if action == "move_multiple":
+        kwargs["positions"] = dict(_MOTORS)
+    kwargs.update(extra)
+    return _call(**kwargs)
+
+
+class TestTheRequestedPacingReachesTheLoop:
+    """The tool's documented options decide the trajectory, not a hardcoded pair."""
+
+    @pytest.mark.parametrize("action", _INTERPOLATING)
+    def test_the_requested_step_count_and_delay_are_the_ones_used(
+        self, action: str, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        _stored_pose(cwd_tmp)
+        result = _drive(action, steps=4, step_delay=0.02)
+        assert result["status"] == "success", _texts(result)
+        # One pause per increment: range(steps + 1).
+        assert pacing["sleeps"].count(0.02) == 5, pacing["sleeps"]
+        assert 0.05 not in pacing["sleeps"], "the hardcoded default delay was used instead"
+
+    @pytest.mark.parametrize("action", _INTERPOLATING)
+    def test_a_finer_request_writes_more_increments_than_a_coarser_one(
+        self, action: str, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        _stored_pose(cwd_tmp)
+        assert _drive(action, steps=3, step_delay=0.01)["status"] == "success"
+        coarse = len(pacing["moves"])
+        pacing["moves"].clear()
+        assert _drive(action, steps=12, step_delay=0.01)["status"] == "success"
+        fine = len(pacing["moves"])
+        assert fine > coarse, f"{fine} writes for 12 steps vs {coarse} for 3 - the count was dropped"
+        # 13 increments vs 4, over the same motors.
+        assert fine == coarse * 13 // 4
+
+    def test_omitting_the_options_keeps_the_documented_default_trajectory(
+        self, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        """The default path is unchanged: 20 increments at 0.05s, ~1s of travel."""
+        assert _drive("move_multiple")["status"] == "success"
+        assert pacing["sleeps"].count(0.05) == 21, pacing["sleeps"]
+
+
+class TestAnUnusableOptionIsRefusedBeforeThePortOpens:
+    """A value the loop cannot honor is reported, not carried onto the bus."""
+
+    @pytest.mark.parametrize("action", _INTERPOLATING)
+    @pytest.mark.parametrize("steps", _UNUSABLE_STEPS)
+    def test_an_unusable_step_count_is_refused(
+        self, action: str, steps: Any, cwd_tmp: Any, fake_serial: list[FakeSerial]
+    ) -> None:
+        _stored_pose(cwd_tmp)
+        result = _drive(action, steps=steps)
+        text = _texts(result)
+        assert result["status"] == "error", text
+        assert "steps" in text and action in text, text
+        assert text.isascii(), text
+        assert fake_serial == [], "the refused call opened the serial port"
+
+    @pytest.mark.parametrize("action", _INTERPOLATING)
+    @pytest.mark.parametrize("step_delay", _UNUSABLE_DELAYS)
+    def test_an_unusable_delay_is_refused(
+        self, action: str, step_delay: Any, cwd_tmp: Any, fake_serial: list[FakeSerial]
+    ) -> None:
+        _stored_pose(cwd_tmp)
+        result = _drive(action, step_delay=step_delay)
+        text = _texts(result)
+        assert result["status"] == "error", text
+        assert "step_delay" in text and action in text, text
+        assert text.isascii(), text
+        assert fake_serial == [], "the refused call opened the serial port"
+
+    def test_the_refusal_precedes_reading_the_pose_file(self, cwd_tmp: Any, fake_serial: list[FakeSerial]) -> None:
+        """The option is checked before the action's own arguments are resolved."""
+        result = _drive("load_pose", pose_name="no_such_pose", steps=0)
+        text = _texts(result)
+        assert result["status"] == "error"
+        assert "steps" in text, text
+        assert "not found" not in text, text
+
+    def test_a_usable_pair_is_accepted(
+        self, cwd_tmp: Any, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        assert _drive("move_multiple", steps=1, step_delay=1e-6)["status"] == "success"
+
+
+class TestOnlyTheInterpolatingActionsReadTheOptions:
+    """A caller is never refused for a value the requested action ignores."""
+
+    @pytest.mark.parametrize(
+        "action,extra",
+        [
+            ("list_poses", {}),
+            ("connect", {}),
+            ("read_all", {}),
+            ("move_motor", {"motor_name": "elbow_flex", "position": 5.0}),
+            ("incremental_move", {"motor_name": "elbow_flex", "delta": 1.0}),
+            ("emergency_stop", {}),
+        ],
+    )
+    def test_a_one_shot_action_ignores_the_interpolation_options(
+        self, action: str, extra: dict[str, Any], cwd_tmp: Any, reading_serial: list[_ReadingSerial]
+    ) -> None:
+        result = _drive(action, steps=0, step_delay=-1, **extra)
+        text = _texts(result)
+        assert "steps" not in text and "step_delay" not in text, text
+
+    def test_move_multiple_with_smooth_false_ignores_them(
+        self, cwd_tmp: Any, reading_serial: list[_ReadingSerial]
+    ) -> None:
+        result = _drive("move_multiple", smooth=False, steps=0, step_delay=-1)
+        assert result["status"] == "success", _texts(result)
+
+    def test_reset_to_home_reads_them_even_with_smooth_false(self, cwd_tmp: Any, fake_serial: list[FakeSerial]) -> None:
+        """It passes ``smooth=True`` itself, so the caller's flag cannot opt out."""
+        result = _drive("reset_to_home", smooth=False, steps=0)
+        assert result["status"] == "error", _texts(result)
+        assert "steps" in _texts(result)
+
+
+class TestWhyTheValuesAreRefused:
+    """Each refused value measured against the loop that would have received it."""
+
+    @staticmethod
+    def _connected(reading_serial: list[_ReadingSerial]) -> MotorController:
+        controller = MotorController("/dev/ttyTEST")
+        connected, error = controller.connect()
+        assert connected, error
+        return controller
+
+    def test_zero_steps_divides_by_zero(self, reading_serial: list[_ReadingSerial]) -> None:
+        controller = self._connected(reading_serial)
+        with pytest.raises(ZeroDivisionError):
+            _smooth(controller, steps=0)
+
+    def test_a_negative_step_count_writes_nothing_yet_reports_success(
+        self, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        """``range(steps + 1)`` is empty, so the move is reported but never made."""
+        controller = self._connected(reading_serial)
+        assert _smooth(controller, steps=-5) is True
+        assert pacing["moves"] == []
+
+    def test_a_boolean_step_count_is_a_full_travel_jump(
+        self, reading_serial: list[_ReadingSerial], pacing: dict[str, list[Any]]
+    ) -> None:
+        """``True`` is a single increment - the jump interpolating exists to avoid."""
+        controller = self._connected(reading_serial)
+        assert _smooth(controller, steps=True) is True
+        assert len(pacing["moves"]) == 2 * len(_MOTORS)
+
+    def test_a_fractional_step_count_cannot_bound_the_loop(self, reading_serial: list[_ReadingSerial]) -> None:
+        controller = self._connected(reading_serial)
+        with pytest.raises(TypeError):
+            _smooth(controller, steps=2.7)
+
+    @pytest.mark.parametrize("delay,expected", [(-0.01, ValueError), (math.nan, ValueError), (math.inf, OverflowError)])
+    def test_an_unusable_delay_raises_from_sleep(
+        self, delay: float, expected: type[BaseException], reading_serial: list[_ReadingSerial]
+    ) -> None:
+        controller = self._connected(reading_serial)
+        with pytest.raises(expected):
+            _smooth(controller, steps=1, step_delay=delay)
+
+
+class TestTheDomainsAreTheSharedOnes:
+    """Both options are held to a library-wide domain, not a local rule."""
+
+    @pytest.mark.parametrize("value", (*_UNUSABLE_STEPS, 1, 20, 500))
+    def test_steps_is_the_shared_positive_count_domain(self, value: Any) -> None:
+        assert _smooth_move_option_error(
+            "move_multiple", smooth=True, steps=value, step_delay=0.05
+        ) == positive_count_error(value, "steps", "move_multiple")
+
+    @pytest.mark.parametrize("value", (*_UNUSABLE_DELAYS, 1e-6, 0.05, 2.5))
+    def test_step_delay_is_the_shared_positive_finite_domain(self, value: Any) -> None:
+        assert _smooth_move_option_error(
+            "move_multiple", smooth=True, steps=20, step_delay=value
+        ) == positive_finite_number_error(value, "step_delay", "move_multiple")
+
+    def test_the_step_count_is_reported_before_the_delay(self) -> None:
+        """Both unusable: the caller is told about the count first, deterministically."""
+        message = _smooth_move_option_error("move_multiple", smooth=True, steps=0, step_delay=-1)
+        assert message is not None and "steps" in message and "step_delay" not in message


### PR DESCRIPTION
## Problem

`pose_tool` documents two interpolation options:

```
steps: Number of steps for smooth movement
step_delay: Delay between movement steps
```

Neither ever reached the loop that reads them. `move_multiple_motors` did not accept them, and invoked the interpolation loop with neither:

```python
def move_multiple_motors(self, positions, smooth=True) -> bool:
    if smooth:
        return self._smooth_move(positions)          # steps / step_delay dropped here
```

So their only appearances in the module were the tool signature, the tool docstring, and `_smooth_move`'s own defaults. Every interpolated move - `load_pose`, `move_multiple` and `reset_to_home` - ran the hardcoded 20 increments at 0.05s and reported success. An agent asking for a slower, finer trajectory on a real arm silently got the default one.

Measured on `upstream/main`, driving `move_multiple` six times against a fake serial bus and recording every goal position that reached it plus the delay each `time.sleep` was asked for - **all six requests produced the identical trajectory**:

| request | goal positions written | commanded duration | delay used |
|---|---|---|---|
| `steps=60, step_delay=0.1` | 42 | 1.110s | 0.05 |
| (both omitted) | 42 | 1.110s | 0.05 |
| `steps=0` | 42 | 1.110s | 0.05 |
| `steps=-5` | 42 | 1.110s | 0.05 |
| `step_delay=0.0` | 42 | 1.110s | 0.05 |
| `step_delay=inf` | 42 | 1.110s | 0.05 |

## Change

`move_multiple_motors` takes both options and forwards them, and all three interpolating call sites pass the caller's values.

Once they are live they need a domain, because each is consumed inside the loop on a live servo bus - `steps` divides each motor's travel and bounds the write loop, `step_delay` is the pause between goal positions - so a new `_smooth_move_option_error` checks them at the tool boundary, **before any pose file is read or the port is opened**. Forwarding without the guard would ship the failures below as a new capability, so the two belong in one change.

Both domains are existing library-wide ones, not new rules:

- `steps` -> `positive_count_error`. Its docstring already covers exactly this shape ("consumed directly as `range()` bounds, slice indices"), and it rejects `bool`.
- `step_delay` -> `positive_finite_number_error`, the same domain the library's other pacing knobs use (`teleoperate(hz=)`, `use_ros(rate=)`, `InputPublisher(hz=)`).

Each refused value measured directly against the loop that would have received it:

| value | what the loop does with it |
|---|---|
| `steps=0` | `(target - current) / steps` -> `ZeroDivisionError` |
| `steps=-5` | `range(steps + 1)` is empty -> returns True having written nothing: a move reported but never made |
| `steps=True` | one increment -> the full-travel jump interpolating exists to avoid |
| `steps=2.7` / `"4"` / `None` | `TypeError` from `range()` |
| `step_delay=0` | no pause at all: the increments go out as fast as the bus accepts them (~126 short writes, order of ten milliseconds at 1 Mbaud) instead of over the requested `steps * step_delay`. The pause **is** the smoothing, and `smooth=False` already spells "go straight to the target" |
| `step_delay=-0.01` / `nan` | `ValueError` from `time.sleep` |
| `step_delay=inf` | blocks forever - the arm stops part-way through its trajectory, and the `finally: controller.disconnect()` never runs, so the port stays open too |

Refusing `0` for `step_delay` follows how the neighbouring cases were settled (#1639 refuses `control_substeps=0`, #1638 refuses `duration=0`, #1684 refuses `hz=0`): a value that reinstates the pathology the parameter exists to prevent.

Only the actions that interpolate are checked. `reset_to_home` passes `smooth=True` itself so it always reads them; `load_pose` and `move_multiple` read them only while `smooth` is truthy; every other action ignores both and is never refused for them.

## Measured

![pose_tool interpolation-option pacing](https://raw.githubusercontent.com/cagataycali/robots/artifacts/pose-tool-pacing/pose_tool_pacing.png)

One request (`steps=60, step_delay=0.1`), the goal positions that reached the bus. `upstream/main`: 21 increments over 1.05s. This change: 61 increments over 6.00s, as asked. The verdict table is the six-request measurement above, before and after.

Every number in the figure is asserted by its generator before saving, including that `upstream/main`'s six rows are identical and that the **default-arguments row is byte-identical across both trees** - nothing that worked before changed. The raw dumps behind it are published alongside it.

## Tests

`tests/tools/test_pose_tool_interpolation_options.py`, 103 tests over five properties:

- the requested step count and delay are the ones used, on all three interpolating actions, and a finer request writes proportionally more increments;
- omitting both keeps the documented default trajectory (21 increments at 0.05s);
- an unusable value is refused, and `fake_serial == []` proves the refusal precedes opening the port (plus a test that it precedes reading the pose file);
- a one-shot action is never refused for an option it ignores, `smooth=False` opts `move_multiple` out, and `reset_to_home` cannot be opted out;
- each refused value measured against `_smooth_move` itself, so the domain is justified by what the loop does rather than by assertion, and a parity test pins both options to the shared helpers rather than to a local rule.

The observable is the *requested* pacing - increments written and the delay asked of `time.sleep` - never elapsed wall clock, so the assertions are exact on any host.

The one existing `move_multiple_motors` double was a `lambda` that could not accept the new keywords; it now accepts and **asserts** them, pinning that the caller's values reach the controller on the failure path too.

**Pre-fix proof** (source reverted to `upstream/main`, tests kept): **63 failed, 16 passed**. The 16 that pass are the never-refuse-a-value-this-action-ignores controls and the `_smooth_move` consequence pins, which measure the loop rather than the guard - they are what stop the guard over-reaching. That run also took **63s against 1.0s** post-fix, because pre-fix the unguarded values genuinely reach the real `time.sleep` loop.

## Gate

Rebased onto `75c4887`; `scripts/check_merge_base_overlap.py` reports no overlap, and the diff-of-diffs across the rebase names zero lines in any file this PR touches.

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean, 1058 files
- `mypy strands_robots tests tests_integ`: **0 errors outside `examples/`**. The 14 `examples/isaac_gs/*` errors are environmental to this checkout - a pristine `upstream/main` worktree in the same working copy reports the identical 14 and 0 elsewhere
- `MUJOCO_GL=egl python -m pytest tests`: **19041 passed, 257 skipped, 0 failures** (504s)
- `scripts/assemble_changelog.py --check`: OK

No blast radius beyond the one completed double: the guard is additive, and the default path is byte-identical.