### PR TITLE
fix(training): the run size a TrainSpec asks for is one shared positive-count domain

### DIFF
--- a/changelog.d/1939-training-run-size-domain.md
+++ b/changelog.d/1939-training-run-size-domain.md
@@ -1,0 +1,24 @@
+### Fixed: the run size a `TrainSpec` asks for is checked against one shared positive-count domain
+
+`TrainSpec.steps` and `TrainSpec.global_batch_size` are the two factors of how
+much training a spec asks for, and every supervised backend reads both straight
+into a discrete consumer - `steps` bounds the optimizer loop (lerobot iterates
+`range(step, cfg.steps)`) and `global_batch_size` becomes a `DataLoader` batch
+size or a `--global_batch_size` flag. Four backends each carried their own
+`if spec.steps <= 0` copy and none checked `global_batch_size` at all, so the
+copies agreed with each other and shared one hole: a comparison admits every
+value that is not comparably non-positive. `steps=True` validated clean and
+trained for exactly one optimizer step; `steps=2.7` / `nan` / `inf` validated
+clean and then raised `TypeError: 'float' object cannot be interpreted as an
+integer` inside the backend's `range()`, after the dataset and the model were
+already loaded; `steps="1000"` raised `TypeError: '<=' not supported between
+instances of 'str' and 'int'` out of `Trainer.validate` itself, which is
+documented to *return* problems. `global_batch_size` reached torch's
+`DataLoader` unchecked for all of `0`, `-8`, `True`, `2.7`, `nan` and `"32"`.
+
+`Trainer._run_size_problems` now routes both fields through the one shared
+`positive_count_error` domain, and the four duplicated comparisons are gone.
+The message names the backend that refused the value. The RL trainers are
+deliberately off this path: per `TrainSpec`, a backend ignores the fields it
+does not support, and they drive training from `total_timesteps` / `batch_size`
+instead - reporting on a field they never read would be a false rejection.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -93,6 +93,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `dataset_repo_id` | Hub dataset id `org/name` | alternative data source; train from the Hub (lerobot) |
 | `streaming` | stream frames, no full materialize | lerobot `StreamingLeRobotDataset`; bounded disk (Hub) / RAM (local) |
 | `base_model` | HF id / local ckpt to tune from | required for GR00T & Cosmos |
+| `steps` / `global_batch_size` | the run size: optimizer steps x batch | each must be a positive integer; `validate()` refuses `0`, a fractional or non-finite value, and a `bool` (`True` would read as a silent one-step run) before anything is loaded |
 | `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |
 | `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
 | `val_episodes` | hold out the LAST N episodes | deterministic split |

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -15,6 +15,16 @@ an arbitrary ``extra`` key could set an arbitrary config attribute / override.
 from every backend's :meth:`Trainer.validate`, which each backend's
 :meth:`Trainer.train` calls (fail-closed) before building any config - so no
 run can start with unvalidated input regardless of the call path.
