### PR TITLE
fix(streaming_dataset): open() refuses a numeric knob it cannot honor

### DIFF
--- a/changelog.d/1969-streaming-open-numeric-domains.md
+++ b/changelog.d/1969-streaming-open-numeric-domains.md
@@ -1,0 +1,24 @@
+### Fixed: `StreamingDatasetReader.open` refuses a numeric knob it cannot honor
+
+`tolerance_s`, `buffer_size`, `max_num_shards` and `seed` were forwarded raw
+into `StreamingLeRobotDataset`, whose constructor validates only `repo_type`.
+Every consumer of the four sits downstream of the call that returned, so an
+unusable value surfaced late or not at all: measured against a locally cached
+dataset, `max_num_shards=0` (and any negative) opened successfully and then
+streamed **zero frames** with no error on any path, `buffer_size=0` raised
+`high <= 0` out of NumPy part-way through iteration, `seed=-1` was refused by
+NumPy in a message naming neither the surface nor the parameter, and
+`tolerance_s=inf` made the delta-grid check `open()` runs for parity with the
+materialized dataset accept an off-grid `delta_timestamps` - while
+`tolerance_s=nan` or a negative one refused a perfectly on-grid one in a
+message blaming the caller's deltas.
+
+Each knob is now checked against a shared domain before the lerobot import,
+so a caller mistake is reported the same way with or without the extra
+installed: the two counts on `positive_count_error` (both are read as a
+`range()` bound or an exclusive upper bound), the seed on
+`non_negative_count_error` (the domain `TrainSpec.seed` already uses, where
+`0` is simply a seed), and `tolerance_s` on the signed `finite_number_error`
+plus a floor of its own, because `0` there asks for an exact grid match
+rather than being degenerate. `dataloader(batch_size=...)` is unchanged:
+torch refuses an unusable batch size at construction.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -623,6 +623,16 @@ edge devices without a torchcodec wheel; requires `delta_timestamps` with at
 least one non-video key, otherwise `open()` raises `ValueError` rather than
 silently streaming video anyway).
 
+The four numeric kwargs (`tolerance_s`, `buffer_size`, `max_num_shards`,
+`seed`) are checked before the lerobot import: `StreamingLeRobotDataset`
+validates only `repo_type` and stores the rest verbatim, so every consumer of
+them is downstream of a call that already returned. `open()` raises `ValueError`
+naming the parameter instead - a shard count of `0` used to open successfully
+and then stream **zero frames**, a `buffer_size` of `0` raised out of NumPy
+part-way through iteration, and a `tolerance_s` of `inf` switched off the
+delta-grid check below. `tolerance_s=0` is accepted and means "require an exact
+grid match"; `seed=0` is accepted and is simply a seed.
+
 One kwarg is **not** tolerant-forwarded because its absence changes semantics:
 `repo_type="bucket"` requires `lerobot>=0.6.1`, which the `[lerobot]` extra
 floors — so a resolver-conformant install always has it. On an environment

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -23,7 +23,12 @@ import sys
 from collections.abc import Callable
 from typing import Any
 
-from strands_robots.utils import lerobot_version
+from strands_robots.utils import (
+    finite_number_error,
+    lerobot_version,
+    non_negative_count_error,
+    positive_count_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +94,69 @@ def _get_streaming_cls() -> Any:
         ) from exc
 
 
