### PR TITLE
docs(training): the lerobot_local install rows name a stack that can actually train

### DIFF
--- a/changelog.d/1958-training-docs-name-the-trainer-extra.md
+++ b/changelog.d/1958-training-docs-name-the-trainer-extra.md
@@ -1,0 +1,20 @@
+### Docs: the training-overview install rows name a stack that can actually train
+
+`docs/training/overview.md` said the base `strands-robots[lerobot]` extra was
+"enough for ACT / diffusion from scratch" and that the `lerobot_local` install
+"works out of the box". Neither held for the operation the page is about.
+LeRobot's `train()` calls `require_package("accelerate", extra="training")`
+before it branches on device, and nothing on the `lerobot_local` path declares
+`accelerate` -- the `[lerobot]` extra is exactly `lerobot[feetech,dataset]`, and
+the only `strands-robots` extra that declares it is `cosmos3-diffusers`, a
+different provider. So the documented install refused on the first `train()`, on
+CPU and on GPU alike, and because `train()` reports that in its `TrainResult`
+rather than raising, an unchecked call passed a `checkpoint_dir` of `None` on
+instead of stopping.
+
+Every `lerobot_local` row now names `lerobot[training]` in its install line and
+quotes the call that refuses, so the "CPU needs it too" claim is checkable
+rather than asserted. The `HW floor` column read `1 consumer GPU`, reinforcing
+the same misconception; notebook 3 trains ACT on CPU, so it now reads `CPU for a
+toy run; 1 consumer GPU in practice`. `docs/troubleshooting.md` gains the
+symptom verbatim, since that string is what a reader searches for.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -30,7 +30,7 @@ and a single `--policy.type` flag can't express them:
 
 | Provider | Upstream entry point | Config surface | Launcher | HW floor |
 |----------|---------------------|----------------|----------|----------|
-| `lerobot_local` | `lerobot.scripts.lerobot_train` | draccus `--dotted.flags` | `python` / `accelerate launch` | 1 consumer GPU |
+| `lerobot_local` | `lerobot.scripts.lerobot_train` | draccus `--dotted.flags` | `python` / `accelerate launch` | CPU for a toy run; 1 consumer GPU in practice |
 | `groot` | Isaac-GR00T `launch_finetune.py` | `FinetuneConfig` (tyro) + `tune_*` flags | `python` / `torchrun` | 1 modern GPU |
 | `cosmos3` | `cosmos_framework.scripts.train` | TOML recipe + Hydra overrides; **DCP convert** + **safetensors export** | `torchrun` (HSDP) | 8×H100 80GB |
 
