### PR TITLE
fix(policies/wbc): a WBCConfig value it cannot honor is refused rather than driven into the robot

### DIFF
--- a/changelog.d/1991-wbc-config-value-domain.md
+++ b/changelog.d/1991-wbc-config-value-domain.md
@@ -1,0 +1,22 @@
+### Fixed: `WBCConfig` refuses a value it cannot honor instead of driving the robot with it
+
+`WBCConfig.__post_init__` rejected impossible dimensions and accepted every
+numeric *value*. Each field is read verbatim into the SONIC PD law that writes
+`data.ctrl` or into the observation the network sees, so an unusable one became a
+wrong torque rather than an error. Measured on a real MuJoCo `unitree_g1` driven
+by the real `compute_targets` -> `pd_control` chain: `action_scale=0.0` returned
+`status="success"` having discarded the network output entirely (5.7 Nm peak
+instead of 21.5, base sagging to 0.309 m), `kps=[-150.0]*15` returned success at
+461.9 Nm with the feedback driving every joint away from its target, and
+`action_scale=nan` failed with a message blaming the embodiment. A `None` or a
+numeric string raised a bare `TypeError` from the per-tick `float()` in
+`compute_targets`, i.e. mid-rollout - the failure this module's docstring says it
+exists to convert into a construction-time message.
+
+`action_scale` must now be a finite number `> 0`, the `kps`/`kds` components
+finite and `>= 0` (a zero gain is a pure-damping joint and stays first-class, a
+negative one is not), and `default_angles`, `cmd_scale`, `rpy_cmd`,
+`obs_scales`, `height_cmd` and `freq_cmd` finite. The existing dimension checks
+also became total: a per-joint field carrying no readable length now names the
+field instead of raising `len()`'s bare `TypeError`, and a NumPy vector of the
+right width is accepted rather than raising the ambiguous-truth `ValueError`.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -92,6 +92,27 @@ WBCPolicy(
 A missing `onnxruntime` or a missing checkpoint raises `RuntimeError` at
 construction - WBC never falls back to silent zero torques.
 
+### Config value domain
+
+`WBCConfig` rejects an unusable *value* at construction, not just an impossible
+dimension - the same reason a bad dimension is refused there. Every numeric
+field is read verbatim into the PD law that writes `data.ctrl` or into the
+observation the network sees, so an unusable one becomes a wrong torque rather
+than an error:
+
+| Field | Accepted | Why |
+|-------|----------|-----|
+| `action_scale` | finite `> 0` | The only path from the network to the joint targets. `0` (or `False`) makes `target_q == default_angles`, discarding the policy; a negative value inverts every offset. |
+| `kps`, `kds` | finite `>= 0`, per component | `kp = 0` with `kd > 0` is a pure-damping joint and stays valid; a *negative* gain makes `(target_q - q) * kp` drive the joint away from its target. |
+| `default_angles`, `cmd_scale`, `rpy_cmd` | finite, per component | Signed quantities (a stance angle, a yaw rate, a roll target), so only finiteness is constrained. |
+| `obs_scales` values, `height_cmd`, `freq_cmd` | finite | A non-finite scale poisons the observation frame the network is given. |
+
+A `nan`/`inf` anywhere reaches `data.ctrl` as a non-finite torque on all
+`num_actions` joints; a `None` or a numeric string raises from the `float()`
+inside `compute_targets`, which runs per tick inside `get_actions` - after the
+ONNX sessions have loaded and the rollout has started. Both now surface as a
+`ValueError` naming the field (and the component index) at construction.
+
 ## Goal kwargs
 
 WBC reads locomotion commands from `**kwargs`, sharing the non-VLA goal

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -15,11 +15,50 @@ not as an opaque ONNX shape error mid-rollout.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from strands_robots.utils import require_optional
+from strands_robots.utils import (
+    finite_number_error,
+    positive_finite_number_error,
+    require_optional,
+    sequence_length,
+)
+
+
+def _non_negative_number_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable finite number ``>= 0``.
+
+    The domain of a PD feedback gain. :func:`~strands_robots.utils.finite_number_error`
+    decides numeric-ness and finiteness - the whole of the rule bar the floor -
+    so only the floor is decided here, and a value the shared guard rejects is
+    reported in its words. Zero is first-class: ``kp = 0`` with ``kd > 0`` is a
+    pure-damping joint, which is a controller a caller may legitimately ask for.
+    A NEGATIVE gain is not: ``tau = (target_q - q) * kp`` with ``kp < 0`` drives
+    the joint AWAY from its target, so the feedback that exists to hold the
+    stance accelerates the humanoid out of it.
+
+    :func:`~strands_robots.utils.positive_finite_number_error` cannot express
+    this domain (it refuses the first-class zero), and the library's only
+    non-negative continuous guard sits under
+    :mod:`strands_robots.simulation`, which :mod:`strands_robots.policies` must
+    not depend on - hence a local binding over the shared numeric rule rather
+    than a second copy of it.
+
+    Args:
+        value: The caller-supplied value.
+        param: The parameter it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if error := finite_number_error(value, param, context):
+        return error
+    return None if float(value) >= 0.0 else f"{context}: {param} must be >= 0, got {value!r}."
+
 
 # Upstream defaults from the GR00T-WholeBodyControl reference controller
 # (decoupled_wbc/sim2mujoco: run_mujoco_gear_wbc.py + resources/robots/g1/
@@ -76,7 +115,12 @@ class WBCConfig:
         kps: Per-joint proportional gains, length ``num_actions``.
         kds: Per-joint derivative gains, length ``num_actions``.
         action_scale: Scale applied to the raw ONNX output before it becomes a
-            joint-position offset (upstream ``action_scale``).
+            joint-position offset (upstream ``action_scale``). Must be a finite
+            number > 0: it is the only thing that carries the network's decision
+            into the joint targets, so a zero (or a ``False``) discards the
+            policy and holds the nominal stance, a negative value inverts every
+            offset, and a ``nan``/``inf`` reaches ``data.ctrl`` as a poisoned
+            torque on all ``num_actions`` joints.
         obs_scales: Named scale factors applied to observation sub-vectors
             (``ang_vel`` / ``dof_pos`` / ``dof_vel``). Defaults match upstream
             g1_gear_wbc.yaml (ang_vel_scale=0.5, dof_pos_scale=1.0,
@@ -130,6 +174,9 @@ class WBCConfig:
     def __post_init__(self) -> None:
         # Fail-fast on dimension mistakes (AGENTS.md #5: raise on fatal errors,
         # never warn-and-continue with a config that will misbehave later).
+        # Dimensions first, then values: a wrong length is the likelier root
+        # cause (a config paired with the wrong checkpoint) and naming it first
+        # keeps its message the one a mismatched pair reports.
         if self.num_actions < 1:
             raise ValueError(f"WBCConfig.num_actions must be >= 1, got {self.num_actions}")
         if self.obs_history_len < 1:
@@ -153,9 +200,20 @@ class WBCConfig:
         # almost certainly means the config was paired with the wrong checkpoint.
         for name in ("default_angles", "kps", "kds"):
             vec = getattr(self, name)
-            if vec and len(vec) != self.num_actions:
+            length = sequence_length(vec)
+            if length is None:
+                # A value carrying no readable component count cannot be a
+                # per-joint vector. Asking first keeps a scalar or a 0-d array
+                # from reaching ``len()`` as a bare TypeError, and a NumPy
+                # vector from reaching ``if vec`` as the ambiguous-truth
+                # ValueError - neither of which names the field.
                 raise ValueError(
-                    f"WBCConfig.{name} has length {len(vec)} but num_actions={self.num_actions}; "
+                    f"WBCConfig.{name} must be a sequence of {self.num_actions} numbers "
+                    f"(or empty to use defaults), got {type(vec).__name__}."
+                )
+            if length and length != self.num_actions:
+                raise ValueError(
+                    f"WBCConfig.{name} has length {length} but num_actions={self.num_actions}; "
                     "they must match (or leave the field empty to use defaults)."
                 )
 
@@ -163,11 +221,48 @@ class WBCConfig:
         # exactly 3 entries when provided (upstream cmd_scale = [2.0, 2.0, 0.5]).
         # A wrong length is rejected rather than silently tolerated, matching the
         # per-joint vectors above.
-        if self.cmd_scale and len(self.cmd_scale) != 3:
+        cmd_scale_length = sequence_length(self.cmd_scale)
+        if cmd_scale_length is None:
+            raise ValueError(
+                "WBCConfig.cmd_scale must be a sequence of 3 numbers [vx, vy, omega] scale, "
+                f"got {type(self.cmd_scale).__name__}."
+            )
+        if cmd_scale_length and cmd_scale_length != 3:
             raise ValueError(
                 f"WBCConfig.cmd_scale must have exactly 3 entries [vx, vy, omega] scale, "
-                f"got {len(self.cmd_scale)}: {self.cmd_scale}."
+                f"got {cmd_scale_length}: {self.cmd_scale}."
             )
+
+        # Now the VALUES. The dimension rules above catch a config paired with
+        # the wrong checkpoint; these catch one whose numbers cannot be honored
+        # at all. Every field below is read verbatim into either the PD law that
+        # writes ``data.ctrl`` or the observation the network sees, and none of
+        # them is checked anywhere downstream: ``compute_targets`` is called
+        # per-tick from ``get_actions``, so a non-real ``action_scale`` surfaces
+        # as a bare ``TypeError`` from its ``float()`` after the ONNX sessions
+        # have loaded and the rollout has started - the mid-rollout failure this
+        # module exists to convert into a construction-time message - while a
+        # ``nan`` surfaces as nothing at all and silently poisons every torque.
+        if error := positive_finite_number_error(self.action_scale, "action_scale", "WBCConfig"):
+            raise ValueError(error)
+        for scalar_name in ("height_cmd", "freq_cmd"):
+            if error := finite_number_error(getattr(self, scalar_name), scalar_name, "WBCConfig"):
+                raise ValueError(error)
+        for vector_name in ("default_angles", "cmd_scale", "rpy_cmd"):
+            for index, component in enumerate(getattr(self, vector_name)):
+                if error := finite_number_error(component, f"{vector_name}[{index}]", "WBCConfig"):
+                    raise ValueError(error)
+        for gain_name in ("kps", "kds"):
+            for index, gain in enumerate(getattr(self, gain_name)):
+                if error := _non_negative_number_error(gain, f"{gain_name}[{index}]", "WBCConfig"):
+                    raise ValueError(error)
+        if not isinstance(self.obs_scales, Mapping):
+            raise ValueError(
+                f"WBCConfig.obs_scales must be a mapping of scale name to number, got {type(self.obs_scales).__name__}."
+            )
+        for scale_name, scale in self.obs_scales.items():
+            if error := finite_number_error(scale, f"obs_scales[{scale_name!r}]", "WBCConfig"):
+                raise ValueError(error)
 
     @property
     def num_obs(self) -> int:

--- a/tests/policies/wbc/test_wbc_config_value_domain.py
+++ b/tests/policies/wbc/test_wbc_config_value_domain.py
@@ -1,0 +1,268 @@
+"""Value-domain contracts for :class:`WBCConfig`.
+
+:meth:`WBCConfig.__post_init__` has always rejected impossible DIMENSIONS - a
+sub-minimal count, a per-joint vector whose length contradicts ``num_actions``.
+It did not reject impossible VALUES, and the two failures are not the same
+size. Every numeric field of this config is read verbatim into either the PD law
+that writes ``data.ctrl`` or the observation the network sees:
+
+* ``target_q = default_angles + action_scale * raw_action`` (``compute_targets``)
+* ``tau = (target_q - q) * kps + (0 - dq) * kds`` (``pd_control``)
+
+so an ``action_scale`` of ``0`` (or ``False``) makes ``target_q ==
+default_angles`` on every tick - the network's decision is discarded and the
+humanoid holds its nominal stance - and a ``nan`` anywhere makes ``tau`` ``nan``
+on all 15 driven joints. Neither is checked downstream: ``compute_targets`` runs
+per-tick inside ``get_actions``, so a non-real value surfaced as a bare
+``TypeError`` from its ``float()`` only after the ONNX sessions had loaded and
+the rollout had started, which is precisely the mid-rollout failure this module's
+docstring says it exists to convert into a construction-time message.
+
+These tests pin the value domain through the public surfaces a caller reaches -
+the constructor, ``from_dict`` and ``from_file`` (the config-FILE path a
+checkpoint's ``config.json`` and the upstream ``g1_gear_wbc.yaml`` both take) -
+and pin the values that remain first-class, so the guard cannot creep into
+refusing a controller a caller may legitimately ask for.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import WBCConfig
+from strands_robots.policies.wbc.config import _non_negative_number_error
+from strands_robots.policies.wbc.control import compute_targets, pd_control
+from strands_robots.utils import finite_number_error
+
+N = 15
+_GOOD_ANGLES = [-0.1, 0.0, 0.0, 0.3, -0.2, 0.0, -0.1, 0.0, 0.0, 0.3, -0.2, 0.0, 0.0, 0.0, 0.0]
+_GOOD_KPS = [150.0, 150.0, 150.0, 200.0, 40.0, 40.0, 150.0, 150.0, 150.0, 200.0, 40.0, 40.0, 250.0, 250.0, 250.0]
+_GOOD_KDS = [2.0, 2.0, 2.0, 4.0, 2.0, 2.0, 2.0, 2.0, 2.0, 4.0, 2.0, 2.0, 5.0, 5.0, 5.0]
+
+# Values no numeric field of this config can be honored as, whatever its sign
+# rule: a non-real one raises from the ``float()`` that consumes it, and a
+# non-finite one poisons whatever it multiplies.
+UNUSABLE_ANY_SIGN: list[Any] = [float("nan"), float("inf"), float("-inf"), True, False, "0.5", None, [0.5], 10**400]
+
+
+def _config(**kwargs: Any) -> WBCConfig:
+    """Build a config through one funnel.
+
+    These tests deliberately supply values outside the declared field types (a
+    string where a ``float`` is annotated, a list where a scalar is), which is
+    the point - the runtime is what must refuse them. Splatting through one
+    ``**kwargs: Any`` funnel states that intent once instead of scattering a
+    suppression over every call.
+    """
+    base: dict[str, Any] = {
+        "policy_path": "p.onnx",
+        "num_actions": N,
+        "default_angles": list(_GOOD_ANGLES),
+        "kps": list(_GOOD_KPS),
+        "kds": list(_GOOD_KDS),
+    }
+    return WBCConfig(**{**base, **kwargs})
+
+
+class TestActionScaleDomain:
+    """``action_scale`` is the only path from the network to the joint targets."""
+
+    @pytest.mark.parametrize("value", [0, 0.0, -0.25, *UNUSABLE_ANY_SIGN])
+    def test_an_unusable_action_scale_is_refused_at_construction(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"action_scale"):
+            _config(action_scale=value)
+
+    @pytest.mark.parametrize("value", [0.25, 1.0, 0.05, np.float32(0.25), np.float64(0.5), 1])
+    def test_a_usable_action_scale_still_builds(self, value: Any) -> None:
+        assert float(_config(action_scale=value).action_scale) == pytest.approx(float(value))
+
+    def test_the_refusal_names_the_field_and_the_value(self) -> None:
+        with pytest.raises(ValueError, match=r"WBCConfig: action_scale must be > 0, got 0\.0\."):
+            _config(action_scale=0.0)
+
+
+class TestWhyTheActionScaleDomainIsWhatItIs:
+    """The refused values are refused because the PD chain cannot honor them.
+
+    Derived from the two functions the config feeds rather than asserted from a
+    message, so the domain stays tied to the consequence that motivates it.
+    """
+
+    @staticmethod
+    def _torque(action_scale: Any) -> np.ndarray:
+        raw = np.full(N, 0.5)  # a network asking every joint 0.5 rad off stance
+        q = np.asarray(_GOOD_ANGLES)  # measured == stance
+        target_q = compute_targets(np.asarray(_GOOD_ANGLES), raw, action_scale)
+        return pd_control(target_q, q, np.asarray(_GOOD_KPS), np.zeros(N), np.zeros(N), np.asarray(_GOOD_KDS))
+
+    def test_a_usable_scale_carries_the_network_decision_into_torque(self) -> None:
+        assert np.all(np.abs(self._torque(0.25)) > 1.0)
+
+    def test_a_zero_scale_would_have_produced_exactly_zero_torque(self) -> None:
+        # The whole network output discarded: target_q == default_angles, so the
+        # PD law has no error to act on. docs/policies/wbc.md states WBC "never
+        # falls back to silent zero torques" - this is that fallback.
+        assert np.array_equal(self._torque(0.0), np.zeros(N))
+
+    def test_a_negative_scale_would_have_inverted_every_torque(self) -> None:
+        assert np.all(np.sign(self._torque(-0.25)) == -np.sign(self._torque(0.25)))
+
+    def test_a_non_finite_scale_would_have_poisoned_every_driven_joint(self) -> None:
+        assert np.all(np.isnan(self._torque(float("nan"))))
+
+    def test_a_non_real_scale_would_have_raised_from_the_per_tick_float(self) -> None:
+        # compute_targets is called from get_actions, i.e. after the ONNX
+        # sessions have loaded and the rollout is already running.
+        with pytest.raises(TypeError):
+            self._torque(None)
+
+
+class TestGainDomain:
+    """A PD gain may be zero; it may not be negative or non-finite."""
+
+    @pytest.mark.parametrize("name", ["kps", "kds"])
+    @pytest.mark.parametrize("value", UNUSABLE_ANY_SIGN)
+    def test_an_unusable_gain_component_is_refused(self, name: str, value: Any) -> None:
+        with pytest.raises(ValueError, match=rf"{name}\[3\]"):
+            _config(**{name: [*(_GOOD_KPS[:3]), value, *(_GOOD_KPS[4:])]})
+
+    @pytest.mark.parametrize("name", ["kps", "kds"])
+    def test_a_negative_gain_is_refused_because_it_inverts_the_feedback(self, name: str) -> None:
+        with pytest.raises(ValueError, match=rf"WBCConfig: {name}\[0\] must be >= 0, got -150\.0\."):
+            _config(**{name: [-150.0, *(_GOOD_KPS[1:])]})
+
+    @pytest.mark.parametrize("name", ["kps", "kds"])
+    def test_a_zero_gain_stays_first_class(self, name: str) -> None:
+        # kp=0 with kd>0 is a pure-damping joint - a controller a caller may
+        # legitimately ask for, so the floor is >= 0 and not > 0.
+        assert getattr(_config(**{name: [0.0] * N}), name) == [0.0] * N
+
+    def test_the_upstream_g1_sonic_gains_still_build(self) -> None:
+        config = _config()
+        assert config.kps == _GOOD_KPS
+        assert config.kds == _GOOD_KDS
+
+
+class TestObservationAndCommandScaleDomain:
+    """The fields that scale what the network sees or is commanded to do."""
+
+    @pytest.mark.parametrize("name", ["height_cmd", "freq_cmd"])
+    @pytest.mark.parametrize("value", UNUSABLE_ANY_SIGN)
+    def test_an_unusable_command_scalar_is_refused(self, name: str, value: Any) -> None:
+        with pytest.raises(ValueError, match=rf"WBCConfig: {name} must be"):
+            _config(**{name: value})
+
+    @pytest.mark.parametrize("name", ["cmd_scale", "rpy_cmd"])
+    @pytest.mark.parametrize("value", UNUSABLE_ANY_SIGN)
+    def test_an_unusable_command_vector_component_is_refused(self, name: str, value: Any) -> None:
+        with pytest.raises(ValueError, match=rf"{name}\[1\]"):
+            _config(**{name: [0.5, value, 0.5]})
+
+    @pytest.mark.parametrize("value", UNUSABLE_ANY_SIGN)
+    def test_an_unusable_observation_scale_is_refused_naming_its_key(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"obs_scales\['dof_vel'\]"):
+            _config(obs_scales={"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": value})
+
+    def test_obs_scales_must_be_a_mapping(self) -> None:
+        with pytest.raises(ValueError, match=r"obs_scales must be a mapping"):
+            _config(obs_scales="ang_vel")
+
+    def test_a_signed_command_stays_first_class(self) -> None:
+        # rpy_cmd carries roll/pitch/yaw and default_angles a stance: negative
+        # entries are ordinary, so these fields constrain finiteness only.
+        config = _config(rpy_cmd=[-0.2, 0.0, 0.1], cmd_scale=[-2.0, 2.0, 0.5])
+        assert config.rpy_cmd == [-0.2, 0.0, 0.1]
+        assert config.cmd_scale == [-2.0, 2.0, 0.5]
+
+    def test_the_upstream_defaults_still_build(self) -> None:
+        config = WBCConfig(policy_path="p.onnx")
+        assert config.obs_scales == {"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05}
+        assert config.cmd_scale == [2.0, 2.0, 0.5]
+        assert (config.height_cmd, config.freq_cmd, config.action_scale) == (0.74, 0.75, 0.25)
+
+
+class TestTheDimensionChecksStayTotal:
+    """A field that carries no readable length gets a reason, not a bare error."""
+
+    @pytest.mark.parametrize("name", ["default_angles", "kps", "kds"])
+    @pytest.mark.parametrize("value", [5.0, np.float64(5.0), np.array(5.0)])
+    def test_a_scalar_per_joint_field_reports_the_field(self, name: str, value: Any) -> None:
+        # ``len()`` raises for a plain float and for a 0-d array (whose __len__
+        # exists and refuses), naming neither the field nor the class.
+        with pytest.raises(ValueError, match=rf"WBCConfig\.{name} must be a sequence of 15 numbers"):
+            _config(**{name: value})
+
+    def test_a_scalar_cmd_scale_reports_the_field(self) -> None:
+        with pytest.raises(ValueError, match=r"WBCConfig\.cmd_scale must be a sequence of 3 numbers"):
+            _config(cmd_scale=2.0)
+
+    @pytest.mark.parametrize("name", ["default_angles", "kps", "kds"])
+    def test_a_numpy_per_joint_vector_of_the_right_width_is_accepted(self, name: str) -> None:
+        # Previously ``if vec and ...`` raised the ambiguous-truth ValueError for
+        # any multi-element array, so a NumPy vector could not be supplied at all.
+        assert len(getattr(_config(**{name: np.full(N, 1.0)}), name)) == N
+
+    def test_the_length_mismatch_message_is_unchanged(self) -> None:
+        with pytest.raises(ValueError, match=r"kps has length 3 but num_actions=15"):
+            _config(kps=[1.0, 2.0, 3.0])
+
+    def test_a_dimension_mistake_is_reported_before_a_value_mistake(self) -> None:
+        # A config paired with the wrong checkpoint is the likelier root cause,
+        # so its message stays the one such a pair reports.
+        with pytest.raises(ValueError, match=r"has length 2 but num_actions=15"):
+            _config(kps=[1.0, float("nan")])
+
+
+class TestTheConfigFilePathIsCovered:
+    """``from_dict`` / ``from_file`` are how a checkpoint's config arrives."""
+
+    def test_from_dict_refuses_an_unusable_action_scale(self) -> None:
+        with pytest.raises(ValueError, match=r"action_scale must be > 0"):
+            WBCConfig.from_dict({"policy_path": "p.onnx", "action_scale": 0})
+
+    def test_from_dict_refuses_an_unusable_flat_upstream_scale_key(self) -> None:
+        # The upstream YAML spells the observation scales flat; the normalised
+        # value must face the same domain as an explicit obs_scales map.
+        with pytest.raises(ValueError, match=r"obs_scales\['ang_vel'\]"):
+            WBCConfig.from_dict({"policy_path": "p.onnx", "ang_vel_scale": float("inf")})
+
+    def test_from_file_refuses_an_unusable_value(self, tmp_path: Path) -> None:
+        path = tmp_path / "wbc.json"
+        path.write_text(json.dumps({"policy_path": "p.onnx", "kps": [150.0] * 14 + [-1.0]}))
+        with pytest.raises(ValueError, match=r"kps\[14\] must be >= 0"):
+            WBCConfig.from_file(path)
+
+    def test_from_file_still_loads_a_usable_config(self, tmp_path: Path) -> None:
+        path = tmp_path / "wbc.json"
+        path.write_text(json.dumps({"policy_path": "p.onnx", "action_scale": 0.25, "kps": _GOOD_KPS}))
+        assert WBCConfig.from_file(path).kps == _GOOD_KPS
+
+
+class TestTheGainFloorIsTheOnlyLocalRule:
+    """The local gain guard adds a floor to the shared numeric rule, nothing else."""
+
+    @pytest.mark.parametrize("value", [*UNUSABLE_ANY_SIGN, 0.0, 0, 1.5, np.float32(2.0), -1.5])
+    def test_it_agrees_with_the_shared_guard_except_on_the_floor(self, value: Any) -> None:
+        shared = finite_number_error(value, "kps[0]", "WBCConfig")
+        local = _non_negative_number_error(value, "kps[0]", "WBCConfig")
+        if shared is not None:
+            assert local == shared, "a value the shared rule rejects must be reported in its words"
+        else:
+            below_floor = float(value) < 0.0
+            assert (local is not None) is below_floor
+            if below_floor:
+                assert "must be >= 0" in local  # type: ignore[operator]
+
+    def test_it_accepts_the_zero_the_positive_guard_would_refuse(self) -> None:
+        assert _non_negative_number_error(0.0, "kds[0]", "WBCConfig") is None
+
+    def test_a_non_finite_value_is_reported_as_non_finite_not_as_below_the_floor(self) -> None:
+        message = _non_negative_number_error(float("nan"), "kps[0]", "WBCConfig")
+        assert message is not None and "must be a finite number" in message
+        assert not math.isfinite(float("nan"))


### PR DESCRIPTION
`WBCConfig.__post_init__` rejected impossible **dimensions** and accepted every numeric **value**. Its own comment says so - *"Fail-fast on dimension mistakes"* - and the module docstring gives the reason those dimensions are checked there: so a mistake surfaces *"at construction with a clear message, not as an opaque ONNX shape error mid-rollout"*. A bad value did the opposite.

Every numeric field of this config is read verbatim into either the SONIC PD law that writes `data.ctrl` or the observation the network sees:

```
target_q = default_angles + action_scale * raw_action     # compute_targets
tau      = (target_q - q) * kps + (0 - dq) * kds          # pd_control
```

so an unusable one became a wrong torque rather than an error.

## Measured

A real MuJoCo `unitree_g1`, headless, driven by the real chain: a stub ONNX session asks every one of the 15 driven joints for a `+0.35 rad` offset off its nominal stance. The honored config stands at 0.721 m on a 21.5 Nm peak.

| config a caller supplies | on `main` | with this change |
|---|---|---|
| `action_scale=0.0` | `status="success"` - 5.7 Nm peak, base sags to **0.309 m**, the network output discarded entirely (`target_q == default_angles` every tick) | `WBCConfig: action_scale must be > 0, got 0.0.` |
| `action_scale=nan` | `status="error"` naming the **embodiment** - *"almost certainly running the wrong embodiment"* - after **0.0 Nm** was ever commanded | `WBCConfig: action_scale must be > 0, got nan.` |
| `kps=[-150.0]*15` | `status="success"` - **461.9 Nm** (21x honored), `(target_q - q) * kp` driving every joint *away* from its target, collapse to **0.186 m** | `WBCConfig: kps[0] must be >= 0, got -150.0.` |
| `obs_scales['ang_vel']=inf` | `status="success"` - the observation frame the network is given is poisoned | `WBCConfig: obs_scales['ang_vel'] must be a finite number, got inf.` |
| `kps=5.0` (a scalar) | bare `TypeError: object of type 'float' has no len()` | `WBCConfig.kps must be a sequence of 15 numbers (or empty to use defaults), got float.` |
| `action_scale=None` | bare `TypeError` from the per-tick `float()` in `compute_targets` - i.e. **after** the ONNX sessions loaded and the rollout started | refused at construction |

`docs/policies/wbc.md` states WBC *"never falls back to silent zero torques"*. The first row is that fallback, reported as success.

![WBCConfig value domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/wbc-config-value-domain/wbc_config_value_domain.png)

Left panel is the honored config; the other three are what `main` does. Every number is re-derived from the two runs' JSON dumps, which are published beside the figure ([raw evidence](https://github.com/cagataycali/robots/tree/artifacts/wbc-config-value-domain), including each tree's own path so the before/after pair is provably two trees and not two runs of one).

## Change

`__post_init__` gains a value block, after the existing dimension rules so a config paired with the wrong checkpoint keeps its current message:

| field | accepted | why that domain |
|---|---|---|
| `action_scale` | finite `> 0` | the only path from the network to the joint targets, so `0` (or `False`) discards the policy and a negative value inverts every offset |
| `kps`, `kds` | finite `>= 0` per component | `kp = 0` with `kd > 0` is a pure-damping joint and **stays first-class**; a negative gain is positive feedback |
| `default_angles`, `cmd_scale`, `rpy_cmd` | finite per component | signed quantities (a stance angle, a yaw rate, a roll target), so only finiteness is constrained |
| `obs_scales` values, `height_cmd`, `freq_cmd` | finite | a non-finite scale poisons the observation frame |

The numeric rules come from `utils` (`positive_finite_number_error`, `finite_number_error`); the only local addition is `_non_negative_number_error`, which delegates numeric-ness and finiteness to the shared guard and decides **only** the floor - so a value the shared rule rejects is reported in its words. `positive_finite_number_error` cannot express that domain (it refuses the first-class zero), and the library's only non-negative continuous guard lives under `strands_robots.simulation`, which `strands_robots.policies` must not depend on. A test loops both functions over the whole probe set and asserts they agree everywhere except the floor.

The existing dimension checks also became **total** via `sequence_length`: a per-joint field carrying no readable length now names the field instead of reaching `len()` as a bare `TypeError`, and a NumPy vector of the right width is accepted rather than reaching `if vec` as the ambiguous-truth `ValueError`. That is not a new dimension rule - it is the existing one no longer failing on the path that exists to report it.

## Scope

Values only. No new dimension rule is added (`rpy_cmd` still has no length check), and the sign question is decided per field from what the consumer can honor rather than uniformly - which is why a zero gain, a negative stance angle and a negative `cmd_scale` component all still build.

## Tests

`tests/policies/wbc/test_wbc_config_value_domain.py`, 130 tests. One class derives the domain from the two functions the config feeds (`compute_targets` -> `pd_control`) rather than asserting a message, so it stays tied to the consequence: a usable scale carries the decision into torque, a zero produces *exactly* zero, a negative inverts every sign, a `nan` poisons all 15 joints, and a `None` raises from the per-tick `float()`. The rest pin the refusals through the surfaces a caller reaches - the constructor, `from_dict`, and `from_file` (the config-file path a checkpoint's `config.json` and the upstream `g1_gear_wbc.yaml` both take) - plus the values that stay first-class.

**Pre-fix proof** (source reverted to the base, tests kept, the one new private symbol replaced by a local declaration of the contract so every behavioural test runs rather than the module failing at collection): **95 failed / 35 passed**. Post-fix **130 passed**. The 35 that pass pre-fix are the over-reach controls (usable values still build) and the pure-numpy consequence derivations, which the fix does not touch - they are what stops the guard reaching further than the values it must refuse.

## Gate

At `be428ef7`:

- `MUJOCO_GL=egl python -m pytest tests` - **21767 passed, 257 skipped, 0 failed** (554.90s)
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` - clean (1090 files)
- `mypy strands_robots tests tests_integ` - **0 errors outside `examples/`**; the 14 in `examples/isaac_gs` are byte-identical to a pristine `upstream/main` worktree of the same working copy (environmental, not from this branch)
- **zero existing-test churn** - no message any test pins was changed; the length-mismatch text is preserved verbatim and a dimension mistake is still reported before a value mistake
- honored path unchanged end to end: same status, same base height (0.793 -> 0.7213 m), same peak torque (21.5217 Nm), renders differing by max 1/255 over 10 of 668,800 pixels