### PR TITLE
fix(training): the reproducibility seed a TrainSpec asks for is one shared non-negative-count domain

### DIFF
--- a/changelog.d/1950-train-seed-domain.md
+++ b/changelog.d/1950-train-seed-domain.md
@@ -1,0 +1,22 @@
+### Fixed: the reproducibility seed a `TrainSpec` asks for is one shared non-negative-count domain
+
+`TrainSpec.seed` is read by four backends and none of them checked it, while its
+appliers disagree about what a single value means. `torch.manual_seed` -- the
+applier on both RL trainers -- reduces its argument modulo `2**64`, so `seed=-1`
+was *silently* `seed=2**64 - 1`: the run was reproducible under a number nobody
+asked for, and collided with a seed another caller could legitimately have named
+(`manual_seed(-1)` and `manual_seed(2**64 - 1)` draw the identical stream, as do
+`True`/`1` and `2.7`/`2`). On the LeRobot path the same value reached lerobot's
+`set_seed`, which reseeds Python's `random` and *then* hands it to NumPy, which
+refuses a negative -- so a rejected seed left the process RNG reseeded by a call
+that failed, under NumPy's message rather than one naming the field. Cosmos and
+LeRobot's argv-parity path rendered every value, including `nan` and `[7]`, into
+an override or a flag token that failed inside the run after the dataset and
+model were loaded, if at all.
+
+`Trainer._seed_problems` now checks the field against the one shared
+`non_negative_count_error` domain -- the same non-negative-integer rule, whose
+`0` is first-class here too because seed `0` is a seed -- and the four backends
+that read the field call it. `None` remains the documented "use the backend's own
+default" sentinel, and the two backends that never read the field (`mock`,
+`groot`) do not report on it.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -98,6 +98,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
 | `val_episodes` | hold out the LAST N episodes | deterministic split |
 | `num_gpus` / `num_nodes` | multi-GPU / multi-node | selects the launcher |
+| `seed` | reproducibility seed | must be a non-negative integer; `validate()` refuses a negative (`torch.manual_seed` would take it modulo `2**64`, so `-1` silently becomes `2**64 - 1`), a fractional or non-finite value, and a `bool`. `None` uses the backend's own default |
 | `extra["policy_type"]` | lerobot `--policy.type` | act/diffusion/smolvla/pi0/pi05/... |
 | `extra["groot_root"]` | Isaac-GR00T checkout | GR00T |
 | `extra["sft_toml"]` / `extra["cosmos_root"]` | recipe + checkout | Cosmos |

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -51,7 +51,11 @@ import re
 from typing import TYPE_CHECKING
 
 from strands_robots.tools._path_validation import validate_save_path
-from strands_robots.utils import positive_count_error, positive_finite_number_error
+from strands_robots.utils import (
+    non_negative_count_error,
+    positive_count_error,
+    positive_finite_number_error,
+)
 
 if TYPE_CHECKING:
     from strands_robots.training.base import TrainSpec
@@ -245,3 +249,58 @@ def learning_rate_problems(spec: TrainSpec, *, context: str) -> list[str]:
         return []
     error = positive_finite_number_error(spec.learning_rate, "learning_rate", context)
     return [error] if error is not None else []
