### PR TITLE
docs(agents): qualify the composition compare ref with the head's fork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -653,8 +653,24 @@ hatch run format            # ruff check --fix, ruff format
    that makes a pair of changes never compiled together:
 
    ```
-   GET /repos/{owner}/{repo}/compare/main...<head>  ->  .behind_by
+   GET /repos/{owner}/{repo}/compare/main...{head_owner}:{head_repo}:{head_branch}
+     ->  .behind_by
    ```
+
+   **Qualify the head with its owner and repository.** Step 1 mandates that the
+   branch live on a fork, and an unqualified fork ref does not resolve in the base
+   repository, so the form a reader reaches for `404`s on every pull request here -
+   same head, same instant:
+
+   | ref | result |
+   |---|---|
+   | `main...feat/ackermann-ros-robot` | `404 Not Found` |
+   | `main...Vivek0712:robots:feat/ackermann-ros-robot` | `diverged  ahead_by=11  behind_by=116` |
+
+   Resolve the three parts from `pullRequest { headRepository { nameWithOwner } }`
+   and `headRefName` rather than assuming them. The qualified form is also correct
+   for a branch in the base repository - `main...strands-labs:robots:main` ->
+   `identical` - so there is one form to remember rather than a choice to make.
 
    `behind_by: 0` means the head already contains every commit on `main`, so the
    tree CI tested **is** the merge result. The two cases separate exactly, each
@@ -682,8 +698,12 @@ hatch run format            # ruff check --fix, ruff format
    `compare/v0.4.1...5757c1a2` reports `ahead_by=877` beside a `commits` array
    truncated to 250, and the reverse direction reports `behind_by=877` beside an
    **empty** one, so deriving the answer from `commits` is itself a false safe.
-   And a head that cannot be compared - a force-pushed fork sha, a `404` - is
-   not a `0`: run the composition.
+   And a head that cannot be compared is not a `0`: run the composition. That
+   case is narrower than a `404`, which has two causes wanting opposite actions -
+   an unqualified fork ref is a query to re-issue, while only a head sha that is
+   genuinely gone (a force-push, a deleted fork) is uncomparable - and the status
+   code does not separate them. Qualify first, then read a `404` on the
+   *qualified* form as the uncomparable one.
 
    Read that run as a **delta, not an absolute**. The environment you verify in
    is almost never the one CI uses, and a partial one fails tests for reasons
@@ -724,6 +744,24 @@ hatch run format            # ruff check --fix, ruff format
    tree rather than two prefixes - and each commit in a batch can be checked that
    way without a suite, which is what the batching case above otherwise has no
    evidence for.
+
+   **That equivalence is scoped to `behind_by == 0`, and it is the field above
+   that says so.** When the branch is behind, the squash tree necessarily
+   incorporates the intervening commits, so the trees differ for a perfectly
+   correct merge. The control and the counterexample:
+
+   | pull request | `behind_by` | head tree | squash tree |
+   |---|---|---|---|
+   | #2012 | `0` | `e174201b7ccf` | `e174201b7ccf` |
+   | #2024 | `1` | `4af91f210d09` | `8b3e7e8a3434` |
+
+   #2024's `main` went green on all four checks afterwards, so the inequality was
+   not drift. Read unequal trees as a question rather than a verdict: at
+   `behind_by: 0` they are the evidence this paragraph claims, and above zero the
+   check does not apply at all, leaving the path-scoped `git diff` against the
+   local composition as the only form that does. An unqualified "equal trees or
+   else" invites reading a correct merge as a broken one, which is the same
+   expensive-in-the-diligent-direction shape as the advisory-`CodeQL` case above.
 
    Fixing forward beats reverting here - the two production changes were both
    correct, and only an assertion and its justification were stale. Prefer a

