### PR TITLE
fix(verify_dataset): an episode-count threshold outside its domain is refused, not applied

### DIFF
--- a/changelog.d/1971-verify-dataset-count-domains.md
+++ b/changelog.d/1971-verify-dataset-count-domains.md
@@ -1,0 +1,22 @@
+### Fixed: the dataset-integrity gate refuses an episode-count threshold it cannot honor
+
+`verify_dataset(root, expected=..., min_frames=...)` - the function behind
+`strands-robots verify-dataset` - guarded `expected` with its own comparison and
+left `min_frames`, the sibling count in the same signature, unchecked. Because the
+per-episode length check runs only when `min_frames > 0`, a value that fails that
+comparison did not fail loudly, it switched the check off: on a dataset holding a
+zero-length episode - the corruption class the check exists to detect - a
+`min_frames` of `-5`, `False` or `nan` returned `status="success"` and the CLI
+exited `0`. A `"2"`, `None` or `[2]` escaped as a bare `TypeError` past a checker
+documented to always produce a report, and a fractional threshold reported a frame
+count no episode can have.
+
+Both counts now share `utils.non_negative_count_error`, which keeps `0`
+first-class - `min_frames=0` remains the documented way to skip the length check,
+`expected=0` still asks that a dataset be empty - and rejects `bool`, closing a
+hole the two hand-rolled copies shared: as an `int` subclass, `True` satisfied
+`isinstance(value, int) and value >= 0` and became a silent threshold, or a silent
+episode count, of one. `SimEngine.verify_dataset_episodes` routes through the same
+helper, so neither surface accepts an episode count the other refuses. Refusals
+are reported in the report's `problems` (exit code `1`) rather than raised,
+matching how the checker already reports a corrupt dataset.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -340,6 +340,17 @@ never written. It resolves each camera's MP4 from `meta/info.json`'s
 `strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1, check_videos=True)`,
 which returns the same report dict.
 
+`--expected` and `--min-frames` are both non-negative integers, and each has a
+meaningful `0`: `--expected 0` asks that a dataset be empty, and `--min-frames 0`
+skips the per-episode length check (useful when the writer omits the `length`
+column). Anything else - a negative threshold, a fraction, a non-finite value -
+is reported as a problem and exits non-zero, rather than being applied. That
+matters for `--min-frames` specifically: the length check runs only when the
+threshold is above zero, so a value that is not a usable count would otherwise
+switch the check off and certify a dataset holding a zero-length episode. The
+same domain backs `verify_dataset_episodes(expected=...)`, so neither surface
+accepts an episode count the other refuses.
+
 `verify-dataset` always produces a report - it never crashes on the corruption
 it exists to flag. A corrupt or foreign `meta/episodes` parquet, a non-v3
 `video_path` template, or a truncated / unreadable MP4 is reported as a problem

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -52,6 +52,7 @@ from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     is_boolean,
+    non_negative_count_error,
     positive_count_error,
     positive_finite_number_error,
     sequence_length,
@@ -2834,7 +2835,8 @@ class SimEngine(ABC):
         still open).
 
         Args:
-            expected: The episode count the caller intended to record.
+            expected: The episode count the caller intended to record. A
+                non-negative int; anything else is reported as an error dict.
 
         Returns:
             Standard status dict. ``status`` is ``"success"`` when the parquet
