### PR TITLE
docs(process): record that the stray-write class recurred, and scope the rule to mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,17 +360,27 @@ hatch run format            # ruff check --fix, ruff format
      literally, preferring the response of the query that named the object by
      `owner`/`name`/`number`; check the prefix against the parameter, since a
      `PR_...` handed to a `repositoryId` is wrong by type alone; and read the
-     `url` in the response back before treating the write as done.
+     `url` in the response back before treating the write as done. Only a
+     mutation takes a bare ID - a query names its subject by
+     `owner`/`name`/`number`, so it cannot address the wrong repository at all.
+     That is why no read has ever been implicated, and why the rule costs one
+     round trip and binds only where something changes.
 
      **Weight it by reversibility rather than by correctness**, because the two
      directions are not symmetric. A refused `mergePullRequest` leaves nothing
      behind; a `createIssue` against a wrong ID succeeds and cannot be undone by
      the account that made it, since `deleteIssue` needs admin on the target and a
-     stray write by definition lands where you have none. So `createIssue`,
+     stray write by definition lands where you have none. It has now happened
+     twice: the second was `Ali111q/todo#1` at 16:23 UTC on 2026-08-07, twenty
+     minutes after #2007 was filed, from a `repositoryId` whose repository field
+     reads `1060491130` and not this repository's `1162027622` - the one
+     direction a decode does catch. So `createIssue`,
      `addComment` and `updateIssue` earn the read-back more than the merge that
      prompted the rule, not less. If one has already landed, the remedy is not
      deletion: retitle it to mark it opened in error, replace the body with an
-     explanation, close it, and do not open a replacement in the same repository.
+     explanation, close it, and do not open a replacement in the same repository -
+     which is what `Ali111q/todo#1` now records, its own body noting that deletion
+     was refused.
      `tests/test_graphql_node_id_targeting.py` decodes both shapes against the
      `databaseId`s the API publishes beside them, so neither the envelope changing
      nor the reject-only limit softening back into a pass goes unnoticed.

--- a/changelog.d/2007-node-id-decode-is-reject-only.md
+++ b/changelog.d/2007-node-id-decode-is-reject-only.md
@@ -16,7 +16,13 @@ naming the object by owner, name and number. The passage also states the
 asymmetry that decides how much the rule is worth, since a refused merge leaves
 nothing behind while a `createIssue` against a wrong ID succeeds and cannot be
 undone by the account that made it, and names the remedy for one that has
-already landed.
+already landed. That has now happened twice: `Ali111q/todo#1` was filed twenty
+minutes after the problem was reported, from an ID whose repository field reads
+`1060491130` rather than this repository's `1162027622` - so the surviving
+reject direction covers it, and the two strays name different repositories
+rather than one stale value. The passage also scopes the rule to mutations,
+since a query names its subject by owner, name and number and cannot address
+the wrong repository at all.
 
 `tests/test_graphql_node_id_targeting.py` executes the limit on the recorded
 cross-repository ID rather than asserting the prose says so, and keeps the

--- a/tests/test_graphql_node_id_targeting.py
+++ b/tests/test_graphql_node_id_targeting.py
@@ -50,6 +50,14 @@ IDs also share 14 of their 19 characters, so comparing one by eye against a
 known-good ID for the same repository is the same unsound test done less
 precisely. See #2007.
 
+The exposure is also not symmetric, and that is what the reject direction is
+worth keeping for. A refused ``mergePullRequest`` leaves nothing behind; a
+``createIssue`` against a wrong ``repositoryId`` succeeds and cannot be undone
+by the account that made it. It has now happened twice - the second was
+``Ali111q/todo#1``, twenty minutes after #2007 was filed - and that second ID
+named a repository that is not this one, which is precisely the shape a decode
+does catch. Narrowing the check is therefore not the same as dropping it.
+
 So three classes are asserted here, and the first two are what keep the third
 honest:
 
@@ -125,6 +133,15 @@ _CROSS_REPOSITORY_NODE_ID = "PR_kwDORUMiZs7Kw3fA"
 _CROSS_REPOSITORY_OWN_DATABASE_ID = 3401807808
 _CROSS_REPOSITORY_RESOLVES_TO = "uutils/coreutils#11342"
 _CROSS_REPOSITORY_ACTUAL_DATABASE_ID = 11847500
