### PR TITLE
fix(training): a reward config that cannot obtain its pretrained asset reports the type and a remedy

### DIFF
--- a/changelog.d/1935-reward-config-asset-failure.md
+++ b/changelog.d/1935-reward-config-asset-failure.md
@@ -1,0 +1,29 @@
+### Fixed: a reward config that cannot obtain its pretrained asset reports the type and a remedy, and the parity suite no longer downloads one
+
+`LerobotTrainer.build_config` translated one class of reward-config constructor
+failure into an actionable error - a `TypeError` from a forwarded field becomes a
+`ValueError` naming the rejected fields - and let every other class leak. A reward
+config may derive a field from a pretrained asset inside its own `__post_init__`:
+`robometer` reads its backbone's config and tokenizer to size `vlm_config`, so
+merely *constructing* it downloads about 11 MB from the Hub. On a host that cannot
+reach the Hub - offline, rate-limited, or behind a proxy - `build_config` therefore
+failed with a bare `OSError: We couldn't connect to 'https://huggingface.co'`,
+naming neither the trainer, nor the reward type, nor a way forward, and after
+`validate()` had already returned no problems for the same spec.
+
+That failure is now translated like its sibling: the error names the reward type,
+quotes the underlying reason, states that the spec is not what is wrong (because
+`validate()` has no network and cannot see this), and gives both remedies - make
+the asset available, or pass the derived field through `extra['reward_model']` so
+the constructor fetches nothing. `OSError` is the narrowest superset that covers
+it: every `huggingface_hub` failure class for an unobtainable file is an `OSError`
+subclass and `transformers` re-raises a plain one, while the `ValueError`s a config
+raises for a bad field value are already actionable and are deliberately left
+alone.
+
+The parity tests hand `robometer` the field it would otherwise derive, so the suite
+measures the discovery and passthrough contracts it is about rather than Hub
+reachability. Both entry points into a backbone fetch are made fatal in a new case,
+so a reward type that starts deriving a field from a pretrained asset must be given
+that field rather than left to download it; the deriving path itself stays covered
+by a case that skips when the backbone is not in the local cache.

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -1050,6 +1050,26 @@ class LerobotTrainer(Trainer):
             reward_cfg = make_reward_model_config(rtype, **reward_kwargs)
         except TypeError as e:
             raise ValueError(f"reward_model type '{rtype}' rejected field(s) {sorted(reward_kwargs)}: {e}") from e
+        except OSError as e:
+            # A reward config may derive a field from a pretrained asset inside
+            # its own __post_init__ (robometer reads its backbone's config and
+            # tokenizer to size ``vlm_config``), so merely CONSTRUCTING it can
+            # need a download. Every huggingface_hub failure class for that is
+            # an OSError subclass (LocalEntryNotFoundError, HfHubHTTPError,
+            # GatedRepoError, OfflineModeIsEnabled), and transformers re-raises
+            # a plain OSError, so this is the narrowest superset that covers
+            # "the asset could not be obtained" without swallowing the
+            # ValueErrors a config raises for a bad field value - those are
+            # already actionable and name the field.
+            raise ValueError(
+                f"reward_model type '{rtype}' could not be constructed: building its config "
+                f"needed a pretrained asset this host could not obtain ({e}). The spec itself "
+                f"is fine - validate() cannot reach the network to see this. Either make the "
+                f"asset available (a warm Hugging Face cache, or network access with "
+                f"HF_HUB_OFFLINE unset), or pass the field the config derives from it in "
+                f"extra['reward_model'] so its constructor fetches nothing. Fields this type "
+                f"accepts: {', '.join(sorted(friendly))}."
+            ) from e
         if hasattr(reward_cfg, "push_to_hub"):
             reward_cfg.push_to_hub = False
         if spec.base_model and hasattr(reward_cfg, "pretrained_path"):

