### PR TITLE
docs(agents): verify the repository still accepts writes before doing the work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,49 @@ hatch run format            # ruff check --fix, ruff format
      IDs against the `databaseId`s the API publishes beside them, so the claim
      that the check is available offline fails loudly rather than quietly if the
      envelope ever changes.
+   - *And that the repository still accepts writes at all.* Archiving is
+     invisible in every field a sweep already reads. `strands-labs/robots-sim`
+     was archived at 01:33 UTC on 2026-08-06, between one scheduled cycle and
+     the next, and a scan taken minutes afterwards returned its open pull
+     request and its four open issues completely normally, next to
+     `viewerPermission: ADMIN`. Nothing in that payload distinguishes it from a
+     live repository. The first and only signal was the mutation:
+
+     ```
+     createIssue  ->  Repository was archived so is read-only
+     ```
+
+     `viewerPermission` is the field that misleads, and it keeps reporting
+     `ADMIN` afterwards because the permission is genuine - the repository is
+     what changed, not the grant. So it is not a stale or buggy read, and no
+     amount of re-reading it helps; it answers a different question than the one
+     being asked.
+
+     What it costs is the whole run rather than a retry, because the refusal
+     arrives at the *end*: an archived repository accepts no branch, no issue and
+     no pull request, so a clone, a branch, a three-file fix, a regression pin
+     verified to fail on pre-fix code, and a clean `black`/`isort`/`flake8` run
+     were all completed before anything reported a problem, and none of it could
+     land. A fork's branch still pushes, which makes it worse rather than better
+     - the pull request it would open is the step that is refused. Ask for the
+     one field on a query already being made, before the work and not after it:
+
+     ```
+     repository(owner: ..., name: ...) { isArchived viewerPermission }
+     ```
+
+     Two consequences beyond the read. An archived repository is terminal, so
+     treat `strands-labs/robots-sim` as closed for good: epic robots-sim#167
+     completed, and any remaining cross-repo item naming it - the
+     `robots-sim MIGRATION.md` half of #1274 - can now only be satisfied or
+     closed on this side. And a defect found in a repository that is already
+     archived is not automatically worth fixing anywhere: the deprecation notice
+     there names an undeclared upstream extra, which is the exact hazard
+     `tests/test_dependency_audit.py` guards here, but robots-sim never cut a
+     release carrying it - its latest tag predates the notice - so it reached no
+     installer and the correct action was to drop the fix rather than relocate
+     it. Check what actually shipped before deciding an archived finding needs a
+     home.
    And before merging, `reviewDecision: APPROVED` alone is not the gate: poll
    the **required** contexts' own conclusions and `mergeStateStatus == CLEAN`
    together, since `reviewDecision` flips before the checks finish.


### PR DESCRIPTION
## Why

PR-workflow step 8 already says to read a pull request's state back before and after changing it, and to confirm a mutation named the object you meant. It was silent on the object every mutation implicitly names: **the repository**.

`strands-labs/robots-sim` was archived at **01:33 UTC on 2026-08-06**, between one scheduled cycle and the next. A scan taken minutes afterwards returned its open pull request and all four open issues completely normally, beside `viewerPermission: ADMIN`. Nothing in that payload distinguishes an archived repository from a live one.

The first and only signal was the mutation:

```
createIssue  ->  Repository was archived so is read-only
```

## Why it costs a run rather than a retry

The refusal arrives at the **end**. An archived repository accepts no branch, no issue and no pull request, so all of this completed before anything reported a problem, and none of it could land:

- clone, branch
- a three-file fix
- a regression pin, verified to fail on pre-fix code
- a clean `black` / `isort` / `flake8` run and a base-vs-fix test delta

A fork's branch still pushes, which makes it worse rather than better: the pull request it would open is the step that is refused, so the usual "push to your fork" recovery does not exist here.

`viewerPermission` cannot be the read that catches it, and this is the part worth writing down: it keeps reporting `ADMIN` after the archive because the permission is *genuine* - the repository is what changed, not the grant. So it is not a stale or buggy read that a second look fixes; it answers a different question than the one being asked. Same shape as the `mergeStateStatus` / `require_last_push_approval` entries already in step 8, where the misleading field is honest and the state is simply invisible.

The remedy is one field on a query already being made:

```graphql
repository(owner: ..., name: ...) { isArchived viewerPermission }
```

## Two consequences also recorded

1. **robots-sim is terminal.** Epic `robots-sim#167` completed, so any remaining cross-repo item naming it - the `robots-sim MIGRATION.md` half of #1274 - can now only be satisfied or closed on this side. Future cycles should stop planning work there.
2. **An archived finding is not automatically worth relocating.** The deprecation notice there names an undeclared upstream extra (`strands-robots[isaac]`; upstream declares `sim-isaac`), which is exactly the hazard `tests/test_dependency_audit.py` guards here. But robots-sim never cut a release carrying it - its latest tag, `v0.1.1`, predates the notice - so it reached no installer, and the correct action was to **drop** the fix rather than find it a new home. Check what actually shipped before deciding.

## Scope

Documentation only: one new bullet in the existing step-8 list in `AGENTS.md`, `+43/-0`, no code and no behaviour change. No changelog fragment - per `changelog.d/README.md`, "it is fragments, not the log, that *behavioural* PRs write to."

Deliberately **not** a workflow gate. Unlike the changelog and closing-reference checks, there is nothing for a gate to watch: the condition is a property of a *remote* repository at the moment an agent decides to work on it, not of any diff or PR in this one.

## Verification

```
tests/test_changelog_fragment_gate.py tests/test_review_thread_reply_gate.py
tests/test_closing_reference_gate.py  tests/test_log_strings_are_ascii.py
tests/test_last_push_approval.py      tests/test_graphql_node_id_targeting.py
  -> 163 passed
```

The added block is pure ASCII (`grep -nP '[^\x00-\x7F]'` clean), so the no-emoji and orphan-combining-mark rules hold.

## §13 Changelog

**Round 1** - initial submission.