### PR TITLE
fix(registry): honour an explicit kwarg over a provider's registry default

### DIFF
--- a/changelog.d/2025-registry-explicit-kwarg-precedence.md
+++ b/changelog.d/2025-registry-explicit-kwarg-precedence.md
@@ -1,0 +1,20 @@
+### Fixed: `build_policy_kwargs` no longer discards a value the caller supplied
+
+A provider's `defaults` in `policies.json` were merged into the kwargs dict
+*before* the caller's `**extra`, and the `extra` loop skipped keys already
+present -- so the default the previous loop had just inserted won, and the
+value the caller passed under the provider's own key was dropped with no error
+on any path. Every one of the twelve `(provider, key)` pairs where a provider
+declares a default for a forwardable key was affected, including
+`build_policy_kwargs("wbc", walk=False)`, which returned `walk=True` and so
+handed back the locomotion controller to a caller who had asked for the
+standing one.
+
+The three merge sources are now applied in precedence order: a value the
+caller supplied under the provider's own key in `extra`, then the generic
+parameter that maps onto the same key (`policy_host` -> `host`), then the
+registry default -- which now only ever fills a key the caller left unset.
+This is the rule `resolve_policy` already applies with its trailing
+`kwargs.update(extra_kwargs)`, and the rule the suite already asserted for the
+generic parameters. The `config_keys` filter is unchanged: a key outside the
+provider's `config_keys` is still dropped.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -51,7 +51,7 @@ from strands_robots.registry import (
 | `list_policy_providers()` | Providers from `policies.json`. |
 | `resolve_policy(uri)` | URI → provider name. |
 | `import_policy_class(provider)` | Lazy import of provider class. |
