### PR TITLE
fix(training): refuse a GAE-lambda the advantage trace cannot decay by

### DIFF
--- a/changelog.d/2003-ppo-gae-lambda-domain.md
+++ b/changelog.d/2003-ppo-gae-lambda-domain.md
@@ -1,0 +1,31 @@
+### Fixed: an unusable GAE-lambda is refused instead of letting the advantage trace diverge
+
+`RLTrainSpec.lam` is the second factor of the advantage trace's decay: PPO's GAE
+recursion carries it forward as `last_adv = delta + gamma * lam * (1 - done) *
+last_adv`, so the trace decays by the *product* `gamma * lam`. The discount-factor
+preflight bounds `gamma` to the closed interval [0, 1]; nothing bounded `lam`, so
+the divergence that gate exists to refuse stayed reachable through the other
+factor. With a `gamma` of `0.99` -- comfortably inside its accepted domain -- a
+`lam` of `1.5` decays by `1.485`, and on this backend's own `compute_gae` over a
+rollout of unit rewards the largest advantage grows from `235` at `T=12` to
+`6.3e+16` at `T=96`: unbounded in the horizon rather than merely large, with the
+run reporting success and writing a checkpoint. `lam=1e6` overflows it to `inf`.
+
+`lam` outside the interval failed three further ways: far enough below zero the
+trace diverges again (the decay is `|gamma * lam|`, so `lam=-2` reaches `1.0e+28`
+by `T=96`) while merely below zero it collapses to the immediate reward and stops
+accumulating future advantage at all; `nan`/`inf` poisoned every advantage and
+surfaced only as a torch constraint error from the distribution sample, naming
+neither the field nor the run, after the env, the networks and a full rollout had
+been built; and `True` was a silent `lam` of one -- a Monte-Carlo estimator rather
+than the bootstrapped trace requested -- because `bool` is an `int` subclass and a
+bare comparison against the bounds accepts it.
+
+`Trainer._gae_lambda_problems` now reports it, on the same closed-interval domain
+the discount factor uses: both endpoints are legitimate and standard (`lam=1` is
+the Monte-Carlo advantage, `lam=0` the one-step TD advantage), so the interval is
+closed rather than a positivity test. It is a separate gate from the discount
+factor's because only the on-policy backend estimates an advantage trace -- per
+`TrainSpec` a backend must not report on a field it never reads -- and an AST
+guard asserts every module that reads `spec.lam` routes through it, so a second
+on-policy backend cannot ship without the domain.

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -68,6 +68,15 @@ scoped like :func:`learning_rate_problems` rather than like
 *every* RL backend reads (PPO discounts the GAE recursion with it, FastSAC
 discounts its target-Q bootstrap), so there is no RL backend for which
 reporting on it would be a false rejection.
+
+:func:`gae_lambda_problems` is the ninth, on the same *return* axis and for the
+sibling factor: ``lam``, the GAE trace-decay coefficient. It is a separate gate
+from :func:`discount_factor_problems` because the two fields are scoped
+differently - every RL backend reads ``gamma``, but only the on-policy backend
+estimates an advantage trace, so per :class:`TrainSpec` FastSAC must not report
+on a field it never reads. They are nonetheless one contract: the trace decays
+by the *product* ``gamma * lam``, so bounding one factor does not bound the
+trace.
 """
 
 from __future__ import annotations
@@ -523,11 +532,13 @@ def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
     generalizes: an interval coefficient is checked against its interval rather
     than left to the arithmetic that consumes it.
 
-    ``lam`` and the remaining PPO coefficients (``clip_param``,
-    ``num_learning_epochs``, ``entropy_coef``, ``value_loss_coef``,
-    ``max_grad_norm``, ``init_noise_std``) are out of scope here: they are read
-    by the on-policy backend only, so per :class:`TrainSpec` a backend that
-    ignores them must not report on them, and they belong in their own gate.
+    ``lam``, the other factor of the trace-decay product, has its own gate for
+    that same scoping reason - see :func:`gae_lambda_problems`. The remaining PPO
+    coefficients (``clip_param``, ``num_learning_epochs``, ``entropy_coef``,
+    ``value_loss_coef``, ``max_grad_norm``, ``init_noise_std``) are out of scope
+    here and there: they weight loss terms and bound gradients rather than the
+    return, and each carries its own undecided question about whether zero is a
+    disabled mode, so they belong in a gate on that axis.
 
     Args:
         spec: The spec to check.
@@ -539,4 +550,65 @@ def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
         A single-element list when ``gamma`` cannot be honored; empty otherwise.
     """
     error = _closed_unit_interval_error(getattr(spec, "gamma", 0.0), "gamma", context)
