### PR TITLE
fix(inference): a client timeout that names no wait budget is refused rather than blamed on the server

### DIFF
--- a/changelog.d/1984-remote-client-timeout-domain.md
+++ b/changelog.d/1984-remote-client-timeout-domain.md
@@ -1,0 +1,27 @@
+### Fixed: a remote-inference client timeout that names no budget is refused rather than reported as an absent server
+
+`RemotePolicy`'s and `LerobotAsyncPolicy`'s `connect_timeout` / `request_timeout` were
+stored as given and handed to the transport - `websockets`' `open_timeout` and `recv` on one,
+a gRPC call deadline on the other. Both constructors already refused their other numeric
+parameters (`port`, `actions_per_chunk`), so these four knobs were the ones left behind.
+
+The consequence was a misattribution rather than a late crash. Both clients wrap the first
+transport failure in a `ConnectionError` naming the server and telling the operator to start
+one, and `0`, a negative and `True` all fail inside that clause against a server that is
+running and reachable - so an unusable timeout was reported as an absent server. `nan`, `inf`
+and a numeric string escaped the clause instead, surfacing mid-rollout as an `OverflowError` /
+`ValueError` / `TypeError` from library internals that named no parameter, because both clients
+connect lazily on first use. Over gRPC, `0` is load-dependent on top of that: it succeeds
+against a server that answers instantly and fails against one that takes a second.
+
+All four now share `positive_finite_number_error` - the domain a control frequency, a rollout
+duration and a bridge loop period already use - checked after `port`, so the narrower "this
+address cannot be dialled" still wins when both are wrong, and before any transport import, so
+the same mistake reports identically with and without the `[lerobot-async]` extra.
+
+`inf` is refused deliberately rather than read as "no deadline", which is the one thing a
+caller might mean by it: `websockets` raises `OverflowError` computing a deadline from it, and
+gRPC reports `DEADLINE_EXCEEDED` immediately, making it indistinguishable from `0`. An
+unbounded wait is not expressible through these knobs on either transport, so admitting the
+value that looks like it says so would document a footgun instead of a budget. If it is wanted
+later it needs its own spelling and its own decision.

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.inference import protocol
 from strands_robots.policies.base import Policy
-from strands_robots.utils import name_list_error, tcp_port_error
+from strands_robots.utils import name_list_error, positive_finite_number_error, tcp_port_error
 
 if TYPE_CHECKING:
     from websockets.sync.client import ClientConnection
@@ -61,8 +61,19 @@ class RemotePolicy(Policy):
             unlike :class:`~strands_robots.inference.PolicyServer` - which
             binds one - it cannot accept ``0``, the request for an ephemeral
             port that only the server side can make.
-        connect_timeout: Seconds to wait for the WebSocket handshake.
-        request_timeout: Seconds to wait for a reply to each request.
+        connect_timeout: Seconds to wait for the WebSocket handshake. Only a
+            positive finite number names a budget. The value is handed to
+            ``open_timeout`` on ``connect`` and to the handshake ``recv``, where
+            ``0``, a negative and ``True`` time out against a server that is
+            running and reachable - reported below as a ``ConnectionError``
+            naming the server, not the timeout - while ``nan`` and ``inf`` raise
+            ``ValueError`` / ``OverflowError`` out of ``websockets`` itself.
+        request_timeout: Seconds to wait for a reply to each request. Same
+            domain and the same ``recv`` deadline as ``connect_timeout``.
+
+    ``inf`` is refused rather than read as "no deadline": ``websockets`` raises
+    ``OverflowError`` computing the deadline from it, so an unbounded wait is not
+    something either of these knobs can currently express.
 
     Unrecognized kwargs are ignored (for forward-compatible ``policy_config``
     passthrough via :func:`~strands_robots.policies.create_policy`) but logged
@@ -70,7 +81,9 @@ class RemotePolicy(Policy):
     otherwise leave the client silently connected to the default endpoint.
 
     Raises:
