### PR TITLE
fix(training): refuse a PPO optimization-epoch count the update cannot honor

### DIFF
--- a/changelog.d/2021-ppo-optimization-epochs-domain.md
+++ b/changelog.d/2021-ppo-optimization-epochs-domain.md
@@ -1,0 +1,21 @@
+### Fixed: PPO refuses an optimization-epoch count it cannot honor
+
+`RLTrainSpec.num_learning_epochs` is the loop bound of PPO's entire optimizer
+step -- `for _ in range(spec.num_learning_epochs)` encloses every
+`optimizer.step()` in the update -- and nothing checked it. A non-positive value
+therefore took **no gradient step at all** while the run still collected its
+rollouts, wrote a deployable checkpoint and reported `status="success"`; the
+metrics read `0.0` rather than blank because the update averages its
+accumulators through `max(1, n_updates)`, so an epoch count that ran no
+minibatch reported plausible losses for a run that learned nothing. Measured
+over a 60-step run, `0` and `-3` both produced 0 optimizer steps and a
+checkpoint bit-identical to the untrained initialisation. `True` was a silent
+single epoch (12 optimizer steps instead of 24), and a non-integer raised a bare
+`TypeError` out of `range()` after the environment, the networks and a full
+rollout had already been built.
+
+`Trainer._optimization_epochs_problems` now holds the field to
+`positive_count_error`, the domain this repository already uses for a value
+consumed as a `range()` bound. It is scoped to the on-policy backend: FastSAC
+optimizes per gradient step from a replay buffer and has no epoch loop, so it
+must not report on a field it never reads.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -204,6 +204,15 @@ endpoints are inside the domain: `gamma=1` is the undiscounted episodic return
 and `gamma=0` a myopic agent that optimizes the immediate reward only. The
 FastSAC `tau` is bounded the same way, in `(0, 1]`.
 
+`num_learning_epochs` must be a positive integer, checked by `validate()` on the
+on-policy backend only (FastSAC optimizes per gradient step from a replay buffer
+and has no epoch loop). It is the loop bound of the entire optimizer step, so a
+non-positive value takes *no* gradient step while the run still collects its
+rollouts, writes a checkpoint and reports success - with losses of `0.0`,
+because the update averages its accumulators through `max(1, n_updates)`. `True`
+is likewise a silent single epoch, and a non-integer raises a bare `TypeError`
+out of `range()` after the environment and the networks are already built.
+
 ## Worked example
 
 `examples/training/train_ppo_reach.py` (on-policy) and `examples/training/train_fastsac_reach.py`

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -77,6 +77,15 @@ estimates an advantage trace, so per :class:`TrainSpec` FastSAC must not report
 on a field it never reads. They are nonetheless one contract: the trace decays
 by the *product* ``gamma * lam``, so bounding one factor does not bound the
 trace.
+
+:func:`optimization_epochs_problems` is the tenth, on the *optimization* axis:
+``num_learning_epochs``, the number of passes the on-policy update makes over
+each rollout batch. It is the loop bound of the entire optimizer step
+(``for _ in range(spec.num_learning_epochs)`` wraps every ``optimizer.step()``),
+so a non-positive value takes no gradient step at all while the run still
+collects its rollouts, writes a deployable checkpoint and reports success. It is
+scoped like :func:`gae_lambda_problems`: only the on-policy backend has an epoch
+loop, so FastSAC must not report on a field it never reads.
 """
 
 from __future__ import annotations
@@ -533,12 +542,18 @@ def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
     than left to the arithmetic that consumes it.
 
     ``lam``, the other factor of the trace-decay product, has its own gate for
-    that same scoping reason - see :func:`gae_lambda_problems`. The remaining PPO
-    coefficients (``clip_param``, ``num_learning_epochs``, ``entropy_coef``,
+    that same scoping reason - see :func:`gae_lambda_problems`, and
+    ``num_learning_epochs`` likewise in :func:`optimization_epochs_problems`.
+    The remaining PPO coefficients (``clip_param``, ``entropy_coef``,
     ``value_loss_coef``, ``max_grad_norm``, ``init_noise_std``) are out of scope
-    here and there: they weight loss terms and bound gradients rather than the
-    return, and each carries its own undecided question about whether zero is a
-    disabled mode, so they belong in a gate on that axis.
+    in all three: they weight loss terms and bound gradients rather than the
+    return, and for each of them zero has a candidate reading as a *disabled
+    mode* that this repository has not settled - ``entropy_coef`` is shipped
+    defaulting to ``0.0``, so zero is already a supported configuration;
+    ``max_grad_norm=0`` reads as "no clipping" in several RL codebases; and
+    ``init_noise_std=0`` is refused by ``torch`` itself, which rejects a
+    ``Normal`` of zero scale. Those are contract questions rather than defects,
+    so they are left to a gate that settles them.
 
     Args:
         spec: The spec to check.
@@ -611,4 +626,71 @@ def gae_lambda_problems(spec: TrainSpec, *, context: str) -> list[str]:
         A single-element list when ``lam`` cannot be honored; empty otherwise.
     """
     error = _closed_unit_interval_error(getattr(spec, "lam", 0.0), "lam", context)
