### PR TITLE
docs(agents): a null reviewDecision is a thread-resolution signature, not an absent requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,6 +383,52 @@ hatch run format            # ruff check --fix, ruff format
      installer and the correct action was to drop the fix rather than relocate
      it. Check what actually shipped before deciding an archived finding needs a
      home.
+   - *And that the field naming the review decision is present at all.*
+     `reviewDecision` has a third reading beyond `APPROVED` and
+     `REVIEW_REQUIRED`: **`null`** - and it does not mean what an absent value
+     suggests. #1974 sat at `mergeStateStatus` `BLOCKED` carrying a current
+     `APPROVED` review that post-dated its head commit, the required check
+     `SUCCESS`, `require_last_push_approval` satisfied, and `reviewDecision`
+     `null`. Resolving its one unresolved thread moved both fields at once:
+
+     | field | one unresolved thread | after `resolveReviewThread` |
+     |---|---|---|
+     | `mergeStateStatus` | `BLOCKED` | `CLEAN` |
+     | `reviewDecision` | `null` | `APPROVED` |
+
+     The gate behind it is already in this file: the `default` ruleset sets
+     `required_review_thread_resolution: true`, and #1890 measured a merge
+     landing 8 seconds after its last thread was resolved. What #1974 adds is
+     the *signature*, and it is the one value that misreads in the reassuring
+     direction - `REVIEW_REQUIRED` at least says a review is owed, whereas
+     `null` reads as "no review requirement applies here" rather than "one
+     resolve from merging". It is not a recompute lag: that approval was more
+     than twenty minutes old when the field was read as `null`. The two also
+     need opposite actions - the `REVIEW_REQUIRED` case above needs a second
+     account, this one needs no review at all. The distinguishing read is the
+     threads, not the decision:
+
+     ```graphql
+     reviewThreads(first: 50) { nodes { id isResolved isOutdated } }
+     ```
+
+     `isOutdated: true` on an unresolved thread is the common form, and it is a
+     prompt rather than reassurance: the diff moved on, so the request has
+     usually already been satisfied by a later commit and only the resolve is
+     outstanding. #1974's was addressed by the commit before its head, and the
+     approving review said so, and it still held the merge.
+
+     **`resolveReviewThread` needs `PAT_TOKEN`.** Under the Actions
+     `GITHUB_TOKEN` it returns `Resource not accessible by integration` - the
+     same refusal shape as the board reads in step 6. Resolving is often the
+     entire remaining distance to a merge, so a sweep holding only an
+     installation token cannot finish the job it has correctly diagnosed.
+
+     Resolve rather than push. A push clears nothing here and costs the approval
+     twice: `dismiss_stale_reviews_on_push` drops it, and
+     `require_last_push_approval` then disqualifies the pushing account from
+     re-supplying it, turning a one-approval merge into one that needs a second
+     reviewer.
    And before merging, `reviewDecision: APPROVED` alone is not the gate: poll
    the **required** contexts' own conclusions and `mergeStateStatus == CLEAN`
    together, since `reviewDecision` flips before the checks finish.


### PR DESCRIPTION
## Why

PR-workflow step 8 is thorough on the review decision misreading. It covers `APPROVED` arriving before the checks finish, and it covers `REVIEW_REQUIRED` on a push whose only approver is the pusher - the #1722 / #1035 pair, where the state is "byte for byte what an unreviewed pull request looks like". Both of those are the field carrying a *wrong value*.

It was silent on the field carrying **no value**.

#1974, this cycle: every signal step 8 tells you to poll was satisfied, and it would not merge.

| signal | reading |
|---|---|
| required check (`call-test-lint / Test and Lint`) | `SUCCESS` |
| current review | `APPROVED`, post-dating head `6118c3f` |
| `require_last_push_approval` (`Detect an approval the last pusher cannot supply`) | `SUCCESS` |
| `mergeable` | `MERGEABLE` |
| `mergeStateStatus` | `BLOCKED` |
| `reviewDecision` | **`null`** |