--- a/changelog.d/2026-compare-ref-fork-qualified.md
+++ b/changelog.d/2026-compare-ref-fork-qualified.md
@@ -1,0 +1,35 @@
+### Docs: the composition shortcut's compare ref is fork-qualified, and its post-merge half is scoped
+
+Step 8's cheap read for whether a pre-merge composition is owed - `behind_by` on a
+comparison against `main` - was documented as `compare/main...<head>`. That ref does
+not resolve in the base repository, and step 1 mandates that the branch live on a
+fork, so the documented form returned `404` for every pull request here. Same head,
+same instant: `main...feat/ackermann-ros-robot` answers `404 Not Found` while
+`main...Vivek0712:robots:feat/ackermann-ros-robot` answers `diverged ahead_by=11
+behind_by=116`.
+
+The consequence was the loss of the whole saving the field was introduced for. A
+reader who gets a `404` reaches the clause saying a head that cannot be compared is
+not a `0`, and runs the composition - a clone and two suite runs - on every branch,
+which is exactly what reading `behind_by` was meant to avoid. Nothing contradicted
+it, because a `404` followed by a composition run looks like diligence and the
+composition then confirms nothing is wrong. The passage now gives the qualified
+template, says to resolve its parts from `headRepository { nameWithOwner }` and
+`headRefName` rather than assume them, and notes that the same form serves a branch
+in the base repository, so there is one spelling rather than a choice. The
+uncomparable case is narrowed rather than dropped: a `404` has two causes wanting
+opposite actions, and only a head sha that is genuinely gone is the one the earlier
+clause describes.
+
+The same step's post-merge half gains the scope it was measured under. Comparing
+`.commit.tree.sha` between the head CI went green on and its squash on `main` is
+evidence only when `behind_by == 0`; when the branch is behind, the squash tree
+incorporates the intervening commits, so the trees differ for a correct merge. #2012
+at `behind_by: 0` has equal trees (`e174201b7ccf`), and #2024 at `behind_by: 1` has
+`4af91f210d09` against `8b3e7e8a3434` with `main` green on all four checks
+afterwards. Stated unscoped, the check invites reading a good merge as drift.
+
+`tests/test_composition_compare_ref_form.py` lifts the ref template out of the prose
+and renders it against a recorded pull request head, so the assertion is that the
+documented ref is the one the API answered rather than that the file mentions forks -
+a template tidied back to `<head>` fails it.

