### PR TITLE
fix(policies/motionbricks): hold result_dir to a path domain instead of a truthiness test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,16 @@ hatch run format            # ruff check --fix, ruff format
 8. **Integration tests required** - each policy needs `tests_integ/` tests with real inference
 9. **Test behavior, not implementation** - assert on outputs, not internal state
 10. **No dead code** - if it's not called and not part of base class, delete it
+11. **A value-domain guard becomes shared when it has a second caller** - the guards
+    in `strands_robots/utils.py` (`positive_finite_number_error` and friends) exist so
+    the refusal for a rate, a count or a name is identical everywhere rather than
+    merely equivalent in verdict, and each one has between 5 and 123 call sites. Do
+    not add one for a single field. Keep the rule local to the config that needs it,
+    state the domain in that field's docstring, and lift it into `utils.py` when a
+    second caller appears - two copies are the evidence that a shared name is the
+    right one, and one caller is evidence of nothing. #2008 asked this for a path
+    field and the answer was local: the only other `if not self.<path field>` in the
+    tree (`training/_inproc.py`) is a branch that skips logging, not a validation.
 
 ## PR Workflow
 

--- a/changelog.d/2011-motionbricks-result-dir-path-domain.md
+++ b/changelog.d/2011-motionbricks-result-dir-path-domain.md
@@ -1,0 +1,30 @@
+### Fixed: `MotionBricksConfig.result_dir` is held to a path domain rather than a truthiness test
+
+`__post_init__` guarded the checkpoint path with `if not self.result_dir`, which
+asserts truthiness rather than path-ness, so the values the field has to sort
+sorted by a property it does not have. Measured with one config per value:
+`result_dir=123` and `result_dir=["out"]` were accepted for being truthy and
+stored verbatim, `b"out"` likewise, and `result_dir=0` was refused for being
+falsy -- by a message reading "must be a non-empty path" about a number. Each
+accepted value travelled to `Path(config.result_dir)` in the generator build and
+raised `TypeError` there, naming neither the field nor the config.
+
+Two consequences did not need the generator at all. A `Path` was accepted and
+stored unnormalised, so a config built from `Path("out")` compared **unequal** to
+the identical config built from `"out"`; and `result_dir=["out"]` left this
+frozen -- therefore hashable -- dataclass unhashable, with `hash(config)` raising
+`unhashable type: 'list'`.
+
+The domain is now "a value a path can be read from" -- a `str` or any
+`os.PathLike` -- normalised to the `str` the field declares, the same shape as the
+`speed_scale` normalisation beside it. A caller holding a `Path` is doing what
+every consumer of this field does, so it is accepted rather than refused, which
+is why the remedy is a normalising domain and not an `isinstance(str)` gate. The
+empty-string refusal is unchanged and keeps its own message: `""` is a
+path-shaped value that names nothing. The rule stays local to this config rather
+than becoming a shared guard in `utils.py`, since the numeric guards there each
+have 5-123 callers and this has exactly one.
+
+The enumeration fields (`clips`, `exp`, `device`) are unchanged: a type check
+would refuse `device=5` and accept `clips="g1"`, so membership rather than type
+is the rule they want, tracked separately.

