### PR TITLE
fix(ros2): a DDS domain id outside the RTPS port map is refused, not published process-wide

### DIFF
--- a/changelog.d/1976-dds-domain-id-domain.md
+++ b/changelog.d/1976-dds-domain-id-domain.md
@@ -1,0 +1,65 @@
+### Fixed: a DDS domain id outside the RTPS port map is refused, not published process-wide
+
+A ROS 2 / DDS domain id is an index into the RTPS port map. RTPS 2.2 sec. 9.6.1.1
+derives every discovery port from it - `PB + DG * domain_id + d0` for the SPDP
+multicast port, `PB + DG * domain_id + d1 + PG * participant_id` for the unicast
+one - so with the standard parameters domain 232 lands on ports 65400/65410 and
+domain 233 lands on 65650, past the end of the port space. Only an `int` in
+`[0, 232]` names a domain, and the bound is the protocol's rather than a choice.
+
+Five surfaces took one and none of them checked it: the hardware `Robot`'s
+`ros2_domain`, a simulation backend's `ros2_domain`, and the `domain_id` of the
+rclpy telemetry bridge, its hardware subclass, and the pure-RTPS bridge. Each
+stored the value through a bare `int(...)`, which is where a `True` became
+domain 1 and a `2.7` became domain 2 - a domain nobody named.
+
+The rclpy bridge is why the range has to be checked at the boundary rather than
+left to the transport. It pins the domain by writing `ROS_DOMAIN_ID` into the
+process environment, and that write lands *before* `rclpy` is imported, so an
+out-of-range value was never offered to DDS for rejection:
+
+| `RosTelemetryBridge(domain_id=...)` | before | `ROS_DOMAIN_ID` after (started at `7`) | after |
+| --- | --- | --- | --- |
+| `0`, `5`, `232` | reaches the transport | `'0'`, `'5'`, `'232'` | unchanged |
+| `233`, `300`, `2**31` | reaches the transport | **`'233'`, `'300'`, `'2147483648'`** | refused, `'7'` |
+| `-1`, `-5` | reaches the transport | **`'-5'`** | refused, `'7'` |
+| `True`, `False`, `2.7` | reaches the transport | **`'1'`, `'0'`, `'2'`** | refused, `'7'` |
+| `nan`, `inf`, `None`, `[5]` | bare `ValueError` / `OverflowError` / `TypeError` | `'7'` | refused, `'7'` |
+
+The environment write is process-wide and outlives the call that made it, so an
+accepted out-of-range domain steered every later participant in the process -
+and every subprocess that inherited the environment - at a domain nothing is
+reachable on. It survived even when the construction went on to fail: the four
+rows above that poisoned `ROS_DOMAIN_ID` all then raised `ImportError` for the
+missing `rclpy`, leaving the bad domain behind them.
+
+`utils.dds_domain_id_error` is now the one domain all five surfaces share, and
+`utils.MAX_DDS_DOMAIN_ID` carries the port arithmetic that fixes its ceiling. It
+lives beside `tcp_port_error` for the same reason that one does: the callers sit
+in different layers, and the two transports exist to advertise the same topics,
+so a domain the RTPS bridge cannot bind must not be one the rclpy bridge
+publishes on. `bool` is rejected explicitly - it is an `int` subclass, so a bare
+range test lets `True` through as a silent domain 1.
+
+Each guard is placed ahead of its surface's transport probe. In the rclpy bridge
+that means ahead of the `ROS_DOMAIN_ID` write, so a refused domain leaves the
+environment as it found it; in the RTPS bridge it means ahead of the `cyclonedds`
+probe, so the same caller mistake reports identically on an install with the
+`[ros2]` extra and one without it. The now-redundant `int(...)` coercions are
+gone, so an accepted domain is stored as the caller wrote it.
+
+Every value that already named a domain still does: the existing usages across
+the tests, docs and examples span 0-42 and none change.
+
+Pinned by `tests/test_dds_domain_id_domain.py`: the RTPS port arithmetic is
+asserted rather than the constant alone, a refused domain is shown not to touch
+`ROS_DOMAIN_ID` while an accepted one still pins it, each guard is shown to
+precede its transport probe, the five surfaces' verdicts are asserted equal over
+the whole probe set, and a structural check requires every domain-taking surface
+to either call the shared domain or forward the value to one that does - so a
+sixth cannot ship without joining the rule.
+
+`spin_period` / `poll_period`, the sibling knobs in two of those signatures, are
+a different quantity with a different consequence (a wait budget: `0`, `-1` and
+`nan` each return from `Event.wait` immediately and spin the command thread,
+while `inf` raises `OverflowError` on it) and are left for their own change.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -37,7 +37,12 @@ from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolResult, ToolSpec, ToolUse
 
 from strands_robots.teleop_mixin import TeleopMixin
-from strands_robots.utils import positive_count_error, positive_finite_number_error, require_optional
+from strands_robots.utils import (
+    dds_domain_id_error,
+    positive_count_error,
+    positive_finite_number_error,
+    require_optional,
+)
 
 if TYPE_CHECKING:
     from lerobot.robots.config import RobotConfig
