### PR TITLE
fix(inference): a remote-inference port is validated on the domain its role actually has

### DIFF
--- a/changelog.d/1952-inference-port-domains.md
+++ b/changelog.d/1952-inference-port-domains.md
@@ -1,0 +1,19 @@
+### Fixed: `PolicyServer` and `RemotePolicy` refuse a port they cannot use
+
+The remote-inference pair stored whatever `port` it was handed. The server's went
+straight onto `.port`; the client's went verbatim into `f"ws://{host}:{port}"`, so
+`ws://127.0.0.1:nan` and `ws://127.0.0.1:[8765]` were constructed and kept. A
+WebSocket target is only resolved on first use, so neither was refused by the
+transport - each surfaced much later as an unreachable server, implicating the
+service the caller was trying to reach rather than the port.
+
+Both halves now validate it, on the two domains the two roles actually have. The
+client dials, so it takes `tcp_port_error`'s `[1, 65535]` unchanged. The server
+binds, so it takes the same range with the floor at `0` - the documented request
+for an ephemeral port, which `start()`/`serve()` still read back onto `.port`. The
+refusal precedes `create_policy`, so a port that can never bind no longer builds a
+policy first, and precedes the client's `uri`, so no unusable endpoint is stored.
+
+The `--port` CLI flag routes through the same bind rule as the constructor it
+calls. Its inline `1 <= port <= 65535` range previously refused `--port 0`, the
+ephemeral bind `PolicyServer` documents as first-class.

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -61,6 +61,11 @@ print(server.port)
 server.stop()
 ```
 
+`port` is an `int` in `[1, 65535]`, plus `0` for the ephemeral bind above. A
+value outside that - a negative, an out-of-range number, a float, a `bool`, a
+string - is refused by the constructor and by `--port`, before any policy is
+built, rather than reaching the socket.
+
 The server binds `127.0.0.1` by default. Set `host="0.0.0.0"` to accept remote
 connections and wrap the link in tailscale / wireguard for production - the v1
 transport is plaintext (auth/TLS is out of scope, see Non-goals).
@@ -82,6 +87,14 @@ The server endpoint is set via `endpoint=` (with a `host=`/`port=` fallback).
 forwarded unchanged, but passing the endpoint under any other name (e.g. `uri=`)
 logs a WARNING naming the ignored kwarg and the endpoint actually in use, rather
 than silently connecting to the default `ws://127.0.0.1:8765`.
+
+When `port=` is the effective spelling it must be an `int` in `[1, 65535]`, and
+is refused before the endpoint is built. Unlike the server the client cannot
+accept `0`: asking the kernel for a free port is something only the binding side
+can do, so there is nothing for a client to dial. Refusing it here matters
+because a WebSocket target is only resolved on first use - an unusable port is
+not rejected by the transport, it surfaces later as an unreachable server and
+implicates the service you were trying to reach.
 
 Then drive it exactly like a local policy. In simulation:
 

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
 from strands_robots.policies.base import Policy
-from strands_robots.utils import name_list_error
+from strands_robots.utils import name_list_error, tcp_port_error
 
 if TYPE_CHECKING:
     from websockets.sync.client import ClientConnection
@@ -56,7 +56,11 @@ class RemotePolicy(Policy):
         endpoint: Full server URL, e.g. ``ws://gpu-box:8765``. When given it
             takes precedence over ``host``/``port``.
         host: Server host (used when ``endpoint`` is not given).
-        port: Server port (used when ``endpoint`` is not given).
+        port: Server port (used when ``endpoint`` is not given). Must be an
+            ``int`` in ``[1, 65535]``: this client has to dial the port, so
+            unlike :class:`~strands_robots.inference.PolicyServer` - which
+            binds one - it cannot accept ``0``, the request for an ephemeral
+            port that only the server side can make.
         connect_timeout: Seconds to wait for the WebSocket handshake.
         request_timeout: Seconds to wait for a reply to each request.
 
@@ -66,6 +70,7 @@ class RemotePolicy(Policy):
     otherwise leave the client silently connected to the default endpoint.
 
     Raises:
