### PR TITLE
fix(policies/wbc): validate a per-call command override on the domain the config enforces

### DIFF
--- a/changelog.d/1996-wbc-command-override-domains.md
+++ b/changelog.d/1996-wbc-command-override-domains.md
@@ -1,0 +1,32 @@
+### Fixed: a WBC per-call command override is validated on the domain the config enforces for the field it overrides
+
+`WBCPolicy._resolve_command` builds the observation's command block from four
+caller-supplied components, and only `target_velocity` was validated. The other
+three are the per-call overrides of `height_cmd`, `freq_cmd` and `rpy_cmd` - the
+three config fields `WBCConfig.__post_init__` does check - and each reached the
+network raw, so the spelling documented to *win* the precedence contest accepted
+values the spelling that loses it refuses.
+
+`height=nan` and a non-finite `target_orientation` component put a non-finite
+value in the frame the network is given; because the policy is dense that reaches
+all 15 joint targets, `send_action` then refuses every one, and the rollout
+aborted with *"100% unresolved keys ... the robot has not moved"* plus a list of
+joint names - a report about the embodiment, produced by one bad `height`. A
+numeric string raised from the `float()` that read it, and a non-numeric
+`target_orientation` surfaced as NumPy's `could not convert string to float`,
+which names neither the kwarg nor the policy.
+
+`WBCGaitPolicy`'s step frequency had the same shape at all three of its sources.
+`GaitClock.update` documents that `freq` "must be strictly positive" (it sets the
+phase increment and the warm-up window `0.5 / freq`) and enforces it - but only
+once the block has been built and handed over from inside `get_actions`, so the
+message named `GaitClock.update` rather than the parameter supplied; and `True`
+and `"0.75"` were not refused at all, they became a silent 1.0 Hz and 0.75 Hz.
+
+Every source is now held to the domain the field's config spelling uses, and the
+step frequency to the gait clock's stricter `> 0` rule at the per-call kwarg, the
+constructor default and `config.freq_cmd`. The constructor check runs before the
+ONNX session loads, so an unusable frequency is reported at construction instead
+of on the first tick of a started rollout. `None` still means "not supplied" at
+every override, and the signed quantities the config accepts (a zero or negative
+height, a negative yaw target) remain first-class.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -119,15 +119,25 @@ WBC reads locomotion commands from `**kwargs`, sharing the non-VLA goal
 vocabulary so a command can flow through `run_policy` / mesh `tell()` without
 coupling to a backend:
 
-| Key | Type | Meaning |
-|-----|------|---------|
-| `target_velocity` | `list[float]` | Locomotion command `[vx, vy, omega]` (m/s, m/s, rad/s). Scaled by `cmd_scale` (`[2.0, 2.0, 0.5]`) into the observation's command block. |
-| `target_orientation` | `list[float]` | Target base `[roll, pitch, yaw]` (rad), written to command slots `[4:7]`. Defaults to the config `rpy_cmd` (`[0,0,0]`). |
-| `height` | `float` | Target base height (m), written to command slot `[3]`. Defaults to the config `height_cmd` (`0.74`). |
+| Key | Type | Accepted | Meaning |
+|-----|------|----------|---------|
+| `target_velocity` | `list[float]` | numeric, >= 3 entries, every component finite | Locomotion command `[vx, vy, omega]` (m/s, m/s, rad/s). Scaled by `cmd_scale` (`[2.0, 2.0, 0.5]`) into the observation's command block. |
+| `target_orientation` | `list[float]` | numeric sequence, finite per component | Target base `[roll, pitch, yaw]` (rad), written to command slots `[4:7]`. Defaults to the config `rpy_cmd` (`[0,0,0]`). |
+| `height` | `float` | finite | Target base height (m), written to command slot `[3]`. Defaults to the config `height_cmd` (`0.74`). |
 
 A per-call `target_velocity` overrides the constructor-time default. With no
 command at all the controller holds a standing balance (zero velocity, default
-height + level orientation).
+height + level orientation). Omitting a key (or passing `None`) selects the next
+source in the precedence chain, so `None` is how a kwarg spells "not supplied".
+
+Each key's accepted domain is the one `WBCConfig` enforces for the field it
+overrides - `height` for `height_cmd`, `target_orientation` for `rpy_cmd` - so a
+value the config refuses is not reachable through the kwarg documented to take
+precedence over it. The command block is the observation's first `command_dim`
+entries, so a non-finite component is not one wrong slot: the network is dense,
+so it reaches all `num_actions` joint targets, every one is then refused by
+`send_action`, and the rollout aborts reporting *"100% unresolved keys ... the
+robot has not moved"* - a message about the embodiment, for a bad `height`.
 
 ## Control contract
 

--- a/docs/policies/wbc_gait.md
+++ b/docs/policies/wbc_gait.md
@@ -11,6 +11,12 @@ NVIDIA's reference repo ships **two** MuJoCo G1 controllers. The non-gait pair
 - A **95-dim** observation frame, stacked x6 -> a `[batch, 570]` network input.
 - An **8-wide command** block with a `freq_cmd` step-frequency slot inserted at
   index 4 (so rpy moves to slots `[5:8]`), set via the `gait_frequency` kwarg.
+  Frequency precedence is per-call kwarg > constructor default > `config.freq_cmd`,
+  and every source in that chain must be a finite number `> 0`: the gait clock
+  advances the phase by `dt * freq` and warms up over `0.5 / freq`, so a
+  non-positive step frequency cannot be honored. That is stricter than the
+  `finite`-only domain `WBCConfig` applies to `freq_cmd`, which the non-gait
+  7-wide command block ignores entirely.
 - A 2-dim **bipedal phase clock** (`[clock_FL, clock_FR]`) appended to each
   frame - the locomotion rhythm the network steps to.
 

--- a/strands_robots/policies/wbc/gait.py
+++ b/strands_robots/policies/wbc/gait.py
@@ -52,6 +52,8 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
+from strands_robots.utils import positive_finite_number_error
+
 from .config import WBCConfig
 from .control import compute_targets, projected_gravity
 from .policy import WBCPolicy
