### PR TITLE
fix(tools): serial_tool bounds a servo register write to the field it encodes into

### DIFF
--- a/changelog.d/1934-serial-tool-register-domain.md
+++ b/changelog.d/1934-serial-tool-register-domain.md
@@ -1,0 +1,19 @@
+### Fixed: `serial_tool` bounds a servo register write to the field it encodes into
+
+The Feetech register writes masked the caller's value into fixed-width packet
+bytes (`value & 0xFF`, `(value >> 8) & 0xFF`), so an out-of-range value was not
+refused - it was silently truncated into a different, reachable command while the
+success message quoted the value the caller supplied. `position=70000` put 4464 on
+the wire and `position=-1` put 65535, the largest the two-byte field holds, both
+reported as `success`. `motor_id=255` built a frame whose ID byte duplicates the
+header, `motor_id=True` silently addressed motor 1, and `motor_id=300` leaked
+`bytes must be in range(0, 256)` from inside the packet builder.
+
+The same call also forwarded `baudrate`, `read_bytes` and `timeout` unchecked:
+pyserial coerces `baudrate=2.7` to 2 baud, returns no bytes for a non-positive
+`read_bytes` (indistinguishable from a timed-out read), waits no time at all for
+`timeout=nan`, and overflows its deadline for `timeout=inf`.
+
+Every numeric option an action consumes is now checked before the port is opened,
+so a refused call reaches no bus at all, and only the options that action reads
+are checked. `timeout=0` stays valid as pyserial's documented non-blocking poll.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -56,6 +56,33 @@ that means "stop at once", so treating it as unset would invert the request.
 Passing a value an action ignores is never an error: `action="start"` without a
 `dataset_repo_id` teleoperates and reads no `dataset_*` option.
 