+def _tolerance_error(value: Any) -> str | None:
+    """Return why ``tolerance_s`` cannot be used as a grid-match half-width.
+
+    ``tolerance_s`` is the half-width of the window
+    ``lerobot.datasets.feature_utils.check_delta_timestamps`` compares each
+    delta against, and :meth:`StreamingDatasetReader.open` runs that check
+    itself to restore the grid validation the streaming path skips. So the
+    value decides whether that check can answer at all, in both directions:
+    ``inf`` makes ``... <= tolerance_s`` true for every delta, silently
+    accepting an off-grid ``delta_timestamps`` and disabling the very parity
+    the call was replicating, while ``nan`` and a negative half-width make it
+    false for every delta, refusing a perfectly on-grid one with a message
+    that blames the caller's deltas.
+
+    ``0`` is first-class here rather than degenerate - it asks for an exact
+    grid match, the strictest tolerance available - so neither shared
+    continuous domain fits (:func:`~strands_robots.utils.positive_finite_number_error`
+    refuses it). This decides only the floor and defers the numeric-ness,
+    finiteness and ``bool`` decisions to
+    :func:`~strands_robots.utils.finite_number_error`, so the two cannot
+    diverge on them.
+
+    Args:
+        value: The caller-supplied tolerance, in seconds.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if error := finite_number_error(value, "tolerance_s", "open"):
+        return error
+    if float(value) < 0.0:
+        return (
+            f"open: tolerance_s must be >= 0, got {value!r}. It is the half-width of the "
+            "grid-match window, so a negative one is satisfied by no delta at all and "
+            "refuses an on-grid delta_timestamps. Pass 0 to require an exact grid match."
+        )
+    return None
+
+
+# Every numeric parameter of ``StreamingDatasetReader.open`` and the domain
+# that decides it. A table rather than an inline chain because the pairing is
+# what stops the two drifting apart: a knob added to the signature without a
+# domain is a knob forwarded raw into a constructor that validates only
+# ``repo_type``, which is how these four came to be unguarded.
+_NUMERIC_DOMAINS: dict[str, Callable[[Any], str | None]] = {
+    # Half-width of the grid-match window; see _tolerance_error.
+    "tolerance_s": _tolerance_error,
+    # Reservoir size: the exclusive upper bound of ``rng.integers(0, buffer_size)``
+    # and the length the frame buffer is compared against, so only a true
+    # positive int can be honored - 0 and a negative raise ``high <= 0`` from
+    # NumPy part-way through iteration, and a fractional one is used verbatim.
+    "buffer_size": lambda value: positive_count_error(value, "buffer_size", "open"),
+    # Shard count: reaches ``min(hf_shards, max_num_shards)`` and then
+    # ``range(num_shards)``, so 0 or a negative yields zero shards and the
+    # reader streams no frames at all under a successful open.
+    "max_num_shards": lambda value: positive_count_error(value, "max_num_shards", "open"),
+    # Reproducibility seed for the reservoir shuffle: ``np.random.default_rng``
+    # refuses a negative or a float, and 0 is simply a seed - the domain
+    # ``TrainSpec.seed`` already uses.
+    "seed": lambda value: non_negative_count_error(value, "seed", "open"),
+}
+
+
 class StreamingDatasetReader:
     """Version-tolerant wrapper over lerobot's StreamingLeRobotDataset.
 
@@ -129,7 +197,20 @@ class StreamingDatasetReader:
     ) -> StreamingDatasetReader:
         """Open a version-tolerant streaming reader.
 
+        Validation:
+            The numeric knobs are checked against
+            :data:`_NUMERIC_DOMAINS` before the lerobot import, because
+            ``StreamingLeRobotDataset`` validates only ``repo_type`` and stores
+            the rest verbatim. So an unusable one is a caller mistake reported
+            the same way with or without the extra installed, rather than a
+            NumPy error part-way through iteration, a shard count of zero that
+            streams no frames, or a tolerance that switches the grid check off.
+
         Raises:
+            ValueError: A numeric knob (``tolerance_s``, ``buffer_size``,
+                ``max_num_shards`` or ``seed``) is outside its domain. The
+                message names the parameter, the value and why it cannot be
+                honored.
             RuntimeError: ``repo_type`` is not ``"dataset"`` but the installed
                 ``StreamingLeRobotDataset`` does not accept a ``repo_type``
                 parameter. lerobot >= :data:`BUCKET_STREAMING_MIN_LEROBOT`
@@ -147,6 +228,21 @@ class StreamingDatasetReader:
                 call would silently do the opposite of what was asked.
             ImportError: ``StreamingLeRobotDataset`` is not importable.
         """
