### PR TITLE
fix(simulation/newton): a viser dashboard port outside the TCP range is refused

### DIFF
--- a/changelog.d/1966-newton-viser-port-domain.md
+++ b/changelog.d/1966-newton-viser-port-domain.md
@@ -1,0 +1,24 @@
+### Fixed: a viser dashboard port that cannot address a port is refused where it is named
+
+`NewtonSimEngine.open_viewer(viewer="viser", port=...)` accepted any value,
+forwarded it verbatim into `ViewerViser(port=...)`, and interpolated it into the
+dashboard URL it reports back - so `port=0`, `-1`, `65536`, `10**9`, `8080.5`,
+`nan`, `inf`, `True`, `'8080'`, `None` and `[8080]` each came back as
+`status="success"` advertising an address such as `http://localhost:nan` or
+`http://localhost:[8080]` for the caller to browse.
+
+Two things followed. The engine holds a single viewer slot, so a value that did
+not raise inside `ViewerViser` filled it, and the obvious recovery - calling
+`open_viewer` again with a usable port - was then refused as
+`"Viewer already open"`. And a value that did raise was reported as
+`"Viewer launch failed: <exc>"` from the surrounding catch-all, which implicates
+the viewer rather than the port the caller got wrong.
+
+The port is now validated through the shared `utils.tcp_port_error` domain on the
+`"viser"` branch, before the lock and before any viewer is constructed, so a
+refusal builds nothing and leaves the slot reusable. The `"gl"` window and the
+`"null"` sink bind nothing and continue to ignore the port, matching how the
+policy providers validate one only when they dial it. `0` is refused rather than
+read as an ephemeral-bind request, because unlike `PolicyServer` - which accepts
+`0` and reads the assigned port back onto `.port` - this surface advertises the
+port that was requested.

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -72,6 +72,7 @@ from strands_robots.utils import (
     require_optional,
     reserved_camera_name_error,
     step_aborted_msg,
+    tcp_port_error,
 )
 
 if TYPE_CHECKING:
@@ -1806,7 +1807,12 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                   tests / benchmarks).
                 * ``"auto"`` (default) -- ``"gl"`` when a display is present,
                   otherwise ``"viser"`` so headless hosts still get a live view.
-            port: TCP port for the ``"viser"`` browser dashboard.
+            port: TCP port for the ``"viser"`` browser dashboard, an ``int``
+                in ``[1, 65535]``. Read only by the ``"viser"`` branch, so
+                ``"gl"`` and ``"null"`` ignore it. ``0`` is refused rather
+                than forwarded as an ephemeral-bind request, because this
+                surface advertises the requested port in the dashboard URL
+                instead of reading the assigned one back.
             width: Window width in pixels for the ``"gl"`` viewer.
             height: Window height in pixels for the ``"gl"`` viewer.
 
@@ -1844,6 +1850,15 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     }
                 ],
             }
+        # Only the viser branch reads ``port`` - it binds the dashboard and the
+        # returned text advertises it - so the domain is applied on that branch
+        # alone, as the policy providers apply theirs only when they dial.
+        # Placed before the lock because a refusal must construct no viewer: the
+        # viewer is a single slot, and a value forwarded verbatim that happens
+        # not to raise inside ``ViewerViser`` fills it, after which the obvious
+        # retry with a usable port is refused as "Viewer already open".
+        if kind == "viser" and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
+            return {"status": "error", "content": [{"text": port_error}]}
         with self._lock:
             try:
                 vmod = self._nt.viewer

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1071,10 +1071,12 @@ def tcp_port_error(value: Any, param: str, context: str) -> str | None:
     reach a service over TCP (``use_rosbridge``'s WebSocket,
     ``gr00t_inference``'s inference service), the mesh bridges that construct
     one, the policy providers that dial one (``groot``, ``moveit2``,
-    ``cosmos3``, ``lerobot_async``, ``vera``), and the Device Connect drivers
+    ``cosmos3``, ``lerobot_async``, ``vera``), the Device Connect drivers
     that address a device daemon
     (:class:`~strands_robots.device_connect.reachy_mini_driver.ReachyMiniDriver`'s
-    ``api_port``). A port is an index into the
+    ``api_port``), and the simulation backends that bind one
+    (:meth:`~strands_robots.simulation.newton.simulation.NewtonSimEngine.open_viewer`'s
+    ``port`` for the viser dashboard). A port is an index into the
     16-bit TCP port
     space, so only an ``int`` in ``[1, 65535]`` names one: ``0`` asks the kernel
     for an ephemeral port rather than naming a port, and a value outside the

