### PR TITLE
fix(training): the optimizer learning rate is one shared positive-finite domain

### DIFF
--- a/changelog.d/1943-training-learning-rate-domain.md
+++ b/changelog.d/1943-training-learning-rate-domain.md
@@ -1,0 +1,28 @@
+### Fixed: the optimizer learning rate is one shared positive-finite domain across every training backend
+
+`TrainSpec.learning_rate` reaches every backend - the supervised three assign it
+to their config's optimizer field (LeRobot `policy.optimizer_lr`, GR00T
+`FinetuneConfig.learning_rate`, Cosmos `optimizer.lr`) and the RL trainers pass
+it straight to `torch.optim.Adam` - and no backend checked it, while each bounded
+its neighbours. `FastSacTrainer.validate` compares eight sibling numerics against
+literals and skipped the one that decides whether any of that work updates a
+weight; the supervised backends gate the two run-size factors and skipped it too.
+
+Both ends of the domain failed silently rather than loudly. `learning_rate=0`
+(and `False`) ran the full `steps` x `global_batch_size` of work and updated no
+weight, so the run reported success and wrote a checkpoint identical to its
+initialisation - the pathology the run-size gate exists to prevent, reached by a
+different route and at full cost. `inf` diverged on the first step and wrote a
+checkpoint of `NaN`, also under a successful result. `True` was honored as a
+silent learning rate of `1.0`. A negative or `nan` rate *was* refused, but by
+`torch.optim.Adam` only once the dataset and model were loaded, and a string or
+list reached the config as a field of the wrong type.
+
+`Trainer.validate` now reports an unusable rate through one shared
+`learning_rate_problems` gate, against the same
+`positive_finite_number_error` domain the rest of the library uses for a
+continuous knob, with a message naming the backend that refused it. `None`
+remains the documented "use the backend's own default" sentinel and every usable
+rate is untouched. An AST guard asserts that every concrete `Trainer` - including
+the two reached through `BaseRLAlgo` - routes through the shared gate rather than
+re-implementing the rule.

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -110,7 +110,10 @@ def train_policy(
         learning_rate: Optimizer learning rate. ``None`` (default) uses the
             backend's own default (the policy training preset for lerobot,
             GR00T's FinetuneConfig default, Cosmos's TOML default); an explicit
-            value is honored by every backend.
+            value must be a positive finite number and is honored by every
+            backend. ``0`` and ``inf`` are refused up front: the first trains
+            for the whole run without updating a weight, the second writes a
+            checkpoint of ``NaN``, and no backend reports either.
         save_freq: Checkpoint cadence in steps.
         num_gpus: GPUs on this node (``>1`` -> accelerate/torchrun multi-GPU).
         num_nodes: Nodes (Cosmos HSDP / torchrun ``--nnodes``).

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -25,6 +25,17 @@ backend "reads the fields it supports and ignores the rest": the RL trainers
 drive training from ``total_timesteps`` / ``batch_size`` and never read either
 field, so reporting a problem for them there would be a false rejection of a
 field that backend does not use.