@@ -313,8 +315,9 @@ class WBCGaitPolicy(WBCPolicy):
             rejected at construction.
         target_velocity: Optional constructor-time default ``[vx, vy, omega]``.
         gait_frequency: Optional constructor-time default step frequency
-            (``freq_cmd``). Per-call ``gait_frequency`` kwarg overrides it, which
-            overrides ``config.freq_cmd``.
+            (``freq_cmd``), in steps/s. Per-call ``gait_frequency`` kwarg
+            overrides it, which overrides ``config.freq_cmd``. Must be a finite
+            number ``> 0`` (see :meth:`_validate_gait_frequency`).
         allow_missing_models: Test/CI seam (see :class:`WBCPolicy`).
         **kwargs: Forward-compatibility absorber (ignored unknown kwargs).
     """
@@ -329,7 +332,11 @@ class WBCGaitPolicy(WBCPolicy):
         **kwargs: Any,
     ) -> None:
         self._gait_clock = GaitClock()
-        self._gait_frequency = float(gait_frequency) if gait_frequency is not None else None
+        # Before ``super().__init__`` - which loads the ONNX session(s) - so a
+        # frequency the gait clock cannot honor is reported here rather than on
+        # the first ``get_actions`` tick of a started rollout. Mirrors the
+        # constructor-time ``target_velocity`` check the base policy already does.
+        self._gait_frequency = self._validate_gait_frequency(gait_frequency) if gait_frequency is not None else None
         # The gait variant is a single-policy controller: force walk=False so the
         # base loader fetches only policy.onnx (no walk_policy.onnx).
         super().__init__(
@@ -354,7 +361,10 @@ class WBCGaitPolicy(WBCPolicy):
         single policy). Any resolved config whose dims disagree with the gait
         layout is rejected up front (AGENTS.md #5: fail fast on a fatal config) -
         loading a non-gait config into the gait observation builder would
-        misplace the clock/torso slots.
+        misplace the clock/torso slots. ``freq_cmd`` is held to the gait clock's
+        stricter ``> 0`` domain here for the same reason: the config's own rule
+        is finiteness, which is all the non-gait variant (with no step-frequency
+        slot) can require.
         """
         cfg = super()._resolve_config(config, checkpoint)
         if config is None and cfg.single_obs_dim == 86 and cfg.command_dim == 7:
@@ -374,6 +384,13 @@ class WBCGaitPolicy(WBCPolicy):
                 f"{GAIT_SINGLE_OBS_DIM}, command_dim={GAIT_COMMAND_DIM}), but the resolved config has "
                 f"single_obs_dim={cfg.single_obs_dim}, command_dim={cfg.command_dim}. "
                 "Use WBCPolicy for the non-gait (86-dim, two-policy) family, or supply a gait config."
+            )
+        # The gait clock needs freq_cmd > 0 (WBCConfig only requires finite,
+        # because the non-gait command block has no step-frequency slot to read).
+        if error := positive_finite_number_error(cfg.freq_cmd, "config.freq_cmd", "WBCGaitPolicy"):
+            raise ValueError(
+                f"{error} The gait clock advances the phase by dt * freq_cmd and warms up over "
+                "0.5 / freq_cmd, so a non-positive step frequency cannot be honored by this variant."
             )
         return cfg
 
@@ -395,6 +412,12 @@ class WBCGaitPolicy(WBCPolicy):
         Note the ``freq_cmd`` slot at index 4 (absent in the non-gait 7-wide
         command) pushes rpy to slots [5:8]. Frequency precedence: per-call
         ``gait_frequency`` kwarg > constructor default > ``config.freq_cmd``.
+
+        Every source in that chain is validated on the same domain, so the
+        spelling that wins the precedence contest cannot accept a value the
+        spelling that loses it would refuse: the per-call kwargs here, the
+        constructor default in :meth:`__init__`, and ``config.freq_cmd`` in
+        :meth:`_resolve_config`.
 
         Returns:
             ``(command, raw_velocity)`` - the 8-wide command block with
@@ -420,21 +443,63 @@ class WBCGaitPolicy(WBCPolicy):
 
         if c > 3:
             height = kwargs.get("height")
-            command[3] = float(height) if height is not None else float(self._config.height_cmd)
+            command[3] = self._validate_height(height) if height is not None else float(self._config.height_cmd)
 
         if c > 4:
             freq = kwargs.get("gait_frequency")
-            if freq is None:
-                freq = self._gait_frequency if self._gait_frequency is not None else self._config.freq_cmd
+            if freq is not None:
+                freq = self._validate_gait_frequency(freq)
+            elif self._gait_frequency is not None:
+                freq = self._gait_frequency
+            else:
+                freq = self._config.freq_cmd
             command[4] = float(freq)
 
         if c > 5:
             rpy_src = kwargs.get("target_orientation")
-            rpy = np.asarray(rpy_src if rpy_src is not None else self._config.rpy_cmd, dtype=np.float64).ravel()
+            rpy = (
+                self._validate_orientation(rpy_src)
+                if rpy_src is not None
+                else np.asarray(self._config.rpy_cmd, dtype=np.float64).ravel()
+            )
             n_rpy = min(c - 5, rpy.shape[0])
             command[5 : 5 + n_rpy] = rpy[:n_rpy]
 
         return command, raw_velocity
+
+    @staticmethod
+    def _validate_gait_frequency(freq: Any) -> float:
+        """Validate a step-frequency command (the ``freq_cmd`` override).
+
+        :meth:`GaitClock.update` documents the domain - ``freq`` "must be
+        strictly positive", because it sets both the phase increment and the
+        warm-up window ``0.5 / freq`` - and enforces it, but only once the
+        command block has been built and handed to it from inside
+        :meth:`get_actions`. Deciding it where the caller's value arrives turns a
+        mid-rollout :class:`ValueError` naming an internal method into one naming
+        the parameter that was supplied.
+
+        The rule is stricter than the ``finite_number_error`` domain
+        :class:`~strands_robots.policies.wbc.config.WBCConfig` applies to
+        ``freq_cmd``, and deliberately so: the non-gait 7-wide command block has
+        no step-frequency slot, so a ``freq_cmd`` of ``0`` is inert for
+        :class:`~strands_robots.policies.wbc.policy.WBCPolicy` and the config
+        cannot demand positivity on its behalf. The gait variant reads the slot,
+        so the positivity rule belongs here - the same place the gait layout
+        itself is enforced.
+
+        Args:
+            freq: The caller-supplied step frequency (steps/s).
+
+        Returns:
+            The value as a ``float``.
+
+        Raises:
+            ValueError: If it is not a usable finite number ``> 0``.
+        """
+        if error := positive_finite_number_error(freq, "gait_frequency", "WBCGaitPolicy"):
+            raise ValueError(error)
+        return float(freq)
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -63,7 +63,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.policies.base import Policy
-from strands_robots.utils import require_optional, sequence_length
+from strands_robots.utils import finite_number_error, require_optional, sequence_length
 
 from .config import WBCConfig
 from .control import compute_targets, pd_control, projected_gravity