--- a/tests/simulation/newton/test_viewer_port_domain.py
+++ b/tests/simulation/newton/test_viewer_port_domain.py
@@ -1,0 +1,351 @@
+"""The viser dashboard port is the shared TCP port domain.
+
+``NewtonSimEngine.open_viewer`` binds the ``"viser"`` browser dashboard on a
+caller-supplied ``port`` and advertises it in the returned text. Before this
+domain landed the value was forwarded verbatim into ``ViewerViser(port=...)``
+and interpolated into the reported URL, so every row below was accepted under
+``status="success"`` and reported as a dashboard address, measured against a
+recording stand-in for the viewer:
+
+    port=0          -> success, http://localhost:0
+    port=-1         -> success, http://localhost:-1
+    port=65536      -> success, http://localhost:65536
+    port=8080.5     -> success, http://localhost:8080.5
+    port=nan        -> success, http://localhost:nan
+    port=True       -> success, http://localhost:True
+    port='8080'     -> success, http://localhost:8080
+    port=None       -> success, http://localhost:None
+    port=[8080]     -> success, http://localhost:[8080]
+
+Two consequences, and they are why this is a defect rather than hardening.
+A value that does not raise inside ``ViewerViser`` **fills the viewer slot** -
+the engine holds one - so the obvious recovery, calling ``open_viewer`` again
+with a usable port, is refused as "Viewer already open"; that is the same
+unreusable-name shape ``test_a_refused_pose_registers_no_object`` removed for
+``add_object``. And a value that *does* raise is reported as
+``"Viewer launch failed: <exc>"``, which implicates the viewer rather than the
+port the caller got wrong.
+
+These tests run solver-free, against a stand-in ``self``, because the guard
+precedes the lock and every viewer construction. That is deliberate: the
+neighbouring ``test_viewer.py`` is gated on ``newton``/``warp`` being importable
+and therefore skips wholesale on a runner without them, so a port pin placed
+there would not run in CI at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import threading
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.simulation as simulation_pkg
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import tcp_port_error
+
+NAN = float("nan")
+INF = float("inf")
+
+#: Every value that cannot name the dashboard's port. Each row was measured as a
+#: pre-fix acceptance reported as a browser URL (see the module docstring).
+UNUSABLE_PORTS: tuple[Any, ...] = (
+    0,
+    -1,
+    65536,
+    99999,
+    10**9,
+    8080.5,
+    NAN,
+    INF,
+    True,
+    False,
+    "8080",
+    None,
+    [8080],
+)
+
+#: Accepted ports: the documented default and both ends of the range.
+USABLE_PORTS: tuple[int, ...] = (1, 8080, 65535)
+
+
+class _RecordingViewer:
+    """Stands in for a newton viewer and records the kwargs it was built with."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.url: str | None = None
+
+    def set_model(self, model: Any, max_worlds: int | None = None) -> None:
+        pass
+
+
+def _viewer_stub(*, has_display: bool = False) -> Any:
+    """A stand-in ``self`` for ``open_viewer``, with every viewer recorded.
+
+    ``built`` collects one entry per constructed viewer, so a test can assert a
+    refusal constructed nothing rather than only that it reported an error.
+    """
+    built: list[tuple[str, dict[str, Any]]] = []
+
+    def _factory(kind: str) -> Any:
+        def _make(**kwargs: Any) -> _RecordingViewer:
+            built.append((kind, kwargs))
+            return _RecordingViewer(**kwargs)
+
+        return _make
+
+    stub = types.SimpleNamespace(
+        _world=object(),
+        _model=object(),
+        _viewer=None,
+        _viewer_kind=None,
+        _lock=threading.RLock(),
+        _VIEWER_KINDS=NewtonSimEngine._VIEWER_KINDS,
+        _nt=types.SimpleNamespace(
+            viewer=types.SimpleNamespace(
+                ViewerGL=_factory("gl"),
+                ViewerViser=_factory("viser"),
+                ViewerNull=_factory("null"),
+            )
+        ),
+        _display_available=lambda: has_display,
+        _sync_viewer=lambda: None,
+        built=built,
+    )
+    return stub
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+class TestUnusablePortIsRefused:
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_the_viser_dashboard_refuses_it(self, port: Any) -> None:
+        stub = _viewer_stub()
+        result = NewtonSimEngine.open_viewer(stub, "viser", port=port)
+        assert result["status"] == "error", (port, result)
+        assert "port" in _text(result)
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_a_refused_port_constructs_no_viewer(self, port: Any) -> None:
+        """Nothing is bound and nothing is advertised for a port that cannot exist."""
+        stub = _viewer_stub()
+        NewtonSimEngine.open_viewer(stub, "viser", port=port)
+        assert stub.built == []
+        assert stub._viewer is None
+        assert stub._viewer_kind is None
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_the_viewer_slot_stays_reusable(self, port: Any) -> None:
+        """The obvious retry must work.
+
+        Pre-fix a value that did not raise inside ``ViewerViser`` filled the
+        single viewer slot, so the retry with a usable port came back as
+        "Viewer already open" rather than opening one.
+        """
+        stub = _viewer_stub()
+        assert NewtonSimEngine.open_viewer(stub, "viser", port=port)["status"] == "error"
+        retry = NewtonSimEngine.open_viewer(stub, "viser", port=8080)
+        assert retry["status"] == "success", retry
+        assert "8080" in _text(retry)
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_auto_refuses_it_when_it_resolves_to_viser(self, port: Any) -> None:
+        """``"auto"`` is the documented headless default, so it reaches the bind."""
+        stub = _viewer_stub(has_display=False)
+        assert NewtonSimEngine.open_viewer(stub, "auto", port=port)["status"] == "error"
+        assert stub.built == []
+
+    @pytest.mark.parametrize("port", (*UNUSABLE_PORTS, *USABLE_PORTS))
+    def test_the_accepted_domain_is_the_shared_tcp_port_domain(self, port: Any) -> None:
+        """Refuses iff the shared helper does, so the two cannot drift apart.
+
+        The equivalence is the point: a second copy of "1-65535" here would let
+        this surface and the policy providers disagree about the same port.
+        """
+        stub = _viewer_stub()
+        refused = NewtonSimEngine.open_viewer(stub, "viser", port=port)["status"] == "error"
+        assert refused is (tcp_port_error(port, "port", "NewtonSimEngine") is not None), port
+
+
+class TestUsablePortIsAccepted:
+    @pytest.mark.parametrize("port", USABLE_PORTS)
+    def test_it_is_bound_and_advertised(self, port: int) -> None:
+        stub = _viewer_stub()
+        result = NewtonSimEngine.open_viewer(stub, "viser", port=port)
+        assert result["status"] == "success", result
+        assert stub.built == [("viser", {"port": port})]
+        assert f"http://localhost:{port}" in _text(result)
+
+    def test_the_documented_default_is_inside_the_domain(self) -> None:
+        """The default must not be a value the guard would refuse."""
+        default = inspect.signature(NewtonSimEngine.open_viewer).parameters["port"].default
+        assert tcp_port_error(default, "port", "NewtonSimEngine") is None, default
+
+
+class TestOnlyTheBoundPortIsValidated:
+    """The guard runs on the branch that reads the port, and only there.
+
+    Mirrors ``TestOnlyTheDialedPortIsValidated`` for the policy providers, where
+    GR00T's local mode ignores a port it never dials. ``"gl"`` opens a native
+    window and ``"null"`` is a sink; neither binds anything, so neither has an
+    opinion about the port and refusing one there would reject a call that works.
+    """
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_the_gl_window_ignores_the_port(self, port: Any) -> None:
+        stub = _viewer_stub(has_display=True)
+        result = NewtonSimEngine.open_viewer(stub, "gl", port=port)
+        assert result["status"] == "success", (port, result)
+        assert [kind for kind, _ in stub.built] == ["gl"]
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_the_null_sink_ignores_the_port(self, port: Any) -> None:
+        stub = _viewer_stub()
+        result = NewtonSimEngine.open_viewer(stub, "null", port=port)
+        assert result["status"] == "success", (port, result)
+        assert [kind for kind, _ in stub.built] == ["null"]
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS)
+    def test_auto_ignores_it_when_a_display_resolves_to_gl(self, port: Any) -> None:
+        stub = _viewer_stub(has_display=True)
+        assert NewtonSimEngine.open_viewer(stub, "auto", port=port)["status"] == "success"
+        assert [kind for kind, _ in stub.built] == ["gl"]
+
+
+class TestEarlierRefusalsStillPrecedeThePort:
+    """The port guard must not reorder the refusals that already existed."""
+
+    def test_no_world_still_wins(self) -> None:
+        stub = _viewer_stub()
+        stub._world = None
+        result = NewtonSimEngine.open_viewer(stub, "viser", port=99999)
+        assert result["status"] == "error"
+        assert "create_world" in _text(result)
+
+    def test_an_unknown_viewer_kind_still_wins(self) -> None:
+        """A typo in ``viewer=`` is the more useful thing to report."""
+        result = NewtonSimEngine.open_viewer(_viewer_stub(), "vizer", port=99999)
+        assert result["status"] == "error"
+        assert "vizer" in _text(result)
+
+    def test_an_already_open_viewer_still_wins(self) -> None:
+        stub = _viewer_stub()
+        assert NewtonSimEngine.open_viewer(stub, "viser", port=8080)["status"] == "success"
+        result = NewtonSimEngine.open_viewer(stub, "viser", port=99999)
+        assert result["status"] == "success"
+        assert "already open" in _text(result)
+
+
+# --------------------------------------------------------------------------- #
+# Structural guard: a port arriving on a *method* was invisible to every scan   #
+# --------------------------------------------------------------------------- #
+def _simulation_module_paths() -> list[Path]:
+    """Every backend module under ``strands_robots.simulation``."""
+    root = Path(inspect.getfile(simulation_pkg)).parent
+    return sorted(root.rglob("*.py"))
+
+
+def _functions_taking_a_port(tree: ast.Module) -> list[ast.FunctionDef]:
+    """Functions declaring a parameter named exactly ``port``.
+
+    Exactly ``port`` rather than any ``*_port`` suffix, matching the existing
+    provider scan: ``lerobot_teleoperate``'s ``robot_port`` / ``teleop_port`` are
+    serial device paths (``/dev/ttyUSB0``), not TCP ports, and a suffix match
+    would demand a TCP domain on them.
+    """
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        args = node.args
+        names = [a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+        if "port" in names:
+            found.append(node)
+    return found
+
+
+def _calls_the_shared_domain(func: ast.FunctionDef) -> bool:
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "tcp_port_error"
+        for node in ast.walk(func)
+    )
+
+
+class TestNoSimulationSurfaceShipsAnUnguardedPort:
+    """A port on a *method* was structurally invisible before this scan.
+
+    Every port-domain drift guard in the suite enumerates ``__init__``
+    definitions - ``TestNoProviderShipsAnUnguardedPort`` over
+    ``policies/*/policy.py``, and the Device Connect scan over exported driver
+    constructors - because until now every port arrived as a constructor
+    parameter. ``open_viewer`` is the one that does not, so no existing scan
+    could have reported it and a second backend method taking a port would have
+    been just as unreported. This closes that shape for the simulation package.
+
+    Scoped to the simulation backends rather than the whole package on purpose:
+    the internal transport clients (``Gr00tInferenceClient`` and its siblings)
+    take a ``port`` they deliberately do not re-validate, because their dialing
+    provider refuses it first and ``TestRefusalPrecedesTheTransport`` pins that
+    ordering. Widening this scan would demand a second, redundant guard there.
+    """
+
+    def test_every_simulation_surface_taking_a_port_validates_it(self) -> None:
+        offenders = []
+        seen = []
+        for path in _simulation_module_paths():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for func in _functions_taking_a_port(tree):
+                seen.append(func.name)
+                if not _calls_the_shared_domain(func):
+                    offenders.append(f"{path.name}::{func.name}")
+        assert "open_viewer" in seen, seen
+        assert offenders == [], (
+            "these simulation surfaces accept a port without validating it against "
+            f"strands_robots.utils.tcp_port_error: {offenders}"
+        )
+
+    def test_the_scan_detects_an_unguarded_method(self) -> None:
+        """A planted omission is reported, so an empty result means clean sources."""
+        planted = ast.parse(
+            "class RogueEngine:\n    def open_dashboard(self, port=8080):\n        return f'http://localhost:{port}'\n"
+        )
+        functions = _functions_taking_a_port(planted)
+        assert [f.name for f in functions] == ["open_dashboard"]
+        assert not _calls_the_shared_domain(functions[0])
+
+    def test_the_scan_accepts_a_guarded_method(self) -> None:
+        """Non-vacuity in the other direction: a guarded method is not an offender."""
+        guarded = ast.parse(
+            "class TidyEngine:\n"
+            "    def open_dashboard(self, port=8080):\n"
+            "        if tcp_port_error(port, 'port', 'TidyEngine'):\n"
+            "            return None\n"
+        )
+        functions = _functions_taking_a_port(guarded)
+        assert [f.name for f in functions] == ["open_dashboard"]
+        assert _calls_the_shared_domain(functions[0])
+
+
+class TestNeighbouringViewerAxesStayOutOfScope:
+    """``width`` / ``height`` are a different domain and are not settled here.
+
+    They are pixel counts read only by the ``"gl"`` window, not an index into
+    the TCP port space, so they belong to the ``positive_whole_number_error``
+    family this module says nothing about. Pinned rather than omitted so the
+    boundary is a stated scope decision, and so this reads as the premise to
+    replace if that axis is taken up - not as an oversight.
+    """
+
+    @pytest.mark.parametrize("bad", (0, -1, 1280.5, NAN, True, "1280", None))
+    def test_an_unusable_gl_window_size_is_still_accepted(self, bad: Any) -> None:
+        stub = _viewer_stub(has_display=True)
+        result = NewtonSimEngine.open_viewer(stub, "gl", width=bad, height=bad)
+        assert result["status"] == "success", (bad, result)
+        assert stub.built == [("gl", {"width": bad, "height": bad})]


