### PR TITLE
fix(simulation): set_gripper reads an unlimited ctrlrange as unset, not as empty

### DIFF
--- a/changelog.d/1942-set-gripper-unlimited-ctrlrange.md
+++ b/changelog.d/1942-set-gripper-unlimited-ctrlrange.md
@@ -1,0 +1,49 @@
+### Fixed: an unlimited gripper actuator is driveable, not undriveable
+
+`set_gripper` derived its open/close set-points from `model.actuator_ctrlrange`
+alone and refused any actuator whose range was not strictly increasing. MuJoCo
+reports exactly `(0, 0)` with `actuator_ctrllimited == 0` for an actuator the
+MJCF left *unlimited*, which is a different claim from "this actuator accepts
+nothing" - so the primitive refused on **so101**, a shipped robot whose registry
+gripper metadata is correct and whose `move_to` and `rotate_wrist` both work:
+
+```
+set_gripper: actuator 'a/6' has no usable ctrlrange (0.0, 0.0);
+cannot infer open/close set-points.
+```
+
+so101's sim MJCF declares neither `ctrlrange` nor `inheritrange="1"` on its
+position servos; so100's sets `inheritrange="1"` on every actuator, which
+compiles a real ctrlrange from the driven joint - the only reason so100 was
+unaffected. The two jaw joints' ranges are near-identical, so nothing about
+so101's gripper was undriveable; its ctrlrange simply was never authored.
+
+For a JOINT / JOINTINPARENT-transmission position servo `ctrl` *is* the joint
+target, so the driven joint's own limits are the open/close set-points - exactly
+what `inheritrange="1"` would have compiled the ctrlrange to. Both sibling
+primitives already made that substitution (`rotate_wrist` and `move_to` read
+`jnt_range` under `jnt_limited`); `set_gripper` was the sole outlier. It now
+falls back to the driven joint's range when the ctrlrange is unusable **and**
+`actuator_ctrllimited == 0` **and** the actuator has a joint-transmission entry
+in `_joint_actuator_map` **and** that joint is itself limited with a strictly
+increasing range.
+
+A tendon actuator keeps refusing: its ctrlrange is a normalised command space
+rather than joint units (the shipped Franka gripper is `(0, 255)`), so a joint
+range would command the wrong quantity. That scoping is structural rather than a
+new special case - only joint transmissions appear in `_joint_actuator_map`, so
+a tendon actuator has no entry to substitute from. A refusal now names every
+source it exhausted instead of only the ctrlrange, and the success payload
+gained `setpoint_sources`, so a substituted joint range is visible per actuator
+rather than silent.
+
+The single-point ctrlrange that looks like a deliberate restriction is not one:
+MuJoCo collapses any non-strictly-increasing `ctrlrange` to
+`ctrllimited == 0` and clamps `ctrl` only when `ctrllimited == 1`, so such a
+range is inert and the substitution widens nothing that was being enforced. The
+compiler also rejects an explicit `ctrllimited="true"` over a degenerate range
+outright, which means the guard respecting such a claim is reachable only on a
+model mutated after compilation - as `policies/wbc/sim_control.py` does when it
+hands `ctrlrange` to a whole-body controller. Both facts are pinned as premise
+tests, so a future MuJoCo that changes the encoding fails loudly and names the
+reason rather than breaking the behaviour tests obscurely.

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -73,8 +73,10 @@ logger = logging.getLogger(__name__)
 _GRIPPER_HINTS = ("gripper", "finger", "jaw")
 
 # Valid values for the registry gripper metadata ``closed`` / ``open`` fields:
-# which ctrlrange END the state maps to. The registry integrity tests
-# shape-check the shipped robots.json against the same two values.
+# which END of the gripper's set-point range the state maps to (that range is
+# normally the actuator ctrlrange; see _gripper_setpoint_range for the driven-
+# joint substitution). The registry integrity tests shape-check the shipped
+# robots.json against the same two values.
 _CTRLRANGE_ENDS = ("low", "high")
 
 # Wrist-yaw joint hints, most-specific first. Fallback: the last non-gripper
@@ -217,6 +219,12 @@ class MotionPrimitivesMixin:
         actuator are included (the DOFs a position set-point can drive).
         Tendon-driven actuators (e.g. a Franka split gripper) have no matching
         joint and are excluded - ``set_gripper`` resolves those by name instead.
