### PR TITLE
fix(policies): the VERA ports take the shared TCP-port domain

### DIFF
--- a/changelog.d/1951-vera-port-domain.md
+++ b/changelog.d/1951-vera-port-domain.md
@@ -1,0 +1,22 @@
+### Fixed: the VERA policy ports take the shared TCP-port domain
+
+`VeraConfig` stored `server_port` / `vis_port` verbatim, and three consumers then
+read the field under three different coercions: the provider dialed
+`int(server_port or 0)`, `VeraConfig.server_uri` interpolated it verbatim, and
+the server runner's argv carried `str(server_port)`. An unusable value was not
+merely refused late but *applied* as three different ports - `server_port=2.7`
+dialed `ws://host:2` while launching `--port 2.7` and reporting
+`ws://host:2.7`, so the client could not reach the server it had just started,
+and `True` produced the non-URI `ws://host:True`. `0`, `-1` and `70000` were
+accepted the same way; `nan`, `inf` and a list escaped the constructor as a bare
+`ValueError` / `OverflowError` / `TypeError` naming neither the field nor the
+class.
+
+Both ports are now checked once, on the effective value, in
+`VeraConfig.__post_init__` - the one funnel the provider keywords, a pre-built
+config and the `VERA_*_PORT` environment overrides all pass through - against
+`tcp_port_error`, the same domain the other port-dialing providers apply.
+`vis_port = 0` keeps its documented meaning (disable the live viewer) via a
+wrapper that decides only that floor and defers the range, so the two ports
+cannot drift apart on what counts as an addressable port. The refusal precedes
+the client and the runner, so a rejected port leaves nothing half-configured.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -144,6 +144,15 @@ wins over code defaults):
 | `motion_plan_scale` | `VERA_MOTION_PLAN_SCALE` | live `configure` |
 | `server_mode` | `VERA_SERVER_MODE` | `subprocess` \| `docker` |
 
+Both ports take the shared TCP-port domain every port-dialing provider applies:
+an `int` in `[1, 65535]`, or `None` for the per-embodiment default. The value is
+checked once, on the config, because three consumers read it — the client dials
+it, the runner launches the server on it, and `VeraConfig.server_uri` reports it
+— so a value outside the range is not merely refused late but resolved
+differently by each of them. `vis_port = 0` is the one exception and disables the
+live viewer (`--vis-port` is omitted). The `VERA_*_PORT` overrides go through the
+same check.
+
 ## Wire protocol
 
 The provider keeps a rolling **context window** of the last `context_frames`

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import dataclasses
 import os
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
+
+from strands_robots.utils import tcp_port_error
 
 Embodiment = Literal["pusht", "mimicgen", "allegro", "droid"]
 # "mimicgen" is the working, faithful embodiment end-to-end (eef-delta -> IK
@@ -67,6 +69,35 @@ def _env_int(name: str) -> int | None:
         return None
 
 