### PR DESCRIPTION
Closes #1965

## Summary

`NewtonSimEngine.open_viewer` binds the `"viser"` browser dashboard on a caller-supplied `port` and advertises it in the returned text, forwarding the value verbatim into `ViewerViser(port=port)` with no domain check. The shared `utils.tcp_port_error` now runs on the `"viser"` branch, before the lock and before any viewer is constructed.

## Measured before (solver-free, recording stand-in for the viewer)

| `port=` | status | handed to `ViewerViser` | reported text |
| --- | --- | --- | --- |
| `0` | success | `0` | `http://localhost:0` |
| `-1` | success | `-1` | `http://localhost:-1` |
| `65536` | success | `65536` | `http://localhost:65536` |
| `10**9` | success | `1000000000` | `http://localhost:1000000000` |
| `8080.5` | success | `8080.5` | `http://localhost:8080.5` |
| `nan` / `inf` | success | `nan` / `inf` | `http://localhost:nan` / `:inf` |
| `True` | success | `True` | `http://localhost:True` |
| `'8080'` | success | `'8080'` | `http://localhost:8080` |
| `None` | success | `None` | `http://localhost:None` |
| `[8080]` | success | `[8080]` | `http://localhost:[8080]` |

Every row is `status="success"` with a non-address advertised to the agent as somewhere to browse. After: every row is refused by the shared domain, no viewer is constructed, and `_viewer` / `_viewer_kind` stay `None`.

