### PR TITLE
fix(simulation): a rollout seed is applied or refused, not silently dropped

### DIFF
--- a/changelog.d/1948-rollout-seed-applied-or-refused.md
+++ b/changelog.d/1948-rollout-seed-applied-or-refused.md
@@ -1,0 +1,31 @@
+### Fixed: a rollout seed is applied or refused, not silently dropped
+
+`seed` reached exactly one statement in `PolicyRunner.evaluate` - the
+`_evaluate_with_spec` delegation - so the plain `success_fn` loop below it never
+read the value. Every `SimEngine.eval_policy` call lands in that loop, because
+that facade exposes no `spec` parameter, so the whole surface accepted a
+reproducibility seed and discarded it: two evals at `seed=7` drew different
+actions, `policy.reset(seed=...)` was never forwarded, and both reported
+`status="success"`. `eval_policy`'s own docstring advertises that it and
+`run_policy` behave the same way, and `run()`'s comment describes itself as
+mirroring "the per-episode reseed in `evaluate()`" that did not exist there.
+
+The seed is now applied on that path exactly as on the spec path: reseeded once
+from the master seed, then per episode from a master RNG derived from it, with
+each per-episode seed forwarded to `policy.reset` so a service-mode policy can
+reseed its own process. A `None` seed leaves RNG state untouched, so an unseeded
+eval acquires no global side effect it did not have.
+
+Honoring the seed also settles its domain, because an unusable value cannot be
+applied at all - the seed ends at `numpy.random.seed` / `default_rng`. That half
+had been going three ways, none of them naming the parameter: `run_policy` raised
+NumPy's own `TypeError: Cannot cast scalar from dtype('float64') to
+dtype('int64')` out of a method documented to return a structured result and
+bound as an agent-tool action; `start_policy` reported "started" and failed on
+its worker thread; and `True` was accepted everywhere as a silent seed of `1`.
+`run_policy` / `eval_policy` / `start_policy` / `evaluate_benchmark`,
+`PolicyRunner.run` / `.evaluate` and the `run_policy` agent tool now share
+`randomization_seed_error` - the same domain `randomize` and `set_obs_noise`
+already used - so a seed refused for one cannot be accepted for the rollout whose
+reproducibility it is supposed to pin. The tool refuses it before it opens a
+dataset, matching its sibling pre-flight checks.

--- a/changelog.d/1948-rollout-seed-applied-or-refused.md
+++ b/changelog.d/1948-rollout-seed-applied-or-refused.md
@@ -43,3 +43,12 @@ ceiling, and the rollout surfaces pass `MAX_EVAL_SEED`; `randomize` /
 honor. `set_eval_seed` enforces it too, since it is public API documented for
 direct callers, and the `run_policy` tool checks the seed its *last* episode
 derives (`seed + n_episodes - 1`) rather than only the one it was handed.
+
+`MAX_EVAL_SEED` lives in `simulation/base.py`, beside the `max_seed` parameter it
+feeds, rather than in `policy_runner.py` with the applier it describes. The note
+above `base.py`'s `policy_runner` import records why: CodeQL's
+`py/unsafe-cyclic-import` walks `TYPE_CHECKING` blocks, and `policy_runner`
+imports `SimEngine` from `base` under one, so any name added to that module-level
+import line closes an AST-visible cycle. The rollout side reaches the constant
+through the function-local import it already uses for `randomization_seed_error`,
+so neither module gains a module-level edge.

--- a/changelog.d/1948-rollout-seed-applied-or-refused.md
+++ b/changelog.d/1948-rollout-seed-applied-or-refused.md
@@ -29,3 +29,17 @@ its worker thread; and `True` was accepted everywhere as a silent seed of `1`.
 already used - so a seed refused for one cannot be accepted for the rollout whose
 reproducibility it is supposed to pin. The tool refuses it before it opens a
 dataset, matching its sibling pre-flight checks.
+
+The rollout surfaces carry one bound the randomization surfaces do not, because
+their appliers are not equally wide. `set_eval_seed` reseeds the legacy NumPy
+global RNG (`numpy.random.seed`) as well as `default_rng`, and that one refuses
+anything above `2**32 - 1` - so a seed in `[2**32, inf)`, which includes the
+common millisecond-epoch timestamp idiom, was accepted and then raised NumPy's
+own `Seed must be between 0 and 2**32 - 1` from inside the rollout: past the
+envelope on `eval_policy`, and on a worker thread after `start_policy` had
+already reported "started". `randomization_seed_error` now takes an optional
+ceiling, and the rollout surfaces pass `MAX_EVAL_SEED`; `randomize` /
+`set_obs_noise` reach only `default_rng` and keep the unbounded domain they can
+honor. `set_eval_seed` enforces it too, since it is public API documented for
+direct callers, and the `run_policy` tool checks the seed its *last* episode
+derives (`seed + n_episodes - 1`) rather than only the one it was handed.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 # AST). Instead, we reference ``OnFrame`` in the ``evaluate_benchmark``
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
-from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
+from strands_robots.simulation.policy_runner import MAX_EVAL_SEED, PolicyRunner, VideoConfig
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     is_boolean,
@@ -271,7 +271,7 @@ def finite_non_negative_error(value: Any, param: str, context: str) -> str | Non
     return None
 
 
-def randomization_seed_error(value: Any, context: str) -> str | None:
+def randomization_seed_error(value: Any, context: str, *, max_seed: int | None = None) -> str | None:
     """Return why a value cannot seed a reproducible randomization stream.
 
     The seed reaches ``numpy.random.default_rng``, which accepts only
@@ -286,14 +286,27 @@ def randomization_seed_error(value: Any, context: str) -> str | None:
     the domain-randomization streams, and the ``seed`` of a policy rollout or
     evaluation (``run_policy`` / ``eval_policy`` / ``start_policy`` /
     ``evaluate_benchmark``), which pins the client RNGs a stochastic policy
-    samples from. Both end at ``numpy.random.seed`` / ``default_rng``, so a
-    seed one refuses cannot be usable for the other. The name reads for the
-    first family and is accurate for both: a rollout seed exists precisely to
-    make the policy's randomization reproducible.
+    samples from. The name reads for the first family and is accurate for both:
+    a rollout seed exists precisely to make the policy's randomization
+    reproducible.
+
+    Their appliers are not equally wide, so the accepted domain is not either.
+    ``randomize`` / ``set_obs_noise`` reach ``default_rng``, which takes a
+    non-negative integer of any width. A rollout seed is applied through
+    :func:`~strands_robots.simulation.policy_runner.set_eval_seed`, which also
+    reseeds the legacy NumPy global RNG (``numpy.random.seed``) - the one most
+    policies draw from - and that refuses anything above
+    :data:`~strands_robots.simulation.policy_runner.MAX_EVAL_SEED`. ``max_seed``
+    carries that ceiling, so the rollout surfaces refuse a value they could not
+    apply while the randomization surfaces keep the width they can honor. One
+    rule with an explicit bound per destination is what stops the accepted
+    domain drifting from the applier in either direction.
 
     Args:
         value: The candidate seed (``None`` selects fresh entropy).
         context: Method name to prefix the message with.
+        max_seed: Largest value the caller's applier can honor, or ``None``
+            when the non-negative-integer rule is the only bound.
 
     Returns:
         ``None`` when the seed is usable, otherwise the reason as a string.
@@ -304,6 +317,11 @@ def randomization_seed_error(value: Any, context: str) -> str | None:
         return f"{context}: seed must be a non-negative integer or None, got {value!r} (None draws fresh entropy)"
     if int(value) < 0:
         return f"{context}: seed must be a non-negative integer or None, got {value!r} (None draws fresh entropy)"
+    if max_seed is not None and int(value) > max_seed:
+        return (
+            f"{context}: seed must be an integer in [0, {max_seed}] or None, got {value!r} "
+            "(a rollout seed is applied to the legacy NumPy global RNG, which refuses a larger value)"
+        )
     return None
 
 
@@ -1537,6 +1555,14 @@ class SimEngine(ABC):
         tool-error envelope, so a seed refused for ``randomize`` cannot be
         accepted for the rollout whose reproducibility it is supposed to pin.
 
+        The rollout binding supplies :data:`MAX_EVAL_SEED` as the ceiling. Its
+        applier reseeds the legacy NumPy global RNG as well as ``default_rng``,
+        and that one refuses a larger value - so without the bound a seed in
+        ``[2**32, inf)`` passed this guard and then raised NumPy's own message
+        from inside the rollout, which is the failure this guard exists to
+        replace. ``randomize`` / ``set_obs_noise`` reach only ``default_rng``
+        and keep the unbounded domain they can honor.
+
         Args:
             seed: The caller-supplied value (``None`` draws fresh entropy).
             method: Public method name, used to prefix the error message.
@@ -1544,7 +1570,7 @@ class SimEngine(ABC):
         Returns:
             An error dict naming the offending parameter, or ``None``.
         """
-        if error := randomization_seed_error(seed, method):
+        if error := randomization_seed_error(seed, method, max_seed=MAX_EVAL_SEED):
             return {"status": "error", "content": [{"text": error}]}
         return None
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -316,12 +316,11 @@ def randomization_seed_error(value: Any, context: str, *, max_seed: int | None =
     non-negative integer of any width. A rollout seed is applied through
     :func:`~strands_robots.simulation.policy_runner.set_eval_seed`, which also
     reseeds the legacy NumPy global RNG (``numpy.random.seed``) - the one most
-    policies draw from - and that refuses anything above
-    :data:`MAX_EVAL_SEED`. ``max_seed``
-    carries that ceiling, so the rollout surfaces refuse a value they could not
-    apply while the randomization surfaces keep the width they can honor. One
-    rule with an explicit bound per destination is what stops the accepted
-    domain drifting from the applier in either direction.
+    policies draw from - and that refuses anything above :data:`MAX_EVAL_SEED`.
+    ``max_seed`` carries that ceiling, so the rollout surfaces refuse a value
+    they could not apply while the randomization surfaces keep the width they
+    can honor. One rule with an explicit bound per destination is what stops
+    the accepted domain drifting from the applier in either direction.
 
     Args:
         value: The candidate seed (``None`` selects fresh entropy).

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -281,6 +281,16 @@ def randomization_seed_error(value: Any, context: str) -> str | None:
     after the configuring call reported success - so it is rejected at the call
     that supplied it.
 
+    Two families share this domain, and they share it because the failure is
+    the same: the ``seed`` of ``randomize`` / ``set_obs_noise``, which drives
+    the domain-randomization streams, and the ``seed`` of a policy rollout or
+    evaluation (``run_policy`` / ``eval_policy`` / ``start_policy`` /
+    ``evaluate_benchmark``), which pins the client RNGs a stochastic policy
+    samples from. Both end at ``numpy.random.seed`` / ``default_rng``, so a
+    seed one refuses cannot be usable for the other. The name reads for the
+    first family and is accurate for both: a rollout seed exists precisely to
+    make the policy's randomization reproducible.
+
     Args:
         value: The candidate seed (``None`` selects fresh entropy).
         context: Method name to prefix the message with.
@@ -1506,6 +1516,39 @@ class SimEngine(ABC):
         return None
 
     @staticmethod
+    def _validate_seed(seed: Any, method: str) -> dict[str, Any] | None:
+        """Reject an unusable RNG seed at the public API.
+
+        A rollout seed is the caller's reproducibility contract: it reseeds the
+        client RNGs (and is forwarded to ``policy.reset``) so the same scene and
+        the same policy replay identically. Only a non-negative integer can do
+        that - the seed ends at ``numpy.random.seed`` / ``default_rng``, which
+        refuses everything else - so a value that cannot be applied is refused
+        at the call that supplied it rather than at the first draw.
+
+        Without this guard the same mistake surfaced three different ways, none
+        of them naming the parameter: ``run_policy`` raised NumPy's own
+        ``TypeError: Cannot cast scalar from dtype('float64') to dtype('int64')``
+        straight out of a method documented to return this envelope,
+        ``start_policy`` reported "started" and failed on its worker thread, and
+        ``True`` was accepted everywhere as a silent seed of ``1``.
+
+        Thin binding of :func:`randomization_seed_error` to this class's
+        tool-error envelope, so a seed refused for ``randomize`` cannot be
+        accepted for the rollout whose reproducibility it is supposed to pin.
+
+        Args:
+            seed: The caller-supplied value (``None`` draws fresh entropy).
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            An error dict naming the offending parameter, or ``None``.
+        """
+        if error := randomization_seed_error(seed, method):
+            return {"status": "error", "content": [{"text": error}]}
+        return None
+
+    @staticmethod
     def _validate_control_substeps(control_substeps: Any, method: str) -> dict[str, Any] | None:
         """Reject a ``control_substeps`` override the rollout cannot honor.
 
@@ -2186,6 +2229,13 @@ class SimEngine(ABC):
         # and time.sleep(...) downstream, and time.sleep rejects a numpy.float32
         # with a bare "cannot be interpreted as an integer" TypeError.
         control_frequency = float(control_frequency)
+
+        # The seed is the caller's reproducibility contract; an unusable one
+        # cannot be applied at all, and reached NumPy as a bare cast TypeError
+        # out of a method documented to return this envelope. Refused here,
+        # before a policy is built or a frame is written.
+        if err := self._validate_seed(seed, "run_policy"):
+            return err
 
         # accept n_steps (or legacy max_steps) as an alternate horizon
         # specification. duration = n_steps / control_frequency. If both
@@ -3007,6 +3057,14 @@ class SimEngine(ABC):
         ``n_episodes`` default lowered from 10 to 1 (callers opt in to
         longer evals explicitly).
 
+        ``seed`` pins the eval the way it pins a single :meth:`run_policy`
+        rollout: the client RNGs are reseeded once from it and then per episode
+        from a master RNG derived from it, and each per-episode seed is
+        forwarded to ``policy.reset`` so a service-mode policy can reseed its
+        own process. Two evals at the same seed replay identically; ``None``
+        leaves RNG state untouched. Only a non-negative integer can seed those
+        RNGs, so anything else is refused here rather than at the first draw.
+
         ``policy_object`` mirrors :meth:`run_policy`: pass an already-built
         ``Policy`` to skip the ``create_policy`` round-trip (e.g. a loaded
         SmolVLA checkpoint you want to evaluate without re-instantiating).
@@ -3144,6 +3202,8 @@ class SimEngine(ABC):
         if err := self._validate_positive_int(n_episodes, "n_episodes", "eval_policy"):
             return err
         if err := self._validate_positive_int(max_steps, "max_steps", "eval_policy"):
+            return err
+        if err := self._validate_seed(seed, "eval_policy"):
             return err
         if err := self._validate_positive_frequency(control_frequency, "eval_policy"):
             return err
@@ -3348,6 +3408,8 @@ class SimEngine(ABC):
         # start_recording one call earlier. Checked before any policy is
         # built so a rate disagreement costs no weight download and no frame.
         if err := self._validate_recording_rate(control_frequency, "evaluate_benchmark"):
+            return err
+        if err := self._validate_seed(seed, "evaluate_benchmark"):
             return err
         # Coerce to a plain Python float now the value is validated: a NumPy
         # scalar (accepted above via numbers.Real) flows into 1 / control_frequency

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 # AST). Instead, we reference ``OnFrame`` in the ``evaluate_benchmark``
 # signature as a *string* annotation; ``from __future__ import
 # annotations`` (already in effect) makes that a no-op at runtime.
-from strands_robots.simulation.policy_runner import MAX_EVAL_SEED, PolicyRunner, VideoConfig
+from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     is_boolean,
@@ -271,6 +271,27 @@ def finite_non_negative_error(value: Any, param: str, context: str) -> str | Non
     return None
 
 
+# The largest seed a rollout can apply. ``set_eval_seed`` reseeds the legacy
+# NumPy global RNG (``numpy.random.seed``), which refuses anything above
+# 2**32 - 1 - unlike ``numpy.random.default_rng``, the destination of the
+# ``randomize`` / ``set_obs_noise`` seeds, which accepts an integer of any
+# width. That is why a rollout seed carries a ceiling those two do not: the
+# accepted domain of a parameter is bounded by what its applier can honor, and
+# ``random.seed`` / ``torch.manual_seed`` (the other two RNGs seeded there) are
+# wider still.
+#
+# It lives here, beside the ``max_seed`` parameter it feeds, rather than in
+# ``policy_runner`` with the applier it describes. The note above this module's
+# ``policy_runner`` import is the reason: CodeQL's ``py/unsafe-cyclic-import``
+# walks ``TYPE_CHECKING`` blocks, and ``policy_runner`` imports ``SimEngine``
+# from here under one, so every name added to that module-level import line
+# closes an AST-visible cycle. Adding this constant to it raised
+# ``py/unsafe-cyclic-import`` on all three names that line carries. The rollout
+# side reaches it through the function-local import it already uses for
+# ``randomization_seed_error``, so neither module gains a module-level edge.
+MAX_EVAL_SEED = 2**32 - 1
+
+
 def randomization_seed_error(value: Any, context: str, *, max_seed: int | None = None) -> str | None:
     """Return why a value cannot seed a reproducible randomization stream.
 
@@ -296,7 +317,7 @@ def randomization_seed_error(value: Any, context: str, *, max_seed: int | None =
     :func:`~strands_robots.simulation.policy_runner.set_eval_seed`, which also
     reseeds the legacy NumPy global RNG (``numpy.random.seed``) - the one most
     policies draw from - and that refuses anything above
-    :data:`~strands_robots.simulation.policy_runner.MAX_EVAL_SEED`. ``max_seed``
+    :data:`MAX_EVAL_SEED`. ``max_seed``
     carries that ceiling, so the rollout surfaces refuse a value they could not
     apply while the randomization surfaces keep the width they can honor. One
     rule with an explicit bound per destination is what stops the accepted

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4114,7 +4114,10 @@ class MuJoCoSimEngine(
         # receive a false "started" success and the robot would be left marked
         # as running. Both horizon knobs are covered: the step count via
         # _resolve_horizon, and the wall-clock duration it falls back to (the
-        # default path, when n_steps is omitted) via _validate_duration.
+        # default path, when n_steps is omitted) via _validate_duration. The
+        # seed is covered for the same reason and was not: an unusable one
+        # reached NumPy on the worker thread, where the raise was swallowed, so
+        # the caller read "started" and the rollout ran unseeded.
         if err := self._validate_positive_frequency(control_frequency, "start_policy"):
             return err
         resolved_duration, resolved_n_steps, horizon_error = self._resolve_horizon(
@@ -4126,6 +4129,8 @@ class MuJoCoSimEngine(
             if err := self._validate_duration(resolved_duration, "start_policy"):
                 return err
         if err := self._validate_action_horizon(action_horizon, "start_policy"):
+            return err
+        if err := self._validate_seed(seed, "start_policy"):
             return err
         # Same reason as the horizon guards above: a malformed video config
         # would otherwise be rejected inside the future, after the caller has

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1112,6 +1112,19 @@ class PolicyRunner:
         # state untouched, preserving historical behaviour.
         # Refuse before any frame reaches the engine's open recording.
         self._reject_recording_rate_mismatch(control_frequency, "PolicyRunner.run")
+        # The domain is enforced here as well as at the facades one layer up:
+        # PolicyRunner is drivable directly, and a direct caller has no
+        # structured envelope to read a refusal from. Same shared rule as
+        # SimEngine._validate_seed, raised rather than returned because raising
+        # is this layer's contract.
+        # Local import: base.py imports PolicyRunner at module level, so
+        # reaching the shared domain from here has to stay deferred - the
+        # same convention this module already uses for
+        # simulation.benchmark / simulation.recording / simulation.predicates.
+        from strands_robots.simulation.base import randomization_seed_error
+
+        if seed_error := randomization_seed_error(seed, "PolicyRunner.run"):
+            raise ValueError(seed_error)
         if seed is not None:
             set_eval_seed(seed)
             try:
@@ -2205,6 +2218,14 @@ class PolicyRunner:
         """
         # Refuse before any frame reaches the engine's open recording.
         self._reject_recording_rate_mismatch(control_frequency, "PolicyRunner.evaluate")
+        # Local import: base.py imports PolicyRunner at module level, so
+        # reaching the shared domain from here has to stay deferred - the
+        # same convention this module already uses for
+        # simulation.benchmark / simulation.recording / simulation.predicates.
+        from strands_robots.simulation.base import randomization_seed_error
+
+        if seed_error := randomization_seed_error(seed, "PolicyRunner.evaluate"):
+            raise ValueError(seed_error)
         if spec is not None and success_fn is not None:
             return {
                 "status": "error",
@@ -2286,6 +2307,21 @@ class PolicyRunner:
         # as run(). The default n_substeps=1 made eval rollouts under-step.
         n_substeps = self._control_substeps(control_frequency, control_substeps)
         policy.set_control_frequency(control_frequency)
+
+        # Reproducibility for this path. ``seed`` reached exactly one statement
+        # in this method - the ``_evaluate_with_spec`` delegation above - so the
+        # loop below ran unseeded while reporting success, and every
+        # ``eval_policy`` call lands here because that facade exposes no
+        # ``spec``. A caller who asked for a reproducible eval got a different
+        # rollout on every run, with ``policy.reset(seed=...)`` never forwarded -
+        # the half a service-mode policy needs to reseed its own process.
+        #
+        # A ``None`` seed leaves the master RNG unbuilt rather than seeding it
+        # from entropy: an unseeded eval must not acquire a global RNG side
+        # effect it never had.
+        master_rng = random.Random(seed) if seed is not None else None
+        if seed is not None:
+            set_eval_seed(seed)
 
         # RTC telemetry, reported in the result json so inference cost (and,
         # under async_rtc, latency masking) is provable without grepping logs.
@@ -2371,6 +2407,25 @@ class PolicyRunner:
                 current_vwriter, _video_err = _RolloutVideoWriter.open(self.sim, ep_vcfg, control_frequency)
                 if _video_err is not None:
                     return _video_err
+
+                # Per-episode reseed, mirroring ``_evaluate_with_spec``: episode
+                # N starts from the same RNG state regardless of what episodes
+                # 0..N-1 drew, so a stochastic policy's sampling is stable across
+                # re-runs at the same master seed. Forwarded to ``policy.reset``
+                # too, because a service-mode policy samples in another process
+                # that ``set_eval_seed`` cannot reach. Best-effort, like every
+                # other ``reset`` call site.
+                if master_rng is not None:
+                    episode_seed = master_rng.randint(0, 2**31 - 1)
+                    set_eval_seed(episode_seed)
+                    try:
+                        policy.reset(seed=episode_seed)
+                    except Exception as e:  # noqa: BLE001 - reset is best-effort
+                        logger.warning(
+                            "policy.reset(seed=%d) raised %s; continuing without per-episode reset",
+                            episode_seed,
+                            e,
+                        )
 
                 if async_rtc:
                     # Opt-in async overlap: a single background worker computes the

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -65,6 +65,16 @@ from strands_robots.simulation.safe_output import validate_output_path, video_sa
 logger = logging.getLogger(__name__)
 
 
+# The largest seed :func:`set_eval_seed` can apply. It reseeds the legacy NumPy
+# global RNG (``numpy.random.seed``), which refuses anything above 2**32 - 1 -
+# unlike ``numpy.random.default_rng``, the destination of the ``randomize`` /
+# ``set_obs_noise`` seeds, which accepts an integer of any width. That is why a
+# rollout seed carries a ceiling those two do not: the accepted domain of a
+# parameter is bounded by what its applier can honor, and ``random.seed`` /
+# ``torch.manual_seed`` (the other two RNGs seeded here) are wider still.
+MAX_EVAL_SEED = 2**32 - 1
+
+
 def set_eval_seed(seed: int) -> None:
     """Seed Python / NumPy / torch RNGs for reproducible eval rollouts.
 
@@ -89,7 +99,9 @@ def set_eval_seed(seed: int) -> None:
 
     * Python ``random.seed``.
     * NumPy ``np.random.seed`` (the legacy global RNG; matches what
-      most policies use under the hood).
+      most policies use under the hood). This is the narrowest of the
+      three: it refuses a seed above :data:`MAX_EVAL_SEED`, so that is
+      the ceiling every rollout surface accepts.
     * PyTorch CPU (``torch.manual_seed``) - if torch is importable.
     * PyTorch CUDA all devices (``torch.cuda.manual_seed_all``) - if
       torch is importable AND CUDA is available.
@@ -108,6 +120,17 @@ def set_eval_seed(seed: int) -> None:
     installs that don't have torch (e.g. ``policy_provider="mock"``
     smoke tests).
     """
+    # Local import: base.py imports this module at module level, so reaching the
+    # shared domain from here has to stay deferred - the same convention this
+    # module already uses for simulation.benchmark / .recording / .predicates.
+    from strands_robots.simulation.base import randomization_seed_error
+
+    # This is public API (exported via ``__all__``) and documented for standalone
+    # callers, so the bound is enforced where it is owned rather than only at the
+    # facades one layer up: NumPy's own "Seed must be between 0 and 2**32 - 1"
+    # names neither the parameter nor the method that accepted it.
+    if seed_error := randomization_seed_error(seed, "set_eval_seed", max_seed=MAX_EVAL_SEED):
+        raise ValueError(seed_error)
     random.seed(seed)
     try:
         import numpy as _np
@@ -1123,7 +1146,7 @@ class PolicyRunner:
         # simulation.benchmark / simulation.recording / simulation.predicates.
         from strands_robots.simulation.base import randomization_seed_error
 
-        if seed_error := randomization_seed_error(seed, "PolicyRunner.run"):
+        if seed_error := randomization_seed_error(seed, "PolicyRunner.run", max_seed=MAX_EVAL_SEED):
             raise ValueError(seed_error)
         if seed is not None:
             set_eval_seed(seed)
@@ -2224,7 +2247,7 @@ class PolicyRunner:
         # simulation.benchmark / simulation.recording / simulation.predicates.
         from strands_robots.simulation.base import randomization_seed_error
 
-        if seed_error := randomization_seed_error(seed, "PolicyRunner.evaluate"):
+        if seed_error := randomization_seed_error(seed, "PolicyRunner.evaluate", max_seed=MAX_EVAL_SEED):
             raise ValueError(seed_error)
         if spec is not None and success_fn is not None:
             return {
@@ -3077,4 +3100,12 @@ class PolicyRunner:
         raise ValueError(f"Unknown success_fn string: {success_fn!r}")
 
 
-__all__ = ["PolicyRunner", "OnFrame", "SuccessFn", "CooperativeStop", "TrajectoryStep", "set_eval_seed"]
+__all__ = [
+    "MAX_EVAL_SEED",
+    "PolicyRunner",
+    "OnFrame",
+    "SuccessFn",
+    "CooperativeStop",
+    "TrajectoryStep",
+    "set_eval_seed",
+]

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -65,16 +65,6 @@ from strands_robots.simulation.safe_output import validate_output_path, video_sa
 logger = logging.getLogger(__name__)
 
 
-# The largest seed :func:`set_eval_seed` can apply. It reseeds the legacy NumPy
-# global RNG (``numpy.random.seed``), which refuses anything above 2**32 - 1 -
-# unlike ``numpy.random.default_rng``, the destination of the ``randomize`` /
-# ``set_obs_noise`` seeds, which accepts an integer of any width. That is why a
-# rollout seed carries a ceiling those two do not: the accepted domain of a
-# parameter is bounded by what its applier can honor, and ``random.seed`` /
-# ``torch.manual_seed`` (the other two RNGs seeded here) are wider still.
-MAX_EVAL_SEED = 2**32 - 1
-
-
 def set_eval_seed(seed: int) -> None:
     """Seed Python / NumPy / torch RNGs for reproducible eval rollouts.
 
@@ -100,7 +90,8 @@ def set_eval_seed(seed: int) -> None:
     * Python ``random.seed``.
     * NumPy ``np.random.seed`` (the legacy global RNG; matches what
       most policies use under the hood). This is the narrowest of the
-      three: it refuses a seed above :data:`MAX_EVAL_SEED`, so that is
+      three: it refuses a seed above
+      :data:`~strands_robots.simulation.base.MAX_EVAL_SEED`, so that is
       the ceiling every rollout surface accepts.
     * PyTorch CPU (``torch.manual_seed``) - if torch is importable.
     * PyTorch CUDA all devices (``torch.cuda.manual_seed_all``) - if
@@ -123,7 +114,7 @@ def set_eval_seed(seed: int) -> None:
     # Local import: base.py imports this module at module level, so reaching the
     # shared domain from here has to stay deferred - the same convention this
     # module already uses for simulation.benchmark / .recording / .predicates.
-    from strands_robots.simulation.base import randomization_seed_error
+    from strands_robots.simulation.base import MAX_EVAL_SEED, randomization_seed_error
 
     # This is public API (exported via ``__all__``) and documented for standalone
     # callers, so the bound is enforced where it is owned rather than only at the
@@ -1144,7 +1135,7 @@ class PolicyRunner:
         # reaching the shared domain from here has to stay deferred - the
         # same convention this module already uses for
         # simulation.benchmark / simulation.recording / simulation.predicates.
-        from strands_robots.simulation.base import randomization_seed_error
+        from strands_robots.simulation.base import MAX_EVAL_SEED, randomization_seed_error
 
         if seed_error := randomization_seed_error(seed, "PolicyRunner.run", max_seed=MAX_EVAL_SEED):
             raise ValueError(seed_error)
@@ -2245,7 +2236,7 @@ class PolicyRunner:
         # reaching the shared domain from here has to stay deferred - the
         # same convention this module already uses for
         # simulation.benchmark / simulation.recording / simulation.predicates.
-        from strands_robots.simulation.base import randomization_seed_error
+        from strands_robots.simulation.base import MAX_EVAL_SEED, randomization_seed_error
 
         if seed_error := randomization_seed_error(seed, "PolicyRunner.evaluate", max_seed=MAX_EVAL_SEED):
             raise ValueError(seed_error)
@@ -3101,7 +3092,6 @@ class PolicyRunner:
 
 
 __all__ = [
-    "MAX_EVAL_SEED",
     "PolicyRunner",
     "OnFrame",
     "SuccessFn",

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -260,8 +260,7 @@ def run_policy(
     # nothing to check for it - and this module keeps every strands_robots import
     # lazy, so a caller who supplies no seed pulls in no extra module.
     if seed is not None:
-        from strands_robots.simulation.base import randomization_seed_error
-        from strands_robots.simulation.policy_runner import MAX_EVAL_SEED
+        from strands_robots.simulation.base import MAX_EVAL_SEED, randomization_seed_error
 
         if seed_error := randomization_seed_error(seed, "run_policy", max_seed=MAX_EVAL_SEED):
             return _err(seed_error)

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -249,6 +249,18 @@ def run_policy(
     if not isinstance(n_steps, int) or isinstance(n_steps, bool) or n_steps < 1:
         return _err(f"run_policy: n_steps must be a positive int, got {n_steps!r}.")
 
+    # Same pre-flight reason as the schema checks below: the per-episode seed is
+    # derived arithmetically (``seed + ep``) OUTSIDE the per-episode try, so a
+    # non-numeric seed raised out of this tool entirely - past the structured
+    # result an agent reads - and a float/negative one reached NumPy inside the
+    # loop after step 2 had already created a dataset. Shares the domain every
+    # rollout surface uses, so a seed this loop accepts is one the facade it
+    # forwards to can apply.
+    from strands_robots.simulation.base import randomization_seed_error
+
+    if seed_error := randomization_seed_error(seed, "run_policy"):
+        return _err(seed_error)
+
     if video is not None and not isinstance(video, dict):
         return _err(
             "run_policy: video must be a dict (VideoConfig kwargs) or None, "

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -256,10 +256,28 @@ def run_policy(
     # loop after step 2 had already created a dataset. Shares the domain every
     # rollout surface uses, so a seed this loop accepts is one the facade it
     # forwards to can apply.
-    from strands_robots.simulation.base import randomization_seed_error
+    # ``None`` is the documented "draw fresh entropy" spelling, so there is
+    # nothing to check for it - and this module keeps every strands_robots import
+    # lazy, so a caller who supplies no seed pulls in no extra module.
+    if seed is not None:
+        from strands_robots.simulation.base import randomization_seed_error
+        from strands_robots.simulation.policy_runner import MAX_EVAL_SEED
 
-    if seed_error := randomization_seed_error(seed, "run_policy"):
-        return _err(seed_error)
+        if seed_error := randomization_seed_error(seed, "run_policy", max_seed=MAX_EVAL_SEED):
+            return _err(seed_error)
+
+        # The value each episode applies is ``seed + ep``, not ``seed``, so a
+        # seed inside the ceiling can still derive one above it - the same
+        # accepted-but-unappliable gap, one derivation further on. The check
+        # above has already established that ``seed`` is an integer, and
+        # ``n_episodes`` is validated further up, so this is computable here.
+        if randomization_seed_error(seed + n_episodes - 1, "run_policy", max_seed=MAX_EVAL_SEED):
+            return _err(
+                f"run_policy: episode seeds are derived as seed + episode index, so seed={seed!r} "
+                f"with n_episodes={n_episodes} reaches {seed + n_episodes - 1} on the last episode - "
+                f"above the {MAX_EVAL_SEED} ceiling every rollout surface accepts. Lower the seed or "
+                "the episode count."
+            )
 
     if video is not None and not isinstance(video, dict):
         return _err(

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -9,6 +9,19 @@ TYPE_CHECKING (so the cycle is a compile-time artifact, not runtime).
 
 This test guards against regression - if someone reintroduces a
 real runtime cycle inside strands_robots, the suite goes red.
+
+Hoisting bought that runtime guarantee at a static cost, and the guards below pin
+the cost. ``policy_runner`` still closes an AST-visible cycle back to ``base``
+(it imports ``SimEngine`` under ``TYPE_CHECKING``), so CodeQL's
+``py/unsafe-cyclic-import`` reports one error-severity finding for *each symbol*
+named on ``base.py``'s module-level import from it - two are open on ``main``, and
+a third symbol would be a third finding. The module-level symbol surface is
+therefore frozen here, and anything ``base.py`` newly needs from ``policy_runner``
+is reached with a deferred import instead. That is the convention both directions
+of this pair already use: ``policy_runner`` defers ``randomization_seed_error``
+and ``MAX_EVAL_SEED`` from ``base`` at three sites. A deferred import cannot
+reintroduce the runtime cycle the first test forbids, because that test excludes
+function-local imports from the graph by construction.
 """
 
 from __future__ import annotations
@@ -97,15 +110,103 @@ def test_no_runtime_import_cycles():
     assert cycles == [], "runtime cycles detected:\n" + "\n".join("  " + " -> ".join(c) + " -> " + c[0] for c in cycles)
 
 
-def test_base_does_not_lazy_import_policy_runner():
-    """The three inline lazy imports were the symptom of the prior cycle.
-    They've been hoisted to module level; don't let them sneak back in."""
+# Each symbol on base.py's module-level import from policy_runner is its own
+# py/unsafe-cyclic-import finding, so the surface is frozen at the two that
+# predate this guard. Reach anything else with a deferred import.
+FROZEN_MODULE_LEVEL_SYMBOLS = ["PolicyRunner", "VideoConfig"]
+
+_POLICY_RUNNER = "strands_robots.simulation.policy_runner"
+
+# The assertion this guard replaces: a count of the import *statements*.
+_SUPERSEDED_PROXY = f"from {_POLICY_RUNNER} import"
+
+
+def _module_level_policy_runner_imports(src: str) -> list[list[str]]:
+    """Symbols ``src`` imports from policy_runner at module level, per statement.
+
+    Module level only: ``ast.parse(...).body`` is scanned directly rather than
+    walked, so an import deferred inside a function or sitting in an
+    ``if TYPE_CHECKING:`` block is not reported.
+    """
+    return [
+        [alias.name for alias in node.names]
+        for node in ast.parse(src).body
+        if isinstance(node, ast.ImportFrom) and node.module == _POLICY_RUNNER
+    ]
+
+
+def test_base_module_level_import_of_policy_runner_names_only_the_frozen_symbols():
+    """base.py may not grow the module-level import that closes the static cycle.
+
+    Replaces an assertion that counted the import *statements* in base.py and
+    required exactly one. That count was a proxy for "no runtime cycle" and it
+    was wrong in both directions, as the two tests below measure: it is
+    satisfied by one statement naming any number of symbols - each of which is
+    its own finding - and it is violated by a deferred import, which cannot
+    cause a runtime cycle at all. What decides whether a finding appears is
+    which symbols ride on the module-level statement, so that is what is pinned.
+    The original intent is unaffected: ``test_no_runtime_import_cycles`` above
+    enforces it directly, over every module, excluding deferred imports.
+    """
     base_src = (PKG / "simulation/base.py").read_text()
-    # Count occurrences of the lazy pattern
-    lazy_pattern = "from strands_robots.simulation.policy_runner import"
-    # Module-level import: 1 occurrence. Any >1 would be a lazy reintroduction.
-    n = base_src.count(lazy_pattern)
-    assert n == 1, (
-        f"expected exactly 1 module-level import of policy_runner in base.py, got {n}. "
-        "Did someone reintroduce an inline lazy import?"
+    statements = _module_level_policy_runner_imports(base_src)
+
+    # Non-vacuity: the import this guard is about must still be there to find.
+    assert len(statements) == 1, (
+        f"expected exactly 1 module-level import of {_POLICY_RUNNER} in base.py, found {len(statements)}: {statements}"
+    )
+    assert statements[0] == FROZEN_MODULE_LEVEL_SYMBOLS, (
+        f"base.py imports {statements[0]} from policy_runner at module level; the "
+        f"frozen surface is {FROZEN_MODULE_LEVEL_SYMBOLS}. Each name here is its own "
+        "error-severity py/unsafe-cyclic-import finding, because policy_runner imports "
+        "SimEngine back from base under TYPE_CHECKING. Reach the new symbol with a "
+        "deferred import inside the function that needs it - the convention "
+        "policy_runner already uses in the other direction."
+    )
+
+
+def test_an_added_symbol_is_detected_where_the_statement_count_was_blind():
+    """A third symbol must fail this guard - the superseded count cannot see it.
+
+    This is the regression the guard exists for: adding a name to the frozen
+    line ships another error-severity finding while leaving the number of import
+    statements at one. Both halves are asserted, so the reason this replaced a
+    statement count is recorded as a measurement rather than as a claim.
+    """
+    base_src = (PKG / "simulation/base.py").read_text()
+    planted = base_src.replace(
+        f"from {_POLICY_RUNNER} import PolicyRunner, VideoConfig",
+        f"from {_POLICY_RUNNER} import OnFrame, PolicyRunner, VideoConfig",
+        1,
+    )
+    assert planted != base_src, "planting failed - the frozen import line was not found"
+
+    # The superseded proxy is blind to it: still exactly one statement.
+    assert planted.count(_SUPERSEDED_PROXY) == base_src.count(_SUPERSEDED_PROXY) == 1
+
+    # The symbol-set guard is not.
+    assert _module_level_policy_runner_imports(planted) == [["OnFrame", "PolicyRunner", "VideoConfig"]], (
+        "the scanner did not see the planted third symbol"
+    )
+
+
+def test_a_deferred_import_is_not_part_of_the_module_level_surface():
+    """A deferred import must be invisible here - it is the prescribed escape hatch.
+
+    The superseded count rejected one (it saw two statements), which is why it
+    also forbade the deferred imports policy_runner uses in the other direction.
+    """
+    base_src = (PKG / "simulation/base.py").read_text()
+    planted = (
+        base_src
+        + "\n\ndef _probe() -> None:\n    from "
+        + _POLICY_RUNNER
+        + " import PolicyRunner\n\n    del PolicyRunner\n"
+    )
+    ast.parse(planted)  # the planted source must still be valid Python
+
+    # The superseded proxy counted this as a violation; the surface check does not.
+    assert planted.count(_SUPERSEDED_PROXY) == 2
+    assert _module_level_policy_runner_imports(planted) == [FROZEN_MODULE_LEVEL_SYMBOLS], (
+        "a deferred import leaked into the module-level surface"
     )

--- a/tests/simulation/test_rollout_seed_is_applied_or_refused.py
+++ b/tests/simulation/test_rollout_seed_is_applied_or_refused.py
@@ -1,0 +1,478 @@
+"""A rollout seed is either applied or refused with a reason.
+
+``seed`` is the reproducibility contract of a policy rollout: it reseeds the
+client RNGs, and each per-episode seed is forwarded to ``policy.reset`` so a
+service-mode policy can reseed the process its sampler runs in. Two evals at the
+same seed are supposed to replay identically.
+
+It reached exactly one statement in :meth:`PolicyRunner.evaluate` - the
+``_evaluate_with_spec`` delegation - so the plain ``success_fn`` loop below it
+never read the value. Every :meth:`SimEngine.eval_policy` call lands in that loop,
+because that facade exposes no ``spec`` parameter, so the whole surface accepted a
+seed and discarded it: two evals at ``seed=7`` drew different actions,
+``policy.reset(seed=...)`` was never called, and both runs reported
+``status="success"``. Its sibling :meth:`SimEngine.run_policy` seeded correctly
+one layer away, while ``eval_policy``'s own docstring advertises that the two
+entry points behave the same way.
+
+Honoring the seed is only half the contract, because an unusable value cannot be
+applied at all - the seed ends at ``numpy.random.seed`` / ``default_rng``, which
+accept only non-negative integers. That half had already gone three separate ways,
+none of them naming the parameter:
+
+* ``run_policy`` raised NumPy's own ``TypeError: Cannot cast scalar from
+  dtype('float64') to dtype('int64')`` (and ``ValueError: Seed must be between 0
+  and 2**32 - 1``) straight out of a method documented to return a structured
+  ``{"status": ...}`` envelope, and bound as an agent-tool action.
+* ``start_policy`` reported ``"started"`` and failed on its worker thread, where
+  the raise was swallowed - the documented reason its sibling horizon knobs are
+  validated synchronously, before ``executor.submit``.
+* ``True`` was accepted everywhere as a silent seed of ``1``.
+
+The domain those values need already existed:
+:func:`~strands_robots.simulation.base.randomization_seed_error`, whose docstring
+states the failure ("A float or string seed raises there ... so it is rejected at
+the call that supplied it") and which ``randomize`` / ``set_obs_noise`` have used
+on both backends since their inputs were hardened. It refused every value above
+while the rollout surfaces that share its destination accepted them.
+
+These tests pin both halves: the seed is applied on the path that dropped it, and
+the one shared domain answers for it at every surface that accepts one.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import random
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.base import SimEngine, randomization_seed_error
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+pytest.importorskip("mujoco")
+
+from strands_robots import Simulation  # noqa: E402  - after the mujoco probe
+from strands_robots.policies import Policy  # noqa: E402
+
+# Values no RNG can be seeded from. ``2.7`` and ``3.0`` are both refused: NumPy
+# rejects a float seed whatever its fractional part, so an integral float is not
+# a usable spelling here even though the whole-number domains honor one.
+UNUSABLE_SEEDS: list[Any] = [
+    -1,
+    -100,
+    2.7,
+    3.0,
+    True,
+    False,
+    math.nan,
+    math.inf,
+    "42",
+    [1],
+    {"a": 1},
+]
+
+# ``None`` is the documented "draw fresh entropy" spelling, not an error.
+USABLE_SEEDS: list[Any] = [None, 0, 7, 2**31]
+
+_ARM_XML = """<mujoco model="arm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 -9.81"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <geom type="box" size="0.05 0.05 0.1"/>
+      <body name="link1" pos="0 0 0.1">
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-2 2" limited="true" damping="2"/>
+        <geom type="capsule" fromto="0 0 0 0.25 0 0" size="0.03"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a_shoulder" joint="shoulder" kp="30" ctrlrange="-2 2"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class _Jitter(Policy):
+    """Draws each action from the global RNG - what a seed exists to pin.
+
+    A deterministic policy cannot tell a seeded rollout from an unseeded one, so
+    the reproducibility half of the contract is unobservable without a policy
+    whose output depends on the RNG state the seed is supposed to fix.
+    """
+
+    def __init__(self) -> None:
+        self.keys: list[str] = []
+        self.reset_seeds: list[Any] = []
+        self.drawn: list[float] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "jitter"
+
+    def set_robot_state_keys(self, keys: list[str]) -> None:
+        self.keys = list(keys)
+
+    def reset(self, seed: int | None = None) -> None:
+        self.reset_seeds.append(seed)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, float]]:
+        value = random.random()
+        self.drawn.append(value)
+        return [{key: value - 0.5 for key in self.keys}]
+
+
+@pytest.fixture
+def arm_xml(tmp_path: Path) -> Path:
+    path = tmp_path / "arm.xml"
+    path.write_text(_ARM_XML, encoding="utf-8")
+    return path
+
+
+def _sim_and_policy(arm_xml: Path) -> tuple[Any, _Jitter]:
+    sim = Simulation(backend="mujoco", tool_name="seed_test", mesh=False)
+    sim.create_world()
+    sim.add_robot(name="arm", urdf_path=str(arm_xml))
+    policy = _Jitter()
+    policy.set_robot_state_keys(sim.robot_action_keys("arm"))
+    return sim, policy
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(block.get("text", "") for block in result.get("content") or [] if isinstance(block, dict))
+
+
+class TestTheSeedIsAppliedOnTheEvalPath:
+    """The half that was silently dropped: eval_policy never read its seed."""
+
+    def test_two_evals_at_the_same_seed_draw_the_same_actions(self, arm_xml: Path) -> None:
+        runs = []
+        for _ in range(2):
+            sim, policy = _sim_and_policy(arm_xml)
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=policy,
+                n_episodes=2,
+                max_steps=4,
+                control_frequency=30.0,
+                seed=7,
+            )
+            sim.cleanup()
+            assert result["status"] == "success", _text(result)
+            runs.append(list(policy.drawn))
+        assert runs[0], "the policy must have been queried, or nothing is measured"
+        assert runs[0] == runs[1], "a seeded eval must replay identically"
+
+    def test_two_evals_at_different_seeds_draw_different_actions(self, arm_xml: Path) -> None:
+        """Non-vacuity: the equality above is the seed's doing, not determinism."""
+        drawn = []
+        for seed in (7, 8):
+            sim, policy = _sim_and_policy(arm_xml)
+            sim.eval_policy(
+                robot_name="arm",
+                policy_object=policy,
+                n_episodes=2,
+                max_steps=4,
+                control_frequency=30.0,
+                seed=seed,
+            )
+            sim.cleanup()
+            drawn.append(list(policy.drawn))
+        assert drawn[0] != drawn[1]
+
+    def test_each_episode_seed_is_forwarded_to_policy_reset(self, arm_xml: Path) -> None:
+        """A service-mode policy samples in a process ``set_eval_seed`` cannot reach."""
+        sim, policy = _sim_and_policy(arm_xml)
+        sim.eval_policy(
+            robot_name="arm",
+            policy_object=policy,
+            n_episodes=3,
+            max_steps=3,
+            control_frequency=30.0,
+            seed=7,
+        )
+        sim.cleanup()
+        assert len(policy.reset_seeds) == 3, policy.reset_seeds
+        assert all(isinstance(s, int) and s >= 0 for s in policy.reset_seeds)
+        assert len(set(policy.reset_seeds)) == 3, "each episode gets its own child seed"
+
+    def test_episode_seeds_are_reproducible_across_runs(self, arm_xml: Path) -> None:
+        seeds = []
+        for _ in range(2):
+            sim, policy = _sim_and_policy(arm_xml)
+            sim.eval_policy(
+                robot_name="arm",
+                policy_object=policy,
+                n_episodes=3,
+                max_steps=3,
+                control_frequency=30.0,
+                seed=7,
+            )
+            sim.cleanup()
+            seeds.append(list(policy.reset_seeds))
+        assert seeds[0] == seeds[1]
+
+    def test_an_unseeded_eval_does_not_touch_policy_reset_or_the_global_rng(self, arm_xml: Path) -> None:
+        """``seed=None`` must not acquire a global RNG side effect it never had."""
+        random.seed(1234)
+        expected = random.getstate()
+        random.seed(1234)
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.eval_policy(
+            robot_name="arm",
+            policy_object=policy,
+            n_episodes=2,
+            max_steps=3,
+            control_frequency=30.0,
+            seed=None,
+        )
+        sim.cleanup()
+        assert result["status"] == "success", _text(result)
+        assert policy.reset_seeds == [], "no seed was supplied, so none is forwarded"
+        # The rollout consumed draws from the un-reseeded stream, so the state
+        # moved on rather than being reset to the start of a new one.
+        assert random.getstate() != expected
+
+    def test_the_seeded_eval_matches_its_sibling_run_policy_contract(self, arm_xml: Path) -> None:
+        """``eval_policy``'s docstring promises the two entry points behave alike."""
+        singles = []
+        for _ in range(2):
+            sim, policy = _sim_and_policy(arm_xml)
+            sim.run_policy(robot_name="arm", policy_object=policy, n_steps=4, control_frequency=30.0, seed=7)
+            sim.cleanup()
+            singles.append(list(policy.drawn))
+        assert singles[0] == singles[1]
+        assert singles[0], "the policy must have been queried"
+
+
+class TestEverySurfaceRefusesAnUnusableSeed:
+    """The domain half, on each facade, through the structured envelope."""
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_run_policy_refuses(self, arm_xml: Path, seed: Any) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.run_policy(robot_name="arm", policy_object=policy, n_steps=4, control_frequency=30.0, seed=seed)
+        sim.cleanup()
+        assert result["status"] == "error"
+        assert "seed must be a non-negative integer or None" in _text(result)
+        assert "run_policy" in _text(result)
+        assert policy.drawn == [], "a refused seed must not run the rollout"
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_eval_policy_refuses(self, arm_xml: Path, seed: Any) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.eval_policy(
+            robot_name="arm",
+            policy_object=policy,
+            n_episodes=2,
+            max_steps=3,
+            control_frequency=30.0,
+            seed=seed,
+        )
+        sim.cleanup()
+        assert result["status"] == "error"
+        assert "seed must be a non-negative integer or None" in _text(result)
+        assert "eval_policy" in _text(result)
+        assert policy.drawn == []
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_start_policy_refuses_before_submitting_to_the_executor(self, arm_xml: Path, seed: Any) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.start_policy(robot_name="arm", policy_object=policy, n_steps=4, control_frequency=30.0, seed=seed)
+        sim.cleanup()
+        assert result["status"] == "error"
+        assert "seed must be a non-negative integer or None" in _text(result)
+        # The false "started" is the whole point of a synchronous check.
+        assert "started" not in _text(result).lower()
+
+    @pytest.mark.parametrize("seed", USABLE_SEEDS, ids=repr)
+    def test_a_usable_seed_is_accepted_everywhere(self, arm_xml: Path, seed: Any) -> None:
+        """Over-reach control: the guard must not refuse a seed that works."""
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.run_policy(robot_name="arm", policy_object=policy, n_steps=3, control_frequency=30.0, seed=seed)
+        sim.cleanup()
+        assert result["status"] == "success", _text(result)
+
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.eval_policy(
+            robot_name="arm",
+            policy_object=policy,
+            n_episodes=1,
+            max_steps=3,
+            control_frequency=30.0,
+            seed=seed,
+        )
+        sim.cleanup()
+        assert result["status"] == "success", _text(result)
+
+
+class TestNothingRaisesPastTheEnvelope:
+    """The refusal replaces NumPy's own message, which named neither the
+    parameter nor the method."""
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_no_bare_numpy_error_escapes(self, arm_xml: Path, seed: Any) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        try:
+            result = sim.run_policy(
+                robot_name="arm", policy_object=policy, n_steps=4, control_frequency=30.0, seed=seed
+            )
+        finally:
+            sim.cleanup()
+        text = _text(result)
+        assert "Cannot cast scalar" not in text
+        assert "2**32" not in text
+        assert "supported seed types" not in text
+
+
+class TestThePolicyRunnerLayerEnforcesItToo:
+    """``PolicyRunner`` is drivable directly; a direct caller has no envelope."""
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_run_raises_a_named_value_error(self, arm_xml: Path, seed: Any) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        try:
+            with pytest.raises(ValueError, match="seed must be a non-negative integer or None"):
+                PolicyRunner(sim).run("arm", policy, n_steps=3, control_frequency=30.0, seed=seed)
+        finally:
+            sim.cleanup()
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_evaluate_raises_a_named_value_error(self, arm_xml: Path, seed: Any) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        try:
+            with pytest.raises(ValueError, match="seed must be a non-negative integer or None"):
+                PolicyRunner(sim).evaluate("arm", policy, n_episodes=1, max_steps=3, control_frequency=30.0, seed=seed)
+        finally:
+            sim.cleanup()
+
+
+class TestTheDomainIsShared:
+    """One rule, so a seed refused for ``randomize`` cannot be accepted for the
+    rollout whose reproducibility it is supposed to pin."""
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS + USABLE_SEEDS, ids=repr)
+    def test_rollout_and_randomize_agree(self, arm_xml: Path, seed: Any) -> None:
+        randomize_refuses = randomization_seed_error(seed, "randomize") is not None
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.run_policy(robot_name="arm", policy_object=policy, n_steps=3, control_frequency=30.0, seed=seed)
+        sim.cleanup()
+        rollout_refuses = result["status"] == "error"
+        assert rollout_refuses == randomize_refuses, (
+            f"verdicts differ for seed={seed!r}: randomize refuses={randomize_refuses}, "
+            f"rollout refuses={rollout_refuses}"
+        )
+
+    def test_the_envelope_binding_carries_the_shared_reason_verbatim(self) -> None:
+        for seed in UNUSABLE_SEEDS:
+            reason = randomization_seed_error(seed, "run_policy")
+            envelope = SimEngine._validate_seed(seed, "run_policy")
+            assert envelope is not None
+            assert _text(envelope) == reason
+
+
+class TestNoRolloutSurfaceCanShipWithoutTheGuard:
+    """Structural: the facades and the runner layer all reach the one domain.
+
+    AST-based, so a surface that stops calling the guard - or a new rollout
+    surface that never starts - fails here rather than silently re-acquiring its
+    own accepted domain, the way ``eval_policy`` and ``start_policy`` each did.
+    """
+
+    _GUARD_CALLS = {"_validate_seed", "randomization_seed_error"}
+    # A surface may also reach the domain by delegating to the one guarded
+    # funnel: ``SimEngine.start_policy`` is literally ``return
+    # self.run_policy(...)``. A backend that overrides ``start_policy`` to
+    # submit to an executor instead does NOT delegate, and is pinned separately
+    # below to guard directly - that is exactly the surface where the seed used
+    # to fail on a worker thread after a false "started".
+    _DELEGATES_TO = {"run_policy"}
+
+    @staticmethod
+    def _seed_taking_methods(module_path: Path) -> dict[str, set[str]]:
+        tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+        found: dict[str, set[str]] = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                continue
+            args = [a.arg for a in node.args.args + node.args.kwonlyargs]
+            if "seed" not in args:
+                continue
+            called: set[str] = set()
+            for call in ast.walk(node):
+                if not isinstance(call, ast.Call):
+                    continue
+                func = call.func
+                if isinstance(func, ast.Name):
+                    called.add(func.id)
+                elif isinstance(func, ast.Attribute):
+                    called.add(func.attr)
+            found[node.name] = called
+        return found
+
+    @staticmethod
+    def _rollout_modules() -> list[Path]:
+        base_dir = Path(inspect.getfile(SimEngine)).parent
+        paths = [base_dir / "base.py", base_dir / "policy_runner.py", base_dir / "mujoco" / "simulation.py"]
+        for path in paths:
+            assert path.is_file(), path
+        return paths
+
+    def test_every_seed_taking_rollout_surface_reaches_the_shared_domain(self) -> None:
+        # ``reset`` is a Policy-protocol hook, not a rollout entry point that
+        # owns the caller's seed; ``set_eval_seed`` IS the applier the domain
+        # protects, and ``generate_heightfield`` seeds a terrain generator whose
+        # own entry point validates it.
+        exempt = {"reset", "set_eval_seed", "generate_heightfield"}
+        checked = 0
+        for module_path in self._rollout_modules():
+            for name, called in self._seed_taking_methods(module_path).items():
+                if name in exempt:
+                    continue
+                assert (self._GUARD_CALLS | self._DELEGATES_TO) & called, (
+                    f"{module_path.name}:{name}() accepts a seed and reaches no shared "
+                    f"seed domain (called: {sorted(called)})"
+                )
+                checked += 1
+        assert checked >= 5, f"expected the known rollout surfaces, found {checked}"
+
+    def test_a_backend_that_does_not_delegate_guards_the_seed_itself(self) -> None:
+        """The delegation clause must not excuse an override that submits work.
+
+        ``MuJoCoSimEngine.start_policy`` runs the rollout on its executor rather
+        than calling ``run_policy``, so a refusal reached from inside the future
+        arrives after the caller has already been told "started". It has to hold
+        the domain itself.
+        """
+        base_dir = Path(inspect.getfile(SimEngine)).parent
+        mujoco_sim = base_dir / "mujoco" / "simulation.py"
+        methods = self._seed_taking_methods(mujoco_sim)
+        assert "start_policy" in methods, sorted(methods)
+        called = methods["start_policy"]
+        assert "run_policy" not in called, "this override does not delegate"
+        assert self._GUARD_CALLS & called, sorted(called)
+
+    def test_the_known_surfaces_are_the_ones_scanned(self) -> None:
+        """Non-vacuity: a scan root resolving elsewhere must fail, not pass."""
+        names: set[str] = set()
+        for module_path in self._rollout_modules():
+            names |= set(self._seed_taking_methods(module_path))
+        assert {"run_policy", "eval_policy", "start_policy", "evaluate_benchmark", "run", "evaluate"} <= names, names
+
+    def test_the_scanner_detects_a_surface_that_drops_the_guard(self, tmp_path: Path) -> None:
+        """A guard that silently matched nothing would look like a clean sweep."""
+        planted = tmp_path / "planted.py"
+        planted.write_text(
+            "def run_policy(self, robot_name, seed=None):\n    return {'status': 'success'}\n",
+            encoding="utf-8",
+        )
+        found = self._seed_taking_methods(planted)
+        assert "run_policy" in found
+        assert not (self._GUARD_CALLS & found["run_policy"])

--- a/tests/simulation/test_rollout_seed_is_applied_or_refused.py
+++ b/tests/simulation/test_rollout_seed_is_applied_or_refused.py
@@ -51,8 +51,8 @@ from typing import Any
 
 import pytest
 
-from strands_robots.simulation.base import SimEngine, randomization_seed_error
-from strands_robots.simulation.policy_runner import MAX_EVAL_SEED, PolicyRunner, set_eval_seed
+from strands_robots.simulation.base import MAX_EVAL_SEED, SimEngine, randomization_seed_error
+from strands_robots.simulation.policy_runner import PolicyRunner, set_eval_seed
 
 pytest.importorskip("mujoco")
 

--- a/tests/simulation/test_rollout_seed_is_applied_or_refused.py
+++ b/tests/simulation/test_rollout_seed_is_applied_or_refused.py
@@ -52,7 +52,7 @@ from typing import Any
 import pytest
 
 from strands_robots.simulation.base import SimEngine, randomization_seed_error
-from strands_robots.simulation.policy_runner import PolicyRunner
+from strands_robots.simulation.policy_runner import MAX_EVAL_SEED, PolicyRunner, set_eval_seed
 
 pytest.importorskip("mujoco")
 
@@ -76,8 +76,21 @@ UNUSABLE_SEEDS: list[Any] = [
     {"a": 1},
 ]
 
+# Integers no *rollout* seed can use, though ``randomize`` / ``set_obs_noise``
+# can: those reach only ``default_rng``, which takes an integer of any width,
+# while a rollout seed is also applied to the legacy NumPy global RNG, which
+# refuses anything above ``MAX_EVAL_SEED``. ``1_754_000_000_000`` is a
+# millisecond-epoch timestamp - the common "just use the clock" seed idiom.
+SEEDS_ABOVE_THE_APPLIERS_BOUND: list[int] = [
+    MAX_EVAL_SEED + 1,
+    MAX_EVAL_SEED + 2,
+    1_754_000_000_000,
+]
+
 # ``None`` is the documented "draw fresh entropy" spelling, not an error.
-USABLE_SEEDS: list[Any] = [None, 0, 7, 2**31]
+# ``MAX_EVAL_SEED`` is the accepted side of that boundary, so both sides of it
+# are pinned rather than only the refused one.
+USABLE_SEEDS: list[Any] = [None, 0, 7, 2**31, MAX_EVAL_SEED]
 
 _ARM_XML = """<mujoco model="arm">
   <compiler angle="radian"/>
@@ -358,17 +371,41 @@ class TestTheDomainIsShared:
     """One rule, so a seed refused for ``randomize`` cannot be accepted for the
     rollout whose reproducibility it is supposed to pin."""
 
-    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS + USABLE_SEEDS, ids=repr)
-    def test_rollout_and_randomize_agree(self, arm_xml: Path, seed: Any) -> None:
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS + USABLE_SEEDS + SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_every_seed_randomize_refuses_is_refused_by_a_rollout_too(self, arm_xml: Path, seed: Any) -> None:
+        """An implication, not an equivalence - the rollout domain is narrower.
+
+        The two families share the non-negative-integer rule, so nothing
+        ``randomize`` refuses may be accepted for the rollout whose
+        reproducibility it pins. The converse does not hold: the rollout applier
+        adds the legacy NumPy global RNG, so it refuses a high integer
+        ``randomize`` can honor. That direction is pinned below, with its reason,
+        rather than smoothed away.
+        """
         randomize_refuses = randomization_seed_error(seed, "randomize") is not None
         sim, policy = _sim_and_policy(arm_xml)
         result = sim.run_policy(robot_name="arm", policy_object=policy, n_steps=3, control_frequency=30.0, seed=seed)
         sim.cleanup()
         rollout_refuses = result["status"] == "error"
-        assert rollout_refuses == randomize_refuses, (
-            f"verdicts differ for seed={seed!r}: randomize refuses={randomize_refuses}, "
-            f"rollout refuses={rollout_refuses}"
-        )
+        if randomize_refuses:
+            assert rollout_refuses, (
+                f"randomize refuses seed={seed!r} but the rollout accepted it - the shared rule is not shared"
+            )
+
+    @pytest.mark.parametrize("seed", SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_the_narrower_rollout_domain_is_the_appliers_and_is_documented(self, seed: int) -> None:
+        """The one divergence: a width ``default_rng`` honors and the legacy
+        global RNG does not.
+
+        Refusing these for ``randomize`` too would remove a capability that
+        works, so the bound is carried per destination instead of narrowing the
+        shared rule.
+        """
+        assert randomization_seed_error(seed, "randomize") is None
+        assert randomization_seed_error(seed, "run_policy", max_seed=MAX_EVAL_SEED) is not None
+        envelope = SimEngine._validate_seed(seed, "run_policy")
+        assert envelope is not None
+        assert f"[0, {MAX_EVAL_SEED}]" in _text(envelope)
 
     def test_the_envelope_binding_carries_the_shared_reason_verbatim(self) -> None:
         for seed in UNUSABLE_SEEDS:
@@ -376,6 +413,109 @@ class TestTheDomainIsShared:
             envelope = SimEngine._validate_seed(seed, "run_policy")
             assert envelope is not None
             assert _text(envelope) == reason
+
+
+class TestTheCeilingIsTheOneItsApplierCanHonor:
+    """A seed above ``MAX_EVAL_SEED`` is refused, not applied and then raised.
+
+    ``set_eval_seed`` reseeds the legacy NumPy global RNG as well as
+    ``default_rng``, and ``numpy.random.seed`` refuses anything above
+    ``2**32 - 1``. An accepted domain wider than that reintroduces both failure
+    modes this file exists to close, on exactly the range it does not cover:
+    ``eval_policy`` raised NumPy's bare ``ValueError`` out of a method
+    documented to return an envelope, and ``start_policy`` reported "started"
+    and died on its worker thread. A millisecond-epoch timestamp - a common
+    seed idiom - lands in that range.
+    """
+
+    @pytest.mark.parametrize("seed", SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_run_policy_refuses(self, arm_xml: Path, seed: int) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.run_policy(robot_name="arm", policy_object=policy, n_steps=4, control_frequency=30.0, seed=seed)
+        sim.cleanup()
+        assert result["status"] == "error"
+        assert f"seed must be an integer in [0, {MAX_EVAL_SEED}]" in _text(result)
+        assert policy.drawn == [], "a refused seed must not run the rollout"
+
+    @pytest.mark.parametrize("seed", SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_eval_policy_refuses_instead_of_raising_numpys_message(self, arm_xml: Path, seed: int) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        try:
+            result = sim.eval_policy(
+                robot_name="arm",
+                policy_object=policy,
+                n_episodes=1,
+                max_steps=3,
+                control_frequency=30.0,
+                seed=seed,
+            )
+        finally:
+            sim.cleanup()
+        assert result["status"] == "error"
+        text = _text(result)
+        assert f"seed must be an integer in [0, {MAX_EVAL_SEED}]" in text
+        assert "eval_policy" in text
+        # NumPy's own wording named neither the parameter nor the method.
+        assert "Seed must be between" not in text
+        assert policy.drawn == []
+
+    @pytest.mark.parametrize("seed", SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_start_policy_refuses_without_reporting_started(self, arm_xml: Path, seed: int) -> None:
+        """The false "started" is why this check is synchronous."""
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.start_policy(robot_name="arm", policy_object=policy, n_steps=4, control_frequency=30.0, seed=seed)
+        sim.cleanup()
+        assert result["status"] == "error"
+        assert f"seed must be an integer in [0, {MAX_EVAL_SEED}]" in _text(result)
+        assert "started" not in _text(result).lower()
+
+    @pytest.mark.parametrize("seed", SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_evaluate_benchmark_refuses(self, arm_xml: Path, seed: int) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.evaluate_benchmark(benchmark_name="whatever", robot_name="arm", policy_object=policy, seed=seed)
+        sim.cleanup()
+        assert result["status"] == "error"
+        assert f"seed must be an integer in [0, {MAX_EVAL_SEED}]" in _text(result)
+
+    @pytest.mark.parametrize("seed", SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_the_runner_layer_raises_a_named_error(self, arm_xml: Path, seed: int) -> None:
+        sim, policy = _sim_and_policy(arm_xml)
+        try:
+            with pytest.raises(ValueError, match=r"seed must be an integer in \[0, 4294967295\]"):
+                PolicyRunner(sim).run("arm", policy, n_steps=3, control_frequency=30.0, seed=seed)
+            with pytest.raises(ValueError, match=r"seed must be an integer in \[0, 4294967295\]"):
+                PolicyRunner(sim).evaluate("arm", policy, n_episodes=1, max_steps=3, control_frequency=30.0, seed=seed)
+        finally:
+            sim.cleanup()
+
+    @pytest.mark.parametrize("seed", SEEDS_ABOVE_THE_APPLIERS_BOUND, ids=repr)
+    def test_the_applier_itself_names_the_bound(self, seed: int) -> None:
+        """``set_eval_seed`` is public API and documented for direct callers, so
+        the rule is enforced where it is owned - not only at the facades."""
+        with pytest.raises(ValueError, match=r"set_eval_seed: seed must be an integer in \[0, 4294967295\]"):
+            set_eval_seed(seed)
+
+    def test_the_accepted_side_of_the_boundary_still_runs(self, arm_xml: Path) -> None:
+        """Over-reach control: the largest seed the applier honors is usable."""
+        set_eval_seed(MAX_EVAL_SEED)
+        sim, policy = _sim_and_policy(arm_xml)
+        result = sim.run_policy(
+            robot_name="arm", policy_object=policy, n_steps=3, control_frequency=30.0, seed=MAX_EVAL_SEED
+        )
+        sim.cleanup()
+        assert result["status"] == "success", _text(result)
+        assert policy.drawn, "the policy must have been queried"
+
+    def test_the_bound_is_the_appliers_own_and_not_a_chosen_number(self) -> None:
+        """Premise: ``MAX_EVAL_SEED`` is exactly where NumPy's legacy global RNG
+        stops, so the domain tracks the applier rather than a literal."""
+        np = pytest.importorskip("numpy")
+        np.random.seed(MAX_EVAL_SEED)
+        with pytest.raises(ValueError):
+            np.random.seed(MAX_EVAL_SEED + 1)
+        # ``default_rng`` - the randomization families' only destination - is
+        # wider, which is why the bound is per-caller and not in the shared rule.
+        np.random.default_rng(MAX_EVAL_SEED + 1)
 
 
 class TestNoRolloutSurfaceCanShipWithoutTheGuard:

--- a/tests/tools/test_run_policy.py
+++ b/tests/tools/test_run_policy.py
@@ -828,6 +828,38 @@ class TestSeedIsPreFlighted:
         assert sim.start_recording_calls == []
         assert sim.run_policy_calls == []
 
+    @pytest.mark.parametrize("seed", [2**32, 2**32 + 1, 1_754_000_000_000], ids=repr)
+    def test_a_seed_above_the_appliers_ceiling_is_refused(self, tmp_path: Path, seed: int) -> None:
+        """The applier reseeds NumPy's legacy global RNG, which stops at
+        ``2**32 - 1``; a millisecond-epoch timestamp is above it."""
+        sim = _FakeSim()
+        result = run_policy_tool(sim, n_episodes=2, n_steps=4, seed=seed, dataset_root=str(tmp_path / "ds"))
+        assert result["status"] == "error"
+        text = " ".join(b.get("text", "") for b in result["content"] if isinstance(b, dict))
+        assert "seed must be an integer in [0, 4294967295]" in text
+        assert sim.start_recording_calls == []
+        assert sim.run_policy_calls == []
+
+    def test_a_seed_whose_last_episode_offset_exceeds_the_ceiling_is_refused(self, tmp_path: Path) -> None:
+        """Each episode applies ``seed + ep``, so the accepted value is the one
+        the last episode derives - not the one the caller passed."""
+        sim = _FakeSim()
+        result = run_policy_tool(sim, n_episodes=3, n_steps=2, seed=2**32 - 1, dataset_root=str(tmp_path / "ds"))
+        assert result["status"] == "error"
+        text = " ".join(b.get("text", "") for b in result["content"] if isinstance(b, dict))
+        assert "seed + episode index" in text
+        assert "4294967297" in text
+        assert sim.start_recording_calls == []
+        assert sim.run_policy_calls == []
+
+    def test_the_largest_seed_every_episode_can_apply_is_accepted(self) -> None:
+        """Over-reach control: the derived check must not refuse a run whose
+        every episode seed fits."""
+        sim = _FakeSim()
+        result = run_policy_tool(sim, n_episodes=3, n_steps=2, seed=2**32 - 3)
+        assert result["status"] == "success", result
+        assert [call["seed"] for call in sim.run_policy_calls] == [2**32 - 3, 2**32 - 2, 2**32 - 1]
+
     @pytest.mark.parametrize("seed", [None, 0, 11], ids=repr)
     def test_a_usable_seed_is_offset_per_episode(self, seed: Any) -> None:
         sim = _FakeSim()

--- a/tests/tools/test_run_policy.py
+++ b/tests/tools/test_run_policy.py
@@ -25,6 +25,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from strands_robots.tools.run_policy import run_policy as run_policy_tool
 
 
@@ -791,3 +793,46 @@ class TestStopWhenPassThrough:
         episodes = result["content"][1]["json"]["episodes"]
         assert episodes[0]["stopped_reason"] == "predicate"
         assert episodes[0]["steps_used"] == 7
+
+
+class TestSeedIsPreFlighted:
+    """A seed this loop cannot use is refused before step 2 opens a dataset.
+
+    The per-episode seed is derived arithmetically (``seed + ep``) and that
+    statement sits OUTSIDE the per-episode ``try``, so a non-numeric seed
+    propagated out of the tool entirely - past the structured result an agent
+    reads - while a float or negative one reached NumPy inside the loop after a
+    dataset had already been created and every episode was reported as raised.
+    That is the failure mode the tool's other pre-flight checks (``video``,
+    ``policy_config``, ``stop_when``) each exist to avoid, stated in their own
+    comments. The seed shares the one rollout seed domain, so a value this loop
+    accepts is one the facade it forwards to can actually apply.
+    """
+
+    @pytest.mark.parametrize("seed", [-1, 2.7, 3.0, True, float("nan"), float("inf"), "42", [1]], ids=repr)
+    def test_an_unusable_seed_is_refused_before_recording_starts(self, tmp_path: Path, seed: Any) -> None:
+        sim = _FakeSim()
+        result = run_policy_tool(
+            sim,
+            n_episodes=2,
+            n_steps=4,
+            seed=seed,
+            dataset_root=str(tmp_path / "ds"),
+        )
+        assert result["status"] == "error"
+        text = " ".join(b.get("text", "") for b in result["content"] if isinstance(b, dict))
+        assert "seed must be a non-negative integer or None" in text
+        assert "run_policy" in text
+        # The pre-flight claim: nothing was set up, so no empty dataset is left
+        # behind and no episode is reported as raised.
+        assert sim.start_recording_calls == []
+        assert sim.run_policy_calls == []
+
+    @pytest.mark.parametrize("seed", [None, 0, 11], ids=repr)
+    def test_a_usable_seed_is_offset_per_episode(self, seed: Any) -> None:
+        sim = _FakeSim()
+        result = run_policy_tool(sim, n_episodes=3, n_steps=2, seed=seed)
+        assert result["status"] == "success", result
+        forwarded = [call["seed"] for call in sim.run_policy_calls]
+        expected = [None, None, None] if seed is None else [seed, seed + 1, seed + 2]
+        assert forwarded == expected


### PR DESCRIPTION
## The seed reached one statement, and it was the one `eval_policy` never takes

`PolicyRunner.evaluate` reads `seed` exactly once - forwarding it to `_evaluate_with_spec`. The plain `success_fn` loop below that delegation never touches the value. `SimEngine.eval_policy` exposes no `spec` parameter, so **every** `eval_policy` call lands in that loop: the whole surface accepted a reproducibility seed and discarded it.

Measured with a policy that draws each action from the global RNG - the state a seed exists to pin:

| | `run_policy(seed=7)` x2 | `eval_policy(seed=7)` x2 |
|---|---|---|
| actions drawn | byte-identical | **completely different** |
| `policy.reset(seed=)` | called with `7` | **never called** |
| status | success | success |

Both runs report `status="success"`, so nothing distinguishes a reproducible eval from a non-reproducible one. `eval_policy`'s own docstring advertises the opposite - it keeps "the two sibling entry points consistent - a policy you just ran with `run_policy()` evals the same way with `eval_policy()`" - and `run()`'s comment describes itself as mirroring "the per-episode reseed in `evaluate()`" that does not exist on that path.

![seeded eval reproducibility](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-seed/seed_contract.png)

The same seeded 2-episode evaluation, run twice, rendered headless in MuJoCo. On `main` the two runs end in different poses (16.3% of pixels differ). With this change the two renders are **byte-identical** (max pixel delta 0) and the per-episode seeds forwarded to `policy.reset` match across runs.

## Honoring it settles its domain, because an unusable seed cannot be applied

The seed ends at `numpy.random.seed` / `default_rng`, which accept only non-negative integers. Applying the seed on the dropped path makes that reachable, and it was already going three separate ways - none of them naming the parameter:

* `run_policy(seed=2.7)` raised NumPy's own `TypeError: Cannot cast scalar from dtype('float64') to dtype('int64') according to the rule 'safe'`, and `seed=-1` `ValueError: Seed must be between 0 and 2**32 - 1`, straight out of a method documented to return a structured `{"status": ...}` result and bound as an agent-tool action.
* `start_policy` returned `success` and failed on its worker thread, where the raise was swallowed. That is the documented reason its sibling horizon knobs are validated *before* `executor.submit`: "the caller would receive a false 'started' success and the robot would be left marked as running."
* `seed=True` was accepted everywhere as a silent seed of `1`.
* The `run_policy` agent tool derives `seed + ep` **outside** its per-episode `try`, so `seed="42"` raised `TypeError: can only concatenate str (not "int") to str` out of the tool entirely, and `seed=-1` reported `2/2 episodes ok` after a dataset had already been created.

The domain those values need already existed: `randomization_seed_error`, whose docstring states the failure verbatim - "A float or string seed raises there ... so it is rejected at the call that supplied it" - and which `randomize` / `set_obs_noise` have used on both backends since their inputs were hardened. It refused every value above while the rollout surfaces sharing its destination accepted them. No new helper; the docstring now names both families.

## Change

* `PolicyRunner.evaluate` applies the seed on the non-spec path exactly as `_evaluate_with_spec` does: reseeded once from the master seed, then per episode from a master RNG derived from it, with each per-episode seed forwarded to `policy.reset` (best-effort, like every other `reset` call site) so a service-mode policy can reseed the process its sampler runs in.
* A `None` seed leaves the master RNG unbuilt rather than seeding it from entropy, so an unseeded eval acquires no global RNG side effect it did not have. Pinned.
* `SimEngine._validate_seed` binds the shared domain to the tool-error envelope; wired into `run_policy`, `eval_policy`, `start_policy` (MuJoCo's override, synchronously, before `executor.submit`) and `evaluate_benchmark`.
* `PolicyRunner.run` / `.evaluate` enforce the same rule and *raise*, because that layer is drivable directly and a direct caller has no envelope to read. Imported function-locally - `base.py` imports `PolicyRunner` at module level, so reaching back has to stay deferred, matching this module's existing convention for `simulation.benchmark` / `.recording` / `.predicates`.
* The `run_policy` agent tool pre-flights the seed, before step 2 opens a dataset, matching its sibling `video` / `policy_config` / `stop_when` checks.
* A rollout seed carries a ceiling the `randomize` family does not: `MAX_EVAL_SEED = 2**32 - 1`, the largest value `set_eval_seed`'s narrowest RNG (`numpy.random.seed`) accepts. `randomization_seed_error` takes a keyword-only `max_seed` (default `None` = unbounded), so one rule carries a bound per destination rather than the rollout re-acquiring its own domain. It lives in `simulation/base.py` beside that parameter - see the round-2 note below.

## Out of scope

`randomization_seed_error` keeps its name. A rollout seed *is* the randomization stream it names - it exists to make the policy's sampling reproducible - and a released CHANGELOG entry refers to the symbol.

## Tests

`tests/simulation/test_rollout_seed_is_applied_or_refused.py` plus `TestSeedIsPreFlighted` in `tests/tools/test_run_policy.py`:

* the seed is applied: two evals at one seed draw the same actions; different seeds differ (non-vacuity); each episode gets its own reproducible child seed; `policy.reset` receives them; an unseeded eval touches neither.
* every surface refuses the unusable set through its own channel, and nothing raises past the envelope - the NumPy strings are asserted *absent*.
* over-reach controls: `None` / `0` / `7` / `2**31` / `2**32 - 1` still accepted everywhere.
* cross-surface parity as an implication: every seed `randomize` refuses, a rollout refuses too, with the one deliberate divergence (`>= 2**32`) pinned separately alongside its reason.
* structural: every seed-taking rollout surface reaches the one domain, directly or by delegating to the guarded funnel - with a backend that does *not* delegate pinned to guard itself, a non-vacuity check on the scanned set, and a planted-defect check so an empty scan cannot read as clean.

**Pre-fix** (source reverted to `main`, tests kept): **115 failed / 65 passed**, failing with `Cannot cast scalar from dtype('float64')`, `can only concatenate str (not "int") to str`, `Seed must be between 0 and 2**32 - 1`, and the tool reporting `2/2 episodes ok` for `seed=-1`. The passing set is the over-reach controls, the non-vacuity checks, the scanner meta-tests and the pre-existing tool tests - they are what stop the guard over-reaching.

## Gate

* `MUJOCO_GL=egl python -m pytest tests -q`: **19912 passed, 257 skipped, 0 failed** (535s)
* `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1068 files)
* `mypy strands_robots tests tests_integ`: 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical on a pristine `main` checkout of the same working copy
* `scripts/assemble_changelog.py --check`: OK
* Rebased onto `62e375da`; merge-base overlap check reports no overlap.

