### PR TITLE
fix(training): an unusable SimEnv numeric is refused instead of silently scaling the policy out of the loop

### DIFF
--- a/changelog.d/1990-rl-env-numeric-domains.md
+++ b/changelog.d/1990-rl-env-numeric-domains.md
@@ -1,0 +1,39 @@
+### Fixed: an unusable `SimEnv` numeric is refused instead of silently scaling the policy out of the loop
+
+`SimEnv.__init__` validated three of its arguments and silently coerced the rest. `action_scale`
+went through a bare `float()`, `max_episode_steps` and `action_dim` through a bare `int()`, and
+`n_substeps`' own hand-rolled `int(n_substeps) < 1` comparison had the `bool` hole every such
+comparison has.
+
+`action_scale` is the consequential one, because it multiplies every action the env sends. The
+constructor already documents this exact pathology one argument away - `n_substeps`' docstring
+explains that "the PD controller needs several substeps to track it, so a single substep barely
+moves the arm" - and the scale does the same thing more completely by scaling the target itself.
+Measured on a MuJoCo two-joint arm over 60 steps of a constant `[0.9, -0.7]` command: `1.0` drives
+the shoulder to `+0.5235 rad`; `0` leaves it at `-0.0` (the elbow's `+0.0117` is gravity sag);
+`-1.0` inverts it to `-0.4511`; and `nan`/`inf` have `send_action` refuse all 60 commands. Every one
+of those runs banked the same full `60.0` return, because `step` discards `send_action`'s status -
+verbatim the pathology the `num_actions` comment three lines below in the same constructor
+describes ("every step wrote no target while the reward was still collected"), reached through the
+scale instead of the width. `True` was a silent scale of `1.0`, and `None` / a list raised a bare
+`TypeError` out of a constructor that otherwise raises documented `ValueError`s.
+
+The other two were the same shape: `max_episode_steps` of `0` or below reports a time-out on the
+first step, so every episode was over before it began - and reported it as a *truncation*, which
+on-policy GAE value-bootstraps; `action_dim=0` sized the action head to zero outputs and `-1` to a
+negative width.
+
+All four now read their domain from one table, checked before the engine is touched so a refused env
+cannot leave a stepped simulation behind. Each domain is the one its *consumer* can honor, so nothing
+is refused here that the code downstream accepts: `positive_finite_number_error` for the continuous
+multiplier; `positive_whole_number_error` for `n_substeps`, which is `send_action`'s own domain for
+that parameter and is what `SimEnv` forwards it to (the narrower guard would have refused an
+`np.int64` or a `3.0` from a config that `send_action` honors) and for `max_episode_steps`, which is
+only ever compared; and `positive_count_error` for `action_dim` alone, because it sizes the trainers'
+action head where an integral float raises rather than being coerced.
+
+`action_dim=None` keeps its documented meaning, a fractional and an `np.float32` scale are unchanged,
+and the hand-rolled `n_substeps` comparison is gone - which also resolves a wording inconsistency an
+earlier contract had recorded as deliberate, since `SimEnv` and `send_action` now refuse the same
+parameter through the same guard. A structural test derives the set of numerics from the live
+signature, so one added later cannot ship without a domain.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -62,6 +62,26 @@ def make_env() -> SimEnv:
     )
 ```
 
+### Numeric arguments
+
+Every numeric `SimEnv` stores is checked at construction, against the shared
+domain for its kind, before the engine is read:
+
+| Argument | Domain | Why |
+|---|---|---|
+| `action_scale` | positive finite | It multiplies every action sent. `0` disconnects the policy from the robot, a negative value inverts every commanded DOF, and `nan`/`inf` make each command unsendable - `send_action` refuses a non-finite action, and `step` discards that status, so the rollout banks its full return having moved nothing. |
+| `max_episode_steps` | positive whole number | `0` or below reports a time-out on the first step, so every episode ends before it begins - and reports it as a *truncation*, which on-policy GAE value-bootstraps. |
+| `n_substeps` | positive whole number | The action is a position target; the PD controller needs several substeps to track it. This is `send_action`'s own domain for the parameter, which `SimEnv` forwards it to. |
+| `action_dim` | positive integer, or `None` | `None` is the documented "size the head from the robot's action keys" spelling. A width of `0` gives the policy no outputs. Narrower than the two above because it sizes the trainers' action head, where an integral float raises rather than being coerced. |
+
+An unusable value raises `ValueError` naming the class and the argument
+(`SimEnv: action_scale must be > 0, got 0.0.`). Each domain is the one its
+consumer can honor, so nothing is refused here that the code downstream accepts:
+a fractional scale (`0.25`) and a scale read from a config array
+(`np.float32(0.25)`) are fine, and so is a whole-number count spelled `50.0` or
+`np.int64(50)` - all normalized to the plain `float`/`int` the attribute
+advertises.
+
 ## PPO
 
 ```python

