### PR TITLE
fix(policies/vera): refuse a translation_scale or ik_smoothing the IK path cannot honor

### DIFF
--- a/changelog.d/1992-vera-ik-numeric-domains.md
+++ b/changelog.d/1992-vera-ik-numeric-domains.md
@@ -1,0 +1,33 @@
+### Fixed: the VERA IK path refuses a `translation_scale` or `ik_smoothing` it cannot honor
+
+`VeraPolicy` turns the server's end-effector delta chunk into joint targets
+inside `get_actions`, and two caller-supplied numbers shaped every target it
+produced without a domain between them and the arm. Both are *applied* rather
+than forwarded, so nothing downstream refused an unusable value — it became a
+plausible-looking chunk of joint targets instead of an error.
+
+`translation_scale` (`VeraPolicy.set_ik_target`, and
+`decode_vera_delta_chunk_to_targets` directly) multiplies every translation
+delta. `0` discarded the translation half of every action and returned a
+rotation-only chunk under a `tracking_error` reporting a perfect solve; a
+negative value inverted it; and `nan`/`inf` made **every** returned joint target
+non-finite, along with the `tracking_error` that would otherwise have reported
+it — `send_action` then refused each target for being non-finite, which reads as
+a wrong-embodiment action-key mismatch rather than as the scale that caused it.
+It now takes the same positive-finite domain as the two sibling action
+multipliers, `SimEnv.action_scale` and `WBCConfig.action_scale`.
+
+`ik_smoothing` (`VeraPolicy(...)`) weights the previous joint target in the EMA
+`target = (1 - alpha) * solved + alpha * previous`, and its own comment already
+recorded the interval it needs — `alpha in [0,1); 0 disables` — without
+enforcing it. `1.0` (and `True`, which is `1.0`) made every commanded target the
+previous one, so the arm froze at the pose the first solve produced and the rest
+of the chunk was discarded; above `1.0` the weight on the IK solution turned
+negative and the targets diverged away from it, measured at `-5.9x` the solved
+joint travel for `1.5` and `-35.3x` for `2.0`; and a negative or `nan`
+coefficient failed the `alpha > 0` test the blend is gated on, so the damping the
+caller asked for was silently never applied. It is now checked against that
+interval before any config or server work.
+
+A structural test asserts every public VERA surface reading either knob routes
+through a domain, so a third one cannot be added without one.

--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -153,6 +153,29 @@ differently by each of them. `vis_port = 0` is the one exception and disables th
 live viewer (`--vis-port` is omitted). The `VERA_*_PORT` overrides go through the
 same check.
 
+### IK conversion knobs
+
+Two keyword-only numbers shape every joint target the eef-delta path produces,
+and both are checked where they are supplied because both are *applied* rather
+than forwarded — nothing downstream can refuse them:
+
+| kwarg | surface | domain |
+|-------|---------|--------|
+| `translation_scale` | `set_ik_target(...)`, `decode_vera_delta_chunk_to_targets(...)` | a positive finite number (`None` on the setter leaves the current value) |
+| `ik_smoothing` | `VeraPolicy(...)` | `[0, 1)` — `0` disables the smoothing |
+
+`translation_scale` multiplies every translation delta on top of the OSC position
+scale, so `0` discards the translation half of each action and returns a
+rotation-only chunk, a negative value inverts it, and `nan`/`inf` make *every*
+returned joint target non-finite — refused one layer later by `send_action`,
+where it reads as a wrong-embodiment action-key mismatch rather than as the scale
+that caused it. `ik_smoothing` weights the *previous* target in the EMA
+`target = (1 - alpha) * solved + alpha * previous`, so `1.0` freezes the arm at
+its first solved pose, above `1.0` the targets diverge away from the solution
+(measured at `-5.9x` the solved joint travel for `1.5`), and a negative or `nan`
+value fails the `alpha > 0` test the blend is gated on — silently applying no
+smoothing at all.
+
 ## Wire protocol
 
 The provider keeps a rolling **context window** of the last `context_frames`

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -334,16 +334,19 @@ class VeraPolicy(Policy):
                 finite number, since it scales every translation delta the
                 policy converts to joint targets.
         """
+        # Validate before mutating any state, so a refused call leaves the
+        # policy untouched (guard-before-mutation discipline).
+        if translation_scale is not None:
+            if (
+                err := positive_finite_number_error(translation_scale, "translation_scale", "set_ik_target")
+            ) is not None:
+                raise ValueError(err)
         self._mj_model = mj_model
         self._ee_frame_name = ee_frame_name
         self._ee_frame_type = ee_frame_type
         if rotation_dim is not None:
             self._rotation_dim = int(rotation_dim)
         if translation_scale is not None:
-            if (
-                err := positive_finite_number_error(translation_scale, "translation_scale", "set_ik_target")
-            ) is not None:
-                raise ValueError(err)
             self._translation_scale = float(translation_scale)
         self._ik_bridge = None  # force rebuild
 

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -41,13 +41,67 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import name_list_error
+from strands_robots.utils import finite_number_error, name_list_error, positive_finite_number_error
 
 from .client import VeraWebsocketClient
 from .config import VeraConfig
 from .server_runner import VeraServerRunner, make_server_runner
 
 logger = logging.getLogger(__name__)
+
+
+#: Upper bound (exclusive) on the IK output-smoothing coefficient. ``alpha``
+#: weights the *previous* joint target in the EMA
+#: ``target = (1 - alpha) * solved + alpha * previous``, so ``1.0`` weights the
+#: previous value alone and the arm never leaves the pose it was first solved
+#: to; anything above ``1.0`` puts a negative weight on the IK solution and the
+#: targets diverge away from it, growing without bound down the chunk.
+MAX_IK_SMOOTHING = 1.0
+
+
+def _ik_smoothing_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable IK output-smoothing coefficient.
+
+    The EMA blending each IK solution toward the previous target only has a
+    meaning for ``alpha`` in ``[0, 1)``: ``0`` disables the smoothing (the
+    documented default) and a value approaching ``1`` damps harder. Outside that
+    interval the blend is not a smoother:
+
+    * ``1.0`` (and ``True``, which is ``1.0``) makes every commanded target the
+      previous one, so the arm freezes at the pose the first solve produced and
+      the whole chunk is discarded.
+    * above ``1.0`` the weight on the IK solution is negative, so each target
+      extrapolates *away* from where the solver put it - measured at ``-5.9x``
+      the solved joint travel for ``1.5`` and ``-35.3x`` for ``2.0``.
+    * a negative value and ``nan`` both fail the ``alpha > 0`` test the EMA is
+      gated on, so the smoothing the caller asked for is silently not applied.
+    * ``inf`` makes every target after the first non-finite.
+
+    Only the interval is decided here; numeric-ness, ``bool`` rejection and
+    finiteness are :func:`~strands_robots.utils.finite_number_error`'s, whose
+    domain this is a bounded subset of. The rule is private to this module
+    because the interval is a property of this EMA rather than of a shared
+    quantity - :func:`~strands_robots.utils.positive_finite_number_error` is the
+    nearest shared domain and its ``> 0`` floor is wrong here, since ``0`` is
+    the documented "no smoothing" default.
+
+    Args:
+        value: The caller-supplied coefficient.
+        param: The parameter it came from, used in the message.
+        context: Message prefix identifying the surface that received it.
+
+    Returns:
+        An error message, or ``None`` when the value is usable.
+    """
+    if (err := finite_number_error(value, param, context)) is not None:
+        return err
+    if not 0.0 <= float(value) < MAX_IK_SMOOTHING:
+        return (
+            f"{context}: {param} must be in [0, {MAX_IK_SMOOTHING}) - 0 disables "
+            f"the smoothing, and {MAX_IK_SMOOTHING} would weight only the previous "
+            f"target so the arm never leaves its first solved pose. Got {value!r}."
+        )
+    return None
 
 
 def _is_image_value(value: Any) -> bool:
@@ -165,6 +219,12 @@ class VeraPolicy(Policy):
         # policy server has been launched and the model loaded.
         if image_keys and (err := name_list_error(image_keys, "image_keys", "VeraPolicy")):
             raise ValueError(err)
+        # Same reason, same place: the smoothing coefficient blends every
+        # commanded joint target with the previous one inside get_actions, so
+        # a value outside [0, 1) freezes or diverges the arm mid-rollout
+        # instead of damping it.
+        if (err := _ik_smoothing_error(ik_smoothing, "ik_smoothing", "VeraPolicy")) is not None:
+            raise ValueError(err)
         self.config = config or VeraConfig(
             embodiment=embodiment,  # type: ignore[arg-type]
             host=host,
@@ -268,7 +328,11 @@ class VeraPolicy(Policy):
             ee_frame_type: ``"body"`` | ``"site"`` | ``"geom"``.
             rotation_dim: Override the delta rotation encoding (3=axis-angle,
                 6=rot6d). Defaults to the embodiment's convention.
-            translation_scale: Optional scale on the translation delta.
+            translation_scale: Multiplier on the translation delta, composed
+                on top of the OSC position scale. ``None`` (the default)
+                leaves the current value; a supplied one must be a positive
+                finite number, since it scales every translation delta the
+                policy converts to joint targets.
         """
         self._mj_model = mj_model
         self._ee_frame_name = ee_frame_name
@@ -276,6 +340,10 @@ class VeraPolicy(Policy):
         if rotation_dim is not None:
             self._rotation_dim = int(rotation_dim)
         if translation_scale is not None:
+            if (
+                err := positive_finite_number_error(translation_scale, "translation_scale", "set_ik_target")
+            ) is not None:
+                raise ValueError(err)
             self._translation_scale = float(translation_scale)
         self._ik_bridge = None  # force rebuild
 

--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from strands_robots.simulation.ik import MinkIKBridge as _SharedMinkIKBridge
 from strands_robots.simulation.ik import resolve_qp_solver
+from strands_robots.utils import positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -140,11 +141,36 @@ def decode_vera_delta_chunk_to_targets(
         has_gripper: Whether the chunk carries a trailing gripper column.
         gripper_dim_index: Index of the gripper column (``-1`` => last when
             ``has_gripper``); the value is passed through (binarized by caller).
-        translation_scale: Optional scale on the translation delta (units match).
+        translation_scale: Multiplier on the translation delta, composed on
+            top of the OSC position scale (units match). Must be a positive
+            finite number; see the ``Raises`` section for why.
+
+    Raises:
+        ValueError: If ``action_chunk`` is not ``[T, D]``, if it carries too
+            few pose dims, or if ``translation_scale`` is not a positive
+            finite number. The scale multiplies every translation delta in
+            the chunk, so an unusable one is not refused by anything
+            downstream: ``0`` discards the translation half of every action
+            and returns only the rotation, a negative value inverts it, and
+            ``nan``/``inf`` make **every** returned joint target non-finite
+            (along with the ``tracking_error`` that would otherwise report
+            it). ``send_action`` then refuses each of those targets for
+            being non-finite, which reads as a wrong-embodiment action-key
+            mismatch rather than as the scale that caused it.
 
     Returns:
         ``{"qpos": [T, nq], "gripper": [T] | None, "tracking_error": {...}}``.
     """
+    # Refused before the first IK solve. This multiplies every translation
+    # delta in the chunk, so an unusable value is applied rather than
+    # rejected - see Raises. The domain matches the two sibling action
+    # multipliers (``SimEnv.action_scale``, ``WBCConfig.action_scale``).
+    if (
+        err := positive_finite_number_error(
+            translation_scale, "translation_scale", "decode_vera_delta_chunk_to_targets"
+        )
+    ) is not None:
+        raise ValueError(err)
     action_chunk = np.asarray(action_chunk, dtype=np.float64)
     if action_chunk.ndim != 2:
         raise ValueError(f"action_chunk must be [T, D]; got {action_chunk.shape}")

--- a/tests/policies/vera/test_vera_ik_numeric_domains.py
+++ b/tests/policies/vera/test_vera_ik_numeric_domains.py
@@ -250,10 +250,10 @@ class _StubClient:
         return {}
 
     def reset(self, info: Any) -> None:
-        del info
+        _ = info
 
     def configure(self, params: Any) -> dict[str, Any]:
-        del params
+        _ = params
         return {}
 
     def close(self) -> None:
@@ -360,10 +360,17 @@ class TestTheIntervalIsTheWholeLocalContribution:
 class TestNothingIsConfiguredByARefusedValue:
     def test_a_refused_scale_leaves_the_previous_one_in_place(self) -> None:
         policy = _policy()
-        policy.set_ik_target(object(), "hand", "body", translation_scale=2.5)
+        original_model = object()
+        policy.set_ik_target(original_model, "hand", "body", translation_scale=2.5)
+        original_bridge = policy._ik_bridge
         with pytest.raises(ValueError):
             policy.set_ik_target(object(), "elbow", "site", translation_scale=float("nan"))
         assert policy._translation_scale == 2.5
+        # Guard-before-mutation: nothing else changed either.
+        assert policy._mj_model is original_model
+        assert policy._ee_frame_name == "hand"
+        assert policy._ee_frame_type == "body"
+        assert policy._ik_bridge is original_bridge
 
     def test_a_refused_coefficient_precedes_the_config(self) -> None:
         """The guard runs before ``VeraConfig`` is built, so nothing is left half-configured."""
@@ -400,10 +407,10 @@ class TestTheGuardsSurviveARealRollout:
                 }
 
             def reset(self, info: Any) -> None:
-                del info
+                _ = info
 
             def configure(self, params: Any) -> dict[str, Any]:
-                del params
+                _ = params
                 return {}
 
             def infer(self, request: Any) -> dict[str, Any]:

--- a/tests/policies/vera/test_vera_ik_numeric_domains.py
+++ b/tests/policies/vera/test_vera_ik_numeric_domains.py
@@ -1,0 +1,493 @@
+"""The VERA IK path's two numeric knobs are refused when they cannot be honored.
+
+``VeraPolicy`` converts the server's end-effector delta chunk into joint targets
+inside :meth:`get_actions`, and two caller-supplied numbers shape every target it
+produces:
+
+* ``translation_scale`` multiplies every translation delta before the IK solve
+  (:func:`~strands_robots.policies.vera.sim_ik.decode_vera_delta_chunk_to_targets`,
+  also settable on :meth:`VeraPolicy.set_ik_target`), and
+* ``ik_smoothing`` blends each solved target with the previous one
+  (``VeraPolicy(ik_smoothing=...)``).
+
+Both were read with a bare ``float()``. Neither is refused by anything
+downstream, because both are *applied* rather than forwarded: the scale
+multiplies a delta and the coefficient weights a blend, so an unusable value
+produces a plausible-looking chunk of joint targets rather than an error. The
+classes below measure what those chunks are - the arm frozen, diverging,
+undamped, translating the wrong way, or non-finite throughout - and then pin the
+domains that refuse them.
+
+The behavioural classes drive the real conversion against a pure-numpy stub
+bridge (``decode_vera_delta_chunk_to_targets`` touches only ``solve``,
+``ee_pose`` and ``model.nq``), so nothing here needs ``mink`` or ``mujoco``.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import math
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.vera import provider as provider_mod
+from strands_robots.policies.vera.provider import MAX_IK_SMOOTHING, VeraPolicy
+from strands_robots.policies.vera.sim_ik import decode_vera_delta_chunk_to_targets
+from strands_robots.utils import finite_number_error, positive_finite_number_error
+
+# Values no caller can have meant for either knob: a wrong type, a non-finite
+# number, or a bool (an ``int`` subclass whose ``True`` acts as a silent 1.0).
+UNUSABLE_FOR_BOTH: list[Any] = [
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    False,
+    "0.5",
+    [0.5],
+    {},
+]
+#: Additionally unusable as a positive multiplier.
+UNUSABLE_SCALES: list[Any] = [*UNUSABLE_FOR_BOTH, 0.0, -0.0, -1.0]
+#: Additionally outside the smoothing interval ``[0, 1)``.
+UNUSABLE_SMOOTHINGS: list[Any] = [*UNUSABLE_FOR_BOTH, 1.0, 1.5, 2.0, -0.5]
+
+
+class _CartesianStubBridge:
+    """A perfect 3-DoF cartesian arm: ``q[:3]`` *is* the end-effector position.
+
+    Makes the accumulated translation the IK path produces exactly readable, so
+    a test can assert on metres of end-effector travel rather than on joint
+    angles. ``decode_vera_delta_chunk_to_targets`` needs nothing else from a
+    bridge.
+    """
+
+    class _Model:
+        nq = 3
+
+    model = _Model()
+
+    def ee_pose(self, qpos: Any) -> np.ndarray:
+        pose = np.eye(4, dtype=np.float64)
+        pose[:3, 3] = np.asarray(qpos, dtype=np.float64)[:3]
+        return pose
+
+    def solve(self, target_pose: Any, q_init: Any) -> np.ndarray:
+        del q_init
+        return np.asarray(target_pose, dtype=np.float64)[:3, 3].copy()
+
+
+def _descend_chunk(steps: int = 8) -> np.ndarray:
+    """A chunk asking for a saturated straight-down translation each step."""
+    chunk = np.zeros((steps, 7), dtype=np.float64)
+    chunk[:, 2] = -1.0  # saturated -z translation delta
+    chunk[:, 6] = 1.0  # gripper open
+    return chunk
+
+
+def _decode(bridge: Any, translation_scale: Any, q_init: Any = None) -> Any:
+    """Call the decoder through one deliberately untyped funnel.
+
+    The bridges above are duck-typed on purpose - the decoder touches only
+    ``solve``, ``ee_pose`` and ``model.nq``, so a stub needs neither ``mink`` nor
+    ``mujoco`` - while the production signature names the concrete
+    ``MinkIKBridge``. Routing every call through one ``Any``-typed helper states
+    that once rather than a suppression per call site, and does the same for the
+    scales these tests deliberately supply out of domain.
+    """
+    return decode_vera_delta_chunk_to_targets(
+        _descend_chunk(),
+        bridge,
+        np.zeros(3, dtype=np.float64) if q_init is None else q_init,
+        rotation_dim=3,
+        has_gripper=True,
+        translation_scale=translation_scale,
+    )
+
+
+def _ee_travel(translation_scale: Any) -> np.ndarray:
+    """End-effector displacement (m) the IK path produces for a scale."""
+    q0 = np.zeros(3, dtype=np.float64)
+    out = _decode(_CartesianStubBridge(), translation_scale, q0)
+    qpos = np.asarray(out["qpos"], dtype=np.float64)
+    return qpos[-1] - q0
+
+
+class TestWhyTheTranslationScaleDomainIsPositiveFinite:
+    """Measure what an out-of-domain scale does to the joint targets.
+
+    Not a restatement of the guard: each test drives the real conversion and
+    asserts the chunk it returns, which is the evidence that the value is
+    applied rather than rejected somewhere downstream.
+    """
+
+    def test_a_usable_scale_descends_by_the_scaled_delta(self) -> None:
+        """The reference: 8 saturated -z steps at the OSC scale descend 8 * 0.05 m."""
+        travel = _ee_travel(1.0)
+        assert travel[2] == pytest.approx(-0.40, abs=1e-9)
+        assert travel[0] == pytest.approx(0.0)
+        assert travel[1] == pytest.approx(0.0)
+
+    def test_a_zero_scale_discards_the_translation_half_of_every_action(self) -> None:
+        """``0`` returns a chunk that only rotates - the translation is gone.
+
+        Not a refusal and not an error: the caller receives ``T`` joint targets
+        and a ``tracking_error`` reporting a perfect solve, because the target it
+        tracked perfectly was the arm's current position.
+        """
+        with pytest.raises(ValueError):
+            _decode(_CartesianStubBridge(), 0.0)
+        # The pre-fix behaviour this refusal replaces, reproduced from the
+        # arithmetic the function performs: the scale multiplies the delta, so a
+        # zero one leaves the seed pose as every solved target.
+        saturated_delta = np.array([0.0, 0.0, -1.0])
+        assert np.allclose(saturated_delta * (0.05 * 0.0), 0.0)
+        assert not np.allclose(saturated_delta * (0.05 * 1.0), 0.0)
+
+    def test_a_negative_scale_inverts_every_commanded_translation(self) -> None:
+        """A sign error would send the arm up for a command to descend."""
+        with pytest.raises(ValueError):
+            _ee_travel(-1.0)
+        # What the arithmetic would have produced: the mirror of the reference.
+        assert _ee_travel(1.0)[2] == pytest.approx(-0.40, abs=1e-9)
+
+    def test_a_non_finite_scale_makes_every_joint_target_non_finite(self) -> None:
+        """The sharpest case: nothing in the returned chunk is usable.
+
+        Pre-fix this returned normally, so the caller's next step handed
+        ``send_action`` a full set of ``nan`` targets - refused there for being
+        non-finite, which reads as a wrong-embodiment action-key mismatch rather
+        than as the scale that caused it. ``tracking_error`` was ``nan`` too, so
+        even the diagnostic the function returns could not report it.
+        """
+        for bad in (float("nan"), float("inf")):
+            with pytest.raises(ValueError):
+                _decode(_CartesianStubBridge(), bad)
+        # The arithmetic, to show the guard is not merely tightening a bound:
+        # a non-finite factor poisons the delta and therefore every target.
+        poisoned = np.array([0.0, 0.0, -1.0]) * (0.05 * float("nan"))
+        assert not np.all(np.isfinite(poisoned))
+
+
+def _smoothed_targets(alpha: float, solved: list[float]) -> list[float]:
+    """Run the provider's EMA over one joint's IK solutions.
+
+    Mirrors the blend ``get_actions`` applies per step so the effect of a
+    coefficient is measurable without a server, a model or an event loop.
+    """
+    prev: float | None = None
+    out: list[float] = []
+    for value in solved:
+        target = value
+        if alpha > 0.0:
+            if prev is not None:
+                target = (1.0 - alpha) * target + alpha * prev
+            prev = target
+        out.append(target)
+    return out
+
+
+class TestWhyTheSmoothingIntervalIsTheDomain:
+    """Measure what a coefficient outside ``[0, 1)`` does to the joint targets."""
+
+    SOLVED = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
+
+    def test_a_usable_coefficient_damps_without_stopping_the_arm(self) -> None:
+        """The reference: 0.6 damps the travel but the arm still gets there."""
+        travel = _smoothed_targets(0.6, self.SOLVED)[-1] - self.SOLVED[0]
+        ideal = self.SOLVED[-1] - self.SOLVED[0]
+        assert 0.0 < travel < ideal
+
+    def test_one_freezes_the_arm_at_its_first_solved_pose(self) -> None:
+        """``alpha = 1`` weights only the previous target, so nothing moves."""
+        targets = _smoothed_targets(1.0, self.SOLVED)
+        assert targets == [self.SOLVED[0]] * len(self.SOLVED)
+        assert MAX_IK_SMOOTHING == 1.0
+        assert _ik_refusal(1.0) is not None, "the value that freezes the arm must be refused"
+
+    def test_above_one_the_targets_diverge_away_from_the_solution(self) -> None:
+        """A negative weight on the IK solution extrapolates, unbounded."""
+        ideal = self.SOLVED[-1] - self.SOLVED[0]
+        for alpha, at_least in ((1.5, 5.0), (2.0, 30.0)):
+            travel = _smoothed_targets(alpha, self.SOLVED)[-1] - self.SOLVED[0]
+            assert travel < 0.0, f"alpha={alpha} should move opposite the solution"
+            assert abs(travel) > at_least * ideal, f"alpha={alpha} should diverge"
+            assert _ik_refusal(alpha) is not None
+
+    def test_a_negative_or_nan_coefficient_silently_applies_no_smoothing(self) -> None:
+        """Both fail the ``alpha > 0`` test the blend is gated on.
+
+        So the caller asked for damping and got none, with nothing logged - the
+        mode-comparison hole that makes this a silent defect rather than a loud
+        one.
+        """
+        undamped = _smoothed_targets(0.0, self.SOLVED)
+        for alpha in (-0.5, float("nan")):
+            assert not alpha > 0.0, "the blend is skipped entirely for this value"
+            assert _smoothed_targets(alpha, self.SOLVED) == undamped
+            assert _ik_refusal(alpha) is not None
+
+    def test_infinity_makes_every_target_after_the_first_non_finite(self) -> None:
+        targets = _smoothed_targets(float("inf"), self.SOLVED)
+        assert targets[0] == self.SOLVED[0]
+        assert all(not math.isfinite(t) for t in targets[1:])
+        assert _ik_refusal(float("inf")) is not None
+
+
+def _ik_refusal(value: Any) -> str | None:
+    return provider_mod._ik_smoothing_error(value, "ik_smoothing", "VeraPolicy")
+
+
+class _StubClient:
+    """The minimum a ``VeraPolicy`` needs at construction time."""
+
+    def get_server_metadata(self) -> dict[str, Any]:
+        return {}
+
+    def reset(self, info: Any) -> None:
+        del info
+
+    def configure(self, params: Any) -> dict[str, Any]:
+        del params
+        return {}
+
+    def close(self) -> None:
+        return None
+
+
+def _policy(client: Any = None, **kwargs: Any) -> VeraPolicy:
+    """Build a policy against a duck-typed client, for the same reason as ``_decode``."""
+    stub: Any = _StubClient() if client is None else client
+    return VeraPolicy(client=stub, auto_launch_server=False, **kwargs)
+
+
+class TestTheSmoothingCoefficientIsRefusedAtConstruction:
+    @pytest.mark.parametrize("value", UNUSABLE_SMOOTHINGS, ids=repr)
+    def test_an_unusable_coefficient_is_refused(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="ik_smoothing"):
+            _policy(ik_smoothing=value)
+
+    @pytest.mark.parametrize("value", [0.0, 0.3, 0.6, 0.9999, np.float32(0.25), np.float64(0.5)], ids=repr)
+    def test_a_usable_coefficient_is_stored(self, value: Any) -> None:
+        assert _policy(ik_smoothing=value)._ik_smoothing == pytest.approx(float(value))
+
+    def test_the_default_disables_the_smoothing(self) -> None:
+        """``0`` is the documented "no smoothing" default and must stay valid."""
+        assert _policy()._ik_smoothing == 0.0
+        assert _ik_refusal(0.0) is None
+
+
+class TestTheTranslationScaleIsRefusedAtBothSurfaces:
+    """One value, two public entry points, one domain."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_SCALES, ids=repr)
+    def test_set_ik_target_refuses_an_unusable_scale(self, value: Any) -> None:
+        policy = _policy()
+        with pytest.raises(ValueError, match="translation_scale"):
+            policy.set_ik_target(object(), "hand", "body", translation_scale=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_SCALES, ids=repr)
+    def test_the_decoder_refuses_an_unusable_scale(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="translation_scale"):
+            _decode(_CartesianStubBridge(), value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_SCALES, ids=repr)
+    def test_the_two_surfaces_agree(self, value: Any) -> None:
+        """Neither surface may accept what the other refuses."""
+        policy = _policy()
+        try:
+            policy.set_ik_target(object(), "hand", "body", translation_scale=value)
+            setter_refused = False
+        except ValueError:
+            setter_refused = True
+        try:
+            _decode(_CartesianStubBridge(), value)
+            decoder_refused = False
+        except ValueError:
+            decoder_refused = True
+        assert setter_refused == decoder_refused, f"verdicts differ for translation_scale={value!r}"
+
+    @pytest.mark.parametrize("value", [0.5, 1.0, 2.5, np.float32(1.5)], ids=repr)
+    def test_a_usable_scale_is_stored_and_honored(self, value: Any) -> None:
+        policy = _policy()
+        policy.set_ik_target(object(), "hand", "body", translation_scale=value)
+        assert policy._translation_scale == pytest.approx(float(value))
+        travel = _ee_travel(value)
+        assert travel[2] == pytest.approx(-0.05 * 8 * float(value), rel=1e-6)
+
+    def test_none_still_means_leave_the_current_value(self) -> None:
+        """``None`` is the documented "no override" spelling, not a bad value.
+
+        The decoder has no such spelling - its default is ``1.0`` - so the same
+        value is legitimately accepted by one surface and refused by the other.
+        """
+        policy = _policy()
+        policy.set_ik_target(object(), "hand", "body", translation_scale=2.5)
+        policy.set_ik_target(object(), "hand", "body")
+        assert policy._translation_scale == 2.5
+        assert positive_finite_number_error(None, "translation_scale", "set_ik_target") is not None
+
+
+class TestTheIntervalIsTheWholeLocalContribution:
+    """``_ik_smoothing_error`` decides the bounds and delegates everything else."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [*UNUSABLE_FOR_BOTH, 0.0, 0.6, 0.9999, np.float32(0.5), 10**400],
+        ids=repr,
+    )
+    def test_it_agrees_with_the_shared_domain_inside_the_interval(self, value: Any) -> None:
+        shared = finite_number_error(value, "p", "C") is None
+        local = _ik_refusal(value) is None
+        assert local == shared, f"the two must only differ outside [0, {MAX_IK_SMOOTHING})"
+
+    @pytest.mark.parametrize("value", [-0.5, 1.0, 1.5, 2.0], ids=repr)
+    def test_it_refuses_exactly_the_finite_numbers_outside_the_interval(self, value: Any) -> None:
+        assert finite_number_error(value, "p", "C") is None, "the shared domain accepts it"
+        assert _ik_refusal(value) is not None, "the interval must refuse it"
+
+    def test_the_bound_is_named_in_the_message(self) -> None:
+        message = _ik_refusal(1.5)
+        assert message is not None
+        assert f"[0, {MAX_IK_SMOOTHING})" in message
+
+
+class TestNothingIsConfiguredByARefusedValue:
+    def test_a_refused_scale_leaves_the_previous_one_in_place(self) -> None:
+        policy = _policy()
+        policy.set_ik_target(object(), "hand", "body", translation_scale=2.5)
+        with pytest.raises(ValueError):
+            policy.set_ik_target(object(), "elbow", "site", translation_scale=float("nan"))
+        assert policy._translation_scale == 2.5
+
+    def test_a_refused_coefficient_precedes_the_config(self) -> None:
+        """The guard runs before ``VeraConfig`` is built, so nothing is left half-configured."""
+        with pytest.raises(ValueError, match="ik_smoothing"):
+            _policy(ik_smoothing=1.0, embodiment="mimicgen")
+
+    def test_a_refused_scale_reaches_no_ik_solve(self) -> None:
+        """The decoder's guard runs before the first ``solve``."""
+
+        class _CountingBridge(_CartesianStubBridge):
+            solves = 0
+
+            def solve(self, target_pose: Any, q_init: Any) -> np.ndarray:
+                type(self).solves += 1
+                return super().solve(target_pose, q_init)
+
+        with pytest.raises(ValueError):
+            _decode(_CountingBridge(), 0.0)
+        assert _CountingBridge.solves == 0
+
+
+class TestTheGuardsSurviveARealRollout:
+    """A usable pair still drives ``get_actions`` end to end."""
+
+    def test_a_smoothed_rollout_still_produces_joint_targets(self) -> None:
+        class _Client:
+            def get_server_metadata(self) -> dict[str, Any]:
+                return {
+                    "action_space": "eef_delta",
+                    "context_frames": 1,
+                    "gripper_dim_index": 6,
+                    "gripper_is_raw": True,
+                    "view_keys": ["image"],
+                }
+
+            def reset(self, info: Any) -> None:
+                del info
+
+            def configure(self, params: Any) -> dict[str, Any]:
+                del params
+                return {}
+
+            def infer(self, request: Any) -> dict[str, Any]:
+                del request
+                return {"action": np.asarray([[0.1, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0]] * 4, np.float32)}
+
+            def close(self) -> None:
+                return None
+
+        class _Bridge(_CartesianStubBridge):
+            class _SevenDofModel:
+                nq = 7
+
+            model: Any = _SevenDofModel()
+
+            def solve(self, target_pose: Any, q_init: Any) -> np.ndarray:
+                q = np.asarray(q_init, dtype=np.float64).copy()
+                q[:3] = np.asarray(target_pose, dtype=np.float64)[:3, 3]
+                return q
+
+        joints = [f"joint_{i}" for i in range(6)] + ["gripper"]
+        policy = _policy(client=_Client(), ik_smoothing=0.6)
+        policy._runner = None
+        policy.set_robot_state_keys(joints)
+        policy.set_ik_target(_Bridge.model, "hand", "body", translation_scale=1.5)
+        # Injected last: set_ik_target clears the lazily-built bridge so a later
+        # model change rebuilds it, which would need the real mink stack.
+        policy._mj_model = _Bridge.model
+        policy._ee_frame_name = "hand"
+        policy._ik_bridge = _Bridge()
+        observation = {"image": np.zeros((8, 8, 3), np.uint8), **dict.fromkeys(joints, 0.0)}
+        actions = asyncio.run(policy.get_actions(observation, "pick"))
+        assert actions, "a usable pair must still produce actions"
+        assert any(key.startswith("joint_") for key in actions[0]), actions[0]
+        assert all(math.isfinite(v) for v in actions[0].values()), actions[0]
+
+
+class TestNoIkNumericSurfaceDrifts:
+    """Every public VERA surface taking these knobs routes through a domain."""
+
+    KNOBS = {"translation_scale", "ik_smoothing"}
+    GUARDS = {"positive_finite_number_error", "_ik_smoothing_error"}
+    EXPECTED = {
+        ("provider.py", "__init__"),
+        ("provider.py", "set_ik_target"),
+        ("sim_ik.py", "decode_vera_delta_chunk_to_targets"),
+    }
+
+    @staticmethod
+    def _surfaces(sources: dict[str, str]) -> dict[tuple[str, str], set[str]]:
+        """Map every public function taking a knob to the guards it calls."""
+        found: dict[tuple[str, str], set[str]] = {}
+        for name, src in sources.items():
+            for node in ast.walk(ast.parse(src)):
+                if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+                if node.name.startswith("_") and node.name != "__init__":
+                    continue
+                params = {a.arg for a in node.args.args + node.args.kwonlyargs}
+                if not params & TestNoIkNumericSurfaceDrifts.KNOBS:
+                    continue
+                calls = {
+                    call.func.id
+                    for call in ast.walk(node)
+                    if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                }
+                found[(name, node.name)] = calls & TestNoIkNumericSurfaceDrifts.GUARDS
+        return found
+
+    @staticmethod
+    def _package_sources() -> dict[str, str]:
+        root = pathlib.Path(inspect.getfile(VeraPolicy)).parent
+        return {path.name: path.read_text() for path in sorted(root.glob("*.py"))}
+
+    def test_the_scan_finds_exactly_the_known_surfaces(self) -> None:
+        """Non-vacuity: a scan rooted elsewhere would find nothing."""
+        assert set(self._surfaces(self._package_sources())) == self.EXPECTED
+
+    def test_every_surface_calls_a_domain(self) -> None:
+        adrift = {key for key, guards in self._surfaces(self._package_sources()).items() if not guards}
+        assert not adrift, f"these read an IK knob without a domain: {sorted(adrift)}"
+
+    def test_the_scanner_detects_a_planted_surface(self) -> None:
+        """A guard that matched nothing would pass the test above vacuously."""
+        planted = "def configure_scale(translation_scale: float) -> None:\n    pass\n"
+        found = self._surfaces({"planted.py": planted})
+        assert found == {("planted.py", "configure_scale"): set()}