---

## §13 Review Rounds

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | rollout seed domain wider than `np.random.seed` ceiling (`>= 2**32` accepted then crashes) | `43200db` | `tests/simulation/test_rollout_seed_is_applied_or_refused.py::TestSeedDomainRefusesUnusable` (probes `2**32`, `2**32+1`, `1_754_000_000_000`; boundary `2**32-1` in `USABLE_SEEDS`) |
| R2 | R1 put `MAX_EVAL_SEED` on `base.py`'s module-level `policy_runner` import, raising `py/unsafe-cyclic-import` on all three names that line carries - CodeQL went `NEUTRAL` -> `FAILURE` | `206a993` | boundary/premise tests unchanged and still green from the new location; `base.py`'s import line is byte-identical to `main` again |
| R3 | the guard meant to protect that import counted import *statements*, so it passed with a third symbol on the line and failed a deferred import - it could not have caught R2 | `ad8303e` | `tests/simulation/test_no_import_cycle.py::test_base_module_level_import_of_policy_runner_names_only_the_frozen_symbols`, plus a planted-symbol check asserting the superseded count was blind and a planted deferred import asserting it stays off the surface |

**R2 note.** The comment directly above that import already documented the rule and the mitigation: `py/unsafe-cyclic-import` walks `TYPE_CHECKING` blocks, and `policy_runner` imports `SimEngine` from `base` under one, so any name added to that line closes an AST-visible cycle - which is why `OnFrame` is referenced there as a string annotation rather than imported. There is no runtime cycle (`policy_runner` reaches `base` only from inside functions) and both import orders resolve all three names, verified - so the finding is that rule's known false positive on a real static edge, and this codebase's established answer is to not add the edge rather than to suppress the alert. `MAX_EVAL_SEED` therefore moved to `simulation/base.py`, beside the `max_seed` parameter it feeds; the three rollout call sites and the `run_policy` tool reach it on the function-local `from ...base import randomization_seed_error` statement they already execute, so neither module gains a module-level edge. Same constant, same value, same domain, same messages.

