### PR TITLE
fix(tests): the torch stand-in skips with a reason instead of failing unactionably

### DIFF
--- a/changelog.d/1970-torch-stand-in-serves-or-skips.md
+++ b/changelog.d/1970-torch-stand-in-serves-or-skips.md
@@ -1,0 +1,28 @@
+### Fixed: the torch stand-in now skips with a reason instead of failing with an unactionable AttributeError
+
+The numpy-backed torch stand-in the test suite installs when real torch is not
+importable covers a subset of the surface, so a test can always reach past it --
+directly, or through a package it imports, since `lerobot` reads `torch.dtype`
+during import. That reach used to surface as `AttributeError: module 'torch' has
+no attribute 'is_tensor'`, which names neither the stand-in nor the missing
+dependency, so the first move was to debug the diff; at module scope it was a
+collection error, and collection errors abort the whole run rather than one
+module.
+
+A reach now raises an exception that is both an `AttributeError` -- so every
+`hasattr` probe and `except AttributeError` fallback behaves exactly as it does
+against real torch -- and a pytest skip naming the attribute, what the stand-in
+covers, and both remedies. Measured on a full torch-less run of `tests/`:
+`pytest tests` went from aborting during collection without executing a single
+test to running, and with `--continue-on-collection-errors` from 758 failed /
+19704 passed / 281 skipped / 23 errors to 87 failed / 19744 passed / 977 skipped
+/ 0 errors. Nothing that passed before fails now, and dunder lookup is left
+alone so the import machinery and pytest introspection are untouched.
+
+The discriminator for "is this torch real?" also has one home now,
+`real_torch_installed()`, promoted out of a single test module; it cannot be
+`pytest.importorskip("torch")`, because the stand-in registers a module in
+`sys.modules` and the import therefore succeeds. The stand-in's docstring, the
+conftest docstring and one test comment claimed it enabled "all unit tests"
+without PyTorch, which was unverifiable by construction in CI (which always
+installs torch); they now state the subset contract they can keep.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 """Shared test fixtures and configuration.
 
-Installs a torch mock (if real torch is unavailable) so CI can run
-all unit tests without PyTorch installed.
+Installs a numpy-backed torch stand-in when real torch is unavailable, so the
+parts of the suite that need only a thin tensor surface run without the ~2GB
+dependency. That stand-in is a subset rather than a replacement: a test reaching
+outside it is skipped with the attribute and the remedy named, not failed.
 
 Also disables the Zenoh mesh by default during the test suite so the
 ``Robot()`` / ``Simulation()`` factory does not spin up real Zenoh

--- a/tests/mocks/torch_mock.py
+++ b/tests/mocks/torch_mock.py
@@ -1,9 +1,19 @@
-"""Comprehensive torch mock for CI environments without PyTorch.
+"""Numpy-backed torch stand-in for environments without PyTorch.
 
-Used by conftest.py to enable running all unit tests in CI without installing
-PyTorch (~2GB). The mock provides numpy-backed replacements sufficient for
-testing policy logic, observation mapping, and action conversion without
-actual GPU inference.
+``conftest`` installs this when ``import torch`` fails, so the parts of the suite
+that need only a thin tensor surface still run without the ~2GB dependency. It is
+a *subset*, not a replacement: it covers policy logic, observation mapping and
+action conversion.
+
+The contract is serve-or-skip. An attribute the mock does not provide raises
+:class:`MissingMockAttribute`, which is both an ``AttributeError`` -- so every
+existing ``hasattr`` probe and ``except AttributeError`` fallback behaves exactly
+as it does against real torch -- and a pytest skip naming the attribute and the
+remedy. So a test that needs real torch is reported as skipped rather than as a
+failure whose text mentions neither the mock nor the absent extra, and a module
+whose imports need more of the surface than the mock has (``lerobot`` reads
+``torch.dtype`` at import time) is skipped rather than erroring during
+collection.
 
 Provides numpy-backed replacements for:
 - torch.Tensor (MockTensor) - arithmetic, reshaping, device, slicing
@@ -12,6 +22,11 @@ Provides numpy-backed replacements for:
 - Factory functions: tensor, zeros, ones, randint, rand, from_numpy, stack, cat
 - Context managers: no_grad, inference_mode
 - Submodules: torch.nn, torch.cuda, torch.backends, torch.amp
+
+A test that knows up front that it needs real torch should say so with
+:func:`real_torch_installed`, which is the one discriminator:
+``pytest.importorskip("torch")`` cannot answer the question, because the mock
+registers a module in ``sys.modules`` and the import therefore succeeds.
 
 Usage:
     from tests.mocks.torch_mock import install_torch_mock
@@ -24,6 +39,12 @@ import types
 from unittest.mock import MagicMock
 
 import numpy as np
+
+# ``pytest.skip.Exception`` is the documented handle for this class, but it is a
+# runtime attribute on a function, so it cannot be used in a base-class
+# position under a type checker. This import is the same object -- pinned as an
+# executable premise by the contract tests rather than left as a claim here.
+from _pytest.outcomes import Skipped
 
 logger = logging.getLogger(__name__)
 
@@ -289,47 +310,87 @@ def _randn(*shape, dtype=None, device=None):
 # Public API
 
 
-def install_torch_mock():
-    """Install a comprehensive torch mock into sys.modules.
+class MissingMockAttribute(AttributeError, Skipped):
+    """A torch attribute this mock does not provide.
 
-    No-op if real torch is already importable.
+    Both base classes are load-bearing:
+
+    - ``AttributeError`` keeps every ``hasattr`` probe and
+      ``except AttributeError`` fallback behaving as it does against real torch,
+      so making a miss visible cannot turn a graceful path into a skip.
+    - ``Skipped`` (which is ``pytest.skip.Exception``) means an *unguarded* miss
+      is reported as a skip
+      that names the attribute and the remedy, rather than as a failure whose
+      text names neither the mock nor the missing extra.
+
+    ``AttributeError`` is first in the MRO, so its ``__init__`` runs and the
+    fields pytest reads off a skip have to be set here rather than delegated.
+    """
+
+    def __init__(self, message: str) -> None:
+        AttributeError.__init__(self, message)
+        self.msg = message
+        self.pytrace = False
+        # Permit the skip during module import: without this, a module whose
+        # imports touch an unsupported attribute is a collection error, and
+        # collection errors abort the whole run rather than one module.
+        self.allow_module_level = True
+        self._use_item_location = False
+
+
+def _missing_attribute(module_name, attribute):
+    """Build the :class:`MissingMockAttribute` for one miss.
+
+    The message opens with the wording real torch uses, so anything matching on
+    that prefix is unaffected, and then states what the reader cannot otherwise
+    know: that a stand-in answered, what it covers, and both remedies.
+    """
+    return MissingMockAttribute(
+        f"module {module_name!r} has no attribute {attribute!r}: this is the "
+        "numpy-backed torch stand-in the test suite installs when real torch is "
+        "not importable, and it covers policy logic, observation mapping and "
+        "action conversion only. Install the real dependency to run this test "
+        '(pip install -e ".[all,dev]"), or -- if the test needs real torch by '
+        "nature -- gate it on real_torch_installed(), because "
+        'pytest.importorskip("torch") cannot skip while the stand-in is '
+        "registered in sys.modules."
+    )
+
+
+def _guard_missing_attributes(module):
+    """Make every miss on ``module`` explain itself, and return the module."""
+
+    def __getattr__(name):
+        # Dunders keep plain lookup semantics: the import machinery probes
+        # ``__path__``, pytest introspects ``__spec__``, and
+        # ``real_torch_installed`` probes ``__version__`` -- none of which is a
+        # test touching an unsupported part of the tensor surface, so none of
+        # them should change behaviour here.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(f"module {module.__name__!r} has no attribute {name!r}")
+        raise _missing_attribute(module.__name__, name)
+
+    module.__getattr__ = __getattr__
+    return module
+
+
+def real_torch_installed():
+    """Return True when the importable ``torch`` is real rather than this mock.
+
+    The one discriminator, so that the reason it cannot be
+    ``pytest.importorskip("torch")`` is written down once: the mock registers a
+    module in ``sys.modules``, so the import succeeds and only attribute access
+    fails. The mock never sets ``__version__``.
     """
     try:
-        import torch  # noqa: F401
+        import torch
+    except ImportError:
+        return False
+    return hasattr(torch, "__version__")
 
-        logger.info("Real torch is available (version=%s) - mock not installed", torch.__version__)
-        return  # Real torch available - nothing to do
-    except Exception as exc:  # noqa: BLE001 - diagnostics: any import failure means we mock
-        # IMPORTANT: print to stderr (not just logging.info, which pytest captures
-        # and hides) so CI logs ALWAYS show WHY the mock was installed. A silent
-        # fallback here previously masked an env-resolution bug (a CUDA torch
-        # wheel that failed to import) for hours of log-archaeology.
-        _msg = (
-            f"[torch_mock] real torch import FAILED ({type(exc).__name__}: {exc}); "
-            "installing numpy mock. If this is unexpected, the torch wheel in this "
-            "env is broken/unimportable (e.g. wrong CUDA build)."
-        )
-        # pytest captures stdout/stderr, so ALSO write to a sentinel file that
-        # CI can cat unconditionally -- this is what makes the diagnosis a
-        # one-line grep instead of log-archaeology.
-        print(_msg, file=sys.stderr)
-        try:
-            import os as _os
 
-            with open(
-                _os.environ.get("TORCH_MOCK_SENTINEL", "/tmp/torch_mock_active.txt"),
-                "w",
-            ) as _fh:
-                _fh.write(_msg + "\n")
-        except OSError:
-            # Sentinel-file write is best-effort diagnostics only (read-only or
-            # full /tmp, restricted CI sandbox, etc.). The stderr message above
-            # already conveys why the mock was installed, so a failed write must
-            # never abort mock installation or fail the test run.
-            pass
-
-    logger.info("Installing torch mock (real torch not available)")
-
+def _build_torch_mock():
+    """Build the mock module tree; return ``{module name: module}``."""
     # Root module
     torch_mock = types.ModuleType("torch")
     torch_mock.Tensor = MockTensor
