### PR TITLE
docs(process): the node-ID decode is a reject, never a pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,33 +323,57 @@ hatch run format            # ruff check --fix, ruff format
      `deleteIssue` needs admin on the *target*, so the stray issue could only be
      closed as `NOT_PLANNED` with an apology. See #1916.
 
-     **A node ID is not opaque, which is what makes this checkable before the
-     write.** It is `<TypePrefix>_<urlsafe-base64(msgpack array)>`, where a
-     repository is `[0, databaseId]` and anything a repository owns is
-     `[0, repository databaseId, own databaseId]` - so the type and the target
-     repository are both readable with no network call:
+     **A node ID is not opaque, which makes one direction of this checkable
+     before the write.** It is `<TypePrefix>_<urlsafe-base64(msgpack array)>`,
+     where a repository is `[0, databaseId]` and anything a repository owns is
+     `[0, repository databaseId, own databaseId]`, so a decode costs no network
+     call:
 
-     | node ID | decodes to | target |
+     | node ID | decodes to | resolves to |
      |---|---|---|
      | `R_kgDORUMiZg` | `[0, 1162027622]` | this repository |
-     | `R_kgDOD1WOFw` | `[0, 257265175]` | the stray one |
-     | `PR_kwDOD1WOF87DdSjQ` | `[0, 257265175, 3279235280]` | **the same stray one** |
+     | `R_kgDOD1WOFw` | `[0, 257265175]` | the #1916 stray |
+     | `PR_kwDOD1WOF87DdSjQ` | `[0, 257265175, 3279235280]` | **the same stray** |
+     | `PR_kwDORUMiZs7Kw3fA` | `[0, 1162027622, 3401807808]` | **`uutils/coreutils#11342`** |
 
-     That third row is the finding. All three guessed IDs in that run carried
-     one wrong repository, so a single stale value contaminated every mutation,
-     and the two that failed did so only because their own databaseId happened
-     not to exist there - `Could not resolve to a node`. Failing closed was luck
-     about the guess, not a property of the API, and the guess that got lucky the
-     other way is the one that wrote.
+     The third row is why #1916's three guessed IDs all failed the same way: one
+     stale value contaminated every mutation, and the two that failed did so only
+     because their own databaseId happened not to exist there - `Could not
+     resolve to a node`. Failing closed was luck about the guess, not a property
+     of the API, and the guess that got lucky the other way is the one that wrote.
 
-     So resolve every ID from a query in the same run whose owner and name are
-     written out literally; check the prefix against the parameter, since a
+     **The fourth row is why a decode is a reject and never a pass.** That ID
+     carries *this* repository's databaseId in its middle field and resolves to a
+     merged pull request in `uutils/coreutils`, whose own repository databaseId is
+     `11847500`. GitHub routes on the third field - the object's own id - and
+     neither validates nor uses the middle one, so a `mergePullRequest` against it
+     was aimed at a stranger's pull request and was stopped by permissions rather
+     than by the check. It also shares 14 of its 19 characters with the correct ID
+     for #2006 (`PR_kwDORUMiZs78G3VE`), so eyeballing it against a known-good ID
+     for the same repository is the same unsound test done less precisely. See
+     #2007.
+
+     So the decode has exactly one sound use: a middle field naming another
+     repository is proof of a wrong ID, and a middle field naming this one proves
+     nothing at all. **The rule is the one with no decode in it** - resolve every
+     ID from a query in the same run whose owner and name are written out
+     literally, preferring the response of the query that named the object by
+     `owner`/`name`/`number`; check the prefix against the parameter, since a
      `PR_...` handed to a `repositoryId` is wrong by type alone; and read the
      `url` in the response back before treating the write as done.