+        ValueError: If ``port`` cannot address a server to dial.
         ConnectionError: On first use, if the server cannot be reached.
     """
 
@@ -79,6 +84,15 @@ class RemotePolicy(Policy):
         request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
         **ignored_kwargs: Any,
     ) -> None:
+        # ``port`` is interpolated into the URI verbatim, and a WebSocket target
+        # is only resolved on first use - so an unusable value is not refused by
+        # the transport, it fails much later as an unreachable server and
+        # implicates the service the caller was trying to reach. Refuse it while
+        # the caller still holds the value, before ``uri`` exists at all.
+        # ``endpoint`` supersedes ``host``/``port``, so the port is validated
+        # only when it is the effective spelling.
+        if not endpoint and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+            raise ValueError(port_error)
         self.uri = endpoint if endpoint else f"ws://{host}:{port}"
         if not self.uri.startswith(("ws://", "wss://")):
             self.uri = f"ws://{self.uri}"

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -34,11 +34,43 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
 from strands_robots.policies.base import Policy
+from strands_robots.utils import tcp_port_error
 
 if TYPE_CHECKING:
     from websockets.sync.server import Server, ServerConnection
 
 logger = logging.getLogger(__name__)
+
+
+def _bind_port_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` cannot be bound as a server port.
+
+    :func:`~strands_robots.utils.tcp_port_error` owns the range and the scalar
+    policy; this wrapper decides only the floor, because a server *binds* a
+    port rather than dialing one and so may ask the kernel for an ephemeral
+    one. :class:`PolicyServer` documents ``0`` as exactly that, and reads the
+    assigned port back onto :attr:`PolicyServer.port` once bound, so a genuine
+    ``int`` zero is accepted here and every other value is deferred - the bind
+    and dial domains cannot drift apart on what counts as an addressable port.
+
+    ``bool`` is deliberately not spelled in the zero test: ``False == 0``, so a
+    bare ``value == 0`` would read ``False`` as the ephemeral request. The type
+    identity is checked first, and a boolean falls through to
+    :func:`~strands_robots.utils.tcp_port_error`, which refuses it for the same
+    reason it refuses one for a port the client dials - otherwise ``True``
+    would bind privileged port 1.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        An error message, or ``None`` when the value can be bound.
+    """
+    if isinstance(value, int) and not isinstance(value, bool) and value == 0:
+        return None
+    return tcp_port_error(value, param, context)
 
 
 class PolicyServer:
@@ -55,11 +87,12 @@ class PolicyServer:
         host: Bind address. Defaults to ``127.0.0.1`` (loopback only); use
             ``0.0.0.0`` to accept remote connections.
         port: Bind port. ``0`` asks the OS for a free port (read back from
-            :attr:`port` after :meth:`start`).
+            :attr:`port` after :meth:`start`); any other value must be an
+            ``int`` in ``[1, 65535]``.
 
     Raises:
         ValueError: If neither or both of ``policy`` / ``policy_provider`` are