--- a/tests/training/test_reward_model_parity.py
+++ b/tests/training/test_reward_model_parity.py
@@ -79,6 +79,46 @@ def _register_subclass_name(deco: ast.expr) -> str | None:
     return None
 
 
+# ``extra['reward_model']`` keys that make each type's config construct from
+# local state alone.
+#
+# A reward config may derive a field from a pretrained asset inside its own
+# ``__post_init__``: robometer reads its backbone's config and tokenizer to size
+# ``vlm_config``, so constructing it with the shipped defaults downloads ~11 MB
+# from the Hub and fails outright on a host that cannot reach it. That download
+# is incidental to what these tests assert - strands' discovery and passthrough
+# are local contracts - so the parity cases supply the derived field and let the
+# constructor skip the fetch. ``__post_init__`` only checks that ``vlm_config``
+# is non-empty, so a minimal backbone-shaped dict is enough.
+#
+# ``test_default_construction_populates_the_backbone_config`` keeps the fetching
+# path covered wherever the backbone is already cached.
+_LOCAL_VLM_CONFIG = {"text_config": {"vocab_size": 151_674}}
+_LOCAL_CONSTRUCTION_EXTRA: dict[str, dict[str, object]] = {
+    "sarm": {},
+    "robometer": {"vlm_config": _LOCAL_VLM_CONFIG},
+    "topreward": {},
+    "reward_classifier": {},
+}
+
+
+def _backbone_is_cached(rtype: str) -> bool:
+    """True when ``rtype``'s config can be built without a Hub round trip.
+
+    Pure local-cache lookup (``try_to_load_from_cache`` never touches the
+    network), so a test can decide to skip instead of failing on a host with a
+    cold cache. Types that derive nothing from a pretrained asset are always
+    constructible.
+    """
+    if rtype != "robometer":
+        return True
+    from huggingface_hub import try_to_load_from_cache
+    from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
+
+    repo = RobometerConfig.base_model_id
+    return all(try_to_load_from_cache(repo, f) is not None for f in ("config.json", "tokenizer_config.json"))
+
+
 @pytest.fixture
 def dataset_root(tmp_path):
     meta = tmp_path / "meta"
@@ -112,7 +152,7 @@ class TestRewardModelConfigParity:
             base_model="",
             output_dir=str(tmp_path / f"{rtype}_out"),
             steps=100,
-            extra={"reward_model": {"type": rtype}},
+            extra={"reward_model": {"type": rtype, **_LOCAL_CONSTRUCTION_EXTRA[rtype]}},
         )
         trainer = LerobotTrainer(device="cpu")
         assert trainer.validate(spec) == [], f"{rtype} failed validation"
@@ -146,7 +186,7 @@ class TestRewardModelConfigParity:
             base_model="",
             output_dir=str(tmp_path / f"{rtype}_out"),
             steps=100,
-            extra={"reward_model": {"type": rtype, field: value}},
+            extra={"reward_model": {"type": rtype, field: value, **_LOCAL_CONSTRUCTION_EXTRA[rtype]}},
         )
         trainer = LerobotTrainer(device="cpu")
         assert trainer.validate(spec) == [], f"{rtype}.{field} rejected"
@@ -211,3 +251,128 @@ class TestRewardModelConfigParity:
         assert "device" in msg
         # The original TypeError is chained for debugging, not swallowed.
         assert isinstance(excinfo.value.__cause__, TypeError)