+    return [error] if error is not None else []
+
+
+def gae_lambda_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return GAE-lambda problems for an on-policy RL :class:`TrainSpec`.
+
+    ``lam`` is the second factor of the advantage trace's decay. The GAE
+    recursion carries it forward as ``last_adv = delta + gamma * lam *
+    (1 - done) * last_adv``, so the trace decays by the **product**
+    ``gamma * lam`` and :func:`discount_factor_problems` bounding ``gamma``
+    alone does not bound it: with a ``gamma`` of ``0.99`` - comfortably inside
+    that gate's closed interval - a ``lam`` of ``1.5`` gives a decay factor of
+    ``1.485`` and the same divergence, measured on this backend's own
+    ``compute_gae`` over a rollout of unit rewards:
+
+    ======  =========  =========  =========  =========
+    ``lam``  ``T=12``   ``T=24``   ``T=48``   ``T=96``
+    ======  =========  =========  =========  =========
+    0.95      8.8        13.0       15.9       16.8
+    1.5     235.1      2.7e+04    3.6e+08    6.3e+16
+    1e6       inf        inf        inf        inf
+    ======  =========  =========  =========  =========
+
+    The largest advantage grows without bound in the rollout horizon rather than
+    being merely large, and nothing refuses it: the run trains on those
+    advantages, reports success, and writes a checkpoint.
+
+    The remaining values outside the interval fail in three further ways:
+
+    * ``lam < -1 / gamma`` diverges as well, because the trace decays by
+      ``|gamma * lam|`` - ``lam=-2`` reaches ``1.0e+28`` by ``T=96`` - while a
+      ``lam`` merely below zero (``-0.5``) collapses the trace to the immediate
+      reward, so the estimator stops accumulating future advantage at all.
+    * ``nan``/``inf`` make every advantage non-finite, which surfaces only once
+      the update samples the action distribution - a torch constraint error
+      naming neither the field nor the run, after the env, the networks and a
+      full rollout have been built.
+    * ``True`` is a silent ``lam`` of one, because a bare comparison against the
+      interval bounds accepts it: ``bool`` is an ``int`` subclass. That is a
+      different estimator from the one the caller asked for - Monte-Carlo return
+      rather than a bootstrapped trace.
+
+    Both endpoints are legitimate and standard, which is why the domain is the
+    *closed* interval [0, 1]: ``lam=1`` is the Monte-Carlo advantage (no
+    bootstrapping, 61.9 at ``T=96`` above) and ``lam=0`` is TD(0), the
+    one-step advantage.
+
+    Unlike ``gamma`` this is read by the on-policy backend only, so it is scoped
+    like :func:`run_size_problems`: FastSAC has no advantage trace and must not
+    report on a field it never reads.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single-element list when ``lam`` cannot be honored; empty otherwise.
+    """
+    error = _closed_unit_interval_error(getattr(spec, "lam", 0.0), "lam", context)
     return [error] if error is not None else []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -455,6 +455,39 @@ class Trainer(ABC):
 
         return discount_factor_problems(spec, context=self.provider_name)
 
+    def _gae_lambda_problems(self, spec: TrainSpec) -> list[str]:
+        """GAE-lambda preflight shared by every backend that estimates a trace.
+
+        Returns a problem when :attr:`RLTrainSpec.lam` is not a real number in
+        the closed interval ``[0, 1]``. A :meth:`validate` implementation that
+        decays an advantage trace with the field MUST call this **in addition
+        to** :meth:`_discount_factor_problems`, because the two fields are one
+        contract: the trace decays by the product ``gamma * lam``, so bounding
+        ``gamma`` alone leaves the divergence that gate exists to refuse
+        reachable through the other factor - a ``gamma`` of ``0.99`` with a
+        ``lam`` of ``1.5`` decays by ``1.485`` and the largest advantage grows
+        without bound in the rollout horizon, under a successful run that writes
+        a checkpoint.
+
+        Both interval endpoints are inside the domain (``lam=1`` is the
+        Monte-Carlo advantage, ``lam=0`` the one-step TD advantage), so the check
+        is a closed interval rather than a positivity test - and it rejects
+        ``bool``, which a bare comparison against the bounds accepts as a silent
+        ``lam`` of one, i.e. a different estimator from the requested one.
+
+        Only the on-policy backend estimates an advantage trace, so unlike
+        :meth:`_discount_factor_problems` a backend that does not read the field
+        MUST NOT call this: per :class:`TrainSpec` a backend ignores the fields
+        it does not support, so reporting on one it never reads would be a false
+        rejection.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import gae_lambda_problems
+
+        return gae_lambda_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -153,6 +153,9 @@ class PpoTrainer(BaseRLAlgo):
         # gamma discounts the return this backend optimizes; the arithmetic that
         # consumes it never judges it, so the shared interval domain does.
         problems.extend(self._discount_factor_problems(spec))
