### PR TITLE
ci: refuse a closing keyword that only appears in a PR title

### DIFF
--- a/.github/workflows/closing-reference.yml
+++ b/.github/workflows/closing-reference.yml
@@ -1,0 +1,113 @@
+# .github/workflows/closing-reference.yml
+#
+# Refuses a pull request whose closing keyword appears only in its title.
+#
+# GitHub parses closing keywords from the body and from commit messages, never
+# from the title. A title reading `... (closes #1891)` therefore links nothing,
+# and nothing on either side of the merge says the claim was dropped -- a bare
+# cross-reference renders identically to the start of a closing link.
+#
+# Measured over the last 100 pull requests here: 29 titles carry a closing
+# keyword before an issue number, 27 also linked the issue, and 2 did not --
+# #1894 (`closes #1891`; #1891 was still open two days after the merge) and #1923
+# (`closes #1912`; closed by hand afterwards). Issue #1961 counts the wider cost:
+# 18 of the last 30 merges have neither a board item nor a closing link, so the
+# merged record is not countable. A dropped keyword is the half of that a machine
+# can catch.
+#
+# The check does not scan the body. #1894's body *does* say `closes #1891` -- in a
+# code span, which GitHub does not link -- so a text scan would have reported that
+# pull request clean. `closingIssuesReferences` is the link set itself, so the
+# only text parsed is the title, where GitHub does nothing and there is no ground
+# truth to read. See scripts/check_closing_reference.py for the full account.
+#
+# Out of scope, deliberately: a pull request that claims nothing anywhere. Whether
+# every change must trace to an issue is undecided (#1961, decision B) and 18 of
+# the last 30 merges would fail such a rule today. This job reads only what a
+# title already claims, so it needs no answer to that question.
+#
+# Unlike last-push-approval.yml, this one is self-clearing: moving the keyword
+# into the body makes GitHub create the link, and the `edited` trigger below means
+# the branch author alone can turn it green without pushing anything. That is why
+# it fails rather than warns.
+#
+# Whether a failure here blocks a merge is a branch-protection decision, not a
+# property of this file. Until the job is added to the required set it surfaces
+# the dropped claim and leaves the call to the reviewer.
+#
+
+name: Closing Reference Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+    # GitHub's default three, plus `edited`. That addition is load-bearing here, and is the deliberate opposite of the
+    # narrowing #1914 applied to the required test job. That job's input is the
+    # code, so re-running it for an event that changes no code buys nothing. This
+    # job's inputs are the *title* and the *link set*, and both change on exactly
+    # this event and on no other. Without it the remedy the report asks for --
+    # move the keyword into the body -- could not be verified without an
+    # unrelated push, which is the one thing a self-clearing check must not need.
+    #
+    # tests/test_pull_request_trigger_types.py refuses a sha-invariant type by
+    # default and exempts this file by name, because the harm it measures needs
+    # the required check to be started by the event: `pr-and-push.yml` does not
+    # subscribe to `edited` and keys its concurrency group on its own workflow
+    # name, so an edit starts no run in that group and cancels nothing. Both
+    # halves of that premise are pinned there, so this exemption cannot outlive
+    # its justification.
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # closingIssuesReferences is GraphQL-only and reads the pull request, so this
+  # is the one scope beyond `contents` the job needs. A fork's read-only token
+  # carries it, so cross-repository pull requests -- which is how every branch
+  # here is opened -- are checked the same way.
+  pull-requests: read
+
+jobs:
+  closing-reference:
+    name: Refuse a closing keyword that only appears in the title
+    runs-on: ubuntu-latest
+
+    steps:
+      # The BASE branch, for the reason changelog-fragment.yml documents at
+      # length (#1791): a branch that forked before this job landed does not
+      # carry the script, and running it out of the head tree dies with exit 2
+      # before the check begins -- a red X that accuses a branch which may have
+      # done nothing wrong, and which can never carry the real signal because it
+      # never gets far enough to compute one.
+      #
+      # Checking out the base costs nothing here because the script reads no file
+      # from the tree at all: its inputs are the title, which arrives through the
+      # environment, and the API. `fetch-depth` is left at its default for the
+      # same reason -- unlike that job, this one computes no merge base.
+      - name: Checkout the base branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # Standard library only, so there is nothing to install.
+      #
+      # The title goes through the environment rather than into the command line,
+      # because it is author-controlled text and `${{ }}` interpolation of it
+      # would be a shell-injection seam in a job that holds a token. The script
+      # reads PR_TITLE itself; it also falls back to the API's copy of the title,
+      # so a workflow that stopped setting it would still check the right string.
+      - name: Check for a closing keyword that links nothing
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/check_closing_reference.py

--- a/.github/workflows/closing-reference.yml
+++ b/.github/workflows/closing-reference.yml
@@ -105,9 +105,34 @@ jobs:
       # would be a shell-injection seam in a job that holds a token. The script
       # reads PR_TITLE itself; it also falls back to the API's copy of the title,
       # so a workflow that stopped setting it would still check the right string.
+      #
+      # The absence guard is the residual case #1791 could not cover. Checking out
+      # the base fixes a head that predates the script; it cannot fix a *base*
+      # that predates it, which is true for exactly one branch -- the one adding
+      # it. Measured on this pull request's own first run:
+      #
+      #     python3: can't open file '.../scripts/check_closing_reference.py'
+      #     Process completed with exit code 2
+      #
+      # and exit 2 is the state that issue reserves its argument for: it is
+      # neither the script's 0 nor its 1, and the checks UI renders it as the same
+      # red X as a real finding. The honest verdict when the base carries no copy
+      # of the check is that this base has no such rule to enforce, so the job
+      # says so and passes.
+      #
+      # It cannot become a standing no-op. The ref checked out is the base branch
+      # *tip*, not the merge base, so the file is absent only for runs that happen
+      # before this lands. Deleting it later is loud rather than silent: the pins
+      # in tests/test_closing_reference_gate.py load the script by path and fail
+      # at import if it is gone, and that suite is in the required check.
       - name: Check for a closing keyword that links nothing
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: python3 scripts/check_closing_reference.py
+        run: |
+          if [ ! -f scripts/check_closing_reference.py ]; then
+            echo "::notice title=No closing-reference rule on this base::The base branch carries no scripts/check_closing_reference.py, so there is no rule here to enforce."
+            exit 0
+          fi
+          python3 scripts/check_closing_reference.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,38 @@ hatch run format            # ruff check --fix, ruff format
    trace - until a `Status` written on the strength of it silently overwrites a
    value that was never read. Read a field before you set it, and treat an
    empty project read as unknown rather than as absent.
+   **A closing keyword in a PR *title* links nothing.** GitHub parses closing
+   keywords from the body and from commit messages, never from the title. A title
+   ending `... (closes #1891)` therefore leaves that issue open on merge, and
+   nothing on either side says the claim was dropped: a bare cross-reference
+   renders identically to the start of a closing link, and the field that would
+   contradict the title is one nobody opens. Measured over the last 100 pull
+   requests here - 29 titles carry a keyword before an issue number, 27 also
+   linked the issue, and two did not:
+
+   | pull request | title claims | links | what it cost |
+   |---|---|---|---|
+   | #1894 | `closes #1891` | none | #1891 was still open two days after the merge |
+   | #1923 | `closes #1912` | none | #1912 had to be closed by hand |
+
+   So put the keyword in the **body** - a line reading `Closes #N` - and leave the
+   title free to describe the change. This is now surfaced by
+   `.github/workflows/closing-reference.yml`, the same documented-and-enforced-by-
+   nothing shape as the changelog rule in step 3 before #1784.
+
+   It deliberately does **not** scan the body for the keyword, because that
+   implementation passes the incident it was written for: #1894's body *does* say
+   `closes #1891` - inside a code span, which GitHub does not link - so a text
+   scan and GitHub disagree on exactly the pull request that matters. The gate
+   compares the title against `closingIssuesReferences`, which is the link set
+   itself. Two consequences worth knowing when you write a description: a keyword
+   in a code span or a fenced block links nothing, and one keyword governs one
+   number, so `fixes #12 and #13` closes only #12.
+
+   The gate is self-clearing - editing the description creates the link and the
+   check re-runs on `edited` - and it says nothing about a pull request that
+   claims nothing anywhere. Whether every change must trace to an issue is the
+   separate question #1961 raises, where the board-coverage half of this lives.
 7. Squash merge into `main`
 8. **Verify a PR's state by reading it back - before and after you change it.**
    Neither direction can be inferred:

--- a/changelog.d/1963-closing-reference-gate.md
+++ b/changelog.d/1963-closing-reference-gate.md
@@ -1,0 +1,49 @@
+### Added: a closing keyword that only appears in a PR title is refused, not silently dropped
+
+GitHub parses closing keywords from a pull request's body and from its commit
+messages, never from its title. A title that ends in a closing keyword and an
+issue number therefore links nothing, and nothing on either side of the merge
+reports it: a bare cross-reference renders identically to the start of a closing
+link, so the title reads as a claim to every human who sees it while the field
+that would contradict it is one nobody opens.
+
+Measured over the last 100 pull requests here - 29 titles carry a closing keyword
+before an issue number, 27 also linked the issue, and two did not. #1894 claimed
+issue 1891 in its title alone, and that issue was still open two days later;
+#1923 claimed issue 1912 the same way and it had to be closed by hand. #1961
+counts the wider cost, 18 of the last 30 merges having neither a board item nor a
+closing link, and asks for this check by name. This is that half of it; the board
+question needs a decision and stays open there.
+
+`scripts/check_closing_reference.py` compares the numbers a title claims against
+`closingIssuesReferences`, surfaced by `.github/workflows/closing-reference.yml`.
+It deliberately does **not** scan the body, because that implementation passes the
+incident it was written for: #1894's body does carry the keyword, inside a code
+span, which GitHub does not link - so a text scan and GitHub disagree on precisely
+the pull request that matters. The link set is the answer GitHub already
+publishes, so the only text parsed is the title, where GitHub does nothing and
+there is consequently no ground truth to read. That the Actions token reads that
+field truthfully was verified against three pull requests rather than assumed,
+since #1961 records `projectItems` returning a false `0` under the same token; an
+unreadable or truncated answer is reported as its own outcome and passes, so a
+permission change can turn this neither into an accusation against every branch
+nor into a silent no-op.
+
+Four outcomes, because a title that claims nothing (71 of 100) and one whose claim
+is linked (27) are both ordinary and already visible. Only the two that dropped a
+claim are a finding. Unlike the last-push-approval report this one is
+self-clearing - moving the keyword into the body creates the link and the check
+re-runs on `edited` - which is why it fails rather than warns, and why it
+subscribes to an activity type that changes no code: its inputs are the title and
+the link set, and that is the only event that changes either. The prohibition in
+`tests/test_pull_request_trigger_types.py` is narrowed rather than waived, since
+the harm it measures needs the required check to be started by the event, and the
+two properties that make the exemption safe are now pinned there.
+
+What a title already claims is all this reads, so it needs no answer to whether
+every change must trace to an issue - the separate question #1961 raises. A pull
+request that claims nothing anywhere stays uncaught, which is the other way a link
+is lost.
+
+Tooling, tests and documentation only; no production code or runtime behaviour
+changes.