+
+    @pytest.mark.parametrize("rtype", ["sarm", "robometer", "topreward", "reward_classifier"])
+    def test_construction_needs_no_backbone_fetch(self, rtype, dataset_root, tmp_path, monkeypatch):
+        """Building a reward config from ``_LOCAL_CONSTRUCTION_EXTRA`` fetches nothing.
+
+        Both backbone entry points are made fatal, so reaching either one fails
+        the test rather than silently downloading. This is what keeps the parity
+        suite a measurement of strands' passthrough instead of a measurement of
+        Hub reachability - a reward type that starts deriving a field from a
+        pretrained asset must be given that field here, not left to download it.
+        """
+        pytest.importorskip("lerobot.rewards")
+        transformers = pytest.importorskip("transformers")
+
+        def _fetched(*args, **kwargs):
+            raise AssertionError("a backbone fetch was attempted")
+
+        monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", _fetched)
+        monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", _fetched)
+
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / f"{rtype}_out"),
+            steps=100,
+            extra={"reward_model": {"type": rtype, **_LOCAL_CONSTRUCTION_EXTRA[rtype]}},
+        )
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.reward_model.type == rtype
+
+    def test_default_construction_populates_the_backbone_config(self, dataset_root, tmp_path):
+        """robometer's shipped defaults still build, wherever the backbone is cached.
+
+        The parity cases above hand robometer its ``vlm_config`` so they stay
+        local; this keeps the deriving path itself covered. It skips - rather
+        than fails - when the backbone is not in the local cache, because that
+        is a property of the host, not of strands.
+        """
+        pytest.importorskip("lerobot.rewards")
+        if not _backbone_is_cached("robometer"):
+            pytest.skip("robometer's backbone config is not in the local Hugging Face cache")
+
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "robometer_default"),
+            steps=100,
+            extra={"reward_model": {"type": "robometer"}},
+        )
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        # The derived field is what the fetch exists to populate.
+        assert cfg.reward_model.vlm_config
+        assert "text_config" in cfg.reward_model.vlm_config
+
+    def test_unobtainable_asset_becomes_actionable_error(self, dataset_root, tmp_path, monkeypatch):
+        """A config whose constructor cannot obtain its asset names the type and a remedy.
+
+        Constructing a reward config can need a download (robometer sizes
+        ``vlm_config`` from its backbone), so on a host that cannot reach the Hub
+        ``build_config`` fails inside ``make_reward_model_config``. transformers
+        and huggingface_hub both report that as an ``OSError``, which said
+        nothing about the trainer, the reward type or what to do next - the same
+        bare, contextless leak the ``TypeError`` translation above exists to
+        prevent. ``validate()`` cannot see it, having no network, so the error
+        must say that the spec is not what is wrong.
+        """
+        pytest.importorskip("lerobot.rewards")
+        import lerobot.rewards as lr
+
+        def _unobtainable(rtype, **kwargs):
+            raise OSError("We couldn't connect to 'https://huggingface.co' to load the files")
+
+        monkeypatch.setattr(lr, "make_reward_model_config", _unobtainable)
+
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "robometer_out"),
+            steps=100,
+            extra={"reward_model": {"type": "robometer"}},
+        )
+        with pytest.raises(ValueError) as excinfo:
+            LerobotTrainer(device="cpu").build_config(spec)
+
+        msg = str(excinfo.value)
+        assert "reward_model type 'robometer' could not be constructed" in msg
+        # The underlying reason is quoted, so the failure stays diagnosable.
+        assert "huggingface.co" in msg
+        # The spec is explicitly cleared, because validate() accepted it.
+        assert "validate()" in msg
+        # Both remedies are named, and the second one is checkable: vlm_config is
+        # a real forwardable field, so a caller can act on the message.
+        assert "cache" in msg
+        assert "extra['reward_model']" in msg
+        assert "vlm_config" in msg
+        assert "vlm_config" in _reward_friendly_fields("robometer")
+        # The original OSError is chained for debugging, not swallowed.
+        assert isinstance(excinfo.value.__cause__, OSError)
+
+    def test_a_rejected_field_value_keeps_its_own_error(self, dataset_root, tmp_path):
+        """A bad field VALUE keeps the config's own message; only asset failures are re-worded.
+
+        ``__post_init__`` already raises a ``ValueError`` naming the field and its
+        accepted values, so re-wrapping it would bury the actionable part. Guards
+        the scope of the asset translation.
+        """
+        pytest.importorskip("lerobot.rewards")
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "robometer_out"),
+            steps=100,
+            extra={
+                "reward_model": {
+                    "type": "robometer",
+                    "reward_output": "not-a-mode",
+                    **_LOCAL_CONSTRUCTION_EXTRA["robometer"],
+                }
+            },
+        )
+        with pytest.raises(ValueError) as excinfo:
+            LerobotTrainer(device="cpu").build_config(spec)
+        msg = str(excinfo.value)
+        assert "reward_output" in msg
+        assert "could not be constructed" not in msg