@@ -2851,13 +2853,12 @@ class SimEngine(ABC):
             since the episodes found are then only a lower bound. An unreadable
             or corrupt parquet is reported as this same error dict, never raised.
         """
-        if not isinstance(expected, int) or expected < 0:
-            return {
-                "status": "error",
-                "content": [
-                    {"text": f"verify_dataset_episodes: expected must be a non-negative int, got {expected!r}."}
-                ],
-            }
+        # Shares the count domain with the programmatic
+        # :func:`strands_robots.verify_dataset.verify_dataset` gate rather than
+        # re-deriving it: one rule for one question, so neither surface can accept
+        # an episode count the other refuses.
+        if error := non_negative_count_error(expected, "expected", "verify_dataset_episodes"):
+            return {"status": "error", "content": [{"text": error}]}
 
         root = self._active_dataset_root()
         if not root:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1129,6 +1129,15 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
       ``torch.manual_seed`` reduces a negative seed modulo ``2**64`` (so ``-1``
       silently becomes ``2**64 - 1`` and collides with a seed a caller could
       have named), while NumPy's legacy seeder refuses a negative or a float.
+    * The episode counts of the dataset-integrity gate
+      (:func:`strands_robots.verify_dataset.verify_dataset`'s ``expected`` and
+      ``min_frames``, and the sim facade's
+      :meth:`~strands_robots.simulation.base.SimEngine.verify_dataset_episodes`).
+      ``expected=0`` asks that a dataset be empty and ``min_frames=0`` skips the
+      per-episode length check, so ``0`` selects a mode there rather than
+      degenerating one. A value outside the domain cannot: the length check runs
+      only for a threshold above zero, so a negative or non-finite one disables
+      the check instead of failing it.
 
     Refusing ``0`` would reject the common configuration for both, which is why
     this is a separate domain rather than a caller of

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -10,7 +10,7 @@ recorder bookkeeping.
 Checks performed against a dataset root (the dir containing ``meta/``):
   1. parquet exists and holds at least one distinct episode;
   2. every episode has at least ``--min-frames`` frames (default 1) - flags any
-     zero-length episode;
+     zero-length episode (``--min-frames 0`` disables this one check);
   3. ``meta/info.json`` ``total_episodes`` / ``total_frames`` (when present)
      agree with the parquet ground truth - flags metadata/parquet drift;
   4. when ``--expected N`` is given, the parquet holds exactly N episodes -
@@ -54,6 +54,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from strands_robots.utils import non_negative_count_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,6 +77,7 @@ def verify_dataset(
         root: Dataset root directory (the dir that contains ``meta/``).
         expected: If given, require exactly this many distinct episodes.
         min_frames: Minimum frames every episode must contain (default 1).
+            A non-negative int; ``0`` disables this check.
         check_videos: When True (default), verify that every per-episode
             video file referenced by the dataset exists and is non-empty.
         check_stats: When True (default), flag any episode whose ``action``
@@ -122,8 +125,20 @@ def verify_dataset(
     }
     problems: list[str] = report["problems"]
 
-    if expected is not None and (not isinstance(expected, int) or expected < 0):
-        problems.append(f"expected must be a non-negative int, got {expected!r}")
+    # Argument domains. ``expected`` and ``min_frames`` are both discrete counts
+    # whose ``0`` is meaningful rather than degenerate - ``expected=0`` asks that a
+    # dataset be empty, ``min_frames=0`` disables the length check - so they share
+    # :func:`~strands_robots.utils.non_negative_count_error` rather than each
+    # carrying its own comparison. A value outside that domain cannot be honored:
+    # a fractional threshold reports a frame count no episode can have, and one
+    # below zero (or a non-finite one) switches off the very check this gate exists
+    # to run. Both are reported rather than raised, because this checker's contract
+    # is that a bad input yields a report exactly as a corrupt dataset does.
+    if expected is not None and (error := non_negative_count_error(expected, "expected", "verify_dataset")):
+        problems.append(error)
+    if error := non_negative_count_error(min_frames, "min_frames", "verify_dataset"):
+        problems.append(error)
+    if problems:
         return report
 
     # Parquet ground truth. A corrupt or foreign parquet under meta/episodes
@@ -163,6 +178,10 @@ def verify_dataset(
 
     # Check 2: every episode has >= min_frames frames. Only when per-episode
     # lengths are available (the length column is optional in some writers).
+    # ``min_frames == 0`` is the documented way to skip this one check; the value
+    # is an already-validated non-negative int here, so this reads as a mode
+    # selector rather than a guard. Before the domain above it was a guard, and
+    # a negative or non-finite threshold disabled the check silently.
     if min_frames > 0 and info["frames_per_episode"]:
         short = [
             (ep, n)
@@ -566,7 +585,7 @@ def main(argv: list[str] | None = None) -> int:
         "--min-frames",
         type=int,
         default=1,
-        help="Minimum frames every episode must contain (default: 1).",
+        help="Minimum frames every episode must contain (default: 1); 0 disables the check.",
     )
     parser.add_argument(
         "--json",

--- a/tests/test_verify_dataset_numeric_domains.py
+++ b/tests/test_verify_dataset_numeric_domains.py
@@ -1,0 +1,227 @@
+"""The dataset-integrity gate refuses a threshold it cannot honor.
+
+:func:`strands_robots.verify_dataset.verify_dataset` and the sim-facade
+:meth:`~strands_robots.simulation.base.SimEngine.verify_dataset_episodes` ask
+one question - does this recording hold the episodes it claims - and take two
+discrete counts to ask it. ``expected`` carried its own comparison on both
+surfaces and ``min_frames`` carried none, so the threshold that decides check 2
+was the one input nothing checked.
+
+The consequence is specific to a gate: ``min_frames`` is compared as
+``min_frames > 0`` before the check runs, so a value that fails that comparison
+does not fail loudly - it *switches the check off*. A dataset holding a
+zero-length episode, the exact corruption class the check exists to detect,
+was certified ``status="success"`` (CLI exit 0) under ``min_frames=-5``,
+``False`` or ``nan``, while ``"2"`` / ``None`` / ``[2]`` escaped as a bare
+``TypeError`` past a checker documented to always produce a report.
+
+Both counts now share :func:`~strands_robots.utils.non_negative_count_error`,
+which keeps ``0`` first-class - ``min_frames=0`` is the documented way to skip
+the length check, and ``expected=0`` asks that a dataset be empty - and rejects
+``bool``, closing a hole both hand-rolled copies shared: as an ``int`` subclass
+``True`` passed ``isinstance(value, int) and value >= 0`` and became a silent
+threshold, or a silent episode count, of one.
+
+Fixtures are pyarrow-only (no lerobot, no mujoco) and every assertion is on
+observable behaviour: the report's ``status`` / ``problems``, whether the
+zero-length episode was actually named, and the CLI exit code.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+from strands_robots.simulation.base import SimEngine
+from strands_robots.utils import non_negative_count_error
+from strands_robots.verify_dataset import main as verify_main
+from strands_robots.verify_dataset import verify_dataset
+
+from .test_verify_dataset import _write_dataset
+
+# Values no episode-count threshold can be honored as. ``-5`` is refused by the
+# sibling ``expected`` on both surfaces, so it also measures the divergence
+# between two counts in one signature.
+UNUSABLE_COUNTS: list[Any] = [-5, -1, True, False, 2.7, 3.0, float("nan"), float("inf"), "2", [2], {"n": 2}]
+
+# Usable: a real threshold, and the documented "skip this check" spelling.
+USABLE_COUNTS: list[Any] = [0, 1, 5]
+
+
+def _corrupt(root: Path) -> Path:
+    """A dataset whose episode 1 holds zero frames - check 2's whole purpose."""
+    return _write_dataset(root, episode_indices=[0, 1], frames_per_episode=[5, 0])
+
+
+def _healthy(root: Path) -> Path:
+    """A dataset every check passes."""
+    return _write_dataset(
+        root,
+        episode_indices=[0, 1],
+        frames_per_episode=[5, 5],
+        info={"total_episodes": 2, "total_frames": 10},
+    )
+
+
+def _verify(**kwargs: Any) -> dict[str, Any]:
+    """Call the gate with deliberately off-type values without narrowing them.
+
+    ``min_frames`` / ``expected`` are annotated ``int``; the point of these
+    tests is what the runtime does with a value an agent or a shell can still
+    supply, so the arguments are splatted rather than passed positionally.
+    """
+    return verify_dataset(**kwargs)
+
+
+def _flagged_short_episode(report: dict[str, Any]) -> bool:
+    """Did the report actually name the zero-length episode?
+
+    Distinguished from "a problem mentioning ``min_frames`` exists", because a
+    refusal of the threshold also names it. Only check 2 reports a frame count.
+    """
+    return any("frame(s)" in p for p in report["problems"])
+
+
+class TestAThresholdOutsideTheDomainIsRefusedNotApplied:
+    """``min_frames`` is reported, and never silently disables the check."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS)
+    def test_the_report_names_the_threshold_as_the_problem(self, tmp_path: Path, value: Any) -> None:
+        report = _verify(root=_corrupt(tmp_path), min_frames=value)
+        assert report["status"] == "error", report
+        assert report["ok"] is False
+        assert any("min_frames must be a non-negative integer" in p for p in report["problems"]), report["problems"]
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS)
+    def test_a_corrupt_dataset_is_never_certified(self, tmp_path: Path, value: Any) -> None:
+        """The headline: no threshold may turn this gate into a pass."""
+        report = _verify(root=_corrupt(tmp_path), min_frames=value)
+        assert report["status"] != "success", report
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS)
+    def test_nothing_escapes_as_a_traceback(self, tmp_path: Path, value: Any) -> None:
+        """The checker's documented contract is that a bad input yields a report."""
+        report = _verify(root=_corrupt(tmp_path), min_frames=value)
+        assert isinstance(report, dict) and isinstance(report["problems"], list)
+
+    def test_the_threshold_is_reported_before_the_parquet_is_read(self, tmp_path: Path) -> None:
+        """A refused threshold is a caller error, not a dataset verdict."""
+        report = _verify(root=_corrupt(tmp_path), min_frames=-5)
+        assert report["total_episodes"] == 0
+        assert report["episode_indices"] == []
+        assert not _flagged_short_episode(report)
+
+
+class TestZeroStaysTheDocumentedSkipSpelling:
+    """``min_frames=0`` skips check 2; it is the only spelling that does."""
+
+    def test_zero_still_disables_the_length_check(self, tmp_path: Path) -> None:
+        report = _verify(root=_corrupt(tmp_path), min_frames=0)
+        assert report["status"] == "success", report
+        assert not _flagged_short_episode(report)
+
+    @pytest.mark.parametrize("value", [1, 5])
+    def test_a_real_threshold_still_flags_the_short_episode(self, tmp_path: Path, value: int) -> None:
+        report = _verify(root=_corrupt(tmp_path), min_frames=value)
+        assert report["status"] == "error"
+        assert _flagged_short_episode(report), report["problems"]
+
+    @pytest.mark.parametrize("value", USABLE_COUNTS)
+    def test_a_healthy_dataset_still_passes(self, tmp_path: Path, value: int) -> None:
+        report = _verify(root=_healthy(tmp_path), min_frames=value)
+        assert report["status"] == "success", report
+
+
+class TestTheSiblingCountSharesTheDomain:
+    """``expected`` keeps its behaviour and loses its ``bool`` hole."""
+
+    def test_a_boolean_episode_count_is_refused(self, tmp_path: Path) -> None:
+        """``expected=True`` used to certify a one-episode dataset."""
+        report = _verify(root=_write_dataset(tmp_path, [0], [3]), expected=True)
+        assert report["status"] == "error"
+        assert any("expected must be a non-negative integer" in p for p in report["problems"])
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS)
+    def test_every_unusable_expected_is_reported(self, tmp_path: Path, value: Any) -> None:
+        report = _verify(root=_write_dataset(tmp_path, [0], [3]), expected=value)
+        assert any("expected must be a non-negative integer" in p for p in report["problems"]), report["problems"]
+
+    def test_none_still_means_no_expected_check(self, tmp_path: Path) -> None:
+        report = _verify(root=_healthy(tmp_path), expected=None)
+        assert report["status"] == "success", report
+
+    def test_zero_still_asks_for_an_empty_dataset(self, tmp_path: Path) -> None:
+        report = _verify(root=_write_dataset(tmp_path, [0], [3]), expected=0)
+        assert report["status"] == "error"
+        assert any("expected" in p and "0" in p for p in report["problems"])
+
+    def test_a_matching_count_still_passes(self, tmp_path: Path) -> None:
+        report = _verify(root=_healthy(tmp_path), expected=2)
+        assert report["status"] == "success", report
+
+    def test_the_existing_message_wording_is_preserved(self, tmp_path: Path) -> None:
+        """The pre-existing pin reads ``"non-negative int"``, a substring here."""
+        report = _verify(root=_write_dataset(tmp_path, [0], [3]), expected=-1)
+        assert any("non-negative int" in p for p in report["problems"])
+
+
+def _episodes_verdict(value: Any) -> str:
+    """Classify the sim facade's answer without needing a recorded dataset."""
+    stub = types.SimpleNamespace(_active_dataset_root=lambda: None)
+    result = SimEngine.verify_dataset_episodes(stub, value)  # type: ignore[arg-type]
+    text = "".join(block.get("text", "") for block in result["content"])
+    return "refused" if "must be a non-negative integer" in text else "accepted"
+
+
+class TestBothSurfacesAgreeOnTheDomain:
+    """One question, one accepted domain, whichever surface asks it."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS)
+    def test_neither_surface_accepts_an_unusable_count(self, tmp_path: Path, value: Any) -> None:
+        gate = _verify(root=_write_dataset(tmp_path, [0], [3]), expected=value)
+        gate_refused = any("expected must be a non-negative integer" in p for p in gate["problems"])
+        assert gate_refused, gate["problems"]
+        assert _episodes_verdict(value) == "refused"
+
+    @pytest.mark.parametrize("value", USABLE_COUNTS)
+    def test_neither_surface_refuses_a_usable_count(self, tmp_path: Path, value: int) -> None:
+        gate = _verify(root=_healthy(tmp_path), expected=value)
+        assert not any("must be a non-negative integer" in p for p in gate["problems"]), gate["problems"]
+        assert _episodes_verdict(value) == "accepted"
+
+    def test_the_facade_message_still_names_the_method(self, tmp_path: Path) -> None:
+        stub = types.SimpleNamespace(_active_dataset_root=lambda: None)
+        result = SimEngine.verify_dataset_episodes(stub, -1)  # type: ignore[arg-type]
+        assert "verify_dataset_episodes: expected must be a non-negative int" in result["content"][0]["text"]
+
+    def test_the_shared_helper_owns_the_rule(self) -> None:
+        """Non-vacuity: the domain under test is the shared helper's, not a copy."""
+        for value in UNUSABLE_COUNTS:
+            assert non_negative_count_error(value, "expected", "verify_dataset") is not None, value
+        for value in USABLE_COUNTS:
+            assert non_negative_count_error(value, "expected", "verify_dataset") is None, value
+
+
+class TestTheCliGateFailsOnARefusedThreshold:
+    """A shell-invoked CI gate must not exit 0 on a refused argument."""
+
+    def test_a_negative_min_frames_exits_nonzero(self, tmp_path: Path, capsys: Any) -> None:
+        """``--min-frames -5`` used to exit 0 on a dataset with a 0-frame episode."""
+        code = verify_main([str(_corrupt(tmp_path)), "--min-frames", "-5"])
+        assert code == 1
+        assert "min_frames must be a non-negative integer" in capsys.readouterr().out
+
+    def test_zero_min_frames_still_exits_zero(self, tmp_path: Path, capsys: Any) -> None:
+        code = verify_main([str(_corrupt(tmp_path)), "--min-frames", "0"])
+        capsys.readouterr()
+        assert code == 0
+
+    def test_the_default_still_catches_the_short_episode(self, tmp_path: Path, capsys: Any) -> None:
+        code = verify_main([str(_corrupt(tmp_path))])
+        assert code == 1
+        assert "frame(s)" in capsys.readouterr().out