+
+:func:`run_size_problems` is the second shared gate, on a different axis: the
+*run size* numerics. ``steps`` and ``global_batch_size`` are the two factors of
+how much training a spec asks for, and both are read straight into a backend's
+loop bound / dataloader. They live in their own gate rather than in
+:func:`validate_train_inputs` because :class:`TrainSpec` documents that a
+backend "reads the fields it supports and ignores the rest": the RL trainers
+drive training from ``total_timesteps`` / ``batch_size`` and never read either
+field, so reporting a problem for them there would be a false rejection of a
+field that backend does not use.
 """
 
 from __future__ import annotations
@@ -23,6 +33,7 @@ import re
 from typing import TYPE_CHECKING
 
 from strands_robots.tools._path_validation import validate_save_path
+from strands_robots.utils import positive_count_error
 
 if TYPE_CHECKING:
     from strands_robots.training.base import TrainSpec
@@ -81,4 +92,37 @@ def validate_train_inputs(spec: TrainSpec) -> list[str]:
                 f"no leading dash, no '=', no whitespace)"
             )
 
+    return problems
+
+
+def run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return run-size problems for a :class:`TrainSpec`.
+
+    ``steps`` and ``global_batch_size`` are the two factors of the amount of
+    training a spec asks for, and each is consumed directly as a discrete
+    count: ``steps`` bounds the backend's optimizer loop (lerobot iterates
+    ``range(step, cfg.steps)``) and ``global_batch_size`` becomes a
+    ``DataLoader`` batch size / a ``--global_batch_size`` flag. Only a positive
+    integer can be honored, which is why both are checked against the one
+    shared :func:`~strands_robots.utils.positive_count_error` domain rather
+    than a local comparison: a bare ``value <= 0`` test admits every value that
+    is not comparably non-positive, so ``True`` reads as a silent run of one
+    step, a fractional or non-finite value reaches ``range()`` and raises
+    there, and a string raises out of the comparison itself - inside a
+    :meth:`Trainer.validate` that is documented to *return* problems.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        One problem per unusable field; empty when both are usable counts.
+    """
+    problems: list[str] = []
+    for param, value in (("steps", spec.steps), ("global_batch_size", spec.global_batch_size)):
+        error = positive_count_error(value, param, context)
+        if error is not None:
+            problems.append(error)
     return problems

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -236,6 +236,32 @@ class Trainer(ABC):
 
         return validate_train_inputs(spec)
 