### PR DESCRIPTION
## Problem

`LerobotTrainer._build_reward_model_config` translated **one** class of reward-config constructor failure into an actionable error and let every other class leak:

```python
try:
    reward_cfg = make_reward_model_config(rtype, **reward_kwargs)
except TypeError as e:
    raise ValueError(f"reward_model type '{rtype}' rejected field(s) {sorted(reward_kwargs)}: {e}") from e
# an OSError from an asset the constructor could not obtain -> propagated raw
```

That translation exists for a stated reason. Its own regression test says the trainer must produce an error that names the problem "and chain the original ... as the cause - **not leak a bare, contextless error**."

A reward config can fail for a second reason: it may derive a field from a pretrained asset **inside its own `__post_init__`**. `robometer` reads its backbone's config and tokenizer to size `vlm_config`, so merely *constructing* the dataclass performs two Hub fetches:

```python
# lerobot/rewards/robometer/configuration_robometer.py
if not self.vlm_config:
    vlm = AutoConfig.from_pretrained(self.base_model_id).to_dict()
    tokenizer = AutoTokenizer.from_pretrained(self.base_model_id)
```

So on any host that cannot reach the Hub - offline, rate-limited, behind a proxy - `build_config` failed with a bare

```
OSError: We couldn't connect to 'https://huggingface.co' to load the files,
and couldn't find them in the cached files.
```

naming neither the trainer, nor the reward type, nor a way forward. And `validate()` had returned `[]` for that same spec moments earlier, so the caller had been told the spec was fine. It has no network and cannot see this.

**The same fetch ran in the test suite.** `test_every_reward_type_validates_and_builds[robometer]` and `test_own_field_passthrough_per_type[robometer]` construct the default config, so a green run required a ~11 MB download of the Qwen3-VL tokenizer (`tokenizer.json` 7.0 MB, `vocab.json` 2.8 MB, `merges.txt` 1.7 MB). Those two cases assert *local* contracts - that strands' discovery matches lerobot's registry, and that a field passes through - so the download is incidental to what they measure, and it made them a measurement of Hub availability instead.

## Change

**`except OSError`** is translated like its `TypeError` sibling. The message names the reward type, quotes the underlying reason, states that the spec is not what is wrong, and gives both remedies - one of which is checkable, because `vlm_config` is a real forwardable field:

```
reward_model type 'robometer' could not be constructed: building its config needed a
pretrained asset this host could not obtain (We couldn't connect to
'https://huggingface.co' ...). The spec itself is fine - validate() cannot reach the
network to see this. Either make the asset available (a warm Hugging Face cache, or
network access with HF_HUB_OFFLINE unset), or pass the field the config derives from it
in extra['reward_model'] so its constructor fetches nothing. Fields this type accepts:
average_temporal_patches, base_model_id, ..., vlm_config.
```

`OSError` is the narrowest superset that covers the failure, measured rather than assumed - every `huggingface_hub` class for an unobtainable file is an `OSError` subclass (`LocalEntryNotFoundError`, `HfHubHTTPError`, `RepositoryNotFoundError`, `GatedRepoError`, `OfflineModeIsEnabled`) and `transformers` re-raises a plain one. The `ValueError`s a config raises for a bad field *value* are deliberately **not** caught: `__post_init__` already names the field and its accepted values, so re-wrapping would bury the actionable part. Pinned both ways.