--- a/scripts/check_closing_reference.py
+++ b/scripts/check_closing_reference.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Refuse a pull request whose closing keyword only appears in its title.
+
+Why this exists
+---------------
+GitHub parses closing keywords from a pull request's **body** and from its
+**commit messages**. It never parses the title. A title reading
+``... (closes #1891)`` therefore links nothing: the issue is referenced, the
+timeline shows a cross-reference, and the pull request merges without closing
+it. Nothing on either side says the claim was dropped, because a cross-reference
+looks exactly like the beginning of a closing link.
+
+Measured over the last 100 pull requests in this repository, 29 titles carry a
+closing keyword followed by an issue number. 27 of them also linked the issue
+and are unaffected. Two did not::
+
+    #1894  "refactor(examples): remove the Isaac Replicator synth-data stub
+            (closes #1891)"          closingIssuesReferences: []   #1891 still OPEN
+    #1923  "fix(training/rl): the action head is sized and named from the
+            action keys (closes #1912)"
+                                     closingIssuesReferences: []   #1912 closed by hand
+
+#1891 was still open two days after the pull request that says it closes it
+merged. #1912 was closed separately, so the loss cost only the link. Both are the
+same defect, and it is invisible from the pull request: the title reads as a
+closing claim to every human who sees it, and the field that would contradict it
+is one nobody opens.
+
+The wider cost is that the merged record stops being countable. Issue #1961
+measured the project board against the last 30 merges and found 18 with neither a
+board item nor a closing link, so "what did this deliver" has no answer that does
+not involve reading diffs. A dropped closing keyword is one of the two ways an
+item gets into that set, and the only one a machine can catch.
+
+Why it reads the link set and not the body
+-----------------------------------------
+The obvious implementation -- scan the body for the same keyword and compare --
+**passes the incident it was written for**. #1894's body does contain the words
+``closes #1891``, inside a code span:
+
+    - [ ] #1891 stays open as the tracker (this PR uses `closes #1891` in the
+      commit for traceability ...)
+
+GitHub does not link from a code span, so the body scan and GitHub disagree on
+exactly the pull request that matters, and the check would report clean while the
+link was lost. Reimplementing enough of GitHub's markdown parser to get that
+right -- fenced blocks, code spans, block quotes, HTML comments -- is a second
+rulebook that can drift from the first, and it can only ever approximate an
+answer GitHub already publishes.
+
+So the body is not scanned at all. ``closingIssuesReferences`` **is** the link
+set, and the only text this script parses is the title, where GitHub does nothing
+and there is consequently no ground truth to read.
+
+That the Actions token can read that field is not assumed. Issue #1961 records
+``PullRequest.projectItems`` returning a false ``0`` under ``GITHUB_TOKEN``, so
+the same lens was checked here before relying on it -- ``GITHUB_TOKEN`` and a
+personal token return identical link sets for #1930 (two issues), #1960 (one) and
+#1894 (none). A false zero would turn this check into an accusation against every
+branch, which is why an ambiguous read is reported as ``unknown-links`` rather
+than as a finding.
+
+What this reports, and what it deliberately does not
+---------------------------------------------------
+``no-claim``
+    The title carries no closing keyword before an issue number. 71 of the last
+    100 pull requests. Nothing to say.
+
+``linked``
+    Every issue the title claims to close is in the link set. 27 of the last 100.
+    The convention working.
+
+``title-only-claim``
+    The finding: the title claims to close an issue that the pull request does
+    not link. Two of the last 100.
+
+``unknown-links``
+    The link set could not be read, or was truncated by the page size. Not a
+    finding -- an unreadable field is not evidence of a dropped claim.
+
+Three things are deliberately out of scope:
+
+- **A pull request that claims nothing anywhere.** Whether every change must
+  trace to an issue is an open question (#1961, decision B) and 18 of the last 30
+  merges would fail such a rule today. This check reads only what a title already
+  claims, so it needs no answer to that question and cannot be dismissed by one.
+  #1885 -- merged with no closing keyword at all while #1871 stayed open -- is in
+  that class and stays uncaught here. Naming it is the honest scope statement:
+  this closes one of the two ways a link is lost.
+- **Cross-repository (``owner/repo#12``) and URL reference forms.** Every
+  observed instance used a bare ``#N``, and a cross-repository claim would have
+  to resolve another repository's numbering to be comparable.
+- **Whether the claimed issue exists, or is already closed.** A stale number in a
+  title is a different defect, and refusing it would make this check fail on a
+  correct pull request whose issue someone else closed first.
+
+Unlike the last-push-approval report, this is **self-clearing**: moving the
+keyword into the body makes GitHub create the link, and the workflow re-runs on
+``edited``, so the branch author alone can turn it green. That is why it exits
+non-zero and annotates as an error rather than a warning.
+
+Usage
+-----
+``--repo``   ``owner/name`` (default: ``$GITHUB_REPOSITORY``).
+``--pr``     pull request number (default: ``$PR_NUMBER``).
+``--title``  the title to read (default: ``$PR_TITLE``; falls back to the pull
+             request's own title). Passed through the environment rather than
+             interpolated into the workflow's shell, because it is author-
+             controlled text.
+``--token``  API token (default: ``$GITHUB_TOKEN``). Needs ``pull-requests:
+             read``.
+
+Exit status is ``1`` for ``title-only-claim``, else ``0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+API_ROOT = "https://api.github.com"
+
+#: The keywords GitHub acts on, spelled out rather than built from stems so the
+#: set is greppable against GitHub's own documented list.
+CLOSING_KEYWORDS = (
+    "close",
+    "closes",
+    "closed",
+    "fix",
+    "fixes",
+    "fixed",
+    "resolve",
+    "resolves",
+    "resolved",
+)
+
+#: A closing claim: one keyword immediately followed by an issue number, with at
+#: most a colon and whitespace between them. Adjacency is what GitHub requires
+#: and it is what keeps this off ordinary titles -- "fix(sim): ... (#1948)" is
+#: not a claim because "(sim)" sits between the keyword and the number, and
+#: "follow-up to #1722" has no keyword at all. Both forms are common here.
+#: The leading word boundary keeps "prefixes #12" and "unfixed #12" out.
+_CLAIM = re.compile(
+    r"\b(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed))\b\s*:?\s*#(\d+)\b",
+    re.IGNORECASE,
+)
+
+#: How many linked issues to ask for. Above this the answer is treated as
+#: unreadable rather than as a short list, because a truncated link set would
+#: manufacture a finding out of a claim that is in fact linked.
+LINK_PAGE_SIZE = 100
+
+NO_CLAIM = "no-claim"
+LINKED = "linked"
+TITLE_ONLY_CLAIM = "title-only-claim"
+UNKNOWN_LINKS = "unknown-links"
+
+_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $first: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      title
+      closingIssuesReferences(first: $first) {
+        totalCount
+        nodes { number }
+      }
+    }
+  }
+}
+"""
+
+
+class LinkSetUnreadable(RuntimeError):
+    """The link set could not be read.
+
+    Named apart from the builtin to keep the distinction explicit at the call
+    site: this is "GitHub did not answer", not "the answer was empty". The two
+    must not collapse, because an empty answer is a finding and an unanswered
+    one is not.
+    """
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The outcome and the two number sets it was computed from."""
+
+    outcome: str
+    claimed: tuple[int, ...] = ()
+    linked: tuple[int, ...] = ()
+    unlinked: tuple[int, ...] = ()
+    detail: str = ""
+
+    @property
+    def is_finding(self) -> bool:
+        return self.outcome == TITLE_ONLY_CLAIM
+
+    @property
+    def summary(self) -> str:
+        if self.outcome == NO_CLAIM:
+            return "The title claims to close no issue, so there is no claim to lose."
+        if self.outcome == LINKED:
+            return (
+                f"The title claims to close {_issues(self.claimed)}, and the pull request links "
+                f"{'them' if len(self.claimed) > 1 else 'it'}. Merging will close "
+                f"{'them' if len(self.claimed) > 1 else 'it'}."
+            )
+        if self.outcome == UNKNOWN_LINKS:
+            return (
+                f"Could not read which issues this pull request links: {self.detail} "
+                "Not treated as a finding, because an unreadable link set is not evidence "
+                "that a claim was dropped."
+            )
+        return (
+            f"The title says this pull request closes {_issues(self.unlinked)}, but "
+            f"{'those issues are' if len(self.unlinked) > 1 else 'that issue is'} not in its "
+            "closing-issue links. GitHub reads closing keywords from the body and from commit "
+            f"messages, never from the title, so merging will leave "
+            f"{'them' if len(self.unlinked) > 1 else 'it'} open."
+        )
+
+
+def _issues(numbers: Sequence[int]) -> str:
+    """Render a number list as ``#1`` / ``#1 and #2`` / ``#1, #2 and #3``."""
+    rendered = [f"#{n}" for n in numbers]
+    if not rendered:
+        return "no issue"
+    if len(rendered) == 1:
+        return rendered[0]
+    return ", ".join(rendered[:-1]) + " and " + rendered[-1]
+
+
+def title_claims(title: str) -> tuple[int, ...]:
+    """Return the issue numbers the title claims to close, sorted and deduplicated.
+
+    One keyword governs one number: ``closes #1506, closes #1516`` claims both
+    (that is #1930's title, and both were linked), while ``fixes #12 and #13``
+    claims only #12 -- which is also how GitHub reads a body, so a title written
+    that way was already only ever going to close one of them.
+    """
+    return tuple(sorted({int(match.group(1)) for match in _CLAIM.finditer(title)}))
+
+
+def unlinked_claims(claimed: Sequence[int], linked: Sequence[int]) -> tuple[int, ...]:
+    """Return the claimed numbers absent from the link set, sorted."""
+    return tuple(sorted(set(claimed) - set(linked)))
+
+
+def classify(title: str, linked: Sequence[int] | None, detail: str = "") -> Verdict:
+    """Decide which of the four states this pull request is in.
+
+    ``linked`` of ``None`` means the link set could not be read, which is its own
+    outcome and not folded into either a pass or a finding: a silent API or
+    permission change must not be able to turn this check into a no-op that
+    always agrees, nor into one that accuses every branch.
+    """
+    claimed = title_claims(title)
+    if not claimed:
+        return Verdict(NO_CLAIM)
+    if linked is None:
+        return Verdict(UNKNOWN_LINKS, claimed, (), (), detail)
+    linked_sorted = tuple(sorted(set(linked)))
+    unlinked = unlinked_claims(claimed, linked_sorted)
+    if not unlinked:
+        return Verdict(LINKED, claimed, linked_sorted)
+    return Verdict(TITLE_ONLY_CLAIM, claimed, linked_sorted, unlinked)
+
+
+def _post(url: str, payload: dict[str, object], token: str) -> object:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "strands-robots-check-closing-reference",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed API host
+        return json.load(response)
+
+
+def resolve_pull_request(repo: str, pr: int, token: str) -> tuple[str, tuple[int, ...]]:
+    """Return the pull request's title and the issues it closes.
+
+    ``closingIssuesReferences`` is GraphQL-only -- no REST field carries it --
+    which is why this posts a query rather than reusing the plain ``GET`` the
+    last-push-approval check makes do with.
+
+    Raises ``LinkSetUnreadable`` for every answer that is not a complete link set,
+    including a truncated page: a link set cut off at ``LINK_PAGE_SIZE`` would
+    report a linked issue as unlinked, and the one thing this check must never do
+    is invent a dropped claim.
+    """
+    owner, _, name = repo.partition("/")
+    if not owner or not name:
+        raise LinkSetUnreadable(f"repository {repo!r} is not in owner/name form.")
+    payload = _post(
+        f"{API_ROOT}/graphql",
+        {"query": _QUERY, "variables": {"owner": owner, "name": name, "number": pr, "first": LINK_PAGE_SIZE}},
+        token,
+    )
+    if not isinstance(payload, dict):
+        raise LinkSetUnreadable("the API response was not a JSON object.")
+    if payload.get("errors"):
+        raise LinkSetUnreadable(f"the API returned errors: {json.dumps(payload['errors'])[:400]}")
+    pull = ((payload.get("data") or {}).get("repository") or {}).get("pullRequest")
+    if not isinstance(pull, dict):
+        raise LinkSetUnreadable(f"no pull request {repo}#{pr} in the response.")
+    references = pull.get("closingIssuesReferences") or {}
+    nodes = references.get("nodes") or []
+    total = references.get("totalCount")
+    if isinstance(total, int) and total > len(nodes):
+        raise LinkSetUnreadable(f"the link set is truncated ({total} links, {len(nodes)} read).")
+    numbers = tuple(int(node["number"]) for node in nodes if isinstance(node, dict) and "number" in node)
+    return str(pull.get("title") or ""), numbers
+
+
+def render(verdict: Verdict, repo: str, pr: int, title: str) -> str:
+    """Render the job-summary report for this run."""
+    escaped = title.replace("|", "\\|")
+    lines = [
+        "## Closing reference",
+        "",
+        f"Outcome: **{verdict.outcome}**",
+        "",
+        verdict.summary,
+        "",
+        "| field | value |",
+        "|---|---|",
+        f"| pull request | {repo}#{pr} |",
+        f"| title | {escaped} |",
+        f"| claimed by the title | {_issues(verdict.claimed)} |",
+        f"| linked by the pull request | {_issues(verdict.linked)} |",
+    ]
+    if verdict.is_finding:
+        lines += [
+            "",
+            "### What clears this",
+            "",
+            f"1. Put the keyword in the **body**: a line reading `Closes {_issues(verdict.unlinked)}`.",
+            "   GitHub creates the link when the description is saved, and this check re-runs on",
+            "   `edited`, so this is self-clearing without a push.",
+            "2. If the pull request should *not* close the issue, reword the title so it does not",
+            "   read as a claim -- `per #N`, `follow-up to #N`, `towards #N`. The reference still",
+            "   renders and the issue's timeline still shows the cross-reference.",
+            "",
+            "Note that a keyword inside a code span or a fenced block does not link either.",
+            "#1894's body contains `` `closes #1891` `` in backticks and linked nothing, which is",
+            "why this check reads the link set GitHub publishes rather than the body's text.",
+        ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--title", default=os.environ.get("PR_TITLE", ""))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    args = parser.parse_args(argv)
+
+    if not args.repo or not args.pr:
+        parser.error("--repo and --pr are required (or set GITHUB_REPOSITORY and PR_NUMBER)")
+    if not args.token:
+        parser.error("--token is required (or set GITHUB_TOKEN)")
+
+    pr = int(args.pr)
+    title = args.title
+    linked: tuple[int, ...] | None
+    detail = ""
+    try:
+        api_title, linked = resolve_pull_request(args.repo, pr, args.token)
+        title = title or api_title
+    except (LinkSetUnreadable, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
+        linked, detail = None, str(exc)
+        print(f"check_closing_reference: {detail}", file=sys.stderr)
+
+    verdict = classify(title, linked, detail)
+    report = render(verdict, args.repo, pr, title)
+    print(report)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+    if verdict.is_finding:
+        print(
+            f"::error title=A closing keyword in the title links nothing::{verdict.summary} "
+            f"Move it into the pull request body."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_closing_reference_gate.py
+++ b/tests/test_closing_reference_gate.py
@@ -387,10 +387,33 @@ def test_the_gate_asks_for_the_scope_the_link_set_needs() -> None:
 
 
 def test_the_gate_runs_the_script_from_the_base_checkout() -> None:
-    """#1791: a branch that forked before this job landed does not carry the script."""
+    """#1791: a branch that forked before this job landed does not carry the script.
+
+    Checking out the base also means the job never executes the code it is
+    reviewing, which matters for a job holding a token on a fork's pull request.
+    """
     workflow = _workflow()
     assert "ref: ${{ github.base_ref }}" in workflow
-    assert "run: python3 scripts/check_closing_reference.py" in workflow
+    assert "python3 scripts/check_closing_reference.py" in workflow
+
+
+def test_the_gate_passes_when_the_base_carries_no_copy_of_the_check() -> None:
+    """The residual case a base checkout cannot cover: the branch that adds the script.
+
+    Measured on this pull request's own first run, which died with
+    ``can't open file ... check_closing_reference.py`` and exit 2 -- neither of the
+    script's own statuses, and rendered by the checks UI as the same red X as a
+    real finding, which is the argument #1791 makes about exit 2.
+
+    This is a bounded condition and not a bypass: the ref checked out is the base
+    branch tip rather than the merge base, so the file is missing only for runs
+    that happen before this lands. A later deletion is caught by the module-level
+    load at the top of this file, which fails at import, in the required check.
+    """
+    workflow = _workflow()
+    assert "if [ ! -f scripts/check_closing_reference.py ]; then" in workflow
+    assert "::notice title=No closing-reference rule on this base::" in workflow
+    assert _SCRIPT.exists()
 
 
 def test_the_title_reaches_the_script_through_the_environment() -> None:
@@ -398,6 +421,6 @@ def test_the_title_reaches_the_script_through_the_environment() -> None:
     workflow = _workflow()
     assert "PR_TITLE: ${{ github.event.pull_request.title }}" in workflow
 
-    run_lines = [line for line in workflow.splitlines() if line.lstrip().startswith("run:")]
-    assert run_lines
-    assert all("${{" not in line for line in run_lines)
+    invocation = [line for line in workflow.splitlines() if "check_closing_reference.py" in line]
+    assert invocation
+    assert all("${{" not in line for line in invocation)

--- a/tests/test_closing_reference_gate.py
+++ b/tests/test_closing_reference_gate.py
@@ -1,0 +1,403 @@
+"""Pins the closing-reference check against the titles this repository actually shipped.
+
+The measurement that motivates the check is a corpus, not an anecdote: over the
+last 100 pull requests, 29 titles carry a closing keyword before an issue number,
+27 of those also linked the issue, and exactly 2 did not. So the interesting
+properties are the two the corpus below fixes in place -- that the scanner fires
+on the two known incidents, and that it stays silent on the 71 ordinary titles,
+whose ``fix(scope):`` prefixes and bare ``#1722`` references are precisely the
+shapes a careless keyword regexp mistakes for a claim.
+
+The other load-bearing pin is ``test_a_body_that_mentions_the_keyword_cannot_clear_a_claim``.
+#1894's body *does* contain the words ``closes #1891``, inside a code span, and
+GitHub linked nothing -- so the obvious implementation of this check passes the
+incident it was written for. Reading the published link set instead is the design
+decision that test exists to protect.
+
+See scripts/check_closing_reference.py, issue #1961, and the "PR Workflow"
+section of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "scripts" / "check_closing_reference.py"
+_WORKFLOW = _ROOT / ".github" / "workflows" / "closing-reference.yml"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_closing_reference", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# The script is annotated and mypy-clean on its own
+# (mypy scripts/check_closing_reference.py); it is reached through importlib here
+# because scripts/ is not an importable package, so its members are module
+# attributes at runtime rather than names mypy can resolve to types.
+mod = _load()
+
+
+# --------------------------------------------------------------------------
+# The measured corpus. Real titles, with the link set GitHub reported for each
+# (verified identical under GITHUB_TOKEN and a personal token, because #1961
+# records PullRequest.projectItems returning a false 0 under the former).
+#
+# The two findings are the whole point; the clean rows are what proves the
+# scanner is not simply firing on everything.
+# --------------------------------------------------------------------------
+MEASURED = [
+    pytest.param(
+        "refactor(examples): remove the Isaac Replicator synth-data stub (closes #1891)",
+        (),
+        mod.TITLE_ONLY_CLAIM,
+        (1891,),
+        id="pr1894-claim-dropped-issue-stayed-open",
+    ),
+    pytest.param(
+        "fix(training/rl): the action head is sized and named from the action keys (closes #1912)",
+        (),
+        mod.TITLE_ONLY_CLAIM,
+        (1912,),
+        id="pr1923-claim-dropped-issue-closed-by-hand",
+    ),
+    pytest.param(
+        "fix(deps): floor lerobot at >=0.6.1 so bucket streaming is resolver-guaranteed (closes #1506, closes #1516)",
+        (1506, 1516),
+        mod.LINKED,
+        (),
+        id="pr1930-two-claims-both-linked",
+    ),
+    pytest.param(
+        "ci: name the pull request whose only approval its own pusher supplied (closes #1905)",
+        (1905,),
+        mod.LINKED,
+        (),
+        id="pr1921-claim-linked",
+    ),
+    pytest.param(
+        "docs(agents): PR Workflow step 1 names the rule that forces a fork",
+        (1959,),
+        mod.NO_CLAIM,
+        (),
+        id="pr1960-linked-without-claiming-in-the-title",
+    ),
+    pytest.param(
+        "fix(training): val_episodes is one shared positive-count domain for both writers of eval_split",
+        (),
+        mod.NO_CLAIM,
+        (),
+        id="pr1955-no-claim-no-link",
+    ),
+    pytest.param(
+        "fix(sim): bound the lock hold in step on every backend",
+        (),
+        mod.NO_CLAIM,
+        (),
+        id="pr1885-the-other-way-a-link-is-lost-stays-uncaught",
+    ),
+]
+
+
+@pytest.mark.parametrize("title,linked,outcome,unlinked", MEASURED)
+def test_the_measured_titles_classify_as_observed(
+    title: str, linked: tuple[int, ...], outcome: str, unlinked: tuple[int, ...]
+) -> None:
+    verdict = mod.classify(title, linked)
+    assert verdict.outcome == outcome
+    assert verdict.unlinked == unlinked
+
+
+def test_the_finding_is_two_of_the_measured_titles_and_not_the_rest() -> None:
+    """Non-vacuity, stated as a count.
+
+    A scanner that matched nothing would make every row above pass its own
+    assertion by reporting ``no-claim``, so the corpus is also asserted as a
+    population: two findings, and the claim-bearing rows outnumber them.
+    """
+    verdicts = [mod.classify(case.values[0], case.values[1]) for case in MEASURED]
+    findings = [v for v in verdicts if v.is_finding]
+    claiming = [v for v in verdicts if v.claimed]
+
+    assert len(findings) == 2
+    assert len(claiming) == 4
+    assert sorted(n for v in findings for n in v.unlinked) == [1891, 1912]
+
+
+@pytest.mark.parametrize("keyword", mod.CLOSING_KEYWORDS)
+@pytest.mark.parametrize("case", [str.lower, str.upper, str.capitalize])
+def test_every_documented_keyword_is_a_claim_in_any_case(keyword: str, case: Any) -> None:
+    """All nine keywords GitHub acts on, in the three casings that occur in titles.
+
+    Pinned against the constant rather than a hand-written list so the two cannot
+    drift: a keyword added to CLOSING_KEYWORDS but not to the pattern fails here.
+    """
+    assert mod.title_claims(f"fix(sim): something {case(keyword)} #1234") == (1234,)
+
+
+@pytest.mark.parametrize(
+    "separator",
+    ["closes #12", "closes  #12", "closes: #12", "closes:#12", "closes#12", "(closes #12)"],
+)
+def test_the_keyword_may_be_separated_from_the_number_by_punctuation(separator: str) -> None:
+    assert mod.title_claims(f"docs: a change {separator}") == (12,)
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        # The dominant title shape in this repository. "fix(" is a keyword
+        # followed by a scope, not by a number, and the trailing reference has no
+        # keyword before it -- both halves have to be got right for the 71
+        # no-claim titles in the corpus to stay quiet.
+        "fix(tools): pose_tool honors its steps / step_delay interpolation options",
+        "fix(sim/newton): set_timestep applies the one shared timestep domain (#1931)",
+        "refactor(mesh): migrate RosbridgeRobot onto MobileBaseRobot, follow-up to #1722",
+        "docs: see #1234 for the rationale",
+        "test(sim): a regression for the defect reported in #1823",
+        "revert of #1840",
+        # Word-boundary traps: both contain a keyword as a substring.
+        "docs: the prefixes #12 uses",
+        "fix: an unfixed #12 remains unfixed",
+    ],
+)
+def test_a_reference_without_an_adjacent_keyword_is_not_a_claim(title: str) -> None:
+    assert mod.title_claims(title) == ()
+
+
+def test_one_keyword_governs_one_number() -> None:
+    """How GitHub reads a body, applied to a title.
+
+    ``closes #1506, closes #1516`` claims both -- that is #1930, and both were
+    linked. ``fixes #12 and #13`` claims only #12, because #13 has no keyword of
+    its own; a body written that way would also only have closed one, so
+    reporting the second as a dropped claim would be wrong.
+    """
+    assert mod.title_claims("fix: closes #1506, closes #1516") == (1506, 1516)
+    assert mod.title_claims("fix: fixes #12 and #13") == (12,)
+
+
+def test_a_number_claimed_twice_is_reported_once() -> None:
+    assert mod.title_claims("fix: closes #12, fixes #12") == (12,)
+
+
+def test_a_body_that_mentions_the_keyword_cannot_clear_a_claim() -> None:
+    """The design decision, pinned.
+
+    #1894's body contains ``closes #1891`` inside a code span. GitHub does not
+    link from a code span, so its link set is empty while its body text matches a
+    keyword scan -- which means the obvious implementation of this check reports
+    the incident it was written for as clean. Reading the published link set is
+    what makes the two agree, and this test fails for any reimplementation that
+    goes back to reading the body.
+    """
+    title = "refactor(examples): remove the Isaac Replicator synth-data stub (closes #1891)"
+    verdict = mod.classify(title, ())
+
+    assert verdict.is_finding
+    assert verdict.unlinked == (1891,)
+
+
+def test_a_claim_linked_to_a_different_issue_is_still_a_finding() -> None:
+    """Linking *something* is not linking what the title promised."""
+    verdict = mod.classify("fix: closes #1891", (1890,))
+    assert verdict.is_finding
+    assert verdict.unlinked == (1891,)
+
+
+def test_a_partially_linked_claim_names_only_the_missing_issue() -> None:
+    verdict = mod.classify("fix: closes #1506, closes #1516", (1506,))
+    assert verdict.is_finding
+    assert verdict.claimed == (1506, 1516)
+    assert verdict.unlinked == (1516,)
+    assert "#1516" in verdict.summary
+    assert "#1506" not in verdict.summary
+
+
+def test_an_unreadable_link_set_is_not_a_finding() -> None:
+    """An unanswered question must not be reported as a dropped claim.
+
+    #1961 measured ``PullRequest.projectItems`` returning a false ``0`` under the
+    Actions token. Were ``closingIssuesReferences`` ever to behave that way, an
+    empty-means-missing reading would put a red X on every branch whose title
+    names an issue, so the two are kept apart: ``None`` is "GitHub did not
+    answer", ``()`` is "GitHub answered none".
+    """
+    verdict = mod.classify("fix: closes #1891", None, "the API returned errors: ...")
+
+    assert verdict.outcome == mod.UNKNOWN_LINKS
+    assert verdict.is_finding is False
+    assert verdict.claimed == (1891,)
+    assert "not evidence" in verdict.summary
+
+
+def test_a_truncated_link_set_is_reported_as_unreadable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A page cut short would report a linked issue as unlinked."""
+    monkeypatch.setattr(
+        mod,
+        "_post",
+        lambda *_a, **_k: {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "title": "fix: closes #12",
+                        "closingIssuesReferences": {"totalCount": 101, "nodes": [{"number": 12}]},
+                    }
+                }
+            }
+        },
+    )
+    with pytest.raises(mod.LinkSetUnreadable, match="truncated"):
+        mod.resolve_pull_request("strands-labs/robots", 1, "token")
+
+
+def test_api_errors_are_unreadable_rather_than_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_post", lambda *_a, **_k: {"errors": [{"message": "Resource not accessible"}]})
+    with pytest.raises(mod.LinkSetUnreadable, match="returned errors"):
+        mod.resolve_pull_request("strands-labs/robots", 1, "token")
+
+
+def test_a_complete_link_set_is_returned_with_the_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_post",
+        lambda *_a, **_k: {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "title": "fix: closes #1506, closes #1516",
+                        "closingIssuesReferences": {"totalCount": 2, "nodes": [{"number": 1506}, {"number": 1516}]},
+                    }
+                }
+            }
+        },
+    )
+    title, linked = mod.resolve_pull_request("strands-labs/robots", 1930, "token")
+    assert title == "fix: closes #1506, closes #1516"
+    assert linked == (1506, 1516)
+
+
+def test_the_finding_report_names_the_issue_and_both_remedies() -> None:
+    verdict = mod.classify("refactor(examples): remove the stub (closes #1891)", ())
+    report = mod.render(verdict, "strands-labs/robots", 1894, "refactor(examples): remove the stub (closes #1891)")
+
+    assert "title-only-claim" in report
+    assert "#1891" in report
+    assert "Closes #1891" in report
+    assert "reword the title" in report
+    assert "code span" in report
+    assert "never from the title" in verdict.summary
+
+
+def test_a_clean_report_says_so_without_a_remedy_section() -> None:
+    verdict = mod.classify("ci: a change (closes #1905)", (1905,))
+    report = mod.render(verdict, "strands-labs/robots", 1921, "ci: a change (closes #1905)")
+
+    assert "linked" in report
+    assert "What clears this" not in report
+
+
+def test_a_pipe_in_the_title_does_not_break_the_report_table() -> None:
+    title = "fix: a | b (closes #12)"
+    report = mod.render(mod.classify(title, ()), "strands-labs/robots", 1, title)
+    assert r"a \| b" in report
+
+
+@pytest.mark.parametrize(
+    "title,linked,status",
+    [
+        ("refactor(examples): remove the stub (closes #1891)", (), 1),
+        ("ci: a change (closes #1905)", (1905,), 0),
+        ("fix(sim): bound the lock hold in step on every backend", (), 0),
+    ],
+)
+def test_the_exit_status_is_one_only_for_the_finding(
+    title: str, linked: tuple[int, ...], status: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(mod, "resolve_pull_request", lambda *_a, **_k: (title, linked))
+
+    argv = ["--repo", "strands-labs/robots", "--pr", "1", "--title", title, "--token", "token"]
+    assert mod.main(argv) == status
+
+
+def test_a_lookup_failure_exits_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The check reports nothing rather than accusing a branch it could not read."""
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+
+    def explode(*_a: object, **_k: object) -> tuple[str, tuple[int, ...]]:
+        raise mod.LinkSetUnreadable("no pull request in the response.")
+
+    monkeypatch.setattr(mod, "resolve_pull_request", explode)
+    argv = ["--repo", "strands-labs/robots", "--pr", "1", "--title", "fix: closes #1891", "--token", "token"]
+    assert mod.main(argv) == 0
+
+
+# --------------------------------------------------------------------------
+# The workflow that runs it.
+#
+# Read as text rather than parsed, which is how every other workflow pin in this
+# suite reads one (tests/test_dependabot_config_location.py,
+# tests/test_codeql_query_filters.py): ``pyyaml`` is an optional dependency here,
+# so a pin that imports it becomes a pin that skips, and skipping is how a
+# structural guard stops guarding without anyone noticing.
+# --------------------------------------------------------------------------
+def _workflow() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_the_gate_reruns_when_the_title_or_body_is_edited() -> None:
+    """``edited`` is the trigger that makes the remedy verifiable.
+
+    The report asks the author to move the keyword into the body, which changes no
+    code. #1914 narrowed the required test job away from exactly such events --
+    correctly, since its input is the code -- so the opposite choice here is
+    pinned rather than left as a line in a comment: without ``edited`` the only
+    way to re-run this check would be an unrelated push, and a self-clearing gate
+    that needs a push to clear is not self-clearing.
+    """
+    match = re.search(r"^\s*types:\s*\[([^\]]*)\]", _workflow(), re.MULTILINE)
+    assert match, "the pull_request trigger declares no explicit types"
+    types = {t.strip() for t in match.group(1).split(",")}
+
+    assert "edited" in types
+    assert {"opened", "reopened", "synchronize"} <= types
+
+
+def test_the_gate_asks_for_the_scope_the_link_set_needs() -> None:
+    """``pull-requests: read`` is what makes closingIssuesReferences readable.
+
+    Without it the query returns errors, the script reports ``unknown-links``, and
+    the check passes everything -- a silent no-op rather than a visible failure,
+    which is the failure mode worth pinning.
+    """
+    assert re.search(r"^permissions:$", _workflow(), re.MULTILINE)
+    assert re.search(r"^\s+pull-requests:\s*read\s*$", _workflow(), re.MULTILINE)
+
+
+def test_the_gate_runs_the_script_from_the_base_checkout() -> None:
+    """#1791: a branch that forked before this job landed does not carry the script."""
+    workflow = _workflow()
+    assert "ref: ${{ github.base_ref }}" in workflow
+    assert "run: python3 scripts/check_closing_reference.py" in workflow
+
+
+def test_the_title_reaches_the_script_through_the_environment() -> None:
+    """Author-controlled text interpolated into a shell would be an injection seam."""
+    workflow = _workflow()
+    assert "PR_TITLE: ${{ github.event.pull_request.title }}" in workflow
+
+    run_lines = [line for line in workflow.splitlines() if line.lstrip().startswith("run:")]
+    assert run_lines
+    assert all("${{" not in line for line in run_lines)

--- a/tests/test_pull_request_trigger_types.py
+++ b/tests/test_pull_request_trigger_types.py
@@ -55,6 +55,22 @@ reintroduces one. Every other ``pull_request`` workflow in the repository
 ``llm-input-safety``) already takes that default; ``pr-and-push.yml`` was the
 only one that did not, and it is the only one holding a required check.
 
