### PR TITLE
ci(last-push-approval): report a finding without failing the job

### DIFF
--- a/.github/workflows/last-push-approval.yml
+++ b/.github/workflows/last-push-approval.yml
@@ -32,8 +32,37 @@
 # Unlike merge-base-overlap.yml the remedy here is not self-clearing: it needs a
 # second human, so the pull request author cannot turn the check green by
 # working. A gate a branch cannot clear by doing anything is a report, and
-# reporting is what this does -- the exit status is 1 so the finding is visible
-# in the checks list, and nothing consumes it as a gate.
+# reporting is what this does.
+#
+# The report does not fail its job, and that is a correction rather than a
+# preference. Reporting through the exit status put a red X on the branch, and a
+# single non-SUCCESS context drags `statusCheckRollup.state` to `FAILURE`, where
+# it is indistinguishable from a broken diff because the rollup carries no
+# reason. Measured on #1722: every required context SUCCESS, every review thread
+# resolved, `mergeable: MERGEABLE`, and a rollup of `FAILURE` whose only
+# non-SUCCESS context was this one. Four consecutive passes over #1905 read that
+# rollup as the branch's own tests failing. Red on a finding also inverts what
+# the colour is for here -- the remedy is another account's review, so the one
+# thing a red X cannot ask for was the only thing it was carrying.
+#
+# The finding is not quieter for it, because the exit status was never the
+# channel. The script writes its full report to $GITHUB_STEP_SUMMARY, which
+# renders on the run page, and emits a
+# `::warning title=Needs an approver who did not push the head` annotation.
+# Both predate this change. The programmatic reader is
+# `check_last_push_approval.py --all-open`, which AGENTS.md requires when
+# reporting repository health and which classifies every open pull request in
+# one pass -- that, and not a check colour, is what separates
+# `awaiting-first-review` from `pusher-only-approval`. The script's own exit
+# status is unchanged at 1 for a finding, because the sweep is consumed that
+# way; this workflow declines to adopt it as the job's conclusion, which is a
+# different question.
+#
+# A non-zero status that is not 1 still fails the job. Exit 2 means the check
+# could not compute an answer -- a broken checkout, a missing argument, an API
+# shape change -- which is a defect in the check itself and actionable by
+# whoever owns it, so it keeps the red X that a finding gives up. Red here now
+# means "this check is broken", never "this branch needs another human".
 #
 
 name: Last Push Approval Check
@@ -65,7 +94,7 @@ permissions:
 
 jobs:
   last-push-approval:
-    name: Detect an approval the last pusher cannot supply
+    name: Report the last-push-approval state
     runs-on: ubuntu-latest
 
     steps:
@@ -117,4 +146,17 @@ jobs:
             echo "which the checks UI cannot tell apart from a real finding."
             exit 0
           fi
+          set +e
           python3 scripts/check_last_push_approval.py --repo "$GITHUB_REPOSITORY"
+          status=$?
+          set -e
+          if [ "$status" -eq 1 ]; then
+            echo "check_last_push_approval: the finding above is reported, not failed."
+            echo "Its remedy is an approving review from an account that did not push the"
+            echo "head, which no work on this branch supplies, so failing here would name"
+            echo "the branch for a state it cannot clear. The verdict is in the step"
+            echo "summary and in the 'Needs an approver who did not push the head'"
+            echo "annotation. Any other non-zero status is a broken check and does fail."
+            exit 0
+          fi
+          exit "$status"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,8 +695,16 @@ hatch run format            # ruff check --fix, ruff format
    All of the above was documented here and enforced by nothing, which is the
    same shape as the changelog rule in step 3 before #1784. It is now surfaced by
    `.github/workflows/last-push-approval.yml`, which names the pusher and the
-   approvers on every review event and fails when they are the same single
-   account. The point of automating it is not that the check is clever - it is
+   approvers on every review event and reports when they are the same single
+   account. It **reports** rather than fails: a finding leaves the job green and
+   lands in the step summary and in a `Needs an approver who did not push the
+   head` annotation, because a red X drags `statusCheckRollup.state` to
+   `FAILURE`, where it cannot be told apart from the branch's own tests failing -
+   measured on #1722, whose rollup read `FAILURE` with every required context
+   `SUCCESS` and this check as the only non-`SUCCESS` context, and misread as a
+   broken diff four times. Red on that job now means the check itself could not
+   compute an answer. The check row is named `Report the last-push-approval
+   state` for the same reason: green must not assert the absence of a finding. The point of automating it is not that the check is clever - it is
    that the state it reports is *invisible*: `REVIEW_REQUIRED` / `BLOCKED` is
    byte for byte what an unreviewed pull request looks like, so the two are
    indistinguishable in every field a sweep reads and they need opposite actions.
