### PR TITLE
fix(training): val_episodes is one shared positive-count domain for both writers of eval_split

### DIFF
--- a/changelog.d/1955-val-episodes-count-domain.md
+++ b/changelog.d/1955-val-episodes-count-domain.md
@@ -1,0 +1,18 @@
+### Fixed: `val_episodes` is one shared positive-count domain across both writers of lerobot's `eval_split`
+
+The held-out validation episode count was compared rather than validated, by each
+of the two surfaces that build lerobot's `dataset.eval_split` flag, and the two
+comparisons disagreed. The count is converted into a real-valued split fraction
+whose ceiling lerobot takes, so a comparison is wrong at both ends: `0` and a
+negative produced no split and no `eval_steps` at all - the run trained on the
+whole dataset and logged no validation loss, with `LerobotTrainer.validate()`
+reporting no problem while the `lerobot_train` tool refused the same value -
+while `True` reserved 1 episode, `2.7` reserved 3, and `0.5` emitted an
+evaluation cadence over a held-out set of zero episodes. A non-numeric count
+raised `TypeError` out of the comparison, from a `validate` documented to
+return problems.
+
+Both writers now apply the shared `positive_count_error` domain through a new
+`Trainer._validation_episodes_problems` gate, so an unusable count is reported
+(never raised) with a message naming the backend, and the tool refuses it before
+it reads the dataset. The dataset-dependent bounds are unchanged.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -96,7 +96,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `steps` / `global_batch_size` | the run size: optimizer steps x batch | each must be a positive integer; `validate()` refuses `0`, a fractional or non-finite value, and a `bool` (`True` would read as a silent one-step run) before anything is loaded |
 | `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |
 | `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