+
+# The repository a second stray write landed in, twenty minutes after #2007 was
+# filed: `createIssue` with a `repositoryId` that was never resolved in that run.
+# Unlike the cross-repository ID above, its repository field is *not* this
+# repository, so the surviving reject direction covers it. Read back from
+# `repository(owner: "Ali111q", name: "todo")`. See #2007.
+_SECOND_STRAY_REPOSITORY_NODE_ID = "R_kgDOPzXPeg"
+_SECOND_STRAY_REPOSITORY_DATABASE_ID = 1060491130
+_SECOND_STRAY_RESOLVES_TO = "Ali111q/todo#1"
 
 #: The ID that mutation should have carried, from
 #: ``repository(owner:, name:) { pullRequest(number: 2006) { id } }``. Kept to
@@ -316,6 +333,30 @@ class TestTheDecodeIsARejectAndNeverAPass:
                 "the check rather than removing it."
             )
 
+    def test_the_second_incident_is_refusable_by_the_surviving_direction(self) -> None:
+        # Why the correction narrows the check instead of deleting it: the write
+        # that landed after #2007 was filed is one a decode would have stopped.
+        encoded = _encoded_repository(_SECOND_STRAY_REPOSITORY_NODE_ID)
+        assert encoded == _SECOND_STRAY_REPOSITORY_DATABASE_ID, (
+            f"{_SECOND_STRAY_REPOSITORY_NODE_ID!r} should decode to the databaseId of "
+            f"the repository {_SECOND_STRAY_RESOLVES_TO} landed in. If it does not, the "
+            "constant drifted; re-read it from a repository(owner:, name:) query."
+        )
+        assert encoded != _REPOSITORY_DATABASE_ID, (
+            f"{_SECOND_STRAY_RESOLVES_TO} was filed from an ID naming another "
+            "repository, which is the one shape a decode catches. This is why "
+            "AGENTS.md keeps the reject rather than dropping the decode outright."
+        )
+
+    def test_the_two_incidents_name_different_wrong_repositories(self) -> None:
+        # #1916's write-up read as one stale value contaminating one run. Two
+        # distinct wrong repositories make it a recurring class instead, which is
+        # what justifies weighting the rule by reversibility at the call site.
+        assert _STRAY_REPOSITORY_DATABASE_ID != _SECOND_STRAY_REPOSITORY_DATABASE_ID, (
+            "the two stray writes must name different repositories for the recurrence "
+            "to be the finding. If these agree, one of the constants is wrong."
+        )
+
     def test_the_prefix_check_is_unaffected_by_the_correction(self) -> None:
         # Orthogonal and still sound: the type is a property of the envelope, not
         # a claim about which object the payload addresses.
@@ -420,7 +461,7 @@ class TestTheGuidanceNamesTheDecodableEnvelope:
 
 
 class TestTheGuidanceLimitsTheDecodeToAReject:
-    """The correction is only actionable with its five qualifiers beside it."""
+    """The correction is only actionable with its seven qualifiers beside it."""
 
     def test_the_slice_is_the_bullet_and_not_its_neighbour(self) -> None:
         # Non-vacuity for `_bullet_after`: an empty or runaway slice would make
@@ -467,6 +508,23 @@ class TestTheGuidanceLimitsTheDecodeToAReject:
             "AGENTS.md must say the two directions are not symmetric: a refused merge "
             "leaves nothing behind, a createIssue against a wrong ID cannot be undone. "
             "That is the sentence that changes behaviour at the call site. See #2007."
