### PR TITLE
fix(ci): the last-push-approval report can be pointed at the standing pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -668,6 +668,44 @@ hatch run format            # ruff check --fix, ruff format
    so it reports and is deliberately absent from the required set. A gate a
    branch cannot clear by doing anything is a report, whatever it is wired to.
 
+   **Automating it is not the same as covering the population, and the gap is
+   silent in the same direction as the bug.** That workflow fires on
+   `pull_request` and `pull_request_review`, so it can only evaluate a pull
+   request that has had one of those *since it landed* - and the pull requests
+   this is written for are the ones that have not. #1035's head was pushed
+   2026-08-01 and approved 51 minutes later, both before the workflow existed on
+   2026-08-04, so `Detect an approval the last pusher cannot supply` is absent
+   from the 11 check runs on that head, while every other check is present. So
+   the check read `SUCCESS` on pull requests that did not have the condition and
+   said nothing at all about the two that did.
+
+   The verdict was never the problem. Run directly, the same script answers
+   immediately, and did before this was noticed:
+
+   ```
+   python3 scripts/check_last_push_approval.py --repo strands-labs/robots --pr 1035
+     -> Outcome: pusher-only-approval, pushed by cagataycali, exit 1
+   ```
+
+   #1905 attributes the silence to the workflow's base-branch guard instead.
+   That is worth correcting rather than leaving, because it points at a fix that
+   would change nothing: the guard checks out the **base**, `main` carries the
+   script, so the guard passes and the script would run. What was missing was a
+   caller, which is now `--all-open`:
+
+   ```
+   python3 scripts/check_last_push_approval.py --repo <owner/name> --all-open
+   ```
+
+   Run that when reporting repository health. A sweep that reads only
+   `reviewDecision` and `mergeStateStatus` cannot tell
+   `awaiting-first-review` from `pusher-only-approval` - both are
+   `REVIEW_REQUIRED` / `BLOCKED` - and reporting the second as the first is
+   exactly how "reviewer bandwidth is the sole constraint" stood for eight
+   consecutive scans over two permanently unmergeable pull requests. Exit 1
+   means at least one open pull request needs an approver who is not its pusher,
+   and no amount of reviewer time supplies one.
+
    The general rule behind all three: **a decision recorded only in a PR or
    issue comment is not durable** - the next contributor will not read the same
    comment. If a decision must survive, it belongs in this file.

--- a/changelog.d/1905-last-push-approval-sweep.md
+++ b/changelog.d/1905-last-push-approval-sweep.md
@@ -1,0 +1,25 @@
+### Fixed: the last-push-approval report can be pointed at the standing open pull requests
+
+`scripts/check_last_push_approval.py` gained `--all-open`, which classifies every
+open non-draft pull request in one pass instead of one named pull request.
+
+The check was reachable only from `pull_request` and `pull_request_review`
+events, so it could evaluate a pull request only if one had fired *since the
+workflow landed* - and the population it was written for is the population that
+had not. #1035's head was pushed 2026-08-01 and approved 51 minutes later, both
+before the workflow existed on 2026-08-04, so `Detect an approval the last pusher
+cannot supply` is absent from the 11 check runs on that head. The verdict was
+never wrong: run directly, the same script reports `pusher-only-approval` on
+#1035 and #1722 immediately. Nothing was asking it.
+
+A sweep is what a status scan needs to tell `awaiting-first-review` from
+`pusher-only-approval`, since `reviewDecision: REVIEW_REQUIRED` with
+`mergeStateStatus: BLOCKED` describes both and they need opposite actions - the
+conflation that stood in eight consecutive scan summaries as "reviewer bandwidth
+is the sole constraint".
+
+Drafts are excluded, because a draft cannot merge whatever its approvals say. A
+per-pull-request lookup failure is named in the report and skipped rather than
+allowed to abort the sweep, so one rate-limited pull request cannot suppress a
+finding on another or read as a clean sweep. Neither `--all-open` nor `--pr` may
+be silently ignored when both are given; the invocation is refused.