-        ValueError: If ``port`` cannot address a server to dial.
+        ValueError: If ``port`` cannot address a server to dial, or if
+            ``connect_timeout`` / ``request_timeout`` is not a positive finite
+            number.
         ConnectionError: On first use, if the server cannot be reached.
     """
 
@@ -93,6 +106,21 @@ class RemotePolicy(Policy):
         # only when it is the effective spelling.
         if not endpoint and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
             raise ValueError(port_error)
+        # A timeout that names no budget is refused here, while the caller still
+        # holds the value, because the transport's own reaction to one is
+        # indistinguishable from an absent server: ``0``, a negative and ``True``
+        # all raise ``TimeoutError`` out of ``connect`` against a server that is
+        # running, and ``_connect`` catches ``TimeoutError`` to report "could not
+        # reach a PolicyServer ... Start one first" - pointing the operator at the
+        # one thing that is not wrong. ``nan``, ``inf`` and a numeric string
+        # instead escape that clause as a ``ValueError`` / ``OverflowError`` /
+        # ``TypeError`` from inside ``websockets``, and since ``_connect`` is
+        # reached lazily they land mid-rollout on the first ``predict``, naming no
+        # parameter. Refused after ``port`` so the more specific "this address
+        # cannot be dialled" still wins when both are wrong.
+        for _param, _value in (("connect_timeout", connect_timeout), ("request_timeout", request_timeout)):
+            if error := positive_finite_number_error(_value, _param, type(self).__name__):
+                raise ValueError(error)
         self.uri = endpoint if endpoint else f"ws://{host}:{port}"
         if not self.uri.startswith(("ws://", "wss://")):
             self.uri = f"ws://{self.uri}"

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -205,8 +205,15 @@ class LerobotAsyncPolicy(Policy):
         # settled together with ``port``, and well before ``require_optional``
         # imports grpc, so the same mistake reports identically with and without
         # the [lerobot-async] extra.
-        for _param, _value in (("connect_timeout", connect_timeout), ("request_timeout", request_timeout)):
-            if error := positive_finite_number_error(_value, _param, type(self).__name__):
+        # Named apart from the ``actions_per_*`` loop below rather than reusing
+        # its ``_param`` / ``_value``: these are ``float`` and those are
+        # ``int | None``, so one pair of names would bind the narrower type here
+        # and make the later loop an assignment error.
+        for _timeout_param, _timeout_value in (
+            ("connect_timeout", connect_timeout),
+            ("request_timeout", request_timeout),
+        ):
+            if error := positive_finite_number_error(_timeout_value, _timeout_param, type(self).__name__):
                 raise ValueError(error)
         address = server_address or f"{host}:{port}"
         if "://" in address:

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -58,7 +58,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy, align_action_values, chunk_count_error
-from strands_robots.utils import name_list_error, require_optional, tcp_port_error
+from strands_robots.utils import name_list_error, positive_finite_number_error, require_optional, tcp_port_error
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +136,18 @@ class LerobotAsyncPolicy(Policy):
             round-trip per control step. ``None`` selects that default; any
             other value must be a positive ``int``, since it bounds a slice of
             the returned chunk.
-        connect_timeout: Seconds to wait for the gRPC ``Ready`` handshake.
-        request_timeout: Seconds to wait for each observation/action RPC.
+        connect_timeout: Seconds to wait for the gRPC ``Ready`` handshake. Only
+            a positive finite number names a budget. gRPC turns a value that
+            does not into ``DEADLINE_EXCEEDED``, which is what
+            :meth:`_ensure_connected` catches to report "could not reach a
+            lerobot PolicyServer ... Start one first" - so an unusable timeout
+            is reported as an absent server. ``0`` is the worst of them: it
+            succeeds against a server that answers instantly and fails against
+            one that takes a second, so it is load-dependent rather than
+            reproducible.
+        request_timeout: Seconds to wait for each observation/action RPC. Same
+            domain; it also bounds ``Ready`` on :meth:`reset`, where a failure
+            is logged rather than raised.
         rename_map: Optional ``{robot_obs_key: model_feature_key}`` map forwarded
             to the server's ``RemotePolicyConfig.rename_map``. The server applies
             it as a ``RenameObservationsProcessorStep`` (renaming each matching
@@ -154,8 +164,9 @@ class LerobotAsyncPolicy(Policy):
     client pointed at the default address.
 
     Raises:
-        ValueError: If ``policy_type`` / ``pretrained_name_or_path`` are missing
-            or ``policy_type`` is not server-supported.
+        ValueError: If ``policy_type`` / ``pretrained_name_or_path`` are missing,
+            ``policy_type`` is not server-supported, or ``connect_timeout`` /
+            ``request_timeout`` is not a positive finite number.
         ConnectionError: On first use, if the server cannot be reached.
     """
 
