### PR TITLE
fix(benchmarks/libero): a per-camera config add_camera cannot accept is refused, not dropped

### DIFF
--- a/changelog.d/1975-libero-camera-config-domain.md
+++ b/changelog.d/1975-libero-camera-config-domain.md
@@ -1,0 +1,20 @@
+### Fixed: a LIBERO per-camera config the backend cannot accept is refused instead of silently dropping the camera
+
+`LiberoAdapter(cameras=...)` documents each value as the keyword arguments
+forwarded to `Simulation.add_camera`, so a key that method does not declare
+cannot be honored on any call. The install loop is deliberately tolerant of a
+sim *failing* to add a camera, and that tolerance covered this case too: a
+one-character typo (`heigth`, `positon`, `resolution`) was logged at WARNING and
+then treated as if the camera had been omitted, so the LIBERO policy's required
+`image` / `wrist_image` view never entered the world and every subsequent
+inference failed for a reason unrelated to the policy under test. A `name` key
+collided with the name the install supplies from the mapping key, the same way.
+
+The install now refuses such a config with a `ValueError` naming every unusable
+key and the accepted set, before any camera is added, on the add path and on the
+skip path alike - the skip path forwards the same mapping to the render-dimension
+publisher, which reads `width` / `height` by name, so a misspelled dimension used
+to publish the 256x256 fallback for a model-side camera under a successful
+install. The accepted key set is read from the sim's own `add_camera` rather than
+hard-coded, because MuJoCo and Newton declare `parent_body` and Isaac does not.
+Every other `add_camera` failure stays best-effort exactly as documented.

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -30,15 +30,17 @@ the one that pulls in the upstream package to discover task files.
 
 from __future__ import annotations
 
+import difflib
 import hashlib
 import importlib
+import inspect
 import json
 import logging
 import math
 import os
 import random
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -72,6 +74,81 @@ logger = logging.getLogger(__name__)
 _ISAAC_FRANKA_ARM_JOINTS: tuple[str, ...] = tuple(f"panda_joint{i}" for i in range(1, 8))
 _ISAAC_FRANKA_GRIPPER_JOINTS: tuple[str, ...] = ("panda_finger_joint1", "panda_finger_joint2")
 _ISAAC_FRANKA_EEF_LINK = "panda_hand"