+
+        That exclusion is load-bearing twice over: it is also what scopes
+        :meth:`_gripper_setpoint_range`'s driven-joint substitution to the
+        transmissions where ``ctrl`` is the joint target, so a tendon gripper
+        with an unusable ctrlrange keeps refusing rather than being commanded
+        in the wrong units.
         """
         mj = self._mj
         joint_trn = {int(mj.mjtTrn.mjTRN_JOINT), int(mj.mjtTrn.mjTRN_JOINTINPARENT)}
@@ -230,6 +238,84 @@ class MotionPrimitivesMixin:
             if jnt_id in joint_ids and int(model.jnt_type[jnt_id]) in settable:
                 out[jnt_id] = act_id
         return out
+
+    def _gripper_setpoint_range(
+        self, model: Any, act_id: int, jnt_id: int | None
+    ) -> tuple[tuple[float, float] | None, str]:
+        """Open/close set-point bounds for a gripper actuator, and their source.
+
+        Returns ``((lo, hi), source)`` - *source* naming where the bounds came
+        from, for the success payload - or ``(None, reason)`` when every source
+        is exhausted, *reason* then naming each one that was tried so the
+        refusal says what it looked at.
+
+        The actuator ``ctrlrange`` is authoritative whenever it is usable. When
+        it is not, MuJoCo's encoding is the thing to read carefully: a position
+        servo whose MJCF declares neither ``ctrlrange`` nor ``inheritrange="1"``
+        compiles to ``ctrlrange == (0, 0)`` with ``actuator_ctrllimited == 0``,
+        and that is the UNLIMITED actuator - a different claim from "this
+        actuator accepts nothing". For a JOINT / JOINTINPARENT transmission
+        ``ctrl`` IS the joint target, so the driven joint's own limits are the
+        open/close set-points, and they are precisely what ``inheritrange="1"``
+        would have compiled the ctrlrange to. Both sibling primitives already
+        make that substitution (``rotate_wrist`` and ``move_to`` read
+        ``jnt_range`` under ``jnt_limited``); ``set_gripper`` read only the
+        ctrlrange and so refused on so101, whose shipped MJCF authors neither
+        attribute while so100's sets ``inheritrange="1"`` on every actuator -
+        the only reason so100 was unaffected (GH #1942).
+
+        Three shapes keep refusing, and none of them is an omission to repair:
+
+        * ``actuator_ctrllimited == 1`` alongside a degenerate range is a claim
+          about the actuator, so it is respected rather than second-guessed.
+          The MJCF compiler cannot produce that combination - it rejects an
+          explicit ``ctrllimited="true"`` whose range is not strictly increasing
+          with *invalid control range for actuator*, and it compiles a bare
+          degenerate range (``"0 0"``, ``"0.5 0.5"``) to ``ctrllimited == 0`` -
+          so this guard bites only on a model mutated after compilation, which
+          this package does do: :mod:`strands_robots.policies.wbc.sim_control`
+          rewrites ``ctrlrange`` to hand control to a whole-body controller and
+          restores it afterwards.
+        * A driven joint that is itself unlimited has no limits to lend.
+        * A tendon actuator's ctrlrange is a normalised command space, not joint
+          units - the shipped Franka gripper is ``(0, 255)`` - so a joint range
+          would command the wrong quantity. *jnt_id* is ``None`` for one by
+          construction: only JOINT / JOINTINPARENT transmissions appear in
+          :meth:`_joint_actuator_map`.
+
+        A degenerate range *stored* under ``ctrllimited == 0`` is inert rather
+        than restrictive - MuJoCo clamps ``ctrl`` only when
+        ``ctrllimited == 1`` - so such an actuator genuinely accepts any
+        command, and substituting the joint range restricts nothing that was
+        previously free and widens nothing that was previously enforced.
+        """
+        lo = float(model.actuator_ctrlrange[act_id][0])
+        hi = float(model.actuator_ctrlrange[act_id][1])
+        if hi > lo:
+            return (lo, hi), "actuator ctrlrange"
+        if bool(model.actuator_ctrllimited[act_id]):
+            return None, (
+                f"its ctrlrange ({lo}, {hi}) is degenerate and ctrllimited=1 declares that "
+                "as a real limit rather than an unset one"
+            )
+        if jnt_id is None:
+            return None, (
+                f"its ctrlrange ({lo}, {hi}) is unset (ctrllimited=0) and it drives no joint "
+                "whose limits could substitute - a tendon actuator's ctrlrange is a normalised "
+                "command space, not joint units"
+            )
+        if not bool(model.jnt_limited[jnt_id]):
+            return None, (
+                f"its ctrlrange ({lo}, {hi}) is unset (ctrllimited=0) and the joint it drives is itself unlimited"
+            )
+        jnt_lo = float(model.jnt_range[jnt_id][0])
+        jnt_hi = float(model.jnt_range[jnt_id][1])
+        if jnt_hi > jnt_lo:
+            return (jnt_lo, jnt_hi), "driven joint range"
+        return None, (
+            f"its ctrlrange ({lo}, {hi}) is unset (ctrllimited=0) and the joint it drives has "
+            f"a degenerate range ({jnt_lo}, {jnt_hi})"
+        )
 
     def _short_name(self, name: str | None, namespace: str) -> str:
         """Strip the robot namespace prefix for hint matching."""
@@ -681,7 +767,9 @@ class MotionPrimitivesMixin:
         Resolves the gripper actuator(s) via :meth:`_resolve_gripper_actuators`
         (registry ``gripper`` metadata for the robot's ``data_config`` when
         present, else the ``gripper`` / ``finger`` / ``jaw`` name heuristic)
-        and commands the actuator ctrlrange end-point. With no metadata,
+        and commands an end-point of its set-point range - the actuator
+        ctrlrange, or the driven joint's limits when the MJCF left the
+        ctrlrange unset (see :meth:`_gripper_setpoint_range`). With no metadata,
         ``"open"`` drives to the HIGH end and ``"close"`` to the LOW end -
         the convention for SO-100/SO-101 (the jaw closes toward the
         low/negative end of its range - the sign trap documented in the
@@ -699,9 +787,12 @@ class MotionPrimitivesMixin:
 
         Returns:
             ``{"status": "success", ...}`` with a json block
-            ``{state, actuators, targets, gripper_joint_positions}``;
-            structured error when the gripper cannot be resolved or the
-            ctrlrange gives no usable set-points. Never raises.
+            ``{state, actuators, targets, setpoint_sources,
+            gripper_joint_positions}`` - ``setpoint_sources`` naming, per
+            actuator, where its bounds came from, so a substituted joint range
+            is visible rather than silent; structured error when the gripper
+            cannot be resolved or no source gives usable set-points. Never
+            raises.
         """
         if state not in ("open", "close"):
             return _err(f'set_gripper: \'state\' must be "open" or "close", got {state!r}.')
@@ -743,7 +834,7 @@ class MotionPrimitivesMixin:
                     "Drive it directly with action='send_action' instead."
                 )
 