+    def _run_size_problems(self, spec: TrainSpec) -> list[str]:
+        """Run-size preflight shared by every backend that consumes it.
+
+        Returns problems for :attr:`TrainSpec.steps` /
+        :attr:`TrainSpec.global_batch_size` - the two factors of how much
+        training the spec asks for - against the one shared positive-count
+        domain. A :meth:`validate` implementation that reads either field MUST
+        call this instead of comparing the value itself: a local ``<= 0`` test
+        admits a ``bool`` as a silent run of one step, admits a fractional or
+        non-finite value that then raises inside the backend's ``range()``
+        after the dataset and model are already loaded, and raises out of the
+        comparison itself for a non-numeric value - from a method documented to
+        *return* problems.
+
+        A backend that drives training from other fields (the RL trainers, on
+        ``total_timesteps`` / ``batch_size``) MUST NOT call this: per
+        :class:`TrainSpec`, a backend ignores the fields it does not support,
+        so reporting on one it never reads would be a false rejection.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import run_size_problems
+
+        return run_size_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -128,7 +128,8 @@ class Cosmos3Trainer(Trainer):
 
         Runs the shared input-safety gate, then checks a LeRobotDataset v3
         ``dataset_root``, a ``base_model`` to convert to DCP, an
-        ``output_dir``, a supported ``method``, positive ``steps``, an
+        ``output_dir``, a supported ``method``, a usable run size (``steps`` /
+        ``global_batch_size``), an
         ``extra['sft_toml']`` recipe that exists, and a resolvable
         ``cosmos_framework`` checkout (COSMOS_ROOT / ``cosmos_root`` /
         ``extra['cosmos_root']``). Returns the problem list; empty means
@@ -153,8 +154,7 @@ class Cosmos3Trainer(Trainer):
             problems.append(
                 f"unsupported method '{spec.method}' for Cosmos3 (expected one of {sorted(_SUPPORTED_METHODS)})"
             )
-        if spec.steps <= 0:
-            problems.append(f"steps must be > 0, got {spec.steps}")
+        problems.extend(self._run_size_problems(spec))
 
         if not spec.extra.get("sft_toml"):
             problems.append(

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -123,8 +123,9 @@ class Gr00tTrainer(Trainer):
 
         Runs the shared input-safety gate, then checks a LeRobotDataset v3
         ``dataset_root``, a ``base_model``, an ``output_dir``, a required
-        ``embodiment`` tag, a supported ``method``, positive ``steps``,
-        single-node only (``num_nodes == 1``), a resolvable Isaac-GR00T
+        ``embodiment`` tag, a supported ``method``, a usable run size (``steps``
+        / ``global_batch_size``), single-node only (``num_nodes == 1``), a
+        resolvable Isaac-GR00T
         checkout (GR00T_ROOT / ``groot_root`` / ``extra['groot_root']``),
         and an optional ``extra['modality_config_path']`` that exists.
         Returns the problem list; empty means launchable. Read-only.
@@ -152,8 +153,7 @@ class Gr00tTrainer(Trainer):
                 f"(expected one of {sorted(_SUPPORTED_METHODS)}); "
                 f"use tune={{...}} for fine-grained control"
             )
-        if spec.steps <= 0:
-            problems.append(f"steps must be > 0, got {spec.steps}")
+        problems.extend(self._run_size_problems(spec))
 
         if spec.num_nodes > 1:
             problems.append(

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -547,8 +547,9 @@ class LerobotTrainer(Trainer):
 
         Runs the shared input-safety gate, then checks a data source -
         exactly one of a local LeRobotDataset v3 ``dataset_root`` or a Hub
-        ``dataset_repo_id`` (for streaming) - an ``output_dir``, positive
-        ``steps``, single-node only (``num_nodes == 1``), a ``val_episodes``
+        ``dataset_repo_id`` (for streaming) - an ``output_dir``, a usable run
+        size (``steps`` / ``global_batch_size``), single-node only
+        (``num_nodes == 1``), a ``val_episodes``
         split below the dataset total, and that ``lerobot.scripts.lerobot_train``
         is importable. ``extra['reward_model']`` switches to reward-model
         preflight; otherwise the default policy path is checked. Returns the
@@ -592,8 +593,7 @@ class LerobotTrainer(Trainer):
         else:
             problems.extend(self._validate_policy(spec))
 
-        if spec.steps <= 0:
-            problems.append(f"steps must be > 0, got {spec.steps}")
+        problems.extend(self._run_size_problems(spec))
 
         if spec.num_nodes > 1:
             problems.append(

--- a/strands_robots/training/mock.py
+++ b/strands_robots/training/mock.py
@@ -49,8 +49,7 @@ class MockTrainer(Trainer):
         if spec.method == "lora" and spec.tune.get("expert_only"):
             problems.append("lora and expert_only are mutually exclusive")
 
-        if spec.steps <= 0:
-            problems.append(f"steps must be > 0, got {spec.steps}")
+        problems.extend(self._run_size_problems(spec))
 
         return problems
 

--- a/tests/tools/test_train_policy.py
+++ b/tests/tools/test_train_policy.py
@@ -216,7 +216,7 @@ def test_export_with_invalid_spec_exports_nothing(tmp_path: Path) -> None:
 
 def test_train_with_invalid_spec_launches_nothing(tmp_path: Path) -> None:
     kwargs = _valid_kwargs(tmp_path)
-    kwargs["steps"] = 0  # steps must be > 0 -> preflight problem
+    kwargs["steps"] = 0  # not a positive integer -> preflight problem
     result = train_policy(action="train", **kwargs)
     _assert_canonical(result)
     assert result["status"] == "error"

--- a/tests/training/test_cosmos3_lifecycle.py
+++ b/tests/training/test_cosmos3_lifecycle.py
@@ -341,7 +341,7 @@ class TestValidateBranches:
 
     def test_nonpositive_steps(self, spec):
         spec.steps = -5
-        assert any("steps must be > 0" in p for p in Cosmos3Trainer().validate(spec))
+        assert any("steps must be a positive integer" in p for p in Cosmos3Trainer().validate(spec))
 
     def test_sft_toml_does_not_exist(self, spec):
         spec.extra["sft_toml"] = "/no/such/recipe.toml"

--- a/tests/training/test_factory.py
+++ b/tests/training/test_factory.py
@@ -109,7 +109,7 @@ class TestValidate:
     def test_nonpositive_steps_reported(self, spec):
         spec.steps = 0
         problems = create_trainer("mock").validate(spec)
-        assert any("steps must be > 0" in p for p in problems)
+        assert any("steps must be a positive integer" in p for p in problems)
 
 
 class TestLifecycle:

--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -93,7 +93,7 @@ class TestValidate:
             (lambda s: setattr(s, "base_model", ""), "base_model is required"),
             (lambda s: setattr(s, "output_dir", ""), "output_dir is required"),
             (lambda s: setattr(s, "method", "bogus"), "unsupported method 'bogus'"),
-            (lambda s: setattr(s, "steps", 0), "steps must be > 0"),
+            (lambda s: setattr(s, "steps", 0), "steps must be a positive integer"),
         ],
     )
     def test_required_field_branch(self, spec, mutate, expected):

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -453,7 +453,7 @@ class TestValidateAdditionalBranches:
     def test_non_positive_steps(self, spec):
         spec.steps = 0
         problems = LerobotTrainer().validate(spec)
-        assert any("steps must be > 0" in p for p in problems)
+        assert any("steps must be a positive integer" in p for p in problems)
 
     def test_multinode_rejected(self, spec):
         spec.num_nodes = 2

--- a/tests/training/test_run_size_domain.py
+++ b/tests/training/test_run_size_domain.py
@@ -1,0 +1,283 @@
+"""The run size a spec asks for is one shared positive-count domain.
+
+:attr:`~strands_robots.training.base.TrainSpec.steps` and
+:attr:`~strands_robots.training.base.TrainSpec.global_batch_size` are the two
+factors of how much training a spec asks for, and every supervised backend
+reads both straight into a discrete consumer: ``steps`` bounds the optimizer
+loop (lerobot iterates ``range(step, cfg.steps)``) and ``global_batch_size``
+becomes a ``DataLoader`` batch size / a ``--global_batch_size`` flag.
+
+Before this contract each backend re-implemented ``if spec.steps <= 0`` and
+none checked ``global_batch_size`` at all, so the four copies agreed with each
+other and shared one hole: a comparison admits every value that is not
+comparably non-positive. ``True`` became a silent run of one optimizer step,
+a fractional or non-finite value reached ``range()`` and raised there - after
+the dataset and the model were already loaded - and a non-numeric value raised
+out of the comparison itself, from a :meth:`Trainer.validate` documented to
+*return* problems rather than raise.
+
+The tests below pin the contract in both directions: every backend that reads
+the run size refuses the same unusable values through the one shared domain,
+a usable run size is untouched, and a backend that drives training from other
+fields (the RL trainers, on ``total_timesteps`` / ``batch_size``) reports
+nothing for a field it never reads.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.training._validate import run_size_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+from strands_robots.training.groot import Gr00tTrainer
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.training.mock import MockTrainer
+
+# The two factors of the run size, and the values no backend can honor. Split
+# by failure mode so a test can say which contract each value belongs to.
+RUN_SIZE_FIELDS = ("steps", "global_batch_size")
+
+# Non-positive: already refused before this change (by four separate copies of
+# the same comparison). Kept so the fix cannot regress what worked.
+NON_POSITIVE = (0, -5)
+
+# Slipped through a comparison, then misbehaved in the consumer.
+WRONG_TYPE = (True, False, 2.7, float("nan"), float("inf"))
+
+# Raised out of the comparison itself, i.e. out of validate().
+NOT_COMPARABLE = ("1000", None, [4])
+
+UNUSABLE = NON_POSITIVE + WRONG_TYPE + NOT_COMPARABLE
+
+# Every backend that reads the run size. The RL trainers are deliberately
+# absent - see TestTheRLTrainersIgnoreAFieldTheyDoNotRead.
+SUPERVISED_TRAINERS = (MockTrainer, Cosmos3Trainer, Gr00tTrainer, LerobotTrainer)
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path) -> TrainSpec:
+    """A spec whose non-numeric fields are all fine, so only the run size varies."""
+    root = tmp_path / "ds"
+    (root / "meta").mkdir(parents=True)
+    (root / "meta" / "info.json").write_text(json.dumps({"total_episodes": 10, "fps": 30}))
+    out = tmp_path / "out"
+    out.mkdir()
+    return TrainSpec(
+        dataset_root=str(root),
+        base_model="lerobot/act",
+        output_dir=str(out),
+        embodiment="so101",
+    )
+
+
+def _mutate(spec: TrainSpec, field: str, value: Any) -> TrainSpec:
+    """Set one run-size field to a value its annotation does not describe."""
+    setattr(spec, field, value)
+    return spec
+
+
+class TestEveryBackendRefusesAnUnusableRunSize:
+    """One domain, four backends, one verdict per value."""
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    @pytest.mark.parametrize("field", RUN_SIZE_FIELDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_unusable_run_size_is_reported(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], field: str, value: Any
+    ) -> None:
+        trainer = trainer_cls()
+        problems = trainer.validate(_mutate(spec, field, value))
+        named = [p for p in problems if field in p]
+        assert named, f"{trainer_cls.__name__} accepted {field}={value!r}: {problems}"
+        assert "must be a positive integer" in named[0]
+        assert repr(value) in named[0], named[0]
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        """A shared domain must still say which backend rejected the spec."""
+        trainer = trainer_cls()
+        problems = trainer.validate(_mutate(spec, "steps", 0))
+        named = [p for p in problems if "steps" in p]
+        assert named and named[0].startswith(f"{trainer.provider_name}: "), named
+
+
+class TestValidateReportsInsteadOfRaising:
+    """``validate`` returns problems - a non-numeric run size must not raise."""
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    @pytest.mark.parametrize("field", RUN_SIZE_FIELDS)
+    @pytest.mark.parametrize("value", NOT_COMPARABLE)
+    def test_a_non_comparable_value_is_a_problem_not_an_exception(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], field: str, value: Any
+    ) -> None:
+        problems = trainer_cls().validate(_mutate(spec, field, value))
+        assert isinstance(problems, list)
+        assert any(field in p for p in problems), problems
+
+
+class TestAUsableRunSizeIsUntouched:
+    """The change is additive: every honorable run size still validates."""
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    @pytest.mark.parametrize(("steps", "batch"), [(10000, 32), (1, 1), (2, 4096)])
+    def test_a_usable_run_size_raises_no_run_size_problem(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], steps: int, batch: int
+    ) -> None:
+        spec.steps = steps
+        spec.global_batch_size = batch
+        problems = trainer_cls().validate(spec)
+        assert not [p for p in problems if "positive integer" in p], problems
+
+
+class TestTheRLTrainersIgnoreAFieldTheyDoNotRead:
+    """A backend must not report on a spec field it never consumes.
+
+    :class:`TrainSpec` documents that a backend "reads the fields it supports
+    and ignores the rest". The RL trainers drive training from
+    ``total_timesteps`` / ``batch_size`` and never read ``steps`` or
+    ``global_batch_size``, so the run-size gate must stay off their path -
+    otherwise an RL spec carrying the inherited defaults would be refused for
+    a reason that has no effect on the run.
+    """
+
+    @pytest.mark.parametrize("field", RUN_SIZE_FIELDS)
+    def test_an_rl_spec_is_not_refused_for_an_unread_field(self, field: str) -> None:
+        pytest.importorskip("torch")
+        from strands_robots.training.rl.base_algo import RLTrainSpec
+        from strands_robots.training.rl.ppo import PpoTrainer
+
+        rl_spec = RLTrainSpec(output_dir="/tmp/rl-out", env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+        setattr(rl_spec, field, 0)
+        problems = PpoTrainer().validate(rl_spec)
+        assert not [p for p in problems if field in p], problems
+
+
+class TestTheRefusedValuesAreOnesTheConsumerCannotHonor:
+    """Ground the domain in what the backends actually do with the values."""
+
+    def test_a_fractional_or_non_finite_step_count_cannot_bound_a_loop(self) -> None:
+        for value in (2.7, float("nan"), float("inf")):
+            # Bound through an ``Any`` local: the point is what the *runtime*
+            # does with the value a spec carried, which is what lerobot's train
+            # loop does with ``cfg.steps``.
+            bound: Any = value
+            with pytest.raises(TypeError):
+                range(0, bound)
+
+    def test_a_boolean_step_count_is_a_silent_run_of_one_step(self) -> None:
+        assert len(range(0, True)) == 1
+
+    def test_an_unusable_batch_size_cannot_build_a_dataloader(self) -> None:
+        torch = pytest.importorskip("torch")
+        from torch.utils.data import DataLoader, TensorDataset
+
+        dataset = TensorDataset(torch.zeros(4, 2))
+        for value in (0, -8, True, 2.7, float("nan"), "32"):
+            size: Any = value
+            with pytest.raises(ValueError):
+                DataLoader(dataset, batch_size=size)
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Top-level training backend modules (the ``rl`` subpackage is excluded).
+
+    Rooted at the module that defines :class:`Trainer` so the scan cannot
+    silently point at the wrong tree.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    return sorted(p for p in root.glob("*.py") if p.name != "__init__.py")
+
+
+def _concrete_trainer_validators(source: str) -> dict[str, ast.FunctionDef]:
+    """Map ``ClassName -> its validate() node`` for each ``Trainer`` subclass."""
+    found: dict[str, ast.FunctionDef] = {}
+    for node in ast.parse(source).body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not any(isinstance(b, ast.Name) and b.id == "Trainer" for b in node.bases):
+            continue
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef) and item.name == "validate":
+                found[node.name] = item
+    return found
+
+
+def _calls_run_size_gate(fn: ast.FunctionDef) -> bool:
+    return any(
+        isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "_run_size_problems"
+        for n in ast.walk(fn)
+    )
+
+
+def _local_run_size_comparisons(source: str) -> list[str]:
+    """Comparisons of a run-size field against a numeric literal.
+
+    That is the shape of a re-implemented domain (``if spec.steps <= 0``). A
+    comparison against another *field* is a different question and is allowed.
+    """
+    hits: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        left = node.left
+        if not (isinstance(left, ast.Attribute) and left.attr in RUN_SIZE_FIELDS):
+            continue
+        if any(isinstance(c, ast.Constant) and isinstance(c.value, (int, float)) for c in node.comparators):
+            hits.append(ast.unparse(node))
+    return hits
+
+
+class TestOneOwnerForTheRunSizeDomain:
+    """A fifth backend cannot ship with its own copy of the rule."""
+
+    def test_every_supervised_backend_routes_through_the_shared_gate(self) -> None:
+        adrift: dict[str, list[str]] = {}
+        seen: set[str] = set()
+        for path in _training_modules():
+            for cls_name, fn in _concrete_trainer_validators(path.read_text()).items():
+                seen.add(cls_name)
+                if not _calls_run_size_gate(fn):
+                    adrift.setdefault(path.name, []).append(cls_name)
+        assert not adrift, f"validate() does not call _run_size_problems: {adrift}"
+        # Non-vacuity: the scan really reached every backend, not an empty tree.
+        assert seen == {t.__name__ for t in SUPERVISED_TRAINERS}, seen
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        copies = {p.name: hits for p in _training_modules() if (hits := _local_run_size_comparisons(p.read_text()))}
+        assert not copies, f"run size compared against a literal instead of the shared gate: {copies}"
+
+    def test_the_scanners_detect_a_planted_copy(self) -> None:
+        """An empty result must mean clean sources, not a scanner matching nothing."""
+        planted = (
+            "class RogueTrainer(Trainer):\n"
+            "    def validate(self, spec):\n"
+            "        problems = []\n"
+            "        if spec.steps <= 0:\n"
+            "            problems.append('bad')\n"
+            "        return problems\n"
+        )
+        validators = _concrete_trainer_validators(planted)
+        assert set(validators) == {"RogueTrainer"}
+        assert not _calls_run_size_gate(validators["RogueTrainer"])
+        assert _local_run_size_comparisons(planted) == ["spec.steps <= 0"]
+
+
+class TestTheGateIsUsableOnItsOwn:
+    """The shared gate is a plain function - the trainers only bind a context."""
+
+    def test_it_reports_both_factors_at_once(self, spec: TrainSpec) -> None:
+        spec.steps = 0
+        spec.global_batch_size = -1
+        problems = run_size_problems(spec, context="probe")
+        assert len(problems) == 2
+        assert all(p.startswith("probe: ") for p in problems)
+
+    def test_a_usable_spec_reports_nothing(self, spec: TrainSpec) -> None:
+        assert run_size_problems(spec, context="probe") == []

