### PR TITLE
fix(training): refuse an on-policy gradient-norm clip the update cannot honor

### DIFF
--- a/changelog.d/2028-gradient-clip-domain.md
+++ b/changelog.d/2028-gradient-clip-domain.md
@@ -23,7 +23,9 @@ the environment, the networks and a full rollout had been built.
 
 `PpoTrainer.validate` now reports the field through a shared
 `gradient_clip_problems` gate, so `train()` fails closed before any rollout is
-collected. `inf` stays inside the domain: it is the field's only spelling of "do
+collected. The preflight stays read-only and reports rather than raises for every
+value, including a real no float64 stands for (`10**400`) and a `numbers.Real`
+registration with no working `__float__`. `inf` stays inside the domain: it is the field's only spelling of "do
 not clip" and the consumer honors it by leaving every gradient untouched. Only
 the on-policy backend clips, so FastSAC and the mock backend stay silent about a
 field they never read.

--- a/changelog.d/2028-gradient-clip-domain.md
+++ b/changelog.d/2028-gradient-clip-domain.md
@@ -1,0 +1,29 @@
+### Fixed: an on-policy gradient-norm clip the update cannot honor is now refused
+
+`RLTrainSpec.max_grad_norm` is the last thing that touches a gradient before PPO
+steps, and nothing judged it. `torch.nn.utils.clip_grad_norm_` does not either:
+it scales every gradient by `max_norm / total_norm` whenever that ratio is below
+one, and that expression is defined for values no caller can have meant. Two of
+them were honored silently, on a run that reported `success` and wrote a
+deployable checkpoint:
+
+- `max_grad_norm=0` scales every gradient to **zero**, so the optimizer steps
+  with no information. Measured over a seeded 60-step run, the resulting
+  parameters were bit-identical to a never-trained control - a parameter delta of
+  exactly `0.0000000000`.
+- A **negative** bound negates the scaling ratio, so the update becomes gradient
+  *ascent* on the loss: a parameter whose gradient is `[3.0, 4.0]` comes out of
+  `clip_grad_norm_(-1.0)` as `[-0.6, -0.8]`, and the same seeded run moved its
+  parameter sum to `17.8211606460` where the honored run moved it to
+  `17.9833114612`, from a `17.9251941755865118` baseline.
+
+`True` was a silent bound of one and `"1.0"` was silently coerced through
+`float()`; `nan`, `None` and a list raised from inside `torch` mid-update, after
+the environment, the networks and a full rollout had been built.
+
+`PpoTrainer.validate` now reports the field through a shared
+`gradient_clip_problems` gate, so `train()` fails closed before any rollout is
+collected. `inf` stays inside the domain: it is the field's only spelling of "do
+not clip" and the consumer honors it by leaving every gradient untouched. Only
+the on-policy backend clips, so FastSAC and the mock backend stay silent about a
+field they never read.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -224,6 +224,21 @@ log-probability in the actor loss the resulting checkpoint holds non-finite
 parameters. Both previously reported success. It is inert when
 `autotune_alpha=False`, which builds no temperature optimizer.
 
+`max_grad_norm` must be a positive number, checked by `validate()` on the
+on-policy backend only (`clip_grad_norm_` appears in `rl/ppo.py` and nowhere
+else). It is the last thing that touches a gradient before the optimizer steps,
+and `clip_grad_norm_` scales every gradient by `max_norm / total_norm` without
+judging the bound, so two values used to be honored silently and wrongly:
+`max_grad_norm=0` scaled every gradient to zero, and the run reported success
+with a checkpoint bit-identical to a never-trained one; a **negative** bound
+negated the scaling ratio, so the update became gradient *ascent* on the loss
+and moved the parameters away from the objective, also under a successful run.
+`True` was a silent bound of one and `"1.0"` was silently coerced, while `nan`,
+`None` and a list raised from inside `torch` mid-update.
+
+`inf` is inside the domain: it is the field's only spelling of *do not clip*, and
+`clip_grad_norm_` honors it by leaving every gradient untouched.
+
 ## Worked example
 
 `examples/training/train_ppo_reach.py` (on-policy) and `examples/training/train_fastsac_reach.py`

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -224,11 +224,12 @@ log-probability in the actor loss the resulting checkpoint holds non-finite
 parameters. Both previously reported success. It is inert when
 `autotune_alpha=False`, which builds no temperature optimizer.
 
-`max_grad_norm` must be a positive number, checked by `validate()` on the
-on-policy backend only (`clip_grad_norm_` appears in `rl/ppo.py` and nowhere
-else). It is the last thing that touches a gradient before the optimizer steps,
-and `clip_grad_norm_` scales every gradient by `max_norm / total_norm` without
-judging the bound, so two values used to be honored silently and wrongly:
+`max_grad_norm` must be a positive number a 64-bit float can represent, checked
+by `validate()` on the on-policy backend only (`clip_grad_norm_` appears in
+`rl/ppo.py` and nowhere else). It is the last thing that touches a gradient
+before the optimizer steps, and `clip_grad_norm_` scales every gradient by
+`max_norm / total_norm` without judging the bound, so two values used to be
+honored silently and wrongly:
 `max_grad_norm=0` scaled every gradient to zero, and the run reported success
 with a checkpoint bit-identical to a never-trained one; a **negative** bound
 negated the scaling ratio, so the update became gradient *ascent* on the loss
@@ -237,7 +238,11 @@ and moved the parameters away from the objective, also under a successful run.
 `None` and a list raised from inside `torch` mid-update.
 
 `inf` is inside the domain: it is the field's only spelling of *do not clip*, and
-`clip_grad_norm_` honors it by leaving every gradient untouched.
+`clip_grad_norm_` honors it by leaving every gradient untouched. A real that no
+64-bit float stands for is refused with the range as its reason rather than the
+sign, and `validate()` reports it like any other unusable bound instead of
+raising: Python integers are arbitrary-precision, so `10**400` is one request
+away.
 
 ## Worked example
 

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -96,10 +96,19 @@ entropy temperature - and passes each straight to
 :func:`learning_rate_problems` documents apply to the second field verbatim.
 It is a separate gate for the same reason as :func:`gae_lambda_problems`: only
 the off-policy backend tunes a temperature.