+def _viewer_port_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` cannot address the MJPEG live-viewer port.
+
+    :func:`~strands_robots.utils.tcp_port_error` owns the range and the scalar
+    policy; this wrapper decides only the floor, because ``vis_port`` documents
+    ``0`` as "disable the live viewer" rather than as a port to bind - the
+    runner omits the ``--vis-port`` flag entirely for a falsy value. A genuine
+    ``int`` zero is therefore accepted here and every other value is deferred,
+    so the two ports cannot drift apart on what counts as an addressable one.
+
+    ``bool`` is deliberately not spelled in the zero test: ``False == 0``, so a
+    bare ``value == 0`` would read ``False`` as the disable spelling. The type
+    identity is checked first, and a boolean falls through to
+    :func:`~strands_robots.utils.tcp_port_error`, which refuses it for the same
+    reason it refuses one for ``server_port``.
+
+    Args:
+        value: The caller-supplied value, after the default has been applied.
+        param: The field name it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if isinstance(value, int) and not isinstance(value, bool) and value == 0:
+        return None
+    return tcp_port_error(value, param, context)
+
+
 def _env_float(name: str) -> float | None:
     v = os.environ.get(name)
     if v is None or v.strip() == "":
@@ -89,8 +120,13 @@ class VeraConfig:
         embodiment: VERA embodiment - selects the WAN/DFoT planner + Jacobian
             IDM pair and the client-side action adapter.
         host: Policy-server hostname.
-        server_port: Policy-server websocket port (per-embodiment default).
-        vis_port: MJPEG live-viewer port; ``None`` / ``0`` disables it.
+        server_port: Policy-server websocket port. ``None`` applies the
+            per-embodiment default; any other value must be an ``int`` in
+            ``[1, 65535]``, because the client dials it and the server binds it.
+        vis_port: MJPEG live-viewer port. ``None`` applies the per-embodiment
+            default; ``0`` disables the viewer (the runner omits
+            ``--vis-port``); any other value must be an ``int`` in
+            ``[1, 65535]``.
         algo_config: WAN planner ``algo_config.yaml`` path. Point at the omni
             config to swap the planner without retraining the IDM.
         dynamics_run_id: Jacobian/IDM checkpoint id (wandb run id); falls back
@@ -147,6 +183,23 @@ class VeraConfig:
         if self.vis_port is None:
             env_vis = _env_int("VERA_VIS_PORT")
             self.vis_port = env_vis if env_vis is not None else default_vis
+
+        # Both ports are validated here, on the effective value, because this is
+        # the one funnel every caller passes through - the ``VeraPolicy``
+        # keywords, a pre-built config handed to it, and the ``VERA_*_PORT``
+        # environment overrides above - and because a port reaches three
+        # consumers under three different coercions: the provider dials
+        # ``int(server_port or 0)``, :attr:`server_uri` interpolates the field
+        # verbatim, and the runner's argv carries ``str(server_port)``. An
+        # unusable value is therefore not merely refused late; it is applied as
+        # three different ports (``2.7`` dials ``:2``, reports
+        # ``ws://host:2.7`` and launches ``--port 2.7``, so the client cannot
+        # reach the server it just started). Refusing before any client or
+        # runner is built leaves nothing half-configured behind.
+        if (err := tcp_port_error(self.server_port, "server_port", type(self).__name__)) is not None:
+            raise ValueError(err)
+        if (err := _viewer_port_error(self.vis_port, "vis_port", type(self).__name__)) is not None:
+            raise ValueError(err)
 
         if self.render_width is None:
             self.render_width = _env_int("VERA_RENDER_WIDTH") or _DEFAULT_RENDER_WIDTH.get(self.embodiment, 128)

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -99,8 +99,12 @@ class VeraPolicy(Policy):
 
     Args:
         embodiment: ``"pusht"`` | ``"mimicgen"`` | ``"allegro"`` | ``"droid"``.
-        server_port: Policy-server websocket port (per-embodiment default).
-        vis_port: MJPEG live-viewer port; ``None`` / ``0`` disables it.
+        server_port: Policy-server websocket port. ``None`` applies the
+            per-embodiment default; any other value must be an ``int`` in
+            ``[1, 65535]``.
+        vis_port: MJPEG live-viewer port. ``None`` applies the per-embodiment
+            default; ``0`` disables the viewer; any other value must be an
+            ``int`` in ``[1, 65535]``.
         algo_config: WAN planner ``algo_config.yaml`` (point at omni to swap).
         text_prompt: Optional text conditioning for the video planner.
         ckpt_root: Root of downloaded VERA checkpoints (``VERA_CKPT_ROOT``).

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1071,7 +1071,8 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
     reach a service over TCP (``use_rosbridge``'s WebSocket,
     ``gr00t_inference``'s inference service), the mesh bridges that construct
     one, and the policy providers that dial one (``groot``, ``moveit2``,
-    ``cosmos3``, ``lerobot_async``). A port is an index into the 16-bit TCP port
+    ``cosmos3``, ``lerobot_async``, ``vera``). A port is an index into the
+    16-bit TCP port
     space, so only an ``int`` in ``[1, 65535]`` names one: ``0`` asks the kernel
     for an ephemeral port rather than naming a port, and a value outside the
     range has nothing to bind or connect to.

--- a/tests/policies/vera/test_vera_port_domain.py
+++ b/tests/policies/vera/test_vera_port_domain.py
@@ -1,0 +1,230 @@
+"""The VERA ports are one shared TCP-port domain, applied at the config funnel.
+
+A ``server_port`` reaches three consumers under three different coercions - the
+provider dials ``int(server_port or 0)``, :attr:`VeraConfig.server_uri`
+interpolates the field verbatim, and the runner's argv carries
+``str(server_port)`` - so an unusable value is not merely refused late, it is
+*applied* as three different ports. ``server_port=2.7`` dialed ``ws://host:2``
+while launching ``--port 2.7`` and reporting ``ws://host:2.7``, so the client
+could not reach the server it had just started; ``True`` produced the
+non-URI ``ws://host:True``. Values outside the coercions' domain
+(``nan`` / ``inf`` / a list) escaped the constructor as a bare
+``ValueError`` / ``OverflowError`` / ``TypeError`` naming neither the field nor
+the class.
+
+These tests pin the domain (:func:`strands_robots.utils.tcp_port_error`, the
+same rule the four other port-dialing providers use), the one documented
+asymmetry (``vis_port=0`` disables the viewer, so zero is a mode selector there
+and not a port), and the property the divergence was: every accepted port is
+named identically by all three consumers.
+
+Everything here is offline - no server, no socket, no ``vera`` package.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.vera import VeraConfig, VeraPolicy, VeraServerRunner
+from strands_robots.policies.vera.config import _viewer_port_error
+
+# Values no TCP port can be addressed by. ``0`` is in this set for
+# ``server_port`` because the client has no way to learn which ephemeral port
+# the kernel handed the server, so it cannot dial one.
+UNUSABLE_PORTS: list[Any] = [
+    0,
+    -1,
+    65536,
+    70000,
+    2.7,
+    8800.0,
+    True,
+    False,
+    math.nan,
+    math.inf,
+    "8800",
+    [8800],
+    {},
+]
+
+# Ports every consumer can honor.
+USABLE_PORTS: list[int] = [1, 8800, 8820, 65535]
+
+
+def _config(**kwargs: Any) -> VeraConfig:
+    """Build a config through the funnel, splatted so off-type values reach it.
+
+    mypy does not narrow a ``**dict[str, Any]`` splat, which is what lets a test
+    hand a deliberately wrong type to a field annotated ``int | None``.
+    """
+    return VeraConfig(**kwargs)
+
+
+def _argv_port(cfg: VeraConfig, flag: str) -> str | None:
+    """The value the server launch argv carries for ``flag``, or None if absent."""
+    cmd = VeraServerRunner(cfg)._build_command()
+    return cmd[cmd.index(flag) + 1] if flag in cmd else None
+
+
+# --------------------------------------------------------------------------- #
+# server_port - refused at the funnel
+# --------------------------------------------------------------------------- #
+class TestServerPortDomain:
+    @pytest.mark.parametrize("value", UNUSABLE_PORTS)
+    def test_an_unusable_server_port_is_refused_by_name(self, value):
+        """The refusal names the field, the value and the accepted range."""
+        with pytest.raises(ValueError, match="server_port"):
+            _config(embodiment="pusht", server_port=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_PORTS)
+    def test_the_refusal_replaces_a_bare_coercion_error(self, value):
+        """No ``int()`` / interpolation failure escapes instead of the verdict."""
+        try:
+            _config(embodiment="pusht", server_port=value)
+        except ValueError as exc:
+            text = str(exc)
+            assert "VeraConfig" in text
+            assert "expected 1-65535" in text
+            assert "convert float" not in text
+            assert "int() argument" not in text
+        else:
+            pytest.fail(f"server_port={value!r} was accepted")
+
+    @pytest.mark.parametrize("value", UNUSABLE_PORTS)
+    def test_the_provider_keyword_reaches_the_same_verdict(self, value):
+        """``VeraPolicy(server_port=...)`` funnels through the same guard."""
+        with pytest.raises(ValueError, match="server_port"):
+            VeraPolicy(embodiment="pusht", server_port=value, auto_launch_server=False)
+
+    @pytest.mark.parametrize("value", UNUSABLE_PORTS)
+    def test_a_prebuilt_config_cannot_carry_one_past_the_provider(self, value):
+        """The guard is on the config, so ``config=`` is not a way around it."""
+        with pytest.raises(ValueError, match="server_port"):
+            VeraPolicy(config=_config(embodiment="pusht", server_port=value))
+
+    @pytest.mark.parametrize("value", USABLE_PORTS)
+    def test_a_usable_server_port_is_applied(self, value):
+        """Over-reach control: the accepted side of the range still works."""
+        cfg = _config(embodiment="pusht", server_port=value)
+        assert cfg.server_port == value
+
+    def test_none_still_applies_the_per_embodiment_default(self):
+        """``None`` is the documented "use the default" spelling, not a port."""
+        assert _config(embodiment="pusht").server_port == 8820
+        assert _config(embodiment="mimicgen").server_port == 8800
+
+
+# --------------------------------------------------------------------------- #
+# The three consumers agree - the property the divergence was
+# --------------------------------------------------------------------------- #
+class TestEveryConsumerNamesTheSamePort:
+    @pytest.mark.parametrize("value", USABLE_PORTS)
+    def test_client_uri_server_uri_and_argv_name_one_port(self, value):
+        """``2.7`` dialed :2, reported ws://host:2.7 and launched --port 2.7."""
+        policy = VeraPolicy(embodiment="pusht", server_port=value, auto_launch_server=False)
+        assert policy._client.uri == f"ws://127.0.0.1:{value}"
+        assert policy.config.server_uri == f"ws://127.0.0.1:{value}"
+        assert _argv_port(policy.config, "--port") == str(value)
+
+    def test_the_default_port_is_named_identically_too(self):
+        """The un-supplied path is held to the same agreement."""
+        policy = VeraPolicy(embodiment="pusht", auto_launch_server=False)
+        assert policy._client.uri == "ws://127.0.0.1:8820"
+        assert policy.config.server_uri == "ws://127.0.0.1:8820"
+        assert _argv_port(policy.config, "--port") == "8820"
+
+
+# --------------------------------------------------------------------------- #
+# vis_port - the same range, with zero as a documented mode selector
+# --------------------------------------------------------------------------- #
+class TestViewerPortDomain:
+    def test_zero_disables_the_viewer_rather_than_naming_a_port(self):
+        """Documented: ``0`` omits ``--vis-port``, so it is not refused."""
+        cfg = _config(embodiment="pusht", vis_port=0)
+        assert cfg.vis_port == 0
+        assert _argv_port(cfg, "--vis-port") is None
+
+    def test_none_applies_the_default_and_enables_the_viewer(self):
+        """``None`` resolves to the per-embodiment default, it does not disable."""
+        cfg = _config(embodiment="pusht")
+        assert cfg.vis_port == 8821
+        assert _argv_port(cfg, "--vis-port") == "8821"
+
+    @pytest.mark.parametrize("value", USABLE_PORTS)
+    def test_a_usable_viewer_port_reaches_the_argv(self, value):
+        cfg = _config(embodiment="pusht", vis_port=value)
+        assert _argv_port(cfg, "--vis-port") == str(value)
+
+    @pytest.mark.parametrize("value", [v for v in UNUSABLE_PORTS if v != 0 and v is not False])
+    def test_an_unusable_viewer_port_is_refused_by_name(self, value):
+        with pytest.raises(ValueError, match="vis_port"):
+            _config(embodiment="pusht", vis_port=value)
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_a_boolean_viewer_port_is_refused_rather_than_read_as_the_zero(self, value):
+        """``False == 0``, so a bare zero test would read it as "disable"."""
+        with pytest.raises(ValueError, match="vis_port"):
+            _config(embodiment="pusht", vis_port=value)
+
+    def test_the_zero_exemption_is_the_only_difference_from_the_shared_rule(self):
+        """Unit: the wrapper decides the floor and defers everything else."""
+        assert _viewer_port_error(0, "vis_port", "VeraConfig") is None
+        for value in UNUSABLE_PORTS:
+            if isinstance(value, int) and not isinstance(value, bool) and value == 0:
+                continue
+            assert _viewer_port_error(value, "vis_port", "VeraConfig") is not None
+
+
+# --------------------------------------------------------------------------- #
+# The environment override goes through the same guard
+# --------------------------------------------------------------------------- #
+class TestEnvironmentOverride:
+    def test_an_unusable_env_server_port_is_refused(self, monkeypatch):
+        """``VERA_SERVER_PORT`` writes the same field, so it is checked too."""
+        monkeypatch.setenv("VERA_SERVER_PORT", "70000")
+        with pytest.raises(ValueError, match="server_port"):
+            _config(embodiment="pusht")
+
+    def test_an_unusable_env_viewer_port_is_refused(self, monkeypatch):
+        monkeypatch.setenv("VERA_VIS_PORT", "-9")
+        with pytest.raises(ValueError, match="vis_port"):
+            _config(embodiment="pusht")
+
+    def test_a_usable_env_override_still_applies(self, monkeypatch):
+        monkeypatch.setenv("VERA_SERVER_PORT", "9999")
+        monkeypatch.setenv("VERA_VIS_PORT", "9998")
+        cfg = _config(embodiment="pusht")
+        assert (cfg.server_port, cfg.vis_port) == (9999, 9998)
+
+
+# --------------------------------------------------------------------------- #
+# Guard placement - nothing is built before the verdict
+# --------------------------------------------------------------------------- #
+class TestNothingIsBuiltBeforeTheVerdict:
+    @pytest.fixture
+    def no_side_effects(self, monkeypatch):
+        """Make building a client or a server runner fatal."""
+        import strands_robots.policies.vera.provider as provider
+
+        def _fatal(*args, **kwargs):
+            raise AssertionError("a refused port reached a client / runner build")
+
+        monkeypatch.setattr(provider, "VeraWebsocketClient", _fatal)
+        monkeypatch.setattr(provider, "make_server_runner", _fatal)
+
+    def test_a_refused_port_builds_no_client_and_no_runner(self, no_side_effects):
+        """The config raises before the provider dials or launches anything."""
+        with pytest.raises(ValueError, match="server_port"):
+            VeraPolicy(embodiment="pusht", server_port=70000)
+
+    def test_a_refused_viewer_port_builds_no_client_and_no_runner(self, no_side_effects):
+        with pytest.raises(ValueError, match="vis_port"):
+            VeraPolicy(embodiment="pusht", vis_port=-1)
+
+    def test_the_fixture_is_not_vacuous(self, no_side_effects):
+        """A usable port really does reach the patched builders."""
+        with pytest.raises(AssertionError, match="refused port reached"):
+            VeraPolicy(embodiment="pusht", server_port=8820)


### PR DESCRIPTION
## The defect

`VeraConfig` stored `server_port` verbatim, and **three consumers then read that
field under three different coercions**:

| consumer | expression |
|---|---|
| the provider's websocket client | `VeraWebsocketClient(host, int(server_port or 0))` |
| the public `VeraConfig.server_uri` | `f"ws://{host}:{server_port}"` |
| the server launch argv | `["--port", str(server_port)]` |

So an unusable value was not merely refused late — it was **applied as several
different ports at once**. Measured on `main@62e375da`:

| `server_port=` | client dials | `config.server_uri` | server argv | verdict |
|---|---|---|---|---|
| `8820` | `:8820` | `ws://127.0.0.1:8820` | `--port 8820` | accepted (control) |
| **`2.7`** | **`:2`** | **`ws://127.0.0.1:2.7`** | **`--port 2.7`** | **accepted — two ports** |
| **`True`** | **`:1`** | **`ws://127.0.0.1:True`** | **`--port True`** | **accepted — two ports** |
| `0` | `:0` | `ws://127.0.0.1:0` | `--port 0` | accepted |
| `-1` | `:-1` | `ws://127.0.0.1:-1` | `--port -1` | accepted |
| `70000` | `:70000` | `ws://127.0.0.1:70000` | `--port 70000` | accepted |
| `nan` | — | — | — | `ValueError: cannot convert float NaN to integer` |
| `'8820'` | `:8820` | `ws://127.0.0.1:8820` | `--port 8820` | accepted (by coincidence) |

