### PR TITLE
test: refuse a comparison that is decided before it runs

### DIFF
--- a/changelog.d/2035-no-vacuous-comparisons.md
+++ b/changelog.d/2035-no-vacuous-comparisons.md
@@ -1,0 +1,17 @@
+### Quality: a comparison written between two literals is refused
+
+`assert True > 0` reads as a measurement and is not one. Both operands are
+literals, so the result is fixed when the line is typed: the assertion cannot
+fail, cannot notice a change in what it claims to measure, and cannot tell a
+correct premise from a mis-transcribed one. Two premise tests carried the shape --
+the places whose whole value is that a claim was measured rather than restated --
+and both now put the value under test through a name so the comparison is decided
+when it runs.
+
+Neither merge gate covered it. `ruff` selects `B015` for this capability, but
+`B015` fires only when a comparison's result is unused, so it is silent by design
+inside an `assert`, which consumes it; CodeQL's `py/comparison-of-constants`
+reported one of the two instances on a pull-request ref while its twin sat on
+`main` unreported, through a default-branch analysis that was current and
+successful. The shape is now refused deterministically by a repository-wide scan
+over every Python file the project ships.

--- a/tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py
+++ b/tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py
@@ -266,9 +266,30 @@ class TestTheFloorIsTheWholeLocalContribution:
             refused = True
         assert refused == shared_refuses
 
-    def test_the_premise_the_bare_comparisons_missed(self):
-        """Why a comparison cannot express either domain."""
-        assert not (NAN < 0) and not (INF < 0)
-        assert not (NAN < 1) and not (INF < 1)
-        assert isinstance(True, int) and not (True < 1)
+    @pytest.mark.parametrize("value", [NAN, INF, True], ids=repr)
+    def test_the_premise_the_bare_comparisons_missed(self, value):
+        """Why a comparison cannot express either domain.
+
+        The pre-fix guards were ``threshold < 0`` and ``patience < 1``, and
+        both are ``False`` for every value here, so every one of them was
+        stored: ``nan`` and ``inf`` because any comparison against them is
+        ``False``, and ``True`` because it reaches a numeric comparison as the
+        ``int`` ``1``.
+
+        The value under test is a parameter rather than a literal. A
+        comparison written between two literals is decided when it is typed,
+        so it would state this premise without measuring it.
+        """
+        assert not (value < 0.0)
+        assert not (value < 1)
+
+    def test_what_replaced_the_comparisons_refuses_all_three(self):
+        """Finiteness sees ``nan``/``inf``; only an explicit test sees ``bool``."""
         assert not math.isfinite(NAN) and not math.isfinite(INF)
+        # A ``bool`` is finite, so a finiteness test alone does not see it. The
+        # shared rules reject it explicitly, which is why they cover all three
+        # where neither a comparison nor finiteness alone does.
+        assert isinstance(True, int) and math.isfinite(True)
+        for value in (NAN, INF, True):
+            assert finite_number_error(value, "threshold", "ZeroActionMonitor") is not None
+            assert positive_whole_number_error(value, "patience", "ZeroActionMonitor") is not None