**R3 note.** R2 took the third name off that line but left in place the guard that should have stopped it being
added. `test_base_does_not_lazy_import_policy_runner` asserted that `base.py` contains exactly one
`from ...policy_runner import` *statement* - a proxy for "no runtime cycle", and wrong in both directions.
Measured rather than argued:

* plant a third symbol on line 51 -> the statement count is still `1`, so the guard **passes** while another
  error-severity finding ships. That is precisely how R2 happened.
* add a deferred import -> the count becomes `2`, so the guard **fails** a change that cannot cause a runtime
  cycle at all, and forbids the convention `policy_runner` uses in the other direction (it defers
  `randomization_seed_error` and now `MAX_EVAL_SEED` from `base` at three sites).

It now pins what decides whether a finding appears - the exact symbol set on the module-level statement - with a
non-vacuity assertion that the statement is still there to find, and two companions: one plants a third symbol
and asserts the new check sees it *where the superseded count was blind*, the other plants a deferred import and
asserts it stays outside the surface. The original intent is untouched: `test_no_runtime_import_cycles` in the
same module enforces it directly, over every module, excluding deferred imports by construction.

End-to-end, with a third symbol actually planted in `base.py`:

```
superseded assertion  count(<pattern>) == 1  ->  actual: 1    => OLD GUARD PASSES (blind)
3 failed, 1 passed                                            # the new guard, showing  + 'OnFrame'
```

The one that passes is `test_no_runtime_import_cycles`.

Alert attribution after R2/R3: `MAX_EVAL_SEED` (865) is gone, and the two that remain on this line are `main`'s
own 814 / 815 (`refs/heads/main`, open since 2026-07-28), re-surfaced on the PR only because the diff touched
line 51 - which is byte-identical to `main` again. Taking those two off the line is a separate change with its
own design decision and is out of scope here. R3 is tests-only: no policy, simulation, rendering, recording or
asset behaviour changes, so it carries no visual artifact.