--- a/docs/policies/motionbricks.md
+++ b/docs/policies/motionbricks.md
@@ -120,7 +120,7 @@ policy = create_policy(
 
 | `MotionBricksConfig` field | Meaning | Default |
 | --- | --- | --- |
-| `result_dir` | Path to the upstream `out/` checkpoint tree | required |
+| `result_dir` | Path to the upstream `out/` checkpoint tree - a `str` or any `os.PathLike`, stored as a `str` | required |
 | `skeleton_xml` / `scene_xml` | G1 skeleton / scene MuJoCo XML | derived from `result_dir` |
 | `clips` | Clip set name | `"G1"` |
 | `style` | Default mode (index or name) | `"walk"` |

--- a/strands_robots/policies/motionbricks/config.py
+++ b/strands_robots/policies/motionbricks/config.py
@@ -21,9 +21,23 @@ for ``fps``, :func:`~strands_robots.utils.positive_finite_number_error` for
 comparison, because a comparison is not a domain: ``fps < 1`` and
 ``generate_dt <= 0`` are both ``False`` for ``nan``, and every value they let
 through reached :attr:`MotionBricksConfig.controller_dt` and from there the
-generator's ``generate_new_frames``. The path/identity fields (``result_dir``,
-``device``, ``clips``, ``exp``, ``style``) keep their own local checks and are
-not part of that numeric domain - see #2008.
+generator's ``generate_new_frames``.
+
+``result_dir`` takes a domain of its own rather than a share of that one,
+because what it must refuse is not out of range - it is not a path. It is held
+to "a value a path can be read from" (a ``str`` or an :class:`os.PathLike`) and
+normalised to the ``str`` the field declares, the same shape as the
+``speed_scale`` normalisation below. That rule stays local rather than becoming
+a shared ``non_empty_string_error`` beside the numeric guards: each of those has
+between 5 and 123 callers in this tree and this would have exactly one, since
+the only other ``if not self.<path field>`` here
+(:mod:`strands_robots.training._inproc`) is a branch that skips logging rather
+than a validation. Lift it when a second config needs it.
+
+The remaining identity fields (``device``, ``clips``, ``exp``) are enumerations,
+for which a type check is not the useful rule - it would refuse ``device=5`` and
+accept ``clips="g1"`` - and ``style`` is already refused for a bool and
+range-checked against the live clip list where the mode is resolved. See #2010.
 
 No checkpoints are bundled: ``result_dir`` must point at the upstream ``out/``
 checkpoint tree (``motionbricks_pose`` / ``motionbricks_root`` /
@@ -34,6 +48,8 @@ NVIDIA license.
 from __future__ import annotations
 
 import json
+import os
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -66,9 +82,14 @@ class MotionBricksConfig:
         result_dir: Path to the upstream ``out/`` checkpoint tree (contains
             ``motionbricks_pose`` / ``motionbricks_root`` / ``motionbricks_vqvae``
             ``version_1/`` dirs + ``G1-clip.ckpt``). Required to build the real
-            generator; not validated for existence here (the stub seam builds a
-            policy without checkpoints) - existence is checked when the agent is
-            constructed.
+            generator. Accepts a ``str`` or any :class:`os.PathLike` - a caller
+            holding a :class:`~pathlib.Path` is doing what every consumer of
+            this field does - and stores ``os.fspath`` of it, so two configs
+            naming the same tree compare and hash equal. A value no path can be
+            read from is refused here rather than at ``Path(result_dir)`` in the
+            generator build. Existence is still not validated here (the stub
+            seam builds a policy without checkpoints) - it is checked when the
+            agent is constructed.
         skeleton_xml: Path to the G1 skeleton MuJoCo XML (upstream
             ``assets/skeletons/g1/g1.xml``). ``None`` lets the builder derive it
             from the package install.
@@ -120,6 +141,26 @@ class MotionBricksConfig:
     def __post_init__(self) -> None:
         # Fail-fast on bad synthesis knobs (AGENTS.md #5: raise on fatal config,
         # never carry a value that will misbehave deep inside the generator).
+        # ``result_dir`` names a location, so its domain is path-ness. ``if not
+        # self.result_dir`` asserted truthiness instead, which sorts these values
+        # by a property the field does not have: ``123`` and ``["out"]`` were
+        # accepted for being truthy, ``0`` was refused for being falsy - by a
+        # message about an empty *path*, about a number - and a ``Path`` was
+        # accepted but stored unnormalised, so a config built from one compared
+        # unequal to the identical config built from a ``str`` and
+        # ``result_dir=["out"]`` left this frozen dataclass unhashable.
+        if isinstance(self.result_dir, os.PathLike):
+            # ``os.fspath`` raises when ``__fspath__`` returns a non-path, so
+            # leave the value unconverted on that: it then falls to the refusal
+            # below, which is the channel a bad value is reported on here.
+            with suppress(TypeError):
+                object.__setattr__(self, "result_dir", os.fspath(self.result_dir))
+        if not isinstance(self.result_dir, str):
+            raise ValueError(
+                f"MotionBricksConfig.result_dir must be a str or os.PathLike path to the 'out/' checkpoint "
+                f"tree, got {self.result_dir!r} ({type(self.result_dir).__name__}); it is read as "
+                "Path(result_dir) when the generator is built, which raises TypeError there rather than here."
+            )
         if not self.result_dir:
             raise ValueError("MotionBricksConfig.result_dir must be a non-empty path to the 'out/' checkpoint tree")
         # The synthesis knobs go through the shared numeric domains rather than a

--- a/tests/policies/motionbricks/test_config_value_domain.py
+++ b/tests/policies/motionbricks/test_config_value_domain.py
@@ -1,4 +1,4 @@
-"""Value-domain contracts for :class:`MotionBricksConfig`'s synthesis knobs.
+"""Value-domain contracts for :class:`MotionBricksConfig`'s knobs and its path.
 
 ``__post_init__`` has always *had* a check for ``fps`` and ``generate_dt``. What
 it had was a COMPARISON, and a comparison is not a domain: ``nan < 1`` and
@@ -44,11 +44,25 @@ verdict. These tests pin that domain through each public surface a caller
 reaches (the constructor, ``from_dict``, ``from_file``), pin the consequence the
 domain exists to prevent, and pin the values that stay first-class so the guard
 cannot creep into refusing a generator a caller may legitimately ask for.
+
+``result_dir`` is the second axis, and it is a different question rather than a
+smaller one: the values it must refuse are not out of range, they are not paths.
+Its check was ``if not self.result_dir``, which asserts truthiness - so ``123``
+and ``["out"]`` were accepted for being truthy and ``0`` refused for being falsy,
+by a message about an empty *path*, about a number. The values sorted by a
+property the field does not have. Its domain is now "a value a path can be read
+from" (``str`` or :class:`os.PathLike`), normalised to the ``str`` the field
+declares, and ``TestResultDirPathDomain`` pins that alongside the two
+consequences the truthiness test carried beyond the eventual ``Path(...)``:
+a ``Path`` was stored unnormalised, so a config built from one compared unequal
+to the identical config built from a ``str``, and a list left this frozen -
+therefore hashable - dataclass unhashable.
 """
 
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -58,6 +72,7 @@ import pytest
 
 from strands_robots.policies.motionbricks import MotionBricksConfig, MotionBricksPolicy
 from strands_robots.policies.motionbricks.config import NUM_REGEN_FRAMES
+from strands_robots.policies.motionbricks.observation import resolve_mode
 
 # Values no numeric knob of this config can be honored as, whatever its sign
 # rule: a non-finite one poisons or collapses the horizon it scales, a boolean
@@ -249,6 +264,129 @@ class TestWhyTheseDomainsAreWhatTheyAre:
         assert agent.horizons[0] == pytest.approx(NUM_REGEN_FRAMES / 60.0 * 0.5)
 
 
+class TestResultDirPathDomain:
+    """``result_dir`` names a location, so its domain is path-ness not truthiness.
+
+    Measured on ``89410ad``, one ``MotionBricksConfig(result_dir=<value>)`` per
+    row, no ``motionbricks`` install:
+
+    ==================== ============================ ==========================
+    value                pre-fix verdict              consequence
+    ==================== ============================ ==========================
+    ``123``              accepted, stored ``123``     ``Path(123)`` -> TypeError
+    ``True``             accepted, stored ``True``    as above
+    ``b"out"``           accepted, stored ``b'out'``  as above; pathlib refuses
+                                                      bytes too
+    ``["out"]``          accepted, stored ``['out']`` as above, AND
+                                                      ``hash(config)`` raised
+                                                      ``unhashable type: 'list'``
+    ``0``                refused                      by the truthiness test, so
+                                                      the message says "non-empty
+                                                      path" about a number
+    ``Path("out")``      accepted, stored as a        unequal to the identical
+                         ``PosixPath``                 config built from ``"out"``
+    ==================== ============================ ==========================
+
+    The first four are the defect this closes; the last two are why the remedy is
+    a normalising domain rather than an ``isinstance(str)`` gate, which would have
+    refused the ``Path`` a caller is most likely to be holding.
+    """
+
+    @pytest.mark.parametrize("value", [123, 0, 3.5, True, False, None, b"out", ["out"], ("out",), {"dir": "out"}])
+    def test_a_value_no_path_can_be_read_from_is_refused(self, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"result_dir must be a str or os\.PathLike"):
+            _config(result_dir=value)
+
+    def test_the_refusal_names_the_value_its_type_and_where_it_would_have_failed(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"MotionBricksConfig\.result_dir must be a str or os\.PathLike path to the 'out/' "
+                r"checkpoint tree, got 123 \(int\); it is read as Path\(result_dir\) when the generator "
+                r"is built, which raises TypeError there rather than here\."
+            ),
+        ):
+            _config(result_dir=123)
+
+    def test_an_empty_result_dir_is_still_refused_as_an_empty_path(self) -> None:
+        # Unchanged, and deliberately a separate message from the one above: an
+        # empty string IS a path-shaped value, it just names nothing.
+        with pytest.raises(ValueError, match=r"result_dir must be a non-empty path"):
+            _config(result_dir="")
+
+    @pytest.mark.parametrize("value", ["out", "~/out", "/srv/ckpt/out", "out/version_1"])
+    def test_a_usable_path_string_still_builds_unchanged(self, value: str) -> None:
+        assert _config(result_dir=value).result_dir == value
+
+    def test_a_whitespace_only_path_stays_first_class(self) -> None:
+        # A directory named with spaces is a legal path, so refusing it is an
+        # allowlist decision rather than a path-ness one. Pinned so this guard
+        # cannot creep into being one.
+        assert _config(result_dir="  ").result_dir == "  "
+
+    def test_a_path_is_accepted_and_normalised_to_the_str_the_field_declares(self) -> None:
+        config = _config(result_dir=Path("~/out"))
+        assert config.result_dir == "~/out"
+        assert type(config.result_dir) is str
+
+    def test_any_pathlike_is_accepted_not_only_pathlib(self) -> None:
+        class _CheckpointTree:
+            def __fspath__(self) -> str:
+                return "out"
+
+        assert _config(result_dir=_CheckpointTree()).result_dir == "out"
+
+    def test_a_pathlike_whose_fspath_is_not_a_path_is_refused_not_raised_from_fspath(self) -> None:
+        # ``os.PathLike`` is a duck-typed ABC, so this satisfies ``isinstance``
+        # and ``os.fspath`` then raises. The refusal is the channel this check
+        # answers on, so that raise must not escape past it.
+        class _Broken:
+            def __fspath__(self) -> str:
+                return 5  # type: ignore[return-value]
+
+        with pytest.raises(ValueError, match=r"result_dir must be a str or os\.PathLike"):
+            _config(result_dir=_Broken())
+
+    def test_two_configs_naming_the_same_tree_are_equal_and_hash_equal(self) -> None:
+        # Pre-fix the ``Path`` was stored verbatim, so these compared unequal
+        # while naming one directory - and this dataclass is frozen, so a caller
+        # may legitimately put it in a set or a dict key.
+        assert _config(result_dir=Path("out")) == _config(result_dir="out")
+        assert hash(_config(result_dir=Path("out"))) == hash(_config(result_dir="out"))
+
+    def test_an_empty_path_object_is_beyond_this_guards_reach(self) -> None:
+        # Recorded as a limit, not an endorsement: ``Path("")`` IS ``Path(".")``
+        # before any of this runs, so the empty string never arrives here as a
+        # path object, and refusing the value that does arrive would mean
+        # refusing ``Path(".")``.
+        assert os.fspath(Path("")) == "."
+        assert _config(result_dir=Path("")).result_dir == "."
+
+    @pytest.mark.parametrize("value", [123, True, ["out"], b"out"])
+    def test_a_refused_value_would_have_raised_out_of_the_generator_build(
+        self, value: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Out of the real ``_build_agent``, applied to a namespace, for the same
+        # reason ``_horizon`` is: a config carrying these values can no longer be
+        # built. ``require_optional`` is the only thing between the config and
+        # ``Path(result_dir)``, and it fails first only because the extra is
+        # absent here - on a host with it installed the TypeError is what a
+        # caller got.
+        monkeypatch.setattr(
+            "strands_robots.policies.motionbricks.policy.require_optional",
+            lambda *a, **k: None,
+        )
+        with pytest.raises(TypeError, match=r"argument should be a str or an os\.PathLike"):
+            MotionBricksPolicy._build_agent(SimpleNamespace(), SimpleNamespace(result_dir=value))  # type: ignore[arg-type]
+
+    def test_the_policy_result_dir_shortcut_reaches_the_same_domain(self) -> None:
+        # ``MotionBricksPolicy(result_dir=...)`` builds the config through
+        # ``from_dict``, so the convenience shortcut is not a second door.
+        shortcut: dict[str, Any] = {"result_dir": 123}
+        with pytest.raises(ValueError, match=r"result_dir must be a str or os\.PathLike"):
+            MotionBricksPolicy(motion_agent=_RecordingAgent(), **shortcut)
+
+
 class TestTheConfigFilePathIsCovered:
     """A checkpoint's ``config.json`` reaches the same domain as the constructor."""
 
@@ -260,11 +398,21 @@ class TestTheConfigFilePathIsCovered:
             {"generate_dt": float("nan")},
             {"speed_scale": [float("nan"), 1.0]},
             {"speed_scale": ["1", "2"]},
+            {"result_dir": 123},
+            {"result_dir": None},
         ],
     )
     def test_from_dict_refuses_an_unusable_knob(self, bad: dict[str, Any]) -> None:
         with pytest.raises(ValueError):
             MotionBricksConfig.from_dict({"result_dir": "out", **bad})