-| `build_policy_kwargs(provider, **kw)` | Normalise + validate kwargs. |
+| `build_policy_kwargs(provider, **kw)` | Normalise + validate kwargs. An explicit value beats the provider's registry default; the provider's own key (`host=`) beats the generic parameter (`policy_host=`). |
 
 ## `strands_robots.simulation`
 

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -250,10 +250,18 @@ def build_policy_kwargs(
         server_address: Full server address host:port (grpc:// URLs, remote providers).
         policy_type: Sub-type (pi0, act, smolvla, ...).
         data_config: Data configuration for groot.
-        **extra: Any additional provider-specific kwargs.
+        **extra: Any additional provider-specific kwargs.  A key declared in
+            the provider's ``config_keys`` is forwarded; any other key is
+            dropped, which is what ``config_keys`` exists to decide.
 
     Returns:
         Dict of kwargs ready for create_policy(provider, **kwargs).
+
+        Where two sources name the same key, the more explicit one wins:
+        a provider-specific value in ``extra`` beats the generic parameter
+        that maps onto it (``host`` beats ``policy_host``), and both beat the
+        provider's registry default.  A default only ever fills a key the
+        caller left unset.
     """
     config = get_policy_provider(provider) or {}
     allowed_keys = set(config.get("config_keys", []))
@@ -275,16 +283,26 @@ def build_policy_kwargs(
         "policy_type": policy_type,
     }
 
+    # Precedence: a value the caller supplied under the provider's own key in
+    # ``extra`` wins over the generic parameter that maps onto the same key,
+    # which in turn wins over the registry default.  ``resolve_policy`` applies
+    # the same rule with its trailing ``kwargs.update(extra_kwargs)``.
+    #
+    # The order of these three loops is the contract.  Applying ``extra`` last
+    # while skipping keys already in ``kwargs`` inverts it: the defaults loop
+    # inserts the default first, so the ``key not in kwargs`` guard then sees
+    # that default and discards a value the caller did supply -- the same
+    # silent fallback to a default that #317 fixed for URL-parsed host/port.
+    for key, value in extra.items():
+        if key in allowed_keys:
+            kwargs[key] = value
+
     for key, value in param_map.items():
-        if value is not None and key in allowed_keys:
+        if value is not None and key in allowed_keys and key not in kwargs:
             kwargs[key] = value
 
     for key, default_val in defaults.items():
         if key not in kwargs:
             kwargs[key] = default_val
-
-    for key, value in extra.items():
-        if key in allowed_keys and key not in kwargs:
-            kwargs[key] = value
 
     return kwargs

--- a/tests/registry/test_explicit_kwarg_beats_registry_default.py
+++ b/tests/registry/test_explicit_kwarg_beats_registry_default.py
@@ -1,0 +1,247 @@
+"""``build_policy_kwargs`` must not discard a value the caller supplied.
+
+The function merges three sources into one kwargs dict: the generic parameters
+(``policy_host``, ``policy_port``, ...), the provider's registry ``defaults``,
+and the provider-specific keys the caller passes through ``**extra``.  Only one
+merge order is honest, and the suite already states it -- ``test_registry.py``'s
+``test_explicit_value_overrides_default`` asserts "An explicit param must win
+over the JSON default for the same key", and the sibling ``resolve_policy``
+implements exactly that with its trailing ``kwargs.update(extra_kwargs)``.
+
+That contract used to hold only for the generic parameters, because they were
+merged before the defaults.  A key reachable only through ``extra`` was merged
+*after* the defaults while skipping keys already present, so the default the
+previous loop had just inserted won and the caller's value was dropped with no
+error anywhere -- the silent fallback to a default that #317 fixed for
+URL-parsed host/port.
+
+The pairs below are derived from ``policies.json`` rather than listed, so a
+provider that gains a default is covered the moment it is declared.  Reading
+the registry as JSON keeps every case here independent of the optional
+dependencies the provider classes need.
+"""
+
+import ast
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.registry.policies import build_policy_kwargs
+
+# ─── registry-derived cases ───────────────────────────────────────────
+
+
+def _registry_path() -> Path:
+    """Locate policies.json from the module under test, never a path literal."""
+    return Path(inspect.getfile(build_policy_kwargs)).parent / "policies.json"
+
+
+def _providers() -> dict[str, Any]:
+    return json.loads(_registry_path().read_text())["providers"]
+
+
+def _distinct_from(default: Any, key: str) -> Any:
+    """A caller value unmistakably different from ``default``.
+
+    A bool is inverted so the discarded value would flip the meaning of the
+    knob rather than merely change it; a number is displaced far enough that no
+    rounding could explain the result.
+    """
+    if isinstance(default, bool):
+        return not default
+    if isinstance(default, (int, float)):
+        return type(default)(default + 41)
+    return f"CALLER-{key}"
+
+
+def _shadowable_pairs() -> list[tuple[str, str, Any]]:
+    """Every (provider, key, default) a caller can also supply through extra."""
+    pairs = []
+    for name, cfg in sorted(_providers().items()):
+        allowed = set(cfg.get("config_keys") or [])
+        for key, default in (cfg.get("defaults") or {}).items():
+            if key in allowed:
+                pairs.append((name, key, default))
+    return pairs
+
+
+PAIRS = _shadowable_pairs()
+PAIR_IDS = [f"{p}-{k}" for p, k, _ in PAIRS]
+
+
+class TestTheRegistryStillDeclaresShadowableDefaults:
+    """Non-vacuity: the cases below are only meaningful if there are any."""
+
+    def test_several_providers_declare_a_default_for_a_forwardable_key(self):
+        """An empty case list would make every parametrised test vacuous."""
+        assert len(PAIRS) >= 8, f"only {len(PAIRS)} shadowable (provider, key) pairs"
+
+    def test_at_least_one_shadowable_key_is_a_boolean_mode_switch(self):
+        """A bool default is the case where a discarded value inverts intent."""
+        assert any(isinstance(d, bool) for _, _, d in PAIRS)
+
+
+class TestAnExplicitExtraValueBeatsTheRegistryDefault:
+    """The caller named the provider's own key; the default must yield."""
+
+    @pytest.mark.parametrize(("provider", "key", "default"), PAIRS, ids=PAIR_IDS)
+    def test_the_caller_value_survives(self, provider, key, default):
+        """A default may fill an unset key, never replace a supplied one."""
+        asked = _distinct_from(default, key)
+        kwargs = build_policy_kwargs(provider, **{key: asked})
+        assert kwargs[key] == asked, (
+            f"{provider}: asked for {key}={asked!r}, got {kwargs.get(key)!r} (registry default {default!r} won)"
+        )
+
+    def test_wbc_walk_false_is_not_turned_back_into_walk_true(self):
+        """The headline case: the discarded value inverted a locomotion mode.
+
+        ``wbc`` declares ``walk: true``, so a caller asking for the balance
+        controller used to receive the walking one -- a policy doing the
+        opposite of what was requested, reported as success.
+        """
+        kwargs = build_policy_kwargs("wbc", walk=False)
+        assert kwargs["walk"] is False
+
+    def test_a_falsy_caller_value_is_not_read_as_absent(self):
+        """0 / False / "" are values, not omissions."""
+        assert build_policy_kwargs("curobo", action_horizon=0)["action_horizon"] == 0
+        assert build_policy_kwargs("cosmos3", prompt="")["prompt"] == ""
+
+
+class TestTheProviderSpecificSpellingBeatsTheGenericParameter:
+    """``host`` and ``policy_host`` name one key; the explicit one wins."""
+
+    def test_extra_host_beats_the_generic_policy_host_default(self):
+        """``policy_host`` carries its own default, so it cannot mean "unset"."""
+        kwargs = build_policy_kwargs("groot", host="gpu-box")
+        assert kwargs["host"] == "gpu-box"
+
+    def test_extra_port_beats_the_registry_default(self):
+        """``policy_port`` defaults to None, so only the registry shadowed it."""
+        kwargs = build_policy_kwargs("cosmos3", port=9100)
+        assert kwargs["port"] == 9100
+
+    def test_extra_wins_when_both_spellings_are_supplied(self):
+        """Both are explicit; the provider's own key is the more specific."""
+        kwargs = build_policy_kwargs("groot", policy_host="generic", host="specific")
+        assert kwargs["host"] == "specific"
+
+
+class TestTheGenericParameterStillBeatsTheDefault:
+    """The middle tier of the chain is unchanged."""
+
+    def test_policy_host_still_overrides_the_json_default(self):
+        """Restates test_registry.py's existing contract for the middle tier."""
+        assert build_policy_kwargs("cosmos3", policy_host="gpu-box")["host"] == "gpu-box"
+
+    def test_policy_port_still_reaches_a_provider_that_declares_port(self):
+        assert build_policy_kwargs("groot", policy_port=5555)["port"] == 5555
+
+
+class TestADefaultStillFillsAnUnsetKey:
+    """Over-reach control: the defaults must still apply when nothing else does."""
+
+    @pytest.mark.parametrize(("provider", "key", "default"), PAIRS, ids=PAIR_IDS)
+    def test_an_omitted_key_takes_the_registry_default(self, provider, key, default):
+        """Honouring an explicit value must not stop a default from filling in.
+
+        ``host`` is the one exception: the generic ``policy_host`` parameter
+        carries its own default, so it fills the key before the registry can.
+        """
+        kwargs = build_policy_kwargs(provider)
+        if key == "host":
+            assert kwargs[key] == "localhost"
+        else:
+            assert kwargs[key] == default
+
+
+class TestUnknownExtraKeysAreStillDropped:
+    """Scope control: the ``config_keys`` filter itself is unchanged."""
+
+    def test_a_key_outside_config_keys_is_not_forwarded(self):
+        """Deciding what is forwardable is what ``config_keys`` is for."""
+        assert "not_a_real_key" not in build_policy_kwargs("groot", not_a_real_key="x")
+
+    def test_an_unknown_provider_still_returns_no_kwargs(self):
+        assert build_policy_kwargs("nonexistent_xyz", host="x") == {}
+
+
+# ─── structural guard ─────────────────────────────────────────────────
+
+
+def _merge_loop_order(source: str) -> list[str]:
+    """The iterables of the three merge loops, in source order."""
+    fn = next(
+        n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.FunctionDef) and n.name == "build_policy_kwargs"
+    )
+    return [str(ast.get_source_segment(source, lp.iter)) for lp in fn.body if isinstance(lp, ast.For)]
+
+
+def _loop_bodies(source: str) -> dict[str, str]:
+    fn = next(
+        n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.FunctionDef) and n.name == "build_policy_kwargs"
+    )
+    out = {}
+    for lp in fn.body:
+        if isinstance(lp, ast.For):
+            out[str(ast.get_source_segment(source, lp.iter))] = str(ast.get_source_segment(source, lp))
+    return out
+
+
+class TestTheMergeOrderIsTheContract:
+    """The precedence is expressed by the loop order, so pin the loop order.
+
+    A behavioural test catches the values that are wrong today.  This catches
+    the edit that would make them wrong again -- moving the ``extra`` loop back
+    below the defaults, or reinstating the ``key not in kwargs`` guard on it.
+    """
+
+    @staticmethod
+    def _source() -> str:
+        return Path(inspect.getfile(build_policy_kwargs)).read_text()
+
+    def test_extra_is_merged_before_the_generic_parameters_and_defaults(self):
+        assert _merge_loop_order(self._source()) == [
+            "extra.items()",
+            "param_map.items()",
+            "defaults.items()",
+        ]
+
+    def test_the_extra_loop_does_not_skip_keys_already_present(self):
+        """That guard is what let an already-inserted default win."""
+        body = _loop_bodies(self._source())["extra.items()"]
+        assert "key not in kwargs" not in body
+
+    def test_the_later_loops_do_skip_keys_already_present(self):
+        """They are the ones that must yield to an explicit value."""
+        bodies = _loop_bodies(self._source())
+        assert "key not in kwargs" in bodies["param_map.items()"]
+        assert "key not in kwargs" in bodies["defaults.items()"]
+
+    def test_the_scan_finds_the_real_function(self):
+        """Non-vacuity: a scan that resolved elsewhere would report nothing."""
+        assert len(_merge_loop_order(self._source())) == 3
+
+    def test_the_order_check_rejects_the_pre_fix_arrangement(self):
+        """Planted defect: the arrangement this change replaced must fail."""
+        planted = (
+            "def build_policy_kwargs(provider, **extra):\n"
+            "    for key, value in param_map.items():\n"
+            "        kwargs[key] = value\n"
+            "    for key, default_val in defaults.items():\n"
+            "        if key not in kwargs:\n"
+            "            kwargs[key] = default_val\n"
+            "    for key, value in extra.items():\n"
+            "        if key not in kwargs:\n"
+            "            kwargs[key] = value\n"
+        )
+        assert _merge_loop_order(planted) != [
+            "extra.items()",
+            "param_map.items()",
+            "defaults.items()",
+        ]
+        assert "key not in kwargs" in _loop_bodies(planted)["extra.items()"]