Six of the eight are unusable and six were accepted. The two divergent rows are
the sharp ones: with `server_port=2.7` the runner launches the server on
`--port 2.7` while the client dials `:2`, so **the provider cannot reach the
server it just started**, and `server_uri` — the attribute a caller reads to
find out where the server is — reports a third spelling. `True` produces
`ws://127.0.0.1:True`, which is not a URI at all. The two that did fail failed
as a bare `ValueError` / `OverflowError` / `TypeError` out of `int()`, naming
neither the field nor the class.

`vis_port` had the same gap on the same field, with its own twist: `False == 0`,
so a boolean was read as the documented "disable the viewer" spelling.

## Why the ports and the domain are one change

`tcp_port_error` already owns this rule and its docstring already listed the
providers that dial a port — `groot`, `moveit2`, `cosmos3`, `lerobot_async`.
`vera` is a fifth and was not among them, which is the whole defect: no new
helper was needed, only the missing application. The docstring's list is
corrected here too, so the next reader counting callers gets five.

## The change

Both ports are validated **once, on the effective value**, in
`VeraConfig.__post_init__` — immediately after the per-embodiment defaults
resolve. That is the one funnel every caller passes through:

* `VeraPolicy(server_port=…)` keywords,
* a pre-built `config=VeraConfig(…)` handed to the provider (which a
  kwarg-only guard would not cover),