-     `tests/test_graphql_node_id_targeting.py` decodes this repository's own node
-     IDs against the `databaseId`s the API publishes beside them, so the claim
-     that the check is available offline fails loudly rather than quietly if the
-     envelope ever changes.
+
+     **Weight it by reversibility rather than by correctness**, because the two
+     directions are not symmetric. A refused `mergePullRequest` leaves nothing
+     behind; a `createIssue` against a wrong ID succeeds and cannot be undone by
+     the account that made it, since `deleteIssue` needs admin on the target and a
+     stray write by definition lands where you have none. So `createIssue`,
+     `addComment` and `updateIssue` earn the read-back more than the merge that
+     prompted the rule, not less. If one has already landed, the remedy is not
+     deletion: retitle it to mark it opened in error, replace the body with an
+     explanation, close it, and do not open a replacement in the same repository.
+     `tests/test_graphql_node_id_targeting.py` decodes both shapes against the
+     `databaseId`s the API publishes beside them, so neither the envelope changing
+     nor the reject-only limit softening back into a pass goes unnoticed.
    - *And that the repository still accepts writes at all.* Archiving is
      invisible in every field a sweep already reads. `strands-labs/robots-sim`
      was archived at 01:33 UTC on 2026-08-06, between one scheduled cycle and

--- a/changelog.d/2007-node-id-decode-is-reject-only.md
+++ b/changelog.d/2007-node-id-decode-is-reject-only.md
@@ -1,0 +1,24 @@
+### Fixed: the node-ID decode AGENTS.md prescribes before a mutation is a reject, never a pass
+
+Step 8 presented the offline node-ID decode as making a mutation's target
+"checkable before the write". It is not: GitHub routes an owned object by its
+own id, the third field of the payload, and neither validates nor uses the
+repository field beside it. A `mergePullRequest` was aimed at
+`PR_kwDORUMiZs7Kw3fA`, which decodes to `[0, 1162027622, 3401807808]` - this
+repository's `databaseId` in the middle - and resolves to a merged pull request
+in `uutils/coreutils`. The prescribed check clears it, and permissions rather
+than the check are what stopped the merge.
+
+The decode is kept as the fast reject it soundly is - a middle field naming
+another repository is proof of a wrong ID, which is the shape #1916 had - and
+the rule is now the one with no decode in it: resolve every ID from a query
+naming the object by owner, name and number. The passage also states the
+asymmetry that decides how much the rule is worth, since a refused merge leaves
+nothing behind while a `createIssue` against a wrong ID succeeds and cannot be
+undone by the account that made it, and names the remedy for one that has
+already landed.
+
+`tests/test_graphql_node_id_targeting.py` executes the limit on the recorded
+cross-repository ID rather than asserting the prose says so, and keeps the
+reject direction pinned so the narrowing is not satisfiable by deleting the
+decode.

--- a/tests/test_graphql_node_id_targeting.py
+++ b/tests/test_graphql_node_id_targeting.py
@@ -19,16 +19,17 @@ What makes the rule worth pinning rather than merely regretting is that the
 premise the incident was written up under is measurably false. The ID is *not*
 opaque. It is ``<TypePrefix>_<urlsafe-base64(msgpack array)>``, where a
 repository is ``[0, databaseId]`` and anything a repository owns is
-``[0, repository databaseId, own databaseId]``, so both the type and the target
-repository are readable offline before the write:
+``[0, repository databaseId, own databaseId]``, so a decode costs no network
+call:
 
-=============================  ==========================  =======================
-node ID                        decodes to                  target
-=============================  ==========================  =======================
-``R_kgDORUMiZg``               ``[0, 1162027622]``          this repository
-``R_kgDOD1WOFw``               ``[0, 257265175]``           the stray repository
-``PR_kwDOD1WOF87DdSjQ``        ``[0, 257265175, ...]``      the same stray one
-=============================  ==========================  =======================
+=========================  ===============================  ==========================
+node ID                    decodes to                       resolves to
+=========================  ===============================  ==========================
+``R_kgDORUMiZg``           ``[0, 1162027622]``              this repository
+``R_kgDOD1WOFw``           ``[0, 257265175]``               the #1916 stray
+``PR_kwDOD1WOF87DdSjQ``    ``[0, 257265175, 3279235280]``   the same stray
+``PR_kwDORUMiZs7Kw3fA``    ``[0, 1162027622, 3401807808]``  ``uutils/coreutils#11342``
+=========================  ===============================  ==========================
 
 That third row is the finding the incident write-up did not have: all three
 guessed IDs in that run carried **one** wrong repository, so a single stale
