### PR TITLE
fix(policies/wbc): refuse a short target_orientation instead of zeroing the axes it omits

### DIFF
--- a/changelog.d/1997-wbc-orientation-arity.md
+++ b/changelog.d/1997-wbc-orientation-arity.md
@@ -1,0 +1,32 @@
+### Fixed: a short `target_orientation` is refused rather than zeroing the axes it does not supply
+
+`WBCPolicy._resolve_command` writes the per-call `target_orientation` into a
+zero-initialised command block with `command[4 : 4 + n_rpy] = rpy[:n_rpy]`, where
+`n_rpy = min(c - 4, rpy.shape[0])`. `_validate_orientation` checked every
+component's value and not the count, so a sequence carrying fewer than three
+components left the axes it did not supply at `0.0` - not at the `rpy_cmd` value
+that applies when the kwarg is omitted entirely.
+
+With `rpy_cmd=[0.7, 0.8, 0.9]`, omitting the kwarg commanded `[0.7, 0.8, 0.9]`
+while `target_orientation=[0.5]` commanded `[0.5, 0.0, 0.0]` and
+`target_orientation=[]` commanded `[0.0, 0.0, 0.0]` - silently commanding zero
+for axes the caller never mentioned, discarding orientation targets they *did*
+configure, under a `success` result. The scalar spellings (`0.5`,
+`np.float64(0.5)`) took the identical path, since `np.asarray(0.5).ravel()` is a
+well-formed one-element array. Every component in each of those inputs is a
+usable finite number, so the per-component value rule could not see any of it.
+
+`target_velocity` - the sibling vector component of the same block, written by
+the same method - already refused exactly this class of caller mistake
+(`target_velocity must have at least 3 elements [vx, vy, omega], got 2`), and the
+kwargs table in `docs/policies/wbc.md` already documented that arity rule for
+`target_velocity` and not for `target_orientation`. `_validate_orientation` now
+applies the same rule in the same order the sibling uses - coercion, then arity,
+then per-component values - so both vector components of the block give one
+answer to a partial triple, and the refusal names the parameter, the axes and the
+count supplied. `WBCGaitPolicy._resolve_command`, whose `freq_cmd` slot pushes
+rpy to `[5:8]`, calls the same inherited validator and is covered too.
+
+A *longer* orientation is deliberately still accepted and truncated to the slots
+available: every component the block has room for is honored and only the surplus
+is dropped, which is what the sibling does with a packed velocity (`vel_full[:3]`).

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -122,7 +122,7 @@ coupling to a backend:
 | Key | Type | Accepted | Meaning |
 |-----|------|----------|---------|
 | `target_velocity` | `list[float]` | numeric, >= 3 entries, every component finite | Locomotion command `[vx, vy, omega]` (m/s, m/s, rad/s). Scaled by `cmd_scale` (`[2.0, 2.0, 0.5]`) into the observation's command block. |
-| `target_orientation` | `list[float]` | numeric sequence, finite per component | Target base `[roll, pitch, yaw]` (rad), written to command slots `[4:7]`. Defaults to the config `rpy_cmd` (`[0,0,0]`). |
+| `target_orientation` | `list[float]` | numeric, >= 3 entries, every component finite | Target base `[roll, pitch, yaw]` (rad), written to command slots `[4:7]`. Defaults to the config `rpy_cmd` (`[0,0,0]`). |
 | `height` | `float` | finite | Target base height (m), written to command slot `[3]`. Defaults to the config `height_cmd` (`0.74`). |
 
 A per-call `target_velocity` overrides the constructor-time default. With no
@@ -133,7 +133,13 @@ source in the precedence chain, so `None` is how a kwarg spells "not supplied".
 Each key's accepted domain is the one `WBCConfig` enforces for the field it
 overrides - `height` for `height_cmd`, `target_orientation` for `rpy_cmd` - so a
 value the config refuses is not reachable through the kwarg documented to take