--- a/tests/training/test_tool.py
+++ b/tests/training/test_tool.py
@@ -310,7 +310,7 @@ class TestTrainErrorBoundary:
         )
         assert res["status"] == "error"
         assert "validation problems (nothing launched)" in _text(res)
-        assert "steps must be > 0" in _text(res)
+        assert "steps must be a positive integer" in _text(res)
         # "launches nothing" is the behavioural claim: no checkpoint stub exists.
         assert not (out / "checkpoints" / "last").exists()
 


### PR DESCRIPTION
## Problem

`TrainSpec.steps` and `TrainSpec.global_batch_size` are the two factors of how much training a spec asks for, and every supervised backend reads both straight into a discrete consumer: `steps` bounds the optimizer loop (lerobot iterates `range(step, cfg.steps)`) and `global_batch_size` becomes a `DataLoader` batch size or a `--global_batch_size` flag.

Four backends each carried their own copy of the same line:

```python
if spec.steps <= 0:
    problems.append(f"steps must be > 0, got {spec.steps}")
```

`mock.py:52`, `cosmos3.py:156`, `groot.py:155`, `lerobot.py:595`. The copies agreed with each other, so no test ever failed — and they shared one hole: a comparison admits every value that is not *comparably* non-positive. The second factor, `global_batch_size`, was checked by nothing at all.