--- a/scripts/check_last_push_approval.py
+++ b/scripts/check_last_push_approval.py
@@ -82,10 +82,51 @@ also cannot be self-cleared by the pull request author alone, which is exactly
 why it reports rather than blocks: a gate whose remedy is "find another human"
 would otherwise sit red on a branch that has done nothing wrong.
 
+Why there is a sweep mode
+-------------------------
+The workflow that runs this is driven by ``pull_request`` and
+``pull_request_review`` events, so it can only ever evaluate a pull request
+that has had one **since the workflow landed**. The population the check was
+written for is precisely the population that has not.
+
+Measured on #1035: its head was pushed 2026-08-01T08:00:37Z and the approval
+submitted 51 minutes later, both before the workflow existed on 2026-08-04, so
+no qualifying event has fired on it since and ``Detect an approval the last
+pusher cannot supply`` is absent from the 11 check runs on that head. Nothing
+about the verdict was ever wrong -- invoked directly against the same pull
+request the classifier answers immediately::
+
+    python3 scripts/check_last_push_approval.py --pr 1035
+    -> Outcome: pusher-only-approval, pushed by cagataycali, exit 1
+
+So the gap was never in the reasoning; it was that on a standing pull request
+nothing asks for it. Issue #1905 attributes the silence to this workflow's
+base-branch guard instead. That is not the cause and the distinction matters,
+because it points at a different fix: the guard checks out the **base**, ``main``
+carries the script, so the guard passes and would run it. What is missing is a
+caller.
+
+``--all-open`` is that caller. It classifies every open pull request on demand,
+which is what a scheduled status scan needs in order to tell "waiting on a
+reviewer" from "cannot merge on any further review by this account" -- the two
+states this file exists to separate, and the ones that stood conflated in eight
+consecutive scan summaries. Draft pull requests are excluded: a draft cannot
+merge whatever its approvals say, so a finding on one does not mean what a
+finding here means.
+
+A per-pull-request lookup failure inside a sweep is reported and skipped rather
+than allowed to abort the run, because one rate-limited pull request must not
+suppress a finding on the others. Skipped numbers are named in the report for
+the same reason the outcomes are: an unevaluated pull request that says nothing
+is the failure mode this whole file is written against.
+
 Usage
 -----
 ``--repo``   ``owner/name`` (default: ``$GITHUB_REPOSITORY``).
 ``--pr``     pull request number (default: ``$PR_NUMBER``).