## Why it is a defect, not hardening

**The single viewer slot was taken.** A value that does not raise inside `ViewerViser` sets `_viewer`, so the obvious recovery is refused:

```
open_viewer("viser", port=10**9) -> success, _viewer_kind='viser', 1 viewer built
open_viewer("viser", port=8080)  -> "Viewer already open (viser)."
```

Same unreusable-slot shape #1858 recorded for Isaac's `mass`, and that `test_a_refused_pose_registers_no_object` removed for `add_object`. Pinned here by `test_the_viewer_slot_stays_reusable`.

**And a value that does raise was misattributed.** `ViewerViser(...)` sits inside a broad `except Exception` returning `"Viewer launch failed: <exc>"`, so a wrong port reads as a viewer failure - the misattribution `tcp_port_error`'s docstring already gives as the reason the domain belongs at the boundary rather than at the socket.

## Design points worth reviewing

- **Only the `"viser"` branch validates.** `"gl"` opens a native window and `"null"` is a sink; neither binds anything, so refusing a port there would reject a call that works. This mirrors `TestOnlyTheDialedPortIsValidated`, where GR00T's local mode ignores a port it never dials. Pinned by `TestOnlyTheBoundPortIsValidated`, including both `"auto"` resolutions.
- **`0` is refused here, and accepted by `inference/server.py`.** That looks inconsistent and is not: `_bind_port_error` accepts `0` for a binding surface *because* `PolicyServer` reads the assigned port back onto `.port`. This surface advertises the **requested** port in the URL and never reads the assigned one, so `0` produces `http://localhost:0`. Same reasoning, opposite conclusion - stated in the `port` docstring so the pair does not read as drift. No new wrapper was added, since without the read-back there is nothing for one to decide.
- **The refusal precedes the lock**, so it cannot interact with the batched lock release from #1885.
- **Existing refusal order is unchanged** - no world, unknown viewer kind, and already-open all still win over the port, pinned by `TestEarlierRefusalsStillPrecedeThePort`.