Measured on `upstream/main`, one script over all four backends. Every verdict was identical across `mock` / `cosmos3` / `groot` / `lerobot_local`:

| field | value | `validate()` on main | what main then did with it |
|---|---|---|---|
| `steps` | `10000` | accepted | 10000 optimizer steps (correct) |
| `steps` | `0` / `-5` | refused | — |
| `steps` | `True` | **accepted** | `len(range(0, True)) == 1` — a silent one-step run reported as a completed job |
| `steps` | `2.7` / `nan` / `inf` | **accepted** | `TypeError: 'float' object cannot be interpreted as an integer` inside `range()`, after the dataset and the model are already loaded |
| `steps` | `'1000'` / `None` | **raised `TypeError`** | `'<=' not supported between instances of 'str' and 'int'`, out of `validate()` itself |
| `global_batch_size` | `32` | accepted | batches of 32 (correct) |
| `global_batch_size` | `0` / `-8` / `True` / `2.7` / `nan` / `'32'` | **accepted** | `ValueError: batch_size should be a positive integer value` from torch's `DataLoader`, once the dataset is materialized |

12 of 16 unusable values were let through. The last `steps` row is the sharpest: `Trainer.validate` is documented as

> Pure, side-effect-free preflight. Return a list of human-readable problems […] it powers a `plan` advisor that runs *before* anything expensive starts.