+``--all-open``
+             Sweep every open non-draft pull request instead of one. Mutually
+             exclusive with ``--pr``.
 ``--head``   head commit SHA (default: ``$HEAD_SHA``; falls back to the pull
              request's own ``head.sha``).
 ``--token``  API token (default: ``$GITHUB_TOKEN``). Needs ``actions: read``
@@ -126,10 +167,39 @@ POSITION_STATES = frozenset({"APPROVED", "CHANGES_REQUESTED", "DISMISSED"})
 # tests/test_last_push_approval.py::test_a_review_triggered_run_does_not_name_the_pusher
 PUSH_ATTRIBUTING_EVENTS = frozenset({"push", "pull_request"})
 
+# Pagination ceiling for the open-pull-request listing. A repository with more
+# than this many open pull requests at once has a different problem, and an
+# unbounded loop over a paginated endpoint is how a transient API shape change
+# becomes a hang rather than an error.
+_MAX_PAGES = 20
+
 SATISFIED = "satisfied"
 AWAITING_FIRST_REVIEW = "awaiting-first-review"
 PUSHER_ONLY_APPROVAL = "pusher-only-approval"
 UNKNOWN_PUSHER = "unknown-pusher"
+
+
+# The remedy text, shared by the single-pull-request report and the sweep so
+# the two cannot drift into describing different remedies for one rule.
+WHAT_CLEARS_THIS: tuple[str, ...] = (
+    "",
+    "### What clears this",
+    "",
+    "1. A second reviewer approves. Preserves the guarantee the rule exists",
+    "   to provide, and is the cheapest of the three.",
+    "2. The branch author pushes the head commit, which makes the existing",
+    "   approval count again. `dismiss_stale_reviews_on_push` is also set, so",
+    "   this costs a re-approval round -- but one that then counts.",
+    "3. Admin bypass. Not recommended: the rule exists to stop one account",
+    "   both writing and approving a change, so bypassing it to merge code",
+    "   that account pushed defeats the control rather than working around a",
+    "   technicality.",
+    "",
+    "Avoiding it next time: pushing a fix onto a contributor's branch consumes",
+    "the approval of whoever owns the token it is pushed with. Prefer leaving",
+    "the change as review feedback for the author to push, or land it as a",
+    "separate pull request against the base branch.",
+)
 
 
 @dataclass(frozen=True)
@@ -292,6 +362,100 @@ def resolve_head_sha(repo: str, pr: int, token: str) -> str:
     return head.get("sha") or ""
 
 
+@dataclass(frozen=True)
+class SweepRow:
+    """One open pull request and the verdict computed for it."""
+
+    pr: int
+    head_sha: str
+    verdict: Verdict
+
+
+def resolve_open_pull_requests(repo: str, token: str) -> list[tuple[int, str]]:
+    """Return ``(number, head_sha)`` for every open non-draft pull request.
+
+    Sorted by number so the sweep report is stable between runs and a diff of
+    two reports shows changed verdicts rather than reordered rows.
+    """
+    found: list[tuple[int, str]] = []
+    for page in range(1, _MAX_PAGES + 1):
+        payload = _get(f"{API_ROOT}/repos/{repo}/pulls?state=open&per_page=100&page={page}", token)
+        rows = payload if isinstance(payload, list) else []
+        for row in rows:
+            if row.get("draft"):
+                continue
+            number = row.get("number")
+            head = ((row.get("head") or {}).get("sha")) or ""
+            if isinstance(number, int) and head:
+                found.append((number, head))
+        if len(rows) < 100:
+            break
+    return sorted(found)
+
+
+def sweep(repo: str, token: str) -> tuple[list[SweepRow], list[int]]:
+    """Classify every open non-draft pull request.
+
+    Returns the rows it could evaluate and the numbers it could not. A failure
+    on one pull request is skipped rather than raised: the sweep exists to
+    surface findings across the standing population, and one unreachable pull
+    request must not take the rest of the report with it.
+    """
+    rows: list[SweepRow] = []
+    skipped: list[int] = []
+    for pr, head_sha in resolve_open_pull_requests(repo, token):
+        try:
+            pusher = resolve_pusher(repo, head_sha, token)
+            reviews = resolve_reviews(repo, pr, token)
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+            print(f"check_last_push_approval: {repo}#{pr} lookup failed, not evaluated: {exc}", file=sys.stderr)
+            skipped.append(pr)
+            continue
+        rows.append(SweepRow(pr, head_sha, classify(pusher, reviews)))
+    return rows, skipped
+
+
+def render_sweep(rows: Sequence[SweepRow], skipped: Sequence[int], repo: str) -> str:
+    """Render one table for the whole sweep, findings named up front."""
+    findings = [row for row in rows if row.verdict.is_finding]
+    lines = [
+        "## Last-push approval sweep",
+        "",
+        f"Evaluated {len(rows)} open non-draft pull request(s) in {repo}.",
+        "",
+    ]
+    if findings:
+        named = ", ".join(f"#{row.pr}" for row in findings)
+        lines += [
+            f"**{len(findings)} needs an approver who did not push the head:** {named}.",
+            "",
+            "Each is approved, and blocked anyway. No further review by the pushing",
+            "account can clear it, so this does not resolve with reviewer time.",
+            "",
+        ]
+    else:
+        lines += ["No pull request is held by an approval its pusher supplied.", ""]
+    lines += [
+        "| pull request | outcome | pushed by | current approvals |",
+        "|---|---|---|---|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| #{row.pr} | {row.verdict.outcome} | {row.verdict.pusher or '(undetermined)'} "
+            f"| {_join(row.verdict.approvers)} |"
+        )
+    if skipped:
+        lines += [
+            "",
+            "Not evaluated (lookup failed): " + ", ".join(f"#{pr}" for pr in skipped) + ".",
+            "A pull request this run could not read is named rather than omitted, so a",
+            "silent gap in coverage cannot read as a clean sweep.",
+        ]
+    if findings:
+        lines += list(WHAT_CLEARS_THIS)
+    return "\n".join(lines)
+
+
 def render(verdict: Verdict, repo: str, pr: int, head_sha: str) -> str:
     lines = [
         "## Last-push approval",
@@ -309,25 +473,35 @@ def render(verdict: Verdict, repo: str, pr: int, head_sha: str) -> str:
     ]
     if verdict.is_finding:
         lines += [
-            "",
-            "### What clears this",
-            "",
-            "1. A second reviewer approves. Preserves the guarantee the rule exists",
-            "   to provide, and is the cheapest of the three.",
-            "2. The branch author pushes the head commit, which makes the existing",
-            "   approval count again. `dismiss_stale_reviews_on_push` is also set, so",
-            "   this costs a re-approval round -- but one that then counts.",
-            "3. Admin bypass. Not recommended: the rule exists to stop one account",
-            "   both writing and approving a change, so bypassing it to merge code",
-            "   that account pushed defeats the control rather than working around a",
-            "   technicality.",
-            "",
-            "Avoiding it next time: pushing a fix onto a contributor's branch consumes",
-            "the approval of whoever owns the token it is pushed with. Prefer leaving",
-            "the change as review feedback for the author to push, or land it as a",
-            "separate pull request against the base branch.",
+            *WHAT_CLEARS_THIS,
         ]
     return "\n".join(lines)
+
+
+def _emit(report: str) -> None:
+    """Print the report, and append it to the step summary when there is one."""
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+
+def _run_sweep(repo: str, token: str) -> int:
+    """Sweep the open pull requests, reporting every finding. Exit 1 if any."""
+    try:
+        rows, skipped = sweep(repo, token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+        # Listing the pull requests is the one lookup with no partial result to
+        # report, so it follows the same rule as a single-pull-request failure.
+        print(f"check_last_push_approval: could not list open pull requests: {exc}", file=sys.stderr)
+        return 0
+
+    _emit(render_sweep(rows, skipped, repo))
+    findings = [row for row in rows if row.verdict.is_finding]
+    for row in findings:
+        print(f"::warning title=Needs an approver who did not push the head::{repo}#{row.pr}: {row.verdict.summary}")
+    return 1 if findings else 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -336,12 +510,28 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
     parser.add_argument("--head", default=os.environ.get("HEAD_SHA", ""))
     parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    parser.add_argument(
+        "--all-open",
+        action="store_true",
+        help="Sweep every open non-draft pull request instead of one.",
+    )
     args = parser.parse_args(argv)
 
-    if not args.repo or not args.pr:
-        parser.error("--repo and --pr are required (or set GITHUB_REPOSITORY and PR_NUMBER)")
     if not args.token:
         parser.error("--token is required (or set GITHUB_TOKEN)")
+    if not args.repo:
+        parser.error("--repo is required (or set GITHUB_REPOSITORY)")
+    # Refused rather than resolved in either direction: silently ignoring --pr
+    # would report on pull requests the caller did not ask about, and silently
+    # ignoring --all-open would report on one when a sweep was wanted. Both
+    # read as a successful run of the other thing.
+    if args.all_open and args.pr:
+        parser.error("--all-open and --pr are mutually exclusive")
+    if not args.all_open and not args.pr:
+        parser.error("--pr is required (or set PR_NUMBER), or pass --all-open")
+
+    if args.all_open:
+        return _run_sweep(args.repo, args.token)
 
     pr = int(args.pr)
     try:
@@ -356,12 +546,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     verdict = classify(pusher, reviews)
     report = render(verdict, args.repo, pr, head_sha)
-    print(report)
-
-    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summary_path:
-        with open(summary_path, "a", encoding="utf-8") as handle:
-            handle.write(report + "\n")
+    _emit(report)
 
     if verdict.is_finding:
         print(f"::warning title=Needs an approver who did not push the head::{verdict.summary}")

--- a/tests/test_last_push_approval.py
+++ b/tests/test_last_push_approval.py
@@ -485,3 +485,217 @@ def test_the_guard_does_not_swallow_a_real_finding(tmp_path):
     assert result.returncode == 1, result.stdout + result.stderr
     assert "stub ran" in result.stdout
     assert "nothing to report" not in result.stdout
+
+
+# --------------------------------------------------------------------------
+# The sweep over the standing open pull requests.
+#
+# The workflow driving this check fires on `pull_request` and
+# `pull_request_review`, so it can only evaluate a pull request that has had one
+# since the workflow landed -- and the population the check was written for is
+# the population that has not. Measured on #1035: head pushed 2026-08-01, the
+# approval 51 minutes later, the workflow landed 2026-08-04, so
+# `Detect an approval the last pusher cannot supply` is absent from the 11 check
+# runs on that head while the classifier answers `pusher-only-approval` the
+# moment it is invoked. These pin the caller that closes that gap, not the
+# verdict, which was never wrong.
+# --------------------------------------------------------------------------
+
+
+def _pull(number: int, sha: str, draft: bool = False) -> dict[str, Any]:
+    return {"number": number, "head": {"sha": sha}, "draft": draft}
+
+
+def _sweep_fixture(monkeypatch, pulls, approvals, *, unreadable=()):
+    """Wire the three lookups a sweep makes from plain fixtures.
+
+    ``approvals`` maps a pull request number to its approving accounts; every
+    head is pushed by ``cagataycali``, which is the measured shape of the two
+    deadlocked pull requests. ``unreadable`` names head shas whose pusher
+    lookup raises, standing in for a rate limit on one pull request.
+    """
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(mod, "_get", lambda *a, **k: pulls)
+
+    def pusher(_repo, head_sha, _token):
+        if head_sha in unreadable:
+            raise mod.urllib.error.URLError("rate limited")
+        return "cagataycali"
+
+    monkeypatch.setattr(mod, "resolve_pusher", pusher)
+    monkeypatch.setattr(
+        mod,
+        "resolve_reviews",
+        lambda _repo, pr, _token: [approved(a) for a in approvals.get(pr, ())],
+    )
+
+
+def test_the_sweep_finds_a_pull_request_no_event_has_fired_on(monkeypatch, capsys):
+    """The measured case: #1035 and #1722 held, #1087 merely unreviewed.
+
+    This is the sweep's whole reason to exist. All three read `REVIEW_REQUIRED`
+    / `BLOCKED`, and the first two need a different reviewer while the third
+    needs any reviewer at all.
+    """
+    _sweep_fixture(
+        monkeypatch,
+        [_pull(1035, "8d6a4c42"), _pull(1087, "8352a8ee"), _pull(1722, "3a32a145")],
+        {1035: ("cagataycali",), 1722: ("cagataycali",)},
+    )
+
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 1
+    report = capsys.readouterr().out
+    assert "#1035, #1722" in report
+    assert "| #1087 | awaiting-first-review |" in report
+    assert "| #1035 | pusher-only-approval | cagataycali | cagataycali |" in report
+
+
+def test_a_draft_pull_request_is_not_swept(monkeypatch):
+    """A draft cannot merge whatever its approvals say.
+
+    So a finding on one does not mean what this check's finding means -- that a
+    pull request otherwise ready needs a second account -- and reporting it
+    would dilute the one thing the red state says.
+    """
+    monkeypatch.setattr(
+        mod,
+        "_get",
+        lambda *a, **k: [_pull(1, "aaa"), _pull(2, "bbb", draft=True)],
+    )
+    assert mod.resolve_open_pull_requests("strands-labs/robots", "t") == [(1, "aaa")]
+
+
+def test_one_unreadable_pull_request_does_not_suppress_the_others(monkeypatch, capsys):
+    """A failure on one pull request must not take the report with it.
+
+    The sweep's value is the finding, and a rate limit on an unrelated pull
+    request silently swallowing it would reproduce the invisibility this whole
+    check exists to remove. The skipped number is named for the same reason.
+    """
+    _sweep_fixture(
+        monkeypatch,
+        [_pull(1035, "8d6a4c42"), _pull(1900, "ffffffff")],
+        {1035: ("cagataycali",)},
+        unreadable={"ffffffff"},
+    )
+
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 1
+    captured = capsys.readouterr()
+    assert "#1035" in captured.out
+    assert "Not evaluated (lookup failed): #1900." in captured.out
+    assert "not evaluated" in captured.err
+
+
+def test_the_sweep_exit_status_is_one_only_for_a_finding(monkeypatch):
+    pulls = [_pull(1035, "8d6a4c42")]
+    _sweep_fixture(monkeypatch, pulls, {1035: ("cagataycali",)})
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 1
+
+    # A second approver clears it, exactly as in the single-pull-request path.
+    _sweep_fixture(monkeypatch, pulls, {1035: ("cagataycali", "yinsong1986")})
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 0
+
+    _sweep_fixture(monkeypatch, pulls, {})
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 0
+
+
+def test_a_clean_sweep_says_so_rather_than_printing_a_bare_table(monkeypatch, capsys):
+    _sweep_fixture(monkeypatch, [_pull(1087, "8352a8ee")], {})
+    mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"])
+    out = capsys.readouterr().out
+    assert "No pull request is held by an approval its pusher supplied." in out
+    # The remedy block belongs only to a finding, in both reports.
+    assert "Admin bypass" not in out
+
+
+def test_both_reports_carry_the_same_remedy_text():
+    """One rule, one remedy. The sweep and the single report share the source.
+
+    They described the same three options in two places before, which is how a
+    fix to one of them silently stops applying to the other.
+    """
+    finding = mod.classify("cagataycali", [approved("cagataycali")])
+    single = mod.render(finding, "strands-labs/robots", 1035, "8d6a4c42")
+    swept = mod.render_sweep([mod.SweepRow(1035, "8d6a4c42", finding)], [], "strands-labs/robots")
+    remedy = "\n".join(mod.WHAT_CLEARS_THIS)
+    assert remedy in single
+    assert remedy in swept
+
+
+def test_the_sweep_rows_are_ordered_by_pull_request_number(monkeypatch):
+    """A stable report, so diffing two sweeps shows changed verdicts only."""
+    monkeypatch.setattr(
+        mod,
+        "_get",
+        lambda *a, **k: [_pull(1722, "c"), _pull(1035, "a"), _pull(1087, "b")],
+    )
+    assert [pr for pr, _ in mod.resolve_open_pull_requests("r", "t")] == [1035, 1087, 1722]
+
+
+def test_the_listing_stops_on_a_short_page_and_is_bounded(monkeypatch):
+    """Pagination ends on a short page, and cannot loop without end.
+
+    An unbounded loop over a paginated endpoint is how an API shape change
+    becomes a hang instead of an error.
+    """
+    pages: list[str] = []
+
+    def paged(url, _token):
+        pages.append(url)
+        return [_pull(1000 + i, f"sha{i}") for i in range(100)] if len(pages) == 1 else [_pull(9, "z")]
+
+    monkeypatch.setattr(mod, "_get", paged)
+    assert len(mod.resolve_open_pull_requests("r", "t")) == 101
+    assert len(pages) == 2
+    assert "page=2" in pages[1]
+
+    pages.clear()
+    monkeypatch.setattr(mod, "_get", lambda url, _t: pages.append(url) or [_pull(i, f"s{i}") for i in range(100)])
+    mod.resolve_open_pull_requests("r", "t")
+    assert len(pages) == mod._MAX_PAGES
+
+
+def test_a_failure_listing_the_pull_requests_reports_nothing(monkeypatch, capsys):
+    """No partial result exists for the listing itself, so it passes and says so."""
+
+    def boom(*_a, **_k):
+        raise mod.urllib.error.URLError("rate limited")
+
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(mod, "_get", boom)
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 0
+    assert "could not list open pull requests" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (["--repo", "r", "--all-open", "--pr", "1035"], "mutually exclusive"),
+        (["--repo", "r"], "--pr is required"),
+    ],
+)
+def test_an_ambiguous_invocation_is_refused_rather_than_resolved(argv, expected, capsys, monkeypatch):
+    """Neither flag may be silently ignored.
+
+    Dropping --pr would report on pull requests the caller did not ask about;
+    dropping --all-open would report on one when a sweep was wanted. Both read
+    as a successful run of the other thing.
+    """
+    monkeypatch.delenv("PR_NUMBER", raising=False)
+    with pytest.raises(SystemExit):
+        mod.main([*argv, "--token", "t"])
+    assert expected in capsys.readouterr().err
+
+
+def test_the_sweep_report_stays_ascii():
+    """Per the repo's Unicode hygiene rule, as the single report already is."""
+    finding = mod.classify("cagataycali", [approved("cagataycali")])
+    waiting = mod.classify("cagataycali", [])
+    unknown = mod.classify(None, [])
+    rows = [
+        mod.SweepRow(1035, "8d6a4c42", finding),
+        mod.SweepRow(1087, "8352a8ee", waiting),
+        mod.SweepRow(1722, "3a32a145", unknown),
+    ]
+    mod.render_sweep(rows, [1900], "strands-labs/robots").encode("ascii")
+    mod.render_sweep([], [], "strands-labs/robots").encode("ascii")