+
+:func:`gradient_clip_problems` is the twelfth, on the same *optimization* axis:
+``max_grad_norm``, the norm the on-policy update clips every gradient to before
+stepping. It is scoped like :func:`gae_lambda_problems` - only the on-policy
+backend clips, so FastSAC must not report on a field it never reads - and it is
+the one coefficient of that group whose zero reading *is* settled, by
+``torch.nn.utils.clip_grad_norm_`` itself: see that gate for the measurement.
 """
 
 from __future__ import annotations
 
+import math
+import numbers
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -552,16 +561,16 @@ def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
     than left to the arithmetic that consumes it.
 
     ``lam``, the other factor of the trace-decay product, has its own gate for
-    that same scoping reason - see :func:`gae_lambda_problems`, and
-    ``num_learning_epochs`` likewise in :func:`optimization_epochs_problems`.
+    that same scoping reason - see :func:`gae_lambda_problems`,
+    ``num_learning_epochs`` likewise in :func:`optimization_epochs_problems`,
+    and ``max_grad_norm`` in :func:`gradient_clip_problems`.
     The remaining PPO coefficients (``clip_param``, ``entropy_coef``,
-    ``value_loss_coef``, ``max_grad_norm``, ``init_noise_std``) are out of scope
-    in all three: they weight loss terms and bound gradients rather than the
-    return, and for each of them zero has a candidate reading as a *disabled
-    mode* that this repository has not settled - ``entropy_coef`` is shipped
-    defaulting to ``0.0``, so zero is already a supported configuration;
-    ``max_grad_norm=0`` reads as "no clipping" in several RL codebases; and
-    ``init_noise_std=0`` is refused by ``torch`` itself, which rejects a
+    ``value_loss_coef``, ``init_noise_std``) are out of scope in all four: they
+    weight loss terms and initialize the action distribution rather than
+    discounting the return, and for each of them zero has a candidate reading as
+    a *disabled mode* that this repository has not settled - ``entropy_coef`` is
+    shipped defaulting to ``0.0``, so zero is already a supported configuration,
+    and ``init_noise_std=0`` is refused by ``torch`` itself, which rejects a
     ``Normal`` of zero scale. Those are contract questions rather than defects,
     so they are left to a gate that settles them.
 
@@ -772,4 +781,102 @@ def temperature_learning_rate_problems(spec: TrainSpec, *, context: str) -> list
     if not getattr(spec, "autotune_alpha", False):
         return []
     error = positive_finite_number_error(getattr(spec, "alpha_lr", 3e-4), "alpha_lr", context)
+    return [error] if error is not None else []
+
+
+def _gradient_clip_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when *value* is not a gradient-norm clip ``clip_grad_norm_`` honors.
+
+    The whole of this function's own contribution is that positive **infinity is
+    also accepted**; every other decision - numeric-ness, ``bool`` rejection,
+    the positivity floor and the message text - is delegated to the shared
+    :func:`~strands_robots.utils.positive_finite_number_error` domain, so those
+    refusals read identically to every other positive-scalar field's.
+
+    Infinity is carved out because the consumer honors it. ``clip_grad_norm_``
+    scales a gradient by ``max_norm / total_norm`` only when that ratio is below
+    one, so an infinite bound leaves every gradient untouched - measured on a
+    parameter whose gradient norm is 5, ``inf`` returns it as ``[3.0, 4.0]``
+    unchanged. That is the only spelling of "do not clip" the field has, and a
+    guard that refused a value its own consumer applies coherently would be
+    narrower than the code it protects.
+
+    Args:
+        value: The caller-supplied value.
+        param: Field name for the message.
+        context: Caller label the message is prefixed with.
+
+    Returns:
+        The error text, or None when *value* is a positive real number (finite
+        or positive infinity).
+    """
+    if isinstance(value, numbers.Real) and not isinstance(value, bool) and float(value) == math.inf:
+        return None
+    return positive_finite_number_error(value, param, context)
+
+
+def gradient_clip_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return gradient-clip problems for an on-policy RL :class:`TrainSpec`.
+
+    ``max_grad_norm`` is the last thing that touches a gradient before the
+    optimizer steps - the on-policy update ends every mini-batch with
+    ``clip_grad_norm_(self.actor_critic.parameters(), spec.max_grad_norm)`` -
+    and nothing judged it. ``clip_grad_norm_`` does not either: it multiplies
+    every gradient by ``max_norm / total_norm`` whenever that ratio is below
+    one, and that expression is defined for values no caller can have meant.
+    Measured on this backend, over a seeded 60-step run whose parameter sum
+    starts at ``17.9251941755865118``:
+
+    ======================  =========================================
+    ``max_grad_norm``       Outcome
+    ======================  =========================================
+    ``1.0`` (the default)   trains; parameter sum ``17.9833114612``
+    ``inf``                 trains, unclipped; sum ``17.9604155714``
+    ``0`` / ``0.0``         **succeeds having learned nothing**
+    ``-1.0`` / ``-0.5``     **trains in the opposite direction**
+    ``True``               a silent clip of one
+    ``"1.0"``              silently accepted
+    ``nan``                 raises mid-update, from inside ``torch``
+    ``None`` / ``[1.0]``    raises mid-update, from inside ``torch``
+    ======================  =========================================
+
+    The two silent rows are the reason this is a gate rather than a lint:
+
+    * **Zero scales every gradient to zero**, so the optimizer steps with no
+      information. The run collects its rollouts, reports ``success`` and writes
+      a deployable checkpoint whose parameters are *bit-identical* to a
+      never-trained control - the parameter delta is exactly ``0.0000000000``.
+      This is the same shape as :func:`optimization_epochs_problems`, reached
+      through a different field.
+    * **A negative bound negates the ratio**, so every gradient is flipped and
+      scaled: the same parameter whose gradient is ``[3.0, 4.0]`` comes out of
+      ``clip_grad_norm_(-1.0)`` as ``[-0.6, -0.8]``. The update is therefore
+      gradient *ascent* on the loss - the seeded run above moves its parameter
+      sum to ``17.8211606460`` while the honored run moves it to
+      ``17.9833114612``, i.e. away from the objective, silently, under a
+      successful run.
+
+    Zero is **not** the "no clipping" spelling, which is the one reading that
+    might have made it a contract question rather than a defect: infinity is,
+    and it is accepted (see :func:`_gradient_clip_error`). So the domain is a
+    positive real, finite or infinite, with no undecided endpoint.
+
+    Only the on-policy backend clips gradients - ``grep`` finds
+    ``clip_grad_norm_`` in ``rl/ppo.py`` and nowhere else - so this is scoped
+    like :func:`gae_lambda_problems` rather than
+    :func:`learning_rate_problems`: a backend that does not clip MUST NOT call
+    it, because per :class:`TrainSpec` a backend ignores the fields it does not
+    support and reporting on one would be a false rejection.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single-element list when ``max_grad_norm`` cannot be honored; empty
+        otherwise.
+    """
+    error = _gradient_clip_error(getattr(spec, "max_grad_norm", 1.0), "max_grad_norm", context)
     return [error] if error is not None else []

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -801,6 +801,18 @@ def _gradient_clip_error(value: Any, param: str, context: str) -> str | None:
     guard that refused a value its own consumer applies coherently would be
     narrower than the code it protects.
 
+    Nothing raises out of here, for any input. The carve-out asks the
+    *conversion* - that is what the consumer performs, ``clip_grad_norm_``
+    reading its bound through ``float()`` - and it wraps that conversion, so a
+    real past the float64 range and a :class:`numbers.Real` registration with
+    no working ``__float__`` are delegated rather than raised on. ``10**400``
+    is a registered real that is neither a ``bool`` nor convertible, and
+    ``Fraction(10**400, 3)`` overflows identically; the shared domain already
+    names that boundary and answers each with a reason of its own. Raising
+    here would fail on the one path that exists to answer an unusable value
+    with a message rather than an exception - the contract every caller of
+    this gate documents.
+
     Args:
         value: The caller-supplied value.
         param: Field name for the message.
@@ -810,8 +822,19 @@ def _gradient_clip_error(value: Any, param: str, context: str) -> str | None:
         The error text, or None when *value* is a positive real number (finite
         or positive infinity).
     """