--- a/tests/test_composition_compare_ref_form.py
+++ b/tests/test_composition_compare_ref_form.py
@@ -1,0 +1,290 @@
+"""Contract pin for the compare ref step 8 tells you to issue, and what a `404` means.
+
+``AGENTS.md`` step 8 offers ``GET /compare/main...<head> -> .behind_by`` as the
+cheap read that says whether a pre-merge composition is owed at all, and #2014
+added the clause that a head which *cannot* be compared is not a ``0``. Both are
+right about their own case. The template was not: an unqualified ref does not
+resolve in the base repository, and step 1 mandates that the branch live on a
+fork, so the documented form ``404``s on **every** pull request in this
+repository.
+
+That deletes the whole benefit the shortcut was introduced for. #2012's finding
+was that ``behind_by: 0`` proves no composition exists and saves a clone plus two
+suite runs; a reader following the template literally gets a ``404``, reaches the
+"not a ``0``" clause, and runs the composition every time. The misreading is
+silent and self-justifying - a ``404`` followed by a composition run looks like
+diligence, and the composition almost always confirms nothing is wrong, so
+nothing ever contradicts it.
+
+The two causes of a ``404`` need opposite actions and are indistinguishable from
+the status code:
+
+==================================  ==========================  ===================
+cause                               means                       correct action
+==================================  ==========================  ===================
+ref not qualified with fork owner   query construction error    re-issue qualified
+head sha genuinely gone             uncomparable                run the composition
+==================================  ==========================  ===================
+
+So two classes are asserted here, and the first is what keeps the second honest.
+
+``TestTheDocumentedCompareRefResolves`` *executes* the claim rather than
+describing it. It lifts the ref template out of the prose, renders it against a
+recorded pull request payload, and asserts the result is the ref the API answered
+``200`` for - with the ref that ``404``d as the negative control. A pin that
+merely asserted ``AGENTS.md`` *mentions* fork qualification would keep passing if
+the template were tidied back to ``<head>``, which is exactly the edit that
+reintroduces the defect.
+
+``TestTheTreeEquivalenceIsScopedToBehindZero`` does the same for the second,
+smaller correction in the same step. The tree-sha equivalence check - equal
+``.commit.tree.sha`` between the head CI went green on and its squash on ``main``
+- holds only when ``behind_by == 0``, which is the single case it was measured on.
+When the branch is behind, the squash tree incorporates the intervening commits,
+so the trees differ for a perfectly correct merge. Unscoped, it invites reading a
+good merge as drift: the same expensive-in-the-diligent-direction shape as the
+advisory-``CodeQL`` case step 8 already documents.
+
+``TestTheGuidanceNamesTheForkConstraint`` pins the prose, because the prose is
+the deliverable - a contributor reads ``AGENTS.md``, not this module. What is
+asserted is *adjacency*: the qualified template, the reason it is obliged, and
+the two-causes split have to stay in the same breath, since the template alone
+reads as an incidental verbosity someone may shorten. Same structural reason
+``tests/test_ref_creation_ruleset_scope.py`` and
+``tests/test_graphql_node_id_targeting.py`` exist.
+
+Negative control: with ``origin/main``'s ``AGENTS.md`` restored, the template
+renders to ``main...<head>`` - not a ref this repository ever answered - and **13 of
+the 17 tests fail**: 5 of the 7 in ``TestTheDocumentedCompareRefResolves``, both
+prose assertions in ``TestTheTreeEquivalenceIsScopedToBehindZero``, and all 6 in
+``TestTheGuidanceNamesTheForkConstraint``.
+
+The 4 that pass are the ones that should, and saying which is the point of running
+it. Two are recorded evidence rather than claims about the file - the ``404`` on the
+unqualified ref, and the two tree pairs - so they are a property of the repository
+and hold whatever ``AGENTS.md`` says. The third,
+``test_the_rendered_ref_is_not_the_unqualified_one``, guards a *different* edit than
+the one being reverted: ``main...<head>`` is already not the bare-branch form, so
+only a template respelled to ``main...{head_branch}`` trips it. It is kept for that
+case and is deliberately not load-bearing here.
+
+See #2026.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AGENTS_PATH = _REPO_ROOT / "AGENTS.md"
+
+
+class _CompareResponse(NamedTuple):
+    """A ``GET /repos/{owner}/{repo}/compare/{ref}`` answer, as recorded."""
+
+    http: int
+    status: str
+    behind_by: int | None
+
+
+#: ``GET /repos/strands-labs/robots/compare/{ref}`` as answered on 2026-08-08,
+#: for #1035's head (``Vivek0712/robots``, ``feat/ackermann-ros-robot``). The
+#: first pair isolates one variable: same head, same instant, only the ref
+#: spelling differs. ``behind_by`` is recorded because it is the field step 8
+#: reads, and it is unavailable in the ``404`` row - which is the whole defect.
+_RECORDED_COMPARE: dict[str, _CompareResponse] = {
+    "main...feat/ackermann-ros-robot": _CompareResponse(404, "Not Found", None),
+    "main...Vivek0712:robots:feat/ackermann-ros-robot": _CompareResponse(200, "diverged", 116),
+    # A branch in the base repository, to show the qualified form is universal
+    # and there is one spelling to remember rather than a choice to make.
+    "main...strands-labs:robots:main": _CompareResponse(200, "identical", 0),
+}
+
+#: The answer for a ref this repository was never asked, so a template that
+#: renders to one fails on the assertion below rather than on a ``KeyError``.
+_NEVER_ASKED = _CompareResponse(0, "not a ref this repository ever answered", None)
+
+#: #1035's head as GraphQL reports it, which is where step 8 now says to resolve
+#: the three parts from.
+_HEAD_REPOSITORY_NAME_WITH_OWNER = "Vivek0712/robots"
+_HEAD_REF_NAME = "feat/ackermann-ros-robot"
+
+
+class _TreePair(NamedTuple):
+    """A head commit's tree and its squash's tree, against that branch's distance."""
+
+    pr: int
+    behind_by: int
+    head_tree: str
+    squash_tree: str
+
+
+#: ``.commit.tree.sha`` for a head whose ``call-test-lint`` was ``SUCCESS`` and
+#: for its squash on ``main``, against that pull request's ``behind_by``. #2012 is
+#: the case the equivalence was measured on; #2024 is the counterexample, whose
+#: ``main`` went green on all four checks afterwards, so its unequal trees are a
+#: correct merge and not drift.
+_RECORDED_TREES: tuple[_TreePair, ...] = (
+    _TreePair(pr=2012, behind_by=0, head_tree="e174201b7ccf", squash_tree="e174201b7ccf"),
+    _TreePair(pr=2024, behind_by=1, head_tree="4af91f210d09", squash_tree="8b3e7e8a3434"),
+)
+
+
+@pytest.fixture(scope="module")
+def agents_text() -> str:
+    """``AGENTS.md`` as shipped."""
+    return _AGENTS_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def step_eight(agents_text: str) -> str:
+    """The step-8 passage carrying the composition guidance.
+
+    Sliced so an assertion cannot be satisfied by matching vocabulary that
+    happens to appear elsewhere in a file this long.
+    """
+    start = agents_text.index("One field says whether a composition exists at all")
+    end = agents_text.index("Fixing forward beats reverting here", start)
+    passage = agents_text[start:end]
+    assert len(passage) > 500, "step-8 slice collapsed; the anchors moved"
+    return passage
+
+
+def _documented_compare_ref_template(text: str) -> str:
+    """The ref half of the ``compare`` template ``AGENTS.md`` tells you to issue.
+
+    Reads the template out of the prose rather than restating it, so the file is
+    the source of truth and a change to it is what this module measures. A
+    trailing ``->  .behind_by`` on the same line is tolerated so that the older
+    one-line spelling still parses: the point of failure should be the ref this
+    renders to, not this function.
+    """
+    match = re.search(
+        r"^\s*GET /repos/\{owner\}/\{repo\}/compare/(?P<ref>\S+?)(?:\s+->.*)?$",
+        text,
+        re.MULTILINE,
+    )
+    assert match is not None, "no compare template found in AGENTS.md; the passage moved or was removed"
+    return match.group("ref")
+
+
+def _render(template: str, *, head_name_with_owner: str, head_branch: str, base_branch: str = "main") -> str:
+    """Substitute a pull request's head into the documented template."""
+    head_owner, _, head_repo = head_name_with_owner.partition("/")
+    return template.format(
+        base_branch=base_branch,
+        head_owner=head_owner,
+        head_repo=head_repo,
+        head_branch=head_branch,
+    )
+
+
+def _recorded(ref: str) -> _CompareResponse:
+    """The recorded API answer for ``ref``, or the never-asked sentinel."""
+    return _RECORDED_COMPARE.get(ref, _NEVER_ASKED)
+
+
+def _rendered_for_the_fork_head(agents_text: str) -> str:
+    """The documented template rendered against #1035's head."""
+    return _render(
+        _documented_compare_ref_template(agents_text),
+        head_name_with_owner=_HEAD_REPOSITORY_NAME_WITH_OWNER,
+        head_branch=_HEAD_REF_NAME,
+    )
+
+
+def _tree_equivalence_applies(behind_by: int) -> bool:
+    """Whether the head/squash tree-sha equivalence is a valid check.
+
+    The derivation step 8 now asks a reader to perform: equal trees are evidence
+    only when the head already contained every commit on ``main``, because
+    otherwise the squash tree incorporates the intervening commits.
+    """
+    return behind_by == 0
+
+
+class TestTheDocumentedCompareRefResolves:
+    """The template in the file, rendered, is a ref the API can answer."""
+
+    def test_the_rendered_ref_is_the_one_that_answered_200(self, agents_text: str) -> None:
+        assert _recorded(_rendered_for_the_fork_head(agents_text)).http == 200
+
+    def test_the_rendered_ref_exposes_the_behind_by_field(self, agents_text: str) -> None:
+        assert _recorded(_rendered_for_the_fork_head(agents_text)).behind_by is not None
+
+    def test_the_rendered_ref_is_not_the_unqualified_one(self, agents_text: str) -> None:
+        assert _rendered_for_the_fork_head(agents_text) != f"main...{_HEAD_REF_NAME}"
+
+    def test_the_template_carries_the_head_owner_and_repository(self, agents_text: str) -> None:
+        template = _documented_compare_ref_template(agents_text)
+        assert "{head_owner}" in template
+        assert "{head_repo}" in template
+
+    def test_the_unqualified_ref_is_the_recorded_404(self) -> None:
+        """The negative control, so the pair above is a measurement and not a preference."""
+        assert _recorded(f"main...{_HEAD_REF_NAME}").http == 404
+
+    def test_the_qualified_form_also_serves_a_base_repository_branch(self, agents_text: str) -> None:
+        rendered = _render(
+            _documented_compare_ref_template(agents_text),
+            head_name_with_owner="strands-labs/robots",
+            head_branch="main",
+        )
+        assert _recorded(rendered).http == 200
+
+    def test_the_passage_says_where_to_resolve_the_head_from(self, step_eight: str) -> None:
+        assert "headRepository" in step_eight
+        assert "headRefName" in step_eight
+
+
+class TestTheTreeEquivalenceIsScopedToBehindZero:
+    """Equal trees are evidence at ``behind_by == 0`` and at no other value."""
+
+    def test_equal_trees_where_the_check_applies(self) -> None:
+        applicable = [row for row in _RECORDED_TREES if _tree_equivalence_applies(row.behind_by)]
+        assert applicable, "no recorded row exercises the applicable branch"
+        for row in applicable:
+            assert row.head_tree == row.squash_tree, row
+
+    def test_a_behind_branch_is_outside_the_check(self) -> None:
+        behind = [row for row in _RECORDED_TREES if not _tree_equivalence_applies(row.behind_by)]
+        assert behind, "no recorded row exercises the inapplicable branch"
+        for row in behind:
+            # Unequal trees for a merge that was correct - which is why reading
+            # the check outside its scope invents drift.
+            assert row.head_tree != row.squash_tree, row
+
+    def test_the_passage_scopes_the_equivalence(self, step_eight: str) -> None:
+        assert "scoped to `behind_by == 0`" in step_eight
+
+    def test_the_passage_names_the_counterexample(self, step_eight: str) -> None:
+        assert "8b3e7e8a3434" in step_eight, "the #2024 counterexample row is the evidence for the scoping"
+
+
+class TestTheGuidanceNamesTheForkConstraint:
+    """The template, its justification and the two-causes split stay adjacent."""
+
+    def test_it_says_to_qualify_the_head(self, step_eight: str) -> None:
+        assert "Qualify the head with its owner and repository" in step_eight
+
+    def test_it_names_the_step_that_forces_a_fork(self, step_eight: str) -> None:
+        assert "Step 1 mandates" in step_eight
+        assert "fork" in step_eight
+
+    def test_it_states_that_the_unqualified_form_always_fails_here(self, step_eight: str) -> None:
+        assert "`404`s on every pull request here" in step_eight
+
+    def test_it_separates_the_two_causes_of_a_404(self, step_eight: str) -> None:
+        assert "two causes wanting opposite actions" in step_eight
+
+    def test_it_keeps_the_uncomparable_case(self, step_eight: str) -> None:
+        """#2014's clause is narrowed, not dropped: a gone sha still needs the run."""
+        assert "is not a `0`: run the composition" in step_eight
+        assert "force-push" in step_eight
+
+    def test_it_says_which_form_the_404_must_be_read_on(self, step_eight: str) -> None:
+        assert "*qualified* form as the uncomparable one" in step_eight


