### PR TITLE
fix(sim): set_gripper resolves set-points on an MJCF that omits ctrlrange, so it works on so101

### DIFF
--- a/changelog.d/1944-set-gripper-unlimited-ctrlrange.md
+++ b/changelog.d/1944-set-gripper-unlimited-ctrlrange.md
@@ -1,0 +1,44 @@
+### Fixed: set_gripper resolves set-points on an MJCF that omits `ctrlrange`, so it works on so101
+
+`set_gripper` derived its open/close set-points from `actuator_ctrlrange` alone
+and refused any actuator whose range was not strictly increasing. But MuJoCo
+reports exactly `(0, 0)` with `actuator_ctrllimited == 0` for an actuator the
+MJCF left **unlimited**, which is a different claim from "this actuator accepts
+nothing" - so the guard rejected a gripper it could drive perfectly well.
+
+That was live on a shipped robot. so101's sim MJCF declares neither `ctrlrange`
+nor `inheritrange="1"` on its position servos, so `set_gripper` errored on an
+arm whose registry metadata named the right actuator (`actuators: ["6"]`) and
+whose `move_to` and `rotate_wrist` both worked:
+
+```python
+sim.add_robot(name="arm", data_config="so101")
+sim.set_gripper(state="close", robot_name="arm", steps=40)
+# before: error "actuator 'arm/6' has no usable ctrlrange (0.0, 0.0)"
+# after:  success, targets {'6': -0.1745}  <- the driven joint's low end
+```
+
+so100 sets `inheritrange="1"` on every actuator, which compiles a real
+ctrlrange from the driven joint - the only reason it was unaffected. The two
+robots' jaw joints are otherwise near-identical (`(-0.174, 1.75)` against
+`(-0.1745, 1.7453)`).
+
+For a JOINT-transmission position servo `ctrl` IS the joint target, so the
+driven joint's own limits are the open/close set-points - the same substitution
+`move_to` and `rotate_wrist` already make (both read `jnt_range` under
+`jnt_limited`; `set_gripper` was the sole outlier), and exactly what
+`inheritrange="1"` would have compiled the ctrlrange to.
+
+The fallback is deliberately narrow, and the three cases it must not swallow
+are pinned as tests. A `mjTRN_TENDON` actuator keeps refusing: its ctrlrange is
+a normalised command space, not joint units - the shipped Franka gripper is
+`(0, 255)` - so substituting a joint range there would command the wrong
+quantity. This falls out of `_joint_actuator_map`, which maps only
+JOINT/JOINTINPARENT transmissions, so a tendon actuator has no entry by
+construction rather than by a separate check. An `actuator_ctrllimited == 1`
+with a degenerate range is an authored claim that the actuator accepts nothing
+and is respected as one. And an unlimited actuator whose driven joint is also
+unlimited has no range anywhere to infer from, so it refuses with an error
+naming both exhausted sources instead of only the ctrlrange.
+
+Fixes #1942.

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -697,11 +697,22 @@ class MotionPrimitivesMixin:
             steps: Control ticks to hold the set-point (1..10000); each tick
                 advances a few physics substeps so the fingers actually travel.
 
+        The set-points come from the actuator's ``ctrlrange``. When an MJCF
+        omits it (MuJoCo then reports ``ctrlrange == (0, 0)`` with
+        ``ctrllimited == 0``, meaning *unlimited* rather than *empty*), a
+        JOINT-transmission position servo falls back to the driven joint's own
+        ``jnt_range`` - for such an actuator ``ctrl`` IS the joint target, so
+        the joint limits are the open/close set-points, which is what
+        ``inheritrange="1"`` would have compiled the ctrlrange to. A TENDON
+        actuator is excluded from that fallback: its ctrlrange is a normalised
+        command space, not joint units.
+
         Returns:
             ``{"status": "success", ...}`` with a json block
             ``{state, actuators, targets, gripper_joint_positions}``;