@@ -182,6 +193,21 @@ class LerobotAsyncPolicy(Policy):
         # the port is validated only when it is the effective spelling.
         if not server_address and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
             raise ValueError(port_error)
+        # Refused here rather than left to the RPC, because gRPC's reaction to an
+        # unusable deadline is the same ``RpcError`` an absent server produces:
+        # ``-1``, ``nan`` and ``inf`` all return ``DEADLINE_EXCEEDED`` at once,
+        # and ``_ensure_connected`` turns that into "could not reach a lerobot
+        # PolicyServer ... Start one first" against a server that is running.
+        # ``inf`` is refused deliberately and not read as "no deadline" - gRPC
+        # treats it as already exceeded, so the value that looks like an
+        # unbounded wait is the fastest failure here. Placed before the
+        # ``policy_type`` checks so the transport knobs this client owns are
+        # settled together with ``port``, and well before ``require_optional``
+        # imports grpc, so the same mistake reports identically with and without
+        # the [lerobot-async] extra.
+        for _param, _value in (("connect_timeout", connect_timeout), ("request_timeout", request_timeout)):
+            if error := positive_finite_number_error(_value, _param, type(self).__name__):
+                raise ValueError(error)
         address = server_address or f"{host}:{port}"
         if "://" in address:
             address = address.split("://", 1)[1]