### PR DESCRIPTION
## What

`scripts/check_last_push_approval.py` gains `--all-open`, which classifies every open non-draft pull request in one pass instead of one named pull request.

Refs #1905.

## Why

The check was reachable only from `pull_request` and `pull_request_review` events, so it could evaluate a pull request only if one had fired **since the workflow landed** -- and the population it was written for is the population that had not.

Measured on #1035: head pushed `2026-08-01T08:00:37Z`, approval submitted 51 minutes later, workflow landed `2026-08-04`. So `Detect an approval the last pusher cannot supply` is absent from the 11 check runs on that head, while every other check is present:

```
call-test-lint / Test and Lint                      success  2026-08-02T02:53:48Z
Detect an untested overlap with the base branch     success  2026-08-01T08:04:36Z
Refuse a changelog entry written outside a fragment  success  2026-08-01T08:04:36Z
... 8 more, none of them this one
```

The net effect is the one #1905 names: the report read `SUCCESS` on pull requests that did not have the condition, and said nothing at all about the two that did.

**The verdict was never wrong.** Invoked directly, on today's `main`, before this change:

```
$ python3 scripts/check_last_push_approval.py --repo strands-labs/robots --pr 1035
Outcome: **pusher-only-approval**   (pushed by cagataycali, approved by cagataycali)   exit 1
```

