### PR TITLE
fix(tools): pose_tool refuses a joint target the arm cannot honor

### DIFF
--- a/changelog.d/1937-pose-target-domain.md
+++ b/changelog.d/1937-pose-target-domain.md
@@ -1,0 +1,33 @@
+### Fixed: a pose_tool joint target the arm cannot honor is refused instead of clamped to the end stop
+
+`MotorController.degrees_to_position` clamps its argument into the motor's
+configured `range` before scaling it onto the 12-bit `Goal_Position` register, so
+every target outside that range shared one encoding -- the mechanical limit --
+while the success text echoed the value the caller asked for. `nan` reached the
+limit through the clamp itself, because `min(max_deg, nan)` returns `max_deg`.
+Measured on `shoulder_pan` (configured `(-180, 180)`), `position=nan`,
+`position=inf` and `position=5000` each returned `status="success"` having
+written `Goal_Position` 4095 -- a full-travel slam to the end stop at servo
+speed, indistinguishable from a deliberate `position=180` -- and reported
+`Moved shoulder_pan to nan deg`. `position=True` was read as a real 1-degree
+move, `bool` being an `int` subclass.
+
+`move_motor`, `move_multiple` and `incremental_move` now refuse a target they
+cannot honor before the port is opened, so the arm never travels on such a
+request. Finiteness, numeric-ness and `bool` are delegated to the shared
+`finite_number_error`, so an off-domain target is reported in the words every
+other surface uses; only the per-joint bounds are decided in `pose_tool`,
+because they are a property of the arm it drives. A `delta` is bounded by the
+joint's *full travel* rather than its endpoints, since a displacement is not
+absolute and only a magnitude exceeding the whole range is unhonorable from
+every starting position.
+
+The bounds now have one authority: the per-joint table is module-level and
+`MotorController` is configured from a copy of it, so the table the guard checks
+cannot disagree with the table the servo is driven from.
+
+The clamp itself stays, and is now unreachable from those three actions. Its
+remaining callers supply targets from somewhere other than the caller's
+arguments -- a stored pose, which `PoseManager.validate_pose` already refuses out
+of bounds, and `reset_to_home`'s own in-range literals -- so removing it would
+turn those paths into raises, which is a separate change.

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -22,7 +22,7 @@ import serial.tools.list_ports
 from strands import tool
 
 from strands_robots.tools._path_validation import validate_save_path
-from strands_robots.utils import positive_count_error, positive_finite_number_error
+from strands_robots.utils import finite_number_error, positive_count_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +211,176 @@ class MotorConfig(TypedDict):
     resolution: int
 
 