so the advisor whose whole job is to report problems crashed on one. Through the `train_policy` tool the raise is caught at the boundary and surfaces as `train_policy error: '<=' not supported between instances of 'str' and 'int'` — a message naming neither the field nor the tool.

## Change

`Trainer._run_size_problems` (base, symmetrical with the existing `_security_problems`) routes both fields through the one shared `utils.positive_count_error` domain — the same domain the simulation's `n_episodes` / `max_steps` / `action_horizon` and the hardware loop's `action_horizon` already use — and the four duplicated comparisons are deleted. `_validate.run_size_problems` holds the rule; the message names the backend that refused the value (`lerobot_local: steps must be a positive integer, got 2.7.`).

**No new helper was needed** — the domain already existed and only the wiring was missing.

| | main | this PR |
|---|---|---|
| local `if spec.steps <= 0` copies in `strands_robots/training/` | 4 | 0 |
| `validate()` call sites of the one shared gate | 0 | 4 |
| the second factor (`global_batch_size`) checked by any backend | no | yes |
| unusable values let through (of 16 probed) | 12 | 0 |

### The RL trainers are deliberately off this path

`TrainSpec` documents that a backend "reads the fields it supports and **ignores the rest**". `FastSacTrainer` / `PpoTrainer` drive training from `total_timesteps` / `rollout_steps` / `batch_size` and never read `steps` or `global_batch_size` (`grep -n "spec.steps\|global_batch_size" strands_robots/training/rl/*.py` → no hits), so the gate is a separate function called by the four supervised backends rather than folded into `validate_train_inputs`, which the RL trainers also call. Reporting on a field they never read would be a false rejection of a value that has no effect on the run. Pinned in both directions.