### PR DESCRIPTION
## Problem

`verify_dataset(root, expected=..., min_frames=...)` - the function behind the `strands-robots verify-dataset` CI gate - guards `expected` with its own comparison and leaves `min_frames`, the sibling count in the same signature, unchecked.

That matters more than a missing guard usually does, because of *how* the threshold is read:

```python
if min_frames > 0 and info["frames_per_episode"]:
```

A value that fails that comparison does not fail loudly - it **switches the check off**. So the one input nothing validated is the input that decides whether check 2 runs at all.

Measured on a real 3-episode MuJoCo recording (3 x 24 frames @ 30 fps) whose episode 2 length is `0` - the corruption class check 2 exists to detect:

| `--min-frames` | on `main` |
| --- | --- |
| `1` (default) | `status=error`, names `episode 2=0 frame(s)` |
| `0` | `status=success` - the documented way to skip the length check |
| `-5` | **`status=success`, CLI exit `0`** - corrupt dataset certified |
| `False` | **`status=success`** - corrupt dataset certified |
| `nan` | **`status=success`** - corrupt dataset certified |
| `2.7` | `status=error`, reported as `below min_frames=2.7` - a frame count no episode can have |
| `"2"` | **bare `TypeError`** |
| `None` | **bare `TypeError`** |