+
+:func:`learning_rate_problems` is the third, on the optimization axis. It lives
+in its own gate for the opposite reason to :func:`run_size_problems`: *every*
+backend reads ``learning_rate`` -- the three supervised ones map it onto their
+config's optimizer field, and the RL trainers hand it straight to
+``torch.optim.Adam`` -- so there is no backend for which reporting on it would
+be a false rejection, and :class:`~strands_robots.training.rl.base_algo.RLTrainSpec`
+documents the field as one of the "universal" ones. It is separate from
+:func:`validate_train_inputs` because that gate answers a different question
+(is this value safe to interpolate into a config or an argv token) from this one
+(can this value be honored at all).
 """
 
 from __future__ import annotations
@@ -33,7 +44,7 @@ import re
 from typing import TYPE_CHECKING
 
 from strands_robots.tools._path_validation import validate_save_path
-from strands_robots.utils import positive_count_error
+from strands_robots.utils import positive_count_error, positive_finite_number_error
 
 if TYPE_CHECKING:
     from strands_robots.training.base import TrainSpec
@@ -126,3 +137,57 @@ def run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
         if error is not None:
             problems.append(error)
     return problems
+
+
+def learning_rate_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return optimizer learning-rate problems for a :class:`TrainSpec`.
+
+    ``learning_rate`` is the one numeric on a :class:`TrainSpec` that decides
+    whether a run *learns* rather than how much work it does, and every backend
+    reads it: the supervised three assign it to their config's optimizer field
+    (LeRobot ``policy.optimizer_lr``, GR00T ``FinetuneConfig.learning_rate``,
+    Cosmos ``optimizer.lr``) and the RL trainers pass it directly to
+    ``torch.optim.Adam(..., lr=...)``.
+
+    Only a positive finite value can be honored, and the two ends of the domain
+    fail *silently* rather than loudly, which is why this is a preflight rather
+    than something the backend can be left to notice:
+
+    * ``0`` (and ``False``, which is ``0`` to every consumer) runs the full
+      ``steps`` x ``global_batch_size`` of work and updates no weight, so the
+      run reports success and writes a checkpoint identical to its
+      initialisation. That is the pathology :func:`run_size_problems` exists to
+      prevent, reached by a different route and at full cost.
+    * ``inf`` diverges on the first optimizer step, so the checkpoint is all
+      ``NaN`` -- again under a successful result.
+    * ``True`` is a silent learning rate of ``1.0``, four orders of magnitude
+      above a typical fine-tuning preset.
+
+    A negative or ``nan`` value *is* refused by ``torch.optim.Adam``
+    (``ValueError: Invalid learning rate``), but only once the dataset and model
+    are already loaded -- after the point :meth:`Trainer.validate` documents
+    itself as running before ("it powers a ``plan`` advisor that runs *before*
+    anything expensive starts").
+
+    ``None`` is the documented sentinel for "use the backend's own default" and
+    is therefore not a problem. It is checked against the shared
+    :func:`~strands_robots.utils.positive_finite_number_error` domain rather
+    than a local comparison because a bare ``value <= 0`` test admits ``nan``
+    (every comparison against it is ``False``), admits a ``bool``, and raises
+    out of the comparison itself for a non-numeric value -- inside a method
+    documented to *return* problems.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single problem when ``learning_rate`` is supplied and unusable;
+        empty when it is usable or left at ``None``.
+    """
+    if spec.learning_rate is None:
+        return []
+    error = positive_finite_number_error(spec.learning_rate, "learning_rate", context)
+    return [error] if error is not None else []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -87,7 +87,11 @@ class TrainSpec:
             ``policy.optimizer_lr`` and rejects it loudly if the policy has no
             such field. RL trainers (PPO/FastSAC) have no preset to defer to,
             so :class:`~strands_robots.training.rl.base_algo.RLTrainSpec`
-            overrides this default with a concrete value.
+            overrides this default with a concrete value. An explicit value
+            must be a positive finite number: ``0`` trains for the full run
+            without updating a weight and ``inf`` writes a checkpoint of
+            ``NaN``, neither of which any backend can report, so both are
+            refused by :meth:`Trainer.validate` before a run starts.
         save_freq: Checkpoint cadence in steps.
         num_gpus: GPUs on this node. ``>1`` runs the backend under torch's
             in-process ``elastic_launch`` (the engine behind ``torchrun``).
@@ -261,6 +265,30 @@ class Trainer(ABC):
         from strands_robots.training._validate import run_size_problems
 
         return run_size_problems(spec, context=self.provider_name)