@@ -388,19 +449,66 @@ def install_torch_mock():
     amp_mock.autocast = MagicMock
     torch_mock.amp = amp_mock
 
-    # Register in sys.modules
-    sys.modules["torch"] = torch_mock
-    sys.modules["torch.nn"] = nn_mock
-    sys.modules["torch.nn.functional"] = nn_functional_mock
-    sys.modules["torch.cuda"] = cuda_mock
-    sys.modules["torch.backends"] = backends_mock
-    sys.modules["torch.backends.mps"] = mps_mock
-    sys.modules["torch.backends.cudnn"] = cudnn_mock
-    sys.modules["torch.amp"] = amp_mock
-
     # torchvision
     torchvision_mock = types.ModuleType("torchvision")
     torchvision_transforms = types.ModuleType("torchvision.transforms")
     torchvision_mock.transforms = torchvision_transforms
-    sys.modules["torchvision"] = torchvision_mock
-    sys.modules["torchvision.transforms"] = torchvision_transforms
+
+    modules = {
+        "torch": torch_mock,
+        "torch.nn": nn_mock,
+        "torch.nn.functional": nn_functional_mock,
+        "torch.cuda": cuda_mock,
+        "torch.backends": backends_mock,
+        "torch.backends.mps": mps_mock,
+        "torch.backends.cudnn": cudnn_mock,
+        "torch.amp": amp_mock,
+        "torchvision": torchvision_mock,
+        "torchvision.transforms": torchvision_transforms,
+    }
+    for module in modules.values():
+        _guard_missing_attributes(module)
+    return modules
+
+
+def install_torch_mock():
+    """Install the torch stand-in into ``sys.modules``.
+
+    No-op if real torch is already importable.
+    """
+    try:
+        import torch  # noqa: F401
+
+        logger.info("Real torch is available (version=%s) - mock not installed", torch.__version__)
+        return  # Real torch available - nothing to do
+    except Exception as exc:  # noqa: BLE001 - diagnostics: any import failure means we mock
+        # IMPORTANT: print to stderr (not just logging.info, which pytest captures
+        # and hides) so CI logs ALWAYS show WHY the mock was installed. A silent
+        # fallback here previously masked an env-resolution bug (a CUDA torch
+        # wheel that failed to import) for hours of log-archaeology.
+        _msg = (
+            f"[torch_mock] real torch import FAILED ({type(exc).__name__}: {exc}); "
+            "installing numpy mock. If this is unexpected, the torch wheel in this "
+            "env is broken/unimportable (e.g. wrong CUDA build)."
+        )
+        # pytest captures stdout/stderr, so ALSO write to a sentinel file that
+        # CI can cat unconditionally -- this is what makes the diagnosis a
+        # one-line grep instead of log-archaeology.
+        print(_msg, file=sys.stderr)
+        try:
+            import os as _os
+
+            with open(
+                _os.environ.get("TORCH_MOCK_SENTINEL", "/tmp/torch_mock_active.txt"),
+                "w",
+            ) as _fh:
+                _fh.write(_msg + "\n")
+        except OSError:
+            # Sentinel-file write is best-effort diagnostics only (read-only or
+            # full /tmp, restricted CI sandbox, etc.). The stderr message above
+            # already conveys why the mock was installed, so a failed write must
+            # never abort mock installation or fail the test run.
+            pass
+
+    logger.info("Installing torch mock (real torch not available)")
+    sys.modules.update(_build_torch_mock())

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -32,6 +32,7 @@ from strands_robots.policies.groot.policy import (  # noqa: E402
     _to_state_batch,
     _to_video_batch,
 )
