### PR TITLE
fix(training): refuse a FastSAC temperature learning rate the optimizer cannot honor

### DIFF
--- a/changelog.d/2024-fastsac-temperature-learning-rate.md
+++ b/changelog.d/2024-fastsac-temperature-learning-rate.md
@@ -1,0 +1,44 @@
+### Fixed: FastSAC refuses an entropy-temperature learning rate its optimizer cannot be driven by
+
+`FastSacTrainer` builds two optimizers from two separate learning-rate fields --
+`learning_rate` for the actor and both critics, and `alpha_lr` for the entropy
+temperature -- and passes each straight to `torch.optim.Adam(..., lr=...)`. Only
+the first went through the shared optimization preflight, so every failure mode
+that gate documents stayed reachable through the second field, which
+`RLTrainSpec` documents as the "Learning rate for the temperature optimizer
+(SAC)".
+
+Measured on a 40-timestep run starting from `init_alpha=1.0`. `alpha_lr=0` (and
+`0.0`, and `False`) builds the optimizer and moves the temperature by nothing, so
+`autotune_alpha=True` silently behaves exactly like `autotune_alpha=False` while
+reporting the automatic temperature it was asked for. `inf` also builds, and
+sends the temperature to an infinity on the first step; because the temperature
+multiplies the log-probability in the *actor* loss the damage is not confined to
+it, and the run finished `status="success"` with a checkpoint whose largest
+parameter magnitude was `inf`. `True` was a silent rate of `1.0`, over three
+thousand times the `3e-4` default. A negative value and `nan` are refused by
+`torch.optim.Adam`, and a `str` / `None` / `list` raises a bare `TypeError`
+naming neither the field nor the value -- but all four only in `setup`, after the
+env and both networks are built, past the point `validate()` documents itself as
+running before.
+
+`validate()` now checks the field against the same
+`positive_finite_number_error` domain as the first rate, via a new
+`temperature_learning_rate_problems` gate reached through
+`Trainer._temperature_learning_rate_problems`. Both rates are reported in the
+same preflight rather than one round at a time. Unlike `learning_rate` there is
+no `None` sentinel to exempt: `alpha_lr` is annotated `float` with a concrete
+`3e-4` default, so `None` is a value the optimizer cannot take. The check is
+inert unless `autotune_alpha` is set, which is the only branch that constructs a
+temperature optimizer, and scoped to the off-policy backend -- PPO and the mock
+trainer never read the field and must not report on it. A structural test derives
+the set of modules in scope from the tree, so a second backend that starts
+driving a temperature optimizer with the field fails until it routes through the
+gate.
+
+`init_alpha` and `target_entropy`, the two neighbouring fields of the same
+temperature block, are out of scope here: `init_alpha=0` yields a temperature of
+zero, which is a coherent "no entropy bonus" configuration rather than an
+unusable value, and `target_entropy` is signed by construction (it defaults to
+`-num_actions`), so both need a different domain and a decision this change does
+not make.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -213,6 +213,17 @@ because the update averages its accumulators through `max(1, n_updates)`. `True`
 is likewise a silent single epoch, and a non-integer raises a bare `TypeError`
 out of `range()` after the environment and the networks are already built.
 
+FastSAC builds two optimizers from two learning-rate fields - `learning_rate`
+for the actor and both critics, `alpha_lr` for the entropy temperature - so
+when `autotune_alpha` is set `alpha_lr` must be a positive finite number too,
+checked by the same `validate()`. `alpha_lr=0` builds the temperature
+optimizer and never moves it, so the temperature stays at `init_alpha` and the
+automatic tuning the spec asked for silently does not happen; `inf` sends it
+to an infinity on the first step, and because the temperature multiplies the
+log-probability in the actor loss the resulting checkpoint holds non-finite
+parameters. Both previously reported success. It is inert when
+`autotune_alpha=False`, which builds no temperature optimizer.
+
 ## Worked example
 
 `examples/training/train_ppo_reach.py` (on-policy) and `examples/training/train_fastsac_reach.py`

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -86,6 +86,16 @@ so a non-positive value takes no gradient step at all while the run still
 collects its rollouts, writes a deployable checkpoint and reports success. It is
 scoped like :func:`gae_lambda_problems`: only the on-policy backend has an epoch
 loop, so FastSAC must not report on a field it never reads.
