### PR TITLE
fix(training): the launch topology a TrainSpec asks for is one shared positive-count domain

### DIFF
--- a/changelog.d/1947-launch-topology-domain.md
+++ b/changelog.d/1947-launch-topology-domain.md
@@ -1,0 +1,45 @@
+### Fixed: the launch topology a TrainSpec asks for is one shared positive-count domain
+
+`TrainSpec.num_gpus` and `TrainSpec.num_nodes` are the two process counts a
+distributed run is sized from, and neither had a domain - while their run-size
+neighbours `steps` and `global_batch_size` shared one. Each is read in three
+places by the three supervised backends: a `spec.num_gpus > 1` /
+`spec.num_nodes > 1` test that selects between the single-process and the
+multi-process launch path, a `nproc_per_node` / `nnodes` argument to torch's
+`elastic_launch`, and a `--nproc_per_node=` / `--nnodes=` / `--num_gpus=` argv
+token. Every way an unusable count failed was silent or late:
+
+* `0`, a negative, `nan` and `True` all compare as *not* greater than one -
+  `nan` compares false against everything - so the selector routed them to the
+  single-process path and the run proceeded on one process under a successful
+  result. The topology the caller asked for simply was not the one that ran, and
+  for `num_nodes` that also slipped past the multi-node refusal LeRobot and
+  GR00T raise for a topology they cannot launch in-process: `num_nodes=8` is
+  refused, `num_nodes=nan` was not.
+* `2.7` and `inf` *are* greater than one, so they selected the multi-process
+  path and reached `elastic_launch` as the worker count.
+  `torch.distributed.launcher.api.LaunchConfig` accepts `2.7`, `inf`, `0`, `-4`
+  and `nan` without complaint, so nothing downstream rejected them either.
+* A string, `None` or a list raised `TypeError: '>' not supported between
+  instances of 'str' and 'int'` out of the comparison itself - from inside a
+  `Trainer.validate` documented to *return* problems.
+
+Both fields are now checked by `launch_topology_problems`, a fourth shared gate
+in `strands_robots.training._validate` alongside the injection-safety, run-size
+and learning-rate ones, reached through `Trainer._launch_topology_problems` and
+built on the same `positive_count_error` domain the run-size gate uses. Every
+`Trainer.train` already fails closed on a `validate` problem, so the preflight
+covers the launch path on every call route.
+
+The gate is scoped like the run-size one rather than made universal: `TrainSpec`
+documents that a backend "reads the fields it supports and ignores the rest", and
+only the three supervised backends launch from either field, so the mock and RL
+trainers must not report on them. That scoping is enforced structurally - the set
+of backends required to route through the gate is derived from which modules
+actually read `spec.num_gpus` / `spec.num_nodes`, so a fourth backend that starts
+launching from one fails the parity test until it does.
+
+LeRobot's and GR00T's multi-node refusals compare `num_nodes`, so each is now
+reached only once the shared domain has established the value *is* a count - a
+string would otherwise still raise out of that comparison. Both refusals still
+fire for a usable count, which is pinned rather than assumed.

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -116,7 +116,9 @@ def train_policy(
             checkpoint of ``NaN``, and no backend reports either.
         save_freq: Checkpoint cadence in steps.
         num_gpus: GPUs on this node (``>1`` -> accelerate/torchrun multi-GPU).
-        num_nodes: Nodes (Cosmos HSDP / torchrun ``--nnodes``).
+            A positive integer; anything else is refused by preflight.
+        num_nodes: Nodes (Cosmos HSDP / torchrun ``--nnodes``). A positive
+            integer; anything else is refused by preflight.
         resume: Resume from the latest checkpoint under ``output_dir``.
         seed: Master seed.
         method: Tuning strategy - ``"full"`` | ``"lora"`` | ``"expert_only"`` |

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -36,6 +36,13 @@ documents the field as one of the "universal" ones. It is separate from
 :func:`validate_train_inputs` because that gate answers a different question
 (is this value safe to interpolate into a config or an argv token) from this one
 (can this value be honored at all).
+
+:func:`launch_topology_problems` is the fourth, on the *launch topology* axis:
+``num_gpus`` and ``num_nodes``, the two process counts every distributed launch
+is sized from. It is scoped like :func:`run_size_problems` rather than like
+:func:`learning_rate_problems` - only the three supervised backends read either
+field (they become a ``torchrun``/``elastic_launch`` ``nproc_per_node`` /
+``nnodes``), so a backend that ignores them must not report on them.
 """
 
 from __future__ import annotations
@@ -133,6 +140,53 @@ def run_size_problems(spec: TrainSpec, *, context: str) -> list[str]:
     """
     problems: list[str] = []
     for param, value in (("steps", spec.steps), ("global_batch_size", spec.global_batch_size)):
+        error = positive_count_error(value, param, context)
+        if error is not None:
+            problems.append(error)
+    return problems
+
+
+def launch_topology_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return launch-topology problems for a :class:`TrainSpec`.
+
+    ``num_gpus`` and ``num_nodes`` are the two process counts a distributed run
+    is sized from. Each is consumed as a discrete count in three places: a
+    ``spec.num_gpus > 1`` / ``spec.num_nodes > 1`` test that selects between the
+    single-process and the multi-process launch path, a ``nproc_per_node`` /
+    ``nnodes`` argument to torch's ``elastic_launch``, and a
+    ``--nproc_per_node=`` / ``--nnodes=`` / ``--num_gpus=`` argv token. Only a
+    positive integer can be honored, and each of the three ways a bad value
+    fails is silent or late:
+
+    * ``0``, a negative, ``nan`` and ``True`` all read as *not* greater than one
+      -- ``nan`` compares false against everything -- so the selector routes
+      them to the single-process path and the run proceeds on one process under
+      a successful result. The topology the caller asked for is simply not the
+      one that ran, and for ``num_nodes`` that also slips past the multi-node
+      refusal the backends raise for an unsupported topology.
+    * ``2.7`` and ``inf`` *are* greater than one, so they select the
+      multi-process path and reach ``elastic_launch`` as the worker count.
+      ``LaunchConfig`` accepts both without complaint, so nothing downstream
+      rejects them either.
+    * A string, ``None`` or a list raises ``TypeError`` out of the comparison
+      itself -- from inside a :meth:`Trainer.validate` that is documented to
+      *return* problems.
+
+    Both are therefore checked against the one shared
+    :func:`~strands_robots.utils.positive_count_error` domain, the same one
+    :func:`run_size_problems` uses, rather than by a local comparison.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        One problem per unusable field; empty when both are usable counts.
+    """
+    problems: list[str] = []
+    for param, value in (("num_gpus", spec.num_gpus), ("num_nodes", spec.num_nodes)):
         error = positive_count_error(value, param, context)
         if error is not None:
             problems.append(error)

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -95,8 +95,14 @@ class TrainSpec:
         save_freq: Checkpoint cadence in steps.
         num_gpus: GPUs on this node. ``>1`` runs the backend under torch's
             in-process ``elastic_launch`` (the engine behind ``torchrun``).
+            A positive integer; a non-positive, fractional, non-finite or
+            ``bool`` process count cannot be honored - the ``>1`` selector
+            would silently route it to a single-process run, or hand it to
+            ``elastic_launch`` as the worker count - so it is refused by
+            :meth:`Trainer.validate` before a run starts.
         num_nodes: Nodes for multi-node training (Cosmos HSDP /
-            ``torchrun --nnodes``).
+            ``torchrun --nnodes``). Same positive-integer domain as
+            ``num_gpus``, and for the same reason.
         resume: Resume from the latest checkpoint under ``output_dir`` when
             one exists.
         seed: Master seed (best-effort; not all backends expose it).
@@ -289,6 +295,33 @@ class Trainer(ABC):
         from strands_robots.training._validate import learning_rate_problems
 
         return learning_rate_problems(spec, context=self.provider_name)
+
+    def _launch_topology_problems(self, spec: TrainSpec) -> list[str]:
+        """Launch-topology preflight shared by every backend that consumes it.
+
+        Returns problems for :attr:`TrainSpec.num_gpus` /
+        :attr:`TrainSpec.num_nodes` - the two process counts a distributed
+        launch is sized from - against the same shared positive-count domain
+        :meth:`_run_size_problems` uses. A :meth:`validate` implementation that
+        reads either field MUST call this instead of comparing the value
+        itself: the ``> 1`` test that selects the multi-process launch path
+        reads ``0``, a negative, ``nan`` and ``True`` as "not more than one" and
+        silently runs on a single process, passes ``2.7`` and ``inf`` through to
+        ``elastic_launch`` (which accepts them), and raises ``TypeError`` for a
+        string or ``None`` - from a method documented to *return* problems.
+
+        A backend that launches from neither field MUST NOT call this: per
+        :class:`TrainSpec`, a backend ignores the fields it does not support, so
+        reporting on one it never reads would be a false rejection. That is why
+        this is a separate gate from :meth:`_learning_rate_problems`, which
+        every backend does call.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import launch_topology_problems
+
+        return launch_topology_problems(spec, context=self.provider_name)
 
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -156,6 +156,7 @@ class Cosmos3Trainer(Trainer):
             )
         problems.extend(self._run_size_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
+        problems.extend(self._launch_topology_problems(spec))
 
         if not spec.extra.get("sft_toml"):
             problems.append(

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -155,8 +155,14 @@ class Gr00tTrainer(Trainer):
             )
         problems.extend(self._run_size_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
+        # Captured rather than extended blind: the multi-node refusal below
+        # compares num_nodes, which is only a meaningful comparison once this
+        # gate has established it IS a count - a string or None would raise out
+        # of the comparison instead of being reported.
+        topology_problems = self._launch_topology_problems(spec)
+        problems.extend(topology_problems)
 
-        if spec.num_nodes > 1:
+        if not topology_problems and spec.num_nodes > 1:
             problems.append(
                 f"num_nodes={spec.num_nodes}: multi-node GR00T needs a per-node "
                 "rendezvous launcher; this in-process trainer runs single-node only. "

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -595,8 +595,14 @@ class LerobotTrainer(Trainer):
 
         problems.extend(self._run_size_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
+        # Captured rather than extended blind: the multi-node refusal below
+        # compares num_nodes, which is only a meaningful comparison once this
+        # gate has established it IS a count - a string or None would raise out
+        # of the comparison instead of being reported.
+        topology_problems = self._launch_topology_problems(spec)
+        problems.extend(topology_problems)
 
-        if spec.num_nodes > 1:
+        if not topology_problems and spec.num_nodes > 1:
             problems.append(
                 f"num_nodes={spec.num_nodes}: multi-node lerobot needs a per-node "
                 "launcher and cannot run in-process; use num_nodes=1."

--- a/tests/training/test_launch_topology_domain.py
+++ b/tests/training/test_launch_topology_domain.py
@@ -1,0 +1,319 @@
+"""The launch topology a TrainSpec asks for is one shared positive-count domain.
+
+:attr:`~strands_robots.training.base.TrainSpec.num_gpus` and
+:attr:`~strands_robots.training.base.TrainSpec.num_nodes` are the two process
+counts a distributed run is sized from. Each is read in three places by the
+three supervised backends: a ``spec.num_gpus > 1`` / ``spec.num_nodes > 1`` test
+that selects between the single-process and the multi-process launch path, a
+``nproc_per_node`` / ``nnodes`` argument to torch's ``elastic_launch``, and a
+``--nproc_per_node=`` / ``--nnodes=`` / ``--num_gpus=`` argv token.
+
+Before this contract neither field had a domain, while their run-size
+neighbours ``steps`` and ``global_batch_size`` shared one - and every way a bad
+process count failed was silent or late:
+
+* ``0``, a negative, ``nan`` and ``True`` all compare as *not* greater than one
+  (``nan`` compares false against everything), so the selector routed them to
+  the single-process path and the run proceeded on one process under a
+  successful result. For ``num_nodes`` that also slipped past the multi-node
+  refusal LeRobot and GR00T raise for a topology they cannot run.
+* ``2.7`` and ``inf`` *are* greater than one, so they selected the multi-process
+  path and reached ``elastic_launch`` as the worker count.
+  ``torch.distributed.launcher.api.LaunchConfig`` accepts both without
+  complaint, so nothing downstream rejected them either.
+* A string, ``None`` or a list raised ``TypeError`` out of the comparison
+  itself - from inside a :meth:`Trainer.validate` documented to *return*
+  problems.
+
+The tests below pin the contract in both directions: every backend that reads
+either field refuses the same unusable values through the one shared domain with
+a message naming itself, a usable topology is untouched (including the
+multi-node refusal, which must still fire for a *usable* count), a backend that
+ignores the fields reports nothing about them, and the refused values are
+grounded in what the comparison and the real launcher do with them.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.training._validate import launch_topology_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+from strands_robots.training.groot import Gr00tTrainer
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.training.mock import MockTrainer
+
+# The two fields, and the backends that launch from them.
+TOPOLOGY_FIELDS = ("num_gpus", "num_nodes")
+LAUNCHING_BACKENDS = (LerobotTrainer, Gr00tTrainer, Cosmos3Trainer)
+
+# Values no launcher can honor, split by how each one failed before the gate.
+
+# Read as "not more than one" by the selector -> a silent single-process run.
+SILENT_SINGLE_PROCESS = (0, -4, True, False, float("nan"))
+
+# Read as "more than one" -> reached elastic_launch as the worker count.
+REACHED_THE_LAUNCHER = (2.7, float("inf"))
+
+# Raised TypeError out of the comparison, from inside validate().
+RAISED_OUT_OF_VALIDATE = ("4", None, [2])
+
+UNUSABLE = SILENT_SINGLE_PROCESS + REACHED_THE_LAUNCHER + tuple(RAISED_OUT_OF_VALIDATE)
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path) -> TrainSpec:
+    """A spec whose topology fields are the only thing under test.
+
+    ``validate`` may well report unrelated problems (GR00T wants a checkout,
+    Cosmos a recipe TOML); every assertion below filters for the field name, so
+    an unrelated problem cannot mask - or fake - a topology verdict.
+    """
+    return TrainSpec(
+        dataset_root=str(tmp_path / "ds"),
+        output_dir=str(tmp_path / "out"),
+        base_model="lerobot/act",
+        embodiment="new_embodiment",
+    )
+
+
+def _problems_about(trainer: Trainer, spec: TrainSpec, field: str) -> list[str]:
+    """``validate`` problems that name *field*."""
+    return [p for p in trainer.validate(spec) if field in p]
+
+
+class TestEveryLaunchingBackendRefusesAnUnusableProcessCount:
+    """Each backend that launches from a field refuses every unusable value."""
+
+    @pytest.mark.parametrize("trainer_cls", LAUNCHING_BACKENDS)
+    @pytest.mark.parametrize("field", TOPOLOGY_FIELDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], field: str, value: Any
+    ) -> None:
+        setattr(spec, field, value)
+        problems = _problems_about(trainer_cls(), spec, field)
+        assert problems, f"{trainer_cls.__name__} accepted {field}={value!r}"
+        assert any("must be a positive integer" in p for p in problems), problems
+
+    @pytest.mark.parametrize("trainer_cls", LAUNCHING_BACKENDS)
+    @pytest.mark.parametrize("field", TOPOLOGY_FIELDS)
+    def test_the_problem_names_the_backend_that_refused_it(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], field: str
+    ) -> None:
+        trainer = trainer_cls()
+        setattr(spec, field, 0)
+        assert any(p.startswith(f"{trainer.provider_name}: {field} ") for p in _problems_about(trainer, spec, field))
+
+    @pytest.mark.parametrize("trainer_cls", LAUNCHING_BACKENDS)
+    @pytest.mark.parametrize("field", TOPOLOGY_FIELDS)
+    @pytest.mark.parametrize("value", RAISED_OUT_OF_VALIDATE)
+    def test_a_non_numeric_count_is_a_problem_not_an_exception(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], field: str, value: Any
+    ) -> None:
+        """``validate`` returns problems; it must not raise out of a comparison."""
+        setattr(spec, field, value)
+        problems = trainer_cls().validate(spec)  # must not raise
+        assert any(field in p for p in problems), problems
+
+
+class TestAUsableTopologyIsUntouched:
+    """A usable process count raises no topology problem on any backend."""
+
+    @pytest.mark.parametrize("trainer_cls", LAUNCHING_BACKENDS)
+    @pytest.mark.parametrize("value", (1, 2, 8))
+    def test_a_usable_gpu_count_is_not_a_problem(self, spec: TrainSpec, trainer_cls: type[Trainer], value: int) -> None:
+        spec.num_gpus = value
+        assert _problems_about(trainer_cls(), spec, "num_gpus") == []
+
+    @pytest.mark.parametrize("trainer_cls", LAUNCHING_BACKENDS)
+    def test_the_single_node_default_is_not_a_problem(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        spec.num_nodes = 1
+        assert _problems_about(trainer_cls(), spec, "num_nodes") == []
+
+    @pytest.mark.parametrize("trainer_cls", (LerobotTrainer, Gr00tTrainer))
+    def test_the_multi_node_refusal_still_fires_for_a_usable_count(
+        self, spec: TrainSpec, trainer_cls: type[Trainer]
+    ) -> None:
+        """The guarded comparison must still run once the count IS a count.
+
+        LeRobot and GR00T cannot launch multi-node in-process and say so. That
+        comparison is now reached only when the shared domain has established
+        ``num_nodes`` is a count - so this pins that gating it did not disable
+        it.
+        """
+        spec.num_nodes = 8
+        problems = _problems_about(trainer_cls(), spec, "num_nodes")
+        assert any("multi-node" in p for p in problems), problems
+        assert not any("must be a positive integer" in p for p in problems), problems
+
+
+class TestABackendThatIgnoresTheFieldsReportsNothing:
+    """A backend must not report on a field it never reads.
+
+    :class:`TrainSpec` documents that a backend "reads the fields it supports
+    and ignores the rest", so this gate is scoped to the launching backends
+    rather than made universal like the learning-rate one.
+    """
+
+    @pytest.mark.parametrize("field", TOPOLOGY_FIELDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_mock_backend_launches_from_neither_field(self, spec: TrainSpec, field: str, value: Any) -> None:
+        setattr(spec, field, value)
+        assert _problems_about(MockTrainer(), spec, field) == []
+
+    @pytest.mark.parametrize("field", TOPOLOGY_FIELDS)
+    def test_an_rl_backend_launches_from_neither_field(self, tmp_path: pathlib.Path, field: str) -> None:
+        pytest.importorskip("torch")
+        from strands_robots.training.rl.base_algo import RLTrainSpec
+        from strands_robots.training.rl.fast_sac import FastSacTrainer
+
+        rl_spec = RLTrainSpec(
+            output_dir=str(tmp_path),
+            env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+        )
+        setattr(rl_spec, field, 0)
+        assert [p for p in FastSacTrainer().validate(rl_spec) if field in p] == []
+
+
+class TestTheRefusedValuesAreOnesTheLauncherCannotHonor:
+    """Ground the domain in what the selector and the real launcher do."""
+
+    @pytest.mark.parametrize("value", SILENT_SINGLE_PROCESS)
+    def test_a_silent_value_reads_as_not_more_than_one(self, value: Any) -> None:
+        """The ``> 1`` selector routes each of these to the single-process path."""
+        assert not value > 1
+
+    def test_nan_compares_false_against_every_bound(self) -> None:
+        """Why ``nan`` slipped through a comparison-based guard in both directions."""
+        nan = float("nan")
+        assert not nan > 1
+        assert not nan <= 0
+        assert math.isnan(nan)
+
+    @pytest.mark.parametrize("value", REACHED_THE_LAUNCHER)
+    def test_a_launcher_bound_value_reads_as_more_than_one(self, value: Any) -> None:
+        assert value > 1
+
+    @pytest.mark.parametrize("value", SILENT_SINGLE_PROCESS + REACHED_THE_LAUNCHER)
+    def test_the_torch_launcher_does_not_reject_it_either(self, value: Any) -> None:
+        """Nothing downstream catches an unusable worker count.
+
+        ``LaunchConfig`` is the value's first destination once the selector
+        chooses the multi-process path, and it accepts every one of these - so
+        the preflight is the only place the caller can be told.
+        """
+        pytest.importorskip("torch")
+        from torch.distributed.launcher.api import LaunchConfig
+
+        config = LaunchConfig(min_nodes=1, max_nodes=1, nproc_per_node=value)
+        assert config.nproc_per_node == value or (
+            isinstance(value, float) and math.isnan(value) and math.isnan(config.nproc_per_node)
+        )
+
+    @pytest.mark.parametrize("value", RAISED_OUT_OF_VALIDATE)
+    def test_a_non_numeric_count_cannot_be_compared_at_all(self, value: Any) -> None:
+        """Which is why the old comparison raised rather than reporting."""
+        with pytest.raises(TypeError):
+            _ = value > 1  # type: ignore[operator]
+
+
+def _trainer_modules() -> list[pathlib.Path]:
+    """Every backend module, INCLUDING the ``rl`` subpackage.
+
+    Rooted at the module that defines :class:`Trainer` so the scan cannot
+    silently point at the wrong tree. The module that *defines* the shared gate
+    is excluded - derived from the gate itself rather than named, so the
+    exclusion cannot drift - because it reads both fields as their owner rather
+    than as a consumer of them.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(launch_topology_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_a_topology_field(source: str) -> bool:
+    """Does *source* read ``spec.num_gpus`` / ``spec.num_nodes``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr in TOPOLOGY_FIELDS and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_launch_topology_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheLaunchTopologyDomain:
+    """No backend may re-implement the domain, and none may skip it.
+
+    The set of backends in scope is derived from the tree rather than listed:
+    a module that *reads* either field must route it through the shared gate, so
+    a fourth backend that starts launching from ``num_gpus`` fails this test
+    until it does.
+    """
+
+    def test_the_scan_finds_the_launching_backends(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
+        readers = {p.name for p in _trainer_modules() if _reads_a_topology_field(p.read_text())}
+        assert readers == {"cosmos3.py", "groot.py", "lerobot.py"}
+
+    def test_every_backend_that_launches_routes_through_the_shared_gate(self) -> None:
+        adrift = sorted(
+            p.name
+            for p in _trainer_modules()
+            if _reads_a_topology_field(source := p.read_text()) and not _calls_the_gate(source)
+        )
+        assert adrift == [], f"modules reading a topology field without the shared gate: {adrift}"
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        """A local ``<= 0`` / ``< 1`` test on either field is the hole this closed.
+
+        A ``> 1`` comparison is a different question - "is this topology one I
+        can launch" - and stays where it is.
+        """
+        offenders: list[str] = []
+        for path in _trainer_modules():
+            for line in path.read_text().splitlines():
+                if any(f"spec.{field}" in line for field in TOPOLOGY_FIELDS) and (
+                    "<= 0" in line or "< 1" in line or "!= int" in line
+                ):
+                    offenders.append(f"{path.name}: {line.strip()}")
+        assert offenders == [], f"local domain checks on a topology field: {offenders}"
+
+    def test_the_scanners_detect_a_planted_defect(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = "def validate(self, spec):\n    return [] if spec.num_gpus > 1 else []\n"
+        assert _reads_a_topology_field(planted)
+        assert not _calls_the_gate(planted)
+
+
+class TestTheGateIsUsableOnItsOwn:
+    """The shared gate's own contract, independent of any backend."""
+
+    def test_it_reports_the_context_it_was_given(self, spec: TrainSpec) -> None:
+        spec.num_gpus = 0
+        assert launch_topology_problems(spec, context="acme") == ["acme: num_gpus must be a positive integer, got 0."]
+
+    def test_a_usable_topology_reports_nothing(self, spec: TrainSpec) -> None:
+        spec.num_gpus, spec.num_nodes = 8, 2
+        assert launch_topology_problems(spec, context="acme") == []
+
+    def test_both_fields_are_reported_together(self, spec: TrainSpec) -> None:
+        spec.num_gpus, spec.num_nodes = 0, "4"  # type: ignore[assignment]
+        problems = launch_topology_problems(spec, context="acme")
+        assert len(problems) == 2
+        assert "num_gpus" in problems[0] and "num_nodes" in problems[1]


### PR DESCRIPTION
## Problem

`TrainSpec.num_gpus` and `TrainSpec.num_nodes` are the two process counts a distributed run is sized from, and neither had a domain — while their run-size neighbours `steps` and `global_batch_size` share one.

Each is read in three places by the three supervised backends: a `spec.num_gpus > 1` / `spec.num_nodes > 1` test that selects between the single-process and the multi-process launch path, a `nproc_per_node` / `nnodes` argument to torch's `elastic_launch`, and a `--nproc_per_node=` / `--nnodes=` / `--num_gpus=` argv token. Every way an unusable count failed was silent or late:

| shape | what happened |
|---|---|
| `0`, `-4`, `True`, `nan` | compare as **not** greater than one (`nan` compares false against everything), so the selector routed them to the single-process path and the run proceeded on one process under a successful result. The topology the caller asked for simply was not the one that ran. |
| `2.7`, `inf` | **are** greater than one, so they selected the multi-process path and reached `elastic_launch` as the worker count. |
| `'4'`, `None`, `[2]` | raised `TypeError: '>' not supported between instances of 'str' and 'int'` out of the comparison itself — from inside a `Trainer.validate` documented to *return* problems. |

Two details make this a preflight rather than something a backend can be left to notice:

- **Nothing downstream rejects it either.** `torch.distributed.launcher.api.LaunchConfig` accepts `0`, `-4`, `True`, `nan`, `2.7` and `inf` as `nproc_per_node` without complaint (measured, and pinned as a test).
- **`nan` slipped past an existing refusal.** LeRobot and GR00T explicitly refuse a multi-node topology they cannot launch in-process (`num_nodes=8` → *"multi-node lerobot needs a per-node launcher and cannot run in-process"*). Because that refusal is a `> 1` comparison, `num_nodes=nan` sailed through it.

Measured over all 54 (value × field × backend) combinations: **44 accepted and ran, 6 raised out of `validate()`**, 4 refused.

## Change

Adds `launch_topology_problems` to `strands_robots.training._validate` — a fourth shared gate beside the existing injection-safety, run-size and learning-rate ones, reached through a new `Trainer._launch_topology_problems` and built on the same `positive_count_error` domain the run-size gate already uses. No new helper: the domain existed, only the wiring was missing.

Every `Trainer.train` already fails closed on a `validate` problem, so the preflight covers the launch path on every call route.

**Scoped like the run-size gate rather than made universal.** `TrainSpec` documents that a backend "reads the fields it supports and ignores the rest", and only the three supervised backends launch from either field — so the mock and RL trainers must not report on them (pinned). That scoping is enforced *structurally*: the set of backends required to route through the gate is derived from which modules actually read `spec.num_gpus` / `spec.num_nodes`, so a fourth backend that starts launching from one fails the parity test until it does. The gate's own defining module is excluded from that scan by deriving its path from the gate symbol, not by name.

**The two multi-node refusals are now ordered after the domain check**, so each is reached only once the shared domain has established the value *is* a count — a string would otherwise still raise out of that comparison. Both still fire for a usable count, which is pinned rather than assumed.

### Deliberately out of scope

- `save_freq` — lerobot's `should_save_checkpoint` documents a non-positive value as a *mode selector* ("disables periodic saving … mirroring how `log_freq`/`eval_freq` treat non-positive values"), so it is a documented capability, not a degenerate size.
- Cosmos' `max(1, spec.num_gpus)` / `max(1, spec.num_nodes)` clamps are left in place: they also serve `build_train_command`, whose own docstring says it is *not* used to launch training and which is reachable without `validate()`. With the gate in place they are no-ops on the launch path.

## Measured verdicts

![launch topology domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/launch-topology-domain/topology_domain.png)

Every cell comes from one measurement script run against two trees (`upstream/main` in a detached worktree, and this branch); the figure generator asserts the two runs resolved to different trees and re-derives every quoted number from the two JSON dumps before saving. Script, generator and both raw dumps: [`artifacts/launch-topology-domain`](https://github.com/cagataycali/robots/tree/artifacts/launch-topology-domain).

| | main | this change |
|---|---|---|
| accepted, run proceeded | 44 of 54 | **0 of 54** |
| raised out of `validate()` | 6 of 54 | **0 of 54** |
| refused before the run starts | 4 of 54 | **54 of 54** |

`num_gpus` 1 / 2 / 8 and `num_nodes` 1 give byte-identical verdicts on both trees (12 control cells), and `num_nodes=8` is still refused as an unsupported topology on LeRobot/GR00T.

No sim, policy, rendering, recording or asset behaviour changes in this PR, so the artifact is a measured verdict matrix rather than a rollout.

## Tests

New `tests/training/test_launch_topology_domain.py` (145 tests), pinning the contract in both directions:

- every launching backend refuses each unusable value for both fields, with a message naming itself;
- a non-numeric count is a **problem, not an exception**;
- a usable count is untouched, **and the multi-node refusal still fires for one** (so gating that comparison did not disable it);
- the mock and RL backends report nothing about fields they never read;
- the refused values are grounded in what the selector and the real `LaunchConfig` do with them, including why `nan` defeats a comparison-based guard in both directions;
- an AST parity guard with a non-vacuity assertion on the discovered backend set and a planted-defect meta-test.

## Gate (Thor, aarch64, `MUJOCO_GL=egl`)

- **Full suite: 19750 passed, 257 skipped, 0 failed** (514s) at base `0365e40c`.
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1066 files).
- `mypy strands_robots tests tests_integ`: **0 errors outside `examples/`**. The 14 `examples/isaac_gs` errors are byte-identical to a pristine `upstream/main` worktree of the same working copy (error sets `diff` clean), i.e. environmental and not introduced here.
- Repo-wide root guards (changelog fragments/format, dangling doc refs, internal file paths, unreachable statements): 42 passed.
- `scripts/check_merge_base_overlap.py`: no overlap with `upstream/main`.
- **Pre-fix proof**: reverting only the three call sites to `upstream/main` (keeping the new gate importable) → **85 failed / 60 passed**; with the wiring → **145 passed**. The 60 that pass pre-fix are the premise pins, the mock/RL tolerance controls, the usable-value controls and the gate's own unit tests — the gate existed, it just was not wired — and they are what stop the guard over-reaching.