-    if isinstance(value, numbers.Real) and not isinstance(value, bool) and float(value) == math.inf:
-        return None
+    if isinstance(value, numbers.Real) and not isinstance(value, bool):
+        try:
+            is_no_clip = float(value) == math.inf
+        except Exception:
+            # Decline to answer rather than raise. A ``numbers.Real``
+            # registration owes this function no working ``__float__``, and a
+            # real past the float64 range raises ``OverflowError`` from the
+            # conversion - ``10**400`` and ``Fraction(10**400, 3)`` both do.
+            # Neither is the no-clip spelling, and the shared domain below
+            # answers each with a reason of its own.
+            is_no_clip = False
+        if is_no_clip:
+            return None
     return positive_finite_number_error(value, param, context)
 
 

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -547,6 +547,41 @@ class Trainer(ABC):
 
         return temperature_learning_rate_problems(spec, context=self.provider_name)
 
+    def _gradient_clip_problems(self, spec: TrainSpec) -> list[str]:
+        """Gradient-clip preflight for a backend that clips before it steps.
+
+        Returns a problem when :attr:`RLTrainSpec.max_grad_norm` is not a
+        positive real number. Positive infinity is inside the domain: it is the
+        field's only spelling of "do not clip", and ``clip_grad_norm_`` honors
+        it by leaving every gradient untouched.
+
+        Zero and negative values are not degenerate spellings of that, which is
+        why this is a positivity test rather than a non-negative one. Zero
+        scales every gradient to zero, so the optimizer steps with no
+        information and the run writes a checkpoint bit-identical to a
+        never-trained one; a negative bound negates the scaling ratio, so the
+        update becomes gradient *ascent* on the loss. Both report success.
+
+        Only a backend that clips may call this: like
+        :meth:`_gae_lambda_problems`, and unlike
+        :meth:`_learning_rate_problems`, a backend that does not read the field
+        MUST NOT report on it, because per :class:`TrainSpec` a backend ignores
+        the fields it does not support.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the module import graph one-way.
+
+        Args:
+            spec: The spec to preflight.
+
+        Returns:
+            A single-element list when the field cannot be honored; empty
+            otherwise.
+        """
+        from strands_robots.training._validate import gradient_clip_problems
+
+        return gradient_clip_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -159,6 +159,10 @@ class PpoTrainer(BaseRLAlgo):
         # num_learning_epochs is the loop bound of the whole optimizer step, so a
         # non-positive value takes no gradient step while the run still succeeds.
         problems.extend(self._optimization_epochs_problems(spec))