### Message text

The five assertions that pinned `"steps must be > 0"` now pin `"steps must be a positive integer"`. That is part of the fix, not churn: `"steps must be > 0, got 2.7"` would be a false statement — `2.7` *is* greater than zero, and it is exactly the class of value that was slipping through. The RL trainers keep their own `total_timesteps must be > 0` wording for their own knobs; the two never appear in one problem list.

### Out of scope

`save_freq` is left alone: lerobot's `should_save_checkpoint` documents a non-positive value as "disables periodic saving (only the final checkpoint is written), mirroring how log_freq/eval_freq treat non-positive values", so it is a documented mode selector, not a degenerate run size.

## Tests

`tests/training/test_run_size_domain.py`, 130 tests, all four backends:

- every unusable value is reported, by every backend, with the field and the value in the message
- the problem names the backend that refused it
- a non-comparable value is a *problem*, not an exception (the `validate()` contract)
- a usable run size is untouched — `(10000, 32)`, `(1, 1)`, `(2, 4096)`
- an RL spec carrying `steps=0` / `global_batch_size=0` reports nothing for a field it never reads
- executable premises for the domain: `range(0, 2.7)` raises, `len(range(0, True)) == 1`, `DataLoader(batch_size=<each>)` raises
- **AST guard**: every concrete supervised `Trainer.validate()` calls the shared gate, and no module re-implements the comparison against a literal — plus a planted-copy meta-test so an empty result means clean sources, and a non-vacuity assertion that the scan really reached all four backends (scan root derived from `inspect.getfile(Trainer)`)