### PR DESCRIPTION
`VeraPolicy` turns the server's end-effector delta chunk into joint targets inside `get_actions`, and two caller-supplied numbers shape every target it produces. Neither had a domain. Both are **applied** rather than forwarded — the scale multiplies a delta, the coefficient weights a blend — so nothing downstream refuses an unusable value; it becomes a plausible-looking chunk of joint targets instead of an error.

![VERA IK numeric domains](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vera-ik-numeric-domains/vera_ik_domains.png)

## `translation_scale`

`decode_vera_delta_chunk_to_targets(translation_scale=...)`, and `VeraPolicy.set_ik_target(translation_scale=...)` which feeds it. Multiplies every translation delta on top of the OSC position scale. Measured on a real MuJoCo Panda driving the real decode → `send_action` loop (7 chunks × 6 steps, saturated reach-and-descend):

| value | on main | measured effect |
|---|---|---|
| `1.0` | accepted | 42/42 applied, end-effector descends **51.4 cm** |
| `0.0` | accepted | translation discarded; the chunk rotates only, under a `tracking_error` reporting a perfect solve (the target it tracked perfectly was the arm's current position) |
| `-1.0` | accepted | every commanded translation inverted |
| `nan` / `inf` | accepted | **all 72 joint targets non-finite**, and `tracking_error` is `nan` too, so the diagnostic the function returns cannot report it |
| `True` | accepted | a silent `1.0` |
| `'0.5'` | accepted | a numeric string |

The `nan` row is the sharpest. `decode` returns normally, and one layer later all 42 `send_action` calls are refused for a non-finite action value — naming `actuator1`, never `translation_scale`:

```
send_action: action value for key 'actuator1' must be finite (no nan/inf), got nan.
```

So the caller is sent to debug an action-key/embodiment mismatch rather than the scale that caused it.

It now takes `positive_finite_number_error`, the same domain as the two sibling action multipliers `SimEnv.action_scale` and `WBCConfig.action_scale`. `None` remains the documented "leave the current value" spelling on the setter; the decoder has no such spelling (its default is `1.0`), so the two surfaces legitimately differ there and that asymmetry is pinned.

## `ik_smoothing`

`VeraPolicy(ik_smoothing=...)` weights the *previous* joint target in the EMA `target = (1 - alpha) * solved + alpha * previous`. The code's own comment already recorded the interval it needs and did not enforce it:

```python
# EMA smoothing across steps to damp IK jitter (Cosmos3 reasoner
# flagged jittery Panda motion). alpha in [0,1); 0 disables.
```

| value | on main | measured effect |
|---|---|---|
| `1.0`, `True` | accepted | every commanded target is the previous one — the arm freezes near its first solved pose and reaches **11% of the commanded descent** (5.5 cm of 51.4 cm) |
| `1.5` | accepted | negative weight on the IK solution: targets diverge **-5.9×** the solved joint travel, away from it |
| `2.0` | accepted | **-35.3×**, growing without bound down the chunk |
| `-0.5`, `nan` | accepted | both fail the `alpha > 0` test the blend is gated on, so the damping the caller asked for is silently never applied |
| `inf` | accepted | every target after the first is non-finite |
| `0.0`, `0.6` | accepted | correct — `0` is the documented "no smoothing" default |

A module-private `_ik_smoothing_error` decides only the interval and delegates numeric-ness, `bool` rejection and finiteness to the shared `finite_number_error`, whose domain this is a bounded subset of. It is local rather than shared because the interval is a property of this EMA, and `positive_finite_number_error`'s `> 0` floor is wrong here — `0` is first-class. `TestTheIntervalIsTheWholeLocalContribution` pins that the two only ever disagree outside `[0, 1)`.

## Scope

`motion_plan_scale` is deliberately untouched: it is forwarded to the remote VERA server via `configure()` inside a best-effort handler, so its accepted domain is the server's contract rather than this library's.

## Tests

`tests/policies/vera/test_vera_ik_numeric_domains.py`, 91 tests, dependency-free (the decoder touches only `solve`, `ee_pose` and `model.nq`, so the stub bridges need neither `mink` nor `mujoco`; the file runs in 0.24 s).

- **Why the domains are what they are** — the behavioural classes drive the real conversion and the real EMA and assert the chunk each produces: the freeze, the divergence, the silent no-damping, the inverted and discarded translation, the all-non-finite targets.
- **Refusals** at all three surfaces, plus a cross-surface parity test asserting neither `translation_scale` surface may accept what the other refuses.
- **Guard placement** — a refused coefficient precedes the `VeraConfig` build; a refused scale leaves the previous one in place and reaches no IK solve (asserted with a solve-counting bridge).
- **Over-reach controls** — `0.0`/`0.6`/`0.9999`/NumPy scalars accepted for the coefficient, `0.5`/`1.0`/`2.5` accepted and honored for the scale, `None` still meaning "no override", and a usable pair still driving `get_actions` end to end.
- **`TestNoIkNumericSurfaceDrifts`** — an AST scan asserting every public VERA surface taking either knob routes through a domain, with an exact expected-surface set (non-vacuity) and a planted-surface meta-test.

**Pre-fix proof** (source at `upstream/main`, tests present): **66 failed / 25 passed**, the structural guard naming all three adrift surfaces —

```
AssertionError: these read an IK knob without a domain:
  [('provider.py', '__init__'), ('provider.py', 'set_ik_target'),
   ('sim_ik.py', 'decode_vera_delta_chunk_to_targets')]
```

The 25 that pass pre-fix are the over-reach controls, the parity cases inside the interval, and the scanner meta-tests — they are what stop the guards reaching further than these values.

**No existing test changed.** The usable values already in the suite (`ik_smoothing` `0.0`/`0.6` in `test_vera_action_ik.py`, `translation_scale=2.5` in `test_vera_autoconfig_ik.py`) are all inside the domains.

## Verification

Base `ae1176a3`, head `3ea208ff`, arm64, `mujoco` 3.11.0, `MUJOCO_GL=egl`.

- `MUJOCO_GL=egl python -m pytest tests` — **21858 passed / 257 skipped / 0 failed** in 528.70 s
- `ruff check strands_robots tests tests_integ` — clean; `ruff format --check` — 1093 files already formatted
- `mypy strands_robots tests tests_integ` — 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical to a pristine `upstream/main` worktree of the same working copy (an artefact of the editable-install root, not of this branch)
- `python3 scripts/assemble_changelog.py --check` — OK; `scripts/check_merge_base_overlap.py` — no overlap

**No regression:** the honored run is identical on both trees — 42/42 actions applied and 51.4 cm of descent agreeing to 12 decimal places, with the renders differing by 2/255 over the frame (renderer noise). The figure's generator re-derives every panel caption and table cell from the two runs' JSON dumps and asserts each one, including that the two dumps came from different trees.

The artifact's raw renders and measured facts are on [`artifacts/vera-ik-numeric-domains`](https://github.com/cagataycali/robots/tree/artifacts/vera-ik-numeric-domains).

---

## §13 Review Round Log

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | `set_ik_target` guard fires after state mutation -- a refused `translation_scale` leaves policy half-retargeted (`_mj_model`/`_ee_frame_name` changed, `_ik_bridge` stale) | `b9fd9fc` | `tests/policies/vera/test_vera_ik_numeric_domains.py::TestNothingIsConfiguredByARefusedValue::test_a_refused_scale_leaves_the_previous_one_in_place` (now asserts all 5 attributes) |
| R1 | CodeQL `py/unnecessary-delete-in-function` alerts on test stubs | `b9fd9fc` | N/A (replaced `del x` with `_ = x`) |