+
+:func:`temperature_learning_rate_problems` is the eleventh, on the same
+*optimization* axis as :func:`learning_rate_problems` and for its sibling
+field. FastSAC builds *two* optimizers from two separate learning-rate fields -
+``learning_rate`` for the actor and both critics, and ``alpha_lr`` for the
+entropy temperature - and passes each straight to
+``torch.optim.Adam(..., lr=...)``, so the failure modes
+:func:`learning_rate_problems` documents apply to the second field verbatim.
+It is a separate gate for the same reason as :func:`gae_lambda_problems`: only
+the off-policy backend tunes a temperature.
 """
 
 from __future__ import annotations
@@ -693,4 +703,73 @@ def optimization_epochs_problems(spec: TrainSpec, *, context: str) -> list[str]:
         empty otherwise.
     """
     error = positive_count_error(getattr(spec, "num_learning_epochs", 1), "num_learning_epochs", context)
+    return [error] if error is not None else []
+
+
+def temperature_learning_rate_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return entropy-temperature learning-rate problems for a :class:`TrainSpec`.
+
+    ``alpha_lr`` is documented on :class:`~strands_robots.training.rl.RLTrainSpec`
+    as the "Learning rate for the temperature optimizer (SAC)", and FastSAC hands
+    it to the same constructor as the already-guarded ``learning_rate`` two lines
+    above it::
+
+        self.actor_optimizer = torch.optim.Adam(actor_params, lr=spec.learning_rate)
+        self.critic_optimizer = torch.optim.Adam(critic_params, lr=spec.learning_rate)
+        ...
+        self.alpha_optimizer = torch.optim.Adam([self.log_alpha], lr=spec.alpha_lr)
+
+    So every failure mode :func:`learning_rate_problems` documents applies to it
+    unchanged, and each was measured on a 40-timestep FastSAC run whose
+    temperature starts at ``init_alpha=1.0``:
+
+    * ``0`` (and ``0.0``, and ``False``, which is ``0`` to the optimizer) builds
+      the optimizer and moves ``log_alpha`` by nothing, so the temperature stays
+      at ``init_alpha`` for the whole run. ``autotune_alpha=True`` then behaves
+      exactly like ``autotune_alpha=False`` while reporting the automatic
+      temperature it was asked for - the "runs the full work and updates no
+      weight" pathology, on the one parameter whose job is to adapt.
+    * ``inf`` also builds, and the first step sends ``log_alpha`` to an infinity.
+      Because ``alpha`` multiplies the log-probability in the *actor* loss, the
+      damage is not confined to the temperature: the run finished with
+      ``status="success"`` and a checkpoint whose largest parameter magnitude was
+      ``inf``.
+    * ``True`` is a silent learning rate of ``1.0``, over three thousand times
+      the ``3e-4`` default, and moved the temperature 407x further in the same
+      40 steps.
+    * A negative value and ``nan`` *are* refused, by ``torch.optim.Adam``
+      (``ValueError: Invalid learning rate``), and a ``str`` / ``None`` /
+      ``list`` raises a bare ``TypeError: '<=' not supported between instances of
+      'float' and 'str'`` naming neither the field nor the value. Both arrive in
+      :meth:`~strands_robots.training.rl.base_algo.BaseRLAlgo.setup`, after the
+      env and both networks are built - past the point :meth:`Trainer.validate`
+      documents itself as running before.
+
+    Unlike ``learning_rate`` there is no ``None`` sentinel to exempt: the field is
+    annotated ``float`` with a concrete ``3e-4`` default, so ``None`` is a value
+    the temperature optimizer cannot take rather than a request for a default.
+
+    The value is read only when ``autotune_alpha`` is set, which is the only
+    branch that constructs a temperature optimizer, so a spec that tunes no
+    temperature is not reported on - refusing a field that call path never reads
+    would be a false rejection. A plain :class:`TrainSpec` has no
+    ``autotune_alpha`` at all and is likewise silent.
+
+    Only the off-policy backend tunes a temperature, so this is scoped like
+    :func:`gae_lambda_problems` rather than :func:`learning_rate_problems`: a
+    backend that does not read the field MUST NOT call this.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single-element list when a tuned temperature's ``alpha_lr`` cannot be
+        honored; empty when it is usable or no temperature is being tuned.
+    """
+    if not getattr(spec, "autotune_alpha", False):
+        return []
+    error = positive_finite_number_error(getattr(spec, "alpha_lr", 3e-4), "alpha_lr", context)
     return [error] if error is not None else []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -517,6 +517,36 @@ class Trainer(ABC):
 
         return optimization_epochs_problems(spec, context=self.provider_name)
 
+    def _temperature_learning_rate_problems(self, spec: TrainSpec) -> list[str]:
+        """Entropy-temperature learning-rate preflight, for backends that tune one.
+
+        Returns a problem when a spec asking for an automatically tuned
+        temperature carries an :attr:`RLTrainSpec.alpha_lr` that is not a positive
+        finite number. A :meth:`validate` implementation that builds a temperature
+        optimizer MUST call this **in addition to**
+        :meth:`_learning_rate_problems`: the two fields are separate learning
+        rates on separate optimizers, so guarding the one that drives the actor
+        and critics leaves the temperature's own rate unchecked. ``alpha_lr=0``
+        freezes the temperature at ``init_alpha`` for the whole run - the
+        requested automatic tuning silently does not happen - and ``alpha_lr=inf``
+        writes a checkpoint holding non-finite parameters, both under a
+        successful result.
+
+        Only the off-policy backend tunes a temperature, so unlike
+        :meth:`_learning_rate_problems` a backend that does not read the field
+        MUST NOT call this: per :class:`TrainSpec` a backend ignores the fields it
+        does not support, so reporting on one it never reads would be a false
+        rejection. For the same reason the check is inert unless the spec's
+        ``autotune_alpha`` is set, since that is the only branch that constructs a
+        temperature optimizer.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+        """
+        from strands_robots.training._validate import temperature_learning_rate_problems
+
+        return temperature_learning_rate_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -142,6 +142,10 @@ class FastSacTrainer(BaseRLAlgo):
         # gamma discounts the return this backend optimizes; the arithmetic that
         # consumes it never judges it, so the shared interval domain does.
         problems.extend(self._discount_factor_problems(spec))
+        # alpha_lr is a second learning rate on a second optimizer: the actor
+        # and critics take spec.learning_rate, the entropy temperature takes
+        # this one, and only the first is covered above.
+        problems.extend(self._temperature_learning_rate_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/tests/training/test_temperature_learning_rate_domain.py
+++ b/tests/training/test_temperature_learning_rate_domain.py
@@ -1,0 +1,337 @@
+"""FastSAC's second learning rate is checked against the same domain as its first.
+
+FastSAC builds two optimizers from two separate learning-rate fields::
+
+    self.actor_optimizer = torch.optim.Adam(actor_params, lr=spec.learning_rate)
+    self.critic_optimizer = torch.optim.Adam(critic_params, lr=spec.learning_rate)
+    ...
+    self.alpha_optimizer = torch.optim.Adam([self.log_alpha], lr=spec.alpha_lr)
+
+``learning_rate`` went through the shared optimization gate; ``alpha_lr`` - which
+``RLTrainSpec`` documents as the "Learning rate for the temperature optimizer
+(SAC)" - reached the same constructor unchecked, so every failure mode that gate
+documents stayed reachable through the second field. Measured on a 40-timestep
+run starting from ``init_alpha=1.0``: ``alpha_lr=0`` builds the optimizer and
+moves the temperature by nothing, so ``autotune_alpha=True`` silently behaves
+like ``autotune_alpha=False``; ``inf`` sends it to an infinity on the first step
+and, because the temperature multiplies the log-probability in the *actor* loss,
+the run finished ``status="success"`` with a checkpoint whose largest parameter
+magnitude was ``inf``; ``True`` was a silent rate of ``1.0``. A negative value
+and ``nan`` are refused by ``torch.optim.Adam``, and a ``str`` / ``None`` /
+``list`` raises a bare ``TypeError``, but all four only in ``setup`` - after the
+env and both networks are built.
+
+Scoped twice over: only the off-policy backend tunes a temperature, and within it
+only the ``autotune_alpha`` branch builds the optimizer, so both the other
+backends and a spec that tunes nothing must stay quiet. Every test reaches the
+real ``validate`` entry point, so the wiring is covered as well as the domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import temperature_learning_rate_problems
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.utils import positive_finite_number_error
+
+# The one backend that tunes an entropy temperature.
+OFF_POLICY = "fast_sac"
+
+# Backends that read ``learning_rate`` but never ``alpha_lr``.
+NO_TEMPERATURE_BACKENDS = ("ppo", "mock")
+
+# Values the temperature optimizer cannot be driven by. ``0`` and ``False`` build
+# it and never move it; ``inf`` poisons it and the actor with it; ``True`` is a
+# silent rate of 1.0; the rest raise, but only once ``setup`` runs.
+UNUSABLE: list[Any] = [
+    0,
+    0.0,
+    -1e-3,
+    -1,
+    False,
+    True,
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    "3e-4",
+    None,
+    [3e-4],
+    {},
+]
+
+# Rates a temperature optimizer can actually be driven by, including the spellings
+# a config or a probed value arrives as.
+USABLE: list[Any] = [3e-4, 1e-5, 1.0, 0.5, np.float64(3e-4), np.float32(1e-4)]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """An otherwise-valid RL spec, so only the field under test is exercised."""
+    return RLTrainSpec(  # type: ignore[return-value]
+        output_dir="/tmp/temperature_learning_rate_domain",
+        env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+    )
+
+
+def _alpha_lr_problems(provider: str, spec: RLTrainSpec) -> list[str]:
+    """Problems the real ``validate`` entry point reports about ``alpha_lr``.
+
+    Filtered on the shared domains' ``"{context}: {param} "`` message shape rather
+    than on a bare ``"alpha_lr"`` substring, so an unrelated problem can neither
+    mask a missing refusal nor be mistaken for one.
+    """
+    return [p for p in create_trainer(provider).validate(spec) if p.startswith(f"{provider}: alpha_lr ")]
+
+
+class TestTheOffPolicyBackendRefusesAnUnusableTemperatureRate:
+    """FastSAC refuses every value its temperature optimizer cannot be driven by."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.alpha_lr = value
+        assert _alpha_lr_problems(OFF_POLICY, spec), f"fast_sac accepted alpha_lr={value!r}"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_problem_names_the_field_and_the_value(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.alpha_lr = value
+        (problem,) = _alpha_lr_problems(OFF_POLICY, spec)
+        assert problem.startswith("fast_sac: alpha_lr must be > 0"), problem
+        assert repr(value) in problem, problem
+
+    def test_a_refusal_does_not_hide_the_first_learning_rate(self, spec: RLTrainSpec) -> None:
+        """Both optimizers' rates are reported at once, not one round at a time."""
+        spec.alpha_lr = 0.0
+        spec.learning_rate = 0.0
+        problems = create_trainer(OFF_POLICY).validate(spec)
+        assert any(p.startswith("fast_sac: alpha_lr ") for p in problems), problems
+        assert any(p.startswith("fast_sac: learning_rate ") for p in problems), problems
+
+
+class TestTheUsableDomainIsUntouched:
+    """A rate the optimizer can be driven by is not newly refused."""
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_usable_rate_reports_nothing(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.alpha_lr = value
+        assert _alpha_lr_problems(OFF_POLICY, spec) == []
+
+    def test_the_default_spec_reports_nothing(self, spec: RLTrainSpec) -> None:
+        """The shipped ``3e-4`` default must not trip the new gate."""
+        assert _alpha_lr_problems(OFF_POLICY, spec) == []
+
+
+class TestTheCheckAppliesOnlyWhenATemperatureIsTuned:
+    """``autotune_alpha`` selects whether the field is read at all.
+
+    ``setup`` builds a temperature optimizer only on that branch, so refusing the
+    field when it is unset would reject a value the run never reads. Both
+    directions are pinned, or "drop the condition" and "drop the check" would each
+    pass.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_a_spec_that_tunes_nothing_is_not_reported_on(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.autotune_alpha = False
+        spec.alpha_lr = value
+        assert _alpha_lr_problems(OFF_POLICY, spec) == []
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_a_spec_that_tunes_a_temperature_is_reported_on(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.autotune_alpha = True
+        spec.alpha_lr = value
+        assert _alpha_lr_problems(OFF_POLICY, spec), f"fast_sac accepted alpha_lr={value!r} while tuning"
+
+    def test_tuning_is_on_by_default(self, spec: RLTrainSpec) -> None:
+        """Non-vacuity: the guarded branch is the one the default spec takes."""
+        assert spec.autotune_alpha is True
+
+
+class TestABackendWithNoTemperatureStaysQuiet:
+    """A backend that never reads the field must not report on it."""
+
+    @pytest.mark.parametrize("provider", NO_TEMPERATURE_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_reports_nothing_about_the_temperature_rate(self, provider: str, spec: RLTrainSpec, value: Any) -> None:
+        spec.alpha_lr = value
+        assert _alpha_lr_problems(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", NO_TEMPERATURE_BACKENDS)
+    def test_silence_is_scoping_rather_than_an_empty_preflight(self, provider: str, spec: RLTrainSpec) -> None:
+        """The same spec's *own* learning rate is still refused by those backends."""
+        spec.learning_rate = 0.0
+        problems = create_trainer(provider).validate(spec)
+        assert any(p.startswith(f"{provider}: learning_rate ") for p in problems), problems
+
+
+class TestNoneIsAValueRatherThanASentinel:
+    """``alpha_lr`` has a concrete default, so ``None`` is not a request for one.
+
+    ``TrainSpec.learning_rate`` is annotated ``float | None`` and documents ``None``
+    as "use the backend's own default", so its gate exempts it. ``alpha_lr`` is
+    annotated ``float`` with no such sentinel anywhere in the hierarchy, so
+    ``None`` is a value the temperature optimizer cannot take rather than a request
+    for a default. The asymmetry is deliberate and pinned here so it is not
+    smoothed away in either direction.
+    """
+
+    def test_a_none_temperature_rate_is_refused(self, spec: RLTrainSpec) -> None:
+        spec.alpha_lr = None  # type: ignore[assignment]
+        assert _alpha_lr_problems(OFF_POLICY, spec)
+
+    def test_a_none_learning_rate_is_still_accepted(self, spec: RLTrainSpec) -> None:
+        # ``RLTrainSpec`` narrows the annotation to ``float``, but the gate still
+        # honours the sentinel the base contract documents - which is the whole
+        # asymmetry under test, so the assignment is deliberate.
+        spec.learning_rate = None  # type: ignore[assignment]
+        problems = [p for p in create_trainer(OFF_POLICY).validate(spec) if "learning_rate" in p]
+        assert problems == []
+
+    def test_only_the_first_rate_declares_the_sentinel(self) -> None:
+        """Executable premise for the asymmetry above: the annotations differ.
+
+        The basis is the declared type rather than the default - ``RLTrainSpec``
+        narrows ``learning_rate`` to a concrete ``1e-4``, so comparing defaults
+        would find no asymmetry at all while the gates still, correctly, differ.
+        """
+        import dataclasses
+
+        from strands_robots.training.base import TrainSpec
+
+        base = {f.name: f for f in dataclasses.fields(TrainSpec)}
+        rl = {f.name: f for f in dataclasses.fields(RLTrainSpec)}
+        assert base["learning_rate"].type == "float | None"
+        assert rl["alpha_lr"].type == "float"
+        assert rl["alpha_lr"].default == pytest.approx(3e-4)
+
+
+class TestTheGateAddsNothingToTheSharedDomain:
+    """The gate contributes the scoping, not a second numeric rule.
+
+    Every verdict is the shared ``positive_finite_number_error`` domain's, so the
+    two cannot drift on what counts as a usable rate.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE + USABLE)
+    def test_the_verdict_is_the_shared_domains(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.alpha_lr = value
+        shared = positive_finite_number_error(value, "alpha_lr", OFF_POLICY)
+        assert bool(_alpha_lr_problems(OFF_POLICY, spec)) is (shared is not None)
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_message_is_the_shared_domains_verbatim(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.alpha_lr = value
+        (problem,) = _alpha_lr_problems(OFF_POLICY, spec)
+        assert problem == positive_finite_number_error(value, "alpha_lr", OFF_POLICY)
+
+
+class TestGuardingTheFirstRateDoesNotGuardTheSecond:
+    """The measured consequence: a run whose temperature never adapts.
+
+    This is why the second field needed its own call rather than being covered by
+    the first. ``alpha_lr=0`` leaves ``log_alpha`` where it started, so the
+    temperature the spec asked to have tuned stays at ``init_alpha`` - while a
+    usable rate moves it - and the pre-fix ``validate`` reported neither.
+    """
+
+    def test_a_zero_temperature_rate_freezes_the_temperature(self) -> None:
+        torch = pytest.importorskip("torch")
+        from strands_robots.training.rl.fast_sac import FastSacTrainer
+
+        def _alpha_after_one_step(alpha_lr: float) -> tuple[float, float]:
+            log_alpha = torch.tensor(0.0, requires_grad=True)  # init_alpha = 1.0
+            opt = torch.optim.Adam([log_alpha], lr=alpha_lr)
+            before = float(log_alpha.detach().exp())
+            (-(log_alpha * torch.tensor(-2.0))).backward()
+            opt.step()
+            return before, float(log_alpha.detach().exp())
+
+        frozen_before, frozen_after = _alpha_after_one_step(0.0)
+        tuned_before, tuned_after = _alpha_after_one_step(3e-4)
+        assert frozen_before == frozen_after == 1.0, (frozen_before, frozen_after)
+        assert tuned_after != tuned_before, (tuned_before, tuned_after)
+        # And the field that *was* guarded cannot express this: it drives a
+        # different optimizer entirely.
+        assert "alpha_lr" in inspect.getsource(FastSacTrainer.setup)
+
+    def test_the_two_rates_drive_different_optimizers(self) -> None:
+        """Executable premise: the guarded field cannot stand in for this one."""
+        from strands_robots.training.rl.fast_sac import FastSacTrainer
+
+        source = inspect.getsource(FastSacTrainer.setup)
+        assert "lr=spec.learning_rate" in source
+        assert "lr=spec.alpha_lr" in source
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(temperature_learning_rate_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_temperature_rate(source: str) -> bool:
+    """Does *source* read ``spec.alpha_lr``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "alpha_lr" and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_temperature_learning_rate_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheTemperatureRateDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.alpha_lr`` must route it through the shared gate, so
+    a second off-policy backend that starts driving a temperature optimizer with
+    the field fails this test until it does.
+    """
+
+    def test_every_module_that_reads_it_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name
+            for p in _training_modules()
+            if _reads_the_temperature_rate(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules read spec.alpha_lr without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_the_temperature_rate(p.read_text())}
+        assert readers == {"fast_sac.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading the field without the gate is really reported."""
+        planted = "def setup(self, spec):\n    return Adam([x], lr=spec.alpha_lr)\n"
+        assert _reads_the_temperature_rate(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        """A local comparison would drift from the shared rule."""
+        offenders = [
+            p.name
+            for p in _training_modules()
+            if "spec.alpha_lr <" in p.read_text() or "spec.alpha_lr >" in p.read_text()
+        ]
+        assert offenders == [], f"modules compare spec.alpha_lr locally: {offenders}"


### PR DESCRIPTION
## The defect

`FastSacTrainer` builds **two** optimizers from **two** separate learning-rate fields, and passes each straight to the same constructor:

```python
self.actor_optimizer  = torch.optim.Adam(actor_params,  lr=spec.learning_rate)
self.critic_optimizer = torch.optim.Adam(critic_params, lr=spec.learning_rate)
...
self.alpha_optimizer  = torch.optim.Adam([self.log_alpha], lr=spec.alpha_lr)
```

`learning_rate` went through the shared optimization preflight. `alpha_lr` -- which `RLTrainSpec` documents as the *"Learning rate for the temperature optimizer (SAC)"* -- did not, so every failure mode `learning_rate_problems` already documents stayed reachable through the second field. `validate()` bounds nine other fields on this backend, including `tau` with a complete interval, so the layer demonstrably knows a coefficient needs a domain; this one field was missed.

## Measured

Real 160-timestep FastSAC runs on the SO-100 reach task, `init_alpha=1.0`, `seed=0`. Every value below passed `validate()` on `main`:

| `alpha_lr` | on `main` | temperature | checkpoint |
|---|---|---|---|
| *omitted* (`3e-4`) | ran | `1.0 -> 0.99103` (adapts) | finite |
| `0` / `0.0` / `False` | ran, `status="success"` | **`1.0 -> 1.0` -- never moves** | finite |
| `True` | ran | `1.0 -> 9.3e-14` (a silent rate of `1.0`) | finite |
| `inf` | ran, `status="success"` | `1.0 -> 0.0` | **largest parameter magnitude = `inf`** |
| `-1e-3`, `nan` | `ValueError: Invalid learning rate`, in `setup` | -- | -- |
| `'3e-4'`, `None`, `[3e-4]`, `{}` | bare `TypeError: '<=' not supported between instances of 'float' and 'str'`, in `setup` | -- | -- |

Two consequences worth separating:

- **`alpha_lr=0` is the silent one.** The optimizer is built and never moves, so `autotune_alpha=True` behaves exactly like `autotune_alpha=False` while reporting the automatic temperature it was asked for. That is the "runs the full work and updates no weight" pathology `learning_rate_problems` exists to prevent, on the one parameter whose entire job is to adapt.
- **`inf` is not confined to the temperature.** `alpha` multiplies the log-probability in the *actor* loss, so the run finished successfully with a checkpoint holding non-finite parameters.

The four that do raise, raise in `setup` -- after the env and both networks are built, past the point `validate()` documents itself as running before -- and the last four name neither the field nor the value.

## The change

`validate()` checks the field against the same `positive_finite_number_error` domain as the first rate, through a new `temperature_learning_rate_problems` gate reached via `Trainer._temperature_learning_rate_problems`. No new numeric rule: the gate contributes only the scoping, and a test asserts every verdict and message is the shared domain's verbatim, so the two cannot drift on what counts as a usable rate.

Three scoping decisions, each pinned in both directions:

- **Inert unless `autotune_alpha` is set**, which is the only branch that constructs a temperature optimizer. Refusing a field that call path never reads would be a false rejection, so `autotune_alpha=False` accepts every value above -- and `autotune_alpha=True` refuses all of them.
- **Off-policy only.** Per `TrainSpec` a backend ignores the fields it does not support, so PPO and the mock trainer must not report on it. Their silence is pinned as *scoping* rather than an empty preflight: the same spec's own `learning_rate` is still refused by both.
- **No `None` sentinel to exempt.** `TrainSpec.learning_rate` is annotated `float | None` and documents `None` as "use the backend's own default"; `alpha_lr` is annotated `float` with no such sentinel, so `None` is a value the optimizer cannot take. The premise test asserts the *annotations*, not the defaults -- `RLTrainSpec` narrows `learning_rate` to a concrete `1e-4`, so comparing defaults would find no asymmetry while the gates still, correctly, differ.

Both rates are reported in the same preflight rather than one round at a time.

A structural test derives the modules in scope from the tree rather than listing them, so a second backend that starts driving a temperature optimizer with the field fails until it routes through the gate. Its pre-fix failure names the adrift module: `modules read spec.alpha_lr without the shared gate: ['fast_sac.py']`.

## Out of scope

`init_alpha` and `target_entropy`, the two neighbouring fields of the same temperature block, need a different domain and a decision this change does not make: `init_alpha=0` yields a temperature of zero, which is a coherent "no entropy bonus" configuration rather than an unusable value, and `target_entropy` is signed by construction (it defaults to `-num_actions`).

## Measurement

![FastSAC alpha_lr domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/fastsac-temperature-lr/alpha_lr_domain.png)

Top: the measured temperature trajectories -- the flat red line is what `alpha_lr=0` delivered against a spec that asked for automatic tuning. Middle: the `validate()` verdict for all eleven values, before and after. Bottom: the honored path on both trees.

**No-regression, measured rather than asserted.** The same spec (`alpha_lr` left at its `3e-4` default, `seed=0`, 160 timesteps) trained on both trees is **bit-identical**: final temperature `0.9910327792167664`, 89631 checkpoint tensors, parameter sum `160.0000000000000000` -- equal to 16 digits. The change adds a preflight refusal and alters no arithmetic on any value it accepts.

## Verification

Base `f654dd6`, arm64, `MUJOCO_GL=egl`.

- **Pre-fix proof** -- call sites reverted to the base, the new tests kept: **68 failed / 62 passed**. The 62 are the over-reach controls (every usable rate, incl. `np.float64` / `np.float32`), the two scoping directions that were already correct, and the premise/meta tests. Identical to the count at the previous base, so the rebase preserved the contract.
- **Existing-test churn: zero, measured.** `tests/training/` is **1683 passed / 4 skipped** on the pure base and **1813 passed / 4 skipped** with this branch -- a difference of exactly the 130 new tests.
- **Full suite**: `23001 passed, 257 skipped, 0 failed` in 507.65s.
- **Lint**: `ruff check` clean, `ruff format --check` clean (1106 files), `mypy strands_robots tests tests_integ` **0 errors** outside `examples/isaac_gs`. The 14 there are environmental and pre-existing: byte-identical to a pristine `upstream/main` checkout in the same working copy.
- Changelog: one fragment. `scripts/assemble_changelog.py --check` OK, plus the five repo-wide root guards (42 tests).
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD`: no overlap.