-precedence over it. The command block is the observation's first `command_dim`
+precedence over it. Both vector keys additionally require at least three
+components: the command block is zero-initialised, so accepting a shorter
+`target_orientation` would leave the axes it omits at `0.0` rather than at the
+configured `rpy_cmd` value the omitted kwarg falls back to - silently commanding
+zero for an axis the caller never mentioned. A LONGER sequence is accepted and
+truncated to the slots available, since every component the block has room for is
+honored and only the surplus is dropped. The command block is the observation's first `command_dim`
 entries, so a non-finite component is not one wrong slot: the network is dense,
 so it reaches all `num_actions` joint targets, every one is then refused by
 `send_action`, and the rollout aborts reporting *"100% unresolved keys ... the

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -1062,12 +1062,23 @@ class WBCPolicy(Policy):
 
         Mirrors the per-component rule
         :class:`~strands_robots.policies.wbc.config.WBCConfig` applies to
-        ``rpy_cmd``, and the numeric-sequence rule :meth:`_validate_velocity`
-        applies to the sibling command component, so a roll/pitch/yaw target the
-        config refuses is not reachable through the kwarg that overrides it.
-        Without it a non-numeric sequence surfaces as NumPy's own
-        ``could not convert string to float`` - which names neither the kwarg nor
-        the policy - and a non-finite component reaches the network.
+        ``rpy_cmd``, and both the numeric-sequence AND at-least-three-elements
+        rules :meth:`_validate_velocity` applies to the sibling command
+        component, so a roll/pitch/yaw target the config refuses is not
+        reachable through the kwarg that overrides it. Without the sequence rule
+        a non-numeric sequence surfaces as NumPy's own ``could not convert
+        string to float`` - which names neither the kwarg nor the policy - and a
+        non-finite component reaches the network.
+
+        Arity: roll, pitch and yaw are a triple, so at least three components are
+        required and a SHORT sequence is refused. The command block is
+        zero-initialised and the write is clamped to what the caller supplied, so
+        accepting two components would leave yaw at 0.0 rather than at the
+        ``rpy_cmd`` value the omitted kwarg falls back to - discarding a
+        configured target for an axis the caller never mentioned. A LONGER
+        sequence is NOT refused: every component the block has room for is
+        honored and only the surplus is dropped, which is what
+        :meth:`_validate_velocity` does with a packed velocity too.
 
         Args:
             rpy_src: The caller-supplied ``[roll, pitch, yaw]`` sequence.
@@ -1076,13 +1087,21 @@ class WBCPolicy(Policy):
             The flattened ``float64`` array.
 
         Raises:
-            ValueError: If it is not a numeric sequence, or any component is not
-                a usable finite number.
+            ValueError: If it is not a numeric sequence, has fewer than three
+                components, or any component is not a usable finite number.
         """
         try:
             arr = np.asarray(rpy_src, dtype=np.float64).ravel()
         except (TypeError, ValueError) as e:
             raise ValueError(f"target_orientation must be a numeric sequence, got {rpy_src!r}") from e
+        # Arity before values, the order :meth:`_validate_velocity` uses. A short
+        # sequence is refused rather than zero-filled: the block is
+        # zero-initialised, so writing only the components supplied would leave
+        # the rest at 0.0 - not at the ``rpy_cmd`` value that applies when the
+        # kwarg is omitted - silently commanding zero for axes the caller never
+        # mentioned and discarding the ones they did configure.
+        if arr.shape[0] < 3:
+            raise ValueError(f"target_orientation must have at least 3 elements [roll, pitch, yaw], got {arr.shape[0]}")
         # Inspect the ORIGINAL elements, not ``arr``: the float coercion above
         # turns a ``True`` into a silent 1.0, and the config refuses a bool
         # component of ``rpy_cmd``. An object view keeps the two spellings of the

--- a/tests/policies/wbc/test_command_override_arity.py
+++ b/tests/policies/wbc/test_command_override_arity.py
@@ -1,0 +1,223 @@
+"""Arity contract for the WBC ``target_orientation`` command override.
+
+:meth:`WBCPolicy._resolve_command` builds the observation's command block, and
+two of its components are VECTORS the caller may override per call. They were
+held to different arity rules:
+
+* ``target_velocity`` goes through :meth:`WBCPolicy._validate_velocity`, which
+  refuses fewer than three entries -- ``target_velocity must have at least 3
+  elements [vx, vy, omega], got 2``.
+* ``target_orientation`` went through :meth:`WBCPolicy._validate_orientation`,
+  which checked every component's VALUE and not the count. The write is
+  ``command[4 : 4 + n_rpy] = rpy[:n_rpy]`` with ``n_rpy = min(c - 4,
+  rpy.shape[0])`` into a ZERO-INITIALISED block, so a short sequence left the
+  axes it did not supply at ``0.0`` -- not at the ``rpy_cmd`` value that applies
+  when the kwarg is omitted entirely.
+
+So with ``rpy_cmd=[0.7, 0.8, 0.9]``, omitting the kwarg commanded
+``[0.7, 0.8, 0.9]`` while ``target_orientation=[0.5]`` commanded
+``[0.5, 0.0, 0.0]`` -- silently commanding zero roll and yaw for axes the caller
+never mentioned, discarding targets they DID configure, under a ``success``
+result. ``target_orientation=[]`` discarded all three. Every component of those
+inputs is a usable finite number, so the per-component value rule cannot see it:
+this is an arity question, and it is the one class of caller mistake the sibling
+vector component of the same block already refused.
+
+The asymmetry with a LONG sequence is deliberate and is pinned below. A longer
+orientation is truncated because every component the block has room for is
+honored and only the surplus is dropped -- which is exactly what
+:meth:`_validate_velocity` does with a packed velocity (``vel_full[:3]``). A
+shorter one is the opposite: components the caller never mentioned are
+overwritten with a value they did not choose.
+
+Both ``_resolve_command`` implementations -- the 7-wide one here and
+:meth:`WBCGaitPolicy._resolve_command`, whose ``freq_cmd`` slot pushes rpy to
+``[5:8]`` -- call the same inherited validator, so both surfaces are pinned.
+
+Out of scope: ``config.rpy_cmd`` itself also accepts a short vector. That is a
+different question rather than the same defect -- a short CONFIG default has no
+other source for the axes it omits, so zero is the only value those axes could
+take, whereas a short per-call override discards a value the caller did supply.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc.policy import WBCPolicy
+
+from .test_command_override_domains import _config, _gait, _resolve
+
+# A distinctive configured orientation, so a discarded axis is unmistakable: a
+# zero left behind by a short override cannot be confused with a configured 0.0.
+RPY_CMD: list[float] = [0.7, 0.8, 0.9]
+
+# Sequences carrying fewer than the three components roll/pitch/yaw needs. Every
+# component in each is a usable finite number, so the per-component value rule
+# accepts them all -- the count is the whole defect. The scalar spellings are the
+# same shape reached through a different type: ``np.asarray(0.5).ravel()`` is a
+# well-formed one-element array.
+SHORT_ORIENTATIONS: list[Any] = [
+    [0.5, 0.6],
+    [0.5],
+    (0.5, 0.6),
+    0.5,
+    np.float64(0.5),
+    np.array([0.5]),
+    [],
+    (),
+    np.array([]),
+]
+
+# Lengths the block honors. Three is exact; more is truncated to what fits, which
+# is deliberate and matches the sibling velocity component.
+HONORED_ORIENTATIONS: list[Any] = [
+    [0.1, 0.2, 0.3],
+    [0.1, 0.2, 0.3, 0.4],
+    [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    np.array([0.1, 0.2, 0.3]),
+]
+
+# The message shape both vector components of the block share.
+_ARITY_MESSAGE = re.compile(r"must have at least 3 elements \[[^]]+\], got \d+")
+
+
+def _main_policy() -> Any:
+    """A non-gait policy whose rpy slots are ``command[4:7]``."""
+    return WBCPolicy(config=_config(rpy_cmd=RPY_CMD), walk=False, allow_missing_models=True)
+
+
+def _gait_policy() -> Any:
+    """A gait policy whose ``freq_cmd`` slot pushes rpy to ``command[5:8]``."""
+    return _gait(config=_config(rpy_cmd=RPY_CMD, command_dim=8, single_obs_dim=95))
+
+
+# (label, policy factory, first rpy slot) for the two independent block builders.
+SURFACES: list[tuple[str, Any, int]] = [
+    ("WBCPolicy", _main_policy, 4),
+    ("WBCGaitPolicy", _gait_policy, 5),
+]
+_SURFACE_IDS = [label for label, _, _ in SURFACES]
+
+
+class TestAShortOrientationIsRefused:
+    """A partial ``target_orientation`` names the parameter instead of zeroing."""
+
+    @pytest.mark.parametrize("value", SHORT_ORIENTATIONS, ids=[repr(v) for v in SHORT_ORIENTATIONS])
+    @pytest.mark.parametrize(("label", "factory", "first"), SURFACES, ids=_SURFACE_IDS)
+    def test_refused_naming_the_parameter_and_the_count(self, label: str, factory: Any, first: int, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"target_orientation must have at least 3 elements") as excinfo:
+            _resolve(factory(), target_orientation=value)
+        # The count the caller actually supplied is what makes it actionable.
+        supplied = np.asarray(value, dtype=np.float64).ravel().shape[0]
+        assert f"got {supplied}" in str(excinfo.value)
+
+    def test_the_refusal_carries_the_axis_names(self) -> None:
+        """``[roll, pitch, yaw]`` tells the caller what the three components are."""
+        with pytest.raises(ValueError, match=r"\[roll, pitch, yaw\]"):
+            _resolve(_main_policy(), target_orientation=[0.5])
+
+    @pytest.mark.parametrize(("label", "factory", "first"), SURFACES, ids=_SURFACE_IDS)
+    def test_no_partial_override_reaches_the_block(self, label: str, factory: Any, first: int) -> None:
+        """The refusal precedes the write, so no axis is left holding a zero.
+
+        This is the behavioural heart: pre-fix the call returned a block whose
+        unsupplied axes held ``0.0`` in place of the configured target.
+        """
+        policy = factory()
+        with pytest.raises(ValueError):
+            _resolve(policy, target_orientation=[0.5])
+        # The same policy still resolves the configured orientation afterwards -
+        # the refused call left no state behind.
+        command, _ = _resolve(policy, target_orientation=None)
+        assert command[first : first + 3] == pytest.approx(RPY_CMD)
+
+
+class TestTheHonoredOrientationsAreUnchanged:
+    """The guard refuses only the arity nothing can honor."""
+
+    @pytest.mark.parametrize(("label", "factory", "first"), SURFACES, ids=_SURFACE_IDS)
+    def test_omitting_it_still_uses_the_configured_orientation(self, label: str, factory: Any, first: int) -> None:
+        command, _ = _resolve(factory(), target_orientation=None)
+        assert command[first : first + 3] == pytest.approx(RPY_CMD)
+
+    @pytest.mark.parametrize(("label", "factory", "first"), SURFACES, ids=_SURFACE_IDS)
+    def test_exactly_three_components_are_written_verbatim(self, label: str, factory: Any, first: int) -> None:
+        command, _ = _resolve(factory(), target_orientation=[0.1, 0.2, 0.3])
+        assert command[first : first + 3] == pytest.approx([0.1, 0.2, 0.3])
+
+    @pytest.mark.parametrize("value", HONORED_ORIENTATIONS, ids=[repr(v) for v in HONORED_ORIENTATIONS])
+    @pytest.mark.parametrize(("label", "factory", "first"), SURFACES, ids=_SURFACE_IDS)
+    def test_a_long_orientation_is_still_truncated_not_refused(
+        self, label: str, factory: Any, first: int, value: Any
+    ) -> None:
+        """Surplus components are dropped, as they are for a packed velocity.
+
+        Every component the block has room for is honored, so unlike a short
+        sequence nothing the caller supplied is replaced by a value they did not
+        choose. Two existing rollout tests supply 4- and 6-component
+        orientations; refusing them would be a behaviour change, not a fix.
+        """
+        command, _ = _resolve(factory(), target_orientation=value)
+        expected = np.asarray(value, dtype=np.float64).ravel()[:3]
+        assert command[first : first + 3] == pytest.approx(expected)
+
+
+class TestTheTwoVectorComponentsAgree:
+    """Neither vector component of the block may accept what the other refuses.
+
+    ``target_velocity`` and ``target_orientation`` are both triples written into
+    the same zero-initialised block by the same method. A caller supplying too
+    few components is one class of mistake, so it must get one answer -- which is
+    what stops the two rules drifting apart again.
+    """
+
+    @pytest.mark.parametrize("value", SHORT_ORIENTATIONS, ids=[repr(v) for v in SHORT_ORIENTATIONS])
+    def test_a_short_vector_is_refused_for_both(self, value: Any) -> None:
+        policy = _main_policy()
+        with pytest.raises(ValueError, match=_ARITY_MESSAGE):
+            _resolve(policy, target_velocity=value)
+        with pytest.raises(ValueError, match=_ARITY_MESSAGE):
+            _resolve(policy, target_orientation=value)
+
+    def test_the_two_refusals_share_one_message_shape(self) -> None:
+        """Same sentence, differing only in the parameter and the axis names."""
+        policy = _main_policy()
+        with pytest.raises(ValueError) as velocity:
+            _resolve(policy, target_velocity=[0.5])
+        with pytest.raises(ValueError) as orientation:
+            _resolve(policy, target_orientation=[0.5])
+        assert str(velocity.value) == "target_velocity must have at least 3 elements [vx, vy, omega], got 1"
+        assert str(orientation.value) == "target_orientation must have at least 3 elements [roll, pitch, yaw], got 1"
+
+    def test_both_still_accept_a_full_triple(self) -> None:
+        """Non-vacuity: the parity above is not two blanket refusals."""
+        policy = _main_policy()
+        assert _resolve(policy, target_velocity=[0.1, 0.2, 0.3])[1] == pytest.approx([0.1, 0.2, 0.3])
+        assert _resolve(policy, target_orientation=[0.1, 0.2, 0.3])[0][4:7] == pytest.approx([0.1, 0.2, 0.3])
+
+
+class TestArityIsCheckedBeforeValues:
+    """A short sequence reports its count, not a component complaint.
+
+    :meth:`_validate_velocity` orders its checks coercion -> arity -> per
+    component, so a caller who supplies too few components learns that first
+    rather than being told about the one component they did supply.
+    """
+
+    def test_a_short_sequence_reports_the_count_not_the_component(self) -> None:
+        with pytest.raises(ValueError, match=r"at least 3 elements"):
+            _resolve(_main_policy(), target_orientation=[float("nan")])
+
+    def test_a_full_triple_still_reports_the_bad_component(self) -> None:
+        with pytest.raises(ValueError, match=r"target_orientation\[1\]"):
+            _resolve(_main_policy(), target_orientation=[0.0, float("nan"), 0.0])
+
+    def test_a_non_numeric_sequence_still_reports_the_type(self) -> None:
+        """The coercion failure precedes the arity check, as it does for velocity."""
+        with pytest.raises(ValueError, match="target_orientation must be a numeric sequence"):
+            _resolve(_main_policy(), target_orientation="ab")


### PR DESCRIPTION
Closes #1997.

`WBCPolicy._resolve_command` writes the per-call `target_orientation` into a **zero-initialised** command block:

```python
n_rpy = min(c - 4, rpy.shape[0])
command[4 : 4 + n_rpy] = rpy[:n_rpy]
```

`_validate_orientation` checked every component's *value* and not the *count*, so a sequence carrying fewer than three components left the axes it did not supply at `0.0` -- not at the `rpy_cmd` value that applies when the kwarg is omitted entirely. A caller who names one axis therefore silently commanded zero for the other two and discarded the targets they had configured, under a `success` result.

## Measured

`WBCConfig(rpy_cmd=[0.10, 0.30, -0.20])`, reading the rpy slots out of `_resolve_command` on both trees:

| `target_orientation=` | components | `upstream/main` | this change |
|---|---|---|---|
| *omitted* | -- | accepted -> `[0.1, 0.3, -0.2]` | unchanged -- the documented fallback |
| `[0.05, 0.10, -0.15]` | 3 | accepted -> `[0.05, 0.1, -0.15]` | unchanged -- honored verbatim |
| `[0.05, 0.10]` | 2 | accepted -> `[0.05, 0.1, **0.0**]` | **refused** -- yaw `-0.20` was discarded |
| `[0.05]` | 1 | accepted -> `[0.05, **0.0**, **0.0**]` | **refused** -- pitch `0.30` and yaw `-0.20` discarded |
| `0.05` / `np.float64(0.05)` | 1 | accepted -> `[0.05, **0.0**, **0.0**]` | **refused** |
| `[]` / `()` | 0 | accepted -> `[**0.0**, **0.0**, **0.0**]` | **refused** -- all three discarded |
| `[0.1, 0.2, 0.3, 0.4]` | 4 | accepted -> `[0.1, 0.2, 0.3]` | unchanged -- see below |

Every component in each of those inputs is a usable finite number, so the per-component value rule cannot see any of it: this is an **arity** question. The scalar spellings take the identical path, since `np.asarray(0.05).ravel()` is a well-formed one-element array.

## The sibling already refused exactly this

`target_velocity` is the other vector component of the same block, written by the same method, and `_validate_velocity` has always required a full triple:

```
target_velocity must have at least 3 elements [vx, vy, omega], got 2
```

So one class of caller mistake -- too few components in a command triple -- had two different answers depending on which of the two vectors it was supplied for. The kwargs table in `docs/policies/wbc.md` already documented the arity rule (*"numeric, >= 3 entries, every component finite"*) for `target_velocity` and not for `target_orientation`, and `_validate_orientation`'s own docstring claimed to mirror *"the numeric-sequence rule `_validate_velocity` applies to the sibling command component"* while omitting the count.

## Change

`_validate_orientation` now applies the same rule in the same order the sibling uses -- coercion, then arity, then per-component values -- so a partial triple reports its count rather than a complaint about the one component that was supplied:

```
target_orientation must have at least 3 elements [roll, pitch, yaw], got 1
```

`WBCGaitPolicy._resolve_command`, whose `freq_cmd` slot pushes rpy to `[5:8]`, calls the same inherited validator, so both surfaces are covered by one guard and both are pinned.

A **longer** orientation is deliberately still accepted and truncated to the slots available: every component the block has room for is honored and only the surplus is dropped, which is what the sibling does with a packed velocity (`vel_full[:3]`). Two existing rollout tests supply 4- and 6-component orientations; refusing those would be a behaviour change rather than a fix.

### Out of scope

`config.rpy_cmd` itself also accepts a short vector. That is a different question rather than the same defect: a short *config default* has no other source for the axes it omits, so zero is the only value those axes could take, whereas a short *per-call override* discards a value the caller did supply.

## Artifact

The honored command run for real -- Unitree G1 under the GR00T WholeBodyControl balance policy, 3.0 s at 50 Hz, MuJoCo headless (EGL) -- beside the command block each spelling actually puts in front of the network, measured on both trees.

![WBC target_orientation arity](https://raw.githubusercontent.com/cagataycali/robots/artifacts/wbc-orientation-arity/art_orientation_arity.png)

The rollout render is **byte-comparable across the two trees** (`max|delta| = 1/255` over 13 of 516,800 px, i.e. renderer noise) and both report `status=success` with an identical `pelvis z = 0.749 m`, so the honored path is untouched. Base *attitude* is deliberately not the visual: WBC is a balance controller, so a 0.30 rad attitude command yields only ~0.028 rad of actual base pitch -- the command block is the quantity at stake and is what the figure measures.

## Verification

All on `arm64`, Python 3.13, `mujoco` 3.11.0, `numpy` 2.5.1, real ONNX weights.

- **Pre-fix proof** -- reverting only `strands_robots/policies/wbc/policy.py` to `upstream/main` and keeping the new tests: **32 failed, 15 passed**. The 15 that pass are the over-reach controls (the omitted-kwarg fallback, an exact triple, the long-sequence truncation, and the per-component value rules), which are what stop the guard reaching past the one arity nothing can honor. After the fix: **47 passed**.
- **Full suite** -- `MUJOCO_GL=egl python -m pytest tests`: **22145 passed, 257 skipped, 0 failed** (528 s).
- **Zero existing-test churn** -- `tests/policies/wbc/` alone: **456 passed**, none modified.
- **Lint** -- `ruff check` clean; `ruff format --check` clean (1096 files); `mypy strands_robots tests tests_integ` reports **0 errors outside `examples/`** (the 14 `examples/isaac_gs` entries are environmental -- byte-identical to a pristine `upstream/main` worktree of the same working copy).
- **Merge-base overlap check** -- no overlap: `upstream/main` moved during verification but changed only `changelog.d/2000-*` and `tests/policies/wbc/test_instruction_discarded.py`, neither of which this branch touches.