### PR TITLE
fix(scripts): refuse an inferred repository at duplicate-claim intake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,17 @@ hatch run format            # ruff check --fix, ruff format
    Before you start, check that no open pull request already claims the issue:
 
    ```
-   python3 scripts/check_duplicate_claim.py --issue <N>
+   python3 scripts/check_duplicate_claim.py --repo strands-labs/robots --issue <N>
    ```
+
+   Name the repository rather than leaving it to be inferred. `$GITHUB_REPOSITORY`
+   is where the command is *running*, which for a scheduled agent need not be a
+   checkout of this one, and an intake check that reads a different repository's
+   open pull requests reports `unique-claim` and exits `0` -- a wrong answer shaped
+   exactly like the right one, and one an issue number alone gives the script no way
+   to detect afterwards. Intake mode refuses an inferred repository for that reason;
+   the `--pr` mode keeps the default, because a workflow reviewing a pull request
+   runs where that pull request lives.
 
    A duplicate claim is invisible to every other check here, because they all read
    one pull request at a time and this is a property of the *set* of open ones. It

--- a/changelog.d/2029-intake-repository-must-be-named.md
+++ b/changelog.d/2029-intake-repository-must-be-named.md
@@ -1,0 +1,24 @@
+### CI: the duplicate-claim intake check refuses an inferred repository
+
+`scripts/check_duplicate_claim.py --issue N` resolved the repository from
+`$GITHUB_REPOSITORY`, which names where the command is *running*. AGENTS.md step 1 asks
+that question at intake -- before any pull request exists -- so it is a local invocation
+by whoever is about to do the work, and nothing ties their working directory to the
+repository the issue belongs to. Run from elsewhere, the check read a different
+repository's open pull requests, found none of them claiming the number, and reported
+`unique-claim` with exit `0`. Measured with `huggingface/lerobot` as the ambient
+repository, `--issue 2029` compared **405** unrelated open pull requests; naming the
+repository compared 4. Both said no duplicate, so the wrong answer was indistinguishable
+from the right one, and it only misled in the reassuring direction -- a spurious
+collision would have been investigated and found nonexistent, a missed one is invisible.
+
+Intake mode now requires `--repo`, refusing at argparse time with a message that names
+what the environment inferred, before any lookup. Nothing can detect the substitution
+after the fact: an issue number alone does not name a repository, so there is no second
+source to compare against, and numbers are dense enough that an unrelated repository
+very often has one at the same number -- which is also why confirming the issue *exists*
+would not be a reliable substitute, on top of reversing this script's deliberate
+decision not to read it. The `--pr` mode keeps the environment default, since a workflow
+reviewing a pull request runs where that pull request lives. Step 1 prints the explicit
+command, and a test runs the printed command through the script's own preconditions, so
+shortening one without the other fails.

--- a/scripts/check_duplicate_claim.py
+++ b/scripts/check_duplicate_claim.py
@@ -120,12 +120,15 @@ work from being done twice, and it is complete as shipped.
 
 Usage
 -----
-``--repo``    ``owner/name`` (default: ``$GITHUB_REPOSITORY``).
+``--repo``    ``owner/name``. Required in intake mode; in ``--pr`` mode it
+              defaults to ``$GITHUB_REPOSITORY``. See
+              :func:`inferred_repository_refusal` for why the two modes differ.
 ``--issue``   an issue number, asked at intake. Mutually exclusive with ``--pr``.
 ``--pr``      a pull request number (default: ``$PR_NUMBER``).
 ``--token``   API token (default: ``$GITHUB_TOKEN``). Needs ``pull-requests: read``.
 