**The parity cases supply the derived field.** A `_LOCAL_CONSTRUCTION_EXTRA` table gives `robometer` a minimal `vlm_config` (`__post_init__` only checks that it is non-empty), so the constructor skips the fetch and the suite measures the contract it is about. The field list is the accepted-key set the trainer already introspects, so this is a documented capability, not a workaround.

Nothing invents a `vlm_config` in the library. Defaulting one there would fabricate a value the caller never supplied.

## Tests

4 new test methods (7 collected cases; the file goes 11 -> 18), 2 existing cases routed through the new table, zero existing assertions changed. The `TypeError` message is byte-identical, so its pin holds.

- **`test_unobtainable_asset_becomes_actionable_error`** - the regression test. Asserts the type is named, the reason is quoted, the spec is explicitly cleared, both remedies appear, the named field really is forwardable (cross-checked against `_reward_friendly_fields`), and the `OSError` is chained rather than swallowed.
- **`test_construction_needs_no_backbone_fetch`** (x4 types) - makes *both* `from_pretrained` entry points fatal, so a reward type that starts deriving a field from a pretrained asset must be given that field here rather than left to download it. This is what keeps the suite offline in future.
- **`test_default_construction_populates_the_backbone_config`** - keeps the deriving path itself covered, and **skips** rather than fails when the backbone is not in the local cache, because that is a property of the host. The availability probe is `try_to_load_from_cache`, a pure local lookup.
- **`test_a_rejected_field_value_keeps_its_own_error`** - scope control: a bad field *value* keeps `__post_init__`'s own message.

**Pre-fix, two arms:**

| arm | result |
|---|---|
| source at `upstream/main`, these tests in place | **1 failed** / 17 passed - the regression test fails with the raw `OSError` escaping |
| pristine `upstream/main`, cold `HF_HOME` + `HF_HUB_OFFLINE=1` | **2 failed** / 9 passed |
| this branch, cold `HF_HOME` + `HF_HUB_OFFLINE=1` | 17 passed / **1 skipped** (the deriving-path case, with a reason) |

The 17 that pass in the first arm are the accepted-value controls and the scope control - they are what stops the translation over-reaching.

## Scope

Measured, not assumed: `tests/training tests/policies tests/test_dataset_recorder.py` with a cold cache and `HF_HUB_OFFLINE=1` is **2 failed / 2877 passed** on main. Those 2 are the only network-dependent tests in that span; every other `from_pretrained` reference in the suite is already mocked. Both are `robometer`; the other three reward types derive nothing from a pretrained asset.

## Gate

- `ruff check strands_robots tests tests_integ` - clean; `ruff format --check` - 1058 files already formatted
- `mypy strands_robots tests tests_integ` - **0 errors outside `examples/`**. The 14 `examples/isaac_gs` errors are byte-identical to a pristine `upstream/main` worktree of the same working copy (an import-resolution artifact of the checkout, not of this branch)
- `MUJOCO_GL=egl python -m pytest tests` - **19048 passed, 257 skipped, 0 failed** (511 s) at base `3877c13d`
- root guards - 42 passed; `assemble_changelog.py --check` - OK; `check_merge_base_overlap.py` - no overlap

## Measured behaviour

Every cell is produced by one script run once per tree with a cold `HF_HOME` and `HF_HUB_OFFLINE=1`; each run records the tree it resolved to, and the figure generator asserts every claim against the two JSON dumps before saving.

![reward config asset failure](https://raw.githubusercontent.com/cagataycali/robots/artifacts/reward-config-asset-failure/reward_asset_failure.png)

Scripts and raw measurements: [`artifacts/reward-config-asset-failure`](https://github.com/cagataycali/robots/tree/artifacts/reward-config-asset-failure).

No policy, simulation, rendering, recording or asset behaviour changes - the change is a config-build error path plus test fixtures, so the artifact is a measured verdict table rather than a rollout.