### PR DESCRIPTION
## The defect

`build_policy_kwargs` merges three sources into one kwargs dict: the generic
parameters (`policy_host`, `policy_port`, ...), the provider's `defaults` from
`policies.json`, and the provider-specific keys the caller passes through
`**extra`.

The defaults were merged **before** `extra`, and the `extra` loop skipped keys
already present:

```python
for key, default_val in defaults.items():
    if key not in kwargs:
        kwargs[key] = default_val          # inserts the default first

for key, value in extra.items():
    if key in allowed_keys and key not in kwargs:   # ...which this then sees
        kwargs[key] = value                         # -> caller's value dropped
```

So the `key not in kwargs` guard -- written to avoid clobbering a caller value --
saw the default the previous loop had just inserted, and discarded the value the
caller did supply. No error on any path.

Measured against the registry, **every** `(provider, key)` pair where a provider
declares a default for a forwardable key was affected:

| provider | key | default | caller asked for | got |
|---|---|---|---|---|
| `cosmos3` | `host` | `localhost` | `CALLER-host` | `localhost` |
| `cosmos3` | `port` | `8000` | `8041` | `8000` |
| `cosmos3` | `embodiment` | `droid` | `CALLER-embodiment` | `droid` |
| `curobo` | `action_horizon` | `16` | `57` | `16` |
| `groot` | `host` | `localhost` | `CALLER-host` | `localhost` |
| `motionbricks` | `style` | `walk` | `CALLER-style` | `walk` |
| `moveit2` | `host` | `127.0.0.1` | `CALLER-host` | `localhost` |
| `moveit2` | `port` | `5556` | `5597` | `5556` |
| `moveit2` | `planning_group` | `arm` | `CALLER-planning_group` | `arm` |
| `vera` | `embodiment` | `pusht` | `CALLER-embodiment` | `pusht` |
| `vera` | `host` | `127.0.0.1` | `CALLER-host` | `localhost` |
| `wbc` | `walk` | `True` | `False` | `True` |