+        # lam is the other factor of the same trace decay: the recursion decays by
+        # gamma * lam, so the gate above cannot bound the trace on its own.
+        problems.extend(self._gae_lambda_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/tests/training/test_gae_lambda_domain.py
+++ b/tests/training/test_gae_lambda_domain.py
@@ -1,0 +1,295 @@
+"""The GAE trace-decay coefficient is checked against its interval.
+
+``RLTrainSpec.lam`` is the second factor of the advantage trace's decay. The
+recursion in ``compute_gae`` carries it forward as ``last_adv = delta + gamma *
+lam * (1 - done) * last_adv``, so the trace decays by the **product**
+``gamma * lam``. The discount-factor gate bounds ``gamma`` to the closed interval
+[0, 1]; nothing bounded ``lam``, so the divergence that gate exists to refuse
+stayed reachable through the other factor: with a ``gamma`` of ``0.99`` well
+inside its domain, a ``lam`` of ``1.5`` decays by ``1.485`` and the largest
+advantage grows without bound in the rollout horizon, under a run that reports
+success and writes a checkpoint.
+
+``lam`` below the interval fails two different ways - far enough below and the
+trace diverges again (the decay is ``|gamma * lam|``), merely below zero and it
+collapses to the immediate reward - a non-finite value poisons every advantage
+and surfaces only as a torch constraint error from the distribution sample, and
+``True`` is a silent ``lam`` of one, a Monte-Carlo estimator rather than the
+bootstrapped trace the caller asked for.
+
+Scoped to the on-policy backend: FastSAC has no advantage trace and must not
+report on a field it never reads. Every test here reaches the real ``validate``
+entry point, so it covers the wiring as well as the domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import (
+    _closed_unit_interval_error,
+    gae_lambda_problems,
+)
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+
+# The one backend that estimates an advantage trace.
+ON_POLICY = "ppo"
+
+# Backends that read ``gamma`` but never ``lam`` - they must stay quiet about it.
+NO_TRACE_BACKENDS = ("fast_sac", "mock")
+
+# Values outside the closed interval. Above 1 the trace diverges in the horizon;
+# below 0 it either diverges again (|gamma * lam| > 1) or stops accumulating.
+OUT_OF_INTERVAL: list[Any] = [1.5, 2.0, 1.0000001, 10.0, 1e6, -0.5, -1, -2.0]
+
+# Values the shared numeric domain refuses before the interval is considered.
+NOT_A_FINITE_NUMBER: list[Any] = [
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    False,
+    "0.95",
+    None,
+    [0.95],
+    {"lam": 0.95},
+]
+
+UNUSABLE: list[Any] = [*OUT_OF_INTERVAL, *NOT_A_FINITE_NUMBER]
+
+# Both endpoints are legitimate and standard: 1 is the Monte-Carlo advantage (no
+# bootstrapping) and 0 is TD(0), the one-step advantage. Integral and NumPy
+# spellings of an in-range value are usable too - the shared domain accepts any
+# finite real, and float() reads them all.
+USABLE: list[Any] = [0.0, 1.0, 0.95, 0.5, 0, 1, np.float64(0.9), np.float32(0.8)]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """An otherwise-valid RL spec, so only the field under test is exercised."""
+    return RLTrainSpec(output_dir="/tmp/gae_lambda_domain", env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+
+
+def _lam_problems(provider: str, spec: RLTrainSpec) -> list[str]:
+    """Problems the real ``validate`` entry point reports about ``lam``.
+
+    Filtered on the shared domains\' ``"{context}: {param} "`` message shape
+    rather than on a bare ``"lam"`` substring, so an unrelated problem can
+    neither mask a missing refusal nor be mistaken for one.
+    """
+    return [p for p in create_trainer(provider).validate(spec) if p.startswith(f"{provider}: lam ")]
+
+
+class TestTheOnPolicyBackendRefusesAnUnusableTraceDecay:
+    """PPO refuses every value the advantage trace cannot decay by."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.lam = value
+        assert _lam_problems(ON_POLICY, spec), f"ppo accepted lam={value!r}"
+
+    @pytest.mark.parametrize("value", OUT_OF_INTERVAL)
+    def test_an_out_of_interval_value_names_the_interval(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.lam = value
+        assert "must be in [0, 1]" in _lam_problems(ON_POLICY, spec)[0]
+
+    @pytest.mark.parametrize("value", NOT_A_FINITE_NUMBER)
+    def test_a_non_numeric_value_reads_like_every_other_numeric_field(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.lam = value
+        assert "must be a finite number" in _lam_problems(ON_POLICY, spec)[0]
+
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: RLTrainSpec) -> None:
+        spec.lam = 1.5
+        assert _lam_problems(ON_POLICY, spec)[0].startswith("ppo: lam ")
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_an_unusable_value_is_a_problem_not_an_exception(self, spec: RLTrainSpec, value: Any) -> None:
+        """``validate`` is documented pure and read-only: it reports, never raises."""
+        spec.lam = value
+        assert isinstance(create_trainer(ON_POLICY).validate(spec), list)
+
+
+class TestTheUsableDomainIsUntouched:
+    """No value the trace can actually decay by becomes a problem."""
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_it_is_accepted(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.lam = value
+        assert _lam_problems(ON_POLICY, spec) == []
+
+    def test_the_default_spec_still_validates_clean(self, spec: RLTrainSpec) -> None:
+        assert _lam_problems(ON_POLICY, spec) == []
+
+
+class TestABackendWithNoAdvantageTraceStaysQuiet:
+    """A backend that never reads the field must not report on it.
+
+    :class:`~strands_robots.training.base.TrainSpec` documents that a backend
+    reads the fields it supports and ignores the rest, so FastSAC - which
+    bootstraps a target-Q rather than estimating a trace - refusing an unusable
+    ``lam`` would be a false rejection. That is the whole reason this is a
+    separate gate from the discount factor's, which every RL backend does read.
+    """
+
+    @pytest.mark.parametrize("provider", NO_TRACE_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_reports_nothing_about_lam(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        spec.lam = value
+        assert _lam_problems(provider, spec) == []
+
+    @pytest.mark.parametrize("value", [1.5, float("nan")])
+    def test_but_the_shared_discount_factor_is_still_refused(self, spec: RLTrainSpec, value: Any) -> None:
+        """Non-vacuity: the quiet backend is not simply ignoring the whole spec."""
+        spec.gamma = value
+        assert [p for p in create_trainer("fast_sac").validate(spec) if p.startswith("fast_sac: gamma ")]
+
+
+class TestTheIntervalIsTheWholeLocalContribution:
+    """The helper decides the interval and delegates everything else.
+
+    Type, ``bool`` and finiteness are the shared numeric domain\'s job, so the two
+    functions must agree on every value except the ones the interval alone
+    excludes. Pinning that keeps the refusal text for a non-numeric ``lam``
+    identical to every other numeric field\'s.
+    """
+
+    @pytest.mark.parametrize("value", [*USABLE, *NOT_A_FINITE_NUMBER])
+    def test_it_agrees_with_the_shared_domain(self, value: Any) -> None:
+        from strands_robots.utils import finite_number_error
+
+        local = _closed_unit_interval_error(value, "lam", "ppo")
+        shared = finite_number_error(value, "lam", "ppo")
+        assert (local is None) == (shared is None), f"diverged for lam={value!r}"
+
+    @pytest.mark.parametrize("value", OUT_OF_INTERVAL)
+    def test_only_the_interval_diverges(self, value: Any) -> None:
+        from strands_robots.utils import finite_number_error
+
+        assert finite_number_error(value, "lam", "ppo") is None
+        assert _closed_unit_interval_error(value, "lam", "ppo") is not None
+
+
+class TestBoundingTheDiscountFactorAloneDoesNotBoundTheTrace:
+    """The executable premise: the decay is a product, so one factor is not enough.
+
+    Measured on this backend\'s own ``compute_gae`` over a rollout of unit
+    rewards. Every ``gamma`` here is inside the discount-factor gate\'s accepted
+    interval, so each divergence below is reachable on a spec that gate passes.
+    """
+
+    @staticmethod
+    def _largest_advantage(gamma: float, lam: float, horizon: int) -> float:
+        torch = pytest.importorskip("torch")
+
+        from strands_robots.training.rl.ppo import compute_gae
+
+        zeros = torch.zeros(horizon)
+        advantages, _ = compute_gae(torch.ones(horizon), zeros, zeros, zeros, zeros, gamma, lam)
+        return float(advantages.abs().max())
+
+    def test_an_accepted_gamma_with_an_out_of_interval_lam_diverges(self) -> None:
+        """gamma=0.99 passes its own gate; lam=1.5 makes the product 1.485."""
+        honored = self._largest_advantage(0.99, 0.95, 24)
+        assert self._largest_advantage(0.99, 1.5, 24) > 1000 * honored
+        # Unbounded, not merely large: doubling the horizon compounds again.
+        assert self._largest_advantage(0.99, 1.5, 48) > 1000 * self._largest_advantage(0.99, 1.5, 24)
+
+    def test_a_large_lam_overflows_the_advantage_entirely(self) -> None:
+        assert self._largest_advantage(0.99, 1e6, 12) == float("inf")
+
+    def test_a_lam_far_below_zero_diverges_too(self) -> None:
+        """The decay is the magnitude of the product, so a sign flip does not save it."""
+        assert self._largest_advantage(0.99, -2.0, 48) > 1e6
+
+    def test_a_lam_just_below_zero_stops_accumulating_future_advantage(self) -> None:
+        """Alternating signs cancel the trace down to the immediate reward."""
+        assert self._largest_advantage(0.99, -0.5, 24) < self._largest_advantage(0.99, 0.95, 24)
+
+    def test_a_non_finite_lam_poisons_every_advantage(self) -> None:
+        torch = pytest.importorskip("torch")
+
+        from strands_robots.training.rl.ppo import compute_gae
+
+        zeros = torch.zeros(8)
+        advantages, _ = compute_gae(torch.ones(8), zeros, zeros, zeros, zeros, 0.99, float("nan"))
+        assert not bool(torch.isfinite(advantages).all())
+
+    def test_a_boolean_lam_is_a_different_estimator(self) -> None:
+        """``True`` is a silent lam of one: Monte-Carlo, not a bootstrapped trace."""
+        assert self._largest_advantage(0.99, True, 24) == self._largest_advantage(0.99, 1.0, 24)
+        assert self._largest_advantage(0.99, True, 24) != self._largest_advantage(0.99, 0.95, 24)
+
+    @pytest.mark.parametrize("endpoint", [0.0, 1.0])
+    def test_both_endpoints_compute_a_finite_trace(self, endpoint: float) -> None:
+        """Neither accepted endpoint is a degenerate spelling of "broken"."""
+        assert 0.0 < self._largest_advantage(0.99, endpoint, 24) < float("inf")
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(gae_lambda_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_trace_decay(source: str) -> bool:
+    """Does *source* read ``spec.lam``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "lam" and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_gae_lambda_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheTraceDecayDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.lam`` must route it through the shared gate, so a
+    second on-policy backend that starts decaying a trace with the field fails
+    this test until it does.
+    """
+
+    def test_every_module_that_reads_it_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name
+            for p in _training_modules()
+            if _reads_the_trace_decay(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules read spec.lam without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_the_trace_decay(p.read_text())}
+        assert readers == {"ppo.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading the field without the gate is really reported."""
+        planted = "def validate(self, spec):\n    return [] if spec.lam else []\n"
+        assert _reads_the_trace_decay(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_interval(self) -> None:
+        """A local copy of the bounds would drift from the shared rule."""
+        offenders = [
+            p.name for p in _training_modules() if "spec.lam <" in p.read_text() or "spec.lam >" in p.read_text()
+        ]
+        assert offenders == [], f"modules compare spec.lam locally: {offenders}"


### PR DESCRIPTION
## The defect

`RLTrainSpec.lam` is the second factor of the advantage trace's decay. PPO's GAE recursion carries it forward as

```python
last_adv = delta + gamma * lam * (1.0 - dones[t]) * last_adv
```

so the trace decays by the **product** `gamma * lam`. The discount-factor preflight bounds `gamma` to the closed interval `[0, 1]`; nothing bounded `lam`, so the divergence that gate exists to refuse stayed reachable through the other factor.

With `gamma = 0.99` -- comfortably inside its accepted domain, so every row below is reachable on a spec that gate passes -- measured on this backend's own `compute_gae` over a rollout of unit rewards:

| `lam` | decay `gamma*lam` | T=12 | T=24 | T=48 | T=96 |
|---|---|---|---|---|---|
| 0.95 (default) | 0.940 | 8.8 | 13.0 | 15.9 | 16.8 |
| **1.5** | **1.485** | **235.1** | **2.7e+04** | **3.6e+08** | **6.3e+16** |
| **2.0** | 1.980 | 3704 | 1.3e+07 | 1.8e+14 | 3.1e+28 |
| **1e6** | 990000 | inf | inf | inf | inf |

The largest advantage grows **without bound in the rollout horizon** rather than being merely large, and nothing refuses it: the run trains on those advantages, reports success, and writes a checkpoint.

Outside the interval it fails three further ways:

- **`lam` far below zero diverges too**, because the decay is `|gamma * lam|` -- `lam=-2` reaches `1.0e+28` by T=96 -- while a `lam` merely below zero (`-0.5`) collapses the trace to the immediate reward, so the estimator stops accumulating future advantage at all. These are two different failures from one sign.
- **`nan`/`inf`** make every advantage non-finite, surfacing only once the update samples the action distribution: a torch constraint error naming neither the field nor the run, after the env, the networks and a full rollout have been built.
- **`True`** is a silent `lam` of one, because a bare comparison against the interval bounds accepts it (`bool` is an `int` subclass). That is a different estimator from the requested one -- Monte-Carlo return rather than a bootstrapped trace.

## The change

`Trainer._gae_lambda_problems` -> `gae_lambda_problems`, on the **same closed-interval domain the discount factor already uses** (`_closed_unit_interval_error`). No new domain helper: type, `bool` and finiteness stay delegated to the shared `finite_number_error`, so a non-numeric `lam` reads identically to every other numeric field, and the only thing decided locally is the interval.

The interval is **closed** because both endpoints are legitimate and standard: `lam=1` is the Monte-Carlo advantage (no bootstrapping) and `lam=0` is TD(0), the one-step advantage.

### Why a separate gate rather than folding it into the discount factor's

The two fields are one contract but are scoped differently. Every RL backend reads `gamma`; only the on-policy backend estimates an advantage trace. Per `TrainSpec` ("a backend reads the fields it supports and ignores the rest"), making FastSAC report on `lam` would be a false rejection of a field it never reads -- it bootstraps a target-Q instead. So the gate is called from `PpoTrainer.validate` only, and the tolerance side is pinned: FastSAC and mock stay silent for every unusable `lam`, while still refusing an unusable `gamma`.

An AST guard derives the in-scope set from the tree rather than listing it: any module that **reads** `spec.lam` must route through the gate, so a second on-policy backend fails until it does. It comes with a non-vacuity pin on the reader set, a planted-defect test, and a no-local-reimplementation test.

### Scope

`clip_param`, `num_learning_epochs`, `entropy_coef`, `value_loss_coef`, `max_grad_norm` and `init_noise_std` are deliberately out of scope. They weight loss terms and bound gradients rather than the return, and each carries its own undecided question about whether zero is a disabled mode -- they belong in a gate on that axis. `lam` is the one that shares an expression, and a product, with an already-bounded field.

## Verification

All on `40c2972`, base `d1c85278`.

| gate | result |
|---|---|
| `pytest tests` (`MUJOCO_GL=egl`) | **22266 passed, 257 skipped, 0 failed** in 523.63s |
| `ruff check strands_robots tests tests_integ` | clean |
| `ruff format --check strands_robots tests tests_integ` | 1097 files already formatted |
| `mypy strands_robots tests tests_integ` | 0 errors outside `examples/isaac_gs` (14 there, error set byte-identical to a pristine `main` worktree of the same working copy, so environmental) |
| `scripts/assemble_changelog.py --check` | OK |
| `scripts/check_merge_base_overlap.py` | no overlap |

**Pre-fix proof.** Reverting only the two call sites (`training/base.py`, `training/rl/ppo.py`) to `upstream/main` and keeping `_validate.py`, so the test module still imports: **36 failed / 98 passed** of 134. The structural guard fails naming the adrift module -- `modules read spec.lam without the shared gate: ['ppo.py']`. Post-fix: 134 passed in 0.26s. The 98 that pass pre-fix are the usable-domain controls, the FastSAC-stays-quiet pins and the divergence premise -- they are what stop the guard reaching further than the field.

**Existing-test churn: zero.**

## Artifact

![PPO GAE-lambda trace-decay domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/ppo-gae-lambda/gae_lambda_domain.png)

The top panel is the premise, measured on the real `compute_gae` and **identical on both trees** -- the recursion is untouched, the change only decides which values reach it. The bottom-left panel is what `PpoTrainer.validate()` reports for each probed `lam`: 10 of 13 flip from accepted to refused, the 3 usable ones unchanged.

The bottom-right panel is the no-regression proof. A real PPO run (so100 reach env, 3 iterations, seed 0) on `lam=0.95` produces a checkpoint whose **34,715 parameters are bit-identical to 16 digits on both trees** (`max|w| = 60.0000000000000000`, `sum(w) = 140.1741638183593750`): the gate reports, it does not change what a usable spec trains.

Every number in the figure is re-derived from two JSON dumps by the compose script, which asserts each rendered claim (including that the two dumps came from different trees) before saving. Figure, `capture.py`, `compose.py` and both raw measurement dumps are on [`artifacts/ppo-gae-lambda`](https://github.com/cagataycali/robots/tree/artifacts/ppo-gae-lambda).