+from tests.mocks.torch_mock import real_torch_installed  # noqa: E402
 
 # (section)
 # Helpers
@@ -108,11 +109,11 @@ def _require_real_torch():
     no-op ``manual_seed`` and its tensors have no ``tolist``, so the assertion
     is both meaningless and crash-prone under the mock. ``importorskip`` alone
     is insufficient because the mock registers a ``torch`` module in
-    ``sys.modules`` (so the import succeeds); the mock never sets
-    ``__version__``, which is the discriminator used here.
+    ``sys.modules``, so the import succeeds; :func:`real_torch_installed` is the
+    one discriminator that answers the question.
     """
     torch = pytest.importorskip("torch", reason="torch not installed")
-    if not hasattr(torch, "__version__"):
+    if not real_torch_installed():
         pytest.skip("requires real torch (mock active); RNG reproducibility is real-torch-only")
     return torch
 

--- a/tests/test_torch_stand_in_serves_or_skips.py
+++ b/tests/test_torch_stand_in_serves_or_skips.py
@@ -1,0 +1,255 @@
+"""The torch stand-in either serves an attribute or skips with the reason.
+
+``conftest`` installs a numpy-backed stand-in when real torch is not importable.
+It covers a subset, so a test can always reach past it -- directly, or through a
+package it imports: ``lerobot`` reads ``torch.dtype`` at import time. What that
+reach costs is the contract pinned here.
+
+Before, a reach produced ``AttributeError: module 'torch' has no attribute
+'is_tensor'``, which names neither the stand-in nor the missing dependency, so
+the first move is to debug the diff. At module scope it was worse than a
+failure: a collection error, and collection errors abort the whole run rather
+than one module.
+
+The contract now is serve-or-skip, and both halves of the exception type it
+rests on are load-bearing, so both are pinned:
+
+* it is still an ``AttributeError``, so every ``hasattr`` probe and
+  ``except AttributeError`` fallback behaves as it does against real torch --
+  making a reach visible must not turn a graceful path into a skip;
+* it is additionally a pytest skip, so an *unguarded* reach is reported as one,
+  naming the attribute and both remedies.
+
+Everything here builds the stand-in in isolation through the module rather than
+installing it, so the contract is verified in the environment CI actually runs:
+one with real torch present.
+"""
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+from tests.mocks import torch_mock as mock_mod
+
+# The stand-in's documented subset -- policy logic, observation mapping and
+# action conversion. Serving these is what makes it worth installing at all.
+SERVED = ("Tensor", "device", "tensor", "zeros", "ones", "from_numpy", "stack", "cat", "no_grad")
+
+# Attributes measured reaching past the stand-in on a full torch-less run of
+# ``tests/``. ``dtype`` is the largest class by a wide margin and is not reached
+# by this repository at all -- it is read inside ``lerobot`` during import, which
+# is why completing the subset is not a way out.
+MEASURED_REACHES = (
+    "dtype",
+    "is_tensor",
+    "arange",
+    "version",
+    "save",
+    "optim",
+    "utils",
+    "int",
+    "uint8",
+    "float16",
+    "bfloat16",
+    "zeros_like",
+    "full",
+    "isfinite",
+    "get_device_name",
+)
+
+
+@pytest.fixture
+def stand_in():
+    """The stand-in module tree, built but not registered in ``sys.modules``."""
+    return mock_mod._build_torch_mock()
+
+
+class TestTheStandInServesItsDocumentedSubset:
+    """The subset still works: a skip for something it covers would be a loss."""
+
+    @pytest.mark.parametrize("name", SERVED)
+    def test_a_served_attribute_is_returned(self, stand_in, name):
+        assert getattr(stand_in["torch"], name) is not None
+
+    def test_the_served_tensor_surface_still_computes(self, stand_in):
+        torch = stand_in["torch"]
+        t = torch.tensor([[0.1], [0.9]])
+        assert t.detach().to("cpu").flatten().tolist() == pytest.approx([0.1, 0.9], abs=1e-6)
+
+    def test_every_module_the_stand_in_registers_is_guarded(self, stand_in):
+        # A submodule left unguarded is a hole in the same shape as the original
+        # defect, so the guard is asserted over the registry rather than over a
+        # hand-listed subset.
+        assert set(stand_in) == {
+            "torch",
+            "torch.nn",
+            "torch.nn.functional",
+            "torch.cuda",
+            "torch.backends",
+            "torch.backends.mps",
+            "torch.backends.cudnn",
+            "torch.amp",
+            "torchvision",
+            "torchvision.transforms",
+        }
+        for name, module in stand_in.items():
+            with pytest.raises(AttributeError, match="numpy-backed torch stand-in"):
+                getattr(module, "definitely_not_served")
+            assert module.__name__ == name
+
+
+class TestAReachPastTheSubsetIsSkippedNotFailed:
+    @pytest.mark.parametrize("name", MEASURED_REACHES)
+    def test_a_measured_reach_is_reported_as_a_skip(self, stand_in, name):
+        with pytest.raises(mock_mod.MissingMockAttribute) as excinfo:
+            getattr(stand_in["torch"], name)
+        assert isinstance(excinfo.value, pytest.skip.Exception)
+
+    def test_a_reach_remains_an_attributeerror(self, stand_in):
+        # The half that keeps graceful paths graceful. Several production
+        # fallbacks catch AttributeError around a torch probe; if the skip were
+        # not also one, those would stop being fallbacks.
+        with pytest.raises(AttributeError):
+            getattr(stand_in["torch"], "is_tensor")
+
+    def test_a_graceful_fallback_still_absorbs_it(self, stand_in):
+        absorbed = False
+        try:
+            stand_in["torch"].is_tensor([1.0])
+        except AttributeError:
+            absorbed = True
+        assert absorbed, "except AttributeError no longer absorbs a reach past the subset"
+
+    def test_a_hasattr_probe_still_answers_false(self, stand_in):
+        assert hasattr(stand_in["torch"], "tensor") is True
+        assert hasattr(stand_in["torch"], "is_tensor") is False
+
+    def test_the_message_names_the_attribute_the_stand_in_and_both_remedies(self, stand_in):
+        with pytest.raises(AttributeError) as excinfo:
+            getattr(stand_in["torch"], "optim")
+        text = str(excinfo.value)
+        # Opens with real torch's own wording, so anything matching on that
+        # prefix is unaffected by the added context.
+        assert text.startswith("module 'torch' has no attribute 'optim'")
+        assert "numpy-backed torch stand-in" in text
+        assert 'pip install -e ".[all,dev]"' in text
+        assert "real_torch_installed()" in text
+        assert 'pytest.importorskip("torch") cannot skip' in text
+
+    def test_the_skip_carries_that_message(self, stand_in):
+        with pytest.raises(mock_mod.MissingMockAttribute) as excinfo:
+            getattr(stand_in["torch"], "utils")
+        # pytest reports ``msg``; a skip whose reason were empty would be as
+        # unactionable as the failure this replaces.
+        assert "numpy-backed torch stand-in" in excinfo.value.msg
+        assert excinfo.value.allow_module_level is True, "a reach during module import must skip, not error"
+
+    def test_the_typed_skip_class_is_the_documented_one(self):
+        # The stand-in subclasses ``_pytest.outcomes.Skipped`` because
+        # ``pytest.skip.Exception`` cannot be a base class under a type checker.
+        # That is only sound while the two are the same object, so the premise is
+        # executed rather than asserted in a comment.
+        from _pytest.outcomes import Skipped
+
+        assert pytest.skip.Exception is Skipped
+        assert issubclass(mock_mod.MissingMockAttribute, pytest.skip.Exception)
+
+
+class TestDunderLookupIsUntouched:
+    """Import machinery and introspection must not see a skip.
+
+    ``types.ModuleType`` genuinely lacks ``__path__``, ``__file__`` and
+    ``__all__``, so the guard sees those probes. Answering them with a skip
+    would change behaviour that has nothing to do with a test reaching past the
+    tensor surface.
+    """
+
+    @pytest.mark.parametrize("name", ["__version__", "__path__", "__file__", "__all__"])
+    def test_a_dunder_reach_stays_a_plain_attributeerror(self, stand_in, name):
+        with pytest.raises(AttributeError) as excinfo:
+            getattr(stand_in["torch"], name)
+        assert not isinstance(excinfo.value, pytest.skip.Exception)
+        assert "numpy-backed torch stand-in" not in str(excinfo.value)
+
+    def test_the_dunders_python_sets_are_still_readable(self, stand_in):
+        assert stand_in["torch"].__spec__ is None
+        assert stand_in["torch"].__name__ == "torch"
+
+
+class TestTheDiscriminatorHasOneHome:
+    """``real_torch_installed`` is the one answer to "is this torch real?"."""
+
+    def test_it_agrees_with_an_independent_witness(self):
+        torch = pytest.importorskip("torch")
+        # Non-circular, and it holds in both environments: ``optim`` is one of
+        # the attributes measured reaching past the stand-in, so serving it is
+        # something only real torch does. Asserting the equivalence rather than
+        # re-deriving ``hasattr(torch, "__version__")`` is also what keeps this
+        # module clean under the scan below.
+        assert mock_mod.real_torch_installed() is hasattr(torch, "optim")
+
+    def test_it_is_false_while_the_stand_in_is_registered(self, stand_in, monkeypatch):
+        monkeypatch.setitem(__import__("sys").modules, "torch", stand_in["torch"])
+        assert mock_mod.real_torch_installed() is False
+
+    def test_installing_is_a_no_op_when_real_torch_is_present(self):
+        import sys
+
+        if not mock_mod.real_torch_installed():
+            pytest.skip("the stand-in is active in this environment")
+        before = sys.modules["torch"]
+        mock_mod.install_torch_mock()
+        assert sys.modules["torch"] is before, "installing replaced real torch"
+
+
+def _test_sources():
+    """Every test module, rooted from a symbol rather than a path literal."""
+    root = pathlib.Path(inspect.getfile(mock_mod)).resolve().parent.parent
+    assert root.name == "tests", root
+    return sorted(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _inlines_the_discriminator(source):
+    """Find ``hasattr(<anything>, "__version__")`` calls, the discriminator's body."""
+    found = []
+    for node in ast.walk(ast.parse(source)):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "hasattr"
+            and len(node.args) == 2
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == "__version__"
+        ):
+            found.append(node.lineno)
+    return found
+
+
+class TestNoTestModuleReimplementsTheDiscriminator:
+    """The knowledge was correct and private to one file; now it has one home.
+
+    A module that re-derives ``hasattr(torch, "__version__")`` inline is the
+    shape this change removes: the reason ``importorskip`` cannot answer the
+    question has to be written down once, not per site.
+    """
+
+    def test_the_scan_sees_the_test_tree(self):
+        sources = _test_sources()
+        assert len(sources) > 500, f"scan root resolved somewhere unexpected: {len(sources)} modules"
+
+    def test_no_module_inlines_it(self):
+        owner = pathlib.Path(inspect.getfile(mock_mod)).resolve()
+        offenders = {}
+        for path in _test_sources():
+            if path.resolve() == owner:
+                continue  # the one home, which is where the body belongs
+            lines = _inlines_the_discriminator(path.read_text(encoding="utf-8"))
+            if lines:
+                offenders[str(path.name)] = lines
+        assert not offenders, f"call real_torch_installed() instead of re-deriving it: {offenders}"
+
+    def test_the_scan_detects_a_planted_one(self):
+        planted = 'import torch\n\n\ndef f():\n    return hasattr(torch, "__version__")\n'
+        assert _inlines_the_discriminator(planted) == [5]