So the gap was not in the reasoning; it was that on a standing pull request nothing asks for it.

### A correction to #1905, which is why this is not the fix that issue asks for

#1905 attributes the silence to the workflow's base-branch guard ("head `8d6a4c4` predates the script, so the workflow's base-branch guard exits 0 by design"). That is not the cause, and the distinction matters because it points at a different fix that would change nothing: the guard checks out the **base**, `main` carries the script, so the guard passes and the script would run. What is missing is a caller. There is no event to run it from, not a guard swallowing it.

## After

```
$ python3 scripts/check_last_push_approval.py --repo strands-labs/robots --all-open
## Last-push approval sweep

Evaluated 3 open non-draft pull request(s) in strands-labs/robots.

**2 needs an approver who did not push the head:** #1035, #1722.

| pull request | outcome | pushed by | current approvals |
|---|---|---|---|
| #1035 | pusher-only-approval | cagataycali | cagataycali |
| #1087 | awaiting-first-review | cagataycali | nobody |
| #1722 | pusher-only-approval | cagataycali | cagataycali |

exit 1
```

That is the distinction a status scan cannot otherwise make: all three read `reviewDecision: REVIEW_REQUIRED` / `mergeStateStatus: BLOCKED`, #1087 needs *any* reviewer and the other two need a *different* one. Reporting the second as the first is how "reviewer bandwidth is the sole constraint" stood for eight consecutive scan summaries over two permanently unmergeable branches.