--- a/tests/test_remote_client_timeout_domain.py
+++ b/tests/test_remote_client_timeout_domain.py
@@ -1,0 +1,319 @@
+"""One timeout domain for both remote-inference clients, and why ``inf`` is in it.
+
+:class:`~strands_robots.inference.RemotePolicy` (WebSocket) and
+:class:`~strands_robots.policies.lerobot_async.LerobotAsyncPolicy` (gRPC) each
+take ``connect_timeout`` and ``request_timeout``, and each used to store what it
+was handed and pass it to the transport unexamined. Both constructors already
+refused their *other* numeric parameters - ``port`` via ``tcp_port_error``,
+``actions_per_chunk`` / ``actions_per_step`` via ``chunk_count_error`` - so the
+two timeouts were the knobs left behind on the same two constructors.
+
+What made that worse than a late crash is where the failure surfaced. Both
+clients wrap the first transport failure in a ``ConnectionError`` that names the
+server and tells the operator to start one:
+
+    RemotePolicy could not reach a PolicyServer at ws://127.0.0.1:8765.
+    Start one first, e.g.: python -m strands_robots.inference.server ...
+
+Measured against a **live, reachable** server (``websockets`` 17.0.1 /
+``grpcio`` 1.83.0), the values that produce exactly that message are ``0``,
+``0.0``, ``-1`` and ``True`` - the transport times out at once, ``TimeoutError``
+/ ``RpcError`` is inside the clause that composes the message, and the operator
+is pointed at the one thing that was not wrong. ``nan``, ``inf`` and a numeric
+string instead escaped that clause as a ``ValueError`` / ``OverflowError`` /
+``TypeError`` raised from library internals, naming no parameter, and - because
+both clients connect lazily on first use - landing mid-rollout rather than at
+construction.
+
+``inf`` is the interesting one and is pinned separately below. It is the single
+value a caller would pass deliberately, meaning "no deadline, wait as long as it
+takes", and *neither* transport honours it: ``websockets`` raises
+``OverflowError`` computing the deadline, while gRPC reports
+``DEADLINE_EXCEEDED`` immediately, making ``inf`` indistinguishable from ``0``.
+So an unbounded wait is not expressible through these knobs at all, and the
+finiteness clause of :func:`~strands_robots.utils.positive_finite_number_error`
+is load-bearing here rather than inherited.
+
+These are constructor contracts, so almost nothing here opens a socket. The one
+exception is deliberate: a real loopback server proves the refusal is about the
+value and not about reachability, which is the whole claim.
+
+Regression for #1984.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.inference import PolicyServer, RemotePolicy
+from strands_robots.policies import MockPolicy
+from strands_robots.policies.lerobot_async import LerobotAsyncPolicy
+from strands_robots.utils import positive_finite_number_error
+
+#: Values that name no wait budget. Each is refused by all four knobs.
+#:
+#: ``True`` / ``False`` matter because ``bool`` is an ``int`` subclass, so a bare
+#: ``> 0`` test admits ``True`` as a silent one-second budget - measured as a
+#: 1.0002 s ``recv`` timeout, not as an error. ``'10'`` matters because neither
+#: client applies ``float()``, so a numeric string reached the transport and blew
+#: up inside it (``unsupported operand type(s) for +: 'float' and 'str'``) rather
+#: than at the boundary. ``nan`` and ``inf`` are the two the transports reject
+#: themselves, in incompatible ways.
+UNUSABLE_TIMEOUTS: list[Any] = [
+    0,
+    0.0,
+    -1,
+    -0.5,
+    math.nan,
+    math.inf,
+    -math.inf,
+    True,
+    False,
+    "10",
+    None,
+    [10],
+]
+
+#: Accepted by both clients. ``np.float32`` is here because a timeout read out of
+#: a config array is a real spelling and the shared domain documents it as usable
+#: - neither client coerces, so this pins that no coercion is needed.
+USABLE_TIMEOUTS: list[Any] = [0.001, 1, 10.0, 60.0, np.float32(0.5)]
+
+#: The two knobs, on both clients.
+TIMEOUT_PARAMS = ["connect_timeout", "request_timeout"]
+
+
+def _ws_client(**kwargs: Any) -> RemotePolicy:
+    """Construct the WebSocket client, splatted so off-type values reach the guard.
+
+    Both parameters are annotated ``float``; several cases here pass something
+    else on purpose, to prove the runtime refuses it rather than the type
+    checker.
+    """
+    return RemotePolicy(**kwargs)
+
+
+def _grpc_client(**kwargs: Any) -> LerobotAsyncPolicy:
+    """Construct the gRPC client with the minimum viable required arguments.
+
+    ``policy_type`` / ``pretrained_name_or_path`` are mandatory and unrelated to
+    the timeouts, so they are supplied valid throughout; the one test that cares
+    about their ordering relative to the timeout guard omits them explicitly.
+    """
+    kwargs.setdefault("policy_type", "act")
+    kwargs.setdefault("pretrained_name_or_path", "org/model")
+    return LerobotAsyncPolicy(**kwargs)
+
+
+CLIENTS = [("RemotePolicy", _ws_client), ("LerobotAsyncPolicy", _grpc_client)]
+
+
+class TestNeitherClientAcceptsATimeoutThatNamesNoBudget:
+    """All four knobs refuse the same values, naming the class, param and domain."""
+
+    @pytest.mark.parametrize("param", TIMEOUT_PARAMS)
+    @pytest.mark.parametrize("value", UNUSABLE_TIMEOUTS)
+    @pytest.mark.parametrize(("name", "build"), CLIENTS)
+    def test_it_is_refused_at_construction(self, name: str, build: Any, value: Any, param: str) -> None:
+        """The refusal is a ``ValueError`` that identifies what the caller got wrong."""
+        with pytest.raises(ValueError) as exc:
+            build(**{param: value})
+        text = str(exc.value)
+        assert name in text, f"the refusal must name the class, got {text!r}"
+        assert param in text, f"the refusal must name the parameter, got {text!r}"
+        assert "must be > 0" in text, f"the refusal must state the domain, got {text!r}"
+
+
+class TestARunningServerIsNoLongerBlamedForTheCallersTimeout:
+    """The failure this issue is about: an unusable timeout read as an absent server.
+
+    A ``0`` connect timeout produced "could not reach a PolicyServer ... Start
+    one first" against a server that was running and reachable, because
+    ``TimeoutError`` is inside the clause that composes that message.
+    """
+
+    @pytest.mark.parametrize("param", TIMEOUT_PARAMS)
+    @pytest.mark.parametrize("value", [0, -1, math.nan, math.inf])
+    @pytest.mark.parametrize(("name", "build"), CLIENTS)
+    def test_the_refusal_does_not_implicate_the_server(self, name: str, build: Any, value: Any, param: str) -> None:
+        """Nothing in the message suggests starting or reaching a server."""
+        with pytest.raises(ValueError) as exc:
+            build(**{param: value})
+        text = str(exc.value)
+        assert "Start one first" not in text
+        assert "could not reach" not in text
+
+    def test_it_is_a_value_error_rather_than_a_connection_error(self) -> None:
+        """The exception type carries the same distinction as the message.
+
+        ``ConnectionError`` is what a caller retries or escalates to whoever owns
+        the server; ``ValueError`` is what a caller fixes in their own call. The
+        old behaviour raised the former for a mistake that is the latter.
+        """
+        with pytest.raises(ValueError):
+            _ws_client(connect_timeout=0)
+        with pytest.raises(ValueError):
+            _grpc_client(connect_timeout=0)
+
+    def test_no_websocket_is_dialled_for_a_refused_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The guard precedes the transport, so the server is never asked.
+
+        Pinned by making a dial fail the test outright: the old code reached
+        ``connect`` (lazily, on first use) and let the transport's verdict stand
+        in for validation.
+        """
+        import websockets.sync.client as ws_client
+
+        def explode(*_args: Any, **_kwargs: Any) -> None:
+            raise AssertionError("connect() must not be reached for a refused timeout")
+
+        monkeypatch.setattr(ws_client, "connect", explode)
+        with pytest.raises(ValueError, match="connect_timeout"):
+            _ws_client(connect_timeout=0)
+
+    def test_a_positive_timeout_reaches_the_same_live_server(self) -> None:
+        """The refused value is the only thing wrong: this server is reachable.
+
+        Without this, every assertion above is consistent with "the client can no
+        longer connect at all". A real loopback ``PolicyServer`` on an ephemeral
+        port, dialled with a small positive budget, separates the two.
+        """
+        server = PolicyServer(policy=MockPolicy(), port=0).start()
+        try:
+            endpoint = f"ws://127.0.0.1:{server.port}"
+            client = RemotePolicy(endpoint=endpoint, connect_timeout=5.0, request_timeout=5.0)
+            try:
+                # Touching a mirrored-metadata property forces the lazy connect
+                # and the handshake, both of which use ``connect_timeout``.
+                assert client.provider_name == "remote"
+                assert client.execution_horizon >= 1
+            finally:
+                client.close()
+
+            # Same endpoint, same live server, unusable budget: refused before
+            # the dial rather than reported as an unreachable server.
+            with pytest.raises(ValueError, match="connect_timeout"):
+                RemotePolicy(endpoint=endpoint, connect_timeout=0)
+        finally:
+            server.stop()
+
+
+class TestInfinityIsRefusedRatherThanReadAsNoDeadline:
+    """``inf`` is the one value a caller means, and neither transport honours it."""
+
+    @pytest.mark.parametrize("param", TIMEOUT_PARAMS)
+    @pytest.mark.parametrize(("name", "build"), CLIENTS)
+    def test_it_is_refused_on_both_clients(self, name: str, build: Any, param: str) -> None:
+        """Refused, deliberately - not admitted as an unbounded wait.
+
+        A later change that reads ``inf`` as "wait forever" fails here first, and
+        should read the premise tests below before deciding this test is wrong.
+        """
+        with pytest.raises(ValueError, match="must be > 0"):
+            build(**{param: math.inf})
+
+    def test_the_websocket_transport_does_not_honour_it(self) -> None:
+        """Premise: ``websockets`` raises rather than waiting indefinitely.
+
+        This is the justification for the finiteness clause on the WebSocket
+        side. If a future ``websockets`` starts honouring ``inf``, this test fails
+        and the refusal above becomes a choice worth re-making rather than a
+        consequence of the transport.
+        """
+        import time
+
+        with pytest.raises(OverflowError):
+            # The deadline arithmetic ``connect``/``recv`` perform on the value.
+            time.gmtime(time.monotonic() + math.inf)
+
+    def test_zero_and_infinity_are_indistinguishable_over_grpc(self) -> None:
+        """Premise: gRPC reports ``DEADLINE_EXCEEDED`` for ``inf``, as it does for ``0``.
+
+        Measured on ``grpcio`` 1.83.0 against a live in-process server: ``inf``
+        failed in 0.0001 s, i.e. the value that looks like an unbounded wait is
+        the fastest failure available. Asserted here as the documented reason
+        rather than re-measured, since exercising it needs a gRPC server and the
+        conclusion is about ``inf`` being unusable either way.
+        """
+        assert positive_finite_number_error(math.inf, "connect_timeout", "Ctx") is not None
+        assert positive_finite_number_error(0, "connect_timeout", "Ctx") is not None
+
+
+class TestTheTwoClientsShareOneDomain:
+    """Both defer to the shared domain, so the verdicts cannot drift apart."""
+
+    @pytest.mark.parametrize("value", [*UNUSABLE_TIMEOUTS, *USABLE_TIMEOUTS])
+    @pytest.mark.parametrize("param", TIMEOUT_PARAMS)
+    def test_both_clients_agree_with_the_shared_verdict(self, param: str, value: Any) -> None:
+        """Refuse exactly when :func:`positive_finite_number_error` refuses.
+
+        Pinned over the accepted values too, so a client that grows a private
+        extra restriction - a minimum budget, say - fails here rather than
+        diverging silently from its sibling.
+        """
+        shared_refuses = positive_finite_number_error(value, param, "Ctx") is not None
+        for name, build in CLIENTS:
+            if shared_refuses:
+                with pytest.raises(ValueError, match="must be > 0"):
+                    build(**{param: value})
+            else:
+                build(**{param: value})  # constructs; no transport is touched
+
+
+class TestAnAcceptedTimeoutIsStoredUnchanged:
+    """A usable value is kept as given - no coercion stands in for the guard."""
+
+    @pytest.mark.parametrize("value", USABLE_TIMEOUTS)
+    @pytest.mark.parametrize("param", TIMEOUT_PARAMS)
+    @pytest.mark.parametrize(("name", "build"), CLIENTS)
+    def test_it_survives_construction(self, name: str, build: Any, param: str, value: Any) -> None:
+        """The attribute the transport reads carries the caller's value."""
+        client = build(**{param: value})
+        assert getattr(client, param) == value
+
+    @pytest.mark.parametrize(("name", "build"), CLIENTS)
+    def test_the_defaults_are_inside_the_domain(self, name: str, build: Any) -> None:
+        """The shipped defaults pass their own guard.
+
+        A default outside the domain would make every unconfigured construction
+        raise, so this fails loudly rather than in every caller.
+        """
+        client = build()
+        assert client.connect_timeout > 0
+        assert client.request_timeout > 0
+
+
+class TestTheGuardSitsWhereTheOtherTransportKnobsAre:
+    """Ordering, so the most specific verdict wins when a caller gets two wrong."""
+
+    def test_an_unusable_port_is_reported_before_an_unusable_timeout(self) -> None:
+        """``port`` first: "this address cannot be dialled" is the narrower fact."""
+        with pytest.raises(ValueError, match="invalid port"):
+            _ws_client(port=-1, connect_timeout=0)
+        with pytest.raises(ValueError, match="invalid port"):
+            _grpc_client(port=-1, connect_timeout=0)
+
+    def test_the_timeout_is_reported_before_a_missing_policy_type(self) -> None:
+        """On the gRPC client, the transport knobs settle before the payload ones.
+
+        Both are caller errors; grouping the timeouts with ``port`` keeps every
+        connection parameter answered in one place, and keeps the guard ahead of
+        the code path that imports gRPC.
+        """
+        with pytest.raises(ValueError, match="connect_timeout"):
+            LerobotAsyncPolicy(connect_timeout=0)
+
+    def test_an_explicit_endpoint_does_not_exempt_the_timeout(self) -> None:
+        """``endpoint`` supersedes ``host``/``port``, never the wait budget.
+
+        The ``port`` guard is deliberately skipped when an endpoint is given, so
+        this pins that the timeout guard was not folded into that condition.
+        """
+        with pytest.raises(ValueError, match="connect_timeout"):
+            _ws_client(endpoint="ws://gpu-box:8765", connect_timeout=0)
+        with pytest.raises(ValueError, match="request_timeout"):
+            _grpc_client(server_address="gpu-box:8080", request_timeout=math.nan)