The `TypeError` rows contradict a documented contract. `docs/recording.md` states:

> `verify-dataset` always produces a report - it never crashes on the corruption it exists to flag.

And the CLI reach is real, because `argparse type=int` blocks the string spellings but not a negative:

```
$ strands-robots verify-dataset <corrupt> --min-frames -5
...
info.json episodes: 3
$ echo $?
0
```

## Change

Both counts now share `utils.non_negative_count_error`. No new helper: that domain already exists, and its docstring already argues for exactly this shape - a discrete count whose `0` is first-class rather than degenerate.

- `min_frames=0` remains the documented way to skip the length check (and is now the *only* spelling that does).
- `expected=0` still asks that a dataset be empty.
- `bool` is rejected, closing a hole the two hand-rolled copies shared: as an `int` subclass, `True` satisfied `isinstance(value, int) and value >= 0` and became a silent threshold - or a silent episode count - of one. `verify_dataset(expected=True)` used to certify a one-episode dataset.
- `SimEngine.verify_dataset_episodes` routes through the same helper, so the programmatic gate and the sim facade cannot accept an episode count the other refuses. The duplication is why the `bool` hole existed twice and `min_frames` got no domain at all: two copies of one comparison agree with each other, so no test fails.
- Refusals are appended to the report's `problems` (exit code `1`) rather than raised, matching how the checker already reports a corrupt dataset. `min_frames > 0` stays, now reading as a mode selector over an already-validated non-negative value rather than as a guard.