**Pre-fix proof** (call sites reverted to `upstream/main`, the new shared gate kept so the module still imports): **110 failed / 20 passed**. The 20 that pass are the over-reach controls (a usable run size, the RL boundary), the dependency premises, and the planted-copy meta-test — they are what stop the guard reaching too far. The five updated pins: **5 failed / 262 passed**. The AST guard's pre-fix failure names all four adrift backends:

```
AssertionError: validate() does not call _run_size_problems:
  {'cosmos3.py': ['Cosmos3Trainer'], 'groot.py': ['Gr00tTrainer'],
   'lerobot.py': ['LerobotTrainer'], 'mock.py': ['MockTrainer']}
AssertionError: run size compared against a literal instead of the shared gate:
  {'cosmos3.py': ['spec.steps <= 0'], 'groot.py': ['spec.steps <= 0'],
   'lerobot.py': ['spec.steps <= 0'], 'mock.py': ['spec.steps <= 0']}
```

## Gate

At `ed128b37`:

- `MUJOCO_GL=egl python -m pytest tests` → **19388 passed, 257 skipped, 0 failed** (568s)
- `ruff check strands_robots tests tests_integ` → clean
- `ruff format --check strands_robots tests tests_integ` → 1062 files already formatted
- `mypy strands_robots tests tests_integ` → `Success: no issues found in 1059 source files`
- `scripts/assemble_changelog.py --check` → OK; the five repo-wide root guards → 42 passed

Rebased onto `ed128b37` after #1936 and #1938 merged. Faithfulness: capturing `git diff upstream/main HEAD -- . ':!changelog.d'` before and after, the diff-of-diffs is **912 removed lines and 0 added**, every one belonging to `tools/lerobot_train.py`, `tools/pose_tool.py` and their two test files — i.e. only the phantom removals a stale merge base was showing. Zero lines in any file this PR owns changed.

## Artifact

No policy, sim, rendering, recording or asset behaviour changes, so the artifact is the measured verdict table rather than a rollout. Every cell comes from one script run in two trees (a `git worktree` at `upstream/main` and this branch); each dump records its own tree and the generator asserts every number it prints, including that the two halves came from different trees.

![run size domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/training-run-size/run_size_domain.png)

The measuring script and the figure generator are alongside it: [`measure_run_size.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/training-run-size/measure_run_size.py), [`make_artifact.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/training-run-size/make_artifact.py).
