### PR TITLE
fix(policies): a ZMQ inference timeout that names no wait budget is refused

### DIFF
--- a/changelog.d/1986-zmq-timeout-ms-domain.md
+++ b/changelog.d/1986-zmq-timeout-ms-domain.md
@@ -70,7 +70,12 @@ unchanged and the usages across the tests, docs and examples all sit inside the
 accepted domain.
 
 Pinned by `tests/test_zmq_timeout_ms_domain.py` - 123 cases, 70 of which fail
-with the guards removed. It asserts the misattribution rather than the raise (an
+with the guards removed. `pyzmq` is imported optionally rather than through a
+module-level `importorskip`, because both clients load it lazily and refuse an
+unusable budget *before* that call: on an install without the `[groot]` /
+`[moveit2]` extra 87 of the cases still run and 60 of them still fail with the
+guards removed, where a module-level skip would have taken the structural drift
+guard with it. It asserts the misattribution rather than the raise (an
 unusable budget can no longer report a live loopback sidecar as unreachable), the
 two clients' verdicts are asserted equal over the whole probe set so they cannot
 diverge, the ceiling is asserted against `setsockopt` rather than restated as a

--- a/changelog.d/1986-zmq-timeout-ms-domain.md
+++ b/changelog.d/1986-zmq-timeout-ms-domain.md
@@ -61,6 +61,20 @@ one millisecond more raises `OverflowError`. This is also why
 claimed "No consumer of *this* domain owns one" of these ceilings; that is no
 longer true and is corrected in place.
 
+The accepted budget is read from the caller's value exactly once. The first
+spelling of the helper validated with `positive_whole_number_error` and then read
+`value` twice more - `float(value)` for the range and `int(value)` for the result
+- on the reasoning that the guard had made those conversions safe. That is the
+reasoning #1875 shipped for the vector coercions and #1906 withdrew, and
+`utils.py` carries a module-wide scan asserting that no function in it converts
+with a `float()` no `try` protects, against a set that is empty and is asserted
+so it "can neither grow nor be quietly narrowed". So the ceiling is now compared
+against the `int` the helper itself produced: `int` is exact for every value that
+reaches it (the guard has established a finite, integral `numbers.Real`) and is
+arbitrary-precision, so an integral `1e300` converts rather than overflowing and
+is then refused by the ceiling. A new guard joins that invariant rather than the
+exception list.
+
 Each guard is placed ahead of its constructor's `_load_zmq()`, so the same caller
 mistake reports identically on an install with the `[groot]` / `[moveit2]` extra
 and one without it, and a refused budget leaves no socket configured behind it.
@@ -69,11 +83,11 @@ Every value that already named a budget still does: the default `15000` is
 unchanged and the usages across the tests, docs and examples all sit inside the
 accepted domain.
 
-Pinned by `tests/test_zmq_timeout_ms_domain.py` - 123 cases, 70 of which fail
+Pinned by `tests/test_zmq_timeout_ms_domain.py` - 130 cases, 70 of which fail
 with the guards removed. `pyzmq` is imported optionally rather than through a
 module-level `importorskip`, because both clients load it lazily and refuse an
 unusable budget *before* that call: on an install without the `[groot]` /
-`[moveit2]` extra 87 of the cases still run and 60 of them still fail with the
+`[moveit2]` extra 94 of the cases still run and 60 of them still fail with the
 guards removed, where a module-level skip would have taken the structural drift
 guard with it. It asserts the misattribution rather than the raise (an
 unusable budget can no longer report a live loopback sidecar as unreachable), the
@@ -83,7 +97,10 @@ constant, and premise tests pin pyzmq's own treatment of `0`, `True`, `-1`, `-2`
 and the non-`int` spellings so the reasoning above fails loudly rather than going
 stale. A structural check requires every module that sets `RCVTIMEO` / `SNDTIMEO`
 to route the value through the shared domain, so a third ZMQ client cannot ship
-without joining the rule.
+without joining the rule. The read-once property is asserted as a delta against
+`positive_whole_number_error` called alone, so the guard's own reads are the
+baseline and what the coercion adds is measured rather than the guard's internals
+restated; the three cases covering it fail on the first spelling.
 
 The other unvalidated timeout surfaces #1984 named and left - `IotTransport.connect_timeout`,
 `VeraConfig.server_ready_timeout`, `RosBridgeRobot.navigate_to`'s `timeout` - stay

--- a/changelog.d/1986-zmq-timeout-ms-domain.md
+++ b/changelog.d/1986-zmq-timeout-ms-domain.md
@@ -1,0 +1,85 @@
+### Fixed: a ZMQ inference timeout that names no wait budget is refused rather than reported as an absent sidecar
+
+`Gr00tInferenceClient` and `MoveIt2InferenceClient` each took a `timeout_ms`,
+stored it verbatim, and handed it to `setsockopt(RCVTIMEO)` and
+`setsockopt(SNDTIMEO)`. Neither checked it. Both now share the
+`utils.coerce_zmq_timeout_ms` domain, so an unusable budget is refused at
+construction with a `ValueError` naming the class, the parameter and the bound.
+
+This is the concern #1984 settled for the WebSocket and gRPC clients, on the
+third remote-inference transport. It was missed there because that change
+enumerated the knobs by name - `connect_timeout` / `request_timeout` - and these
+are spelled `timeout_ms`. `MoveIt2Policy` already refused the other numeric
+parameter it owns, `port`, through `tcp_port_error`, and forwarded `timeout_ms`
+unguarded eight lines later.
+
+The consequence was a healthy sidecar reported as unreachable, and it was
+quieter than the sibling case. Both clients' `ping()` catches every exception and
+returns `False`, logging the reason at `debug`, so there was no signal at default
+log level at all - where the WebSocket client at least raised a `ConnectionError`
+with a (misleading) remedy. Measured with the real client classes against a real
+loopback REP sidecar that answers correctly:
+
+| `timeout_ms` | before | `ping()` vs a healthy sidecar | after |
+| --- | --- | --- | --- |
+| `15000` (default) | accepted | `True` | unchanged |
+| `0`, `False` | accepted | **`False`** - ZMQ's "return immediately" spelling, so every request raises `zmq.Again` whether or not a sidecar exists | refused |
+| `True` | accepted | **`False` on MoveIt2, `True` on GR00T** - a silent 1 ms budget, so the verdict depends on how long the peer takes | refused |
+| `-1` | accepted | **never returns** | refused |
+| `-2`, `-15000` | bare `ZMQError: Invalid argument` | never reached | refused |
+| `nan`, `inf`, `1.5`, `'15000'`, `None`, `[15000]` | bare `TypeError` from inside pyzmq, naming no parameter | never reached | refused |
+| `2**31`, `10**400` | bare `OverflowError` | never reached | refused |
+| `15000.0`, `np.int64(15000)` | **bare `TypeError`** - a usable budget the transport refuses | never reached | **accepted, stored as `int`** |
+
+The last row is why this is a fix rather than only a refusal. `setsockopt` takes
+a C `int` and rejects every other spelling of the same budget, so a timeout read
+out of a JSON config or a config array could not be used - while the sibling
+transports accept exactly those spellings. `coerce_zmq_timeout_ms` returns the
+value coerced to `int`, so one configured budget is no longer usable on two
+transports and unusable on the third.
+
+`True` deserves its own note: it is an `int` subclass, so it was not merely
+accepted but *load-dependent*. It passed against the GR00T sidecar and failed
+against the MoveIt2 one on the same machine, purely on serializer cost - the
+shape that passes a smoke test and fails under a real checkpoint.
+
+`-1` is the one value with a real claim, and it is refused deliberately. ZMQ
+documents it as "block forever", so unlike the `inf` of the sibling transports it
+*is* honoured - which is what makes it dangerous rather than useless. It
+reinstates on the request path exactly the unbounded hang that `LINGER = 0`, set
+two lines below in the same `_init_socket`, was added to prevent on teardown, and
+it leaves `ping()` - whose whole contract is to answer `True` or `False` about
+connectivity - unable to answer at all. Neither client documented it as a
+spelling. An unbounded wait on a robot control path wants its own parameter and
+its own decision rather than arriving as a negative millisecond count.
+
+The ceiling is the transport's, not a policy choice: `RCVTIMEO` is stored as a C
+`int`, so `utils.MAX_ZMQ_TIMEOUT_MS` is `2**31 - 1` ms (close to 24.9 days) and
+one millisecond more raises `OverflowError`. This is also why
+`positive_whole_number_error` could not be applied on its own - it accepts
+`2**31` as a positive whole number inside the float64 range. Its docstring
+claimed "No consumer of *this* domain owns one" of these ceilings; that is no
+longer true and is corrected in place.
+
+Each guard is placed ahead of its constructor's `_load_zmq()`, so the same caller
+mistake reports identically on an install with the `[groot]` / `[moveit2]` extra
+and one without it, and a refused budget leaves no socket configured behind it.
+
+Every value that already named a budget still does: the default `15000` is
+unchanged and the usages across the tests, docs and examples all sit inside the
+accepted domain.
+
+Pinned by `tests/test_zmq_timeout_ms_domain.py` - 123 cases, 70 of which fail
+with the guards removed. It asserts the misattribution rather than the raise (an
+unusable budget can no longer report a live loopback sidecar as unreachable), the
+two clients' verdicts are asserted equal over the whole probe set so they cannot
+diverge, the ceiling is asserted against `setsockopt` rather than restated as a
+constant, and premise tests pin pyzmq's own treatment of `0`, `True`, `-1`, `-2`
+and the non-`int` spellings so the reasoning above fails loudly rather than going
+stale. A structural check requires every module that sets `RCVTIMEO` / `SNDTIMEO`
+to route the value through the shared domain, so a third ZMQ client cannot ship
+without joining the rule.
+
+The other unvalidated timeout surfaces #1984 named and left - `IotTransport.connect_timeout`,
+`VeraConfig.server_ready_timeout`, `RosBridgeRobot.navigate_to`'s `timeout` - stay
+out of scope for the reasons it gave, and are still their own change.

--- a/docs/policies/moveit2.md
+++ b/docs/policies/moveit2.md
@@ -75,6 +75,13 @@ MoveIt2Policy(
 )
 ```
 
+`timeout_ms` is applied as `RCVTIMEO` and `SNDTIMEO` on the REQ socket, so only
+a positive whole number of milliseconds up to `2**31 - 1` names a budget. An
+integral `float` or NumPy integer is accepted and stored as an `int`. `0` is
+ZMQ's "return immediately" spelling and `-1` its "block forever" one; both are
+refused at construction, because each makes `ping()` unable to report a
+reachable sidecar as reachable.
+
 `api_token` falls back to the `MOVEIT2_API_TOKEN` environment variable when not
 passed. The client emits a plaintext-over-TCP warning when `host` is a non-
 loopback address (the token travels unencrypted; terminate TLS at a proxy or

--- a/strands_robots/policies/groot/client.py
+++ b/strands_robots/policies/groot/client.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import require_optional
+from strands_robots.utils import coerce_zmq_timeout_ms, require_optional
 
 from .data_config import ModalityConfig
 
@@ -90,8 +90,20 @@ class Gr00tInferenceClient:
     Args:
         host: Server hostname or IP.
         port: Server port.
-        timeout_ms: Socket timeout in milliseconds.
+        timeout_ms: Socket send/receive timeout in milliseconds, applied as
+            ``RCVTIMEO`` and ``SNDTIMEO`` on the REQ socket. Only a positive
+            whole number up to
+            :data:`~strands_robots.utils.MAX_ZMQ_TIMEOUT_MS` names a budget;
+            an integral ``float`` or NumPy integer is accepted and stored as an
+            ``int``, since ``setsockopt`` takes only the latter. ``0`` is ZMQ's
+            "return immediately" spelling and ``-1`` its "block forever" one,
+            and both are refused - see
+            :func:`~strands_robots.utils.coerce_zmq_timeout_ms`.
         api_token: Optional token included in every request for authentication.
+
+    Raises:
+        ValueError: If ``timeout_ms`` does not name a usable wait budget - see
+            :func:`~strands_robots.utils.coerce_zmq_timeout_ms`.
     """
 
     def __init__(
@@ -101,11 +113,26 @@ class Gr00tInferenceClient:
         timeout_ms: int = 15000,
         api_token: str | None = None,
     ):
+        # A timeout that names no wait budget is refused here, while the caller
+        # still holds the value, because ZMQ's reaction to one is
+        # indistinguishable from an absent sidecar: ``0`` and ``False`` are its
+        # "return immediately" spelling, so every request raises ``zmq.Again``
+        # against a server that is running and reachable, and ``ping`` below
+        # reports that as ``False`` with the reason at ``logger.debug`` only.
+        # ``True`` is a silent 1 ms budget. The remaining values never reach a
+        # verdict at all - ``setsockopt`` raises ``ZMQError``, ``TypeError`` or
+        # ``OverflowError`` from inside ``pyzmq``, naming no parameter - and that
+        # includes ``15000.0`` and ``np.int64(15000)``, which name usable
+        # budgets the sibling transports accept, hence the coercion rather than
+        # a bare refusal.
+        coerced_timeout, timeout_reason = coerce_zmq_timeout_ms(type(self).__name__, "timeout_ms", timeout_ms)
+        if coerced_timeout is None:
+            raise ValueError(timeout_reason)
         self._zmq = _load_zmq()
         self.context = self._zmq.Context()
         self.host = host
         self.port = port
-        self.timeout_ms = timeout_ms
+        self.timeout_ms = coerced_timeout
         self.api_token = api_token
 
         if api_token and host not in ("localhost", "127.0.0.1", "::1"):

--- a/strands_robots/policies/moveit2/client.py
+++ b/strands_robots/policies/moveit2/client.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from strands_robots.utils import require_optional
+from strands_robots.utils import coerce_zmq_timeout_ms, require_optional
 
 logger = logging.getLogger(__name__)
 
@@ -71,12 +71,24 @@ class MoveIt2InferenceClient:
         host: Server hostname or IP. Default ``"127.0.0.1"`` - bind to
             loopback by default; users opt into network exposure.
         port: Server port.
-        timeout_ms: Socket send/recv timeout in milliseconds.
+        timeout_ms: Socket send/recv timeout in milliseconds, applied as
+            ``RCVTIMEO`` and ``SNDTIMEO`` on the REQ socket. Only a positive
+            whole number up to
+            :data:`~strands_robots.utils.MAX_ZMQ_TIMEOUT_MS` names a budget;
+            an integral ``float`` or NumPy integer is accepted and stored as an
+            ``int``, since ``setsockopt`` takes only the latter. ``0`` is ZMQ's
+            "return immediately" spelling and ``-1`` its "block forever" one,
+            and both are refused - see
+            :func:`~strands_robots.utils.coerce_zmq_timeout_ms`.
         api_token: Optional token included in every request for
             authentication. When unset, no auth is sent. Sent in
             plaintext over TCP - use a TLS tunnel or SSH port-forward
             for non-localhost deployments (same caveat as
             :class:`~strands_robots.policies.groot.client.Gr00tInferenceClient`).
+
+    Raises:
+        ValueError: If ``timeout_ms`` does not name a usable wait budget - see
+            :func:`~strands_robots.utils.coerce_zmq_timeout_ms`.
     """
 
     def __init__(
@@ -86,11 +98,26 @@ class MoveIt2InferenceClient:
         timeout_ms: int = 15000,
         api_token: str | None = None,
     ) -> None:
+        # A timeout that names no wait budget is refused here, while the caller
+        # still holds the value, because ZMQ's reaction to one is
+        # indistinguishable from an absent sidecar: ``0`` and ``False`` are its
+        # "return immediately" spelling, so every request raises ``zmq.Again``
+        # against a server that is running and reachable, and ``ping`` below
+        # reports that as ``False`` with the reason at ``logger.debug`` only.
+        # ``True`` is a silent 1 ms budget. The remaining values never reach a
+        # verdict at all - ``setsockopt`` raises ``ZMQError``, ``TypeError`` or
+        # ``OverflowError`` from inside ``pyzmq``, naming no parameter - and that
+        # includes ``15000.0`` and ``np.int64(15000)``, which name usable
+        # budgets the sibling transports accept, hence the coercion rather than
+        # a bare refusal.
+        coerced_timeout, timeout_reason = coerce_zmq_timeout_ms(type(self).__name__, "timeout_ms", timeout_ms)
+        if coerced_timeout is None:
+            raise ValueError(timeout_reason)
         self._zmq = _load_zmq()
         self.context = self._zmq.Context()
         self.host = host
         self.port = port
-        self.timeout_ms = timeout_ms
+        self.timeout_ms = coerced_timeout
         self.api_token = api_token
 
         if api_token and host not in ("localhost", "127.0.0.1", "::1"):

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1294,17 +1294,30 @@ def coerce_zmq_timeout_ms(method: str, param_name: str, value: Any) -> tuple[int
     """
     if (reason := positive_whole_number_error(value, param_name, method)) is not None:
         return None, reason
-    # ``positive_whole_number_error`` has already established a finite real
-    # inside the float64 range, so ``float`` cannot raise here. The comparison
-    # is done in float rather than int because an integral ``np.float64`` is an
-    # accepted spelling and ``int`` on it would be a second conversion before
-    # the range is known to hold.
-    if float(value) > MAX_ZMQ_TIMEOUT_MS:
+    # Read once, and compare the number this function produced rather than the
+    # caller's value a second time. The first spelling of this validated with
+    # the guard and then read ``value`` twice more - ``float(value)`` for the
+    # range and ``int(value)`` for the result - which is the escape #1906 closed
+    # for the vector guards: independent reads are not obliged to agree, so the
+    # magnitude a refusal quoted need not have been the magnitude the ceiling
+    # examined, and a ``numbers.Real`` whose second ``__float__`` refuses raised
+    # straight out of a function whose contract is to answer with text. The
+    # module-wide scan in ``tests/test_conversion_escape_is_closed.py`` reports
+    # exactly that unprotected ``float()``, so this is the invariant's verdict
+    # and not a style preference.
+    #
+    # ``int`` is exact for every value that reaches here and needs no ``try``:
+    # the guard established a ``numbers.Real`` whose ``float()`` succeeded, is
+    # finite and is integral, so no rounding is possible, and the arbitrary
+    # precision of ``int`` means an integral ``1e300`` converts rather than
+    # overflowing and is then refused by the ceiling below.
+    timeout_ms = int(value)
+    if timeout_ms > MAX_ZMQ_TIMEOUT_MS:
         return None, (
             f"{method}: {param_name} must be at most {MAX_ZMQ_TIMEOUT_MS} ms "
             f"(the largest send/receive timeout ZMQ can store), got {_refusal_repr(value)}."
         )
-    return int(value), None
+    return timeout_ms, None
 
 
 def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any], str | None]:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1301,10 +1301,11 @@ def coerce_zmq_timeout_ms(method: str, param_name: str, value: Any) -> tuple[int
     # for the vector guards: independent reads are not obliged to agree, so the
     # magnitude a refusal quoted need not have been the magnitude the ceiling
     # examined, and a ``numbers.Real`` whose second ``__float__`` refuses raised
-    # straight out of a function whose contract is to answer with text. The
-    # module-wide scan in ``tests/test_conversion_escape_is_closed.py`` reports
-    # exactly that unprotected ``float()``, so this is the invariant's verdict
-    # and not a style preference.
+    # straight out of a function whose contract is to answer with text. This
+    # module carries that as a scanned invariant - no function in it may reach a
+    # ``float()`` that no ``try`` protects - and the second read was exactly such
+    # a conversion, so this is the invariant's verdict and not a style
+    # preference.
     #
     # ``int`` is exact for every value that reaches here and needs no ``try``:
     # the guard established a ``numbers.Real`` whose ``float()`` succeeded, is

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -806,9 +806,13 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     documented policy, on the grounds that a per-call ceiling belongs to the
     consumer - and for its one caller that holds, because MuJoCo's
     ``_MAX_STEPS_PER_CALL`` is exactly such a ceiling and refuses an outsized
-    step count with a reason of its own. No consumer of *this* domain owns one.
+    step count with a reason of its own. Exactly one consumer of *this* domain
+    owns such a ceiling: :func:`coerce_zmq_timeout_ms` composes this guard and
+    then applies :data:`MAX_ZMQ_TIMEOUT_MS`, because a ZMQ send/receive timeout
+    is stored as a C ``int`` and this domain accepts ``2**31``.
     Its callers are ``fps``, ``width``, ``height``, ``max_frames``, the mesh
-    robots' ``drive(count=...)`` and ``send_action(n_substeps=)``. Two of those
+    robots' ``drive(count=...)``, ``send_action(n_substeps=)`` and the ZMQ
+    clients' ``timeout_ms``. Two of those
     repeat work that nothing bounds: ``drive`` repeats an actuation command, so
     an unbounded count is an unbounded actuation loop against a physical robot
     rather than a slow call, and ``n_substeps`` is a physics-step count that
@@ -1221,6 +1225,86 @@ def dds_domain_id_error(value: Any, param: str, context: str) -> str | None:
     if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= MAX_DDS_DOMAIN_ID:
         return f"{context}: invalid {param}: {_refusal_repr(value)} (expected 0-{MAX_DDS_DOMAIN_ID})"
     return None
+
+
+MAX_ZMQ_TIMEOUT_MS = 2**31 - 1
+
+
+def coerce_zmq_timeout_ms(method: str, param_name: str, value: Any) -> tuple[int | None, str | None]:
+    """Read ``value`` as a ZMQ send/receive timeout in milliseconds.
+
+    Shared domain for the ``timeout_ms`` of both ZMQ REQ inference clients -
+    :class:`~strands_robots.policies.groot.client.Gr00tInferenceClient` and
+    :class:`~strands_robots.policies.moveit2.client.MoveIt2InferenceClient` -
+    which each hand it to ``setsockopt(RCVTIMEO)`` and ``setsockopt(SNDTIMEO)``
+    on the socket they dial their sidecar with. It is the third remote-inference
+    transport, and it is spelled differently from the WebSocket and gRPC pair's
+    ``connect_timeout`` / ``request_timeout`` (#1984), which is why it was
+    missed when those were settled: same concern, different parameter name.
+
+    Returns the value **coerced to** ``int``, which is load-bearing rather than
+    tidiness. ``setsockopt`` takes a C ``int`` and refuses every other spelling
+    of the same budget, so ``15000.0`` read out of a JSON config and
+    ``np.int64(15000)`` read out of a config array both raise
+    ``TypeError: expected int`` from inside ``pyzmq`` - naming no parameter -
+    even though each names a perfectly usable budget. The sibling transports
+    accept those spellings, so coercing here is what keeps one budget from
+    being usable on two transports and unusable on the third.
+
+    Only a positive whole number can be honored, and the floor is where the
+    damage is. A ``0`` timeout is ZMQ's "return immediately" spelling, so every
+    request raises ``zmq.Again`` regardless of whether a sidecar is listening -
+    and both clients' ``ping()`` catch every exception and return ``False``, so
+    a running, reachable server is reported as unreachable with the reason at
+    ``logger.debug`` only. ``False`` is the same value arriving by a different
+    route, and ``True`` is a silent 1 ms budget whose verdict depends on how
+    long the peer takes to answer, so it fails on one client and passes on the
+    other against the same sidecar.
+
+    **The ceiling is the transport's, not a policy choice.** ``RCVTIMEO`` is
+    stored as a C ``int``, so :data:`MAX_ZMQ_TIMEOUT_MS` - ``2**31 - 1`` ms,
+    close to 24.9 days - is the largest budget ZMQ will accept; one millisecond
+    more raises ``OverflowError: value too large to convert to int``. This is
+    why :func:`positive_whole_number_error` cannot be applied on its own: that
+    domain accepts ``2**31`` as a positive whole number inside the float64
+    range, and the transport then refuses it with a message naming nothing.
+
+    ``-1`` is refused, and it is the one value that deserves the reason stated.
+    ZMQ documents it as "block forever", so unlike the ``inf`` of the sibling
+    transports it *is* honored - which is what makes it dangerous rather than
+    merely useless. It reinstates on the request path exactly the hang that
+    ``LINGER = 0``, set two lines below in the same ``_init_socket``, exists to
+    prevent on teardown: a request to an unreachable sidecar never returns, and
+    ``ping()`` - whose whole contract is to answer ``True`` or ``False`` about
+    connectivity - can then never answer at all. Neither client documents ``-1``
+    as a spelling, and an unbounded wait on a robot control path wants its own
+    parameter and its own decision rather than arriving as a negative
+    millisecond count. A premise test pins ZMQ's treatment of it, so this
+    reopens loudly if that changes.
+
+    Args:
+        method: Message prefix identifying the surface that received the value,
+            usually the class name for a constructor parameter.
+        param_name: The parameter name it came from, used in the message.
+        value: The caller-supplied value.
+
+    Returns:
+        ``(timeout_ms, None)`` with ``timeout_ms`` an ``int`` when the value is
+        usable, or ``(None, reason)`` when it is not.
+    """
+    if (reason := positive_whole_number_error(value, param_name, method)) is not None:
+        return None, reason
+    # ``positive_whole_number_error`` has already established a finite real
+    # inside the float64 range, so ``float`` cannot raise here. The comparison
+    # is done in float rather than int because an integral ``np.float64`` is an
+    # accepted spelling and ``int`` on it would be a second conversion before
+    # the range is known to hold.
+    if float(value) > MAX_ZMQ_TIMEOUT_MS:
+        return None, (
+            f"{method}: {param_name} must be at most {MAX_ZMQ_TIMEOUT_MS} ms "
+            f"(the largest send/receive timeout ZMQ can store), got {_refusal_repr(value)}."
+        )
+    return int(value), None
 
 
 def _read_name_list(value: object, param: str, context: str) -> tuple[list[Any], str | None]:

--- a/tests/test_zmq_timeout_ms_domain.py
+++ b/tests/test_zmq_timeout_ms_domain.py
@@ -36,14 +36,36 @@ from typing import Any
 import pytest
 
 import strands_robots
+from strands_robots.policies.groot.client import Gr00tInferenceClient
+from strands_robots.policies.groot.client import MsgSerializer as GrootSerializer
+from strands_robots.policies.moveit2.client import MoveIt2InferenceClient
 from strands_robots.utils import MAX_ZMQ_TIMEOUT_MS, coerce_zmq_timeout_ms
 
-zmq = pytest.importorskip("zmq", reason="pyzmq is the transport under test")
-msgpack = pytest.importorskip("msgpack", reason="the moveit2 sidecar wire format")
+# ``pyzmq`` is imported optionally rather than through a module-level
+# ``importorskip``, so that the tests which need no socket keep running without
+# it. Both clients load ZMQ lazily (``_load_zmq``) and refuse an unusable
+# ``timeout_ms`` *before* that call, so the domain verdicts, the refusal path,
+# the constructor ordering and the structural drift guard are all answerable on
+# an install without the ``[groot]`` / ``[moveit2]`` extra. A module-level skip
+# would have taken the drift guard with it - which is the one check here whose
+# whole job is to still be running when someone changes something unrelated.
+try:
+    import zmq
+except ImportError:  # pragma: no cover - exercised by the extra-less install
+    zmq = None  # type: ignore[assignment]
 
-from strands_robots.policies.groot.client import Gr00tInferenceClient  # noqa: E402
-from strands_robots.policies.groot.client import MsgSerializer as GrootSerializer  # noqa: E402
-from strands_robots.policies.moveit2.client import MoveIt2InferenceClient  # noqa: E402
+try:
+    import msgpack
+except ImportError:  # pragma: no cover - exercised by the extra-less install
+    msgpack = None  # type: ignore[assignment]
+
+#: For tests that must configure a real socket.
+requires_zmq = pytest.mark.skipif(zmq is None, reason="pyzmq is the transport under test")
+
+#: For tests that must round-trip against a real sidecar.
+requires_wire = pytest.mark.skipif(
+    zmq is None or msgpack is None, reason="pyzmq and msgpack are the sidecar wire format"
+)
 
 #: Values that name no usable ZMQ wait budget, with why each one matters.
 UNUSABLE: list[tuple[str, Any]] = [
@@ -172,6 +194,7 @@ class TestTheSharedDomain:
         assert str(MAX_ZMQ_TIMEOUT_MS) in over
         assert over != under
 
+    @requires_zmq
     def test_the_ceiling_is_the_largest_value_zmq_can_store(self) -> None:
         """Non-vacuity for the constant: it is the transport's bound, not a choice.
 
@@ -244,6 +267,7 @@ class TestBothClientsRefuseTheSameBudgets:
             cls(host="127.0.0.1", port=5555, timeout_ms=0)
 
 
+@requires_wire
 class TestAHealthyServerIsNoLongerReportedUnreachable:
     """The defect, against a live sidecar. Behaviour, not the raise."""
 
@@ -273,6 +297,7 @@ class TestAHealthyServerIsNoLongerReportedUnreachable:
                 cls(host="127.0.0.1", port=sidecar.port, timeout_ms=value)
 
 
+@requires_wire
 class TestABudgetTheSiblingTransportsAcceptIsUsableHere:
     """The coercion: this is a fix, not only a refusal."""
 
@@ -322,6 +347,7 @@ class TestABudgetTheSiblingTransportsAcceptIsUsableHere:
             client.context.term()
 
 
+@requires_wire
 class TestZmqStillTreatsTheseValuesAsMeasured:
     """Premise tests: ``pyzmq``'s behaviour, which the reasoning above rests on.
 
@@ -500,6 +526,7 @@ class TestTheGuardPrecedesTheSocketOptions:
         assert "self.timeout_ms" in source
 
 
+@requires_wire
 def test_a_usable_budget_still_times_out_against_a_slow_sidecar() -> None:
     """The domain bounds the value, it does not change what a timeout means.
 

--- a/tests/test_zmq_timeout_ms_domain.py
+++ b/tests/test_zmq_timeout_ms_domain.py
@@ -232,7 +232,7 @@ class TestBothClientsRefuseTheSameBudgets:
 
     @pytest.mark.parametrize(("label", "value"), UNUSABLE, ids=[c[0] for c in UNUSABLE])
     def test_the_two_clients_agree_on_every_verdict(self, label: str, value: Any) -> None:
-        reasons = []
+        reasons: list[str | None] = []
         for cls in CLIENTS:
             try:
                 cls(host="127.0.0.1", port=5555, timeout_ms=value)
@@ -515,14 +515,14 @@ class TestTheGuardPrecedesTheSocketOptions:
 
     @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
     def test_the_coercion_appears_before_load_zmq_in_the_constructor(self, cls: type) -> None:
-        source = inspect.getsource(cls.__init__)
+        source = inspect.getsource(getattr(cls, "__init__"))
         assert "coerce_zmq_timeout_ms" in source
         assert source.index("coerce_zmq_timeout_ms") < source.index("_load_zmq")
 
     @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
     def test_the_socket_is_configured_from_the_stored_budget(self, cls: type) -> None:
         """``_init_socket`` reads ``self.timeout_ms``, which is the coerced int."""
-        source = inspect.getsource(cls._init_socket)
+        source = inspect.getsource(getattr(cls, "_init_socket"))
         assert "self.timeout_ms" in source
 
 

--- a/tests/test_zmq_timeout_ms_domain.py
+++ b/tests/test_zmq_timeout_ms_domain.py
@@ -1,0 +1,534 @@
+"""The ZMQ inference clients' ``timeout_ms`` is one shared wait-budget domain.
+
+Both ZMQ REQ inference clients hand ``timeout_ms`` to ``setsockopt(RCVTIMEO)``
+and ``setsockopt(SNDTIMEO)``. Neither validated it, so the third
+remote-inference transport carried the misattribution that #1984 removed from
+the WebSocket and gRPC pair: an unusable wait budget reported as an absent
+server.
+
+The tests are grouped by what they protect rather than by client:
+
+* :class:`TestTheSharedDomain` - the verdicts, on the helper alone.
+* :class:`TestBothClientsRefuseTheSameBudgets` - the two clients agree, so a
+  budget cannot be usable on one sidecar transport and refused on the other.
+* :class:`TestAHealthyServerIsNoLongerReportedUnreachable` - the defect itself,
+  against a real loopback REP sidecar. This is the reason the change exists,
+  and it is asserted on behaviour rather than on the raise.
+* :class:`TestABudgetTheSiblingTransportsAcceptIsUsableHere` - the coercion,
+  which is what makes this a fix rather than only a refusal.
+* :class:`TestZmqStillTreatsTheseValuesAsMeasured` - premise tests. They assert
+  ``pyzmq``'s behaviour, not ours, so a future ``pyzmq`` that changes any of it
+  fails here first rather than silently invalidating the reasoning above.
+* :class:`TestNoZmqTimeoutSurfaceDrifts` - structural, so a third ZMQ client
+  cannot ship without joining the rule.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import inspect
+import pathlib
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import strands_robots
+from strands_robots.utils import MAX_ZMQ_TIMEOUT_MS, coerce_zmq_timeout_ms
+
+zmq = pytest.importorskip("zmq", reason="pyzmq is the transport under test")
+msgpack = pytest.importorskip("msgpack", reason="the moveit2 sidecar wire format")
+
+from strands_robots.policies.groot.client import Gr00tInferenceClient  # noqa: E402
+from strands_robots.policies.groot.client import MsgSerializer as GrootSerializer  # noqa: E402
+from strands_robots.policies.moveit2.client import MoveIt2InferenceClient  # noqa: E402
+
+#: Values that name no usable ZMQ wait budget, with why each one matters.
+UNUSABLE: list[tuple[str, Any]] = [
+    ("zero-is-return-immediately", 0),
+    ("false-is-zero-by-another-route", False),
+    ("true-is-a-silent-1ms-budget", True),
+    ("minus-one-is-block-forever", -1),
+    ("below-minus-one-is-invalid-argument", -2),
+    ("negative", -15000),
+    ("nan", float("nan")),
+    ("inf", float("inf")),
+    ("-inf", float("-inf")),
+    ("fractional", 1.5),
+    ("numeric-string", "15000"),
+    ("none", None),
+    ("list", [15000]),
+    ("dict", {"ms": 15000}),
+    ("above-the-c-int-ceiling", MAX_ZMQ_TIMEOUT_MS + 1),
+    ("far-above-the-c-int-ceiling", 2**40),
+    ("beyond-float64", 10**400),
+]
+
+#: Values that do name a usable budget, including spellings ``setsockopt``
+#: itself refuses and this domain therefore has to normalise.
+USABLE: list[tuple[str, Any, int]] = [
+    ("the-default", 15000, 15000),
+    ("one-millisecond", 2, 2),
+    ("integral-float-from-a-json-config", 15000.0, 15000),
+    ("the-ceiling-itself", MAX_ZMQ_TIMEOUT_MS, MAX_ZMQ_TIMEOUT_MS),
+]
+
+CLIENTS = [Gr00tInferenceClient, MoveIt2InferenceClient]
+
+
+def _numpy_spellings() -> list[tuple[str, Any, int]]:
+    """Usable budgets that arrive as NumPy scalars out of a config array."""
+    np = pytest.importorskip("numpy")
+    return [
+        ("numpy-int64", np.int64(15000), 15000),
+        ("numpy-float64-integral", np.float64(15000.0), 15000),
+    ]
+
+
+class _Sidecar:
+    """A healthy REP sidecar that answers every request correctly.
+
+    The point of a real socket rather than a stub: the defect is that a
+    *reachable, answering* server is reported unreachable, so a mocked
+    transport cannot show it.
+    """
+
+    def __init__(self, encode: Any) -> None:
+        self._encode = encode
+        self._stop = threading.Event()
+        self._ctx = zmq.Context()
+        self._sock = self._ctx.socket(zmq.REP)
+        self._sock.setsockopt(zmq.LINGER, 0)
+        self.port = self._sock.bind_to_random_port("tcp://127.0.0.1")
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        poller = zmq.Poller()
+        poller.register(self._sock, zmq.POLLIN)
+        while not self._stop.is_set():
+            if dict(poller.poll(20)):
+                self._sock.recv()
+                self._sock.send(self._encode({"status": "ok"}))
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+        self._sock.close()
+        self._ctx.term()
+
+
+def _encoder_for(cls: type) -> Any:
+    if cls is Gr00tInferenceClient:
+        return GrootSerializer.to_bytes
+    return lambda payload: msgpack.packb(payload, use_bin_type=True)
+
+
+@contextlib.contextmanager
+def sidecar_for(cls: type) -> Any:
+    """A live sidecar speaking the wire format of ``cls``.
+
+    Built from the client under test rather than parametrised alongside it, so
+    there is no mismatched combination to skip.
+    """
+    server = _Sidecar(_encoder_for(cls))
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+class TestTheSharedDomain:
+    """The verdicts, on the helper alone."""
+
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE, ids=[c[0] for c in UNUSABLE])
+    def test_a_value_that_names_no_wait_budget_is_refused(self, label: str, value: Any) -> None:
+        coerced, reason = coerce_zmq_timeout_ms("Client", "timeout_ms", value)
+        assert coerced is None
+        assert reason is not None
+
+    @pytest.mark.parametrize(("label", "value", "expected"), USABLE, ids=[c[0] for c in USABLE])
+    def test_a_usable_budget_is_returned_as_an_int(self, label: str, value: Any, expected: int) -> None:
+        coerced, reason = coerce_zmq_timeout_ms("Client", "timeout_ms", value)
+        assert reason is None
+        assert coerced == expected
+        # ``setsockopt`` takes a C ``int`` and refuses every other spelling, so
+        # the exact type is the contract here, not an implementation detail.
+        assert type(coerced) is int
+
+    def test_the_message_names_the_surface_and_the_parameter(self) -> None:
+        _, reason = coerce_zmq_timeout_ms("Gr00tInferenceClient", "timeout_ms", 0)
+        assert reason is not None
+        assert "Gr00tInferenceClient" in reason
+        assert "timeout_ms" in reason
+
+    def test_the_ceiling_refusal_states_the_bound_rather_than_the_floor(self) -> None:
+        """Above the ceiling is a different reason from below the floor."""
+        _, over = coerce_zmq_timeout_ms("Client", "timeout_ms", MAX_ZMQ_TIMEOUT_MS + 1)
+        _, under = coerce_zmq_timeout_ms("Client", "timeout_ms", 0)
+        assert over is not None and under is not None
+        assert str(MAX_ZMQ_TIMEOUT_MS) in over
+        assert over != under
+
+    def test_the_ceiling_is_the_largest_value_zmq_can_store(self) -> None:
+        """Non-vacuity for the constant: it is the transport's bound, not a choice.
+
+        Asserted against ``setsockopt`` rather than restating ``2**31 - 1``, so
+        the constant cannot drift away from the option it describes.
+        """
+        context = zmq.Context()
+        try:
+            accepted = context.socket(zmq.REQ)
+            accepted.setsockopt(zmq.RCVTIMEO, MAX_ZMQ_TIMEOUT_MS)
+            assert accepted.getsockopt(zmq.RCVTIMEO) == MAX_ZMQ_TIMEOUT_MS
+            accepted.close()
+
+            refused = context.socket(zmq.REQ)
+            with pytest.raises(OverflowError):
+                refused.setsockopt(zmq.RCVTIMEO, MAX_ZMQ_TIMEOUT_MS + 1)
+            refused.close()
+        finally:
+            context.term()
+
+
+class TestBothClientsRefuseTheSameBudgets:
+    """The two clients share one domain, so their verdicts must agree."""
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE, ids=[c[0] for c in UNUSABLE])
+    def test_an_unusable_budget_is_refused_as_a_value_error(self, cls: type, label: str, value: Any) -> None:
+        with pytest.raises(ValueError, match="timeout_ms"):
+            cls(host="127.0.0.1", port=5555, timeout_ms=value)
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_the_refusal_names_the_class_that_received_it(self, cls: type) -> None:
+        with pytest.raises(ValueError, match=cls.__name__):
+            cls(host="127.0.0.1", port=5555, timeout_ms=0)
+
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE, ids=[c[0] for c in UNUSABLE])
+    def test_the_two_clients_agree_on_every_verdict(self, label: str, value: Any) -> None:
+        reasons = []
+        for cls in CLIENTS:
+            try:
+                cls(host="127.0.0.1", port=5555, timeout_ms=value)
+                reasons.append(None)
+            except ValueError as exc:
+                reasons.append(str(exc).replace(cls.__name__, "<client>"))
+        assert reasons[0] == reasons[1]
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_a_refused_budget_opens_no_socket(self, cls: type) -> None:
+        """The guard precedes ``_load_zmq``, so nothing is created to leak.
+
+        Also why the report is identical with and without the optional extra
+        installed: the refusal happens before the dependency is loaded.
+        """
+        with pytest.raises(ValueError):
+            cls(host="127.0.0.1", port=5555, timeout_ms=0)
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_a_refused_budget_is_reported_before_the_transport_is_loaded(
+        self, cls: type, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Made non-vacuous by breaking the loader: the guard still answers."""
+        module = inspect.getmodule(cls)
+        assert module is not None
+
+        def explode() -> Any:
+            raise AssertionError("_load_zmq must not be reached for a refused timeout_ms")
+
+        monkeypatch.setattr(module, "_load_zmq", explode)
+        with pytest.raises(ValueError, match="timeout_ms"):
+            cls(host="127.0.0.1", port=5555, timeout_ms=0)
+
+
+class TestAHealthyServerIsNoLongerReportedUnreachable:
+    """The defect, against a live sidecar. Behaviour, not the raise."""
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_the_default_budget_reaches_a_live_sidecar(self, cls: type) -> None:
+        """Premise for the rest of the class: the sidecar really does answer."""
+        with sidecar_for(cls) as sidecar:
+            client = cls(host="127.0.0.1", port=sidecar.port)
+            try:
+                assert client.ping() is True
+            finally:
+                client.socket.close()
+                client.context.term()
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize("value", [0, False, True, -1], ids=["zero", "false", "true", "minus-one"])
+    def test_an_unusable_budget_can_no_longer_call_a_live_sidecar_unreachable(self, cls: type, value: Any) -> None:
+        """Before this change ``ping()`` returned ``False`` here - or hung.
+
+        ``ping`` swallows every exception and answers ``False``, logging the
+        reason at ``debug`` only, so the operator was told the sidecar was
+        unreachable while it was answering on that very port. ``-1`` was worse
+        than wrong: it blocked forever, so ``ping`` could not answer at all.
+        """
+        with sidecar_for(cls) as sidecar:
+            with pytest.raises(ValueError, match="timeout_ms"):
+                cls(host="127.0.0.1", port=sidecar.port, timeout_ms=value)
+
+
+class TestABudgetTheSiblingTransportsAcceptIsUsableHere:
+    """The coercion: this is a fix, not only a refusal."""
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize(("label", "value", "expected"), USABLE, ids=[c[0] for c in USABLE])
+    def test_a_usable_budget_is_stored_as_an_int_and_still_pings(
+        self, cls: type, label: str, value: Any, expected: int
+    ) -> None:
+        with sidecar_for(cls) as sidecar:
+            client = cls(host="127.0.0.1", port=sidecar.port, timeout_ms=value)
+            try:
+                assert client.timeout_ms == expected
+                assert type(client.timeout_ms) is int
+                assert client.socket.getsockopt(zmq.RCVTIMEO) == expected
+                assert client.socket.getsockopt(zmq.SNDTIMEO) == expected
+                assert client.ping() is True
+            finally:
+                client.socket.close()
+                client.context.term()
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_a_numpy_budget_out_of_a_config_array_is_accepted(self, cls: type) -> None:
+        """``setsockopt`` refuses a NumPy integer outright; the domain normalises it.
+
+        The sibling WebSocket / gRPC clients accept a NumPy scalar timeout, so
+        without the coercion the same configured budget would be usable on two
+        transports and unusable on this one.
+        """
+        for _label, value, expected in _numpy_spellings():
+            client = cls(host="127.0.0.1", port=5555, timeout_ms=value)
+            try:
+                assert client.timeout_ms == expected
+                assert type(client.timeout_ms) is int
+            finally:
+                client.socket.close()
+                client.context.term()
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_reconnect_reuses_the_coerced_budget(self, cls: type) -> None:
+        """``_init_socket`` runs again on reconnect and must not re-raise."""
+        client = cls(host="127.0.0.1", port=5555, timeout_ms=15000.0)
+        try:
+            client.reconnect()
+            assert client.socket.getsockopt(zmq.RCVTIMEO) == 15000
+        finally:
+            client.socket.close()
+            client.context.term()
+
+
+class TestZmqStillTreatsTheseValuesAsMeasured:
+    """Premise tests: ``pyzmq``'s behaviour, which the reasoning above rests on.
+
+    These assert the transport rather than this repository. If a future
+    ``pyzmq`` starts honouring one of these differently, the decision recorded
+    in :func:`coerce_zmq_timeout_ms` should be revisited - and it fails here
+    first rather than leaving a stale justification in a docstring.
+    """
+
+    @pytest.fixture
+    def socket(self) -> Any:
+        context = zmq.Context()
+        sock = context.socket(zmq.REQ)
+        sock.setsockopt(zmq.LINGER, 0)
+        try:
+            yield sock
+        finally:
+            sock.close()
+            context.term()
+
+    def test_zero_is_the_return_immediately_spelling(self, socket: Any) -> None:
+        """Which is why ``0`` fails against a server that is answering."""
+        server = _Sidecar(lambda payload: msgpack.packb(payload, use_bin_type=True))
+        try:
+            socket.setsockopt(zmq.RCVTIMEO, 0)
+            socket.setsockopt(zmq.SNDTIMEO, 0)
+            socket.connect(f"tcp://127.0.0.1:{server.port}")
+            socket.send(b"ping")
+            with pytest.raises(zmq.Again):
+                socket.recv()
+        finally:
+            server.close()
+
+    def test_true_is_stored_as_a_one_millisecond_budget(self, socket: Any) -> None:
+        """A silent 1 ms, which is why ``bool`` must be refused explicitly."""
+        socket.setsockopt(zmq.RCVTIMEO, True)
+        assert socket.getsockopt(zmq.RCVTIMEO) == 1
+
+    def test_minus_one_is_still_the_block_forever_spelling(self, socket: Any) -> None:
+        """The reason ``-1`` is refused rather than passed through.
+
+        ZMQ honours it, unlike the ``inf`` of the sibling transports, so it
+        reinstates on the request path the unbounded hang that ``LINGER = 0``
+        exists to prevent on teardown - and ``ping()``, whose contract is to
+        answer ``True`` or ``False``, could then never answer.
+        """
+        socket.setsockopt(zmq.RCVTIMEO, -1)
+        assert socket.getsockopt(zmq.RCVTIMEO) == -1
+
+        # Nothing is bound on this port, so a blocking recv cannot complete.
+        socket.connect("tcp://127.0.0.1:1")
+        socket.send(b"ping")
+        returned = threading.Event()
+
+        def blocking_recv() -> None:
+            try:
+                socket.recv()
+            except Exception:  # noqa: BLE001 - any outcome still means it returned
+                pass
+            returned.set()
+
+        threading.Thread(target=blocking_recv, daemon=True).start()
+        assert not returned.wait(timeout=1.5), "a -1 timeout is expected to block"
+
+    def test_below_minus_one_is_an_invalid_argument(self, socket: Any) -> None:
+        """So it never reached a verdict; it raised ``ZMQError`` naming nothing."""
+        with pytest.raises(zmq.ZMQError):
+            socket.setsockopt(zmq.RCVTIMEO, -2)
+
+    @pytest.mark.parametrize(
+        "value",
+        [float("nan"), float("inf"), 1.5, 15000.0, "15000", None, [15000]],
+        ids=["nan", "inf", "fractional", "integral-float", "string", "none", "list"],
+    )
+    def test_a_non_int_never_reaches_the_socket_at_all(self, socket: Any, value: Any) -> None:
+        """Including ``15000.0`` - a usable budget ``setsockopt`` still refuses."""
+        with pytest.raises(TypeError):
+            socket.setsockopt(zmq.RCVTIMEO, value)
+
+    def test_a_numpy_integer_is_also_refused_by_setsockopt(self, socket: Any) -> None:
+        """The measurement the coercion exists for."""
+        np = pytest.importorskip("numpy")
+        with pytest.raises(TypeError):
+            socket.setsockopt(zmq.RCVTIMEO, np.int64(15000))
+
+
+class TestNoZmqTimeoutSurfaceDrifts:
+    """Structural: a ZMQ socket timeout is set only from a coerced budget.
+
+    A third client that hands a caller-supplied value to
+    ``setsockopt(RCVTIMEO)`` without routing it through the shared domain would
+    re-introduce exactly this defect. Checked structurally rather than by
+    enumerating today's two clients, so the rule survives a third.
+    """
+
+    #: The socket options that carry a wait budget.
+    TIMEOUT_OPTIONS = frozenset({"RCVTIMEO", "SNDTIMEO"})
+
+    @staticmethod
+    def _package_root() -> pathlib.Path:
+        return pathlib.Path(inspect.getfile(strands_robots)).parent
+
+    @classmethod
+    def _sets_a_timeout(cls, node: ast.AST) -> bool:
+        """Whether this subtree calls ``setsockopt(<zmq>.RCVTIMEO/SNDTIMEO, ...)``."""
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            if not (isinstance(call.func, ast.Attribute) and call.func.attr == "setsockopt"):
+                continue
+            for arg in call.args:
+                if isinstance(arg, ast.Attribute) and arg.attr in cls.TIMEOUT_OPTIONS:
+                    return True
+        return False
+
+    @classmethod
+    def _modules_setting_a_timeout(cls) -> dict[str, str]:
+        """Map ``relative module path -> source`` for every module that sets one."""
+        found: dict[str, str] = {}
+        root = cls._package_root()
+        for path in sorted(root.rglob("*.py")):
+            source = path.read_text()
+            if "setsockopt" not in source:
+                continue
+            if cls._sets_a_timeout(ast.parse(source)):
+                found[str(path.relative_to(root))] = source
+        return found
+
+    def test_the_scan_finds_every_known_zmq_timeout_surface(self) -> None:
+        """Non-vacuity: a scan that found nothing would pass everything below."""
+        assert set(self._modules_setting_a_timeout()) == {
+            "policies/groot/client.py",
+            "policies/moveit2/client.py",
+        }
+
+    def test_every_module_that_sets_a_timeout_routes_it_through_the_shared_domain(self) -> None:
+        offenders = [
+            module
+            for module, source in self._modules_setting_a_timeout().items()
+            if "coerce_zmq_timeout_ms" not in source
+        ]
+        assert not offenders, f"these set a ZMQ timeout without the shared domain: {offenders}"
+
+    def test_the_scanner_detects_a_module_that_does_neither(self) -> None:
+        """The scanner is answering the question, not returning ``True``."""
+        unguarded = ast.parse(
+            "import zmq\n"
+            "class Rogue:\n"
+            "    def __init__(self, timeout_ms):\n"
+            "        self.socket.setsockopt(zmq.RCVTIMEO, timeout_ms)\n"
+        )
+        assert self._sets_a_timeout(unguarded)
+
+        elsewhere = ast.parse("sock.setsockopt(zmq.LINGER, 0)\n")
+        assert not self._sets_a_timeout(elsewhere)
+
+
+class TestTheGuardPrecedesTheSocketOptions:
+    """Ordering: the budget is coerced before any option is written.
+
+    A guard placed after ``_init_socket`` would leave a socket configured from
+    a value the constructor then refused, which is the half-created-object
+    shape #1858 records for a different axis.
+    """
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_the_coercion_appears_before_load_zmq_in_the_constructor(self, cls: type) -> None:
+        source = inspect.getsource(cls.__init__)
+        assert "coerce_zmq_timeout_ms" in source
+        assert source.index("coerce_zmq_timeout_ms") < source.index("_load_zmq")
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    def test_the_socket_is_configured_from_the_stored_budget(self, cls: type) -> None:
+        """``_init_socket`` reads ``self.timeout_ms``, which is the coerced int."""
+        source = inspect.getsource(cls._init_socket)
+        assert "self.timeout_ms" in source
+
+
+def test_a_usable_budget_still_times_out_against_a_slow_sidecar() -> None:
+    """The domain bounds the value, it does not change what a timeout means.
+
+    Guards against a fix that made every budget effectively unbounded.
+    """
+    slow = threading.Event()
+    ctx = zmq.Context()
+    rep = ctx.socket(zmq.REP)
+    rep.setsockopt(zmq.LINGER, 0)
+    port = rep.bind_to_random_port("tcp://127.0.0.1")
+
+    def serve() -> None:
+        poller = zmq.Poller()
+        poller.register(rep, zmq.POLLIN)
+        while not slow.is_set():
+            if dict(poller.poll(20)):
+                slow.wait(timeout=2.0)
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    client = MoveIt2InferenceClient(host="127.0.0.1", port=port, timeout_ms=200)
+    try:
+        started = time.monotonic()
+        assert client.ping() is False
+        assert time.monotonic() - started < 1.5
+    finally:
+        slow.set()
+        thread.join(timeout=5)
+        client.socket.close()
+        client.context.term()
+        rep.close()
+        ctx.term()

--- a/tests/test_zmq_timeout_ms_domain.py
+++ b/tests/test_zmq_timeout_ms_domain.py
@@ -21,6 +21,8 @@ The tests are grouped by what they protect rather than by client:
   fails here first rather than silently invalidating the reasoning above.
 * :class:`TestNoZmqTimeoutSurfaceDrifts` - structural, so a third ZMQ client
   cannot ship without joining the rule.
+* :class:`TestTheCoercionReadsTheValueOnce` - the module's no-unprotected-
+  conversion invariant, stated over this helper.
 """
 
 from __future__ import annotations
@@ -28,6 +30,7 @@ from __future__ import annotations
 import ast
 import contextlib
 import inspect
+import numbers
 import pathlib
 import threading
 import time
@@ -39,7 +42,7 @@ import strands_robots
 from strands_robots.policies.groot.client import Gr00tInferenceClient
 from strands_robots.policies.groot.client import MsgSerializer as GrootSerializer
 from strands_robots.policies.moveit2.client import MoveIt2InferenceClient
-from strands_robots.utils import MAX_ZMQ_TIMEOUT_MS, coerce_zmq_timeout_ms
+from strands_robots.utils import MAX_ZMQ_TIMEOUT_MS, coerce_zmq_timeout_ms, positive_whole_number_error
 
 # ``pyzmq`` is imported optionally rather than through a module-level
 # ``importorskip``, so that the tests which need no socket keep running without
@@ -160,6 +163,41 @@ def sidecar_for(cls: type) -> Any:
         yield server
     finally:
         server.close()
+
+
+class CountingWholeNumber:
+    """A registered :class:`numbers.Real` that counts every read of itself.
+
+    Registered rather than subclassed for :class:`RealNoFloat`'s reason in
+    ``tests/test_conversion_escape_is_closed.py``: ``numbers.Real`` is a
+    registration, so a value can satisfy a guard's ``isinstance`` check while
+    owing it nothing else. It names a perfectly usable budget, so it travels the
+    accept path to the end - which is the path where a second read is a silent
+    hazard rather than an immediate refusal.
+    """
+
+    def __init__(self, value: int) -> None:
+        self._value = value
+        self.float_reads = 0
+        self.int_reads = 0
+
+    def __float__(self) -> float:
+        self.float_reads += 1
+        return float(self._value)
+
+    def __int__(self) -> int:
+        self.int_reads += 1
+        return self._value
+
+    @property
+    def reads(self) -> int:
+        return self.float_reads + self.int_reads
+
+    def __repr__(self) -> str:
+        return f"CountingWholeNumber({self._value})"
+
+
+numbers.Real.register(CountingWholeNumber)
 
 
 class TestTheSharedDomain:
@@ -559,3 +597,124 @@ def test_a_usable_budget_still_times_out_against_a_slow_sidecar() -> None:
         client.context.term()
         rep.close()
         ctx.term()
+
+
+class TestTheCoercionReadsTheValueOnce:
+    """The module's no-unprotected-conversion invariant, over this helper.
+
+    ``strands_robots/utils.py`` carries a module-wide scan
+    (``tests/test_conversion_escape_is_closed.py``) asserting that no function in
+    it converts with a ``float()`` no ``try`` protects. The set it compares
+    against is empty and is asserted "so it can neither grow nor be quietly
+    narrowed", so a new guard joins the rule rather than the exception list.
+
+    The first spelling of :func:`coerce_zmq_timeout_ms` did not: it validated
+    with :func:`positive_whole_number_error` and then read the caller's value
+    twice more, ``float(value)`` for the range and ``int(value)`` for the result,
+    on the reasoning that the guard had made the conversion safe. That is the
+    reasoning #1875 shipped for the vector coercions and #1906 withdrew - the
+    scan could not see the upstream guarantee, and independent reads are not
+    obliged to agree, so the magnitude a refusal quoted need not have been the
+    magnitude the ceiling examined. The tests below state both halves: no
+    unprotected conversion, *and* the value is read exactly once, because a
+    helper that stopped converting at all would satisfy the first alone.
+    """
+
+    METHOD = "Gr00tInferenceClient"
+    PARAM = "timeout_ms"
+
+    @staticmethod
+    def _bare_float_calls(func: Any) -> list[str]:
+        """Names converted by a ``float()`` call that no ``try`` protects.
+
+        The module-wide scanner's question, asked here so a re-introduced
+        conversion fails in the file that owns this helper rather than only in
+        the shared invariant file.
+        """
+        tree = ast.parse(inspect.getsource(func).lstrip())
+        protected: set[ast.AST] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Try):
+                for stmt in node.body:
+                    for inner in ast.walk(stmt):
+                        if isinstance(inner, ast.Call):
+                            protected.add(inner)
+        return [
+            ast.unparse(node.args[0])
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "float"
+            and node not in protected
+            and node.args
+        ]
+
+    def test_it_makes_no_unprotected_conversion(self) -> None:
+        assert self._bare_float_calls(coerce_zmq_timeout_ms) == []
+
+    def test_the_scanner_reports_a_planted_conversion(self) -> None:
+        """Control: an always-empty scan would satisfy the test above."""
+
+        def planted(value: Any) -> bool:
+            return float(value) > 1.0
+
+        assert self._bare_float_calls(planted) == ["value"]
+
+    def test_the_guard_alone_already_reads_the_value(self) -> None:
+        """Non-vacuity for the double: the baseline below is a measurement."""
+        counted = CountingWholeNumber(15_000)
+        assert positive_whole_number_error(counted, self.PARAM, self.METHOD) is None
+        assert counted.reads > 0
+
+    def test_it_adds_exactly_one_read_to_the_guards_own(self) -> None:
+        """The accepted budget is converted once, by this helper.
+
+        Measured as a delta against :func:`positive_whole_number_error` called
+        alone, so the guard's own reads are the baseline and this asserts what
+        the coercion adds rather than restating the guard's internals.
+        """
+        baseline = CountingWholeNumber(15_000)
+        assert positive_whole_number_error(baseline, self.PARAM, self.METHOD) is None
+
+        counted = CountingWholeNumber(15_000)
+        assert coerce_zmq_timeout_ms(self.METHOD, self.PARAM, counted) == (15_000, None)
+
+        assert counted.reads - baseline.reads == 1
+
+    def test_the_one_added_read_is_the_int_the_caller_gets(self) -> None:
+        """And it is the ``int``, not a re-read of the range.
+
+        Stated separately from the count so that trading the ``int()`` for a
+        second ``float()`` - which keeps the total at one - fails here.
+        """
+        baseline = CountingWholeNumber(15_000)
+        assert positive_whole_number_error(baseline, self.PARAM, self.METHOD) is None
+
+        counted = CountingWholeNumber(15_000)
+        assert coerce_zmq_timeout_ms(self.METHOD, self.PARAM, counted) == (15_000, None)
+
+        assert counted.float_reads == baseline.float_reads
+        assert counted.int_reads == baseline.int_reads + 1
+
+    def test_an_integral_value_above_the_float64_int_range_is_still_refused(self) -> None:
+        """The ceiling comparison happens on an ``int``, which cannot overflow.
+
+        ``1e300`` is integral, finite and inside the float64 range, so the guard
+        accepts it and the ceiling is what refuses it. Converting it with ``int``
+        first is safe because ``int`` is arbitrary-precision - the case that
+        makes reading the value as an ``int`` rather than a ``float`` a
+        correctness statement and not only a read-count one.
+        """
+        timeout_ms, reason = coerce_zmq_timeout_ms(self.METHOD, self.PARAM, 1e300)
+        assert timeout_ms is None
+        assert reason is not None
+        assert f"at most {MAX_ZMQ_TIMEOUT_MS} ms" in reason
+
+    def test_the_ceiling_itself_is_unchanged_by_the_read(self) -> None:
+        """Boundary pin: the accepted edge and the first refused value."""
+        assert coerce_zmq_timeout_ms(self.METHOD, self.PARAM, MAX_ZMQ_TIMEOUT_MS) == (
+            MAX_ZMQ_TIMEOUT_MS,
+            None,
+        )
+        timeout_ms, reason = coerce_zmq_timeout_ms(self.METHOD, self.PARAM, MAX_ZMQ_TIMEOUT_MS + 1)
+        assert (timeout_ms, reason is None) == (None, False)


### PR DESCRIPTION
Closes #1986

Both ZMQ REQ inference clients - `Gr00tInferenceClient` and `MoveIt2InferenceClient` - handed `timeout_ms` straight to `setsockopt(RCVTIMEO)` / `setsockopt(SNDTIMEO)` without checking it. They now share the `utils.coerce_zmq_timeout_ms` domain, so an unusable wait budget is refused at construction with a `ValueError` naming the class, the parameter and the bound.

This is the concern #1984 settled for the WebSocket and gRPC clients, on the **third** remote-inference transport. It was missed there because that change enumerated the knobs by name - `connect_timeout` / `request_timeout` - and these are spelled `timeout_ms`. `MoveIt2Policy` already refused the other numeric parameter it owns, `port`, through `tcp_port_error`, and forwarded `timeout_ms` unguarded eight lines later.

## Why it mattered

The misattribution was quieter here than on the sibling transports. Both clients' `ping()` catches every exception and returns `False`, logging the reason at `debug` only, so there was **no signal at default log level** - where the WebSocket client at least raised a `ConnectionError` with a (misleading) remedy.

Measured with the real client classes against a real loopback REP sidecar that answers correctly (pyzmq 27.1.0 / libzmq 4.3.5, Python 3.13):

| `timeout_ms` | before | `ping()` vs a healthy sidecar | after |
| --- | --- | --- | --- |
| `15000` (default) | accepted | `True` | unchanged |
| `0`, `False` | accepted | **`False`** - ZMQ's "return immediately" spelling, so every request raises `zmq.Again` whether or not a sidecar exists | refused |
| `True` | accepted | **`False` on MoveIt2, `True` on GR00T** - a silent 1 ms budget | refused |
| `-1` | accepted | **never returns** | refused |
| `-2`, `-15000` | bare `ZMQError: Invalid argument` | never reached | refused |
| `nan`, `inf`, `1.5`, `'15000'`, `None`, `[15000]` | bare `TypeError` from inside pyzmq, naming no parameter | never reached | refused |
| `2**31`, `10**400` | bare `OverflowError` | never reached | refused |
| `15000.0`, `np.int64(15000)` | **bare `TypeError`** - a usable budget the transport refuses | never reached | **accepted, stored as `int`** |

Three rows deserve calling out.

**The last row is why this is a fix rather than only a refusal.** `setsockopt` takes a C `int` and rejects every other spelling of the same budget, so a timeout read out of a JSON config or a config array could not be used at all - while the sibling transports accept exactly those spellings (#1984 explicitly valued "a timeout read out of a config array still works"). The domain returns the value coerced to `int`, so one configured budget is no longer usable on two transports and unusable on the third.

**`True` was load-dependent, not merely wrong.** It is an `int` subclass, so it stored a 1 ms budget, and the verdict then turned on how long the peer took: against the same class of sidecar it returned `False` on MoveIt2 (msgpack round trip) and `True` on GR00T, on the same machine. That is the shape that passes a smoke test and fails under a real checkpoint.

**`-1` is refused deliberately, and it is the one decision here.** ZMQ documents it as "block forever", so unlike the `inf` of the sibling transports it *is* honoured - which makes it dangerous rather than useless. It reinstates on the request path exactly the unbounded hang that `LINGER = 0`, set two lines below in the same `_init_socket` with a comment explaining it, was added to prevent on teardown; and it leaves `ping()` - whose whole contract is to answer `True` or `False` about connectivity - unable to answer at all. Neither client documented it as a spelling. An unbounded wait on a robot control path wants its own parameter and its own decision rather than arriving as a negative millisecond count. A premise test pins ZMQ's treatment of `-1` so this reopens loudly if that ever changes.

## The shared whole-number domain was necessary but not sufficient

`positive_whole_number_error` gives the right floor and type domain but accepts `2**31` - a positive whole number well inside the float64 range - which ZMQ then refuses, because `RCVTIMEO` is stored as a C `int`. So `MAX_ZMQ_TIMEOUT_MS = 2**31 - 1` (close to 24.9 days) is the transport's bound, not a policy choice, and the test derives it from `setsockopt` rather than restating the constant.

That also made a claim in `positive_whole_number_error`'s own docstring stale - it stated "No consumer of *this* domain owns one" of these ceilings. Corrected in place rather than left to be re-derived.

## Placement

Each guard sits ahead of its constructor's `_load_zmq()`, so the same caller mistake reports identically on an install with the `[groot]` / `[moveit2]` extra and one without it, and a refused budget leaves no socket configured behind it. Both properties are pinned, the second by monkeypatching `_load_zmq` to raise.

## Tests

`tests/test_zmq_timeout_ms_domain.py` - **123 cases, 70 of which fail with the guards removed** (tests kept, clients reverted to `main`).

- The **misattribution** is asserted rather than the raise: an unusable budget can no longer report a live loopback sidecar as unreachable, with a premise test first showing that sidecar really does answer.
- Both clients' verdicts are asserted **equal** over the whole probe set, so they cannot diverge on what budget is usable.
- `15000.0` and `np.int64(15000)` are accepted, stored as `int`, land on the socket, and still ping a live sidecar; `reconnect()` reuses the coerced value.
- A usable budget still times out against a deliberately slow sidecar, so the fix cannot have made every budget effectively unbounded.
- **Premise tests** pin pyzmq's own behaviour for `0`, `True`, `-1`, `-2` and the non-`int` spellings, so the reasoning above fails loudly rather than going stale.
- A **structural** check requires every module that sets `RCVTIMEO` / `SNDTIMEO` to route the value through the shared domain, with a non-vacuity test on the scanner itself, so a third ZMQ client cannot ship without joining the rule.
- `pyzmq` is imported **optionally** rather than through a module-level `importorskip`, so on an install without the extras 87 of the cases still run and 60 still fail with the guards removed. See the round-1 note below for why that mattered.

No behaviour changes for any value that already named a budget: the `15000` default is unchanged and the usages across the tests, docs and examples all sit inside the accepted domain. `hatch run lint` (`ruff check`, `ruff format --check`, `mypy`) is clean; `tests/test_utils.py` + `tests/policies` report an identical 1614 passed / 19 failed before and after this change, the 19 being optional deps absent from the scratch environment (`mujoco`, `lerobot`, `strands`).

## Deliberately out of scope

The other unvalidated timeout surfaces #1984 named and left - `IotTransport.connect_timeout`, `VeraConfig.server_ready_timeout`, `RosBridgeRobot.navigate_to`'s `timeout` - stay out for the reasons it gave: different transports, different failure modes. This change is the ZMQ pair only, which is one concern because they share a transport, a wire shape, a `ping()` contract and a defect.

---

### §13 round-1 changelog

Two commits, no review feedback yet. The second is a self-correction found while verifying that the pin actually runs in CI.

**`b8a50a5`** - the fix: the shared `coerce_zmq_timeout_ms` domain, both client guards, the stale docstring claim in `positive_whole_number_error`, the `moveit2` docs paragraph, the changelog fragment, and `tests/test_zmq_timeout_ms_domain.py`.

**`e8afa76`** - the test file's own vacuity risk. The original module-level `importorskip("zmq")` made *every* case conditional on the `[groot]` / `[moveit2]` extras, including the structural drift guard - the one check whose entire job is to still be running when someone changes something unrelated. Had pyzmq ever left the `all` feature, the pin would have gone vacuously green rather than failing. Since both clients load ZMQ lazily and refuse an unusable budget *before* `_load_zmq()`, the domain verdicts, both refusal paths, the ordering checks and the drift guard are all answerable with no transport installed at all. `pyzmq` / `msgpack` are now imported optionally behind `requires_zmq` / `requires_wire` markers applied only to the tests that configure a real socket or round-trip against a real sidecar. Verified against a simulated extra-less install: 87 of 123 cases still run, 60 of them still fail with the guards removed, where previously the count would have been 0.

### §13 round-2 changelog

Two commits since the round-1 section. No review threads are open; both are CI-driven self-corrections, and neither adds scope.

**`7b0b53e`** - a typing annotation in the test file (`list[str | None]`, two `getattr` spellings) so mypy accepts it. Behaviour-neutral.

**`b10f4dc`** - the reason `call-test-lint` was red while the PR read `APPROVED` / `MERGEABLE`. This is a defect in the round-1 fix, not environment noise: `main` at `00cccb06` is green on the same job, so the delta is mine.

`strands_robots/utils.py` carries a module-wide scan - `tests/test_conversion_escape_is_closed.py::TestTheModuleConvertsOnlyInsideAGuardedRead` - asserting that no function in the module converts with a `float()` that no `try` protects. It compares against `EXPECTED_REMAINING`, which is empty and is commented as asserted "so it can neither grow nor be quietly narrowed". `coerce_zmq_timeout_ms` was reported by it:

```
assert {'coerce_zmq_timeout_ms'} == set()
```

The failure is the invariant's verdict on the round-1 reasoning, not a lint preference. That reasoning - validate with the guard, then convert on the strength of its upstream guarantee - is what #1875 shipped for the three vector coercions and #1906 explicitly withdrew, for two reasons the scan's own docstring records: the scan cannot see an upstream guarantee, and the reads were independent, so "the components a refusal quoted need not have been the components any check examined". The round-1 helper read the caller's value twice beyond the guard, `float(value)` for the range and `int(value)` for the result.

The ceiling is now compared against the `int` the helper itself produced. `int` needs no `try` here and is exact: the guard has already established a `numbers.Real` whose `float()` succeeded, is finite and is integral, so no rounding is possible, and `int` being arbitrary-precision means an integral `1e300` converts rather than overflowing and is then refused by the ceiling exactly as before. `non_negative_whole_number_error` already reads its value this way, so this is the sibling guard's existing idiom rather than a new one.

**No accepted or refused value changes.** Every value above the ceiling exceeds `2**31 - 1`, which is far below the `2**53` at which a float read would have lost precision, so the two spellings agree on the whole domain.

**Two alternatives were rejected.** Adding the name to `EXPECTED_REMAINING` is the "quiet growth" that set exists to prevent. Lifting the read into a shared `_read_positive_whole_number` and having `positive_whole_number_error` delegate to it is the fuller #1906 shape, but that guard has 58 references across the package and its `_beyond_float_range` presence is itself asserted by a sibling test, so refactoring it belongs to its own change rather than to a ZMQ timeout fix at round 3.

Pinned by `TestTheCoercionReadsTheValueOnce` (7 cases): the no-unprotected-conversion property stated over this helper, so a re-introduced conversion fails in the file that owns it and not only in the shared invariant file; the read count as a delta against `positive_whole_number_error` called alone, so what the coercion adds is measured rather than the guard's internals restated; and the added read asserted to be the `int`, so trading it for a second `float()` - which keeps the total at one - still fails. Three of the seven fail on the round-1 spelling, reporting two added reads rather than one. Fragment counts updated to the measured `130` / `94`.

### §13 round-3 changelog

One commit. No review threads are open; this is a CI-driven self-correction of the round-2 commit, and it adds no scope.

**`a3f3e3f`** - the reason `call-test-lint` was still red at `b10f4dc`. The job's only failure was `tests/test_docstrings_no_dangling_doc_refs.py::test_no_reference_to_test_files_by_name`:

```
AssertionError: shipped source cites test files by name: {'utils.py': ['test_conversion_escape_is_closed.py']}
```

The round-2 comment justified the read-once respelling by citing, *by filename*, the module-wide conversion scan that had reported it. That is the third dangling-reference class this package-wide guard exists to refuse: the published wheel ships no test tree, so the pointer is a dead end for a package reader, and it rots the moment that test is renamed. The comment now states the invariant it was pointing at - no function in this module may reach a `float()` that no `try` protects - which is the durable form and survives a rename.

**Comment text only.** No accepted or refused value changes, no signature or behaviour change, and no new test: the guard that caught this *is* the pin, and a second assertion over one comment would be scope this round should not add.

There is a mildly recursive shape worth naming, because it is the actual lesson: round 2 fixed a finding from one package-wide structural scan, and the sentence explaining that fix tripped a *second* package-wide structural scan. Both guards were doing their job.

#### Why the previous round's verification missed it

The round-2 check was scoped to `tests/test_utils.py` + `tests/policies` + the new domain file - the tests that own the code being changed. This guard owns no code: it scans the whole shipped package, so any comment edit is inside its blast radius, and it sits in none of those paths. Verification was widened accordingly, to every test file in the tree that scans the package (`rglob("*.py")` over the install root - 41 files):

- **`tests/test_docstrings_no_dangling_doc_refs.py` now passes** (4/4), and it is not vacuous - it is the check that failed on `b10f4dc`.
- Across all 41 guards the failure set is **identical on this branch and on `main` at `00cccb06`: 92 either way, the same test IDs on both**, so this branch regresses none of them. Those 92 are optional dependencies absent from the scratch environment (`device_connect_edge`, `torch`, `qpsolvers`), not verdicts about this change.
- `ruff check` and `ruff format --check` are clean; the domain file plus `tests/test_utils.py` and the two conversion scans report 262 passed / 36 skipped, unchanged.
