### PR TITLE
ci: report whether an open pull request already claims an issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,28 @@ hatch run format            # ruff check --fix, ruff format
    `createPullRequest` takes the base repository as `repositoryId` and the fork
    as a separate `headRepositoryId`. Step 5 already says "from your fork"; step 1
    is where that stops being a preference.
+
+   Before you start, check that no open pull request already claims the issue:
+
+   ```
+   python3 scripts/check_duplicate_claim.py --issue <N>
+   ```
+
+   A duplicate claim is invisible to every other check here, because they all read
+   one pull request at a time and this is a property of the *set* of open ones. It
+   is an intake failure rather than a drift: measured over the last 100 pull
+   requests, three pairs claimed one issue each and **all three opened inside one
+   ~35-minute window**. Three of the six were abandoned and every one of those had
+   already been **approved**, so what a duplicate spends is a review approval on a
+   change that could never ship - and review is the scarcest resource here (#1905).
+   Two of the three pairs also carried a real `git merge-tree` content conflict, so
+   they could not both have landed.
+
+   One query, reading the same `closingIssuesReferences` field the closing-keyword
+   gate reads. Asking it here prevents the authoring rather than capping it, which
+   is why it belongs at step 1 and not at review. If a competing implementation is
+   wanted on purpose, exactly one should claim the close and the other should
+   cross-reference (`per #N`, `towards #N`) instead.
 2. Make changes, run `hatch run format && hatch run lint && hatch run test`
 3. Record the change as a news fragment: `changelog.d/<pr-number>-<slug>.md`
    (see [`changelog.d/README.md`](changelog.d/README.md)). **Never append to

--- a/changelog.d/2017-duplicate-claim-check.md
+++ b/changelog.d/2017-duplicate-claim-check.md
@@ -1,0 +1,20 @@
+### CI: report whether an open pull request already closes an issue
+
+Every check here reads one pull request at a time, so a branch claiming an issue
+another open branch already claims passed all of them. Over the last 100 pull requests
+three pairs did exactly that -- #1944/#1946 (#1942), #1995/#1996 (#1994) and
+#2015/#2016 (#2007) -- and all three abandoned halves had already been **approved**, so
+what a duplicate spends is a review approval on a change that could never ship. Two of
+the pairs also carried a real `git merge-tree` content conflict, so they could not both
+have landed.
+
+`scripts/check_duplicate_claim.py` reads `closingIssuesReferences` across the open pull
+requests. `--issue N` is the intake question, asked before a second pull request exists;
+`--pr N` compares an existing one's claims and excludes itself. It takes no position on
+which of a pair is at fault: measured on those pairs, the *newer* pull request is the one
+that merged in two of the three cases. An unreadable or truncated answer reports
+`unknown-claims` rather than a pass, and the open set is read through
+`repository.pullRequests(states: OPEN)` rather than `search`, which is eventually
+consistent and would return a clean answer inside the ~35-minute window where every
+observed collision happened. AGENTS.md step 1 asks the question at intake, which prevents
+the duplicated authoring rather than capping it.

--- a/scripts/check_duplicate_claim.py
+++ b/scripts/check_duplicate_claim.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Report whether an open pull request already closes a given issue.
+
+Why this exists
+---------------
+``scripts/check_closing_reference.py`` reads one pull request in isolation: it
+compares the issues a *title* claims against that same pull request's
+``closingIssuesReferences``. Both of its inputs are per-pull-request, so a branch
+that claims an issue **another open pull request already claims** passes every
+check in this repository, and measured over the last 100 pull requests (#1867
+through #2016) the notice has arrived after review every time.
+
+Three pairs claimed one issue each -- six pull requests, three of them wasted::
+
+    issue   pair            opened apart   abandoned   had reached
+    #1942   #1944, #1946    8m 32s         #1944       APPROVED
+    #1994   #1995, #1996    31m 58s        #1995       APPROVED
+    #2007   #2015, #2016    4m 9s          #2016       APPROVED
+
+The costly property is the last column. What a duplicate wastes is not the
+authoring, it is a **review approval spent on a change that could never ship**,
+and review is the scarcest resource here -- #1905 measures the same scarcity from
+the other direction. Two of the three pairs could not both land regardless: the
+closing comments on #1944 and #1995 each record a ``git merge-tree`` content
+conflict, so the duplication was a merge failure waiting on whichever pull request
+lost the race.
+
+Every pair also opened inside one ~35-minute window, and that is what decides
+where this belongs. The collision is an **intake** failure -- the second pull
+request is opened before anything has observed the first -- not a drift that
+accumulates over days. A check that reads two existing pull requests recovers the
+review cost but not the authoring cost; a check run *before* the second one is
+opened prevents both. So the primary entry point is ``--issue``, asked at intake,
+and AGENTS.md step 1 is where it is asked.
+
+Why the existing gate cannot see it
+-----------------------------------
+That check reads the title and the link set GitHub publishes, and that scope is
+right for what it does. A duplicate claim is a property of the *set* of open pull
+requests, so no single-pull-request assertion can reach it. The link set is still
+the right thing to read -- it just has to be read across the open pull requests
+rather than for one.
+
+Why there is no rule about which of the two is at fault
+------------------------------------------------------
+Issue #2017 proposed failing "the newer of the two". Measured against the three
+pairs, that names the wrong pull request twice::
+
+    issue   older   newer   merged
+    #1942   #1944   #1946   #1946   <- the newer one
+    #1994   #1995   #1996   #1996   <- the newer one
+    #2007   #2015   #2016   #2015
+
+So in two of three the newer pull request is the one that survived, and an age
+rule would have accused the eventual survivor. It is also not this check's
+question: both numbers go in the report and which claim to drop stays with the
+people who know what the two branches do.
+
+That a repository-read token can see another pull request's link set is not
+assumed. Issue #1961 records ``PullRequest.projectItems`` returning a false ``0``
+under ``GITHUB_TOKEN``, so the lens was checked before relying on it: an Actions
+token and a personal token return identical link sets for all the open pull
+requests, including the one linking #1034. A false empty would turn this into a
+silent no-op that always agrees, which is why an incomplete read is reported as
+``unknown-claims`` rather than as a pass.
+
+The open list is read through ``repository.pullRequests(states: OPEN)`` and not
+through ``search``. Search is eventually consistent, so a pull request opened
+seconds ago may not be indexed -- and the missing row would be a false clean in
+exactly the ~35-minute window where every observed collision happened.
+
+Two questions, one comparison
+-----------------------------
+``--issue N``
+    Intake. *Before* authoring: does an open pull request already close #N?
+    Nothing is excluded from the comparison, because no pull request for it exists
+    yet.
+
+``--pr N``
+    Review. Do this pull request's own claims collide with another open one's?
+    #N is excluded from its own comparison -- a pull request always shares its own
+    claim.
+
+What this reports, and what it deliberately does not
+----------------------------------------------------
+``no-claim``
+    The pull request links no issue, so it can collide with nothing. Reachable
+    only from ``--pr``; an issue is always its own claim.
+
+``unique-claim``
+    Nothing else claims it. The convention working.
+
+``duplicate-claim``
+    The finding.
+
+``unknown-claims``
+    A link set, or the open-pull-request list, could not be read completely. Not a
+    finding -- an unreadable field is not evidence of a duplicate.
+
+Out of scope, deliberately:
+
+- **A pull request that claims nothing anywhere.** Two competing branches that
+  both omit the keyword collide invisibly here. That is the same residual the
+  sibling gate names and the one #1961 is about, and 18 of the last 30 merges
+  would fail a rule requiring a claim, so this needs no answer to that question
+  and cannot be dismissed by one.
+- **Whether the issue exists, or is already closed.** A stale number is a
+  different defect, and refusing it would report a finding against correct work
+  whose issue someone else closed first.
+- **Draft pull requests are included.** A draft's link is a real claim -- GitHub
+  will close the issue when it merges -- so excluding drafts would hide a
+  collision for as long as one side stays a draft.
+
+Not wired to CI here, and that is a scope statement rather than an oversight. A
+``pull_request`` job running ``--pr`` on ``opened``/``edited`` is the natural
+follow-up and would cap the review cost of a collision this query did not
+prevent; it needs a credential that can write ``.github/workflows/``, which is a
+separate change. The intake half stands on its own: it is the half that stops the
+work from being done twice, and it is complete as shipped.
+
+Usage
+-----
+``--repo``    ``owner/name`` (default: ``$GITHUB_REPOSITORY``).
+``--issue``   an issue number, asked at intake. Mutually exclusive with ``--pr``.
+``--pr``      a pull request number (default: ``$PR_NUMBER``).
+``--token``   API token (default: ``$GITHUB_TOKEN``). Needs ``pull-requests: read``.
+
+Exit status is ``1`` for ``duplicate-claim``, else ``0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+API_ROOT = "https://api.github.com"
+
+#: How many linked issues to ask for per pull request. A set longer than this is
+#: treated as unreadable rather than as a short list, because a link set cut off
+#: here could hide the very issue that collides and report a clean answer.
+LINK_PAGE_SIZE = 100
+
+#: How many open pull requests to read per page.
+OPEN_PAGE_SIZE = 100
+
+#: A bound on pagination, so a pathological repository cannot spin this job.
+#: Reaching it is reported as ``unknown-claims`` -- an unread page is not
+#: evidence of no collision.
+MAX_OPEN_PAGES = 20
+
+NO_CLAIM = "no-claim"
+UNIQUE_CLAIM = "unique-claim"
+DUPLICATE_CLAIM = "duplicate-claim"
+UNKNOWN_CLAIMS = "unknown-claims"
+
+#: ``closingIssuesReferences`` is GraphQL-only -- no REST field carries it.
+_SELF_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $links: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      number
+      closingIssuesReferences(first: $links) {
+        totalCount
+        nodes { number }
+      }
+    }
+  }
+}
+"""
+
+_OPEN_QUERY = """
+query($owner: String!, $name: String!, $links: Int!, $open: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN, first: $open, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        closingIssuesReferences(first: $links) {
+          totalCount
+          nodes { number }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class ClaimSetUnreadable(RuntimeError):
+    """A link set, or the list of open pull requests, could not be read.
+
+    Named apart from the builtin to keep the distinction explicit at the call
+    site: this is "GitHub did not answer", not "the answer was empty". The two
+    must not collapse, because an empty answer is a pass and an unanswered one is
+    neither a pass nor a finding.
+    """
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The outcome and the claim sets it was computed from."""
+
+    outcome: str
+    #: The issues the pull request under test links.
+    claimed: tuple[int, ...] = ()
+    #: ``(issue, the other open pull requests linking it)``, sorted by issue.
+    collisions: tuple[tuple[int, tuple[int, ...]], ...] = ()
+    #: How many other open pull requests were compared against.
+    scanned: int = 0
+    detail: str = ""
+
+    @property
+    def is_finding(self) -> bool:
+        return self.outcome == DUPLICATE_CLAIM
+
+    @property
+    def rivals(self) -> tuple[int, ...]:
+        """Every other open pull request implicated, sorted and deduplicated."""
+        return tuple(sorted({pr for _, prs in self.collisions for pr in prs}))
+
+    @property
+    def summary(self) -> str:
+        if self.outcome == NO_CLAIM:
+            return "This pull request links no issue, so it cannot duplicate another's claim."
+        if self.outcome == UNIQUE_CLAIM:
+            # Worded without a subject so it reads correctly for both entry points:
+            # an issue checked at intake has no pull request to call "this" yet.
+            return (
+                f"{_issues(self.claimed)} "
+                f"{'are' if len(self.claimed) > 1 else 'is'} claimed by no open pull request "
+                f"({self.scanned} compared)."
+            )
+        if self.outcome == UNKNOWN_CLAIMS:
+            return (
+                f"Could not read every claim: {self.detail} Not treated as a finding, because "
+                "an unreadable link set is not evidence that an issue is claimed twice."
+            )
+        # Semicolons rather than :func:`_join`, which would put an "and" between two
+        # clauses that already each contain one ("... by #5 and #6 and #30 is ...").
+        parts = "; ".join(f"{_issues((issue,))} is also claimed by {_pulls(prs)}" for issue, prs in self.collisions)
+        return (
+            f"{parts}. Two pull requests closing one issue cannot both "
+            "land as written, and whichever loses the race spends a review approval on a "
+            "change that will be closed."
+        )
+
+
+def _join(parts: Sequence[str]) -> str:
+    """Render a clause list as ``a`` / ``a and b`` / ``a, b and c``."""
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return parts[0]
+    return ", ".join(parts[:-1]) + " and " + parts[-1]
+
+
+def _issues(numbers: Sequence[int]) -> str:
+    """Render an issue list as ``#1`` / ``#1 and #2`` / ``#1, #2 and #3``."""
+    return _join([f"#{n}" for n in numbers]) or "no issue"
+
+
+def _pulls(numbers: Sequence[int]) -> str:
+    """Render a pull-request list the same way, for the report's other half."""
+    return _join([f"#{n}" for n in numbers]) or "no pull request"
+
+
+def find_collisions(
+    claimed: Sequence[int], others: Mapping[int, Sequence[int]]
+) -> tuple[tuple[int, tuple[int, ...]], ...]:
+    """Return each claimed issue that another open pull request also claims.
+
+    Deterministic in both axes -- issues ascending, and the pull requests
+    claiming each ascending -- so the report reads the same on a re-run.
+    """
+    collisions = []
+    for issue in sorted(set(claimed)):
+        rivals = tuple(sorted(pr for pr, links in others.items() if issue in set(links)))
+        if rivals:
+            collisions.append((issue, rivals))
+    return tuple(collisions)
+
+
+def classify(
+    claimed: Sequence[int] | None,
+    others: Mapping[int, Sequence[int]] | None,
+    detail: str = "",
+) -> Verdict:
+    """Decide which of the four states this pull request is in.
+
+    Either argument being ``None`` means that half could not be read, which is
+    its own outcome and folded into neither a pass nor a finding: a silent API or
+    permission change must not be able to turn this check into a no-op that
+    always agrees, nor into one that accuses every branch.
+    """
+    if claimed is None or others is None:
+        return Verdict(UNKNOWN_CLAIMS, tuple(sorted(set(claimed or ()))), (), 0, detail)
+    claimed_sorted = tuple(sorted(set(claimed)))
+    if not claimed_sorted:
+        return Verdict(NO_CLAIM, (), (), len(others))
+    collisions = find_collisions(claimed_sorted, others)
+    if not collisions:
+        return Verdict(UNIQUE_CLAIM, claimed_sorted, (), len(others))
+    return Verdict(DUPLICATE_CLAIM, claimed_sorted, collisions, len(others))
+
+
+def _post(query: str, variables: dict[str, object], token: str) -> object:
+    request = urllib.request.Request(
+        f"{API_ROOT}/graphql",
+        data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "strands-robots-check-duplicate-claim",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed API host
+        return json.load(response)
+
+
+def _repository(payload: object) -> dict[str, object]:
+    """Return the ``repository`` object, or refuse the answer."""
+    if not isinstance(payload, dict):
+        raise ClaimSetUnreadable("the API response was not a JSON object.")
+    if payload.get("errors"):
+        raise ClaimSetUnreadable(f"the API returned errors: {json.dumps(payload['errors'])[:400]}")
+    repository = (payload.get("data") or {}).get("repository")
+    if not isinstance(repository, dict):
+        raise ClaimSetUnreadable("the response carried no repository.")
+    return repository
+
+
+def link_numbers(pull: Mapping[str, object]) -> tuple[int, ...]:
+    """Return the issues one pull-request node links, refusing a truncated set.
+
+    A set cut off at :data:`LINK_PAGE_SIZE` could omit the issue that collides,
+    so it is refused rather than read short -- the one thing this check must never
+    do is report clean because it did not look far enough.
+    """
+    references = pull.get("closingIssuesReferences") or {}
+    if not isinstance(references, dict):
+        raise ClaimSetUnreadable(f"#{pull.get('number')} carried no link set.")
+    nodes = references.get("nodes") or []
+    total = references.get("totalCount")
+    if isinstance(total, int) and total > len(nodes):
+        raise ClaimSetUnreadable(f"#{pull.get('number')}'s link set is truncated ({total} links, {len(nodes)} read).")
+    return tuple(sorted({int(node["number"]) for node in nodes if isinstance(node, dict) and "number" in node}))
+
+
+def resolve_claim(repo: str, pr: int, token: str) -> tuple[int, ...]:
+    """Return the issues the pull request under test links.
+
+    Read by number rather than from the open list, so the answer does not depend
+    on the pull request having been indexed or on it fitting the first page.
+    """
+    owner, _, name = repo.partition("/")
+    if not owner or not name:
+        raise ClaimSetUnreadable(f"repository {repo!r} is not in owner/name form.")
+    repository = _repository(
+        _post(_SELF_QUERY, {"owner": owner, "name": name, "number": pr, "links": LINK_PAGE_SIZE}, token)
+    )
+    pull = repository.get("pullRequest")
+    if not isinstance(pull, dict):
+        raise ClaimSetUnreadable(f"no pull request {repo}#{pr} in the response.")
+    return link_numbers(pull)
+
+
+def resolve_open_claims(repo: str, token: str, pr: int | None = None) -> dict[int, tuple[int, ...]]:
+    """Return ``{open pull request number: the issues it links}``, excluding ``pr``.
+
+    ``pr`` of ``None`` excludes nothing, which is the intake question: *is anything
+    already claiming this issue?* There is no pull request to leave out yet.
+
+    Paginates rather than reading one page: a repository with more open pull
+    requests than :data:`OPEN_PAGE_SIZE` would otherwise get a clean answer
+    computed from a prefix of the set.
+    """
+    owner, _, name = repo.partition("/")
+    if not owner or not name:
+        raise ClaimSetUnreadable(f"repository {repo!r} is not in owner/name form.")
+    claims: dict[int, tuple[int, ...]] = {}
+    cursor: str | None = None
+    for _ in range(MAX_OPEN_PAGES):
+        repository = _repository(
+            _post(
+                _OPEN_QUERY,
+                {
+                    "owner": owner,
+                    "name": name,
+                    "links": LINK_PAGE_SIZE,
+                    "open": OPEN_PAGE_SIZE,
+                    "after": cursor,
+                },
+                token,
+            )
+        )
+        page = repository.get("pullRequests")
+        if not isinstance(page, dict):
+            raise ClaimSetUnreadable("the response carried no open pull requests.")
+        for node in page.get("nodes") or []:
+            if not isinstance(node, dict) or "number" not in node:
+                continue
+            number = int(node["number"])
+            if pr is not None and number == pr:
+                continue
+            claims[number] = link_numbers(node)
+        info = page.get("pageInfo") or {}
+        if not info.get("hasNextPage"):
+            return claims
+        cursor = info.get("endCursor")
+        if not isinstance(cursor, str):
+            raise ClaimSetUnreadable("the open pull request list is paged but carried no cursor.")
+    raise ClaimSetUnreadable(f"more than {MAX_OPEN_PAGES * OPEN_PAGE_SIZE} open pull requests; the list was truncated.")
+
+
+def render(verdict: Verdict, repo: str, pr: int | None = None, issue: int | None = None) -> str:
+    """Render the report for this run.
+
+    Exactly one of ``pr`` and ``issue`` names the subject: a pull request whose
+    claims were compared, or -- at intake -- an issue checked before a pull
+    request for it exists.
+    """
+    subject = f"| pull request | {repo}#{pr} |" if pr is not None else f"| issue | {repo}#{issue} |"
+    lines = [
+        "## Duplicate closing claim",
+        "",
+        f"Outcome: **{verdict.outcome}**",
+        "",
+        verdict.summary,
+        "",
+        "| field | value |",
+        "|---|---|",
+        subject,
+        f"| issues it closes | {_issues(verdict.claimed)} |",
+    ]
+    # Only stated when a comparison happened. A pull request claiming nothing
+    # short-circuits before the open list is read, and printing "0 compared"
+    # there would read as "the check could not see the other pull requests".
+    if verdict.outcome != NO_CLAIM:
+        lines.append(f"| other open pull requests compared | {verdict.scanned} |")
+    if verdict.is_finding and issue is not None:
+        lines += [
+            f"| already claimed by | {_pulls(verdict.rivals)} |",
+            "",
+            "### What this means",
+            "",
+            f"{_pulls(verdict.rivals)} is already open against {_issues((issue,))}. Read it before",
+            "starting: if it does the work, there is nothing to author, and if it does not, say so",
+            "there rather than opening a second pull request against the same issue. If a competing",
+            "implementation is wanted on purpose, exactly one of the two should claim the close and",
+            "the other should cross-reference instead (`per #N`, `towards #N`).",
+        ]
+    elif verdict.is_finding:
+        lines += [
+            f"| also claimed by | {_pulls(verdict.rivals)} |",
+            "",
+            "### What clears this",
+            "",
+            "1. Decide which pull request closes the issue. The other drops the keyword from",
+            "   its description -- `per #N`, `follow-up to #N`, `towards #N` all still",
+            "   cross-reference without linking. GitHub drops the link when the description is",
+            "   saved and this check re-runs on `edited`, so either side can clear its own run",
+            "   without a push.",
+            "2. If one of the two is redundant, close it.",
+            "",
+            "Both pull requests are named above rather than one being blamed: measured over the",
+            "last 100 pull requests, the newer of a duplicate pair is the one that merged in two",
+            "of the three cases, so which to keep is not something this check can decide.",
+        ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--issue", default="")
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        parser.error("--repo is required (or set GITHUB_REPOSITORY)")
+    if bool(args.pr) == bool(args.issue):
+        parser.error("pass exactly one of --pr (review a pull request) and --issue (intake)")
+    if not args.token:
+        parser.error("--token is required (or set GITHUB_TOKEN)")
+
+    pr = int(args.pr) if args.pr else None
+    issue = int(args.issue) if args.issue else None
+    claimed: tuple[int, ...] | None
+    others: dict[int, tuple[int, ...]] | None
+    detail = ""
+    try:
+        # In intake mode the "claim" is the issue being considered, and nothing is
+        # excluded from the comparison because no pull request for it exists yet.
+        claimed = (issue,) if issue is not None else resolve_claim(args.repo, int(args.pr), args.token)
+        others = resolve_open_claims(args.repo, args.token, pr) if claimed else {}
+    except (ClaimSetUnreadable, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
+        claimed, others, detail = None, None, str(exc)
+        print(f"check_duplicate_claim: {detail}", file=sys.stderr)
+
+    verdict = classify(claimed, others, detail)
+    report = render(verdict, args.repo, pr, issue)
+    print(report)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+    if verdict.is_finding:
+        print(f"::error title=Two open pull requests claim one issue::{verdict.summary}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -1,0 +1,511 @@
+"""Pins the duplicate-claim check against the pairs this repository actually shipped.
+
+The measurement behind the check is a corpus rather than an anecdote: over the last
+100 pull requests (#1867 through #2016) three pairs claimed one issue each, and the
+interesting property is not that they existed but that **every abandoned half had
+already been approved**. :data:`_MEASURED_PAIRS` fixes all three in place, so the
+scanner is tested against the real shapes rather than invented ones.
+
+Two pins carry design decisions rather than behaviour:
+
+``TestThereIsNoAgeRule``
+    Issue #2017 proposed failing "the newer of the two". On this corpus the newer
+    pull request is the one that merged in two of the three cases, so an age rule
+    would have named the eventual survivor. The verdict is therefore symmetric,
+    and that is asserted from both perspectives of every pair -- if someone later
+    adds the age rule, these fail and say why not.
+
+``TestAnIncompleteAnswerIsNotAFinding``
+    A truncated link set, a truncated open-pull-request list and an API error must
+    all reach ``unknown-claims``. The failure mode this guards is not a false
+    accusation but a silent no-op: a check that reports clean because it could not
+    see the other pull requests is worse than no check, because it looks like one.
+
+See scripts/check_duplicate_claim.py, issue #2017, and the "PR Workflow" section
+of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "scripts" / "check_duplicate_claim.py"
+_AGENTS = _ROOT / "AGENTS.md"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_duplicate_claim", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# The script is annotated and mypy-clean on its own
+# (mypy scripts/check_duplicate_claim.py); it is reached through importlib here
+# because scripts/ is not an importable package, so its members are module
+# attributes at runtime rather than names mypy can resolve to types.
+mod = _load()
+
+#: The duplicate pairs measured over #1867 - #2016, as
+#: ``(issue, older pull request, newer pull request, the one that merged)``.
+#: Every abandoned half of these three was ``APPROVED`` when it was closed.
+_MEASURED_PAIRS: tuple[tuple[int, int, int, int], ...] = (
+    (1942, 1944, 1946, 1946),
+    (1994, 1995, 1996, 1996),
+    (2007, 2015, 2016, 2015),
+)
+
+
+def _pair_ids() -> list[str]:
+    return [f"#{issue}" for issue, _, _, _ in _MEASURED_PAIRS]
+
+
+class TestTheClassifierNamesTheCollisionAndNothingElse:
+    """The four outcomes, and the boundary between a pass and a finding."""
+
+    def test_a_pull_request_linking_nothing_cannot_collide(self) -> None:
+        verdict = mod.classify([], {1: [7], 2: [7]})
+        assert verdict.outcome == mod.NO_CLAIM
+        assert not verdict.is_finding
+        assert verdict.collisions == ()
+
+    def test_a_claim_no_other_open_pull_request_shares_is_unique(self) -> None:
+        verdict = mod.classify([1034], {1087: [], 1722: [], 2018: []})
+        assert verdict.outcome == mod.UNIQUE_CLAIM
+        assert not verdict.is_finding
+        assert verdict.claimed == (1034,)
+        assert verdict.scanned == 3
+
+    def test_a_shared_claim_is_the_finding_and_names_the_rival(self) -> None:
+        verdict = mod.classify([2007], {2015: [2007], 1722: []})
+        assert verdict.outcome == mod.DUPLICATE_CLAIM
+        assert verdict.is_finding
+        assert verdict.collisions == ((2007, (2015,)),)
+        assert verdict.rivals == (2015,)
+
+    def test_a_rival_claiming_a_different_issue_is_not_a_collision(self) -> None:
+        """The near-miss that a set-membership bug would report as a finding."""
+        verdict = mod.classify([2007], {2015: [2008], 1722: [1034]})
+        assert verdict.outcome == mod.UNIQUE_CLAIM
+
+    def test_only_the_shared_issue_is_reported_when_a_claim_is_partly_unique(self) -> None:
+        verdict = mod.classify([10, 20], {5: [20]})
+        assert verdict.outcome == mod.DUPLICATE_CLAIM
+        assert verdict.collisions == ((20, (5,)),)
+        assert verdict.claimed == (10, 20)
+
+    def test_the_pull_request_under_test_is_not_its_own_rival(self) -> None:
+        """The bug that would make every claiming pull request a finding.
+
+        :func:`resolve_open_claims` drops the number under test, and this is the
+        assertion that says why: a pull request always shares its own claim.
+        """
+        verdict = mod.classify([2007], {})
+        assert verdict.outcome == mod.UNIQUE_CLAIM
+
+    def test_collisions_and_rivals_are_sorted_and_deduplicated(self) -> None:
+        """A re-run must render the same report, so both axes are ordered."""
+        verdict = mod.classify([30, 20, 20], {6: [30, 20], 5: [20]})
+        assert verdict.claimed == (20, 30)
+        assert verdict.collisions == ((20, (5, 6)), (30, (6,)))
+        assert verdict.rivals == (5, 6)
+
+    def test_find_collisions_reports_every_rival_of_one_issue(self) -> None:
+        assert mod.find_collisions([7], {3: [7], 4: [7], 5: []}) == ((7, (3, 4)),)
+
+
+class TestTheMeasuredPairsAreDuplicateClaims:
+    """Each of the three shipped pairs must classify as the finding."""
+
+    @pytest.mark.parametrize(("issue", "older", "newer", "merged"), _MEASURED_PAIRS, ids=_pair_ids())
+    def test_the_pair_is_reported_from_the_newer_pull_requests_run(
+        self, issue: int, older: int, newer: int, merged: int
+    ) -> None:
+        verdict = mod.classify([issue], {older: [issue]})
+        assert verdict.outcome == mod.DUPLICATE_CLAIM
+        assert verdict.rivals == (older,)
+
+    @pytest.mark.parametrize(("issue", "older", "newer", "merged"), _MEASURED_PAIRS, ids=_pair_ids())
+    def test_the_pair_is_reported_from_the_older_pull_requests_run_too(
+        self, issue: int, older: int, newer: int, merged: int
+    ) -> None:
+        """The older side reports it as well, on its next ``edited`` run.
+
+        A rule that decided by age would report clean here while a live collision
+        stood, which is the one state a reporting check must not have.
+        """
+        verdict = mod.classify([issue], {newer: [issue]})
+        assert verdict.outcome == mod.DUPLICATE_CLAIM
+        assert verdict.rivals == (newer,)
+
+
+class TestThereIsNoAgeRule:
+    """Why #2017's "fail the newer" was not implemented, kept as a measurement."""
+
+    def test_the_newer_pull_request_is_the_survivor_in_two_of_the_three_pairs(self) -> None:
+        """The corpus fact that rules out an age rule.
+
+        Not a property of this code -- a property of what shipped -- which is
+        exactly why it belongs beside the check rather than only in its prose.
+        """
+        newer_survived = [issue for issue, _, newer, merged in _MEASURED_PAIRS if newer == merged]
+        assert newer_survived == [1942, 1994], newer_survived
+        assert len(newer_survived) == 2
+
+    def test_the_verdict_does_not_depend_on_which_pull_request_is_older(self) -> None:
+        younger_view = mod.classify([2007], {2015: [2007]})
+        older_view = mod.classify([2007], {2016: [2007]})
+        assert younger_view.outcome == older_view.outcome == mod.DUPLICATE_CLAIM
+
+    def test_the_report_says_the_choice_is_not_the_checks_to_make(self) -> None:
+        report = mod.render(mod.classify([2007], {2015: [2007]}), "strands-labs/robots", 2016)
+        assert "newer of a duplicate pair is the one that merged in two" in report
+
+
+class TestAnIncompleteAnswerIsNotAFinding:
+    """An unreadable answer must reach neither a pass nor an accusation."""
+
+    def test_an_unreadable_half_is_its_own_outcome(self) -> None:
+        verdict = mod.classify(None, None, "the API returned errors: [...]")
+        assert verdict.outcome == mod.UNKNOWN_CLAIMS
+        assert not verdict.is_finding
+        assert "the API returned errors" in verdict.summary
+
+    def test_an_unreadable_open_list_does_not_clear_a_claim(self) -> None:
+        """The silent no-op this guards: a claim read, the rivals not."""
+        verdict = mod.classify([2007], None, "the open pull request list is truncated.")
+        assert verdict.outcome == mod.UNKNOWN_CLAIMS
+        assert verdict.claimed == (2007,)
+
+    def test_a_truncated_link_set_is_refused_rather_than_read_short(self) -> None:
+        with pytest.raises(mod.ClaimSetUnreadable, match="truncated"):
+            mod.link_numbers({"number": 7, "closingIssuesReferences": {"totalCount": 2, "nodes": [{"number": 1}]}})
+
+    def test_a_complete_link_set_is_read(self) -> None:
+        assert mod.link_numbers(
+            {"number": 7, "closingIssuesReferences": {"totalCount": 2, "nodes": [{"number": 9}, {"number": 1}]}}
+        ) == (1, 9)
+
+    def test_api_errors_are_unreadable_rather_than_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(mod, "_post", lambda *_a, **_k: {"errors": [{"message": "nope"}]})
+        with pytest.raises(mod.ClaimSetUnreadable, match="the API returned errors"):
+            mod.resolve_claim("o/n", 7, "t")
+
+    def test_a_repository_that_is_not_in_owner_name_form_is_refused(self) -> None:
+        with pytest.raises(mod.ClaimSetUnreadable, match="owner/name"):
+            mod.resolve_claim("nope", 7, "t")
+
+    def test_a_missing_pull_request_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(mod, "_post", lambda *_a, **_k: {"data": {"repository": {"pullRequest": None}}})
+        with pytest.raises(mod.ClaimSetUnreadable, match="no pull request"):
+            mod.resolve_claim("o/n", 7, "t")
+
+
+class TestTheOpenListIsReadLiveAndPaginated:
+    """The two ways a prefix of the open set would be a false clean."""
+
+    def test_the_number_under_test_is_excluded_from_its_own_comparison(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        page = {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [
+                            {"number": 7, "closingIssuesReferences": {"totalCount": 1, "nodes": [{"number": 42}]}},
+                            {"number": 8, "closingIssuesReferences": {"totalCount": 0, "nodes": []}},
+                        ],
+                    }
+                }
+            }
+        }
+        monkeypatch.setattr(mod, "_post", lambda *_a, **_k: page)
+        assert mod.resolve_open_claims("o/n", "t", 7) == {8: ()}
+
+    def test_every_page_is_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pages = [
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                            "nodes": [{"number": 8, "closingIssuesReferences": {"totalCount": 0, "nodes": []}}],
+                        }
+                    }
+                }
+            },
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [
+                                {
+                                    "number": 9,
+                                    "closingIssuesReferences": {"totalCount": 1, "nodes": [{"number": 42}]},
+                                }
+                            ],
+                        }
+                    }
+                }
+            },
+        ]
+        seen: list[object] = []
+
+        def fake_post(_query: str, variables: dict[str, object], _token: str) -> object:
+            seen.append(variables.get("after"))
+            return pages[len(seen) - 1]
+
+        monkeypatch.setattr(mod, "_post", fake_post)
+        assert mod.resolve_open_claims("o/n", "t", 7) == {8: (), 9: (42,)}
+        assert seen == [None, "c1"], seen
+
+    def test_a_list_longer_than_the_page_bound_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A never-ending pager must not silently return the prefix it read."""
+        endless = {
+            "data": {"repository": {"pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": "c"}, "nodes": []}}}
+        }
+        monkeypatch.setattr(mod, "_post", lambda *_a, **_k: endless)
+        with pytest.raises(mod.ClaimSetUnreadable, match="truncated"):
+            mod.resolve_open_claims("o/n", "t", 7)
+
+    def test_a_page_without_a_cursor_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        broken = {
+            "data": {
+                "repository": {"pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": None}, "nodes": []}}
+            }
+        }
+        monkeypatch.setattr(mod, "_post", lambda *_a, **_k: broken)
+        with pytest.raises(mod.ClaimSetUnreadable, match="cursor"):
+            mod.resolve_open_claims("o/n", "t", 7)
+
+    def test_the_open_set_is_read_from_the_repository_and_not_from_search(self) -> None:
+        """``search`` is eventually consistent, and this job runs on ``opened``.
+
+        A just-opened pull request may not be indexed yet, so a search-backed
+        query would return a clean answer on exactly the event that matters.
+        """
+        assert "pullRequests(states: OPEN" in mod._OPEN_QUERY
+        assert "search(" not in mod._OPEN_QUERY
+        assert "search(" not in mod._SELF_QUERY
+
+    def test_the_pull_request_under_test_is_read_by_number(self) -> None:
+        """So the answer does not depend on it being indexed or on page order."""
+        assert "pullRequest(number: $number)" in mod._SELF_QUERY
+
+
+class TestTheReportNamesBothPullRequestsAndBothRemedies:
+    """The report is the whole output, so its content is part of the contract."""
+
+    def test_the_finding_names_the_issue_the_rival_and_both_remedies(self) -> None:
+        report = mod.render(mod.classify([2007], {2015: [2007], 1722: []}), "strands-labs/robots", 2016)
+        assert "duplicate-claim" in report
+        assert "strands-labs/robots#2016" in report
+        assert "| also claimed by | #2015 |" in report
+        assert "drops the keyword from" in report
+        assert "close it" in report
+
+    def test_a_clean_report_carries_no_remedy_section(self) -> None:
+        report = mod.render(mod.classify([1034], {1: []}), "o/n", 1035)
+        assert "unique-claim" in report
+        assert "What clears this" not in report
+
+    def test_a_report_for_a_pull_request_claiming_nothing_omits_the_compared_count(self) -> None:
+        """ "0 compared" would read as "the check could not see the other pull requests"."""
+        report = mod.render(mod.classify([], {}), "o/n", 7)
+        assert "no-claim" in report
+        assert "other open pull requests compared" not in report
+
+    def test_a_clean_report_states_how_many_were_compared(self) -> None:
+        report = mod.render(mod.classify([1034], {1: [], 2: []}), "o/n", 1035)
+        assert "| other open pull requests compared | 2 |" in report
+
+    def test_one_clause_per_shared_issue(self) -> None:
+        summary = mod.classify([20, 30], {5: [20], 6: [20, 30]}).summary
+        assert "#20 is also claimed by #5 and #6" in summary
+        assert "#30 is also claimed by #6" in summary
+        # Semicolons, not "and", between clauses that already contain one.
+        assert "#6 and #30" not in summary
+
+
+class TestTheExitStatusIsOneOnlyForTheFinding:
+    """What CI reads, as opposed to what the report says."""
+
+    @pytest.mark.parametrize(
+        ("claimed", "others", "expected"),
+        [
+            ((), {}, 0),
+            ((1034,), {1: ()}, 0),
+            ((2007,), {2015: (2007,)}, 1),
+        ],
+        ids=["no-claim", "unique-claim", "duplicate-claim"],
+    )
+    def test_the_exit_status(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        claimed: tuple[int, ...],
+        others: dict[int, tuple[int, ...]],
+        expected: int,
+    ) -> None:
+        monkeypatch.setattr(mod, "resolve_claim", lambda *_a, **_k: claimed)
+        monkeypatch.setattr(mod, "resolve_open_claims", lambda *_a, **_k: others)
+        status = mod.main(["--repo", "o/n", "--pr", "7", "--token", "t"])
+        capsys.readouterr()
+        assert status == expected
+
+    def test_a_lookup_failure_exits_zero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        def boom(*_a: object, **_k: object) -> None:
+            raise mod.ClaimSetUnreadable("nope.")
+
+        monkeypatch.setattr(mod, "resolve_claim", boom)
+        assert mod.main(["--repo", "o/n", "--pr", "7", "--token", "t"]) == 0
+        assert "unknown-claims" in capsys.readouterr().out
+
+    def test_a_pull_request_claiming_nothing_does_not_read_the_open_list(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """One API call saved on the majority case, and the reason it is safe."""
+
+        def unreached(*_a: object, **_k: object) -> None:
+            raise AssertionError("the open list must not be read when nothing is claimed")
+
+        monkeypatch.setattr(mod, "resolve_claim", lambda *_a, **_k: ())
+        monkeypatch.setattr(mod, "resolve_open_claims", unreached)
+        assert mod.main(["--repo", "o/n", "--pr", "7", "--token", "t"]) == 0
+        assert "no-claim" in capsys.readouterr().out
+
+
+class TestTheIntakeModeAsksAboutAnIssue:
+    """``--issue`` is the half that prevents the work rather than capping it.
+
+    Every observed pair opened inside one ~35-minute window, so the cheap question
+    is asked before the second pull request exists -- at which point there is no
+    pull request to compare, only an issue to look up.
+    """
+
+    def test_nothing_is_excluded_when_no_pull_request_exists_yet(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The ``--pr`` self-exclusion must not silently drop a rival at intake."""
+        page = {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [
+                            {"number": 7, "closingIssuesReferences": {"totalCount": 1, "nodes": [{"number": 42}]}},
+                            {"number": 8, "closingIssuesReferences": {"totalCount": 0, "nodes": []}},
+                        ],
+                    }
+                }
+            }
+        }
+        monkeypatch.setattr(mod, "_post", lambda *_a, **_k: page)
+        assert mod.resolve_open_claims("o/n", "t") == {7: (42,), 8: ()}
+
+    def test_an_issue_another_pull_request_claims_is_the_finding(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(mod, "resolve_open_claims", lambda *_a, **_k: {2015: (2007,)})
+        status = mod.main(["--repo", "o/n", "--issue", "2007", "--token", "t"])
+        out = capsys.readouterr().out
+        assert status == 1
+        assert "duplicate-claim" in out
+        assert "| issue | o/n#2007 |" in out
+        assert "| already claimed by | #2015 |" in out
+        assert "Read it before" in out
+
+    def test_an_unclaimed_issue_is_clean(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(mod, "resolve_open_claims", lambda *_a, **_k: {2015: (2007,), 1722: ()})
+        status = mod.main(["--repo", "o/n", "--issue", "2017", "--token", "t"])
+        out = capsys.readouterr().out
+        assert status == 0
+        assert "unique-claim" in out
+        assert "| issue | o/n#2017 |" in out
+
+    def test_the_intake_report_does_not_offer_the_review_remedy(self) -> None:
+        """At intake there is no second pull request whose keyword could be dropped."""
+        report = mod.render(mod.classify([2007], {2015: [2007]}), "o/n", None, 2007)
+        assert "What this means" in report
+        assert "What clears this" not in report
+
+    def test_the_review_mode_excludes_the_pull_request_under_test(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The asymmetry between the two modes, asserted rather than implied."""
+        seen: list[object] = []
+
+        def spy(_repo: str, _token: str, pr: int | None = None) -> dict[int, tuple[int, ...]]:
+            seen.append(pr)
+            return {}
+
+        monkeypatch.setattr(mod, "resolve_claim", lambda *_a, **_k: (2007,))
+        monkeypatch.setattr(mod, "resolve_open_claims", spy)
+        mod.main(["--repo", "o/n", "--pr", "2016", "--token", "t"])
+        capsys.readouterr()
+        assert seen == [2016], seen
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--repo", "o/n", "--token", "t"],
+            ["--repo", "o/n", "--pr", "1", "--issue", "2", "--token", "t"],
+        ],
+        ids=["neither", "both"],
+    )
+    def test_exactly_one_subject_is_required(self, argv: list[str]) -> None:
+        """Two subjects would silently answer only one of the two questions."""
+        with pytest.raises(SystemExit):
+            mod.main(argv)
+
+
+class TestTheGuidanceRecordsTheIntakeCheck:
+    """The CI half caps the cost; the intake half is what prevents it."""
+
+    @staticmethod
+    def _step_one() -> str:
+        """Return step 1 of the PR Workflow, whitespace-collapsed.
+
+        Bounded at step 2 so a qualifier reworded down into another step leaves
+        the slice and fails, and collapsed so a reflow cannot.
+        """
+        text = _AGENTS.read_text(encoding="utf-8")
+        start = text.index("1. Create the feature branch")
+        end = text.index("2. Make changes", start)
+        return " ".join(text[start:end].split())
+
+    def test_the_slice_is_step_one_and_nothing_else(self) -> None:
+        step_one = self._step_one()
+        assert len(step_one) > 1500, len(step_one)
+        assert "Make changes" not in step_one
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "check that no open pull request already claims the issue",
+            "every one of those had",
+            "property of the *set* of open ones",
+            "closingIssuesReferences",
+            "check_duplicate_claim.py --issue",
+            "prevents the authoring rather than capping it",
+        ],
+    )
+    def test_step_one_carries_the_intake_check(self, phrase: str) -> None:
+        assert phrase in self._step_one()
+
+    def test_the_guidance_names_the_escape_hatch(self) -> None:
+        """Two deliberate implementations are allowed -- one claim between them."""
+        step_one = self._step_one()
+        assert "exactly one should claim the close" in step_one
+        assert re.search(r"per #N|towards #N", step_one)


### PR DESCRIPTION
## Every check here reads one pull request at a time

`scripts/check_closing_reference.py` compares the issues a *title* claims against that same pull request's `closingIssuesReferences`. Both inputs are per-pull-request. A duplicate claim is a property of the **set** of open pull requests, so no single-pull-request assertion can reach it — and a branch claiming an issue another open branch already claims passes everything in this repository.

Over the last 100 pull requests (#1867 – #2016), three pairs did exactly that. Every row verified by reading the pull requests back:

| issue | pair | opened apart | abandoned | had reached | both landable? |
|---|---|---|---|---|---|
| #1942 | #1944, #1946 | 8m 32s | #1944 | `APPROVED` | no — `merge-tree` conflict |
| #1994 | #1995, #1996 | 31m 58s | #1995 | `APPROVED` | no — `merge-tree` conflict |
| #2007 | #2015, #2016 | 4m 9s | #2016 | `APPROVED` | yes |

The costly column is the fifth. What a duplicate wastes is not the authoring, it is a **review approval spent on a change that could never ship** — and review is the scarcest resource here (#1905 measures the same scarcity from the other side).

## The window is what decides where this belongs

All three pairs opened inside one ~35-minute window. That makes the collision an **intake** failure — the second pull request is opened before anything has observed the first — rather than a drift that accumulates. A check that reads two *existing* pull requests recovers the review cost but not the authoring cost. A check asked *before* the second one exists prevents both.

So the primary entry point is `--issue`, and AGENTS.md step 1 is where it is asked:

```
python3 scripts/check_duplicate_claim.py --issue <N>
```

`--pr N` is the sibling question for an existing pull request, and excludes itself from its own comparison — a pull request always shares its own claim.

**Run live on this repository just now**, both directions:

```
--issue 2017   unique-claim     #2017 is claimed by no open pull request (3 compared).
--issue 1034   duplicate-claim  #1034 is also claimed by #1035.        exit 1
```

## Three design decisions, each from a measurement

**No rule about which of the pair is at fault.** #2017 proposed failing "the newer of the two". Measured, that names the eventual survivor twice:

| issue | older | newer | merged |
|---|---|---|---|
| #1942 | #1944 | #1946 | **#1946** (the newer) |
| #1994 | #1995 | #1996 | **#1996** (the newer) |
| #2007 | #2015 | #2016 | #2015 |

Both numbers go in the report and the choice stays with the people who know what the two branches do. `TestThereIsNoAgeRule` keeps that corpus fact beside the code, so a later attempt to add the age rule fails and says why not.

**The open set is read through `repository.pullRequests(states: OPEN)`, not `search`.** Search is eventually consistent, so a pull request opened seconds ago may not be indexed — and the missing row would be a false clean inside exactly the ~35-minute window where every observed collision happened.

**An incomplete read is `unknown-claims`, never a pass.** A truncated link set, a truncated open-pull-request list, a paged answer with no cursor and an API error all reach it. The failure mode guarded against is not a false accusation but a *silent no-op*: a check that reports clean because it could not see the other pull requests is worse than no check, because it looks like one. That the lens really works was measured rather than assumed — #1961 records `projectItems` returning a false `0` under `GITHUB_TOKEN`, so both an Actions token and a personal token were checked and return identical link sets for all the open pull requests, including the one linking #1034.

## Scope

**No CI job in this change, and that is a scope statement rather than an oversight.** A `pull_request` job running `--pr` on `opened`/`edited` is the natural follow-up and would cap the review cost of a collision this query did not prevent. It needs a credential that can write `.github/workflows/`, which is a separate change. The intake half stands on its own: it is the half that stops the work being done twice, and it is complete as shipped. The script's docstring says so where a reader will find it.

Also deliberately out of scope, each with its reason in the docstring: a pull request that claims nothing anywhere (the residual #1961 is about — 18 of the last 30 merges would fail a rule requiring a claim, so this needs no answer to that question); whether the issue exists or is already closed; and drafts, which are **included**, because a draft's link is a real claim.

## Tests

55 tests over 9 classes, no existing test changed. `tests/test_pull_request_trigger_types.py` is untouched — with no workflow there is nothing to exempt.

The two that carry design decisions rather than behaviour are `TestThereIsNoAgeRule` (above) and `TestAnIncompleteAnswerIsNotAFinding`. `TestTheOpenListIsReadLiveAndPaginated` pins pagination, the self-exclusion, the cursor-less page and the `search`-vs-`repository` choice; `TestTheIntakeModeAsksAboutAnIssue` pins that intake excludes *nothing* — the `--pr` self-exclusion must not silently drop a rival when there is no pull request yet.

**Pre-fix proof** at `ce85113` (base `5757c1a`), tests kept, deliverables reverted:

| arm | reverted | result |
|---|---|---|
| 1 | everything | `FileNotFoundError: scripts/check_duplicate_claim.py` — collection error; the check does not exist on `main` |
| 2 | `AGENTS.md` only (script kept, so the module imports) | **8 failed / 47 passed**, all 8 in `TestTheGuidanceRecordsTheIntakeCheck` |

## Verification

At `ce85113`, base `5757c1a`, `aarch64`, `MUJOCO_GL=egl`:

| gate | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check strands_robots tests tests_integ` | 1103 files already formatted |
| `ruff check scripts/` + `ruff format --check scripts/` | clean, 7 files formatted |
| `mypy strands_robots tests tests_integ` | 14 errors, all in `examples/isaac_gs`, **0 outside** — error set byte-identical to a pristine `upstream/main` worktree of the same working copy, so environmental |
| `mypy --disallow-untyped-defs --warn-return-any scripts/check_duplicate_claim.py` | Success (`scripts/` is outside CI's lint scope, so it is checked explicitly, as the sibling script is) |
| `pytest tests` | **22740 passed, 257 skipped, 0 failed** in 509s (pristine `main` is 22685; +55 is this change) |
| root guards (changelog fragments/format, dangling doc refs, internal paths, unreachable statements) | 42 passed |
| `scripts/assemble_changelog.py --check` | OK (216 pending) |
| `scripts/check_merge_base_overlap.py` | No overlap — 0 paths changed on `upstream/main` since the branch diverged |

No visual artifact accompanies this: the change is one stdlib-only script, its tests, an `AGENTS.md` step and a changelog fragment, and touches no policy, simulation, rendering, recording or robot asset.

Refs #2017 — the intake half. The title carries no closing keyword before an issue number, so `closing-reference.yml` expects no link, which is correct: the CI half of that issue is not in this change.