+One workflow is exempt, and the shape of the exemption matters more than the
+entry. The rule above is a statement about *what a workflow reads*: a run whose
+input is the tree learns nothing from an event that cannot change the tree.
+``closing-reference.yml`` does not read the tree -- its inputs are the pull
+request's title and its ``closingIssuesReferences``, and ``edited`` is the only
+event that changes either. It is also the event that check's own remedy produces:
+moving a closing keyword out of the title and into the body changes no sha, so
+without ``edited`` the report would ask for a fix it could never observe.
+
+The measured harm cannot follow from it either, and that is a premise rather than
+an assurance: cancellation is per concurrency group, ``pr-and-push.yml`` keys its
+group on its own ``github.workflow`` name and does not subscribe to ``edited``,
+so an edit starts no run in that group. Both halves are read back by
+``test_an_exempt_workflow_cannot_cancel_the_required_check``, so an exemption
+cannot outlive the reasoning that admitted it.
+
 ``test_no_workflow_gates_on_draft_status`` is the premise behind dropping
 ``ready_for_review`` specifically: nothing in the fleet skips a draft pull
 request, so a draft's CI has already run and marking it ready re-runs the same
@@ -82,6 +98,19 @@ _REQUIRED_CHECK_WORKFLOW = _WORKFLOW_DIR / "pr-and-push.yml"
 #: for ``pull_request``, which is why omitting the key entirely is the preferred
 #: spelling: there is then no second copy of this list to drift from it.
 _SHA_CHANGING_TYPES = frozenset({"opened", "synchronize", "reopened"})
