### PR TITLE
fix(policies): a seed the client reseed cannot apply is refused, not half-applied

### DIFF
--- a/changelog.d/1973-client-reseed-seed-domain.md
+++ b/changelog.d/1973-client-reseed-seed-domain.md
@@ -1,0 +1,43 @@
+### Fixed: a seed the client reseed cannot apply no longer half-seeds the process
+
+`reseed_client_rngs` is the applier `Gr00tPolicy.reset` and `Cosmos3Policy.reset`
+both route through, so it is how a rollout makes an episode reproducible. It
+reseeds Python `random`, then NumPy's legacy global RNG, then torch - three
+appliers with three different accepted domains, in that order, inside one
+`try` whose `except Exception` logs at `INFO` and swallows.
+
+Only the second of them bounds the value. So for every seed NumPy refuses -
+anything negative, fractional, non-integral, or above `MAX_EVAL_SEED` - Python
+`random` was reseeded, NumPy was not, and `reset` returned normally. Seven of
+twelve probe values left that state:
+
+| seed | Python `random` | NumPy | `reset` |
+| --- | --- | --- | --- |
+| `7`, `0` | reseeded | reseeded | returns |
+| `None` | untouched | untouched | returns (documented no-op) |
+| `-1`, `2.5`, `3.0`, `"abc"`, `nan`, `2**32`, `MAX_EVAL_SEED + 1` | **reseeded** | **untouched** | **returns** |
+| `True` | reseeded (seed 1) | reseeded (seed 1) | returns |
+
+A caller was therefore told the episode was seeded while half the streams a
+stochastic policy draws from were not, with the reason visible only at `INFO`.
+That is worse than a refusal: nothing distinguishes it from success, and
+partial reproducibility is not a weaker form of reproducibility.
+
+The seed is now checked before the first applier runs, so the reseed is
+all-or-nothing for every value it accepts. The domain is the one the sibling
+applier `set_eval_seed` already enforces, down to the `MAX_EVAL_SEED` ceiling
+that `randomization_seed_error` carries for exactly this destination - both
+reseed the same legacy NumPy global RNG, so both can honor the same seeds.
+`set_eval_seed`'s own docstring already called that ceiling "the ceiling every
+rollout surface accepts"; this is the rollout surface that was not applying it.
+
+Refusing rather than logging is what lets a caller tell "this episode is
+reproducible" from "it is not". The module's best-effort clause is unchanged
+and still covers what it was written for - an applier that *fails*, such as an
+absent torch - because swallowing that leaves every RNG consistently unseeded,
+which is a different outcome from leaving half of them seeded.
+
+Pinned by `tests/policies/test_client_reseed_seed_domain.py`: a refused seed
+moves neither RNG, an accepted seed reaches all three appliers, and the two
+appliers' verdicts are asserted equal over the whole probe set so neither can
+drift from the other.