@@ -328,15 +328,34 @@ TrainSpec(..., num_gpus=8,
 
 ## Dependencies & extras (per provider)
 
-The base `strands-robots[lerobot]` extra is enough for **ACT / diffusion from
-scratch**, but VLA post-tunes pull in policy-specific stacks. Install the extra
-that matches your `extra["policy_type"]` / provider — verified on an L40S GPU:
+**Every `lerobot_local` row below also needs `lerobot[training]`, on CPU as well
+as GPU.** LeRobot's `train()` calls
+`require_package("accelerate", extra="training")` *before* it branches on
+device, so "no GPU" does not mean "no extra" - and nothing on this path pulls
+`accelerate` in: the `[lerobot]` extra is exactly `lerobot[feetech,dataset]`, and
+the only `strands-robots` extra that declares `accelerate` is
+`cosmos3-diffusers`, a different provider.
+
+```bash
+pip install "lerobot[training]"
+```
+
+`train()` reports the missing package in its `TrainResult` rather than raising,
+so check `result.status` and surface `result.message` - it carries LeRobot's own
+install remedy. An unchecked call hands whatever consumes `checkpoint_dir` a
+`None` instead.
+
+The base `strands-robots[lerobot]` extra covers **recording, streaming, and
+loading a trained checkpoint**, and with `lerobot[training]` it covers **ACT /
+diffusion from scratch**; VLA post-tunes pull in policy-specific stacks on top.
+Install the extra that matches your `extra["policy_type"]` / provider — verified
+on an L40S GPU:
 
 | Provider / policy | Install | Notes |
 |---|---|---|
-| `lerobot_local` + ACT / diffusion | `pip install 'strands-robots[lerobot]'` | works out of the box (torch + torchcodec + datasets) |
-| `lerobot_local` + `smolvla` | `pip install 'strands-robots[lerobot]' 'lerobot[smolvla]'` | lerobot 0.6's `[smolvla]` extra layers `transformers>=5.4.0,<5.6.0` + num2words on top. Do **not** pin `transformers==5.3.0` - it conflicts with lerobot 0.6's transformers floor. |
-| `lerobot_local` + `pi0` / `pi05` | `pip install 'strands-robots[lerobot]' 'lerobot[pi]'` | lerobot 0.6's `[pi]` extra (same `transformers>=5.4.0,<5.6.0` range + scipy) |
+| `lerobot_local` + ACT / diffusion | `pip install 'strands-robots[lerobot]' 'lerobot[training]'` | `[lerobot]` supplies torch + torchcodec + datasets; it does **not** supply `accelerate` |
+| `lerobot_local` + `smolvla` | `pip install 'strands-robots[lerobot]' 'lerobot[training]' 'lerobot[smolvla]'` | lerobot 0.6's `[smolvla]` extra layers `transformers>=5.4.0,<5.6.0` + num2words on top. Do **not** pin `transformers==5.3.0` - it conflicts with lerobot 0.6's transformers floor. |
+| `lerobot_local` + `pi0` / `pi05` | `pip install 'strands-robots[lerobot]' 'lerobot[training]' 'lerobot[pi]'` | lerobot 0.6's `[pi]` extra (same `transformers>=5.4.0,<5.6.0` range + scipy) |
 | `groot` | Isaac-GR00T checkout + its own venv (`omegaconf`, `tyro`, …); point `extra["groot_root"]` / `GR00T_ROOT` at it | launched as a subprocess, so it uses GR00T's interpreter, not ours |
 | `cosmos3` | cosmos-framework checkout (`uv sync --group=cu130-train`); point `extra["cosmos_root"]` / `COSMOS_ROOT` at it | torchrun-driven; same subprocess-interpreter rule |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,6 +11,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | `ModuleNotFoundError: mujoco` | Missing `[sim-mujoco]` | `uv pip install "strands-robots[sim-mujoco]"` |
 | `move_to: IK bridge unavailable: ... No module named 'mink'` | Missing `[sim-mujoco]` (the extra declares the IK solver) | `uv pip install "strands-robots[sim-mujoco]"` |
 | `ModuleNotFoundError: lerobot` | Missing `[lerobot]` | `uv pip install "strands-robots[lerobot]"` |
+| `training failed: 'accelerate' is required but not installed` | Missing LeRobot's `[training]` extra. `strands-robots[lerobot]` does not pull `accelerate` in, and `train()` requires it on CPU as well as GPU | `uv pip install "lerobot[training]"` |
 | `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.1,<0.7.0`) |
 | `ImportError: cannot import name 'MolmoAct2Policy'` | `lerobot < 0.6` (`MolmoAct2Policy` ships in lerobot >= 0.6) | `uv pip install "strands-robots[molmoact2]"` |
 | pyav build fails on Jetson/aarch64 | No prebuilt wheel for sm_110 | Use `--no-build-isolation` or install `torchcodec>=0.7` and skip pyav. See [installation](getting-started/installation.md#molmoact2-on-jetson) |

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -322,3 +322,97 @@ def test_wbc_extra_huggingface_hub_floor_is_at_least_1_0() -> None:
     assert ">=0.20.0" not in spec, f"[wbc] still pins the dead pre-1.0 huggingface_hub floor: {spec!r}"
     # keep the MAJOR cap (<2.0.0) per repo convention (>=1.0 deps cap the major)
     assert "<2.0.0" in spec, f"[wbc] huggingface_hub pin lost its <2.0.0 major cap: {spec!r}"
+
+
+# --- negative contract: the training docs must name a stack that can actually
+#     train. LeRobot's ``train()`` calls
+#     ``require_package("accelerate", extra="training")`` *before* it branches on
+#     device, so "no GPU" does not mean "no extra" -- and nothing on the
+#     ``lerobot_local`` path pulls ``accelerate`` in (the ``[lerobot]`` extra is
+#     exactly ``lerobot[feetech,dataset]``). ``docs/training/overview.md`` called
+#     that row "works out of the box", which is false for the one thing the page
+#     is about: a reader following it gets ``'accelerate' is required but not
+#     installed`` on the first ``train()``, on CPU and GPU alike, and -- because
+#     ``train()`` reports the failure in its ``TrainResult`` rather than raising --
+#     an unchecked call passes a ``checkpoint_dir`` of ``None`` on instead.
+#
+#     The notebooks state the requirement (pinned by
+#     ``tests/test_notebook_min_version_docs.py``); the canonical training page
+#     contradicted them. These keep both it and the troubleshooting table from
+#     drifting back. ---
+
+# every extra a `lerobot_local` user could install to reach `trainer.train(...)`
+_LEROBOT_PATH_EXTRAS = ("lerobot", "lerobot-async", "molmoact2", "all")
+
+
+def _extras_declaring_accelerate() -> set[str]:
+    return {
+        name
+        for name, reqs in _extras().items()
+        if any(Requirement(r).name.replace("-", "_").lower() == "accelerate" for r in reqs)
+    }
+
+
+def test_no_lerobot_path_extra_declares_accelerate() -> None:
+    """The premise the docs' ``lerobot[training]`` instruction rests on.
+
+    If a ``strands-robots`` extra on this path ever *does* vendor ``accelerate``
+    -- the deferred ``training`` extra that would layer ``lerobot[training]`` the
+    way ``lerobot-async`` layers ``lerobot[async]`` -- then the instruction is
+    obsolete and the docs must be re-cut to name that extra instead. Failing here
+    is the signal to do that, not to loosen the assertion.
+    """
+    declaring = _extras_declaring_accelerate()
+    # non-vacuity: the matcher really does find `accelerate` where it is declared,
+    # so the emptiness below is a fact about these extras and not a broken parse.
+    assert declaring, "no extra declares accelerate at all - the requirement matcher is not matching"
+    available = _extras()
+    for name in _LEROBOT_PATH_EXTRAS:
+        assert name in available, f"[{name}] extra vanished from pyproject; update _LEROBOT_PATH_EXTRAS"
+        assert name not in declaring, (
+            f"[{name}] now declares accelerate, so `pip install 'strands-robots[{name}]'` can train "
+            "on its own; docs/training/overview.md and docs/troubleshooting.md must stop instructing "
+            "`lerobot[training]` and name this extra instead"
+        )
+
+
+def _unwrapped(text: str) -> str:
+    """Collapse whitespace runs so a prose assertion survives a reflow.
+
+    Markdown joins the lines of a paragraph when it renders, so where a sentence
+    happens to wrap is not semantic -- and a pin that reads the raw file cannot
+    tell "the claim was removed" from "the paragraph was re-filled one column
+    narrower". Only the rendered wording is asserted below.
+    """
+    return " ".join(text.split())
+
+
+def test_training_overview_names_the_trainer_extra() -> None:
+    text = _unwrapped(_TRAINING_OVERVIEW.read_text())
+    # the false claim: [lerobot] alone cannot run train() on any device
+    assert "works out of the box" not in text, (
+        "docs/training/overview.md calls the lerobot_local ACT/diffusion install "
+        "'works out of the box', but train() refuses without accelerate, which no "
+        "extra on that path declares"
+    )
+    assert "extra is enough for **ACT / diffusion from" not in text, (
+        "docs/training/overview.md still claims the [lerobot] extra alone is enough to train from scratch"
+    )
+    # the remedy, and why it applies with no GPU in sight
+    assert "lerobot[training]" in text, "docs/training/overview.md lost the lerobot[training] requirement"
+    assert 'require_package("accelerate", extra="training")' in text, (
+        "docs/training/overview.md should name the call that refuses, so the "
+        "'CPU needs it too' claim is checkable rather than asserted"
+    )
+    assert "on CPU as well as GPU" in text
+
+
+def test_troubleshooting_has_a_remedy_for_the_missing_trainer_extra() -> None:
+    text = _unwrapped(_TROUBLESHOOTING.read_text())
+    # the symptom a reader actually sees, verbatim from lerobot's require_package
+    assert "'accelerate' is required but not installed" in text, (
+        "docs/troubleshooting.md has no row for the missing-accelerate training failure"
+    )
+    assert 'uv pip install "lerobot[training]"' in text, (
+        "docs/troubleshooting.md names the accelerate symptom without the lerobot[training] remedy"
+    )


### PR DESCRIPTION
## What

`docs/training/overview.md` is the canonical entry point for training, and its install table named a stack that cannot train.

Two claims, both false for the one operation the page is about:

- "The base `strands-robots[lerobot]` extra is **enough for ACT / diffusion from scratch**"
- the `lerobot_local` + ACT / diffusion row: `pip install 'strands-robots[lerobot]'`, noted as **"works out of the box"**

LeRobot's `train()` calls `require_package("accelerate", extra="training")` *before* it branches on device, and nothing on the `lerobot_local` path declares `accelerate`:

| extra | contents |
|---|---|
| `[lerobot]` | `lerobot[feetech,dataset]>=0.6.1,<0.7.0` |
| `[lerobot-async]`, `[molmoact2]`, `[all]` | layer on `[lerobot]`, add no `accelerate` |
| `[cosmos3-diffusers]` | `accelerate>=0.26` -- a **different provider**, not this path |

So the documented install refuses on the first `train()`, on CPU and on GPU alike. And because `train()` reports the failure in its `TrainResult` rather than raising, an unchecked call passes a `checkpoint_dir` of `None` on to whatever consumes it instead of stopping:

```
training failed: 'accelerate' is required but not installed. Install it with: pip install 'lerobot[training]'
```

The notebooks state this correctly as of #1956. This page contradicted them, which is the drift this PR closes.

## Changes

- **`docs/training/overview.md`** -- states the `lerobot[training]` requirement once for every `lerobot_local` row, quoting the call that refuses so the "CPU needs it too" claim is checkable rather than asserted, plus the `result.status` check that surfaces LeRobot's own remedy. Each row's install line now carries `lerobot[training]`, so a reader copying one line gets a working stack.
- **the `HW floor` column** read `1 consumer GPU`, which reinforces the same misconception the paragraph above corrects. Notebook 3 trains ACT on CPU, so it now reads `CPU for a toy run; 1 consumer GPU in practice`.
- **`docs/troubleshooting.md`** -- adds the symptom to the install table, quoting the error verbatim, since that string is what a reader will search for.
- **`changelog.d/1958-training-docs-name-the-trainer-extra.md`** -- news fragment; `scripts/assemble_changelog.py --check` OK (178 pending).

## Testing

Three pins added to `tests/test_lerobot_dependency_docs.py`, the suite that already owns training-doc dependency claims.

The two doc pins fail on the pre-fix docs -- verified by reverting `docs/` while keeping the tests:

| tree | result |
|---|---|
| pre-fix docs + new tests | **2 failed**, 17 passed |
| this branch | **19 passed** |

The third pins the *premise* rather than the prose: `test_no_lerobot_path_extra_declares_accelerate` reads `pyproject.toml` and asserts no extra on this path vendors `accelerate`, with a non-vacuity check that the matcher does find it where it is declared (so the emptiness is a fact about these extras, not a broken parse). If the deferred `training` extra ever lands -- layering `lerobot[training]` the way `lerobot-async` layers `lerobot[async]` -- that test fails and says to re-cut the docs onto the new extra rather than to loosen the assertion.

Prose assertions read a whitespace-normalized copy. Markdown joins the lines of a paragraph when it renders, so a pin on the raw file cannot tell a removed claim from a re-filled paragraph; this was caught while writing the pin, when a line-wrapped `require_package(...)` failed a pin that the rendered page satisfies.

```
pytest tests/test_lerobot_dependency_docs.py tests/test_docs_policy_coverage.py \
       tests/test_docs_home_navigation.py tests/test_docs_policy_nav_coverage.py \
       tests/test_changelog_fragments.py tests/test_notebook_min_version_docs.py
-> 56 passed
```

`ruff check` and `ruff format --check` clean on the changed test file.

## Scope

Docs, tests, and a changelog fragment only. No `strands_robots/` or `pyproject.toml` change.

**Deliberately not included:** declaring `accelerate` a real dependency via a `training` extra. That is the underlying bug, it changes the dependency graph, and #1956 already scoped it out of the patch cutting the floor fix for the same reason -- adding `wandb` + `accelerate` to `[lerobot]` would burden read-only dataset installs. This PR makes the *documentation* honest about the stack as it ships today, and the premise test above is what will flag the docs for a re-cut when that extra lands.

## Note for review

The branch is pushed from the account that would also approve it, so `require_last_push_approval` on the `default` ruleset means this needs an approving review from a **second** account -- `reviewDecision` will read `REVIEW_REQUIRED` until then, which is byte-for-byte what an unreviewed PR looks like. Flagging it per the AGENTS.md finding on #1722 / #1035 so it does not read as a mystery block.