@@ -493,6 +493,12 @@ class WBCPolicy(Policy):
         - ``target_orientation = [roll, pitch, yaw]`` -> rpy command slots.
         - ``height`` -> the height command slot.
 
+        Every caller-supplied component is validated on the domain
+        :class:`~strands_robots.policies.wbc.config.WBCConfig` enforces for the
+        field it overrides - a command block goes into the observation the
+        network is given, so a value the config refuses must not reach it
+        through the kwarg documented to take precedence over the config.
+
         Returns:
             ``(command, raw_velocity)`` where ``command`` is the ``command_dim``-
             wide (default 7) observation block with ``cmd_scale`` already applied
@@ -523,13 +529,17 @@ class WBCPolicy(Policy):
         # Slot [3]: target base height (per-call ``height`` overrides the config).
         if c > 3:
             height = kwargs.get("height")
-            command[3] = float(height) if height is not None else float(self._config.height_cmd)
+            command[3] = self._validate_height(height) if height is not None else float(self._config.height_cmd)
 
         # Slots [4:7]: target roll/pitch/yaw (per-call ``target_orientation``
         # overrides the config ``rpy_cmd``).
         if c > 4:
             rpy_src = kwargs.get("target_orientation")
-            rpy = np.asarray(rpy_src if rpy_src is not None else self._config.rpy_cmd, dtype=np.float64).ravel()
+            rpy = (
+                self._validate_orientation(rpy_src)
+                if rpy_src is not None
+                else np.asarray(self._config.rpy_cmd, dtype=np.float64).ravel()
+            )
             n_rpy = min(c - 4, rpy.shape[0])
             command[4 : 4 + n_rpy] = rpy[:n_rpy]
 
@@ -1019,6 +1029,67 @@ class WBCPolicy(Policy):
         for i, v in enumerate(arr):
             if math.isnan(v) or math.isinf(v):
                 raise ValueError(f"target_velocity[{i}]={v!r} must be finite")
+        return arr
+
+    @staticmethod
+    def _validate_height(height: Any) -> float:
+        """Validate a per-call ``height`` command (the ``height_cmd`` override).
+
+        Adopts the domain :class:`~strands_robots.policies.wbc.config.WBCConfig`
+        enforces for ``height_cmd`` verbatim, so the two spellings of one field
+        cannot diverge: a target base height the config refuses must not be
+        reachable through the kwarg documented to override it. Signed, because
+        the slot is an absolute height in metres and only finiteness is
+        constrained; a non-finite one is written straight into the observation
+        block the network is given.
+
+        Args:
+            height: The caller-supplied value.
+
+        Returns:
+            The value as a ``float``.
+
+        Raises:
+            ValueError: If it is not a usable finite number.
+        """
+        if error := finite_number_error(height, "height", "WBCPolicy"):
+            raise ValueError(error)
+        return float(height)
+
+    @staticmethod
+    def _validate_orientation(rpy_src: Any) -> np.ndarray:
+        """Validate a per-call ``target_orientation`` (the ``rpy_cmd`` override).
+
+        Mirrors the per-component rule
+        :class:`~strands_robots.policies.wbc.config.WBCConfig` applies to
+        ``rpy_cmd``, and the numeric-sequence rule :meth:`_validate_velocity`
+        applies to the sibling command component, so a roll/pitch/yaw target the
+        config refuses is not reachable through the kwarg that overrides it.
+        Without it a non-numeric sequence surfaces as NumPy's own
+        ``could not convert string to float`` - which names neither the kwarg nor
+        the policy - and a non-finite component reaches the network.
+
+        Args:
+            rpy_src: The caller-supplied ``[roll, pitch, yaw]`` sequence.
+
+        Returns:
+            The flattened ``float64`` array.
+
+        Raises:
+            ValueError: If it is not a numeric sequence, or any component is not
+                a usable finite number.
+        """
+        try:
+            arr = np.asarray(rpy_src, dtype=np.float64).ravel()
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"target_orientation must be a numeric sequence, got {rpy_src!r}") from e
+        # Inspect the ORIGINAL elements, not ``arr``: the float coercion above
+        # turns a ``True`` into a silent 1.0, and the config refuses a bool
+        # component of ``rpy_cmd``. An object view keeps the two spellings of the
+        # field on the same domain.
+        for index, component in enumerate(np.asarray(rpy_src, dtype=object).ravel()):
+            if error := finite_number_error(component, f"target_orientation[{index}]", "WBCPolicy"):
+                raise ValueError(error)
         return arr
 
 

