### PR TITLE
fix(simulation/isaac): an add_object keyword it cannot use is named rather than dropped

### DIFF
--- a/changelog.d/1977-isaac-add-object-unknown-keyword.md
+++ b/changelog.d/1977-isaac-add-object-unknown-keyword.md
@@ -1,0 +1,23 @@
+### Fixed: an `add_object` keyword the Isaac backend cannot use is named rather than dropped
+
+All three backends declare the same ten `add_object` parameters. MuJoCo and Newton
+declare no `**kwargs`, so Python refuses an unknown keyword with a `TypeError`.
+`IsaacSimulation.add_object` alone declared a `**kwargs` sink, read exactly one key
+out of it -- `scale`, the documented `size` alias -- and discarded the rest. So
+`add_object(name="crate", heigth=0.3)` returned `status="success"` on Isaac having
+compiled the default extents and reported them back in the result `json`, while the
+same call is a `TypeError` on both siblings. Measured over six unusable keywords
+(`heigth`, `positon`, `colour`, `density`, `friction`, `rgba`), every one was
+accepted and silently dropped.
+
+`unknown_kwargs_error` exists for exactly this shape and its docstring already
+divides `**kwargs` methods into *forwarding* sinks, where dropping is right, and
+*discarding* sinks, where it "turns a misspelled or invented parameter into a
+successful no-op". The action dispatcher states the same delegation from the other
+side -- it skips its own unknown-key check for a `**kwargs` method because "those
+methods own the check instead" -- so Isaac's `add_object` was the one action that
+skip left uncovered.
+
+The sink stays, because `scale` is a real Isaac-only capability that the docs use;
+it now rejects every keyword it does not read, before any prim is constructed, so a
+refused call takes no lock, registers nothing and leaves the name reusable.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -118,6 +118,19 @@ sim.destroy()
 backend selection is identical whether you go through `Robot()` or
 `create_simulation()`.
 
+`scale=` above is an accepted alias for `add_object(size=...)`, and it is the only
+extra keyword that method reads. Any other keyword is refused by name rather than
+dropped -- the same contract `IsaacConfig` applies to `create_simulation` kwargs,
+and the same verdict the MuJoCo and Newton backends give (they declare the same
+`add_object` parameters and no `**kwargs`, so an unknown keyword is a `TypeError`
+there):
+
+```python
+sim.add_object(name="cube", heigth=0.3)
+# {"status": "error", "content": [{"text":
+#   "Unknown parameter(s) ['heigth'] for action 'add_object'. Valid: [...]"}]}
+```
+
 ## Configuration (`IsaacConfig`)
 
 Keyword arguments to `create_simulation("isaac", ...)` (or

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import numpy as np
 
-from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.base import SimEngine, unknown_kwargs_error
 from strands_robots.simulation.isaac.config import IsaacConfig
 from strands_robots.simulation.isaac.joint_names import demangle_usd_joint_names, urdf_joint_names
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
@@ -233,6 +233,26 @@ class SimulationAppLaunchConfig(TypedDict, total=False):
 # throughout the docs; it normalizes to the canonical ``"box"`` (see #88).
 # A unit test pins this mapping so docs and code can't drift apart again.
 _SHAPE_ALIASES: dict[str, str] = {"cuboid": "box"}
+
+# Every keyword :meth:`IsaacSimulation.add_object` honors, including the one it
+# reads out of its own ``**kwargs`` (``scale``, the ``size`` alias). Doubles as
+# the "Valid:" hint in the unknown-keyword refusal, so it lists the declared
+# parameters too rather than only the residual-key vocabulary. A unit test pins
+# it against the live signature so a parameter added to ``add_object`` cannot
+# start being reported as unknown.
+_ADD_OBJECT_PARAMS: tuple[str, ...] = (
+    "color",
+    "is_static",
+    "mass",
+    "material",
+    "mesh_path",
+    "name",
+    "orientation",
+    "position",
+    "scale",
+    "shape",
+    "size",
+)
 
 
 def _rgb_png_block(rgb: np.ndarray) -> dict[str, Any] | None:
@@ -1912,6 +1932,10 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             Visual material/texture spec. NOT supported by the Isaac backend
             yet; a non-``None`` value is rejected loudly rather than silently
             dropped (use the MuJoCo backend for matte/textured surfaces).
+        **kwargs
+            ``scale`` (the ``size`` alias documented above) is the only
+            keyword read here. Any other keyword is refused rather than
+            dropped -- see Validation below.
 
         Validation
         ----------
@@ -1933,6 +1957,18 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         ``_objects``, leaving the name permanently taken. A static object's mass
         is never read, so it is not validated - the same scope MuJoCo uses.
 
+        A keyword this method does not honor is refused by name on the shared
+        :func:`~strands_robots.simulation.base.unknown_kwargs_error` contract the
+        MuJoCo and Newton backends' discarding ``**kwargs`` sinks (``randomize``,
+        ``set_obs_noise``) already apply, so a caller mistake reports the same way
+        on every backend. Both sibling ``add_object`` implementations declare the
+        same ten parameters with no ``**kwargs`` at all, so Python refuses an
+        unknown keyword there with a ``TypeError``; here the keys reached a sink
+        that read ``scale`` and discarded the rest, turning ``heigth=0.3`` or
+        ``colour=[1, 0, 0]`` into a silent no-op reported as success. The check
+        runs before anything else so a refused call constructs no prim, takes no
+        lock and leaves the name reusable.
+
         Returns
         -------
         dict