* `VeraConfig(…)` used directly (it is public API),
* the `VERA_SERVER_PORT` / `VERA_VIS_PORT` environment overrides.

The check precedes both the client and the server runner, so a refused port
leaves nothing half-configured — pinned with a fixture that makes building
either one fatal.

### The one documented asymmetry

`vis_port = 0` is documented as *disable the live viewer* (the runner omits
`--vis-port` for a falsy value), so zero there is a mode selector and not a port.
A private `_viewer_port_error` decides **only that floor** and defers the range
and the scalar policy to `tcp_port_error`, so the two ports cannot drift apart
on what counts as an addressable port. `bool` is deliberately not spelled in the
zero test — the type identity is checked first so `False` falls through to the
shared rule rather than reading as "disable".

While documenting the domain, the `vis_port` prose also said `None` disables the
viewer. It does not: `None` resolves to the per-embodiment default and the viewer
runs. Corrected in the same place.

## Visual artifact

Every cell below is read from two measurement runs of one script — one in a
worktree at `62e375da`, one on this branch — and the composing script asserts
each figure claim (and that the two runs came from different trees) before
saving. Offline: no server, no socket, no `vera` package.

![VERA port domain measured before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vera-port-domain/vera_port_domain.png)

The lower band is the no-regression half: `vis_port=0` still disables the viewer
and `vis_port=8821` still reaches the argv, identically on both trees. The raw
measurements and both scripts are alongside the image
([`before_main.json`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vera-port-domain/before_main.json),
[`after_branch.json`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vera-port-domain/after_branch.json),
[`measure_ports.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vera-port-domain/measure_ports.py),
[`compose_figure.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vera-port-domain/compose_figure.py)).

