### PR TITLE
fix(simulation): set_eval_seed requires a seed - None is refused, not half-applied

### DIFF
--- a/changelog.d/1949-set-eval-seed-requires-a-seed.md
+++ b/changelog.d/1949-set-eval-seed-requires-a-seed.md
@@ -1,0 +1,25 @@
+### Fixed: `set_eval_seed(None)` is refused instead of half-reseeding the process from entropy
+
+`set_eval_seed` is public API, and its shared domain
+(`randomization_seed_error`) accepts `None` because for `randomize(seed=None)`
+that legitimately means "draw fresh entropy". The applier has no seed to apply
+for it, and the three RNGs it drives disagree: `random.seed(None)` and
+`numpy.random.seed(None)` reseed from entropy, then `torch.manual_seed(None)`
+raised a bare `TypeError` naming neither the parameter nor the method - leaving
+`random` and NumPy already reseeded by a call that failed. On an install without
+torch the same call reported nothing at all and reseeded both from entropy, so
+the two installs disagreed about whether anything had happened.
+
+Either way an unseeded rollout acquired a process-wide RNG side effect it never
+asked for, which inverts the rule `PolicyRunner.evaluate` states one layer up:
+"a `None` seed leaves the master RNG unbuilt rather than seeding it from
+entropy".
+
+`randomization_seed_error` now takes `allow_none`, the same per-destination shape
+as the existing `max_seed` ceiling: `None` stays valid where it selects fresh
+entropy or means "do not seed", and the applier opts out with `allow_none=False`.
+The refusal names the parameter and the reason, sits ahead of every RNG so it has
+no side effect either, and the messages for other unusable values stop
+advertising `None` at a destination that refuses it. Callers that want the RNGs
+untouched should not call `set_eval_seed` - which is what every caller in the
+module already does.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -292,7 +292,9 @@ def finite_non_negative_error(value: Any, param: str, context: str) -> str | Non
 MAX_EVAL_SEED = 2**32 - 1
 
 
-def randomization_seed_error(value: Any, context: str, *, max_seed: int | None = None) -> str | None:
+def randomization_seed_error(
+    value: Any, context: str, *, max_seed: int | None = None, allow_none: bool = True
+) -> str | None:
     """Return why a value cannot seed a reproducible randomization stream.
 
     The seed reaches ``numpy.random.default_rng``, which accepts only
@@ -322,24 +324,47 @@ def randomization_seed_error(value: Any, context: str, *, max_seed: int | None =
     can honor. One rule with an explicit bound per destination is what stops
     the accepted domain drifting from the applier in either direction.
 
+    ``allow_none`` is the same idea at the other end of the domain. ``None`` is
+    a legitimate *parameter* value for most callers - it selects fresh entropy
+    for ``randomize`` / ``set_obs_noise`` and means "do not seed" at the rollout
+    facades - but it is not a *seed*, so an applier that has to hand one to an
+    RNG cannot honor it: ``random`` and NumPy would reseed from entropy while
+    ``torch.manual_seed`` refuses it, leaving a process-wide RNG side effect on
+    a rollout that asked for none. ``allow_none=False`` refuses it there and
+    drops ``None`` from the messages, so the reason a caller is given always
+    describes the domain that caller actually has.
+
     Args:
         value: The candidate seed (``None`` selects fresh entropy).
         context: Method name to prefix the message with.
         max_seed: Largest value the caller's applier can honor, or ``None``
             when the non-negative-integer rule is the only bound.
+        allow_none: Whether ``None`` is a value this caller can honor. True for
+            a parameter where it selects fresh entropy or means "do not seed";
+            False for an applier that has to hand a seed to an RNG, which has
+            nothing to apply. When False the messages stop advertising ``None``
+            too, so a caller is never offered a value this destination refuses.
 
     Returns:
         ``None`` when the seed is usable, otherwise the reason as a string.
     """
+    none_clause = " or None" if allow_none else ""
+    entropy_hint = " (None draws fresh entropy)" if allow_none else ""
     if value is None:
-        return None
+        if allow_none:
+            return None
+        return (
+            f"{context}: seed is required; None is the absence of a seed, not a seed to apply. "
+            f"To leave the RNGs untouched, do not call {context} - reseeding them from entropy "
+            "is a global side effect an unseeded rollout must not acquire."
+        )
     if isinstance(value, bool) or not isinstance(value, numbers.Integral):