--- a/tests/test_no_vacuous_comparisons.py
+++ b/tests/test_no_vacuous_comparisons.py
@@ -1,0 +1,118 @@
+"""Regression: no comparison may be written between two literal constants.
+
+``assert True > 0`` reads as a measurement and is not one. Both operands are
+literals, so the result is fixed when the line is typed: the assertion cannot
+fail, cannot notice a change in what it claims to measure, and cannot tell a
+correct premise from a mis-transcribed one. The shape turns up where it does the
+most damage -- in a *premise* test, written to record why some guard is needed,
+whose whole value is that the claim was measured rather than restated.
+
+Neither merge gate covers it.
+
+``ruff`` selects ``B015`` (useless-comparison) for exactly this capability:
+``.github/codeql/codeql-config.yml`` hands it that job in writing, because ruff
+is merge-blocking here where CodeQL is advisory. But B015 fires only when a
+comparison's *result is unused*, so it is silent by design on every instance
+inside an ``assert`` -- the ``assert`` consumes the result. Measured on the two
+sites this guard was written for, ``ruff check`` reports no finding at all.
+
+CodeQL's ``py/comparison-of-constants`` is unreliable across instances. It
+reported ``True < 1`` on a pull-request ref while the twin ``True > 0`` sat on
+``main`` unreported, through a default-branch analysis that was both current and
+successful.
+
+So the shape is refused here instead: deterministically, on every comparison in
+the repository rather than on whichever one a scanner happens to surface, in the
+gate that blocks a merge.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots
+
+# The repository root, reached through this module's own location rather than a
+# path literal.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Every tree whose Python ships with the repository. The package is reached
+# through the imported module so a layout change cannot silently narrow the scan
+# to nothing, and the remaining roots are asserted to exist below.
+_SCAN_ROOTS = (
+    Path(strands_robots.__file__).resolve().parent,
+    _REPO_ROOT / "tests",
+    _REPO_ROOT / "tests_integ",
+    _REPO_ROOT / "scripts",
+    _REPO_ROOT / "examples",
+)
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for root in _SCAN_ROOTS for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def constant_comparisons(source: str) -> list[tuple[int, str]]:
+    """Comparisons in ``source`` whose every operand is a literal.
+
+    A tuple, an f-string and a name are all excluded: only a comparison the
+    reader can evaluate without running anything is reported, which is the one
+    shape that has no legitimate use.
+
+    Args:
+        source: Python source text.
+
+    Returns:
+        One ``(line number, expression)`` pair per comparison whose result is
+        decided before it runs.
+    """
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Compare):
+            operands = [node.left, *node.comparators]
+            if all(isinstance(operand, ast.Constant) for operand in operands):
+                found.append((node.lineno, ast.unparse(node)))
+    return found
+
+
+def test_scan_roots_discovered() -> None:
+    """Guard: the scan walked the whole repository rather than one subtree."""
+    for root in _SCAN_ROOTS:
+        assert root.is_dir(), f"scan root missing: {root}"
+    sources = _python_sources()
+    assert len(sources) > 1000
+    top_level = {p.relative_to(_REPO_ROOT).parts[0] for p in sources}
+    assert {"strands_robots", "tests", "tests_integ", "scripts", "examples"} <= top_level
+
+
+def test_no_comparison_is_decided_before_it_runs() -> None:
+    """No shipped comparison has a literal on both sides."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        rel = path.relative_to(_REPO_ROOT)
+        for line, expression in constant_comparisons(path.read_text(encoding="utf-8")):
+            offenders.append(f"{rel}:{line}  {expression}")
+    assert not offenders, (
+        "Comparisons whose result is fixed when they are typed, so they measure nothing:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_scanner_detects_a_planted_constant_comparison() -> None:
+    """Meta: an empty result means clean sources, not a scanner that matches nothing."""
+    planted = "def f() -> None:\n    assert True > 0\n"
+    assert constant_comparisons(planted) == [(2, "True > 0")]
+
+
+def test_scanner_accepts_every_comparison_with_a_runtime_operand() -> None:
+    """A comparison that is actually decided when it runs is not flagged."""
+    legitimate = (
+        "LIMIT = 1\n"
+        "def f(value: float) -> None:\n"
+        "    assert value > 0\n"
+        "    assert LIMIT < 2\n"
+        "    assert len(str(value)) > 0\n"
+        "    assert (1, 2) == (1, 2)\n"
+        "    assert f'{value}' == '1'\n"
+    )
+    assert constant_comparisons(legitimate) == []

--- a/tests/test_wait_budget_domain.py
+++ b/tests/test_wait_budget_domain.py
@@ -127,9 +127,17 @@ class TestWhyAnUnusablePeriodCannotPaceALoop:
             threading.Event().wait(float("inf"))
 
     def test_a_boolean_period_is_a_silent_one_second_cadence(self) -> None:
-        """``bool`` is an ``int`` subclass, so a bare positivity test admits it."""
-        assert float(True) == 1.0
-        assert True > 0
+        """``bool`` is an ``int`` subclass, so a bare positivity test admits it.
+
+        The value is bound rather than written into the comparison as a
+        literal: a comparison between two literals is decided when it is
+        typed, so it would state this premise without measuring it.
+        """
+        period: Any = True
+        assert float(period) == 1.0
+        assert period > 0
+        # What replaced that comparison does see it.
+        assert positive_finite_number_error(period, "poll_period", "HardwareRtpsBridge") is not None
 
     def test_a_numpy_float32_period_cannot_be_waited_on(self) -> None:
         """Why the ``float()`` conversion after the guard is load-bearing.


### PR DESCRIPTION
## What

`assert True > 0` reads as a measurement and is not one. Both operands are literals, so the result is
fixed when the line is typed: the assertion cannot fail, cannot notice a change in what it claims to
measure, and cannot tell a correct premise from a mis-transcribed one.

Two tests on `main` carry the shape, and both are *premise* tests -- written to record why some guard
is needed, so their whole value is that the claim was measured rather than restated:

| site | assertion | the premise it records |
|---|---|---|
| `tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py:273` | `assert isinstance(True, int) and not (True < 1)` | a `bool` slips through `ZeroActionMonitor`'s pre-fix `patience < 1` |
| `tests/test_wait_budget_domain.py:132` | `assert True > 0` | a `bool` slips through a bridge period's pre-fix positivity test |

Both pass today, and would pass just as readily if the premise were wrong.

### Neither merge gate covers it

`ruff` selects `B015` for exactly this capability -- `.github/codeql/codeql-config.yml` hands it that
job in writing, because ruff is merge-blocking here where CodeQL is advisory. But `B015` fires only
when a comparison's *result is unused*, so it is silent by design inside an `assert`, which consumes
it:

```
$ ruff check tests/test_wait_budget_domain.py \
    tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py
All checks passed!
```

On a probe file carrying `assert True > 0`, `assert not (True < 1)` and a bare `1 == 1`, `B015`
reports the bare statement and neither `assert`.

CodeQL's `py/comparison-of-constants` is unreliable across instances. It reported `True < 1` on a
pull-request ref (alert 875) while the twin `True > 0` sat on `main` unreported -- through a
default-branch analysis that was both current and successful (it ran at 09:24:28Z on `5229cf77`, two
days after that twin landed). `GET /code-scanning/alerts` for the rule on the default branch returns
zero in every state, so nothing was dismissed: the twin was simply never surfaced.

## Change

- Both premise tests now put the value under test through a **name**, so the comparison is decided
  when it runs, against something that could have been different. The `ZeroActionMonitor` premise is
  parametrized over the three values its pre-fix `threshold < 0` / `patience < 1` guards failed to
  refuse, which also makes it state more than the three hand-written lines did, and it gains a
  sibling asserting that the shared rules refuse all three where **neither a comparison nor
  finiteness alone does** -- a `bool` is finite, so it is the explicit `bool` rejection that catches
  it. The wait-budget premise binds the bool and asserts that the domain which replaced its
  comparison sees it.
- `tests/test_no_vacuous_comparisons.py` refuses the shape across every Python file the project
  ships -- `strands_robots`, `tests`, `tests_integ`, `scripts`, `examples`, 1199 files -- with the
  three companions the sibling scan guard uses: a non-vacuity check on the scan roots, a
  planted-defect meta-test, and a negative control covering a name, a module constant, a call, a
  tuple and an f-string.

A tuple and an f-string are deliberately **not** reported: only a comparison a reader can evaluate
without running anything is, which is the one shape with no legitimate use. That keeps the scan clean
on the tree as it stands, so it ships with no exemption list and there is nowhere for the next
instance to hide.

## Tests

`tests/test_no_vacuous_comparisons.py` is the regression test. Pre-fix, with only the two line
changes reverted to `main`:

```
E   AssertionError: Comparisons whose result is fixed when they are typed, so they measure nothing:
E     tests/policies/lerobot_local/test_nonfinite_action_is_not_reported_as_near_zero.py:273  True < 1
E     tests/test_wait_budget_domain.py:132  True > 0
1 failed, 3 passed
```

The 3 that pass are the scan-root non-vacuity check, the planted-defect meta-test and the negative
control -- all correctly independent of the two line changes. In that same reverted state the two
premise tests themselves report **180 passed**, which is the whole point: the shape is silent, not
broken.

Net **+7** collected tests (23774 -> 23781): the single premise test becomes 3 parametrized cases
plus 1 sibling, and the guard adds 4. Nothing else changed.

## Verification

Head `20e6306`, base `95a4701b`; `scripts/check_merge_base_overlap.py` reports no overlap. The guard
is repository-wide, so its verdict depends on the base -- it was also run against the merged tree
(`git merge-tree --write-tree`, 1199 files) and is clean there.

- `ruff check strands_robots tests tests_integ` -- clean
- `ruff format --check strands_robots tests tests_integ` -- 1111 files already formatted
- `mypy strands_robots tests tests_integ` -- `Success: no issues found in 1108 source files`
- `MUJOCO_GL=egl pytest tests` -- **23524 passed / 257 skipped**, 576s
- `ruff check scripts/ && ruff format --check scripts/` -- clean; that tree is outside CI's lint
  scope and this guard reads it
- `scripts/assemble_changelog.py --check` -- OK

No visual artifact: this changes two test assertions and adds a test. No policy, simulation,
rendering, recording or asset behaviour is touched.