-            # Which ctrlrange END each state maps to: the registry metadata's
+            # Which END of the set-point range each state maps to: the registry metadata's
             # `closed`/`open` fields when present, else the open=HIGH /
             # close=LOW convention (correct for SO-100/SO-101 and Franka, but
             # a convention, not a law - the metadata field exists to remove
@@ -754,17 +845,18 @@ class MotionPrimitivesMixin:
                 end = "high" if state == "open" else "low"
 
             targets: dict[int, float] = {}
+            setpoint_sources: dict[int, str] = {}
             for act_id in gripper_acts:
-                lo = float(model.actuator_ctrlrange[act_id][0])
-                hi = float(model.actuator_ctrlrange[act_id][1])
-                if not (hi > lo):
+                span, detail = self._gripper_setpoint_range(model, act_id, jnt_by_act.get(act_id))
+                if span is None:
                     act_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, act_id)
                     return _err(
-                        f"set_gripper: actuator '{act_name}' has no usable ctrlrange "
-                        f"({lo}, {hi}); cannot infer open/close set-points. Drive it directly "
-                        "with action='send_action'."
+                        f"set_gripper: actuator '{act_name}' has no usable open/close set-points - "
+                        f"{detail}. Drive it directly with action='send_action'."
                     )
+                lo, hi = span
                 targets[act_id] = hi if end == "high" else lo
+                setpoint_sources[act_id] = detail
 
         for _ in range(steps):
             with self._lock:
@@ -787,6 +879,7 @@ class MotionPrimitivesMixin:
             "state": state,
             "actuators": act_names,
             "targets": {n: targets[a] for n, a in zip(act_names, gripper_acts, strict=True)},