+        # max_grad_norm scales every gradient before the optimizer steps: zero
+        # scales them all to zero and a negative bound negates them, so neither
+        # takes the step the caller asked for while the run still succeeds.
+        problems.extend(self._gradient_clip_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/tests/training/test_gradient_clip_domain.py
+++ b/tests/training/test_gradient_clip_domain.py
@@ -88,37 +88,64 @@ NOT_A_CLIP: list[Any] = [
     np.bool_(True),
 ]
 
-# Reals no float64 stands for. Positive and finite, so ``must be > 0`` would be a
-# false statement about them - the shared domain answers them with a reason of its
-# own, and the carve-out has to reach it rather than raising on the conversion.
-BEYOND_FLOAT_RANGE: list[Any] = [10**400, -(10**400), Fraction(10**400, 3)]
-
 
 class _RealWithNoFloat:
-    """A :class:`numbers.Real` registration that can be read as no number at all.
+    """A :class:`numbers.Real` registration whose conversion refuses.
 
-    ``numbers.Real`` is a registration rather than an inheritance, so a value that
-    satisfies the type test owes a guard nothing else - neither a working
-    ``__float__`` nor a working ``__eq__``. Both raise here, so a carve-out that
-    converted *or* compared without wrapping it would fail on this value.
+    ``numbers.Real`` is a registration rather than an inheritance, so a value
+    that satisfies the type test owes a guard no working ``__float__``. The
+    carve-out converts, so this is the shape that reaches its wrapper: without
+    one, the conversion's own exception escapes ``validate``.
+
+    The exception is supplied per instance rather than fixed, because the
+    handler is deliberately broader than any single type - a probe that raised
+    only one would let an ``except`` clause narrowed to it keep passing. Each
+    type used is one the data model prescribes for a conversion that cannot be
+    performed, which is also what keeps these probes out of a merge gate: the
+    ``py/unexpected-raise-in-special-method`` CodeQL rule reports a special
+    method that always raises an exception unexpected for it, an alert opens a
+    review thread, and thread resolution is required to merge - so a
+    ``RuntimeError`` here would block the PR it is testing. Suppression is not
+    the alternative: the filter set is deliberately exactly two rule ids, pinned
+    by ``tests/test_codeql_query_filters.py``.
     """
 
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
     def __float__(self) -> float:
-        raise RuntimeError("this real cannot be read as a float")
-
-    def __eq__(self, other: object) -> bool:
-        raise RuntimeError("this real cannot be compared")
-
-    def __hash__(self) -> int:
-        return 0
+        raise self._error
 
     def __repr__(self) -> str:
-        return "<a real with no float>"
+        return f"<a real whose float raises {type(self._error).__name__}>"
 
 
 numbers.Real.register(_RealWithNoFloat)
 
-UNREADABLE_REAL: list[Any] = [_RealWithNoFloat()]
+#: The exceptions the data model prescribes for a conversion that cannot be
+#: performed: ``TypeError`` for an unsupported operand, and the two ``float()``
+#: itself raises for a value it cannot represent.
+PRESCRIBED_CONVERSION_ERRORS = (TypeError, ValueError, OverflowError)
+
+# A registration the conversion cannot read at all. Neither reason the shared
+# domain has for a *number* is true of it, so it earns the positivity message,
+# the same as every other value that is not a usable positive real.
+UNREADABLE_REAL: list[Any] = [
+    _RealWithNoFloat(TypeError("this real cannot be read as a float")),
+    _RealWithNoFloat(ValueError("this real has no float value")),
+]
+
+# A registration whose conversion *overflows* is beyond the float range by the
+# shared helper's own definition - ``_beyond_float_range`` asks the conversion,
+# not the type - so it earns the range reason and belongs with ``10**400``
+# rather than with the values above. Keeping it in the right family is what
+# makes the two refusal-reason tests below mean anything.
+OVERFLOWING_REAL: list[Any] = [_RealWithNoFloat(OverflowError("this real is past the float range"))]
+
+# Reals no float64 stands for. Positive and finite, so ``must be > 0`` would be a
+# false statement about them - the shared domain answers them with a reason of its
+# own, and the carve-out has to reach it rather than raising on the conversion.
+BEYOND_FLOAT_RANGE: list[Any] = [10**400, -(10**400), Fraction(10**400, 3), *OVERFLOWING_REAL]
 
 # Every unusable value whose refusal is the shared domain's ``must be > 0``.
 PLAIN_REFUSAL: list[Any] = [*NO_GRADIENT_STEP, *INVERTED_GRADIENT, *NOT_A_CLIP, *UNREADABLE_REAL]
@@ -243,6 +270,22 @@ class TestInfinityIsTheOnlyDifferenceFromTheSharedRule:
     def test_the_carve_out_declines_rather_than_raising(self, value: Any) -> None:
         """A value the carve-out cannot read is delegated, never raised on."""
         assert isinstance(_gradient_clip_error(value, "max_grad_norm", "ppo"), str)
+
+    def test_the_unreadable_probes_span_the_prescribed_conversion_errors(self) -> None:
+        """Non-vacuity for the wrapper, and a guard against the probes drifting.
+
+        The wrapper is broad on purpose, so the probes have to be broader than
+        one exception or an ``except`` clause narrowed to it would still pass.
+        They also have to stay *prescribed*: a special method that always raises
+        an exception the data model does not expect for it is a CodeQL alert, and
+        an alert opens a review thread that blocks the merge.
+        """
+        raised = []
+        for probe in [*UNREADABLE_REAL, *OVERFLOWING_REAL]:
+            with pytest.raises(PRESCRIBED_CONVERSION_ERRORS) as excinfo:
+                float(probe)
+            raised.append(excinfo.type)
+        assert set(raised) == set(PRESCRIBED_CONVERSION_ERRORS)
 
     def test_a_string_spelling_of_infinity_is_not_carved_out(self) -> None:
         """``float("inf")`` is the carve-out's value, so the type test carries it."""

--- a/tests/training/test_gradient_clip_domain.py
+++ b/tests/training/test_gradient_clip_domain.py
@@ -1,0 +1,340 @@
+"""The on-policy gradient-norm clip is checked against its domain.
+
+``RLTrainSpec.max_grad_norm`` is the last thing that touches a gradient before
+PPO steps: ``PpoTrainer.update`` ends every mini-batch with
+``clip_grad_norm_(self.actor_critic.parameters(), spec.max_grad_norm)``. Nothing
+judged the value, and ``clip_grad_norm_`` does not either - it multiplies every
+gradient by ``max_norm / total_norm`` whenever that ratio is below one, and that
+expression is defined for values no caller can have meant.
+
+Measured on this backend before the gate existed, over a seeded 60-step run
+whose checkpoint parameter sum starts at ``17.9251941755865118``:
+
+* ``0`` and ``0.0`` reported ``status="success"`` and wrote a deployable
+  checkpoint whose parameters were **bit-identical to a never-trained control** -
+  the parameter delta was exactly ``0.0000000000``. Every gradient had been
+  scaled to zero, so the optimizer stepped with no information.
+* ``-1.0`` and ``-0.5`` also reported success, and moved the parameter sum to
+  ``17.8211606460`` while the honored run moved it to ``17.9833114612`` - i.e.
+  **away** from the objective. A negative bound negates the scaling ratio, so
+  the same parameter whose gradient is ``[3.0, 4.0]`` comes out of
+  ``clip_grad_norm_(-1.0)`` as ``[-0.6, -0.8]`` and the update becomes gradient
+  *ascent* on the loss.
+* ``True`` was a silent clip of one and ``"1.0"`` was silently accepted, because
+  ``clip_grad_norm_`` coerces its bound through ``float()``.
+* ``nan``, ``None`` and ``[1.0]`` raised from inside ``torch`` mid-update, after
+  the environment, the networks and a full rollout had been built.
+
+``inf`` is **inside** the domain: it is the field's only spelling of "do not
+clip", and the consumer honors it by leaving every gradient untouched. That is
+the reading which, had it belonged to zero, would have made this a contract
+question rather than a defect - so the domain is a positive real, finite or
+infinite, with no undecided endpoint.
+
+Scoped to the on-policy backend: ``clip_grad_norm_`` appears in ``rl/ppo.py``
+and nowhere else, so a backend that does not clip must not report on a field it
+never reads. Every domain test here reaches the real ``validate`` entry point,
+so it covers the wiring as well as the domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import _gradient_clip_error, gradient_clip_problems
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.utils import positive_finite_number_error
+
+# The one backend whose update clips a gradient.
+ON_POLICY = "ppo"
+
+# Backends that never clip - they must stay quiet about the field.
+NO_CLIP_BACKENDS = ("fast_sac", "mock")
+
+# Zero scales every gradient to zero, so the run takes no informed step at all.
+NO_GRADIENT_STEP: list[Any] = [0, 0.0]
+
+# A negative bound negates the scaling ratio: the update inverts.
+INVERTED_GRADIENT: list[Any] = [-1.0, -0.5, -100.0]
+
+# Values the clip cannot mean, or reads as a different bound than the caller
+# wrote. ``True`` is a bound of one; ``"1.0"`` is coerced through ``float()``.
+NOT_A_CLIP: list[Any] = [
+    True,
+    False,
+    float("nan"),
+    float("-inf"),
+    "1.0",
+    None,
+    [1.0],
+    {"max_grad_norm": 1.0},
+    np.bool_(True),
+]
+
+UNUSABLE: list[Any] = [*NO_GRADIENT_STEP, *INVERTED_GRADIENT, *NOT_A_CLIP]
+
+# The silent half: these reach a full run and report success.
+SILENT: list[Any] = [*NO_GRADIENT_STEP, *INVERTED_GRADIENT, True, "1.0"]
+
+# Any positive real. Unlike the count domains this one is continuous, so an
+# integral float and a NumPy real are both usable - the consumer divides by the
+# gradient norm rather than indexing with the value.
+USABLE: list[Any] = [1.0, 0.5, 10.0, 1e-8, 3, np.float64(1.0), np.float32(0.5), np.int64(2)]
+
+# The one value this gate accepts that the shared positive-finite domain does
+# not: the consumer applies it coherently as "do not clip".
+NO_CLIPPING: list[Any] = [math.inf, np.float64(np.inf)]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """An otherwise-valid RL spec, so only the field under test is exercised."""
+    return RLTrainSpec(output_dir="/tmp/gradient_clip_domain", env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+
+
+def _clip_problems(provider: str, spec: RLTrainSpec) -> list[str]:
+    """Problems the real ``validate`` entry point reports about the field.
+
+    Filtered on the shared domains' ``"{context}: {param} "`` message shape
+    rather than on a bare substring, so an unrelated problem can neither mask a
+    missing refusal nor be mistaken for one.
+    """
+    prefix = f"{provider}: max_grad_norm "
+    return [p for p in create_trainer(provider).validate(spec) if p.startswith(prefix)]
+
+
+class TestTheOnPolicyBackendRefusesAnUnusableGradientClip:
+    """PPO refuses every value ``clip_grad_norm_`` cannot honor."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.max_grad_norm = value
+        assert _clip_problems(ON_POLICY, spec), f"ppo accepted max_grad_norm={value!r}"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_problem_names_the_field_the_domain_and_the_value(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.max_grad_norm = value
+        (problem,) = _clip_problems(ON_POLICY, spec)
+        assert "max_grad_norm" in problem
+        assert "must be > 0" in problem
+        assert repr(value) in problem, problem
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.max_grad_norm = value
+        (problem,) = _clip_problems(ON_POLICY, spec)
+        assert problem.startswith(f"{ON_POLICY}: ")
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_preflight_reports_rather_than_raises(self, spec: RLTrainSpec, value: Any) -> None:
+        """``validate`` is read-only, so even a value ``float()`` chokes on reports."""
+        spec.max_grad_norm = value
+        assert isinstance(create_trainer(ON_POLICY).validate(spec), list)
+
+    @pytest.mark.parametrize("value", SILENT)
+    def test_a_silently_honored_value_never_reaches_a_run(self, spec: RLTrainSpec, value: Any) -> None:
+        """``train`` is fail-closed on ``validate``, so no rollout is collected."""
+        spec.max_grad_norm = value
+        result = create_trainer(ON_POLICY).train(spec)
+        assert result.status == "error"
+        assert "max_grad_norm" in result.message
+
+
+class TestTheUsableDomainIsUntouched:
+    """Every bound the clip can honor still passes."""
+
+    @pytest.mark.parametrize("value", [*USABLE, *NO_CLIPPING])
+    def test_a_positive_real_is_accepted(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.max_grad_norm = value
+        assert _clip_problems(ON_POLICY, spec) == []
+
+    def test_the_shipped_default_is_inside_the_domain(self, spec: RLTrainSpec) -> None:
+        assert spec.max_grad_norm == 1.0
+        assert _clip_problems(ON_POLICY, spec) == []
+
+    def test_a_spec_without_the_field_is_silent(self) -> None:
+        """A plain ``TrainSpec`` has no ``max_grad_norm``, so there is nothing to judge."""
+        from strands_robots.training.base import TrainSpec
+
+        plain = TrainSpec(output_dir="/tmp/gradient_clip_domain")
+        assert gradient_clip_problems(plain, context="ppo") == []
+
+
+class TestInfinityIsTheOnlyDifferenceFromTheSharedRule:
+    """The local domain's whole contribution is accepting "do not clip"."""
+
+    @pytest.mark.parametrize("value", [*USABLE, *UNUSABLE])
+    def test_it_agrees_with_the_shared_positive_finite_rule(self, value: Any) -> None:
+        mine = _gradient_clip_error(value, "max_grad_norm", "ppo")
+        shared = positive_finite_number_error(value, "max_grad_norm", "ppo")
+        assert mine == shared, f"diverged on {value!r}: {mine!r} vs {shared!r}"
+
+    @pytest.mark.parametrize("value", NO_CLIPPING)
+    def test_infinity_is_the_carve_out(self, value: Any) -> None:
+        assert _gradient_clip_error(value, "max_grad_norm", "ppo") is None
+        assert positive_finite_number_error(value, "max_grad_norm", "ppo") is not None
+
+    def test_negative_infinity_is_not_carved_out(self) -> None:
+        assert _gradient_clip_error(float("-inf"), "max_grad_norm", "ppo") is not None
+
+
+class TestTheBackendsThatDoNotClipStaySilent:
+    """A backend that never reads the field must not report on it."""
+
+    @pytest.mark.parametrize("provider", NO_CLIP_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_no_problem_is_reported(self, spec: RLTrainSpec, provider: str, value: Any) -> None:
+        spec.max_grad_norm = value
+        assert _clip_problems(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", NO_CLIP_BACKENDS)
+    def test_the_silence_is_scoping_and_not_an_empty_preflight(self, spec: RLTrainSpec, provider: str) -> None:
+        """Non-vacuity: these backends do refuse a field they *do* read."""
+        spec.max_grad_norm = 0.0
+        spec.learning_rate = -1.0
+        problems = create_trainer(provider).validate(spec)
+        assert any(p.startswith(f"{provider}: learning_rate ") for p in problems), problems
+        assert not any(p.startswith(f"{provider}: max_grad_norm ") for p in problems), problems
+
+
+def _ppo_update_source() -> str:
+    """The source of the on-policy update, for premise checks."""
+    from strands_robots.training.rl.ppo import PpoTrainer
+
+    return inspect.getsource(PpoTrainer.update)
+
+
+class TestTheConsumerHonorsTheDomain:
+    """The premises the domain rests on, measured against ``torch`` itself."""
+
+    def test_the_update_clips_with_the_field(self) -> None:
+        source = _ppo_update_source()
+        assert "clip_grad_norm_" in source
+        assert "spec.max_grad_norm" in source
+
+    def test_the_clip_is_the_last_thing_before_the_step(self) -> None:
+        """So the bound decides the whole update, not a fraction of it."""
+        source = _ppo_update_source()
+        clip = source.index("clip_grad_norm_")
+        step = source.index("self.optimizer.step()")
+        backward = source.index("loss.backward()")
+        assert backward < clip < step
+
+    @pytest.mark.parametrize(
+        ("bound", "expected"),
+        [
+            (1.0, [0.6, 0.8]),  # clipped: scaled by max_norm / total_norm
+            (math.inf, [3.0, 4.0]),  # honored as "do not clip"
+            (0.0, [0.0, 0.0]),  # every gradient scaled to zero
+            (-1.0, [-0.6, -0.8]),  # the ratio is negated: the update inverts
+        ],
+    )
+    def test_clip_grad_norm_applies_the_bound_verbatim(self, bound: float, expected: list[float]) -> None:
+        torch = pytest.importorskip("torch")
+        param = torch.nn.Parameter(torch.tensor([3.0, 4.0]))
+        param.grad = torch.tensor([3.0, 4.0])  # norm 5
+        torch.nn.utils.clip_grad_norm_([param], bound)
+        assert param.grad is not None
+        assert param.grad.tolist() == pytest.approx(expected, abs=1e-5)
+
+    def test_a_bool_bound_is_a_silent_clip_of_one(self) -> None:
+        """Which is why ``bool`` must be refused rather than read as one."""
+        torch = pytest.importorskip("torch")
+        params = []
+        for bound in (True, 1.0):
+            param = torch.nn.Parameter(torch.tensor([3.0, 4.0]))
+            param.grad = torch.tensor([3.0, 4.0])
+            torch.nn.utils.clip_grad_norm_([param], bound)
+            assert param.grad is not None
+            params.append(param.grad.tolist())
+        assert params[0] == params[1]
+
+    def test_a_string_bound_is_silently_accepted(self) -> None:
+        """So the consumer cannot be relied on to reject a non-numeric bound."""
+        torch = pytest.importorskip("torch")
+        param = torch.nn.Parameter(torch.tensor([3.0, 4.0]))
+        param.grad = torch.tensor([3.0, 4.0])
+        torch.nn.utils.clip_grad_norm_([param], "1.0")  # type: ignore[arg-type]
+        assert param.grad is not None
+        assert param.grad.tolist() == pytest.approx([0.6, 0.8], abs=1e-5)
+
+    def test_a_non_finite_bound_poisons_every_gradient(self) -> None:
+        torch = pytest.importorskip("torch")
+        param = torch.nn.Parameter(torch.tensor([3.0, 4.0]))
+        param.grad = torch.tensor([3.0, 4.0])
+        torch.nn.utils.clip_grad_norm_([param], float("nan"))
+        assert param.grad is not None
+        assert not bool(torch.isfinite(param.grad).all())
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(gradient_clip_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_clip(source: str) -> bool:
+    """Does *source* read ``spec.max_grad_norm``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "max_grad_norm" and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_gradient_clip_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheGradientClipDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.max_grad_norm`` must route it through the shared
+    gate, so a second backend that starts clipping with the field fails this
+    test until it does.
+    """
+
+    def test_every_module_that_reads_it_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name for p in _training_modules() if _reads_the_clip(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules read spec.max_grad_norm without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_the_clip(p.read_text())}
+        assert readers == {"ppo.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading the field without the gate is really reported."""
+        planted = "def validate(self, spec):\n    return [] if spec.max_grad_norm else []\n"
+        assert _reads_the_clip(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_bound(self) -> None:
+        """A hand-rolled comparison agrees with the shared rule until it drifts."""
+        offenders = [
+            p.name
+            for p in _training_modules()
+            if "max_grad_norm <= 0" in p.read_text() or "max_grad_norm < 0" in p.read_text()
+        ]
+        assert offenders == [], f"modules compare max_grad_norm themselves: {offenders}"

--- a/tests/training/test_gradient_clip_domain.py
+++ b/tests/training/test_gradient_clip_domain.py
@@ -31,6 +31,11 @@ the reading which, had it belonged to zero, would have made this a contract
 question rather than a defect - so the domain is a positive real, finite or
 infinite, with no undecided endpoint.
 
+The preflight is read-only, so it reports rather than raises for every value -
+including a real no float64 stands for (``10**400``, ``Fraction(10**400, 3)``)
+and a :class:`numbers.Real` registration with no working ``__float__``. Those
+reach the shared domain, which answers each with a reason of its own.
+
 Scoped to the on-policy backend: ``clip_grad_norm_`` appears in ``rl/ppo.py``
 and nowhere else, so a backend that does not clip must not report on a field it
 never reads. Every domain test here reaches the real ``validate`` entry point,
@@ -42,7 +47,9 @@ from __future__ import annotations
 import ast
 import inspect
 import math
+import numbers
 import pathlib
+from fractions import Fraction
 from typing import Any
 
 import numpy as np
@@ -74,13 +81,49 @@ NOT_A_CLIP: list[Any] = [
     float("nan"),
     float("-inf"),
     "1.0",
+    "inf",
     None,
     [1.0],
     {"max_grad_norm": 1.0},
     np.bool_(True),
 ]
 
-UNUSABLE: list[Any] = [*NO_GRADIENT_STEP, *INVERTED_GRADIENT, *NOT_A_CLIP]
+# Reals no float64 stands for. Positive and finite, so ``must be > 0`` would be a
+# false statement about them - the shared domain answers them with a reason of its
+# own, and the carve-out has to reach it rather than raising on the conversion.
+BEYOND_FLOAT_RANGE: list[Any] = [10**400, -(10**400), Fraction(10**400, 3)]
+
+
+class _RealWithNoFloat:
+    """A :class:`numbers.Real` registration that can be read as no number at all.
+
+    ``numbers.Real`` is a registration rather than an inheritance, so a value that
+    satisfies the type test owes a guard nothing else - neither a working
+    ``__float__`` nor a working ``__eq__``. Both raise here, so a carve-out that
+    converted *or* compared without wrapping it would fail on this value.
+    """
+
+    def __float__(self) -> float:
+        raise RuntimeError("this real cannot be read as a float")
+
+    def __eq__(self, other: object) -> bool:
+        raise RuntimeError("this real cannot be compared")
+
+    def __hash__(self) -> int:
+        return 0
+
+    def __repr__(self) -> str:
+        return "<a real with no float>"
+
+
+numbers.Real.register(_RealWithNoFloat)
+
+UNREADABLE_REAL: list[Any] = [_RealWithNoFloat()]
+
+# Every unusable value whose refusal is the shared domain's ``must be > 0``.
+PLAIN_REFUSAL: list[Any] = [*NO_GRADIENT_STEP, *INVERTED_GRADIENT, *NOT_A_CLIP, *UNREADABLE_REAL]
+
+UNUSABLE: list[Any] = [*PLAIN_REFUSAL, *BEYOND_FLOAT_RANGE]
 
 # The silent half: these reach a full run and report success.
 SILENT: list[Any] = [*NO_GRADIENT_STEP, *INVERTED_GRADIENT, True, "1.0"]
@@ -120,13 +163,23 @@ class TestTheOnPolicyBackendRefusesAnUnusableGradientClip:
         spec.max_grad_norm = value
         assert _clip_problems(ON_POLICY, spec), f"ppo accepted max_grad_norm={value!r}"
 
-    @pytest.mark.parametrize("value", UNUSABLE)
+    @pytest.mark.parametrize("value", PLAIN_REFUSAL)
     def test_the_problem_names_the_field_the_domain_and_the_value(self, spec: RLTrainSpec, value: Any) -> None:
         spec.max_grad_norm = value
         (problem,) = _clip_problems(ON_POLICY, spec)
         assert "max_grad_norm" in problem
         assert "must be > 0" in problem
         assert repr(value) in problem, problem
+
+    @pytest.mark.parametrize("value", BEYOND_FLOAT_RANGE)
+    def test_a_value_past_the_float64_range_is_refused_with_its_own_reason(self, spec: RLTrainSpec, value: Any) -> None:
+        """It is positive and finite, so ``must be > 0`` would be false of it."""
+        spec.max_grad_norm = value
+        (problem,) = _clip_problems(ON_POLICY, spec)
+        assert "max_grad_norm" in problem
+        assert "must be within the range of a 64-bit float" in problem
+        assert "must be > 0" not in problem
+        assert repr(value) in problem
 
     @pytest.mark.parametrize("value", UNUSABLE)
     def test_the_problem_names_the_backend_that_refused_it(self, spec: RLTrainSpec, value: Any) -> None:
@@ -185,6 +238,16 @@ class TestInfinityIsTheOnlyDifferenceFromTheSharedRule:
 
     def test_negative_infinity_is_not_carved_out(self) -> None:
         assert _gradient_clip_error(float("-inf"), "max_grad_norm", "ppo") is not None
+
+    @pytest.mark.parametrize("value", [*BEYOND_FLOAT_RANGE, *UNREADABLE_REAL])
+    def test_the_carve_out_declines_rather_than_raising(self, value: Any) -> None:
+        """A value the carve-out cannot read is delegated, never raised on."""
+        assert isinstance(_gradient_clip_error(value, "max_grad_norm", "ppo"), str)
+
+    def test_a_string_spelling_of_infinity_is_not_carved_out(self) -> None:
+        """``float("inf")`` is the carve-out's value, so the type test carries it."""
+        assert float("inf") == math.inf  # the premise the type test guards
+        assert _gradient_clip_error("inf", "max_grad_norm", "ppo") is not None
 
 
 class TestTheBackendsThatDoNotClipStaySilent:


### PR DESCRIPTION
## Problem

`RLTrainSpec.max_grad_norm` is the last thing that touches a gradient before PPO steps — `PpoTrainer.update` ends every mini-batch with `clip_grad_norm_(self.actor_critic.parameters(), spec.max_grad_norm)` — and nothing judged the value.

`clip_grad_norm_` does not judge it either. It multiplies every gradient by `max_norm / total_norm` whenever that ratio is below one, and that expression is defined for values no caller can have meant. Measured on a seeded 60-step run of the SO-100 `Elbow`-reach `SimEnv` (34,701 actor-critic parameters, checkpoint parameter sum `17.9251941755865118` before any update):

| `max_grad_norm` | `clip_grad_norm_` on a gradient `[3.0, 4.0]` | `validate()` | `train()` | what the run did |
|---|---|---|---|---|
| `1.0` (default) | `[0.6, 0.8]` | `[]` | success | trains; sum `17.9833114612` |
| `inf` | `[3.0, 4.0]` unchanged | `[]` | success | trains unclipped; sum `17.9604155714` |
| `0` / `0.0` | `[0.0, 0.0]` | `[]` | **success** | **0 of 34,701 parameters moved** |
| `-1.0` / `-0.5` | `[-0.6, -0.8]` | `[]` | **success** | **96.50% of parameters flipped sign** |
| `True` | `[0.6, 0.8]` | `[]` | success | a silent bound of one |
| `"1.0"` | `[0.6, 0.8]` | `[]` | success | silently coerced through `float()` |
| `nan` | `[nan, nan]` | `[]` | raises | `ValueError` from inside `torch`, mid-update |
| `None` / `[1.0]` | `TypeError` | `[]` | raises | bare `TypeError` from inside `torch` |

The two silent rows are the reason this is a gate rather than a lint:

- **Zero scales every gradient to zero**, so the optimizer steps with no information. The run collects its rollouts, reports `status="success"` and writes a deployable checkpoint whose parameters are *bit-identical to a never-trained control* — the parameter delta is exactly `0.0000000000`. Same shape as `optimization_epochs_problems`, reached through a different field.
- **A negative bound negates the scaling ratio**, so the update becomes gradient *ascent* on the loss. The per-parameter update is near-perfectly anti-parallel to the honored one: cosine similarity `-0.992055`, with 96.50% of the moved parameters flipping sign, and the parameter sum moving to `17.8211606460` where the honored run moves it to `17.9833114612`.

## Why `inf` stays inside the domain

`inf` is the field's only spelling of *do not clip*, and the consumer honors it — `clip_grad_norm_` scales only when `max_norm / total_norm < 1`, so an infinite bound returns every gradient untouched. A guard that refused a value its own consumer applies coherently would be narrower than the code it protects, so the domain is a positive real, finite **or** positive infinity. The whole of the local `_gradient_clip_error` is that carve-out; numeric-ness, `bool` rejection, the positivity floor and the message text are all delegated to the shared `positive_finite_number_error`, and a parity test asserts the two agree on every other probe value. The carve-out asks the *conversion*, because that is what the consumer performs, and it cannot raise while doing so (see Round 2).

## A corrected premise

`discount_factor_problems`' docstring left this field out of scope on the grounds that

> `max_grad_norm=0` reads as "no clipping" in several RL codebases

That is the one reading which would have made it a contract question rather than a defect, and `torch` disproves it: `0` zeroes the gradients and `inf` is what leaves them alone. So the field's zero reading is settled, not undecided. That paragraph is corrected here, and the remaining coefficients it names (`clip_param`, `entropy_coef`, `value_loss_coef`, `init_noise_std`) stay out of scope with their genuine reasons — `entropy_coef` ships defaulting to `0.0`, so zero is already a supported configuration there.

## Change

- `gradient_clip_problems` in `training/_validate.py`, the twelfth shared gate, plus the private `_gradient_clip_error` domain.
- `Trainer._gradient_clip_problems` on the base, and a call from `PpoTrainer.validate` — so `train()`, which is fail-closed on `validate()`, refuses before a rollout is collected.
- Scoped to the on-policy backend: `clip_grad_norm_` appears in `rl/ppo.py` and nowhere else, so FastSAC and the mock backend stay silent about a field they never read. A test pins that their silence is scoping and not an empty preflight (they still refuse a bad `learning_rate` on the same spec).

## Tests

`tests/training/test_gradient_clip_domain.py`, 200 tests, 0.40 s, no GL:

- Every unusable value is reported through the real `validate()` entry point, with a message naming the field, the domain and the value, and prefixed with the backend that refused it.
- Every silently-honored value is shown never to reach a run (`train()` returns `status="error"`).
- The whole accepted domain still passes, including `inf`, integral floats and NumPy reals, and the shipped default.
- The premises are executable: `clip_grad_norm_` really applies `1.0`, `inf`, `0.0` and `-1.0` verbatim to a gradient of norm 5; `True` really is a silent bound of one; `"1.0"` really is accepted; `nan` really poisons the gradient. So the domain's justification cannot silently stop being true.
- One owner: an AST guard derived from the tree requires every module that reads `spec.max_grad_norm` to route through the shared gate, with a non-vacuity assertion on the reader set and a planted-reader meta-test.

Pre-fix, with the two call sites reverted to `main` and the tests kept: **65 failed / 118 passed**, the structural guard reporting `modules read spec.max_grad_norm without the shared gate: ['ppo.py']`. The 118 that pass are the domain unit tests, the consumer premises and the scoping tests — the parts that hold either way, and are what stop the guard reaching further than the one field.

## Measured

![gradient-clip domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gradient-clip-domain/gradient_clip_domain.png)

Left: the per-parameter update with `max_grad_norm=-1.0` plotted against the honored one, lying on the inversion line. Right: where each value leaves the checkpoint relative to a never-trained control — `0.0` exactly on the baseline, `-1.0` below it. Every number in the figure is re-derived from two JSON dumps captured by one script run in a `main` checkout and in this branch, with the generator asserting the two trees differ and each claim holds; the [capture](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gradient-clip-domain/capture_ppo_gradient_clip.py) and [compose](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gradient-clip-domain/compose_figure.py) scripts are alongside it.

No regression: the two accepted rows are **bit-identical across the two trees** (`17.9833114612` and `17.9604155714`), so training behaviour for every value that was already usable is unchanged.

## Round 2 — the carve-out could raise

The infinity carve-out converted with a bare `float(value)` *before* delegating, so `validate()` raised instead of reporting for any `numbers.Real` the conversion cannot read:

| `max_grad_norm` | `positive_finite_number_error` | `validate()` at `db809ff` |
|---|---|---|
| `10**400` | reports `must be within the range of a 64-bit float` | **raises `OverflowError`** |
| `Fraction(10**400, 3)` | reports the same | **raises `OverflowError`** |
| a `numbers.Real` whose `__float__` raises | reports `must be > 0` | **raises `RuntimeError`** |

That reintroduced, ahead of the delegation, the exact class the delegated-to guard was hardened for — `positive_finite_number_error` routes through `_beyond_float_range` because it *"used to raise `OverflowError` out of the `float()` this guard converts with — failing on the path that exists so it does not"*.

Comparing without converting (`value == math.inf`) was measured and is **insufficient**: it moves the hazard from `__float__` to `__eq__`, and a `numbers.Real` registration owes the guard neither. The carve-out therefore wraps its conversion and declines to answer, so both values reach the shared domain and each gets a reason of its own. It still asks the conversion rather than an operator, because the conversion is what the consumer performs — `clip_grad_norm_` reads its bound through `float()`.

The beyond-range reals and an unreadable `numbers.Real` join the unusable probe set, so the parity test now covers the one region where the two domains could diverge. That split the refusal families: `10**400` is positive *and* finite, so `must be > 0` would be false of it, and a dedicated test pins that it gets the range reason instead. The region also exposed that `float("inf") == math.inf`, so the type test is what stops the *string* `"inf"` being carved out — now covered.

**No previously-decided value changed verdict.** Over 26 values spanning the accepted domain, both `inf` spellings, every silently-honored row and every raising row, the branch head and this round return the identical result: 26 / 26, 0 diverged. Only the four values that *crashed* now report, so the figure above — all of whose rows are previously-decided values — still holds and no new artifact is warranted.

Round-2 pre-fix, source reverted to `db809ff` with the new tests kept: **24 failed / 159 passed**, every failure an exception escaping `validate()`, including `test_the_preflight_reports_rather_than_raises` and the parity test.

## Round 3 — the probe was blocking its own merge gate

The probe Round 2 added to prove the preflight reports rather than raises raised `RuntimeError` from `__float__`, and that is a CodeQL alert in its own right: `py/unexpected-raise-in-special-method` reports a special method that always raises an exception the data model does not prescribe for it, and for a conversion that cannot be performed the prescribed type is `TypeError`. An alert opens a `github-advanced-security` review thread and the `default` ruleset requires thread resolution, so the probe written to unblock this PR was blocking it.

Suppression was not the alternative. The filter set is deliberately **exactly two** rule ids and `tests/test_codeql_query_filters.py` fails if a third is added, precisely so clearing an alert by appending its id is a visible edit rather than the cheap path.

The exception is now supplied per instance, which also repairs a weakness the single probe had: the wrapper is broad on purpose, and one exception type let an `except` clause narrowed to that type keep passing. Three probes span the errors a refusing conversion may legitimately raise, and a test pins both the span and the prescribed-ness, so they cannot drift back into the gate.

### Splitting them exposed a mis-filed probe

A registration whose conversion **overflows** is beyond the float range by `_beyond_float_range`'s own definition — it asks the conversion, not the type — so it earns the range reason, not the positivity one. Filed with the `must be > 0` family it made `test_the_problem_names_the_field_the_domain_and_the_value` fail on a message that would have been a false statement about it, exactly as `10**400` did in Round 2. It moves to `BEYOND_FLOAT_RANGE`, which is what keeps the two refusal-reason tests from masking each other.

The raising `__eq__` goes with it. The data model requires `__eq__` never to raise, and nothing reads it — the carve-out asks the conversion because the conversion is what the consumer performs. That retires the *executable* half of Round 2's "comparing is also unsafe" note; the load-bearing reason for converting is unchanged and is the consumer's own behaviour.

**No behaviour change.** `positive_finite_number_error` wraps its conversion, so every probe is reported exactly as before — only the exception type reaching that wrapper differs.

### Docs

The reference page said `max_grad_norm` "must be a positive number", which is false of `10**400`: it is a positive number and it is refused. The changelog fragment recorded the range refusal and the page did not, so the two disagreed about one field's domain. The page now states the float64 bound and which reason applies.

### Verified

Measured in a container without a GPU, without a hardware GL driver (software `osmesa`) and without `lerobot`, so the absolute totals below are **not** comparable to CI's — which is why the load-bearing check is a same-command comparison against the unmodified Round-2 head rather than a number on its own:

| | round-2 head `51f64a58` | this branch `d9b4e25` |
|---|---|---|
| failed | 668 | **668** |
| errors | 270 | **270** |
| skipped | 663 | **663** |
| passed | 20791 | **20808** |

Identical failure and error sets; the `+17` passed are the widened probe parametrizations. So this round introduces no failure, and the 668/270 are this environment (software GL, absent optional deps) rather than the tree.

- `tests/training/test_gradient_clip_domain.py` → **200 passed** in 0.40 s, no GL.
- `ruff check strands_robots tests` clean; `ruff format --check` → 1065 files already formatted; `mypy` clean on the changed module.
- `scripts/assemble_changelog.py --check` → OK. Repository-wide guards including `tests/test_codeql_query_filters.py`, the changelog pair, dangling doc refs and unreachable statements → **254 passed**.

The full `MUJOCO_GL=egl` suite, `mypy` over `tests_integ`, and `scripts/check_merge_base_overlap.py` are left to CI, which has the driver and the optional dependencies this environment does not.

## Verification

Head `d9b4e25`, base `519b9f93`.

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` → **23206 passed, 257 skipped, 0 failed** in 539.82 s.
- `ruff check strands_robots tests tests_integ` → clean. `ruff format --check` → 1108 files already formatted.
- `mypy strands_robots tests tests_integ` → **0 errors outside `examples/`**. The 14 reported there are byte-identical to a pristine `upstream/main` checkout of the same working copy, so they are environmental rather than introduced.
- `scripts/assemble_changelog.py --check` → OK, and the five repository-wide guards (changelog fragments and format, dangling doc refs, internal source paths, unreachable statements) → 42 passed.
- `scripts/check_merge_base_overlap.py` → no overlap with `upstream/main`, so the checks above describe the tree that merges.