-        return f"{context}: seed must be a non-negative integer or None, got {value!r} (None draws fresh entropy)"
+        return f"{context}: seed must be a non-negative integer{none_clause}, got {value!r}{entropy_hint}"
     if int(value) < 0:
-        return f"{context}: seed must be a non-negative integer or None, got {value!r} (None draws fresh entropy)"
+        return f"{context}: seed must be a non-negative integer{none_clause}, got {value!r}{entropy_hint}"
     if max_seed is not None and int(value) > max_seed:
         return (
-            f"{context}: seed must be an integer in [0, {max_seed}] or None, got {value!r} "
+            f"{context}: seed must be an integer in [0, {max_seed}]{none_clause}, got {value!r} "
             "(a rollout seed is applied to the legacy NumPy global RNG, which refuses a larger value)"
         )
     return None

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -107,6 +107,16 @@ def set_eval_seed(seed: int) -> None:
     going through ``evaluate_benchmark`` can call it directly to get
     reproducible rollouts.
 
+    ``seed`` is required. ``None`` is the absence of a seed, and the three RNGs
+    disagree about it: ``random`` and NumPy reseed from entropy while
+    ``torch.manual_seed`` refuses it outright, so passing it through would leave
+    a process-wide RNG side effect on a rollout that asked for none - and none at
+    all on an install without torch, where the same call silently succeeds. The
+    shared domain accepts ``None`` because ``randomize(seed=None)`` legitimately
+    means "draw fresh entropy"; this applier opts out with ``allow_none=False``.
+    To leave the RNGs untouched, do not call it - which is what every caller in
+    this module already does (``if seed is not None``).
+
     NumPy / torch are imported lazily so this helper works on minimal
     installs that don't have torch (e.g. ``policy_provider="mock"``
     smoke tests).
@@ -120,7 +130,15 @@ def set_eval_seed(seed: int) -> None:
     # callers, so the bound is enforced where it is owned rather than only at the
     # facades one layer up: NumPy's own "Seed must be between 0 and 2**32 - 1"
     # names neither the parameter nor the method that accepted it.
-    if seed_error := randomization_seed_error(seed, "set_eval_seed", max_seed=MAX_EVAL_SEED):
+    #
+    # ``allow_none=False``: this is the applier, and there is no seed to apply for
+    # ``None``. Passing it through would reseed ``random`` / NumPy from entropy and
+    # then raise out of ``torch.manual_seed`` (or, on an install without torch,
+    # silently succeed) - a process-wide side effect on a rollout that asked for no
+    # seed, which is the opposite of the rule ``evaluate`` states below: "a ``None``
+    # seed leaves the master RNG unbuilt rather than seeding it from entropy". The
+    # refusal sits ahead of every RNG, so it has no side effect either.
+    if seed_error := randomization_seed_error(seed, "set_eval_seed", max_seed=MAX_EVAL_SEED, allow_none=False):
         raise ValueError(seed_error)
     random.seed(seed)
     try:

--- a/tests/simulation/test_set_eval_seed_requires_a_seed.py
+++ b/tests/simulation/test_set_eval_seed_requires_a_seed.py
@@ -1,0 +1,246 @@
+"""``set_eval_seed`` requires a seed - ``None`` is refused, not half-applied.
+
+``set_eval_seed`` is public API (exported via ``__all__`` and documented for
+standalone callers who drive a rollout without going through
+``evaluate_benchmark``). Its domain is
+:func:`~strands_robots.simulation.base.randomization_seed_error`, which accepts
+``None`` because for ``randomize(seed=None)`` / ``set_obs_noise(seed=None)`` that
+is a legitimate parameter value meaning "draw fresh entropy".
+
+For the applier there is no seed to apply, and the three RNGs it drives disagree
+about it. ``random.seed(None)`` and ``numpy.random.seed(None)`` reseed from
+entropy; ``torch.manual_seed(None)`` raises ``TypeError: int() argument must be a
+string, a bytes-like object or a real number, not 'NoneType'``. So the call
+reseeded two global RNGs and *then* raised - a partial side effect from a call
+that failed - with a message naming neither the parameter nor the method. On an
+install without torch the same call raised nothing at all and reseeded both from
+entropy, so the two installs disagreed about whether anything had happened.
+
+Either way an unseeded rollout acquires a process-wide RNG side effect it never
+asked for, which is the opposite of the rule ``PolicyRunner.evaluate`` states one
+layer up: "a ``None`` seed leaves the master RNG unbuilt rather than seeding it
+from entropy: an unseeded eval must not acquire a global RNG side effect it never
+had."
+
+The domain now carries ``allow_none``, the same per-destination shape as the
+existing ``max_seed`` ceiling: ``None`` stays valid where it selects fresh
+entropy or means "do not seed", and the applier opts out. These tests pin the
+refusal, the absence of any side effect on the refusal path, that both installs
+agree on it, and - deliberately - that the shared domain keeps accepting ``None``,
+so a later change that "harmonises" the two fails here instead of silently
+reintroducing the entropy side effect.
+
+Nothing here needs a simulator or torch: ``set_eval_seed`` is a pure RNG helper
+and both heavy imports inside it are lazy. That is the point of the
+torch-absent case, so this module deliberately does not import the sibling
+``test_rollout_seed_is_applied_or_refused``, whose module-level
+``importorskip("mujoco")`` would skip it on exactly the minimal install the
+contract has to hold on. The facade side of the boundary - an unseeded
+``run_policy`` / ``eval_policy`` still succeeding at ``seed=None`` - is pinned
+there.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import sys
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.base import MAX_EVAL_SEED, randomization_seed_error
+from strands_robots.simulation.policy_runner import set_eval_seed
+
+# Values no RNG can be seeded from, mirroring the sibling module's list. Kept
+# local rather than imported for the reason in the module docstring.
+UNUSABLE_SEEDS: list[Any] = [-1, 2.7, 3.0, True, False, math.nan, math.inf, "42", [1]]
+
+# What the applier can honor. The rollout facades' usable set is this plus
+# ``None``, and that one difference is the asymmetry this module exists to pin.
+APPLIER_USABLE_SEEDS: list[int] = [0, 7, 2**31, MAX_EVAL_SEED]
+
+_PROBE_SEED = 0xC0FFEE
+
+# The bare message the torch branch used to leak, asserted absent below.
+_TORCH_TYPE_ERROR_FRAGMENT = "int() argument must be a string"
+
+
+def _apply(seed: Any) -> None:
+    """Call the applier with a value its ``seed: int`` annotation excludes.
+
+    A single funnel so the deliberately off-type arguments below need one
+    documented ``Any`` rather than a suppression at every call site.
+    """
+    set_eval_seed(seed)
+
+
+def _refusal_moved_python_rng(call: Callable[[], None]) -> bool:
+    """Whether a refused call moved Python's global RNG.
+
+    Asserts the refusal itself, so the measurement cannot pass vacuously on a
+    build where the call succeeds silently instead of raising.
+    """
+    random.seed(_PROBE_SEED)
+    before = [random.random() for _ in range(3)]
+    random.seed(_PROBE_SEED)
+    with pytest.raises(ValueError):
+        call()
+    after = [random.random() for _ in range(3)]
+    return before != after
+
+
+class TestTheApplierRequiresASeed:
+    """``None`` is the absence of a seed, so there is nothing to apply."""
+
+    def test_none_raises_a_named_value_error(self) -> None:
+        with pytest.raises(ValueError, match=r"set_eval_seed: seed is required"):
+            _apply(None)
+
+    def test_the_bare_torch_type_error_no_longer_escapes(self) -> None:
+        """The old failure named neither the parameter nor the method."""
+        with pytest.raises(ValueError) as excinfo:
+            _apply(None)
+        assert _TORCH_TYPE_ERROR_FRAGMENT not in str(excinfo.value)
+        assert "NoneType" not in str(excinfo.value)
+
+    def test_the_message_names_what_to_do_instead(self) -> None:
+        """A refusal with no alternative is a dead end: the caller wanting the
+        RNGs untouched has to be told not to call this at all."""
+        with pytest.raises(ValueError) as excinfo:
+            _apply(None)
+        text = str(excinfo.value)
+        assert "do not call set_eval_seed" in text
+        assert "not a seed to apply" in text
+
+
+class TestTheRefusalTouchesNoRng:
+    """The check sits ahead of every RNG, so the partial reseed goes with it."""
+
+    def test_the_python_random_stream_is_unchanged(self) -> None:
+        assert _refusal_moved_python_rng(lambda: _apply(None)) is False
+
+    def test_the_numpy_global_stream_is_unchanged(self) -> None:
+        np = pytest.importorskip("numpy")
+        np.random.seed(_PROBE_SEED)
+        before = np.random.random(3).tolist()
+        np.random.seed(_PROBE_SEED)
+        with pytest.raises(ValueError):
+            _apply(None)
+        assert np.random.random(3).tolist() == before
+
+
+class TestBothInstallsAgreeAboutIt:
+    """Without torch the call used to succeed silently and reseed from entropy,
+    so the two installs disagreed about whether anything had happened."""
+
+    @pytest.fixture
+    def without_torch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A ``None`` entry makes ``import torch`` raise ImportError, which the
+        # applier's own handler catches - the pattern the RNG-parity and
+        # norm-stats tests already use for a torch-free install.
+        monkeypatch.setitem(sys.modules, "torch", None)
+
+    def test_the_same_value_error_is_raised(self, without_torch: None) -> None:
+        with pytest.raises(ValueError, match=r"set_eval_seed: seed is required"):
+            _apply(None)
+
+    def test_no_rng_is_reseeded_from_entropy(self, without_torch: None) -> None:
+        assert _refusal_moved_python_rng(lambda: _apply(None)) is False
+
+    def test_a_usable_seed_is_still_applied(self, without_torch: None) -> None:
+        """Over-reach control: the torch-free path still seeds what it can."""
+        set_eval_seed(7)
+        first = [random.random() for _ in range(3)]
+        set_eval_seed(7)
+        assert [random.random() for _ in range(3)] == first
+
+
+class TestTheAsymmetryIsDeliberate:
+    """``None`` is a valid *parameter* for the randomize family and not a valid
+    *seed* for anything, so the two domains differ on exactly one value."""
+
+    def test_the_shared_domain_still_accepts_none(self) -> None:
+        """``randomize(seed=None)`` depends on it, and the message documents it
+        as the fresh-entropy spelling."""
+        assert randomization_seed_error(None, "randomize") is None
+        assert randomization_seed_error(None, "set_obs_noise") is None
+
+    def test_the_rollout_facades_still_accept_none(self) -> None:
+        """At a facade ``None`` means "do not seed", which is why every caller
+        guards with ``if seed is not None`` rather than forwarding it."""
+        assert randomization_seed_error(None, "PolicyRunner.run", max_seed=MAX_EVAL_SEED) is None
+        assert randomization_seed_error(None, "run_policy", max_seed=MAX_EVAL_SEED) is None
+
+    def test_the_applier_refuses_the_one_value_the_shared_domain_accepts(self) -> None:
+        """Both halves in one assertion: a later change that harmonises them by
+        accepting ``None`` at the applier fails here instead of silently
+        reintroducing the entropy side effect."""
+        assert randomization_seed_error(None, "set_eval_seed", max_seed=MAX_EVAL_SEED) is None
+        with pytest.raises(ValueError, match=r"seed is required"):
+            _apply(None)
+
+    def test_the_opt_out_is_what_refuses_it(self) -> None:
+        assert randomization_seed_error(None, "set_eval_seed", allow_none=False) is not None
+        assert randomization_seed_error(None, "set_eval_seed", allow_none=True) is None
+
+
+class TestTheMessagesDescribeTheDomainTheCallerHas:
+    """A reason that offers a value the destination refuses is a dead end."""
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_the_applier_never_advertises_none(self, seed: Any) -> None:
+        reason = randomization_seed_error(seed, "set_eval_seed", max_seed=MAX_EVAL_SEED, allow_none=False)
+        assert reason is not None
+        assert "None" not in reason
+
+    def test_the_ceiling_message_does_not_advertise_none_either(self) -> None:
+        reason = randomization_seed_error(MAX_EVAL_SEED + 1, "set_eval_seed", max_seed=MAX_EVAL_SEED, allow_none=False)
+        assert reason is not None
+        assert "None" not in reason
+        assert f"[0, {MAX_EVAL_SEED}]" in reason
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=repr)
+    def test_every_default_path_message_is_unchanged(self, seed: Any) -> None:
+        """The opt-out is per destination: every caller that keeps ``None`` gets
+        byte-identical text, so this change refuses nothing it did not before."""
+        reason = randomization_seed_error(seed, "randomize")
+        assert reason is not None
+        assert reason == (
+            f"randomize: seed must be a non-negative integer or None, got {seed!r} (None draws fresh entropy)"
+        )
+
+    def test_the_default_ceiling_message_is_unchanged(self) -> None:
+        assert randomization_seed_error(MAX_EVAL_SEED + 1, "run_policy", max_seed=MAX_EVAL_SEED) == (
+            f"run_policy: seed must be an integer in [0, {MAX_EVAL_SEED}] or None, got {MAX_EVAL_SEED + 1} "
+            "(a rollout seed is applied to the legacy NumPy global RNG, which refuses a larger value)"
+        )
+
+
+class TestUsableSeedsAreStillApplied:
+    """Over-reach control: the refusal is scoped to the one value that has no
+    seed to apply."""
+
+    @pytest.mark.parametrize("seed", APPLIER_USABLE_SEEDS, ids=repr)
+    def test_a_usable_seed_is_applied_reproducibly(self, seed: int) -> None:
+        set_eval_seed(seed)
+        first = [random.random() for _ in range(3)]
+        set_eval_seed(seed)
+        assert [random.random() for _ in range(3)] == first
+
+    @pytest.mark.parametrize("seed", APPLIER_USABLE_SEEDS, ids=repr)
+    def test_a_usable_seed_reaches_numpy_too(self, seed: int) -> None:
+        np = pytest.importorskip("numpy")
+        set_eval_seed(seed)
+        first = np.random.random(3).tolist()
+        set_eval_seed(seed)
+        assert np.random.random(3).tolist() == first
+
+    def test_distinct_seeds_stay_distinct(self) -> None:
+        """A refusal that collapsed seeds onto one stream would pass the tests
+        above; different seeds must still give different streams."""
+        set_eval_seed(7)
+        seven = [random.random() for _ in range(3)]
+        set_eval_seed(8)
+        assert [random.random() for _ in range(3)] != seven


### PR DESCRIPTION
Closes #1949.

## The one value the domain accepts that the applier cannot apply

`set_eval_seed` is public API (exported via `__all__`, documented for standalone callers who drive a rollout without going through `evaluate_benchmark`). Its domain is `randomization_seed_error`, which accepts `None` because for `randomize(seed=None)` / `set_obs_noise(seed=None)` that is a legitimate parameter value meaning "draw fresh entropy".

For the applier there is no seed to apply, and the three RNGs it drives disagree about it. `random.seed(None)` and `numpy.random.seed(None)` reseed from entropy; `torch.manual_seed(None)` refuses it. They run in that order, so the call reseeded two global RNGs and *then* raised:

```
>>> randomization_seed_error(None, "set_eval_seed", max_seed=MAX_EVAL_SEED)
None                                    # accepted
>>> set_eval_seed(None)
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

That message names neither the parameter nor the method, and it is not the worst part. Measured across the two install shapes, **one value produced two different outcomes**:

| install | outcome | `random` global | `numpy.random` global |
|---|---|---|---|
| torch present | bare `TypeError` | reseeded from entropy | reseeded from entropy |
| torch absent | **no error at all** | reseeded from entropy | reseeded from entropy |

Without torch the `except ImportError` handler swallows the only thing that objected, so the caller is told the seed was applied when there was no seed. Either way an unseeded rollout acquires a process-wide RNG side effect it never asked for - which is the opposite of the rule `PolicyRunner.evaluate` states one layer up:

> A `None` seed leaves the master RNG unbuilt rather than seeding it from entropy: an unseeded eval must not acquire a global RNG side effect it never had.

`set_eval_seed` is the one place that rule is inverted. The `seed: int` annotation never advertised `None` either, so refusing it also makes the runtime match the declared type.

## The change

`randomization_seed_error` gains `allow_none`, the same per-destination shape as the `max_seed` ceiling that function already carries - and for the same stated reason, that "one rule with an explicit bound per destination is what stops the accepted domain drifting from the applier in either direction". `max_seed` bounds the top of the domain per destination; `allow_none` bounds the bottom.

* Default `True`: `None` stays valid where it selects fresh entropy (`randomize`, `set_obs_noise`) and where it means "do not seed" (the rollout facades, each of which guards with `if seed is not None`). **Every existing message is byte-identical.**
* `set_eval_seed` passes `False`, so the refusal lands ahead of every RNG and the partial reseed goes with it.

A purely local `if seed is None: raise` in the applier would have left a second defect behind: `randomization_seed_error(2.5, "set_eval_seed", ...)` says *"seed must be a non-negative integer **or None**"*, i.e. it would keep offering `None` at the one destination that refuses it. Carrying the bound in the rule fixes the refusal and the reason together.

The refusal names an alternative rather than dead-ending, because a caller who wants the RNGs untouched has one - not calling it, which is what every caller in the module already does:

```
set_eval_seed: seed is required; None is the absence of a seed, not a seed to apply.
To leave the RNGs untouched, do not call set_eval_seed - reseeding them from entropy
is a global side effect an unseeded rollout must not acquire.
```

## Scope

No in-tree caller could reach this: all four production call sites guard it (two with `if seed is not None`, two with a seed derived from `master_rng.randint`), which is why this is a follow-up rather than a bug in a shipped path. But it is a *public* function whose guard lived in five callers instead of in the function, and the two installs did not agree on what it did.

`randomization_seed_error` keeps accepting `None` - `randomize(seed=None)` depends on it, and its message documents it as the fresh-entropy spelling. That asymmetry is deliberate and pinned in both directions, so a later change that "harmonises" the two by accepting `None` at the applier fails a test instead of silently reintroducing the entropy side effect.

## Measured evidence

One script run in a `git worktree` at `upstream/main` and once on this branch; each dump records the tree it resolved, and the figure asserts every number it prints against those two dumps before saving. Scripts and raw JSON: [`artifacts/set-eval-seed-none`](https://github.com/cagataycali/robots/tree/artifacts/set-eval-seed-none).

![measured evidence](https://raw.githubusercontent.com/cagataycali/robots/artifacts/set-eval-seed-none/artifact_1949.png)

This is a validation-layer change to an RNG-seeding helper: no policy, simulation, rendering, recording or asset behaviour changes, so the artifact is the measured contract rather than a rollout. The unchanged half is measured too - `randomize(seed=None)` and `run_policy(seed=None)` still accepted, every default-path message byte-identical, seeds `0` / `7` / `MAX_EVAL_SEED` still reproducible, and distinct seeds still distinct.

## Tests

`tests/simulation/test_set_eval_seed_requires_a_seed.py` - 41 tests, 0.15 s, no simulator and no torch required (both heavy imports in the applier are lazy, and that is the point of the torch-absent case). It deliberately does not import the sibling `test_rollout_seed_is_applied_or_refused`, whose module-level `importorskip("mujoco")` would skip it on exactly the minimal install the contract has to hold on; the facade side of the boundary is pinned there.

Pinned: the named refusal and that the bare `TypeError` no longer escapes; that the message names the alternative; that neither the Python nor the NumPy global stream moves on the refusal path (the helper asserts the refusal itself, so it cannot pass vacuously against a build that succeeds silently); that a torch-free install now reaches the *same* `ValueError`; the asymmetry in both directions; that the applier's reasons never advertise `None`; that every default-path message is byte-identical; and over-reach controls that usable seeds stay reproducible and distinct seeds stay distinct.

**Pre-fix: 19 failed / 22 passed.** The failures quote the defect verbatim - `TypeError: int() argument must be a string ... not 'NoneType'` for the torch-present path and `Failed: DID NOT RAISE ValueError` for the torch-absent one. The 22 that pass pre-fix are the over-reach controls, the default-path message parity and the shared-domain-accepts-`None` cases: they are what stops the guard reaching further than the one value, so they are expected to hold on both trees.

## Gate

* `MUJOCO_GL=egl python -m pytest tests` -> **20137 passed, 257 skipped, 0 failed** (576.63 s) at `b55eb652`.
* `ruff check` / `ruff format --check` clean (1071 files); `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1068 source files`.
* The five repo-wide root guards: 42 passed. `scripts/assemble_changelog.py --check` OK.
* `scripts/check_merge_base_overlap.py` -> no overlap with `upstream/main`.
* Scoped re-run of everything covering the two changed files (the rollout-seed contract, randomization guards, `run_policy` tool, seed reproducibility, benchmark horizon, boolean-input validators): 603 passed, **zero existing-test changes**.