@@ -38,7 +39,18 @@ their own databaseId happened not to exist under that repository
 a property of the API - and the one that got lucky the other way is the one
 that wrote.
 
-So two classes are asserted here, and the first is what keeps the second
+The fourth row is why the decode can only ever *reject*. That ID carries this
+repository's databaseId in its middle field and resolves to a merged pull
+request in ``uutils/coreutils``, whose own repository databaseId is
+``11847500``: GitHub routes on the third field, the object's own id, and
+neither validates nor uses the middle one. So the middle field agreeing is not
+evidence the ID names anything here, and a ``mergePullRequest`` aimed at that ID
+while merging #2006 was stopped by permissions rather than by any check. The two
+IDs also share 14 of their 19 characters, so comparing one by eye against a
+known-good ID for the same repository is the same unsound test done less
+precisely. See #2007.
+
+So three classes are asserted here, and the first two are what keep the third
 honest:
 
 ``TestTheNodeIdEnvelopeIsCheckableOffline`` *executes* the claim. It decodes
@@ -51,6 +63,12 @@ against a future ID format that had stopped being checkable, leaving the
 guidance reading plausibly while advising something impossible. This fails
 instead.
 
+``TestTheDecodeIsARejectAndNeverAPass`` *executes* the limit, on the recorded
+cross-repository ID: its middle field equals this repository's databaseId while
+the object it names belongs to another repository, so a matching middle field
+cannot establish the target. The reject direction is asserted alongside it, so
+the fix is not satisfiable by deleting the decode.
+
 ``TestTheGuidanceNamesTheDecodableEnvelope`` pins the prose, because the prose
 is the deliverable: an agent reads ``AGENTS.md``, not this module. What is
 asserted is *adjacency* rather than vocabulary - the fail-open property, the
@@ -62,10 +80,10 @@ the same structural reason ``tests/test_merge_gate_viewer_scope.py`` and
 ``tests/test_codeql_query_filters.py`` exist, and these text assertions follow
 the shape those modules established.
 
-Negative control: with ``origin/main``'s ``AGENTS.md`` restored, all 5 tests in
-``TestTheGuidanceNamesTheDecodableEnvelope`` fail - the four qualifiers and the
-context guard that locates the passage - while ``TestTheNodeIdEnvelopeIsCheckableOffline``
-passes unchanged. The envelope is a property of GitHub's IDs rather than of this
+Negative control: with ``origin/main``'s ``AGENTS.md`` restored, the five
+qualifiers the correction introduces fail while the four the #1916 write-up
+already carried keep passing, and both executable classes pass unchanged. The
+envelope and the routing field are properties of GitHub's IDs rather than of this
 change; only the guidance is new.
 """
 
@@ -98,6 +116,20 @@ _OWNED_OBJECTS = [
 _STRAY_REPOSITORY_NODE_ID = "R_kgDOD1WOFw"
 _STRAY_PULL_REQUEST_NODE_ID = "PR_kwDOD1WOF87DdSjQ"
 _STRAY_REPOSITORY_DATABASE_ID = 257265175
+
+# The node ID a `mergePullRequest` was aimed at while merging #2006. Its middle
+# field is *this* repository's databaseId, so the decode clears it; the object it
+# names is a merged pull request in another repository entirely. Both values read
+# back from one `node(id:)` query afterwards. See #2007.
+_CROSS_REPOSITORY_NODE_ID = "PR_kwDORUMiZs7Kw3fA"
+_CROSS_REPOSITORY_OWN_DATABASE_ID = 3401807808
+_CROSS_REPOSITORY_RESOLVES_TO = "uutils/coreutils#11342"
+_CROSS_REPOSITORY_ACTUAL_DATABASE_ID = 11847500
+
+#: The ID that mutation should have carried, from
+#: ``repository(owner:, name:) { pullRequest(number: 2006) { id } }``. Kept to
+#: measure how little an eyeball comparison against a known-good ID buys.
+_INTENDED_PULL_REQUEST_NODE_ID = "PR_kwDORUMiZs78G3VE"
 
 # msgpack tags the envelope uses. A GitHub node ID is a short array of unsigned
 # integers, so this is the whole grammar needed - anything else is a shape this
@@ -164,12 +196,16 @@ def _decode_node_id(node_id: str) -> tuple[str, list[int]]:
     return prefix, values
 
 
-def _target_repository(node_id: str) -> int:
-    """The ``databaseId`` of the repository ``node_id`` writes to.
+def _encoded_repository(node_id: str) -> int:
+    """The repository ``databaseId`` *encoded in* ``node_id``.
 
-    A repository's own ID names it directly; anything it owns carries it as the
-    second element. Either way the answer is available without a network call,
-    which is the property the guidance rests on.
+    A repository's own ID names it directly; anything it owns carries one as its
+    second element. Named for what it reads rather than for what the mutation
+    will address, because those differ: GitHub routes an owned object by its own
+    id - the third element - and neither validates nor uses this one. So a value
+    that disagrees with the intended repository is proof of a wrong ID, and a
+    value that agrees proves nothing. ``TestTheDecodeIsARejectAndNeverAPass``
+    holds that asymmetry.
     """
     prefix, values = _decode_node_id(node_id)
     if prefix == "R":
