### PR TITLE
fix(policies): report a non-finite action as its own fault, not as near-zero

### DIFF
--- a/changelog.d/2034-nonfinite-action-diagnosis.md
+++ b/changelog.d/2034-nonfinite-action-diagnosis.md
@@ -1,0 +1,23 @@
+### Fixed: a non-finite action stream is no longer diagnosed as a near-zero one
+
+`ZeroActionMonitor` classifies the per-step `max(abs(action))` behind the
+`lerobot_local` "policy runs but the robot does not move" diagnostics. It had two
+buckets - real motion and near-zero - and forced a third case into the wrong one.
+`nan` compares `False` against every threshold, so a poisoned action stream
+advanced the near-zero streak and produced the near-zero warning byte-identically
+to a genuinely dead policy, prescribing the obs/rename pipeline for a fault that
+pipeline cannot cause; because a single `nan` component makes
+`np.abs(...).max()` `nan`, a vector carrying five real commands was reported as
+emitting no command at all. `inf` compares `True` and cleared the streak instead,
+so an action every backend refuses outright went entirely unreported. A
+non-finite magnitude is now reported as its own fault, on the first such step,
+with a message that names what was measured and points at the checkpoint's
+normalization statistics and the observation values rather than at `obs_rename`.
+
+The two constructor knobs shared the root cause: their bare comparisons
+(`threshold < 0`, `patience < 1`) are `False` for `nan`/`inf` and let a `bool`
+through as `1`, so a `threshold` of `nan`/`inf`/`True` made the watchdog fire on
+a healthy policy and a `patience` of `nan`/`inf` silently disabled the warning
+the class exists to emit. Both now delegate numeric-ness, `bool` and finiteness
+to the shared numeric rules and are normalized to their declared types. The
+near-zero contract, including a `threshold` of `0`, is unchanged.

--- a/docs/policies/molmoact2.md
+++ b/docs/policies/molmoact2.md
@@ -138,8 +138,8 @@ robot you actually instantiate: `embodiment="so101"` for the sim examples,
 
 ## Debugging "runs but does not move"
 
-The provider surfaces two previously-silent failure modes as `WARNING` logs from
-the `lerobot_local` logger:
+The provider surfaces three previously-silent failure modes as `WARNING` logs
+from the `lerobot_local` logger:
 
 1. **Action-dim mismatch.** Actions are mapped onto actuators by index. If the
    model emits fewer values than the embodiment declares actuators, the