@@ -722,8 +730,9 @@ hatch run format            # ruff check --fix, ruff format
    request that has had one of those *since it landed* - and the pull requests
    this is written for are the ones that have not. #1035's head was pushed
    2026-08-01 and approved 51 minutes later, both before the workflow existed on
-   2026-08-04, so `Detect an approval the last pusher cannot supply` is absent
-   from the 11 check runs on that head, while every other check is present. So
+   2026-08-04, so `Report the last-push-approval state` (then named `Detect an
+   approval the last pusher cannot supply`) is absent from the 11 check runs on
+   that head, while every other check is present. So
    the check read `SUCCESS` on pull requests that did not have the condition and
    said nothing at all about the two that did.
 

--- a/changelog.d/2005-last-push-approval-reports-without-failing.md
+++ b/changelog.d/2005-last-push-approval-reports-without-failing.md
@@ -1,0 +1,19 @@
+### Fixed: the last-push-approval report no longer makes a healthy branch look broken
+
+`last-push-approval.yml` names a pull request whose only approvals come from the
+account that pushed its head, and it reported that finding through its exit
+status. A single non-`SUCCESS` context drags `statusCheckRollup.state` to
+`FAILURE`, and the rollup carries no reason, so the red was indistinguishable
+from the branch's own tests failing. Measured on #1722: every required context
+`SUCCESS`, threads resolved, `mergeable: MERGEABLE`, rollup `FAILURE` with this
+report as the only non-`SUCCESS` context - misread as a broken diff four times.
+
+The finding now leaves the job green and lands where it already landed before
+this change: the full report in `$GITHUB_STEP_SUMMARY` and a `Needs an approver
+who did not push the head` annotation. The script's own exit status is unchanged
+at `1`, because `--all-open` sweeps are consumed that way; only the workflow's
+adoption of it as a job conclusion changed. A status that is not 0 or 1 still
+fails the job, so red now means the check could not compute an answer rather
+than that the branch needs another human. The check row is renamed to `Report
+the last-push-approval state`, since green must not assert the absence of a
+finding.

--- a/tests/test_last_push_approval.py
+++ b/tests/test_last_push_approval.py
@@ -453,38 +453,79 @@ def test_the_workflow_passes_when_the_base_lacks_the_script(tmp_path):
     assert "nothing to report" in result.stdout
 
 
-def test_the_guard_does_not_swallow_a_real_finding(tmp_path):
-    """With the script present, the guard is transparent and the exit status is the script's.
+def _run_body_against_stub(tmp_path, exit_code: int):
+    """Execute the workflow's shell body against a stub script exiting ``exit_code``.
 
-    Otherwise the fix for the bootstrapping case would have turned the whole
-    check into a permanent no-op, which is the failure mode that would be
-    hardest to notice: a green check that never looks at anything.
+    Pins the shipped text rather than a paraphrase of it, which is the reason
+    this reads the body out of the YAML instead of restating the shell.
     """
     import shutil
     import subprocess
     import textwrap
 
     (tmp_path / "scripts").mkdir()
-    stub = tmp_path / "scripts" / "check_last_push_approval.py"
-    stub.write_text(
-        textwrap.dedent("""
+    (tmp_path / "scripts" / "check_last_push_approval.py").write_text(
+        textwrap.dedent(f"""
         import sys
         print("stub ran")
-        sys.exit(1)
+        sys.exit({exit_code})
     """)
     )
     assert shutil.which("sh")
 