+            "setpoint_sources": {n: setpoint_sources[a] for n, a in zip(act_names, gripper_acts, strict=True)},
             "gripper_joint_positions": joint_positions,
         }
         return {

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1979,8 +1979,9 @@ class MuJoCoSimEngine(
         base["methods"]["set_gripper"] = (
             "(robot_name=None, state='open'|'close', steps=12) -> dict  # "
             "drive the gripper actuator(s) to the open/close set-point "
-            "(registry gripper metadata when present, else open=ctrlrange "
-            "HIGH / close=LOW)"
+            "(registry gripper metadata when present, else open=HIGH / "
+            "close=LOW end of the actuator ctrlrange, or of the driven joint's "
+            "range when the MJCF left the ctrlrange unset)"
         )
         base["methods"]["rotate_wrist"] = (
             "(robot_name=None, target_yaw, tol=0.02, max_steps=200) -> dict  "

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -311,7 +311,7 @@
     "state": {
       "type": "string",
       "enum": ["open", "close"],
-      "description": "set_gripper set-point: 'open'/'close' drive the gripper actuator(s) to the ctrlrange end declared in the robot registry's gripper metadata when present, else the default convention: 'open' = HIGH end, 'close' = LOW end (SO-100/SO-101 jaw closes toward the low end)"
+      "description": "set_gripper set-point: 'open'/'close' drive the gripper actuator(s) to the set-point-range end declared in the robot registry's gripper metadata when present, else the default convention: 'open' = HIGH end, 'close' = LOW end (SO-100/SO-101 jaw closes toward the low end). The range is the actuator ctrlrange, falling back to the driven joint's limits when the MJCF left the ctrlrange unset"
     },
     "steps": {
       "type": "integer",

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -15,8 +15,10 @@ inline MJCF arm - no asset downloads):
   error with the IK residual for an unreachable one (never a hang or raise),
   rejects targets outside the workspace sanity box, and degrades to a
   structured error (not a raise) when ``mink`` is missing; ``set_gripper``
-  drives toward the correct ctrlrange end per state; ``rotate_wrist`` reaches
-  a set-point and rejects out-of-range targets;
+  drives toward the correct set-point-range end per state (the range itself,
+  including the driven-joint substitution for an MJCF that left the ctrlrange
+  unset, is pinned by ``test_set_gripper_setpoint_range_sources.py``);
+  ``rotate_wrist`` reaches a set-point and rejects out-of-range targets;
 * recording interplay (the #1498 bug class): primitive motion does NOT feed
   the dataset recorder - pinned explicitly so a silent zero-frame "recording"
   can never masquerade as a recorded episode.

--- a/tests/simulation/mujoco/test_set_gripper_setpoint_range_sources.py
+++ b/tests/simulation/mujoco/test_set_gripper_setpoint_range_sources.py
@@ -1,0 +1,418 @@
+"""Regression tests for GH #1942: where ``set_gripper`` gets its set-points.
+
+``set_gripper`` derived its open/close set-points from ``actuator_ctrlrange``
+alone and refused any actuator whose range was not strictly increasing. MuJoCo
+reports exactly ``(0, 0)`` with ``actuator_ctrllimited == 0`` for an actuator
+the MJCF left **unlimited**, which is a different claim from "this actuator
+accepts nothing" - so ``set_gripper`` refused on so101, a shipped robot whose
+registry gripper metadata is correct and whose ``move_to`` / ``rotate_wrist``
+both work:
+
+    set_gripper: actuator 'a/6' has no usable ctrlrange (0.0, 0.0);
+    cannot infer open/close set-points.
+
+so101's MJCF declares neither ``ctrlrange`` nor ``inheritrange="1"`` on its
+position servos; so100's sets ``inheritrange="1"`` on every actuator, which
+compiles a real ctrlrange from the driven joint - the only reason so100 was
+unaffected. Measured on the downloaded assets:
+
+    robot  gripper act  ctrllimited  ctrlrange       jnt_limited  jnt_range
+    so100  Jaw          True         (-0.174, 1.75)  True         (-0.174, 1.75)
+    so101  6            False        (0.0, 0.0)      True         (-0.1745, 1.7453)
+
+These tests are hermetic - one inline MJCF arm per case, no asset download -
+and vary exactly one thing between the working and refusing shapes: the jaw
+actuator's declaration. They pin, in order:
+
+1. The MuJoCo premise the fix rests on (an unauthored ctrlrange compiles to
+   ``(0, 0)`` / ``ctrllimited == 0``, and ``inheritrange="1"`` compiles a real
+   one). If a future MuJoCo changes that encoding, this fails first and names
+   the reason, rather than the behaviour tests failing obscurely.
+2. The regression: the so101 shape drives to the driven joint's limits.
+3. Precedence: an authored ctrlrange wins over the joint range, so the fix
+   cannot silently widen a deliberately narrowed command range.
+4. The three shapes that must KEEP refusing - an authored ``ctrllimited == 1``
+   with a degenerate range, an unlimited driven joint, and a tendon actuator
+   (whose ctrlrange is a normalised command space, not joint units, so a joint
+   range would command the wrong quantity).
+"""
+
+from typing import Any
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Jaw joint limits shared by every variant below: what the driven-joint
+# substitution must produce, and what an authored ctrlrange must override.
+JAW_LO, JAW_HI = -0.2, 1.5
+
+# A minimal pan + jaw arm. The jaw joint and its actuator are the only things
+# that vary between cases, so each variant differs from the next by exactly the
+# MuJoCo attribute under test. The gripper resolves via the name heuristic (no
+# data_config -> no registry metadata), which keeps these tests about the
+# set-point range rather than about actuator classification.
+_ARM_TEMPLATE = """
+<mujoco model="setpoint_range_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002" gravity="0 0 0"/>
+  <default>
+    <joint armature="0.05" damping="0.5"/>
+    <geom density="2000"/>
+  </default>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <geom type="cylinder" size="0.04 0.02"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+        <body name="jaw_body" pos="0 0 0.2">
+          {jaw_joint}
+          <geom type="box" size="0.01 0.01 0.02" contype="0" conaffinity="0"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan" joint="shoulder_pan" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    {jaw_actuator}
+  </actuator>
+</mujoco>
+"""
+
+_LIMITED_JAW_JOINT = (
+    f'<joint name="jaw" type="hinge" axis="0 0 1" range="{JAW_LO} {JAW_HI}" armature="0.01" damping="0.1"/>'
+)
+# No `range` attribute -> jnt_limited is False (nothing to substitute).
+_UNLIMITED_JAW_JOINT = '<joint name="jaw" type="hinge" axis="0 0 1" armature="0.01" damping="0.1"/>'
+
+
+def _arm(jaw_actuator: str, jaw_joint: str = _LIMITED_JAW_JOINT) -> str:
+    return _ARM_TEMPLATE.format(jaw_joint=jaw_joint, jaw_actuator=jaw_actuator)
+
+
+# so101's shape: a position servo with neither ctrlrange nor inheritrange.
+UNSET_CTRLRANGE_XML = _arm('<position name="jaw" joint="jaw" kp="2" dampratio="1"/>')
+
+# so100's shape: inheritrange="1" compiles the ctrlrange from the driven joint.
+INHERITRANGE_XML = _arm('<position name="jaw" joint="jaw" kp="2" dampratio="1" inheritrange="1"/>')
+
+# An authored ctrlrange deliberately NARROWER than the joint range: the
+# substitution must not widen it back out.
+AUTHORED_LO, AUTHORED_HI = -0.1, 0.9
+AUTHORED_CTRLRANGE_XML = _arm(
+    f'<position name="jaw" joint="jaw" kp="2" dampratio="1" ctrlrange="{AUTHORED_LO} {AUTHORED_HI}"/>'
+)
+
+# A degenerate range written out in the MJCF. This does NOT compile to
+# ctrllimited=1 - MuJoCo treats a non-strictly-increasing ctrlrange as unset
+# (see TestMujocoEncodingPremise) - so it takes the same fallback as so101.
+DEGENERATE_UNLIMITED_XML = _arm('<position name="jaw" joint="jaw" kp="2" dampratio="1" ctrlrange="0.5 0.5"/>')
+
+# Unset ctrlrange AND an unlimited driven joint: both sources exhausted.
+UNLIMITED_JOINT_XML = _arm(
+    '<position name="jaw" joint="jaw" kp="2" dampratio="1"/>',
+    jaw_joint=_UNLIMITED_JAW_JOINT,
+)
+
+# A tendon gripper (the Franka/Panda shape) with an unset ctrlrange. A tendon
+# actuator's ctrlrange is a normalised command space, so the driven joints'
+# limits are the wrong quantity; it has no _joint_actuator_map entry by
+# construction, which is what scopes the substitution away from it.
+TENDON_XML = """
+<mujoco model="setpoint_range_tendon">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002" gravity="0 0 0"/>
+  <default>
+    <joint armature="0.05" damping="0.5"/>
+    <geom density="2000"/>
+  </default>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <geom type="cylinder" size="0.04 0.02"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+        <body name="hand" pos="0 0 0.2">
+          <geom type="box" size="0.03 0.03 0.01" contype="0" conaffinity="0"/>
+          <body name="finger1" pos="0.03 0 0">
+            <joint name="finger_joint1" type="slide" axis="1 0 0" range="0 0.04"/>
+            <geom type="box" size="0.005 0.01 0.02" contype="0" conaffinity="0"/>
+          </body>
+          <body name="finger2" pos="-0.03 0 0">
+            <joint name="finger_joint2" type="slide" axis="-1 0 0" range="0 0.04"/>
+            <geom type="box" size="0.005 0.01 0.02" contype="0" conaffinity="0"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="split">
+      <joint joint="finger_joint1" coef="1"/>
+      <joint joint="finger_joint2" coef="1"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <position name="shoulder_pan" joint="shoulder_pan" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="gripper" tendon="split" kp="1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def make_sim(tmp_path):
+    """Build a Simulation holding one robot loaded from *xml*, and clean it up."""
+    sims: list[Simulation] = []
+
+    def _make(xml: str, name: str = "arm") -> Simulation:
+        path = tmp_path / f"{name}_{len(sims)}.xml"
+        path.write_text(xml)
+        s = Simulation(tool_name="test_set_gripper_setpoint_range_sources", mesh=False)
+        sims.append(s)
+        assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+        assert s.add_robot(name, urdf_path=str(path))["status"] == "success"
+        return s
+
+    yield _make
+    for s in sims:
+        s.cleanup(policy_stop_timeout=2.0)
+
+
+def _json_block(result: dict[str, Any]) -> dict[str, Any]:
+    for block in result["content"]:
+        if isinstance(block, dict) and "json" in block:
+            return block["json"]
+    raise AssertionError(f"no json block in result: {result}")
+
+
+def _set_gripper(s: Simulation, state: str, robot_name: str = "arm", steps: int = 40) -> dict[str, Any]:
+    return s._dispatch_action(
+        "set_gripper", {"action": "set_gripper", "robot_name": robot_name, "state": state, "steps": steps}
+    )
+
+
+def _jaw_position(s: Simulation, robot_name: str = "arm", joint: str = "jaw") -> float:
+    state = _json_block(s.get_robot_state(robot_name))["state"]
+    return float(state[joint]["position"])
+
+
+class TestMujocoEncodingPremise:
+    """The fix reads ``ctrllimited == 0`` as "unset". Pin that encoding.
+
+    Nothing in the behaviour tests below would say *why* they broke if MuJoCo
+    ever compiled an unauthored ctrlrange differently, so this asserts the
+    premise directly and separately.
+    """
+
+    def test_an_unauthored_ctrlrange_compiles_to_zero_zero_and_ctrllimited_false(self):
+        model = mujoco.MjModel.from_xml_string(UNSET_CTRLRANGE_XML)
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "jaw")
+        jnt = int(model.actuator_trnid[act, 0])
+
+        assert bool(model.actuator_ctrllimited[act]) is False
+        assert tuple(float(v) for v in model.actuator_ctrlrange[act]) == (0.0, 0.0)
+        # ... while the joint it drives carries perfectly good limits, and the
+        # transmission is the one where ctrl IS the joint target.
+        assert int(model.actuator_trntype[act]) == int(mujoco.mjtTrn.mjTRN_JOINT)
+        assert bool(model.jnt_limited[jnt]) is True
+        assert tuple(float(v) for v in model.jnt_range[jnt]) == (JAW_LO, JAW_HI)
+
+    def test_inheritrange_compiles_the_joint_range_into_the_ctrlrange(self):
+        """so100's shape - and the substitution the fix performs by hand."""
+        model = mujoco.MjModel.from_xml_string(INHERITRANGE_XML)
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "jaw")
+
+        assert bool(model.actuator_ctrllimited[act]) is True
+        # approx: the compiler round-trips the joint range through float storage.
+        assert tuple(float(v) for v in model.actuator_ctrlrange[act]) == pytest.approx((JAW_LO, JAW_HI))
+
+    @pytest.mark.parametrize("ctrlrange", ["0 0", "0.5 0.5", "1 0"])
+    def test_a_bare_degenerate_ctrlrange_compiles_to_unlimited(self, ctrlrange):
+        """MuJoCo treats any non-strictly-increasing ctrlrange as UNSET.
+
+        This is why ``ctrllimited`` is the right signal for "was a command range
+        authored", and why ``(0, 0)`` cannot be told apart from an omitted
+        attribute: the compiler collapses both to the same state.
+        """
+        model = mujoco.MjModel.from_xml_string(
+            _arm(f'<position name="jaw" joint="jaw" kp="2" dampratio="1" ctrlrange="{ctrlrange}"/>')
+        )
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "jaw")
+
+        assert bool(model.actuator_ctrllimited[act]) is False
+
+    def test_the_compiler_refuses_an_explicit_limit_over_a_degenerate_range(self):
+        """So ``ctrllimited == 1`` + degenerate range is unreachable from MJCF.
+
+        The guard that respects such a claim is therefore reachable only on a
+        model mutated after compilation - which is exactly how it is exercised
+        in ``TestTheExhaustedSourcesStillRefuse``.
+        """
+        with pytest.raises(ValueError, match="invalid control range"):
+            mujoco.MjModel.from_xml_string(
+                _arm('<position name="jaw" joint="jaw" kp="2" ctrllimited="true" ctrlrange="0 0"/>')
+            )
+
+    def test_an_unclamped_actuator_ignores_its_stored_degenerate_range(self):
+        """A stored range under ctrllimited=0 is inert, not restrictive.
+
+        MuJoCo clamps ``ctrl`` only when ``ctrllimited == 1``, so substituting
+        the joint range cannot widen a restriction that was being enforced -
+        there was none.
+        """
+        model = mujoco.MjModel.from_xml_string(DEGENERATE_UNLIMITED_XML)
+        data = mujoco.MjData(model)
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "jaw")
+
+        data.ctrl[act] = JAW_HI  # far above the stored (0.5, 0.5)
+        mujoco.mj_step(model, data)
+
+        assert float(data.ctrl[act]) == pytest.approx(JAW_HI)
+
+    def test_a_tendon_actuator_has_no_driven_joint_to_substitute(self):
+        """The scope guard is structural: trntype is TENDON, not JOINT."""
+        model = mujoco.MjModel.from_xml_string(TENDON_XML)
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "gripper")
+
+        assert int(model.actuator_trntype[act]) == int(mujoco.mjtTrn.mjTRN_TENDON)
+        assert bool(model.actuator_ctrllimited[act]) is False
+
+
+class TestUnsetCtrlrangeFallsBackToTheDrivenJoint:
+    """GH #1942: the so101 shape is driveable, and drives to the joint limits."""
+
+    @pytest.mark.parametrize(
+        ("state", "expected"),
+        [("close", JAW_LO), ("open", JAW_HI)],
+    )
+    def test_set_gripper_commands_the_driven_joint_range_end(self, make_sim, state, expected):
+        s = make_sim(UNSET_CTRLRANGE_XML)
+
+        result = _set_gripper(s, state)
+
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["targets"]["jaw"] == pytest.approx(expected)
+
+    def test_the_substituted_source_is_named_in_the_payload(self, make_sim):
+        """A substitution that changes which quantity defines the set-point is
+        reported, not silent: an operator reading ``targets`` can tell an
+        authored command range from an inferred one."""
+        s = make_sim(UNSET_CTRLRANGE_XML)
+
+        payload = _json_block(_set_gripper(s, "close"))
+
+        assert payload["setpoint_sources"] == {"jaw": "driven joint range"}
+
+    def test_the_jaw_actually_travels_toward_the_commanded_end(self, make_sim):
+        """Behaviour, not just target arithmetic: the fingers move."""
+        s = make_sim(UNSET_CTRLRANGE_XML)
+
+        assert _set_gripper(s, "open", steps=80)["status"] == "success"
+        opened = _jaw_position(s)
+        assert _set_gripper(s, "close", steps=80)["status"] == "success"
+        closed = _jaw_position(s)
+
+        assert closed < opened, f"jaw did not travel: open={opened}, close={closed}"
+
+
+class TestAnAuthoredCtrlrangeStillWins:
+    """The substitution is a fallback, not an override."""
+
+    def test_inheritrange_uses_the_compiled_ctrlrange(self, make_sim):
+        """so100's shape is unchanged - and reports the ctrlrange as its source."""
+        s = make_sim(INHERITRANGE_XML)
+
+        payload = _json_block(_set_gripper(s, "open"))
+
+        assert payload["targets"]["jaw"] == pytest.approx(JAW_HI)
+        assert payload["setpoint_sources"] == {"jaw": "actuator ctrlrange"}
+
+    @pytest.mark.parametrize(
+        ("state", "expected"),
+        [("close", AUTHORED_LO), ("open", AUTHORED_HI)],
+    )
+    def test_a_narrower_authored_ctrlrange_is_not_widened_to_the_joint_range(self, make_sim, state, expected):
+        """An MJCF that deliberately restricts the command range below the joint
+        range keeps that restriction: the fallback never fires when the
+        ctrlrange is usable."""
+        s = make_sim(AUTHORED_CTRLRANGE_XML)
+
+        payload = _json_block(_set_gripper(s, state))
+
+        assert payload["targets"]["jaw"] == pytest.approx(expected)
+        assert payload["setpoint_sources"] == {"jaw": "actuator ctrlrange"}
+
+
+class TestAnInertDegenerateCtrlrangeAlsoFallsBack:
+    """A ctrlrange the MJCF wrote but MuJoCo ignores is not a restriction."""
+
+    def test_a_degenerate_authored_ctrlrange_uses_the_driven_joint_range(self, make_sim):
+        s = make_sim(DEGENERATE_UNLIMITED_XML)
+
+        payload = _json_block(_set_gripper(s, "open"))
+
+        assert payload["targets"]["jaw"] == pytest.approx(JAW_HI)
+        assert payload["setpoint_sources"] == {"jaw": "driven joint range"}
+
+
+class TestTheExhaustedSourcesStillRefuse:
+    """Three shapes where no source yields set-points; each names what it tried."""
+
+    def test_a_declared_limit_over_a_degenerate_range_is_respected(self, make_sim):
+        """``ctrllimited == 1`` is a claim about the actuator, so it is not
+        second-guessed even though the driven joint has usable limits.
+
+        The MJCF compiler refuses to emit this combination, so it is produced
+        the only way it can occur in practice - by mutating the compiled model,
+        as ``policies/wbc/sim_control.py`` does when it hands ``ctrlrange`` to a
+        whole-body controller.
+        """
+        s = make_sim(UNSET_CTRLRANGE_XML)
+        model = s._world._model
+        act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "arm/jaw")
+        assert act >= 0, "jaw actuator not found under the robot namespace"
+        assert bool(model.actuator_ctrllimited[act]) is False  # fallback applies before the mutation
+        model.actuator_ctrllimited[act] = 1  # now it claims (0, 0) as a real limit
+
+        result = _set_gripper(s, "close")
+
+        assert result["status"] == "error", result
+        text = str(result["content"])
+        assert "no usable open/close set-points" in text
+        assert "ctrllimited=1" in text
+
+    def test_an_unlimited_driven_joint_leaves_nothing_to_substitute(self, make_sim):
+        s = make_sim(UNLIMITED_JOINT_XML)
+
+        result = _set_gripper(s, "close")
+
+        assert result["status"] == "error", result
+        text = str(result["content"])
+        assert "no usable open/close set-points" in text
+        assert "itself unlimited" in text
+
+    def test_a_tendon_gripper_refuses_rather_than_borrowing_joint_units(self, make_sim):
+        """The scope limit from the issue: a tendon ctrlrange is a normalised
+        command space, so substituting a joint range would command the wrong
+        quantity. Refusing is correct."""
+        s = make_sim(TENDON_XML)
+
+        result = _set_gripper(s, "close")
+
+        assert result["status"] == "error", result
+        text = str(result["content"])
+        assert "no usable open/close set-points" in text
+        assert "normalised command space" in text
+
+    def test_every_refusal_still_points_at_the_direct_escape_hatch(self, make_sim):
+        """The error stays actionable - send_action remains the way through."""
+        for xml in (UNLIMITED_JOINT_XML, TENDON_XML):
+            s = make_sim(xml)
+            result = _set_gripper(s, "close")
+            assert result["status"] == "error", result
+            assert "send_action" in str(result["content"])