+
+#: Workflows whose input is not the tree, mapped to the sha-invariant activity
+#: types they consequently need. An entry here is not a waiver of the rule above
+#: but an application of it -- the rule asks whether an event can change what the
+#: workflow reads, and for these the answer is yes. Safety rests on the required
+#: check being unreachable by the event, which
+#: ``test_an_exempt_workflow_cannot_cancel_the_required_check`` reads back.
+_INPUT_IS_NOT_THE_TREE = {
+    # Reads the title and the link set (scripts/check_closing_reference.py), and
+    # ``edited`` is both the only event that changes them and the event its own
+    # remedy produces.
+    "closing-reference.yml": frozenset({"edited"}),
+}
 
 #: Matches a top-level trigger key inside an ``on:`` mapping, e.g.
 #: ``  pull_request:`` or ``  push:``.
@@ -138,6 +167,12 @@ def _pull_request_types(text: str) -> list[str] | None:
     return None
 
 
+def _workflow_name(text: str) -> str:
+    """Return a workflow's ``name:``, which is the ``github.workflow`` its concurrency group keys on."""
+    match = re.search(r"^name:\s*(?P<name>.+?)\s*$", text, re.MULTILINE)
+    return match.group("name") if match else ""
+
+
 def test_the_scanner_finds_the_pull_request_workflows() -> None:
     """Guard the pins below against a regex that quietly matches nothing.
 
@@ -170,7 +205,8 @@ def test_no_pull_request_trigger_subscribes_to_a_sha_invariant_type() -> None:
         types = _pull_request_types(path.read_text(encoding="utf-8"))
         if types is None:
             continue
-        extra = sorted(set(types) - _SHA_CHANGING_TYPES)
+        allowed = _SHA_CHANGING_TYPES | _INPUT_IS_NOT_THE_TREE.get(path.name, frozenset())
+        extra = sorted(set(types) - allowed)
         if extra:
             offenders[path.name] = extra
     assert not offenders, (
@@ -195,6 +231,34 @@ def test_the_required_check_workflow_takes_the_default_types() -> None:
         f"{_REQUIRED_CHECK_WORKFLOW.name} lists pull_request types explicitly ({types}); "
         "omit the key so there is one definition of which events can change a head sha"
     )
+
+
+def test_an_exempt_workflow_cannot_cancel_the_required_check() -> None:
+    """The premise every entry in :data:`_INPUT_IS_NOT_THE_TREE` rests on.
+
+    An exemption is safe only while the exempt event cannot reach the required
+    check, and that holds for two independent reasons which are both read back
+    here: the required check does not subscribe to the event, and cancellation is
+    scoped to a concurrency group keyed on the workflow's own name. If either
+    stops being true, the exempt workflow starts discarding the required check's
+    progress and this fails with the entry that did it.
+    """
+    required = _REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8")
+    required_types = set(_pull_request_types(required) or _SHA_CHANGING_TYPES)
+
+    assert _INPUT_IS_NOT_THE_TREE, "the exemption table is empty; this pin has nothing to check"
+    for name, exempt_types in _INPUT_IS_NOT_THE_TREE.items():
+        path = _WORKFLOW_DIR / name
+        assert path.exists(), f"{name} is exempt but does not exist"
+        text = path.read_text(encoding="utf-8")
+
+        assert not exempt_types & required_types, (
+            f"{name} is exempt for {sorted(exempt_types)}, but the required check now subscribes to "
+            f"{sorted(exempt_types & required_types)} too, so those events do discard its run"
+        )
+        assert _workflow_name(text) != _workflow_name(required), (
+            f"{name} now shares the required check's workflow name, so it shares its concurrency group"
+        )
 
 
 def test_the_required_check_discards_its_in_flight_run() -> None:


### PR DESCRIPTION
## What this refuses

GitHub parses closing keywords from a pull request's **body** and from its **commit messages**. It never parses the title. A title that ends in a closing keyword and an issue number therefore links nothing: the issue is cross-referenced, the pull request merges, and the issue stays open. Nothing on either side reports it, because a bare cross-reference renders identically to the start of a closing link, and the field that would contradict the title is one nobody opens.

Two pull requests in the last hundred did exactly that. Titles quoted in a fenced block so this description does not itself create the links it is about:

```
#1894  refactor(examples): remove the Isaac Replicator synth-data stub (closes #1891)
#1923  fix(training/rl): the action head is sized and named from the action keys (closes #1912)
```

| pull request | title claims | `closingIssuesReferences` | what it cost |
|---|---|---|---|
| #1894 | issue 1891 | empty | issue 1891 was still open two days after the merge, and is open now |
| #1923 | issue 1912 | empty | issue 1912 had to be closed by hand |

Issue #1961 counts the wider cost - 18 of the last 30 merges carry neither a board item nor a closing link, so the merged record is not countable - and asks for this check by name. This delivers that half. It is **not** a resolution of that issue, which needs decision A (the board's unit of work) and decision B (whether an unlinked pull request is acceptable) from a maintainer.

> Recorded because it happened while writing this description, and it is the argument in miniature: the first draft of the sentence above placed a closing keyword immediately before that issue's number inside an explicit **denial**, and GitHub created the closing link anyway - `closingIssuesReferences: [1961]` on this pull request until the wording was changed. The parse is lexical, not semantic. The two titles in the fenced block above, by contrast, linked nothing at all. One body, both failure directions, and no field on the pull request distinguishes an intended link from an accident. That is why the check compares the title against the link set GitHub publishes rather than against anybody's reading of the prose.

## The measurement

Re-running the classifier over the last 100 pull requests, using the link set GitHub publishes for each:

| outcome | count |
|---|---|
| `no-claim` - title claims nothing | 71 |
| `linked` - title claims, and the pull request links it | 27 |
| `title-only-claim` - **the finding** | 2 (#1894, #1923) |

No false positive on a real title. That matters because the dominant title shape here is `fix(scope): ...`, whose first token *is* a closing keyword, and references like `follow-up to #1722` are common. Adjacency is what separates them: a keyword must be followed by the number, with at most a colon and whitespace between, which is also GitHub's own rule.

End to end against the live API, with the Actions token:

```
--- PR #1894 -> exit 1 :: Outcome: **title-only-claim**
--- PR #1923 -> exit 1 :: Outcome: **title-only-claim**
--- PR #1930 -> exit 0 :: Outcome: **linked**        (two claims, both linked)
--- PR #1960 -> exit 0 :: Outcome: **no-claim**      (linked without claiming in the title)
--- PR #1955 -> exit 0 :: Outcome: **no-claim**
```

## Why it does not read the body

The obvious implementation - scan the body for the same keyword and compare - **passes the incident it was written for.** #1894's body does carry the words, inside a code span:

```
- [ ] #1891 stays open as the tracker (this PR uses `closes #1891` in the
  commit for traceability ...)
```

GitHub does not link from a code span, so a text scan and GitHub disagree on precisely the pull request that matters, and the check would report it clean. Reimplementing enough of GitHub's markdown handling to get that right - fenced blocks, code spans, block quotes, HTML comments - is a second rulebook that can drift from the first, and it can only ever approximate an answer GitHub already publishes.

So the body is not read at all. `closingIssuesReferences` **is** the link set. The only text parsed is the title, where GitHub does nothing and there is consequently no ground truth to read. `tests/test_closing_reference_gate.py::test_a_body_that_mentions_the_keyword_cannot_clear_a_claim` fails for any reimplementation that goes back to reading the body.

That the Actions token reads that field truthfully was verified rather than assumed - #1961 records `PullRequest.projectItems` returning a false `0` under `GITHUB_TOKEN`, so the same lens was checked here: `GITHUB_TOKEN` and a personal token return identical link sets for #1930 (two), #1960 (one) and #1894 (none). An unreadable or truncated answer is reported as `unknown-links` and passes, so a permission change cannot turn this into an accusation against every branch - nor into a silent no-op, since `unknown-links` is a distinct outcome rather than a fold into a pass.

## The trigger, and the guard it had to answer to

`tests/test_pull_request_trigger_types.py` refuses a `pull_request` activity type that cannot change the head sha. This gate needs `edited`: its inputs are the title and the link set, `edited` is the only event that changes either, and it is the event the check's own remedy produces - moving a keyword into the body changes no sha, so without it the report would ask for a fix it could never observe, and a self-clearing gate that needs a push to clear is not self-clearing.

The rule is **narrowed to what its evidence supports, not waived.** Its harm is that a redundant event discards an in-flight run of the required check. That needs the required check to be started by the event, and it is not: `pr-and-push.yml` does not subscribe to `edited`, and cancellation is scoped to a concurrency group keyed on `github.workflow`, which differs. Both halves are now read back by `test_an_exempt_workflow_cannot_cancel_the_required_check`, so the exemption cannot outlive its justification.

The original prohibition is unchanged. Planting `edited` onto `pr-and-push.yml` still fails, and now names the exemption that relied on it:

```
FAILED test_no_pull_request_trigger_subscribes_to_a_sha_invariant_type
  - {'pr-and-push.yml': ['edited']}
FAILED test_the_required_check_workflow_takes_the_default_types
FAILED test_an_exempt_workflow_cannot_cancel_the_required_check
  - closing-reference.yml is exempt for ['edited'], but the required check now
    subscribes to ['edited'] too, so those events do discard its run
```

## What is deliberately out of scope

- **A pull request that claims nothing anywhere.** Whether every change must trace to an issue is undecided (#1961, decision B) and 18 of the last 30 merges would fail such a rule today. This job reads only what a title already claims, so it needs no answer to that question and cannot be dismissed by one. #1885 - merged with no closing keyword at all while issue 1871 stayed open - is in that class and stays uncaught. That is the honest scope statement: this closes one of the two ways a link is lost.
- **Cross-repository (`owner/repo#12`) and URL reference forms.** Every observed instance used a bare `#N`.
- **Whether the claimed issue exists or is already closed.** A stale number in a title is a different defect, and refusing it would fail a correct pull request whose issue someone else closed first.

## Shape

| file | why |
|---|---|
| `scripts/check_closing_reference.py` | the check; pure decision functions plus one GraphQL read |
| `.github/workflows/closing-reference.yml` | runs it from the base checkout (#1791), title passed via the environment rather than interpolated into a shell |
| `tests/test_closing_reference_gate.py` | 70 pins, including the measured corpus and the code-span design decision |
| `tests/test_pull_request_trigger_types.py` | the narrowing above, plus the premise pin |
| `AGENTS.md` | the rule itself, in PR Workflow step 6 next to the board-tracking guidance |
| `changelog.d/1963-closing-reference-gate.md` | news fragment |

Not in the required set - whether a finding blocks is a branch-protection decision, not a property of this file. Unlike the last-push-approval report it is self-clearing, so it fails and annotates as an error rather than warning.

## Gate

```
pytest tests/test_closing_reference_gate.py                    70 passed
pytest tests/test_pull_request_trigger_types.py                 6 passed
pytest <14 CI/process guard modules>                          223 passed
ruff check / ruff format --check  (script + both tests)        clean
mypy scripts/check_closing_reference.py                        clean
mypy tests/test_closing_reference_gate.py                      clean
bash -n  (the workflow's one shell fragment)                   clean
```

The script is standard library only. `pyyaml` is deliberately not imported by the workflow pins - it is an optional dependency here, and a pin that skips when a dep is missing is not a pin, which is the reason the sibling CI-config pins read workflow text directly.

And the gate reports `SUCCESS` on its own pull request, which is the end-to-end evidence that matters most here.

Related: #1961 (the board-coverage half, and both open decisions), #1784 (the changelog gate this mirrors in shape), #1791 (base-checkout lesson), #1914 (the trigger-narrowing this exempts itself from, with the premise pinned).

---

## Round 1 - `cab1661`

**The gate's first run on this pull request failed, and the failure was real.** Not a flake, and not the check working: it died before it began.

```
python3: can't open file '.../scripts/check_closing_reference.py'
Process completed with exit code 2
```

This is the residual case a base checkout cannot cover. Checking out the base fixes a *head* that predates the script, which is what #1791 established; it cannot fix a *base* that predates it, and that is true for exactly one branch - the one adding the script. Exit 2 is also precisely the state #1791 reserves its argument for: neither of the script's own statuses, rendered by the checks UI as the same red X as a real finding. So the job accused a branch while computing nothing, on its own first outing.

The honest verdict when the base carries no copy of the check is that this base has no such rule to enforce. The step now says so as a `::notice` and passes.

It cannot become a standing no-op, and that is the part worth checking rather than asserting: the ref checked out is the base branch **tip**, not the merge base, so the file is missing only for runs that happen before this lands. A later deletion is loud rather than silent - the pins load the script by path and fail at import if it is gone, inside the required check. Pinned by `test_the_gate_passes_when_the_base_carries_no_copy_of_the_check`.

One consequential detail: the step is now a block, so the injection-seam pin reads the invocation line rather than every `run:` line. Same guarantee, correct subject.

After the fix, `Refuse a closing keyword that only appears in the title` is `SUCCESS` at `cab1661`.

> Process note, since it is the same class of defect this pull request is about: the round entry above was briefly replaced by the string `PLACEHOLDER` when a malformed mutation probe was sent against this description. Restored in full within the minute, and nothing but the description was touched. The lesson is the one AGENTS.md step 8 already states - read a field back after you write it - and it is why that read-back is in this cycle's log.