@@ -451,6 +456,8 @@ class Robot(TeleopMixin, AgentTool):
                 missing. Defaults to False - the robot never touches ROS 2,
                 so disabling the bridge is simply the default (opt-in).
             ros2_domain: ROS 2 domain id (``ROS_DOMAIN_ID``) to publish on.
+                Only an ``int`` in ``[0, 232]`` names a domain: RTPS derives its
+                discovery ports from it, and 233 lands past the end of the port space.
             ros2_commands: When True (default), the bridge also subscribes to
                 ``/<robot>/joint_command`` and forwards inbound messages to
                 ``send_action`` so an external ROS 2 stack can drive the real
@@ -667,6 +674,8 @@ class Robot(TeleopMixin, AgentTool):
         Args:
             ros2_bridge: Enable the ROS 2 bridge for this robot.
             ros2_domain: ROS 2 / DDS domain id to publish on.
+                Only an ``int`` in ``[0, 232]`` names a domain: RTPS derives its
+                discovery ports from it, and 233 lands past the end of the port space.
             ros2_commands: When True (default), also subscribe to
                 ``joint_command`` and drive the arm; False for read-only.
             ros2_transport: ``"rclpy"`` or ``"rtps"`` (see above).
@@ -679,13 +688,18 @@ class Robot(TeleopMixin, AgentTool):
                 layer, not by a config dict).
 
         Raises:
-            ValueError: If ``ros2_transport`` is not ``"rclpy"`` or ``"rtps"``;
+            ValueError: If ``ros2_domain`` is outside ``[0, 232]``; if
+                ``ros2_transport`` is not ``"rclpy"`` or ``"rtps"``;
                 if ``joint_limits`` / ``dds_security_config`` are supplied with
                 ``ros2_bridge=False``; or if ``dds_security_config`` is supplied
                 with ``ros2_transport="rclpy"``.
         """
         self._ros2_bridge_enabled = bool(ros2_bridge)
-        self._ros2_domain = int(ros2_domain)
+        # A domain id outside the RTPS port map cannot be published on by either
+        # transport, so refuse it here rather than letting it reach one of them.
+        if error := dds_domain_id_error(ros2_domain, "ros2_domain", type(self).__name__):
+            raise ValueError(error)
+        self._ros2_domain = ros2_domain
         self._ros2_transport = ros2_transport
         self._ros_bridge: Any = None
         if not self._ros2_bridge_enabled:

--- a/strands_robots/hardware_ros_bridge.py
+++ b/strands_robots/hardware_ros_bridge.py
@@ -69,6 +69,8 @@ class HardwareRosBridge(RosTelemetryBridge):
             that only publish (the per-step control-loop path) opt out of the
             inbound half entirely.
         domain_id: ROS 2 domain (``ROS_DOMAIN_ID``) to publish/subscribe on.
+            Only an ``int`` in ``[0, 232]`` names a domain: RTPS derives its
+            discovery ports from it, and 233 lands past the end of the port space.
         node_name: Internal rclpy node name (defaults to ``strands_hardware``).
         qos_depth: Depth of the publishers'/subscription's KEEP_LAST history.
         enable_commands: When True (default) and a ``robot`` is bound, subscribe
@@ -85,8 +87,9 @@ class HardwareRosBridge(RosTelemetryBridge):
             single out-of-range joint can never drive part of the arm.
 
     Raises:
-        ValueError: If ``joint_limits`` is not a ``{motor: (min, max)}`` mapping
-            of numeric pairs with ``min <= max``.
+        ValueError: If ``domain_id`` is outside ``[0, 232]``, or if
+            ``joint_limits`` is not a ``{motor: (min, max)}`` mapping of numeric
+            pairs with ``min <= max``.
     """
 
     default_node_name = "strands_hardware"

--- a/strands_robots/hardware_rtps_bridge.py
+++ b/strands_robots/hardware_rtps_bridge.py
@@ -44,7 +44,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.ros_telemetry import RosTelemetryBase
-from strands_robots.utils import require_optional
+from strands_robots.utils import dds_domain_id_error, require_optional
 
 if TYPE_CHECKING:
     import numpy as np
@@ -104,6 +104,8 @@ class HardwareRtpsBridge(RosTelemetryBase):
             ``None``, no command surface is created (telemetry-only), mirroring
             the rclpy bridge's pure-publisher mode.
         domain_id: ROS 2 / DDS domain id to publish/subscribe on.
+            Only an ``int`` in ``[0, 232]`` names a domain: RTPS derives its
+            discovery ports from it, and 233 lands past the end of the port space.
         enable_commands: When True (default) and a ``robot`` is bound, subscribe
             to ``/<robot>/joint_command`` and drive the arm.
         command_robot_name: Topic namespace for the command topic; defaults to
@@ -125,9 +127,11 @@ class HardwareRtpsBridge(RosTelemetryBase):
 
     Raises:
         ImportError: If ``cyclonedds`` (the ``[ros2]`` extra) is not installed.