+    return [error] if error is not None else []
+
+
+def optimization_epochs_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return optimization-epoch problems for an on-policy RL :class:`TrainSpec`.
+
+    ``num_learning_epochs`` is the number of passes the update makes over each
+    rollout batch, and it is consumed as a bare loop bound around the whole
+    optimizer step - ``for _ in range(spec.num_learning_epochs)`` encloses every
+    ``optimizer.step()`` in the PPO update. So the field does not merely scale
+    how much optimization happens; a non-positive value removes *all* of it, and
+    nothing downstream notices:
+
+    ==========================  =========  ==============  ==============
+    ``num_learning_epochs``     verdict    optimizer       reported
+                                           steps taken     losses
+    ==========================  =========  ==============  ==============
+    5 (the shipped default)     honored    24              real values
+    0                           accepted   **0**           all ``0.0``
+    -3                          accepted   **0**           all ``0.0``
+    ==========================  =========  ==============  ==============
+
+    Measured on this backend over a 60-step run: ``0`` and ``-3`` both report
+    ``status="success"``, take **zero** gradient steps, and write a checkpoint
+    whose parameters are bit-identical to each other - the untrained
+    initialisation. The losses read ``0.0`` rather than blank because the update
+    averages its accumulators through ``max(1, n_updates)``, so an epoch count
+    that ran no minibatch reports plausible metrics for a run that learned
+    nothing. A caller therefore gets a deployable-looking checkpoint, a
+    successful result and a metrics dict, with no signal anywhere that the
+    optimizer never ran.
+
+    The remaining values outside the domain fail in two further ways:
+
+    * ``True`` is a silent single epoch, because ``range(True)`` is
+      ``range(1)`` - the same run takes 12 optimizer steps instead of 24. That
+      is a different amount of optimization from the one requested, reported as
+      success.
+    * ``2.7``/``nan``/``inf``/``"5"``/``None`` raise a bare ``TypeError:
+      'float' object cannot be interpreted as an integer`` out of ``range()``,
+      naming neither the field nor the run, and only after the environment, the
+      networks and a full rollout have been built - exactly the deep stack trace
+      a read-only preflight exists to replace. No checkpoint is written at all.
+
+    The domain is therefore a positive integer, checked by
+    :func:`~strands_robots.utils.positive_count_error`, which is already the
+    domain this repository uses for a value consumed as a ``range()`` bound: an
+    integral float is not usable there (``range(2.0)`` raises) and ``bool`` must
+    be rejected rather than silently read as one.
+
+    Unlike ``gamma`` this is read by the on-policy backend only - FastSAC
+    optimizes per gradient step from a replay buffer and has no epoch loop over a
+    rollout batch - so it is scoped like :func:`gae_lambda_problems`: per
+    :class:`TrainSpec` a backend ignores the fields it does not support, so
+    reporting on one it never reads would be a false rejection.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single-element list when ``num_learning_epochs`` cannot be honored;
+        empty otherwise.
+    """
+    error = positive_count_error(getattr(spec, "num_learning_epochs", 1), "num_learning_epochs", context)
     return [error] if error is not None else []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -488,6 +488,35 @@ class Trainer(ABC):
 
         return gae_lambda_problems(spec, context=self.provider_name)
 
+    def _optimization_epochs_problems(self, spec: TrainSpec) -> list[str]:
+        """Optimization-epoch preflight for a backend with an epoch loop.
+
+        Returns a problem when :attr:`RLTrainSpec.num_learning_epochs` is not a
+        positive integer. A :meth:`validate` implementation whose update makes
+        ``num_learning_epochs`` passes over each rollout batch MUST call this,
+        because the field is the loop bound of the whole optimizer step: a
+        non-positive value takes no gradient step at all, and the run still
+        collects its rollouts, writes a checkpoint and reports success with
+        losses of ``0.0`` (the update averages through ``max(1, n_updates)``).
+        ``True`` is likewise a silent single epoch, and a non-integer raises a
+        bare ``TypeError`` out of ``range()`` after the environment and the
+        networks have been built.
+
+        Only a backend that loops over a rollout batch reads the field - an
+        off-policy backend optimizes per gradient step from a replay buffer - so
+        like :meth:`_gae_lambda_problems`, and unlike
+        :meth:`_discount_factor_problems`, a backend that does not read it MUST
+        NOT call this: per :class:`TrainSpec` a backend ignores the fields it
+        does not support, so reporting on one it never reads would be a false
+        rejection.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import optimization_epochs_problems
+
+        return optimization_epochs_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -156,6 +156,9 @@ class PpoTrainer(BaseRLAlgo):
         # lam is the other factor of the same trace decay: the recursion decays by
         # gamma * lam, so the gate above cannot bound the trace on its own.
         problems.extend(self._gae_lambda_problems(spec))