+# Default motor configurations for SO-101.
+#
+# Module-level rather than built inside ``MotorController.__init__`` because the
+# ``range`` of each joint is consulted twice: by
+# :meth:`MotorController.degrees_to_position`, which converts a target into a
+# ``Goal_Position``, and by :func:`_joint_target_error`, which refuses a target
+# that conversion could not represent. A second copy of these bounds could
+# disagree with the one the servo is actually driven from, which is the failure
+# the guard exists to prevent.
+_DEFAULT_MOTOR_CONFIGS: dict[str, MotorConfig] = {
+    "shoulder_pan": {"id": 1, "range": (-180, 180), "resolution": 4095},
+    "shoulder_lift": {"id": 2, "range": (-90, 90), "resolution": 4095},
+    "elbow_flex": {"id": 3, "range": (-150, 150), "resolution": 4095},
+    "wrist_flex": {"id": 4, "range": (-90, 90), "resolution": 4095},
+    "wrist_roll": {"id": 5, "range": (-180, 180), "resolution": 4095},
+    "gripper": {"id": 6, "range": (0, 100), "resolution": 4095},
+}
+
+# The degree-valued target each action reads. An action absent from this map
+# commands no joint and is never refused here.
+_TARGET_OPTION_BY_ACTION: dict[str, str] = {
+    "move_motor": "position",
+    "move_multiple": "positions",
+    "incremental_move": "delta",
+}
+
+
+def _target_unit(motor_name: str) -> str:
+    """The unit a target for ``motor_name`` is quoted in.
+
+    Args:
+        motor_name: The motor the target is for.
+
+    Returns:
+        ``"percent"`` for the gripper, which is configured 0-100, else
+        ``"degrees"``.
+    """
+    return "percent" if motor_name == "gripper" else "degrees"
+
+
+def _joint_target_error(action: str, label: str, motor_name: str | None, value: Any) -> str | None:
+    """Error text when ``value`` is not a target ``motor_name`` can be driven to.
+
+    ``degrees_to_position`` clamps its argument into the joint's configured
+    ``range`` before scaling it onto the 12-bit ``Goal_Position`` register, so
+    every value outside that range shares one encoding: the mechanical limit.
+    That makes the clamp a silent rewrite rather than a safety net -- the arm
+    travels to the end stop, and the caller is told it moved to the value it
+    asked for, because the success text echoes the request. ``nan`` lands there
+    too, since ``min(max_deg, nan)`` returns ``max_deg``.
+
+    Finiteness, numeric-ness and ``bool`` are delegated to
+    :func:`~strands_robots.utils.finite_number_error` so an off-domain target is
+    reported in the words every other surface uses; only the per-joint bounds
+    are decided here, because they are a property of the arm this module drives.
+
+    A motor absent from :data:`_DEFAULT_MOTOR_CONFIGS` has no bounds to check
+    against and is left to the action's own unknown-motor path.
+
+    Args:
+        action: The requested action, used as the message prefix.
+        label: How the target is named in the message.
+        motor_name: The motor the target is for.
+        value: The caller-supplied target.
+
+    Returns:
+        An error message, or ``None`` when the target can be honored.
+    """
+    if error := finite_number_error(value, label, action):
+        return error
+    name = motor_name or ""
+    config = _DEFAULT_MOTOR_CONFIGS.get(name)
+    if config is None:
+        return None
+    low, high = config["range"]
+    if not low <= value <= high:
+        return (
+            f"{action}: {label} must be within [{low}, {high}] {_target_unit(name)} "
+            f"(the configured travel of '{name}'), got {value}."
+        )
+    return None
+
+
+def _joint_delta_error(action: str, motor_name: str | None, delta: Any) -> str | None:
+    """Error text when ``delta`` is not a displacement ``motor_name`` can travel.
+
+    Bounded by the joint's *full travel* rather than by its endpoints, which is
+    the one way this domain differs from :func:`_joint_target_error`: the
+    endpoints are absolute and a displacement is not, so the value cannot be
+    compared against them without knowing where the joint currently is. A
+    magnitude larger than the whole range is unhonorable from every starting
+    position, which is checkable without that reading.
+
+    The resulting absolute target is left to ``degrees_to_position``, whose clamp
+    remains the last resort for a target computed from a live position reading
+    rather than supplied by the caller.
+
+    Args:
+        action: The requested action, used as the message prefix.
+        motor_name: The motor the displacement is for.
+        delta: The caller-supplied displacement.
+
+    Returns:
+        An error message, or ``None`` when the displacement can be honored.
+    """
+    if error := finite_number_error(delta, "delta", action):
+        return error
+    name = motor_name or ""
+    config = _DEFAULT_MOTOR_CONFIGS.get(name)
+    if config is None:
+        return None
+    low, high = config["range"]
+    span = high - low
+    if abs(delta) > span:
+        return (
+            f"{action}: delta must be at most {span} {_target_unit(name)} in magnitude "
+            f"(the full travel of '{name}', so no starting position could honor more), got {delta}."
+        )
+    return None
+
+
+def _pose_target_error(
+    action: str,
+    *,
+    motor_name: str | None,
+    position: Any,
+    delta: Any,
+    positions: Any,
+) -> str | None:
+    """Error text for a degree-valued target ``action`` reads but cannot honor.
+
+    Only the target the requested action consumes is checked, so a caller is
+    never refused for a value the action never looks at. A target left unset
+    stays the concern of the action's own "required" check, which reports the
+    whole missing pair at once.
+
+    Args:
+        action: The requested action.
+        motor_name: The motor ``position`` / ``delta`` are for.
+        position: The absolute target for ``move_motor``.
+        delta: The displacement for ``incremental_move``.
+        positions: The per-motor targets for ``move_multiple``.
+
+    Returns:
+        The first error message, or ``None`` when every target read is usable.
+    """
+    param = _TARGET_OPTION_BY_ACTION.get(action)
+    if param is None:
+        return None
+
+    if param == "positions":
+        # A non-mapping (or empty) ``positions`` is reported by the action's own
+        # required check, which names the parameter rather than one motor.
+        if not isinstance(positions, dict):
+            return None
+        for name, value in positions.items():
+            if error := _joint_target_error(action, f"positions[{name!r}]", name, value):
+                return error
+        return None
+
+    if param == "position":
+        if position is None:
+            return None
+        return _joint_target_error(action, "position", motor_name, position)
+
+    if delta is None:
+        return None
+    return _joint_delta_error(action, motor_name, delta)
+
+
 class MotorController:
     """Low-level motor control for fine movements."""
 
