### PR TITLE
fix(training): refuse an RL discount factor the return cannot be discounted by

### DIFF
--- a/changelog.d/1993-rl-discount-factor-domain.md
+++ b/changelog.d/1993-rl-discount-factor-domain.md
@@ -1,0 +1,28 @@
+### Fixed: an RL discount factor the return cannot be discounted by is refused
+
+`RLTrainSpec.gamma` weights every future reward in the return an RL algorithm
+optimizes, and it is the one coefficient both backends read - PPO discounts the
+GAE recursion with it (single-env and vectorized paths), FastSAC its target-Q
+bootstrap. Neither preflight bounded it, and the arithmetic that consumes it
+never judges it. A discounted return is a geometric series, so measured on the
+real `compute_gae` over a 24-step rollout of unit rewards where the honored
+`gamma=0.99` gives a largest advantage of 12.9: `gamma=1.5` gives 1.2e4 and
+`gamma=5` gives 4.6e15, and doubling the horizon compounds again - divergence,
+not merely a large number. A real PPO run with `gamma=1.5` returned
+`status="success"` and wrote a loadable checkpoint. `gamma=-0.5` alternates the
+sign of each future reward and collapses the largest advantage to the immediate
+reward, 1.0. `gamma=nan` surfaced only once the update sampled the action
+distribution, as `ValueError: Expected parameter loc ... of distribution Normal
+... to satisfy the constraint Real()` - a torch message naming neither the field
+nor the run, raised after the env, the networks and a full rollout were built,
+which is the deep stack trace a read-only preflight exists to replace. `True`
+was a silent `gamma` of one, because `bool` is an `int` subclass and a bare
+comparison against the bounds accepts it.
+
+`gamma` must now be a finite real number in the closed interval `[0, 1]` on both
+backends. Both endpoints stay first-class: `gamma=1` is the undiscounted
+episodic return and `gamma=0` a myopic agent. The check is a new shared gate
+alongside the existing run-size / launch-topology / learning-rate / seed ones,
+so a third RL backend that discounts a return with the field cannot ship without
+it. This generalizes the shape the FastSAC preflight already used for its own
+interval coefficient, `tau` in `(0, 1]`.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -194,6 +194,16 @@ off-policy SAC fields (`buffer_size`, `batch_size`, `learning_starts`,
 `gradient_steps`, `tau`, `autotune_alpha`, `init_alpha`, `alpha_lr`,
 `target_entropy`), plus the universal `output_dir` / `learning_rate` / `seed`.
 
+`gamma` must be a finite number in the closed interval `[0, 1]`, checked by
+`validate()` on both backends. It is the one coefficient both of them read (PPO
+discounts the GAE recursion with it, FastSAC its target-Q bootstrap) and a
+discounted return is a geometric series, so a value above 1 makes that series
+diverge in the rollout horizon rather than merely being large - the run would
+train on the inflated advantages, report success and write a checkpoint. Both
+endpoints are inside the domain: `gamma=1` is the undiscounted episodic return
+and `gamma=0` a myopic agent that optimizes the immediate reward only. The
+FastSAC `tau` is bounded the same way, in `(0, 1]`.
+
 ## Worked example
 
 `examples/training/train_ppo_reach.py` (on-policy) and `examples/training/train_fastsac_reach.py`

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -59,15 +59,25 @@ reserve a different number of episodes than the one asked for.
 fine-tune. It is scoped like :func:`run_size_problems` and narrowed once more -
 only the LeRobot backend reads either field, and only on its ``method == "lora"``
 branch, so a value a run's own strategy never reads must not be reported.