-            given.
+            given, or if ``port`` cannot be bound.
     """
 
     def __init__(
@@ -73,6 +106,14 @@ class PolicyServer:
     ) -> None:
         if (policy is None) == (policy_provider is None):
             raise ValueError("provide exactly one of 'policy' or 'policy_provider'")
+
+        # ``port`` is the port this server binds, so a value it cannot bind is
+        # refused here rather than at ``serve()``: building the policy first can
+        # download a checkpoint, and the port is only actionable at the point the
+        # caller named it. ``0`` stays valid - it is the documented request for an
+        # ephemeral port, which ``start()``/``serve()`` read back onto ``port``.
+        if (port_error := _bind_port_error(port, "port", type(self).__name__)) is not None:
+            raise ValueError(port_error)
 
         if policy is None:
             from strands_robots.policies import create_policy
@@ -279,11 +320,19 @@ def main(argv: list[str] | None = None) -> None:
         help="Policy provider name or smart string (e.g. 'mock', 'lerobot/act_so101').",
     )
     parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1).")
-    parser.add_argument("--port", type=int, default=8765, help="Bind port (default: 8765).")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Bind port, or 0 to ask the OS for a free one (default: 8765).",
+    )
     args = parser.parse_args(argv)
 
-    if not 1 <= args.port <= 65535:
-        parser.error(f"--port must be between 1 and 65535, got {args.port}")
+    # Same bind domain as the constructor, so the CLI cannot refuse a port the
+    # class it constructs accepts. The previous inline range did exactly that
+    # for ``--port 0``, the documented ephemeral bind.
+    if (port_error := _bind_port_error(args.port, "--port", parser.prog)) is not None:
+        parser.error(port_error)
 
     logging.basicConfig(level=logging.INFO)
     PolicyServer(policy_provider=args.provider, host=args.host, port=args.port).serve()

--- a/tests/inference/test_bind_and_dial_port_domains.py
+++ b/tests/inference/test_bind_and_dial_port_domains.py
@@ -1,0 +1,240 @@
+"""One ``port`` parameter, two accepted domains: the server binds, the client dials.
+
+:class:`~strands_robots.inference.PolicyServer` and
+:class:`~strands_robots.inference.RemotePolicy` both take a ``port``, and both
+used to store whatever they were handed. The server's field went straight onto
+``self.port``; the client's went verbatim into ``f"ws://{host}:{port}"``, so
+``ws://127.0.0.1:nan`` and ``ws://127.0.0.1:[8765]`` were constructed and kept.
+A WebSocket target is only resolved on first use, so neither was refused by the
+transport - each surfaced much later as an unreachable server, implicating the
+service the caller was trying to reach rather than the port.
+
+The two halves cannot share one domain, which is what this module pins:
+
+* the client **dials**, so it needs a port it can address -
+  :func:`~strands_robots.utils.tcp_port_error`'s ``[1, 65535]`` unchanged;
+* the server **binds**, so it may ask the kernel for an ephemeral port -
+  ``PolicyServer`` documents ``0`` as exactly that and reads the assigned port
+  back onto ``.port``, so its domain is the same range with the floor at 0.
+
+The asymmetry is pinned deliberately: a later change that "harmonises" the two
+fails here rather than silently removing the ephemeral bind or admitting a
+client that cannot dial what it was pointed at.
+
+These are constructor-level contracts, so nothing here opens a socket except
+the one test that asserts the documented ephemeral bind still works end to end.
+"""
+
+from typing import Any
+
+import pytest
+
+from strands_robots.inference import PolicyServer, RemotePolicy
+from strands_robots.inference import server as server_mod
+from strands_robots.policies import MockPolicy
+
+#: Values that name no port on either side. Each is refused by both surfaces.
+#: ``2.7`` and ``'8765'`` matter because neither half applies ``int()``, so a
+#: non-integer reached the URI and the bind unchanged; ``True``/``False``
+#: because ``bool`` is an ``int`` subclass, so a bare range test admits ``True``
+#: as a silent privileged port 1 and a bare zero test reads ``False`` as the
+#: ephemeral request.
+UNUSABLE_PORTS: list[Any] = [-1, 70000, 2.7, True, False, float("nan"), float("inf"), "8765", [8765], None]
+
+#: Accepted by both halves - the boundaries of the addressable range, so a guard
+#: that is off by one at either end fails here rather than in the field.
+DIALABLE_PORTS: list[Any] = [1, 8765, 65535]
+
+
+def _server(**kwargs: Any) -> PolicyServer:
+    """Construct a ``PolicyServer``, splatted so off-type ports reach the guard.
+
+    The ``port`` parameter is annotated ``int``; several cases here deliberately
+    pass something else to prove the runtime refuses it, which a direct call
+    would make a type error rather than a test.
+    """
+    return PolicyServer(policy=MockPolicy(), **kwargs)
+
+
+def _client(**kwargs: Any) -> RemotePolicy:
+    """Construct a ``RemotePolicy``, splatted for the same reason as ``_server``."""
+    return RemotePolicy(**kwargs)
+
+
+class TestNeitherHalfAcceptsAnUnusablePort:
+    """A value that names no port is refused by the bind and the dial surface."""
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_the_server_refuses_it(self, port: Any) -> None:
+        """``PolicyServer`` refuses it, naming the parameter, value and range."""
+        with pytest.raises(ValueError) as exc:
+            _server(port=port)
+        text = str(exc.value)
+        assert "PolicyServer" in text
+        assert "invalid port" in text
+        assert "1-65535" in text
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_the_client_refuses_it(self, port: Any) -> None:
+        """``RemotePolicy`` refuses it the same way."""
+        with pytest.raises(ValueError) as exc:
+            _client(port=port)
+        text = str(exc.value)
+        assert "RemotePolicy" in text
+        assert "invalid port" in text
+        assert "1-65535" in text
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_no_client_uri_is_built_from_it(self, port: Any) -> None:
+        """The refusal precedes ``uri``, so no unusable endpoint is ever stored.
+
+        Asserts the object does not exist rather than that a later connect
+        fails: ``uri`` is the client's whole addressing state, and a stored
+        ``ws://127.0.0.1:nan`` is what turned a bad port into an apparently
+        unreachable server.
+        """
+        with pytest.raises(ValueError):
+            client = _client(port=port)
+            pytest.fail(f"constructed a client addressing {client.uri!r}")
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_the_server_refuses_it_before_building_a_policy(self, port: Any) -> None:
+        """The refusal precedes ``create_policy``, which can download a checkpoint.
+
+        Uses the ``policy_provider`` spelling, where accepting the port first
+        would resolve and build a policy for a server that can never bind.
+        """
+        calls: list[str] = []
+
+        class _Boom(Exception):
+            pass
+
+        def _fail(provider: str, **_kwargs: Any) -> Any:
+            calls.append(provider)
+            raise _Boom("create_policy must not be reached")
+
+        import strands_robots.policies as policies_pkg
+
+        original = policies_pkg.create_policy
+        policies_pkg.create_policy = _fail  # type: ignore[assignment]
+        try:
+            with pytest.raises(ValueError, match="invalid port"):
+                PolicyServer(policy_provider="mock", port=port)
+        finally:
+            policies_pkg.create_policy = original  # type: ignore[assignment]
+        assert calls == [], "the port was accepted long enough to build a policy"
+
+
+class TestAnAddressablePortIsAcceptedByBoth:
+    """The over-reach controls: the guards refuse only what they must."""
+
+    @pytest.mark.parametrize("port", DIALABLE_PORTS)
+    def test_the_server_accepts_it(self, port: int) -> None:
+        """A port in range is stored for the bind."""
+        assert _server(port=port).port == port
+
+    @pytest.mark.parametrize("port", DIALABLE_PORTS)
+    def test_the_client_dials_it(self, port: int) -> None:
+        """A port in range is interpolated into the endpoint."""
+        assert _client(port=port).uri == f"ws://127.0.0.1:{port}"
+
+
+class TestOnlyTheServerMayAskForAnEphemeralPort:
+    """``0`` is the documented ephemeral bind, and only a binder can make it."""
+
+    def test_the_server_accepts_zero(self) -> None:
+        """``PolicyServer(port=0)`` is the documented "any free port" request."""
+        assert _server(port=0).port == 0
+
+    def test_the_client_refuses_zero(self) -> None:
+        """``RemotePolicy`` cannot dial "any free port", so ``0`` is refused.
+
+        This is the asymmetry that makes the two domains distinct rather than a
+        single shared rule. Harmonising them in either direction breaks one of
+        these two tests.
+        """
+        with pytest.raises(ValueError, match="invalid port"):
+            _client(port=0)
+
+    def test_zero_still_binds_and_reports_the_assigned_port(self) -> None:
+        """The ephemeral path works end to end: ``start()`` reports the real port.
+
+        The one behaviour that must not regress - accepting ``0`` is only
+        meaningful because the OS-assigned port is readable afterwards.
+        """
+        server = _server(port=0).start()
+        try:
+            assert server.port > 0
+            assert server.port != 0
+        finally:
+            server.stop()
+
+    def test_false_is_not_read_as_the_ephemeral_request(self) -> None:
+        """``False == 0``, so the zero test must check the type first.
+
+        Otherwise a boolean would be accepted as "any free port", and ``True``
+        would bind privileged port 1.
+        """
+        with pytest.raises(ValueError, match="invalid port"):
+            _server(port=False)
+        with pytest.raises(ValueError, match="invalid port"):
+            _server(port=True)
+
+
+class TestTheZeroExemptionIsTheOnlyDifferenceFromTheSharedRule:
+    """``_bind_port_error`` defers everything but the floor to the shared domain."""
+
+    @pytest.mark.parametrize("port", [*UNUSABLE_PORTS, *DIALABLE_PORTS])
+    def test_it_agrees_with_the_shared_domain_away_from_zero(self, port: Any) -> None:
+        """Away from ``0``, bind and dial return byte-identical verdicts."""
+        from strands_robots.utils import tcp_port_error
+
+        assert server_mod._bind_port_error(port, "port", "Ctx") == tcp_port_error(port, "port", "Ctx")
+
+    def test_it_differs_from_the_shared_domain_at_zero(self) -> None:
+        """At ``0`` the wrapper accepts and the shared domain refuses."""
+        from strands_robots.utils import tcp_port_error
+
+        assert server_mod._bind_port_error(0, "port", "Ctx") is None
+        assert tcp_port_error(0, "port", "Ctx") is not None
+
+
+class TestAnExplicitEndpointSupersedesThePort:
+    """``endpoint`` wins over ``host``/``port``, so only the effective knob is checked."""
+
+    def test_a_port_is_not_refused_when_an_endpoint_is_given(self) -> None:
+        """The port is unread on this path, so refusing it would be a false rejection."""
+        client = _client(endpoint="ws://gpu-box:9999", port=0)
+        assert client.uri == "ws://gpu-box:9999"
+
+    def test_the_port_is_checked_when_it_is_the_effective_spelling(self) -> None:
+        """An empty endpoint falls back to ``host``/``port``, so the port is read."""
+        with pytest.raises(ValueError, match="invalid port"):
+            _client(endpoint="", port=0)
+
+
+class TestTheCliBindsOnTheSameDomainAsTheClassItConstructs:
+    """The CLI cannot refuse a port ``PolicyServer`` accepts, or vice versa."""
+
+    def test_it_accepts_the_ephemeral_bind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``--port 0`` reaches ``serve()``.
+
+        It previously exited 2 on an inline ``1 <= port <= 65535`` range, so the
+        CLI refused the ephemeral bind its own class documents as first-class.
+        """
+        served: dict[str, object] = {}
+
+        def fake_serve(self: PolicyServer) -> None:
+            served["port"] = self.port
+
+        monkeypatch.setattr(PolicyServer, "serve", fake_serve)
+        server_mod.main(["--provider", "mock", "--port", "0"])
+
+        assert served == {"port": 0}
+
+    @pytest.mark.parametrize("port", ["-1", "70000"])
+    def test_it_refuses_an_out_of_range_port(self, port: str) -> None:
+        """A port outside the range still exits 2, with the shared reason."""
+        with pytest.raises(SystemExit) as exc:
+            server_mod.main(["--provider", "mock", "--port", port])
+        assert exc.value.code == 2

