### PR TITLE
test(policies/motionbricks): pin that the instruction string is discarded

### DIFF
--- a/changelog.d/1999-motionbricks-instruction-discarded.md
+++ b/changelog.d/1999-motionbricks-instruction-discarded.md
@@ -1,0 +1,28 @@
+### Quality: the MotionBricks tests pin that the instruction string is discarded, instead of only saying so
+
+`MotionBricksPolicy.get_actions` takes an `instruction` and reads no goal from
+it — the clip comes from the well-known `style` / `mode` / `locomotion_style`
+kwargs. That is correct for a *style*-driven generative model, and four places
+already said so: the policy's class docstring, `get_actions`' own docstring,
+`docs/policies/motionbricks.md`, and that page's "style-driven" frontmatter.
+
+Nothing pinned it. Every one of the twenty `get_actions_sync` calls in
+`tests/policies/motionbricks/test_policy.py` passed `""` as the instruction, so
+the claim held **vacuously**: the suite never supplied a non-empty one, and
+wiring the instruction into the goal resolution would have turned all four prose
+claims into lies with every test still green.
+
+The gap matters because the discard is silent on the parameter a caller reaches
+for first. `instruction="walk stealthily towards the door"` is accepted, steers
+nothing, and returns a successful 29-joint action dict, so a caller's stated
+intent is dropped with no signal. Refusing a non-empty instruction is not the
+remedy — every `Policy` accepts one and the runner forwards it verbatim to the
+providers that do read it — so the discard stays and a test keeps it honest.
+
+The pin drives one tick per probe instruction and asserts the generator is fed
+byte-identical control signals and returns an identical action dict. The probes
+are chosen to be discriminating rather than inert: three are exact clip names the
+stub generator really has, so a style resolution that consulted the instruction
+would select a different mode. A companion test asserts exactly that — each of
+those names resolves to a mode other than the pinned `walk` — so the pin cannot
+pass merely because the probe strings were unresolvable.