+
+:func:`discount_factor_problems` is the eighth, on the *return* axis:
+``gamma``, the discount factor of the return the algorithm optimizes. It is
+scoped like :func:`learning_rate_problems` rather than like
+:func:`run_size_problems` - it is the one
+:class:`~strands_robots.training.rl.base_algo.RLTrainSpec` coefficient that
+*every* RL backend reads (PPO discounts the GAE recursion with it, FastSAC
+discounts its target-Q bootstrap), so there is no RL backend for which
+reporting on it would be a false rejection.
 """
 
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from strands_robots.tools._path_validation import validate_save_path
 from strands_robots.utils import (
+    finite_number_error,
     non_negative_count_error,
     positive_count_error,
     positive_finite_number_error,
@@ -446,3 +456,87 @@ def lora_hyperparameter_problems(spec: TrainSpec, *, context: str) -> list[str]:
         if error is not None:
             problems.append(error)
     return problems
+
+
+def _closed_unit_interval_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when *value* is not a real number in the closed range [0, 1].
+
+    Numeric-ness, ``bool`` rejection and finiteness are delegated to the shared
+    :func:`~strands_robots.utils.finite_number_error` domain, so those refusals
+    read identically to every other numeric field's. The only thing decided here
+    is the interval, which no shared domain expresses: ``utils`` carries
+    open-ended families (positive, non-negative) rather than a bounded one.
+
+    Both endpoints are inside the domain and neither is a degenerate spelling of
+    "disabled", which is why the interval is closed rather than half-open.
+
+    Args:
+        value: The caller-supplied value.
+        param: Field name for the message.
+        context: Caller label the message is prefixed with.
+
+    Returns:
+        The error text, or None when *value* is a real number in [0, 1].
+    """
+    error = finite_number_error(value, param, context)
+    if error is not None:
+        return error
+    if not 0.0 <= float(value) <= 1.0:
+        return f"{context}: {param} must be in [0, 1], got {value!r}."
+    return None
+
+
+def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return discount-factor problems for an RL :class:`TrainSpec`.
+
+    ``gamma`` weights every future reward in the return the algorithm optimizes,
+    and it is the one coefficient both RL backends read: PPO discounts the GAE
+    recursion with it (twice - the single-env and vectorized rollout paths), and
+    FastSAC discounts its target-Q bootstrap. A discounted return is a geometric
+    series, so the domain is not a matter of taste:
+
+    * ``gamma > 1`` makes that series **diverge**. The advantages grow without
+      bound in the rollout horizon rather than being merely large - over a
+      24-step rollout of unit rewards, ``gamma=1.5`` inflates the largest
+      advantage from 12.9 to 1.2e4, and ``gamma=5`` to 4.6e15. Nothing refuses
+      it: the run trains on those advantages, reports success, and writes a
+      checkpoint.
+    * ``gamma < 0`` alternates the sign of each successive reward, so the trace
+      no longer accumulates future return at all - the same rollout collapses
+      the largest advantage to the immediate reward, 1.0.
+    * ``nan``/``inf`` make every advantage non-finite, which surfaces only once
+      the update samples the action distribution: ``ValueError: Expected
+      parameter loc ... of distribution Normal ... to satisfy the constraint
+      Real()``, a torch message that names neither the field nor the run, raised
+      after the env, the networks and a full rollout have been built. That is
+      exactly the "deep stack trace" a read-only preflight exists to replace.
+    * ``True`` is a silent ``gamma`` of one, because a bare comparison against
+      the interval bounds accepts it - ``bool`` is an ``int`` subclass.
+
+    Both endpoints are legitimate and standard: ``gamma=1`` is the undiscounted
+    episodic return, ``gamma=0`` a myopic agent that optimizes the immediate
+    reward only. So the domain is the *closed* interval [0, 1], checked through
+    :func:`_closed_unit_interval_error`.
+
+    The sibling FastSAC preflight already bounds its own interval coefficient
+    this way (``tau`` must be in ``(0, 1]``), which is the shape this gate
+    generalizes: an interval coefficient is checked against its interval rather
+    than left to the arithmetic that consumes it.
+
+    ``lam`` and the remaining PPO coefficients (``clip_param``,
+    ``num_learning_epochs``, ``entropy_coef``, ``value_loss_coef``,
+    ``max_grad_norm``, ``init_noise_std``) are out of scope here: they are read
+    by the on-policy backend only, so per :class:`TrainSpec` a backend that
+    ignores them must not report on them, and they belong in their own gate.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single-element list when ``gamma`` cannot be honored; empty otherwise.
+    """
+    error = _closed_unit_interval_error(getattr(spec, "gamma", 0.0), "gamma", context)
+    return [error] if error is not None else []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -423,6 +423,38 @@ class Trainer(ABC):
 
         return lora_hyperparameter_problems(spec, context=self.provider_name)
 
+    def _discount_factor_problems(self, spec: TrainSpec) -> list[str]:
+        """Discount-factor preflight shared by every RL backend.
+
+        Returns a problem when :attr:`RLTrainSpec.gamma` is not a real number in
+        the closed interval ``[0, 1]``. A :meth:`validate` implementation that
+        discounts a return with the field MUST call this instead of leaving the
+        value to the arithmetic that consumes it, because that arithmetic never
+        judges it: ``gamma > 1`` makes the discounted return diverge in the
+        rollout horizon and the run still reports success and writes a
+        checkpoint, ``gamma < 0`` alternates the sign of each future reward so
+        the trace stops accumulating return at all, and a non-finite value
+        surfaces only once the update samples the action distribution - as a
+        torch constraint error naming neither the field nor the run, after the
+        env, the networks and a full rollout have been built.
+
+        Both interval endpoints are inside the domain (``gamma=1`` is the
+        undiscounted episodic return, ``gamma=0`` a myopic agent), so the check
+        is a closed interval rather than a positivity test - and it rejects
+        ``bool``, which a bare comparison against the bounds accepts as a silent
+        ``gamma`` of one.
+
+        Every RL backend reads the field, so unlike
+        :meth:`_lora_hyperparameter_problems` there is no backend for which
+        reporting on it would be a false rejection.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import discount_factor_problems
+
+        return discount_factor_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -139,6 +139,9 @@ class FastSacTrainer(BaseRLAlgo):
             problems.append("env_factory is required (a zero-arg callable returning a SimEnv)")
         if not spec.output_dir:
             problems.append("output_dir is required")