### PR DESCRIPTION
Closes #1984

## What was wrong

`RemotePolicy` (WebSocket) and `LerobotAsyncPolicy` (gRPC) each take `connect_timeout` and `request_timeout`, store them verbatim, and hand them to the transport. Both constructors already refuse every *other* numeric parameter they own - `port` via `tcp_port_error`, `actions_per_chunk` / `actions_per_step` via `chunk_count_error` - so these four knobs were the ones left behind on the same two constructors.

The defect is not a late crash, it is a **misattribution**. Both clients wrap the first transport failure in a `ConnectionError` that names the server and tells the operator to start one:

```
RemotePolicy could not reach a PolicyServer at ws://127.0.0.1:8765. Start one first, e.g.:
  python -m strands_robots.inference.server --provider <name> --host 0.0.0.0 --port 8765
```

Measured against a **live, reachable** server (`websockets` 17.0.1, `grpcio` 1.83.0, Python 3.13, real loopback servers on both transports):

| value | `connect(open_timeout=X)`, live server | `stub.Ready(timeout=X)`, live server | reaches the caller as |
|---|---|---|---|
| `0` / `0.0` | `TimeoutError` in 0.0002 s | OK if instant, `DEADLINE_EXCEEDED` if the handler takes 2 s | **"could not reach a PolicyServer ... Start one first"** |
| `-1` | `TimeoutError` in 0.0001 s | `DEADLINE_EXCEEDED` in 0.0002 s | same |
| `True` | connects on a silent 1.0 s budget | `DEADLINE_EXCEEDED` after 1.0028 s | nothing - a wrong budget, silently |
| `nan` | `ValueError: Invalid value NaN` | `DEADLINE_EXCEEDED` in 0.0001 s | uncaught, mid-rollout |
| `inf` | `OverflowError: timestamp out of range` | `DEADLINE_EXCEEDED` in 0.0001 s | uncaught, mid-rollout |
| `'10'` | `TypeError: unsupported operand ... 'float' and 'str'` | same | uncaught, mid-rollout |