## Decisions taken, each pinned

| decision | why | test |
|---|---|---|
| drafts excluded | a draft cannot merge whatever its approvals say, so a finding on one does not mean what a finding here means | `test_a_draft_pull_request_is_not_swept` |
| a per-PR lookup failure is skipped, not raised | one rate-limited pull request must not suppress a finding on another | `test_one_unreadable_pull_request_does_not_suppress_the_others` |
| skipped numbers are named in the report | an unevaluated pull request that says nothing is the failure mode this file exists against; it must not read as a clean sweep | same test |
| `--all-open` with `--pr` is refused | silently ignoring either reads as a successful run of the other thing | `test_an_ambiguous_invocation_is_refused_rather_than_resolved` |
| remedy text shared by both reports | they described the same three options in two places, which is how a fix to one stops applying to the other | `test_both_reports_carry_the_same_remedy_text` |
| rows sorted by number, pagination bounded | a stable report diffs as changed verdicts; an unbounded paginated loop turns an API change into a hang | `test_the_sweep_rows_are_ordered_by_pull_request_number`, `test_the_listing_stops_on_a_short_page_and_is_bounded` |

Not in scope: nothing here is wired as a gate, and the workflow's triggers are unchanged. The remedy still needs a second human, so this reports rather than blocks, for the reason the workflow file already documents at length.

