### PR TITLE
refactor(policies/vera): delete the inert n_action_steps knob

### DIFF
--- a/changelog.d/2013-vera-delete-inert-n-action-steps.md
+++ b/changelog.d/2013-vera-delete-inert-n-action-steps.md
@@ -1,0 +1,32 @@
+### Removed: the inert VERA `n_action_steps` knob
+
+`VeraConfig.n_action_steps` was documented twice as the "deploy chunk size
+(actions executed per infer)" and read by nothing. It was public in four
+spellings at once - a `VeraPolicy` keyword, a `VeraConfig` field, a
+`VERA_N_ACTION_STEPS` deploy variable, and an entry in the `vera` provider's
+`config_keys` - and each of them reported success. `VeraPolicy(n_action_steps=8)`
+constructed, stored `8`, and executed chunks of whatever length the server
+returned; `-7` and `"eight"` were stored just as happily, and the launched server
+argv was byte-identical in every case, in both the subprocess and docker launch
+modes.
+
+The chunk length is a server-side quantity: `_infer` returns the raw `[H, D]`
+array the server sent and `_chunk_to_action_dicts` maps all `H` rows into the
+queue, so there was no local slicing step for the field to be the width of. The
+neighbouring `sample_steps` shows what wired-up looks like on the same dataclass
+- it is forwarded as `--sample-steps` and as `VERA_SAMPLE_STEPS` - and
+`n_action_steps` appeared in the server runner not at all.
+
+It is deleted rather than validated. A value domain would have refused `-7` and
+then still honored nothing, which is a worse contract than an unvalidated knob,
+not a better one; that is why #2012 settled the neighbouring `render_width` on
+the shared media pixel domain and deliberately left this field alone.
+
+**Breaking:** passing `n_action_steps` to `VeraPolicy` or `VeraConfig`, or
+through `create_policy("vera", ...)`, now raises `TypeError` instead of being
+accepted and ignored. Every such caller was already getting no effect from it,
+and the deploy variable is now simply unread. Removing the registry entry in the
+same change is load-bearing: `VeraPolicy` takes no `**kwargs`, so a `config_keys`
+entry left behind would have turned a silently-ignored value into a `TypeError`
+on the factory path. The general form of that registry-vs-signature guard is
+tracked as #2022.

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -144,7 +144,6 @@ class VeraConfig:
             ``VERA_CKPT_ROOT`` for the server subprocess.
         sample_steps: WAN denoise steps (deploy default is 10; ``None`` uses the
             planner yaml's value).
-        n_action_steps: Deploy chunk size (actions executed per infer).
         tracker_backend: IDM point tracker backend override.
         motion_plan_scale: IDM motion-plan scale override (live-tunable).
         teacache: Enable the near-lossless DiT teacache speedup (default True).
@@ -167,7 +166,6 @@ class VeraConfig:
     ckpt_root: Path | None = None
     wan_ckpt_root: Path | None = None  # frozen Wan2.1-T2V-1.3B base (mimicgen/omni); env VERA_WAN_CKPT_ROOT
     sample_steps: int | None = None
-    n_action_steps: int | None = None
     tracker_backend: str | None = None
     motion_plan_scale: float | None = None
     teacache: bool = True
@@ -260,8 +258,6 @@ class VeraConfig:
             self.wan_ckpt_root = Path(wr) if wr else None
         if self.sample_steps is None:
             self.sample_steps = _env_int("VERA_SAMPLE_STEPS")
-        if self.n_action_steps is None:
-            self.n_action_steps = _env_int("VERA_N_ACTION_STEPS")
         if self.tracker_backend is None:
             self.tracker_backend = _env("VERA_TRACKER_BACKEND")
         if self.motion_plan_scale is None:

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -163,7 +163,6 @@ class VeraPolicy(Policy):
         text_prompt: Optional text conditioning for the video planner.
         ckpt_root: Root of downloaded VERA checkpoints (``VERA_CKPT_ROOT``).
         auto_launch_server: Launch + manage the server subprocess on first use.
-        n_action_steps: Deploy chunk size (actions per infer).
         dynamics_run_id: Jacobian/IDM checkpoint id (per-embodiment default).
         tracker_backend: IDM point-tracker backend override.
         motion_plan_scale: IDM motion-plan scale (applied live via ``configure``).
@@ -197,7 +196,6 @@ class VeraPolicy(Policy):
         text_prompt: str | None = None,
         ckpt_root: Any = None,
         auto_launch_server: bool = True,
-        n_action_steps: int | None = None,
         dynamics_run_id: str | None = None,
         tracker_backend: str | None = None,
         motion_plan_scale: float | None = None,
@@ -234,7 +232,6 @@ class VeraPolicy(Policy):
             text_prompt=text_prompt,
             ckpt_root=ckpt_root,
             auto_launch_server=auto_launch_server,
-            n_action_steps=n_action_steps,
             dynamics_run_id=dynamics_run_id,
             tracker_backend=tracker_backend,
             motion_plan_scale=motion_plan_scale,

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -232,7 +232,6 @@
         "text_prompt",
         "ckpt_root",
         "auto_launch_server",
-        "n_action_steps",
         "dynamics_run_id",
         "tracker_backend",
         "motion_plan_scale",

--- a/tests/policies/vera/test_vera_n_action_steps_removed.py
+++ b/tests/policies/vera/test_vera_n_action_steps_removed.py
@@ -1,0 +1,242 @@
+"""``n_action_steps`` was a public VERA knob that no code read, so it is deleted.
+
+The field was documented twice as "deploy chunk size (actions executed per
+infer)" and consumed nowhere. On ``94de3a5`` its complete set of occurrences
+under the shipped provider was six lines - a docstring, a dataclass field, a
+``VERA_N_ACTION_STEPS`` environment override, a second docstring, a
+``VeraPolicy`` keyword and the line forwarding that keyword into
+:class:`~strands_robots.policies.vera.config.VeraConfig` - and not one of them
+was a read.
+
+Measured before the deletion, no server and no ``vera`` package:
+
+| spelling | what it did |
+| --- | --- |
+| ``VeraConfig(n_action_steps=8)`` | stored ``8`` |
+| ``VeraConfig(n_action_steps=-7)`` | stored ``-7`` |
+| ``VeraConfig(n_action_steps="eight")`` | stored ``'eight'`` |
+| ``VeraPolicy(n_action_steps=8)`` | constructed, ``config.n_action_steps == 8`` |
+| ``VERA_N_ACTION_STEPS=8`` | stored ``8`` |
+| ``build_policy_kwargs("vera", n_action_steps=8)`` | ``{... 'n_action_steps': 8}`` |
+
+and in every row the launched server argv was identical - subprocess mode:
+
+    ['python', '-m', 'vera.server.start_vera_server', '--embodiment', 'mimicgen',
+     '--host', '127.0.0.1', '--port', '8800', '--vis-port', '8801',
+     '--teacache-thresh', '0.1']
+
+with no ``--n-action-steps`` flag; and docker mode, whose argv is built by a
+different class, carrying no ``VERA_N_ACTION_STEPS`` container variable either.
+``server_env()`` reported no key containing ``ACTION``.
+
+The chunk length is a server-side quantity: ``_infer`` returns the raw ``[H, D]``
+array the server sent and ``_chunk_to_action_dicts`` maps all ``H`` rows into the
+queue, so there was no local slicing step for this field to be the width of.
+
+**Why deletion rather than a value domain.** A domain would have refused ``-7``
+and then still honored nothing - a knob that validates its input and ignores it,
+which is a worse contract than an unvalidated one. That is the reason #2012
+settled the neighbouring ``render_width`` on the shared media pixel domain and
+deliberately left this field alone: ``render_width`` *is* read, on a hot path,
+which is what makes a guard at the config funnel worth having.
+
+**The fourth spelling is the one that makes a half-deletion break at runtime.**
+``strands_robots/registry/policies.json`` advertised ``n_action_steps`` in the
+``vera`` provider's ``config_keys``, and ``build_policy_kwargs`` forwards exactly
+the extra kwargs that appear there. ``VeraPolicy.__init__`` takes no ``**kwargs``,
+so a registry entry left behind after the keyword is removed turns
+``create_policy("vera", n_action_steps=8)`` from a silently-ignored value into
+``TypeError: unexpected keyword argument`` - a regression strictly worse than the
+defect. :class:`TestTheRegistryAgreesWithTheConstructor` pins the whole set
+rather than this one name, so the same class of half-deletion cannot recur on
+another ``vera`` key.
+
+Everything here is offline: no socket, no ``vera`` package, no GPU. The provider
+module is imported for its signature only, and the ``msgpack``-dependent
+websocket client is never constructed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.vera import VeraConfig
+from strands_robots.policies.vera.provider import VeraPolicy
+from strands_robots.policies.vera.server_runner import make_server_runner
+from strands_robots.registry.policies import build_policy_kwargs, get_policy_provider
+
+FIELD = "n_action_steps"
+ENV_VAR = "VERA_N_ACTION_STEPS"
+
+#: The shipped VERA provider package - the tree the deleted field lived in.
+VERA_PKG = Path(VeraConfig.__module__.replace(".", "/")).parent
+
+
+def _config(**kwargs: Any) -> VeraConfig:
+    """Build a config through the funnel, splatted so a removed name reaches it.
+
+    mypy does not narrow a ``**dict[str, Any]`` splat, which is what lets a test
+    pass a keyword the dataclass no longer declares.
+    """
+    return VeraConfig(**kwargs)
+
+
+def _launch_argv(mode: str) -> list[str]:
+    """Argv the given ``server_mode`` would launch the VERA server with.
+
+    The two modes are built by two different classes reached through
+    ``make_server_runner`` - ``VeraServerRunner._build_command`` for a local
+    subprocess and ``DockerServerRunner._build_run_command`` for the container -
+    so a test that builds only one of them cannot speak for both. Nothing is
+    started; only the command is composed.
+    """
+    runner = make_server_runner(VeraConfig(embodiment="mimicgen", sample_steps=10, server_mode=mode))
+    builder = getattr(runner, "_build_command", None) or runner._build_run_command
+    return list(builder())
+
+
+def _vera_sources() -> dict[str, str]:
+    """Every ``.py`` file of the shipped VERA provider package, by name."""
+    root = Path(__file__).resolve().parents[3] / VERA_PKG
+    files = {p.name: p.read_text(encoding="utf-8") for p in sorted(root.glob("*.py"))}
+    # Non-vacuity: the scan root must actually resolve to the provider package.
+    assert "config.py" in files and "provider.py" in files, f"unexpected scan root {root}"
+    return files
+
+
+# --------------------------------------------------------------------------- #
+# The three spellings inside the provider
+# --------------------------------------------------------------------------- #
+class TestTheFieldIsGone:
+    def test_the_dataclass_no_longer_declares_it(self):
+        """It was ``n_action_steps: int | None = None`` on :class:`VeraConfig`."""
+        assert FIELD not in {f.name for f in dataclasses.fields(VeraConfig)}
+
+    def test_a_default_config_carries_no_such_attribute(self):
+        """A leftover class attribute would keep ``cfg.n_action_steps`` readable
+        even with the dataclass field gone, which is the shape a partial
+        deletion takes.
+        """
+        assert not hasattr(VeraConfig(embodiment="mimicgen"), FIELD)
+
+    @pytest.mark.parametrize("value", [8, -7, 0, "eight", 2.5, None, True])
+    def test_the_config_refuses_the_keyword(self, value):
+        """Every value the field used to store is now refused by name.
+
+        ``None`` and ``0`` are in the set deliberately: a stale caller passing
+        the old default must be told, not silently accepted.
+        """
+        with pytest.raises(TypeError, match=FIELD):
+            _config(embodiment="mimicgen", **{FIELD: value})
+
+    def test_the_policy_refuses_the_keyword(self):
+        """It was a ``VeraPolicy`` keyword too, forwarded into the config.
+
+        Python binds arguments before the body runs, so this raises without
+        reaching the websocket client - no ``msgpack`` and no socket needed.
+        """
+        with pytest.raises(TypeError, match=FIELD):
+            VeraPolicy(embodiment="mimicgen", **{FIELD: 8})
+
+    def test_it_is_not_a_policy_constructor_parameter(self):
+        assert FIELD not in inspect.signature(VeraPolicy.__init__).parameters
+
+    def test_the_environment_override_is_gone(self, monkeypatch):
+        """``VERA_N_ACTION_STEPS`` was read in ``__post_init__``.
+
+        A deploy variable that survives the field is the worst leftover: it
+        reports nothing at all, on a path nobody constructs by hand.
+        """
+        monkeypatch.setenv(ENV_VAR, "8")
+        assert not hasattr(VeraConfig(embodiment="mimicgen"), FIELD)
+
+    def test_the_name_appears_nowhere_in_the_provider_package(self):
+        """The premise of the deletion, asserted against the tree.
+
+        The field's justification was that nothing read it. That is now
+        expressible as an absence, which is a stronger property than any
+        behavioural assertion about a field that no longer exists: if a later
+        change reintroduces the name in any spelling - a docstring promising the
+        knob included - this fails and the decision in #2013 gets re-taken
+        rather than quietly undone.
+        """
+        offenders = sorted(name for name, src in _vera_sources().items() if FIELD in src)
+        assert offenders == [], f"{FIELD} reappeared in {offenders}"
+
+    def test_the_deploy_variable_appears_nowhere_either(self):
+        offenders = sorted(name for name, src in _vera_sources().items() if ENV_VAR in src)
+        assert offenders == [], f"{ENV_VAR} reappeared in {offenders}"
+
+
+# --------------------------------------------------------------------------- #
+# The fourth spelling: the policy registry
+# --------------------------------------------------------------------------- #
+class TestTheRegistryAgreesWithTheConstructor:
+    def test_the_key_is_gone_from_the_vera_provider(self):
+        assert FIELD not in get_policy_provider("vera")["config_keys"]
+
+    def test_an_extra_kwarg_is_no_longer_forwarded(self):
+        """``build_policy_kwargs`` keeps exactly the extras naming a config key.
+
+        Before the registry edit this returned ``{'n_action_steps': 8, ...}``,
+        which ``create_policy`` splatted into a constructor that no longer takes
+        it.
+        """
+        assert FIELD not in build_policy_kwargs("vera", **{FIELD: 8})
+
+    def test_every_vera_config_key_is_a_real_constructor_parameter(self):
+        """The guard that makes a half-deletion impossible on any ``vera`` key.
+
+        ``VeraPolicy.__init__`` declares no ``**kwargs``, so a ``config_keys``
+        entry with no matching parameter is a ``TypeError`` for every caller
+        arriving through the factory - and nothing else in the tree compares the
+        two. Scoped to ``vera`` because that is the provider this change edits;
+        the general form across all providers is #2022.
+        """
+        params = inspect.signature(VeraPolicy.__init__).parameters
+        assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()), (
+            "VeraPolicy grew a **kwargs, which makes a stale registry key silent again "
+            "and weakens this guard - reconsider it rather than deleting it"
+        )
+        orphans = [k for k in get_policy_provider("vera")["config_keys"] if k not in params]
+        assert orphans == [], f"config_keys entries with no VeraPolicy parameter: {orphans}"
+
+    def test_the_guard_would_catch_a_planted_orphan(self):
+        """Non-vacuity for the test above: an unknown key must be reported."""
+        keys = [*get_policy_provider("vera")["config_keys"], "definitely_not_a_parameter"]
+        params = inspect.signature(VeraPolicy.__init__).parameters
+        assert [k for k in keys if k not in params] == ["definitely_not_a_parameter"]
+
+
+# --------------------------------------------------------------------------- #
+# The knob one line away that *is* wired up stays wired up
+# --------------------------------------------------------------------------- #
+class TestTheNeighbouringLiveKnobIsUntouched:
+    """``sample_steps`` is what "wired up" looks like on this dataclass.
+
+    It sits one line from where ``n_action_steps`` was and is forwarded to the
+    server in both launch modes. Pinned here so this deletion is demonstrably a
+    removal of the inert field and not of a live one - a test suite that would
+    pass with ``sample_steps`` deleted too proves nothing about which field went.
+    """
+
+    def test_sample_steps_still_reaches_the_subprocess_argv(self):
+        argv = _launch_argv("subprocess")
+        assert "--sample-steps" in argv
+        assert argv[argv.index("--sample-steps") + 1] == "10"
+
+    def test_sample_steps_still_reaches_the_docker_environment(self):
+        assert "VERA_SAMPLE_STEPS=10" in _launch_argv("docker")
+
+    @pytest.mark.parametrize("mode", ["subprocess", "docker"])
+    def test_no_launch_path_grew_a_substitute_for_the_deleted_field(self, mode):
+        """With the field gone, the remaining check is that neither launch path
+        acquired an equivalent under another name.
+        """
+        argv = _launch_argv(mode)
+        assert not [a for a in argv if "action_steps" in a.lower()], argv

--- a/tests/policies/vera/test_vera_render_width_domain.py
+++ b/tests/policies/vera/test_vera_render_width_domain.py
@@ -391,12 +391,17 @@ class TestNeighbouringWidthAxesStayOutOfScope:
         req = _run(8)
         assert req["context_rgb"].shape[1:3] == (8, 8)
 
-    def test_n_action_steps_is_still_read_by_nothing(self):
-        """``VeraConfig.n_action_steps`` is documented as the deploy chunk size
-        and is consumed by no code on any path - the chunk length comes from the
-        server's response. It is therefore neither validated nor honored, and
-        deciding between implementing and deleting it is a separate question
-        (tracked as its own issue) rather than part of a width domain.
+    def test_n_action_steps_is_gone_rather_than_unvalidated(self):
+        """The neighbouring ``n_action_steps`` was documented as the deploy chunk
+        size and read by nothing, so it was deleted rather than given a domain.
+
+        This replaces the boundary pin that asserted the old behaviour
+        (``n_action_steps=-7`` accepted and ignored). A domain here would have
+        refused ``-7`` and then still honored nothing, which is a worse contract
+        than an unvalidated knob, not a better one - so this axis is settled by
+        removal. The full account, including the fourth spelling in the policy
+        registry, lives in ``test_vera_n_action_steps_removed.py``; asserted here
+        so the width domain cannot silently re-acquire an inert neighbour.
         """
-        cfg = _config(embodiment="mimicgen", n_action_steps=-7)
-        assert cfg.n_action_steps == -7  # accepted, and read by nothing
+        with pytest.raises(TypeError, match="n_action_steps"):
+            _config(embodiment="mimicgen", n_action_steps=-7)

--- a/tests/policies/vera/test_vera_unit.py
+++ b/tests/policies/vera/test_vera_unit.py
@@ -75,7 +75,6 @@ class TestConfig:
         monkeypatch.setenv("VERA_VIS_PORT", "xyz")
         monkeypatch.setenv("VERA_RENDER_WIDTH", "wide")
         monkeypatch.setenv("VERA_SAMPLE_STEPS", "ten")
-        monkeypatch.setenv("VERA_N_ACTION_STEPS", "")
         monkeypatch.setenv("VERA_MOTION_PLAN_SCALE", "fast")
 
         c = VeraConfig(embodiment="pusht")
@@ -86,7 +85,6 @@ class TestConfig:
         assert c.render_width == 252  # pusht per-embodiment default
         # Non-numeric optional knobs stay unset (planner yaml decides).
         assert c.sample_steps is None
-        assert c.n_action_steps is None
         assert c.motion_plan_scale is None
 
 


### PR DESCRIPTION
Closes #2013.

## The decision

#2013 asked for a contract call rather than a defect fix: `VeraConfig.n_action_steps` is not *mis*-validated, it is **read by nothing**, so the question was whether to implement it or delete it. This takes option 1 - delete - and the reason is that option 2 cannot be made honest without inventing a behaviour the provider does not have.

The chunk length is a server-side quantity. `_infer` returns the raw `[H, D]` array the server sent, `_chunk_to_action_dicts` maps all `H` rows into the queue, and the provider's own docstring says so: *"one infer returns `action_horizon` steps"* - `action_horizon` being the server's, not this field. There is no local slicing step for `n_action_steps` to be the width of, so implementing it would mean adding one, then deciding what happens to the rows it discards, then deciding whether shortening the executed horizon below what the video planner dreamed is meaningful at all. That is new behaviour under the name of a fix.

A value domain was the other tempting move and is worse than doing nothing: it would refuse `-7` and then still honor nothing, converting a silently-ignored knob into one that validates its input and ignores it. That is precisely why #2012 settled the neighbouring `render_width` on the shared media pixel domain and deliberately left this field alone - `render_width` **is** read, on a hot path, after the server is up, and neither half of that argument transfers here.

## Measured

Before the deletion, offline - no server, no `vera` package, no GPU:

| spelling | what it did |
| --- | --- |
| `VeraConfig(n_action_steps=8)` | stored `8` |
| `VeraConfig(n_action_steps=-7)` | stored `-7` |
| `VeraConfig(n_action_steps="eight")` | stored `'eight'` |
| `VeraConfig(n_action_steps=2.5)` | stored `2.5` |
| `VeraPolicy(n_action_steps=8)` | constructed, `config.n_action_steps == 8` |
| `VERA_N_ACTION_STEPS=8` | stored `8` |
| `build_policy_kwargs("vera", n_action_steps=8)` | `{..., 'n_action_steps': 8}` |

and in every row the launched server command was byte-identical. Subprocess mode:

```
['python', '-m', 'vera.server.start_vera_server', '--embodiment', 'mimicgen',
 '--host', '127.0.0.1', '--port', '8800', '--vis-port', '8801',
 '--teacache-thresh', '0.1']
```

no `--n-action-steps` flag; docker mode, built by a different class, carried no `VERA_N_ACTION_STEPS` container variable either; and `server_env()` reported no key containing `ACTION`.

The neighbour one line away shows what wired-up looks like on this dataclass - `sample_steps` reaches the server as `--sample-steps 10` in subprocess mode and `VERA_SAMPLE_STEPS=10` in docker mode. `n_action_steps` appeared in `server_runner.py` **not at all**.

## A fourth spelling the issue's own measurement missed

#2013 called its six-line list "the complete list", and it was complete for the grep it ran - scoped to `strands_robots/policies/vera/`. There is a seventh line outside that directory: `strands_robots/registry/policies.json` advertises `n_action_steps` in the `vera` provider's `config_keys`, and `build_policy_kwargs` forwards exactly the extra kwargs appearing there.

This is load-bearing rather than tidy-up. `VeraPolicy.__init__` declares **no** `**kwargs`, so had the registry entry stayed behind, `create_policy("vera", n_action_steps=8)` would have gone from silently ignoring the value to `TypeError: unexpected keyword argument` - a regression strictly worse than the defect, introduced by its fix, and invisible to every existing test: `grep -rn config_keys tests/` finds presence checks and filtering behaviour, never a comparison against a constructor signature.

So `TestTheRegistryAgreesWithTheConstructor` pins the whole `vera` key set rather than this one name, which makes the same half-deletion impossible on any other `vera` key. It also asserts that `VeraPolicy` has not grown a `**kwargs` - that would make a stale registry key silent again and weaken the guard, so the message says to reconsider it rather than delete it.

**Deliberately scoped to `vera`.** The general form across all twelve providers is #2022, filed with the per-provider measurement: the tree is consistent today, `cosmos3` and `vera` are the two classes without `**kwargs` (hard `TypeError`), and the other ten swallow a stale key silently - which is the same inert-public-knob shape rather than a safer one. A repo-wide guard changes the contract for eleven providers this PR does not touch and needs a judgement about whether a registry key routed through `**kwargs` is legitimate; that judgement belongs in its own change.

## The change

Seven lines removed across three files, plus tests and a fragment:

- `config.py` - the docstring line, the `n_action_steps: int | None = None` field, and the `VERA_N_ACTION_STEPS` override in `__post_init__`.
- `provider.py` - the docstring line, the `VeraPolicy.__init__` keyword, and the line forwarding it into `VeraConfig`.
- `registry/policies.json` - the `vera` `config_keys` entry.

No docs change is owed: `docs/policies/vera.md` never mentioned the field (the `n_action_steps` occurrences remaining in `docs/` and elsewhere in the tree are LeRobot's own model-config attribute, an unrelated quantity that *is* read, by `_auto_detect_actions_per_step`).

## Tests

`tests/policies/vera/test_vera_n_action_steps_removed.py` - 3 classes, 22 tests, GL-free and socket-free, 0.10s. Beyond asserting the four spellings are refused it pins:

- **the premise, as an absence** - the identifier and the deploy variable appear in *no* `.py` file of the shipped provider package. The field's whole justification was that nothing read it, and after deletion that is expressible as a scan rather than as a behavioural claim about a field that no longer exists, so a later change reintroducing the name in any spelling - a docstring promising the knob included - fails here and re-takes the decision instead of quietly undoing it. The scan asserts its own root resolves to the provider package, so it cannot pass vacuously;
- **`None` and `0` are refused too** - a stale caller passing the old default gets told, not silently accepted;
- **the registry guard's non-vacuity**, via a planted orphan key;
- **the neighbouring live knob is untouched** - `sample_steps` still reaches both launch modes, routed through `make_server_runner` because the two modes are built by two different classes and a test building only one cannot speak for both. Without this, a suite that would also pass with `sample_steps` deleted proves nothing about which field went.

`test_vera_render_width_domain.py::test_n_action_steps_is_still_read_by_nothing` asserted exactly the behaviour #2013 questioned, so it is **replaced** rather than deleted, per the premise-test guidance in AGENTS.md and the issue's own boundary-pin note. `test_vera_unit.py` drops `VERA_N_ACTION_STEPS` from the malformed-env family test, since the knob no longer exists to be fed a malformed value.

## Verification

Run at `5b098b7` in a clone whose `strands_robots` resolves to this tree.

- **Pre-fix proof** - source reverted to `main`, the new and edited tests kept: **17 failed / 100 passed**. The 100 that pass are the neighbouring-live-knob assertions and the planted-orphan meta-test, neither of which depends on the deletion, which is why they are kept rather than written to fail.
- **Affected suites**: `tests/policies/vera tests/registry tests/test_registry.py` -> **1022 passed, 13 skipped, 0 failed**.
- **Wider slice, read as a delta**: `tests/policies` (less `lerobot_local`, no `torch` here) + changelog + dependency-audit -> **10 failed, 2086 passed** on this branch against **10 failed, 2064 passed** on a pristine `main` worktree of the same working copy. Same 10 failures both sides, all `ModuleNotFoundError` for optional deps this host lacks (`robot_descriptions`, `qpsolvers`); the entire effect of the branch is **+22 passes** - exactly the 22 tests it adds.
- **Lint**: `ruff check` and `ruff format --check` clean on every file this PR touches; the repo-wide counts are identical on this branch and pristine `main` (`examples/` only). `mypy strands_robots/policies/vera tests/policies/vera` -> **Success: no issues found in 26 source files**.
- **Composition**: `scripts/check_merge_base_overlap.py` reports no overlap, and the branch is `behind_by: 0` against `main` at `f654dd68`, so the tree CI tests is the merge result and no composition run is owed.