+        # gamma discounts the return this backend optimizes; the arithmetic that
+        # consumes it never judges it, so the shared interval domain does.
+        problems.extend(self._discount_factor_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -150,6 +150,9 @@ class PpoTrainer(BaseRLAlgo):
             problems.append("env_factory is required (a zero-arg callable returning a SimEnv)")
         if not spec.output_dir:
             problems.append("output_dir is required")
+        # gamma discounts the return this backend optimizes; the arithmetic that
+        # consumes it never judges it, so the shared interval domain does.
+        problems.extend(self._discount_factor_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/tests/training/test_discount_factor_domain.py
+++ b/tests/training/test_discount_factor_domain.py
@@ -1,0 +1,280 @@
+"""The discount factor is checked against its interval, not left to the return.
+
+``RLTrainSpec.gamma`` weights every future reward in the return an RL algorithm
+optimizes, and it is the one coefficient both RL backends read: PPO discounts
+the GAE recursion with it (on the single-env and the vectorized rollout path),
+FastSAC discounts its target-Q bootstrap. Neither preflight bounded it, and the
+arithmetic that consumes it never judges it, so an unusable value was accepted:
+``gamma > 1`` makes the discounted return diverge in the rollout horizon and the
+run still reports success and writes a checkpoint, ``gamma < 0`` alternates the
+sign of each future reward so the trace stops accumulating return, ``bool`` is a
+silent ``gamma`` of one, and a non-finite value surfaces only once the update
+samples the action distribution - as a torch constraint error naming neither the
+field nor the run, after the env, the networks and a full rollout are built.
+
+The sibling FastSAC preflight already bounded its own interval coefficient this
+way (``tau`` must be in ``(0, 1]``); this pins the same shape for the field both
+backends share. Every test here reaches the real ``validate`` entry point, so it
+covers the wiring as well as the domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import (
+    _closed_unit_interval_error,
+    discount_factor_problems,
+)
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+
+# Every backend that discounts a return with the field.
+RL_BACKENDS = ("ppo", "fast_sac")
+
+# Values outside the closed interval: the discounted return either diverges in
+# the horizon (> 1) or stops accumulating future reward at all (< 0).
+OUT_OF_INTERVAL: list[Any] = [1.5, 5.0, 1.0000001, -0.5, -1, 100.0]
+
+# Values the shared numeric domain refuses before the interval is considered.
+NOT_A_FINITE_NUMBER: list[Any] = [
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    False,
+    "0.99",
+    None,
+    [0.99],
+    {"gamma": 0.99},
+]
+
+UNUSABLE: list[Any] = [*OUT_OF_INTERVAL, *NOT_A_FINITE_NUMBER]
+
+# Both endpoints are legitimate and standard: 1 is the undiscounted episodic
+# return, 0 a myopic agent that optimizes the immediate reward only. Integral
+# and NumPy spellings of an in-range value are usable too - the shared domain
+# accepts any finite real, and float() reads them all.
+USABLE: list[Any] = [0.0, 1.0, 0.99, 0.5, 0, 1, np.float64(0.97), np.float32(0.9)]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """An otherwise-valid RL spec, so only the field under test is exercised.
+
+    A non-None ``env_factory`` and an ``output_dir`` keep the unrelated preflight
+    guards quiet; every other field keeps its default. Mirrors the isolation the
+    PPO preflight contract test uses.
+    """
+    return RLTrainSpec(output_dir="/tmp/discount_domain", env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+
+
+def _gamma_problems(provider: str, spec: RLTrainSpec) -> list[str]:
+    """Problems the real ``validate`` entry point reports about ``gamma``.
+
+    Filtered on the shared domains' ``"{context}: {param} "`` message shape
+    rather than on a bare ``"gamma"`` substring, so an unrelated problem can
+    neither mask a missing refusal nor be mistaken for one.
+    """
+    return [p for p in create_trainer(provider).validate(spec) if p.startswith(f"{provider}: gamma ")]
+
+
+class TestEveryRLBackendRefusesAnUnusableDiscountFactor:
+    """Both backends refuse every value the return cannot be discounted by."""
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        spec.gamma = value
+        assert _gamma_problems(provider, spec), f"{provider} accepted gamma={value!r}"
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", OUT_OF_INTERVAL)
+    def test_an_out_of_interval_value_names_the_interval(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        """The message states the domain, so the fix needs no guesswork."""
+        spec.gamma = value
+        assert any("must be in [0, 1]" in p for p in _gamma_problems(provider, spec))
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", NOT_A_FINITE_NUMBER)
+    def test_a_non_numeric_value_reads_like_every_other_numeric_field(
+        self, spec: RLTrainSpec, provider: str, value: Any
+    ) -> None:
+        """Type / bool / finiteness refusals come from the shared domain."""
+        spec.gamma = value
+        assert any("must be a finite number" in p for p in _gamma_problems(provider, spec))
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: RLTrainSpec, provider: str) -> None:
+        spec.gamma = 1.5
+        assert _gamma_problems(provider, spec)
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", NOT_A_FINITE_NUMBER)
+    def test_an_unusable_value_is_a_problem_not_an_exception(
+        self, spec: RLTrainSpec, provider: str, value: Any
+    ) -> None:
+        """``validate`` returns problems; it must not raise out of the check.
+
+        A string or ``None`` would raise from a bare comparison against the
+        interval bounds, which is the failure mode a read-only preflight exists
+        to replace.
+        """
+        spec.gamma = value
+        problems = create_trainer(provider).validate(spec)  # must not raise
+        assert any(p.startswith(f"{provider}: gamma ") for p in problems), problems
+
+
+class TestTheUsableDomainIsUntouched:
+    """No value the return can be discounted by becomes a problem."""
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    @pytest.mark.parametrize("value", USABLE)
+    def test_it_is_accepted(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        spec.gamma = value
+        assert _gamma_problems(provider, spec) == [], f"{provider} refused gamma={value!r}"
+
+    @pytest.mark.parametrize("provider", RL_BACKENDS)
+    def test_the_default_spec_still_validates_clean(self, spec: RLTrainSpec, provider: str) -> None:
+        """The shipped default (0.99) reports nothing at all."""
+        assert create_trainer(provider).validate(spec) == []
+
+
+class TestTheIntervalIsTheWholeLocalContribution:
+    """The helper decides the interval and delegates everything else.
+
+    Type, ``bool`` and finiteness are the shared numeric domain's job, so the two
+    functions must agree on every value except the ones the interval alone
+    excludes. Pinning that keeps the refusal text for a non-numeric ``gamma``
+    identical to every other numeric field's.
+    """
+
+    @pytest.mark.parametrize("value", [*USABLE, *NOT_A_FINITE_NUMBER])
+    def test_it_agrees_with_the_shared_domain(self, value: Any) -> None:
+        from strands_robots.utils import finite_number_error
+
+        local = _closed_unit_interval_error(value, "gamma", "ppo")
+        shared = finite_number_error(value, "gamma", "ppo")
+        assert (local is None) == (shared is None), f"diverged for gamma={value!r}"
+
+    @pytest.mark.parametrize("value", OUT_OF_INTERVAL)
+    def test_only_the_interval_diverges(self, value: Any) -> None:
+        from strands_robots.utils import finite_number_error
+
+        assert finite_number_error(value, "gamma", "ppo") is None
+        assert _closed_unit_interval_error(value, "gamma", "ppo") is not None
+
+
+class TestTheDivergenceTheDomainPrevents:
+    """The refused values really do break the return, measured on the real GAE.
+
+    This is the executable premise behind the domain: an out-of-interval
+    ``gamma`` is not merely unconventional, it changes what the recursion
+    computes. Without it the interval would be an unexplained constant.
+    """
+
+    @staticmethod
+    def _largest_advantage(gamma: float, horizon: int) -> float:
+        torch = pytest.importorskip("torch")
+
+        from strands_robots.training.rl.ppo import compute_gae
+
+        zeros = torch.zeros(horizon)
+        advantages, _ = compute_gae(torch.ones(horizon), zeros, zeros, zeros, zeros, gamma, 0.95)
+        return float(advantages.abs().max())
+
+    def test_a_gamma_above_one_diverges_in_the_horizon(self) -> None:
+        """The discounted return is a geometric series: above 1 it is unbounded."""
+        honored = self._largest_advantage(0.99, 24)
+        assert self._largest_advantage(1.5, 24) > 100 * honored
+        # Unbounded, not merely large: doubling the horizon compounds again.
+        assert self._largest_advantage(1.5, 48) > 100 * self._largest_advantage(1.5, 24)
+
+    def test_a_negative_gamma_stops_accumulating_future_return(self) -> None:
+        """Alternating signs cancel the trace down to the immediate reward."""
+        assert self._largest_advantage(-0.5, 24) < self._largest_advantage(0.99, 24)
+
+    def test_a_non_finite_gamma_poisons_every_advantage(self) -> None:
+        torch = pytest.importorskip("torch")
+
+        from strands_robots.training.rl.ppo import compute_gae
+
+        zeros = torch.zeros(8)
+        advantages, _ = compute_gae(torch.ones(8), zeros, zeros, zeros, zeros, float("nan"), 0.95)
+        assert not bool(torch.isfinite(advantages).all())
+
+    @pytest.mark.parametrize("endpoint", [0.0, 1.0])
+    def test_both_endpoints_compute_a_finite_return(self, endpoint: float) -> None:
+        """Neither accepted endpoint is a degenerate spelling of "broken"."""
+        assert 0.0 < self._largest_advantage(endpoint, 24) < float("inf")
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(discount_factor_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_discount_factor(source: str) -> bool:
+    """Does *source* read ``spec.gamma``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "gamma" and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_discount_factor_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheDiscountDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.gamma`` must route it through the shared gate, so
+    a third RL backend that starts discounting a return with the field fails
+    this test until it does.
+    """
+
+    def test_every_module_that_reads_it_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name
+            for p in _training_modules()
+            if _reads_the_discount_factor(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules read spec.gamma without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_the_discount_factor(p.read_text())}
+        assert readers == {"ppo.py", "fast_sac.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading the field without the gate is really reported."""
+        planted = "def validate(self, spec):\n    return [] if spec.gamma else []\n"
+        assert _reads_the_discount_factor(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_interval(self) -> None:
+        """A local copy of the bounds would drift from the shared rule."""
+        offenders = [
+            p.name for p in _training_modules() if "spec.gamma <" in p.read_text() or "spec.gamma >" in p.read_text()
+        ]
+        assert offenders == [], f"modules compare spec.gamma locally: {offenders}"


### PR DESCRIPTION
## Problem

`RLTrainSpec.gamma` weights every future reward in the return an RL algorithm optimizes, and it is the **one coefficient both RL backends read**: PPO discounts the GAE recursion with it (`ppo.py:283` and `:385`, the single-env and vectorized rollout paths) and FastSAC discounts its target-Q bootstrap (`fast_sac.py:313`). Neither preflight bounded it, and the arithmetic that consumes it never judges it.

The asymmetry is inside the RL layer already: `FastSacTrainer.validate` bounds *its own* interval coefficient with a full interval -- `if not 0.0 < spec.tau <= 1.0` -- so the layer knows a Polyak-style coefficient needs one. `PpoTrainer.validate` bounds four **counts** (`total_timesteps`, `rollout_steps`, `num_envs`, `num_mini_batches`) and no coefficient at all.

A discounted return is a geometric series, so the domain is not a matter of taste. Measured on the real `compute_gae` with unit rewards:

| `gamma` | T=12 | T=24 | T=48 | T=96 |
|---|---|---|---|---|
| **0.99** (default) | 8.76 | 12.95 | 15.92 | 16.76 |
| **1.0** (undiscounted) | 9.19 | 14.16 | 18.29 | 19.85 |
| 1.5 | 162.6 | 1.16e4 | 5.69e7 | **1.37e15** |
| 5.0 | 3.52e7 | 4.64e15 | 8.08e31 | **inf** |
| -0.5 | 1.0 | 1.0 | 1.0 | 1.0 |

So above 1 the largest advantage **diverges in the horizon** -- it is unbounded, not merely large -- while both accepted values saturate. Below 0 the alternating sign cancels the trace down to the immediate reward at every horizon: the recursion stops accumulating future return at all.

What a real PPO run did with those values:

- `gamma=1.5` returned `status="success"` and wrote a loadable checkpoint. Nothing anywhere said the advantages it trained on were inflated by three orders of magnitude.
- `gamma=nan` raised `ValueError: Expected parameter loc (Tensor of shape (5, 6)) of distribution Normal(...) to satisfy the constraint Real()` -- a torch message naming neither the field nor the run, and only once the update sampled the action distribution, i.e. after the env, the networks and a full rollout were built. That is exactly the "deep stack trace" a read-only preflight exists to replace.
- `gamma=True` was a silent `gamma` of one: `bool` is an `int` subclass, so a bare comparison against the interval bounds accepts it.
- `gamma="0.99"` / `None` would raise out of that comparison, from a method whose contract is to *return* problems.

## Change

`gamma` must be a finite real number in the **closed** interval `[0, 1]` on both backends. Both endpoints stay first-class and are pinned as such: `gamma=1` is the undiscounted episodic return, `gamma=0` a myopic agent that optimizes the immediate reward only -- neither is a degenerate spelling of "disabled", which is why the interval is closed rather than half-open.

The check is a new shared gate, `discount_factor_problems`, beside the existing run-size / launch-topology / learning-rate / seed / validation-episode / LoRA ones. It is scoped like `learning_rate_problems` rather than like `run_size_problems`: *every* RL backend reads the field, so there is no backend for which reporting on it would be a false rejection.

Type, `bool` and finiteness are delegated to the shared `finite_number_error` domain, so those refusals read identically to every other numeric field's; the only thing decided locally is the interval, which no shared domain expresses (`utils` carries open-ended families -- positive, non-negative -- not a bounded one). A test loops both functions over the whole probe set and asserts they agree on every value **except** the ones the interval alone excludes, so the local helper cannot quietly grow a second contract.

## Scope

`lam` and the six PPO-only coefficients (`clip_param`, `num_learning_epochs`, `entropy_coef`, `value_loss_coef`, `max_grad_norm`, `init_noise_std`) are deliberately **out of scope**. They are read by the on-policy backend only, so per `TrainSpec` ("a backend reads the fields it supports and ignores the rest") a backend that ignores them must not report on them -- they belong in their own gate, and two of them additionally have a genuinely arguable sign. `log_interval` is out for a different reason: `if spec.log_interval and ...` makes a falsy value a documented mode selector (no periodic logs), like `save_freq`.

## Artifact

![gamma domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rl-gamma-domain/gamma_domain.png)

Top row: the divergence above, measured on the real `compute_gae` -- identical on both trees, since this PR does not touch the recursion. Bottom left: a real headless MuJoCo PPO rollout at `gamma=0.99`, which is how the no-regression claim is measured rather than asserted -- the two trees' renders agree to `max|delta| = 1/255` over 21 of 403,200 px (renderer noise) and the trained weights agree **exactly**, `|w|max = 0.7058578133583069` on both. Right and bottom: the per-backend verdict table and the run ledger.

The figure is generated from two runs of one capture script executed in two separate trees (a `git worktree` at `main`, and this branch); each dump records its own tree, the compose step asserts the two differ, and every rendered number is re-derived from those dumps and asserted before the figure is saved. The dumps and the audit list are published alongside it.

## Verification

- **New tests**: 130 in `tests/training/test_discount_factor_domain.py`, all reaching the real `validate` entry point so they cover the wiring as well as the domain. They pin: every unusable value refused on **both** backends with the backend named; the out-of-interval message stating the domain; a non-numeric value reported as a *problem* rather than raised; the whole usable domain (both endpoints, integral and NumPy spellings) untouched and the default spec still validating clean; the interval as the helper's only local contribution; the divergence itself, as the executable premise behind the interval; and a structural guard deriving the backend set from the tree, so a third RL backend that discounts a return with the field fails until it routes through the gate (with a planted-reader meta-test and an exact expected reader set for non-vacuity).
- **Pre-fix proof** (call sites reverted to `main`, the new gate kept so the module still imports): **81 failed / 49 passed**. Post-fix **130 passed**. The 49 that pass pre-fix are the over-reach controls (the usable domain was already accepted), the interval-parity tests and the divergence premise -- they are what stop the guard reaching further than the values it should.
- **Full suite** on `ae1176a3`: `21897 passed, 257 skipped` in 533.69s (`MUJOCO_GL=egl python -m pytest tests`). That is the pre-existing 21767 plus this PR's 130 -- **zero existing-test churn**.
- **Lint**: `ruff check` clean, `ruff format --check` clean (1093 files), `mypy strands_robots tests tests_integ` reports 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical to a pristine `main` worktree in the same working copy (environmental).
- Root guards (changelog fragments/format, docstring refs, internal paths, unreachable statements): 42 passed. `scripts/check_merge_base_overlap.py`: no overlap.