--- a/tests/inference/test_policy_server_lifecycle.py
+++ b/tests/inference/test_policy_server_lifecycle.py
@@ -115,9 +115,16 @@ def test_serve_foreground_binds_and_shuts_down():
 
 
 def test_main_rejects_out_of_range_port():
-    """The CLI validates the port range before touching the network."""
+    """The CLI validates the port range before touching the network.
+
+    Uses a genuinely out-of-range value. This previously asserted on
+    ``--port 0``, which is not out of range for a *bind* - it is the documented
+    request for an ephemeral port, and the CLI refusing it was the defect fixed
+    alongside this rename. The accepted-zero case is pinned in
+    ``test_bind_and_dial_port_domains``.
+    """
     with pytest.raises(SystemExit) as exc:
-        server_mod.main(["--provider", "mock", "--port", "0"])
+        server_mod.main(["--provider", "mock", "--port", "70000"])
     assert exc.value.code == 2
 
 


### PR DESCRIPTION
Closes #1952.

## The defect

`PolicyServer` and `RemotePolicy` both take a `port` and both stored whatever they were handed. The server's went straight onto `.port`; the client's went verbatim into `f"ws://{host}:{port}"`. Neither half applies `int()`, so nothing failed even for a value that is not a number — `ws://127.0.0.1:nan` and `ws://127.0.0.1:[8765]` were constructed and kept as the client's whole addressing state.

