### PR TITLE
fix(dataset_recorder): the bucket-sync hub floor is the release that ships the `hf` bucket CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,9 @@ sim.stop_recording(bucket="your-org/robot-fave")   # → hf://buckets/your-org/r
 ```
 
 Requires the `hf` CLI with the `buckets`/`sync` subcommands
-(`pip install -U "huggingface_hub>=1.0"` + `hf auth login` — 0.x releases of
-`huggingface_hub` ship an `hf` entry point without them).
+(`pip install -U "huggingface_hub>=1.5"` + `hf auth login` — those subcommands
+first ship in 1.5.0; every earlier release, including 1.0–1.4.x, installs an
+`hf` entry point without them).
 
 Any on-disk dataset directory can be synced (or daily re-synced) without a live
 recording session — one recorded earlier in the process, or on hardware via

--- a/changelog.d/1957-bucket-cli-floor.md
+++ b/changelog.d/1957-bucket-cli-floor.md
@@ -1,0 +1,17 @@
+### Fixed: the huggingface_hub floor bucket sync declares is the release that actually ships the `hf` bucket CLI
+
+`sync_dataset_to_bucket` runs `hf buckets create` and `hf sync`. Both first ship
+in **huggingface_hub 1.5.0** (`huggingface_hub/cli/buckets.py`, registered by
+`cli/hf.py`); every earlier release installs an `hf` entry point without them and
+answers either invocation with `Error: No such command 'buckets'`.
+
+The version gate, the upgrade instructions it emits, and the `[wbc]` extra's pin
+all named `>=1.0`, so a caller on 1.0-1.4.x passed the gate and received that raw
+CLI usage noise - exactly what the gate exists to replace - and the remedy the
+library printed (`pip install -U 'huggingface_hub>=1.0'`) could be followed to
+the letter and still resolve a CLI that cannot run a bucket sync.
+
+The floor is now a single constant the gate, both messages, the README guidance
+and the `[wbc]` pin are all checked against, so they cannot drift apart again.
+A fresh install is unaffected (it already resolved 1.26.0); the change is to what
+a constrained or pre-existing environment is permitted to resolve.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,14 +137,19 @@ wbc = [
     # Required so create_policy("wbc") with no local checkpoint works out of the
     # box - WBCPolicy._maybe_download_checkpoint raises RuntimeError naming the
     # [wbc] extra when it is absent.
-    # Floor at >=1.0 (cap the MAJOR only, <2.0.0): the docs' bucket-sync
+    # Floor at >=1.5 (cap the MAJOR only, <2.0.0): the docs' bucket-sync
     # guidance (README streamed-training section + dataset_recorder.sync_to_bucket)
-    # instructs `pip install -U "huggingface_hub>=1.0"` because the `hf buckets`/
-    # `hf sync` CLI subcommands only exist on huggingface_hub>=1.0; a <1.0 floor
-    # lets a fresh resolve land on 0.36.x, whose `hf` entry point lacks those
-    # subcommands. >=1.0 also matches lerobot (huggingface-hub>=1.0.0) - and
-    # [wbc] is pulled into [all] alongside lerobot, so the two co-resolve.
-    "huggingface_hub>=1.0,<2.0.0",
+    # instructs `pip install -U "huggingface_hub>=1.5"` because the `hf buckets`/
+    # `hf sync` CLI subcommands first ship in huggingface_hub 1.5.0
+    # (huggingface_hub/cli/buckets.py, registered by cli/hf.py). Every earlier
+    # release installs an `hf` entry point WITHOUT them - 0.36.x, but also
+    # 1.0-1.4.x, which answer `hf buckets create` with
+    # "Error: No such command 'buckets'". A floor below 1.5 therefore lets a
+    # fresh resolve land on a CLI that cannot run a bucket sync while satisfying
+    # the documented minimum. lerobot floors it higher still
+    # (lerobot 0.6.1 requires huggingface-hub>=1.6.0) and [wbc] is pulled into
+    # [all] alongside lerobot, so the two co-resolve on the stricter of the two.
+    "huggingface_hub>=1.5,<2.0.0",
 ]
 motionbricks = [
     # MotionBricks (NVlabs/GR00T-WholeBodyControl `motionbricks/`) generative

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -144,7 +144,7 @@ def sync_dataset_to_bucket(
     Mutable, Xet-deduplicated dump target for COLLECTION - avoids git-LFS
     history bloat of push_to_hub during recording. Daily re-sync uploads
     only changed chunks (content-defined chunking). Requires the ``hf`` CLI
-    with the ``buckets``/``sync`` subcommands (``huggingface_hub>=1.0``)
+    with the ``buckets``/``sync`` subcommands (``huggingface_hub>=1.5``)
     and ``hf auth login``.
 
     ``bucket`` and ``run_id`` are validated against an allowlist before any
@@ -180,12 +180,13 @@ def sync_dataset_to_bucket(
     if hf is None:
         return {
             "status": "error",
-            "message": '`hf` CLI not found. pip install -U "huggingface_hub>=1.0" and run `hf auth login`.',
+            "message": f'`hf` CLI not found. pip install -U "{_HF_BUCKET_CLI_MIN_SPEC}" and run `hf auth login`.',
         }
 
-    # `hf buckets` / `hf sync` need huggingface_hub>=1.0; on 0.x the CLI
-    # exists but rejects those subcommands with argparse noise. Gate on the
-    # installed package version so users get an upgrade instruction instead.
+    # `hf buckets` / `hf sync` need huggingface_hub>=1.5; on every older
+    # release (0.36.x, but also 1.0-1.4.x) the CLI exists and rejects those
+    # subcommands with usage noise. Gate on the installed package version so
+    # users get an upgrade instruction instead.
     version_error = _huggingface_hub_version_error()
     if version_error is not None:
         return {"status": "error", "message": version_error}
@@ -272,19 +273,42 @@ def _hf_executable() -> str | None:
     return shutil.which("hf")
 
 
+#: Oldest ``huggingface_hub`` release whose ``hf`` CLI carries the
+#: ``hf buckets`` / ``hf sync`` subcommands :func:`sync_dataset_to_bucket`
+#: invokes.
+#:
+#: They first ship in 1.5.0, as ``huggingface_hub/cli/buckets.py`` registered by
+#: ``cli/hf.py`` (``app.add_group(buckets_cli, name="buckets")`` and
+#: ``app.command()(sync)``). 1.0-1.4.x install the ``hf`` entry point without
+#: that module, so they answer both invocations with
+#: ``Error: No such command 'buckets'`` / ``'sync'``.
+#:
+#: This is the single source of the floor: the version gate below, the upgrade
+#: instructions it and :func:`sync_dataset_to_bucket` emit, and the pin the
+#: ``[wbc]`` extra declares are all checked against it, so the accepted domain
+#: cannot drift from the release that can actually honor a bucket sync.
+_HF_BUCKET_CLI_MIN_VERSION = (1, 5)
+
+#: The requirement string every bucket-sync upgrade instruction quotes, derived
+#: from :data:`_HF_BUCKET_CLI_MIN_VERSION` so the advice cannot name a release
+#: that does not ship the subcommands.
+_HF_BUCKET_CLI_MIN_SPEC = "huggingface_hub>=" + ".".join(str(part) for part in _HF_BUCKET_CLI_MIN_VERSION)
+
+
 def _huggingface_hub_version_error() -> str | None:
     """Return an actionable error message if ``huggingface_hub`` is too old for bucket sync.
 
-    The ``hf buckets`` / ``hf sync`` subcommands ship in huggingface_hub>=1.0.
-    On older releases (e.g. the 0.36.x stable line) the ``hf`` binary exists,
-    so :func:`_hf_executable` succeeds, but the subcommands fail with argparse
-    usage noise ("invalid choice: 'buckets'") that gives no hint the fix is an
+    The ``hf buckets`` / ``hf sync`` subcommands ship in
+    :data:`_HF_BUCKET_CLI_MIN_VERSION` and later. On any older release - the
+    0.36.x stable line, but equally 1.0-1.4.x - the ``hf`` binary exists, so
+    :func:`_hf_executable` succeeds, but the subcommands fail with usage noise
+    (``Error: No such command 'buckets'``) that gives no hint the fix is an
     upgrade. Version-checking the installed package up front turns that noise
     into a clear upgrade instruction without spawning a subprocess.
 
     Returns ``None`` (no error) when:
 
-    - the installed version is >= 1.0, or
+    - the installed version is >= :data:`_HF_BUCKET_CLI_MIN_VERSION`, or
     - ``huggingface_hub`` is not importable in this interpreter (the ``hf``
       binary may come from a different environment on PATH whose version we
       cannot see; the normal subprocess error path still applies), or
@@ -300,11 +324,11 @@ def _huggingface_hub_version_error() -> str | None:
     match = re.match(r"(\d+)\.(\d+)", version)
     if match is None:
         return None
-    if (int(match.group(1)), int(match.group(2))) >= (1, 0):
+    if (int(match.group(1)), int(match.group(2))) >= _HF_BUCKET_CLI_MIN_VERSION:
         return None
     return (
-        f"bucket sync requires huggingface_hub>=1.0 (`hf buckets`/`hf sync`); "
-        f"installed: {version}. pip install -U 'huggingface_hub>=1.0'."
+        f"bucket sync requires {_HF_BUCKET_CLI_MIN_SPEC} (`hf buckets`/`hf sync`); "
+        f"installed: {version}. pip install -U '{_HF_BUCKET_CLI_MIN_SPEC}'."
     )
 
 

--- a/tests/test_bucket_cli_floor_ships_the_subcommands.py
+++ b/tests/test_bucket_cli_floor_ships_the_subcommands.py
@@ -1,0 +1,211 @@
+"""The declared huggingface_hub floor must actually ship the bucket CLI.
+
+``sync_dataset_to_bucket`` runs two subcommands of the ``hf`` CLI:
+``hf buckets create`` and ``hf sync``. Both first ship in **huggingface_hub
+1.5.0**, as ``huggingface_hub/cli/buckets.py`` registered by ``cli/hf.py``.
+Every earlier release installs an ``hf`` entry point without that module and
+answers either invocation with ``Error: No such command 'buckets'`` / ``'sync'``.
+
+The library's version gate, its upgrade instructions and the ``[wbc]`` extra's
+pin all previously named ``>=1.0``, which is two-and-a-half minor releases below
+the capability. That made three claims wrong at once:
+
+* a caller on 1.0-1.4.x passed the gate, so the gate that exists to replace CLI
+  usage noise with an upgrade instruction stayed silent for exactly the releases
+  it describes;
+* the upgrade instruction the library printed - ``pip install -U
+  'huggingface_hub>=1.0'`` - could be followed to the letter and still resolve a
+  CLI that cannot run a bucket sync; and
+* the ``[wbc]`` pin let a fresh resolve land on such a CLI while satisfying the
+  documented minimum.
+
+Every assertion below reads the floor from
+``dataset_recorder._HF_BUCKET_CLI_MIN_VERSION`` rather than restating it, so the
+gate, the messages, the docs and the packaging pin cannot drift apart again.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from strands_robots import dataset_recorder
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_README = _REPO_ROOT / "README.md"
+_RECORDER_SRC = Path(dataset_recorder.__file__)
+
+_FLOOR = Version(".".join(str(part) for part in dataset_recorder._HF_BUCKET_CLI_MIN_VERSION))
+
+# Releases whose `hf` entry point exists but carries no `buckets`/`sync`
+# subcommand. Verified against the published wheels: `huggingface_hub/cli/
+# buckets.py` is absent from every one of them, and 1.4.1's CLI answers
+# `hf buckets create demo` with "Error: No such command 'buckets'" (rc=2).
+_WITHOUT_THE_SUBCOMMANDS = ["0.36.2", "1.0.0", "1.0.1", "1.1.0", "1.2.4", "1.3.7", "1.4.0", "1.4.1"]
+
+# Releases that ship them. 1.5.0 is the first; the CLI there answers the same
+# invocation with rc=0.
+_WITH_THE_SUBCOMMANDS = ["1.5.0", "1.6.0", "1.7.0", "1.26.0"]
+
+
+def _dataset_root(tmp_path: Path) -> Path:
+    """A finalized-looking dataset directory (``meta/`` present)."""
+    root = tmp_path / "cube_pick"
+    (root / "meta").mkdir(parents=True)
+    (root / "meta" / "info.json").write_text('{"fps": 30}')
+    return root
+
+
+def _install_hint_floors(text: str) -> list[Version]:
+    """Every ``huggingface_hub>=X`` floor a piece of guidance names.
+
+    The version is matched without a trailing separator so a pin that ends a
+    sentence (``... needs huggingface_hub>=1.5.``) parses as ``1.5`` rather than
+    raising ``InvalidVersion`` on ``"1.5."``.
+    """
+    return [Version(m) for m in re.findall(r"huggingface_hub>=([0-9]+(?:\.[0-9]+)*)", text)]
+
+
+class TestTheGateRefusesEveryReleaseWithoutTheSubcommands:
+    """The accepted domain is exactly the releases that can honor a sync."""
+
+    @pytest.mark.parametrize("version", _WITHOUT_THE_SUBCOMMANDS)
+    def test_a_release_without_the_subcommands_is_refused(self, version, monkeypatch):
+        import huggingface_hub
+
+        monkeypatch.setattr(huggingface_hub, "__version__", version)
+        problem = dataset_recorder._huggingface_hub_version_error()
+        assert problem is not None, f"huggingface_hub {version} has no `hf buckets`/`hf sync` but the gate accepted it"
+        assert version in problem, "the refusal must quote the installed version"
+
+    @pytest.mark.parametrize("version", _WITH_THE_SUBCOMMANDS)
+    def test_a_release_that_ships_them_is_accepted(self, version, monkeypatch):
+        import huggingface_hub
+
+        monkeypatch.setattr(huggingface_hub, "__version__", version)
+        assert dataset_recorder._huggingface_hub_version_error() is None, (
+            f"huggingface_hub {version} ships the subcommands and must not be refused"
+        )
+
+    def test_the_floor_itself_is_the_boundary(self, monkeypatch):
+        """The refused/accepted split falls exactly at the declared floor."""
+        import huggingface_hub
+
+        major, minor = dataset_recorder._HF_BUCKET_CLI_MIN_VERSION
+        monkeypatch.setattr(huggingface_hub, "__version__", f"{major}.{minor}.0")
+        assert dataset_recorder._huggingface_hub_version_error() is None
+        monkeypatch.setattr(huggingface_hub, "__version__", f"{major}.{minor - 1}.99")
+        assert dataset_recorder._huggingface_hub_version_error() is not None
+
+
+class TestTheUpgradeInstructionNamesAReleaseThatShipsThem:
+    """A remedy that resolves a CLI without the subcommands is not a remedy."""
+
+    def test_the_version_gate_remedy_is_at_least_the_capability_floor(self, monkeypatch):
+        import huggingface_hub
+
+        monkeypatch.setattr(huggingface_hub, "__version__", "1.4.1")
+        problem = dataset_recorder._huggingface_hub_version_error()
+        assert problem is not None
+        floors = _install_hint_floors(problem)
+        assert floors, f"the upgrade instruction names no huggingface_hub floor: {problem!r}"
+        assert all(f >= _FLOOR for f in floors), (
+            f"the upgrade instruction advises a release without the subcommands: {problem!r}"
+        )
+        assert "pip install -U" in problem, "the remedy must be a runnable install command"
+
+    def test_the_cli_not_found_message_names_the_same_floor(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(dataset_recorder, "_hf_executable", lambda: None)
+        result = dataset_recorder.sync_dataset_to_bucket(root=_dataset_root(tmp_path), bucket="my-org/robot-fave")
+        assert result["status"] == "error"
+        floors = _install_hint_floors(result["message"])
+        assert floors and all(f >= _FLOOR for f in floors), (
+            f"the `hf` CLI-not-found remedy advises a release without the subcommands: {result['message']!r}"
+        )
+
+
+class TestTheRefusalPrecedesTheSubprocess:
+    """A too-old hub is reported without spawning the CLI that cannot serve it."""
+
+    def test_no_subprocess_runs_for_a_release_without_the_subcommands(self, tmp_path, monkeypatch):
+        import huggingface_hub
+
+        monkeypatch.setattr(dataset_recorder, "_hf_executable", lambda: "hf")
+        monkeypatch.setattr(huggingface_hub, "__version__", "1.4.1")
+
+        def _boom(*_args, **_kwargs):
+            raise AssertionError("the CLI must not be spawned when it cannot serve the request")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        result = dataset_recorder.sync_dataset_to_bucket(root=_dataset_root(tmp_path), bucket="my-org/robot-fave")
+        assert result["status"] == "error"
+        assert "No such command" not in result["message"], (
+            "the caller got raw CLI usage noise instead of an upgrade instruction"
+        )
+
+
+class TestEveryDeclaredFloorAgrees:
+    """Guidance, packaging and the gate name one version."""
+
+    @pytest.mark.parametrize(
+        "path", [_README, _RECORDER_SRC, _PYPROJECT], ids=["README", "dataset_recorder", "pyproject"]
+    )
+    def test_no_documented_floor_is_below_the_capability(self, path):
+        floors = _install_hint_floors(path.read_text())
+        assert floors, f"{path.name} names no huggingface_hub floor to check"
+        assert all(f >= _FLOOR for f in floors), (
+            f"{path.name} names a huggingface_hub floor below {_FLOOR}, which has no "
+            f"`hf buckets`/`hf sync`: {[str(f) for f in floors]}"
+        )
+
+    def test_the_packaging_floor_is_at_least_the_capability_floor(self):
+        extras = tomllib.loads(_PYPROJECT.read_text())["project"]["optional-dependencies"]
+        specs = [s for s in extras["wbc"] if Requirement(s).name.replace("-", "_").lower() == "huggingface_hub"]
+        assert len(specs) == 1, f"expected exactly one huggingface_hub pin in [wbc], got {specs!r}"
+        lower = min(s.version for s in Requirement(specs[0]).specifier if s.operator == ">=")
+        assert Version(lower) >= _FLOOR, (
+            f"[wbc] resolves an `hf` CLI that may lack the buckets/sync subcommands: {specs[0]!r}"
+        )
+
+
+class TestTheFloorsClaimIsExecutable:
+    """The installed hub really carries what the floor says it does.
+
+    A prose claim about a dependency goes stale silently. Reading the CLI
+    surface out of the installed package means a rename upstream fails here
+    instead of turning the advice quietly wrong.
+    """
+
+    def test_the_installed_hub_ships_the_registered_subcommands(self):
+        huggingface_hub = pytest.importorskip("huggingface_hub")
+        installed = Version(huggingface_hub.__version__)
+        if installed < _FLOOR:
+            pytest.skip(f"installed huggingface_hub {installed} predates the bucket CLI floor {_FLOOR}")
+        buckets = pytest.importorskip("huggingface_hub.cli.buckets")
+        assert hasattr(buckets, "buckets_cli"), "the `hf buckets` command group is gone"
+        assert hasattr(buckets, "sync"), "the `hf sync` command is gone"
+        entry = Path(huggingface_hub.__file__).parent / "cli" / "hf.py"
+        registration = entry.read_text()
+        assert 'name="buckets"' in registration, "`hf` no longer registers the buckets group"
+        assert "(sync)" in registration, "`hf` no longer registers the sync command"
+
+
+class TestTheGateStillFailsOpen:
+    """Only a version it can read and compare is refused."""
+
+    def test_an_unparseable_version_is_not_refused(self, monkeypatch):
+        import huggingface_hub
+
+        monkeypatch.setattr(huggingface_hub, "__version__", "not-a-version")
+        assert dataset_recorder._huggingface_hub_version_error() is None
+
+    def test_an_unimportable_hub_is_not_refused(self, monkeypatch):
+        monkeypatch.setitem(__import__("sys").modules, "huggingface_hub", None)
+        assert dataset_recorder._huggingface_hub_version_error() is None

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1707,11 +1707,11 @@ def test_sync_to_bucket_missing_hf_cli_errors(tmp_path, monkeypatch):
 
 
 def test_sync_to_bucket_old_huggingface_hub_errors(tmp_path, monkeypatch):
-    """huggingface_hub<1.0 -> clear upgrade instruction, never a subprocess call.
+    """A hub too old for the subcommands -> upgrade instruction, never a subprocess call.
 
-    Regression test for the version gate: on 0.x the ``hf`` binary exists but
-    lacks the ``buckets``/``sync`` subcommands, so without the gate the user
-    gets argparse usage noise piped verbatim into the status dict.
+    Regression test for the version gate: on every release before 1.5 the ``hf``
+    binary exists but lacks the ``buckets``/``sync`` subcommands, so without the
+    gate the user gets CLI usage noise piped verbatim into the status dict.
     """
     import subprocess
 
@@ -1731,13 +1731,13 @@ def test_sync_to_bucket_old_huggingface_hub_errors(tmp_path, monkeypatch):
     result = _sync_recorder(tmp_path).sync_to_bucket("my-org/robot-fave")
 
     assert result["status"] == "error"
-    assert "huggingface_hub>=1.0" in result["message"]
+    assert "huggingface_hub>=1.5" in result["message"]
     assert "0.36.2" in result["message"]
-    assert "pip install -U 'huggingface_hub>=1.0'" in result["message"]
+    assert "pip install -U 'huggingface_hub>=1.5'" in result["message"]
 
 
 def test_sync_to_bucket_new_huggingface_hub_passes_version_gate(tmp_path, monkeypatch):
-    """huggingface_hub>=1.0 passes the version gate and proceeds to sync."""
+    """The oldest hub that ships the subcommands passes the gate and proceeds to sync."""
     import subprocess
 
     import huggingface_hub
@@ -1746,7 +1746,7 @@ def test_sync_to_bucket_new_huggingface_hub_passes_version_gate(tmp_path, monkey
 
     _write_meta(tmp_path)
     monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
-    monkeypatch.setattr(huggingface_hub, "__version__", "1.0.0")
+    monkeypatch.setattr(huggingface_hub, "__version__", "1.5.0")
 
     def _fake_run(cmd, *_a, **_k):
         return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -27,8 +27,15 @@ from pathlib import Path
 from packaging.requirements import Requirement
 from packaging.version import Version
 
+from strands_robots import dataset_recorder
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _bucket_cli_floor_spec() -> str:
+    """The requirement string the library's bucket-sync guidance must quote."""
+    return dataset_recorder._HF_BUCKET_CLI_MIN_SPEC
 
 
 def _extras() -> dict[str, list[str]]:
@@ -242,17 +249,19 @@ def test_readme_streamed_training_invocation_is_current() -> None:
     )
 
 