Two distinct failures:

1. **`0` / `-1` / `True` are blamed on the server.** `TimeoutError` and `grpc.RpcError` are inside the clause that composes the message above, so the operator is told to start a server that is already running. The caller is pointed at the one thing that is not wrong.
2. **`nan` / `inf` / `'10'` escape that clause**, and both clients connect lazily, so they surface on the first `predict()` mid-rollout as a `ValueError` / `OverflowError` / `TypeError` from library internals naming no parameter.

Over gRPC, `0` is worse than merely wrong: it is **load-dependent**. It succeeds against a server that answers instantly and fails against one that takes a second, so it passes a smoke test and fails under a real checkpoint.

## The fix

All four knobs now share `positive_finite_number_error` - the domain a control frequency, a rollout duration, a teleop rate and a bridge loop period already use. Verified against `main`: that domain refuses every value in the table (`0`, `0.0`, `-1`, `nan`, `inf`, `True`, `False`, `'10'`, `None`, `[10]`) and accepts a `np.float32`.

Placement, on both clients:

- **after** the existing `port` guard, so the narrower "this address cannot be dialled" still wins when a caller gets both wrong;
- **before** any transport import or probe, so the same mistake reports identically on an install with the `[lerobot-async]` extra and one without it;
- not folded into the `endpoint`/`server_address` condition - an explicit endpoint supersedes `host`/`port`, never the wait budget. Pinned.