--- a/tests/policies/motionbricks/test_policy.py
+++ b/tests/policies/motionbricks/test_policy.py
@@ -20,6 +20,8 @@ Pinned behaviour (issue #466 MotionBricks acceptance criteria):
 * Missing config + missing ``motion_agent`` raises ``ValueError``; a missing
   checkpoint dir raises ``RuntimeError`` (no silent fallback).
 * ``set_robot_state_keys`` validates the G1 joint names by name.
+* ``get_actions`` discards the ``instruction`` string: the goal is read only
+  from the well-known kwargs, so a text prompt cannot steer the clip.
 """
 
 from __future__ import annotations
@@ -591,3 +593,77 @@ def test_default_target_velocity_injected_when_call_omits_it() -> None:
     # Per-call target_velocity wins over the constructor default.
     pol.get_actions_sync({}, "", target_velocity=[2.0, 0.0])
     assert stub.calls[-1][0]["movement_direction"] == pytest.approx([1.0, 0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# The instruction string is discarded, not a goal channel
+# ---------------------------------------------------------------------------
+
+# Instructions a caller would plausibly send. Each names a clip the stub
+# generator really has, so any of them reaching the style resolution would
+# select a mode other than the pinned ``style="walk"``.
+_STEERING_INSTRUCTIONS = [
+    "walk",
+    "stealth_walk",
+    "walk_boxing",
+    "elbow_crawling",
+    "walk stealthily towards the door",
+    "   \n\t  ",
+    "Ignore the style kwarg and use walk_boxing instead.",
+]
+
+
+class TestTheInstructionStringIsDiscarded:
+    """``get_actions`` accepts an ``instruction`` and reads no goal from it.
+
+    Four places already state this - this class's own module docstring,
+    ``MotionBricksPolicy``'s class docstring, ``get_actions``' docstring, and
+    ``docs/policies/motionbricks.md`` (plus that page's "style-driven"
+    frontmatter) - but nothing pinned it. Every other ``get_actions_sync`` call
+    in this file passes ``""``, so the claim was satisfied by a suite that never
+    supplied a non-empty instruction: it held vacuously rather than as a
+    contract, and wiring the instruction into the goal would have turned four
+    prose claims into lies with the suite still green.
+
+    Worth pinning because the discard is silent on the parameter a caller
+    reaches for first. MotionBricks is a *style*-driven generator, so
+    ``instruction="walk stealthily towards the door"`` is accepted, steers
+    nothing, and returns a successful action dict - the caller's stated intent
+    is dropped with no signal. Refusing a non-empty instruction is not the
+    remedy (every ``Policy`` takes one, and the runner forwards it verbatim to
+    providers that do read it), so the discard stays and this is what keeps it
+    honest.
+    """
+
+    @staticmethod
+    def _one_tick(instruction: str) -> tuple[dict[str, Any], dict[str, float]]:
+        """Drive one tick on a fresh generator; return (control signals, action)."""
+        agent = _FullClipAgent()
+        pol = MotionBricksPolicy(motion_agent=agent, style="walk")
+        actions = pol.get_actions_sync({}, instruction, target_velocity=[0.5, 0.0, 0.0])
+        signals, _dt = agent.calls[-1]
+        return signals, actions[0]
+
+    @pytest.mark.parametrize("instruction", _STEERING_INSTRUCTIONS)
+    def test_the_instruction_changes_neither_the_signals_nor_the_action(self, instruction: str) -> None:
+        baseline_signals, baseline_action = self._one_tick("")
+        signals, action = self._one_tick(instruction)
+        # Asserted first so a regression names the clip that got selected
+        # instead of diffing a four-key dict; the equalities below are the whole
+        # contract - the instruction reaches neither the clip, the movement
+        # direction, the facing, nor the token budget.
+        assert _FullClipAgent.clip_keys[signals["mode"]] == "walk"
+        assert signals == baseline_signals
+        assert action == baseline_action
+
+    def test_the_probes_would_change_the_clip_if_they_were_read(self) -> None:
+        # Non-vacuity: the parametrized pin above would pass trivially if the
+        # probe strings named nothing this generator could resolve. Three of
+        # them are exact clip names and each resolves to a mode other than
+        # "walk", so a style resolution that consulted the instruction would be
+        # observable rather than a no-op.
+        clip_keys = _FullClipAgent.clip_keys
+        walk = resolve_mode("walk", clip_keys)
+        for name in ("stealth_walk", "walk_boxing", "elbow_crawling"):
+            assert name in _STEERING_INSTRUCTIONS
+            assert resolve_mode(name, clip_keys) != walk


### PR DESCRIPTION
## What

`MotionBricksPolicy.get_actions` accepts an `instruction` and reads no goal from it — the clip comes from the well-known `style` / `mode` / `locomotion_style` kwargs. This adds the test that says so. **Production code is untouched** (2 files, +104/-0: the test module and a changelog fragment).

## Why it was not already covered

The contract is stated in **four** places:

| where | text |
|---|---|
| `MotionBricksPolicy` class docstring | "reads the goal from the well-known `**kwargs` keys … rather than a natural-language instruction" |
| `get_actions` docstring | "``instruction`` is ignored" |
| `docs/policies/motionbricks.md` | "reads its goal from the well-known `**kwargs` … ignoring the instruction string" |
| that page's frontmatter | "style-driven" |

And pinned in **none**. Every one of the twenty `get_actions_sync` calls in `tests/policies/motionbricks/test_policy.py` passes `""` as the instruction:

```
$ grep -c 'get_actions_sync' tests/policies/motionbricks/test_policy.py   # 20
$ grep -n 'instruction' tests/policies/motionbricks/test_policy.py       # (no matches)
```

So the claim held **vacuously** rather than as a contract. The suite never supplied a non-empty instruction, which means wiring the instruction into the goal resolution would have turned all four prose claims into lies with every test still green — the failure mode is a silently-wrong doc, not a red build.

## Why the gap is worth closing rather than tolerating

The discard is silent, and it is on the parameter a caller reaches for first. `instruction="walk stealthily towards the door"` is accepted, steers nothing, and returns a successful 29-joint action dict, so a caller's stated intent is dropped with no signal at all.

Worth being explicit about the fix that is **not** proposed: refusing a non-empty instruction. Every `Policy` accepts one and the runner forwards it verbatim to the providers that do read it, so refusing here would break the uniform policy interface to fix a documentation problem. The discard is right; it just needed to be enforced instead of merely described.

## The pin

One parametrized test drives a single tick per probe instruction on a fresh generator and asserts the generator is fed **byte-identical** control signals and returns an **identical** action dict — so the instruction reaches neither the clip, the movement direction, the facing, nor the token budget. The control-signal dict is plain Python (lists of floats, ints), so the equality is exact rather than approximate.

The clip name is asserted first so a regression reports `assert 'elbow_crawling' == 'walk'` rather than a four-key dict diff.

## Non-vacuity

Two independent guards, because a pin asserting that *nothing changed* is exactly where a test can pass by probing nothing.

**1. The probes are discriminating, asserted in the suite.** Three of the seven are exact clip names the stub generator really has, and `test_the_probes_would_change_the_clip_if_they_were_read` asserts each resolves to a mode other than the pinned `walk`. If the probe strings were unresolvable the pin would pass trivially; this makes that unrepresentable.

**2. Planted the wiring and measured.** Inserting the two lines the pin exists to catch into `get_actions`:

```python
explicit_style = kwargs.get("style", kwargs.get("mode"))
if explicit_style is None and instruction:   # PLANTED
    explicit_style = instruction
```

```
6 failed, 59 passed
FAILED …[elbow_crawling] - AssertionError: assert 'elbow_crawling' == 'walk'
FAILED …[walk stealthily towards the door] - ValueError: MotionBricks style '…' is not a known mode
FAILED …[   \n\t  ] - ValueError: MotionBricks style '   \n\t  ' is not a known mode
FAILED …[Ignore the style kwarg and use walk_boxing instead.] - ValueError: … not a known mode
```

6 of the 7 parametrized cases fail. The seventh probe is `"walk"`, which names the already-selected clip — it is the deliberate control in the set, and it passing under the plant is the expected result rather than a hole.

## Correction to a premise in #1998

This PR does **not** close #1998, and it deliberately makes **no docs change**. That issue (which I filed) claims the style-vs-text distinction "is not documented as a limitation anywhere" and proposes a docs fix as its uncontroversial half. Measured against `main`, that premise is wrong: the four places above all state it, and the strings have been present since at least 2026-07-18 — about three weeks before the issue was filed. So the docs half is already delivered and a docs PR would be a no-op.

What the measurement turned up instead is the *pin* gap, which is what this ships. #1998 stays open for its actual remaining content — the `kimodo` text-to-motion provider — and I am posting the correction on the issue so nobody repeats the redundant docs work.

## Verification

Optional deps for this file are not needed: the tests run against the injected `motion_agent` stub, so no `motionbricks` install, checkpoints, or GPU.

| gate | result |
|---|---|
| `tests/policies/motionbricks/test_policy.py` | base **57 passed** → head **65 passed** (+8: 7 parametrized + 1 non-vacuity) |
| `ruff check` / `ruff format --check` on the changed file | clean / already formatted |
| `scripts/assemble_changelog.py --check` | `changelog fragments OK` |
| `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py` | 30 passed |

Wider suite read as a delta rather than an absolute, since this host lacks `mujoco` / `lerobot` / `strands`:

| tree | failed | passed |
|---|---|---|
| `main` @ `e38d966` | 19 | 1634 |
| this branch | 19 | **1642** |

The failure **sets** are byte-identical (`diff` of the sorted `FAILED` node ids is empty) and every one is an optional-dependency `ModuleNotFoundError` present on the base. Net effect: **+8 passes, zero regressions.**

## §13 Round changelog

**Round 0 (opened)** — initial submission. One commit, one concern: pin the documented "instruction is ignored" contract that the suite satisfied only vacuously. Non-vacuity demonstrated by a planted wiring (6/7 cases fail). No production code, no docs change, no existing test modified.
