### PR TITLE
fix(simulation/isaac): cross-repo references name the repository they belong to

### DIFF
--- a/changelog.d/1968-isaac-cross-repo-reference-provenance.md
+++ b/changelog.d/1968-isaac-cross-repo-reference-provenance.md
@@ -1,0 +1,35 @@
+### Fixed: cross-repo references in the Isaac backend name the repository they belong to
+
+`strands_robots/simulation/isaac/` was absorbed from `strands-labs/robots-sim` by
+#1156 and arrived carrying that repository's issue and pull-request numbering in
+the bare `PR #N` / `issue #N` form, which resolves against *this* repository. All
+18 such references are now written `robots-sim#N`.
+
+The two that could be checked cheaply were both wrong, in the two different ways
+that matter:
+
+| reference | means in robots-sim | resolves here to |
+|---|---|---|
+| `PR #117` | fail fast on the LIBERO `load_scene` gap | **nothing** - this repo has no #117 |
+| `PR #31` | `IsaacSimulation` backend skeleton (R7) | #31 `chore: code hygiene, logging cleanup, and f-string logging migration` |
+
+`PR #117` fails loudly, which is the harmless case. `PR #31` is the expensive
+one: the docstring calls it "the exception-hygiene pin", and this repository's
+#31 is a real merged *code hygiene* PR -- so a reader who follows the reference
+to check the claim finds a plausible-sounding match and concludes it verifies. A
+false pass is worse than a dead link, because nothing prompts a second look.
+`issue #69` and `issue #88` behave the same way: both numbers exist here, both
+are unrelated CI issues.
+
+Comment and docstring text only -- no behaviour change. The two sites that
+already carried a full URL keep it; only their misleading bare link text
+changed. Three genuine local references in the package (`issue #1537` twice,
+`issue #1812`) are deliberately left bare, because they are correct.
+
+`tests/simulation/isaac/test_migrated_reference_provenance.py` pins the rule. It
+is scoped to this package -- the only part of the tree holding two numbering
+namespaces in one syntax, since `strands_robots/` elsewhere cites this repo's own
+`PR #85` / `PR #92` / `PR #86` bare and correctly -- and thresholded at 1000
+rather than absolute: robots-sim never issued a number above 173, while this
+repository was already at #1156 when it absorbed the backend, so the ranges
+cannot overlap and a four-digit reference here is unambiguously local.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -1,6 +1,6 @@
 """Robot description file loaders -> :class:`ProceduralRobot`.
 
-Follow-up to the R7 Phase 1 procedural-builder slice (PR #46): instead of
+Follow-up to the R7 Phase 1 procedural-builder slice (robots-sim#46): instead of
 hardcoding ``_build_so100`` / ``_build_panda`` / ``_build_unitree_g1`` in
 :mod:`strands_robots.simulation.isaac.procedural`, drive the same
 ``ProceduralRobot`` dataclass from existing
@@ -539,7 +539,7 @@ def _extract_mjcf_shape(body_el: ET.Element) -> tuple[str, tuple[float, ...]]:
 
 
 def _lazy_import_usd() -> tuple[Any, Any, Any]:
-    """Lazy-import pxr.Usd / Sdf / UsdPhysics. Mirrors the pattern from PR #44.
+    """Lazy-import pxr.Usd / Sdf / UsdPhysics. Mirrors the pattern from robots-sim#44.
 
     Returns (Usd, Sdf, UsdPhysics) tuple. Raises ImportError with an install
     hint when the modules are unavailable (Pixar USD ships only via the

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -63,7 +63,8 @@ logger = logging.getLogger(__name__)
 # width and upscales. Below ~300 px internal resolution DLSS falls back
 # to a temporal-accumulation path that smears a moving arm into a
 # translucent "ghost" (long-standing front/oblique-view bug seen during
-# the SO-101 cuRobo example's GPU validation -- see issue #69 / PR #68).
+# the SO-101 cuRobo example's GPU validation -- see robots-sim#69 /
+# robots-sim#68).
 # Rendering at >= 640 px wide keeps the DLSS internal resolution above
 # that threshold so every frame is crisp on its own; captured frames
 # are downscaled to the caller's requested size before return.
@@ -613,7 +614,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         # instead of producing a default-config sim with no warning.
         #
         # A small allow-list of legacy kwargs from the example-local
-        # adapter retired by issue #69 is accepted for backward compat
+        # adapter retired by robots-sim#69 is accepted for backward compat
         # with callers that still pass them via
         # ``create_simulation("isaac", tool_name=..., default_timestep=...)``.
         # They are stored on the instance (not on ``IsaacConfig``) so the
@@ -710,7 +711,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         # cache, and worker-thread actions are enqueued for the pump to
         # apply. ``_main_tid`` identifies the owning thread; when called
         # ON it we run inline (no queue), so the headless smoke-test path
-        # is unchanged. See issue #69 for the consolidation rationale.
+        # is unchanged. See robots-sim#69 for the consolidation rationale.
         self._main_tid = threading.get_ident()
         self._action_q: queue.Queue = queue.Queue()
         self._main_jobs: queue.Queue = queue.Queue()
@@ -1989,7 +1990,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             # Normalize shape aliases. ``"cuboid"`` is accepted as an
             # alias for ``"box"`` because it matches Isaac's underlying
             # ``DynamicCuboid`` / ``FixedCuboid`` class names and is the
-            # vocabulary used throughout the docs (see issue #88). The
+            # vocabulary used throughout the docs (see robots-sim#88). The
             # canonical name stored / reported is ``"box"``.
             shape = _SHAPE_ALIASES.get(shape, shape)
 
@@ -2010,7 +2011,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
             # ``scale`` is accepted as an alias for ``size`` (matches
             # Isaac's ``DynamicCuboid(scale=...)`` convention and the docs
-            # vocabulary -- see issue #88). An explicit ``size`` always
+            # vocabulary -- see robots-sim#88). An explicit ``size`` always
             # wins over ``scale`` if both are passed.
             # Validate the pose vectors on the shared ``coerce_pose_vector`` domain the
             # MuJoCo backend's ``add_object`` and this backend's own ``add_camera`` already
@@ -2117,7 +2118,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 # sim view) before constructing dynamic prims, so the
                 # eager query never runs. That keeps this clause free of a
                 # bare ``except Exception`` (forbidden by the
-                # exception-hygiene pin, PR #31).
+                # exception-hygiene pin, robots-sim#31).
                 logger.error(
                     "Failed to add object '%s' (shape=%s, static=%s): %s",
                     name,
@@ -2200,11 +2201,12 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         which is fatal for :meth:`load_scene` -- it builds a LIBERO
         task's movable objects as ``Dynamic*`` prims after the world has
         already been initialised (see
-        `#159 <https://github.com/strands-labs/robots-sim/issues/159>`_).
+        `robots-sim#159
+        <https://github.com/strands-labs/robots-sim/issues/159>`_).
 
         We *prevent* the failure rather than catching it: a bare
         ``except Exception`` is forbidden in this module by the
-        exception-hygiene pin (PR #31), and ``omni.physics.tensors``
+        exception-hygiene pin (robots-sim#31), and ``omni.physics.tensors``
         raises exactly that bare type. Before constructing any
         ``Dynamic*`` prim we stop the timeline, which clears the
         physics-tensor view so ``RigidPrim.__init__`` skips its eager
@@ -2215,10 +2217,10 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
         The stop is *unconditional* for dynamic prims rather than gated on
         a ``SimulationManager.get_physics_sim_view()`` probe. The earlier
-        probe-gated guard (PR #161) was a no-op on the actual ``#159``
-        ``load_scene`` path: in a real Isaac 6.0 run the probe reported no
-        live view while ``RigidPrim.__init__`` still issued the eager
-        velocity query and crashed -- the probe checks a *different*
+        probe-gated guard (robots-sim#161) was a no-op on the actual
+        ``robots-sim#159`` ``load_scene`` path: in a real Isaac 6.0 run the
+        probe reported no live view while ``RigidPrim.__init__`` still issued
+        the eager velocity query and crashed -- the probe checks a *different*
         tensor-view handle than the one ``RigidPrim`` keys off, so the two
         fell out of sync. ``timeline.stop()`` is idempotent (a no-op when
         the timeline is already stopped, the common scene-build case), so
@@ -2417,8 +2419,9 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         each task's scene. This Isaac override translates the same
         robosuite-compiled MJCF into Isaac stage prims so the LIBERO eval
         runs end-to-end on the Isaac backend (closes the substantive
-        LIBERO-on-Isaac gap that PR #117 deferred with a fail-fast stub --
-        see `#129 <https://github.com/strands-labs/robots-sim/issues/129>`_).
+        LIBERO-on-Isaac gap that robots-sim#117 deferred with a fail-fast
+        stub -- see `robots-sim#129
+        <https://github.com/strands-labs/robots-sim/issues/129>`_).
 
         Translation layer (BDDL/MJCF -> USD):
             * The ``scene_path`` is a robosuite-compiled LIBERO MJCF XML
@@ -3421,7 +3424,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
           Happens when the camera was added before the
           ``add_camera`` Phase-2 wiring landed (or when the camera
           construction failed but bookkeeping was still seeded -- not
-          possible after PR #61, but kept as a defensive fallback).
+          possible after robots-sim#61, but kept as a defensive fallback).
         * ``Rendered (RTX <render_mode>)`` -- Phase-2 path: real
           frames pulled from the Camera handle. ``rgb`` / ``depth``
           are the actual array shapes returned by Isaac (matching
@@ -3592,7 +3595,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     # Camera was constructed without the depth annotator
                     # (Isaac Sim ships rgba on by default but depth is
                     # opt-in via ``Camera.add_distance_to_image_plane_to_frame()``;
-                    # PR #61's add_camera enables it post-initialize, but
+                    # robots-sim#61's add_camera enables it post-initialize, but
                     # an older sim or a manually-attached Phase-1 camera
                     # state may not). Surface a zero-depth array sized to
                     # rgb so callers see a stable shape, plus a WARNING
@@ -4601,7 +4604,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         # is opt-in via this method; without it, ``camera.get_depth()``
         # returns ``None`` with a "Annotator 'distance_to_image_plane'
         # not found" warning -- which then crashes downstream
-        # ``np.asarray`` calls in ``render()``. Caught during PR #61
+        # ``np.asarray`` calls in ``render()``. Caught during robots-sim#61
         # GPU validation against the Isaac Sim 4.5 docker image.
         # ``add_distance_to_image_plane_to_frame`` is idempotent on
         # repeat calls so this is safe even if the camera has already
@@ -4612,7 +4615,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             # Older Isaac Sim builds expose this under a different name
             # (``add_depth_to_frame``). Try the fallback before giving
             # up; downstream ``get_depth`` will still return ``None``
-            # but ``render()``'s defensive None-handling (PR #62) will
+            # but ``render()``'s defensive None-handling (robots-sim#62) will
             # cover it.
             try:
                 camera.add_depth_to_frame()
@@ -5048,7 +5051,7 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
     # --- SimEngine: extra helpers for the SO-101 cuRobo example -------------
     #
     # These methods migrated in from the example-local Isaac adapter
-    # (``examples/so101_curobo/isaac/simulation.py``) when issue #69
+    # (``examples/so101_curobo/isaac/simulation.py``) when robots-sim#69
     # consolidated it into this library backend. They cover three
     # concerns the headless ``SimEngine`` core doesn't:
     #

--- a/tests/simulation/isaac/test_migrated_reference_provenance.py
+++ b/tests/simulation/isaac/test_migrated_reference_provenance.py
@@ -1,0 +1,141 @@
+"""Every cross-repo reference in the absorbed Isaac package names its repository.
+
+``strands_robots/simulation/isaac/`` did not originate here. #1156
+(``feat(sim): absorb Isaac Sim backend from robots-sim into this repo``) moved it
+from ``strands-labs/robots-sim``, and it arrived carrying that repository's issue
+and pull-request numbering written in the bare ``PR #N`` / ``issue #N`` form. In
+this repository that form resolves against *this* repository, so each such
+reference silently renamed itself on the way in.
+
+Two of them were checkable, and they failed in the two different ways that
+matter (#1967):
+
+* ``PR #117`` -- this repository has no #117 at all, so the reference resolves to
+  nothing and a reader knows to dig.
+* ``PR #31`` -- this repository's #31 is ``chore: code hygiene, logging cleanup,
+  and f-string logging migration``, merged, real, and *unrelated*. The docstring
+  citing it calls it "the exception-hygiene pin", so a reader who follows the
+  reference to check the claim finds a plausible-sounding hygiene PR and
+  concludes it verifies. A false pass is worse than a dead link, because nothing
+  prompts a second look. ``robots-sim#69`` / ``robots-sim#88`` behave the same
+  way: this repository's #69 and #88 are both real, both about CI, and neither is
+  what the comment means.
+
+So the rule this module pins is that a reference in this package must name the
+repository it belongs to. It is scoped and thresholded rather than absolute, and
+both choices are load-bearing:
+
+**Scoped to the Isaac package.** It is the only part of the tree holding two
+numbering namespaces in one syntax. ``strands_robots/`` elsewhere cites this
+repository's own pull requests bare -- ``PR #85``, ``PR #92``, ``PR #86``,
+``PR #101`` -- and AGENTS.md documents #85, #92 and #86 by name under "Review
+Learnings", so a tree-wide ban would demand rewriting correct references.
+
+**Thresholded at 1000, not absolute.** ``robots-sim`` never issued a number above
+**173** (its newest issue is #171 and its newest pull request #173, and it is
+being archived under its own #171), while this repository was already at #1156
+on the day it absorbed the backend. The two ranges therefore cannot overlap, and
+a four-digit reference in this package is unambiguously local. Three such
+references exist and are deliberately left bare, because they are correct:
+``issue #1537`` twice in ``simulation.py`` and ``issue #1812`` in
+``delta_eef.py`` -- all three added by later commits to *this* repository, which
+``git blame`` attributes to a different commit than #1156.
+
+``TestTheThresholdIsJustified`` pins that reasoning against drift, so the day
+this repository's numbering could collide with the retired one, this module fails
+rather than quietly narrowing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Numbers at or above this cannot be robots-sim's: its highest ever is 173.
+_LOCAL_NUMBER_FLOOR = 1000
+
+# The bare forms that silently re-target on import into this repository.
+_BARE_REFERENCE = re.compile(r"(?:PR|issue)\s+#(\d+)", re.IGNORECASE)
+
+_ISAAC_PACKAGE = Path(__file__).resolve().parents[3] / "strands_robots" / "simulation" / "isaac"
+
+
+def _isaac_sources() -> list[Path]:
+    return sorted(_ISAAC_PACKAGE.glob("*.py"))
+
+
+def _unqualified_foreign_references(text: str) -> list[str]:
+    """Return bare references whose number falls in the robots-sim range."""
+    return [match.group(0) for match in _BARE_REFERENCE.finditer(text) if int(match.group(1)) < _LOCAL_NUMBER_FLOOR]
+
+
+class TestTheIsaacPackageIsClean:
+    """The absorbed package carries no bare reference to its origin repository."""
+
+    def test_the_package_has_sources_to_scan(self) -> None:
+        """An empty scan must mean a clean package, not a broken path."""
+        sources = _isaac_sources()
+        assert sources, f"no Python sources found under {_ISAAC_PACKAGE}"
+        assert (_ISAAC_PACKAGE / "simulation.py") in sources
+
+    @pytest.mark.parametrize("source", _isaac_sources(), ids=lambda p: p.name)
+    def test_no_source_cites_a_foreign_number_bare(self, source: Path) -> None:
+        offenders = _unqualified_foreign_references(source.read_text(encoding="utf-8"))
+        assert not offenders, (
+            f"{source.name} cites {offenders} in a bare form. Numbers below "
+            f"{_LOCAL_NUMBER_FLOOR} in this package are robots-sim's (see #1967); "
+            f"write them as 'robots-sim#N' so they name the repository they belong to."
+        )
+
+
+class TestTheScannerReportsARealProperty:
+    """A planted defect is caught and a planted correct reference is not."""
+
+    def test_a_planted_bare_foreign_reference_is_caught(self) -> None:
+        planted = "See PR #31 for the exception-hygiene pin."
+        assert _unqualified_foreign_references(planted) == ["PR #31"]
+
+    def test_a_planted_issue_form_is_caught(self) -> None:
+        assert _unqualified_foreign_references("retired by issue #69") == ["issue #69"]
+
+    def test_the_qualified_form_is_accepted(self) -> None:
+        """'robots-sim#31' is the remedy, so it must not itself trip the scan."""
+        assert _unqualified_foreign_references("the exception-hygiene pin (robots-sim#31)") == []
+
+    def test_a_local_four_digit_reference_is_accepted_bare(self) -> None:
+        """The three genuine local references in this package stay legal."""
+        assert _unqualified_foreign_references("This is issue #1812's option 1") == []
+        assert _unqualified_foreign_references("previously example-side, issue #1537") == []
+
+
+class TestTheThresholdIsJustified:
+    """The threshold separates two ranges that cannot overlap."""
+
+    def test_the_floor_clears_the_highest_robots_sim_number(self) -> None:
+        """robots-sim's newest issue is #171 and newest pull request #173."""
+        assert _LOCAL_NUMBER_FLOOR > 173
+
+    def test_the_floor_is_below_the_absorbing_pull_request(self) -> None:
+        """#1156 absorbed the package, so every local number since exceeds the floor."""
+        assert _LOCAL_NUMBER_FLOOR < 1156
+
+    def test_the_genuine_local_references_sit_above_the_floor(self) -> None:
+        for number in (1537, 1812):
+            assert number >= _LOCAL_NUMBER_FLOOR
+
+
+class TestNeighbouringReferenceFormsStayOutOfScope:
+    """Stated boundaries, so an omission reads as a decision."""
+
+    def test_a_full_url_is_not_flagged(self) -> None:
+        """A URL already names the repository; only its link text needed fixing."""
+        url = "`robots-sim#159 <https://github.com/strands-labs/robots-sim/issues/159>`_"
+        assert _unqualified_foreign_references(url) == []
+
+    def test_the_rest_of_the_tree_is_not_scanned(self) -> None:
+        """Elsewhere a bare 'PR #85' is a correct local reference, so this scan is
+        deliberately confined to the one package with two namespaces."""
+        assert _ISAAC_PACKAGE.name == "isaac"
+        assert _ISAAC_PACKAGE.parent.name == "simulation"


### PR DESCRIPTION
Closes #1967

## Summary

`strands_robots/simulation/isaac/` did not originate here. #1156 (`feat(sim): absorb Isaac Sim backend from robots-sim into this repo`) moved it from `strands-labs/robots-sim`, and it arrived carrying that repository's issue and pull-request numbering written in the bare `PR #N` / `issue #N` form. In this repository that form resolves against *this* repository, so every one of those references silently renamed itself on the way in.

This qualifies all 18 of them as `robots-sim#N`. Comment and docstring text only - no behaviour change, no signature change, no test modified.

## Why it is a defect, not tidying

The two references that can be checked cheaply are both wrong, and they are wrong in the two different ways that matter.

| reference | robots-sim referent | what the number means **here** |
| --- | --- | --- |
| `PR #117` | #117 `fix(isaac): fail fast on LIBERO load_scene gap + non-zero exit (closes #116)` | **does not exist** - `Could not resolve to a PullRequest with the number of 117` |
| `PR #31` | #31 `feat(isaac): IsaacSimulation backend skeleton + entry-point registration (R7)` | #31 `chore: code hygiene, logging cleanup, and f-string logging migration` - real, merged 2026-03-11, **unrelated** |
| `issue #69` | #69 `Consolidate the example-local Isaac adapter (examples/so101_curobo/isaac) into strands_robots_sim/isaac` | #69 `ci: enable running integ tests as part of CI` - unrelated |
| `issue #88` | #88 `Docs vs code: add_object uses shape="cuboid"/scale= everywhere, but the API only accepts shape="box"/size=` | #88 `ci: investigate and fix CI failures on PR #48 (Zenoh dashboard)` - unrelated |

`PR #117` fails loudly, which is the harmless case: the number resolves to nothing, so a reader knows to dig.

**`PR #31` does the opposite, and that is the reason this is worth a PR.** The docstring citing it reads "a bare `except Exception` is forbidden in this module by the exception-hygiene pin (PR #31)", and this repository's #31 is a merged *code hygiene and f-string logging* PR. A reader who follows the reference to verify the claim finds a plausible-sounding hygiene PR and concludes the citation checks out. The verification step returns a **false pass**, which is strictly worse than a dead link because nothing prompts a second look. `issue #69` and `issue #88` behave the same way - both numbers exist here, both are real CI issues, neither is what the comment means.

Same shape as #1891's finding that the migrated example's robots-sim pointers "died with the migration", except those dangled visibly and these resolve confidently onto the wrong object.

## Provenance is uniform, which is what makes the fix mechanical

The risk in a change like this is guessing each referent. There is no guessing: `git blame` attributes **all 13 reference sites** to one commit, `1fbe0c07` = #1156. The correction therefore rests on a single verified fact - the file came wholesale from robots-sim - rather than on 18 individual judgements about what each number meant.

## Design points worth reviewing

- **Two of the sites already named the repository by URL** (`simulation.py:2203`, `:2421`). Those keep their URLs; only the misleading bare link text changed, `` `#159` `` -> `` `robots-sim#159` ``. Note archival does not break them - an archived repository stays readable - so the URLs were never the urgent half.
- **Three references in the package are deliberately left bare, because they are correct.** `issue #1537` twice in `simulation.py` and `issue #1812` in `delta_eef.py` are genuine local references, and `git blame` attributes all three to later commits to *this* repository, not to #1156.
- **The pin is scoped to the Isaac package, not tree-wide.** `strands_robots/` elsewhere cites this repository's own pull requests bare - `PR #85`, `PR #92`, `PR #86`, `PR #101`, `PR #716`, `PR #930` - and AGENTS.md documents #85, #92 and #86 by name under "Review Learnings". A tree-wide ban would demand rewriting correct references. The Isaac package is the only part of the tree holding two numbering namespaces in one syntax, which is exactly what makes it undecidable by inspection.
- **The pin is thresholded at 1000, not absolute.** robots-sim never issued a number above **173** (newest issue #171, newest pull request #173), while this repository was already at #1156 on the day it absorbed the backend. The ranges cannot overlap, so a four-digit reference in this package is unambiguously local and stays legal. `TestTheThresholdIsJustified` pins that reasoning, so if this repository's numbering could ever collide with the retired one the module fails rather than quietly narrowing.

## The durable half

The rule was otherwise documented-and-enforced-by-nothing, the same shape as the changelog rule before #1784 and the closing-keyword rule before #1963. `tests/simulation/isaac/test_migrated_reference_provenance.py` (19 tests, hermetic, no network) scans the package for a bare reference in the robots-sim range and names every offender in the failure message.

It carries a planted-defect meta-test **and** a planted-correct-reference counterpart, so an empty result means clean sources rather than a broken scanner:

- `test_a_planted_bare_foreign_reference_is_caught` / `test_a_planted_issue_form_is_caught`
- `test_the_qualified_form_is_accepted` - the remedy must not itself trip the scan
- `test_a_local_four_digit_reference_is_accepted_bare` - the three genuine references stay legal
- `test_the_package_has_sources_to_scan` - an empty glob fails loudly rather than passing vacuously

**Non-vacuity:** on the pre-fix tree the module reports **2 failed, 17 passed**, and names the offenders:

```
loaders.py cites ['PR #46', 'PR #44'] in a bare form
simulation.py cites ['issue #69', 'PR #68', 'issue #69', 'issue #69', 'issue #88',
                     'issue #88', 'PR #31', 'PR #31', 'PR #161', 'PR #117',
                     'PR #61', 'PR #61', 'PR #61', 'PR #62'] in a bare form
```

## Verification

`ruff check` and `ruff format --check` clean on all three files. New module: **19 passed** on this branch, **2 failed / 17 passed** on the base. No existing test was modified, and no line exceeds the configured 120-character limit (the two pre-existing long lines in `simulation.py` are untouched and outside every edited region).

Because the diff is confined to comments and docstrings, there is no behaviour delta to measure - the compiled module is byte-identical in behaviour, and the affected suite is unchanged apart from the added file.

## Related, filed separately rather than folded in

While verifying the `PR #31` claim I found two things that need a **behaviour** decision rather than a text change, so they are noted in #1967 instead of being bundled here:

1. The "exception-hygiene pin" the docstring cites does not exist in this tree - zero hits for `exception.hygiene` under `tests/`.
2. `strands_robots/simulation/isaac/recording.py:383` carries a live bare `except Exception` inside the package whose docstring calls the construct forbidden.

Keeping them out preserves this PR as one concern: a reference that names the wrong object now names the right one.

---

### Round changelog

**Round 1** - initial submission.