--- a/tests/policies/wbc/test_command_override_domains.py
+++ b/tests/policies/wbc/test_command_override_domains.py
@@ -1,0 +1,445 @@
+"""Value-domain contracts for the WBC per-call command overrides.
+
+:meth:`WBCPolicy._resolve_command` builds the observation's command block from
+four caller-supplied components. ONE of them was validated: ``target_velocity``
+goes through :meth:`WBCPolicy._validate_velocity` (numeric sequence, at least
+three entries, every component finite). The other three are the per-call
+overrides of ``height_cmd``, ``freq_cmd`` and ``rpy_cmd`` - the three config
+fields :meth:`WBCConfig.__post_init__` does validate - and each reached the
+network raw:
+
+* ``command[3] = float(height)`` - a ``nan`` height put a non-finite value in
+  the frame the network is given; a numeric string raised from that ``float()``.
+* ``command[4:7] = np.asarray(target_orientation)`` - same, per component, and a
+  non-numeric sequence surfaced as NumPy's own ``could not convert string to
+  float``, which names neither the kwarg nor the policy.
+* ``command[4] = float(gait_frequency)`` (the gait variant's step-frequency
+  slot) - :meth:`GaitClock.update` documents that ``freq`` "must be strictly
+  positive" and refuses a non-positive one, but only once the block has been
+  built and handed to it from inside :meth:`get_actions`, so the message named
+  ``GaitClock.update`` rather than the parameter the caller supplied. ``True``
+  and ``"0.75"`` were not refused at all - they were coerced to a silent 1.0 Hz
+  and 0.75 Hz.
+
+The command block is the observation's first ``command_dim`` entries, so a
+non-finite component is not a wrong number in one slot: through the shipped
+dense MLP it makes every one of the 15 joint targets non-finite. The docs table
+for the config spellings states exactly that consequence ("A non-finite scale
+poisons the observation frame the network is given") twelve lines above the
+goal-kwargs table for their unguarded overrides.
+
+These tests pin one contract: every source of a command component is validated
+on the domain the config enforces for the field it overrides, so the spelling
+documented to WIN the precedence contest cannot accept a value the spelling that
+loses it would refuse. The step frequency is held to the gait clock's stricter
+``> 0`` rule at all three of its sources, and the values that remain first-class
+are pinned too, so the guard cannot creep into refusing a command a caller may
+legitimately give.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import math
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import GaitClock, WBCConfig, WBCGaitPolicy, build_gait_frame
+from strands_robots.policies.wbc.policy import WBCPolicy
+from strands_robots.utils import finite_number_error, positive_finite_number_error
+
+from .test_gait import _full_g1_obs, _gait_config
+
+# Values no command component can be honored as: a non-finite one poisons the
+# observation frame, and a non-real one raises from the ``float()`` that reads
+# it. ``bool`` is in the list because ``float(True)`` is a silent 1.0 - the
+# config refuses it for the same reason. ``None`` is NOT: it is how every one
+# of these kwargs spells "not supplied", so it means the config default and is
+# pinned as such below.
+UNUSABLE_ANY_SIGN: list[Any] = [float("nan"), float("inf"), float("-inf"), True, False, "0.75", [0.75]]
+
+# Additionally unusable as a step frequency: the gait clock divides by it.
+UNUSABLE_AS_FREQUENCY: list[Any] = [*UNUSABLE_ANY_SIGN, 0, 0.0, -0.75]
+
+# Signed quantities the config accepts for these fields, so the overrides must too.
+USABLE_HEIGHTS: list[Any] = [0.74, 0.8, 0.0, -0.1, 1, np.float64(0.72)]
+USABLE_FREQUENCIES: list[Any] = [0.75, 1.5, 1e-6, 3, np.float64(2.0)]
+
+
+def _resolve(policy: Any, **kwargs: Any) -> Any:
+    """Build a command block through one funnel.
+
+    These tests deliberately supply values outside the declared kwarg types (a
+    string where a ``float`` is documented, a list where a scalar is), which is
+    the point - the runtime is what must refuse them. Splatting through one
+    ``**kwargs: Any`` funnel states that intent once instead of scattering a
+    per-call suppression over every case.
+    """
+    return policy._resolve_command(kwargs)
+
+
+def _gait(**kwargs: Any) -> Any:
+    """Construct a gait policy through one funnel (see :func:`_resolve`)."""
+    return WBCGaitPolicy(allow_missing_models=True, **kwargs)
+
+
+def _config(**kwargs: Any) -> WBCConfig:
+    """Build a config through one funnel (see :func:`_resolve`)."""
+    return WBCConfig(policy_path="policy.onnx", **kwargs)
+
+
+class _DenseSession:
+    """A seeded dense layer standing in for the shipped gait MLP.
+
+    The point is propagation, not fidelity: every ONNX policy in this family is
+    a dense network, so a single non-finite entry in the 570-wide input reaches
+    all 15 outputs. A stub returning a CONSTANT action would hide exactly that.
+    """
+
+    def __init__(self) -> None:
+        rng = np.random.default_rng(0)
+        self.weights = rng.normal(0.0, 0.02, (570, 15)).astype(np.float32)
+        self.seen: list[np.ndarray] = []
+
+    def get_inputs(self) -> list[Any]:
+        class _In:
+            name = "obs"
+
+        return [_In()]
+
+    def run(self, _outputs: Any, feeds: dict[str, Any]) -> list[np.ndarray]:
+        obs = np.asarray(next(iter(feeds.values())), dtype=np.float32)
+        self.seen.append(obs)
+        return [(obs @ self.weights).astype(np.float32)]
+
+
+def _tick(policy: Any, **kwargs: Any) -> tuple[np.ndarray, np.ndarray]:
+    """Run one real ``get_actions`` tick; return (network input, joint targets)."""
+    session = _DenseSession()
+    policy.policy_session = session
+    with np.errstate(all="ignore"):
+        actions = asyncio.run(policy.get_actions(_full_g1_obs(), "", **kwargs))
+    return session.seen[-1], np.asarray(list(actions[0].values()), dtype=np.float64)
+
+
+class TestAPerCallHeightOverrideSharesTheConfigDomain:
+    """``height`` is the per-call override of ``height_cmd``: one field, one domain."""
+
+    @pytest.mark.parametrize("policy_factory", [WBCPolicy, _gait], ids=["non_gait", "gait"])
+    @pytest.mark.parametrize("value", UNUSABLE_ANY_SIGN, ids=repr)
+    def test_an_unusable_height_is_refused_naming_the_kwarg(self, policy_factory: Any, value: Any) -> None:
+        policy = policy_factory(allow_missing_models=True) if policy_factory is WBCPolicy else policy_factory()
+        with pytest.raises(ValueError, match="height"):
+            _resolve(policy, height=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_ANY_SIGN, ids=repr)
+    def test_the_override_refuses_exactly_what_the_config_field_refuses(self, value: Any) -> None:
+        """Neither spelling of the field may accept what the other rejects."""
+        config_refuses = finite_number_error(value, "height_cmd", "WBCConfig") is not None
+        try:
+            _resolve(WBCPolicy(allow_missing_models=True), height=value)
+            override_refuses = False
+        except ValueError:
+            override_refuses = True
+        assert override_refuses is config_refuses, f"verdicts differ for height={value!r}"
+
+    @pytest.mark.parametrize("value", USABLE_HEIGHTS, ids=repr)
+    def test_a_usable_height_still_reaches_the_command_block(self, value: Any) -> None:
+        command, _ = _resolve(WBCPolicy(allow_missing_models=True), height=value)
+        assert command[3] == pytest.approx(float(value))
+
+    def test_none_means_not_supplied_and_keeps_the_config_default(self) -> None:
+        """The one asymmetry with the config field, and it is deliberate.
+
+        ``kwargs.get("height")`` returns ``None`` when the caller did not supply
+        one, so ``None`` selects ``config.height_cmd`` rather than being a value
+        the guard must refuse. The config field itself has no such spelling - it
+        always holds a number - which is why the parity above excludes it.
+        """
+        policy = WBCPolicy(config=_config(height_cmd=0.71), allow_missing_models=True)
+        assert _resolve(policy, height=None)[0][3] == pytest.approx(0.71)
+        assert _resolve(policy)[0][3] == pytest.approx(0.71)
+        assert finite_number_error(None, "height_cmd", "WBCConfig") is not None
+
+
+class TestAPerCallOrientationOverrideSharesTheConfigDomain:
+    """``target_orientation`` is the per-call override of ``rpy_cmd``."""
+
+    @pytest.mark.parametrize("policy_factory", [WBCPolicy, _gait], ids=["non_gait", "gait"])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf"), True, None], ids=repr)
+    def test_an_unusable_component_is_refused_naming_its_index(self, policy_factory: Any, bad: Any) -> None:
+        policy = policy_factory(allow_missing_models=True) if policy_factory is WBCPolicy else policy_factory()
+        with pytest.raises(ValueError, match=r"target_orientation\[1\]"):
+            _resolve(policy, target_orientation=[0.0, bad, 0.0])
+
+    def test_a_non_numeric_sequence_is_refused_naming_the_kwarg(self) -> None:
+        """Not with NumPy's ``could not convert string to float``, which names nothing."""
+        with pytest.raises(ValueError, match="target_orientation must be a numeric sequence"):
+            _resolve(WBCPolicy(allow_missing_models=True), target_orientation="abc")
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), True], ids=repr)
+    def test_the_override_refuses_exactly_what_the_config_field_refuses(self, bad: Any) -> None:
+        config_refuses = finite_number_error(bad, "rpy_cmd[0]", "WBCConfig") is not None
+        try:
+            _resolve(WBCPolicy(allow_missing_models=True), target_orientation=[bad, 0.0, 0.0])
+            override_refuses = False
+        except ValueError:
+            override_refuses = True
+        assert override_refuses is config_refuses, f"verdicts differ for rpy component {bad!r}"
+
+    def test_a_usable_orientation_still_reaches_the_command_block(self) -> None:
+        command, _ = _resolve(WBCPolicy(allow_missing_models=True), target_orientation=[0.05, -0.1, 0.2])
+        assert command[4:7] == pytest.approx([0.05, -0.1, 0.2])
+
+    def test_a_bool_component_is_refused_despite_the_float_coercion(self) -> None:
+        """``np.asarray([0.0, True, 0.0], float)`` is ``[0., 1., 0.]``.
+
+        The coercion would hide the bool the config refuses for ``rpy_cmd``, so
+        the components are inspected before it.
+        """
+        assert np.asarray([0.0, True, 0.0], dtype=np.float64)[1] == 1.0
+        with pytest.raises(ValueError, match=r"target_orientation\[1\]"):
+            _resolve(WBCPolicy(allow_missing_models=True), target_orientation=[0.0, True, 0.0])
+
+    def test_none_means_not_supplied_and_keeps_the_config_default(self) -> None:
+        policy = WBCPolicy(config=_config(rpy_cmd=[0.01, 0.02, 0.03]), allow_missing_models=True)
+        assert _resolve(policy, target_orientation=None)[0][4:7] == pytest.approx([0.01, 0.02, 0.03])
+
+
+class TestEveryStepFrequencySourceSharesOneDomain:
+    """Per-call kwarg, constructor default and ``config.freq_cmd`` - one rule.
+
+    The precedence chain is documented as per-call > constructor > config, so a
+    guard on only the config would sit behind both spellings that win.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_AS_FREQUENCY, ids=repr)
+    def test_the_per_call_kwarg_is_refused_naming_the_kwarg(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="gait_frequency"):
+            _resolve(_gait(), gait_frequency=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_AS_FREQUENCY, ids=repr)
+    def test_the_constructor_default_is_refused_naming_the_kwarg(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="gait_frequency"):
+            _gait(gait_frequency=value)
+
+    @pytest.mark.parametrize("value", [0, 0.0, -0.75], ids=repr)
+    def test_the_config_field_is_refused_for_the_gait_layout(self, value: Any) -> None:
+        """The third source: a config the gait clock could not honor either."""
+        config = _config(freq_cmd=value, single_obs_dim=95, command_dim=8)
+        with pytest.raises(ValueError, match="freq_cmd"):
+            _gait(config=config)
+
+    @pytest.mark.parametrize("value", UNUSABLE_AS_FREQUENCY, ids=repr)
+    def test_all_three_sources_agree(self, value: Any) -> None:
+        """No source may accept a step frequency another source refuses."""
+        verdicts = {}
+        try:
+            _resolve(_gait(), gait_frequency=value)
+            verdicts["per_call"] = "accepted"
+        except ValueError:
+            verdicts["per_call"] = "refused"
+        try:
+            _gait(gait_frequency=value)
+            verdicts["constructor"] = "accepted"
+        except ValueError:
+            verdicts["constructor"] = "refused"
+        if isinstance(value, float | int) and not isinstance(value, bool):
+            try:
+                _gait(config=_config(freq_cmd=value, single_obs_dim=95, command_dim=8))
+                verdicts["config"] = "accepted"
+            except ValueError:
+                verdicts["config"] = "refused"
+        assert len(set(verdicts.values())) == 1, f"sources disagree for {value!r}: {verdicts}"
+
+    def test_none_means_not_supplied_at_both_the_kwarg_and_the_constructor(self) -> None:
+        """``None`` selects the next source in the precedence chain, as documented."""
+        config = _config(freq_cmd=0.9, single_obs_dim=95, command_dim=8)
+        assert _resolve(_gait(config=config), gait_frequency=None)[0][4] == pytest.approx(0.9)
+        assert _resolve(_gait(config=config, gait_frequency=None))[0][4] == pytest.approx(0.9)
+        assert _resolve(_gait(config=config, gait_frequency=1.4))[0][4] == pytest.approx(1.4)
+
+    @pytest.mark.parametrize("value", USABLE_FREQUENCIES, ids=repr)
+    def test_a_usable_frequency_still_reaches_the_slot(self, value: Any) -> None:
+        command, _ = _resolve(_gait(gait_frequency=value))
+        assert command[4] == pytest.approx(float(value))
+        per_call, _ = _resolve(_gait(), gait_frequency=value)
+        assert per_call[4] == pytest.approx(float(value))
+
+    def test_the_frequency_rule_is_deliberately_stricter_than_the_config_rule(self) -> None:
+        """``WBCConfig`` cannot demand positivity on the gait variant's behalf.
+
+        The non-gait 7-wide command block has no step-frequency slot, so a
+        ``freq_cmd`` of ``0`` is inert for :class:`WBCPolicy` and the config's
+        rule is finiteness. The gait variant reads the slot, so the positivity
+        rule lives at the gait layer - which is also why the two rules must not
+        be collapsed into one.
+        """
+        assert finite_number_error(0.0, "freq_cmd", "WBCConfig") is None
+        assert positive_finite_number_error(0.0, "gait_frequency", "WBCGaitPolicy") is not None
+        # A non-gait config with freq_cmd=0 stays constructible and usable.
+        non_gait = WBCPolicy(config=_config(freq_cmd=0.0), allow_missing_models=True)
+        command, _ = _resolve(non_gait)
+        assert len(command) == 7, "the non-gait block has no step-frequency slot to poison"
+
+
+class TestTheGaitClockDomainIsWhatTheGuardEnforces:
+    """The guard is the clock's own documented rule, decided where the value arrives."""
+
+    @pytest.mark.parametrize("value", [0.0, -0.75, float("nan"), float("inf")], ids=repr)
+    def test_every_frequency_the_clock_refuses_is_refused_up_front(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="freq must be finite and > 0"):
+            GaitClock().update(np.array([0.5, 0.0, 0.0]), value)
+        with pytest.raises(ValueError, match="gait_frequency"):
+            _resolve(_gait(), gait_frequency=value)
+
+    def test_the_guard_also_refuses_what_the_clock_would_silently_coerce(self) -> None:
+        """``True`` reaches the clock as a 1.0 Hz gait nobody asked for."""
+        clock_output = GaitClock().update(np.array([0.5, 0.0, 0.0]), True)
+        assert np.all(np.isfinite(clock_output)), "the clock accepts a bool as 1.0 Hz"
+        with pytest.raises(ValueError, match="gait_frequency"):
+            _resolve(_gait(), gait_frequency=True)
+
+
+class TestARefusalPrecedesTheModelLoader:
+    """A constructor-time refusal must not first load the ONNX session(s)."""
+
+    def test_a_bad_constructor_frequency_never_reaches_the_loader(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        loads: list[str] = []
+
+        def _fatal(self: Any, *args: Any, **kwargs: Any) -> Any:
+            loads.append("loaded")
+            raise AssertionError("the ONNX loader must not run for a refused frequency")
+
+        monkeypatch.setattr(WBCPolicy, "_load_sessions", _fatal, raising=False)
+        with pytest.raises(ValueError, match="gait_frequency"):
+            _gait(gait_frequency=0.0)
+        assert loads == []
+
+    def test_a_usable_constructor_frequency_still_constructs(self) -> None:
+        assert _gait(gait_frequency=1.5)._gait_frequency == pytest.approx(1.5)
+
+
+class TestAnUnusableComponentNeverReachesTheNetwork:
+    """Why the domain matters: one non-finite slot is 15 non-finite joint targets."""
+
+    def test_a_non_finite_command_slot_poisons_every_joint_target(self) -> None:
+        """The premise, measured on the command block directly."""
+        config = _gait_config()
+        command = np.zeros(config.command_dim, dtype=np.float64)
+        command[3] = float("nan")  # the height slot, as an unguarded override wrote it
+        frame = build_gait_frame(
+            config,
+            command=command,
+            base_ang_vel=np.zeros(3),
+            proj_gravity=np.array([0.0, 0.0, -1.0]),
+            qj=np.zeros(29),
+            dqj=np.zeros(29),
+            prev_action=np.zeros(15),
+            clock=np.zeros(2),
+        )
+        assert int((~np.isfinite(frame)).sum()) == 1, "one poisoned slot"
+        session = _DenseSession()
+        stacked = np.tile(frame, 6).reshape(1, 570).astype(np.float32)
+        with np.errstate(all="ignore"):
+            out = session.run(None, {"obs": stacked})[0]
+        assert int((~np.isfinite(out)).sum()) == 15, "a dense layer spreads it to every target"
+
+    @pytest.mark.parametrize(
+        ("kwargs_", "pattern"),
+        [
+            ({"height": float("nan")}, "height"),
+            ({"target_orientation": [float("inf"), 0.0, 0.0]}, r"target_orientation\[0\]"),
+            ({"gait_frequency": 0.0}, "gait_frequency"),
+        ],
+        ids=["height", "target_orientation", "gait_frequency"],
+    )
+    def test_a_full_rollout_tick_refuses_instead_of_feeding_the_network(
+        self, kwargs_: dict[str, Any], pattern: str
+    ) -> None:
+        with pytest.raises(ValueError, match=pattern):
+            _tick(_gait(), **kwargs_)
+
+    def test_a_fully_specified_usable_command_keeps_the_frame_finite(self) -> None:
+        obs, targets = _tick(
+            _gait(),
+            target_velocity=[0.5, 0.0, 0.0],
+            height=0.8,
+            gait_frequency=1.5,
+            target_orientation=[0.0, 0.05, 0.1],
+        )
+        assert obs.shape == (1, 570)
+        assert np.all(np.isfinite(obs)), "a usable command must not be refused or poisoned"
+        assert np.all(np.isfinite(targets)) and targets.size == 15
+
+
+class TestEveryCallerSuppliedCommandComponentIsValidated:
+    """Structural guard: a fifth component cannot be added without a domain.
+
+    Both ``_resolve_command`` implementations read their caller-supplied
+    components out of ``kwargs`` by name. Every such name must reach a
+    ``_validate_*`` call in the same method, so a new goal kwarg cannot start
+    flowing into the observation block unchecked.
+    """
+
+    @staticmethod
+    def _components_and_validators(func: Any) -> tuple[set[str], set[str]]:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+        node = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
+        read: set[str] = set()
+        validated: set[str] = set()
+        for call in (n for n in ast.walk(node) if isinstance(n, ast.Call)):
+            if isinstance(call.func, ast.Attribute):
+                if call.func.attr == "get" and call.args and isinstance(call.args[0], ast.Constant):
+                    read.add(str(call.args[0].value))
+                elif call.func.attr.startswith("_validate_"):
+                    validated.add(call.func.attr)
+        return read, validated
+
+    @pytest.mark.parametrize(
+        "method", [WBCPolicy._resolve_command, WBCGaitPolicy._resolve_command], ids=["non_gait", "gait"]
+    )
+    def test_every_component_read_from_kwargs_has_a_validator(self, method: Any) -> None:
+        read, validated = self._components_and_validators(method)
+        assert read, "the scanner found no kwargs.get(...) component at all"
+        expected = {
+            "target_velocity": "_validate_velocity",
+            "height": "_validate_height",
+            "target_orientation": "_validate_orientation",
+            "gait_frequency": "_validate_gait_frequency",
+        }
+        missing = {name for name in read if expected.get(name, "") not in validated}
+        assert not missing, f"command components read without a domain: {sorted(missing)}"
+
+    def test_the_scanner_would_notice_an_unguarded_component(self) -> None:
+        """Non-vacuity: a planted component with no validator must be reported."""
+
+        def _planted(self: Any, kwargs: dict[str, Any]) -> None:
+            _ = kwargs.get("target_velocity")
+            _ = kwargs.get("stride_length")  # no domain
+            self._validate_velocity(_)
+
+        read, validated = self._components_and_validators(_planted)
+        assert read == {"target_velocity", "stride_length"}
+        assert validated == {"_validate_velocity"}
+
+    def test_both_implementations_are_the_real_ones(self) -> None:
+        """Non-vacuity: the scan root must resolve to the shipped module."""
+        for method in (WBCPolicy._resolve_command, WBCGaitPolicy._resolve_command):
+            assert Path(inspect.getfile(method)).parent.name == "wbc"
+
+
+class TestTheGuardsDoNotDependOnMathIsnanDirectly:
+    """The overrides delegate to the shared numeric rule, not a local copy."""
+
+    def test_the_height_and_orientation_rules_are_the_shared_domain(self) -> None:
+        for value in UNUSABLE_ANY_SIGN:
+            assert finite_number_error(value, "height", "WBCPolicy") is not None
+        assert finite_number_error(0.0, "height", "WBCPolicy") is None
+        assert not math.isnan(0.0)  # the sibling velocity rule still uses math directly


### PR DESCRIPTION
## Problem

`WBCPolicy._resolve_command` builds the observation's command block from four caller-supplied components. **One** of them was validated: `target_velocity` goes through `_validate_velocity` (numeric sequence, >= 3 entries, every component finite). The other three are the per-call overrides of `height_cmd`, `freq_cmd` and `rpy_cmd` -- the three config fields `WBCConfig.__post_init__` *does* check -- and each reached the network raw.

The precedence is documented as **per-call kwarg > constructor default > `config.freq_cmd`**, so the guard sat behind every spelling that wins.

Closes #1994

### Measured on a real Unitree G1 with the real `GR00T-WholeBodyControl-Balance.onnx` weights

`run_policy(policy_provider="wbc", policy_kwargs={"target_velocity": [0,0,0], "height": nan})`:

```
Policy failed: All of the first 3 action steps had 100% unresolved keys on
'unitree_g1' -- the robot has not moved. Unresolved keys:
['left_hip_pitch_joint', 'left_hip_roll_joint', 'left_hip_yaw_joint', ...]
```

The command block is the observation's first `command_dim` entries, so the `nan` did not land in one wrong slot. The policy is dense, so it reached **all 15 joint targets**; `send_action` then refused every one; and the fail-fast probe concluded the rollout is running the wrong **embodiment** and listed the joint names. A caller who mistyped one `height` is sent to debug fifteen joint names.

| override | source | on `main` |
|---|---|---|
| `height` (overrides `height_cmd`) | per-call kwarg | `nan`/`inf` reach the observation; `"0.8"` raises from the `float()` |
| `target_orientation` (`rpy_cmd`) | per-call kwarg | non-finite per component reaches it; a non-numeric sequence surfaces as NumPy's `could not convert string to float`, naming neither the kwarg nor the policy |
| `gait_frequency` (`freq_cmd`) | per-call kwarg | `0`/`-0.75`/`nan`/`inf` -> `ValueError` naming `GaitClock.update`, mid-`get_actions`; `True` -> a silent **1.0 Hz**; `"0.75"` accepted |
| `gait_frequency` | constructor default | stored with a bare `float()`, never checked |
| `gait_frequency` | `config.freq_cmd` | `finite` only, so `0` constructs and the clock refuses it later |

`GaitClock.update` already documents the domain -- `freq` *"must be strictly positive"*, because it sets both the phase increment and the warm-up window `0.5 / freq` -- and enforces it. But only once the block has been built and handed to it from inside `get_actions`, which is why the message named an internal method; and it accepts a `bool` as 1.0, so that spelling was not refused at all.

## Change

Each override adopts the domain the config enforces for the field it overrides, so the two spellings of one field cannot diverge:

- `WBCPolicy._validate_height` -> `finite_number_error` (the `height_cmd` rule). Signed: an absolute height, so only finiteness is constrained.
- `WBCPolicy._validate_orientation` -> numeric sequence + `finite_number_error` per component (the `rpy_cmd` rule), inspecting the **original** elements. `np.asarray([0.0, True, 0.0], float)` is `[0., 1., 0.]`, so coercing first would hide the `bool` the config refuses.
- `WBCGaitPolicy._validate_gait_frequency` -> `positive_finite_number_error`, applied at the per-call kwarg, the constructor default **and** `config.freq_cmd`. The constructor check runs before `super().__init__()` loads the ONNX session, so an unusable frequency is reported at construction rather than on the first tick of a started rollout -- mirroring the constructor-time `target_velocity` check the base policy already does.

Both `_resolve_command` implementations are covered: the non-gait 7-wide block shares the `height` and `target_orientation` overrides.

No new helper -- these are the same `strands_robots.utils` domains `WBCConfig` already uses.

### Why the frequency rule is stricter than the config's, deliberately

The non-gait 7-wide command block has no step-frequency slot, so `freq_cmd = 0` is inert for `WBCPolicy` and the config cannot demand positivity on its behalf. The gait variant reads the slot, so the positivity rule lives at the gait layer -- the same place the gait layout itself is enforced. Both halves are pinned, including that a non-gait config with `freq_cmd = 0` stays constructible and usable.

### Preserved

`None` still means "not supplied" at every override and selects the next source in the precedence chain (the one deliberate asymmetry with the config field, which always holds a number). The signed values the config accepts -- a zero or negative height, a negative yaw target -- remain first-class, and `target_velocity` is unchanged.

## Verification

Base `ae1176a3`, head `bb4da05f`.

- **Pre-fix proof** (source reverted to `upstream/main`, the new tests present): **74 failed / 28 passed**. The structural guard names the adrift components verbatim -- `command components read without a domain: ['height', 'target_orientation']` for the non-gait block and `['gait_frequency', 'height', 'target_orientation']` for the gait block. Post-fix: **102 passed**. The 28 that pass pre-fix are the over-reach controls (every usable value still honored), the config-domain premises and the scanner's own non-vacuity tests.
- **Full suite**: `MUJOCO_GL=egl python -m pytest tests` -> **21869 passed, 257 skipped, 0 failed** (642 s). **Zero existing-test churn** -- the 307 pre-existing `tests/policies/wbc/` tests pass unchanged.
- **Lint**: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1090 source files`.
- `python3 scripts/assemble_changelog.py --check` -> OK. Merge-base overlap check -> no overlap.

## Scope: one residual on this surface is deliberately not in here

`target_orientation` is validated per component here, which is a **value** rule. It does not
constrain the number of components, and a *short* orientation silently zeroes the axes it does not
supply rather than leaving them on `config.rpy_cmd`: with `rpy_cmd=[0.7, 0.8, 0.9]`, a
`target_orientation=[0.5]` writes `[0.5, 0.0, 0.0]` while omitting the kwarg writes
`[0.7, 0.8, 0.9]`. Every component supplied is a usable finite number, so no per-component domain
can see it -- measured identical on `main`, on this branch, and on the closed #1995. It is an arity
question with two defensible contracts (refuse a short orientation, or fill the unsupplied axes from
the config field), so it is filed as #1997 with the measurements rather than guessed here.

Longer orientations are unaffected: the existing truncation behaviour is deliberate and stays pinned.

## Independent verification at this head

Re-measured rather than carried over, because the base branch advanced to `2429b17d` (#1993) after
the figures above were taken. Run on the tree that actually lands -- this branch merged with current
`main`, which merges cleanly (`122cecc`) -- on aarch64, Python 3.13, mujoco 3.11.0, `MUJOCO_GL=egl`:

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly` -> **21999 passed, 257 skipped, 0 failed** in 581 s
- `ruff check strands_robots tests tests_integ` -> clean; `ruff format --check` -> 1093 files already formatted
- `mypy strands_robots tests tests_integ` -> 14 errors, **all** in `examples/isaac_gs`, **0 outside**; the
  error set is byte-identical to a pristine `upstream/main` worktree of the same working copy, so it is
  environmental to this checkout rather than introduced here
- `python3 scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -> no overlap
  (7 paths changed on `main` in that span, none of them this branch's)
- `python3 scripts/assemble_changelog.py --check` -> OK, exactly one fragment for this change
- #1993's content is present and intact on the merged tree (`training/_validate.py`, `tests/training/test_discount_factor_domain.py`)

The contract was also swept independently of the test suite: one probe script run unchanged in three
worktrees (`main`, this branch, #1995), covering every component of the command block against a fixed
probe set on both policy classes, 68 cells each. This branch changes **34** of them from `main`; the
one nan-goal poisoning measured above is `later ticks STILL non-finite` on `main` and
`refused up front` here, on both `WBCPolicy` and `WBCGaitPolicy`.

## Artifact

Real Unitree G1, real `GR00T-WholeBodyControl-Balance.onnx` weights, headless MuJoCo, 200 ticks at 50 Hz.

![WBC per-call command override domains](https://raw.githubusercontent.com/cagataycali/robots/artifacts/wbc-command-override-domains/wbc_command_override_domains.png)

**A** is the no-regression panel: under the honored command the balance policy holds the pelvis at 0.7477 m over 4 s with 6.4 cm of drift, and the pelvis-height trace is **byte-identical on both trees** (`np.array_equal` over 201 samples) -- the render differs by max 1/255 over 0.007% of pixels, which is renderer noise. **B** and **C** are what a caller is told for the *same* `height=nan`: on `main`, a report about the embodiment listing fifteen joint names; with this change, the parameter that was supplied, before the network is queried.

The physical outcome is the same either way -- the rollout aborts and nothing moves -- so what the panels show is the difference between a report a caller can act on and one that sends them somewhere else. Every number in the figure is read from the two runs' JSON dumps; the generator asserts each one, and asserts the two runs came from different source trees.