--- a/tests/test_registry_integrity.py
+++ b/tests/test_registry_integrity.py
@@ -195,8 +195,8 @@ def test_rebot_b601_family_is_drivable_real(registry: dict) -> None:
         assert get_hardware_type(canonical) == lerobot_type
 
 
-# Valid values for gripper.closed / gripper.open: which ctrlrange END the
-# state maps to. Kept in sync with
+# Valid values for gripper.closed / gripper.open: which END of the gripper's
+# set-point range the state maps to. Kept in sync with
 # strands_robots/simulation/mujoco/motion_primitives.py::_CTRLRANGE_ENDS.
 _GRIPPER_ENDS = {"low", "high"}
 


### PR DESCRIPTION
Fixes #1942.

## The bug

`set_gripper` derived its open/close set-points from `model.actuator_ctrlrange` alone and refused any actuator whose range was not strictly increasing. MuJoCo reports exactly `(0, 0)` with `actuator_ctrllimited == 0` for an actuator the MJCF left **unlimited**, which is a different claim from "this actuator accepts nothing" - so the primitive refused on **so101**, a shipped robot whose registry gripper metadata is correct and whose `move_to` and `rotate_wrist` both work:

```
set_gripper: actuator 'a/6' has no usable ctrlrange (0.0, 0.0);
cannot infer open/close set-points.
```