+
+    def test_from_file_refuses_a_result_dir_no_path_can_be_read_from(self, tmp_path: Path) -> None:
+        # JSON carries a number natively, so a checkpoint's ``config.json`` can
+        # hold one where a path belongs.
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"result_dir": 123}))
+        with pytest.raises(ValueError, match=r"result_dir must be a str or os\.PathLike"):
+            MotionBricksConfig.from_file(path)
 
     def test_from_file_refuses_an_unusable_knob(self, tmp_path: Path) -> None:
         path = tmp_path / "config.json"
@@ -294,30 +442,40 @@ class TestTheUpstreamDefaultsStayFirstClass:
 
 
 class TestNeighbouringConfigFieldsStayOutOfScope:
-    """The identity/path fields are NOT part of this numeric domain.
+    """The enumeration fields are NOT part of the path domain above.
 
-    A pin of current behaviour, not an endorsement of it: ``result_dir=123`` is
-    accepted today and reaches ``Path(...)`` downstream. It is a string-identity
-    question rather than a numeric one, so settling it here would make this two
-    changes; tracked in #2008. Per the premise-test guidance in ``AGENTS.md``
-    this boundary should be REPLACED rather than deleted when that lands.
+    A pin of current behaviour, not an endorsement of it: ``device=5`` and
+    ``clips="g1"`` are both accepted today and fail inside ``torch`` or upstream
+    ``motionbricks``. A non-empty-string check is not the rule they want - it
+    would refuse the first and accept the second, which are the two rows a
+    caller is most likely to write - because the useful domain here is
+    membership, and where the member list lives is a decision rather than a
+    copy. Tracked in #2010; per the premise-test guidance in ``AGENTS.md`` this
+    boundary should be REPLACED rather than deleted when that lands.
+
+    ``style`` is pinned here for the opposite reason: it is not silently
+    honored downstream, so the config admitting it costs nothing.
     """
 
-    @pytest.mark.parametrize("value", [123, True, ["out"]])
-    def test_a_non_string_result_dir_is_still_accepted(self, value: Any) -> None:
-        assert _config(result_dir=value).result_dir == value
-
-    def test_an_empty_result_dir_is_still_refused_by_its_own_local_check(self) -> None:
-        with pytest.raises(ValueError, match=r"result_dir must be a non-empty path"):
-            _config(result_dir="")
-
     @pytest.mark.parametrize("field", ["device", "clips", "exp"])
-    def test_a_non_string_identity_field_is_still_accepted(self, field: str) -> None:
+    def test_a_non_string_enumeration_field_is_still_accepted(self, field: str) -> None:
         assert getattr(_config(**{field: 5}), field) == 5
+
+    def test_a_mistyped_member_name_is_still_accepted(self) -> None:
+        # The row a type check would not have caught either: ``"G1"`` is the only
+        # shipped clip set.
+        assert _config(clips="g1").clips == "g1"
 
     def test_the_style_check_is_unchanged(self) -> None:
         # ``style`` admits an int index OR a str name, so it is neither a numeric
-        # domain nor a string one and keeps its own local check.
+        # domain nor a path one and keeps its own local check.
         with pytest.raises(ValueError, match=r"style must be an int mode index or a str mode name"):
             _config(style=3.5)
         assert _config(style=True).style is True
+
+    def test_a_bool_style_is_refused_where_the_mode_is_resolved(self) -> None:
+        # Which is why the row above is not an open defect: the check that can
+        # see the live clip list is the one placed to refuse it, and it names the
+        # field and lists the modes.
+        with pytest.raises(ValueError, match=r"style must be a mode index or name, not a bool"):
+            resolve_mode(_config(style=True).style, ["idle", "walk"])


### PR DESCRIPTION
Closes #2008

`MotionBricksConfig.result_dir` was guarded by `if not self.result_dir`. That asserts truthiness, not path-ness, so the values this field has to sort sorted by a property it does not have.

## Measured

On `89410ad`, one `MotionBricksConfig(result_dir=<value>)` per row, no `motionbricks` install:

| value | before | consequence |
| --- | --- | --- |
| `123` | accepted, stored `123` | `Path(123)` raises `TypeError` in the generator build |
| `True` | accepted, stored `True` | as above |
| `b"out"` | accepted, stored `b'out'` | as above - pathlib refuses bytes too |
| `["out"]` | accepted, stored `['out']` | as above, **and** `hash(config)` raised `unhashable type: 'list'` |
| `0` | refused | by the truthiness test, so the message says "non-empty path" about a number |
| `Path("out")` | accepted, stored a `PosixPath` | compared **unequal** to the identical config built from `"out"` |

The first four are the defect the issue names. The last two rows are the reason the remedy is a *normalising* domain rather than an `isinstance(str)` gate: this is a frozen - therefore hashable - dataclass, and a caller holding a `Path` is doing exactly what every consumer of this field does (`Path(config.result_dir)` in `_build_agent`, `result_dir.name` in the adapter). A gate on `str` alone would have refused the most likely correct input and left the equality defect standing.

## The change

The domain is now "a value a path can be read from" - a `str` or any `os.PathLike` - stored as `os.fspath` of it, the same shape as the `speed_scale` normalisation two checks below. The empty-string refusal is unchanged and deliberately keeps its own message: `""` *is* a path-shaped value, it just names nothing.

`os.PathLike` is a duck-typed ABC, so a class whose `__fspath__` returns a non-path satisfies `isinstance` and then makes `os.fspath` raise. That raise is suppressed and the value falls through to the refusal, because the refusal is the channel this check exists to answer a bad value on; pinned by a test rather than asserted.

## The decision the issue asked for

> whether `strands_robots/utils.py` gains a `non_empty_string_error(value, param, context)` beside the numeric guards, or whether each config keeps its own

**Local, and lift on the second caller.** The shared guards exist so the refusal text is identical everywhere rather than merely equivalent in verdict, and that value scales with callers - measured across `strands_robots/`:

| guard | call sites |
| --- | --- |
| `finite_number_error` | 123 |
| `positive_finite_number_error` | 81 |
| `positive_count_error` | 63 |
| `positive_whole_number_error` | 56 |
| `entity_name_error` | 26 |
| `validation_split_error` | 5 |
| a path guard, today | **1** |

The issue's premise for a shared helper was that "this is not the only config in the tree checking a path with `if not self.<field>`". It is: the one other match, `training/_inproc.py:81`, is a branch that skips logging when no log path was given, not a validation. So there is no second caller to be consistent *with*, and the rule stays in the config with the domain stated on the field.

Sub-question 1 - `str` alone or `str | Path` - is answered by the two rows above and by `resolve_asset_path`, which already declares `str | Path` as this library's path input. The narrowest honest domain is `os.PathLike`, not `Path`, so a caller's own path type works too.

That decision is recorded as **AGENTS.md convention 11** rather than only here, since the next config to validate a path will otherwise re-ask it.

## Held out of scope, deliberately

- **`clips` / `exp` / `device`** -> #2010. A non-empty-string check would refuse `device=5` and accept `clips="g1"`, which are the two rows a caller is most likely to write; the useful domain is membership, and where the member list lives is a decision (the clip names are only importable with the `[motionbricks]` extra, which this config is explicitly constructible without). `TestNeighbouringConfigFieldsStayOutOfScope` is **replaced, not deleted** - narrowed to those fields and repointed at #2010, per the premise-test rule in AGENTS.md.
- **`style`** stays as it is, and #2008's table row for it is answered rather than carried forward: `observation.resolve_mode` already refuses a bool explicitly and range-checks an index against the live clip list, so `style=True` surviving `__post_init__` costs nothing. Pinned by a test so the claim is checkable.
- **`skeleton_xml` / `scene_xml`** are untouched. They are optional, so `None` is meaningful and the remedy has a different shape; and `scene_xml` is not read anywhere in `strands_robots/` at all, which is a question about whether the field is live rather than about its domain.

## Verification

- `pytest tests/policies/motionbricks` -> **197 passed, 4 skipped**.
- With **only** `config.py` reverted: **19 failed, 111 passed** in `test_config_value_domain.py`. Every new assertion fails on pre-fix code, including the two behavioural ones (equality and `hash`) that no `TypeError` would have surfaced.
- `ruff check` and `ruff format --check` clean on both changed Python files.
- Docs: the `result_dir` row of the config table in `docs/policies/motionbricks.md` now states the accepted domain, since `Path` is newly first-class.

## Round changelog (§13)

**Round 1** - initial submission. Scope: one field, one domain, one decision recorded.