Message text is compatible with the existing pins: they assert `"non-negative int"`, which is a substring of the shared helper's `"non-negative integer"`. **Zero existing tests changed.**

## Not in scope

`read_dataset_episode_indices` reports `frames_per_episode: []` for a dataset whose *only* episode has length `0` (rather than `[0]`), so that one shape skips check 2 for an unrelated reason. Separate surface, separate question - not touched here.

## Verification

Recorded a real dataset, derived the corruption from it, and measured the gate on both trees. Every number in the figure is asserted in its generator against the two dumps, which also assert they came from different trees.

![verify-dataset episode-count threshold domains](https://raw.githubusercontent.com/cagataycali/robots/artifacts/verify-dataset-gate/verify_dataset_gate.png)

The left panel is a frame decoded back out of the recording's own MP4, so the dataset under test is a genuine recording rather than a synthetic parquet. Recording behaviour is unchanged: the frame decoded from each tree's own independently-recorded dataset is **byte-identical** (`max delta 0/255`), both trees record 3 x 24 frames, and both certify the intact dataset.

| | |
| --- | --- |
| new tests | `tests/test_verify_dataset_numeric_domains.py`, 75 tests, pyarrow-only (no lerobot, no mujoco), 0.44s |
| pre-fix | **46 failed / 29 passed** at `cbd5e45e`, incl. `test_a_negative_min_frames_exits_nonzero - assert 0 == 1` |
| post-fix | 75 passed |
| existing tests changed | **0** |
| full suite | `MUJOCO_GL=egl pytest tests` -> **20743 passed / 257 skipped / 0 failed** in 522.83s |
| lint | `ruff check` clean (1079 files), `ruff format --check` clean |
| mypy | `mypy strands_robots tests tests_integ` - 0 errors outside `examples/isaac_gs`, error set byte-identical to a pristine `main` worktree |
| overlap gate | `scripts/check_merge_base_overlap.py` - no overlap with `main` since `cbd5e45e` |

The 29 tests that pass pre-fix are the over-reach controls - a healthy dataset still passes, `min_frames=0` still skips the check, a matching `expected` still passes, `expected=-1` was already refused - which is what stops the new domain reaching further than the values it should.

The measurement scripts and both raw JSON dumps are alongside the figure on the artifact branch.