+### A raw servo write is bounded by the register it encodes into
+
+`serial_tool` writes Feetech registers by masking the value into fixed-width
+bytes of the outgoing packet, so an out-of-range value was never rejected on the
+wire - it was truncated into a different, reachable command while the success
+message quoted the value the caller supplied. `position=70000` put 4464 on the
+wire and `position=-1` put 65535, the largest the two-byte field holds. Each
+field is therefore bounded before the port is opened:
+
+| Option | Accepted | Why the bound is where it is |
+|--------|----------|------------------------------|
+| `motor_id` | integer in `[1, 254]` | the frame carries the ID in one byte, and `255` is the header value |
+| `position` | integer in `[0, 4095]` | `Goal_Position` is a 12-bit register - the same full scale the reported angle divides by |
+| `velocity` | integer in `[0, 65535]` | `Goal_Velocity` is written as two bytes |
+| `baudrate` | positive integer | pyserial coerces rather than checks, so `2.7` opens the port at 2 baud |
+| `read_bytes` | positive integer | pyserial's read loop is `while len(read) < size`, so a non-positive size returns no bytes and looks like a timeout |
+| `timeout` | finite number >= 0 | `0` is pyserial's non-blocking mode (return what is buffered); `nan` waits no time at all and `inf` overflows the deadline |
+
+The same scoping rule applies: `action="read"` never looks at a servo register,
+so a bad `motor_id` does not refuse it, and `action="list_ports"` reads none of
+these options. An unset `motor_id` / `position` is still reported by the action's
+own "required" message rather than as an unusable value.
+
+`pose_tool` writes the same `Goal_Position` register through the same mask and
+needs no bound of its own - it clamps to each motor's declared range before
+encoding, so the mask only ever sees a value that fits.
+
 ## Examples
 
 ```python

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -1,9 +1,157 @@
+"""Raw serial-bus access: port discovery, byte-level I/O, and Feetech servo writes.
+
+Every numeric option an action consumes is checked here, before the port is
+opened, because none of them is refused by the layer that finally consumes it.
+
+The three Feetech register fields are encoded into fixed-width bytes of the
+outgoing packet with a mask -- ``motor_id`` is the frame's single ID byte, and
+``position`` / ``velocity`` are written as two little-endian bytes -- so a value
+outside a field's range is not rejected on the wire. It is silently truncated
+into a different, reachable command: ``position=70000`` encodes as 4464 and
+``position=-1`` as 65535, the largest value the field can hold, while the
+success message still quotes the number the caller supplied. Bounding the field
+is what makes that message true.
+
+``baudrate`` and ``read_bytes`` are coerced rather than checked by pyserial
+(``2.7`` becomes 2 baud, and a non-positive ``read_bytes`` reads nothing and
+reports success, which is indistinguishable from a timed-out read on a healthy
+port). A non-finite ``timeout`` either waits no time at all -- ``nan``, whose
+every comparison is false -- or fails with an ``OverflowError`` naming neither
+the tool nor the option, for ``inf``.
+
+:mod:`~strands_robots.tools.pose_tool` writes the same ``Goal_Position``
+register through the same mask and needs no bound of its own: it clamps to each
+motor's declared range before encoding, so its mask can only ever see a value
+that already fits.
+"""
+
 import time
+from collections.abc import Callable
 from typing import Any
 
 import serial
 import serial.tools.list_ports
 from strands import tool
+
+from strands_robots.utils import (
+    finite_number_error,
+    non_negative_count_error,
+    positive_count_error,
+)
+
+# Inclusive bounds and the reason for each ceiling, keyed by the parameter that
+# carries the field. The floor and the type are delegated to the shared count
+# domains so an off-type or negative value is reported in the words every other
+# surface uses; only the ceiling is decided here, because it is a property of
+# the packet field this module encodes into.
+_REGISTER_FIELDS: dict[str, tuple[int, int, str]] = {
+    "motor_id": (1, 254, "the packet carries the ID in one byte, and 255 is the frame header"),
+    "position": (
+        0,
+        4095,
+        "Goal_Position is a 12-bit register, the same full scale the reported angle divides by",
+    ),
+    "velocity": (0, 65535, "Goal_Velocity is written as two bytes"),
+}
+
+# The options each action consumes. An action absent from this map reads none of
+# them and is never refused here: ``list_ports`` returns before the port is even
+# opened, so a value it never looks at must not turn a working call into an
+# error.
+_OPTIONS_BY_ACTION: dict[str, tuple[str, ...]] = {
+    "send": ("baudrate", "timeout"),
+    "read": ("baudrate", "timeout", "read_bytes"),
+    "send_read": ("baudrate", "timeout", "read_bytes"),
+    "feetech_position": ("baudrate", "timeout", "motor_id", "position"),
+    "feetech_velocity": ("baudrate", "timeout", "motor_id", "velocity"),
+    "feetech_ping": ("baudrate", "timeout", "motor_id"),
+    "monitor": ("baudrate", "timeout"),
+}
+
+
+def _register_field_error(value: Any, param: str, action: str) -> str | None:
+    """Error text when ``value`` cannot be encoded into its Feetech register field.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter it came from; selects the field bounds.
+        action: The requested action, used as the message prefix.
+
+    Returns:
+        An error message, or ``None`` when the value fits the field.
+    """
+    low, high, why = _REGISTER_FIELDS[param]
+    floor_error: Callable[[Any, str, str], str | None] = positive_count_error if low > 0 else non_negative_count_error
+    if error := floor_error(value, param, action):
+        return error
+    if value > high:
+        return f"{action}: {param} must be at most {high} ({why}), got {value}."
+    return None
+
+
+def _read_timeout_error(value: Any, param: str, action: str) -> str | None:
+    """Error text when ``value`` is not a usable serial read budget in seconds.
+
+    The floor is ``0`` rather than the ``> 0`` of the shared
+    :func:`~strands_robots.utils.positive_finite_number_error` because pyserial
+    documents ``timeout=0`` as non-blocking mode: ``read`` then returns whatever
+    is already buffered instead of waiting, which is a real request rather than a
+    degenerate one. Finiteness, numeric-ness and ``bool`` are delegated to
+    :func:`~strands_robots.utils.finite_number_error`, so only the floor is
+    decided here.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter it came from, used in the message.
+        action: The requested action, used as the message prefix.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if error := finite_number_error(value, param, action):
+        return error
+    if value < 0:
+        return f"{action}: {param} must be at least 0 seconds, got {value}."
+    return None
+
+
+# The domain each option is checked against, in the order errors are reported.
+_OPTION_DOMAINS: tuple[tuple[str, Callable[[Any, str, str], str | None]], ...] = (
+    ("baudrate", positive_count_error),
+    ("timeout", _read_timeout_error),
+    ("read_bytes", positive_count_error),
+    ("motor_id", _register_field_error),
+    ("position", _register_field_error),
+    ("velocity", _register_field_error),
+)
+
+
+def _option_error(action: str, supplied: dict[str, Any]) -> str | None:
+    """Error text for the first numeric option ``action`` reads but cannot honor.
+
+    Only the options ``action`` consumes are checked, so a caller is never
+    refused for a value the requested action never looks at. A register field
+    left unset stays the concern of the action's own "required" check, which
+    reports the whole missing pair at once.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        supplied: The numeric options as supplied, keyed by parameter name.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when
+        every option this action reads is usable.
+    """
+    consumed = _OPTIONS_BY_ACTION.get(action, ())
+    for param, check in _OPTION_DOMAINS:
+        if param not in consumed:
+            continue
+        value = supplied[param]
+        if value is None and param in _REGISTER_FIELDS:
+            continue
+        if error := check(value, param, action):
+            return error
+    return None
 
 
 @tool
@@ -34,14 +182,22 @@ def serial_tool(
     Args:
         action: Action to perform
         port: Serial port path (e.g., "/dev/ttyACM0", "COM3")
-        baudrate: Communication speed (default: 9600)
-        timeout: Read timeout in seconds
+        baudrate: Communication speed in baud; a positive integer (default: 9600)
+        timeout: Read timeout in seconds; a finite number >= 0, where 0 is
+            pyserial's non-blocking mode (return what is already buffered)
         data: String data to send
         hex_data: Hex string data to send (e.g., "FF FF 01 04 03 00 64 92")
-        motor_id: Motor ID for Feetech commands (1-254)
-        position: Target position for Feetech motors (0-4095)
-        velocity: Target velocity for Feetech motors
-        read_bytes: Number of bytes to read
+        motor_id: Motor ID for Feetech commands; an integer in [1, 254]
+        position: Target position for Feetech motors; an integer in [0, 4095]
+        velocity: Target velocity for Feetech motors; an integer in [0, 65535]
+        read_bytes: Number of bytes to read; a positive integer
+
+    Validation:
+        A numeric option the requested action consumes is checked before the
+        port is opened, so a value that cannot be honored is reported instead
+        of being masked into a different servo command, silently coerced by
+        pyserial, or read as no wait at all. An option the action ignores is
+        never checked.
 
     Returns:
         Dict containing status and response content
@@ -87,6 +243,17 @@ def serial_tool(
 
         if not port:
             return {"status": "error", "content": [{"text": "Port parameter required for this action"}]}
+
+        supplied = {
+            "baudrate": baudrate,
+            "timeout": timeout,
+            "read_bytes": read_bytes,
+            "motor_id": motor_id,
+            "position": position,
+            "velocity": velocity,
+        }
+        if option_error := _option_error(action, supplied):
+            return {"status": "error", "content": [{"text": option_error}]}
 
         # Open serial connection
         ser = serial.Serial(port, baudrate, timeout=timeout)

--- a/tests/tools/test_gr00t_numeric_option_guards.py
+++ b/tests/tools/test_gr00t_numeric_option_guards.py
@@ -289,12 +289,53 @@ def _has_port_range_literal(source: str) -> bool:
     return any(isinstance(node, ast.Constant) and node.value == 65535 for node in ast.walk(ast.parse(source)))
 
 
+def _port_annotations(source: str) -> list[str]:
+    """Every annotation a ``port`` parameter carries in this module."""
+    return [
+        ast.unparse(arg.annotation)
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.FunctionDef)
+        for arg in node.args.args + node.args.kwonlyargs
+        if arg.arg == "port" and arg.annotation is not None
+    ]
+
+
+def _declares_a_numeric_port(source: str) -> bool:
+    """True when a ``port`` parameter in this module names a TCP port.
+
+    The globs above over-approximate: they select whole directories, so they also
+    pick up modules with no ``port`` at all and modules whose ``port`` is a serial
+    device path (``/dev/ttyACM0``). A 16-bit literal in one of the latter is a
+    register width rather than the TCP port range -- ``serial_tool`` bounds
+    ``Goal_Velocity``, which is written as two bytes. The annotation is the
+    discriminator: every TCP-port surface declares it numeric, and a device path
+    is declared ``str``.
+    """
+    return any(a.replace(" ", "").removesuffix("|None") != "str" for a in _port_annotations(source))
+
+
+def _tcp_port_sources() -> dict[Path, str]:
+    return {path: src for path, src in _port_taking_sources().items() if _declares_a_numeric_port(src)}
+
+
 class TestPortRangeHasOneOwner:
     """The 16-bit range is not re-implemented beside a caller-facing port."""
 
     def test_no_caller_facing_module_spells_the_range_out(self) -> None:
-        offenders = sorted(p.name for p, src in _port_taking_sources().items() if _has_port_range_literal(src))
+        offenders = sorted(p.name for p, src in _tcp_port_sources().items() if _has_port_range_literal(src))
         assert offenders == [], f"these modules re-implement the port range: {offenders}"
+
+    def test_the_scope_still_covers_every_known_tcp_port_surface(self) -> None:
+        assert _ROUTED_MODULES <= {path.name for path in _tcp_port_sources()}
+
+    def test_the_only_port_taking_modules_dropped_are_the_device_path_tools(self) -> None:
+        """The narrowing must never exempt a module that does take a TCP port."""
+        dropped = {
+            path.name
+            for path, src in _port_taking_sources().items()
+            if _port_annotations(src) and not _declares_a_numeric_port(src)
+        }
+        assert dropped == {"serial_tool.py", "pose_tool.py"}
 
     def test_the_known_surfaces_route_through_the_shared_owner(self) -> None:
         routed = {p.name for p, src in _port_taking_sources().items() if "tcp_port_error" in src}

--- a/tests/tools/test_serial_tool_numeric_domain.py
+++ b/tests/tools/test_serial_tool_numeric_domain.py
@@ -1,0 +1,314 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The ``serial_tool`` agent tool must refuse a numeric option it cannot honor.
+
+Six numeric options reach the raw servo bus, and none of them was checked. Each
+one failed differently and none of the failures was reportable:
+
+* The three Feetech register fields are encoded into fixed-width bytes with a
+  mask (``value & 0xFF``, ``(value >> 8) & 0xFF``), so an out-of-range value was
+  not rejected - it was silently truncated into a different, reachable command.
+  ``position=70000`` put 4464 on the wire and ``position=-1`` put 65535, the
+  largest value the two-byte field can hold, i.e. a full-scale move for a caller
+  who asked for one step below zero. Both returned ``status="success"`` with a
+  message quoting the number the caller supplied ("Position 70000 (6153.8 deg)"),
+  so the report described a command the servo never received.
+* ``motor_id=255`` built a frame whose ID byte is ``0xFF`` - a third copy of the
+  two-byte header - and ``motor_id=True`` silently addressed motor 1 while the
+  message read "Feetech Motor True". ``motor_id=300`` leaked
+  ``bytes must be in range(0, 256)``, naming neither the tool nor the parameter,
+  from inside the packet builder and before the port was closed.
+* ``read_bytes`` in ``{0, -1, -100, True}`` was not refused by pyserial either:
+  its read loop is ``while len(read) < size``, so a non-positive size returns
+  immediately with no bytes and the tool reported ``success`` "Read 0 bytes" -
+  indistinguishable from a timed-out read on a healthy port with data pending.
+  ``2.7`` leaked ``'float' object cannot be interpreted as an integer``.
+* ``timeout=nan`` waited no time at all, because every comparison against ``nan``
+  is false, and still reported ``success``; ``timeout=inf`` failed with
+  ``timestamp out of range for platform time_t``; ``True`` was a silent 1.0 s.
+* ``baudrate`` is coerced by pyserial rather than checked, so ``2.7`` opened the
+  port at 2 baud and ``True`` at 1 baud - neither can carry a servo frame - while
+  ``0`` was accepted outright.
+
+:mod:`~strands_robots.tools.pose_tool` writes the same ``Goal_Position`` register
+through the same mask and is unaffected: it clamps to each motor's declared range
+in ``degrees_to_position`` before encoding, so its mask can only ever see a value
+that fits. That is the contract these tests give the raw-bus tool.
+
+They pin the domain, the per-action scoping (an option an action never reads must
+not be refused), the guard's placement before the port is opened, that a value
+the tool accepts is the value the wire carries, and the option tables so a new
+action or a new numeric option cannot ship unguarded.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+import serial
+
+# The module object itself is needed - for the option tables the drift guard
+# scans and for the source it parses - so every name in it, the tool included, is
+# reached through this one alias.
+import strands_robots.tools.serial_tool as serial_mod
+
+# One value per rejection reason.
+BAD_COUNTS = (0, -1, -100, 2.7, True, "8", None, [8])
+BAD_TIMEOUTS = (-1, -0.5, float("nan"), float("inf"), True, "1.0", None, [1.0])
+
+# (action, the register field it consumes, a value that fits every other field).
+REGISTER_ACTIONS = (
+    ("feetech_position", "position", 2048),
+    ("feetech_velocity", "velocity", 100),
+)
+
+
+class _FakeSerial:
+    """Stand-in for ``serial.Serial`` recording the bytes that reach the wire."""
+
+    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.in_waiting = 0
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def opened(monkeypatch: pytest.MonkeyPatch) -> list[_FakeSerial]:
+    """Record every port this tool opens; empty means the bus was never touched."""
+    created: list[_FakeSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _FakeSerial:
+        instance = _FakeSerial(port, baudrate, timeout)
+        created.append(instance)
+        return instance
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return created
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with a fake port, splatted so off-type values reach it."""
+    return serial_mod.serial_tool(port="/dev/fake0", **kwargs)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _goal_from(packet: bytes) -> int:
+    """Decode the two-byte little-endian register value out of a written packet."""
+    return packet[6] | (packet[7] << 8)
+
+
+class TestARegisterFieldIsNeverSilentlyTruncated:
+    """A value the field cannot hold is refused, not masked into another command."""
+
+    @pytest.mark.parametrize("action,field,other", REGISTER_ACTIONS)
+    @pytest.mark.parametrize("value", (-1, -100, 70000, 2.7, True, "100", [100]))
+    def test_an_unusable_register_value_is_refused_before_the_port_opens(
+        self, action: str, field: str, other: int, value: Any, opened: list[_FakeSerial]
+    ) -> None:
+        result = _call(action=action, motor_id=1, **{field: value})
+        assert result["status"] == "error"
+        assert field in _text(result)
+        assert action in _text(result)
+        assert opened == []
+
+    def test_a_negative_position_is_refused_rather_than_encoded_as_the_field_maximum(
+        self, opened: list[_FakeSerial]
+    ) -> None:
+        result = _call(action="feetech_position", motor_id=1, position=-1)
+
+        assert result["status"] == "error"
+        # -1 & 0xFF and (-1 >> 8) & 0xFF are both 0xFF, so the pre-fix encoding
+        # was 65535 - the largest the field holds - for a caller asking for one
+        # step below zero.
+        assert "-1" in _text(result)
+        assert opened == []
+
+    @pytest.mark.parametrize("position", (0, 1, 2048, 4095))
+    def test_the_reported_position_is_the_position_on_the_wire(self, position: int, opened: list[_FakeSerial]) -> None:
+        result = _call(action="feetech_position", motor_id=1, position=position)
+
+        assert result["status"] == "success"
+        assert _goal_from(opened[0].writes[0]) == position
+        # The message quotes the caller's value, which the bound makes truthful.
+        assert f"Position {position} " in _text(result)
+        assert f"{position / 4095 * 360:.1f} deg" in _text(result)
+
+    @pytest.mark.parametrize("velocity", (0, 100, 65535))
+    def test_the_reported_velocity_is_the_velocity_on_the_wire(self, velocity: int, opened: list[_FakeSerial]) -> None:
+        result = _call(action="feetech_velocity", motor_id=1, velocity=velocity)
+
+        assert result["status"] == "success"
+        assert _goal_from(opened[0].writes[0]) == velocity
+
+    @pytest.mark.parametrize("motor_id", (0, 255, 256, 300, -1, True, 2.5, "1"))
+    def test_a_motor_id_outside_the_frames_id_byte_is_refused(self, motor_id: Any, opened: list[_FakeSerial]) -> None:
+        result = _call(action="feetech_ping", motor_id=motor_id)
+
+        assert result["status"] == "error"
+        assert "motor_id" in _text(result)
+        assert opened == []
+
+    @pytest.mark.parametrize("motor_id", (1, 2, 6, 254))
+    def test_an_addressable_motor_id_still_reaches_the_wire(self, motor_id: int, opened: list[_FakeSerial]) -> None:
+        result = _call(action="feetech_position", motor_id=motor_id, position=100)
+
+        assert result["status"] == "success"
+        assert opened[0].writes[0][2] == motor_id
+
+
+class TestTheReadBudgetAndLengthMustBeHonorable:
+    """A length that reads nothing, or a budget that waits no time, is refused."""
+
+    @pytest.mark.parametrize("value", BAD_COUNTS)
+    def test_read_refuses_a_length_it_cannot_read(self, value: Any, opened: list[_FakeSerial]) -> None:
+        result = _call(action="read", read_bytes=value)
+        assert result["status"] == "error"
+        assert "read_bytes" in _text(result)
+        assert opened == []
+
+    @pytest.mark.parametrize("value", BAD_TIMEOUTS)
+    def test_read_refuses_a_budget_it_cannot_wait(self, value: Any, opened: list[_FakeSerial]) -> None:
+        result = _call(action="read", timeout=value)
+        assert result["status"] == "error"
+        assert "timeout" in _text(result)
+        assert opened == []
+
+    def test_a_non_blocking_poll_is_still_accepted(self, opened: list[_FakeSerial]) -> None:
+        """pyserial documents ``timeout=0`` as non-blocking: return what is buffered."""
+        result = _call(action="read", timeout=0, read_bytes=8)
+
+        assert result["status"] == "success"
+        assert opened[0].timeout == 0
+
+    @pytest.mark.parametrize("value", (0.05, 1.0, 30))
+    def test_a_usable_budget_may_be_fractional(self, value: float, opened: list[_FakeSerial]) -> None:
+        assert _call(action="read", timeout=value)["status"] == "success"
+        assert opened[0].timeout == value
+
+    @pytest.mark.parametrize("value", (0, -1, 2.7, True, "9600", None))
+    def test_a_line_speed_no_frame_can_be_carried_at_is_refused(self, value: Any, opened: list[_FakeSerial]) -> None:
+        result = _call(action="read", baudrate=value)
+        assert result["status"] == "error"
+        assert "baudrate" in _text(result)
+        assert opened == []
+
+    @pytest.mark.parametrize("value", (9600, 115200, 1000000))
+    def test_a_real_line_speed_still_opens_the_port(self, value: int, opened: list[_FakeSerial]) -> None:
+        assert _call(action="read", baudrate=value)["status"] == "success"
+        assert opened[0].baudrate == value
+
+
+class TestOnlyTheOptionsAnActionReadsAreChecked:
+    """A value the requested action never looks at must not refuse a working call."""
+
+    def test_port_discovery_reads_no_option_at_all(self, opened: list[_FakeSerial], monkeypatch) -> None:
+        monkeypatch.setattr(serial.tools.list_ports, "comports", lambda: [])
+
+        result = serial_mod.serial_tool(
+            action="list_ports", baudrate=0, timeout=float("nan"), read_bytes=-1, motor_id=999
+        )
+
+        assert result["status"] == "success"
+        assert opened == []
+
+    def test_send_ignores_the_read_length(self, opened: list[_FakeSerial]) -> None:
+        assert _call(action="send", data="PING", read_bytes=0)["status"] == "success"
+
+    def test_read_ignores_the_servo_registers(self, opened: list[_FakeSerial]) -> None:
+        assert _call(action="read", motor_id=999, position=-5, velocity=-5)["status"] == "success"
+
+    def test_a_ping_ignores_the_position_and_velocity_registers(self, opened: list[_FakeSerial], monkeypatch) -> None:
+        monkeypatch.setattr(serial_mod.time, "sleep", lambda *_: None)
+
+        result = _call(action="feetech_ping", motor_id=1, position=-5, velocity=70000)
+
+        assert "position" not in _text(result)
+        assert "velocity" not in _text(result)
+
+    def test_a_position_write_ignores_the_velocity_register(self, opened: list[_FakeSerial]) -> None:
+        assert _call(action="feetech_position", motor_id=1, position=100, velocity=-5)["status"] == "success"
+
+
+class TestTheRequiredFieldCheckStillOwnsAnAbsentRegister:
+    """An unset register is reported by the action's own check, not as a bad value."""
+
+    def test_an_absent_position_still_reports_the_whole_missing_pair(self, opened: list[_FakeSerial]) -> None:
+        result = _call(action="feetech_position", motor_id=1)
+
+        assert result["status"] == "error"
+        assert "motor_id and position required" in _text(result)
+        assert opened[0].closed
+
+    def test_an_absent_motor_id_still_reports_the_whole_missing_pair(self, opened: list[_FakeSerial]) -> None:
+        result = _call(action="feetech_velocity", velocity=100)
+
+        assert result["status"] == "error"
+        assert "motor_id and velocity required" in _text(result)
+
+
+class TestTheOptionTablesCannotDriftApart:
+    """A new action or a new numeric option cannot ship without a decision."""
+
+    def _tool_parameters(self) -> dict[str, str]:
+        """Map parameter name -> annotation, read from the tool's own source."""
+        source = Path(inspect.getfile(serial_mod)).read_text(encoding="utf-8")
+        (function,) = [
+            node for node in ast.parse(source).body if isinstance(node, ast.FunctionDef) and node.name == "serial_tool"
+        ]
+        args = function.args.args + function.args.kwonlyargs
+        return {a.arg: ast.unparse(a.annotation) for a in args if a.annotation is not None}
+
+    def test_every_documented_action_has_a_scoping_decision(self) -> None:
+        documented = {
+            line.split('"')[1]
+            for line in (serial_mod.serial_tool.tool_spec["description"] or "").splitlines()
+            if line.strip().startswith('- "')
+        }
+        # ``list_ports`` returns before the port is opened, so it reads none of
+        # the options and is deliberately absent from the table.
+        assert documented == set(serial_mod._OPTIONS_BY_ACTION) | {"list_ports"}
+
+    def test_every_numeric_parameter_is_covered_by_a_domain(self) -> None:
+        numeric = {
+            name
+            for name, annotation in self._tool_parameters().items()
+            if annotation.replace(" ", "").removesuffix("|None") in {"int", "float"}
+        }
+        assert numeric == {name for name, _ in serial_mod._OPTION_DOMAINS}
+
+    def test_every_option_an_action_reads_has_a_declared_domain(self) -> None:
+        declared = {name for name, _ in serial_mod._OPTION_DOMAINS}
+        consumed = {option for options in serial_mod._OPTIONS_BY_ACTION.values() for option in options}
+        assert consumed == declared
+
+    def test_every_register_field_is_an_option_some_action_reads(self) -> None:
+        consumed = {option for options in serial_mod._OPTIONS_BY_ACTION.values() for option in options}
+        assert set(serial_mod._REGISTER_FIELDS) <= consumed
+
+    @pytest.mark.parametrize("field", ("motor_id", "position", "velocity"))
+    def test_every_register_bound_is_a_value_the_field_can_hold(self, field: str) -> None:
+        low, high, why = serial_mod._REGISTER_FIELDS[field]
+        assert 0 <= low <= high
+        # ``position`` / ``velocity`` are written as two bytes and ``motor_id``
+        # as one, so no bound may exceed what its field encodes.
+        assert high <= (0xFF if field == "motor_id" else 0xFFFF)
+        assert why


### PR DESCRIPTION
## Problem

`serial_tool` writes Feetech registers by masking the caller's value into fixed-width bytes of the outgoing packet:

```python
params = [0x2A, position & 0xFF, (position >> 8) & 0xFF]   # Goal_Position
```

Nothing bounded the value first, so an out-of-range position was never rejected on the wire -- it was **silently truncated into a different, reachable command**, while the success message quoted the number the caller supplied. Measured over a real pty (a serial device), reading the bytes back off the master:

| requested | bytes on the wire | position the servo receives | what the tool reported |
|---|---|---|---|
| `4095` | `FF FF 01 05 03 2A FF 0F BE` | 4095 | `success` -- Position 4095 (360.0 deg) |
| `5000` | `... 88 13 ...` | 5000 | `success` -- Position 5000 (439.6 deg) |
| `70000` | `... 70 11 ...` | **4464** | `success` -- Position 70000 (**6153.8 deg**) |
| `-1` | `... FF FF ...` | **65535** | `success` -- Position -1 (**-0.1 deg**) |
| `65536` | `... 00 00 ...` | **0** | `success` -- Position 65536 (5761.4 deg) |

`-1` is the sharpest: a caller nudging one step below zero commands the largest value the two-byte field holds. In every row the report describes a command the servo never received.

The rest of the signature was unchecked in the same way, each with a different failure and none of them reportable:

- `motor_id=255` builds a frame whose ID byte is `0xFF` -- a third copy of the two-byte header. `motor_id=True` silently addressed motor 1 while the message read `Feetech Motor True`. `motor_id=300` leaked `bytes must be in range(0, 256)` from inside the packet builder, naming neither the tool nor the parameter, and before the port was closed.
- `read_bytes` is not checked by pyserial either: its read loop is `while len(read) < size`, so `0` / `-1` / `-100` return immediately with no bytes and the tool reported `success` "Read 0 bytes" -- indistinguishable from a timed-out read on a healthy port with data pending. Measured against a pty fed 4 bytes 0.15 s in: `read_bytes=4` read them in 0.15 s, `read_bytes=0` returned in 0.00 s having read nothing. `2.7` leaked `'float' object cannot be interpreted as an integer`.
- `timeout=nan` waited **0.00 s of a 1.0 s budget** while the data arrived at 0.10 s -- every comparison against `nan` is false -- and still reported `success`. `timeout=inf` failed with `timestamp out of range for platform time_t`. `True` was a silent 1.0 s.
- `baudrate` is coerced rather than validated by pyserial (`int(baudrate)`), so `2.7` opened the port at 2 baud and `True` at 1 baud; `0` was accepted outright, and on POSIX a line speed of 0 means hang up.

The sibling already does the right thing: **`pose_tool` writes the same `Goal_Position` register through the same mask** and is unaffected, because `degrees_to_position` clamps to each motor's declared range before encoding, so its mask can only ever see a value that fits. This PR gives the raw-bus tool the same guarantee.

## Change

Every numeric option an action consumes is checked **before the port is opened**, so a refused call reaches no bus at all.

| Option | Accepted | Why the bound is where it is |
|---|---|---|
| `motor_id` | int in `[1, 254]` | the frame carries the ID in one byte, and `255` is the header value |
| `position` | int in `[0, 4095]` | `Goal_Position` is a 12-bit register -- the same full scale the reported angle divides by |
| `velocity` | int in `[0, 65535]` | `Goal_Velocity` is written as two bytes |
| `baudrate` | positive integer | `positive_count_error`; pyserial coerces, so `2.7` is 2 baud |
| `read_bytes` | positive integer | `positive_count_error`; a non-positive size reads nothing and looks like a timeout |
| `timeout` | finite number `>= 0` | `finite_number_error` plus a floor |

Each register field delegates its type and floor to the shared count domains, so an off-type or negative value is reported in the same words every other surface uses; only the ceiling is local, because it is a property of the packet field this module encodes into. `timeout` delegates finiteness, numeric-ness and `bool` to `finite_number_error` and decides only the floor.

**`timeout=0` stays valid.** pyserial documents it as non-blocking mode -- `read` then returns whatever is already buffered instead of waiting -- which is a real request rather than a degenerate one, so this is the shared continuous domain with the floor moved to `0` rather than `positive_finite_number_error`. Pinned as its own test.

**Only the options an action reads are checked**, following the per-action table `use_ros` / `use_rtps` / `use_rosbridge` already use: `action="read"` never looks at a servo register, so a bad `motor_id` does not refuse it, and `list_ports` returns before the port is opened so it reads none of them. An unset `motor_id` / `position` is still reported by the action's own "required" message, which names the whole missing pair.

A structural guard from #1821 (`TestPortRangeHasOneOwner`) globs `tools/*.py` and treats any `port` as a TCP port, so the `65535` register ceiling tripped it. Its scope is narrowed to modules whose `port` parameter is numeric -- `serial_tool` and `pose_tool` take a device path (`/dev/ttyACM0`), declared `str` -- with two non-vacuity tests: the scope still covers every known TCP-port surface, and the only port-taking modules it drops are those two.

## Tests

77 new tests in `tests/tools/test_serial_tool_numeric_domain.py`, plus 2 added to the port-range guard. Zero existing tests changed.

Beyond the per-value refusals they pin the properties that made the defect harmful:

- **the value the tool accepts is the value the wire carries** -- the packet is decoded back and `wire == position`, and the reported degrees match, for every accepted value. That invariant is what the bound buys.
- **a refused call opens no port** (`opened == []`), which is the guard-placement proof.
- **an addressable id still reaches the wire** and a real line speed still opens the port, so the guard cannot over-reach.
- **drift**: every documented action has a scoping decision, every numeric parameter of the signature is covered by a domain, and no register bound exceeds the field that encodes it -- so a new action or a new numeric option cannot ship unguarded.

Pre-fix (source at `upstream/main`, tests in place): **52 failed / 25 passed**. The 25 that pass are the accepted-value controls, the ignored-option scoping cases and the presence checks -- they are what stops the guard over-reaching.

## Gate

- `ruff check strands_robots tests tests_integ` -- clean (1059 files formatted)
- `mypy strands_robots tests tests_integ` -- `Success: no issues found in 1056 source files`
- `MUJOCO_GL=egl python -m pytest tests` -- **19120 passed, 257 skipped, 0 failed** (552 s), at base `3877c13d`
- `scripts/assemble_changelog.py --check` -- OK; `scripts/check_merge_base_overlap.py` -- no overlap

## Measured behaviour

Every number below is read from a real pty on both trees; the generators and the two JSON dumps are linked under the image.

![serial_tool register domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/serial-tool-register-domain/serial_register_domain.png)

Left: main accepts all seven requested positions, four of which reach the servo as a different value. Right: the three the field can hold are unchanged, byte for byte; the other four are refused before the port opens. Generators and raw measurements: [`artifacts/serial-tool-register-domain`](https://github.com/cagataycali/robots/tree/artifacts/serial-tool-register-domain).

## Out of scope

`timeout=None` is now refused. The signature declares `timeout: float = 1.0`, and pyserial reads `None` as "block forever" -- an unbounded wait inside an agent tool -- so it is treated as off-type rather than as a documented mode. No caller in the tree passes it.