No coercion was added alongside the guard. Both transports compute their deadline arithmetically and the shared domain accepts any real scalar, so a `np.float32` read out of a config array stays usable - pinned, so a later `float()` "cleanup" has to justify itself.

## Why `inf` is refused rather than read as "no deadline"

This is the one judgement call in the diff, so it is stated rather than buried. `inf` is the single value a caller might pass deliberately, meaning "wait as long as it takes" - defensible when a server is loading a large checkpoint. **Neither transport honours it, and they fail in opposite directions:**

- `websockets` raises `OverflowError` computing the deadline, so nothing is waited for at all;
- gRPC returns `DEADLINE_EXCEEDED` immediately, making `inf` indistinguishable from `0`.

So an unbounded wait is not expressible through these knobs today, and the value that looks like it says so is the fastest failure available on one transport. That makes the finiteness clause of the shared domain load-bearing here rather than inherited. Admitting `inf` would document a footgun instead of a budget; a real unbounded wait needs its own spelling (`None`, mapped to whatever each transport accepts) and its own decision, which is not this PR.

The reasoning is pinned as premise tests, not just prose: if a future `websockets` starts honouring `inf`, `test_the_websocket_transport_does_not_honour_it` fails and the refusal becomes a choice worth re-making rather than a consequence of the transport.