+
+    def _learning_rate_problems(self, spec: TrainSpec) -> list[str]:
+        """Learning-rate preflight shared by EVERY backend.
+
+        Returns a problem when :attr:`TrainSpec.learning_rate` is supplied and
+        is not a usable positive finite number, against the one shared
+        continuous domain. Unlike :meth:`_run_size_problems` there is no
+        backend that may skip this: the supervised backends assign the value to
+        their config's optimizer field and the RL trainers pass it to
+        ``torch.optim.Adam``, so every concrete :meth:`validate` MUST call it.
+
+        Checking it here rather than leaving it to the optimizer matters
+        because the silent ends of the domain never reach an exception: ``0``
+        does the full run and updates nothing, and ``inf`` writes a checkpoint
+        of ``NaN`` - both under a successful result. The values the optimizer
+        *does* reject only reach it after the dataset and model are loaded,
+        which is what this preflight exists to precede.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import learning_rate_problems
+
+        return learning_rate_problems(spec, context=self.provider_name)
 
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -155,6 +155,7 @@ class Cosmos3Trainer(Trainer):
                 f"unsupported method '{spec.method}' for Cosmos3 (expected one of {sorted(_SUPPORTED_METHODS)})"
             )
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._learning_rate_problems(spec))
 
         if not spec.extra.get("sft_toml"):
             problems.append(

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -154,6 +154,7 @@ class Gr00tTrainer(Trainer):
                 f"use tune={{...}} for fine-grained control"
             )
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._learning_rate_problems(spec))
 
         if spec.num_nodes > 1:
             problems.append(

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -594,6 +594,7 @@ class LerobotTrainer(Trainer):
             problems.extend(self._validate_policy(spec))
 
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._learning_rate_problems(spec))
 
         if spec.num_nodes > 1:
             problems.append(

--- a/strands_robots/training/mock.py
+++ b/strands_robots/training/mock.py
@@ -50,6 +50,7 @@ class MockTrainer(Trainer):
             problems.append("lora and expert_only are mutually exclusive")
 
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._learning_rate_problems(spec))
 
         return problems
 

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -130,6 +130,7 @@ class FastSacTrainer(BaseRLAlgo):
     def validate(self, spec: TrainSpec) -> list[str]:
         """Preflight an :class:`RLTrainSpec` for a FastSAC run (pure / read-only)."""
         problems = self._security_problems(spec)
+        problems.extend(self._learning_rate_problems(spec))
         if not isinstance(spec, RLTrainSpec):
             problems.append(f"fast_sac requires an RLTrainSpec, got {type(spec).__name__}")
             return problems

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -141,6 +141,7 @@ class PpoTrainer(BaseRLAlgo):
     def validate(self, spec: TrainSpec) -> list[str]:
         """Preflight an :class:`RLTrainSpec` for a PPO run (pure / read-only)."""
         problems = self._security_problems(spec)
+        problems.extend(self._learning_rate_problems(spec))
         if not isinstance(spec, RLTrainSpec):
             problems.append(f"ppo requires an RLTrainSpec, got {type(spec).__name__}")
             return problems

--- a/tests/training/test_learning_rate_domain.py
+++ b/tests/training/test_learning_rate_domain.py
@@ -1,0 +1,377 @@
+"""The optimizer learning rate is one shared positive-finite domain.
+
+:attr:`~strands_robots.training.base.TrainSpec.learning_rate` is the one
+numeric on a spec that decides whether a run *learns* rather than how much work
+it does, and unlike the run-size fields **every** backend reads it: the three
+supervised trainers assign it to their config's optimizer field (LeRobot
+``policy.optimizer_lr``, GR00T ``FinetuneConfig.learning_rate``, Cosmos
+``optimizer.lr``) and the RL trainers pass it straight to
+``torch.optim.Adam(..., lr=...)``. ``rl/base_algo.py`` calls it one of the
+"universal" spec fields.
+
+Before this contract no backend checked it, while each bounded its neighbours:
+``FastSacTrainer.validate`` compares eight sibling numerics against literals
+(``total_timesteps``, ``rollout_steps``, ``num_envs``, ``buffer_size``,
+``batch_size``, ``gradient_steps``, ``tau``, ``learning_starts``) and skipped
+the one that decides whether any of that work updates a weight, and the
+supervised backends gate the two run-size factors and skipped it too.
+
+The two ends of the domain fail *silently*, which is why this is a preflight
+rather than something a backend can be left to notice:
+
+* ``0`` (and ``False``) runs the full ``steps`` x ``global_batch_size`` of work
+  and updates no weight - the checkpoint equals the initialisation and the run
+  reports success. That is the pathology the run-size gate exists to prevent,
+  reached by a different route and at full cost.
+* ``inf`` diverges on the first step, so the checkpoint is all ``NaN``, again
+  under a successful result.
+* ``True`` is a silent learning rate of ``1.0``.
+
+A negative or ``nan`` value *is* refused - by ``torch.optim.Adam`` itself - but
+only once the dataset and model are loaded, past the point
+:meth:`Trainer.validate` documents itself as running before.
+
+The tests below pin the contract in both directions: every backend refuses the
+same unusable values through the one shared domain with a message naming itself,
+a usable rate and the documented ``None`` sentinel are untouched, and the
+refused values are grounded in what a real optimizer does with them.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.training._validate import learning_rate_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+from strands_robots.training.groot import Gr00tTrainer
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.training.mock import MockTrainer
+
+# Values no backend can honor, split by how each one failed before the gate.
+
+# Ran the whole schedule and updated nothing, under a successful result.
+SILENT_NO_OP = (0, 0.0, False)
+
+# Completed and wrote a checkpoint of NaN, also under a successful result.
+SILENT_DIVERGENCE = (float("inf"),)
+
+# Honored as 1.0 - four orders of magnitude above a fine-tuning preset.
+SILENT_MISREAD = (True,)
+
+# Refused by the optimizer, but only after the dataset and model were loaded.
+LOUD_BUT_LATE = (-1e-3, float("nan"))
+
+# Never reached an optimizer at all: a config field of the wrong type.
+NOT_A_NUMBER = ("1e-4", [1e-4], {"lr": 1e-4})
+
+UNUSABLE = SILENT_NO_OP + SILENT_DIVERGENCE + SILENT_MISREAD + LOUD_BUT_LATE + NOT_A_NUMBER
+
+SUPERVISED_TRAINERS = (MockTrainer, Cosmos3Trainer, Gr00tTrainer, LerobotTrainer)
+RL_TRAINER_NAMES = ("FastSacTrainer", "PpoTrainer")
+ALL_TRAINER_NAMES = tuple(t.__name__ for t in SUPERVISED_TRAINERS) + RL_TRAINER_NAMES
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path) -> TrainSpec:
+    """A spec whose other fields are all fine, so only the rate varies."""
+    root = tmp_path / "ds"
+    (root / "meta").mkdir(parents=True)
+    (root / "meta" / "info.json").write_text(json.dumps({"total_episodes": 10, "fps": 30}))
+    out = tmp_path / "out"
+    out.mkdir()
+    return TrainSpec(
+        dataset_root=str(root),
+        base_model="lerobot/act",
+        output_dir=str(out),
+        embodiment="so101",
+    )
+
+
+def _rl_trainers() -> list[Trainer]:
+    """The two RL trainers, which read the rate straight into ``Adam``."""
+    pytest.importorskip("torch")
+    from strands_robots.training.rl.fast_sac import FastSacTrainer
+    from strands_robots.training.rl.ppo import PpoTrainer
+
+    return [FastSacTrainer(), PpoTrainer()]
+
+
+def _rl_spec(tmp_path: pathlib.Path, rate: Any) -> Any:
+    """An otherwise-valid RL spec carrying ``rate``."""
+    pytest.importorskip("torch")
+    from strands_robots.training.rl.base_algo import RLTrainSpec
+
+    spec = RLTrainSpec(
+        output_dir=str(tmp_path),
+        env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+    )
+    spec.learning_rate = rate
+    return spec
+
+
+class TestEveryBackendRefusesAnUnusableLearningRate:
+    """One domain, six backends, one verdict per value."""
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_a_supervised_backend_reports_it(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.learning_rate = value
+        problems = trainer_cls().validate(spec)
+        named = [p for p in problems if "learning_rate" in p]
+        assert named, f"{trainer_cls.__name__} accepted learning_rate={value!r}: {problems}"
+        assert "must be > 0" in named[0], named[0]
+        assert repr(value) in named[0], named[0]
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_an_rl_backend_reports_it(self, tmp_path: pathlib.Path, value: Any) -> None:
+        for trainer in _rl_trainers():
+            problems = trainer.validate(_rl_spec(tmp_path, value))
+            named = [p for p in problems if "learning_rate" in p]
+            assert named, f"{trainer.provider_name} accepted learning_rate={value!r}: {problems}"
+            assert "must be > 0" in named[0], named[0]
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        """A shared domain must still say which backend rejected the spec."""
+        trainer = trainer_cls()
+        spec.learning_rate = 0
+        named = [p for p in trainer.validate(spec) if "learning_rate" in p]
+        assert named and named[0].startswith(f"{trainer.provider_name}: "), named
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    @pytest.mark.parametrize("value", NOT_A_NUMBER)
+    def test_a_non_numeric_rate_is_a_problem_not_an_exception(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any
+    ) -> None:
+        """``validate`` returns problems - it must not raise on a bad type."""
+        spec.learning_rate = value
+        problems = trainer_cls().validate(spec)
+        assert isinstance(problems, list)
+        assert any("learning_rate" in p for p in problems), problems
+
+
+class TestAUsableLearningRateIsUntouched:
+    """The change is additive: nothing honorable becomes a problem."""
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    @pytest.mark.parametrize("value", [1e-5, 1e-4, 3e-4, 0.1, 1.0])
+    def test_a_usable_rate_raises_no_learning_rate_problem(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], value: float
+    ) -> None:
+        spec.learning_rate = value
+        assert not [p for p in trainer_cls().validate(spec) if "learning_rate" in p]
+
+    @pytest.mark.parametrize("trainer_cls", SUPERVISED_TRAINERS)
+    def test_the_none_sentinel_is_not_a_problem(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        """``None`` is the documented "use the backend's own default" spelling."""
+        spec.learning_rate = None
+        assert not [p for p in trainer_cls().validate(spec) if "learning_rate" in p]
+
+    def test_an_rl_spec_at_its_own_default_is_not_a_problem(self, tmp_path: pathlib.Path) -> None:
+        """``RLTrainSpec`` pins a concrete rate instead of the sentinel."""
+        pytest.importorskip("torch")
+        from strands_robots.training.rl.base_algo import RLTrainSpec
+
+        spec = RLTrainSpec(
+            output_dir=str(tmp_path),
+            env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+        )
+        assert spec.learning_rate > 0
+        for trainer in _rl_trainers():
+            assert not [p for p in trainer.validate(spec) if "learning_rate" in p]
+
+
+class TestTheRefusedValuesAreOnesTheConsumerCannotHonor:
+    """Ground the domain in what a real optimizer does with each value."""
+
+    @staticmethod
+    def _run(rate: Any, steps: int = 20) -> tuple[float, bool]:
+        """Train a 1-layer model for ``steps`` - returns (max weight delta, any NaN)."""
+        import torch
+
+        torch.manual_seed(0)
+        model = torch.nn.Linear(4, 1)
+        before = model.weight.detach().clone()
+        optimizer = torch.optim.Adam(model.parameters(), lr=rate)
+        inputs, targets = torch.randn(8, 4), torch.randn(8, 1)
+        for _ in range(steps):
+            optimizer.zero_grad()
+            torch.nn.functional.mse_loss(model(inputs), targets).backward()
+            optimizer.step()
+        after = model.weight.detach()
+        return float((after - before).abs().max()), bool(torch.isnan(after).any())
+
+    @pytest.mark.parametrize("value", SILENT_NO_OP)
+    def test_a_zero_rate_completes_the_run_and_updates_nothing(self, value: Any) -> None:
+        pytest.importorskip("torch")
+        delta, has_nan = self._run(value)
+        assert delta == 0.0, f"lr={value!r} moved the weights by {delta}"
+        assert not has_nan
+
+    def test_a_usable_rate_does_move_the_weights(self) -> None:
+        """Non-vacuity: the probe can tell learning from no learning."""
+        pytest.importorskip("torch")
+        delta, has_nan = self._run(1e-3)
+        assert delta > 0.0
+        assert not has_nan
+
+    @pytest.mark.parametrize("value", SILENT_DIVERGENCE)
+    def test_an_infinite_rate_completes_the_run_with_nan_weights(self, value: Any) -> None:
+        pytest.importorskip("torch")
+        _, has_nan = self._run(value)
+        assert has_nan, f"lr={value!r} was expected to diverge"
+
+    @pytest.mark.parametrize("value", SILENT_MISREAD)
+    def test_a_boolean_rate_is_read_as_one(self, value: Any) -> None:
+        pytest.importorskip("torch")
+        assert self._run(value)[0] == pytest.approx(self._run(1.0)[0])
+
+    @pytest.mark.parametrize("value", LOUD_BUT_LATE)
+    def test_a_negative_or_nan_rate_is_refused_by_the_optimizer(self, value: Any) -> None:
+        """Refused, but only once a model exists to build an optimizer over."""
+        torch = pytest.importorskip("torch")
+        with pytest.raises(ValueError, match="[Ll]earning rate"):
+            torch.optim.Adam(torch.nn.Linear(2, 1).parameters(), lr=value)
+
+    def test_the_backend_config_layer_does_not_catch_it_either(self) -> None:
+        """lerobot's own optimizer config accepts every unusable rate."""
+        pytest.importorskip("lerobot")
+        from lerobot.optim.optimizers import AdamWConfig
+
+        for value in (0.0, -1e-3, float("nan"), float("inf")):
+            assert AdamWConfig(lr=value).lr == value or value != value
+
+
+def _trainer_sources() -> dict[str, str]:
+    """``filename -> source`` for every backend module in the tree."""
+    return {p.name: p.read_text() for p in _trainer_modules()}
+
+
+def _trainer_modules() -> list[pathlib.Path]:
+    """Every backend module, INCLUDING the ``rl`` subpackage.
+
+    Rooted at the module that defines :class:`Trainer` so the scan cannot
+    silently point at the wrong tree. The rl subpackage is in scope here
+    (unlike for the run-size gate) precisely because there is no backend that
+    may skip this rule.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py")
+
+
+def _trainer_class_defs(sources: dict[str, str]) -> dict[str, ast.ClassDef]:
+    """Every class in the backend tree that descends from :class:`Trainer`.
+
+    The base chain is followed to a fixpoint rather than matched against one
+    name: the RL trainers reach :class:`Trainer` through ``BaseRLAlgo``, so a
+    scanner keyed on ``class X(Trainer)`` alone would silently skip the two
+    backends that hand the rate straight to ``torch.optim.Adam``.
+    """
+    classes: dict[str, ast.ClassDef] = {}
+    for source in sources.values():
+        for node in ast.parse(source).body:
+            if isinstance(node, ast.ClassDef):
+                classes[node.name] = node
+
+    descendants = {"Trainer"}
+    grew = True
+    while grew:
+        grew = False
+        for name, node in classes.items():
+            if name in descendants:
+                continue
+            if any(isinstance(b, ast.Name) and b.id in descendants for b in node.bases):
+                descendants.add(name)
+                grew = True
+    return {n: c for n, c in classes.items() if n in descendants - {"Trainer"}}
+
+
+def _concrete_trainer_validators(sources: dict[str, str]) -> dict[str, ast.FunctionDef]:
+    """Map ``ClassName -> its validate() node`` for each concrete backend.
+
+    A class that does not define ``validate`` of its own (the abstract
+    ``BaseRLAlgo``) has no gate to call and is not a backend.
+    """
+    found: dict[str, ast.FunctionDef] = {}
+    for name, node in _trainer_class_defs(sources).items():
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef) and item.name == "validate":
+                found[name] = item
+    return found
+
+
+def _calls_learning_rate_gate(fn: ast.FunctionDef) -> bool:
+    return any(
+        isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "_learning_rate_problems"
+        for n in ast.walk(fn)
+    )
+
+
+def _local_learning_rate_comparisons(source: str) -> list[str]:
+    """Comparisons of ``learning_rate`` against a numeric literal.
+
+    That is the shape of a re-implemented domain (``if spec.learning_rate <= 0``).
+    """
+    hits: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        left = node.left
+        if not (isinstance(left, ast.Attribute) and left.attr == "learning_rate"):
+            continue
+        if any(isinstance(c, ast.Constant) and isinstance(c.value, (int, float)) for c in node.comparators):
+            hits.append(ast.unparse(node))
+    return hits
+
+
+class TestOneOwnerForTheLearningRateDomain:
+    """A seventh backend cannot ship without the rule."""
+
+    def test_every_backend_routes_through_the_shared_gate(self) -> None:
+        validators = _concrete_trainer_validators(_trainer_sources())
+        adrift = sorted(n for n, fn in validators.items() if not _calls_learning_rate_gate(fn))
+        assert not adrift, f"validate() does not call _learning_rate_problems: {adrift}"
+        # Non-vacuity: the scan really reached every backend, not an empty tree.
+        assert set(validators) == set(ALL_TRAINER_NAMES), sorted(validators)
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        copies = {p.name: hits for p in _trainer_modules() if (hits := _local_learning_rate_comparisons(p.read_text()))}
+        assert not copies, f"learning_rate compared against a literal instead of the shared gate: {copies}"
+
+    def test_the_scanners_detect_a_planted_copy(self) -> None:
+        """An empty result must mean clean sources, not a scanner matching nothing."""
+        planted = (
+            "class RogueTrainer(Trainer):\n"
+            "    def validate(self, spec):\n"
+            "        problems = []\n"
+            "        if spec.learning_rate <= 0:\n"
+            "            problems.append('bad')\n"
+            "        return problems\n"
+        )
+        validators = _concrete_trainer_validators({"planted.py": planted})
+        assert set(validators) == {"RogueTrainer"}
+        assert not _calls_learning_rate_gate(validators["RogueTrainer"])
+        assert _local_learning_rate_comparisons(planted) == ["spec.learning_rate <= 0"]
+
+
+class TestTheGateIsUsableOnItsOwn:
+    """The shared gate is a plain function - the trainers only bind a context."""
+
+    def test_it_reports_the_context_it_was_given(self, spec: TrainSpec) -> None:
+        spec.learning_rate = 0
+        problems = learning_rate_problems(spec, context="probe")
+        assert len(problems) == 1
+        assert problems[0].startswith("probe: ")
+
+    def test_a_usable_spec_reports_nothing(self, spec: TrainSpec) -> None:
+        spec.learning_rate = 1e-4
+        assert learning_rate_problems(spec, context="probe") == []
+        spec.learning_rate = None
+        assert learning_rate_problems(spec, context="probe") == []


### PR DESCRIPTION
## Problem

`TrainSpec.learning_rate` is the one numeric on a spec that decides whether a run *learns* rather than how much work it does, and **every** backend reads it: the three supervised trainers assign it to their config's optimizer field (LeRobot `policy.optimizer_lr`, GR00T `FinetuneConfig.learning_rate`, Cosmos `optimizer.lr`) and the RL trainers pass it straight to `torch.optim.Adam(..., lr=...)`. `rl/base_algo.py` calls it one of the "universal" spec fields.

No backend checked it, while each bounded its neighbours. `FastSacTrainer.validate` compares **eight** sibling numerics against literals -- `total_timesteps`, `rollout_steps`, `num_envs`, `buffer_size`, `batch_size`, `gradient_steps`, `tau`, `learning_starts` -- and skipped the one that decides whether any of that work updates a weight. On the supervised side `_run_size_problems` gates the two run-size factors and skipped it too.

Measured across all six backends: **54 of 54** unusable value/backend pairs were accepted by `Trainer.validate`.

## What each accepted value does

Measured with a real 40-step Adam run (torch 2.11.0):

| `learning_rate` | outcome | how it fails |
| --- | --- | --- |
| `0` / `0.0` / `False` | run completes, `max|dW| = 0.0`, loss `1.1968 -> 1.1968` | **silent**: the full `steps` x `global_batch_size` of work, and the checkpoint *is* the initialisation |
| `inf` | run completes, every weight `NaN` | **silent**: a checkpoint of `NaN` under a successful result |
| `True` | honored as `1.0` -- 10,000x a typical fine-tuning preset | **silent** |
| `-1e-3`, `nan` | `ValueError: Invalid learning rate` | loud, but only once the dataset and model are loaded |
| `'1e-4'`, `[1e-4]`, `{...}` | reaches the config as a field of the wrong type | -- |

The first row is the pathology `run_size_problems` exists to prevent, reached by a different route and at full cost. The fourth is refused past the point `Trainer.validate` documents itself as running before ("it powers a `plan` advisor that runs *before* anything expensive starts"). Neither lerobot's own `AdamWConfig` nor any backend config catches any of it -- `AdamWConfig(lr=nan)` is accepted verbatim.

## The change

One shared gate, `learning_rate_problems`, on the same `positive_finite_number_error` domain the library already uses for every continuous knob, bound by `Trainer._learning_rate_problems` so a problem names the backend that refused it:

```
lerobot_local: learning_rate must be > 0, got 0.
```

It is a separate gate from `run_size_problems` for the *opposite* reason that one is separate from `validate_train_inputs`: no backend ignores `learning_rate`, so there is none for which reporting on it would be a false rejection. It is separate from `validate_train_inputs` because that gate answers a different question (is this value safe to interpolate into a config or argv token) from this one (can it be honored at all). `_validate.py`'s module docstring already states that criterion; this follows it.

`None` remains the documented "use the backend's own default" sentinel and is not a problem. Every usable rate is untouched -- **zero existing tests changed**.

## Artifact

![learning-rate domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/lr-domain/lr_domain.png)

Top: what each rate does to a real run (a property of the optimizer, identical on both trees). Bottom: `Trainer.validate`'s verdict per backend, before and after -- a cell is green when the verdict matches the contract, so the usable rate must be *accepted* and every other row *refused*.

Both halves were measured by one script run in a `git worktree` at `0692a439` and on the branch; the generator asserts every number in the figure against the two dumps (including that they came from different trees) before saving. Dumps and provenance: [`artifacts/lr-domain`](https://github.com/cagataycali/robots/tree/artifacts/lr-domain).

No policy, sim, rendering, recording or asset behaviour changes, so the artifact is a measured consequence + verdict matrix rather than a rollout.

## Tests

`tests/training/test_learning_rate_domain.py`, 105 tests:

- every backend refuses each unusable value, with a message naming itself; a non-numeric value is a *problem*, not an exception
- a usable rate and the `None` sentinel are untouched, and an `RLTrainSpec` at its own default is fine (no false rejection)
- the refused values are grounded in what a real optimizer does with them -- `0` completes and moves nothing, `1e-3` does move the weights (non-vacuity), `inf` yields `NaN`, `True` equals `1.0`, and `-1e-3`/`nan` are refused only at optimizer construction. One test pins that lerobot's own config layer does not catch them either.
- an AST guard: every concrete `Trainer` routes through the shared gate and none re-implements it, with a planted-copy meta-test and a non-vacuity assertion on the discovered class set

The guard follows the `Trainer` base chain to a fixpoint rather than matching `class X(Trainer)`: the RL trainers reach `Trainer` through `BaseRLAlgo`, so a name-keyed scanner would silently skip the two backends that hand the rate straight to Adam. It scans the `rl` subpackage too -- in scope here, unlike for the run-size gate, precisely because no backend may skip this rule.

**Pre-fix** (call sites reverted to `upstream/main`, shared gate kept so the module imports): **67 failed / 38 passed**, the guard naming every backend:

```
validate() does not call _learning_rate_problems:
  ['Cosmos3Trainer', 'FastSacTrainer', 'Gr00tTrainer',
   'LerobotTrainer', 'MockTrainer', 'PpoTrainer']
```

The 38 that pass pre-fix are the accepted-value controls, the optimizer-premise measurements and the standalone-gate tests -- they are what stop the guard over-reaching.

## Gate

- `ruff check` + `ruff format --check strands_robots tests tests_integ` clean (1063 files)
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1060 source files`
- `MUJOCO_GL=egl pytest tests`: **19492 passed / 257 skipped** in 720s.
  One unrelated flake, `tests/simulation/test_policy_runner.py::test_run_policy_video_writes_mp4`, hit the 120s pytest-timeout while the host was loaded by a concurrent job; it passes in ~3s on re-run (twice) and this change touches no file under `simulation/`.
- `scripts/check_merge_base_overlap.py`: no overlap with `upstream/main`
- `scripts/assemble_changelog.py --check`: OK

## Out of scope

- `save_freq` -- lerobot documents a non-positive value as a *mode selector* (`should_save_checkpoint`: "disables periodic saving ... mirroring how log_freq/eval_freq treat non-positive values"), so it is a documented capability rather than a degenerate size.
- `num_gpus` / `num_nodes` -- Cosmos clamps both with `max(1, ...)`, so `0` and negatives silently become 1. A real gap, but a different axis (a resource count with a per-backend meaning) and worth its own change.
- `RLTrainSpec` declares `learning_rate` as `float` with a concrete default, so an explicit `None` there is a declared-type violation rather than the documented sentinel; nothing here changes that.