## Verification

- `44 passed` in `tests/test_last_push_approval.py` (33 existing, 11 new)
- `ruff check`, `ruff format --check`, `mypy scripts/check_last_push_approval.py` all clean
- New tests are non-vacuous -- three targeted mutations, each caught by exactly one test:

| mutation | test that fails |
|---|---|
| stop excluding drafts | `test_a_draft_pull_request_is_not_swept` |
| let one failed lookup abort the sweep | `test_one_unreadable_pull_request_does_not_suppress_the_others` |
| drop the shared remedy from the sweep report | `test_both_reports_carry_the_same_remedy_text` |

- Run live against this repository, output above.

## Note on what this does not do

It does not unblock #1035 or #1722. Both still need an approving review from an account that did not push their heads; #1722 additionally has no `call-test-lint` context on `3a32a14` and needs a workflow run authorised on that head. I deliberately did not supply the approval from automation: the rule exists to stop one principal both writing and approving a change, and an approval issued by the scheduled agent of the account that pushed both heads is that bypass wearing a different name. What this change does is stop the condition from being invisible on any pull request that is standing rather than active.

## Files

| file | change |
|---|---|
| `scripts/check_last_push_approval.py` | `--all-open`, `resolve_open_pull_requests`, `sweep`, `render_sweep`, shared remedy constant |
| `tests/test_last_push_approval.py` | 11 new pins |
| `AGENTS.md` | records the coverage limit, the `--all-open` invocation for status scans, and corrects the cause #1905 assigns |
| `changelog.d/1905-last-push-approval-sweep.md` | news fragment |