@@ -159,9 +159,30 @@ the `lerobot_local` logger:
    consecutive steps: the robot will not move. ...
    ```
 
-These do not raise (a near-zero action can be legitimate mid-trajectory); they
-point you at the embodiment / rename config. The warnings re-arm on
-`policy.reset()` so each episode is evaluated independently.
+3. **A non-finite action.** If `max(abs(action))` is `nan` or `inf`, the policy
+   logs once - on the first such step, since unlike a near-zero action a
+   non-finite one is never legitimate mid-trajectory:
+
+   ```
+   lerobot_local: Policy emitted a non-finite action (max abs = nan): the robot
+   will not move. This is not the near-zero case ... Check the checkpoint's
+   normalization statistics (a zero divisor yields inf/nan) and whether any
+   observation value is itself non-finite.
+   ```
+
+   This is reported separately because it has a different cause. `nan` compares
+   `False` against every threshold, so it would otherwise advance the near-zero
+   streak and be reported as case 2 - naming the obs/rename pipeline for an
+   action that is not near zero but not a number, and doing so even when only
+   one component of the vector is `nan` and the other five carry real commands.
+   `inf` compares `True` and would instead clear the streak, leaving an action
+   the backends refuse outright entirely unreported.
+
+None of these raise; each points you at the configuration that can cause it -
+cases 1 and 2 at the embodiment / rename config, case 3 at the checkpoint's
+normalization statistics and the observation values. All three re-arm on
+`policy.reset()` so each episode is evaluated independently, and each is emitted
+at most once per episode so a 50 Hz control loop is not spammed.
 
 ### Repro / debug script
 

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -27,12 +27,15 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+from strands_robots.utils import finite_number_error, positive_whole_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -404,25 +407,54 @@ class ZeroActionMonitor:
     warning when it stays below ``threshold`` for ``patience`` consecutive steps,
     pointing the operator at the embodiment / rename config.
 
+    A NON-FINITE magnitude is reported separately, because it is a different
+    fault with a different cause. ``nan`` compares ``False`` against every
+    threshold, so it would otherwise advance the near-zero streak and be
+    reported as a near-zero stream -- naming the obs/rename pipeline for an
+    action that is not near zero but not a number, while five real commands in
+    the same vector are ignored. ``inf`` compares ``True`` and would instead
+    clear the streak, leaving an action the backends refuse outright entirely
+    unreported. Neither value is evidence about the observation pipeline.
+
     Stateful but dependency-free (no torch/lerobot) so it is unit-testable in
     isolation. Call :meth:`update` once per inference step and :meth:`reset` on
     episode reset.
 
     Attributes:
         threshold: Max-abs action magnitude below which a step counts as
-            near-zero.
-        patience: Consecutive near-zero steps required before warning.
+            near-zero. Finite and ``>= 0``. The comparison is ``>=``, so a
+            threshold of ``0`` accepts every magnitude as motion and thereby
+            disables the near-zero report; it is permitted for compatibility.
+        patience: Consecutive near-zero steps required before warning. A
+            positive whole number.
     """
 
     def __init__(self, threshold: float = 1e-3, patience: int = 10) -> None:
-        if threshold < 0:
-            raise ValueError(f"threshold must be >= 0, got {threshold}")
-        if patience < 1:
-            raise ValueError(f"patience must be >= 1, got {patience}")
-        self.threshold = threshold
-        self.patience = patience
+        # The floor is decided here and everything else -- numeric-ness, bool,
+        # finiteness -- is delegated to the shared numeric rule, the same
+        # division of labour as WBCConfig's gain domain. A bare ``threshold < 0``
+        # comparison cannot express it: ``nan < 0`` and ``inf < 0`` are both
+        # False, so both were stored, and a threshold of ``nan`` or ``inf``
+        # compares False against EVERY magnitude -- the watchdog then fires on a
+        # healthy policy. ``True`` is an ``int`` subclass, so it was stored as a
+        # threshold of 1.0: on an SO-arm that reads every real action as
+        # near-zero. Symmetrically ``patience`` of ``nan``/``inf`` made
+        # ``streak >= patience`` False forever, silently disabling the warning
+        # this class exists to emit.
+        if error := finite_number_error(threshold, "threshold", "ZeroActionMonitor"):
+            raise ValueError(error)
+        if float(threshold) < 0.0:
+            raise ValueError(f"ZeroActionMonitor: threshold must be >= 0, got {threshold!r}.")
+        if error := positive_whole_number_error(patience, "patience", "ZeroActionMonitor"):
+            raise ValueError(error)
+        # Normalized so the two public attributes match their declared types:
+        # ``patience`` is read as a step count by callers (``range(mon.patience)``),
+        # which an integral float the guard accepts would break.
+        self.threshold = float(threshold)
+        self.patience = int(patience)
         self._streak = 0
         self._warned = False
+        self._nonfinite_warned = False
 
     def update(self, max_abs_action: float) -> str | None:
         """Record one step's max-abs action magnitude.
@@ -431,10 +463,30 @@ class ZeroActionMonitor:
             max_abs_action: ``max(abs(action))`` for this inference step.
 
         Returns:
-            A warning string exactly once -- on the step where the near-zero
-            streak first reaches ``patience`` -- and ``None`` otherwise. A single
-            above-threshold step clears the streak and re-arms the warning.
+            A warning string exactly once per fault -- on the step where the
+            near-zero streak first reaches ``patience``, or on the first step
+            whose magnitude is not finite -- and ``None`` otherwise. A single
+            above-threshold step clears the near-zero streak and re-arms that
+            warning; the two faults are tracked independently.
+
+        Raises:
+            TypeError: If ``max_abs_action`` is not a real number, as before.
         """
+        if not math.isfinite(max_abs_action):
+            # Neither motion nor near-zero: report the fault that was measured
+            # and leave the near-zero streak untouched, so a stream that is
+            # genuinely both still gets both warnings.
+            if self._nonfinite_warned:
+                return None
+            self._nonfinite_warned = True
+            return (
+                f"Policy emitted a non-finite action (max abs = {max_abs_action:g}): the robot "
+                f"will not move. This is not the near-zero case -- a non-finite action is refused "
+                f"by the simulation and hardware backends rather than applied, so the obs_rename / "
+                f"camera keys are not implicated. Check the checkpoint's normalization statistics "
+                f"(a zero divisor yields inf/nan) and whether any observation value is itself "
+                f"non-finite."
+            )
         if max_abs_action >= self.threshold:
             self._streak = 0
             self._warned = False
@@ -451,9 +503,10 @@ class ZeroActionMonitor:
         return None
 
     def reset(self) -> None:
-        """Reset streak + warned state (call on episode reset)."""
+        """Reset streak + warned state for both faults (call on episode reset)."""
         self._streak = 0
         self._warned = False
+        self._nonfinite_warned = False
 
 
 # Registered pipeline step: pack scalar joint obs -> observation.state

--- a/tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py
+++ b/tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py
@@ -1,0 +1,274 @@
+"""A non-finite action stream must not be diagnosed as a near-zero one.
+
+``ZeroActionMonitor`` classifies a per-step ``max(abs(action))`` so the operator
+of a VLA that "runs but does not move" is pointed at the right cause. It had two
+buckets -- real motion and near-zero -- and forced a third case into the wrong
+one:
+
+* ``nan`` compares ``False`` against every threshold, so a poisoned action
+  stream advanced the near-zero streak and produced the near-zero warning
+  BYTE-IDENTICALLY to a genuinely dead policy, prescribing the obs/rename
+  pipeline for a fault that pipeline cannot cause. A single ``nan`` component
+  makes ``np.abs(...).max()`` ``nan``, so a vector with five real commands in it
+  was reported as emitting no command at all.
+* ``inf`` compares ``True``, so it cleared the streak instead: an action every
+  backend refuses outright went entirely unreported.
+
+The two constructor knobs shared the root cause. Their bare comparisons
+(``threshold < 0``, ``patience < 1``) are ``False`` for ``nan``/``inf`` and let a
+``bool`` through as ``1``, so a threshold of ``nan``/``inf``/``True`` made the
+watchdog fire on a healthy policy and a patience of ``nan``/``inf`` silently
+disabled it.
+
+This pins the classification: which fault each stream is reported as, that the
+near-zero contract is unchanged, and the accepted domain of both knobs.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+import torch  # real or conftest mock - both work
+
+from strands_robots.policies.lerobot_local.embodiment import ZeroActionMonitor
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.utils import finite_number_error, positive_whole_number_error
+
+NAN = float("nan")
+INF = float("inf")
+
+# Values no threshold can be honored as. ``-1.0`` is refused by the floor this
+# class decides; the rest by the shared numeric rule it delegates to.
+UNUSABLE_THRESHOLD: list[Any] = [NAN, INF, -INF, True, False, -1.0, -1e-9, "0.5", None, [0.5], {}]
+# ``0`` was explicitly permitted before this change; see the test that pins what it
+# actually does (it disables the near-zero report rather than tightening it).
+USABLE_THRESHOLD: list[Any] = [0, 0.0, 1e-3, 0.5, 2.0, np.float64(1e-3)]
+
+UNUSABLE_PATIENCE: list[Any] = [0, -5, NAN, INF, True, False, 2.7, "10", None, [10], {}]
+USABLE_PATIENCE: list[Any] = [1, 10, 10.0, np.int64(7)]
+
+
+def _monitor(**kwargs: Any) -> Any:
+    """Construct the monitor through one funnel so a deliberately-invalid
+    value reaches the runtime guard as a caller would supply it."""
+    return ZeroActionMonitor(**kwargs)
+
+
+def _warnings_for(action: list[float], *, steps: int = 12) -> list[str]:
+    """Drive the production wiring and return the warnings a caller would see."""
+    policy = LerobotLocalPolicy()
+    policy.set_robot_state_keys(["1", "2", "3", "4", "5", "6"])
+    captured: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    handler = _Capture()
+    logger = logging.getLogger("strands_robots.policies.lerobot_local.policy")
+    logger.addHandler(handler)
+    previous = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        for _ in range(steps):
+            policy._tensor_to_action_dicts(torch.tensor(action, dtype=torch.float32))
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
+    return captured
+
+
+class TestANonFiniteStreamIsReportedAsItsOwnFault:
+    """The reachable half: ``max_abs_action`` comes straight from model output."""
+
+    def test_a_nan_stream_and_a_dead_policy_no_longer_report_the_same_fault(self):
+        """The headline: these two messages used to be byte-identical."""
+        dead = _warnings_for([0.0] * 6)
+        poisoned = _warnings_for([NAN] * 6)
+        assert len(dead) == 1 and len(poisoned) == 1
+        assert dead != poisoned
+        assert "near-zero actions" in dead[0]
+        assert "non-finite action" in poisoned[0]
+        assert "near-zero actions" not in poisoned[0]
+
+    def test_the_non_finite_report_does_not_claim_the_magnitude_was_below_the_threshold(self):
+        """``nan`` is not ``< 0.001``; it is not comparable."""
+        (message,) = _warnings_for([NAN] * 6)
+        assert "max abs <" not in message
+        assert "max abs = nan" in message
+
+    def test_the_non_finite_report_does_not_prescribe_the_observation_pipeline(self):
+        """A missing or mis-renamed observation key produces the near-zero case."""
+        (message,) = _warnings_for([NAN] * 6)
+        assert "not implicated" in message
+        assert "normalization statistics" in message
+
+    def test_a_single_non_finite_component_is_not_reported_as_no_command_at_all(self):
+        """Five of the six actuators are commanded, so "near-zero" would be false."""
+        (message,) = _warnings_for([0.4, -0.3, NAN, 0.2, 0.1, -0.5])
+        assert "non-finite action" in message
+        assert "near-zero actions" not in message
+
+    def test_an_infinite_stream_is_reported_rather_than_clearing_the_streak(self):
+        """``inf >= threshold`` used to read as real motion, so nothing warned."""
+        (message,) = _warnings_for([INF] * 6)
+        assert "non-finite action" in message
+        assert "max abs = inf" in message
+
+    def test_the_non_finite_report_is_emitted_once_not_per_control_tick(self):
+        monitor = _monitor(patience=3)
+        fired = [monitor.update(NAN) for _ in range(20)]
+        assert len([message for message in fired if message]) == 1
+
+    def test_the_two_faults_are_tracked_independently(self):
+        """A stream that is genuinely both still reports both."""
+        monitor = _monitor(patience=3)
+        fired = [monitor.update(value) for value in (0.0, 0.0, NAN, 0.0, 0.0)]
+        reported = [message for message in fired if message]
+        assert len(reported) == 2
+        assert any("non-finite action" in message for message in reported)
+        assert any("near-zero actions" in message for message in reported)
+
+    def test_a_non_finite_step_neither_advances_nor_clears_the_near_zero_streak(self):
+        monitor = _monitor(patience=2)
+        assert monitor.update(0.0) is None
+        assert monitor.update(NAN) is not None  # its own fault, reported
+        near_zero = monitor.update(0.0)  # the second genuinely near-zero step
+        assert near_zero is not None and "near-zero actions" in near_zero
+
+    def test_reset_re_arms_the_non_finite_report(self):
+        monitor = _monitor()
+        assert monitor.update(NAN) is not None
+        assert monitor.update(NAN) is None
+        monitor.reset()
+        assert monitor.update(NAN) is not None
+
+    def test_a_non_numeric_magnitude_still_raises_as_it_always_did(self):
+        with pytest.raises(TypeError):
+            _monitor().update("0.5")  # type: ignore[arg-type]
+
+
+class TestTheNearZeroContractIsUnchanged:
+    """Over-reach controls: the fault this class was written for is untouched."""
+
+    def test_a_dead_policy_still_reports_the_original_near_zero_message(self):
+        (message,) = _warnings_for([0.0] * 6)
+        assert "Policy emitted near-zero actions (max abs < 0.001) for 10 consecutive steps" in message
+        assert "obs_rename / camera keys" in message
+
+    def test_a_healthy_policy_reports_nothing(self):
+        assert _warnings_for([0.9] * 6) == []
+
+    def test_a_real_action_still_clears_the_near_zero_streak(self):
+        monitor = _monitor(patience=3)
+        assert all(monitor.update(0.0) is None for _ in range(2))
+        assert monitor.update(1.0) is None
+        assert all(monitor.update(0.0) is None for _ in range(2))
+        assert monitor.update(0.0) is not None
+
+
+class TestTheWatchdogKnobsHaveADomain:
+    """Direct-API: a value that makes the watchdog useless is refused."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_THRESHOLD, ids=repr)
+    def test_an_unusable_threshold_is_refused(self, value):
+        with pytest.raises(ValueError) as excinfo:
+            _monitor(threshold=value)
+        assert "threshold" in str(excinfo.value)
+        assert "ZeroActionMonitor" in str(excinfo.value)
+
+    @pytest.mark.parametrize("value", USABLE_THRESHOLD, ids=repr)
+    def test_a_usable_threshold_is_accepted_and_normalized(self, value):
+        monitor = _monitor(threshold=value)
+        assert type(monitor.threshold) is float
+        assert monitor.threshold == float(value)
+
+    @pytest.mark.parametrize("value", UNUSABLE_PATIENCE, ids=repr)
+    def test_an_unusable_patience_is_refused(self, value):
+        with pytest.raises(ValueError) as excinfo:
+            _monitor(patience=value)
+        assert "patience" in str(excinfo.value)
+        assert "ZeroActionMonitor" in str(excinfo.value)
+
+    @pytest.mark.parametrize("value", USABLE_PATIENCE, ids=repr)
+    def test_a_usable_patience_is_accepted_and_normalized_to_a_step_count(self, value):
+        """``range(monitor.patience)`` is how a caller consumes it."""
+        monitor = _monitor(patience=value)
+        assert type(monitor.patience) is int
+        assert len(range(monitor.patience)) == int(value)
+
+    def test_a_zero_threshold_is_accepted_and_disables_the_near_zero_report(self):
+        """Zero was explicitly permitted before this change and still is.
+
+        Its measured meaning is not "only an exactly-zero action counts": the
+        comparison is ``magnitude >= threshold``, so ``0`` accepts EVERY
+        magnitude as motion and the near-zero report never fires. Whether a
+        silent disable with no documented spelling should instead be refused is
+        a separate question from the classification this module pins, so the
+        accepted domain is unchanged in that direction and the behaviour is
+        recorded here rather than altered.
+        """
+        monitor = _monitor(threshold=0.0, patience=2)
+        assert all(monitor.update(0.0) is None for _ in range(50))
+        # the non-finite report is independent of the threshold, so it survives
+        assert monitor.update(NAN) is not None
+
+    def test_the_refusal_names_the_value_it_received(self):
+        with pytest.raises(ValueError, match="got nan"):
+            _monitor(threshold=NAN)
+        with pytest.raises(ValueError, match="got 2.7"):
+            _monitor(patience=2.7)
+
+    def test_a_refused_threshold_that_fires_on_a_healthy_policy_is_the_reason(self):
+        """Each refused threshold would have warned about a moving arm."""
+        for value in (NAN, INF, True):
+            with pytest.raises(ValueError):
+                _monitor(threshold=value)
+        # the accepted default does not
+        monitor = _monitor()
+        assert all(monitor.update(0.9) is None for _ in range(30))
+
+    def test_a_refused_patience_that_disables_the_warning_is_the_reason(self):
+        """Each refused patience would have silenced the warning entirely."""
+        for value in (NAN, INF):
+            with pytest.raises(ValueError):
+                _monitor(patience=value)
+        monitor = _monitor(patience=2)
+        assert monitor.update(0.0) is None
+        assert monitor.update(0.0) is not None
+
+
+class TestTheFloorIsTheWholeLocalContribution:
+    """The shared numeric rule decides everything but the floor."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_THRESHOLD + USABLE_THRESHOLD, ids=repr)
+    def test_threshold_delegates_every_decision_but_the_sign(self, value):
+        shared_refuses = finite_number_error(value, "threshold", "ZeroActionMonitor") is not None
+        below_floor = not shared_refuses and float(value) < 0.0
+        try:
+            _monitor(threshold=value)
+            refused = False
+        except ValueError:
+            refused = True
+        assert refused == (shared_refuses or below_floor)
+
+    @pytest.mark.parametrize("value", UNUSABLE_PATIENCE + USABLE_PATIENCE, ids=repr)
+    def test_patience_delegates_every_decision(self, value):
+        shared_refuses = positive_whole_number_error(value, "patience", "ZeroActionMonitor") is not None
+        try:
+            _monitor(patience=value)
+            refused = False
+        except ValueError:
+            refused = True
+        assert refused == shared_refuses
+
+    def test_the_premise_the_bare_comparisons_missed(self):
+        """Why a comparison cannot express either domain."""
+        assert not (NAN < 0) and not (INF < 0)
+        assert not (NAN < 1) and not (INF < 1)
+        assert isinstance(True, int) and not (True < 1)
+        assert not math.isfinite(NAN) and not math.isfinite(INF)


### PR DESCRIPTION
## What

`ZeroActionMonitor` classifies the per-step `max(abs(action))` behind the `lerobot_local`
"policy runs but the robot does not move" diagnostics. It had two buckets - real motion and
near-zero - and forced a third case into the wrong one.

`nan` compares `False` against every threshold, so a poisoned action stream advanced the
near-zero streak and produced the near-zero warning **byte-identically** to a genuinely dead
policy, prescribing the obs/rename pipeline for a fault that pipeline cannot cause. Because a
single `nan` component makes `np.abs(...).max()` `nan`, a vector carrying five real joint
commands was reported as emitting no command at all. `inf` compares `True` and cleared the
streak instead, so an action every backend refuses outright went entirely unreported.

`grep -rn "isfinite\|isnan" strands_robots/policies/lerobot_local/` finds nothing, so that one
diagnostic was the whole signal on this axis.

### Measured, driving the production wiring (`LerobotLocalPolicy._tensor_to_action_dicts`, 12 steps)

| action stream | actual fault | main reports | main told the operator to check | this change |
|---|---|---|---|---|
| `0.0` x 6 (dead policy) | near-zero | near-zero | obs_rename / camera keys | near-zero (unchanged) |
| `nan` x 6 | non-finite | **near-zero** (same bytes as row 1) | obs_rename / camera keys | non-finite |
| `inf` x 6 | non-finite | **nothing at all** | - | non-finite |
| `[0.4, -0.3, nan, 0.2, 0.1, -0.5]` | non-finite | **near-zero** | obs_rename / camera keys | non-finite |
| `0.9` x 6 (healthy) | none | silent | - | silent (unchanged) |

Streams reported as the wrong fault: **3 of 5 -> 0 of 5.**

The two constructor knobs shared the root cause. Their bare comparisons (`threshold < 0`,
`patience < 1`) are `False` for `nan`/`inf` and let a `bool` through as `1`:

| constructor value | main | what main's acceptance did | this change |
|---|---|---|---|
| `threshold=nan` / `inf` / `True` | accepted | warned about a **moving** arm (magnitude 0.9) | refused |
| `patience=nan` / `inf` | accepted | **0** warnings on a dead policy - the watchdog was off | refused |
| `patience=2.7` | accepted | silently 3 | refused |
| `threshold=1e-3`, `patience=10` (defaults) | accepted | correct | accepted (unchanged) |

## Change

- `update()` classifies a non-finite magnitude as its own fault and reports it on the **first**
  such step - unlike a near-zero action, a non-finite one is never legitimate mid-trajectory. The
  message names what was measured (`max abs = nan`) and points at the checkpoint's normalization
  statistics and the observation values rather than at `obs_rename`. It leaves the near-zero
  streak untouched, so a stream that is genuinely both still reports both, and it is emitted at
  most once per episode so a 50 Hz control loop is not spammed.
- `threshold` and `patience` delegate numeric-ness, `bool` and finiteness to
  `finite_number_error` / `positive_whole_number_error`. Only the `threshold` floor stays local -
  the same division of labour as `WBCConfig`'s gain domain. A named helper would be a second name
  for a one-line comparison on a single field, so it is inline with that precedent cited.
- Both are normalized to their declared types. That is load-bearing rather than cosmetic:
  `patience` is read as a step count by callers (`range(monitor.patience)`), which an integral
  float the shared guard accepts would break.

### Out of scope, deliberately

`threshold = 0` was explicitly permitted before this change and still is. Its measured meaning is
not "only an exactly-zero action counts": the comparison is `magnitude >= threshold`, so `0`
accepts every magnitude as motion and the near-zero report never fires. Whether a silent disable
with no documented spelling should instead be refused is a separate question from the
classification here, so the accepted domain is unchanged in that direction and the behaviour is
recorded in the docstring and pinned by a test rather than altered.

## Artifact

![ZeroActionMonitor non-finite action classification](https://raw.githubusercontent.com/cagataycali/robots/artifacts/nonfinite-action-diagnosis/nonfinite-action-diagnosis.png)

The left panel is a real MuJoCo headless render (`MUJOCO_GL=egl`, SO-101): the finite action dict
the provider emits, applied for 20 control steps. It is there to prove the honored path is
untouched - the emitted action dict and the final joint positions are **identical on both trees**
to 12 dp, travel is `44.126527 deg` on both, and the two renders agree to `max|delta| = 1/255`
over 164 of 471,200 px. The verdict rows are measured, not illustrated.

[`capture.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/nonfinite-action-diagnosis/capture.py)
runs unchanged in a `git worktree` at `main` and in this branch, each printing the tree it
resolved `strands_robots` from;
[`compose.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/nonfinite-action-diagnosis/compose.py)
asserts every rendered number against the two JSON dumps (and that the two trees differ) before
saving.

## Tests

`tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py`, 82 tests in
four classes: which fault each stream is reported as (including that a `nan` stream and a dead
policy no longer produce the same message, and that the report does not claim `max abs <`); the
near-zero contract as over-reach controls; the accepted domain of both knobs including
normalization; and a parity class asserting the local floor is the *whole* local contribution -
the ctor's verdict equals the shared rule's for every probe value except the out-of-floor ones.

Pre-fix, with `strands_robots/policies/lerobot_local/embodiment.py` reverted to `main`:
**54 failed / 28 passed**. The 28 that pass are the unchanged near-zero controls, the
accepted-value controls, the premise test, and the three refusals the bare comparisons *did*
catch (`threshold=-1.0`, `patience=0`, `patience=-5`).

**No existing test changed** - `tests/policies/lerobot_local/` is 806 passed / 2 skipped before
and after.

## Verification

Head `56bec87`, base `ac8b1001` (re-checked against `5229cf7`: `check_merge_base_overlap.py`
reports no overlap).

- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - 1110 files already formatted
- `mypy strands_robots tests tests_integ` - 14 errors, all in `examples/isaac_gs`, **0 outside**;
  byte-identical to a pristine `upstream/main` worktree of the same working copy
- `MUJOCO_GL=egl pytest tests` - **23173 passed / 257 skipped**, 503s (pristine `main`: 23091
  passed, i.e. exactly the 82 new tests)

One caveat reported rather than hidden: a first full-suite run showed a single failure in
`tests/simulation/test_rollout_seed_is_applied_or_refused.py::test_the_seeded_eval_matches_its_sibling_run_policy_contract`
(a seeded float-stream equality between two sequential `run_policy(seed=7)` calls, in a file this
branch does not touch). It did not reproduce on the re-run above, and the new test file provably
does not perturb it - running it, or the whole `tests/policies/lerobot_local/` directory,
immediately ahead of that file passes (206 and 930 passed). Pre-existing order/global-state
sensitivity rather than anything in this diff.