+        # Before the lerobot import: a value outside these domains is a caller
+        # mistake rather than a capability question, so it must be reported the
+        # same way whether or not the extra is installed - and refusing it here
+        # means an unusable value never reaches the constructor, which fetches
+        # dataset metadata and re-shards before any of it would be consumed.
+        supplied = {
+            "tolerance_s": tolerance_s,
+            "buffer_size": buffer_size,
+            "max_num_shards": max_num_shards,
+            "seed": seed,
+        }
+        for param, domain in _NUMERIC_DOMAINS.items():
+            if error := domain(supplied[param]):
+                raise ValueError(error)
+
         StreamingCls = _get_streaming_cls()
         init_sig = inspect.signature(StreamingCls).parameters
         # If the constructor accepts **kwargs, every candidate is forwardable.

--- a/tests/test_streaming_open_numeric_domains.py
+++ b/tests/test_streaming_open_numeric_domains.py
@@ -1,0 +1,373 @@
+"""``StreamingDatasetReader.open`` refuses a numeric knob it cannot honor.
+
+``open`` forwards ``tolerance_s`` / ``buffer_size`` / ``max_num_shards`` /
+``seed`` into ``StreamingLeRobotDataset``, whose constructor validates only
+``repo_type`` and stores the rest verbatim. Every consumer of the four is
+downstream of the call that returned successfully, so an unusable value used to
+surface - when it surfaced at all - as a NumPy error part-way through iteration,
+a shard count that streamed nothing, or a grid check that answered the same way
+for every input.
+
+The premise tests here measure each consumer directly rather than asserting it
+in prose, so the reason a value is refused stays true against the installed
+lerobot/NumPy rather than against this module's description of them. They skip
+when lerobot is absent; every other test in this file runs without it, which is
+the point of validating ahead of the import.
+"""
+
+from __future__ import annotations
+
+import math
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.streaming_dataset as sd
+
+# Values no consumer of these knobs can honor, grouped by why.
+UNUSABLE_TOLERANCES = [-1.0, -1e-9, float("nan"), float("inf"), float("-inf"), True, "1e-4", None, [1e-4]]
+UNUSABLE_COUNTS = [0, -1, -16, 2.7, float("nan"), float("inf"), True, False, "8", None, [8]]
+UNUSABLE_SEEDS = [-1, -42, 2.7, float("nan"), float("inf"), True, False, "42", None, [7]]
+
+# Accepted values, one per knob, that must keep reaching the constructor. Annotated
+# because the lists are deliberately heterogeneous - a NumPy scalar tolerance has to
+# be accepted alongside a Python float.
+USABLE: dict[str, list[Any]] = {
+    "tolerance_s": [0.0, 1e-4, 0.5, np.float32(1e-4)],
+    "buffer_size": [1, 256, 1000],
+    "max_num_shards": [1, 8, 16],
+    "seed": [0, 42],
+}
+
+
+class _FakeStreaming:
+    """Constructor-shaped stand-in that records the kwargs it was handed."""
+
+    def __init__(self, repo_id: str, **kw: Any) -> None:
+        self.repo_id = repo_id
+        self.kw = kw
+        self.num_frames = 1000
+        self.num_episodes = 10
+        self.fps = 30
+
+    def __iter__(self) -> Any:
+        yield {"observation.state": [0.0]}
+
+
+@pytest.fixture
+def fake_lerobot(monkeypatch: pytest.MonkeyPatch) -> type[_FakeStreaming]:
+    """Inject the constructor stand-in ``_get_streaming_cls`` honors."""
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    return _FakeStreaming
+
+
+@pytest.fixture
+def lerobot_import_is_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make reaching the lerobot import a test failure.
+
+    Every refusal must be decided before it, so a refusal test that trips this
+    is a guard-placement regression rather than a domain one.
+    """
+
+    def _explode() -> Any:
+        raise AssertionError("the lerobot import was reached: the refusal must precede it")
+
+    monkeypatch.setattr(sd, "_get_streaming_cls", _explode)
+
+
+def _open(**kwargs: Any) -> Any:
+    """Call ``open`` with a splat so a deliberately off-type value type-checks."""
+    return sd.StreamingDatasetReader.open("org/ds", validate_deltas=False, **kwargs)
+
+
+class TestTheNumericKnobsAreRefusedBeforeTheImport:
+    """An unusable knob is a caller mistake, so it needs no lerobot installed."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_TOLERANCES, ids=repr)
+    def test_an_unusable_tolerance_is_refused(self, value: Any, lerobot_import_is_fatal: None) -> None:
+        with pytest.raises(ValueError, match="tolerance_s"):
+            _open(tolerance_s=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS, ids=repr)
+    def test_an_unusable_buffer_size_is_refused(self, value: Any, lerobot_import_is_fatal: None) -> None:
+        with pytest.raises(ValueError, match="buffer_size"):
+            _open(buffer_size=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS, ids=repr)
+    def test_an_unusable_shard_count_is_refused(self, value: Any, lerobot_import_is_fatal: None) -> None:
+        with pytest.raises(ValueError, match="max_num_shards"):
+            _open(max_num_shards=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_SEEDS, ids=repr)
+    def test_an_unusable_seed_is_refused(self, value: Any, lerobot_import_is_fatal: None) -> None:
+        with pytest.raises(ValueError, match="seed"):
+            _open(seed=value)
+
+    def test_the_message_names_the_surface_the_parameter_and_the_value(self, lerobot_import_is_fatal: None) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _open(max_num_shards=0)
+        text = str(excinfo.value)
+        assert text.startswith("open: "), text
+        assert "max_num_shards" in text
+        assert "0" in text
+
+
+class TestAUsableKnobStillReachesTheConstructor:
+    """The guard is additive: every honorable value is forwarded unchanged."""
+
+    @pytest.mark.parametrize(
+        ("param", "value"),
+        [(p, v) for p, values in USABLE.items() for v in values],
+        ids=[f"{p}={v!r}" for p, values in USABLE.items() for v in values],
+    )
+    def test_a_usable_value_is_forwarded_verbatim(
+        self, param: str, value: Any, fake_lerobot: type[_FakeStreaming]
+    ) -> None:
+        reader = _open(**{param: value})
+        assert reader.dataset.kw[param] == value
+
+    def test_the_defaults_are_inside_every_domain(self, fake_lerobot: type[_FakeStreaming]) -> None:
+        """A call passing none of the four must not be refused by its own defaults."""
+        reader = _open()
+        assert reader.dataset.kw["buffer_size"] == 1000
+        assert reader.dataset.kw["max_num_shards"] == 16
+        assert reader.dataset.kw["seed"] == 42
+        assert reader.dataset.kw["tolerance_s"] == pytest.approx(1e-4)
+
+
+class TestZeroIsFirstClassForTheToleranceOnly:
+    """``0`` is the strictest grid match, and a degenerate size/shard count."""
+
+    def test_a_zero_tolerance_is_accepted(self, fake_lerobot: type[_FakeStreaming]) -> None:
+        assert _open(tolerance_s=0.0).dataset.kw["tolerance_s"] == 0.0
+
+    def test_a_zero_tolerance_is_the_only_difference_from_the_shared_signed_domain(self) -> None:
+        """The floor is the whole of ``_tolerance_error``'s own contribution."""
+        from strands_robots.utils import finite_number_error
+
+        for value in [0.0, 1e-4, float("nan"), True, "x", None, [1.0]]:
+            shared = finite_number_error(value, "tolerance_s", "open")
+            local = sd._tolerance_error(value)
+            assert (local is None) == (shared is None), value
+        assert sd._tolerance_error(-1.0) is not None
+        assert finite_number_error(-1.0, "tolerance_s", "open") is None
+
+    @pytest.mark.parametrize("param", ["buffer_size", "max_num_shards"])
+    def test_a_zero_count_is_refused(self, param: str, lerobot_import_is_fatal: None) -> None:
+        with pytest.raises(ValueError, match=param):
+            _open(**{param: 0})
+
+    def test_a_zero_seed_is_accepted(self, fake_lerobot: type[_FakeStreaming]) -> None:
+        assert _open(seed=0).dataset.kw["seed"] == 0
+
+
+class TestTheRefusalPrecedesEveryEffect:
+    """Nothing is imported, constructed or fetched for a refused call."""
+
+    def test_no_constructor_is_called(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        built: list[str] = []
+
+        class _Recording(_FakeStreaming):
+            def __init__(self, repo_id: str, **kw: Any) -> None:
+                built.append(repo_id)
+                super().__init__(repo_id, **kw)
+
+        monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Recording, raising=False)
+        with pytest.raises(ValueError):
+            _open(buffer_size=-1)
+        assert built == []
+
+    def test_a_usable_call_does_reach_the_constructor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-vacuity for the test above: the recorder does fire when it should."""
+        built: list[str] = []
+
+        class _Recording(_FakeStreaming):
+            def __init__(self, repo_id: str, **kw: Any) -> None:
+                built.append(repo_id)
+                super().__init__(repo_id, **kw)
+
+        monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Recording, raising=False)
+        _open(buffer_size=1)
+        assert built == ["org/ds"]
+
+
+class TestEveryNumericParameterOfOpenHasADomain:
+    """The signature, the domain table and the values passed to it must agree.
+
+    A knob added to ``open`` without an entry here is a knob forwarded raw into
+    a constructor that validates only ``repo_type`` - which is how these four
+    came to be unguarded - so the pairing is asserted rather than left to
+    review.
+    """
+
+    @staticmethod
+    def _open_node() -> Any:
+        import ast
+        import inspect
+        import pathlib
+
+        tree = ast.parse(pathlib.Path(inspect.getfile(sd)).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "open":
+                return node
+        raise AssertionError("StreamingDatasetReader.open not found")
+
+    @staticmethod
+    def _numeric_params(node: Any) -> set[str]:
+        import ast
+
+        found = set()
+        for arg in list(node.args.args) + list(node.args.kwonlyargs):
+            if arg.annotation is not None and ast.unparse(arg.annotation) in {"int", "float"}:
+                found.add(arg.arg)
+        return found
+
+    def test_the_signature_declares_exactly_the_four_numeric_knobs(self) -> None:
+        """Non-vacuity: a scanner finding nothing would pass every test below."""
+        assert self._numeric_params(self._open_node()) == {
+            "tolerance_s",
+            "buffer_size",
+            "max_num_shards",
+            "seed",
+        }
+
+    def test_the_domain_table_covers_every_numeric_parameter(self) -> None:
+        assert set(sd._NUMERIC_DOMAINS) == self._numeric_params(self._open_node())
+
+    def test_the_checked_values_are_the_parameters_themselves(self) -> None:
+        """The mapping ``open`` builds must read each knob, not a stale copy."""
+        import ast
+
+        node = self._open_node()
+        for stmt in ast.walk(node):
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and stmt.targets[0].id == "supplied"
+                and isinstance(stmt.value, ast.Dict)
+            ):
+                keys = {k.value for k in stmt.value.keys if isinstance(k, ast.Constant)}
+                values = {v.id for v in stmt.value.values if isinstance(v, ast.Name)}
+                assert keys == set(sd._NUMERIC_DOMAINS)
+                assert values == keys
+                return
+        raise AssertionError("open() does not build a `supplied` mapping of its numeric knobs")
+
+    def test_a_planted_knob_without_a_domain_is_detected(self) -> None:
+        """The scanner must fail for the shape it exists to catch."""
+        import ast
+
+        node = self._open_node()
+        planted = ast.arg(arg="prefetch_depth", annotation=ast.Name(id="int"))
+        node.args.kwonlyargs.append(planted)
+        assert self._numeric_params(node) - set(sd._NUMERIC_DOMAINS) == {"prefetch_depth"}
+
+
+class TestWhyEachValueCannotBeHonored:
+    """Measure each consumer, so the reasons stay true against the installed deps."""
+
+    def test_an_infinite_tolerance_accepts_an_off_grid_delta(self) -> None:
+        """The grid check ``open`` replicates answers the same way for every input."""
+        feature_utils = pytest.importorskip("lerobot.datasets.feature_utils")
+        off_grid = {"observation.state": [0.0, -0.0167]}
+        with pytest.raises(ValueError):
+            feature_utils.check_delta_timestamps(off_grid, 30, 1e-4, raise_value_error=True)
+        assert feature_utils.check_delta_timestamps(off_grid, 30, float("inf"), raise_value_error=True)
+
+    def test_a_nan_tolerance_refuses_an_on_grid_delta(self) -> None:
+        feature_utils = pytest.importorskip("lerobot.datasets.feature_utils")
+        on_grid = {"observation.state": [0.0, -1 / 30, -2 / 30]}
+        assert feature_utils.check_delta_timestamps(on_grid, 30, 1e-4, raise_value_error=True)
+        with pytest.raises(ValueError):
+            feature_utils.check_delta_timestamps(on_grid, 30, float("nan"), raise_value_error=True)
+
+    @pytest.mark.parametrize("value", [0, -5])
+    def test_a_non_positive_shard_count_iterates_no_shards(self, value: int) -> None:
+        """``min(hf_shards, v)`` then ``range(num_shards)`` - so nothing streams."""
+        assert list(range(min(16, value))) == []
+
+    @pytest.mark.parametrize("value", [0, -5])
+    def test_a_non_positive_buffer_size_has_no_reservoir_index(self, value: int) -> None:
+        with pytest.raises(ValueError, match="high <= 0"):
+            np.random.default_rng(0).integers(0, value, size=1)
+
+    def test_a_fractional_shard_count_is_not_a_range_bound(self) -> None:
+        # Bound through Any: the point is what the runtime does with the value the
+        # clamp lets through, not what a type checker would have said about it.
+        bound: Any = min(16, 2.7)
+        with pytest.raises(TypeError, match="cannot be interpreted as an integer"):
+            range(bound)
+
+    @pytest.mark.parametrize("value", [-1, 2.7, float("nan")])
+    def test_an_unusable_seed_has_no_generator(self, value: Any) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            np.random.default_rng(value)
+
+    def test_a_non_finite_shard_count_is_discarded_by_the_clamp(self) -> None:
+        """``min`` keeps the left operand, so nan/inf silently mean "the default"."""
+        assert min(16, float("nan")) == 16
+        assert min(16, float("inf")) == 16
+
+
+class TestTheDataloaderKnobsStayOutOfScope:
+    """``dataloader`` hands its knobs to torch, which refuses them at construction."""
+
+    def test_torch_refuses_an_unusable_batch_size_itself(self) -> None:
+        torch = pytest.importorskip("torch")
+        for value in [0, -8, 2.7, True, math.nan, "32"]:
+            with pytest.raises(ValueError, match="batch_size"):
+                torch.utils.data.DataLoader([1, 2, 3], batch_size=value)
+
+    def test_dataloader_is_not_guarded_here(self) -> None:
+        """Its knobs are absent from the table, and that is deliberate."""
+        assert "batch_size" not in sd._NUMERIC_DOMAINS
+        assert "num_workers" not in sd._NUMERIC_DOMAINS
+
+
+class TestTheGuardDoesNotDisturbTheNeighbouringContracts:
+    """The three non-numeric decisions ``open`` already made are unchanged."""
+
+    def test_a_bucket_repo_type_still_raises_on_an_older_constructor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Narrow:
+            def __init__(self, repo_id: str) -> None:
+                self.repo_id = repo_id
+                self.num_frames = self.num_episodes = self.fps = 0
+
+        monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+        with pytest.raises(RuntimeError, match="repo_type"):
+            _open(repo_type="bucket")
+
+    def test_drop_videos_without_proprio_deltas_still_raises(self, fake_lerobot: type[_FakeStreaming]) -> None:
+        with pytest.raises(ValueError, match="drop_videos"):
+            _open(drop_videos=True)
+
+    def test_a_missing_lerobot_still_reports_the_install_remedy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A usable call on an install without lerobot keeps its own message."""
+        monkeypatch.setattr(sd, "StreamingLeRobotDataset", None, raising=False)
+        monkeypatch.setitem(__import__("sys").modules, "lerobot.datasets", None)
+        with pytest.raises(ImportError, match="strands-robots\\[lerobot\\]"):
+            _open(buffer_size=256)
+
+
+def test_the_module_needs_no_simulation_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The domains come from ``utils``, so the dataset layer stays independent."""
+    import ast
+    import inspect
+    import pathlib
+
+    tree = ast.parse(pathlib.Path(inspect.getfile(sd)).read_text(encoding="utf-8"))
+    imported = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module is not None}
+    assert not any(m.startswith("strands_robots.simulation") for m in imported), imported
+    assert "strands_robots.utils" in imported
+
+
+def test_the_domain_table_entries_are_callables_returning_a_reason() -> None:
+    """Every entry answers with a string or None - never raises, never a bool."""
+    for param, domain in sd._NUMERIC_DOMAINS.items():
+        assert isinstance(domain, types.FunctionType), param
+        assert domain(-1) is not None, param
+        reason = domain(-1)
+        assert isinstance(reason, str) and param in reason, (param, reason)


### PR DESCRIPTION
`StreamingDatasetReader.open` forwards `tolerance_s`, `buffer_size`, `max_num_shards` and `seed` verbatim into `StreamingLeRobotDataset`, whose constructor validates only `repo_type` and stores the rest. Every consumer of the four sits downstream of the call that already returned, so an unusable value surfaced late or not at all.

## What was measured

One script, opening a locally cached `lerobot/pusht` (206 episodes, 25 650 frames, proprio-only so no torchcodec is needed) once per case and counting the frames that actually came out. Run on `upstream/main` and on this branch; each dump records the tree it measured.

| the call | on main | with this change |
|---|---|---|
| defaults *(control)* | success, 40 frames | success, 40 frames |
| `max_num_shards=0` | **success, iteration success, 0 frames** | refused at `open()` |
| `max_num_shards=-5` | **success, iteration success, 0 frames** | refused at `open()` |
| `buffer_size=0` | success, then NumPy `high <= 0` after 0 frames | refused at `open()` |
| `seed=-1` | refused by NumPy, naming neither surface nor parameter | refused at `open()`, naming both |
| `tolerance_s=inf`, **off-grid** deltas | **success, 40 frames** | refused at `open()` |
| `tolerance_s=nan`, **on-grid** deltas | refused, blaming the caller's deltas | refused at `open()`, naming the tolerance |
| `tolerance_s=1e-4`, **off-grid** deltas *(control)* | refused, blaming the deltas | refused, blaming the deltas |

Outcomes that do not match the request: **6 of 8 on main, 0 of 8 here.**

![measured before/after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/streaming-numeric-domains/streaming_domains.png)

*The script and both JSON dumps are published alongside the figure, so every cell is re-derivable: [`measure_stream.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/streaming-numeric-domains/measure_stream.py), [before](https://raw.githubusercontent.com/cagataycali/robots/artifacts/streaming-numeric-domains/before_upstream_main.json), [after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/streaming-numeric-domains/after_this_change.json).*

## Why each one goes wrong

**`max_num_shards` is clamped, not checked.** `self.num_shards = min(self.hf_dataset.num_shards, max_num_shards)` and then `for idx in range(self.num_shards)`. A `min()` against a caller value is not a guard: `0` and any negative pass straight through and `range` yields nothing, so the reader iterates zero shards and streams **no frames at all** with no error on any path. A caller counting frames sees an empty dataset. `2.7` reaches `range` and raises `TypeError` part-way through iteration instead; `nan`/`inf` are silently discarded (`min` keeps its left operand), so they quietly mean "the default".

**`tolerance_s` decides whether a guard can answer.** `open()` deliberately runs `check_delta_timestamps` itself, with the comment *"the streaming path skips check_delta_timestamps; replicate it for parity with the materialized dataset"*. That check is `abs(ts * fps - round(ts * fps)) / fps <= tolerance_s`. An infinite tolerance makes it true for **every** delta, so the parity the call exists to restore is switched off by a value it never checked - rows 6 and 8 above are the same off-grid `delta_timestamps`, refused with a usable tolerance and accepted with `inf`. `nan` and a negative half-width are the mirror: false for every delta, so a perfectly on-grid `delta_timestamps` is refused in a message that blames the caller's deltas.

**`buffer_size` is the reservoir bound.** It is the exclusive upper bound of `rng.integers(0, buffer_size)` and the length the frame buffer is compared against, so `0` and negatives raise `high <= 0` from NumPy mid-iteration, after `open()` has already returned.

**`seed` builds the generator.** `np.random.default_rng(seed)` refuses a negative or a float - but only after the constructor has resolved metadata and re-sharded, and in a message naming neither `open` nor `seed`. `True` is accepted as a silent seed of 1.

A sibling makes the gap concrete: `FastSacTrainer.validate` refuses `buffer_size <= 0` with `"buffer_size must be > 0"`. Same parameter name, same "how many items are held in memory" role, opposite verdicts.

## The change

One table pairing each numeric parameter with the domain that decides it, checked at the top of `open()` **before the lerobot import**, so a caller mistake is reported identically with or without the extra installed and never reaches the constructor's metadata fetch:

| knob | domain | why that one |
|---|---|---|
| `buffer_size` | `positive_count_error` | read as an exclusive `integers()` bound - the docstring's own "`range()` bounds, slice indices" family |
| `max_num_shards` | `positive_count_error` | read as a `range()` bound |
| `seed` | `non_negative_count_error` | the domain `TrainSpec.seed` already uses; `0` is simply a seed, and NumPy refuses a negative or a float |
| `tolerance_s` | `finite_number_error` + a floor | `0` asks for an *exact* grid match, the strictest tolerance available, so `positive_finite_number_error` would refuse a first-class value |

No new shared helper: `_tolerance_error` is a module-private wrapper that decides **only** the floor and defers numeric-ness, finiteness and `bool` to the shared signed rule, so the two cannot diverge on them. That is pinned as a test - the floor is the whole of its own contribution.

The domains come from `strands_robots.utils`, so the dataset layer stays independent of `strands_robots.simulation` (asserted).

### Deliberately out of scope

`dataloader(batch_size=..., num_workers=...)` hands its knobs to torch, which refuses an unusable `batch_size` at construction for every value probed (`0`, `-8`, `2.7`, `True`, `nan`, `"32"`). It is the in-module control and stays unguarded; a test asserts both that torch does the refusing and that neither knob is in the table.

## Tests

84 new tests in `tests/test_streaming_open_numeric_domains.py`. Pre-fix, with only the source file reverted to `main`: **51 failed / 33 passed**. The 33 that pass are the over-reach controls - the consumer-premise measurements, the usable-value forwarding, and the three neighbouring contracts (`repo_type`, `drop_videos`, the missing-lerobot remedy) - so they are what stops the guard reaching further than these four values.

Every refusal test runs with lerobot **absent**: a fixture makes reaching the import a test failure, which turns guard placement into an assertion rather than a convention. Two more pin it directly - a refused call constructs nothing, and its non-vacuity twin shows the recorder does fire for a usable one.

The reasons are measured rather than described. `TestWhyEachValueCannotBeHonored` runs `check_delta_timestamps`, `range(min(...))`, `rng.integers` and `default_rng` itself, so a claim in a docstring cannot drift away from the installed lerobot/NumPy.

`TestEveryNumericParameterOfOpenHasADomain` asserts a three-way agreement - the numeric parameters in `open`'s signature, the keys of the domain table, and the values the loop reads - plus a non-vacuity test naming the four, and a planted-knob test proving the scanner fails for the shape it exists to catch. A knob added later without a domain fails rather than being forwarded raw.

Zero existing tests changed.

## Gate

Measured on `1116f90`, whose tree differs from the current head `69b32be` only in the name of the changelog fragment (renamed to the PR number after opening; no source, test or docs line differs). Base `cbd5e45`, `MUJOCO_GL=egl`, aarch64, lerobot 0.6.2, mujoco 3.11.0):

- `pytest tests` - **20752 passed, 257 skipped, 0 failed** in 529.38s
- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - 1079 files already formatted
- `mypy strands_robots tests tests_integ` - **0 errors outside `examples/isaac_gs`**. The 14 reported there are environmental in this working copy: the same run on a pristine `upstream/main` worktree produces a **byte-identical** error set.
- `scripts/check_merge_base_overlap.py` - no overlap; `assemble_changelog.py --check` - OK

## Docs

`docs/recording.md`'s "Useful kwargs" block already named `buffer_size` and `max_num_shards` and explained which kwarg is *not* tolerant-forwarded. It now also states what the four numeric ones accept, including that `tolerance_s=0` means "require an exact grid match" and `seed=0` is simply a seed.