-def test_hf_cli_install_guidance_pins_huggingface_hub_1_0() -> None:
-    # `pip install -U huggingface_hub` (unversioned) resolves to 0.36.x in many
-    # envs, which has no `buckets`/`sync` subcommands; every install line next
-    # to `sync_to_bucket` guidance must pin >=1.0.
+def test_hf_cli_install_guidance_pins_the_bucket_cli_floor() -> None:
+    # `pip install -U huggingface_hub` (unversioned) resolves to whatever is
+    # newest, and an environment pinned below the floor resolves to a CLI
+    # without the `buckets`/`sync` subcommands; every install line next to
+    # `sync_to_bucket` guidance must name the floor that ships them.
+    floor = _bucket_cli_floor_spec()
     for path in (_README, _DATASET_RECORDER):
         text = path.read_text()
         assert "pip install -U huggingface_hub" not in text, (
             f"{path.name} recommends an unversioned huggingface_hub install; "
-            "the `hf buckets`/`hf sync` subcommands need >=1.0"
+            f"the `hf buckets`/`hf sync` subcommands need {floor}"
         )
-        assert "huggingface_hub>=1.0" in text, f"{path.name} lost the huggingface_hub>=1.0 pin"
+        assert floor in text, f"{path.name} lost the {floor} pin"
 
 
 def test_shard_size_claim_names_both_lerobot_defaults() -> None:
@@ -290,15 +299,16 @@ def test_dataset_recorder_codec_docs_track_the_supported_lerobot_floor() -> None
 
 # --- positive contract: the [wbc] extra's huggingface_hub floor must guarantee
 #     the `hf buckets`/`hf sync` CLI subcommands the bucket-sync docs instruct.
-#     Those subcommands only exist on huggingface_hub>=1.0; the docs (README
+#     Those subcommands first ship in huggingface_hub 1.5.0; the docs (README
 #     streamed-training section + dataset_recorder.sync_to_bucket, pinned by
-#     test_hf_cli_install_guidance_pins_huggingface_hub_1_0) tell users to
-#     `pip install -U "huggingface_hub>=1.0"`, so a fresh
+#     test_hf_cli_install_guidance_pins_the_bucket_cli_floor) tell users to
+#     `pip install -U "huggingface_hub>=1.5"`, so a fresh
 #     `pip install strands-robots[wbc]` that resolves an `hf` entry point WITHOUT
-#     those subcommands (huggingface_hub 0.36.x satisfies a <1.0 floor) silently
-#     reproduces the exact "hf CLI not found / no such subcommand" failure the
-#     docs' own error message calls out. Floor the direct pin at >=1.0 so the
-#     resolver can't drift below the documented minimum. See issue #1549. ---
+#     those subcommands (0.36.x, but equally 1.0-1.4.x, satisfy a <1.5 floor)
+#     silently reproduces the exact "hf CLI not found / no such subcommand"
+#     failure the docs' own error message calls out. Floor the direct pin at the
+#     capability version so the resolver can't drift below the documented
+#     minimum. See issue #1549. ---
 
 
 def _wbc_huggingface_hub_spec() -> str:
@@ -311,14 +321,16 @@ def _wbc_huggingface_hub_spec() -> str:
     raise AssertionError("no huggingface_hub pin found in the [wbc] extra")
 
 
-def test_wbc_extra_huggingface_hub_floor_is_at_least_1_0() -> None:
+def test_wbc_extra_huggingface_hub_floor_ships_the_bucket_cli() -> None:
     spec = _wbc_huggingface_hub_spec()
-    # floor at >=1.0 so the resolved `hf` CLI carries the buckets/sync subcommands
-    assert ">=1.0" in spec, (
-        f"[wbc] huggingface_hub floor must be >=1.0 (the `hf buckets`/`hf sync` "
-        f"CLI subcommands the bucket-sync docs instruct only exist on >=1.0); got {spec!r}"
+    # Assert the declared lower BOUND, not a `">=X" in spec` substring: a later
+    # floor raise falsifies the substring while the property it stands for -
+    # "the resolved `hf` CLI carries the buckets/sync subcommands" - still holds.
+    lower = min(Version(s.version) for s in Requirement(spec).specifier if s.operator == ">=")
+    minimum = Version(".".join(str(part) for part in dataset_recorder._HF_BUCKET_CLI_MIN_VERSION))
+    assert lower >= minimum, (
+        f"[wbc] huggingface_hub floor must be >= {minimum} (the `hf buckets`/`hf sync` "
+        f"CLI subcommands the bucket-sync docs instruct first ship there); got {spec!r}"
     )
-    # the dead pre-1.0 floor must not linger
-    assert ">=0.20.0" not in spec, f"[wbc] still pins the dead pre-1.0 huggingface_hub floor: {spec!r}"
     # keep the MAJOR cap (<2.0.0) per repo convention (>=1.0 deps cap the major)
     assert "<2.0.0" in spec, f"[wbc] huggingface_hub pin lost its <2.0.0 major cap: {spec!r}"


### PR DESCRIPTION
## Problem

`sync_dataset_to_bucket` runs two subcommands of the `hf` CLI: `hf buckets create` and `hf sync`. Both first ship in **huggingface_hub 1.5.0**, as `huggingface_hub/cli/buckets.py` registered by `cli/hf.py` (`app.add_group(buckets_cli, name="buckets")` and `app.command()(sync)`). Every earlier release installs an `hf` entry point without that module.

The version gate, the two upgrade instructions it and `sync_dataset_to_bucket` emit, and the `[wbc]` extra's pin all named `>=1.0` — two and a half minor releases below the capability. Measured against the genuine CLI of each release (only the version string the gate reads is emulated):

| huggingface_hub | `hf buckets --help` | `sync_dataset_to_bucket` on main |
|---|---|---|
| 1.0.0 | rc=2, `Error: No such command 'buckets'` | gate **accepted** -> `error: bucket create failed: Usage: hf ... Error: No such command 'buckets'.` |
| 1.4.1 | rc=2, same | gate **accepted** -> same raw CLI noise |
| 1.5.0 | rc=0 | `success` |

So three claims were wrong at once:

- a caller on 1.0–1.4.x **passed the gate**, and the gate that exists to replace CLI usage noise with an upgrade instruction stayed silent for exactly the releases its own docstring describes;
- the remedy the library printed — `pip install -U 'huggingface_hub>=1.0'` — could be followed to the letter and still resolve a CLI that cannot run a bucket sync;
- the `[wbc]` pin let a fresh resolve land on such a CLI while satisfying the documented minimum.

The gate's docstring already stated the intent ("turns that noise into a clear upgrade instruction"); only the number was wrong.

## Change

One constant, `_HF_BUCKET_CLI_MIN_VERSION = (1, 5)`, is the single source of the floor. The gate compares against it, both upgrade instructions are derived from it, and the README guidance plus the `[wbc]` pin are checked against it, so they cannot drift apart again.

- `strands_robots/dataset_recorder.py` — the gate's floor, both messages (now derived, not retyped), and the docstrings/comments that named `>=1.0`.
- `pyproject.toml` — `huggingface_hub>=1.5,<2.0.0`, and the comment's reasoning, which cited the bucket CLI as the justification for `>=1.0` and additionally claimed lerobot pins `huggingface-hub>=1.0.0` (lerobot 0.6.1 pins `>=1.6.0`, so the two co-resolve on the stricter of the pair).
- `README.md` — the install hint beside the bucket-sync snippet.

The design is unchanged: the gate still version-checks the installed package rather than spawning a probe subprocess, and still fails open when the version is unparseable or `huggingface_hub` is not importable (the `hf` binary may come from another environment on PATH).

**Resolution is unaffected.** `pip install --dry-run` for the `[wbc]` hub pin resolves 15 packages and huggingface_hub 1.26.0 both before and after — added `[]`, removed `[]`. What changes is the version a constrained or pre-existing environment is *permitted* to resolve.

### Out of scope

The gate reads only MAJOR.MINOR and fails open on a prerelease string; that is pre-existing and deliberate (a cosmetic version format must not block a possibly-capable CLI).

## Tests

New `tests/test_bucket_cli_floor_ships_the_subcommands.py` (23 tests). Every assertion reads the floor from the constant rather than restating it:

- the accepted domain is exactly the releases that ship the subcommands, parametrized over 8 releases that do not (0.36.2, 1.0.0, 1.0.1, 1.1.0, 1.2.4, 1.3.7, 1.4.0, 1.4.1) and 4 that do (1.5.0, 1.6.0, 1.7.0, 1.26.0), plus the boundary itself;
- both upgrade instructions name a release that ships them — the version is parsed out of the message and compared to the floor, so a remedy pointing below it fails here;
- the refusal precedes the subprocess (`subprocess.run` raises), and the caller never receives `No such command`;
- no floor named in the README, the module or `pyproject.toml` is below the capability, and the `[wbc]` lower bound is at least it;
- **the floor's claim is executable**: the installed hub really exposes `buckets_cli` and `sync` and `cli/hf.py` really registers both, so an upstream rename fails here instead of turning the advice quietly wrong;
- the fail-open paths still hold.

Two existing tests were named for the version they were written against and are renamed for the behaviour they check (`..._pins_huggingface_hub_1_0` -> `..._pins_the_bucket_cli_floor`, `..._floor_is_at_least_1_0` -> `..._floor_ships_the_bucket_cli`). The `[wbc]` assertion now compares the declared lower **bound** instead of a `">=1.0" in spec` substring: a later floor raise falsifies the substring while the property it stands for still holds, matching the `min(Version(...))` idiom already used in seven places in this suite.

**Pre-fix proof** (source reverted to `main`, tests kept): **17 failed / 22 passed** -> **39 passed**. The 22 that pass pre-fix are the releases already refused, the accepted-value controls and the fail-open paths — they are what stops the guard reaching further than the one wrong number.

## Gate

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **20362 passed, 257 skipped, 0 failed** (570.94s), at base `893998c0`.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (1074 files formatted, 1071 source files, `Success: no issues found`).
- `scripts/assemble_changelog.py --check` -> OK; `scripts/check_merge_base_overlap.py` -> no overlap.

## Measured evidence

No policy, simulation, rendering, recording or asset behaviour changes, so the artifact is a measured verdict matrix rather than a rollout. Every cell is read from two JSON dumps produced by one script run in two source trees (`main` and this branch) against the real `hf` binaries; the generator asserts each rendered claim, and that the two dumps came from different trees, before saving.

![measured huggingface_hub bucket-CLI floor](https://raw.githubusercontent.com/cagataycali/robots/artifacts/bucket-cli-floor/bucket_cli_floor.png)

The capable release is untouched: on 1.5.0 **both trees synced the dataset for real**, to a byte-identical bucket URI (`hf://buckets/.../cube_pick`) — asserted in the generator. Scripts: [wheel bisect](https://raw.githubusercontent.com/cagataycali/robots/artifacts/bucket-cli-floor/wheel_bisect.py), [real-CLI runtime probe](https://raw.githubusercontent.com/cagataycali/robots/artifacts/bucket-cli-floor/real_cli_runtime.sh), [measurement](https://raw.githubusercontent.com/cagataycali/robots/artifacts/bucket-cli-floor/measure_floor.py), [figure](https://raw.githubusercontent.com/cagataycali/robots/artifacts/bucket-cli-floor/compose_figure.py).