### PR TITLE
fix(tools): robot_mesh bounds the two numeric options its command body cannot carry

### DIFF
--- a/changelog.d/1940-robot-mesh-numeric-option-domain.md
+++ b/changelog.d/1940-robot-mesh-numeric-option-domain.md
@@ -1,0 +1,25 @@
+### Fixed: `robot_mesh` bounds the two numeric options its command body cannot carry
+
+`robot_mesh`'s `duration` and `policy_port` ride inside the command body that
+`validate_command` inspects, so that validator already bounds them. `timeout`
+and `limit` never enter a command body and had no domain at all.
+
+`timeout` becomes a `threading.Event` wait, which returns immediately for `0`,
+a negative value or `nan` - so the tool reported `{"status": "timeout"}` under
+`status="success"` for a peer it never gave the chance to answer, having waited
+0.0s of the 30s a caller asked for. `stop`'s `min(timeout, 5.0)` cap did not
+help, because `min(nan, 5.0)` is `nan`. `inf` surfaced an `OverflowError` from
+the deadline arithmetic, `True` was a silent 1s budget, and a string or `None`
+reached a bare comparison; `None` blocked forever.
+
+`limit` is a slice index into the `inbox` buffer, and `inbox` is the action that
+pulls a peer's stream into an agent's context. `0`, `-5` and `nan` all selected
+the *whole* buffer rather than capping it, and `2.7` / `"50"` / `None` raised
+`TypeError` out of a dispatcher documented never to raise.
+
+Both are now checked against the shared domains - `timeout` against
+`positive_finite_number_error` (the same domain the ROS transports' `timeout`
+uses, being the same quantity consumed the same way) and `limit` against
+`positive_count_error` - before the human-in-the-loop approval gate, the
+rate-limit accounting and any transport call. Only the options an action reads
+are checked, so `peers` is never refused for a wait budget it does not consume.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -83,6 +83,28 @@ own "required" message rather than as an unusable value.
 needs no bound of its own - it clamps to each motor's declared range before
 encoding, so the mask only ever sees a value that fits.
 
