### PR TITLE
fix(policies/motionbricks): refuse a synthesis knob the generator cannot integrate

### DIFF
--- a/changelog.d/2009-motionbricks-config-value-domain.md
+++ b/changelog.d/2009-motionbricks-config-value-domain.md
@@ -1,0 +1,31 @@
+### Fixed: a `MotionBricksConfig` synthesis knob the generator cannot integrate is refused
+
+`MotionBricksConfig.__post_init__` guarded `fps` and `generate_dt` with a
+comparison, and a comparison is not a domain: `nan < 1` and `nan <= 0` are both
+`False`, `inf < 1` is `False`, and `True` is an `int` subclass satisfying `>= 1`.
+Every value they let through reached `controller_dt` --
+`(NUM_REGEN_FRAMES / fps) * generate_dt` -- which `MotionBricksPolicy` caches and
+hands to the generator on every `get_actions` call. Measured with one config per
+value: `fps=nan` gave a `nan` horizon, `fps=inf` gave exactly `0.0` (the
+generator asked to integrate no time at all, under a success result), `fps=True`
+gave `16.0` from a boolean, `fps=2.5` a fractional frame rate, and
+`generate_dt=inf` an unbounded horizon. A numeric string escaped as a bare
+`TypeError` from the comparison operator, naming neither the field nor the
+config.
+
+`speed_scale` had a second failure: the pair was normalised with `float()` and
+only *then* range-checked, so `("1", "2")` was laundered into `(1.0, 2.0)` and
+stored as if the caller had written floats, while `(nan, nan)` and `(1.0, inf)`
+passed `lo <= 0 or hi <= 0 or hi < lo` untouched -- `nan` fails all three
+comparisons. A scalar `speed_scale=0.5` raised `'float' object is not iterable`
+out of the arity check itself.
+
+`fps` now takes `positive_whole_number_error` and `generate_dt` and each
+`speed_scale` component `positive_finite_number_error`, so the refusal is
+identical word for word to every other rate and multiplier in the library rather
+than merely equivalent in verdict. Pair arity is read with `sequence_length`, so
+a scalar is refused by the arity message instead of raising past it. The
+`min <= max` ordering rule stays local, since both components can be
+individually usable and still be in the wrong order. A fractional
+`generate_dt`, a NumPy scalar knob, a list-valued `speed_scale` and the upstream
+defaults all stay first-class.

--- a/strands_robots/policies/motionbricks/config.py
+++ b/strands_robots/policies/motionbricks/config.py
@@ -14,6 +14,17 @@ typed dataclass (rather than a raw dict) means a bad path or an out-of-range
 synthesis knob surfaces at construction with a clear message rather than as an
 opaque failure deep inside the generator.
 
+The numeric knobs are held to the shared domains in
+:mod:`strands_robots.utils` (:func:`~strands_robots.utils.positive_whole_number_error`
+for ``fps``, :func:`~strands_robots.utils.positive_finite_number_error` for
+``generate_dt`` and each ``speed_scale`` component) rather than to a local
+comparison, because a comparison is not a domain: ``fps < 1`` and
+``generate_dt <= 0`` are both ``False`` for ``nan``, and every value they let
+through reached :attr:`MotionBricksConfig.controller_dt` and from there the
+generator's ``generate_new_frames``. The path/identity fields (``result_dir``,
+``device``, ``clips``, ``exp``, ``style``) keep their own local checks and are
+not part of that numeric domain - see #2008.
+
 No checkpoints are bundled: ``result_dir`` must point at the upstream ``out/``
 checkpoint tree (``motionbricks_pose`` / ``motionbricks_root`` /
 ``motionbricks_vqvae`` + ``G1-clip.ckpt``), fetched with git-LFS under the
@@ -26,6 +37,12 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from strands_robots.utils import (
+    positive_finite_number_error,
+    positive_whole_number_error,
+    sequence_length,
+)
 
 # Upstream defaults from ``interactive_demo_g1.py`` + the demo controllers.
 # The reference controller regenerates motion every ``NUM_REGEN_FRAMES`` (8)