--- a/tests/training/test_reward.py
+++ b/tests/training/test_reward.py
@@ -178,11 +178,11 @@ class TestRewardProgress:
         # ``rewards.detach().to("cpu").flatten().tolist()``. When real torch is
         # absent, tests/conftest.py installs tests/mocks/torch_mock.MockTensor as
         # ``torch``; ``pytest.importorskip("torch")`` above therefore resolves to
-        # the mock rather than skipping (the mock IS a torch module). The mock
-        # must implement every method in that chain or the "run all unit tests
-        # without PyTorch installed" contract in conftest breaks -- a
-        # torch-return test would fail with AttributeError only in the mocked
-        # (no-real-torch) environment. Pin that ``flatten``/``tolist`` (the two
+        # the mock rather than skipping (the mock IS a torch module). This chain
+        # is inside the subset the stand-in covers, so it must keep working: a
+        # link it lacked would skip this test in the mocked (no-real-torch)
+        # environment while passing everywhere else. Pin that
+        # ``flatten``/``tolist`` (the two
         # links the mock previously lacked) survive on MockTensor and that the
         # full chain a torch tensor takes through reward_progress still yields
         # the right floats.


### PR DESCRIPTION
Closes #1970.

## The problem

`conftest` installs a numpy-backed torch stand-in when `import torch` fails, so the parts of the suite that need only a thin tensor surface still run without the ~2GB dependency. It covers a subset, so a test can always reach past it -- directly, or through a package it imports.