-        ValueError: If ``joint_limits`` / ``dds_security_config`` is malformed,
-            or commands are enabled with neither a security config nor the
-            explicit insecure opt-out.
+        ValueError: If ``domain_id`` is outside ``[0, 232]`` (checked before
+            the ``cyclonedds`` probe, so the same caller mistake reports
+            identically on an install without the extra), if ``joint_limits`` /
+            ``dds_security_config`` is malformed, or if commands are enabled
+            with neither a security config nor the explicit insecure opt-out.
     """
 
     def __init__(
@@ -141,6 +145,12 @@ class HardwareRtpsBridge(RosTelemetryBase):
         joint_limits: dict[str, tuple[float, float]] | None = None,
         dds_security_config: dict[str, str] | None = None,
     ) -> None:
+        # Refuse a domain id outside the RTPS port map first, so the same caller
+        # mistake reports identically whether or not the [ros2] extra is
+        # installed - and so it is answered before any DDS state is built.
+        if error := dds_domain_id_error(domain_id, "domain_id", type(self).__name__):
+            raise ValueError(error)
+
         # cyclonedds is the only dependency - no rclpy, no sourced ROS 2 distro.
         require_optional(
             "cyclonedds",
@@ -156,7 +166,7 @@ class HardwareRtpsBridge(RosTelemetryBase):
         self._dds_topic_name = dds_topic_name
 
         self._robot = robot
-        self._domain_id = int(domain_id)
+        self._domain_id = domain_id
 
         # Whether this bridge exposes an inbound (arm-driving) command surface.
         # Resolved BEFORE the participant is built so the DDS Security gate and

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -31,7 +31,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.utils import require_optional
+from strands_robots.utils import dds_domain_id_error, require_optional
 
 if TYPE_CHECKING:
     import numpy as np
@@ -310,10 +310,15 @@ class RosTelemetryBridge(RosTelemetryBase):
 
     Args:
         domain_id: ROS 2 domain (``ROS_DOMAIN_ID``) the bridge publishes on.
+            Only an ``int`` in ``[0, 232]`` names a domain: RTPS derives its
+            discovery ports from it, and 233 lands past the end of the port space.
         node_name: Name of the internal rclpy node.
         qos_depth: Depth of the publishers' KEEP_LAST history.
 
     Raises:
+        ValueError: If ``domain_id`` is outside ``[0, 232]``. Checked before the
+            process-wide ``ROS_DOMAIN_ID`` write, so a refused domain leaves the
+            environment as it found it.
         ImportError: When ``rclpy`` / the ROS 2 message packages are not
             importable, with an install hint (system ROS 2 or the docker image).
     """
@@ -322,10 +327,17 @@ class RosTelemetryBridge(RosTelemetryBase):
     default_node_name = "strands_robots"
 
     def __init__(self, domain_id: int = 0, node_name: str | None = None, qos_depth: int = 10) -> None:
+        # Refuse a domain id outside the RTPS port map BEFORE writing it. The
+        # write below is process-wide and lands ahead of the rclpy import, so an
+        # unusable value would otherwise outlive this call and steer every later
+        # participant - a value the transport is never given the chance to reject.
+        if error := dds_domain_id_error(domain_id, "domain_id", type(self).__name__):
+            raise ValueError(error)
+
         # Pin the domain before rclpy reads it. Set it unconditionally so the
         # bridge publishes where the caller asked, not where the shell happened
         # to point.