--- a/strands_robots/training/rl/env.py
+++ b/strands_robots/training/rl/env.py
@@ -31,9 +31,54 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import torch
 
+from strands_robots.utils import (
+    positive_count_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from strands_robots.simulation.base import SimEngine
     from strands_robots.simulation.predicates import RewardTerm
+
+
+#: Accepted domain of every numeric :class:`SimEnv` stores, by parameter name.
+#:
+#: The constructor already refused an empty ``actor_obs_keys`` / ``reward_terms``
+#: and a non-positive ``n_substeps`` -- and ``n_substeps``' own reason ("the PD
+#: controller needs several substeps to track the target, so a single substep
+#: barely moves the arm") is exactly what an unusable ``action_scale`` does, more
+#: completely: it multiplies the target itself. Reading the domain from one table
+#: keeps the two kinds of numeric on the two shared rules the rest of the library
+#: uses for them, and lets a test assert that no numeric is left unchecked.
+#:
+#: Each domain is the one its *consumer* can honor, so no knob is refused here
+#: for a value the code downstream accepts:
+#:
+#: * ``action_scale`` is a dimensionless multiplier - the family
+#:   :func:`~strands_robots.utils.positive_finite_number_error` already owns
+#:   (``0`` makes the scaled quantity degenerate, a negative value inverts it,
+#:   ``nan`` poisons every comparison and ``inf`` is not a large scale).
+#: * ``n_substeps`` is forwarded verbatim to ``SimEngine.send_action``, which
+#:   guards it with :func:`~strands_robots.utils.positive_whole_number_error` -
+#:   so that is the domain here too. The narrower alternative would refuse an
+#:   ``np.int64`` or a ``3.0`` read from a config that ``send_action`` honors,
+#:   making this guard stricter than the surface it feeds.
+#: * ``max_episode_steps`` is only ever compared against the step counter, so an
+#:   integral real is equally usable and it takes the same whole-number domain.
+#: * ``action_dim`` sizes the trainers' action head (a ``torch.nn.Linear`` width),
+#:   where an integral float raises rather than being coerced, so only a true
+#:   ``int`` can be honored: :func:`~strands_robots.utils.positive_count_error`.
+#:
+#: All three count domains refuse the same unusable values (``0``, a negative,
+#: ``bool``, a fractional, ``nan``/``inf``, a string); they differ only in which
+#: *usable* spellings of a count they admit.
+_NUMERIC_DOMAINS: dict[str, Callable[[Any, str, str], str | None]] = {
+    "action_scale": positive_finite_number_error,
+    "max_episode_steps": positive_whole_number_error,
+    "n_substeps": positive_whole_number_error,
+    "action_dim": positive_count_error,
+}
 
 
 class SimEnv:
@@ -49,17 +94,26 @@ class SimEnv:
         action_dim: Size of the action vector sent to ``engine.send_action``.
             Defaults to ``len(engine.robot_action_keys(robot_name))`` - the
             actuator count ``send_action`` binds a vector against, which is not
-            always the robot's joint count.
+            always the robot's joint count. When given it must be a positive
+            integer.
         robot_name: Robot to observe / drive. Defaults to the engine's first
             registered robot.
         critic_obs_keys: Optional privileged keys appended to the critic
             observation (asymmetric actor-critic). Defaults to ``actor_obs_keys``
             (symmetric).
         max_episode_steps: Steps before the episode is truncated (time-out).
+            Must be a positive whole number; ``0`` reports a time-out on the
+            first step, so every episode is over before it begins.
         action_scale: Scalar multiplier applied to actions before sending.
+            Must be a positive finite number: it is the magnitude bound on how
+            far one action step may move a joint, so ``0`` disconnects the
+            policy from the robot and a non-finite value makes every command
+            unsendable (see :data:`_NUMERIC_DOMAINS`).
         n_substeps: Physics control substeps per env step. The action is a
             position target; the PD controller needs several substeps to track
-            it, so a single substep barely moves the arm. Default 5.
+            it, so a single substep barely moves the arm. Default 5. Shares
+            ``send_action``'s own domain for this parameter (see
+            :data:`_NUMERIC_DOMAINS`).
         success_fn: Optional predicate; when it returns ``True`` the episode
             terminates (a genuine terminal, not a time-out).
         reset_fn: Optional callable run on ``engine`` at each reset (e.g. to
@@ -90,14 +144,34 @@ class SimEnv:
             raise ValueError("actor_obs_keys must be a non-empty ordered sequence of observation keys")
         if not reward_terms:
             raise ValueError("reward_terms must be a non-empty sequence of RewardTerm callables")
+        # Every numeric this constructor stores is checked here, against the
+        # shared domain for its kind, before the engine is touched below: a
+        # value that cannot be honored must not leave a partly-built env (or a
+        # stepped simulation) behind. ``action_dim=None`` is the documented
+        # "size the head from the robot's action keys" spelling, so only a
+        # supplied width has a domain.
+        supplied: dict[str, Any] = {
+            "action_scale": action_scale,
+            "max_episode_steps": max_episode_steps,
+            "n_substeps": n_substeps,
+        }
+        if action_dim is not None:
+            supplied["action_dim"] = action_dim
+        for _param, _value in supplied.items():
+            problem = _NUMERIC_DOMAINS[_param](_value, _param, type(self).__name__)
+            if problem is not None:
+                raise ValueError(problem)
         self.engine = engine
         self.actor_obs_keys = list(actor_obs_keys)
         self.critic_obs_keys = list(critic_obs_keys) if critic_obs_keys is not None else list(actor_obs_keys)
         self.reward_terms = list(reward_terms)
+        # The conversions below normalize, they do not validate. Each domain above
+        # deliberately admits more spellings than the field annotation names (an
+        # ``np.float32`` scale, an ``np.int64`` or ``3.0`` count), so these turn an
+        # accepted value into the plain ``float`` / ``int`` the attribute advertises.
+        # ``action_dim`` needs none: its domain admits only a true ``int`` already.
         self.max_episode_steps = int(max_episode_steps)
         self.action_scale = float(action_scale)
-        if int(n_substeps) < 1:
-            raise ValueError(f"n_substeps must be >= 1, got {n_substeps}")
         self.n_substeps = int(n_substeps)
         self.success_fn = success_fn
         self.reset_fn = reset_fn
@@ -107,7 +181,7 @@ class SimEnv:
         names = engine.list_robots()
         self.robot_name = robot_name or (names[0] if names else None)
         if action_dim is not None:
-            self.num_actions = int(action_dim)
+            self.num_actions = action_dim
         elif self.robot_name is not None:
             # ``robot_action_keys``, not ``robot_joint_names``: ``step`` sends a
             # numeric vector, and ``send_action`` binds a vector positionally to

--- a/tests/simulation/test_send_action_substep_domain_across_backends.py
+++ b/tests/simulation/test_send_action_substep_domain_across_backends.py
@@ -269,16 +269,18 @@ class TestTheFloorIsADecisionWithEvidence:
         assert runner._control_substeps(30.0) >= 1
 
     def test_the_rl_env_that_produces_this_count_also_refuses_a_non_positive(self) -> None:
-        """The second producer, refusing the same parameter name by its own raise.
+        """The second producer, on this very domain.
 
-        Read from the source rather than by constructing a ``SimEnv`` (which
-        needs a live engine): the point being pinned is that the floor exists in
-        a second place, so a reader cannot conclude ``1`` was invented here.
+        ``SimEnv`` forwards ``n_substeps`` verbatim to ``send_action``, and reads
+        its domain from the same guard, so the floor exists in a second place and
+        a reader cannot conclude ``1`` was invented here. Asserted through the
+        domain table rather than by constructing a ``SimEnv`` (which needs a live
+        engine) or by matching its message text (which would pin wording).
         """
         from strands_robots.training.rl import env as rl_env
 
-        source = inspect.getsource(rl_env)
-        assert "n_substeps must be >= 1" in source
+        assert rl_env._NUMERIC_DOMAINS["n_substeps"] is positive_whole_number_error
+        assert positive_whole_number_error(0, "n_substeps", "SimEnv") is not None
 
     def test_advance_nothing_still_has_a_spelling_and_it_is_named(self) -> None:
         """Refusing ``0`` removes nothing a caller can express, and says so.
@@ -638,13 +640,14 @@ class TestNeighbouringSubstepSurfacesStayOutOfScope:
     def test_the_rl_env_still_raises_rather_than_returning_a_structured_error(self) -> None:
         """``SimEnv`` refuses the same parameter with a ``ValueError`` of its own.
 
-        Left alone: it is a gym-style constructor rather than an agent tool, so a
-        raise is its documented channel and it has no ``{status, content}`` to
-        return. Recorded because the two refusals now differ in wording for the
-        same parameter name, which is a real inconsistency and a deliberate one.
+        The *channel* differs deliberately and is left alone: ``SimEnv`` is a
+        gym-style constructor rather than an agent tool, so a raise is its
+        documented channel and it has no ``{status, content}`` to return. The
+        *wording* no longer differs - it reads this domain from the same shared
+        guard, so the inconsistency this test used to record is resolved.
         """
         from strands_robots.training.rl import env as rl_env
 
-        source = inspect.getsource(rl_env)
-        assert "n_substeps must be >= 1" in source
-        assert "must be a positive whole number" not in source
+        assert rl_env._NUMERIC_DOMAINS["n_substeps"] is positive_whole_number_error
+        message = positive_whole_number_error(0, "n_substeps", "SimEnv")
+        assert message is not None and "must be a positive whole number" in message

--- a/tests/training/test_rl_env_numeric_domains.py
+++ b/tests/training/test_rl_env_numeric_domains.py
@@ -1,0 +1,409 @@
+"""Every numeric ``SimEnv`` stores has a domain, checked before the engine is touched.
+
+``SimEnv.__init__`` already refused an empty ``actor_obs_keys``, an empty
+``reward_terms`` and a non-positive ``n_substeps``. It silently coerced the other
+three numerics it stores -- ``action_scale`` with a bare ``float()``,
+``max_episode_steps`` and ``action_dim`` with a bare ``int()`` -- and
+``n_substeps``' own hand-rolled ``int(n_substeps) < 1`` comparison had the ``bool``
+hole every such comparison has.
+
+``action_scale`` is the consequential one. It multiplies *every* action the env
+sends, and the constructor's own ``n_substeps`` docstring already states the
+pathology it guards against ("the PD controller needs several substeps to track
+it, so a single substep barely moves the arm") -- which is what an unusable scale
+does, more completely, by scaling the target itself. Measured on a real MuJoCo
+two-joint arm, 60 steps of a constant ``[0.9, -0.7]`` command:
+
+===============  ==============  ==========  ==============  =================
+``action_scale``  ``send_action``  reward      shoulder (rad)  elbow (rad)
+===============  ==============  ==========  ==============  =================
+``1.0``           60 ok           60.0        ``+0.5235``     ``-0.6910``
+``0``             60 ok           60.0        ``-0.0``        ``+0.0117``
+``-1.0``          60 ok           60.0        ``-0.4511``     ``+0.6558``
+``nan``           **60 errors**   **60.0**    ``0.0``         ``0.0``
+``inf``           **60 errors**   **60.0**    ``0.0``         ``0.0``
+===============  ==============  ==========  ==============  =================
+
+A non-finite scale makes every command unsendable -- ``send_action`` refuses a
+non-finite action -- and :meth:`SimEnv.step` discards that status, so the arm
+never moved and the rollout still banked the full return. That is verbatim the
+pathology the ``num_actions`` comment three lines below in the same constructor
+describes ("every step wrote no target while the reward was still collected"),
+reached through the scale instead of the width. ``0`` disconnects the policy from
+the robot at full cost (the elbow's ``+0.0117`` is gravity sag, not tracking),
+``-1.0`` inverts every commanded DOF, and ``True`` is a silent scale of ``1.0``.
+
+The tests below pin the contract in three parts: every unusable value is refused
+with a message naming the class and the parameter; a usable value (including the
+``np.float32`` the continuous domain deliberately admits and the ``action_dim=None``
+sentinel) is untouched; and the refusal happens before the engine is read, so a
+rejected env cannot leave a stepped simulation behind. A structural test then
+derives the set of numerics from the live signature, so a numeric added later
+cannot ship without a domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+from typing import Any, cast
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import numpy as np  # noqa: E402 - after torch importorskip
+
+import strands_robots.training.rl.env as rl_env  # noqa: E402
+from strands_robots.simulation.base import SimEngine  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine  # noqa: E402
+from strands_robots.training.rl import SimEnv  # noqa: E402
+from strands_robots.utils import positive_whole_number_error  # noqa: E402
+
+# Values no numeric of this constructor can honor. ``0`` and a negative are in
+# both lists: for the continuous scale they make the multiplier degenerate or
+# inverting, for a count they make the loop empty or nonsensical.
+UNUSABLE_SCALES: list[Any] = [0, 0.0, -1.0, -0.25, math.nan, math.inf, -math.inf, True, False, "0.5", None, [1.0]]
+# ``3.0`` and ``np.int64(3)`` are deliberately absent: they are *usable* counts
+# for the two whole-number knobs (and for the ``send_action`` one forwards to),
+# and refused only by ``action_dim``'s narrower domain - pinned separately.
+UNUSABLE_COUNTS: list[Any] = [0, -5, True, False, 2.7, math.nan, math.inf, "10", None, [2]]
+
+
+class _Recorder:
+    """Fake engine that records every method the constructor calls on it.
+
+    Two robots' worth of shape is unnecessary here; what matters is that each
+    call is observable, so a test can assert a *refused* construction touched the
+    engine not at all.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.actions: list[list[float]] = []
+        self.statuses: list[str] = []
+
+    def list_robots(self) -> list[str]:
+        self.calls.append("list_robots")
+        return ["fake"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        self.calls.append("robot_joint_names")
+        return ["A", "B"]
+
+    def robot_action_keys(self, robot_name: str) -> list[str]:
+        self.calls.append("robot_action_keys")
+        return ["A", "B"]
+
+    def reset(self) -> dict[str, Any]:
+        self.calls.append("reset")
+        return {"status": "success"}
+
+    def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, Any]:
+        self.calls.append("get_observation")
+        return {"A": 0.0, "B": 0.0}
+
+    def send_action(self, action: Any, robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
+        self.calls.append("send_action")
+        vals = [float(v) for v in action]
+        self.actions.append(vals)
+        # Mirror the real ``SimEngine._coerce_action`` contract: a non-finite
+        # command is refused rather than clamped.
+        status = "success" if all(math.isfinite(v) for v in vals) else "error"
+        self.statuses.append(status)
+        return {"status": status}
+
+
+def _env(engine: _Recorder, **kwargs: Any) -> SimEnv:
+    """Build a ``SimEnv`` over the recorder.
+
+    ``kwargs`` is splatted so a deliberately off-type value reaches the runtime
+    guard as a caller would supply it, without the type checker objecting at each
+    individual call site.
+    """
+    return SimEnv(
+        cast(SimEngine, engine),
+        actor_obs_keys=["A", "B"],
+        reward_terms=[lambda _e: 1.0],
+        **kwargs,
+    )
+
+
+class TestEveryUnusableNumericIsRefused:
+    """A value no numeric can honor is refused, naming the class and the parameter."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_SCALES, ids=[repr(v) for v in UNUSABLE_SCALES])
+    def test_action_scale(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"SimEnv: action_scale"):
+            _env(_Recorder(), action_scale=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS, ids=[repr(v) for v in UNUSABLE_COUNTS])
+    def test_max_episode_steps(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"SimEnv: max_episode_steps"):
+            _env(_Recorder(), max_episode_steps=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_COUNTS, ids=[repr(v) for v in UNUSABLE_COUNTS])
+    def test_n_substeps(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"SimEnv: n_substeps"):
+            _env(_Recorder(), n_substeps=value)
+
+    # ``None`` is excluded deliberately: for ``action_dim`` alone it is the
+    # documented "size the head from the robot's action keys" spelling, so it is a
+    # sentinel rather than a value with a domain (pinned as accepted below).
+    @pytest.mark.parametrize(
+        "value",
+        [v for v in UNUSABLE_COUNTS if v is not None],
+        ids=[repr(v) for v in UNUSABLE_COUNTS if v is not None],
+    )
+    def test_action_dim(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"SimEnv: action_dim"):
+            _env(_Recorder(), action_dim=value)
+
+    def test_the_message_names_the_reason_not_only_the_parameter(self) -> None:
+        with pytest.raises(ValueError, match=r"action_scale must be > 0, got 0\.0"):
+            _env(_Recorder(), action_scale=0.0)
+        with pytest.raises(ValueError, match=r"max_episode_steps must be a positive whole number, got 0"):
+            _env(_Recorder(), max_episode_steps=0)
+        with pytest.raises(ValueError, match=r"action_dim must be a positive integer, got 0"):
+            _env(_Recorder(), action_dim=0)
+
+
+class TestUsableValuesAreUntouched:
+    """The change is additive: nothing that could be honored is now refused."""
+
+    def test_the_defaults_build(self) -> None:
+        env = _env(_Recorder())
+        assert (env.action_scale, env.max_episode_steps, env.n_substeps) == (1.0, 200, 5)
+
+    def test_a_fractional_scale_is_honored(self) -> None:
+        assert _env(_Recorder(), action_scale=0.25).action_scale == 0.25
+
+    def test_a_numpy_real_scale_is_honored_and_normalized(self) -> None:
+        # ``positive_finite_number_error`` deliberately admits any real scalar so a
+        # rate or scale read from a config array passes; the stored value is a
+        # plain ``float``.
+        env = _env(_Recorder(), action_scale=np.float32(0.25))
+        assert isinstance(env.action_scale, float)
+        assert env.action_scale == pytest.approx(0.25)
+
+    def test_a_single_step_episode_is_honored(self) -> None:
+        assert _env(_Recorder(), max_episode_steps=1, n_substeps=1).max_episode_steps == 1
+
+    def test_an_omitted_action_dim_still_sizes_from_the_action_keys(self) -> None:
+        # ``None`` is the documented "size the head from the robot's action keys"
+        # spelling, not a value with a domain.
+        engine = _Recorder()
+        assert _env(engine, action_dim=None).num_actions == 2
+        assert "robot_action_keys" in engine.calls
+
+    def test_an_explicit_action_dim_is_honored(self) -> None:
+        assert _env(_Recorder(), action_dim=3).num_actions == 3
+
+    @pytest.mark.parametrize("value", [3.0, np.int64(3), np.float64(4.0)], ids=["3.0", "np.int64", "np.float64"])
+    def test_an_integral_real_substep_count_is_honored(self, value: Any) -> None:
+        # ``send_action`` honors these spellings, so this constructor must too;
+        # the stored value is normalized to a plain ``int``.
+        env = _env(_Recorder(), n_substeps=value)
+        assert env.n_substeps == 3 or env.n_substeps == 4
+        assert isinstance(env.n_substeps, int)
+
+    @pytest.mark.parametrize("value", [50.0, np.int64(50)], ids=["50.0", "np.int64"])
+    def test_an_integral_real_episode_ceiling_is_honored(self, value: Any) -> None:
+        # Only ever compared against the step counter, so an integral real is
+        # equally usable; normalized to a plain ``int``.
+        env = _env(_Recorder(), max_episode_steps=value)
+        assert env.max_episode_steps == 50
+        assert isinstance(env.max_episode_steps, int)
+
+    @pytest.mark.parametrize("value", [3.0, np.int64(3)], ids=["3.0", "np.int64"])
+    def test_an_integral_real_action_dim_is_refused(self, value: Any) -> None:
+        # The one knob that is deliberately narrower: it sizes the trainers'
+        # action head, where an integral float raises rather than being coerced.
+        with pytest.raises(ValueError, match=r"SimEnv: action_dim"):
+            _env(_Recorder(), action_dim=value)
+
+    def test_a_usable_env_still_steps(self) -> None:
+        engine = _Recorder()
+        env = _env(engine, action_scale=0.5, max_episode_steps=4, n_substeps=2)
+        env.reset()
+        _obs, reward, done, info = env.step(torch.tensor([1.0, -1.0]))
+        assert engine.actions[-1] == pytest.approx([0.5, -0.5])
+        assert engine.statuses == ["success"]
+        assert float(reward.item()) == 1.0
+        assert not bool(done.item()) and not info["time_out"]
+
+
+class TestTheRefusalPrecedesTheEngine:
+    """A refused numeric must not leave a stepped simulation behind."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"action_scale": 0.0},
+            {"action_scale": math.nan},
+            {"max_episode_steps": 0},
+            {"n_substeps": 0},
+            {"action_dim": 0},
+        ],
+        ids=["scale=0", "scale=nan", "max_episode_steps=0", "n_substeps=0", "action_dim=0"],
+    )
+    def test_no_engine_call_is_made(self, kwargs: dict[str, Any]) -> None:
+        engine = _Recorder()
+        with pytest.raises(ValueError):
+            _env(engine, **kwargs)
+        assert engine.calls == []
+
+    def test_a_usable_construction_does_read_the_engine(self) -> None:
+        # Non-vacuity: the assertion above would hold for any refusal reason if the
+        # constructor never read the engine at all.
+        engine = _Recorder()
+        _env(engine)
+        assert "get_observation" in engine.calls
+
+
+class TestWhatTheUnusableScalesDid:
+    """Ground the refused values in what the env and engine really do with them.
+
+    These drive a *usable* env and reproduce the arithmetic the constructor used
+    to permit, so the reason each value is refused is measured rather than
+    asserted.
+    """
+
+    def test_a_non_finite_scale_makes_every_command_unsendable(self) -> None:
+        engine = _Recorder()
+        scaled = (np.array([0.9, -0.7], dtype=np.float64) * math.nan).tolist()
+        assert engine.send_action(scaled)["status"] == "error"
+
+    def test_step_discards_the_send_action_status(self) -> None:
+        # Why a non-finite scale is silent: the refusal never reaches the caller.
+        # ``step`` banks the reward for a step whose command the engine rejected.
+        class _AlwaysRefuses(_Recorder):
+            def send_action(self, action: Any, robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
+                super().send_action(action, robot_name, n_substeps)
+                self.statuses[-1] = "error"
+                return {"status": "error", "content": [{"text": "refused"}]}
+
+        engine = _AlwaysRefuses()
+        env = _env(engine)
+        env.reset()
+        _obs, reward, _done, _info = env.step(torch.tensor([0.9, -0.7]))
+        assert engine.statuses == ["error"]
+        assert float(reward.item()) == 1.0
+
+    def test_a_zero_scale_commands_the_same_target_every_step(self) -> None:
+        # The policy's output cannot reach the robot: whatever it asks for, the
+        # command is the zero vector.
+        engine = _Recorder()
+        env = _env(engine, action_scale=1.0)
+        env.reset()
+        env.step(torch.tensor([0.9, -0.7]) * 0.0)
+        assert engine.actions[-1] == pytest.approx([0.0, 0.0])
+
+    def test_a_negative_scale_inverts_every_commanded_dof(self) -> None:
+        engine = _Recorder()
+        env = _env(engine, action_scale=1.0)
+        env.reset()
+        env.step(torch.tensor([0.9, -0.7]) * -1.0)
+        assert engine.actions[-1] == pytest.approx([-0.9, 0.7])
+
+    def test_a_zero_max_episode_steps_would_time_out_before_the_first_step(self) -> None:
+        # ``time_out = step_count >= max_episode_steps`` is evaluated after the
+        # increment, so a ceiling of 1 is the smallest that runs a step; 0 or below
+        # reports a truncation the trainer would value-bootstrap.
+        env = _env(_Recorder(), max_episode_steps=1)
+        env.reset()
+        _obs, _r, done, info = env.step(torch.tensor([0.0, 0.0]))
+        assert bool(done.item()) and info["time_out"]
+
+
+# ---------------------------------------------------------------------------
+# Structural: no numeric of this constructor may ship without a domain.
+# ---------------------------------------------------------------------------
+#: Annotations that make a parameter a *magnitude* this contract governs. A
+#: ``bool`` flag (``skip_images``) is excluded by construction: it selects a mode
+#: rather than sizing or scaling anything.
+_NUMERIC_ANNOTATIONS = frozenset({"int", "float", "int | None", "float | None"})
+
+
+def _numeric_parameters() -> set[str]:
+    """Numeric parameters of the live ``SimEnv.__init__`` signature."""
+    sig = inspect.signature(SimEnv.__init__)
+    return {
+        name
+        for name, p in sig.parameters.items()
+        if isinstance(p.annotation, str) and p.annotation in _NUMERIC_ANNOTATIONS
+    }
+
+
+def _consulted_parameters() -> set[str]:
+    """Parameter names the constructor body puts through the domain table.
+
+    Both spellings count: a key of the literal mapping, and a key added to it by
+    subscript (``supplied["action_dim"] = action_dim``, which is how the one
+    parameter with a sentinel default is added only when it was supplied).
+    """
+    init = ast.parse(inspect.getsource(SimEnv.__init__).lstrip())
+    names: set[str] = set()
+    for node in ast.walk(init):
+        if isinstance(node, ast.Dict):
+            keys = node.keys
+        elif isinstance(node, ast.Subscript):
+            keys = [node.slice]
+        else:
+            continue
+        for key in keys:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                names.add(key.value)
+    return names
+
+
+class TestEveryNumericHasADomain:
+    """The table and the signature cannot drift apart."""
+
+    def test_the_signature_is_the_expected_set(self) -> None:
+        # Non-vacuity: a scan that resolved to nothing would satisfy the two
+        # set relations below trivially.
+        assert _numeric_parameters() == {"action_dim", "max_episode_steps", "action_scale", "n_substeps"}
+
+    def test_every_numeric_parameter_has_a_domain(self) -> None:
+        missing = _numeric_parameters() - set(rl_env._NUMERIC_DOMAINS)
+        assert not missing, f"numeric parameters with no entry in _NUMERIC_DOMAINS: {sorted(missing)}"
+
+    def test_the_table_describes_only_real_parameters(self) -> None:
+        stale = set(rl_env._NUMERIC_DOMAINS) - set(inspect.signature(SimEnv.__init__).parameters)
+        assert not stale, f"_NUMERIC_DOMAINS names parameters the constructor does not take: {sorted(stale)}"
+
+    def test_the_constructor_consults_the_table_for_every_numeric(self) -> None:
+        unchecked = _numeric_parameters() - _consulted_parameters()
+        assert not unchecked, f"numerics the constructor never puts through a domain: {sorted(unchecked)}"
+
+    def test_the_scanner_detects_a_numeric_left_out(self) -> None:
+        # A planted numeric with no table entry must be reported, so an empty
+        # ``missing`` set above means the signature really is covered.
+        planted = _numeric_parameters() | {"action_jitter"}
+        assert planted - set(rl_env._NUMERIC_DOMAINS) == {"action_jitter"}
+
+    def test_each_domain_is_the_one_its_consumer_can_honor(self) -> None:
+        # Not one blanket check: each knob is on the shared rule its own consumer
+        # accepts, so none is refused here for a value the code downstream honors.
+        from strands_robots.utils import (
+            positive_count_error,
+            positive_finite_number_error,
+            positive_whole_number_error,
+        )
+
+        assert rl_env._NUMERIC_DOMAINS == {
+            "action_scale": positive_finite_number_error,
+            "max_episode_steps": positive_whole_number_error,
+            "n_substeps": positive_whole_number_error,
+            "action_dim": positive_count_error,
+        }
+
+    def test_the_substep_domain_is_the_one_send_action_uses(self) -> None:
+        # ``n_substeps`` is forwarded verbatim to ``send_action``. Were this guard
+        # the narrower one, an ``np.int64`` or a ``3.0`` from a config would be
+        # refused here and honored there - a guard stricter than its own applier.
+        engine_src = inspect.getsource(MuJoCoSimEngine.send_action)
+        assert "positive_whole_number_error" in engine_src
+        assert rl_env._NUMERIC_DOMAINS["n_substeps"] is positive_whole_number_error


### PR DESCRIPTION
## Problem

`SimEnv.__init__` validated three of its arguments and silently coerced the rest. `action_scale` went through a bare `float()`, `max_episode_steps` and `action_dim` through a bare `int()`, and `n_substeps`' own hand-rolled `int(n_substeps) < 1` comparison had the `bool` hole every such comparison has.

`action_scale` is the consequential one, because it multiplies **every** action the env sends. The constructor already documents this exact pathology one argument away — `n_substeps`' docstring explains that *"the PD controller needs several substeps to track it, so a single substep barely moves the arm"* — and the scale does the same thing more completely, by scaling the target itself.

Measured on a MuJoCo two-joint arm, 60 env steps of a constant `[0.9, -0.7]` command, `n_substeps=10`:

| `action_scale` | ctor | `send_action` | return | shoulder | elbow |
|---|---|---|---|---|---|
| `1.0` | accepted | 60 ok | 60.0 | `+0.3120` | `-0.6711` |
| `0` | accepted | 60 ok | **60.0** | `-0.1046` (droop) | `+0.0225` |
| `-1.0` | accepted | 60 ok | **60.0** | inverted | inverted |
| `nan` | accepted | **0 ok / 60 refused** | **60.0** | `0.0000` | `0.0000` |
| `inf` | accepted | **0 ok / 60 refused** | **60.0** | `0.0000` | `0.0000` |
| `True` | accepted | 60 ok | 60.0 | a silent scale of `1.0` |  |
| `None`, `[1.0]` | bare `TypeError` from `float()` |  |  |  |  |

A non-finite scale makes every command unsendable — `send_action` refuses a non-finite action — and `step` **discards that status**, so the arm never moved and the rollout still banked its full return. That is verbatim the pathology the `num_actions` comment three lines below in the same constructor describes (*"every step wrote no target while the reward was still collected"*), reached through the scale instead of the width. `0` disconnects the policy from the robot at full cost. `max_episode_steps` of `0` or below reports a time-out on the *first* step — and reports it as a **truncation**, which on-policy GAE value-bootstraps; `action_dim=0` sized the action head to zero outputs and `-1` to a negative width.

## Change

All four numerics now read their domain from one table in `SimEnv`, checked **before the engine is touched**, so a refused env cannot leave a stepped simulation behind. Each domain is the one its *consumer* can honor, so nothing is refused here that the code downstream accepts:

| Argument | Domain | Grounded in |
|---|---|---|
| `action_scale` | `positive_finite_number_error` | A dimensionless multiplier — the family that guard already owns (`0` degenerate, negative inverts, `nan` poisons every comparison, `inf` is not a large scale). |
| `n_substeps` | `positive_whole_number_error` | Forwarded verbatim to `send_action`, which guards it with the **same** rule. The narrower alternative would refuse an `np.int64` or a `3.0` from a config that `send_action` honors — a guard stricter than its own applier. |
| `max_episode_steps` | `positive_whole_number_error` | Only ever compared against the step counter, so an integral real is equally usable. |
| `action_dim` | `positive_count_error` | Sizes the trainers' action head (a `torch.nn.Linear` width), where an integral float raises rather than being coerced — so only a true `int` can be honored. |

The surviving `int()` / `float()` conversions **normalize, they do not validate**: each domain deliberately admits more spellings than the field annotation names, so they turn an accepted value into the plain `float`/`int` the attribute advertises. `action_dim` needs none.

As a side effect this resolves a wording inconsistency an earlier contract had recorded as deliberate: `SimEnv` and `send_action` now refuse `n_substeps` through the same guard, so the two source-text pins that recorded the divergence assert the shared domain instead.

## Not changed

- `action_dim=None` keeps its documented "size the head from the robot's action keys" meaning — a sentinel, not a value with a domain (pinned as accepted).
- A fractional scale (`0.25`), an `np.float32(0.25)` scale, and a `50.0` / `np.int64(50)` count are all still honored.
- `skip_images: bool` is excluded by construction: it selects a mode rather than sizing or scaling anything.
- `step` still discards `send_action`'s status. That is a separate surface with its own contract question; this change removes the caller-supplied route to it rather than altering it.

## Verification

At `00cccb06` (the branch base, which `upstream/main` has not moved past):

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` → **21507 passed, 257 skipped, 0 failed** (515 s)
- `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` → clean; 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical to a pristine `main` worktree of the same working copy (normalized line numbers, `diff` empty), i.e. environmental
- `scripts/assemble_changelog.py --check` → OK; `scripts/check_merge_base_overlap.py` → no overlap
- **Pre-fix proof**: with `strands_robots/training/rl/env.py` reverted to `upstream/main` and the tests kept, `tests/training/test_rl_env_numeric_domains.py` is **54 failed / 20 passed**. The 20 that pass are the over-reach controls (a usable env still builds and steps), the grounding tests (which drive a *usable* env to measure what the refused values do), and the non-vacuity pins — they are what stop the guard reaching further than the four values.
- Blast radius: no in-tree caller passes `action_scale` or `action_dim` to `SimEnv`. `tests/training/` is 1312 passed / 4 skipped with **zero** existing-test changes; the only edited existing test file is the pair of source-text pins above.

## Artifact

Three real MuJoCo headless rollouts (`MUJOCO_GL=egl`) plus the measured before/after verdict table. The grey post marks the commanded reach.

![SimEnv action_scale rollouts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rl-action-scale/artifact_action_scale.png)

The honored `action_scale=1.0` rollout is **byte-identical** across the two trees (`max|delta| = 0` over 620x760x3), which is the no-regression proof; the two silent-failure panels differ from it on 18.1% and 15.9% of pixels. Every number in the figure is re-derived from the two runs' JSON dumps by the generator, which asserts each one (and that the two captures came from different trees) before saving. The capture and compose scripts are published alongside it.