-    result = subprocess.run(
+    return subprocess.run(
         ["sh", "-c", _run_step_body()],
         cwd=tmp_path,
         capture_output=True,
         text=True,
         env={"BASE_REF": "main", "GITHUB_REPOSITORY": "strands-labs/robots", "PATH": os.environ["PATH"]},
     )
-    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_the_guard_does_not_swallow_a_real_finding(tmp_path):
+    """With the script present, the guard is transparent and the finding is stated.
+
+    Otherwise the fix for the bootstrapping case would have turned the whole
+    check into a permanent no-op, which is the failure mode that would be
+    hardest to notice: a green check that never looks at anything. The property
+    is unchanged; only the evidence for it moved, because the job no longer
+    reports a finding through its exit status. So this reads the output: the
+    script must actually have run, and the body must say what it found and why
+    it is not failing, rather than exiting 0 in silence.
+    """
+    result = _run_body_against_stub(tmp_path, 1)
+
     assert "stub ran" in result.stdout
+    assert "reported, not failed" in result.stdout
     assert "nothing to report" not in result.stdout
+
+
+def test_a_finding_does_not_fail_the_job(tmp_path):
+    """Exit 1 from the script is a finding, and a finding is not a job failure.
+
+    A single non-SUCCESS context drags ``statusCheckRollup.state`` to
+    ``FAILURE``, which carries no reason and so cannot be told apart from the
+    branch's own tests failing. Measured on #1722: every required context
+    SUCCESS, threads resolved, ``mergeable: MERGEABLE``, rollup ``FAILURE``
+    whose only non-SUCCESS context was this check. The remedy is a review from
+    another account, which no work on the branch supplies, so a red X here asks
+    the branch for something it cannot give.
+    """
+    assert _run_body_against_stub(tmp_path, 1).returncode == 0
+
+
+def test_a_check_that_cannot_compute_an_answer_still_fails_the_job(tmp_path):
+    """Exit 2 is a broken check, not a finding, and keeps the red X.
+
+    This is what keeps the test above from being satisfied by a body that
+    swallows every status: red still means something here, and what it means is
+    that this check could not do its job -- a broken checkout, a missing
+    argument, an API shape change -- which is a defect someone owns.
+    """
+    result = _run_body_against_stub(tmp_path, 2)
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "reported, not failed" not in result.stdout
 
 
 # --------------------------------------------------------------------------
@@ -495,7 +536,8 @@ def test_the_guard_does_not_swallow_a_real_finding(tmp_path):
 # since the workflow landed -- and the population the check was written for is
 # the population that has not. Measured on #1035: head pushed 2026-08-01, the
 # approval 51 minutes later, the workflow landed 2026-08-04, so
-# `Detect an approval the last pusher cannot supply` is absent from the 11 check
+# `Report the last-push-approval state` (then named `Detect an approval the last
+# pusher cannot supply`) is absent from the 11 check
 # runs on that head while the classifier answers `pusher-only-approval` the
 # moment it is invoked. These pin the caller that closes that gap, not the
 # verdict, which was never wrong.


### PR DESCRIPTION
## Problem

`last-push-approval.yml` names a pull request whose only approvals come from the account that pushed its head. It reported that finding through its **exit status**, so the job went red -- and a single non-`SUCCESS` context drags `statusCheckRollup.state` to `FAILURE`. The rollup carries no reason, so that red is indistinguishable from the branch's own tests failing.

Measured on #1722, right now:

| signal | value |
|---|---|
| `call-test-lint / Test and Lint` (the one required check) | `SUCCESS` |
| every other required context | `SUCCESS` |
| unresolved review threads | 0 |
| `mergeable` | `MERGEABLE` |
| `Detect an approval the last pusher cannot supply` | `FAILURE` |
| **`statusCheckRollup.state`** | **`FAILURE`** |

The reporting check is the *only* non-`SUCCESS` context on that head, and it is deliberately not in the required set, so it blocks nothing. It just makes the branch look broken. Four consecutive passes over #1905 read that rollup as #1722's own CI failing; the fourth diagnosed the cause and stated the fix, which is what this PR is:

> anyone triaging by rollup colour will misread this branch as having a broken diff. That is the cost of a report-only check living in the same rollup as the required set, and it argues for the reporting check being excluded from the rollup rather than for it being made a gate.

Red here also inverts what the colour is *for*. The remedy for this finding is an approving review from an account that did not push the head. No work on the branch supplies one. So the red X asked the branch for the only thing it cannot give, while the states a branch **can** act on -- a lint failure, a broken test -- share the same colour.

## Change

The workflow no longer adopts the script's finding status as the job's conclusion.

```sh
status=$?
if [ "$status" -eq 1 ]; then   # the finding
  echo "...reported, not failed..."
  exit 0
fi
exit "$status"                  # anything else: a broken check, still red
```

**The exit status was never the channel.** Both replacement channels already ship and predate this PR -- `_emit()` writes the full report to `$GITHUB_STEP_SUMMARY`, which renders on the run page, and the finding emits a `::warning title=Needs an approver who did not push the head` annotation. The programmatic reader is `--all-open` (#1983), which AGENTS.md requires when reporting repository health and which is what actually separates `awaiting-first-review` from `pusher-only-approval`. A check colour never made that distinction.

**The script is untouched.** Its exit status stays `1` for a finding, because `--all-open` is consumed that way by sweeps and `test_the_exit_status_is_one_only_for_the_finding` still pins it. Whether the *workflow* adopts that status as a job conclusion is a different question, and only that answer changes here.

**Exit 2 still fails the job.** A status that is not 0 or 1 means the check could not compute an answer -- broken checkout, missing argument, API shape change -- which is a defect someone owns and is exactly the case the bootstrapping guard was added for (#1791). So red keeps a meaning, and the meaning is now single: *this check is broken*, never *this branch needs another human*.

**The job is renamed** to `Report the last-push-approval state`. This is load-bearing, not cosmetic: a green row named `Detect an approval the last pusher cannot supply` on a pull request that **has** the condition would trade the current false positive for a false negative, which is the worse of the two. Green must not assert the absence of a finding. Both historical references to the old name (AGENTS.md, the test module's section comment) keep the measurement they record and name the rename, rather than being rewritten.

## Why not a `neutral` conclusion instead

That was the first design, and it is the better one in the abstract -- `neutral` is visible, distinct, and does not drag the rollup (empirically: `CodeQL` reports `NEUTRAL` on this repo's heads while the rollup reads `SUCCESS`). It was dropped because it cannot work on the population that motivates the change.

Publishing a check run needs `checks: write`, and on a `pull_request` event from a fork GitHub forces the token read-only. This repo has already settled that, twice, in its own workflow comments -- `breaking-change-check.yml:28` (`pull-requests: write # post/update PR comment (read-only on fork PRs)`) and `agent-api-check.yml:128`, both marking such steps best-effort and both explicitly refusing to switch to `pull_request_target`. **#1722 and #1035 are both `isCrossRepository: true`**, so the `neutral` row would be refused on exactly the two branches this exists for, leaving the machinery to pay off only where the problem is absent. Cut rather than shipped behind a degradation path.

## Tests

`tests/test_last_push_approval.py`, executing the workflow's own shell body out of the YAML rather than a paraphrase of it:

- `test_a_finding_does_not_fail_the_job` -- script exits 1, job exits 0.
- `test_a_check_that_cannot_compute_an_answer_still_fails_the_job` -- script exits 2, job exits 2. This is what stops the test above being satisfiable by a body that swallows every status.
- `test_the_guard_does_not_swallow_a_real_finding` -- **replaced, not deleted**, per the premise-test guidance in AGENTS.md. Its property is unchanged (the bootstrapping guard must not turn the check into a permanent no-op -- "a green check that never looks at anything"); only the evidence moved, from the exit status to the output, so it now asserts the script ran *and* that the body states what it found and why it is not failing. Exiting 0 in silence fails it.

The three stub invocations share one helper, so the shipped shell body is the thing under test in each.

**Non-vacuity proved by mutation, not asserted.** Reverting the run body to the pre-change form fails exactly the two tests that pin the new contract and nothing else:

```
FAILED test_the_guard_does_not_swallow_a_real_finding - assert 'reported, not failed' in 'stub ran\n'
FAILED test_a_finding_does_not_fail_the_job          - assert 1 == 0
2 failed, 44 passed
```

Restored: `46 passed`. Neighbouring workflow scanners green (`test_pull_request_trigger_types.py`, `test_log_strings_are_ascii.py`: 9 passed). YAML parses; triggers, `concurrency` and `permissions` are unchanged -- **no new permission is requested by this PR**. Every added line is ASCII.

## Docs

AGENTS.md said the check "fails when they are the same single account", which this makes wrong. Updated in place with the measurement and the new meaning of red, since a decision recorded only in a PR comment is not durable -- the rule this file states about itself.

## Scope

CI reporting shape only. No production file touched, no script behaviour changed, no assertion weakened, and nothing about the `require_last_push_approval` deadlock itself is affected: #1722 and #1035 still each need one approving review from an account that did not push their heads. This removes the misdiagnosis, not the deadlock.

Refs #1905.