+        # num_learning_epochs is the loop bound of the whole optimizer step, so a
+        # non-positive value takes no gradient step while the run still succeeds.
+        problems.extend(self._optimization_epochs_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/tests/training/test_optimization_epochs_domain.py
+++ b/tests/training/test_optimization_epochs_domain.py
@@ -1,0 +1,316 @@
+"""The on-policy optimization-epoch count is checked against its domain.
+
+``RLTrainSpec.num_learning_epochs`` is the number of passes PPO's update makes
+over each rollout batch, and it is consumed as a bare loop bound around the
+whole optimizer step: ``for _ in range(spec.num_learning_epochs)`` encloses
+every ``self.optimizer.step()`` in ``PpoTrainer.update``. So the field does not
+merely scale how much optimization happens - a non-positive value removes all of
+it, and nothing downstream notices.
+
+Measured on this backend over a 60-step run before the gate existed: ``0`` and
+``-3`` both reported ``status="success"``, took **zero** gradient steps, and
+wrote a checkpoint whose parameters were bit-identical to each other, i.e. the
+untrained initialisation. The reported losses read ``0.0`` rather than blank
+because the update averages its accumulators through ``max(1, n_updates)``, so
+an epoch count that ran no minibatch reports plausible metrics for a run that
+learned nothing. ``True`` was a silent single epoch (12 optimizer steps instead
+of 24), and ``2.7``/``nan``/``inf``/``"5"``/``None`` raised a bare ``TypeError``
+out of ``range()`` after the environment, the networks and a full rollout had
+been built.
+
+Scoped to the on-policy backend: FastSAC optimizes per gradient step from a
+replay buffer and has no epoch loop over a rollout batch, so it must not report
+on a field it never reads. Every domain test here reaches the real ``validate``
+entry point, so it covers the wiring as well as the domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import optimization_epochs_problems
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.utils import positive_count_error
+
+# The one backend whose update loops over a rollout batch.
+ON_POLICY = "ppo"
+
+# Backends with no epoch loop - they must stay quiet about the field.
+NO_EPOCH_LOOP_BACKENDS = ("fast_sac", "mock")
+
+# Non-positive counts. These are the silent half: the run succeeds having taken
+# no gradient step, and reports losses of 0.0 through ``max(1, n_updates)``.
+NO_OPTIMIZATION: list[Any] = [0, -1, -3, -100]
+
+# Values ``range()`` cannot use as a bound, or reads as a different count than
+# the caller wrote. ``True`` is ``range(1)``; an integral float still raises.
+NOT_A_COUNT: list[Any] = [
+    True,
+    False,
+    2.7,
+    5.0,
+    float("nan"),
+    float("inf"),
+    "5",
+    None,
+    [5],
+    {"num_learning_epochs": 5},
+]
+
+UNUSABLE: list[Any] = [*NO_OPTIMIZATION, *NOT_A_COUNT]
+
+# A positive ``int`` is the whole domain.
+USABLE: list[Any] = [1, 2, 5, 5000]
+
+# ``range()`` itself accepts any object with ``__index__``, so these three DO
+# bound a loop (``len(range(np.int64(4))) == 4``) and are nonetheless refused:
+# the shared count domain is strict about ``int``, and it is the domain every
+# other count in this preflight already uses (``val_episodes``). The wider
+# alternative, ``positive_whole_number_error``, would accept the integral float
+# ``5.0`` that ``range()`` raises on - a guard accepting what its own consumer
+# refuses - so the narrower rule is the correct one and this is its cost.
+REFUSED_BY_THE_SHARED_COUNT_RULE: list[Any] = [np.int64(4), np.int32(3), np.uint8(2)]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """An otherwise-valid RL spec, so only the field under test is exercised."""
+    return RLTrainSpec(output_dir="/tmp/optimization_epochs_domain", env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+
+
+def _epoch_problems(provider: str, spec: RLTrainSpec) -> list[str]:
+    """Problems the real ``validate`` entry point reports about the field.
+
+    Filtered on the shared domains\' ``"{context}: {param} "`` message shape
+    rather than on a bare substring, so an unrelated problem can neither mask a
+    missing refusal nor be mistaken for one.
+    """
+    prefix = f"{provider}: num_learning_epochs "
+    return [p for p in create_trainer(provider).validate(spec) if p.startswith(prefix)]
+
+
+class TestTheOnPolicyBackendRefusesAnUnusableEpochCount:
+    """PPO refuses every value its epoch loop cannot honor."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.num_learning_epochs = value
+        assert _epoch_problems(ON_POLICY, spec), f"ppo accepted num_learning_epochs={value!r}"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_problem_names_the_field_and_the_domain(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.num_learning_epochs = value
+        (problem,) = _epoch_problems(ON_POLICY, spec)
+        assert "num_learning_epochs" in problem
+        assert "positive integer" in problem
+        assert repr(value) in problem, problem
+
+    @pytest.mark.parametrize("value", NO_OPTIMIZATION)
+    def test_a_non_positive_count_never_reaches_a_run(self, spec: RLTrainSpec, value: Any) -> None:
+        """``train`` is fail-closed on ``validate``, so no rollout is collected."""
+        spec.num_learning_epochs = value
+        result = create_trainer(ON_POLICY).train(spec)
+        assert result.status == "error"
+        assert "num_learning_epochs" in result.message
+
+
+class TestTheUsableDomainIsUntouched:
+    """Every count the epoch loop can honor still passes."""
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_positive_integer_is_accepted(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.num_learning_epochs = value
+        assert _epoch_problems(ON_POLICY, spec) == []
+
+    def test_the_shipped_default_is_accepted(self, spec: RLTrainSpec) -> None:
+        """Non-vacuity: the fixture is not refused before the field is set."""
+        assert spec.num_learning_epochs == 5
+        assert _epoch_problems(ON_POLICY, spec) == []
+
+    @pytest.mark.parametrize("value", REFUSED_BY_THE_SHARED_COUNT_RULE)
+    def test_a_numpy_integer_is_refused_although_range_would_accept_it(self, spec: RLTrainSpec, value: Any) -> None:
+        """The measured cost of using the strict shared count rule.
+
+        These spellings do bound a loop, so refusing them is a narrowing rather
+        than a fix. It is the right narrowing: the wider domain would accept the
+        integral float ``5.0``, which ``range()`` raises on, and every other
+        count in this preflight is already held to this same rule. No caller in
+        the repository passes one - the examples, docs and tests all write a
+        plain ``int`` literal.
+        """
+        assert len(range(value)) == int(value)
+        spec.num_learning_epochs = value
+        assert _epoch_problems(ON_POLICY, spec)
+
+
+class TestABackendWithNoEpochLoopStaysQuiet:
+    """A backend that never reads the field must not report on it."""
+
+    @pytest.mark.parametrize("provider", NO_EPOCH_LOOP_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_reports_nothing_about_the_field(self, provider: str, spec: RLTrainSpec, value: Any) -> None:
+        spec.num_learning_epochs = value
+        assert _epoch_problems(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", NO_EPOCH_LOOP_BACKENDS)
+    def test_but_it_still_refuses_a_field_it_does_read(self, provider: str, spec: RLTrainSpec) -> None:
+        """Non-vacuity: silence is scoping, not a preflight that reports nothing.
+
+        ``learning_rate`` is the field chosen here because it is the universal
+        one - every backend reads it, including the non-RL ``mock``, which has no
+        discount factor to report on either.
+        """
+        spec.learning_rate = -1.0
+        prefix = f"{provider}: learning_rate "
+        assert [p for p in create_trainer(provider).validate(spec) if p.startswith(prefix)]
+
+
+class TestTheDomainIsTheSharedCountRule:
+    """The gate contributes no rule of its own beyond reading the field."""
+
+    @pytest.mark.parametrize("value", [*UNUSABLE, *USABLE, *REFUSED_BY_THE_SHARED_COUNT_RULE])
+    def test_it_agrees_with_the_shared_count_domain(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.num_learning_epochs = value
+        shared = positive_count_error(value, "num_learning_epochs", "ppo")
+        assert (optimization_epochs_problems(spec, context="ppo") == []) is (shared is None)
+
+    def test_the_message_is_the_shared_one_verbatim(self, spec: RLTrainSpec) -> None:
+        spec.num_learning_epochs = 0
+        assert optimization_epochs_problems(spec, context="ppo") == [
+            positive_count_error(0, "num_learning_epochs", "ppo")
+        ]
+
+    def test_the_context_names_the_backend_that_refused(self, spec: RLTrainSpec) -> None:
+        spec.num_learning_epochs = 0
+        (problem,) = _epoch_problems(ON_POLICY, spec)
+        assert problem.startswith("ppo: ")
+
+
+# --- why the domain exists: the field bounds the whole optimizer step --------
+
+
+def _ppo_update_source() -> str:
+    """Source of ``PpoTrainer.update`` - read via the class, not a path."""
+    from strands_robots.training.rl.ppo import PpoTrainer
+
+    return inspect.getsource(PpoTrainer.update)
+
+
+class TestTheFieldBoundsTheEntireOptimizerStep:
+    """The premise the domain rests on, asserted rather than described.
+
+    If a later change moves ``optimizer.step()`` out of the epoch loop, or stops
+    averaging through ``max(1, n_updates)``, these fail and the gate's stated
+    reason gets re-examined instead of quietly becoming wrong.
+    """
+
+    def test_the_epoch_range_encloses_the_optimizer_step(self) -> None:
+        tree = ast.parse(textwrap.dedent(_ppo_update_source()))
+        loops = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.For) and ast.unparse(node.iter) == "range(spec.num_learning_epochs)"
+        ]
+        assert len(loops) == 1, "the epoch loop is no longer bounded by the field"
+        stepped = [
+            ast.unparse(call)
+            for call in ast.walk(loops[0])
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) and call.func.attr == "step"
+        ]
+        assert "self.optimizer.step()" in stepped, stepped
+
+    def test_a_non_positive_bound_iterates_zero_times(self) -> None:
+        """So a non-positive count takes no gradient step at all."""
+        assert [len(range(n)) for n in (5, 1, 0)] == [5, 1, 0]
+        assert len(range(-3)) == 0
+
+    def test_true_is_a_silent_single_epoch(self) -> None:
+        """Which is why ``bool`` must be refused rather than read as one."""
+        assert len(range(True)) == 1
+
+    def test_a_non_integer_bound_raises_out_of_range(self) -> None:
+        bound: Any = 2.7
+        with pytest.raises(TypeError, match="cannot be interpreted as an integer"):
+            range(bound)
+
+    def test_the_reported_losses_are_averaged_through_a_clamp(self) -> None:
+        """Which is why a zero-epoch run reports 0.0 rather than nothing."""
+        assert "max(1, n_updates)" in _ppo_update_source()
+        assert 0.0 / max(1, 0) == 0.0
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(optimization_epochs_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_epoch_count(source: str) -> bool:
+    """Does *source* read ``spec.num_learning_epochs``?"""
+    return any(
+        isinstance(node, ast.Attribute)
+        and node.attr == "num_learning_epochs"
+        and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_optimization_epochs_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheEpochCountDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.num_learning_epochs`` must route it through the
+    shared gate, so a second on-policy backend that starts looping over a
+    rollout batch with the field fails this test until it does.
+    """
+
+    def test_every_module_that_reads_it_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name
+            for p in _training_modules()
+            if _reads_the_epoch_count(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules read spec.num_learning_epochs without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_the_epoch_count(p.read_text())}
+        assert readers == {"ppo.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading the field without the gate is really reported."""
+        planted = "def validate(self, spec):\n    return [] if spec.num_learning_epochs else []\n"
+        assert _reads_the_epoch_count(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_bound(self) -> None:
+        """A local copy of the bound would drift from the shared rule."""
+        offenders = [
+            p.name
+            for p in _training_modules()
+            if "spec.num_learning_epochs <" in p.read_text() or "spec.num_learning_epochs >" in p.read_text()
+        ]
+        assert offenders == [], f"modules compare spec.num_learning_epochs locally: {offenders}"


### PR DESCRIPTION
## The defect

`RLTrainSpec.num_learning_epochs` is the number of passes PPO's update makes over each rollout batch. It is consumed as a bare loop bound around the **whole optimizer step** -- `for _ in range(spec.num_learning_epochs)` encloses every `self.optimizer.step()` in `PpoTrainer.update` -- and nothing checked it. So the field does not merely scale how much optimization happens: a non-positive value removes all of it, and nothing downstream notices.

Measured over a real 60-step PPO run on the SO-100 reach task (seed 0, `rollout_steps=20`, `num_mini_batches=4`):

| `num_learning_epochs` | preflight | run | optimizer steps | reported losses |
|---|---|---|---|---|
| `5` (the shipped default) | silent | `success` | 60 | real values |
| `0` | silent | `success` | **0** | all `0.0` |
| `-3` | silent | `success` | **0** | all `0.0` |
| `True` | silent | `success` | **12** | real values |
| `2.7` / `nan` / `inf` / `"5"` / `None` | silent | bare `TypeError` | 0 | none |

Three things make the first two rows the finding rather than merely a wrong number:

1. **The checkpoint is the untrained network, and that is measured against a control.** The bit-exact actor-critic parameter sum of the checkpoint written by `0` and by `-3` is `17.9251941755865118` -- identical to 16 digits to a control run of `5` epochs whose `update()` was replaced by a no-op. The honored run writes `18.0997320867186318`. So a caller gets a deployable-looking `policy.pt` containing the initialisation.
2. **The metrics look plausible.** They read `0.0` rather than blank because the update averages its accumulators through `max(1, n_updates)`, so an epoch count that ran no minibatch reports a full metrics dict for a run that learned nothing. There is no signal anywhere -- not the status, not the metrics, not the checkpoint -- that the optimizer never ran.
3. **`True` is a silent single epoch**, because `range(True)` is `range(1)`: a fifth of the requested optimization, reported as success.

The non-integer rows are the loud half, and they are still worth refusing: the `TypeError` names neither the field nor the run and arrives only after the environment, the networks and a full rollout have been built -- exactly the deep stack trace a read-only preflight exists to replace.

## The change

`optimization_epochs_problems` holds the field to `positive_count_error` -- **no new helper**: that is already the domain this repository uses for a value consumed as a `range()` bound, and `val_episodes` is held to the same rule. `Trainer._optimization_epochs_problems` exposes it, and `PpoTrainer.validate` calls it directly after the trace-decay gate. `train()` is fail-closed on `validate()`, so a refused value now collects no rollout and writes no checkpoint.

It is a separate gate rather than part of `discount_factor_problems` for the scoping reason `_validate.py` already documents: FastSAC optimizes per gradient step from a replay buffer and has no epoch loop, so per `TrainSpec` ("a backend reads the fields it supports and ignores the rest") it must not report on a field it never reads. That tolerance side is pinned too.

The `discount_factor_problems` docstring previously listed `num_learning_epochs` among the coefficients left for "a gate on that axis"; it now points at this one.

### Measured evidence

![PPO optimization-epoch domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/ppo-optimization-epochs/epochs_evidence.png)

Both halves of that figure come from one script run unchanged in two worktrees (`upstream/main` and this branch), each dump recording its own tree; the compose step asserts every number it draws. Script and raw dumps: [`artifacts/ppo-optimization-epochs`](https://github.com/cagataycali/robots/tree/artifacts/ppo-optimization-epochs).

### No regression, measured bit-exactly

The honored run is **bit-identical across both trees** -- 60 optimizer steps and an actor-critic parameter sum of `18.0997320867186318` on each. Nothing about a usable configuration changes.

## One deliberate narrowing, stated because it is a real cost

`range()` accepts any object with `__index__`, so `np.int64(4)` does bound a loop and is now refused. That is a narrowing, not a fix, and it is the right one: the wider alternative (`positive_whole_number_error`) would accept the integral float `5.0`, which `range()` raises on -- a guard accepting what its own consumer refuses. Every other count in this preflight is already held to the strict rule, and no caller in the repository passes a NumPy integer (the examples, docs and tests all write a plain `int` literal). `TestTheUsableDomainIsUntouched::test_a_numpy_integer_is_refused_although_range_would_accept_it` pins it with that reasoning.

## Out of scope, with the reason measured per field

The remaining PPO coefficients (`clip_param`, `entropy_coef`, `value_loss_coef`, `max_grad_norm`, `init_noise_std`) are left alone. For each of them zero has a candidate reading as a *disabled mode* that has not been settled here, and that is a contract question rather than a defect:

- `entropy_coef` **ships defaulting to `0.0`**, so zero is already a supported configuration.
- `max_grad_norm=0` reads as "no clipping" in several RL codebases (it zeroes the gradient here).
- `init_noise_std=0` is refused by `torch` itself, which rejects a `Normal` of zero scale.

`num_learning_epochs` has no such reading: it is a `range()` bound over the optimizer, its default is 5, and zero means the run takes no gradient step at all.

## Tests

`tests/training/test_optimization_epochs_domain.py` -- 6 classes, 20 tests, 102 parametrized cases, GL-free, 0.21s. Beyond the domain and the wiring it pins:

- `train()` really refuses (`status="error"`, message names the field) so no rollout is collected;
- the gate contributes **no rule of its own** -- it agrees with `positive_count_error` over the whole probe set and emits its message verbatim;
- FastSAC and `mock` stay silent about the field *while still refusing a field they do read* (the non-vacuity half);
- **the premise the domain rests on**, by AST: the `range(spec.num_learning_epochs)` loop encloses `self.optimizer.step()`, and the update averages through `max(1, n_updates)`. If a later change moves the optimizer step out of that loop, these fail and the stated reason gets re-examined rather than quietly becoming wrong;
- one owner: the reader set is derived from the tree, so a second on-policy backend that starts reading the field fails until it routes through the gate. Includes a planted-reader meta-test and a non-vacuity assertion on the scan root.

## Verification

Run at `e5a76ec7` in a clone whose `strands_robots` resolves to this tree.

- **Pre-fix proof** -- call sites (`base.py`, `rl/ppo.py`) reverted to `upstream/main`, the gate module and the tests kept: **37 failed / 65 passed**. The AST guard's failure names the adrift module (`['ppo.py']`). The 65 that pass are the direct-gate parity tests, the shared-domain agreement tests and the AST premise assertions -- none of which depend on the wiring, which is why they are kept rather than deleted.
- **Full suite**: `MUJOCO_GL=egl python -m pytest tests` -> **22842 passed, 257 skipped, 0 failed** (526s). Zero existing-test churn.
- **Lint**: `ruff check` clean, `ruff format --check` clean (1104 files), `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/`** (the 14 in `examples/isaac_gs` are byte-identical to a pristine `upstream/main` worktree of the same working copy, i.e. environmental).
- **Merge-base overlap**: `scripts/check_merge_base_overlap.py` reports no overlap -- this branch edits nothing `upstream/main` has changed since they diverged.
