### PR TITLE
docs(agents): a head commit the Actions token created carries no check suite, so BLOCKED is terminal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,6 +493,54 @@ hatch run format            # ruff check --fix, ruff format
    the sole constraint". It bites CI and process pull requests specifically,
    because those are the ones carrying workflow edits. See #1917.
 
+   A third cause of that same presentation needs no workflow edit, and no second
+   token to see. The `mergeStateStatus` values above - `BLOCKED` while the required
+   check runs, then `UNSTABLE` or `CLEAN` - assume the required check runs. A head
+   commit created through the API under the Actions `GITHUB_TOKEN`
+   (`createCommitOnBranch`, or `PUT /repos/{owner}/{repo}/contents/{path}`) spawns
+   **no check suite at all**, because GitHub suppresses workflow triggers for events
+   it attributes to that token so that a workflow cannot re-trigger itself. Nothing
+   ever reports `call-test-lint / Test and Lint`, so the required set is never
+   satisfied and `BLOCKED` is terminal rather than transient.
+
+   It is legible in one field, and only as an absence:
+
+   ```
+   commits(last: 1) { nodes { commit { checkSuites { totalCount } } } }   ->  0
+   ```
+
+   Zero suites, not a red one. On #1987 every commit pushed from a clone carried
+   10-13 suites and the one written through the API carried none, same branch, same
+   day:
+
+   | head | committer | `checkSuites.totalCount` |
+   |---|---|---|
+   | `b10f4dce` | `./c²` (clone) | 13 |
+   | `a3f3e3f6` | `cagataycali` (API) | 0 |
+
+   At `a3f3e3f6` that PR satisfied every gate this file tells you to read -
+   `APPROVED` by an account other than the pusher, `MERGEABLE`, no unresolved
+   thread - while `statusCheckRollup` read `null` and `mergeStateStatus` read
+   `BLOCKED`. That payload is indistinguishable from a required check still
+   queued, so it was reported as waiting on CI for two consecutive scheduled
+   cycles.
+
+   **Reopen it; do not re-push it.** `pr-and-push.yml` takes the default
+   `pull_request` types, so `reopened` recomputes the *unchanged* head sha: no
+   commit, therefore no push, therefore neither `dismiss_stale_reviews_on_push` nor
+   a new last pusher, and the approval survives. Re-pushing the same tree with
+   `PAT_TOKEN` triggers too, but pays a re-approval round that reviews no changed
+   behaviour - and re-running is not on the table, since `totalCount` is `0` so
+   there is no suite to re-run and the workflow has no `workflow_dispatch`.
+
+   **The flip needs `PAT_TOKEN` as well.** A close/reopen attributed to the Actions
+   token is suppressed for the same reason the commit was, so the remedy applied
+   with the wrong token is a silent no-op that looks like the diagnosis was wrong.
+   Read `timelineItems(itemTypes: [CLOSED_EVENT, REOPENED_EVENT])` first, as this
+   step already requires: #1987 had none and cleared on a single flip - same head,
+   still `APPROVED`, nine suites queued including the required one. #1988 has the
+   full account.
+
    This is worth the words because the failure mode is silent and expensive in the
    opposite direction from the usual one. Treating an advisory red as a merge
    blocker does not look like a mistake; it looks like diligence, and it costs a


### PR DESCRIPTION
Closes #1988

## What

AGENTS.md step 8 says `mergeStateStatus` is the field to trust and lists its values as `BLOCKED`
while the required check runs, then `UNSTABLE` or `CLEAN`. That list assumes the required check
runs. This adds the case where it never does, so `BLOCKED` is terminal rather than transient.

A head commit created through the API under the Actions `GITHUB_TOKEN` - `createCommitOnBranch`,
or `PUT /repos/{owner}/{repo}/contents/{path}` - spawns **no check suite at all**, because GitHub
suppresses workflow triggers for events it attributes to that token so a workflow cannot
re-trigger itself. Nothing ever reports `call-test-lint / Test and Lint`, the repository's one
required context, so the ruleset is never satisfied.

## Evidence

Measured on #1987 - same branch, same day, the difference is only how the commit was written:

| head | committer | `checkSuites.totalCount` |
|---|---|---|
| `b8a50a54` | clone | 10 |
| `e8afa76a` | clone | 12 |
| `7b0b53e7` | clone | 12 |
| `b10f4dce` | clone | 13 |
| `a3f3e3f6` | API | **0** |

At `a3f3e3f6` that PR satisfied every gate AGENTS.md names - `reviewDecision: APPROVED` from an
account other than the pusher, so `require_last_push_approval` was met, `mergeable: MERGEABLE`,
zero unresolved threads - while `statusCheckRollup` read `null` and `mergeStateStatus` read
`BLOCKED`.

That payload is indistinguishable from a required check still queued, which is why it was
reported as waiting on CI for two consecutive scheduled cycles. It is the same presentation the
viewer-scope paragraph above it already records for a different cause, and the same one #1905
records for a third - an approved PR polled as though its gate could move, and written up as
reviewer bandwidth. The new text is placed directly after that paragraph for exactly that reason.

## Verified, not just described

The remedy the section prescribes was applied to #1987 while writing this:

- `reopened` fired against the unchanged head `a3f3e3f6`
- nine suites appeared, `call-test-lint / Test and Lint` among them
- head sha unchanged, `reviewDecision` still `APPROVED` - no push, so
  `dismiss_stale_reviews_on_push` never fired and the last pusher never changed

The two obvious alternatives are recorded as rejected with their costs: re-pushing the tree with
`PAT_TOKEN` does trigger, but dismisses the approval and buys a re-approval round that reviews no
changed behaviour; re-running is not available at all, since `totalCount` is `0` (there is no
suite to re-run) and `pr-and-push.yml` has no `workflow_dispatch`.

The trap is also recorded: the flip itself needs `PAT_TOKEN`, because a close/reopen attributed to
the Actions token is suppressed for the same reason the commit was - so the correct remedy applied
with the wrong token is a silent no-op that reads as a wrong diagnosis.

## Scope

AGENTS.md only, +48 lines, one insertion, no existing line reworded. Placed after the paragraph
ending `See #1917.` rather than beside the `mergeStateStatus` value list it qualifies, because the
sentence immediately after that list opens "That trust has a reader attached to it, which the
sentence above does not say" - inserting there would orphan its referent.

No changelog fragment: this changes no shipped behaviour, matching #1980 and #1981, the two most
recent `docs(agents)` changes, which were also AGENTS.md-only at 43 and 46 lines.

## Checks

The seven tests that read `AGENTS.md` by path pass against the edited file - 69 passed:

```
tests/test_review_thread_reply_gate.py
tests/test_ref_creation_ruleset_scope.py
tests/test_source_strings_no_review_archaeology.py
tests/test_merge_gate_viewer_scope.py
tests/test_codeql_query_filters.py
tests/test_graphql_node_id_targeting.py
tests/test_dependabot_config_location.py
```

The ASCII / no-emoji / no-unicode-dash guards scan `strands_robots/**.py` and do not read this
file; the one non-ASCII character added is `²`, in a committer name inside a table, and the file
already carries box-drawing glyphs in its tree diagram.