-Exit status is ``1`` for ``duplicate-claim``, else ``0``.
+Exit status is ``1`` for ``duplicate-claim``, else ``0``. A usage error, including an
+intake question whose repository was left to be inferred, exits ``2``.
 """
 
 from __future__ import annotations
@@ -478,18 +481,59 @@ def render(verdict: Verdict, repo: str, pr: int | None = None, issue: int | None
     return "\n".join(lines)
 
 
+def inferred_repository_refusal(inferred: str) -> str:
+    """Return why an inferred repository cannot answer an intake question.
+
+    ``$GITHUB_REPOSITORY`` names the repository a command is *running in*. For the
+    ``--pr`` mode that is the right answer by construction -- a workflow reviewing a
+    pull request runs in the repository the pull request lives in, which is why the
+    default is kept there. Intake runs *before* any pull request exists, so it is a
+    local invocation by whoever is about to do the work, and nothing ties their
+    working directory to the repository the issue belongs to.
+
+    The failure that follows is silent rather than loud, which is why this is a
+    refusal rather than a warning. The check reads a different repository's open
+    pull requests, finds none of them claiming that number, and reports
+    ``unique-claim`` with exit ``0``. Nothing in that report distinguishes it from
+    the answer to the question that was meant, and it only misleads in the
+    reassuring direction: a spurious collision would be investigated and found
+    nonexistent, whereas a missed one is invisible.
+
+    Nor can the substitution be detected after the fact. An issue number alone does
+    not name a repository, so there is no second source to compare the resolved one
+    against, and issue numbers are dense enough that an unrelated repository very
+    often has one at the same number -- which is also why confirming the issue
+    *exists* would not be a reliable substitute for naming the repository, on top of
+    reversing this script's deliberate decision not to read the issue at all.
+    """
+    return (
+        "intake mode must name the repository: pass --repo owner/name. The environment "
+        f"infers {inferred!r}, which is where this command is running rather than "
+        "necessarily the repository the issue belongs to, and an intake check that reads "
+        "the wrong repository reports no duplicate."
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    # ``None`` rather than the environment value, so "was it supplied?" stays
+    # answerable after parsing -- the intake refusal below turns on that, not on
+    # what the repository resolves to.
+    parser.add_argument("--repo", default=None)
     parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
     parser.add_argument("--issue", default="")
     parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
     args = parser.parse_args(argv)
 
-    if not args.repo:
+    inferred = os.environ.get("GITHUB_REPOSITORY", "")
+    repo = inferred if args.repo is None else args.repo
+
+    if not repo:
         parser.error("--repo is required (or set GITHUB_REPOSITORY)")
     if bool(args.pr) == bool(args.issue):
         parser.error("pass exactly one of --pr (review a pull request) and --issue (intake)")
+    if args.repo is None and args.issue:
+        parser.error(inferred_repository_refusal(repo))
     if not args.token:
         parser.error("--token is required (or set GITHUB_TOKEN)")
 
@@ -501,14 +545,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         # In intake mode the "claim" is the issue being considered, and nothing is
         # excluded from the comparison because no pull request for it exists yet.
-        claimed = (issue,) if issue is not None else resolve_claim(args.repo, int(args.pr), args.token)
-        others = resolve_open_claims(args.repo, args.token, pr) if claimed else {}
+        claimed = (issue,) if issue is not None else resolve_claim(repo, int(args.pr), args.token)
+        others = resolve_open_claims(repo, args.token, pr) if claimed else {}
     except (ClaimSetUnreadable, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
         claimed, others, detail = None, None, str(exc)
         print(f"check_duplicate_claim: {detail}", file=sys.stderr)
 
     verdict = classify(claimed, others, detail)
-    report = render(verdict, args.repo, pr, issue)
+    report = render(verdict, repo, pr, issue)
     print(report)
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -65,6 +65,30 @@ _MEASURED_PAIRS: tuple[tuple[int, int, int, int], ...] = (
 )
 
 
+#: Check scripts that can infer their repository from the environment, derived
+#: rather than listed: a script that never reads ``$GITHUB_REPOSITORY`` (the local
+#: git ones) has nothing to infer and so nothing to be given.
+_INFERS_REPOSITORY: tuple[str, ...] = tuple(
+    sorted(
+        path.name
+        for path in sorted((_ROOT / "scripts").glob("check_*.py"))
+        if "GITHUB_REPOSITORY" in path.read_text(encoding="utf-8")
+    )
+)
+
+
+def _documented_intake_argv(issue: int) -> list[str]:
+    """Return the intake command step 1 prints, as an ``argv`` list."""
+    found = re.findall(r"python3 scripts/check_duplicate_claim\.py([^\n`]*)", _AGENTS.read_text(encoding="utf-8"))
+    assert len(found) == 1, found
+    return [part.replace("<N>", str(issue)) for part in found[0].split()]
+
+
+def _documented_check_invocations() -> list[tuple[str, str]]:
+    """Return ``(script, remaining argv)`` for every check AGENTS.md invokes."""
+    return re.findall(r"python3 scripts/(check_[a-z_]+\.py)([^\n`]*)", _AGENTS.read_text(encoding="utf-8"))
+
+
 def _pair_ids() -> list[str]:
     return [f"#{issue}" for issue, _, _, _ in _MEASURED_PAIRS]
 
@@ -497,7 +521,9 @@ class TestTheGuidanceRecordsTheIntakeCheck:
             "every one of those had",
             "property of the *set* of open ones",
             "closingIssuesReferences",
-            "check_duplicate_claim.py --issue",
+            "check_duplicate_claim.py --repo strands-labs/robots --issue",
+            "where the command is *running*",
+            "refuses an inferred repository",
             "prevents the authoring rather than capping it",
         ],
     )
@@ -509,3 +535,120 @@ class TestTheGuidanceRecordsTheIntakeCheck:
         step_one = self._step_one()
         assert "exactly one should claim the close" in step_one
         assert re.search(r"per #N|towards #N", step_one)
+
+
+class TestIntakeModeMustNameTheRepository:
+    """``$GITHUB_REPOSITORY`` names where a command runs, not what an issue belongs to.
+
+    Intake is the mode that runs *before* any pull request exists, so it is a local
+    invocation whose working directory says nothing about the target repository. The
+    ``--pr`` mode is the opposite: a workflow reviewing a pull request runs in the
+    repository that pull request lives in, so inference is right by construction
+    there and the default is kept.
+
+    Refused rather than warned about because the failure is silent and only misleads
+    in the reassuring direction. Measured on this script with ``huggingface/lerobot``
+    as the ambient repository, ``--issue 2029`` compared **405** unrelated open pull
+    requests and reported ``unique-claim`` with exit ``0``; naming the repository
+    compared 4. Both said no duplicate, so nothing in the report distinguished them.
+    """
+
+    def test_an_inferred_repository_is_refused_at_intake(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("GITHUB_REPOSITORY", "someone/elsewhere")
+        with pytest.raises(SystemExit) as excinfo:
+            mod.main(["--issue", "2029", "--token", "t"])
+        assert excinfo.value.code == 2, excinfo.value.code
+        err = capsys.readouterr().err
+        assert "--repo owner/name" in err
+        assert "'someone/elsewhere'" in err, err
+        assert "reports no duplicate" in err
+
+    def test_the_refusal_is_about_inference_not_the_value(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The very same repository, named explicitly, is accepted."""
+        monkeypatch.setenv("GITHUB_REPOSITORY", "o/n")
+        monkeypatch.setattr(mod, "resolve_open_claims", lambda *_a, **_k: {})
+        assert mod.main(["--repo", "o/n", "--issue", "2029", "--token", "t"]) == 0
+        assert "| issue | o/n#2029 |" in capsys.readouterr().out
+
+    def test_the_review_mode_keeps_the_inferred_default(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The asymmetry, asserted rather than implied by the intake tests."""
+        monkeypatch.setenv("GITHUB_REPOSITORY", "o/n")
+        monkeypatch.setattr(mod, "resolve_claim", lambda *_a, **_k: (7,))
+        monkeypatch.setattr(mod, "resolve_open_claims", lambda *_a, **_k: {})
+        assert mod.main(["--pr", "5", "--token", "t"]) == 0
+        assert "| pull request | o/n#5 |" in capsys.readouterr().out
+
+    def test_the_refusal_precedes_every_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A refused invocation reads nothing -- not even to decide it is refused."""
+
+        def fatal(*_a: object, **_k: object) -> object:
+            raise AssertionError("the refused invocation reached the API")
+
+        monkeypatch.setenv("GITHUB_REPOSITORY", "someone/elsewhere")
+        monkeypatch.setattr(mod, "_post", fatal)
+        monkeypatch.setattr(mod, "resolve_open_claims", fatal)
+        monkeypatch.setattr(mod, "resolve_claim", fatal)
+        with pytest.raises(SystemExit):
+            mod.main(["--issue", "2029", "--token", "t"])
+
+    def test_nothing_to_infer_still_names_the_flag(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """With no ambient repository the original precondition is what fires."""
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        with pytest.raises(SystemExit):
+            mod.main(["--issue", "2029", "--token", "t"])
+        assert "--repo is required" in capsys.readouterr().err
+
+    def test_the_reason_names_what_was_inferred_and_what_follows(self) -> None:
+        """A refusal that named neither would send the reader to the wrong place."""
+        reason = mod.inferred_repository_refusal("someone/elsewhere")
+        assert "--repo owner/name" in reason
+        assert "'someone/elsewhere'" in reason
+        assert "where this command is running" in reason
+        assert "reports no duplicate" in reason
+
+    def test_the_documented_command_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The invocation step 1 prints must survive this script's own preconditions.
+
+        Pins guidance and code together from the guidance side: shortening the
+        documented command back to an inferred repository fails here, and so does
+        adding the refusal without updating the command it refuses.
+        """
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        monkeypatch.setattr(mod, "resolve_open_claims", lambda *_a, **_k: {})
+        assert mod.main([*_documented_intake_argv(2029), "--token", "t"]) == 0
+        assert "| issue | strands-labs/robots#2029 |" in capsys.readouterr().out
+
+
+class TestNoDocumentedInvocationLeavesTheRepositoryInferred:
+    """The defect was a documented command, so the durable pin is on the guidance.
+
+    Measured over the check scripts AGENTS.md invokes, exactly one omitted ``--repo``.
+    ``check_last_push_approval.py`` names it in both of its invocations, and
+    ``check_closing_reference.py`` has no local invocation at all -- its workflow calls
+    it with no arguments, where the environment is correct by construction. Scoped to
+    the scripts that can *infer* a repository, since the local-git checks have nothing
+    to infer and requiring a flag of them would be a false rejection.
+    """
+
+    def test_the_inferring_scripts_are_the_ones_measured(self) -> None:
+        """Non-vacuity: the scope is a real set, and this script is in it."""
+        assert "check_duplicate_claim.py" in _INFERS_REPOSITORY, _INFERS_REPOSITORY
+        assert len(_INFERS_REPOSITORY) == 3, _INFERS_REPOSITORY
+
+    def test_every_documented_invocation_names_the_repository(self) -> None:
+        invocations = _documented_check_invocations()
+        assert len(invocations) >= 3, invocations
+        inferring = [(script, rest) for script, rest in invocations if script in _INFERS_REPOSITORY]
+        assert inferring, invocations
+        missing = [f"{script}{rest}" for script, rest in inferring if "--repo" not in rest]
+        assert not missing, missing


### PR DESCRIPTION
## Problem

AGENTS.md step 1 opens with the duplicate-claim intake check, and the invocation it prints resolves the repository from the ambient environment:

```
python3 scripts/check_duplicate_claim.py --issue <N>
```

`$GITHUB_REPOSITORY` names the repository a command is **running in**. Intake asks its question *before* any pull request exists, so it is a local invocation by whoever is about to do the work, and nothing ties their working directory to the repository the issue belongs to. Run from anywhere else, the check reads a different repository's open pull requests, finds none of them claiming that number, and reports `unique-claim` with exit `0`.

Measured with `huggingface/lerobot` as the ambient repository, both commands seconds apart in one shell:

| invocation | `issue` field in the report | open pull requests compared | exit |
|---|---|---|---|
| `--issue 2029` (as step 1 says) | `huggingface/lerobot#2029` | **405** | 0 |
| `--repo strands-labs/robots --issue 2029` | `strands-labs/robots#2029` | 4 | 0 |

The first compared four hundred and five pull requests belonging to a project that has nothing to do with the change, very confidently. **Both rows say no duplicate, so the wrong answer is indistinguishable from the right one** — and it only misleads in the reassuring direction: a spurious collision would be investigated and found nonexistent, whereas a missed one is silent. That is what the check exists to prevent: measured over the last 100 pull requests, three duplicate pairs each burned a review **approval** on a change that could never ship (#2017), and review is the scarcest resource here (#1905).

This is a local-invocation defect only, which is also why no CI run would ever surface it. There is no workflow calling this script — `git grep check_duplicate_claim .github/` is empty, and the file says so itself: *"Not wired to CI here, and that is a scope statement rather than an oversight."* So the intake invocation is the **only** invocation, and it is the one that infers.

## Change

Intake mode requires `--repo`. The flag's default becomes `None` rather than the environment value, so *"was it supplied?"* stays answerable after parsing, and the refusal turns on that rather than on what the repository resolves to:

```
$ GITHUB_REPOSITORY=huggingface/lerobot python3 scripts/check_duplicate_claim.py --issue 2029
check_duplicate_claim.py: error: intake mode must name the repository: pass --repo owner/name.
The environment infers 'huggingface/lerobot', which is where this command is running rather
than necessarily the repository the issue belongs to, and an intake check that reads the
wrong repository reports no duplicate.
```

Refused at argparse time, before any lookup, and it names what was inferred so the reader is not sent to the wrong place. A usage error exits `2`, which stays distinguishable from `1` for a finding.

The `--pr` mode keeps the environment default. That mode is the CI-shaped one: a workflow reviewing a pull request runs in the repository that pull request lives in, so inference is right there by construction, and the follow-up workflow the file describes would rely on it.

Step 1 now prints the explicit command with a paragraph on why, and the script's `Usage` block records that the two modes differ.

## Why not the alternatives

The issue offered two others, and measuring them is what settled the shape:

- **Refuse when the resolved repository disagrees with where the issue lives** rests on a premise that does not hold in this mode. Intake never reads the issue — `claimed = (issue,) if issue is not None else resolve_claim(...)` simply wraps the number — so there is no existing query to compare against, and no second source either: **an issue number alone does not name a repository.** The weaker form, confirming the issue *exists* in the resolved repository, is not a reliable substitute for the reason the issue itself gives — numbers are dense, so an unrelated repository very often has one at the same number — and it would reverse a documented decision, since *"Whether the issue exists, or is already closed"* is in this script's deliberate out-of-scope list with a stated reason.
- **Drop the environment default entirely** was rejected in the issue as breaking the CI caller. There is no CI caller, so that objection is void — but the default is still right for `--pr`, so the scoping above keeps it where it is correct instead of removing it from where it is not.

## Tests

`tests/test_duplicate_claim_check.py`, +9 tests (66 total, 0.11 s, no network):

- The inferred intake invocation is refused with exit `2`, and the message names the inferred repository and what would otherwise follow.
- **The refusal is about inference, not the value**: the very same repository named explicitly is accepted.
- **The asymmetry is asserted rather than implied**: `--pr` with an inferred repository still works and still names it.
- **A refused invocation reads nothing** — `_post`, `resolve_claim` and `resolve_open_claims` are all made fatal, and the refusal still happens.
- With nothing to infer, the original `--repo is required` precondition is what fires, unchanged.
- `test_the_documented_command_is_accepted` extracts the command step 1 prints and runs it through the script's own preconditions. That pins guidance and code together from the guidance side: shortening the documented command back fails here, and so does adding the refusal without updating the command it refuses.
- `TestNoDocumentedInvocationLeavesTheRepositoryInferred` generalises it. The defect was a documented command, so the durable pin is on the documentation: every check invocation in AGENTS.md must name the repository. Scoped to the scripts that can *infer* one, derived by reading which of them mention `$GITHUB_REPOSITORY` rather than listed, because the local-git checks have nothing to infer and requiring a flag of them would be a false rejection.

That last one encodes the sibling census the issue asks for. Of the three scripts that can infer a repository, exactly one was exposed: `check_last_push_approval.py` names it in **both** of its documented invocations and its workflow passes `--repo "$GITHUB_REPOSITORY"` explicitly, and `check_closing_reference.py` has no local invocation at all — its workflow calls it with no arguments, where the environment is correct by construction. So no sibling needed changing, and the guard now says so.

Pre-fix, with `scripts/check_duplicate_claim.py` and `AGENTS.md` reverted to `main` and the tests kept: **8 failed / 58 passed**, including

```
FAILED ...::test_the_refusal_precedes_every_lookup - AssertionError: the refused invocation reached the API
FAILED ...::test_every_documented_invocation_names_the_repository
  - AssertionError: ['check_duplicate_claim.py --issue <N>']
```

The 58 that pass are the pre-existing contract, untouched, plus the three over-reach controls — the `--pr` default, the explicitly-named repository and the nothing-to-infer path all behave identically either way, which is what stops the refusal reaching further than the one mode.

## Measured

![duplicate-claim intake repository](https://raw.githubusercontent.com/cagataycali/robots/artifacts/duplicate-claim-intake-repo/intake_repository.png)

Five real invocations against the live API, run in a `main` checkout and in this branch. The first row is derived from **each tree's own AGENTS.md**, so the pair (guidance, script) is measured together rather than the script alone: on `main` the printed command reports about `huggingface/lerobot#2029` over 405 pull requests, on this branch about `strands-labs/robots#2029` over 4. Three of the five rows are byte-identical across the two trees, asserted in the generator, so the only behaviour that changed is the one invocation that could not answer its question. Every cell is re-derived from two JSON dumps; the generator asserts the dumps came from different trees and that each rendered claim holds, and the [capture](https://raw.githubusercontent.com/cagataycali/robots/artifacts/duplicate-claim-intake-repo/capture_intake_repo.py) and [compose](https://raw.githubusercontent.com/cagataycali/robots/artifacts/duplicate-claim-intake-repo/compose_figure.py) scripts are alongside it.

No policy, simulation, rendering, recording or asset behaviour is touched, so the artifact is a measurement rather than a rollout.

## Verification

Head `7fd5ee5`, base `3b87871b`.

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` → **23091 passed, 257 skipped, 0 failed** in 533 s.
- `ruff check strands_robots tests tests_integ` → clean. `ruff format --check` → 1109 files already formatted.
- `mypy strands_robots tests tests_integ` → **0 errors outside `examples/`**. The 14 reported there are byte-identical to a pristine `upstream/main` checkout of the same working copy, so they are environmental rather than introduced.
- `scripts/` is outside CI's lint scope, so explicitly: `ruff check scripts/` clean, `ruff format --check scripts/` → 7 files already formatted, `mypy --disallow-untyped-defs --warn-return-any scripts/check_duplicate_claim.py` → clean.
- `scripts/assemble_changelog.py --check` → OK (223 pending), and the five repository-wide guards → 42 passed.
- `scripts/check_merge_base_overlap.py` → no overlap with `upstream/main`, so the checks above describe the tree that merges.

Closes #2029