That reach surfaced as:

```
AttributeError: module 'torch' has no attribute 'is_tensor'
```

which names neither the stand-in nor the missing dependency. A contributor's first move is therefore to debug their own diff. At module scope it was worse than a failure: a **collection error**, and collection errors abort the whole run -- so on a torch-less machine `pytest tests` executed **zero tests**.

The stand-in's docstring, the `conftest` docstring and one test comment all claimed it enabled "all unit tests" without PyTorch. That claim was unverifiable by construction: CI installs `-e ".[all,dev]"`, so the only configuration that could falsify it is the one CI is built to avoid.

## Completing the subset is not the alternative

Measured over a full torch-less run of `tests/`, `torch.dtype` is **622 of the 676** reaches -- and it is not read by this repository at all. It is read inside `lerobot` during import:

```
strands_robots/training/lerobot.py:164: in _policy_registry
E   AttributeError: module 'torch' has no attribute 'dtype'
```

So "add the missing attributes" is a treadmill against a third-party package, and several of the remaining reaches are tests pinning **real torch's own** behaviour (`torch.utils.data.DataLoader` refusing a bad `batch_size`, `torch.optim`, `torch.version` in `doctor.check_cuda`) which no stand-in can honestly satisfy. The honest contract is serve-or-skip.

## The change