12 of 12 discarded before, 0 of 12 after.

## Why the contract is not a judgement call

Three places in the tree already state it:

- **The sibling in the same module.** `resolve_policy(policy, **extra_kwargs)`
  ends every one of its eight return paths with `kwargs.update(extra_kwargs)` --
  the caller's value wins. Two functions, one module, both taking `**extra`,
  opposite precedence.
- **The suite.** `tests/test_registry.py::test_explicit_value_overrides_default`
  is docstringed *"An explicit param must win over the JSON default for the same
  key."* That held only for the generic parameters, because they were merged
  before the defaults; a key reachable only through `extra` broke it.
- **This file's own history.** The `cosmos3://` and `vera://` URL branches carry
  comments explaining that without them a caller's host/port is lost and the call
  *"silently falls back to the default localhost:8000 (#317)"* -- the same shape,
  already treated as a defect here.

## The change

The three sources are applied in precedence order: a value the caller supplied
under the provider's own key in `extra`, then the generic parameter that maps
onto the same key (`policy_host` -> `host`), then the registry default -- which
now only ever fills a key the caller left unset. `param_map` gained the
`key not in kwargs` guard it needs to yield to `extra`; the `extra` loop lost the
guard that inverted the order.

`policy_host` carries its own default (`"localhost"`), so it cannot be
distinguished from an omission, which is why the unambiguous provider-specific
spelling wins over it when both are given.