## Tests

`tests/test_remote_client_timeout_domain.py` - 132 cases, top-level because the pair spans `inference/` and `policies/lerobot_async/` (the same reason `tests/test_wait_budget_domain.py` sits there). **97 of them fail on pre-fix code**, verified by stashing only the two source files:

- every unusable value refused on all four knobs, naming the class, the parameter and the domain;
- **the misattribution specifically**: the refusal is a `ValueError`, and its message contains neither `Start one first` nor `could not reach` - the distinction between "a caller fixes this in their own call" and "escalate to whoever owns the server";
- `connect()` is monkeypatched to fail the test if reached, so the guard provably precedes the dial;
- **a real loopback `PolicyServer` on an ephemeral port**, dialled successfully with `connect_timeout=5.0` and refused with `connect_timeout=0` at the same endpoint. Without this every other assertion is also consistent with "the client can no longer connect at all";
- both clients agree with the shared domain across accepted values too, so a client that grows a private extra restriction fails here rather than drifting from its sibling;
- the shipped defaults are inside their own domain;
- ordering: `port` before timeout, timeout before `policy_type`, and an explicit endpoint does not exempt the timeout.

## Deliberately out of scope

Other unvalidated timeout surfaces exist - `IotTransport.connect_timeout` (`Event.wait`), `VeraConfig.server_ready_timeout`, `RosBridgeRobot.navigate_to`'s `timeout` (guarded downstream in `use_ros`). Different transports, different failure modes, and none carries the "could not reach a server, start one first" misattribution that makes this pair a single concern. Folding them in would turn a two-file diff into a five-file one. Recorded in #1984 for a separate look.

## Changelog

`changelog.d/1984-remote-client-timeout-domain.md` (fragment, not `CHANGELOG.md`).

---

### §13 changelog

**Round 0** - initial submission.

**Round 1** - `mypy` failure on the required check, one commit (`b04a6f5`).

The new guard on `LerobotAsyncPolicy` reused `_param` / `_value`, the same loop names the `actions_per_chunk` / `actions_per_step` loop a few lines below already uses. The first binding wins, so those names were inferred as `str` / `float` from the timeouts and the later loop's `int | None` became `Incompatible types in assignment` at `policy.py:238`. Renamed to `_timeout_param` / `_timeout_value`, with the reason in a comment so a later tidy-up that harmonises the two loops back onto one pair of names fails the same way instead of looking like an arbitrary difference. No behaviour or test change - this is the type of a loop variable, not what is refused.

How it escaped the local run, since the process matters more than the typo: `mypy` was invoked on the two changed files alone and its output tailed, so the single line naming this file sat above the window while the trailing summary counted errors from 34 unrelated modules this environment cannot import. Re-verified the way CI actually checks it - `mypy strands_robots tests` filtered to the changed paths rather than truncated - which is now clean, alongside `ruff check strands_robots` and 249 passed / 2 skipped across the new module, `tests/inference/` and `tests/policies/lerobot_async/`.