A reach now raises `MissingMockAttribute`, and **both** of its base classes are load-bearing:

- it is still an `AttributeError`, so every `hasattr` probe and `except AttributeError` fallback behaves exactly as it does against real torch -- making a reach visible must not turn a graceful path into a skip;
- it is additionally a pytest skip, so an *unguarded* reach is reported as one, naming the attribute, what the stand-in covers, and both remedies.

`allow_module_level` is set, which is what turns the 13 collection errors into 13 skipped modules. Dunder lookup keeps plain semantics: `types.ModuleType` genuinely lacks `__path__`/`__file__`/`__all__`, so the guard sees the import machinery's and pytest's own probes, and answering those with a skip would change behaviour unrelated to a test reaching past the tensor surface.

The discriminator for "is this torch real?" also has **one home** now, `real_torch_installed()`, promoted out of a single test module where it was private. It cannot be `pytest.importorskip("torch")`, because the stand-in registers a module in `sys.modules` and the import therefore succeeds -- that reason is written down once, and a structural test keeps it there.

The served subset is unchanged. Widening it is a separate question and is deliberately not mixed in here, so the measurements below attribute cleanly to the contract alone.

## Measured

A full torch-less run of `tests/` (a `MetaPathFinder` refusing `torch` before any conftest is imported, so `conftest` installs the stand-in exactly as it would without the `[all]` extra):