+### A mesh wait budget is bounded where the command body cannot carry it
+
+`robot_mesh` takes four numeric options. `duration` and `policy_port` travel
+inside the command body that
+[`validate_command`](../security.md) inspects, so that validator already bounds
+them. `timeout` and `limit` never enter a command body, so they are bounded by
+the tool:
+
+| Option | Accepted | Why the floor is where it is |
+|--------|----------|------------------------------|
+| `timeout` | positive finite number | it becomes a `threading.Event` wait; `0`/negative/`nan` return from that wait immediately, so the tool reports `{"status": "timeout"}` for a peer it never gave the chance to answer, and `inf` overflows the deadline |
+| `limit` | positive integer | it is a slice index into the `inbox` buffer; a non-positive or `nan` value selected the *whole* buffer, and a fractional one raised out of the dispatcher |
+
+`stop` additionally caps `timeout` at 5s so a stop cannot hang, but the cap
+cannot replace the domain: `min(nan, 5.0)` is `nan`, so `nan` passed straight
+through it.
+
+The same scoping rule applies: `timeout` is read by `tell` / `send` / `rpc` /
+`broadcast` / `stop`, `limit` only by `inbox`, and the rest are never refused
+for either. `emergency_stop` fans out on a fixed internal budget, so the
+caller's `timeout` is not effective there.
+
 ## Examples
 
 ```python

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -46,6 +46,7 @@ from strands import tool
 from strands.types.tools import ToolContext
 
 from strands_robots.mesh import security as _security
+from strands_robots.utils import positive_count_error, positive_finite_number_error
 
 # Literal peer-id pattern for watch(target=...). Peer ids are an enumerable
 # surface (per AGENTS.md > Review Learnings (PR #92) > "Allowlist enumerable
@@ -441,6 +442,77 @@ def _ok(text: str) -> dict[str, Any]:
     return {"status": "success", "content": [{"text": text}]}
 
 
+# ── Numeric-option domain ──────────────────────────────────────────────────
+#
+# Which of the two numeric options each action actually consumes. Scoped per
+# action rather than validated unconditionally because a caller must never be
+# refused for a value the requested action never looks at: ``peers`` lists the
+# graph without a wait budget, and ``emergency_stop`` fans out on a fixed
+# internal budget rather than the caller's. An action absent from this table
+# reads neither option and is never refused here.
+#
+# ``duration`` and ``policy_port`` are deliberately absent: they travel inside
+# the command body that :func:`~strands_robots.mesh.security.validate_command`
+# inspects, which already bounds them (``duration`` to ``[0,
+# MAX_DURATION_S]``, ``policy_port`` to ``[1, 65535]``). ``timeout`` and
+# ``limit`` never enter a command body, so nothing on that path can see them.
+_ACTION_NUMERIC_OPTIONS: dict[str, tuple[str, ...]] = {
+    "tell": ("timeout",),
+    "send": ("timeout",),
+    "rpc": ("timeout",),
+    "broadcast": ("timeout",),
+    "stop": ("timeout",),
+    "inbox": ("limit",),
+}
+
+
+def _numeric_option_error(action: str, *, timeout: Any, limit: Any) -> str | None:
+    """Error text for the first numeric option *action* consumes but cannot honor.
+
+    ``timeout`` is a wait budget: every action that reads it hands it to a
+    :class:`threading.Event` wait (:meth:`strands_robots.mesh.core.Mesh.send`)
+    or to a Device Connect ``invoke``, and returns ``{"status": "timeout"}`` when
+    nothing arrived in time. Only a positive finite number can be honored, so it
+    is checked against
+    :func:`~strands_robots.utils.positive_finite_number_error` - the same domain
+    :mod:`~strands_robots.tools._numeric_options` applies to the ROS transports'
+    ``timeout``, which is the same quantity consumed the same way. A fractional
+    budget is perfectly usable, which is why the domain is the continuous one.
+
+    ``limit`` is the number of buffered messages ``inbox`` returns, consumed
+    directly as a slice index, so it is checked against
+    :func:`~strands_robots.utils.positive_count_error`: an integral float raises
+    ``TypeError`` from the slice rather than being coerced.
+
+    This tool keeps its own table and calls the two shared domains directly
+    rather than reusing
+    :func:`~strands_robots.tools._numeric_options.numeric_option_error`, whose
+    documented scope is the three tools that drive a ROS graph and whose options
+    are ``timeout`` / ``count`` / ``rate``. The domains are shared; only the
+    per-action scoping, a property of this tool's transports, is local.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        timeout: Seconds to wait for a response, as supplied.
+        limit: Max messages ``inbox`` returns, as supplied.
+
+    Returns:
+        An error message naming the tool, the action and the option, or ``None``
+        when every option this action reads is usable.
+    """
+    consumed = _ACTION_NUMERIC_OPTIONS.get(action, ())
+    context = f"robot_mesh {action}"
+    if "timeout" in consumed:
+        error = positive_finite_number_error(timeout, "timeout", context)
+        if error:
+            return error
+    if "limit" in consumed:
+        error = positive_count_error(limit, "limit", context)
+        if error:
+            return error
+    return None
+
+
 def _resolve_mesh(target: str) -> Any | None:
     """Return a local Mesh in this process to use as the gateway for RPC.
 
@@ -713,6 +785,9 @@ def _device_connect_dispatch(
         if action == "stop":
             if not target:
                 return _DCResult(_err("stop requires target"))
+            # A stop is capped at 5s so it cannot hang. This is a cap over an
+            # already-validated positive finite budget, not a guard: min() would
+            # pass nan straight through (min(nan, 5.0) is nan).
             result = conn.invoke(target, "stop", _with_identity({}), timeout=min(timeout, 5.0))
             r = result.get("result", result)
             _audit_tool_action(action, target, True, "")
@@ -788,9 +863,15 @@ def robot_mesh(
         policy_provider: Policy provider tag forwarded with ``tell``.
         policy_port: Optional policy port forwarded with ``tell``.
         duration: Task duration (seconds) forwarded with ``tell``.
-        timeout: Response timeout for RPC actions (seconds).
+        timeout: Response timeout for RPC actions (seconds). A positive finite
+            number; read by ``tell`` / ``send`` / ``rpc`` / ``broadcast`` /
+            ``stop`` and ignored by the rest. ``stop`` additionally caps it at
+            5s. Zero or negative would report ``{"status": "timeout"}`` without
+            waiting at all, so an unusable value is refused rather than reported
+            as a peer that did not answer.
         name: Optional subscription name for ``subscribe`` / ``inbox``.
-        limit: Max messages returned by ``inbox`` (default: 50).
+        limit: Max messages returned by ``inbox`` (default: 50). A positive
+            integer; read by ``inbox`` only.
         function: Device-native function name for ``rpc`` (e.g. ``nod``).
 
     Returns:
@@ -846,6 +927,16 @@ def robot_mesh(
     if rl_err is not None:
         _audit_tool_action(action, target, False, f"rate_limit: {rl_err}")
         return _err(rl_err)
+
+    # Reject a numeric option this action cannot honor before anything else -
+    # for the same reason the command-body pre-pass below runs early, and one
+    # step sooner because this check needs no parsing. A wait budget of ``nan``
+    # or a message ``limit`` of ``0`` must not burn an operator approval at the
+    # HITL gate, consume a rate-limit slot, or reach a transport.
+    num_err = _numeric_option_error(action, timeout=timeout, limit=limit)
+    if num_err is not None:
+        _audit_tool_action(action, target, False, f"validation: {num_err}")
+        return _err(num_err)
 
     # Parse + validate any command body BEFORE the HITL interrupt so
     # the operator never approves an action the validator then rejects
@@ -1136,6 +1227,8 @@ def robot_mesh(
             _audit_tool_action(action, target, False, "missing target")
             return _err("stop requires target")
         try:
+            # Capped at 5s so a stop cannot hang - a cap over an already-validated
+            # positive finite budget, not a guard (min(nan, 5.0) is nan).
             result = mesh.send(target, {"action": "stop"}, timeout=min(timeout, 5.0))
         except Exception as exc:  # noqa: BLE001
             _audit_tool_action(action, target, False, f"dispatch error: {type(exc).__name__}: {exc}")
@@ -1246,7 +1339,11 @@ def robot_mesh(
             # inbox access (agent read attempt), not just non-empty ones.
             _audit_tool_action(action, sub_name, True, "read=0")
             return _ok(f"[inbox '{sub_name}'] no messages")
-        head = msgs[-limit:] if limit > 0 else msgs
+        # ``limit`` is a validated positive int by here, so the tail slice is
+        # always the cap the caller asked for. The former ``if limit > 0 else
+        # msgs`` fallback returned the WHOLE buffer for a non-positive limit -
+        # the opposite of a cap - and is unreachable now.
+        head = msgs[-limit:]
         # Audit the read: which subscription, how many frames the agent
         # pulled into its context. Gives operators the "agent read N frames
         # from sub X at time T" trail that raw telemetry access otherwise

--- a/tests/mesh/test_robot_mesh_numeric_option_domain.py
+++ b/tests/mesh/test_robot_mesh_numeric_option_domain.py
@@ -1,0 +1,345 @@
+"""Numeric-option domain for the ``robot_mesh`` dispatcher.
+
+``robot_mesh`` exposes an agent four numeric options. Two of them travel inside
+the command body that :func:`strands_robots.mesh.security.validate_command`
+inspects, so that validator already bounds them: ``duration`` to
+``[0, MAX_DURATION_S]`` and ``policy_port`` to ``[1, 65535]``. The other two
+never enter a command body, so nothing on that path can see them:
+
+* ``timeout`` is a wait budget. Every action that reads it hands it to a
+  :class:`threading.Event` wait inside :meth:`strands_robots.mesh.core.Mesh.send`
+  (or to a Device Connect ``invoke``) and reports ``{"status": "timeout"}`` when
+  nothing arrived in time. A non-positive or ``nan`` budget makes that wait
+  return immediately, so the tool reports a peer that did not answer without
+  ever giving it the chance - and ``stop``'s ``min(timeout, 5.0)`` cap does not
+  help, because ``min(nan, 5.0)`` is ``nan``.
+* ``limit`` caps how many buffered messages ``inbox`` pulls into the agent's
+  context, consumed directly as a slice index. A non-positive or ``nan`` limit
+  used to select the whole buffer - the opposite of a cap - and a fractional one
+  raised ``TypeError`` from the slice, out of a dispatcher documented never to
+  raise.
+
+These tests pin both options against the shared domains
+(:func:`strands_robots.utils.positive_finite_number_error` for the continuous
+budget, :func:`strands_robots.utils.positive_count_error` for the discrete cap),
+pin the per-action scoping in both directions so an action is never refused for
+an option it does not read, and pin that a refusal precedes the operator
+approval gate, the rate-limit accounting and the transport.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_robots.tools.robot_mesh import (
+    _ACTION_NUMERIC_OPTIONS,
+    _reset_rate_limits,
+    robot_mesh,
+)
+from strands_robots.utils import positive_count_error, positive_finite_number_error
+
+#: Every action the tool advertises, from its own unknown-action message.
+ALL_ACTIONS = (
+    "peers",
+    "status",
+    "tell",
+    "send",
+    "rpc",
+    "broadcast",
+    "stop",
+    "emergency_stop",
+    "subscribe",
+    "unsubscribe",
+    "watch",
+    "inbox",
+)
+
+#: Actions that hand ``timeout`` to a wait, so an unusable value is refused.
+READS_TIMEOUT = ("tell", "send", "rpc", "broadcast", "stop")
+
+#: Wait budgets that cannot be honored. ``0`` / ``-1`` / ``nan`` make the wait
+#: return immediately (reported as a peer that did not answer), ``inf`` raises
+#: ``OverflowError`` from the deadline arithmetic, ``True`` is a silent 1s, and
+#: the non-numerics reach a bare comparison.
+UNUSABLE_TIMEOUTS: tuple[Any, ...] = (0, -1.0, float("nan"), float("inf"), True, "30", None, [30.0])
+
+#: Message caps that cannot be honored. ``0`` / ``-5`` / ``nan`` used to select
+#: the whole buffer; ``2.7`` and the non-numerics reached the slice or a bare
+#: comparison.
+UNUSABLE_LIMITS: tuple[Any, ...] = (0, -5, float("nan"), True, 2.7, "50", None)
+
+
+class RecordingMesh:
+    """Mesh stand-in that records the budget each call was handed.
+
+    Returns immediately rather than waiting, so these tests never sleep: the
+    contract under test is which value reaches the transport, not how long the
+    transport then blocks for.
+    """
+
+    def __init__(self) -> None:
+        self.peer_id = "local-a"
+        self.peer_type = "sim"
+        self.inbox: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+        self.calls: list[tuple[str, Any]] = []
+
+    def send(self, target: str, cmd: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
+        self.calls.append(("send", timeout))
+        return {"status": "ok"}
+
+    def broadcast(self, cmd: dict[str, Any], timeout: float = 5.0) -> list[dict[str, Any]]:
+        self.calls.append(("broadcast", timeout))
+        return []
+
+    def tell(self, target: str, instruction: str, **kw: Any) -> dict[str, Any]:
+        self.calls.append(("tell", kw))
+        return {"status": "ok"}
+
+    def emergency_stop(self) -> list[dict[str, Any]]:
+        self.calls.append(("emergency_stop", None))
+        return []
+
+    def unsubscribe(self, name: str) -> bool:
+        self.calls.append(("unsubscribe", name))
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rate_limits():
+    """Each accepted call consumes a per-action rate-limit slot; reset so the
+    cases stay independent of collection order."""
+    _reset_rate_limits()
+    yield
+    _reset_rate_limits()
+
+
+@pytest.fixture
+def mesh():
+    """A recording mesh installed as the only local peer."""
+    fake = RecordingMesh()
+    with (
+        patch("strands_robots.mesh.get_local_robots", return_value={"local-a": fake}),
+        patch("strands_robots.mesh.session.get_peers", return_value=[]),
+    ):
+        yield fake
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock(name="ToolContext")
+    ctx.interrupt.return_value = "y"
+    return ctx
+
+
+def _call(*, _ctx_obj: MagicMock | None = None, **kwargs: Any) -> dict[str, Any]:
+    """Invoke the underlying tool fn (Strands ``@tool`` wraps it as ``.original``)."""
+    fn = getattr(robot_mesh, "original", robot_mesh)
+    return fn(tool_context=_ctx_obj if _ctx_obj is not None else _ctx(), **kwargs)
+
+
+def _text(out: dict[str, Any]) -> str:
+    return str(out["content"][0]["text"])
+
+
+def _args_for(action: str) -> dict[str, Any]:
+    """The minimum arguments that carry *action* past its own presence checks."""
+    if action in ("tell",):
+        return {"target": "peer-b", "instruction": "pick up the cube"}
+    if action in ("send", "broadcast"):
+        return {"target": "peer-b", "command": '{"action": "status"}'}
+    if action == "rpc":
+        return {"target": "peer-b", "function": "nod"}
+    if action == "stop":
+        return {"target": "peer-b"}
+    if action == "inbox":
+        return {"name": "sub-x"}
+    if action == "unsubscribe":
+        return {"name": "sub-x"}
+    return {}
+
+
+class TestTimeoutIsAPositiveFiniteBudget:
+    """Every action that waits on ``timeout`` refuses a budget it cannot honor."""
+
+    @pytest.mark.parametrize("action", READS_TIMEOUT)
+    @pytest.mark.parametrize("value", UNUSABLE_TIMEOUTS, ids=repr)
+    def test_an_unusable_budget_is_refused(self, mesh, action, value):
+        out = _call(action=action, timeout=value, **_args_for(action))
+        assert out["status"] == "error", f"{action} accepted timeout={value!r}"
+        text = _text(out)
+        assert "timeout" in text
+        assert "robot_mesh" in text and action in text, f"message does not name the surface: {text}"
+
+    @pytest.mark.parametrize("action", READS_TIMEOUT)
+    def test_a_usable_budget_is_not_refused(self, mesh, action):
+        """Asserted as the absence of a budget refusal rather than as success:
+        ``rpc`` has no Zenoh-mesh equivalent and declines for that reason on a
+        host without Device Connect, which is not a verdict about the budget."""
+        out = _call(action=action, timeout=2.5, **_args_for(action))
+        assert "timeout must be" not in _text(out), _text(out)
+
+    @pytest.mark.parametrize("action", ["tell", "send", "broadcast", "stop"])
+    def test_a_usable_budget_reaches_the_transport(self, mesh, action):
+        out = _call(action=action, timeout=2.5, **_args_for(action))
+        assert out["status"] == "success", _text(out)
+        assert mesh.calls, f"{action} accepted the budget but made no transport call"
+
+    def test_a_fractional_budget_is_usable(self, mesh):
+        """The budget is a span of seconds, so 2.7s is a real request - the
+        domain constrains only the sign and the finiteness."""
+        out = _call(action="send", timeout=2.7, **_args_for("send"))
+        assert out["status"] == "success"
+        assert ("send", 2.7) in mesh.calls
+
+
+class TestLimitIsAPositiveCount:
+    """``inbox``'s cap is a count, consumed as a slice index."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_LIMITS, ids=repr)
+    def test_an_unusable_cap_is_refused(self, mesh, value):
+        mesh.inbox = {"sub-x": [("strands/peer/stream", {"step": i}) for i in range(120)]}
+        out = _call(action="inbox", name="sub-x", limit=value)
+        assert out["status"] == "error", f"inbox accepted limit={value!r}"
+        text = _text(out)
+        assert "limit" in text and "robot_mesh inbox" in text
+
+    def test_the_cap_bounds_what_reaches_the_agent_context(self, mesh):
+        """A usable cap returns exactly that many of the buffered messages.
+
+        Pinned as the count actually rendered rather than only the status,
+        because a non-positive cap used to report success while returning the
+        WHOLE buffer - the opposite of a cap, on the action that pulls another
+        peer's stream into the agent's context.
+        """
+        mesh.inbox = {"sub-x": [("strands/peer/stream", {"step": i}) for i in range(120)]}
+        out = _call(action="inbox", name="sub-x", limit=5)
+        assert out["status"] == "success"
+        text = _text(out)
+        assert "120 total, showing last 5" in text
+        assert text.count("strands/peer/stream") == 5
+
+
+class TestOnlyTheOptionsAnActionReadsAreRefused:
+    """A caller is never refused for a value the requested action ignores."""
+
+    @pytest.mark.parametrize("action", [a for a in ALL_ACTIONS if a not in READS_TIMEOUT])
+    def test_an_action_that_never_waits_ignores_the_budget(self, mesh, action):
+        out = _call(action=action, timeout=float("nan"), **_args_for(action))
+        assert "timeout must be" not in _text(out), f"{action} was refused for a budget it never reads"
+
+    def test_an_action_that_never_reads_the_cap_ignores_it(self, mesh):
+        out = _call(action="send", limit=0, **_args_for("send"))
+        assert out["status"] == "success", _text(out)
+
+    def test_emergency_stop_fans_out_on_its_own_budget(self, mesh):
+        """``emergency_stop`` uses a fixed internal budget, so the caller's
+        ``timeout`` is not effective and must not be refused."""
+        out = _call(action="emergency_stop", timeout=-1.0)
+        assert out["status"] == "success", _text(out)
+        assert ("emergency_stop", None) in mesh.calls
+
+
+class TestARefusedOptionReachesNothing:
+    """The refusal precedes the approval gate, the rate limit and the transport."""
+
+    def test_no_transport_call_is_made(self, mesh):
+        out = _call(action="stop", target="peer-b", timeout=float("nan"))
+        assert out["status"] == "error"
+        assert mesh.calls == [], f"a refused stop still reached the transport: {mesh.calls}"
+
+    def test_the_operator_is_not_asked_to_approve_it(self, mesh):
+        """``broadcast`` is human-in-the-loop gated. An option the action cannot
+        honor must not burn an operator approval on a call that never runs."""
+        ctx = _ctx()
+        out = _call(action="broadcast", command='{"action": "status"}', timeout=0, _ctx_obj=ctx)
+        assert out["status"] == "error"
+        ctx.interrupt.assert_not_called()
+
+    def test_it_does_not_consume_a_rate_limit_slot(self, mesh):
+        """``broadcast`` is capped at 10 calls/min. Refused calls must not spend
+        the budget, or a malformed argument would lock out a valid one."""
+        for _ in range(12):
+            out = _call(action="broadcast", command='{"action": "status"}', timeout=0)
+            assert out["status"] == "error"
+            assert "timeout must be" in _text(out), _text(out)
+        good = _call(action="broadcast", command='{"action": "status"}', timeout=2.5)
+        assert good["status"] == "success", _text(good)
+
+
+class TestTheStopCapIsACapNotAGuard:
+    """``stop`` caps the budget at 5s; the cap cannot stand in for the domain."""
+
+    def test_a_long_budget_is_capped(self, mesh):
+        out = _call(action="stop", target="peer-b", timeout=30.0)
+        assert out["status"] == "success"
+        assert ("send", 5.0) in mesh.calls, mesh.calls
+
+    def test_a_budget_below_the_cap_is_passed_through(self, mesh):
+        out = _call(action="stop", target="peer-b", timeout=2.5)
+        assert out["status"] == "success"
+        assert ("send", 2.5) in mesh.calls, mesh.calls
+
+    def test_the_cap_does_not_bound_a_non_finite_budget(self, mesh):
+        """``min(nan, 5.0)`` is ``nan``, so the cap passes it straight through -
+        which is why ``stop`` needs the domain and not only the cap."""
+        assert min(float("nan"), 5.0) != 5.0
+        out = _call(action="stop", target="peer-b", timeout=float("nan"))
+        assert out["status"] == "error"
+        assert mesh.calls == []
+
+
+class TestTheSharedDomainsAreTheOwner:
+    """The tool's verdict is the shared domain's verdict, not a local rule."""
+
+    @pytest.mark.parametrize("value", [*UNUSABLE_TIMEOUTS, 2.5, 30.0, 0.001, 1, 3600.0], ids=repr)
+    def test_a_budget_is_refused_exactly_when_the_shared_domain_refuses_it(self, mesh, value):
+        shared_refuses = positive_finite_number_error(value, "timeout", "robot_mesh send") is not None
+        out = _call(action="send", timeout=value, **_args_for("send"))
+        tool_refuses = out["status"] == "error"
+        assert tool_refuses is shared_refuses, f"verdicts differ for timeout={value!r}: {_text(out)}"
+
+    @pytest.mark.parametrize("value", [*UNUSABLE_LIMITS, 1, 5, 50, 1000], ids=repr)
+    def test_a_cap_is_refused_exactly_when_the_shared_domain_refuses_it(self, mesh, value):
+        mesh.inbox = {"sub-x": [("strands/peer/stream", {"step": i}) for i in range(120)]}
+        shared_refuses = positive_count_error(value, "limit", "robot_mesh inbox") is not None
+        out = _call(action="inbox", name="sub-x", limit=value)
+        tool_refuses = out["status"] == "error"
+        assert tool_refuses is shared_refuses, f"verdicts differ for limit={value!r}: {_text(out)}"
+
+
+class TestNumericOptionScopingDoesNotDrift:
+    """The per-action table must keep describing the actions the tool has."""
+
+    def test_every_scoped_action_is_a_real_action(self):
+        assert set(_ACTION_NUMERIC_OPTIONS) <= set(ALL_ACTIONS)
+
+    def test_the_table_scopes_exactly_the_actions_that_read_an_option(self):
+        assert {a for a, opts in _ACTION_NUMERIC_OPTIONS.items() if "timeout" in opts} == set(READS_TIMEOUT)
+        assert {a for a, opts in _ACTION_NUMERIC_OPTIONS.items() if "limit" in opts} == {"inbox"}
+
+    def test_only_the_two_options_the_wire_validator_cannot_see_are_scoped_here(self):
+        """``duration`` and ``policy_port`` ride inside the command body, so
+        ``validate_command`` owns them; duplicating them here would be a second
+        owner for one rule."""
+        scoped = {opt for opts in _ACTION_NUMERIC_OPTIONS.values() for opt in opts}
+        assert scoped == {"timeout", "limit"}
+
+    @pytest.mark.parametrize(
+        ("param", "value", "reason"),
+        [
+            ("duration", -1.0, "out of bounds"),
+            ("duration", float("nan"), "must be finite"),
+            ("duration", True, "must be a number"),
+            ("policy_port", 70000, "out of bounds"),
+            ("policy_port", float("nan"), "must be finite"),
+        ],
+    )
+    def test_the_wire_validator_really_bounds_the_other_two(self, mesh, param, value, reason):
+        """Non-vacuity for the test above: the reason ``duration`` and
+        ``policy_port`` are out of scope is that they are already refused."""
+        out = _call(action="tell", target="peer-b", instruction="go", **{param: value})
+        assert out["status"] == "error"
+        text = _text(out)
+        assert param in text and reason in text, text


### PR DESCRIPTION
## Problem

`robot_mesh` takes four numeric options. Two of them travel inside the command body that `validate_command` inspects, so that validator already bounds them: `duration` to `[0, MAX_DURATION_S]` and `policy_port` to `[1, 65535]`. `timeout` and `limit` never enter a command body, so nothing on that path can see them — and neither had a domain of its own.

Measured through the real tool, with one value set unusable for all four options:

| value | `duration` | `policy_port` | `timeout` | `limit` |
|---|---|---|---|---|
| `-1` | refused | refused | **accepted** | **accepted** |
| `nan` | refused | refused | **accepted** | **accepted** |
| `inf` | refused | refused | **accepted** | **raised** |
| `True` | refused | refused | **accepted** | **accepted** |
| `"30"` | refused | refused | **accepted** | **raised** |

`validate_command`'s two options: 0 of 10 cells unbounded. The tool's own two: 10 of 10.

### `timeout` is a wait budget

Every action that reads it hands it to a `threading.Event` wait inside `Mesh.send`, which then returns `{"status": "timeout"}` when nothing arrived. `Event.wait` returns **immediately** for `0`, a negative value and `nan` — so the tool reported a peer that did not answer, under `status="success"`, having waited `0.0s` of the 30 the caller asked for. That is a false verdict about a healthy peer, not a slow one.

`stop` caps the wait with `min(timeout, 5.0)` so a stop cannot hang, and the cap does not help: `min(nan, 5.0)` is `nan` and `min(True, 5.0)` is `True`. Measured budget reaching the transport on `action="stop"`:

| requested | on main | this change |
|---|---|---|
| `30.0` | `5.0` (capped) | `5.0` (unchanged) |
| `2.5` | `2.5` | `2.5` (unchanged) |
| `nan` | **`nan`** | refused, nothing sent |
| `True` | **`True`** | refused, nothing sent |
| `-1.0` | **`-1.0`** | refused, nothing sent |

The remaining values were loud but contextless: `inf` surfaced `OverflowError: timestamp out of range for platform time_t`, `"30"` and `[30.0]` a bare `'>' not supported between instances of 'str' and 'int'` naming neither the tool nor the option, and `None` **blocked forever**.

### `limit` is a slice index, and it inverted

`head = msgs[-limit:] if limit > 0 else msgs` — so a non-positive or `nan` cap took the `else` branch and selected the *whole* buffer. On a 120-message subscription:

| `limit` | on main | this change |
|---|---|---|
| `50` | 50 of 120 | 50 of 120 |
| `5` | 5 of 120 | 5 of 120 |
| `0` | **120 of 120** | refused |
| `-5` | **120 of 120** | refused |
| `nan` | **120 of 120** | refused |

`inbox` is the action that pulls a peer's stream into an agent's context — the tool's own `watch` guard says watching a peer's stream "exposes its observations and policy actions" — so the cap being inverted is what bounds that read. `2.7` / `"50"` / `None` raised `TypeError` straight out of a dispatcher whose contract is documented as "always returns a structured `{"status": "error"}` dict (it never raises out of the dispatcher)".

## Change

Both options are now checked against the existing shared domains, before anything else happens:

- `timeout` against `positive_finite_number_error`. This is the same domain `_numeric_options` already applies to the ROS transports' `timeout`, whose module docstring states the rule for exactly this quantity: "`timeout` is a wait budget. Only a positive finite value can be honored by any of them, so this module is the single owner of that rule." A fractional budget stays usable (`2.7` seconds is a real request), which is why the continuous domain is the right one.
- `limit` against `positive_count_error`, whose docstring already names its second family: values "consumed directly as `range()` bounds, **slice indices**, or an array / framebuffer dimension, where an integral float raises `TypeError` … rather than being coerced" — precisely what `limit=2.7` produced.

No new helper: the domains existed, only the wiring was missing. The tool keeps its own per-action table and calls the two domains directly rather than reusing `numeric_option_error`, whose documented scope is the three tools driving a ROS graph and whose options are `timeout` / `count` / `rate`; the *domains* are shared, only the per-action scoping — a property of this tool's transports — is local.

The guard runs immediately after the rate-limit **check** and before the command-body pre-pass, for the reason that pre-pass already documents: a value the action cannot honor must not burn an operator approval at the HITL gate, consume a rate-limit slot, or reach a transport. Refusals are audited like every other validation failure.

Only the options an action reads are checked. `timeout` is read by `tell` / `send` / `rpc` / `broadcast` / `stop`; `limit` only by `inbox`; `peers`, `status`, `subscribe`, `unsubscribe` and `watch` read neither, and `emergency_stop` fans out on a fixed internal budget, so none of them is refused for a value it ignores.

Two follow-through edits: the 5s `stop` cap stays but is now a cap over an already-validated value rather than a guard that never was one, and the `if limit > 0 else msgs` fallback is unreachable and gone.

## Artifact

![robot_mesh numeric-option verdict matrix, stop-path wire trace and inbox cap](https://raw.githubusercontent.com/cagataycali/robots/artifacts/robot-mesh-numeric-options/robot_mesh_numeric_options.png)

This change is transport-layer only — it touches no policy, simulation, rendering, recording or robot asset — so the artifact is a measured verdict matrix and wire trace rather than a rollout. Every cell comes from one script driving the real tool, run once in a worktree at `upstream/main` and once on this branch; each dump records the tree it resolved and the generator asserts the two differ, plus every number and denominator in the figure, before composing anything. The measurement script, both JSON dumps and the figure generator are published alongside the image.

## Tests

`tests/mesh/test_robot_mesh_numeric_option_domain.py`, 105 tests. Against `upstream/main`'s `robot_mesh.py`: **66 failed, 36 passed** — failures quoting the defect verbatim (`TypeError: slice indices must be integers or None or have an __index__ method`, `TypeError: '>' not supported between instances of 'str' and 'int'`). The 36 that pass are the over-reach controls, and they are the point: usable and fractional budgets, every action that ignores an option, the `stop` cap on a good value, and the non-vacuity check that `validate_command` really does bound the other two.

Beyond the per-value domain, it pins:

- the scoping in **both** directions, so a caller is never refused for an option the requested action does not read;
- that a refused option reaches nothing — no transport call recorded, `ctx.interrupt` never called on the HITL-gated `broadcast`, and 12 refused `broadcast` calls do not exhaust its 10/min budget for a valid one;
- that `stop`'s cap is a cap and not a guard, including the `min(nan, 5.0) != 5.0` premise it rests on;
- that the cap actually bounds what reaches the agent's context, asserted as the number of messages rendered rather than only the status;
- a two-way parity: the tool refuses a value **iff** the shared domain refuses it, so the two cannot drift;
- that the per-action table still describes the tool's real actions, and that exactly the two options `validate_command` cannot see are scoped here.

Zero existing tests changed.

## Gate

Rebased onto `0692a439`; `scripts/check_merge_base_overlap.py` reports no overlap at that tip.

- `ruff check strands_robots tests tests_integ` — clean
- `ruff format --check strands_robots tests tests_integ` — 1062 files already formatted
- `mypy strands_robots tests tests_integ` — 0 errors outside `examples/`; the 14 `examples/isaac_gs` errors are byte-identical to a pristine `upstream/main` checkout in the same working copy (`diff` of the two error sets is empty), i.e. environmental to this editable install
- `MUJOCO_GL=egl python -m pytest tests` — **19493 passed, 257 skipped, 0 failed** in 573.87s
- `python3 scripts/assemble_changelog.py --check` — OK; changelog fragment + docs guards pass

Docs: `docs/hardware/tools.md` gains a `robot_mesh` subsection in the same style as the `lerobot_teleoperate` and `serial_tool` ones already there, giving the accepted domain per option and why each floor is where it is.