--- a/strands_robots/policies/_rng.py
+++ b/strands_robots/policies/_rng.py
@@ -6,6 +6,13 @@ global NumPy RNG. Two providers conforming to the same ``Policy`` contract must
 behave identically for ``set_eval_seed``-style reproducibility (#187). This
 module is the single source of truth for the client-side reseed so both
 providers stay in parity.
+
+Parity covers which seeds are *accepted* as well as which RNGs are reseeded.
+The appliers here do not share one domain - Python ``random`` takes a string,
+NumPy's legacy global RNG takes a non-negative integer below 2**32 - so the
+narrowest of them decides what this helper can honor, and that is the same
+bound :func:`~strands_robots.simulation.policy_runner.set_eval_seed` applies
+for the same reason.
 """
 
 from __future__ import annotations
@@ -24,11 +31,56 @@ def reseed_client_rngs(seed: int | None) -> None:
     policy providers); any other failure is logged and swallowed because
     ``reset`` is a soft reproducibility hint, not a hard requirement.
 
+    A seed outside the domain is refused up front, which is a different case
+    from the best-effort clause above rather than an exception to it. That
+    clause covers a *failure of an applier* - torch absent, a runtime hiccup -
+    and swallowing one leaves every RNG consistently unseeded. An unusable
+    value is a caller mistake no applier can accept, and swallowing it left
+    the process *half* seeded: the appliers run in sequence and only the
+    second bounds the domain, so Python ``random`` was reseeded and NumPy was
+    not for every seed NumPy refuses - anything negative, fractional,
+    non-integral, or above
+    :data:`~strands_robots.simulation.base.MAX_EVAL_SEED`. ``reset`` still
+    returned normally, so a caller was told the episode was seeded while half
+    the streams a policy draws from were not, with the reason only at
+    ``INFO``. Checking before the first applier runs makes the reseed
+    all-or-nothing for every value it accepts.
+
+    The domain is the one its sibling applier
+    :func:`~strands_robots.simulation.policy_runner.set_eval_seed` already
+    enforces, down to the ``MAX_EVAL_SEED`` ceiling that
+    :func:`~strands_robots.simulation.base.randomization_seed_error` carries
+    for exactly this destination - both reseed the legacy NumPy global RNG,
+    so both can honor exactly the same seeds. A rollout that reseeds through
+    a provider's ``reset`` therefore accepts what one seeding through
+    ``set_eval_seed`` accepts.
+
     Args:
         seed: Master per-episode seed, or ``None`` to leave RNGs untouched.
+
+    Raises:
+        ValueError: If *seed* is neither ``None`` nor an integer in
+            ``[0, MAX_EVAL_SEED]``. Raising rather than logging is what the
+            caller needs to distinguish "this episode is reproducible" from
+            "it is not": the alternative is a rollout that reports success
+            having seeded some of its RNGs, which is the state this guard
+            exists to make unreachable.
     """
     if seed is None:
         return
+
+    # Deferred import: strands_robots.simulation.base imports policy_runner at
+    # module level and policy_runner imports policies.base, so reaching the
+    # shared seed domain from module scope here would close that ring. Both
+    # callers of this helper import it the same way, for the same reason.
+    from strands_robots.simulation.base import MAX_EVAL_SEED, randomization_seed_error
+
+    # ``None`` returned above, so a seed is required past this line;
+    # ``allow_none=False`` keeps the reason from offering ``None`` as a remedy
+    # for a value that already got here.
+    if error := randomization_seed_error(seed, "reseed_client_rngs", max_seed=MAX_EVAL_SEED, allow_none=False):
+        raise ValueError(error)
+
     try:
         import random as _random
 

--- a/tests/policies/test_client_reseed_seed_domain.py
+++ b/tests/policies/test_client_reseed_seed_domain.py
@@ -1,0 +1,264 @@
+"""The client-side reseed accepts exactly the seeds it can apply to every RNG.
+
+:func:`~strands_robots.policies._rng.reseed_client_rngs` is the applier both
+service-mode providers route ``Policy.reset`` through, so it is how a rollout
+makes an episode reproducible. It reseeds Python ``random``, then NumPy's
+legacy global RNG, then torch - three appliers with three different accepted
+domains, run in sequence inside one swallowing ``try``.
+
+Only the second of them bounds the value, so before the guard under test every
+seed NumPy refuses left the process *half* seeded: Python ``random`` reseeded,
+NumPy untouched, ``reset`` returning normally, and the reason only at ``INFO``.
+A caller was told the episode was seeded while half the streams a stochastic
+policy draws from were not - the failure mode that is worse than a refusal,
+because nothing distinguishes it from success.
+
+What is pinned here:
+
+* every seed the helper cannot apply is refused *before the first applier
+  runs*, so neither RNG moves;
+* every seed it accepts reaches all three appliers, so an accepted value can
+  never leave a partial state either;
+* the accepted domain is the one the sibling applier
+  :func:`~strands_robots.simulation.policy_runner.set_eval_seed` already
+  enforces - both reseed the same legacy NumPy global RNG, so they can honor
+  the same seeds and a divergence between them is a defect in whichever moved;
+* the best-effort swallow the module documents still covers what it was
+  written for - an applier that *fails* - which is a different case from a
+  value no applier can accept.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import math
+import pathlib
+import random
+import sys
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies import _rng
+from strands_robots.policies._rng import reseed_client_rngs
+from strands_robots.simulation.base import MAX_EVAL_SEED
+from strands_robots.simulation.policy_runner import set_eval_seed
+
+#: Seeds this path cannot apply. Each is refused by NumPy's legacy global RNG,
+#: which is the narrowest applier: negatives and anything above
+#: :data:`MAX_EVAL_SEED` are out of its range, a fractional *or integral* float
+#: is refused by its dtype cast, and ``bool`` is an ``int`` subclass whose
+#: ``True`` would install a silent seed of 1. Python ``random`` accepts most of
+#: them, which is exactly why they used to half-seed the process.
+UNUSABLE_SEEDS: list[Any] = [
+    -1,
+    -5,
+    2.5,
+    3.0,
+    True,
+    False,
+    "42",
+    [7],
+    math.nan,
+    math.inf,
+    MAX_EVAL_SEED + 1,
+    2**64,
+]
+
+#: Seeds every applier on this path honors, including both endpoints of the
+#: accepted range - ``0`` is a seed, not the absence of one.
+USABLE_SEEDS: list[Any] = [0, 1, 7, 12345, MAX_EVAL_SEED]
+
+#: Baseline the RNGs are put into before each measurement. Kept out of both
+#: lists above so "the state changed" is never true by coincidence.
+BASELINE_SEED = 999
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_rngs() -> Iterator[None]:
+    """Restore the process-wide RNGs this module reseeds.
+
+    The subject is a helper whose whole job is a global side effect, so every
+    test here mutates interpreter-wide state. Restoring it keeps that from
+    reaching an unrelated test through execution order.
+    """
+    python_state = random.getstate()
+    numpy_state = np.random.get_state()
+    yield
+    random.setstate(python_state)
+    np.random.set_state(numpy_state)
+
+
+def _rng_fingerprint() -> tuple[Any, Any]:
+    """A comparable snapshot of the two global RNGs the helper reseeds.
+
+    ``get_state`` is annotated as returning the keyword-argument form, so the
+    legacy tuple it actually returns here is read through an ``Any`` binding.
+    """
+    numpy_state: Any = np.random.get_state()
+    return random.getstate(), (tuple(int(v) for v in numpy_state[1][:8]), int(numpy_state[2]))
+
+
+def _at_baseline() -> tuple[Any, Any]:
+    """Put both RNGs in a known state and return its fingerprint."""
+    random.seed(BASELINE_SEED)
+    np.random.seed(BASELINE_SEED)
+    return _rng_fingerprint()
+
+
+def _verdict(applier: Callable[[Any], None], seed: Any) -> str:
+    """Classify what *applier* does with *seed*.
+
+    The seeds below are deliberately outside the ``int`` the appliers annotate,
+    so every call goes through this one funnel: mypy does not narrow an ``Any``
+    argument, and a single place to widen keeps the parity comparison honest.
+    Only ``ValueError`` counts as a refusal - anything else escaping is a
+    finding rather than a verdict.
+    """
+    _at_baseline()
+    try:
+        applier(seed)
+    except ValueError:
+        return "refused"
+    return "applied"
+
+
+class TestAnUnusableSeedIsRefusedBeforeAnyRngIsTouched:
+    """The guard's placement is the fix: a refusal must move no RNG at all."""
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS, ids=[repr(s) for s in UNUSABLE_SEEDS])
+    def test_it_raises_and_leaves_both_rngs_untouched(self, seed: Any) -> None:
+        before = _at_baseline()
+        with pytest.raises(ValueError, match=r"reseed_client_rngs: seed must be"):
+            reseed_client_rngs(seed)
+        assert _rng_fingerprint() == before, (
+            f"a refused seed ({seed!r}) reseeded one of the global RNGs; the guard has to run "
+            "before the first applier or the process is left half seeded"
+        )
+
+    def test_the_reason_names_the_helper_and_the_value(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            reseed_client_rngs(-1)
+        text = str(excinfo.value)
+        assert text.startswith("reseed_client_rngs: "), text
+        assert "-1" in text, text
+
+    def test_the_ceiling_reason_names_the_bound_that_produced_it(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            reseed_client_rngs(MAX_EVAL_SEED + 1)
+        assert f"[0, {MAX_EVAL_SEED}]" in str(excinfo.value), str(excinfo.value)
+
+    def test_none_is_not_offered_as_a_remedy(self) -> None:
+        """``None`` returned earlier as a documented no-op, so a value that
+        reached the guard cannot be fixed by passing it."""
+        # Bound through ``Any`` because the point is what the runtime does with
+        # a value outside the annotated ``int | None``.
+        fractional: Any = 2.5
+        with pytest.raises(ValueError) as excinfo:
+            reseed_client_rngs(fractional)
+        assert "or None" not in str(excinfo.value), str(excinfo.value)
+
+
+class TestEverySeedItAcceptsReachesEveryApplier:
+    """The other half of all-or-nothing, and what stops the guard over-reaching."""
+
+    @pytest.mark.parametrize("seed", USABLE_SEEDS, ids=[repr(s) for s in USABLE_SEEDS])
+    def test_python_and_numpy_are_both_reseeded(self, seed: Any) -> None:
+        before = _at_baseline()
+        reseed_client_rngs(seed)
+        after = _rng_fingerprint()
+        assert after[0] != before[0], f"Python random was not reseeded by {seed!r}"
+        assert after[1] != before[1], f"the NumPy global RNG was not reseeded by {seed!r}"
+
+    @pytest.mark.parametrize("seed", USABLE_SEEDS, ids=[repr(s) for s in USABLE_SEEDS])
+    def test_torch_is_reseeded_too(self, seed: Any) -> None:
+        torch = pytest.importorskip("torch")
+        torch.manual_seed(BASELINE_SEED)
+        reseed_client_rngs(seed)
+        assert torch.initial_seed() == int(seed), (
+            f"torch kept its previous seed after reseed_client_rngs({seed!r}); every accepted "
+            "value has to reach every applier or an accepted seed can half-seed the process too"
+        )
+
+    def test_an_accepted_seed_is_still_reproducible(self) -> None:
+        reseed_client_rngs(4242)
+        first = ([random.random() for _ in range(3)], np.random.rand(3).tolist())
+        reseed_client_rngs(4242)
+        second = ([random.random() for _ in range(3)], np.random.rand(3).tolist())
+        assert first == second
+
+
+class TestTheDomainMatchesTheSiblingApplier:
+    """Both appliers reseed the same legacy NumPy global RNG, so both can honor
+    exactly the same seeds. Pinned as an equality rather than assumed from the
+    shared helper, so either side drifting fails here."""
+
+    @pytest.mark.parametrize(
+        "seed", UNUSABLE_SEEDS + USABLE_SEEDS, ids=[repr(s) for s in UNUSABLE_SEEDS + USABLE_SEEDS]
+    )
+    def test_the_two_appliers_agree(self, seed: Any) -> None:
+        assert _verdict(reseed_client_rngs, seed) == _verdict(set_eval_seed, seed), (
+            f"reseed_client_rngs and set_eval_seed disagree about {seed!r}; they apply the same "
+            "seed to the same RNGs, so a value one refuses the other cannot honor"
+        )
+
+    def test_the_probe_set_exercises_both_verdicts(self) -> None:
+        """Non-vacuity: the parity assertion above is worthless if every row
+        lands on one verdict."""
+        verdicts = {_verdict(set_eval_seed, seed) for seed in UNUSABLE_SEEDS + USABLE_SEEDS}
+        assert verdicts == {"refused", "applied"}, verdicts
+
+
+class TestTheBestEffortSwallowIsPreserved:
+    """The guard narrows which values are accepted. It does not change what
+    happens when an applier itself fails, which is the case the module's
+    best-effort clause was written for."""
+
+    def test_a_failing_applier_is_still_logged_and_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def boom(_seed: Any) -> None:
+            raise RuntimeError("simulated RNG backend failure")
+
+        monkeypatch.setattr(np.random, "seed", boom)
+        with caplog.at_level(logging.INFO, logger=_rng.logger.name):
+            reseed_client_rngs(7)  # must not raise
+        assert any("reseed failed" in record.getMessage() for record in caplog.records), [
+            record.getMessage() for record in caplog.records
+        ]
+
+    def test_a_missing_torch_is_still_skipped_silently(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "torch", None)
+        with caplog.at_level(logging.INFO, logger=_rng.logger.name):
+            reseed_client_rngs(7)
+        assert not [r for r in caplog.records if "reseed failed" in r.getMessage()], [
+            r.getMessage() for r in caplog.records
+        ]
+
+
+class TestNoneIsStillANoOp:
+    def test_none_touches_neither_rng(self) -> None:
+        before = _at_baseline()
+        reseed_client_rngs(None)
+        assert _rng_fingerprint() == before
+
+
+def test_the_shared_domain_is_imported_lazily() -> None:
+    """Reaching :mod:`strands_robots.simulation.base` from module scope here
+    would close an import ring - it imports ``policy_runner``, which imports
+    ``policies.base`` - and a cyclic module-level import is reported as
+    possibly-undefined rather than merely untidy. Pinned because the deferred
+    form looks like something to tidy up."""
+    source = pathlib.Path(inspect.getfile(_rng)).read_text(encoding="utf-8")
+    leaked = [
+        ast.unparse(node)
+        for node in ast.parse(source).body
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("strands_robots.simulation")
+    ]
+    assert not leaked, f"import must stay inside the function: {leaked}"


### PR DESCRIPTION
## The defect

`reseed_client_rngs` is the applier `Gr00tPolicy.reset` and `Cosmos3Policy.reset` both route through, so it is how a rollout makes an episode reproducible. It reseeds Python `random`, then NumPy's legacy global RNG, then torch — three appliers with three different accepted domains, in that order, inside one `try` whose `except Exception` logs at `INFO` and swallows.

Only the second of them bounds the value. So for every seed NumPy refuses, Python `random` was reseeded, NumPy was not, and `reset` returned normally:

| seed | Python `random` | NumPy | `reset()` |
| --- | --- | --- | --- |
| `7`, `0`, `4294967295` | reseeded | reseeded | returns |
| `None` | untouched | untouched | returns (documented no-op) |
| `-1`, `2.5`, `3.0`, `"abc"`, `nan`, `2**32` | **reseeded** | **untouched** | **returns** |
| `True` | reseeded (seed 1) | reseeded (seed 1) | returns |

Six of ten measured seeds left that state. The consequence is directly observable: run two episodes seeded identically with `2**32` and the Python stream *is* reproducible while the NumPy stream is not — a caller was told the episode was seeded while half the streams a stochastic policy draws from were not, with the reason visible only at `INFO`.

That is worse than a refusal rather than a milder version of one. Nothing distinguishes it from success, and partial reproducibility is not a weaker form of reproducibility.

`True` is the same root cause in its accepted form: both appliers take it, as a silent seed of `1`.

## Why this is not the module's best-effort clause

The module documents that a failure is "logged and swallowed because `reset` is a soft reproducibility hint". That clause covers a *failure of an applier* — torch absent, a runtime hiccup — and swallowing one leaves every RNG **consistently unseeded**. An unusable value is a caller mistake no applier can accept, and swallowing it left **half** of them seeded. Different outcome, so it is a different case rather than an exception to the clause, which is unchanged and still pinned.

## The change

The seed is checked before the first applier runs, so the reseed is all-or-nothing for every value it accepts.

The domain is not new. It is the one the sibling applier `set_eval_seed` already enforces, down to the `MAX_EVAL_SEED` ceiling that `randomization_seed_error` carries **for exactly this destination** — both reseed the same legacy NumPy global RNG, so both can honor the same seeds. `randomization_seed_error`'s own docstring already says `max_seed` exists "so the rollout surfaces refuse a value they could not apply", and `set_eval_seed`'s calls that ceiling "the ceiling every rollout surface accepts". This is the rollout surface that was not applying it.

`allow_none=False` is passed because the `None` no-op returns earlier, so a value that reaches the guard cannot be fixed by passing `None` and the reason should not offer it.

Refusing rather than logging is what lets a caller tell "this episode is reproducible" from "it is not". The import of the shared domain is deferred: `simulation.base` imports `policy_runner`, which imports `policies.base`, so reaching it from module scope here would close that ring. Both callers of this helper import it the same way, for the same reason, and a test pins it so the deferred form is not tidied up into a cycle.

## Measured

![reseed seed domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/client-reseed-seed-domain/reseed_seed_domain.png)

Top row is `main`: the same call, the same seed, the two streams disagreeing about whether the episode is reproducible. Bottom left is the refusal; bottom right shows an in-domain seed still reseeding every RNG on this branch, unchanged.

Every cell is produced by [`measure_reseed.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/client-reseed-seed-domain/measure_reseed.py) run once per tree and composed by [`compose_figure.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/client-reseed-seed-domain/compose_figure.py), which asserts every claim it renders — including that the two probes resolved to different trees — before saving. Nothing is hand-typed.

No policy inference, simulation, rendering, recording or asset behaviour changes, so the artifact is a measurement rather than a rollout.

## Tests

`tests/policies/test_client_reseed_seed_domain.py`, 48 tests:

- a refused seed moves **neither** RNG — the guard's placement is the fix, so this is asserted per value rather than inferred;
- every accepted seed reaches **all three** appliers, including both endpoints of the range, so an accepted value cannot half-seed either;
- the two appliers' verdicts are asserted **equal** over the whole probe set, so neither can drift from the other, with a non-vacuity test that both verdicts actually occur in that set;
- the best-effort swallow still covers a failing applier and an absent torch;
- `None` is still a no-op, and the shared domain is still imported lazily.

An autouse fixture restores the two process-wide RNGs, since the subject's whole job is a global side effect.

**Pre-fix:** 27 failed, 21 passed. **Post-fix:** 48 passed. The 21 that pass pre-fix are the over-reach controls — the accepted-seed rows, the reproducibility round trip, the `None` no-op, the two best-effort cases and the structural pins. They are what stops this guard reaching past the values no applier can accept.

## Verification

Full suite on the branch head: **20894 passed, 257 skipped, 0 failed** (583.66s, `MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly`).

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1082 files); `mypy strands_robots tests tests_integ` clean (1079 source files); the five repo-wide root guards 42 passed; `scripts/assemble_changelog.py --check` OK.

Existing tests touching this path — `tests/policies/test_rng_parity.py`, `tests/policies/groot/test_policy.py`, `tests/policies/cosmos3`, and the four `set_eval_seed` / rollout-seed modules — **650 passed with no changes to any of them**. The production seeds reaching `reset` are derived from an already-guarded master seed, so no in-tree caller supplies a value this now refuses.

## Out of scope

`randomize` / `set_obs_noise` keep the wider domain they can honor: they reach `default_rng`, which takes a non-negative integer of any width, so the `MAX_EVAL_SEED` ceiling would over-refuse there. That asymmetry is the `max_seed` parameter's documented purpose and is unchanged.