## Tests

`tests/policies/vera/test_vera_port_domain.py` — 88 tests, 0.13 s, no server,
no socket, no `vera` package:

* the domain over 13 unusable values × both entry points (provider keyword and
  pre-built config), asserting the message names the field, the value and the
  range, and that no bare coercion error escapes in its place;
* **every consumer names the same port** for every accepted value — the property
  the divergence was: `client.uri == config.server_uri == --port <n>`;
* `vis_port`: `0` still disables, `None` still applies the default and enables,
  a boolean is refused rather than read as the zero, and a unit test that the
  zero exemption is the *only* difference from the shared rule;
* the environment overrides go through the same check;
* guard placement — a refused port builds no client and no runner, plus a
  non-vacuity test that a usable port really does reach those builders;
* over-reach controls at `1`, `8800`, `8820`, `65535`.

**Pre-fix proof** (reverting `config.py` + `provider.py` to `upstream/main`, with
the new symbol replaced by a local stand-in so every behavioural test still
runs): **69 failed, 19 passed**. The 19 that pass are the accepted-value
controls, the default-resolution premises and the stand-in's own unit test —
they are what stops the guard over-reaching.

**Blast radius: zero.** No existing test changed; every port already in the
suite is a usable one.

## Gate

* `ruff check strands_robots tests tests_integ` — clean
* `ruff format --check` — 1068 files already formatted
* `mypy strands_robots tests tests_integ` — 0 errors outside `examples/isaac_gs`;
  the 14 there are byte-identical to a pristine `upstream/main` worktree of the
  same working copy (environment-dependent, not from this branch)
* `MUJOCO_GL=egl pytest tests` — **19858 passed, 257 skipped**, 553 s
* `scripts/assemble_changelog.py --check` — OK; `scripts/check_merge_base_overlap.py`
  — no overlap, base is current `upstream/main` (`62e375da`)

## Out of scope

* **`PolicyServer` / `RemotePolicy` (`strands_robots/inference/`)** take an
  unvalidated `port` too, but they need a *different* domain rather than this
  one: `PolicyServer` documents `0` as "ask the OS for a free port", which
  `tcp_port_error` refuses by design, while the client that dials it cannot use
  an ephemeral port. That split is a contract decision of its own, filed with
  measurements as #1952 rather than folded in here.
* The other non-port `VeraConfig` numerics (`render_width`, `sample_steps`,
  `n_action_steps`, `teacache_thresh`) are a separate axis; this change is
  scoped to the two ports, matching how the range rule was applied to the other
  providers one surface at a time.