One `resolveReviewThread` moved both fields at once, with nothing else changed:

| field | before | after |
|---|---|---|
| `mergeStateStatus` | `BLOCKED` | `CLEAN` |
| `reviewDecision` | `null` | `APPROVED` |

It merged immediately afterwards (`fb5476c`).

## Why `null` is worth its own entry

The gate itself is **already in this file** - the `default` ruleset sets `required_review_thread_resolution: true`, and #1890 measured a merge landing 8 seconds after its last thread was resolved. This PR does not restate the gate. It records the **signature**, for three reasons:

1. **`null` misreads in the reassuring direction.** `REVIEW_REQUIRED` at least asserts a review is owed. `null` reads as "no review requirement applies here" - so a sweep that branches on `reviewDecision` does not conclude "one resolve from merging", it concludes there is nothing to wait for.
2. **It is not a recompute lag.** That approval was more than twenty minutes old when the field read `null`, so a second look does not fix it. Same shape as the `viewerPermission: ADMIN` entry added in #1980: the field is honest, it just answers a different question.
3. **It needs the opposite action from the neighbouring case.** `REVIEW_REQUIRED` from `require_last_push_approval` needs a second account and no work by the author clears it. `null` here needs no review at all - only a resolve.

So the distinguishing read is the threads, not the decision, and the entry says so.

## Two operational facts recorded with it

1. **`isOutdated: true` on an unresolved thread is a prompt, not reassurance.** The diff moved on, so the request has usually already been satisfied by a later commit and only the resolve is outstanding. #1974's was addressed by the commit before its head - the approving review confirmed the previously-red check now passed - and it still held the merge.
2. **`resolveReviewThread` is refused to the Actions `GITHUB_TOKEN`** (`Resource not accessible by integration`) and needs `PAT_TOKEN`, the same refusal shape as the board reads in step 6. This one is load-bearing rather than trivia: resolving is often the entire remaining distance to a merge, so an agent holding only an installation token can diagnose the blocker correctly and still be unable to clear it.

The entry also states why the answer is a resolve and **not** a push, which the existing `#1821` / `require_last_push_approval` material makes precise: a push clears nothing here and costs the approval twice - `dismiss_stale_reviews_on_push` drops it, then `require_last_push_approval` disqualifies the pushing account from re-supplying it, turning a one-approval merge into one needing a second reviewer.

## Scope

Documentation only: one new bullet appended to step 8's existing `- *And ...*` series in `AGENTS.md`, `+46/-0`. No code, no behaviour change, **no existing line modified** (`git diff --numstat` -> `46 0 AGENTS.md`).

No changelog fragment - per `changelog.d/README.md`, "it is fragments, not the log, that *behavioural* PRs write to." Same call as #1980.

Deliberately **not** a workflow gate. `mergeStateStatus` / `reviewDecision` are properties of a pull request's *current* state that GitHub already surfaces on the merge box; there is no diff for a gate to inspect, and unlike the last-push-approval check there is no ambiguity to disambiguate - the merge box says "unresolved conversations" outright. The failure this documents is an agent polling the wrong field, which is a reading habit, and habits live in this file.

## Verification

```
tests/test_changelog_fragment_gate.py   tests/test_review_thread_reply_gate.py
tests/test_closing_reference_gate.py    tests/test_log_strings_are_ascii.py
tests/test_last_push_approval.py        tests/test_graphql_node_id_targeting.py
tests/test_ref_creation_ruleset_scope.py tests/test_pull_request_trigger_types.py
  -> 187 passed
```

The added block is pure ASCII (`grep -nP '[^\x00-\x7F]'` over lines 386-431 is clean), so the no-emoji and orphan-combining-mark rules hold. The pre-existing non-ASCII in the file (the repository tree at lines 20-42, and lines 747 / 768 / 964-965) is untouched.

Evidence for every number above is #1974 itself, read back before and after the resolve rather than inferred.

## §13 Changelog

**Round 1** - initial submission.