-            structured error when the gripper cannot be resolved or the
-            ctrlrange gives no usable set-points. Never raises.
+            structured error when the gripper cannot be resolved or neither the
+            ctrlrange nor a limited joint range gives usable set-points. Never
+            raises.
         """
         if state not in ("open", "close"):
             return _err(f'set_gripper: \'state\' must be "open" or "close", got {state!r}.')
@@ -757,13 +768,48 @@ class MotionPrimitivesMixin:
             for act_id in gripper_acts:
                 lo = float(model.actuator_ctrlrange[act_id][0])
                 hi = float(model.actuator_ctrlrange[act_id][1])
+                source = "ctrlrange"
                 if not (hi > lo):
-                    act_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id)
-                    return _err(
-                        f"set_gripper: actuator '{act_name}' has no usable ctrlrange "
-                        f"({lo}, {hi}); cannot infer open/close set-points. Drive it directly "
-                        "with action='send_action'."
+                    # An unlimited actuator (MuJoCo reports ctrlrange (0, 0) with
+                    # ctrllimited=0 when the MJCF omits `ctrlrange`/`inheritrange`)
+                    # is not a gripper we cannot drive - for a JOINT-transmission
+                    # position servo, ctrl IS the joint target, so the driven
+                    # joint's own limits are the open/close set-points. This is
+                    # the same substitution move_to and rotate_wrist already make
+                    # (they read jnt_range under jnt_limited), and it is what
+                    # `inheritrange="1"` would have compiled the ctrlrange to.
+                    # SO-101 ships exactly this MJCF (SO-100 sets inheritrange
+                    # and so has always worked), so set_gripper refused on an arm
+                    # whose registry metadata named the right actuator.
+                    #
+                    # Scope, deliberately narrow: JOINT/JOINTINPARENT transmission
+                    # only. A TENDON actuator's ctrlrange is a normalised command
+                    # space (the Franka split gripper's [0, 255]), not joint units,
+                    # so substituting a joint range there would command the wrong
+                    # quantity - those keep refusing.
+                    jnt_id = jnt_by_act.get(act_id)
+                    jlo, jhi = (
+                        (float(model.jnt_range[jnt_id][0]), float(model.jnt_range[jnt_id][1]))
+                        if jnt_id is not None and bool(model.jnt_limited[jnt_id])
+                        else (0.0, 0.0)
                     )
+                    if not bool(model.actuator_ctrllimited[act_id]) and jhi > jlo:
+                        lo, hi, source = jlo, jhi, "joint range"
+                    else:
+                        act_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id)
+                        return _err(
+                            f"set_gripper: actuator '{act_name}' has no usable ctrlrange "
+                            f"({lo}, {hi}) and no limited joint range to fall back on; cannot "
+                            "infer open/close set-points. Drive it directly with "
+                            "action='send_action'."
+                        )
+                logger.debug(
+                    "set_gripper: actuator %d open/close set-points from %s [%.4f, %.4f]",
+                    act_id,
+                    source,
+                    lo,
+                    hi,
+                )
                 targets[act_id] = hi if end == "high" else lo
 
         for _ in range(steps):

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -159,6 +159,46 @@ SO101_STYLE_XML = """
 </mujoco>
 """
 
+# so101's REAL shipped MJCF shape: the jaw's position servo declares neither
+# `ctrlrange` nor `inheritrange="1"`, so MuJoCo compiles it as an UNLIMITED
+# actuator and reports ctrlrange == (0, 0) with ctrllimited == 0. so100's MJCF
+# sets inheritrange="1" on every actuator, which is why set_gripper worked
+# there and refused here. Verified against the downloaded assets: so101's
+# actuator "6" reports ctrllimited=False ctrlrange=(0.0, 0.0) with
+# jnt_range=(-0.1745, 1.7453); so100's "Jaw" reports ctrllimited=True
+# ctrlrange=(-0.174, 1.75).
+NO_CTRLRANGE_XML = SO101_STYLE_XML.replace('"so101_style_arm"', '"so101_no_ctrlrange_arm"').replace(
+    '<position name="6" joint="6" kp="2" dampratio="1" ctrlrange="-0.2 1.5"/>',
+    '<position name="6" joint="6" kp="2" dampratio="1"/>',
+)
+assert '<position name="6" joint="6" kp="2" dampratio="1"/>' in NO_CTRLRANGE_XML  # jaw ctrlrange dropped
+
+# Same missing ctrlrange, but the jaw is driven through a TENDON. A tendon
+# actuator's ctrl is a normalised command space (the Franka split gripper's
+# shipped [0, 255]), NOT joint units, so the driven joint's range is the wrong
+# quantity to substitute and the fallback must not apply.
+TENDON_NO_CTRLRANGE_XML = (
+    NO_CTRLRANGE_XML.replace('"so101_no_ctrlrange_arm"', '"so101_tendon_arm"')
+    .replace(
+        "  <actuator>",
+        '  <tendon>\n    <fixed name="jaw_tendon">\n      <joint joint="6" coef="1"/>\n'
+        "    </fixed>\n  </tendon>\n  <actuator>",
+    )
+    .replace(
+        '<position name="6" joint="6" kp="2" dampratio="1"/>',
+        '<position name="6" tendon="jaw_tendon" kp="2" dampratio="1"/>',
+    )
+)
+assert 'tendon="jaw_tendon"' in TENDON_NO_CTRLRANGE_XML
+
+# Missing ctrlrange AND an unlimited driven joint: there is no range anywhere
+# to infer set-points from, so this must still refuse.
+NO_RANGE_ANYWHERE_XML = NO_CTRLRANGE_XML.replace('"so101_no_ctrlrange_arm"', '"so101_no_range_arm"').replace(
+    '<joint name="6" type="hinge" axis="0 0 1" range="-0.2 1.5" armature="0.01" damping="0.1"/>',
+    '<joint name="6" type="hinge" axis="0 0 1" limited="false" armature="0.01" damping="0.1"/>',
+)
+assert 'limited="false"' in NO_RANGE_ANYWHERE_XML
+
 # GH #1661's second failure mode (fallback shift): the most distal arm joint
 # is named ``finger_camera_roll`` - the raw heuristic excluded it from the
 # wrist candidate set, shifting the last-non-gripper-hinge fallback onto the
@@ -652,6 +692,105 @@ class TestGripperRegistryMetadata:
         result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=5)
         assert result["status"] == "success", result
         assert _json_block(result)["actuators"] == ["jaw"]
+
+
+class TestSetGripperUnlimitedCtrlrange:
+    """set_gripper resolves set-points on an MJCF that omits ``ctrlrange``.
+
+    ``actuator_ctrlrange == (0, 0)`` with ``actuator_ctrllimited == 0`` is how
+    MuJoCo reports an UNLIMITED actuator, not an empty one - and set_gripper
+    read the range alone, so it refused. That is live on a shipped robot:
+    so101's sim MJCF declares neither ``ctrlrange`` nor ``inheritrange="1"``
+    on its position servos, so ``set_gripper`` errored on an arm whose registry
+    metadata named the right actuator (``actuators: ["6"]``) and whose
+    ``move_to`` / ``rotate_wrist`` both worked. so100 sets
+    ``inheritrange="1"``, which is the only reason it was unaffected.
+
+    For a JOINT-transmission position servo ``ctrl`` IS the joint target, so
+    the driven joint's own ``jnt_range`` is the correct substitution - the same
+    one ``move_to`` and ``rotate_wrist`` already make, and exactly what
+    ``inheritrange="1"`` would have compiled the ctrlrange to. The fallback is
+    scoped to that transmission class and to a genuinely unlimited actuator;
+    the three cases that must keep refusing are pinned below.
+    """
+
+    def _sim(self, tmp_path, xml, name):
+        path = tmp_path / f"{name}.xml"
+        path.write_text(xml)
+        s = Simulation(tool_name=f"test_{name}", mesh=False)
+        assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+        assert s.add_robot("arm", urdf_path=str(path), data_config="so101")["status"] == "success"
+        return s
+
+    @pytest.fixture
+    def no_ctrlrange_sim(self, tmp_path):
+        s = self._sim(tmp_path, NO_CTRLRANGE_XML, "no_ctrlrange")
+        yield s
+        s.cleanup(policy_stop_timeout=2.0)
+
+    def test_close_uses_joint_range_low_end(self, no_ctrlrange_sim):
+        """The regression: pre-fix this errored with 'no usable ctrlrange'."""
+        result = _dispatch(no_ctrlrange_sim, "set_gripper", robot_name="arm", state="close", steps=80)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["actuators"] == ["6"], payload
+        assert payload["targets"]["6"] == pytest.approx(-0.2)  # the JOINT's low end
+        assert payload["gripper_joint_positions"]["6"] < -0.15  # and it traveled there
+
+    def test_open_uses_joint_range_high_end(self, no_ctrlrange_sim):
+        result = _dispatch(no_ctrlrange_sim, "set_gripper", robot_name="arm", state="open", steps=80)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["targets"]["6"] == pytest.approx(1.5)  # the JOINT's high end
+        assert payload["gripper_joint_positions"]["6"] > 1.4
+
+    def test_tendon_transmission_still_refuses(self, tmp_path):
+        """A tendon actuator's ctrl is a normalised command space, not joint
+        units, so substituting the driven joint's range would command the wrong
+        quantity. Refusing is the correct outcome, not a missed case."""
+        s = self._sim(tmp_path, TENDON_NO_CTRLRANGE_XML, "tendon_no_ctrlrange")
+        try:
+            result = _dispatch(s, "set_gripper", robot_name="arm", state="close", steps=10)
+            assert result["status"] == "error", result
+            assert "no usable ctrlrange" in result["content"][0]["text"]
+        finally:
+            s.cleanup(policy_stop_timeout=2.0)
+
+    def test_unlimited_joint_too_still_refuses(self, tmp_path):
+        """No ctrlrange and an unlimited driven joint: nothing to infer from."""
+        s = self._sim(tmp_path, NO_RANGE_ANYWHERE_XML, "no_range_anywhere")
+        try:
+            result = _dispatch(s, "set_gripper", robot_name="arm", state="open", steps=10)
+            assert result["status"] == "error", result
+            assert "no limited joint range to fall back on" in result["content"][0]["text"]
+        finally:
+            s.cleanup(policy_stop_timeout=2.0)
+
+    def test_explicitly_limited_degenerate_range_still_refuses(self, no_ctrlrange_sim):
+        """``ctrllimited == 1`` with a degenerate range is an authored claim
+        that the actuator accepts nothing, which the fallback must respect -
+        unlike ``ctrllimited == 0``, which means unlimited. Set on the compiled
+        model because MuJoCo rejects ``ctrlrange="0 0"`` with
+        ``ctrllimited="true"`` at compile time ('invalid control range')."""
+        import mujoco  # noqa: PLC0415 - local: the module-level importorskip gates this file
+
+        model = no_ctrlrange_sim._world._model
+        act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "arm/6")
+        assert act_id >= 0
+        model.actuator_ctrllimited[act_id] = 1
+        model.actuator_ctrlrange[act_id] = [0.0, 0.0]
+
+        result = _dispatch(no_ctrlrange_sim, "set_gripper", robot_name="arm", state="close", steps=10)
+        assert result["status"] == "error", result
+        assert "no usable ctrlrange" in result["content"][0]["text"]
+
+    def test_so100_style_ctrlrange_is_unaffected(self, sim):
+        """The ctrlrange path is untouched: ARM_XML declares an explicit jaw
+        ctrlrange and still resolves from it (identical to so100's shipped
+        ``inheritrange="1"`` MJCF, which compiles a real ctrlrange)."""
+        result = _dispatch(sim, "set_gripper", robot_name="arm", state="close", steps=40)
+        assert result["status"] == "success", result
+        assert _json_block(result)["targets"]["jaw"] == pytest.approx(-0.2)
 
 
 class TestRotateWristRegistryMetadata:


### PR DESCRIPTION
Fixes #1942.

`set_gripper` refused on `so101` with

```
set_gripper: actuator '6' has an empty ctrlrange (0.0, 0.0); cannot infer
open/close set-points.
```

even though the registry names the right actuator and the joint is perfectly
driveable.

## Root cause

`actuator_ctrlrange == (0, 0)` paired with `actuator_ctrllimited == 0` is how
MuJoCo reports an **unlimited** actuator, not an empty one. It is what you get
when an MJCF omits both `ctrlrange` and `inheritrange`. `set_gripper` read the
range alone and treated the sentinel as "no usable set-points".

`so101`'s sim MJCF (`robotstudio_so101/so101_new_calib.xml`) omits both; every
`so100` actuator sets `inheritrange="1"`, which is the only reason `so100` ever
worked. Measured on the downloaded assets:

| robot | gripper actuator | `ctrllimited` | `ctrlrange` | `trntype` | `jnt_limited` / `jnt_range` |
|---|---|---|---|---|---|
| so100 | `Jaw` | True | (-0.174, 1.75) | 0 JOINT | True / (-0.174, 1.75) |
| so101 | `6` | **False** | **(0.0, 0.0)** | 0 JOINT | True / (-0.1745, 1.7453) |
| panda | `actuator8` | True | (0.0, 255.0) | **3 TENDON** | no joint map entry |

## Fix

When the ctrlrange is degenerate *and* the actuator is unlimited, fall back to
the driven joint's own `jnt_range` (under `jnt_limited`). For a
JOINT-transmission position servo `ctrl` **is** the joint target, so the joint
limits are the open/close set-points - exactly what `inheritrange="1"` would
have compiled the ctrlrange to.

This is the substitution `move_to` and `rotate_wrist` in the same module
already make; `set_gripper` was the sole outlier.

The scope is deliberately narrow, and each boundary keeps refusing:

- **TENDON transmission** - a tendon actuator's ctrlrange is a normalised
  command space (the Franka split gripper's `[0, 255]`), not joint units, so
  substituting a joint range would command the wrong quantity. Excluded by
  construction: `_joint_actuator_map` only maps JOINT/JOINTINPARENT
  transmissions on hinge/slide joints, so a tendon actuator has no entry.
- **Unlimited joint too** - nothing to fall back on, so it still refuses, now
  with a message that says so.
- **Explicitly limited with a degenerate range** - `ctrllimited=1` is a
  deliberate declaration; not overridden.

## Verification

Physical jaw travel on the real downloaded assets, not just success statuses:

- so101: open `1.7442913`, close `-0.1737141`, open `1.7442929`
- so100 unchanged (still the ctrlrange path): open `1.750000`, close `-0.174003`
- panda unchanged (tendon, ctrlrange path)

All four decision branches probed through `Simulation`: no-ctrlrange succeeds;
tendon, unlimited-joint and forced-limited-degenerate each refuse. Pre-fix, all
four refused with the old message.

`tests/simulation/mujoco/test_motion_primitives.py` adds
`TestSetGripperUnlimitedCtrlrange` (6 tests, 3 MJCF fixtures). **3 of the 6 fail
on pre-fix code** - the two joint-range pins and the new refusal message; the
other 3 are scope guards that correctly pass both ways. Whole file: 47 passed.

MuJoCo rejects `ctrlrange="0 0"` with `ctrllimited="true"` at compile time
("invalid control range for actuator"), so the explicitly-limited-degenerate
case is set on the compiled model in the test, with a comment saying why.

Lint clean (`ruff check`, `ruff format --check` on 1018 files). Full-directory
test delta read per AGENTS.md rather than as an absolute: base 68 failed / 2452
passed -> 68 failed / **2458** passed, with a `diff`-identical failing set. The
68 are pre-existing local-environment failures (no GPU, software OSMesa GL).