## The durable half: a port on a *method* was structurally invisible

Every port-domain drift guard in the suite enumerates `__init__` definitions - `TestNoProviderShipsAnUnguardedPort` over `policies/*/policy.py`, and the Device Connect scan from #1964 over exported driver constructors - because until now every caller-supplied port arrived as a constructor parameter. `open_viewer` is the only one that does not, so no existing scan could have reported it.

`TestNoSimulationSurfaceShipsAnUnguardedPort` scans simulation-backend **methods** for a parameter named exactly `port` and requires the shared helper, with a planted-defect meta-test and a planted-guard counterpart so an empty result means clean sources rather than a broken scanner. Two scoping decisions, both stated in the test docstrings:

- **Exactly `port`, not any `*_port` suffix** - `lerobot_teleoperate`'s `robot_port` / `teleop_port` are serial device paths (`/dev/ttyUSB0`), and a suffix match would demand a TCP domain on them.
- **Scoped to the simulation package** - the internal transport clients (`Gr00tInferenceClient` and siblings) take a `port` they deliberately do not re-validate, because their dialing provider refuses it first and `TestRefusalPrecedesTheTransport` pins that ordering. Widening the scan would demand a second, redundant guard there.

## Tests

New `tests/simulation/newton/test_viewer_port_domain.py`, 124 tests, **solver-free**. That is deliberate: the neighbouring `test_viewer.py` is gated on `newton`/`warp` being importable and skips wholesale without them, so a port pin placed there would not run in CI at all. These use the stand-in-`self` idiom of `test_pose_vector_domain_across_backends.py`, which works because the guard precedes the lock and the solver.

