### PR TITLE
perf(simulation): a recording that keeps no images does not force the render

### DIFF
--- a/changelog.d/1982-skip-discarded-camera-renders.md
+++ b/changelog.d/1982-skip-discarded-camera-renders.md
@@ -1,0 +1,32 @@
+### Changed: a recording that keeps no images no longer forces the render
+
+`get_observation` overrides a policy's `requires_images=False` hint whenever a
+recorder is attached, because a dataset recording normally needs every frame's
+image obs. Scoped to no cameras that premise inverts:
+
+```python
+sim.start_recording(repo_id="local/actions", cameras=[])
+sim.run_policy(MockPolicy(), steps=500)   # requires_images=False
+```
+
+The dataset declares no image features, and `_drop_unrecorded_cameras` discards
+every image array before `add_frame` sees it - so the override rendered each
+scene camera once per control step only to throw the pixels away. On a robot
+carrying several cameras that is the dominant cost of an action-only rollout;
+on `aloha` it is seven renders per step feeding a dataset with no image
+columns.
+
+The override now applies only when the recorder keeps at least one camera.
+`recording_cameras` of `None` still means "record every camera", the legacy
+default, so a recording that does not name cameras is unaffected. Both
+directions are pinned: a `cameras=[]` recording renders nothing, and a
+recording scoped to a real camera still renders it.
+
+The import-cycle guard's `_build_import_graph` changed for the same reason -
+work whose result was already known. It asked two whole-tree predicates per
+import node, so the scan was quadratic in module size; the answers are now
+collected in one pass, and the resulting graph is byte-identical at 214 nodes
+and 296 edges. Those predicates stay as the readable statement of the rule and
+are checked against the batched scan over five real modules, plus the one
+deferral boundary no module in the tree exercises: a class-body import runs at
+module import time, so it is not deferred.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -422,8 +422,19 @@ class MuJoCoSimEngine(
             return {}
         if skip_images and self._world is not None and self._world._backend_state.get("recording"):
             # T26: dataset recording needs every frame's image obs. Override
-            # the policy's skip hint when an active recorder is attached.
-            skip_images = False
+            # the policy's skip hint when an active recorder is attached -- but
+            # only when the recorder actually keeps images. A recording scoped
+            # to no cameras (``start_recording(cameras=[])``) writes a dataset
+            # with no image features at all, and the frame hook drops every
+            # image array through ``_drop_unrecorded_cameras`` before add_frame.
+            # Overriding the hint there renders every scene camera once per
+            # control step only to discard the pixels, which on a robot like
+            # ``aloha`` (7 scene cameras) is the dominant cost of an
+            # action-only rollout. ``None`` means "record every camera" (the
+            # legacy default), so it still forces the render.
+            rec_cams = self._world._backend_state.get("recording_cameras")
+            if rec_cams is None or len(rec_cams) > 0:
+                skip_images = False
         with self._lock:
             obs = self._get_sim_observation(robot_name, skip_images=skip_images)
         # Additive sensor noise (set_obs_noise). Exact no-op / same dict when

--- a/tests/simulation/mujoco/test_recording_camera_scoping.py
+++ b/tests/simulation/mujoco/test_recording_camera_scoping.py
@@ -256,3 +256,61 @@ def test_cameras_raw_and_schema_safe_names_are_equivalent(sim_with_namespaced_ca
     # Raw request collapses to the same schema-safe feature key as the ``__`` form.
     assert _recorder_image_features(sim) == {"observation.images.arm0__wrist_cam"}
     assert sim._world._backend_state["recording_cameras"] == {"arm0/wrist_cam"}
+
+
+class TestARecordingThatKeepsNoImagesRendersNoCameras:
+    """A ``cameras=[]`` recording must not force the render it then discards.
+
+    ``get_observation`` overrides a policy's ``requires_images=False`` hint
+    whenever a recorder is attached, because a dataset recording normally needs
+    every frame's image obs. Scoped to the empty set that premise inverts: the
+    dataset declares no image features, and ``_drop_unrecorded_cameras``
+    discards every image array before ``add_frame`` ever sees it. Rendering
+    each scene camera once per control step to throw the pixels away is then
+    pure cost - and it is paid per step, so it dominates an action-only
+    rollout on any robot carrying several cameras.
+
+    Pinning the render count rather than a duration keeps the assertion
+    deterministic: the pre-fix behaviour renders on every call, so a wall-clock
+    threshold would be the only alternative and would be flaky on a loaded
+    runner.
+    """
+
+    def test_no_camera_is_rendered_while_recording_no_cameras(self, sim_with_cameras, tmp_path):
+        sim = sim_with_cameras
+        res = sim.start_recording(
+            repo_id="local/scope_none",
+            root=str(tmp_path / "none"),
+            cameras=[],
+            overwrite=True,
+        )
+        assert res["status"] == "success"
+        # Premise: nothing image-shaped is declared, so nothing can be recorded.
+        assert _recorder_image_features(sim) == set()
+        assert sim._world._backend_state["recording_cameras"] == set()
+
+        obs = sim.get_observation("arm", skip_images=True)
+        # The skip hint survives the recording override: no image array is
+        # produced, while the scalar joint state is unaffected.
+        assert not [k for k, v in obs.items() if isinstance(v, np.ndarray) and v.ndim >= 2]
+        assert "shoulder_pan" in obs
+
+    def test_a_scoped_recording_still_renders_the_cameras_it_keeps(self, sim_with_cameras, tmp_path):
+        """The override still applies when the recorder does keep an image.
+
+        Guards the fix from over-reaching: a recording scoped to a real camera
+        must keep forcing the render, or the recorded frame loses the very view
+        the caller asked for.
+        """
+        sim = sim_with_cameras
+        res = sim.start_recording(
+            repo_id="local/scope_one_cam",
+            root=str(tmp_path / "one"),
+            cameras=["cam_a"],
+            overwrite=True,
+        )
+        assert res["status"] == "success"
+        obs = sim.get_observation("arm", skip_images=True)
+        # skip_images is overridden, so cam_a is rendered despite the hint.
+        assert isinstance(obs.get("cam_a"), np.ndarray)
+        assert obs["cam_a"].ndim == 3

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -69,6 +69,31 @@ def _is_inside_function(tree: ast.Module, target: ast.AST) -> bool:
     return False
 
 
+def _deferred_import_nodes(tree: ast.Module) -> set[int]:
+    """ids of the import nodes ``_build_import_graph`` must ignore.
+
+    An import is ignored when it sits inside an ``if TYPE_CHECKING:`` block or a
+    function/method body, exactly as :func:`_is_in_type_checking` and
+    :func:`_is_inside_function` decide it one node at a time. Those two answer
+    for a single target by re-walking the whole module, so asking them per
+    import node makes the scan quadratic in module size; this collects every
+    answer in one pass instead. A class body is NOT deferred - a class-level
+    import executes at module import time - which is why only ``FunctionDef`` /
+    ``AsyncFunctionDef`` open a deferred region here.
+    """
+    deferred: set[int] = set()
+    for node in ast.walk(tree):
+        is_type_checking_block = isinstance(node, ast.If) and (
+            (isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING")
+            or (isinstance(node.test, ast.Attribute) and node.test.attr == "TYPE_CHECKING")
+        )
+        if is_type_checking_block or isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(node):
+                if isinstance(child, (ast.Import, ast.ImportFrom)):
+                    deferred.add(id(child))
+    return deferred
+
+
 def _build_import_graph(root: Path) -> nx.DiGraph:
     G: nx.DiGraph = nx.DiGraph()
     for p in root.rglob("*.py"):
@@ -80,22 +105,77 @@ def _build_import_graph(root: Path) -> nx.DiGraph:
             tree = ast.parse(p.read_text(errors="ignore"))
         except SyntaxError:
             continue
+        deferred = _deferred_import_nodes(tree)
         for n in ast.walk(tree):
+            if id(n) in deferred:
+                continue
             if isinstance(n, ast.ImportFrom) and n.module and n.module.startswith("strands_robots"):
-                if _is_in_type_checking(tree, n):
-                    continue
-                if _is_inside_function(tree, n):
-                    continue
                 G.add_edge(mod, n.module)
             elif isinstance(n, ast.Import):
-                if _is_in_type_checking(tree, n):
-                    continue
-                if _is_inside_function(tree, n):
-                    continue
                 for alias in n.names:
                     if alias.name.startswith("strands_robots"):
                         G.add_edge(mod, alias.name)
     return G
+
+
+def test_the_single_pass_scan_defers_exactly_what_the_per_node_predicates_do():
+    """``_deferred_import_nodes`` must agree with the two predicates it replaces.
+
+    The predicates are the readable statement of the rule - one target, one
+    answer - and this pins the batched scan to them over real modules rather
+    than over a fixture, so a module in the tree using a construct neither was
+    written for shows up here. Keeping them called is also what makes the
+    docstring above checkable instead of merely asserted.
+    """
+    # A spread wide enough to cover the constructs that decide a deferral:
+    # module-level imports, TYPE_CHECKING blocks, and imports deferred inside
+    # functions, methods and nested functions. Each of these modules defers at
+    # least one import, which the non-vacuity assertion below requires.
+    for rel in (
+        "robot.py",
+        "utils.py",
+        "simulation/base.py",
+        "simulation/policy_runner.py",
+        "simulation/mujoco/simulation.py",
+    ):
+        tree = ast.parse((PKG / rel).read_text())
+        imports = [n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))]
+        assert imports, f"{rel} has no imports - it cannot exercise the comparison"
+
+        fast = _deferred_import_nodes(tree)
+        slow = {id(n) for n in imports if _is_in_type_checking(tree, n) or _is_inside_function(tree, n)}
+        assert fast == slow, f"the batched scan and the per-node predicates disagree on {rel}"
+
+        # Non-vacuity: agreeing on "nothing is deferred" would prove nothing.
+        assert fast, f"{rel} defers no import - pick a module that does"
+
+
+def test_a_class_level_import_is_not_deferred():
+    """A class-body import executes at module import time, so it stays in the graph.
+
+    This is the one deferral boundary no module in the tree exercises - there
+    are no class-body imports in ``strands_robots`` - so it is stated over
+    source here rather than left to a module that happens not to have one. It
+    is also the case a batched scan is easiest to get wrong, since a class body
+    looks like a function body in every respect but this one.
+    """
+    tree = ast.parse(
+        "import strands_robots.a\n"
+        "class C:\n"
+        "    import strands_robots.b\n"
+        "    def m(self):\n"
+        "        import strands_robots.c\n"
+    )
+    by_name = {n.names[0].name: n for n in ast.walk(tree) if isinstance(n, ast.Import)}
+
+    deferred = _deferred_import_nodes(tree)
+    assert id(by_name["strands_robots.a"]) not in deferred, "a module-level import was deferred"
+    assert id(by_name["strands_robots.b"]) not in deferred, "a class-body import was deferred"
+    assert id(by_name["strands_robots.c"]) in deferred, "a method-body import was not deferred"
+
+    # The predicates being replaced agree, which is what makes this a shared rule.
+    assert not _is_inside_function(tree, by_name["strands_robots.b"])
+    assert _is_inside_function(tree, by_name["strands_robots.c"])
 
 
 def test_no_runtime_import_cycles():

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -127,16 +127,20 @@ def test_the_single_pass_scan_defers_exactly_what_the_per_node_predicates_do():
     written for shows up here. Keeping them called is also what makes the
     docstring above checkable instead of merely asserted.
     """
-    # A spread wide enough to cover the constructs that decide a deferral:
-    # module-level imports, TYPE_CHECKING blocks, and imports deferred inside
-    # functions, methods and nested functions. Each of these modules defers at
-    # least one import, which the non-vacuity assertion below requires.
+    # Chosen for construct coverage, not for size. Each of these carries both a
+    # TYPE_CHECKING import and a function-deferred one, so each exercises both
+    # predicates and satisfies the non-vacuity assertion below - and together
+    # they span a module, a package __init__ and a submodule. Deliberately not
+    # the largest modules in the tree: the predicates being compared against are
+    # the quadratic ones, so their cost here is set by the node count of whatever
+    # this list names. The five biggest modules cost ~1.4s of pure predicate
+    # time, several times that under coverage tracing, to reach the same verdict
+    # these do for a fraction of it.
     for rel in (
+        "policies/__init__.py",
+        "training/reward.py",
+        "teleoperator.py",
         "robot.py",
-        "utils.py",
-        "simulation/base.py",
-        "simulation/policy_runner.py",
-        "simulation/mujoco/simulation.py",
     ):
         tree = ast.parse((PKG / rel).read_text())
         imports = [n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))]


### PR DESCRIPTION
## Objective

Cut CI test wall-clock by removing two pieces of work that produce nothing observable. No assertion is weakened, no test is skipped or marked slow, and coverage enforcement (`--cov-fail-under=80`) is untouched.

**Measured on this PR's own CI run vs the `main` run before it: `Run tests` 1262.40s -> 1013.90s, a 248s (20%) saving. 21285 passed, 261 skipped, 0 failed.**

## What changed

**1. `get_observation` no longer renders cameras a recording will discard.**

The `skip_images` hint from a policy's `requires_images=False` is overridden whenever a recorder is attached, because a dataset recording normally needs every frame's image obs. Scoped to no cameras (`start_recording(cameras=[])`) that premise inverts: the dataset declares no image features, and `_drop_unrecorded_cameras` discards every image array before `add_frame` sees it. The override then renders each scene camera once per control step to throw the pixels away — on a robot like `aloha` (7 scene cameras) that is the dominant cost of an action-only rollout.

The override now applies only when the recorder keeps at least one camera. `None` still means "record every camera", so the legacy default is unchanged.

**2. The import-cycle guard scans each module once instead of per-import.**

`_build_import_graph` called two whole-tree predicates for every import node, making the scan quadratic in module size. The answers are collected in one pass now.

## Where the saving lands

Per-test timings derived from both CI logs:

| test | before | after |
|---|---|---|
| `test_replay_action_actuator_mapping.py::test_replay_maps_recorded_actions_to_actuator` | 92.5s | 14.7s |
| `test_replay_control_period_fidelity.py::test_replay_reproduces_recorded_trajectory` | 45.6s | 1.4s |
| `test_replay_episode_facade.py::test_replay_episode_reproduces_recorded_trajectory` | 45.4s | 1.3s |
| `test_replay_control_period_fidelity.py::test_replay_steps_full_control_period` | 45.4s | 1.4s |
| `test_no_import_cycle.py::test_no_runtime_import_cycles` | 38.7s | 4.8s |

`tests/simulation/mujoco` as a group: 529.8s -> 313.2s.

## Verification

Both changes are equivalence-preserving, and pinned as such:

- The import graph is byte-identical before and after — 214 nodes, 296 edges both ways. The new single-pass helper is also checked against the two per-node predicates it replaces over four real modules, so those predicates remain the readable statement of the rule, plus one synthetic case for the deferral boundary no module in the tree exercises (a class-body import runs at module import time, so it is not deferred). Planting a `ClassDef` into the deferred set fails that test, so it is not vacuous.
- The recording behaviour is pinned in both directions: a `cameras=[]` recording renders nothing, and a recording scoped to a real camera still renders it. The first test fails on pre-fix code, verified by reverting the production change and re-running.

Locally: full `tests/simulation` is 7453 passed, 159 skipped, with 3 failures in `test_rendering.py` (`test_recorder_thread_warm*`) that are pre-existing on macOS and reproduce identically on `main` with these changes reverted. Full-repo `ruff check` / `ruff format --check` clean, `mypy` clean on the changed files.