+        )
+
+    def test_the_guidance_scopes_the_rule_to_mutations(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and "Only a mutation takes a bare ID" in bullet, (
+            "AGENTS.md must say only a mutation takes a bare ID. Without it the rule "
+            "reads as applying to every call, which makes it look expensive enough to "
+            "skip - and a query cannot address the wrong repository at all. See #2007."
+        )
+
+    def test_the_guidance_records_the_second_incident(self) -> None:
+        bullet = _bullet_after(_agents_text(), _SUBJECT_CLAIM)
+        assert bullet is not None and _SECOND_STRAY_RESOLVES_TO in bullet, (
+            f"AGENTS.md must record that this recurred: {_SECOND_STRAY_RESOLVES_TO} "
+            "landed twenty minutes after #2007 was filed, from an ID a decode would "
+            "have rejected. One incident reads as a mishap; two is the reason the "
+            "reject direction is kept and the read-back is not optional. See #2007."
         )
 
     def test_the_guidance_names_the_remedy_for_a_write_that_landed(self) -> None:


### PR DESCRIPTION
## One incident reads as a mishap; two is a class

#2015 corrected step 8's node-ID decode to a reject-only check and added the reversibility argument that decides how much the read-back is worth: a refused `mergePullRequest` leaves nothing behind, a `createIssue` against a wrong `repositoryId` succeeds and cannot be undone by the account that made it. It rested that argument on **one** incident, #1916.

It has happened twice. `Ali111q/todo#1` was filed at **16:23:46Z on 2026-08-07 — twenty minutes after the problem was reported** — from a `repositoryId` whose repository field reads `1060491130` rather than this repository's `1162027622`.

Three things follow, and all three are measured rather than recalled:

- **That is the one direction a decode *does* catch.** It is therefore the argument for narrowing the check rather than removing it, which is exactly the distinction #2015 landed. A recurrence a decode would have stopped is the strongest available reason to keep the reject.
- **The two strays name different repositories** (`257265175` and `1060491130`). #1916 reads as one stale value travelling through one run; two distinct wrong targets make it a recurring class, which is what makes the asymmetry worth carrying to the call site rather than filing as a one-off.
- **The remedy the passage prescribes is what that issue now records.** Retitled "Opened in error - please ignore (wrong repository)", body replaced, closed, not replaced there. Its body notes deletion was refused — so the `deleteIssue` claim the passage makes is measured in the artifact, not asserted beside it.

## And the rule now says what it does not bind

> Only a mutation takes a bare ID - a query names its subject by `owner`/`name`/`number`, so it cannot address the wrong repository at all.

This is the missing half of "read every ID back". Without it the rule reads as a tax on every call, and something that looks expensive gets skipped — which is the likelier failure than an unsound check, and is what happened here: the ID was never resolved rather than resolved and mis-checked. Scoped, the rule costs one round trip on the calls that can change something, and nothing on the ones that cannot. It also explains a fact worth stating: no *read* has been implicated in either incident.

## Tests

`tests/test_graphql_node_id_targeting.py` grows from 26 to 30 collected. The split is the point — two of the four are **executable**, not assertions that prose exists.

`TestTheDecodeIsARejectAndNeverAPass` gains two:

- `test_the_second_incident_is_refusable_by_the_surviving_direction` decodes `R_kgDOPzXPeg` and asserts it recovers `1060491130` and that this is not this repository. So "a decode would have rejected that ID" is an offline computation. Encoding `1060491130` back into the envelope reproduces `R_kgDOPzXPeg` **exactly**, which is how the constant was obtained independently of the recollection.
- `test_the_two_incidents_name_different_wrong_repositories` asserts the recurrence is two targets rather than one.

Both pass with `AGENTS.md` reverted, because they are properties of GitHub's IDs rather than of this passage — which is precisely why deleting the decode does not satisfy this class.

`TestTheGuidanceLimitsTheDecodeToAReject` gains two prose pins, `test_the_guidance_scopes_the_rule_to_mutations` and `test_the_guidance_records_the_second_incident`, read through the bullet-bounded, whitespace-collapsed slice #2015 introduced — so a reflow cannot fail them and a qualifier moved to a neighbouring bullet must.

**Negative control** — `AGENTS.md` reverted to `main` (which already carries #2015) with this branch's tests kept:

| class | result |
|---|---|
| `TestTheNodeIdEnvelopeIsCheckableOffline` | 10 passed |
| `TestTheDecodeIsARejectAndNeverAPass` | 7 passed |
| `TestTheGuidanceNamesTheDecodableEnvelope` | 5 passed |
| `TestTheGuidanceLimitsTheDecodeToAReject` | **2 failed**, 6 passed |
| | **2 failed / 28 passed** |

Exactly the two qualifiers this change adds fail, and nothing else — the six qualifiers already on `main` still pass, so the round is additive rather than a rewrite.

## Changelog

The `#2007` fragment is **extended** rather than joined by a second one, so the assembled entry stays a single coherent description of one passage instead of a second entry that only parses after the first. Same shape as #1736 amending the `#1728` fragment.

## Verification

At `a7750585` (base `10260882`), `aarch64`, `MUJOCO_GL=egl`:

| gate | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check strands_robots tests tests_integ` | 1102 files already formatted |
| `mypy strands_robots tests tests_integ` | 14 errors, all in `examples/isaac_gs`, **0 outside** — error set byte-identical to a pristine `upstream/main` worktree of the same working copy, so environmental |
| `pytest tests` | **22685 passed, 257 skipped, 0 failed** in 512s |
| root guards (changelog fragments/format, dangling doc refs, internal paths, unreachable statements) | 42 passed |
| `scripts/assemble_changelog.py --check` | OK (215 pending) |
| `scripts/check_merge_base_overlap.py` | No overlap — 0 paths changed on `upstream/main` since the branch diverged |

No visual artifact accompanies this: the change is `AGENTS.md` prose, one changelog fragment and a test module, and touches no policy, simulation, rendering, recording or robot asset. Every claim above is reproducible from one query naming the object by owner and name.

Context: #2007, corrected by #2015. #2016 opened four minutes after #2015 with the same correction and is closed as the duplicate; the two cells it was better on are the two this change carries, with the evidence extended past prose.