+
+
+#: Key the per-camera config must not carry: :meth:`LiberoAdapter._install_libero_cameras`
+#: supplies the camera name itself from the mapping key, so a config that also
+#: sets it collides on every backend.
+_CAMERA_NAME_KEY = "name"
+
+
+def camera_config_error(add_camera: Any, cam_name: str, cam_kwargs: Mapping[str, Any]) -> str | None:
+    """Report a per-camera config the sim's ``add_camera`` cannot accept.
+
+    ``LiberoAdapter(cameras=...)`` documents each value as the keyword
+    arguments forwarded to :meth:`Simulation.add_camera`, so a key that
+    method does not declare cannot be honored on any call: the splat raises
+    :class:`TypeError` before the camera is created. The install loop is
+    best-effort about a sim *failing* to add a camera - one flaky camera must
+    not kill a whole eval - and that tolerance used to cover this case too,
+    which left a one-character typo silently equivalent to omitting the
+    camera: the policy's required ``image`` / ``wrist_image`` view never
+    entered the world and every subsequent inference failed for a reason
+    unrelated to the policy under test.
+
+    The accepted key set belongs to the backend, not to this adapter -
+    MuJoCo and Newton declare ``parent_body`` and Isaac does not - so it is
+    read from the bound method rather than hard-coded here. A sim whose
+    ``add_camera`` takes ``**kwargs`` genuinely accepts any key, so only the
+    reserved name is checked there.
+
+    ``name`` is reserved: the install loop supplies it positionally by
+    keyword, so a config that also sets it is a guaranteed
+    "multiple values for keyword argument" on every backend.
+
+    Args:
+        add_camera: The bound ``add_camera`` of the sim under configuration.
+        cam_name: Camera name the config is keyed by, for the message.
+        cam_kwargs: The caller-supplied per-camera keyword mapping.
+
+    Returns:
+        A message naming every unusable key, or ``None`` when every key can
+        be forwarded.
+    """
+    try:
+        params = inspect.signature(add_camera).parameters
+    except (TypeError, ValueError):
+        # Not introspectable (a C-implemented or exotic callable): nothing can
+        # be checked, so defer to the call itself as before.
+        return None
+
+    takes_var_kw = any(pp.kind is inspect.Parameter.VAR_KEYWORD for pp in params.values())
+    accepted = {
+        pname
+        for pname, pp in params.items()
+        if pname != "self" and pp.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
+    prefix = f"LiberoAdapter cameras[{cam_name!r}]: "
+
+    if _CAMERA_NAME_KEY in cam_kwargs:
+        return (
+            f"{prefix}{_CAMERA_NAME_KEY!r} must not be set - the camera name is the mapping key, "
+            f"and the install passes it to add_camera itself. Drop it from the config."
+        )
+    if takes_var_kw:
+        return None
+
+    unknown = [str(k) for k in cam_kwargs if k not in accepted]
+    if not unknown:
+        return None
+    parts = []
+    for key in sorted(unknown):
+        close = difflib.get_close_matches(key.lower(), sorted(accepted), n=1, cutoff=0.7)
+        parts.append(f"{key!r}" + (f" (did you mean {close[0]!r}?)" if close else ""))
+    return (
+        f"{prefix}add_camera does not accept {', '.join(parts)}. "
+        f"Accepted keys: {', '.join(sorted(accepted - {_CAMERA_NAME_KEY}))}."
+    )
 
 
 class LiberoAdapter(BenchmarkProtocol):
@@ -205,8 +282,11 @@ class LiberoAdapter(BenchmarkProtocol):
                 no-ops on auto-generated scenes.
             cameras: Override / extend :attr:`LIBERO_CAMERAS`. Keyed by
                 camera name, each value is forwarded as ``**kwargs`` to
-                :meth:`Simulation.add_camera`. Passing an empty dict
-                disables camera installation regardless of
+                :meth:`Simulation.add_camera`; a key that method does not
+                accept, or a ``"name"`` key (the mapping key already names
+                the camera), is refused when the cameras are installed
+                rather than leaving the camera silently absent. Passing an
+                empty dict disables camera installation regardless of
                 ``install_cameras``.
             eef_body_name: MuJoCo body name whose pose is read for the
                 LIBERO ``state.x/y/z/roll/pitch/yaw`` keys *as a fallback*
@@ -2854,6 +2934,13 @@ class LiberoAdapter(BenchmarkProtocol):
 
         Other ``add_camera`` failures are logged at WARNING but never
         fatal - one missing camera shouldn't kill the whole eval.
+
+        A per-camera config carrying a key ``add_camera`` cannot accept is the
+        one exception: :func:`camera_config_error` refuses it with a
+        ``ValueError`` rather than letting the splat's ``TypeError`` fall into
+        the tolerance above. Retrying cannot help - the key is wrong on every
+        episode - and swallowing it leaves the policy's required view absent
+        from the world with only a WARNING to say so.
         """
         add_camera = getattr(sim, "add_camera", None)
         if add_camera is None:
@@ -2863,6 +2950,16 @@ class LiberoAdapter(BenchmarkProtocol):
         existing = self._existing_camera_names(sim)
 
         for cam_name, cam_kwargs in self._cameras.items():
+            # Refuse a config this sim's add_camera cannot accept BEFORE either
+            # branch below. The skip branch is as affected as the add branch:
+            # it forwards the same mapping to _publish_camera_dims_to_world,
+            # which reads ``width`` / ``height`` by name, so a misspelled
+            # dimension silently publishes the 256x256 fallback for a
+            # model-side camera. A key no call can honor is a caller error no
+            # retry fixes, unlike the add_camera failures the loop below is
+            # deliberately tolerant of.
+            if config_error := camera_config_error(add_camera, cam_name, cam_kwargs):
+                raise ValueError(config_error)
             if cam_name in existing:
                 logger.debug("LiberoAdapter: camera %r already in sim; skipping install", cam_name)
                 # #168: even when we skip add_camera (because

--- a/tests/benchmarks/libero/test_libero_camera_config_domain.py
+++ b/tests/benchmarks/libero/test_libero_camera_config_domain.py
@@ -1,0 +1,331 @@
+"""``LiberoAdapter(cameras=...)`` refuses a per-camera config it cannot install.
+
+Each value of the ``cameras`` mapping is documented as the keyword arguments
+forwarded to ``Simulation.add_camera``, so a key that method does not declare
+cannot be honored on any call - the splat raises :class:`TypeError` before the
+camera is created. The install loop is deliberately tolerant of a sim *failing*
+to add a camera (one flaky camera must not kill a whole eval) and that tolerance
+used to cover this case too, which made a one-character typo silently equivalent
+to omitting the camera: the LIBERO policy's required ``image`` / ``wrist_image``
+view never entered the world, and every subsequent inference failed for a reason
+unrelated to the policy under test.
+
+The two halves this pins:
+
+* the caller's mistake is refused, on the add path *and* on the skip path (the
+  skip path forwards the same mapping to ``_publish_camera_dims_to_world``,
+  which reads ``width`` / ``height`` by name, so a misspelled dimension used to
+  publish the 256x256 fallback for a model-side camera instead);
+* the resilience contract is untouched - an ``add_camera`` that raises, or that
+  reports the camera already exists, is still best-effort.
+
+The accepted key set is read from the sim's own ``add_camera`` rather than
+hard-coded: MuJoCo and Newton declare ``parent_body`` and Isaac does not, so
+hard-coding either would refuse a key a backend honors or accept one it cannot.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+import pytest
+
+from strands_robots.benchmarks.libero.adapter import camera_config_error
+
+from .test_libero_camera_install_resilience import (
+    PICK_CUBE_BDDL,
+    _adapter,
+    _FakeSim,
+)
+
+# A good config for one camera, in the shape the adapter documents.
+GOOD: dict[str, Any] = {
+    "position": [1.0, 0.0, 1.5],
+    "target": [0.0, 0.0, 0.85],
+    "fov": 60.0,
+    "width": 320,
+    "height": 320,
+}
+
+
+def _mujoco_shaped_add_camera(
+    name: str,
+    position: list[float] | None = None,
+    target: list[float] | None = None,
+    fov: float = 60.0,
+    width: int = 640,
+    height: int = 480,
+    parent_body: str | None = None,
+) -> dict[str, Any]:
+    """The MuJoCo / Newton ``add_camera`` signature, which declares ``parent_body``."""
+    return {"status": "success"}
+
+
+def _isaac_shaped_add_camera(
+    name: str,
+    position: list[float] | None = None,
+    target: list[float] | None = None,
+    width: int = 640,
+    height: int = 480,
+    fov: float = 60.0,
+) -> dict[str, Any]:
+    """The Isaac ``add_camera`` signature, which does NOT declare ``parent_body``."""
+    return {"status": "success"}
+
+
+def _recording_add_camera(calls: list[tuple[str, dict[str, Any]]]) -> Any:
+    """A MuJoCo-shaped ``add_camera`` that records what it was called with."""
+
+    def _add_camera(
+        name: str,
+        position: list[float] | None = None,
+        target: list[float] | None = None,
+        fov: float = 60.0,
+        width: int = 640,
+        height: int = 480,
+        parent_body: str | None = None,
+    ) -> dict[str, Any]:
+        calls.append((name, {"width": width, "height": height, "fov": fov}))
+        return {"status": "success"}
+
+    return _add_camera
+
+
+class TestTheAcceptedKeySetComesFromTheSim:
+    """The domain is the backend's, read from the bound method."""
+
+    def test_a_key_the_signature_declares_is_accepted(self):
+        assert camera_config_error(_mujoco_shaped_add_camera, "image", GOOD) is None
+
+    def test_parent_body_is_accepted_where_the_backend_declares_it(self):
+        cfg = {**GOOD, "parent_body": "robot0_right_hand"}
+        assert camera_config_error(_mujoco_shaped_add_camera, "wrist_image", cfg) is None
+
+    def test_parent_body_is_refused_where_the_backend_does_not_declare_it(self):
+        cfg = {**GOOD, "parent_body": "robot0_right_hand"}
+        msg = camera_config_error(_isaac_shaped_add_camera, "wrist_image", cfg)
+        assert msg is not None
+        assert "'parent_body'" in msg
+        # Hard-coding one backend's set would have accepted this.
+        assert "parent_body" not in msg.split("Accepted keys:")[1]
+
+    def test_a_signature_taking_var_keyword_accepts_any_key(self):
+        def _tolerant(name: str, **kwargs: Any) -> None:
+            return None
+
+        assert camera_config_error(_tolerant, "image", {**GOOD, "anything": 1}) is None
+
+    def test_a_non_introspectable_callable_defers_to_the_call(self):
+        """A C-implemented callable whose signature CPython cannot report must
+        not be turned into a caller error - there is nothing to check against,
+        so the call itself stays the judge."""
+        opaque = min  # stands in for a callable with no reportable signature
+        with pytest.raises(ValueError, match="no signature found"):
+            inspect.signature(opaque)  # premise: the branch under test is reached
+
+        assert camera_config_error(opaque, "image", {"unknowable": 1}) is None
+
+    def test_an_empty_config_is_accepted(self):
+        assert camera_config_error(_mujoco_shaped_add_camera, "image", {}) is None
+
+
+class TestTheMessageNamesEveryUnusableKey:
+    """A refusal has to be actionable without reading the backend's source."""
+
+    def test_a_typo_is_named_with_a_suggestion(self):
+        msg = camera_config_error(_mujoco_shaped_add_camera, "image", {**GOOD, "heigth": 320})
+        assert msg is not None
+        assert "cameras['image']" in msg
+        assert "'heigth'" in msg
+        assert "did you mean 'height'?" in msg
+
+    def test_an_unrelated_key_is_named_without_a_wrong_suggestion(self):
+        msg = camera_config_error(_mujoco_shaped_add_camera, "image", {"resolution": [320, 320]})
+        assert msg is not None
+        assert "'resolution'" in msg
+        assert "did you mean" not in msg
+
+    def test_every_unusable_key_is_named(self):
+        msg = camera_config_error(_mujoco_shaped_add_camera, "image", {"positon": [0.0, 0.0, 1.0], "fovy": 60.0})
+        assert msg is not None
+        assert "'fovy'" in msg
+        assert "'positon'" in msg
+
+    def test_the_accepted_keys_are_listed(self):
+        msg = camera_config_error(_mujoco_shaped_add_camera, "image", {"nope": 1})
+        assert msg is not None
+        listed = msg.split("Accepted keys:")[1]
+        for key in ("position", "target", "fov", "width", "height", "parent_body"):
+            assert key in listed
+        # ``name`` is supplied by the install, so offering it would be wrong.
+        assert "name" not in listed
+
+    def test_the_reserved_name_key_is_refused_with_its_own_reason(self):
+        msg = camera_config_error(_mujoco_shaped_add_camera, "image", {**GOOD, "name": "other"})
+        assert msg is not None
+        assert "'name' must not be set" in msg
+
+    def test_the_reserved_name_key_is_refused_even_by_a_tolerant_signature(self):
+        def _tolerant(name: str, **kwargs: Any) -> None:
+            return None
+
+        msg = camera_config_error(_tolerant, "image", {"name": "other"})
+        assert msg is not None
+        assert "'name' must not be set" in msg
+
+
+class TestInstallRefusesAConfigItCannotHonor:
+    """The install loop raises instead of leaving the camera silently absent."""
+
+    def test_an_unusable_key_raises_before_any_camera_is_added(self):
+        adapter = _adapter()
+        adapter._cameras = {"image": {**GOOD, "heigth": 320}}
+        calls: list[tuple[str, dict[str, Any]]] = []
+        sim = _FakeSim(_recording_add_camera(calls))
+
+        with pytest.raises(ValueError, match="does not accept 'heigth'"):
+            adapter._install_libero_cameras(sim)  # type: ignore[arg-type]
+
+        # The refusal precedes the side effect: nothing was half-installed.
+        assert calls == []
+        assert sim._world.cameras == {}
+
+    def test_the_skip_path_refuses_too_instead_of_publishing_default_dims(self):
+        """A camera already in the model took the skip branch, which forwards the
+        same mapping to ``_publish_camera_dims_to_world``. That reads ``width`` /
+        ``height`` by name, so a misspelled dimension used to publish the
+        256x256 fallback under a successful install."""
+        adapter = _adapter()
+        adapter._cameras = {"image": {**GOOD, "heigth": 320}}
+        calls: list[tuple[str, dict[str, Any]]] = []
+        sim = _FakeSim(_recording_add_camera(calls))
+        # Mimic a scene MJCF that already declared the camera.
+        sim._world.cameras["image"] = object()
+
+        with pytest.raises(ValueError, match="does not accept 'heigth'"):
+            adapter._install_libero_cameras(sim)  # type: ignore[arg-type]
+
+        assert calls == []
+
+    def test_a_usable_config_still_installs(self):
+        adapter = _adapter()
+        adapter._cameras = {"image": dict(GOOD)}
+        calls: list[tuple[str, dict[str, Any]]] = []
+        sim = _FakeSim(_recording_add_camera(calls))
+
+        adapter._install_libero_cameras(sim)  # type: ignore[arg-type]
+
+        assert [name for name, _ in calls] == ["image"]
+        assert calls[0][1]["width"] == 320
+        assert calls[0][1]["height"] == 320
+
+
+class TestTheResilienceContractIsUntouched:
+    """A sim *failing* to add a camera is still best-effort - only a config the
+    backend can never accept is refused."""
+
+    def test_a_raising_add_camera_is_still_swallowed(self, caplog):
+        adapter = _adapter()
+        adapter._cameras = {"image": dict(GOOD), "wrist_image": dict(GOOD)}
+        attempted: list[str] = []
+
+        def _raising(
+            name: str,
+            position: list[float] | None = None,
+            target: list[float] | None = None,
+            fov: float = 60.0,
+            width: int = 640,
+            height: int = 480,
+            parent_body: str | None = None,
+        ) -> None:
+            attempted.append(name)
+            raise RuntimeError(f"boom installing {name}")
+
+        sim = _FakeSim(_raising)
+        with caplog.at_level(logging.WARNING, logger="strands_robots.benchmarks.libero.adapter"):
+            assert adapter._install_libero_cameras(sim) is None  # type: ignore[arg-type]
+
+        # Every camera was still attempted: a transient failure is not a caller error.
+        assert set(attempted) == {"image", "wrist_image"}
+
+    def test_an_already_exists_error_still_publishes_the_configured_dims(self):
+        adapter = _adapter()
+        adapter._cameras = {"image": dict(GOOD)}
+
+        def _already_exists(
+            name: str,
+            position: list[float] | None = None,
+            target: list[float] | None = None,
+            fov: float = 60.0,
+            width: int = 640,
+            height: int = 480,
+            parent_body: str | None = None,
+        ) -> dict[str, Any]:
+            return {"status": "error", "content": [{"text": f"camera {name!r} already exists"}]}
+
+        sim = _FakeSim(_already_exists)
+        adapter._install_libero_cameras(sim)  # type: ignore[arg-type]
+
+        published = sim._world.cameras["image"]
+        assert (published.width, published.height) == (320, 320)
+
+
+class TestOnTheRealMuJoCoBackend:
+    """End to end against the backend whose signature the domain is read from."""
+
+    @staticmethod
+    def _engine(tool_name: str):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+        sim = MuJoCoSimEngine(tool_name=tool_name, mesh=False)
+        sim.create_world()
+        sim.add_robot(name="panda", data_config="panda")
+        return sim
+
+    def test_the_accepted_set_matches_the_real_signature(self):
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+        declared = {p for p in inspect.signature(MuJoCoSimEngine.add_camera).parameters if p not in ("self", "name")}
+        msg = camera_config_error(MuJoCoSimEngine.add_camera, "image", {"nope": 1})
+        assert msg is not None
+        listed = msg.split("Accepted keys:")[1]
+        assert declared and all(key in listed for key in declared)
+
+    def test_a_usable_config_installs_and_renders(self):
+        sim = self._engine("libero_cam_domain_good")
+        try:
+            adapter = _adapter()
+            adapter._cameras = {"image": dict(GOOD)}
+            adapter._install_libero_cameras(sim)
+
+            assert "image" in sim._world.cameras
+            entry = sim._world.cameras["image"]
+            assert (entry.width, entry.height) == (320, 320)
+            assert sim.render(camera_name="image", width=64, height=64)["status"] == "success"
+        finally:
+            sim.cleanup()
+
+    def test_a_typo_is_refused_and_the_camera_never_enters_the_world(self):
+        sim = self._engine("libero_cam_domain_typo")
+        try:
+            adapter = _adapter()
+            adapter._cameras = {"image": {**GOOD, "heigth": 320}}
+
+            with pytest.raises(ValueError, match="did you mean 'height'"):
+                adapter._install_libero_cameras(sim)
+
+            assert "image" not in sim._world.cameras
+            # The view the policy reads is simply not there.
+            assert sim.render(camera_name="image", width=64, height=64)["status"] == "error"
+        finally:
+            sim.cleanup()
+
+
+def test_the_bddl_fixture_is_the_shared_one():
+    """Premise: the reused fixture really parses, so an adapter exists to test."""
+    assert "grasped cube_1" in PICK_CUBE_BDDL
+    assert set(_adapter()._cameras) == {"image", "wrist_image"}