@@ -198,8 +234,8 @@ class TestTheNodeIdEnvelopeIsCheckableOffline:
         _, values = _decode_node_id(node_id)
         assert values == [0, _REPOSITORY_DATABASE_ID, database_id], (
             f"{node_id!r} should decode to [0, this repository, its own databaseId]. "
-            "That middle element is what lets a mutation on an issue or a pull "
-            "request be checked against the repository it was meant for."
+            "That middle element is what makes a *disagreeing* value a fast reject; "
+            "an agreeing one establishes nothing, per #2007."
         )
 
     def test_the_type_prefix_separates_a_repository_from_what_it_owns(self) -> None:
@@ -211,13 +247,13 @@ class TestTheNodeIdEnvelopeIsCheckableOffline:
     def test_the_stray_id_is_distinguishable_from_the_intended_one(self) -> None:
         # The check that would have caught #1916, in the form it was available:
         # the two spellings are visually close and decode to different targets.
-        assert _target_repository(_REPOSITORY_NODE_ID) == _REPOSITORY_DATABASE_ID
-        assert _target_repository(_STRAY_REPOSITORY_NODE_ID) == _STRAY_REPOSITORY_DATABASE_ID
-        assert _target_repository(_STRAY_REPOSITORY_NODE_ID) != _target_repository(_REPOSITORY_NODE_ID)
+        assert _encoded_repository(_REPOSITORY_NODE_ID) == _REPOSITORY_DATABASE_ID
+        assert _encoded_repository(_STRAY_REPOSITORY_NODE_ID) == _STRAY_REPOSITORY_DATABASE_ID
+        assert _encoded_repository(_STRAY_REPOSITORY_NODE_ID) != _encoded_repository(_REPOSITORY_NODE_ID)
 
     def test_every_stray_id_from_the_incident_names_one_wrong_repository(self) -> None:
         strays = {_STRAY_REPOSITORY_NODE_ID, _STRAY_PULL_REQUEST_NODE_ID}