| | main | this change |
|---|---|---|
| `pytest tests` (what a contributor types) | aborts during collection, **0 tests run** | runs: 19745 passed |
| collection errors aborting that run | 13 | **0** |
| with `--continue-on-collection-errors`: failed | 758 | **87** |
| &nbsp;&nbsp;of those, a reach past the stand-in | 676 | **3** |
| &nbsp;&nbsp;collection errors | 23 | **0** |
| &nbsp;&nbsp;passed | 19704 | 19744 |
| &nbsp;&nbsp;skipped (now carrying the reason) | 281 | 977 |
| `tests/simulation/` alone (clean control) | 103 failed, 4 errors | **0 failed, 0 errors** |

Nothing that passed before fails now (set difference over failing node ids). The 3 residual reaches are all in `tests/tools/test_use_lerobot.py`, were each already failing on `main`, and are the dual inheritance working as intended: production *caught* the `AttributeError` and put its text into an error envelope that those tests assert on.

CI's environment is untouched, measured on both trees:

| | passed | skipped |
|---|---|---|
| `main` | 20771 | 257 |
| this change | 20814 | 257 |

`+43` is exactly this PR's new tests and the skip count is identical, so no existing test's behaviour changes where torch is real -- the stand-in is never installed there, which is itself pinned.

![measured contract](https://raw.githubusercontent.com/cagataycali/robots/artifacts/torch-stand-in-contract/torch_stand_in_contract.png)

The figure is generated by a script that re-parses the four pytest logs it names and asserts every number it renders before saving; it is published alongside the image with the `blocktorch` plugin used to produce the torch-less environment.

## Tests

`tests/test_torch_stand_in_serves_or_skips.py`, 43 tests. They build the stand-in through the module rather than installing it, so the contract is verified in the environment CI actually runs -- one with real torch present.

Pinned in both directions, because either half alone would be wrong: the documented subset still serves and still computes; a reach is an `AttributeError`; a reach is also a skip; a `hasattr` probe still answers `False`; a graceful `except AttributeError` still absorbs it; the message names the attribute and both remedies; every registered submodule behaves the same; dunder lookup stays plain; installing is a no-op when torch is real. The premise that `_pytest.outcomes.Skipped` *is* `pytest.skip.Exception` is executed rather than asserted in a comment, since the base class rests on it.

A structural test asserts no test module re-derives `hasattr(torch, "__version__")` inline, with a non-vacuity check on the scan root and a planted-defect meta-test. It caught an inline re-derivation I had written in this very module while drafting it.

**Pre-fix proof** (source at `upstream/main`, new tests kept): **41 of 43 red** -- 4 failed, 37 errored, and `test_no_module_inlines_it` failed naming `test_policy.py:115`, the private discriminator. Post-fix: 43 passed. The 2 that pass on both trees are the scanner's own non-vacuity and planted-defect meta-tests, which test the scanner rather than the fix.

## Gate

- `MUJOCO_GL=egl python -m pytest tests` -> **20814 passed, 257 skipped, 0 failed** in 519s
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` -> clean, 1081 files
- `mypy strands_robots tests tests_integ` -> 0 errors outside `examples/`; the 14 in `examples/isaac_gs` are pre-existing and the error set is byte-identical to a pristine `upstream/main` worktree of the same working copy
- the five repo-wide root guards -> 42 passed; `assemble_changelog.py --check` -> OK

One note for completeness: in the *full* torch-less run, `test_the_seeded_eval_matches_its_sibling_run_policy_contract` fails on a seeded float-stream equality. It passes in isolation and passes in `tests/simulation/` on **both** trees, so it is a pre-existing sensitivity to global RNG state left by earlier modules, surfaced differently now that those modules skip instead of erroring mid-way. It passes with real torch on both trees.

## Out of scope

Widening the served subset (`is_tensor` and `arange` are reached by this repository and would be cheap and honest additions) is a separate change: it would restore coverage rather than fix a report, and mixing it in would make the numbers above impossible to attribute. The measured attribute list is recorded in the new test module's `MEASURED_REACHES` so it is not lost.