@@ -1942,6 +1978,19 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             ``mass``, and ``is_static`` so an agent can confirm what
             actually landed on the stage without re-querying.
         """
+        # ``**kwargs`` exists for one keyword - the documented ``scale`` alias
+        # read below - and every other residual key used to be dropped. That
+        # made a misspelled or invented parameter a successful no-op on the
+        # backend's most-used scene surface: ``add_object(name="crate",
+        # heigth=0.3)`` returned ``status="success"`` having compiled the
+        # default extents, while the sibling backends' ``add_object`` - which
+        # declare the same ten parameters and no ``**kwargs`` - refuse the same
+        # call with a ``TypeError``. The action dispatcher deliberately skips
+        # its own unknown-key check for a ``**kwargs`` method and delegates it
+        # to the method (see ``_validate_and_build_kwargs``), so this is the
+        # only place it can run.
+        if err := unknown_kwargs_error("add_object", kwargs, _ADD_OBJECT_PARAMS):
+            return err
         if material is not None:
             return {
                 "status": "error",

--- a/tests/simulation/test_add_object_unknown_keyword_across_backends.py
+++ b/tests/simulation/test_add_object_unknown_keyword_across_backends.py
@@ -1,0 +1,362 @@
+"""Regression tests: every backend refuses an ``add_object`` keyword it cannot use.
+
+All three backends declare the *same ten* ``add_object`` parameters. Two of them
+declare no ``**kwargs``, so Python refuses an unknown keyword with a
+``TypeError``. The Isaac backend alone declared a ``**kwargs`` sink, read exactly
+one key out of it -- ``scale``, the documented ``size`` alias -- and dropped
+every other key silently.
+
+``unknown_kwargs_error`` in :mod:`strands_robots.simulation.base` exists for
+precisely that shape, and its docstring names the two kinds a ``**kwargs`` method
+can be:
+
+    For a *forwarding* sink (``attach_teleop``, ``stream_dataset``) dropping is
+    right - the keys belong to the callee. For a *discarding* sink it turns a
+    misspelled or invented parameter into a successful no-op [...] Discarding
+    sinks call this helper instead, so an unusable parameter is named rather than
+    swallowed.
+
+The action dispatcher states the same delegation from the other side, in
+``MuJoCoSimEngine._validate_and_build_kwargs``:
+
+    ``**kwargs`` methods accept arbitrary inputs, so we skip the unknown-key
+    check for them. Those methods own the check instead [...] otherwise skipping
+    here would make a misspelled parameter a silent no-op on exactly those
+    actions.
+
+Isaac's ``add_object`` is a discarding sink that never called the helper, so it
+was the one action the dispatcher's skip left uncovered.
+
+Measured on the probe set below, one ``add_object`` per case, with no
+``isaacsim`` / ``newton`` / ``warp`` installed -- six of eight keywords diverged:
+
+===========================  ==========  ==========  ====================
+keyword                      MuJoCo      Newton      Isaac (before)
+===========================  ==========  ==========  ====================
+(none -- control)            success     success     success
+``scale`` (documented)       TypeError   TypeError   success, honored
+``heigth``                   TypeError   TypeError   success, dropped
+``positon``                  TypeError   TypeError   success, dropped
+``colour``                   TypeError   TypeError   success, dropped
+``density``                  TypeError   TypeError   success, dropped
+``friction``                 TypeError   TypeError   success, dropped
+``rgba``                     TypeError   TypeError   success, dropped
+===========================  ==========  ==========  ====================
+
+Every dropped row compiled the *default* extents and reported them back in the
+result ``json``, so nothing downstream could tell the request from a call that
+never carried the keyword at all.
+
+``scale`` is the reason the sink exists and is a real Isaac-only capability, so
+deleting ``**kwargs`` is not the fix: the sink stays and rejects everything it
+does not read. ``TestTheScaleAliasIsStillHonored`` pins that half, so a future
+"just drop the ``**kwargs``" change fails here.
+
+``TestNoAddObjectKeywordSinkDrifts`` keeps it structural: a backend
+``add_object`` may declare ``**kwargs`` only if it calls the shared helper.
+
+These tests are GL-free and need no optional backend: the guard is the method's
+first statement, so calling the unbound method with a small stand-in for ``self``
+exercises it in every environment.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import textwrap
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation import base as sim_base
+
+# Imported as a module rather than by symbol so the accepted-keyword tuple is
+# reached through it: one import of this module keeps py/import-and-import-from
+# quiet, and a test that names a symbol the module does not define reports that
+# directly instead of failing the whole file at collection.
+from strands_robots.simulation.isaac import simulation as isaac_sim
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from tests.simulation.test_pose_vector_domain_across_backends import _isaac_stub, _newton_stub
+
+#: Keywords no ``add_object`` can use: two misspellings of a real parameter, a
+#: British spelling of one, an MJCF attribute name, and two plausible physics
+#: options this API does not expose. Each was accepted and discarded.
+UNKNOWN_KEYWORDS: tuple[tuple[str, Any], ...] = (
+    ("heigth", 0.30),
+    ("positon", [1.0, 2.0, 0.3]),
+    ("colour", [1.0, 0.0, 0.0]),
+    ("density", 500.0),
+    ("friction", 0.9),
+    ("rgba", [1.0, 0.0, 0.0, 1.0]),
+)
+
+#: The one residual keyword Isaac's sink exists to read.
+HONORED_EXTRA = "scale"
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+def _json(result: dict[str, Any]) -> dict[str, Any]:
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+def _isaac_counting() -> tuple[Any, dict[str, int]]:
+    """An Isaac stand-in counting what a refused call must never reach."""
+    stub = _isaac_stub()
+    calls = {"construct": 0, "scene_add": 0}
+
+    def construct(**kwargs: Any) -> tuple[Any, Any]:
+        calls["construct"] += 1
+        return object(), list(kwargs.get("size") or [])
+
+    def scene_add(handle: Any) -> None:
+        calls["scene_add"] += 1
+
+    stub._construct_shape_prim = construct
+    stub._world.scene.add = scene_add
+    return stub, calls
+
+
+def _isaac_add(stub: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call the unbound method so a deliberately invalid keyword reaches it."""
+    return isaac_sim.IsaacSimulation.add_object(stub, **kwargs)
+
+
+def _newton_add(stub: Any, **kwargs: Any) -> dict[str, Any]:
+    return NewtonSimEngine.add_object(stub, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# The Isaac backend: the keyword is named rather than swallowed               #
+# --------------------------------------------------------------------------- #
+
+
+class TestIsaacAddObjectRefusesAKeywordItCannotUse:
+    """Each unknown keyword is refused, naming it and the accepted vocabulary."""
+
+    @pytest.mark.parametrize(("key", "value"), UNKNOWN_KEYWORDS, ids=[k for k, _ in UNKNOWN_KEYWORDS])
+    def test_an_unknown_keyword_is_refused_by_name(self, key: str, value: Any) -> None:
+        stub, _ = _isaac_counting()
+        result = _isaac_add(stub, name="crate", shape="box", size=[0.1, 0.1, 0.1], **{key: value})
+        assert result["status"] == "error"
+        text = _text(result)
+        assert key in text, text
+        assert "add_object" in text, text
+        # The accepted vocabulary is the actionable half: without it the caller
+        # only learns the key was wrong, not what to write instead.
+        assert "size" in text and "position" in text, text
+
+    def test_several_unknown_keywords_are_all_named(self) -> None:
+        """Reporting one at a time would need one round trip per typo."""
+        stub, _ = _isaac_counting()
+        result = _isaac_add(stub, name="crate", heigth=0.3, positon=[0, 0, 1], density=500.0)
+        assert result["status"] == "error"
+        text = _text(result)
+        for key in ("density", "heigth", "positon"):
+            assert key in text, text
+
+    def test_a_usable_call_is_unaffected(self) -> None:
+        stub, calls = _isaac_counting()
+        result = _isaac_add(stub, name="crate", shape="box", size=[0.1, 0.1, 0.1])
+        assert result["status"] == "success"
+        assert calls["construct"] == 1
+        assert _json(result)["size"] == [0.1, 0.1, 0.1]
+
+
+class TestTheRefusalPrecedesEveryEffect:
+    """A refused keyword must leave the scene, the registry and the name alone."""
+
+    def test_no_prim_is_constructed_and_nothing_is_registered(self) -> None:
+        stub, calls = _isaac_counting()
+        result = _isaac_add(stub, name="crate", shape="box", size=[0.1, 0.1, 0.1], heigth=0.3)
+        assert result["status"] == "error"
+        assert calls == {"construct": 0, "scene_add": 0}
+        assert stub._objects == {}
+        assert stub._prim_registry == []
+
+    def test_the_name_is_still_usable_afterwards(self) -> None:
+        """A refused call must not consume the name the caller asked for."""
+        stub, calls = _isaac_counting()
+        assert _isaac_add(stub, name="crate", size=[0.1, 0.1, 0.1], colour=[1, 0, 0])["status"] == "error"
+        retry = _isaac_add(stub, name="crate", size=[0.1, 0.1, 0.1], color=[1.0, 0.0, 0.0])
+        assert retry["status"] == "success", _text(retry)
+        assert calls["construct"] == 1
+        assert "crate" in stub._objects
+
+
+class TestTheScaleAliasIsStillHonored:
+    """``scale`` is why the sink exists; the guard must not cost that capability."""
+
+    def test_scale_supplies_the_extent_when_size_is_omitted(self) -> None:
+        stub, calls = _isaac_counting()
+        result = _isaac_add(stub, name="crate", shape="box", scale=[0.2, 0.3, 0.4])
+        assert result["status"] == "success", _text(result)
+        assert _json(result)["size"] == [0.2, 0.3, 0.4]
+        assert calls["construct"] == 1
+
+    def test_an_explicit_size_still_wins_over_scale(self) -> None:
+        stub, _ = _isaac_counting()
+        result = _isaac_add(stub, name="crate", shape="box", size=[0.1, 0.1, 0.1], scale=[0.9, 0.9, 0.9])
+        assert result["status"] == "success", _text(result)
+        assert _json(result)["size"] == [0.1, 0.1, 0.1]
+
+    def test_scale_beside_an_unknown_keyword_is_still_refused(self) -> None:
+        """The honored key must not license the rest of the mapping."""
+        stub, calls = _isaac_counting()
+        result = _isaac_add(stub, name="crate", scale=[0.2, 0.2, 0.2], heigth=0.3)
+        assert result["status"] == "error"
+        assert "heigth" in _text(result)
+        assert calls["construct"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Cross-backend parity                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def _refuses(call: Any, **kwargs: Any) -> bool:
+    """Did this backend refuse the call, by either documented channel?"""
+    try:
+        return bool(call(**kwargs)["status"] == "error")
+    except TypeError:
+        # A backend with no ``**kwargs`` refuses an unknown keyword here.
+        return True
+
+
+class TestEveryBackendRefusesAnUnknownAddObjectKeyword:
+    """One API, one verdict: no backend accepts a keyword it cannot honor."""
+
+    @pytest.mark.parametrize(("key", "value"), UNKNOWN_KEYWORDS, ids=[k for k, _ in UNKNOWN_KEYWORDS])
+    def test_no_backend_accepts_it(self, key: str, value: Any) -> None:
+        isaac, _ = _isaac_counting()
+        verdicts = {
+            "isaac": _refuses(lambda **kw: _isaac_add(isaac, **kw), name="crate", size=[0.1] * 3, **{key: value}),
+            "newton": _refuses(
+                lambda **kw: _newton_add(_newton_stub(), **kw), name="crate", size=[0.1] * 3, **{key: value}
+            ),
+        }
+        assert all(verdicts.values()), f"{key} was accepted by: {[b for b, v in verdicts.items() if not v]}"
+
+    def test_a_usable_call_is_accepted_by_every_backend(self) -> None:
+        """Non-vacuity: the parity above must not hold by refusing everything."""
+        isaac, _ = _isaac_counting()
+        assert _isaac_add(isaac, name="crate", size=[0.1] * 3)["status"] == "success"
+        assert _newton_add(_newton_stub(), name="crate", size=[0.1] * 3)["status"] == "success"
+
+
+# --------------------------------------------------------------------------- #
+# The accepted set, and no drift                                              #
+# --------------------------------------------------------------------------- #
+
+
+class TestTheAcceptedSetIsDerivedFromTheSignature:
+    """The vocabulary must be the live signature plus the keys the sink reads."""
+
+    def test_it_is_the_declared_parameters_plus_scale(self) -> None:
+        declared = {
+            name
+            for name, param in inspect.signature(isaac_sim.IsaacSimulation.add_object).parameters.items()
+            if name != "self" and param.kind is not inspect.Parameter.VAR_KEYWORD
+        }
+        assert set(isaac_sim._ADD_OBJECT_PARAMS) == declared | {HONORED_EXTRA}
+
+    def test_every_declared_parameter_is_accepted_by_keyword(self) -> None:
+        """A declared parameter passed by keyword must never read as unknown."""
+        for name in isaac_sim._ADD_OBJECT_PARAMS:
+            if name == HONORED_EXTRA:
+                continue
+            assert sim_base.unknown_kwargs_error("add_object", {name: None}, isaac_sim._ADD_OBJECT_PARAMS) is None
+
+
+def _scan_add_object_sinks(root: pathlib.Path) -> tuple[set[tuple[str, str]], list[str]]:
+    """Find every backend ``add_object`` with a ``**kwargs`` sink; flag the unguarded.
+
+    Returns ``(found, adrift)`` where ``found`` is every public ``add_object``
+    defined on a class under a backend package and ``adrift`` names those that
+    declare ``**kwargs`` without calling the shared helper.
+    """
+    found: set[tuple[str, str]] = set()
+    adrift: list[str] = []
+    for backend in sorted(p for p in root.iterdir() if p.is_dir() and not p.name.startswith("_")):
+        for path in sorted(backend.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # pragma: no cover - not expected in-tree
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                for member in node.body:
+                    if not isinstance(member, ast.FunctionDef) or member.name != "add_object":
+                        continue
+                    found.add((backend.name, member.name))
+                    if member.args.kwarg is None:
+                        continue
+                    calls = {
+                        getattr(n.func, "id", None) or getattr(n.func, "attr", None)
+                        for n in ast.walk(member)
+                        if isinstance(n, ast.Call)
+                    }
+                    if "unknown_kwargs_error" not in calls:
+                        adrift.append(f"{backend.name}/{path.name}::{node.name}.add_object")
+    return found, adrift
+
+
+#: Every backend package that defines an ``add_object``. ``SpecBuilder`` in the
+#: MuJoCo package takes an already-validated ``SimObject``, so the scan keys on
+#: the backend rather than the class and both MuJoCo definitions collapse here.
+_KNOWN_ADD_OBJECT_BACKENDS = {("isaac", "add_object"), ("mujoco", "add_object"), ("newton", "add_object")}
+
+
+class TestNoAddObjectKeywordSinkDrifts:
+    """An ``add_object`` may declare ``**kwargs`` only if it rejects the residue."""
+
+    def test_every_backend_sink_rejects_unknown_keywords(self) -> None:
+        root = pathlib.Path(inspect.getfile(sim_base)).parent
+        found, adrift = _scan_add_object_sinks(root)
+        assert found == _KNOWN_ADD_OBJECT_BACKENDS, f"the set of add_object backends changed: {found}"
+        assert adrift == [], "these drop unknown keywords silently: " + ", ".join(adrift)
+
+    def test_the_scanner_reports_a_planted_sink(self, tmp_path: pathlib.Path) -> None:
+        """Without this, an empty result could mean a scanner matching nothing."""
+        backend = tmp_path / "planted"
+        backend.mkdir()
+        (backend / "simulation.py").write_text(
+            textwrap.dedent(
+                """
+                class Engine:
+                    def add_object(self, name, size=None, **kwargs):
+                        kwargs.pop("scale", None)
+                        return {"status": "success"}
+                """
+            ),
+            encoding="utf-8",
+        )
+        found, adrift = _scan_add_object_sinks(tmp_path)
+        assert found == {("planted", "add_object")}
+        assert len(adrift) == 1
+        assert "Engine.add_object" in adrift[0]
+
+    def test_the_scanner_accepts_a_guarded_sink(self, tmp_path: pathlib.Path) -> None:
+        """The negative control: declaring ``**kwargs`` is not itself the defect."""
+        backend = tmp_path / "planted"
+        backend.mkdir()
+        (backend / "simulation.py").write_text(
+            textwrap.dedent(
+                """
+                class Engine:
+                    def add_object(self, name, size=None, **kwargs):
+                        if err := unknown_kwargs_error("add_object", kwargs, ("name", "size")):
+                            return err
+                        return {"status": "success"}
+                """
+            ),
+            encoding="utf-8",
+        )
+        found, adrift = _scan_add_object_sinks(tmp_path)
+        assert found == {("planted", "add_object")}
+        assert adrift == []


### PR DESCRIPTION
All three backends declare the **same ten** `add_object` parameters. MuJoCo and Newton declare no `**kwargs`, so Python refuses an unknown keyword with a `TypeError`. `IsaacSimulation.add_object` alone declared a `**kwargs` sink, read exactly one key out of it -- `scale`, the documented `size` alias -- and discarded every other key silently.

So one caller mistake had opposite verdicts depending on the backend:

```python
sim.add_object(name="crate", size=[0.1, 0.1, 0.1], heigth=0.3)
# mujoco / newton -> TypeError: add_object() got an unexpected keyword argument 'heigth'
# isaac (before)  -> {"status": "success", ...}   the keyword is gone
```

## What was measured

One `add_object` per case, with no `isaacsim` / `newton` / `warp` installed. Six of eight keywords diverged, and every dropped row compiled the **default** extents and reported them back in the result `json`, so nothing downstream could tell the request from a call that never carried the keyword:

| extra keyword | MuJoCo | Newton | Isaac (before) | Isaac (this PR) |
|---|---|---|---|---|
| *(none -- control)* | success | success | success | success |
| `scale` *(documented alias)* | `TypeError` | `TypeError` | success, **honored** | success, **honored** |
| `heigth` | `TypeError` | `TypeError` | success, **dropped** | refused |
| `positon` | `TypeError` | `TypeError` | success, **dropped** | refused |
| `colour` | `TypeError` | `TypeError` | success, **dropped** | refused |
| `density` | `TypeError` | `TypeError` | success, **dropped** | refused |
| `friction` | `TypeError` | `TypeError` | success, **dropped** | refused |
| `rgba` | `TypeError` | `TypeError` | success, **dropped** | refused |

## Why this method, and why it is the only place the check can run

`unknown_kwargs_error` already exists for exactly this shape, and its docstring divides `**kwargs` methods into the two kinds:

> For a *forwarding* sink (`attach_teleop`, `stream_dataset`) dropping is right - the keys belong to the callee. For a *discarding* sink it turns a misspelled or invented parameter into a successful no-op [...] Discarding sinks call this helper instead, so an unusable parameter is named rather than swallowed.

The action dispatcher states the same delegation from the other side, in `MuJoCoSimEngine._validate_and_build_kwargs`:

> `**kwargs` methods accept arbitrary inputs, so we skip the unknown-key check for them. Those methods own the check instead [...] otherwise skipping here would make a misspelled parameter a silent no-op on exactly those actions.

`add_object` is a discarding sink that never called the helper, so it was the one action the dispatcher's skip left uncovered. The helper had two callers on each of the other two backends (`randomize`, `set_obs_noise`) and none here.

## The change

`unknown_kwargs_error("add_object", kwargs, _ADD_OBJECT_PARAMS)` as the method's **first** statement, plus the accepted-keyword tuple and the docs/docstring contract.

The sink **stays**. `scale` is a real Isaac-only capability that `docs/simulation/isaac.md` uses in its Usage example, so deleting `**kwargs` would have cost it -- the sink now rejects only what it does not read. `TestTheScaleAliasIsStillHonored` pins that half in both spellings (`scale` supplies the extent when `size` is omitted; an explicit `size` still wins), so a later "just drop the `**kwargs`" change fails here.

Placement is the method's first statement, matching `randomize` / `set_obs_noise` on the other two backends. A refused call therefore takes no lock, constructs no prim, registers nothing and leaves the name reusable -- all four pinned, including the retry.

`_ADD_OBJECT_PARAMS` is asserted against the live signature (`declared parameters | {"scale"}`), so a parameter added to `add_object` cannot start being reported as unknown.

## Visual artifact

Renders replay the extent Isaac's `add_object` **actually compiled** (captured at the prim constructor), drawn in MuJoCo headless. The blue post is 0.30 m -- the requested size.

![add_object unknown-keyword verdicts and replay renders](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-add-object-unknown-keyword/add_object_unknown_keyword.png)

A caller asking for a 30 cm crate got a **5 cm** one under `status="success"` when the keyword was misspelled -- the documented box fallback `[0.05, 0.05, 0.05]`, six times too small per axis. Panel A (the honored `scale` path) is **byte-identical across the two trees** (max delta `0/255`), which is the no-regression evidence; main's dropped-key result differs from it on 54.6% of pixels. Every number in the figure is re-derived from the two measurement dumps by the generator, which also asserts the two probes resolved to different trees.

## Tests

`tests/simulation/test_add_object_unknown_keyword_across_backends.py`, 25 tests, GL-free and needing no optional backend (the guard is the first statement, so the unbound method with a small stand-in for `self` exercises it in every environment) -- 0.95 s.

**Pre-fix: 19 failed / 6 passed.** The structural guard names the adrift surface directly:

```
FAILED ...::TestNoAddObjectKeywordSinkDrifts::test_every_backend_sink_rejects_unknown_keywords
  AssertionError: these drop unknown keywords silently: isaac/simulation.py::IsaacSimulation.add_object
FAILED ...::TestEveryBackendRefusesAnUnknownAddObjectKeyword::test_no_backend_accepts_it[density]
  AssertionError: density was accepted by: ['isaac']
```

The 6 that pass pre-fix are the over-reach controls -- the `scale` alias still working, a usable call succeeding, the scanner's planted-defect and negative-control meta-tests, and the cross-backend non-vacuity check. They are what stop the guard reaching past the one thing it is for.

`TestNoAddObjectKeywordSinkDrifts` keeps it structural: a backend `add_object` may declare `**kwargs` only if it calls the shared helper. It carries a planted-sink test (so an empty result cannot mean a scanner matching nothing), a negative control (declaring `**kwargs` is not itself the defect) and an exact expected-backend set.

## Out of scope

`IsaacConfig.from_kwargs` was checked in the same pass and is correct -- it delegates to the dataclass `__init__`, which raises `TypeError` on an unexpected kwarg, exactly as its docstring claims.

## Gate

Verified on `92fc9b4`, base `66a822a6`:

- `ruff check strands_robots tests tests_integ` -- All checks passed
- `ruff format --check strands_robots tests tests_integ` -- 1086 files already formatted
- `mypy strands_robots tests tests_integ` -- 14 errors, all in `examples/isaac_gs`, **0 outside**; the error set is byte-identical to a pristine `upstream/main` worktree of the same working copy, so they are environmental rather than from this change
- `MUJOCO_GL=egl pytest tests` -- **21107 passed, 257 skipped, 0 failed** in 558 s, **zero existing tests changed**
- `scripts/assemble_changelog.py --check` -- OK; `scripts/check_merge_base_overlap.py` -- no overlap