A WebSocket target is only resolved on first use, so an unusable port was **not** refused by the transport. It surfaced much later as an unreachable server, implicating the service the caller was trying to reach rather than the port. The client already warns loudly when a *mistyped kwarg name* leaves it "silently pointed at the default `ws://127.0.0.1:8765`" for exactly that reason; a mistyped port *value* got no such treatment.

While measuring it, a third surface turned up: `main()`'s `--port` flag carries an inline `if not 1 <= args.port <= 65535`, so **the CLI refused `--port 0`** — the ephemeral bind `PolicyServer` documents as first-class one screen above it. One parameter, three surfaces, three domains, and the only one that validated anything rejected a documented capability.

## Why it is not one shared domain

The two roles have genuinely different accepted sets, which is the substance of the change rather than an inconvenience:

- the client **dials**, so it needs a port it can address — `tcp_port_error`'s `[1, 65535]`, unchanged and shared with every other dialing surface;
- the server **binds**, so it may ask the kernel for an ephemeral port. `PolicyServer` documents `0` as exactly that and reads the assigned port back onto `.port`, so its domain is the same range with the floor moved to 0.

`_bind_port_error` expresses that as the shared rule plus one accepted value, mirroring the `positive_*` / `non_negative_*` pairs in `strands_robots.utils` — same range, same scalar policy, one extra value. A genuine `int` zero is accepted and everything else is deferred, so bind and dial cannot drift apart on what counts as an addressable port. `bool` is deliberately not spelled in the zero test: `False == 0` would read as the ephemeral request, and `True` would bind privileged port 1; both fall through to the shared helper's own explicit `bool` rejection.