--- a/tests/benchmarks/test_public_member_docstrings.py
+++ b/tests/benchmarks/test_public_member_docstrings.py
@@ -56,6 +56,7 @@ _EXPECTED_CLASSES = {
 
 # Every public module-level function the package exposes.
 _EXPECTED_FUNCTIONS = {
+    "libero/adapter.py::camera_config_error",
     "libero/bddl_parser.py::parse_bddl",
     "libero/bddl_parser.py::parse_bddl_file",
     "libero/bddl_parser.py::compile_goal",


### PR DESCRIPTION
## Problem

`LiberoAdapter(cameras=...)` documents each value as the keyword arguments forwarded to `Simulation.add_camera`, so a key that method does not declare cannot be honored on **any** call - the splat raises `TypeError` before the camera is created.

`_install_libero_cameras` is deliberately tolerant of a sim *failing* to add a camera ("one bad camera shouldn't kill the whole eval") and that tolerance covered this case too. Measured on a real MuJoCo world, a one-character typo was therefore silently equivalent to omitting the camera:

| `cameras={"image": {...}}` | install call | `'image' in world.cameras` | `render(camera_name="image")` |
|---|---|---|---|
| `"height": 320` | returns | yes, 320x320 | success |
| `"heigth": 320` | **returns** | **NO** | **error** |
| `"positon": [...]` | **returns** | **NO** | **error** |
| `"resolution": [320, 320]` | **returns** | **NO** | **error** |
| `"name": "other"` | **returns** | **NO** | **error** |

The only caller-visible signal was a WARNING in the log. The eval then ran on without the view the LIBERO policy reads, so every subsequent inference failed with `Video key 'video.image' must be in observation` - a reason unrelated to the policy under test, and the failure mode the adapter's own docstring cites the camera install as existing to prevent.

The skip path is affected identically and more quietly. A camera the scene MJCF already declares takes the `cam_name in existing` branch, which forwards the *same* mapping to `_publish_camera_dims_to_world`; that reads `width` / `height` by name, so a misspelled dimension published the 256x256 fallback under a fully successful install - feeding the model a resolution nobody configured.

## Change

A new `camera_config_error(add_camera, cam_name, cam_kwargs)` reports a per-camera config the sim cannot accept, and the install refuses it with a `ValueError` **before either branch runs**:

```
LiberoAdapter cameras['image']: add_camera does not accept 'heigth' (did you mean 'height'?).
Accepted keys: fov, height, parent_body, position, target, width.
```

A key no call can honor is a caller error no retry fixes, which is a different case from the `add_camera` failures the loop is tolerant of - a transient failure leaves every camera consistently unattempted-or-retryable, whereas this leaves a required view absent with only a WARNING to say so. Every other `add_camera` failure stays best-effort exactly as documented, and both existing resilience contracts are pinned unchanged.

`name` is reported separately: the install supplies it from the mapping key, so a config that also sets it is a guaranteed "multiple values for keyword argument" on every backend.

### The accepted key set is read from the sim, not hard-coded

`add_camera` is a per-backend method with no abstract declaration, and the signatures differ - MuJoCo and Newton declare `parent_body`, Isaac does not. Hard-coding either set would refuse a key one backend honors or accept one it cannot, so it is read from the bound method. A sim whose `add_camera` takes `**kwargs` genuinely accepts any key, so only the reserved `name` is checked there; a callable with no reportable signature defers to the call as before. All four cases are pinned.

## Visual artifact

MuJoCo headless (EGL). Left is what the config asks for, rendered from the installed `image` camera; centre and right are what each tree does with a single `"heigth"` typo.

![LIBERO per-camera config domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/libero-camera-config/libero_camera_config.png)

The left panel is byte-comparable across the two trees (max|delta| = 1/255, renderer noise) - a usable config is untouched - and the reference view is a real scene (85.4% of pixels saturated). Every number in the figure is re-derived from the two measurement dumps by the generator, which asserts each claim plus that the two halves came from different trees before saving.

## Tests

`tests/benchmarks/libero/test_libero_camera_config_domain.py`, 21 tests reusing the established `_adapter` / `_FakeSim` fixtures:

- the accepted set comes from the sim: `parent_body` accepted on a MuJoCo-shaped signature and refused on an Isaac-shaped one, `**kwargs` accepts any key, a non-introspectable callable defers (with an executable premise so that branch cannot stop being reached silently);
- the message names every unusable key, suggests a close match, lists the accepted set and never offers `name`;
- the install raises **before any `add_camera` call** (nothing half-installed) - on the add path and on the skip path;
- the resilience contract is untouched: a raising `add_camera` is still swallowed and still attempts every camera, and an "already exists" error still publishes the configured dims;
- end to end on the real MuJoCo backend: a usable config installs at 320x320 and renders; the typo is refused and the camera never enters the world.

**Pre-fix proof** (source reverted to `upstream/main`, tests kept, new-symbol import replaced by a local stand-in so every behavioural test runs): **3 failed / 5 passed**, the three being the add-path, skip-path and real-backend refusals, with the pre-fix WARNING captured in the failure output. The 5 that pass are the resilience over-reach controls, the usable-config controls and the fixture premise - they are what stop the guard reaching past the one case.

## Gate

Base `d1810bbf`, head `16d0b33e`.

- `MUJOCO_GL=egl python -m pytest tests` -> **20958 passed, 257 skipped, 0 failed** (506s)
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -> clean (1084 files formatted, 0 mypy errors)
- `tests/benchmarks/` -> 548 passed / 28 skipped; **zero existing-test changes** other than registering the new public function in the `tests/benchmarks/test_public_member_docstrings.py` pinned set
- `scripts/check_merge_base_overlap.py` -> no overlap

## Out of scope

The *values* inside a per-camera config (a non-finite `fov`, a negative `width`) are already the domain of `add_camera` itself on every backend and are refused there; this change is about keys the method cannot receive at all.