-        targets = {_target_repository(node_id) for node_id in strays}
+        targets = {_encoded_repository(node_id) for node_id in strays}
         assert targets == {_STRAY_REPOSITORY_DATABASE_ID}, (
             "The repository ID and the pull-request ID guessed in that run should both "
             "decode to the same wrong repository. That is why one stale value was able "
@@ -238,6 +274,71 @@ class TestTheNodeIdEnvelopeIsCheckableOffline:
             _decode_node_id(malformed)
 
 
+class TestTheDecodeIsARejectAndNeverAPass:
+    """A middle field that agrees is not evidence about what the ID names."""
+
+    def test_the_cross_repository_id_decodes_to_this_repository(self) -> None:
+        # The check as AGENTS.md first stated it, run on the stray: it passes.
+        _, values = _decode_node_id(_CROSS_REPOSITORY_NODE_ID)
+        assert values == [
+            0,
+            _REPOSITORY_DATABASE_ID,
+            _CROSS_REPOSITORY_OWN_DATABASE_ID,
+        ], (
+            f"{_CROSS_REPOSITORY_NODE_ID!r} should carry this repository's databaseId "
+            "in its middle field. That it does is the whole point: the offline check "
+            "clears it. See #2007."
+        )
+        assert _encoded_repository(_CROSS_REPOSITORY_NODE_ID) == _REPOSITORY_DATABASE_ID
+
+    def test_the_object_it_names_belongs_to_another_repository(self) -> None:
+        # ...and the object is somewhere else, so the pass was false.
+        assert _CROSS_REPOSITORY_ACTUAL_DATABASE_ID != _REPOSITORY_DATABASE_ID, (
+            f"{_CROSS_REPOSITORY_RESOLVES_TO} must be in a different repository from "
+            "this one for the measurement to mean anything. If these two databaseIds "
+            "ever agree the constants have drifted; re-read them from a node(id:) "
+            "query rather than relaxing this. See #2007."
+        )
+        assert _encoded_repository(_CROSS_REPOSITORY_NODE_ID) != _CROSS_REPOSITORY_ACTUAL_DATABASE_ID, (
+            "The repository encoded in the ID must differ from the repository the ID "
+            "resolves to. That inconsistency is what proves GitHub neither validates "
+            "nor uses the middle field, and therefore that a decode cannot confirm a "
+            "target. See #2007."
+        )
+
+    def test_a_differing_middle_field_is_still_a_sound_reject(self) -> None:
+        # The direction that survives, so "delete the decode" does not pass this
+        # class: #1916's IDs are refusable offline and must stay refusable.
+        for stray in (_STRAY_REPOSITORY_NODE_ID, _STRAY_PULL_REQUEST_NODE_ID):
+            assert _encoded_repository(stray) != _REPOSITORY_DATABASE_ID, (
+                f"{stray!r} named the wrong repository in #1916, which is the one shape "
+                "a decode does catch. Keeping this reject is why the correction narrows "
+                "the check rather than removing it."
+            )
+
+    def test_the_prefix_check_is_unaffected_by_the_correction(self) -> None:
+        # Orthogonal and still sound: the type is a property of the envelope, not
+        # a claim about which object the payload addresses.
+        assert _decode_node_id(_CROSS_REPOSITORY_NODE_ID)[0] == "PR"
+        assert _decode_node_id(_REPOSITORY_NODE_ID)[0] == "R"
+
+    def test_an_eyeball_comparison_is_the_same_unsound_test(self) -> None:
+        # Why "it looked right" is not a defence: the stray and the intended ID
+        # agree on their whole prefix and differ only in the routing field.
+        shared = 0
+        for left, right in zip(_CROSS_REPOSITORY_NODE_ID, _INTENDED_PULL_REQUEST_NODE_ID, strict=False):
+            if left != right:
+                break
+            shared += 1
+        assert shared >= 14, (
+            f"{_CROSS_REPOSITORY_NODE_ID!r} and {_INTENDED_PULL_REQUEST_NODE_ID!r} share "
+            f"only {shared} leading characters. The recorded measurement is 14 of 19, "
+            "which is why AGENTS.md says an eyeball comparison against a known-good ID "
+            "is no better than the decode. See #2007."
+        )
+        assert _decode_node_id(_CROSS_REPOSITORY_NODE_ID)[1][2] != _decode_node_id(_INTENDED_PULL_REQUEST_NODE_ID)[1][2]
+
+
 def _agents_text() -> str:
     return _AGENTS_PATH.read_text(encoding="utf-8")
 
@@ -246,18 +347,29 @@ def _agents_text() -> str:
 #: from it, so its absence fails outright rather than making the rest vacuous.
 _SUBJECT_CLAIM = "names its subject by node ID"
 
-#: How far a qualifier may sit from the claim while still reading as one
-#: instruction. Generous enough to survive rewording, tight enough that moving a
-#: qualifier out of step 8 fails.
-_ADJACENCY_WINDOW = 2600
+#: The step-8 bullet boundary. Bounding the slice here makes "in the same
+#: bullet" the literal assertion, so a qualifier reworded down into a
+#: neighbouring bullet fails while one reworded within this bullet keeps passing
+#: however far the bullet grows. The fixed 2600-character window this replaced
+#: was measured against a 2320-character bullet, so it reached 280 characters
+#: into the next one - and it would have excluded the qualifiers this correction
+#: adds, since the bullet is now 3813 characters.
+_BULLET_DELIMITER = "\n   - *"
 
 
-def _window_after(text: str, anchor: str) -> str | None:
-    """The ``_ADJACENCY_WINDOW`` characters following ``anchor``, or ``None``."""
+def _bullet_after(text: str, anchor: str) -> str | None:
+    """The step-8 bullet containing ``anchor``, whitespace collapsed.
+
+    Collapsed because the assertion is about a qualifier being in the same
+    breath as the instruction, not about where the line happens to wrap: a
+    reflow must not fail a pin, and a phrase moved to another bullet must.
+    """
     position = text.find(anchor)
     if position < 0:
         return None
-    return text[position : position + _ADJACENCY_WINDOW]
+    end = text.find(_BULLET_DELIMITER, position)
+    bullet = text[position:] if end < 0 else text[position:end]
+    return " ".join(bullet.split())
 
 
 class TestTheGuidanceNamesTheDecodableEnvelope:
@@ -274,16 +386,16 @@ class TestTheGuidanceNamesTheDecodableEnvelope:
         )
 
     def test_the_guidance_states_that_a_wrong_id_fails_open(self) -> None:
-        window = _window_after(_agents_text(), _SUBJECT_CLAIM)
-        assert window is not None and "does not fail" in window, (
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "does not fail" in bullet, (
             "AGENTS.md must say that a well-formed but wrong node ID succeeds against "
             "whatever object it does name. Without that, the rule reads as tidiness "
             "rather than as the reason the write is unsafe. See #1916."
         )
 
     def test_the_guidance_names_the_decodable_envelope(self) -> None:
-        window = _window_after(_agents_text(), _SUBJECT_CLAIM)
-        assert window is not None and "databaseId" in window, (
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "databaseId" in bullet, (
             "AGENTS.md must say that a node ID decodes to a type and a target "
             "repository databaseId offline. 'Always query the ID' is advice that can be "
             "forgotten under a stale value, which is exactly what happened; a check that "
@@ -291,17 +403,76 @@ class TestTheGuidanceNamesTheDecodableEnvelope:
         )
 
     def test_the_guidance_states_that_there_is_no_undo(self) -> None:
-        window = _window_after(_agents_text(), _SUBJECT_CLAIM)
-        assert window is not None and "deleteIssue" in window, (
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "deleteIssue" in bullet, (
             "AGENTS.md must say that a write to the wrong repository cannot be undone - "
             "deleteIssue needs admin on the target. That is what makes this a "
             "check-before rather than a verify-after. See #1916."
         )
 
     def test_the_guidance_tells_the_reader_to_check_the_response(self) -> None:
-        window = _window_after(_agents_text(), _SUBJECT_CLAIM)
-        assert window is not None and "url" in window, (
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "url" in bullet, (
             "AGENTS.md must keep the response-url check beside the rule: it is the only "
             "signal for the cases the envelope cannot cover, and in #1916 it was the "
             "single clue that anything had gone wrong. See #1916."
+        )
+
+
+class TestTheGuidanceLimitsTheDecodeToAReject:
+    """The correction is only actionable with its five qualifiers beside it."""
+
+    def test_the_slice_is_the_bullet_and_not_its_neighbour(self) -> None:
+        # Non-vacuity for `_bullet_after`: an empty or runaway slice would make
+        # every assertion below meaningless in opposite directions.
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None
+        assert len(bullet) > 1500, (
+            f"the node-ID bullet collapsed to {len(bullet)} characters, so the pins "
+            "below are reading a fragment rather than the passage."
+        )
+        assert "still accepts writes at all" not in bullet, (
+            "the slice ran past the node-ID bullet into the archived-repository one, so "
+            "a qualifier moved out of this bullet would still pass. Check "
+            "_BULLET_DELIMITER against AGENTS.md's list indentation."
+        )
+
+    def test_the_guidance_states_the_decode_is_a_reject_not_a_pass(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "reject and never a pass" in bullet, (
+            "AGENTS.md must say the decode is a reject and never a pass. Stated as a "
+            "check that can be run before the write, it reads as a guard and clears an "
+            "ID naming an object in another repository. See #2007."
+        )
+
+    def test_the_guidance_says_a_matching_repository_proves_nothing(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "proves nothing at all" in bullet, (
+            "AGENTS.md must state the false-safe direction explicitly. 'Reject only' "
+            "without it invites the reader to keep treating a clean decode as "
+            "confirmation, which is the whole failure. See #2007."
+        )
+
+    def test_the_guidance_carries_the_cross_repository_measurement(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "uutils/coreutils" in bullet, (
+            "AGENTS.md must keep the measured ID that clears the decode and resolves "
+            "elsewhere. Without it the narrowing is an assertion about GitHub's routing "
+            "that a reader has no reason to accept. See #2007."
+        )
+
+    def test_the_guidance_weights_the_rule_by_reversibility(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "reversibility" in bullet, (
+            "AGENTS.md must say the two directions are not symmetric: a refused merge "
+            "leaves nothing behind, a createIssue against a wrong ID cannot be undone. "
+            "That is the sentence that changes behaviour at the call site. See #2007."
+        )
+
+    def test_the_guidance_names_the_remedy_for_a_write_that_landed(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "opened in error" in bullet, (
+            "AGENTS.md must name the remedy for a stray write that succeeded, because "
+            "the instinct - delete it - is the one thing that does not work: deleteIssue "
+            "needs admin on the target. See #2007."
         )


### PR DESCRIPTION
## The check cleared a mutation aimed at a stranger's pull request

AGENTS.md step 8 records incident #1916 and prescribes an offline pre-write check, introduced with the claim that a node ID **"is not opaque, which is what makes this checkable before the write"**. The encoding description is correct. The conclusion drawn from it is not.

GitHub routes an owned object by the **third** field of the payload, the object's own id, and neither validates nor uses the repository field beside it. So the middle field agreeing with the intended repository is not evidence the ID names anything there:

| node ID | decodes to | resolves to |
|---|---|---|
| `R_kgDORUMiZg` | `[0, 1162027622]` | `strands-labs/robots` |
| `PR_kwDORUMiZs78G3VE` | `[0, 1162027622, 4229657924]` | #2006, the intended object |
| `PR_kwDORUMiZs7Kw3fA` | `[0, **1162027622**, 3401807808]` | **`uutils/coreutils#11342`** (repository `databaseId` `11847500`) |

A `mergePullRequest` was aimed at that third ID while merging #2006 — a squash of a stranger's pull request. The prescribed decode reads `1162027622` out of it, gets this repository, and **passes**. Permissions rather than the check are what stopped the merge. The two IDs also share 14 of their 19 characters (`PR_kwDORUMiZs7`), so eyeballing one against a known-good ID for the same repository is the same unsound test done less precisely.

That is a false *safe*, which is the direction that matters for a guard.

## What changes

The decode is **kept as the fast reject it soundly is** — #1916's three IDs all named a genuinely different repository (`[0, 257265175, …]`) and are refusable offline, which is why the check looked like it worked. What the passage now says is that the reject is its only sound use, and that the rule is the one with no decode in it: resolve every ID from a query in the same run naming the object by `owner`/`name`/`number`.

Two additions from the follow-up measurement on this issue, both of which change behaviour at the call site rather than restating correctness:

- **The two directions are not symmetric, so weight the rule by reversibility.** A refused `mergePullRequest` leaves nothing behind. A `createIssue` against a wrong ID succeeds and cannot be undone by the account that made it — `deleteIssue` needs admin on the *target*, which a stray write by definition lands where you have none. So `createIssue`, `addComment` and `updateIssue` earn the read-back more than the merge that prompted the rule, not less.
- **The remedy for one that has already landed is named**, because the instinct — delete it — is the one thing that does not work: retitle it to mark it opened in error, replace the body with an explanation, close it, and do not open a replacement in the same repository.

The prefix check is untouched and still sound: a `PR_...` handed to a `repositoryId` is wrong by type alone, and the type is a property of the envelope rather than a claim about which object the payload addresses.

## Tests

`tests/test_graphql_node_id_targeting.py` grows from 15 tests to 26, and the split matters: the correction is **executed**, not merely asserted to be written down.

`TestTheDecodeIsARejectAndNeverAPass` (5 new) runs the check as first stated on the recorded cross-repository ID and asserts it passes, then asserts the object it names belongs to another repository — so a matching middle field provably cannot establish the target. It pins the reject direction alongside, so the narrowing is **not satisfiable by deleting the decode**, and it pins the 14-character shared prefix so "it looked right" is not available as a defence.

`TestTheGuidanceLimitsTheDecodeToAReject` (6 new) pins the prose, because the prose is the deliverable — an agent reads AGENTS.md, not this module.

Two corrections inside the module itself, which carried the same false claim:

- `_target_repository` was named and documented as *"the databaseId of the repository `node_id` **writes to**"*, which is exactly what the measurement disproves. Renamed in place to `_encoded_repository` and documented for what it reads, with the asymmetry stated.
- An assertion message said the middle element *"is what lets a mutation … be checked against the repository it was meant for."* Corrected to name the reject direction only.

**A latent false pass in the existing pins, found while measuring.** The prose slice was a fixed `_ADJACENCY_WINDOW = 2600` against a bullet measuring **2320** characters, so it already reached 280 characters into the *next* step-8 bullet — a qualifier moved just past the boundary would still have passed. It is now bounded at the bullet delimiter, which makes "in the same bullet" the literal assertion, and whitespace-collapsed so a reflow cannot fail a pin while a phrase moved to another bullet must. This was also necessary rather than opportunistic: the bullet is now 3813 characters, so the fixed window would have excluded every qualifier this change adds. `test_the_slice_is_the_bullet_and_not_its_neighbour` is the non-vacuity guard for both directions.

**Negative control** — with `upstream/main`'s AGENTS.md restored and this branch's tests kept:

| class | result |
|---|---|
| `TestTheNodeIdEnvelopeIsCheckableOffline` | 10 passed |
| `TestTheDecodeIsARejectAndNeverAPass` | 5 passed |
| `TestTheGuidanceNamesTheDecodableEnvelope` | 5 passed |
| `TestTheGuidanceLimitsTheDecodeToAReject` | **5 failed**, 1 passed |
| | **5 failed / 21 passed** |

Exactly the five qualifiers the correction introduces fail. Both executable classes pass unchanged, and so do the four qualifiers the #1916 write-up already carried — the envelope and the routing field are properties of GitHub's IDs rather than of this change, and the slice mechanism is independent of it. Only the guidance is new.

## Verification

At `763305ed`, `aarch64`, `MUJOCO_GL=egl`:

| gate | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check strands_robots tests tests_integ` | 1102 files already formatted |
| `mypy strands_robots tests tests_integ` | 14 errors, all in `examples/isaac_gs`, **0 outside** — byte-identical to a pristine `upstream/main` worktree of the same working copy, so environmental |
| `pytest tests` | **22681 passed, 257 skipped, 0 failed** in 668s |
| root guards (changelog fragments/format, dangling doc refs, internal paths, unreachable statements) | 42 passed |
| `scripts/check_merge_base_overlap.py` | No overlap — 0 paths changed on `upstream/main` since the branch diverged |

No visual artifact accompanies this: the change is AGENTS.md prose plus a test module, and touches no policy, simulation, rendering, recording or robot asset. The measurement it rests on is the ID resolution table above, which is reproducible with one `node(id:)` query.

## Follow-up

This merged at `ea5e3ff8`. A round prepared against it landed on the branch one minute after the squash was computed, so it is **not** in this PR: it records that the stray-write class recurred (`Ali111q/todo#1`, from an ID whose repository field a decode does reject) and scopes the rule to mutations, since a query names its subject by `owner`/`name`/`number` and cannot address the wrong repository at all. It ships separately, on top of this.

#2016 opened four minutes after this one with the same correction and is closed as the duplicate; the per-cell comparison that decided it is on that PR.

Closes #2007