The CLI now routes through that same bind rule, so it cannot refuse a port the class it constructs accepts.

## Guard placement

Both guards run before any side effect:

- **before `create_policy`** — accepting the port first resolves and builds a policy (which can download a checkpoint) for a server that could never bind. Pinned by a test that fails if `create_policy` is reached at all.
- **before the client's `uri`** — the tests assert the object does not exist, not that a later connect fails, because a stored `ws://127.0.0.1:nan` is precisely what turned a bad port into an apparently unreachable server.

`endpoint` supersedes `host`/`port`, so the client validates the port only when it is the effective spelling — the same shape `lerobot_async` and `cosmos3` already use for their `server_address` / `client` overrides.

## Measured

![port domain verdict matrix](https://raw.githubusercontent.com/cagataycali/robots/artifacts/1952-inference-port-domains/artifact_1952.png)

Each cell is measured by constructing the object (or invoking the CLI) with that value, in a `git worktree` at `main` and in this branch; green means the surface's verdict matches the domain its role actually has. **20 of 39 cells disagreed with the role's domain; 0 do now.**

The documented ephemeral path is unchanged and asserted end to end: `PolicyServer(port=0).start()` still reports a real OS-assigned port (42483 before, 35059 after — different runs, both non-zero). It is the one behaviour accepting `0` exists for, and the existing suite already relies on it at ten call sites.

This is a transport/configuration-layer change — no policy, simulation, rendering, recording or asset behaviour is touched — so the artifact is a measured verdict matrix rather than a rollout.

## Tests

`tests/inference/test_bind_and_dial_port_domains.py` pins:

- every unusable value refused by **both** halves, with the parameter, value and range named;
- the asymmetry — `0` accepted by the server, refused by the client — so a later change that "harmonises" the two fails here rather than silently removing the ephemeral bind or admitting a client that cannot dial what it was pointed at;
- over-reach controls at `1`, `8765` and `65535` on both halves;
- `False`/`True` not read as the ephemeral request;
- `_bind_port_error` agrees with `tcp_port_error` byte-for-byte away from `0` and differs only there;
- `endpoint=` supersedes the port, and an empty endpoint does not;
- the CLI accepts `--port 0` and still exits 2 for a genuinely out-of-range value.

`test_main_rejects_out_of_range_port` previously asserted on `--port 0`, which is not out of range for a *bind* — it pinned the CLI's refusal of the ephemeral bind as intended behaviour. It now uses a genuinely out-of-range value, with the reason recorded in its docstring; the accepted-zero case lives in the new module.

## Verification

All on `main@1bf78706`, which the merge-base overlap check reports this branch does not overlap.

- **Pre-fix proof** (source reverted to `main`, tests kept): **58 failed / 23 passed** → **81 passed** after. The failures include `test_it_accepts_the_ephemeral_bind - SystemExit: 2` (the CLI refusing `--port 0`) and `_Boom: create_policy must not be reached` (a policy built for a port that can never bind). The 23 that pass pre-fix are the accepted-value controls and the ephemeral-bind path — they are what stop the guards over-reaching.
- **Full suite**: `MUJOCO_GL=egl python -m pytest tests` → **19935 passed, 257 skipped, 0 failed** (565s).
- **Lint**: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean (1066 source files).
- **Guards**: the five repo-wide root guards pass (42 tests); `scripts/assemble_changelog.py --check` OK.