@@ -64,11 +81,21 @@ class MotionBricksConfig:
             clip mode name (``str``, e.g. ``"walk"``, ``"stealth_walk"``).
             Overridable per call via the ``style`` / ``mode`` kwarg.
         generate_dt: Synthesis horizon multiplier (upstream ``--generate_dt``).
-            Larger values plan further ahead per regeneration.
-        fps: Motion frame rate (upstream model fps, 30).
+            Larger values plan further ahead per regeneration. Must be a
+            positive finite number: it is the multiplier of
+            :attr:`controller_dt`, so ``0`` gives the generator no time to
+            integrate, ``inf`` an unbounded horizon and ``nan`` a horizon that
+            poisons every frame synthesised from it.
+        fps: Motion frame rate (upstream model fps, 30). Must be a positive
+            whole number - it is the divisor of :attr:`controller_dt`, so a
+            fractional rate is not a frame count the generator can emit, and
+            ``inf`` collapses the horizon to ``0`` rather than making it small.
         device: Torch device for the generator (``"cuda"`` or ``"cpu"``).
         speed_scale: ``(min, max)`` root-velocity perturbation range (upstream
-            ``--speed_scale``). ``(1.0, 1.0)`` disables perturbation.
+            ``--speed_scale``). ``(1.0, 1.0)`` disables perturbation. Both
+            components must be positive finite numbers with ``min <= max``;
+            they multiply the synthesised root velocity, so a non-finite
+            component scales it to a velocity no integrator can consume.
         exp: Upstream experiment key selecting the checkpoint layout
             (``"default"``).
         style_map: Optional overrides merged over the built-in
@@ -95,19 +122,32 @@ class MotionBricksConfig:
         # never carry a value that will misbehave deep inside the generator).
         if not self.result_dir:
             raise ValueError("MotionBricksConfig.result_dir must be a non-empty path to the 'out/' checkpoint tree")
-        if self.fps < 1:
-            raise ValueError(f"MotionBricksConfig.fps must be >= 1, got {self.fps}")
-        if self.generate_dt <= 0:
-            raise ValueError(f"MotionBricksConfig.generate_dt must be > 0, got {self.generate_dt}")
+        # The synthesis knobs go through the shared numeric domains rather than a
+        # local comparison, because a comparison is not a domain: ``fps < 1`` is
+        # ``False`` for ``nan`` and for ``inf``, and ``True`` is an ``int``
+        # subclass that reads as a 1 Hz frame rate. Each of those reached
+        # ``controller_dt`` and, from there, ``generate_new_frames``.
+        if error := positive_whole_number_error(self.fps, "fps", "MotionBricksConfig"):
+            raise ValueError(error)
+        if error := positive_finite_number_error(self.generate_dt, "generate_dt", "MotionBricksConfig"):
+            raise ValueError(error)
         if not isinstance(self.style, (int, str)):
             raise ValueError(
                 f"MotionBricksConfig.style must be an int mode index or a str mode name, got {self.style!r}"
             )
-        scale = tuple(self.speed_scale)
-        if len(scale) != 2:
+        # Arity is read with ``sequence_length`` rather than ``len(tuple(...))``
+        # so a scalar is refused by this message instead of raising ``'float'
+        # object is not iterable`` from the arity check itself.
+        if sequence_length(self.speed_scale) != 2:
             raise ValueError(f"MotionBricksConfig.speed_scale must be a (min, max) pair, got {self.speed_scale!r}")
-        lo, hi = float(scale[0]), float(scale[1])
-        if lo <= 0 or hi <= 0 or hi < lo:
+        lo_raw, hi_raw = tuple(self.speed_scale)
+        for index, component in ((0, lo_raw), (1, hi_raw)):
+            # Before the ``float()`` below, not after: that conversion is what
+            # used to launder ``speed_scale=("1", "2")`` into ``(1.0, 2.0)``.
+            if error := positive_finite_number_error(component, f"speed_scale[{index}]", "MotionBricksConfig"):
+                raise ValueError(error)
+        lo, hi = float(lo_raw), float(hi_raw)
+        if hi < lo:
             raise ValueError(f"MotionBricksConfig.speed_scale must be 0 < min <= max, got ({lo}, {hi})")
         # Normalise speed_scale to a plain float tuple (frozen -> object.__setattr__).
         object.__setattr__(self, "speed_scale", (lo, hi))