- `test_the_accepted_domain_is_the_shared_tcp_port_domain` asserts refuses-**iff** against `tcp_port_error` over every probe, so this surface and the providers cannot drift on the same port.
- `test_the_documented_default_is_inside_the_domain` reads the default off the signature, so the default can never become a value the guard refuses.
- `TestNeighbouringViewerAxesStayOutOfScope` pins `width` / `height` as out of scope - pixel counts on the `positive_whole_number_error` family, not an index into the port space. A stated boundary rather than an omission, and the premise to replace if that axis is taken up.

**Non-vacuity:** on the pre-fix tree the new module reports **66 failed, 58 passed**, and the structural guard names the offender as `simulation.py::open_viewer`.

## Verification

`ruff format --check` and `ruff check` clean on all three files. The affected suite (`tests/simulation/newton/`, all four port-domain modules, the refusal-message and unreachable-statement scanners, and the describe/discovery test) read as a **delta** against the untouched tree in the same environment:

| | passed | failed | skipped | errors |
| --- | --- | --- | --- | --- |
| base | 501 | 15 | 187 | 41 |
| this branch | **625** | 15 | 187 | 41 |

**+124, exactly the tests added**, with the failures and errors identical on both sides - they are this minimal environment's missing optional deps (`device_connect_edge`, `torch`), not the diff.

## No behaviour change for any usable port

`1`, `8080` (the documented default) and `65535` are accepted and forwarded unchanged, and no existing test was modified.

---

### Round changelog

**Round 1** - initial submission.