@@ -219,14 +389,8 @@ class MotorController:
         self.baudrate = baudrate
         self.serial_conn: serial.Serial | None = None
 
-        # Default motor configurations for SO-101
         self.motor_configs: dict[str, MotorConfig] = {
-            "shoulder_pan": {"id": 1, "range": (-180, 180), "resolution": 4095},
-            "shoulder_lift": {"id": 2, "range": (-90, 90), "resolution": 4095},
-            "elbow_flex": {"id": 3, "range": (-150, 150), "resolution": 4095},
-            "wrist_flex": {"id": 4, "range": (-90, 90), "resolution": 4095},
-            "wrist_roll": {"id": 5, "range": (-180, 180), "resolution": 4095},
-            "gripper": {"id": 6, "range": (0, 100), "resolution": 4095},
+            name: config.copy() for name, config in _DEFAULT_MOTOR_CONFIGS.items()
         }
 
     def connect(self) -> tuple[bool, str]:
@@ -501,9 +665,17 @@ def pose_tool(
         port: Serial port for robot communication
         pose_name: Name for pose operations
         motor_name: Motor name for single motor operations
-        position: Target position in degrees (or 0-100% for gripper)
-        delta: Incremental movement in degrees
-        positions: Dictionary of motor positions {motor_name: degrees}
+        position: Target position in degrees (or 0-100% for gripper). A finite
+            number within the motor's configured travel - a value outside it is
+            refused rather than clamped to the mechanical limit, because the
+            clamp cannot be told apart from a typo and the success text echoes
+            the value asked for.
+        delta: Incremental movement in degrees. A finite number whose magnitude
+            is at most the motor's full travel, which no starting position could
+            exceed.
+        positions: Dictionary of motor positions {motor_name: degrees}. Every
+            value is held to the same domain as ``position``, and the first that
+            is not names the motor it came from.
         description: Description for stored poses
         smooth: Use smooth interpolated movement
         steps: Number of increments for an interpolated move. A positive
@@ -521,7 +693,8 @@ def pose_tool(
 
     Returns:
         Dict containing status and response content, or an error dict when an
-        interpolation option the requested action reads cannot be honored.
+        interpolation option or a joint target the requested action reads cannot
+        be honored.
     """
 
     # Both interpolation options are consumed on a live servo bus - one as a
@@ -530,6 +703,17 @@ def pose_tool(
     # is opened, rather than raising part-way through a trajectory.
     if option_error := _smooth_move_option_error(action, smooth=smooth, steps=steps, step_delay=step_delay):
         return {"status": "error", "content": [{"text": option_error}]}
+
+    # Every degree-valued target is scaled onto ``Goal_Position`` by
+    # ``degrees_to_position``, which clamps into the joint's configured range -
+    # so a target outside it is not refused but silently rewritten to the
+    # mechanical limit, while the success text echoes the value asked for. It is
+    # refused here, before the port is opened, so the arm never travels to an
+    # end stop on a request that could not be honored.
+    if target_error := _pose_target_error(
+        action, motor_name=motor_name, position=position, delta=delta, positions=positions
+    ):
+        return {"status": "error", "content": [{"text": target_error}]}
 
     # Initialize managers
     pose_manager = PoseManager(robot_id)

--- a/tests/tools/test_pose_tool_target_domain.py
+++ b/tests/tools/test_pose_tool_target_domain.py
@@ -1,0 +1,357 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for the degree-valued targets ``pose_tool`` drives a joint to.
+
+``position``, ``delta`` and the values of ``positions`` all reach a servo the
+same way: ``MotorController.degrees_to_position`` clamps them into the motor's
+configured ``range`` and scales the result onto the 12-bit ``Goal_Position``
+register. The clamp is what makes an off-domain target dangerous rather than
+merely wrong, and it is why this module measures the refusals against that
+conversion instead of only asserting on them:
+
+* **Every refused value shared an encoding with a mechanical limit.**
+  ``TestWhyTheTargetsAreRefused`` shows ``nan``, ``inf`` and an out-of-range
+  target all converting to ``Goal_Position`` 0 or 4095 - a full-travel command
+  to an end stop. ``nan`` gets there because ``min(max_deg, nan)`` returns
+  ``max_deg``, so the guard that looks like a safety net is the thing that
+  fabricates the command.
+
+* **And the caller was told it went where it asked.** The success text echoes
+  the *requested* value, so the pre-guard behaviour reported
+  ``"Moved shoulder_pan to nan deg"`` for a move to +180. That is the property
+  ``TestTheBusIsNotTouched`` pins: a refused target produces no write at all.
+
+The domain itself is delegated to :func:`~strands_robots.utils.finite_number_error`
+so an off-type or non-finite target is reported in the words every other surface
+uses; only the per-joint bounds are decided in this module, because they are a
+property of the arm it drives. That split is asserted in
+``TestTheBoundsHaveOneAuthority`` rather than left to convention.
+
+Every test that reaches the motor path takes ``fake_serial`` and passes an
+explicit fake ``port``: ``pose_tool``'s ``port`` defaults to ``/dev/ttyACM0``,
+so a test that omits it drives whatever arm is plugged into the machine running
+the suite.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.pose_tool import (
+    _DEFAULT_MOTOR_CONFIGS,
+    _TARGET_OPTION_BY_ACTION,
+    MotorController,
+    _pose_target_error,
+    pose_tool,
+)
+from strands_robots.utils import finite_number_error
+
+_PORT = "/dev/fake-pose-target"
+
+# A joint with a symmetric range, and the gripper, which is configured 0-100 and
+# is the one motor whose targets are a percentage rather than degrees.
+_JOINT = "shoulder_pan"
+_JOINT_RANGE = (-180, 180)
+
+# Targets no joint can be driven to. Each is refused for one of two reasons -
+# it is not a finite number, or it is outside the joint's configured travel -
+# and ``TestWhyTheTargetsAreRefused`` measures both against the conversion.
+_UNUSABLE_TARGETS: tuple[Any, ...] = (
+    math.nan,
+    math.inf,
+    -math.inf,
+    5000,
+    -5000,
+    180.5,
+    True,
+    False,
+    "90",
+    [90],  # a list is not a scalar target
+    10**400,
+)
+
+# Targets inside the joint's travel, which must keep working unchanged.
+_USABLE_TARGETS: tuple[Any, ...] = (0, 0.0, 90.0, -90.0, 180, -180, 12.5)
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool through one funnel.
+
+    Several tests deliberately supply values outside the declared types (that is
+    the contract under test), and a ``**dict[str, Any]`` splat is not narrowed,
+    so routing every call through here states the intent once instead of
+    scattering per-call suppressions.
+
+    Args:
+        **kwargs: Forwarded verbatim to :func:`pose_tool`.
+
+    Returns:
+        The tool result dict.
+    """
+    return pose_tool(**kwargs)
+
+
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate every ``text`` field of a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _goal_position(motor_name: str, degrees: Any) -> int:
+    """The ``Goal_Position`` ``degrees`` would be written as, clamp included."""
+    return MotorController(_PORT).degrees_to_position(motor_name, degrees)
+
+
+class TestWhyTheTargetsAreRefused:
+    """The domain is justified by what the conversion does with the value."""
+
+    @pytest.mark.parametrize("target", [math.nan, math.inf, 5000, 180.5])
+    def test_an_over_range_target_encodes_as_the_upper_end_stop(self, target):
+        """Each collides with the *same* command: full travel to the limit.
+
+        This is the whole reason a clamp cannot stand in for a refusal - the
+        encoding is lossy in the one direction that matters, so ``nan`` and a
+        deliberate ``180`` are indistinguishable once on the wire.
+        """
+        assert _goal_position(_JOINT, target) == _goal_position(_JOINT, _JOINT_RANGE[1])
+        assert _goal_position(_JOINT, target) == 4095
+
+    @pytest.mark.parametrize("target", [-math.inf, -5000, -180.5])
+    def test_an_under_range_target_encodes_as_the_lower_end_stop(self, target):
+        assert _goal_position(_JOINT, target) == _goal_position(_JOINT, _JOINT_RANGE[0])
+        assert _goal_position(_JOINT, target) == 0
+
+    def test_nan_reaches_the_limit_through_the_clamp_itself(self):
+        """``min(max_deg, nan)`` returns ``max_deg``, so the clamp fabricates it."""
+        assert min(_JOINT_RANGE[1], math.nan) == _JOINT_RANGE[1]
+        assert _goal_position(_JOINT, math.nan) == 4095
+
+    def test_a_bool_would_have_been_read_as_one_degree(self):
+        """``True`` is an ``int`` subclass, so it encodes as a real 1-degree move."""
+        assert _goal_position(_JOINT, True) == _goal_position(_JOINT, 1)
+
+    @pytest.mark.parametrize("target", _USABLE_TARGETS)
+    def test_an_in_range_target_is_not_the_end_stop_it_is_distinguishable_from(self, target):
+        """An accepted target keeps its own encoding, which is the point."""
+        encoded = _goal_position(_JOINT, target)
+        assert 0 <= encoded <= 4095
+        if target not in _JOINT_RANGE:
+            assert encoded not in (0, 4095)
+
+
+class TestTheBusIsNotTouched:
+    """A refused target produces no serial write, on any of the three actions."""
+
+    @pytest.mark.parametrize("target", _UNUSABLE_TARGETS)
+    def test_move_motor_refuses_without_writing(self, target, fake_serial, cwd_tmp):
+        result = _call(action="move_motor", port=_PORT, motor_name=_JOINT, position=target)
+        assert result["status"] == "error"
+        assert "position" in _texts(result)
+        assert fake_serial == [], "the port was opened for a target that cannot be honored"
+
+    @pytest.mark.parametrize("target", _UNUSABLE_TARGETS)
+    def test_move_multiple_refuses_without_writing(self, target, fake_serial, cwd_tmp):
+        result = _call(action="move_multiple", port=_PORT, positions={_JOINT: target})
+        assert result["status"] == "error"
+        assert f"positions[{_JOINT!r}]" in _texts(result)
+        assert fake_serial == []
+
+    @pytest.mark.parametrize("target", [math.nan, math.inf, True, "90", [90], 10**400])
+    def test_incremental_move_refuses_a_non_finite_delta_without_writing(self, target, fake_serial, cwd_tmp):
+        result = _call(action="incremental_move", port=_PORT, motor_name=_JOINT, delta=target)
+        assert result["status"] == "error"
+        assert "delta" in _texts(result)
+        assert fake_serial == []
+
+    def test_a_delta_larger_than_the_full_travel_is_refused(self, fake_serial, cwd_tmp):
+        """No starting position could honor it, so it is unhonorable by construction."""
+        span = _JOINT_RANGE[1] - _JOINT_RANGE[0]
+        result = _call(action="incremental_move", port=_PORT, motor_name=_JOINT, delta=span + 1)
+        assert result["status"] == "error"
+        assert f"at most {span} degrees in magnitude" in _texts(result)
+        assert fake_serial == []
+
+    def test_the_refusal_names_the_motor_and_its_travel(self, fake_serial, cwd_tmp):
+        result = _call(action="move_motor", port=_PORT, motor_name=_JOINT, position=5000)
+        text = _texts(result)
+        assert "[-180, 180] degrees" in text
+        assert f"'{_JOINT}'" in text
+        assert "5000" in text
+
+    def test_the_gripper_is_quoted_as_a_percentage(self, fake_serial, cwd_tmp):
+        """Its configured range is 0-100, so "degrees" would be the wrong word."""
+        result = _call(action="move_motor", port=_PORT, motor_name="gripper", position=200)
+        assert "[0, 100] percent" in _texts(result)
+
+
+class TestUsableTargetsStillReachTheServo:
+    """The guard refuses; it must not start refusing what already worked."""
+
+    @pytest.mark.parametrize("target", _USABLE_TARGETS)
+    def test_move_motor_still_writes_the_goal_position(self, target, fake_serial, cwd_tmp):
+        result = _call(action="move_motor", port=_PORT, motor_name=_JOINT, position=target)
+        assert result["status"] == "success"
+        assert len(fake_serial) == 1
+        written = fake_serial[0].writes
+        assert len(written) == 1
+        # Feetech INST_WRITE to Goal_Position (0x2A), little-endian payload.
+        encoded = _goal_position(_JOINT, target)
+        assert written[0][4] == 0x03
+        assert written[0][5] == 0x2A
+        assert written[0][6] == encoded & 0xFF
+        assert written[0][7] == (encoded >> 8) & 0xFF
+
+    def test_move_multiple_still_drives_every_motor(self, fake_serial, cwd_tmp):
+        result = _call(
+            action="move_multiple",
+            port=_PORT,
+            positions={_JOINT: 10.0, "elbow_flex": -20.0},
+            smooth=False,
+        )
+        assert result["status"] == "success"
+        assert len(fake_serial[0].writes) == 2
+
+    def test_a_target_exactly_on_each_bound_is_accepted(self, fake_serial, cwd_tmp):
+        """The bounds are inclusive - they are reachable positions, not limits."""
+        for bound in _JOINT_RANGE:
+            assert (
+                _pose_target_error("move_motor", motor_name=_JOINT, position=bound, delta=None, positions=None) is None
+            )
+
+
+class TestOnlyTheTargetTheActionReadsIsChecked:
+    """A caller is never refused for a value the requested action never looks at."""
+
+    @pytest.mark.parametrize("action", ["read_all", "list_poses", "connect", "read_position"])
+    def test_an_action_reading_no_target_is_not_refused(self, action):
+        assert (
+            _pose_target_error(
+                action, motor_name=_JOINT, position=math.nan, delta=math.nan, positions={_JOINT: math.nan}
+            )
+            is None
+        )
+
+    def test_move_motor_ignores_an_unusable_delta(self):
+        """It commands an absolute position; ``delta`` is not its parameter."""
+        assert _pose_target_error("move_motor", motor_name=_JOINT, position=0.0, delta=math.nan, positions=None) is None
+
+    def test_incremental_move_ignores_an_unusable_position(self):
+        assert (
+            _pose_target_error("incremental_move", motor_name=_JOINT, position=math.nan, delta=0.0, positions=None)
+            is None
+        )
+
+    @pytest.mark.parametrize("action", list(_TARGET_OPTION_BY_ACTION))
+    def test_an_absent_target_is_left_to_the_required_check(self, action):
+        """The action reports the whole missing pair; this guard must not pre-empt it."""
+        assert _pose_target_error(action, motor_name=_JOINT, position=None, delta=None, positions=None) is None
+
+    def test_a_missing_position_still_reports_the_required_pair(self, fake_serial, cwd_tmp):
+        result = _call(action="move_motor", port=_PORT, motor_name=_JOINT)
+        assert result["status"] == "error"
+        assert "required" in _texts(result)
+
+
+class TestTheBoundsHaveOneAuthority:
+    """The servo and the guard must not read two copies of the same range."""
+
+    def test_the_controller_is_configured_from_the_module_table(self):
+        controller = MotorController(_PORT)
+        assert {name: cfg["range"] for name, cfg in controller.motor_configs.items()} == {
+            name: cfg["range"] for name, cfg in _DEFAULT_MOTOR_CONFIGS.items()
+        }
+
+    def test_each_controller_gets_its_own_copy(self):
+        """Hoisting the table must not make one instance's edit global."""
+        first = MotorController(_PORT)
+        first.motor_configs[_JOINT]["range"] = (-1, 1)
+        assert MotorController(_PORT).motor_configs[_JOINT]["range"] == _JOINT_RANGE
+        assert _DEFAULT_MOTOR_CONFIGS[_JOINT]["range"] == _JOINT_RANGE
+
+    def test_the_shared_domain_owns_finiteness_and_type(self):
+        """Only the per-joint bounds are decided here; the rest is delegated.
+
+        Asserted as an equality with the shared helper's own text so the two
+        cannot drift into reporting the same value in different words.
+
+        ``None`` is excluded deliberately: it is the omitted-target spelling,
+        which the action's own required check reports as a missing pair. That
+        exception is pinned by
+        ``TestOnlyTheTargetTheActionReadsIsChecked::test_an_absent_target_is_left_to_the_required_check``.
+        """
+        for value in (math.nan, math.inf, True, "90", [90], 10**400):
+            expected = finite_number_error(value, "position", "move_motor")
+            if expected is None:
+                continue
+            assert (
+                _pose_target_error("move_motor", motor_name=_JOINT, position=value, delta=None, positions=None)
+                == expected
+            )
+
+
+class TestNoTargetSurfaceDrifts:
+    """A target parameter added to the tool cannot skip the guard silently."""
+
+    def test_every_declared_target_parameter_is_routed(self):
+        """Each ``float | None`` / ``dict[str, float] | None`` option is covered.
+
+        ``steps`` and ``step_delay`` are excluded by annotation rather than by
+        name: they are ``int`` and ``float`` with defaults, never ``| None``,
+        because they are interpolation options with their own guard.
+        """
+        routed = set(_TARGET_OPTION_BY_ACTION.values())
+        declared = {
+            name
+            for name, param in inspect.signature(pose_tool.__wrapped__).parameters.items()
+            if str(param.annotation) in ("float | None", "dict[str, float] | None")
+        }
+        assert declared, "the signature probe matched nothing - it has stopped testing anything"
+        assert declared == routed, f"unrouted joint-target parameters: {sorted(declared - routed)}"
+
+    def test_every_routed_action_is_a_real_action(self):
+        """A typo in the map would silently disable the guard for that action."""
+        doc = pose_tool.__wrapped__.__doc__ or ""
+        for action in _TARGET_OPTION_BY_ACTION:
+            assert f'"{action}"' in doc
+
+
+class TestNeighbouringTargetProducersStayOutOfScope:
+    """The boundary of this change, pinned so it narrows deliberately.
+
+    Both remaining producers of a clamped target come from somewhere other than
+    the caller's arguments, so neither is reachable from the guard above:
+
+    * a **stored pose** is validated by ``PoseManager.validate_pose``, which
+      already refuses an out-of-bounds position - but only when the pose file
+      carries ``safety_bounds``;
+    * ``reset_to_home`` supplies its own literal targets, which are in range.
+
+    ``degrees_to_position`` therefore keeps its clamp: it is unreachable from
+    ``move_motor`` / ``move_multiple`` / ``incremental_move`` now, and removing
+    it would turn those other two paths into raises, which is a separate
+    concern.
+    """
+
+    def test_the_clamp_is_still_present_for_the_paths_that_rely_on_it(self):
+        assert _goal_position(_JOINT, 5000) == 4095
+
+    def test_load_pose_is_not_routed_through_the_target_guard(self):
+        assert "load_pose" not in _TARGET_OPTION_BY_ACTION
+        assert "reset_to_home" not in _TARGET_OPTION_BY_ACTION
+
+    def test_an_unknown_motor_is_left_to_the_existing_path(self, fake_serial, cwd_tmp):
+        """No configured range means no bounds to check it against."""
+        assert (
+            _pose_target_error("move_motor", motor_name="no_such_joint", position=5000, delta=None, positions=None)
+            is None
+        )
+
+    def test_an_unknown_motor_with_a_non_finite_target_is_still_refused(self):
+        """Finiteness needs no range, so the shared domain still applies."""
+        assert (
+            _pose_target_error("move_motor", motor_name="no_such_joint", position=math.nan, delta=None, positions=None)
+            is not None
+        )


### PR DESCRIPTION
Closes #1937.

## The defect

`MotorController.degrees_to_position` clamps its argument into the motor's configured `range` before scaling it onto the 12-bit `Goal_Position` register:

```python
# Clamp to range
degrees = max(min_deg, min(max_deg, degrees))
```

So every target outside the range shares one encoding -- the mechanical limit -- and the caller is told it moved to the value it asked for, because the success text echoes the request rather than what was sent.

`nan` reaches the limit *through the clamp itself*: `min(max_deg, nan)` returns `max_deg`, because the comparison is false. The guard that looks like a safety net is what fabricates the command.

## Measured, before this change

On `3804e64`, `action="move_motor"`, `motor_name="shoulder_pan"` (configured `(-180, 180)`), with a recording serial double:

| `position=` | result | `Goal_Position` written | reported text |
| --- | --- | --- | --- |
| `nan` | `success` | **4095** | `Moved shoulder_pan to nan deg` |
| `inf` | `success` | **4095** | `Moved shoulder_pan to inf deg` |
| `5000` | `success` | **4095** | `Moved shoulder_pan to 5000 deg` |
| `True` | `success` | 2058 | `Moved shoulder_pan to True deg` |

4095 is the upper end stop. At servo speed that is a full-travel slam on a request that could not be honored, under `status="success"`, and nothing distinguishes it from a deliberate `position=180`. `True` is an `int` subclass, so it was read as a real 1-degree move.

## Why a refusal rather than a clamp

The contract already exists in two places, and this path is the one that did not apply it:

- **In this same file.** `PoseManager.validate_pose` refuses an out-of-bounds position with a message naming the motor and its bounds, and `load_pose` uses it. `move_motor` did not.
- **On the same register.** #1934 bounded `serial_tool`'s `position` to `(0, 4095)` because `Goal_Position` is a 12-bit field. `pose_tool` is the surface that *computes* that field from degrees, and it did not bound its input.

`tests/test_hardware_servo_safety_clamp.py` already refuses `nan` / `inf` on the `max_relative_target` travel clamp for the same reason. Per AGENTS.md Key Convention 6 there is no safe default here: clamping substitutes a value the caller did not ask for, the reasoning that decided the colour component counts in #1856.

## What changed

Three caller-supplied surfaces are gated at the tool boundary, before the port is opened, mirroring the `_smooth_move_option_error` gate already there:

| action | option |
| --- | --- |
| `move_motor` | `position` |
| `move_multiple` | every value of `positions` |
| `incremental_move` | `delta` |

- Finiteness, numeric-ness and `bool` are delegated to the shared `finite_number_error`, so an off-domain target is refused in the words every other surface uses. Only the per-joint bounds are decided here, because they are a property of the arm this module drives -- the same split `serial_tool`'s `_REGISTER_FIELDS` makes.
- `delta` is bounded by the joint's **full travel** rather than its endpoints: the endpoints are absolute and a displacement is not, so only a magnitude exceeding the whole range is unhonorable from every starting position, which is checkable without a live position reading.
- The bounds have **one authority**. The per-joint table moved to module level and `MotorController` is configured from a copy of it, so the table the guard checks cannot disagree with the table the servo is driven from. Each instance still gets its own copy, pinned.

Refusals name the motor, its travel and the value:

```
move_motor: position must be within [-180, 180] degrees (the configured travel of 'shoulder_pan'), got 5000.
move_motor: position must be within [0, 100] percent (the configured travel of 'gripper'), got 200.
incremental_move: delta must be at most 360 degrees in magnitude (the full travel of 'shoulder_pan', so no starting position could honor more), got 5000.
move_multiple: positions['elbow_flex'] must be a finite number, got nan.
```

The gripper is quoted as a percentage because its configured range is 0-100, so "degrees" would be the wrong word.

## Tests

`tests/tools/test_pose_tool_target_domain.py`, 75 cases. The refusals are measured against the conversion rather than only asserted:

- `TestWhyTheTargetsAreRefused` shows `nan`, `inf` and an out-of-range target all converting to `Goal_Position` 0 or 4095 -- i.e. that the encoding is lossy in the one direction that matters, which is why a clamp cannot stand in for a refusal. It also pins `min(max_deg, nan) == max_deg` directly, and that `True` encodes as a real 1-degree move.
- `TestTheBusIsNotTouched` asserts a refused target opens no port and writes no byte, on all three actions.
- `TestUsableTargetsStillReachTheServo` decodes the actual `INST_WRITE` / `Goal_Position` payload for accepted targets, so the guard cannot pass by refusing everything.
- `TestOnlyTheTargetTheActionReadsIsChecked` -- an action reading no target is never refused for one, `move_motor` ignores an unusable `delta`, and an absent target stays the action's own required check.
- `TestTheBoundsHaveOneAuthority` asserts the controller is configured from the module table, that instances get independent copies, and that the shared helper's text is reproduced verbatim so the two cannot drift into different words for the same value.
- `TestNoTargetSurfaceDrifts` scans the tool signature: every `float | None` / `dict[str, float] | None` parameter must be routed through the guard, so a new joint target cannot skip it. The probe asserts it matched something, so it fails loudly rather than vacuously.

**Non-vacuous:** on the pre-fix tree the module cannot import the guard at all (collection error), and the behavioural claim is the measured table above.

## Out of scope, pinned rather than left silent

`TestNeighbouringTargetProducersStayOutOfScope` holds the boundary. `degrees_to_position` **keeps its clamp**: it is now unreachable from these three actions, but its other callers supply targets from somewhere other than the caller's arguments -- a stored pose, which `validate_pose` already refuses out of bounds, and `reset_to_home`'s own in-range literals. Removing it would turn those paths into raises, which is a separate concern. An unknown motor name has no configured range to check against and is left to the existing unknown-motor path; a non-finite target for one is still refused, since finiteness needs no range.

## Verification

- `ruff format --check` and `ruff check` clean on both files.
- `mypy strands_robots/tools/pose_tool.py`: no errors in the file.
- `pytest tests/tools/`: **1215 passed**. The 3 remaining failures are `lerobot_camera` / `lerobot_teleoperate` / `lerobot_train` lazy-import cases, which fail identically on a pristine tree in this environment (`No module named 'lerobot'` / `'psutil'`) and are untouched by this change.
- The four `pose_tool` modules together: 249 passed.

## §13 changelog

**Round 0** -- initial submission.