+
+
+def seed_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return reproducibility-seed problems for a :class:`TrainSpec`.
+
+    ``seed`` is the field a caller sets to make a run reproducible, and the four
+    backends that read it apply it through appliers that disagree about what a
+    single value means:
+
+    * The RL trainers hand it to ``torch.manual_seed``, which reduces it modulo
+      ``2**64``. A negative seed is therefore *silently a different seed*:
+      ``manual_seed(-1)`` and ``manual_seed(2**64 - 1)`` draw the identical
+      stream, so two seeds the caller means to be distinct collapse onto one and
+      the run is reproducible under a number nobody asked for. ``True`` is
+      likewise a silent seed of ``1`` and ``2.7`` a silent seed of ``2``.
+    * LeRobot assigns it to ``cfg.seed``, which reaches lerobot's ``set_seed``:
+      ``random.seed`` first, then ``numpy.random.seed``. NumPy is far narrower
+      than torch - it refuses a negative value and a float or string outright -
+      but only *after* ``random.seed`` has run, so a refused seed leaves the
+      process RNG reseeded by a call that failed.
+    * Cosmos interpolates it into a ``trainer.seed=`` Hydra override, and
+      LeRobot's argv-parity path into a ``--seed=`` token. There every value
+      renders - ``nan``, ``2.7``, ``[7]`` - and fails, if at all, inside the
+      run after the dataset and model are already loaded.
+
+    So the same ``seed=-1`` is silently rewritten by one backend and refused with
+    a bare third-party message by the next. Only a non-negative integer can be
+    honored by all of them, so it is checked against the one shared
+    :func:`~strands_robots.utils.non_negative_count_error` domain: the same
+    non-negative-integer rule, whose ``0`` is first-class here too (seed ``0`` is
+    a seed), and which rejects ``bool`` explicitly because a bare ``value < 0``
+    test lets ``True`` through as a silent seed of one.
+
+    ``None`` is the documented sentinel for "use the backend's own default"
+    (LeRobot's is ``1000``) and is therefore not a problem, exactly as it is not
+    one for :func:`learning_rate_problems`.
+
+    One boundary this does not decide: the appliers also disagree about the
+    upper end - torch accepts up to ``2**64 - 1`` while NumPy's legacy seeder
+    stops at ``2**32 - 1`` - so a per-backend ceiling is a separate question from
+    the floor and type checked here.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single problem when ``seed`` is supplied and unusable; empty otherwise.
+    """
+    if spec.seed is None:
+        return []
+    error = non_negative_count_error(spec.seed, "seed", context)
+    return [] if error is None else [error]

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -323,6 +323,33 @@ class Trainer(ABC):
 
         return launch_topology_problems(spec, context=self.provider_name)
 
+    def _seed_problems(self, spec: TrainSpec) -> list[str]:
+        """Reproducibility-seed preflight shared by every backend that reads it.
+
+        Returns a problem when :attr:`TrainSpec.seed` is supplied and is not a
+        usable non-negative integer, against the one shared non-negative-count
+        domain. A :meth:`validate` implementation that reads the field MUST call
+        this rather than pass the value straight to its applier: the appliers do
+        not agree about it. ``torch.manual_seed`` takes the value modulo
+        ``2**64``, so a negative seed silently becomes a large positive one and
+        collides with a seed a caller could legitimately have named, while
+        lerobot's ``set_seed`` reseeds Python's ``random`` and only then hands
+        the value to NumPy, which refuses a negative - leaving the process RNG
+        reseeded by a call that failed.
+
+        A backend that does not read the field MUST NOT call this: per
+        :class:`TrainSpec`, a backend ignores the fields it does not support, so
+        reporting on one it never reads would be a false rejection. That is why
+        this is a separate gate from :meth:`_learning_rate_problems`, which
+        every backend does call.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import seed_problems
+
+        return seed_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -156,6 +156,7 @@ class Cosmos3Trainer(Trainer):
             )
         problems.extend(self._run_size_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
+        problems.extend(self._seed_problems(spec))
         problems.extend(self._launch_topology_problems(spec))
 
         if not spec.extra.get("sft_toml"):

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -595,6 +595,7 @@ class LerobotTrainer(Trainer):
 
         problems.extend(self._run_size_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
+        problems.extend(self._seed_problems(spec))
         # Captured rather than extended blind: the multi-node refusal below
         # compares num_nodes, which is only a meaningful comparison once this
         # gate has established it IS a count - a string or None would raise out

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -131,6 +131,7 @@ class FastSacTrainer(BaseRLAlgo):
         """Preflight an :class:`RLTrainSpec` for a FastSAC run (pure / read-only)."""
         problems = self._security_problems(spec)
         problems.extend(self._learning_rate_problems(spec))
+        problems.extend(self._seed_problems(spec))
         if not isinstance(spec, RLTrainSpec):
             problems.append(f"fast_sac requires an RLTrainSpec, got {type(spec).__name__}")
             return problems

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -142,6 +142,7 @@ class PpoTrainer(BaseRLAlgo):
         """Preflight an :class:`RLTrainSpec` for a PPO run (pure / read-only)."""
         problems = self._security_problems(spec)
         problems.extend(self._learning_rate_problems(spec))
+        problems.extend(self._seed_problems(spec))
         if not isinstance(spec, RLTrainSpec):
             problems.append(f"ppo requires an RLTrainSpec, got {type(spec).__name__}")
             return problems

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1111,21 +1111,31 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
 def non_negative_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable non-negative integer count.
 
-    Shared domain for a discrete count whose ``0`` is a first-class value rather
-    than a degenerate one - the number of control steps a loop executes while an
-    inference request is in flight
-    (:attr:`~strands_robots.policies.base.Policy.rtc_observed_delay_steps`).
-    That count is exactly ``0`` in the dominant case: a synchronous eval loop
-    pauses the world during inference, so no step elapses. Refusing ``0`` here
-    would therefore reject the common configuration, which is why this is a
-    separate domain rather than a caller of :func:`positive_count_error`.
+    Shared domain for two families of discrete quantity whose ``0`` is a
+    first-class value rather than a degenerate one:
 
-    In every other respect it mirrors :func:`positive_count_error`: the value is
-    consumed as an offset into an action chunk, so only a true ``int`` can be
-    honored (an integral float raises ``TypeError`` at the slice rather than
-    being coerced), and ``bool`` is rejected explicitly because as an ``int``
-    subclass a bare ``value < 0`` test lets ``True`` through as a silent count
-    of one.
+    * The number of control steps a loop executes while an inference request is
+      in flight
+      (:attr:`~strands_robots.policies.base.Policy.rtc_observed_delay_steps`).
+      That count is exactly ``0`` in the dominant case: a synchronous eval loop
+      pauses the world during inference, so no step elapses.
+    * A reproducibility seed
+      (:attr:`~strands_robots.training.base.TrainSpec.seed`), where ``0`` is
+      simply a seed. Its appliers disagree about everything outside this domain:
+      ``torch.manual_seed`` reduces a negative seed modulo ``2**64`` (so ``-1``
+      silently becomes ``2**64 - 1`` and collides with a seed a caller could
+      have named), while NumPy's legacy seeder refuses a negative or a float.
+
+    Refusing ``0`` would reject the common configuration for both, which is why
+    this is a separate domain rather than a caller of
+    :func:`positive_count_error`.
+
+    In every other respect it mirrors :func:`positive_count_error`: only a true
+    ``int`` can be honored - an integral float raises ``TypeError`` at an action
+    chunk's slice, and ``numpy.random.seed(3.0)`` raises the same class of cast
+    error rather than being coerced - and ``bool`` is rejected explicitly because
+    as an ``int`` subclass a bare ``value < 0`` test lets ``True`` through as a
+    silent count, or a silent seed, of one.
 
     Args:
         value: The caller-supplied value.

--- a/tests/training/test_seed_domain.py
+++ b/tests/training/test_seed_domain.py
@@ -1,0 +1,309 @@
+"""The reproducibility seed a TrainSpec asks for is one shared non-negative-count domain.
+
+:attr:`~strands_robots.training.base.TrainSpec.seed` is the field a caller sets
+to make a run reproducible, and four backends read it - LeRobot (``cfg.seed`` and
+a ``--seed=`` argv token), Cosmos (a ``trainer.seed=`` Hydra override) and the two
+RL trainers (``torch.manual_seed``). Before this contract none of them checked it,
+and the appliers do not agree about a single value:
+
+* ``torch.manual_seed`` reduces the value modulo ``2**64``, so a negative seed is
+  *silently a different seed*: ``manual_seed(-1)`` and ``manual_seed(2**64 - 1)``
+  draw the identical stream. Two seeds a caller means to be distinct collapse
+  onto one, and the run is reproducible under a number nobody asked for. ``True``
+  is a silent seed of ``1`` and ``2.7`` a silent seed of ``2``.
+* LeRobot's ``set_seed`` reseeds Python's ``random`` and only *then* hands the
+  value to NumPy, which refuses a negative or a float. A refused seed therefore
+  leaves the process RNG reseeded by a call that failed, and the message that
+  surfaces is NumPy's rather than one naming the field.
+* Every value renders into a Hydra override or an argv token, so on those paths a
+  bad seed fails - if at all - inside the run, after the dataset and model are
+  loaded.
+
+The tests below pin the contract in both directions: every backend that reads the
+field refuses the same unusable values through the one shared domain with a
+message naming itself, a usable seed (``0`` included) is untouched, a backend that
+ignores the field reports nothing about it, and the refused values are grounded in
+what the real appliers do with them.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.training._validate import seed_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+from strands_robots.training.groot import Gr00tTrainer
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.training.mock import MockTrainer
+
+# The backends that seed from the field. The RL trainers are exercised through
+# their own spec type further down (their validate() needs an RLTrainSpec).
+SEEDING_BACKENDS = (LerobotTrainer, Cosmos3Trainer)
+
+# Values no applier can honor, split by how each one failed before the gate.
+
+# Silently rewritten by torch's modulo, and refused by NumPy - so no applier
+# honors the value the caller supplied.
+SILENTLY_REWRITTEN = (-1, -5, True, False, 2.7, 3.0)
+
+# Raised out of the applier: torch refuses nan/inf/list, NumPy refuses the float
+# and the string.
+RAISED_IN_THE_APPLIER = (float("nan"), float("inf"), "42", [7])
+
+UNUSABLE = SILENTLY_REWRITTEN + RAISED_IN_THE_APPLIER
+
+# Seeds every applier honors as themselves. ``0`` is a seed, not a degenerate
+# value, which is why the domain's floor is zero rather than one.
+USABLE = (0, 1, 42, 1000, 2**31 - 1)
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path) -> TrainSpec:
+    """A spec whose ``seed`` is the only thing under test.
+
+    ``validate`` may well report unrelated problems (Cosmos wants a recipe TOML,
+    LeRobot a dataset); every assertion below filters for the field name, so an
+    unrelated problem can neither mask nor fake a seed verdict.
+    """
+    return TrainSpec(
+        dataset_root=str(tmp_path / "ds"),
+        output_dir=str(tmp_path / "out"),
+        base_model="lerobot/act",
+        embodiment="new_embodiment",
+    )
+
+
+# The shape the shared domain emits: ``"{context}: seed must be ..."``. Matched
+# rather than the bare word because pytest derives ``tmp_path`` from the test
+# name, so a path in an unrelated problem can contain "seed" too - a filter that
+# picked that up could both mask and fake a verdict.
+_NAMES_THE_SEED = ": seed "
+
+
+def _seed_problems_of(trainer: Trainer, spec: TrainSpec) -> list[str]:
+    """``validate`` problems about ``seed``."""
+    return [p for p in trainer.validate(spec) if _NAMES_THE_SEED in p]
+
+
+def _rl_spec(tmp_path: pathlib.Path) -> Any:
+    """A minimal :class:`RLTrainSpec` for the two RL trainers."""
+    from strands_robots.training.rl.base_algo import RLTrainSpec
+
+    return RLTrainSpec(
+        output_dir=str(tmp_path),
+        env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+    )
+
+
+def _rl_trainers() -> list[Any]:
+    """The two RL trainers, or skip when torch is absent."""
+    pytest.importorskip("torch")
+    from strands_robots.training.rl.fast_sac import FastSacTrainer
+    from strands_robots.training.rl.ppo import PpoTrainer
+
+    return [FastSacTrainer(), PpoTrainer()]
+
+
+class TestEverySeedingBackendRefusesAnUnusableSeed:
+    """Each backend that seeds from the field refuses every unusable value."""
+
+    @pytest.mark.parametrize("trainer_cls", SEEDING_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.seed = value
+        problems = _seed_problems_of(trainer_cls(), spec)
+        assert problems, f"{trainer_cls.__name__} accepted seed={value!r}"
+        assert any("must be a non-negative integer" in p for p in problems), problems
+
+    @pytest.mark.parametrize("trainer_cls", SEEDING_BACKENDS)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        trainer = trainer_cls()
+        spec.seed = -1
+        assert any(p.startswith(f"{trainer.provider_name}: seed ") for p in _seed_problems_of(trainer, spec))
+
+    @pytest.mark.parametrize("trainer_cls", SEEDING_BACKENDS)
+    @pytest.mark.parametrize("value", RAISED_IN_THE_APPLIER)
+    def test_an_unusable_seed_is_a_problem_not_an_exception(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any
+    ) -> None:
+        """``validate`` returns problems; it must not raise out of the check."""
+        spec.seed = value
+        problems = trainer_cls().validate(spec)  # must not raise
+        assert any(_NAMES_THE_SEED in p for p in problems), problems
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_both_rl_trainers_refuse_it_too(self, tmp_path: pathlib.Path, value: Any) -> None:
+        rl_spec = _rl_spec(tmp_path)
+        rl_spec.seed = value
+        for trainer in _rl_trainers():
+            problems = [p for p in trainer.validate(rl_spec) if _NAMES_THE_SEED in p]
+            assert problems, f"{type(trainer).__name__} accepted seed={value!r}"
+            assert any(p.startswith(f"{trainer.provider_name}: seed ") for p in problems), problems
+
+
+class TestAUsableSeedIsUntouched:
+    """A seed every applier honors raises no problem, and zero is one of them."""
+
+    @pytest.mark.parametrize("trainer_cls", SEEDING_BACKENDS)
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_usable_seed_is_not_a_problem(self, spec: TrainSpec, trainer_cls: type[Trainer], value: int) -> None:
+        spec.seed = value
+        assert _seed_problems_of(trainer_cls(), spec) == []
+
+    @pytest.mark.parametrize("trainer_cls", SEEDING_BACKENDS)
+    def test_an_unset_seed_is_not_a_problem(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        """``None`` is the documented "use the backend's own default" sentinel."""
+        assert spec.seed is None
+        assert _seed_problems_of(trainer_cls(), spec) == []
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_the_rl_trainers_accept_it_too(self, tmp_path: pathlib.Path, value: int) -> None:
+        rl_spec = _rl_spec(tmp_path)
+        rl_spec.seed = value
+        for trainer in _rl_trainers():
+            assert [p for p in trainer.validate(rl_spec) if _NAMES_THE_SEED in p] == []
+
+
+class TestABackendThatIgnoresTheFieldReportsNothing:
+    """A backend must not report on a field it never reads.
+
+    :class:`TrainSpec` documents that a backend "reads the fields it supports and
+    ignores the rest", so this gate is scoped to the seeding backends rather than
+    made universal like the learning-rate one.
+    """
+
+    @pytest.mark.parametrize("trainer_cls", (MockTrainer, Gr00tTrainer))
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_seeds_from_nothing(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.seed = value
+        assert _seed_problems_of(trainer_cls(), spec) == []
+
+
+class TestTheRefusedValuesAreOnesNoApplierCanHonor:
+    """Ground the domain in what the real appliers do with each value."""
+
+    @pytest.mark.parametrize(("supplied", "actual"), ((-1, 2**64 - 1), (-5, 2**64 - 5), (True, 1), (2.7, 2)))
+    def test_torch_silently_seeds_a_different_stream(self, supplied: Any, actual: int) -> None:
+        """The headline: a refused value is not merely rejected downstream.
+
+        ``torch.manual_seed`` reduces its argument, so the run IS reproducible -
+        under a seed the caller did not name, and one another caller could have.
+        """
+        torch = pytest.importorskip("torch")
+        torch.manual_seed(supplied)
+        as_supplied = torch.rand(8).tolist()
+        torch.manual_seed(actual)
+        as_rewritten = torch.rand(8).tolist()
+        assert as_supplied == as_rewritten, f"seed={supplied!r} no longer collapses onto {actual}"
+
+    @pytest.mark.parametrize("value", (-1, -5, 2.7, 3.0, float("nan"), float("inf"), "42"))
+    def test_numpys_legacy_seeder_refuses_it(self, value: Any) -> None:
+        """The narrowest applier on the LeRobot path refuses what torch rewrites."""
+        np = pytest.importorskip("numpy")
+        with pytest.raises((ValueError, TypeError)):
+            np.random.seed(value)
+
+    def test_a_refused_seed_still_reseeds_pythons_random_first(self) -> None:
+        """Why the check must precede the applier rather than trust it.
+
+        ``set_seed`` reseeds ``random`` before NumPy refuses, so the failed call
+        mutates process state a caller never asked it to touch.
+        """
+        pytest.importorskip("numpy")
+        set_seed = pytest.importorskip("lerobot.utils.random_utils").set_seed
+        import random
+
+        random.seed(999)
+        untouched = [random.random() for _ in range(2)]
+        random.seed(999)
+        with pytest.raises((ValueError, TypeError)):
+            set_seed(-1)
+        after_the_failure = [random.random() for _ in range(2)]
+        assert untouched != after_the_failure
+
+
+def _trainer_modules() -> list[pathlib.Path]:
+    """Every trainer module, minus the one that defines the shared gate.
+
+    Rooted at the module that defines :class:`Trainer` so the scan cannot
+    silently point at the wrong tree. The module that *defines* the gate is
+    excluded - derived from the gate itself rather than named, so the exclusion
+    cannot drift - because it reads the field as its owner, not as a consumer.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(seed_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_seed(source: str) -> bool:
+    """Does *source* read ``spec.seed``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "seed" and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_seed_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheSeedDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.seed`` must route it through the shared gate, so a
+    fifth backend that starts seeding from the field fails this test until it does.
+    """
+
+    def test_the_scan_finds_the_seeding_backends(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
+        readers = {p.name for p in _trainer_modules() if _reads_the_seed(p.read_text())}
+        assert readers == {"cosmos3.py", "lerobot.py", "fast_sac.py", "ppo.py"}
+
+    def test_every_backend_that_seeds_routes_through_the_shared_gate(self) -> None:
+        adrift = sorted(
+            p.name
+            for p in _trainer_modules()
+            if _reads_the_seed(source := p.read_text()) and not _calls_the_gate(source)
+        )
+        assert adrift == [], f"modules reading spec.seed without the shared gate: {adrift}"
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        """A local sign or type test on the field is the hole this closed."""
+        offenders: list[str] = []
+        for path in _trainer_modules():
+            for line in path.read_text().splitlines():
+                if "spec.seed" in line and ("< 0" in line or ">= 0" in line or "int(" in line):
+                    offenders.append(f"{path.name}: {line.strip()}")
+        assert offenders == [], f"local domain checks on spec.seed: {offenders}"
+
+    def test_the_scanners_detect_a_planted_defect(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = "def validate(self, spec):\n    return [] if spec.seed is None else []\n"
+        assert _reads_the_seed(planted)
+        assert not _calls_the_gate(planted)
+
+
+class TestTheGateIsUsableOnItsOwn:
+    """The shared gate's own contract, independent of any backend."""
+
+    def test_it_reports_the_context_it_was_given(self, spec: TrainSpec) -> None:
+        spec.seed = -1
+        assert seed_problems(spec, context="acme") == ["acme: seed must be a non-negative integer, got -1."]
+
+    def test_a_usable_seed_reports_nothing(self, spec: TrainSpec) -> None:
+        spec.seed = 0
+        assert seed_problems(spec, context="acme") == []
+
+    def test_an_unset_seed_reports_nothing(self, spec: TrainSpec) -> None:
+        assert seed_problems(spec, context="acme") == []


### PR DESCRIPTION
## The problem

`TrainSpec.seed` is the field a caller sets to make a run reproducible. Four backends read it and none of them checked it, while their appliers disagree about what a single value means.

**The RL trainers hand it to `torch.manual_seed`, which reduces its argument modulo `2**64`.** So `seed=-1` was *silently* `seed=2**64 - 1` - the run was reproducible under a number nobody asked for, and one another caller could legitimately have named. Measured:

```
>>> torch.manual_seed(-1);          torch.rand(4)
tensor([0.9938, 0.5713, 0.5700, 0.0495])
>>> torch.manual_seed(2**64 - 1);   torch.rand(4)
tensor([0.9938, 0.5713, 0.5700, 0.0495])      # identical stream
```

Same collapse for `-5` onto `2**64 - 5`, `True` onto `1`, and `2.7` onto `2`.

**LeRobot assigns it to `cfg.seed`, which reaches lerobot's `set_seed`:** `random.seed` first, then `numpy.random.seed`. NumPy is far narrower than torch - it refuses a negative and a float or string outright - but only *after* `random.seed` has already run, so a refused seed left the process RNG reseeded by a call that failed, under NumPy's message rather than one naming the field:

```
>>> random.seed(999); [random.random() for _ in range(2)]
[0.7813, 0.0801]
>>> random.seed(999); set_seed(-1)
ValueError: Seed must be between 0 and 2**32 - 1
>>> [random.random() for _ in range(2)]
[0.1344, 0.8474]                              # the failed call reseeded it anyway
```

**Cosmos interpolates it into a `trainer.seed=` Hydra override and LeRobot's argv-parity path into a `--seed=` token.** Every value renders - `nan`, `2.7`, `[7]` - and fails, if at all, inside the run after the dataset and model are already loaded, past the point `Trainer.validate` documents itself as running before.

So the same `seed=-1` was silently rewritten by one backend and refused with a bare third-party message by the next. Measured across the four backends and 12 values, **36 of 48 verdicts were not the one the appliers can honor**.

## The change

`Trainer._seed_problems` checks the field against the one shared `non_negative_count_error` domain, and the four backends that read the field call it. No new helper was needed: that is already exactly the rule - a true non-negative `int`, `bool` rejected - and its `0` is first-class here too, because seed `0` is a seed. Its docstring is widened to name the second family and the failure each consumer has outside the domain.

The refused set is the intersection of what the appliers can honor: for every value refused here, at least one applier either rewrites it or raises. `None` remains the documented "use the backend's own default" sentinel (LeRobot's is `1000`), exactly as it is for `learning_rate_problems`.

**Scoped to the seeding backends, not universal.** `TrainSpec` documents that a backend "reads the fields it supports and ignores the rest", so `mock` and `groot` - which never read `seed` - do not call the gate and report nothing about it. That is pinned. This mirrors `_run_size_problems` / `_launch_topology_problems` rather than the universal `_learning_rate_problems`.

**Not decided here:** the appliers also disagree about the *upper* end - torch accepts up to `2**64 - 1` while NumPy's legacy seeder stops at `2**32 - 1`, and the Cosmos path's ceiling is not measurable without a cosmos-framework checkout. A per-backend ceiling is a separate question from the floor and type checked here; the boundary is stated in the gate's docstring.

## Artifact

![TrainSpec.seed verdict matrix](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-seed-domain/seed_domain.png)

Every cell is a verdict from the backend's own `validate()`, measured by one script run against `upstream/main` in a worktree and against this branch (the generator asserts the two runs resolved to different trees, and re-derives every number in the figure from the two JSON dumps). A cell is red when the verdict is not the one the appliers can honor: **36 of 48 on main, 0 of 48 here.** The bottom-left panel is why `accepted` was the wrong verdict rather than a harmless one; the bottom-right is the no-regression control - `seed=42` produces the byte-identical `trainer.seed=42` override and `--seed=42` token on both trees.

Generators and both raw measurement dumps: [`measure_seed.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-seed-domain/measure_seed.py), [`figure_seed.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-seed-domain/figure_seed.py), [`main_verdicts.json`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-seed-domain/main_verdicts.json), [`branch_verdicts.json`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-seed-domain/branch_verdicts.json).

## Tests

`tests/training/test_seed_domain.py`, 96 tests, pinning the contract in both directions:

* every backend that reads the field refuses each unusable value through the shared domain, with a message naming itself, and returns a problem rather than raising;
* a usable seed - `0` included - and an unset one raise nothing, on all four;
* `mock` and `groot` report nothing about a field they never read;
* the refused values are grounded in what the real appliers do: the torch collision is asserted directly, NumPy's refusal of what torch rewrites is asserted, and so is the partial reseed that makes checking-before-the-applier necessary;
* a structural guard derives the in-scope backends from the tree - a module that *reads* `spec.seed` must route it through the shared gate - with a non-vacuity check on the scan and a planted-defect meta-test, so a fifth backend that starts seeding from the field fails until it does.

**Pre-fix proof** (call sites reverted to `upstream/main`, the gate left importable): `41 failed, 55 passed`. The 55 that pass are the over-reach controls (usable seeds accepted, the ignoring backends silent), the applier-grounding tests and the gate's own unit contract - they are what stops the change over-reaching.

The filter used throughout matches the message shape `": seed "` rather than the bare word, because pytest derives `tmp_path` from the test name: a path in an unrelated problem can contain "seed" too, and a filter that picked that up could both mask and fake a verdict.

## Gate

* `MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly` -> **19866 passed, 257 skipped, 0 failed** (580s). Zero existing-test churn.
* `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` -> clean (1065 source files).
* The five repo-wide root guards -> 42 passed.
* `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -> no overlap; base `62e375da`.

## Docs

`docs/training/overview.md` gains a `seed` row in the `TrainSpec` field table (the field had none), documenting the domain and why a negative is refused.