-        os.environ["ROS_DOMAIN_ID"] = str(int(domain_id))
+        os.environ["ROS_DOMAIN_ID"] = str(domain_id)
 
         rclpy_mod: Any = require_optional(
             "rclpy", extra="ros2", purpose="the ROS 2 telemetry bridge (ros2_bridge=True)"

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
+    dds_domain_id_error,
     is_boolean,
     non_negative_count_error,
     positive_count_error,
@@ -572,9 +573,15 @@ class SimEngine(ABC):
                 an :class:`ImportError` is raised here if it is missing.
                 Defaults to False - the sim never touches ROS 2.
             ros2_domain: ROS 2 domain id (``ROS_DOMAIN_ID``) to publish on.
+                Only an ``int`` in ``[0, 232]`` names a domain; a value
+                outside the RTPS port map raises :class:`ValueError`.
         """
         self._ros2_bridge_enabled = bool(ros2_bridge)
-        self._ros2_domain = int(ros2_domain)
+        # Refuse a domain id outside the RTPS port map here, so a backend that
+        # only publishes later still rejects it at construction.
+        if error := dds_domain_id_error(ros2_domain, "ros2_domain", type(self).__name__):
+            raise ValueError(error)
+        self._ros2_domain = ros2_domain
         self._ros_bridge: Any = None
         if self._ros2_bridge_enabled:
             from strands_robots.simulation.ros_bridge import SimRosBridge

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1166,6 +1166,63 @@ def non_negative_count_error(value: Any, param: str, context: str) -> str | None
     return None
 
 
+#: Highest DDS domain id whose RTPS discovery ports fit the 16-bit port space.
+#:
+#: RTPS derives every discovery port from the domain id (RTPS 2.2 sec. 9.6.1.1):
+#: ``PB + DG * domain_id + d0`` for the SPDP multicast port and
+#: ``PB + DG * domain_id + d1 + PG * participant_id`` for the unicast one. With
+#: the standard values (``PB=7400``, ``DG=250``, ``d0=0``, ``d1=10``,
+#: ``PG=2``) domain 232 lands on ports 65400/65410 and domain 233 lands on
+#: 65650 - past the end of the port space, so there is nothing to bind. The
+#: bound is the protocol's, not a policy choice.
+MAX_DDS_DOMAIN_ID = 232
+
+
+def dds_domain_id_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` cannot name a DDS domain.
+
+    Shared domain for every caller-supplied ROS 2 / DDS domain id: the hardware
+    ``Robot``'s ``ros2_domain``, a simulation backend's ``ros2_domain``, and the
+    ``domain_id`` the rclpy telemetry bridge
+    (:class:`~strands_robots.ros_telemetry.RosTelemetryBridge`) and the pure-RTPS
+    bridge (:class:`~strands_robots.hardware_rtps_bridge.HardwareRtpsBridge`)
+    publish on. A domain id indexes the RTPS port map, so only an ``int`` in
+    ``[0, MAX_DDS_DOMAIN_ID]`` names one - see :data:`MAX_DDS_DOMAIN_ID` for the
+    arithmetic that fixes the ceiling.
+
+    The rclpy bridge makes the range load-bearing at the boundary rather than at
+    the participant: it pins the domain by writing ``ROS_DOMAIN_ID`` into the
+    process environment, and that write happens before ``rclpy`` is even
+    imported. So a value outside the range is not refused by the transport - it
+    is published to the whole process, where it outlives the call that set it
+    and steers every later participant (and every subprocess that inherits the
+    environment) at a domain nothing can be reached on.
+
+    It lives here rather than beside one of its callers for the same reason
+    :func:`tcp_port_error` does: those callers sit in different layers
+    (:mod:`strands_robots.hardware_robot`, :mod:`strands_robots.simulation` and
+    the two bridge modules) and the accepted domain must not diverge between
+    them - the same domain id cannot be refused by the rclpy bridge and accepted
+    by the RTPS one, when the two exist to advertise the same topics.
+
+    ``bool`` is rejected explicitly. It is an ``int`` subclass, so a bare
+    ``0 <= value <= 232`` test lets ``True`` through as a silent domain 1 and
+    ``False`` through as domain 0 - a domain the caller never named.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it,
+            usually the class name for a constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= MAX_DDS_DOMAIN_ID:
+        return f"{context}: invalid {param}: {_refusal_repr(value)} (expected 0-{MAX_DDS_DOMAIN_ID})"
+    return None
+
+
 def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any], str | None]:
     """Read ``value`` into a list once, or return why the read could not finish.
 

--- a/tests/test_dds_domain_id_domain.py
+++ b/tests/test_dds_domain_id_domain.py
@@ -1,0 +1,338 @@
+"""The DDS domain id every ROS 2 surface publishes on is one shared domain.
+
+A ROS 2 / DDS domain id is an index into the RTPS port map, so only an ``int``
+in ``[0, MAX_DDS_DOMAIN_ID]`` names a domain. Five surfaces take one - the
+hardware ``Robot``'s ``ros2_domain``, a simulation backend's ``ros2_domain``,
+and the ``domain_id`` of the rclpy telemetry bridge, its hardware subclass and
+the pure-RTPS bridge - and they must not disagree about which values name a
+domain, because the two transports exist to advertise the same topics.
+
+The rclpy bridge is why the range is load-bearing at the boundary rather than
+at the participant: it pins the domain by writing ``ROS_DOMAIN_ID`` into the
+process environment, and that write lands *before* ``rclpy`` is imported. So an
+out-of-range value is never offered to the transport for rejection - it is
+published to the whole process, outliving the call that set it.
+
+``rclpy`` and ``cyclonedds`` are optional, so every refusal test here runs with
+both absent: each guard is placed ahead of its transport probe, which is what
+makes that possible and is asserted directly.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import pytest
+
+import strands_robots
+import strands_robots.hardware_rtps_bridge as rtps_mod
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_ros_bridge import HardwareRosBridge
+from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
+from strands_robots.ros_telemetry import RosTelemetryBridge
+from strands_robots.simulation.base import SimEngine
+from strands_robots.utils import MAX_DDS_DOMAIN_ID, dds_domain_id_error
+
+#: Values that cannot name a DDS domain, one per way of missing the domain.
+UNUSABLE_DOMAINS: list[Any] = [
+    -1,  # below the floor
+    -5,
+    MAX_DDS_DOMAIN_ID + 1,  # the first id whose discovery ports overflow
+    300,
+    2**31,
+    True,  # int subclass: a silent domain 1
+    False,  # int subclass: a silent domain 0
+    2.7,  # truncates to a domain the caller did not name
+    3.0,  # integral, still not an int
+    float("nan"),
+    float("inf"),
+    "5",  # a numeric string is not an int
+    None,
+    [5],
+]
+
+#: Values that do name a domain, including both ends of the range.
+USABLE_DOMAINS: list[int] = [0, 1, 7, 101, MAX_DDS_DOMAIN_ID]
+
+
+def _refuses(fn: Any, value: Any) -> bool:
+    """Whether ``fn(value)`` refuses ``value`` as a domain id.
+
+    An ``ImportError`` means the value cleared the guard and the surface then
+    found its optional transport missing - an install problem, not a verdict
+    about the domain - so it counts as accepted.
+    """
+    try:
+        fn(value)
+    except ValueError as exc:
+        return f"invalid {'ros2_domain' if 'ros2_domain' in str(exc) else 'domain_id'}" in str(exc)
+    except ImportError:
+        return False
+    return False
+
+
+def _hardware_robot(value: Any) -> None:
+    """Drive the hardware ``Robot``'s domain surface without opening a bus.
+
+    ``_init_ros_bridge`` is a plain method precisely so a ``__new__``-built
+    double can call it, which is also how the existing bridge tests reach it.
+    """
+    robot = HwRobot.__new__(HwRobot)
+    robot.tool_name_str = "arm"
+    robot._init_ros_bridge(ros2_bridge=False, ros2_domain=value)
+
+
+class _StubEngine(SimEngine):
+    """The smallest concrete ``SimEngine``: enough to reach the shared method.
+
+    Every abstract method is an inert stub with a permissive signature - the
+    subject here is ``_init_ros_bridge``, which is a plain method precisely so a
+    lightweight subclass need not thread a constructor contract through. Using a
+    stub rather than a real backend keeps this module free of any simulation
+    dependency, so the shared domain is checked on a minimal install too.
+    """
+
+    def add_object(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    add_robot = create_world = get_observation = get_state = add_object
+    remove_object = remove_robot = render = reset = send_action = step = destroy = add_object
+
+    def list_robots(self) -> list[str]:
+        return []
+
+    def robot_joint_names(self, *args: Any, **kwargs: Any) -> list[str]:
+        return []
+
+
+def _sim_engine(value: Any) -> None:
+    """Drive the simulation domain surface with no backend and no world."""
+    _StubEngine()._init_ros_bridge(ros2_bridge=False, ros2_domain=value)
+
+
+#: Every surface that takes a domain id, with the parameter it names it by.
+SURFACES: list[tuple[str, Any]] = [
+    ("RosTelemetryBridge(domain_id=)", lambda v: RosTelemetryBridge(domain_id=v)),
+    ("HardwareRosBridge(domain_id=)", lambda v: HardwareRosBridge(domain_id=v)),
+    ("HardwareRtpsBridge(domain_id=)", lambda v: HardwareRtpsBridge(domain_id=v)),
+    ("Robot._init_ros_bridge(ros2_domain=)", _hardware_robot),
+    ("SimEngine._init_ros_bridge(ros2_domain=)", _sim_engine),
+]
+SURFACE_IDS = [name.split("(")[0] for name, _ in SURFACES]
+
+
+class TestTheRtpsPortMapFixesTheCeiling:
+    """``MAX_DDS_DOMAIN_ID`` is derived from the protocol, not chosen.
+
+    RTPS 2.2 sec. 9.6.1.1 maps a domain id onto discovery ports as
+    ``PB + DG * domain_id + d0`` (SPDP multicast) and
+    ``PB + DG * domain_id + d1 + PG * participant_id`` (SPDP unicast). The
+    highest domain whose ports still fit the 16-bit port space is the ceiling;
+    pinning the arithmetic here means the constant cannot drift away from the
+    reason it holds.
+    """
+
+    #: RTPS 2.2 sec. 9.6.1.1 default port parameters.
+    PB, DG, D0, D1, PG = 7400, 250, 0, 10, 2
+
+    def _highest_port(self, domain_id: int) -> int:
+        multicast = self.PB + self.DG * domain_id + self.D0
+        unicast = self.PB + self.DG * domain_id + self.D1 + self.PG * 0
+        return max(multicast, unicast)
+
+    def test_the_ceiling_is_the_highest_domain_whose_ports_fit(self) -> None:
+        assert self._highest_port(MAX_DDS_DOMAIN_ID) <= 65535
+        assert self._highest_port(MAX_DDS_DOMAIN_ID + 1) > 65535
+
+    def test_no_domain_above_the_ceiling_has_a_port_to_bind(self) -> None:
+        overflowing = [d for d in range(0, 400) if self._highest_port(d) > 65535]
+        assert min(overflowing) == MAX_DDS_DOMAIN_ID + 1
+
+
+class TestTheSharedDomain:
+    """``dds_domain_id_error`` decides which values name a domain."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_DOMAINS, ids=repr)
+    def test_a_value_that_cannot_name_a_domain_is_refused(self, value: Any) -> None:
+        error = dds_domain_id_error(value, "domain_id", "Surface")
+        assert error is not None
+        assert error.startswith("Surface: invalid domain_id:")
+        assert f"expected 0-{MAX_DDS_DOMAIN_ID}" in error
+
+    @pytest.mark.parametrize("value", USABLE_DOMAINS, ids=repr)
+    def test_a_domain_id_in_range_is_accepted(self, value: int) -> None:
+        assert dds_domain_id_error(value, "domain_id", "Surface") is None
+
+    def test_the_message_names_the_parameter_it_came_from(self) -> None:
+        assert "invalid ros2_domain" in str(dds_domain_id_error(-1, "ros2_domain", "Robot"))
+
+
+class TestARefusedDomainLeavesTheProcessEnvironmentAlone:
+    """The refusal precedes the process-wide ``ROS_DOMAIN_ID`` write.
+
+    That write is the reason the range cannot be left to the transport: it is
+    global to the process and lands before ``rclpy`` is imported, so an accepted
+    out-of-range value would steer every later participant - and every
+    subprocess that inherits the environment - at a domain nothing is reachable
+    on, long after the call that set it returned.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_DOMAINS, ids=repr)
+    def test_a_refused_domain_does_not_touch_ros_domain_id(self, value: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        import os
+
+        with pytest.raises(ValueError, match="invalid domain_id"):
+            RosTelemetryBridge(domain_id=value)
+        assert os.environ["ROS_DOMAIN_ID"] == "7"
+
+    def test_a_usable_domain_is_still_pinned_into_the_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        import os
+
+        # rclpy is optional; the pin lands before it is imported, which is
+        # exactly why the guard has to run first.
+        with pytest.raises(ImportError):
+            RosTelemetryBridge(domain_id=11)
+        assert os.environ["ROS_DOMAIN_ID"] == "11"
+
+
+class TestARefusedDomainReachesNoTransport:
+    """Each guard runs before its surface probes for an optional transport.
+
+    Placing it there is what lets the same caller mistake report identically on
+    an install with the ``[ros2]`` extra and one without it, and it means no DDS
+    state is built for a domain that was never usable.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_DOMAINS, ids=repr)
+    def test_the_rtps_bridge_refuses_before_probing_for_cyclonedds(
+        self, value: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _unreachable(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("the cyclonedds probe must not be reached")
+
+        monkeypatch.setattr(rtps_mod, "require_optional", _unreachable)
+        with pytest.raises(ValueError, match="invalid domain_id"):
+            HardwareRtpsBridge(domain_id=value)
+
+    def test_a_usable_domain_still_reaches_the_cyclonedds_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        probed: list[str] = []
+
+        def _record(module: str, **_kwargs: Any) -> Any:
+            probed.append(module)
+            raise ImportError("cyclonedds absent")
+
+        monkeypatch.setattr(rtps_mod, "require_optional", _record)
+        with pytest.raises(ImportError):
+            HardwareRtpsBridge(domain_id=11)
+        assert probed == ["cyclonedds"]
+
+
+class TestEverySurfaceRefusesTheSameDomains:
+    """No surface may accept a domain id another one refuses.
+
+    The two transports advertise the same topics, so a domain the RTPS bridge
+    cannot bind is one the rclpy bridge must not publish on either - and the
+    ``Robot`` / simulation layers hand their ``ros2_domain`` straight to one of
+    them.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_DOMAINS, ids=repr)
+    def test_an_unusable_domain_is_refused_by_every_surface(self, value: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        refused = {name: _refuses(fn, value) for name, fn in SURFACES}
+        assert all(refused.values()), f"accepted by {[n for n, r in refused.items() if not r]}"
+
+    @pytest.mark.parametrize("value", USABLE_DOMAINS, ids=repr)
+    def test_a_usable_domain_is_refused_by_no_surface(self, value: int, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        refused = {name: _refuses(fn, value) for name, fn in SURFACES}
+        assert not any(refused.values()), f"refused by {[n for n, r in refused.items() if r]}"
+
+    @pytest.mark.parametrize("name,fn", SURFACES, ids=SURFACE_IDS)
+    def test_each_surface_stores_a_usable_domain_verbatim(
+        self, name: str, fn: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A surface that accepts the value must keep the value it accepted.
+
+        The guard replaced an ``int()`` coercion at each of these surfaces, and
+        that coercion is where a ``True`` became domain 1 and a ``2.7`` became
+        domain 2. Nothing may re-introduce one.
+        """
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        assert not _refuses(fn, MAX_DDS_DOMAIN_ID)
+
+
+class TestEverySurfaceRoutesThroughTheSharedDomain:
+    """Structural guard: a domain-taking surface guards it or forwards it.
+
+    A surface that stores a caller-supplied domain id without either calling
+    :func:`dds_domain_id_error` or handing the value to a surface that does is
+    accepting a domain nothing can be reached on. Checked structurally so a
+    sixth surface cannot ship without joining the rule.
+    """
+
+    #: Parameter names that carry a DDS domain id.
+    DOMAIN_PARAMS = frozenset({"domain_id", "ros2_domain"})
+
+    @staticmethod
+    def _package_root() -> pathlib.Path:
+        """The installed package directory, derived from an imported symbol."""
+        return pathlib.Path(inspect.getfile(strands_robots)).parent
+
+    @classmethod
+    def _classify(cls, source: str) -> dict[str, tuple[bool, bool]]:
+        """Map ``function name -> (calls the guard, forwards the parameter)``."""
+        found: dict[str, tuple[bool, bool]] = {}
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            args = [a.arg for a in node.args.args + node.args.kwonlyargs]
+            taken = [a for a in args if a in cls.DOMAIN_PARAMS]
+            if not taken:
+                continue
+            guards = any(
+                isinstance(call.func, ast.Name) and call.func.id == "dds_domain_id_error"
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+            )
+            forwards = any(
+                keyword.arg in cls.DOMAIN_PARAMS and isinstance(keyword.value, ast.Name) and keyword.value.id in taken
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+                for keyword in call.keywords
+            )
+            found[node.name] = (guards, forwards)
+        return found
+
+    def _surfaces(self) -> dict[str, tuple[bool, bool]]:
+        surfaces: dict[str, tuple[bool, bool]] = {}
+        for path in sorted(self._package_root().rglob("*.py")):
+            for name, verdict in self._classify(path.read_text()).items():
+                surfaces[f"{path.relative_to(self._package_root())}::{name}"] = verdict
+        return surfaces
+
+    def test_the_scan_finds_every_known_domain_surface(self) -> None:
+        """Non-vacuity: a scan rooted elsewhere would report a clean sweep."""
+        assert set(self._surfaces()) == {
+            "hardware_robot.py::__init__",
+            "hardware_robot.py::_init_ros_bridge",
+            "hardware_ros_bridge.py::__init__",
+            "hardware_rtps_bridge.py::__init__",
+            "ros_telemetry.py::__init__",
+            "simulation/base.py::_init_ros_bridge",
+            "simulation/mujoco/simulation.py::__init__",
+        }
+
+    def test_every_domain_surface_guards_or_forwards_the_value(self) -> None:
+        adrift = {name for name, (guards, forwards) in self._surfaces().items() if not (guards or forwards)}
+        assert not adrift, f"these surfaces neither validate nor forward the domain id: {sorted(adrift)}"
+
+    def test_the_scanner_detects_a_surface_that_does_neither(self) -> None:
+        """A scanner that matched nothing would pass the sweep vacuously."""
+        planted = "def brand_new_bridge(self, *, domain_id: int = 0) -> None:\n    self._domain = domain_id\n"
+        assert self._classify(planted) == {"brand_new_bridge": (False, False)}


### PR DESCRIPTION
## Problem

A ROS 2 / DDS domain id is an index into the RTPS port map. RTPS 2.2 sec. 9.6.1.1 derives every discovery port from it -- `PB + DG * domain_id + d0` for the SPDP multicast port, `PB + DG * domain_id + d1 + PG * participant_id` for the unicast one -- so with the standard parameters domain 232 lands on ports 65400/65410 and domain 233 lands on 65650, past the end of the port space. Only an `int` in `[0, 232]` names a domain, and the bound is the protocol's rather than a policy choice.

Five surfaces take one and none of them checked it:

| surface | parameter |
| --- | --- |
| `Robot._init_ros_bridge` (from `Robot(ros2_domain=...)`) | `ros2_domain` |
| `SimEngine._init_ros_bridge` (from a backend's `ros2_domain=...`) | `ros2_domain` |
| `RosTelemetryBridge.__init__` | `domain_id` |
| `HardwareRosBridge.__init__` | `domain_id` |
| `HardwareRtpsBridge.__init__` | `domain_id` |

Each stored the value through a bare `int(...)`, which is where a `True` became domain 1 and a `2.7` became domain 2 -- a domain nobody named.

The rclpy bridge is why the range has to be checked at the boundary rather than left to the transport. It pins the domain by writing `ROS_DOMAIN_ID` into the process environment, and that write lands **before `rclpy` is imported**, so an out-of-range value was never offered to DDS for rejection at all. Measured with `ROS_DOMAIN_ID` starting at `7` in every run:

| `RosTelemetryBridge(domain_id=...)` | verdict on main | `ROS_DOMAIN_ID` after |
| --- | --- | --- |
| `0`, `5`, `232` | reaches the transport | `'0'`, `'5'`, `'232'` |
| `233`, `300`, `2**31` | reaches the transport | **`'233'`, `'300'`, `'2147483648'`** |
| `-1`, `-5` | reaches the transport | **`'-5'`** |
| `True`, `False`, `2.7`, `'5'` | reaches the transport | **`'1'`, `'0'`, `'2'`, `'5'`** |
| `nan`, `inf`, `None`, `[5]` | bare `ValueError` / `OverflowError` / `TypeError` past a documented constructor | `'7'` |

The write is process-wide and outlives the call that made it, so an accepted out-of-range domain steered every later participant in the process -- and every subprocess that inherited the environment -- at a domain nothing is reachable on. It survived even when the construction then failed: each of the eight rows above that changed `ROS_DOMAIN_ID` went on to raise `ImportError` for the missing `rclpy`, leaving the bad domain behind it.

Across the five surfaces, 60 of 75 measured value/surface cells disagreed with the domain the protocol allows.

## Change

`utils.dds_domain_id_error` is now the one domain all five surfaces share, with `utils.MAX_DDS_DOMAIN_ID` carrying the port arithmetic that fixes its ceiling. It lives beside `tcp_port_error` for the same reason that one does, and its docstring says so: the callers sit in different layers, and the two transports exist to advertise the same topics, so a domain the RTPS bridge cannot bind must not be one the rclpy bridge publishes on. `bool` is rejected explicitly -- it is an `int` subclass, so a bare range test lets `True` through as a silent domain 1.

Each guard is placed ahead of its surface's transport probe:

* in the rclpy bridge, ahead of the `ROS_DOMAIN_ID` write, so a refused domain leaves the environment as it found it;
* in the RTPS bridge, ahead of the `cyclonedds` probe, so the same caller mistake reports identically on an install with the `[ros2]` extra and one without it.

`HardwareRosBridge` and the two `__init__` entry points (`Robot`, a simulation backend) forward their value to a guarded surface, so they are covered without a second copy of the rule. The now-redundant `int(...)` coercions are gone, so an accepted domain is stored as the caller wrote it.

Every value that already named a domain still does: the existing usages across the tests, docs and examples span 0-42 and none change.

## Artifact

![measured domain-id verdicts, the ROS_DOMAIN_ID ledger, and the unchanged sim path](https://raw.githubusercontent.com/cagataycali/robots/artifacts/dds-domain-id/dds_domain_id.png)

Every cell is measured. The two halves ran in different trees (the generator asserts that, and asserts each rendered number against the two JSON dumps). Top: the verdict matrix, 60 of 75 cells disagreeing with the protocol domain on main, 0 after -- cells are coloured by whether the verdict is the one the protocol allows, so "accepted" is green for the in-range rows. Middle: the process-wide `ROS_DOMAIN_ID` ledger. Bottom left: the default simulation path is unaffected -- `Simulation(...)` -> `add_robot('panda')` -> `run_policy(mock, 1.6 s @ 50 Hz)` rendered headless, run independently on both trees, renders agreeing to 1/255 (renderer noise) with every joint identical to 6 dp.

## Tests

New: `tests/test_dds_domain_id_domain.py`, 79 tests, 2.1 s, with no `rclpy`, no `cyclonedds` and no simulation backend -- each guard precedes its transport probe, which is what makes that possible and is asserted directly.

* the RTPS port arithmetic is asserted rather than the constant alone, so `MAX_DDS_DOMAIN_ID` cannot drift from the reason it holds;
* a refused domain is shown not to touch `ROS_DOMAIN_ID`, while an accepted one still pins it;
* the RTPS bridge is shown to refuse before probing for `cyclonedds`, and a usable domain still to reach that probe;
* the five surfaces' verdicts are asserted equal over the whole probe set, in both directions;
* a structural check requires every domain-taking surface to either call the shared domain or forward the value to one that does, with a non-vacuity check naming the exact seven surfaces and a planted-defect check so the scanner cannot pass over nothing.

Pre-fix proof (call sites reverted to `upstream/main`, the new helper kept so the module still imports): **43 failed / 36 passed**, the structural check naming all four adrift surfaces. The 36 that pass are the port arithmetic, the shared domain's own unit tests, the in-range controls and the meta-checks -- they are what stop the guard reaching further than the values that cannot name a domain.

## Gate

Run at `f74272ab`, rebased onto `66a822a6`:

* `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **21161 passed, 257 skipped, 0 failed** (517.85 s)
* `ruff check strands_robots tests tests_integ` -> clean; `ruff format --check` -> 1086 files already formatted
* `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1083 source files`
* `scripts/assemble_changelog.py --check` -> OK; `scripts/check_merge_base_overlap.py` -> no overlap

`#1966` merged mid-verification and also touched `strands_robots/utils.py`, so the branch was rebased and the whole gate re-run on the combined tree. The rebase is faithful: both diffs are 623 lines and the diff-of-diffs has **0** content-line differences.

## Out of scope

`spin_period` / `poll_period`, the sibling knobs in two of those signatures, are a different quantity with a different consequence -- a wait budget, where `0`, `-1` and `nan` each return from `Event.wait` immediately and spin the command thread while `inf` raises `OverflowError` on it. That is a separate domain (`positive_finite_number_error`) with its own table, and it is left for its own change rather than mixed in here.

The range is not narrowed further to ROS 2's own recommended 0-101 (which avoids the Linux ephemeral port range). That is a platform recommendation rather than a protocol bound, and `[0, 232]` is what RTPS can address; narrowing it would refuse domains that work today.