--- a/tests/policies/motionbricks/test_config_value_domain.py
+++ b/tests/policies/motionbricks/test_config_value_domain.py
@@ -1,0 +1,323 @@
+"""Value-domain contracts for :class:`MotionBricksConfig`'s synthesis knobs.
+
+``__post_init__`` has always *had* a check for ``fps`` and ``generate_dt``. What
+it had was a COMPARISON, and a comparison is not a domain: ``nan < 1`` and
+``nan <= 0`` are both ``False``, ``inf < 1`` is ``False``, and ``True`` is an
+``int`` subclass that satisfies ``>= 1``. So the guard that exists to make "an
+out-of-range synthesis knob surface at construction with a clear message rather
+than as an opaque failure deep inside the generator" (this module's own
+docstring) let every one of those through.
+
+They do not stop at the config. All three knobs are read by
+:attr:`MotionBricksConfig.controller_dt` -
+``(NUM_REGEN_FRAMES / fps) * generate_dt`` - which
+:class:`MotionBricksPolicy` caches as ``self._controller_dt`` and passes to
+``MotionAgent.next_qpos`` on every ``get_actions`` call, where the real adapter
+hands it straight to the upstream ``full_navigation_agent.generate_new_frames``.
+Measured on the pre-fix tree, per accepted value:
+
+===================== ===================== =====================================
+value                 ``controller_dt``     what the generator was asked for
+===================== ===================== =====================================
+``fps=float("nan")``  ``nan``               a horizon that poisons every frame
+``fps=float("inf")``  ``0.0``               integrate nothing, under success
+``fps=True``          ``16.0``              a 1 Hz frame rate from a boolean
+``fps=2.5``           ``3.2``               a fractional frame rate
+``generate_dt=nan``   ``nan``               as above
+``generate_dt=inf``   ``inf``               an unbounded horizon
+``generate_dt=True``  ``0.2666...``         a multiplier from a boolean
+===================== ===================== =====================================
+
+``speed_scale`` had a second failure of its own: the pair was normalised with
+``float(scale[0]), float(scale[1])`` and only *then* range-checked, so
+``("1", "2")`` was laundered into ``(1.0, 2.0)`` and stored as if the caller had
+written floats, while ``(nan, nan)`` and ``(1.0, inf)`` passed the
+``lo <= 0 or hi <= 0 or hi < lo`` test unchanged and were stored verbatim.
+
+The fix composes the shared domains in :mod:`strands_robots.utils` -
+:func:`~strands_robots.utils.positive_whole_number_error` for ``fps`` (whose own
+docstring already names a recorder's ``fps`` as a caller) and
+:func:`~strands_robots.utils.positive_finite_number_error` for ``generate_dt``
+and each ``speed_scale`` component - so the refusal text is identical to every
+other rate and multiplier in the library rather than merely equivalent in
+verdict. These tests pin that domain through each public surface a caller
+reaches (the constructor, ``from_dict``, ``from_file``), pin the consequence the
+domain exists to prevent, and pin the values that stay first-class so the guard
+cannot creep into refusing a generator a caller may legitimately ask for.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.motionbricks import MotionBricksConfig, MotionBricksPolicy
+from strands_robots.policies.motionbricks.config import NUM_REGEN_FRAMES
+
+# Values no numeric knob of this config can be honored as, whatever its sign
+# rule: a non-finite one poisons or collapses the horizon it scales, a boolean
+# would act as a silent 1, and a non-real one has no horizon at all.
+UNUSABLE_ANY_KNOB: list[Any] = [
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    False,
+    "2.0",
+    None,
+    [2.0],
+    10**400,
+]
+
+
+def _config(**kwargs: Any) -> MotionBricksConfig:
+    """Build a config through one funnel.
+
+    These tests deliberately supply values outside the declared field types (a
+    string where a ``float`` is annotated, a list where a scalar is), which is
+    the point - the runtime is what must refuse them. Splatting through one
+    ``**kwargs: Any`` funnel states that intent once instead of scattering a
+    suppression over every call.
+    """
+    return MotionBricksConfig(**{"result_dir": "out", **kwargs})
+
+
+def _horizon(*, fps: Any, generate_dt: Any) -> float:
+    """The horizon a value WOULD have produced, out of the real property.
+
+    Applied to a ``SimpleNamespace`` rather than to a config, because a config
+    carrying these values can no longer be built - that is the fix. Reading
+    ``MotionBricksConfig.controller_dt`` itself (not a re-derivation of its
+    arithmetic) keeps these measurements honest if the formula ever changes.
+    """
+    return float(MotionBricksConfig.controller_dt.fget(SimpleNamespace(fps=fps, generate_dt=generate_dt)))  # type: ignore[attr-defined]
+
+
+class _RecordingAgent:
+    """Records the ``controller_dt`` the policy forwards per ``get_actions``.
+
+    Stands in for the ``motion_agent`` seam so the horizon can be observed
+    reaching the generator without the ``motionbricks`` install or a GPU.
+    """
+
+    clip_keys = ["idle", "walk"]
+    clip_token_specs: list[list[int] | None] = [None, [1] * 11]
+    min_token = 6
+    max_token = 16
+
+    def __init__(self) -> None:
+        self.horizons: list[float] = []
+
+    def reset(self) -> None:
+        pass
+
+    def next_qpos(self, control_signals: dict[str, Any], controller_dt: float) -> np.ndarray:
+        self.horizons.append(controller_dt)
+        return np.zeros(7 + 29, dtype=np.float64)
+
+
+class TestFpsDomain:
+    """``fps`` is the divisor of the generator's integration horizon."""
+
+    @pytest.mark.parametrize("value", [0, -30, 2.5, *UNUSABLE_ANY_KNOB])
+    def test_an_unusable_fps_is_refused_at_construction(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"fps"):
+            _config(fps=value)
+
+    @pytest.mark.parametrize("value", [1, 30, 60, 30.0, np.int64(30), np.float64(50)])
+    def test_a_usable_fps_still_builds(self, value: Any) -> None:
+        assert _config(fps=value).controller_dt == pytest.approx(NUM_REGEN_FRAMES / float(value) * 2.0)
+
+    def test_the_refusal_names_the_field_and_the_value(self) -> None:
+        with pytest.raises(ValueError, match=r"MotionBricksConfig: fps must be a positive whole number, got 0\."):
+            _config(fps=0)
+
+    def test_a_non_real_fps_is_refused_rather_than_raising_from_the_comparison(self) -> None:
+        # Pre-fix this escaped as ``'<' not supported between instances of 'str'
+        # and 'int'``, which names neither the field nor the config.
+        with pytest.raises(ValueError, match=r"MotionBricksConfig: fps must be a positive whole number, got '30'\."):
+            _config(fps="30")
+
+
+class TestGenerateDtDomain:
+    """``generate_dt`` is the multiplier of that same horizon."""
+
+    @pytest.mark.parametrize("value", [0, 0.0, -2.0, *UNUSABLE_ANY_KNOB])
+    def test_an_unusable_generate_dt_is_refused_at_construction(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"generate_dt"):
+            _config(generate_dt=value)
+
+    @pytest.mark.parametrize("value", [0.5, 1, 2.0, 4.5, np.float32(2.0), np.float64(1.5)])
+    def test_a_usable_generate_dt_still_builds(self, value: Any) -> None:
+        assert _config(generate_dt=value).controller_dt == pytest.approx(NUM_REGEN_FRAMES / 30.0 * float(value))
+
+    def test_a_fractional_generate_dt_stays_first_class(self) -> None:
+        # Unlike ``fps`` this is a continuous multiplier, so the two knobs take
+        # different shared guards rather than one.
+        assert _config(generate_dt=0.25).controller_dt == pytest.approx(NUM_REGEN_FRAMES / 30.0 * 0.25)
+
+    def test_the_refusal_names_the_field_and_the_value(self) -> None:
+        with pytest.raises(ValueError, match=r"MotionBricksConfig: generate_dt must be > 0, got 0\.0\."):
+            _config(generate_dt=0.0)
+
+
+class TestSpeedScaleDomain:
+    """Both ``speed_scale`` components multiply the synthesised root velocity."""
+
+    @pytest.mark.parametrize("index", [0, 1])
+    @pytest.mark.parametrize("value", [0, 0.0, -1.0, *UNUSABLE_ANY_KNOB])
+    def test_an_unusable_component_is_refused_naming_its_index(self, index: int, value: Any) -> None:
+        pair: list[Any] = [1.0, 1.0]
+        pair[index] = value
+        with pytest.raises(ValueError, match=rf"speed_scale\[{index}\]"):
+            _config(speed_scale=tuple(pair))
+
+    def test_a_string_component_is_no_longer_laundered_into_a_float(self) -> None:
+        # Pre-fix ``float()`` ran before the range test, so this was accepted and
+        # STORED as ``(1.0, 2.0)`` - a config reporting floats the caller never
+        # wrote.
+        with pytest.raises(ValueError, match=r"MotionBricksConfig: speed_scale\[0\] must be > 0, got '1'\."):
+            _config(speed_scale=("1", "2"))
+
+    @pytest.mark.parametrize("value", [0.5, (1.0,), (1.0, 1.0, 1.0), (), np.float64(1.0)])
+    def test_a_pair_of_the_wrong_arity_is_refused_as_an_arity_mistake(self, value: Any) -> None:
+        # Including the scalar: pre-fix ``tuple(0.5)`` raised ``'float' object is
+        # not iterable`` out of the arity check itself, past this message.
+        with pytest.raises(ValueError, match=r"speed_scale must be a \(min, max\) pair"):
+            _config(speed_scale=value)
+
+    def test_a_two_character_string_is_refused_componentwise_not_as_an_arity_mistake(self) -> None:
+        # ``"ab"`` DOES carry a component count of 2, so the arity rule has
+        # nothing to say about it and the component domain is what refuses it.
+        # Recorded because the two rules are easy to conflate.
+        with pytest.raises(ValueError, match=r"MotionBricksConfig: speed_scale\[0\] must be > 0, got 'a'\."):
+            _config(speed_scale="ab")
+
+    def test_an_inverted_pair_is_still_refused_as_an_ordering_mistake(self) -> None:
+        # Both components are individually usable, so this rule is the config's
+        # own and cannot come from a shared scalar domain.
+        with pytest.raises(ValueError, match=r"speed_scale must be 0 < min <= max, got \(2\.0, 1\.0\)"):
+            _config(speed_scale=(2.0, 1.0))
+
+    @pytest.mark.parametrize("value", [(1.0, 1.0), (0.8, 1.2), [0.8, 1.2], (2.0, 2.0), (np.float32(0.9), 1.1)])
+    def test_a_usable_pair_still_builds_and_normalises_to_plain_floats(self, value: Any) -> None:
+        scale = _config(speed_scale=value).speed_scale
+        assert scale == pytest.approx((float(value[0]), float(value[1])))
+        assert [type(component) for component in scale] == [float, float]
+
+
+class TestWhyTheseDomainsAreWhatTheyAre:
+    """The horizon each refused value would have produced, and where it goes.
+
+    Without these the domain reads as tidying: it is not, because every value in
+    the table reached the generator.
+    """
+
+    @pytest.mark.parametrize(
+        ("fps", "generate_dt", "expected"),
+        [
+            (float("inf"), 2.0, 0.0),
+            (True, 2.0, 16.0),
+            (2.5, 2.0, 6.4),
+            (30, float("inf"), float("inf")),
+            (30, True, NUM_REGEN_FRAMES / 30.0),
+        ],
+    )
+    def test_a_refused_knob_would_have_produced_this_horizon(self, fps: Any, generate_dt: Any, expected: float) -> None:
+        assert _horizon(fps=fps, generate_dt=generate_dt) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("knob", ["fps", "generate_dt"])
+    def test_a_non_finite_knob_would_have_poisoned_the_horizon(self, knob: str) -> None:
+        args: dict[str, Any] = {"fps": 30, "generate_dt": 2.0, knob: float("nan")}
+        assert np.isnan(_horizon(**args))
+
+    def test_the_horizon_reaches_the_generator_on_every_call(self) -> None:
+        # The reason the table above is a defect and not a curiosity: this is the
+        # same value, unexamined by anything between the config and
+        # ``full_navigation_agent.generate_new_frames``.
+        agent = _RecordingAgent()
+        config = _config(fps=60, generate_dt=0.5)
+        policy = MotionBricksPolicy(config=config, motion_agent=agent, style="walk")
+        policy.get_actions_sync({}, "")
+        policy.get_actions_sync({}, "")
+        assert agent.horizons == [pytest.approx(config.controller_dt)] * 2
+        assert agent.horizons[0] == pytest.approx(NUM_REGEN_FRAMES / 60.0 * 0.5)
+
+
+class TestTheConfigFilePathIsCovered:
+    """A checkpoint's ``config.json`` reaches the same domain as the constructor."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"fps": float("inf")},
+            {"fps": 2.5},
+            {"generate_dt": float("nan")},
+            {"speed_scale": [float("nan"), 1.0]},
+            {"speed_scale": ["1", "2"]},
+        ],
+    )
+    def test_from_dict_refuses_an_unusable_knob(self, bad: dict[str, Any]) -> None:
+        with pytest.raises(ValueError):
+            MotionBricksConfig.from_dict({"result_dir": "out", **bad})
+
+    def test_from_file_refuses_an_unusable_knob(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.json"
+        # ``Infinity`` is what ``json.dump`` writes for ``inf`` and what
+        # ``json.loads`` reads back, so a JSON config can carry one.
+        path.write_text(json.dumps({"result_dir": "out", "generate_dt": float("inf")}))
+        with pytest.raises(ValueError, match=r"generate_dt must be > 0"):
+            MotionBricksConfig.from_file(path)
+
+    def test_from_file_still_loads_a_usable_config(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"result_dir": "out", "fps": 60, "generate_dt": 1.5, "speed_scale": [0.9, 1.1]}))
+        config = MotionBricksConfig.from_file(path)
+        assert (config.fps, config.generate_dt, config.speed_scale) == (60, 1.5, (0.9, 1.1))
+
+
+class TestTheUpstreamDefaultsStayFirstClass:
+    """The domain must not refuse the configuration the reference runner uses."""
+
+    def test_the_defaults_build(self) -> None:
+        config = _config()
+        assert (config.fps, config.generate_dt, config.speed_scale) == (30, 2.0, (1.0, 1.0))
+        assert config.controller_dt == pytest.approx(NUM_REGEN_FRAMES / 30.0 * 2.0)
+
+    def test_the_upstream_perturbation_range_builds(self) -> None:
+        assert _config(speed_scale=(0.7, 1.3)).speed_scale == pytest.approx((0.7, 1.3))
+
+
+class TestNeighbouringConfigFieldsStayOutOfScope:
+    """The identity/path fields are NOT part of this numeric domain.
+
+    A pin of current behaviour, not an endorsement of it: ``result_dir=123`` is
+    accepted today and reaches ``Path(...)`` downstream. It is a string-identity
+    question rather than a numeric one, so settling it here would make this two
+    changes; tracked in #2008. Per the premise-test guidance in ``AGENTS.md``
+    this boundary should be REPLACED rather than deleted when that lands.
+    """
+
+    @pytest.mark.parametrize("value", [123, True, ["out"]])
+    def test_a_non_string_result_dir_is_still_accepted(self, value: Any) -> None:
+        assert _config(result_dir=value).result_dir == value
+
+    def test_an_empty_result_dir_is_still_refused_by_its_own_local_check(self) -> None:
+        with pytest.raises(ValueError, match=r"result_dir must be a non-empty path"):
+            _config(result_dir="")
+
+    @pytest.mark.parametrize("field", ["device", "clips", "exp"])
+    def test_a_non_string_identity_field_is_still_accepted(self, field: str) -> None:
+        assert getattr(_config(**{field: 5}), field) == 5
+
+    def test_the_style_check_is_unchanged(self) -> None:
+        # ``style`` admits an int index OR a str name, so it is neither a numeric
+        # domain nor a string one and keeps its own local check.
+        with pytest.raises(ValueError, match=r"style must be an int mode index or a str mode name"):
+            _config(style=3.5)
+        assert _config(style=True).style is True


### PR DESCRIPTION
## What

`MotionBricksConfig.__post_init__` holds `fps`, `generate_dt` and each `speed_scale` component to the shared numeric domains in `strands_robots/utils.py` instead of to a local comparison.

## Why a comparison was not a domain

The guard already existed. What it contained was `if self.fps < 1` and `if self.generate_dt <= 0`, and those are false for the values that matter: `nan < 1` is `False`, `nan <= 0` is `False`, `inf < 1` is `False`, and `True` is an `int` subclass that satisfies `>= 1`. So the check that exists to make "an out-of-range synthesis knob surface at construction with a clear message rather than as an opaque failure deep inside the generator" (the module's own docstring) let every one of them through.

They do not stop at the config. All three knobs are read by `controller_dt` -- `(NUM_REGEN_FRAMES / fps) * generate_dt` -- which `MotionBricksPolicy` caches as `self._controller_dt` and passes to `MotionAgent.next_qpos` on **every** `get_actions` call, where the real adapter hands it straight to `full_navigation_agent.generate_new_frames`.

Measured on `e9d2542`, one `MotionBricksConfig(...)` per row, no `motionbricks` install:

| value | verdict | `controller_dt` | what the generator was asked for |
| --- | --- | --- | --- |
| `fps=float("nan")` | accepted | `nan` | a horizon that poisons every frame synthesised from it |
| `fps=float("inf")` | accepted | `0.0` | integrate nothing, under a success result |
| `fps=True` | accepted | `16.0` | a 1 Hz frame rate read out of a boolean |
| `fps=2.5` | accepted | `3.2` | a fractional frame rate on an `int` field |
| `generate_dt=nan` | accepted | `nan` | as above |
| `generate_dt=inf` | accepted | `inf` | an unbounded horizon |
| `generate_dt=True` | accepted | `0.2666...` | a multiplier read out of a boolean |
| `fps="30"` | **raised** `TypeError: '<' not supported between instances of 'str' and 'int'` | -- | names neither the field nor the config |
| `generate_dt="2.0"` | **raised** `TypeError: '<=' not supported ...` | -- | as above |

`fps=inf` is the row worth pausing on: it does not make the horizon large, it makes it exactly `0.0`, so the generator is asked to integrate no time at all and reports success doing it. That is Key Convention 6 ("no silent defaults on error") reached from an input the guard was written to catch.

### `speed_scale` had a second failure of its own

The pair was normalised with `float(scale[0]), float(scale[1])` and only **then** range-checked, so the conversion ran ahead of the domain:

| value | verdict | stored |
| --- | --- | --- |
| `("1", "2")` | accepted | `(1.0, 2.0)` -- floats the caller never wrote |
| `(nan, nan)` | accepted | `(nan, nan)` verbatim |
| `(1.0, inf)` | accepted | `(1.0, inf)` verbatim |
| `(True, True)` | accepted | `(1.0, 1.0)` -- a boolean read as a scale |
| `0.5` | **raised** `TypeError: 'float' object is not iterable` | -- out of `tuple()` in the arity check itself |

`lo <= 0 or hi <= 0 or hi < lo` is three comparisons and `nan` fails all three, which is the same defect as above wearing a different shape.

## What changed

- `fps` takes `positive_whole_number_error`. That guard's own docstring already names a recorder's `fps` as a caller, so this is the frame-rate domain the library already has, not a new one.
- `generate_dt` and **each** `speed_scale` component take `positive_finite_number_error` -- the docstring names "a dimensionless multiplier" as exactly this case. The component check runs **before** the `float()` that used to launder strings.
- Pair arity is read with `sequence_length` rather than `len(tuple(...))`, so a scalar is refused by the arity message instead of raising out of the arity check.
- `min <= max` stays a local rule. Both components can be individually usable and still be in the wrong order, so no shared scalar domain can express it.

No new helper. Composing the existing guards means the refusal text is **identical word for word** to every other rate and multiplier in the library, not merely equivalent in verdict:

```
MotionBricksConfig: fps must be a positive whole number, got inf.
MotionBricksConfig: generate_dt must be > 0, got nan.
MotionBricksConfig: speed_scale[1] must be > 0, got inf.
```

The two `TypeError` rows now come back as `ValueError` naming the field, and `fps=10**400` gets the float64-range reason of its own that the shared guard already has.

## What stays first-class

`fps` as `30`, `30.0`, `np.int64(30)`; `generate_dt` fractional (`0.25`, `0.5`) and as `np.float32`; `speed_scale` as a tuple **or** a list, normalised to plain `float`s; and the upstream defaults `(30, 2.0, (1.0, 1.0))`. All pinned, so the guard cannot creep into refusing a generator a caller may legitimately ask for.

## Tests

New `tests/policies/motionbricks/test_config_value_domain.py`, in the shape of the neighbouring `tests/policies/wbc/test_wbc_config_value_domain.py`:

- the refused and the accepted set per knob, through **each** public surface a caller reaches -- the constructor, `from_dict`, and `from_file` (a checkpoint's `config.json` can carry `Infinity`, which `json.loads` reads back as `inf`);
- exact-message pins, so a refusal cannot silently stop naming the field;
- **the consequence**, without which the domain would read as tidying: each refused value's horizon is measured out of the real `controller_dt` property applied to a `SimpleNamespace` (not a re-derivation of its arithmetic, so the measurements stay honest if the formula changes), and one test drives `get_actions_sync` through the `motion_agent` seam to pin that this horizon is the value the generator receives, unexamined by anything in between;
- that a 2-character string is refused *componentwise* rather than as an arity mistake -- it does carry a component count of 2, so the two rules are easy to conflate and the distinction is recorded.

**Non-vacuous:** 52 of the new assertions fail on the pre-fix tree with only `config.py` reverted; all 173 tests in `tests/policies/motionbricks/` pass with it.

**Verified locally:** `ruff check` / `ruff format --check` / `mypy` clean over the exact `hatch run lint` scope (`strands_robots tests tests_integ`, 1098 source files); 4602 passed across `tests/policies`, `tests/training` and the changelog-fragment guards. Two pre-existing failures in this container are unrelated and reproduce on `main` unchanged: `tests/training/test_lerobot_e2e.py::test_record_train_load_loop`, and native aborts in the MuJoCo rendering modules (no display available).

## Scope, stated explicitly

The path/identity fields (`result_dir`, `device`, `clips`, `exp`) are **not** in this change. `result_dir` is checked only for truthiness, so `result_dir=123` and `result_dir=["out"]` are accepted today and reach `Path(...)` downstream -- a string-identity question rather than a numeric one, with different remedies and a genuine open sub-question (whether the domain is `str` or `str | Path`, and whether `clips`/`exp` want membership checks instead). Filed as #2008 and pinned here in `TestNeighbouringConfigFieldsStayOutOfScope` so the boundary is a stated assertion rather than an omission; per the premise-test guidance in `AGENTS.md` that pin should be **replaced** rather than deleted when #2008 lands, since what it asserts today is the defective behaviour.

`style` is excluded too, and deliberately: it admits an `int` mode index **or** a `str` mode name, so it is neither domain and its local `isinstance` check is the right shape. Its `style=True` row is noted on #2008.

## Notes

- No public signature changes; no accepted value becomes refused that any test, doc or example uses.
- `docs/policies/motionbricks.md`'s field table is unchanged in meaning; the per-field domains are documented on the attributes themselves, which is where the config docstring already carried this information.
- Changelog fragment: `changelog.d/2009-motionbricks-config-value-domain.md`.

### §13 Round changelog

**Round 0 (initial):** `fps` / `generate_dt` / `speed_scale` held to the shared numeric domains (`positive_whole_number_error` / `positive_finite_number_error`), component check moved ahead of the `float()` that laundered strings, pair arity read with `sequence_length`; new `test_config_value_domain.py` regression module (52 assertions fail pre-fix); identity-field axis split to #2008 with a boundary pin; changelog fragment added.