**Out of scope, deliberately:** the `config_keys` filter itself. A key outside a
provider's `config_keys` is still dropped -- that is what `config_keys` exists to
decide, and it is pinned by
`test_extra_kwargs_not_in_allowed_keys_ignored`. Two tests here keep that
behaviour pinned so this change cannot be read as touching it.

## The consequence, in sim

`wbc` declares `defaults: {"walk": true}`, and `walk` is documented as selecting
whether the locomotion network may run at all -- *"When `False` only [the main
policy runs]"*. A caller writing `walk=False` is instructing the policy not to
enter locomotion. That instruction was discarded.

An 8 s MuJoCo rollout of the Unitree G1 headless (`MUJOCO_GL=egl`), real
GR00T-WholeBodyControl ONNX weights, 0.6 m/s forward velocity command, driven
from whatever `build_policy_kwargs("wbc", checkpoint=..., walk=False,
target_velocity=[0.6, 0, 0])` returns:

![Registry kwarg precedence: which controller a caller asking for walk=False actually got](https://raw.githubusercontent.com/cagataycali/robots/artifacts/registry-kwarg-precedence/artifact_kwarg_precedence.png)

| | before | after |
|---|---|---|
| `kwargs["walk"]` returned | `True` | `False` |
| walk network loaded | `True` | `False` |
| main-network inferences | **0 of 400** | 400 of 400 |
| walk-network inferences | **400 of 400** | 0 of 400 |
| `run_policy` status | `success` | `success` |
| distance walked in 8 s | 3.811 m | 3.080 m |
| pelvis height at 8 s | 0.7454 m | 0.7500 m |

Every inference step ran on the network the caller had asked not to use, and the
rollout reported success either way. The `t = 0 s` frames are pixel-identical
across both trees (`max|delta| = 1/255`), so the scene, seed and command are the
same and the whole difference is which network ran. The ruler posts are at 1, 2,
3 and 4 m; they sit beside the walking line rather than on it, so nothing the
figure measures is perturbed by the markers.

Capture and compose scripts, which assert every number rendered:
[`artifacts/registry-kwarg-precedence`](https://github.com/cagataycali/robots/tree/artifacts/registry-kwarg-precedence).

## Tests

`tests/registry/test_explicit_kwarg_beats_registry_default.py`, 40 tests. The
`(provider, key, default)` cases are derived from `policies.json` rather than
listed, so a provider that gains a default is covered the moment it is declared;
reading the registry as JSON keeps every case independent of the optional
dependencies the provider classes need.

- an explicit `extra` value survives, for every registry-declared pair
- `wbc walk=False` specifically, as the boolean case where the discarded value
  inverted the meaning of the knob
- a falsy caller value (`0`, `""`) is not read as an omission
- the provider-specific spelling beats the generic parameter, including when both
  are supplied
- **over-reach controls:** a default still fills an omitted key (all 12 pairs),
  the generic parameter still beats the default, unknown keys are still dropped,
  an unknown provider still returns `{}`
- **non-vacuity:** the derived case list is non-empty and still contains a
  boolean pair, so no parametrised test can pass on nothing
- a structural guard pinning the merge order (`extra` -> `param_map` ->
  `defaults`) and the presence/absence of the `key not in kwargs` guard on each
  loop, with a planted pre-fix arrangement that must be rejected

Pre-fix (source at `upstream/main`, tests kept): **20 failed / 20 passed**, e.g.
`AssertionError: cosmos3: asked for embodiment='CALLER-embodiment', got 'droid'
(registry default 'droid' won)`. The 20 that pass pre-fix are the over-reach
controls and the non-vacuity checks -- they are what stop the change reaching
further than the precedence.

## Verification

Full suite on the branch (`MUJOCO_GL=egl python -m pytest tests`):
**22933 passed, 257 skipped, 0 failed** in 521 s, with **zero existing-test
changes** -- the new precedence breaks nothing that was relying on the old order.

`ruff check` clean (1107 files), `ruff format --check` clean, `mypy
strands_robots tests tests_integ` reports 0 errors outside `examples/isaac_gs`;
the 14 there are byte-identical to a pristine `upstream/main` worktree of the
same working copy, so they are environmental rather than introduced here.
`scripts/check_merge_base_overlap.py` reports no overlap with `upstream/main`.