Measured on the actual downloaded assets (`robot_descriptions`, mujoco 3.11.0), which reproduces the issue's table exactly:

| robot | gripper act | `ctrllimited` | `ctrlrange` | `trntype` | `jnt_limited` | `jnt_range` |
|---|---|---|---|---|---|---|
| so100 | `Jaw` | `True` | `(-0.174, 1.75)` | 0 (JOINT) | `True` | `(-0.174, 1.75)` |
| so101 | `6` | **`False`** | **`(0.0, 0.0)`** | 0 (JOINT) | `True` | `(-0.1745, 1.7453)` |

so101's MJCF declares neither `ctrlrange` nor `inheritrange="1"` on its position servos; so100's sets `inheritrange="1"` on every actuator, which compiles a real ctrlrange from the driven joint - the only reason so100 was unaffected. The two jaw joint ranges are near-identical, so nothing about so101's gripper is undriveable.

## The fix

For a JOINT / JOINTINPARENT-transmission position servo `ctrl` **is** the joint target, so the driven joint's own limits are the open/close set-points - precisely what `inheritrange="1"` would have compiled the ctrlrange to. Both sibling primitives already made that substitution (`rotate_wrist` and `move_to` read `jnt_range` under `jnt_limited`); `set_gripper` was the sole outlier.