-| `val_episodes` | hold out the LAST N episodes | deterministic split |
+| `val_episodes` | hold out the LAST N episodes | deterministic split; must be a positive integer below the dataset's episode count. `validate()` refuses `0` or a negative (they produced no split and no eval cadence at all - the run trained on everything and logged no validation loss), a `bool`, and a fractional value (`2.7` reserved 3 episodes, `0.5` reserved none while still evaluating) |
 | `num_gpus` / `num_nodes` | multi-GPU / multi-node | selects the launcher |
 | `seed` | reproducibility seed | must be a non-negative integer; `validate()` refuses a negative (`torch.manual_seed` would take it modulo `2**64`, so `-1` silently becomes `2**64 - 1`), a fractional or non-finite value, and a `bool`. `None` uses the backend's own default |
 | `extra["policy_type"]` | lerobot `--policy.type` | act/diffusion/smolvla/pi0/pi05/... |

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -509,8 +509,14 @@ def build_train_command(
             cmd.append(f"--peft.target_modules={lora_target_modules}")
 
     if val_episodes is not None:
-        if val_episodes <= 0:
-            raise ValueError(f"val_episodes must be positive, got {val_episodes}")
+        # The same shared count domain the trainer's validate() applies, rather
+        # than a local `<= 0` test: that comparison reads True as a silent
+        # request for one episode, lets 2.7 through to a fraction that reserves
+        # a different whole number, renders nan as `eval_split=nan`, and raises
+        # out of itself for a string.
+        count_err = positive_count_error(val_episodes, "val_episodes", "lerobot_train")
+        if count_err:
+            raise ValueError(count_err)
         total = _read_total_episodes(dataset_root)
         if val_episodes >= total:
             raise ValueError(
@@ -630,8 +636,9 @@ def lerobot_train(
         lora_target_modules: PEFT target module spec (e.g. "all-linear").
         train_expert_only: Freeze the VLM, train only the action expert
             (policies exposing train_expert_only: pi0/pi05/smolvla).
-        val_episodes: Reserve the LAST N episodes as a held-out validation
-            split, evaluated every ``save_freq`` steps so each checkpoint has
+        val_episodes: A positive integer below the dataset's episode count, or
+            None for no held-out set. Reserves the LAST N episodes as a held-out
+            validation split, evaluated every ``save_freq`` steps so each checkpoint has
             a validation loss beside it.
         num_gpus: Number of GPUs; >1 launches via accelerate --multi_gpu.
         push_to_hub: Push the trained checkpoint to the HF Hub at the end.

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -128,7 +128,10 @@ def train_policy(
         tune: Fine-grained component toggles for GR00T
             (``{"llm","visual","projector","diffusion"}``).
         val_episodes: Hold out the LAST N episodes for validation; the run
-            logs an eval loss over them at the checkpoint cadence.
+            logs an eval loss over them at the checkpoint cadence. A positive
+            integer below the dataset's episode count, or None for no held-out
+            set - the split is a fraction lerobot takes the ceiling of, so a
+            fractional count would reserve a different number of episodes.
         augmentation: Backend-specific augmentation dict.
         fps: Dataset control rate (when a backend needs it).
         extra: Backend-specific passthrough. lerobot: ``policy_type``,

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -43,6 +43,16 @@ is sized from. It is scoped like :func:`run_size_problems` rather than like
 :func:`learning_rate_problems` - only the three supervised backends read either
 field (they become a ``torchrun``/``elastic_launch`` ``nproc_per_node`` /
 ``nnodes``), so a backend that ignores them must not report on them.
+
+:func:`seed_problems` is the fifth, on the reproducibility axis, and
+:func:`validation_episodes_problems` the sixth, on the *evaluation* axis:
+``val_episodes``, the episode count a caller reserves as a held-out validation
+set. It is scoped like :func:`run_size_problems` - only the LeRobot backend
+reads the field (GR00T, Cosmos and the RL trainers never do), so a backend that
+ignores it must not report on it. What makes a shared gate the right home
+rather than a local test is the conversion: the count becomes a real-valued
+split fraction whose ceiling lerobot takes, so a comparison admits values that
+reserve a different number of episodes than the one asked for.
 """
 
 from __future__ import annotations
@@ -303,4 +313,59 @@ def seed_problems(spec: TrainSpec, *, context: str) -> list[str]:
     if spec.seed is None:
         return []
     error = non_negative_count_error(spec.seed, "seed", context)
+    return [] if error is None else [error]
+
+
+def validation_episodes_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return held-out-validation-set problems for a :class:`TrainSpec`.
+
+    ``val_episodes`` is the count of episodes a caller reserves from the tail of
+    the dataset to validate on. It is not read straight into a loop bound like
+    :func:`run_size_problems`' fields: the LeRobot backend converts it into
+    lerobot's ``dataset.eval_split`` FRACTION via
+    :func:`~strands_robots.utils.validation_split_fraction`, and lerobot then
+    holds out ``ceil(episodes_in_task * eval_split)``. That conversion is what
+    makes a local comparison unsafe in both directions at once:
+
+    * A non-positive value is *silently dropped*. The fraction is only computed
+      for a count in ``(0, total)``, so ``val_episodes=0`` (or a negative)
+      produces no ``eval_split`` and no ``eval_steps`` at all: the run trains on
+      the whole dataset, records no validation loss, and reports no problem. The
+      caller asked for a validation set and got a run without one.
+    * A value that merely *compares* as positive is silently rewritten, because
+      the fraction is real-valued and lerobot takes its ceiling: ``True``
+      reserves 1 episode and ``2.7`` reserves 3 - a whole number the caller never
+      named. ``0.5`` is the sharpest of these: it clears the ``0 < count <
+      total`` test, so it emits ``eval_split=0.0`` - a held-out set of zero
+      episodes - *together with* an ``eval_steps`` cadence, asking lerobot to
+      validate periodically on nothing.
+    * A non-numeric value raises out of the comparison itself, from a
+      :meth:`~strands_robots.training.base.Trainer.validate` documented to
+      *return* problems.
+
+    Only a positive integer strictly below the dataset's episode count can be
+    honored, so the type and floor are checked here against the same shared
+    :func:`~strands_robots.utils.positive_count_error` domain that
+    :func:`run_size_problems` uses. The upper bound is dataset-dependent (it needs
+    ``total_episodes`` from ``meta/info.json``) and stays with the backend that
+    reads the metadata, which also owns the per-task-fraction refusal in
+    :func:`~strands_robots.utils.validation_split_error`.
+
+    ``None`` is the documented sentinel for "train on every episode, no held-out
+    set" and is therefore not a problem, exactly as it is not one for
+    :func:`seed_problems` or :func:`learning_rate_problems`.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single problem when ``val_episodes`` is supplied and unusable as a
+        count; empty otherwise.
+    """
+    if spec.val_episodes is None:
+        return []
+    error = positive_count_error(spec.val_episodes, "val_episodes", context)
     return [] if error is None else [error]

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -122,6 +122,13 @@ class TrainSpec:
             produce a validation signal, not merely shrink the training set;
             the lerobot backend maps it onto ``--dataset.eval_split`` plus a
             non-zero ``--eval_steps`` so an eval loss is logged periodically.
+            Must be a positive integer below the dataset's episode count, or
+            ``None`` to train on every episode. Because the count is converted
+            into a real-valued split fraction whose ceiling lerobot takes, a
+            backend MUST check it with
+            :meth:`Trainer._validation_episodes_problems` rather than compare it
+            itself: a non-positive value produces no split at all, and ``True``
+            / ``2.7`` / ``0.5`` reserve 1 / 3 / 0 episodes respectively.
         augmentation: Backend-specific data augmentation (GR00T
             ``color_jitter_params`` / ``random_rotation_angle``; Cosmos
             dataset filter dict).
@@ -349,6 +356,39 @@ class Trainer(ABC):
         from strands_robots.training._validate import seed_problems
 
         return seed_problems(spec, context=self.provider_name)
+
+    def _validation_episodes_problems(self, spec: TrainSpec) -> list[str]:
+        """Held-out-validation preflight shared by every backend that reads it.
+
+        Returns a problem when :attr:`TrainSpec.val_episodes` is supplied and is
+        not a usable positive integer, against the same shared positive-count
+        domain :meth:`_run_size_problems` uses. A :meth:`validate`
+        implementation that reads the field MUST call this instead of comparing
+        the value itself, because the count is converted into a real-valued
+        split fraction and the comparison is wrong at both ends: a non-positive
+        value produces no split and no evaluation cadence at all - the run
+        trains on the whole dataset and records no validation loss, with nothing
+        reported - while ``True`` reserves one episode, ``2.7`` reserves three,
+        and ``0.5`` emits an evaluation cadence over a held-out set of zero
+        episodes. A non-numeric value raises out of the comparison from a method
+        documented to *return* problems.
+
+        The dataset-dependent upper bound (``val_episodes`` must leave training
+        data behind) stays with the backend, which is the side that reads
+        ``total_episodes`` from the dataset metadata.
+
+        A backend that does not read the field MUST NOT call this: per
+        :class:`TrainSpec`, a backend ignores the fields it does not support, so
+        reporting on one it never reads would be a false rejection. That is why
+        this is a separate gate from :meth:`_learning_rate_problems`, which
+        every backend does call.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import validation_episodes_problems
+
+        return validation_episodes_problems(spec, context=self.provider_name)
 
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -609,7 +609,14 @@ class LerobotTrainer(Trainer):
                 "launcher and cannot run in-process; use num_nodes=1."
             )
 
-        if spec.val_episodes is not None and spec.dataset_root:
+        # Captured rather than extended blind, for the same reason as the
+        # topology gate above: the two dataset-dependent checks below compare
+        # val_episodes and interpolate it into a split fraction, and both are
+        # only meaningful once this gate has established that it IS a count.
+        val_problems = self._validation_episodes_problems(spec)
+        problems.extend(val_problems)
+
+        if not val_problems and spec.val_episodes is not None and spec.dataset_root:
             total = self._dataset_total_episodes(spec.dataset_root)
             if total is not None and spec.val_episodes >= total:
                 problems.append(f"val_episodes={spec.val_episodes} >= total_episodes={total}")

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -729,10 +729,17 @@ def test_list_reports_no_active_sessions_when_empty(tmp_path: Path) -> None:
     assert "No active sessions" in _texts(result)
 
 
-def test_build_command_rejects_nonpositive_val_episodes(tmp_path: Path) -> None:
-    """val_episodes <= 0 is rejected before the dataset is even read."""
-    with pytest.raises(ValueError, match="val_episodes must be positive"):
-        build_train_command(dataset_root=str(_write_dataset(tmp_path / "ds")), val_episodes=0)
+def test_build_command_rejects_a_val_episodes_that_is_not_a_count(tmp_path: Path) -> None:
+    """The shared positive-count domain is applied before the dataset is read.
+
+    Was ``val_episodes <= 0``, whose message ("must be positive") was false for
+    the values that slipped through it: ``2.7`` and ``True`` both compare as
+    positive and reserved a whole number the caller never named.
+    """
+    root = str(_write_dataset(tmp_path / "ds"))
+    for value in (0, -5, True, 2.7, float("nan"), "5"):
+        with pytest.raises(ValueError, match="val_episodes must be a positive integer"):
+            build_train_command(dataset_root=root, val_episodes=value)  # type: ignore[arg-type]
 
 
 def test_read_total_episodes_raises_on_missing_and_bad_metadata(tmp_path: Path) -> None:

--- a/tests/tools/test_lerobot_train_size_knob_domain.py
+++ b/tests/tools/test_lerobot_train_size_knob_domain.py
@@ -237,7 +237,7 @@ class TestTheScopeIsNoWiderThanTheDefect:
         """The guards that already existed are untouched."""
         with pytest.raises(ValueError, match="num_gpus must be >= 1"):
             _build(num_gpus=0)
-        with pytest.raises(ValueError, match="val_episodes must be positive"):
+        with pytest.raises(ValueError, match="val_episodes must be a positive integer"):
             _build(val_episodes=0)
 
 

--- a/tests/training/test_validation_episodes_domain.py
+++ b/tests/training/test_validation_episodes_domain.py
@@ -130,13 +130,33 @@ def _eval_flags(cmd: list[str]) -> list[str]:
     return [c for c in cmd if "eval_split" in c or "eval_steps" in c]
 
 
+def _raising_tool(exc: BaseException) -> Any:
+    """A ``build_train_command`` stand-in that raises, so the width is observable."""
+
+    def tool(**_kwargs: Any) -> list[str]:
+        raise exc
+
+    return tool
+
+
 def _tool_verdict(dataset_root: pathlib.Path, value: Any) -> str:
-    """``refused`` / ``accepted`` for the tool that writes the same flag."""
+    """``refused`` / ``accepted`` for the tool that writes the same flag.
+
+    The returned string is *compared* as an answer about ``val_episodes``, so
+    the handler catches :class:`Exception` and stops there. A library failure is
+    one of the answers being collected - the tool raising instead of refusing is
+    part of what this file pins - so it must not abort the comparison. An
+    interrupt is not an answer about the field, though: recording one as "the
+    tool did not refuse this value" and comparing it against the backend turns an
+    operator's Ctrl-C into a verdict. ``pytest``'s own ``skip`` and ``fail``
+    outcomes derive from ``BaseException`` for the same reason, so they have to
+    reach the runner rather than becoming a verdict.
+    """
     try:
         build_train_command(dataset_root=str(dataset_root), policy_type="act", val_episodes=value)
     except ValueError as exc:
         return "refused" if "val_episodes" in str(exc) else f"other-error: {exc}"
-    except BaseException as exc:  # noqa: BLE001 - an escape is itself the finding
+    except Exception as exc:  # noqa: BLE001 - a library failure is a verdict, control flow is not
         return f"raised {type(exc).__name__}: {exc}"
     return "accepted"
 
@@ -325,6 +345,56 @@ class TestBothWritersOfTheSplitShareOneDomain:
         """The domain does not depend on the metadata, so it is checked first."""
         with pytest.raises(ValueError, match="val_episodes must be a positive integer"):
             build_train_command(dataset_root=str(tmp_path / "absent"), policy_type="act", val_episodes=value)
+
+
+class TestTheParityClassifierCollectsFailuresWithoutSwallowingControlFlow:
+    """``_tool_verdict`` must catch a library failure and only a library failure.
+
+    The classifier turns "what did the tool do with this value" into the string
+    the two parity tests above compare against ``refused`` / ``accepted``. A raise
+    is one of the answers it has to collect - a non-numeric count really does
+    raise out of the tool - so a library failure cannot be allowed to abort the
+    comparison. An interrupt is not an answer about the field, though: recording
+    one as a verdict and then comparing it against the backend turns an operator's
+    Ctrl-C into a claim about ``val_episodes``. Both halves are pinned here
+    because the correct handler is the one that satisfies both.
+    """
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            TypeError("'>=' not supported between instances of 'str' and 'int'"),
+            FileNotFoundError("meta/info.json"),
+        ],
+        ids=["TypeError", "FileNotFoundError"],
+    )
+    def test_a_library_failure_is_collected_as_the_verdict(
+        self, monkeypatch: pytest.MonkeyPatch, dataset: pathlib.Path, exc: Exception
+    ) -> None:
+        """Dropping the catch-all would let these escape instead of being recorded."""
+        monkeypatch.setattr(f"{__name__}.build_train_command", _raising_tool(exc))
+        assert _tool_verdict(dataset, 3) == f"raised {type(exc).__name__}: {exc}"
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            KeyboardInterrupt(),
+            SystemExit(1),
+            pytest.skip.Exception("the lerobot extra is not installed"),
+            pytest.fail.Exception("the dataset fixture is incomplete"),
+        ],
+        ids=["KeyboardInterrupt", "SystemExit", "pytest.skip", "pytest.fail"],
+    )
+    def test_control_flow_reaches_the_runner_instead_of_becoming_a_verdict(
+        self, monkeypatch: pytest.MonkeyPatch, dataset: pathlib.Path, exc: BaseException
+    ) -> None:
+        # Executable premise: each of these derives from BaseException without
+        # deriving from Exception, which is the whole reason the handler width
+        # is observable at all.
+        assert not isinstance(exc, Exception), f"{type(exc).__name__} no longer tests the handler width"
+        monkeypatch.setattr(f"{__name__}.build_train_command", _raising_tool(exc))
+        with pytest.raises(type(exc)):
+            _tool_verdict(dataset, 3)
 
 
 class TestABackendThatIgnoresTheFieldReportsNothing:

--- a/tests/training/test_validation_episodes_domain.py
+++ b/tests/training/test_validation_episodes_domain.py
@@ -1,0 +1,436 @@
+"""The held-out validation episode count is one shared positive-count domain.
+
+:attr:`~strands_robots.training.base.TrainSpec.val_episodes` is the number of
+episodes a caller reserves from the tail of the dataset to validate on, and it is
+consumed by two independent writers of the same lerobot flag: the LeRobot
+trainer's :meth:`~strands_robots.training.lerobot.LerobotTrainer.validate` /
+config path, and the ``lerobot_train`` tool's ``build_train_command``. Before
+this contract each writer compared the value itself, and the two comparisons
+disagreed about the same input.
+
+Neither comparison is safe, because the count is not read into a loop bound - it
+is converted into lerobot's real-valued ``dataset.eval_split`` fraction, and
+lerobot then holds out ``ceil(episodes_in_task * eval_split)``:
+
+* A non-positive count is **silently dropped**. The fraction is only computed for
+  a count in ``(0, total)``, so ``val_episodes=0`` produced no ``eval_split`` and
+  no ``eval_steps`` at all: the run trained on the whole dataset, recorded no
+  validation loss, and ``validate`` reported no problem. The tool refused the
+  same value, so one field had opposite verdicts on the two paths.
+* A value that merely *compares* as positive is silently rewritten: ``True``
+  reserved 1 episode and ``2.7`` reserved 3 - a whole number nobody asked for -
+  on both paths, and ``nan`` rendered as the literal ``--dataset.eval_split=nan``.
+* A non-numeric value raised ``TypeError`` out of the comparison itself, from a
+  ``validate`` documented to *return* problems.
+
+The tests below pin the contract in both directions: every unusable value is
+reported (never raised) by the backend that reads the field and refused by the
+tool that writes the same flag, a usable count still produces the split and the
+evaluation cadence, the dataset-dependent bounds that already worked still fire,
+and a backend that ignores the field reports nothing about it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import math
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.lerobot_train import build_train_command
+from strands_robots.training._validate import validation_episodes_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+from strands_robots.training.groot import Gr00tTrainer
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.training.mock import MockTrainer
+from strands_robots.utils import validation_split_fraction
+
+TOTAL_EPISODES = 10
+
+# Values that were silently dropped: the split fraction is only computed for a
+# count in ``(0, total)``, so the run held nothing out and said nothing.
+SILENTLY_DROPPED = (0, -1, -5, float("nan"))
+
+# Values that compared as positive and were silently rewritten by the ceiling
+# lerobot applies to the fraction, mapped to the count each one really reserved.
+REWRITTEN_TO = ((True, 1), (2.7, 3), (0.5, 0))
+SILENTLY_REWRITTEN = tuple(supplied for supplied, _ in REWRITTEN_TO)
+
+# Values that raised out of the comparison, from a method documented to return.
+RAISED_IN_THE_COMPARISON = ("5", [5], {"n": 5})
+
+UNUSABLE = SILENTLY_DROPPED + SILENTLY_REWRITTEN + RAISED_IN_THE_COMPARISON
+
+# Counts that reserve exactly what they name on a 10-episode single-task dataset.
+USABLE = (1, 2, 3, 9)
+
+
+def _write_dataset(root: pathlib.Path, total_episodes: int = TOTAL_EPISODES, total_tasks: int = 1) -> pathlib.Path:
+    """A minimal LeRobot v3 dataset stub the episode-count checks can read."""
+    meta = root / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+    meta.joinpath("info.json").write_text(
+        json.dumps(
+            {
+                "codebase_version": "v3.0",
+                "total_episodes": total_episodes,
+                "total_tasks": total_tasks,
+                "total_frames": total_episodes * 120,
+                "fps": 30,
+                "features": {},
+            }
+        )
+    )
+    return root
+
+
+@pytest.fixture
+def dataset(tmp_path: pathlib.Path) -> pathlib.Path:
+    return _write_dataset(tmp_path / "ds")
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path, dataset: pathlib.Path) -> TrainSpec:
+    """A spec whose ``val_episodes`` is the only thing under test.
+
+    ``validate`` may report unrelated problems (a missing policy config, an
+    absent lerobot); every assertion below filters for the field name, so an
+    unrelated problem can neither mask nor fake a verdict.
+    """
+    return TrainSpec(
+        dataset_root=str(dataset),
+        output_dir=str(tmp_path / "out"),
+        base_model="lerobot/act",
+        embodiment="so101",
+        steps=100,
+        global_batch_size=8,
+        extra={"policy_type": "act"},
+    )
+
+
+# The shape the shared domain emits: ``"{context}: val_episodes must be ..."``.
+# Matched rather than the bare word because pytest derives ``tmp_path`` from the
+# test name, so a path in an unrelated problem can contain "val_episodes" too - a
+# filter that picked that up could both mask and fake a verdict.
+_NAMES_THE_COUNT = ": val_episodes "
+
+
+def _count_problems_of(trainer: Trainer, spec: TrainSpec) -> list[str]:
+    """``validate`` problems emitted by the shared count domain."""
+    return [p for p in trainer.validate(spec) if _NAMES_THE_COUNT in p]
+
+
+def _eval_flags(cmd: list[str]) -> list[str]:
+    """The flags that make lerobot hold data out and evaluate on it."""
+    return [c for c in cmd if "eval_split" in c or "eval_steps" in c]
+
+
+def _tool_verdict(dataset_root: pathlib.Path, value: Any) -> str:
+    """``refused`` / ``accepted`` for the tool that writes the same flag."""
+    try:
+        build_train_command(dataset_root=str(dataset_root), policy_type="act", val_episodes=value)
+    except ValueError as exc:
+        return "refused" if "val_episodes" in str(exc) else f"other-error: {exc}"
+    except BaseException as exc:  # noqa: BLE001 - an escape is itself the finding
+        return f"raised {type(exc).__name__}: {exc}"
+    return "accepted"
+
+
+class TestTheBackendRefusesAnUnusableValidationCount:
+    """Every value no split can honor is reported as a problem, never raised."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: TrainSpec, value: Any) -> None:
+        spec.val_episodes = value
+        problems = _count_problems_of(LerobotTrainer(), spec)
+        assert problems, f"LerobotTrainer accepted val_episodes={value!r}"
+        assert any("must be a positive integer" in p for p in problems), problems
+
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: TrainSpec) -> None:
+        trainer = LerobotTrainer()
+        spec.val_episodes = 0
+        assert any(p.startswith(f"{trainer.provider_name}: val_episodes ") for p in _count_problems_of(trainer, spec))
+
+    @pytest.mark.parametrize("value", RAISED_IN_THE_COMPARISON)
+    def test_a_non_numeric_count_is_a_problem_not_an_exception(self, spec: TrainSpec, value: Any) -> None:
+        """The comparison the gate replaced raised ``TypeError`` for these."""
+        spec.val_episodes = value
+        problems = LerobotTrainer().validate(spec)  # must not raise
+        assert any(_NAMES_THE_COUNT in p for p in problems), problems
+
+    @pytest.mark.parametrize("value", RAISED_IN_THE_COMPARISON)
+    def test_the_dataset_dependent_comparison_is_not_reached(self, spec: TrainSpec, value: Any) -> None:
+        """Guard order: the domain gate runs before anything compares the value.
+
+        The ``>= total_episodes`` refusal below it is only a meaningful comparison
+        once the value IS a count, so a non-numeric must be reported by the gate
+        and stop there rather than reaching - and raising out of - the bound.
+        """
+        spec.val_episodes = value
+        problems = LerobotTrainer().validate(spec)
+        assert not [p for p in problems if "total_episodes=" in p], problems
+
+
+class TestANonPositiveCountWasSilentlyDropped:
+    """The headline: the request produced a run with no validation at all.
+
+    A count outside ``(0, total)`` never became an ``eval_split``, so lerobot was
+    given no held-out set and no ``eval_steps`` cadence - the run trained on every
+    episode and recorded no validation loss, and nothing reported it.
+    """
+
+    @pytest.mark.parametrize("value", SILENTLY_DROPPED)
+    def test_no_split_and_no_evaluation_cadence_is_produced(self, spec: TrainSpec, value: Any) -> None:
+        spec.val_episodes = value
+        assert _eval_flags(LerobotTrainer().build_command(spec)) == []
+
+    @pytest.mark.parametrize("value", SILENTLY_DROPPED)
+    def test_so_the_request_is_refused_instead(self, spec: TrainSpec, value: Any) -> None:
+        spec.val_episodes = value
+        assert _count_problems_of(LerobotTrainer(), spec)
+
+
+class TestACountThatComparesAsPositiveWasSilentlyRewritten:
+    """A value the comparison admitted reserved a count nobody asked for."""
+
+    @pytest.mark.parametrize(("supplied", "reserved"), REWRITTEN_TO)
+    def test_the_fraction_holds_out_a_count_that_was_never_asked_for(self, supplied: Any, reserved: int) -> None:
+        """Ground the refusal in what lerobot really does with the fraction.
+
+        lerobot holds out ``ceil(episodes_in_task * eval_split)``, so the
+        real-valued fraction a non-integer count maps to reserves a whole number
+        the caller never named as one: ``2.7`` reserves 3, a ``bool`` reserves 1,
+        and ``0.5`` reserves nothing at all.
+        """
+        fraction = validation_split_fraction(supplied, TOTAL_EPISODES)
+        assert math.ceil(TOTAL_EPISODES * fraction) == reserved
+        assert not (type(supplied) is int and supplied == reserved), (
+            f"{supplied!r} is an integer count of {reserved}, so it is not a rewrite"
+        )
+
+    def test_a_fractional_count_below_one_reserves_nothing_yet_still_evaluates(self, spec: TrainSpec) -> None:
+        """The sharpest of the three: an evaluation pass over an empty set.
+
+        ``0.5`` clears the ``0 < count < total`` test, so unlike a non-positive
+        count it DOES emit a split - ``eval_split=0.0``, which holds out zero
+        episodes - together with an ``eval_steps`` cadence. lerobot is asked to
+        validate periodically on nothing.
+        """
+        # Bound through Any because the point is what the RUNTIME did with a
+        # value outside the field's declared ``int | None``, which is exactly
+        # what the gate now refuses.
+        fractional: Any = 0.5
+        assert math.ceil(TOTAL_EPISODES * validation_split_fraction(fractional, TOTAL_EPISODES)) == 0
+        spec.val_episodes = fractional
+        assert _count_problems_of(LerobotTrainer(), spec)
+
+    @pytest.mark.parametrize("value", SILENTLY_REWRITTEN)
+    def test_so_the_request_is_refused_instead(self, spec: TrainSpec, value: Any) -> None:
+        spec.val_episodes = value
+        assert _count_problems_of(LerobotTrainer(), spec)
+
+
+class TestAUsableCountIsUntouched:
+    """A count the split reproduces exactly still produces the split."""
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_usable_count_is_not_a_problem(self, spec: TrainSpec, value: int) -> None:
+        spec.val_episodes = value
+        assert _count_problems_of(LerobotTrainer(), spec) == []
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_it_still_produces_the_split_and_the_evaluation_cadence(self, spec: TrainSpec, value: int) -> None:
+        spec.val_episodes = value
+        flags = _eval_flags(LerobotTrainer().build_command(spec))
+        expected = validation_split_fraction(value, TOTAL_EPISODES)
+        assert f"--dataset.eval_split={expected}" in flags
+        assert any(f.startswith("--eval_steps=") for f in flags), flags
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_the_split_reserves_exactly_what_was_asked_for(self, value: int) -> None:
+        fraction = validation_split_fraction(value, TOTAL_EPISODES)
+        assert math.ceil(TOTAL_EPISODES * fraction) == value
+
+    def test_an_unset_count_is_not_a_problem(self, spec: TrainSpec) -> None:
+        """``None`` is the documented "train on every episode" sentinel."""
+        assert spec.val_episodes is None
+        assert _count_problems_of(LerobotTrainer(), spec) == []
+        assert _eval_flags(LerobotTrainer().build_command(spec)) == []
+
+
+class TestTheDatasetDependentBoundsStillApply:
+    """Over-reach controls: the checks that already worked are untouched.
+
+    The gate decides the type and the floor; the upper bound and the per-task
+    fraction refusal stay with the backend that reads the dataset metadata.
+    """
+
+    def test_a_count_that_leaves_no_training_data_is_still_refused(self, spec: TrainSpec) -> None:
+        spec.val_episodes = TOTAL_EPISODES
+        problems = LerobotTrainer().validate(spec)
+        assert any("total_episodes=" in p for p in problems), problems
+
+    def test_a_multi_task_dataset_still_refuses_a_global_count(self, tmp_path: pathlib.Path) -> None:
+        root = _write_dataset(tmp_path / "multi", total_tasks=3)
+        spec = TrainSpec(
+            dataset_root=str(root),
+            output_dir=str(tmp_path / "out"),
+            base_model="lerobot/act",
+            embodiment="so101",
+            steps=100,
+            global_batch_size=8,
+            extra={"policy_type": "act"},
+            val_episodes=2,
+        )
+        problems = LerobotTrainer().validate(spec)
+        assert any("cannot be reserved exactly" in p for p in problems), problems
+
+
+class TestBothWritersOfTheSplitShareOneDomain:
+    """The trainer and the tool build the same flag, so they refuse the same set.
+
+    An implication rather than an equivalence: the tool additionally reads the
+    dataset itself and may refuse a count the backend defers on, so the pinned
+    property is that nothing the backend refuses is accepted by the tool.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_tool_refuses_every_value_the_backend_refuses(
+        self, spec: TrainSpec, dataset: pathlib.Path, value: Any
+    ) -> None:
+        spec.val_episodes = value
+        assert _count_problems_of(LerobotTrainer(), spec), f"backend accepted {value!r}"
+        assert _tool_verdict(dataset, value) == "refused", f"tool accepted {value!r}"
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_the_tool_accepts_every_value_the_backend_accepts(
+        self, spec: TrainSpec, dataset: pathlib.Path, value: int
+    ) -> None:
+        spec.val_episodes = value
+        assert _count_problems_of(LerobotTrainer(), spec) == []
+        assert _tool_verdict(dataset, value) == "accepted"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_tool_names_the_field_and_the_domain(self, dataset: pathlib.Path, value: Any) -> None:
+        with pytest.raises(ValueError, match="val_episodes must be a positive integer"):
+            build_train_command(dataset_root=str(dataset), policy_type="act", val_episodes=value)
+
+    @pytest.mark.parametrize("value", SILENTLY_REWRITTEN + RAISED_IN_THE_COMPARISON)
+    def test_the_tool_refuses_before_it_reads_the_dataset(self, tmp_path: pathlib.Path, value: Any) -> None:
+        """The domain does not depend on the metadata, so it is checked first."""
+        with pytest.raises(ValueError, match="val_episodes must be a positive integer"):
+            build_train_command(dataset_root=str(tmp_path / "absent"), policy_type="act", val_episodes=value)
+
+
+class TestABackendThatIgnoresTheFieldReportsNothing:
+    """A backend must not report on a field it never reads.
+
+    :class:`TrainSpec` documents that a backend "reads the fields it supports and
+    ignores the rest", so this gate is scoped to the LeRobot backend rather than
+    made universal like the learning-rate one.
+    """
+
+    @pytest.mark.parametrize("trainer_cls", (MockTrainer, Gr00tTrainer, Cosmos3Trainer))
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_validates_nothing_about_the_count(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any
+    ) -> None:
+        spec.val_episodes = value
+        assert _count_problems_of(trainer_cls(), spec) == []
+
+
+def _trainer_modules() -> list[pathlib.Path]:
+    """Every trainer module, minus the one that defines the shared gate.
+
+    Rooted at the module that defines :class:`Trainer` so the scan cannot
+    silently point at the wrong tree. The module that *defines* the gate is
+    excluded - derived from the gate itself rather than named, so the exclusion
+    cannot drift - because it reads the field as its owner, not as a consumer.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(validation_episodes_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_count(source: str) -> bool:
+    """Does *source* read ``spec.val_episodes``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "val_episodes" and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_validation_episodes_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheValidationEpisodesDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.val_episodes`` must route it through the shared
+    gate, so a second backend that starts reserving a validation set fails this
+    test until it does.
+    """
+
+    def test_the_scan_finds_the_backend_that_reads_the_field(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
+        readers = {p.name for p in _trainer_modules() if _reads_the_count(p.read_text())}
+        assert readers == {"lerobot.py"}
+
+    def test_every_backend_that_reads_it_routes_through_the_shared_gate(self) -> None:
+        adrift = sorted(
+            p.name
+            for p in _trainer_modules()
+            if _reads_the_count(source := p.read_text()) and not _calls_the_gate(source)
+        )
+        assert adrift == [], f"modules reading spec.val_episodes without the shared gate: {adrift}"
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        """A local sign or type test on the field is the hole this closed."""
+        offenders: list[str] = []
+        for path in _trainer_modules():
+            for line in path.read_text().splitlines():
+                if "spec.val_episodes" in line and ("<= 0" in line or "> 0" in line or "int(" in line):
+                    offenders.append(f"{path.name}: {line.strip()}")
+        assert offenders == [], f"local domain checks on spec.val_episodes: {offenders}"
+
+    def test_the_scanners_detect_a_planted_defect(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = "def validate(self, spec):\n    return [] if spec.val_episodes is None else []\n"
+        assert _reads_the_count(planted)
+        assert not _calls_the_gate(planted)
+
+
+class TestTheGateIsUsableOnItsOwn:
+    """The shared gate's own contract, independent of any backend."""
+
+    def test_it_reports_the_context_it_was_given(self, spec: TrainSpec) -> None:
+        spec.val_episodes = 0
+        (problem,) = validation_episodes_problems(spec, context="anything")
+        assert problem.startswith("anything: val_episodes ")
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_reports_exactly_one_problem_per_unusable_value(self, spec: TrainSpec, value: Any) -> None:
+        spec.val_episodes = value
+        assert len(validation_episodes_problems(spec, context="ctx")) == 1
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_it_reports_nothing_for_a_usable_count(self, spec: TrainSpec, value: int) -> None:
+        spec.val_episodes = value
+        assert validation_episodes_problems(spec, context="ctx") == []
+
+    def test_an_unset_count_is_not_a_problem(self, spec: TrainSpec) -> None:
+        assert spec.val_episodes is None
+        assert validation_episodes_problems(spec, context="ctx") == []


### PR DESCRIPTION
## Problem

`TrainSpec.val_episodes` is the episode count a caller reserves as a held-out validation set. Two independent surfaces build lerobot's `dataset.eval_split` flag from it, each compared the value itself, and the two comparisons disagreed about the same input.

A comparison cannot decide this field, because the count is not read into a loop bound - it is converted into a **real-valued split fraction** (`validation_split_fraction`) whose ceiling lerobot takes (`ceil(episodes_in_task * eval_split)`). That makes a `<= 0` / `>= total` test wrong at both ends. Measured on a 10-episode single-task dataset:

| `val_episodes` | `LerobotTrainer.validate()` | what the run did | `lerobot_train` tool |
|---|---|---|---|
| `3` | no problem | reserved 3, `split=0.25` | accepted |
| `0` | **no problem** | **no split, no eval pass** | refused |
| `-5` | **no problem** | **no split, no eval pass** | refused |
| `True` | **no problem** | **reserved 1**, `split=0.05` | **accepted** |
| `2.7` | **no problem** | **reserved 3**, `split=0.22` | **accepted** |
| `0.5` | **no problem** | **reserved 0** while still evaluating, `split=0.0` | **accepted** |
| `nan` | **no problem** | **no split, no eval pass** | **accepted** (`--dataset.eval_split=nan`) |
| `'5'` | **raises `TypeError`** | raises | raises `TypeError` |
| `[5]` | **raises `TypeError`** | raises | raises `TypeError` |
| `None` | no problem | no split (documented) | accepted |

Three distinct failure modes, none reported:

- **Silently dropped.** The fraction is only computed for a count in `(0, total)`, so `0`, a negative and `nan` produced no `eval_split` **and no `eval_steps`**: the run trained on all 10 episodes and logged no validation loss, and `validate()` called the spec launchable. The tool refused the same value, so one field had opposite verdicts on the two paths.
- **Silently rewritten.** `True` reserved 1 and `2.7` reserved 3 - a whole number the caller never named. `0.5` is the sharpest: it clears `0 < count < total`, so it emits `eval_split=0.0` *together with* an `eval_steps` cadence, asking lerobot to validate periodically on nothing.
- **Raised out of a method documented to return.** A non-numeric count raised `TypeError` from the comparison, and `Trainer.validate`'s docstring is explicit that it returns a list of problems.

The five sibling gates in `training/_validate.py` each document exactly this rule - `_run_size_problems`' docstring already says a local `<= 0` test "admits a `bool` as a silent run of one step, admits a fractional or non-finite value ... and raises out of the comparison itself for a non-numeric value - from a method documented to *return* problems".

## Change

One rule, applied by both writers:

- `training/_validate.py`: new `validation_episodes_problems(spec, *, context)`, the sixth shared gate, built on the same `positive_count_error` domain `run_size_problems` uses.
- `training/base.py`: `Trainer._validation_episodes_problems`, mirroring the five existing wrappers, with the rule and the scoping reason in its docstring.
- `training/lerobot.py`: `validate()` calls the gate and the two dataset-dependent checks below it are **gated on it being empty**, so a non-numeric value is reported rather than compared (the same shape as the `num_nodes > 1` refusal directly above).
- `tools/lerobot_train.py`: the local `val_episodes <= 0` is replaced by the same shared domain, which the module already imports for `steps` / `batch_size`.

Scoped like `run_size_problems` rather than `learning_rate_problems`: `spec.val_episodes` is read by the LeRobot backend only (`groot`, `cosmos3`, `mock` and the RL trainers never read it), and `TrainSpec` documents that a backend "reads the fields it supports and ignores the rest", so reporting on it elsewhere would be a false rejection. That tolerance is pinned too.

The dataset-dependent bounds stay with the backend that reads the metadata: the count must leave training data behind, and a global count is not expressible on a multi-task dataset (`validation_split_error`). Both still fire, pinned as over-reach controls.

**Message text.** The tool's refusal changes from `val_episodes must be positive` to the shared `val_episodes must be a positive integer`. The old wording was *false* for the values that slipped through it - `2.7` and `True` both compare as positive - so adopting the shared wording is part of the fix. Two pins updated.

## Artifact

A measured verdict table rather than a rollout: the change touches no policy, simulation, rendering, recording or asset behaviour. Every cell is produced by one script run in a worktree at `main` and again on the branch (each run records the tree it imported; the generator asserts the two differ, asserts every number it prints, and asserts the `3` and `None` rows are byte-identical across the two trees).

![val_episodes contract divergences: 22 of 30 cells on main, 0 of 30 on this branch](https://raw.githubusercontent.com/cagataycali/robots/artifacts/val-episodes-domain/val_episodes_domain.png)

Contract divergences: **22 of 30 cells -> 0 of 30**. Cells are coloured by agreement with each surface's own contract, not by verdict, so "accepted" is correct for the two shaded rows. The measurement scripts and both JSON dumps are on the `artifacts/val-episodes-domain` branch.

## Tests

`tests/training/test_validation_episodes_domain.py`, 133 tests:

- every unusable value is **reported, not raised**, with a message naming the backend;
- guard order: a non-numeric value never reaches the `>= total_episodes` comparison;
- the headline - a non-positive count produced no split *and* no eval cadence, so it is refused instead;
- the rewrite is grounded in what lerobot really does with the fraction (`ceil` maps `True`/`2.7`/`0.5` to 1/3/0), including the evaluate-on-nothing case;
- over-reach controls: a usable count still produces the split *and* the cadence and reserves exactly what it named; `None` still means "train on everything"; both dataset-dependent refusals still fire;
- cross-surface parity as an implication - nothing the backend refuses is accepted by the tool, and the tool refuses before it reads the dataset;
- the three backends that ignore the field report nothing about it;
- the parity classifier itself collects a library failure and lets control flow reach the runner, so the verdict it hands the two parity tests is always an answer about the field (see round 2);
- an AST parity guard deriving the in-scope modules from the tree (a second backend that starts reserving a validation set fails until it routes through the gate), with a non-vacuity assertion, a no-local-re-implementation scan and a planted-defect meta-test.

**Pre-fix** (call sites reverted to `main`, keeping the module that defines the new gate so the suite still imports): **52 failed / 81 passed**, the parity guard reporting `modules reading spec.val_episodes without the shared gate: ['lerobot.py']`. The 81 that pass are the over-reach controls, the ignoring backends, the gate's own unit tests and the six classifier tests added in round 2 - they are what stops this reaching further than the one field. (An earlier revision of this section said 53 failed / 75 passed; re-measured at the previous head the count is 52 / 75, so the failing count is unchanged by round 2 and the delta is exactly the six new tests.)

## Verification

Base `b4671434` (unchanged - `upstream/main` has not moved since the two diverged). Everything below was run on the current head `fe1b036`.

- `MUJOCO_GL=egl python -m pytest tests` -> **20339 passed, 257 skipped, 0 failed** (576s)
- `ruff check strands_robots tests tests_integ` -> clean; `ruff format --check` -> 1073 files already formatted
- `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/`**. The 14 `examples/isaac_gs` errors are environmental: they are byte-identical to a pristine `upstream/main` worktree of the same working copy, and `examples/` is outside the lint scope CI runs.
- 42 repo-wide root guards pass; `python3 scripts/assemble_changelog.py --check` -> OK; `scripts/check_merge_base_overlap.py` -> no overlap

## Round 2 - the parity classifier's handler width

`fe1b036`. **No production line moves in this round**: the diff is `+70/-2` in one test file.

CodeQL flagged `except BaseException` in `_tool_verdict`, the helper that turns "what did the tool do with this value" into the string the two cross-surface parity tests compare against `refused` / `accepted`. That handler width is load-bearing rather than stylistic, because the return value is *compared as an answer*: catching `BaseException` records an operator's Ctrl-C - or a `pytest.skip` raised inside `build_train_command` - as a verdict and lets the comparison carry on as though the tool had answered about `val_episodes`.

The alert implies a second option (drop the catch-all), so all three widths were measured over the outcome classes the tool can produce plus the four control-flow classes:

| variant | library failure collected | control flow escapes |
|---|---|---|
| `except BaseException` | 5/5 | **0/4** |
| no catch-all at all | **3/5** | 4/4 |
| `except Exception` | **5/5** | **4/4** |

Exactly one width satisfies both halves. The five library rows are **identical** between `BaseException` and `Exception` and all four control-flow rows **differ**, so narrowing changes no verdict this file collects and every verdict it must not. Dropping the catch-all instead would lose two answers the file exists to record - a non-numeric count really does raise out of the tool, and that raise is one of the compared outcomes.

This adopts the width and the shape the sibling `_domain_refused` classifier already uses in `tests/simulation/test_create_world_difficulty_domain.py`, whose docstring states the same reasoning ("a library failure is one of the answers being collected, but an interrupt is not an answer about the domain").

`TestTheParityClassifierCollectsFailuresWithoutSwallowingControlFlow` pins both directions - control flow reaches the runner (4 classes) and a library failure is still recorded (2 classes), so neither widening nor deleting the handler passes - with an executable premise that each control-flow class still derives from `BaseException` without deriving from `Exception`. Pre-fix, with only the handler width reverted: **4 failed / 2 passed**, failing as `Failed: DID NOT RAISE KeyboardInterrupt` / `DID NOT RAISE Skipped`.

## Out of scope

`LerobotTrainer.build_command` still interpolates the split for a value `validate()` refuses. It is documented as a *pure argv-parity helper* that is "NOT used to launch training", retained for `test_native_parity` and as a human-readable description of an already-validated spec, and `spec.steps` is interpolated there verbatim for the same reason. `train()` fails closed on `validate()`, so the action path is covered.

`save_freq` is deliberately untouched: lerobot's `should_save_checkpoint` documents a non-positive value as a mode selector ("disables periodic saving ... mirroring how log_freq/eval_freq treat non-positive values"), so it is not a degenerate count.