### PR DESCRIPTION
Closes #2026

## The defect

Step 8 offers `behind_by` on a comparison against `main` as the cheap read that says whether a pre-merge composition is owed at all, and #2014 added the clause that a head which *cannot* be compared is not a `0`. Both are right about their own case. The template was not:

```
GET /repos/strands-labs/robots/compare/main...feat/ackermann-ros-robot
  -> 404 Not Found

GET /repos/strands-labs/robots/compare/main...Vivek0712:robots:feat/ackermann-ros-robot
  -> diverged  ahead_by=11  behind_by=116
```

Same head (#1035), same instant. An unqualified ref does not resolve in the base repository, and **step 1 mandates that the branch live on a fork**, so the documented form `404`s on every pull request in this repository.

What that costs is the entire saving the field was introduced for in #2012. A reader who gets a `404` reaches the "not a `0`" clause and runs the composition - a clone and two suite runs - on every branch. The misreading is silent and self-justifying: a `404` followed by a composition run looks like diligence, and the composition then confirms nothing is wrong, so nothing ever contradicts it.

A `404` has two causes, they need opposite actions, and the status code does not separate them:

| cause | means | correct action |
|---|---|---|
| ref not qualified with the fork owner | query construction error | re-issue qualified |
| head sha genuinely gone (force-push, deleted fork) | uncomparable | run the composition |

So the earlier clause is **narrowed, not dropped** - it still governs the second row.

## Second item, same step

The post-merge tree-sha equivalence check gains the scope it was measured under. Equal `.commit.tree.sha` between the head CI went green on and its squash on `main` is evidence only at `behind_by == 0`; when the branch is behind, the squash tree necessarily incorporates the intervening commits, so the trees differ for a **correct** merge:

| pull request | `behind_by` | head tree | squash tree |
|---|---|---|---|
| #2012 | `0` | `e174201b7ccf` | `e174201b7ccf` |
| #2024 | `1` | `4af91f210d09` | `8b3e7e8a3434` |

#2024's `main` went green on all four checks afterwards, so the inequality was not drift. Stated unscoped, the check invites reading a good merge as broken - the same expensive-in-the-diligent-direction shape as the advisory-`CodeQL` case step 8 already documents.

## Scope

Documentation and one test module. **No change under `strands_robots/`**, no runtime path, no dependency. Verified that no shipped script or workflow builds a compare URL, so there is no tooling half to this fix (`grep -rn "compare/" scripts/ .github/workflows/` is empty).

## The pin

`tests/test_composition_compare_ref_form.py` (17 tests) **executes** the claim rather than describing it: it lifts the ref template out of the prose, renders it against a recorded pull request head, and asserts the result is the ref the API answered `200` for, with the `404` ref as the negative control. A pin that merely asserted the file *mentions* fork qualification would keep passing if the template were tidied back to `<head>` - which is exactly the edit that reintroduces the defect.

Because this is a docs correction there is no pre-fix behavioural failure to show; the equivalent is the negative control, stated in the module docstring and measured:

> With `origin/main`'s `AGENTS.md` restored, **13 of the 17 fail** - 5 of 7 in `TestTheDocumentedCompareRefResolves`, both prose assertions in `TestTheTreeEquivalenceIsScopedToBehindZero`, and all 6 in `TestTheGuidanceNamesTheForkConstraint`.

The 4 that pass are the ones that should, and the docstring says which and why: two are recorded API evidence (a property of the repository, not of this change), and one guards a different respelling than the one being reverted. That classification was corrected after measuring it - the first draft claimed 15/2.

## Verification

Read as a delta, not an absolute, per step 8. Same 20 AGENTS.md-reading modules, same command:

| tree | result |
|---|---|
| `origin/main` baseline | 8 failed, **488 passed**, 53 skipped |
| this branch | 8 failed, **505 passed**, 53 skipped |

Zero regressions; the delta is exactly the +17 this branch adds. The 8 failures are `tests/test_robot_factory.py` missing optional deps (`strands`, `device_connect_edge`) in this environment and are identical on both trees.

- `ruff check` / `ruff format --check` / `mypy` on the new module: clean
- `scripts/assemble_changelog.py --check`: `changelog fragments OK`
- `scripts/check_changelog_fragment.py`: no `[Unreleased]` entry added (fragment used)
- `scripts/check_duplicate_claim.py --repo strands-labs/robots --issue 2026`: claimed by no open pull request (3 compared)
- non-ASCII sweep (`grep -nP '[^\x00-\x7F]'`) on both new files: clean

## §13 Round changelog

**Round 0 (initial):** step-8 compare template made fork-qualified with the two-causes split for a `404`; tree-sha equivalence scoped to `behind_by == 0` with the #2024 counterexample; `tests/test_composition_compare_ref_form.py` added as an executing pin; `changelog.d/2026-compare-ref-fork-qualified.md` fragment added.