The new `_gripper_setpoint_range` owns the resolution order **and** the explanation, so a refusal names every source it exhausted instead of only the ctrlrange. It falls back to the driven joint's range when the ctrlrange is unusable **and** `actuator_ctrllimited == 0` **and** the actuator has a joint-transmission entry in `_joint_actuator_map` **and** that joint is itself limited with a strictly increasing range.

A tendon actuator keeps refusing - its ctrlrange is a normalised command space rather than joint units (the shipped Franka gripper is `(0, 255)`), so a joint range would command the wrong quantity. **That scoping is structural, not a new special case**: only joint transmissions appear in `_joint_actuator_map`, so a tendon actuator has no entry to substitute from by construction.

## Two things I measured that the issue did not anticipate

These changed the shape of the change, so they are worth flagging rather than burying:

**1. `ctrllimited == 1` with a degenerate range is unreachable from MJCF.** The issue proposed gating on `ctrllimited == 0` to distinguish an omission from "an authored `ctrllimited == 1` with a degenerate range, which is a claim to respect". That combination cannot be compiled - MuJoCo rejects an explicit `ctrllimited="true"` over a non-increasing range with `invalid control range for actuator`, and collapses a bare `ctrlrange="0 0"` / `"0.5 0.5"` / `"1 0"` to `ctrllimited == 0`:

```
ctrlrange="0 0"                    ctrllimited=False ctrlrange=(0.0, 0.0)
ctrlrange="0.5 0.5"                ctrllimited=False ctrlrange=(0.5, 0.5)
ctrlrange="1 0" (inverted)         ctrllimited=False ctrlrange=(1.0, 0.0)
ctrllimited=true ctrlrange="0 0"   COMPILE ERROR: invalid control range for actuator
```

The guard is still kept, and is still correct, but for a narrower reason than the issue gives: it is reachable only on a model **mutated after compilation**, which this package does do - `policies/wbc/sim_control.py` rewrites `ctrlrange` to hand control to a whole-body controller and restores it afterwards. The test exercises it that way rather than via an MJCF that cannot exist, so it is not dead code.

**2. A degenerate range that looks like a deliberate restriction is inert.** `ctrlrange="0.5 0.5"` reads like a pinned command range that the fallback would wrongly widen. It is not: MuJoCo clamps `ctrl` only when `ctrllimited == 1`, so the stored values are ignored and the actuator genuinely accepts any command. Verified - `ctrl = 1.4` against a stored `(0.5, 0.5)` survives `mj_step` unclamped. The substitution therefore restricts nothing that was free and widens nothing that was enforced.

Both facts are pinned as **premise tests**, so a future MuJoCo that changes the encoding fails loudly and names the reason rather than breaking the behaviour tests obscurely.

## Verification

**The regression test goes red on `main`.** With this branch's tests against `main`'s `motion_primitives.py`, 11 fail with the issue's exact message:

```
set_gripper: actuator 'arm/jaw' has no usable ctrlrange (0.0, 0.0); ...
11 failed, 9 passed
```

With the fix: `20 passed`. The 9 that pass either way are the premise tests (they describe MuJoCo, not our code) plus the refusals that were already refusing.

**No regression, read as a delta** rather than an absolute (this host lacks GL, so the rendering suites cannot run here at all). Same command, same env, on the affected surface - `test_motion_primitives`, `test_primitive_teardown_abort`, `test_actuator_ownership_by_transmission`, `test_gripper_action_key_equivalence`, `test_tendon_actuator`, both `test_ctrl_clamp_warning*`, `test_docstring_module_xrefs`, `test_agenttool_contract`, `test_registry_integrity`:

| tree | passed | skipped | failed |
|---|---|---|---|
| `main` | 173 | 6 | 0 |
| this branch | **193** | 6 | 0 |

`+20` is exactly the new file; the skip set is identical. `ruff check`, `ruff format --check` and `mypy` on the changed module are clean, and `scripts/assemble_changelog.py --check` reports `changelog fragments OK`.

## Tests

`tests/simulation/mujoco/test_set_gripper_setpoint_range_sources.py` - hermetic, one inline MJCF arm per case, no asset download. Each variant differs from the next by exactly the actuator attribute under test.

- the MuJoCo encoding premise (4 tests, incl. the two findings above);
- the so101 shape drives to the driven joint's limits, close -> LOW / open -> HIGH, and the jaw **actually travels** (behaviour, not target arithmetic);
- precedence: an authored ctrlrange wins, and a deliberately *narrower* one is not widened to the joint range;
- the inert-degenerate range takes the fallback;
- the three shapes that must keep refusing - declared limit, unlimited driven joint, tendon - each asserting the refusal names what it exhausted and still points at `send_action`.

## Doc drift

Swept for every place claiming the set-points come from the ctrlrange: the `set_gripper` docstring (resolution paragraph + `Returns` block), the `end`-selection comment, the `_CTRLRANGE_ENDS` comment and its mirror in `test_registry_integrity.py`, `_joint_actuator_map`'s docstring (its tendon exclusion now scopes the substitution too), `describe()["methods"]["set_gripper"]`, the `state` parameter in `tool_spec.json`, and the primitives test-module docstring. `docs/` and `examples/` carry no such claim - the only `docs/` hit is the unrelated hardware `pose_tool`.

## Note on the payload

The success payload gains one additive key, `setpoint_sources`, naming per actuator where its bounds came from. The whole bug class here is a set-point source changing invisibly, and without this an operator seeing `targets: {"6": 1.7453}` on so101 cannot tell an authored command range from an inferred one - which the repo's "no silent defaults" convention argues against. No test pinned the payload's key set, so nothing breaks. Happy to drop it if you would rather keep the payload frozen; it is a 3-line revert.
