### PR TITLE
fix(mesh): refuse an IoT connect timeout the transport cannot spend

### DIFF
--- a/changelog.d/2036-iot-connect-timeout-domain.md
+++ b/changelog.d/2036-iot-connect-timeout-domain.md
@@ -1,0 +1,27 @@
+### Fixed: `IotMqttTransport` refuses a connect timeout it cannot spend
+
+`IotMqttTransport(connect_timeout=...)` stored whatever it was handed and spent it
+on `threading.Event.wait` inside `connect()`. It is the third surface in the
+library to carry that parameter name; the two remote-inference clients
+(`RemotePolicy`, `LerobotAsyncPolicy`) already refuse a value that names no wait
+budget, and the mesh transport did not.
+
+An unusable value was worse than a late crash because `connect()`'s report could
+not be told apart from a broker that was genuinely unreachable. Measured against
+a fake broker whose CONNACK arrives 50 ms after `start()`: `0`, `-1` and `nan`
+made the wait return in ~0 ms, so `connect()` logged "IoT connection to ... timed
+out after 0.0s", stopped the client that was connecting normally and returned
+`False` - pointing the operator at the endpoint, the certs and the broker, the
+three things that were not wrong. `inf` and `'15'` raised `OverflowError` /
+`TypeError` from the wait, which sits after the `try` that contains client
+construction, so they escaped a method documented to return `bool` leaving the
+MQTT5 client started with no `stop()` on any path. `None` blocked forever while
+`connect()` held the instance lock, so `close()` could never run, and `True`
+was a silent one-second budget.
+
+The constructor now applies `positive_finite_number_error` - the same domain, the
+same message shape and the same reasoning the two clients record. The guard sits
+in the constructor rather than beside the wait so that it also precedes the
+`awsiot` import inside `connect()`: the same mistake reports identically with and
+without the `[mesh-iot]` extra installed. A structural test scoped by the
+parameter name keeps a fourth surface from shipping the knob without the rule.

--- a/strands_robots/mesh/transport/iot_transport.py
+++ b/strands_robots/mesh/transport/iot_transport.py
@@ -53,6 +53,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from strands_robots.utils import positive_finite_number_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -294,6 +296,34 @@ class IotMqttTransport:
     -------------
     The ``awscrt`` library calls handlers on its own IO thread. We protect
     the subscription dict with a small lock; ``put`` is lock-free.
+
+    Args:
+        thing_name: AWS IoT Thing name, which MUST equal the cert's CN and the
+            :class:`~strands_robots.mesh.core.Mesh` peer_id. Falls back to
+            ``STRANDS_IOT_THING_NAME``.
+        endpoint: The AWS IoT Core ATS endpoint. Falls back to
+            ``STRANDS_IOT_ENDPOINT``.
+        cert_dir: Directory holding the cert, private key and root CA. Falls
+            back to ``STRANDS_IOT_CERT_DIR``, then ``~/.strands_robots/iot``.
+        ca_file: Path to the root CA file. Falls back to
+            ``STRANDS_IOT_CA_FILE``, then ``AmazonRootCA1.pem`` in ``cert_dir``.
+        connect_timeout: Seconds :meth:`connect` waits for CONNACK before
+            reporting the broker unreachable. Only a positive finite number can
+            be honored, and the value is refused here rather than at the wait:
+            :meth:`connect` spends it on ``threading.Event.wait``, which returns
+            ``False`` at once for ``0``, a negative and ``nan`` - so a broker
+            that is connecting normally is reported as having "timed out", and
+            its client is torn down. ``inf`` and a numeric string instead raise
+            ``OverflowError`` / ``TypeError`` out of a method documented to
+            return ``bool``, after the MQTT5 client has been started and with
+            nothing left to stop it. ``None`` is not a spelling for an unbounded
+            wait: ``Event.wait(None)`` blocks forever while :meth:`connect`
+            holds the instance lock, so :meth:`close` can never run. This is the
+            domain the two remote-inference clients already apply to the
+            parameter of the same name (#1984).
+
+    Raises:
+        ValueError: If ``connect_timeout`` is not a positive finite number.
     """
 
     def __init__(
@@ -304,6 +334,16 @@ class IotMqttTransport:
         ca_file: str | None = None,
         connect_timeout: float = 15.0,
     ) -> None:
+        # Refuse a wait budget that names no budget while the caller still holds
+        # the value. ``connect()`` spends it on ``Event.wait``, whose reaction to
+        # an unusable one is indistinguishable from an unreachable broker: it
+        # returns ``False`` immediately, and ``connect()`` then logs "timed out
+        # after 0.0s" and stops a client that was connecting fine. Placed here,
+        # and not beside the wait, so the refusal also precedes the ``awsiot``
+        # import inside ``connect()`` - the same mistake then reports identically
+        # with and without the [mesh-iot] extra installed.
+        if error := positive_finite_number_error(connect_timeout, "connect_timeout", type(self).__name__):
+            raise ValueError(error)
         self._thing_name = thing_name or os.getenv("STRANDS_IOT_THING_NAME", "")
         self._endpoint = endpoint or os.getenv("STRANDS_IOT_ENDPOINT", "")
         self._cert_dir = Path(cert_dir or os.getenv("STRANDS_IOT_CERT_DIR") or Path.home() / ".strands_robots" / "iot")

--- a/tests/mesh/test_iot_connect_timeout_domain.py
+++ b/tests/mesh/test_iot_connect_timeout_domain.py
@@ -1,0 +1,371 @@
+"""``IotMqttTransport`` refuses a connect timeout it cannot spend.
+
+``connect_timeout`` is the third surface in the library to carry that exact
+parameter name, and it was the one left without a domain. The other two are the
+remote-inference clients settled by #1984 -
+:class:`~strands_robots.inference.RemotePolicy` over WebSocket and
+:class:`~strands_robots.policies.lerobot_async.LerobotAsyncPolicy` over gRPC -
+whose contracts live in :mod:`tests.test_remote_client_timeout_domain`. That
+module's own framing is why this one was missed: it settled "the knobs left
+behind on the same two constructors", and the survey it describes was scoped to
+remote-inference clients. A mesh transport spelling the same knob the same way
+sat outside it.
+
+What the transport does with the value makes an unusable one worse than a late
+crash, because ``connect()``'s failure report cannot tell it apart from a broker
+that is genuinely unreachable. It spends the budget on ``threading.Event.wait``,
+and measured against a fake broker whose CONNACK arrives 50 ms after ``start()``
+(a real one is a network round trip, never instant):
+
+* ``0``, ``-1`` and ``nan`` make ``wait`` return ``False`` in ~0 ms, so
+  ``connect()`` logs "IoT connection to ... timed out after 0.0s", stops the
+  client that was connecting normally, and returns ``False``. The operator is
+  pointed at the endpoint, the certs and the broker - the three things that were
+  not wrong.
+* ``inf`` and ``'15'`` raise ``OverflowError`` / ``TypeError`` from the ``wait``
+  itself. That call sits *after* the ``try`` that contains client construction,
+  so the exception leaves a method documented to return ``bool`` with the MQTT5
+  client started and no ``stop()`` on any path.
+* ``None`` is not a spelling for an unbounded wait. ``Event.wait(None)`` blocks
+  forever, and ``connect()`` holds ``self._lock`` for its whole body, so
+  :meth:`close` and every subscription call block behind it with no deadline.
+* ``True`` is a silent one-second budget, arriving through ``bool`` being an
+  ``int`` subclass.
+
+The domain is therefore :func:`~strands_robots.utils.positive_finite_number_error`
+unchanged - the same function, the same message shape, the same reasoning the two
+clients already record. The guard sits in the constructor rather than beside the
+wait so that it also precedes the ``awsiot`` import inside ``connect()``: the same
+caller mistake then reports identically whether or not the ``[mesh-iot]`` extra is
+installed, which is the property the gRPC client's own comment names.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+import sys
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.inference import RemotePolicy
+from strands_robots.mesh.transport.iot_transport import IotMqttTransport
+from strands_robots.policies.lerobot_async import LerobotAsyncPolicy
+from strands_robots.utils import positive_finite_number_error
+
+from .test_iot_reconnect_client_lifecycle import _FakeClient, _make_certs
+
+#: Seconds the fake broker takes to report CONNACK. Non-zero on purpose: with an
+#: instant callback ``Event.wait(0)`` returns ``True`` because the event is
+#: already set, and the misdiagnosis this module is about would be invisible.
+_CONNACK_DELAY_S = 0.05
+
+#: Values that name no wait budget. Shared with the two remote-inference clients;
+#: spelled out here rather than imported so this module stays readable on its own
+#: and does not inherit another module's import surface.
+UNUSABLE_TIMEOUTS: list[Any] = [
+    0,
+    0.0,
+    -1,
+    -0.5,
+    math.nan,
+    math.inf,
+    -math.inf,
+    True,
+    False,
+    "15",
+    None,
+    [15],
+]
+
+#: Accepted. ``np.float32`` is a real spelling for a budget read out of a config
+#: array, and the shared domain documents it as usable, so this pins that the
+#: transport needs no coercion of its own.
+USABLE_TIMEOUTS: list[Any] = [0.001, 1, 15.0, 60.0, np.float32(0.5)]
+
+
+def _transport(tmp_path: Any, **kwargs: Any) -> IotMqttTransport:
+    """Build the transport, splatted so off-type values reach the guard.
+
+    ``connect_timeout`` is annotated ``float``; several cases here hand it
+    something else on purpose, to prove the runtime refuses it rather than the
+    type checker.
+    """
+    kwargs.setdefault("thing_name", "thor-arm")
+    kwargs.setdefault("endpoint", "x-ats.iot.us-west-2.amazonaws.com")
+    kwargs.setdefault("cert_dir", str(_make_certs(tmp_path)))
+    return IotMqttTransport(**kwargs)
+
+
+class _ConnectingClient(_FakeClient):
+    """A broker whose CONNACK arrives after a delay, as a real one does."""
+
+    def start(self) -> None:
+        self.started = True
+        success = self._kwargs["on_lifecycle_connection_success"]
+        threading.Timer(_CONNACK_DELAY_S, lambda: success(object())).start()
+
+
+class _SilentClient(_FakeClient):
+    """A broker that never reports CONNACK, so the wait runs to its deadline."""
+
+    def start(self) -> None:
+        self.started = True
+
+
+def _install_broker(monkeypatch: pytest.MonkeyPatch, client_cls: type[_FakeClient]) -> list[_FakeClient]:
+    """Point ``mtls_from_path`` at ``client_cls`` and collect what it built."""
+    import awsiot.mqtt5_client_builder as builder
+
+    built: list[_FakeClient] = []
+
+    def fake_mtls_from_path(**kwargs: Any) -> _FakeClient:
+        client = client_cls(**kwargs)
+        built.append(client)
+        return client
+
+    monkeypatch.setattr(builder, "mtls_from_path", fake_mtls_from_path)
+    return built
+
+
+def _refuses_the_timeout(build: Callable[[], object]) -> bool:
+    """Did ``build`` refuse specifically because of ``connect_timeout``?
+
+    Only a ``ValueError`` naming the parameter counts. The gRPC client also
+    raises ``ValueError`` for an absent ``policy_type``, so the verdict has to
+    read the message rather than the exception type; anything else propagates.
+    """
+    try:
+        build()
+    except ValueError as exc:
+        return "connect_timeout" in str(exc)
+    return False
+
+
+class TestTheTransportRefusesAConnectTimeoutThatNamesNoBudget:
+    """The refusal is a ``ValueError`` naming the class, the parameter and the domain."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_TIMEOUTS)
+    def test_it_is_refused_at_construction(self, tmp_path: Any, value: Any) -> None:
+        with pytest.raises(ValueError) as exc:
+            _transport(tmp_path, connect_timeout=value)
+        text = str(exc.value)
+        assert "IotMqttTransport" in text, f"the refusal must name the class, got {text!r}"
+        assert "connect_timeout" in text, f"the refusal must name the parameter, got {text!r}"
+        assert "must be > 0" in text, f"the refusal must state the domain, got {text!r}"
+
+    @pytest.mark.parametrize("value", USABLE_TIMEOUTS)
+    def test_a_usable_budget_is_stored_unchanged(self, tmp_path: Any, value: Any) -> None:
+        """No coercion: the shared domain accepts these spellings as they are."""
+        transport = _transport(tmp_path, connect_timeout=value)
+        assert transport._connect_timeout == value
+
+    def test_the_default_is_inside_the_domain(self, tmp_path: Any) -> None:
+        """A caller who names no budget gets one the transport can spend."""
+        transport = _transport(tmp_path)
+        assert positive_finite_number_error(transport._connect_timeout, "connect_timeout", "x") is None
+
+
+class TestAConnectingBrokerIsNoLongerReportedAsUnreachable:
+    """The misdiagnosis: ``connect()`` blamed the broker for the caller's budget."""
+
+    def test_a_usable_budget_reaches_a_connecting_broker(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Control: the same fake broker connects, so the refusals below are about the value."""
+        built = _install_broker(monkeypatch, _ConnectingClient)
+        transport = _transport(tmp_path, connect_timeout=5.0)
+        assert transport.connect() is True
+        assert len(built) == 1
+        assert built[0].stopped is False
+
+    @pytest.mark.parametrize("value", [0, -1, math.nan])
+    def test_a_budget_that_expires_at_once_never_reaches_the_broker(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, value: Any
+    ) -> None:
+        """Each of these used to return ``False`` and stop a healthy client."""
+        built = _install_broker(monkeypatch, _ConnectingClient)
+        with pytest.raises(ValueError, match="connect_timeout"):
+            _transport(tmp_path, connect_timeout=value)
+        assert built == [], "the refusal must precede client construction"
+
+    @pytest.mark.parametrize("value", [math.inf, "15"])
+    def test_a_budget_the_wait_cannot_read_no_longer_escapes_connect(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, value: Any
+    ) -> None:
+        """These raised out of ``connect()`` leaving a started client with no ``stop()``."""
+        built = _install_broker(monkeypatch, _ConnectingClient)
+        with pytest.raises(ValueError, match="connect_timeout"):
+            _transport(tmp_path, connect_timeout=value)
+        assert built == [], "no MQTT5 client may be started for a refused budget"
+
+    def test_a_usable_budget_is_still_bounded_against_a_silent_broker(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The genuine timeout path is untouched: report ``False`` and stop the client."""
+        built = _install_broker(monkeypatch, _SilentClient)
+        transport = _transport(tmp_path, connect_timeout=0.05)
+        assert transport.connect() is False
+        assert built[0].stopped is True
+        assert transport._client is None
+
+
+class TestAnUnboundedWaitIsNotExpressibleThroughThisKnob:
+    """``None`` blocks forever *and* holds the lock, so it is refused rather than read."""
+
+    def test_none_is_refused(self, tmp_path: Any) -> None:
+        with pytest.raises(ValueError, match="connect_timeout"):
+            _transport(tmp_path, connect_timeout=None)
+
+    def test_the_wait_would_never_return_and_would_hold_the_lock(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Premise for the refusal, measured on the real ``connect()`` body.
+
+        ``connect_timeout`` is smuggled past the constructor guard by writing the
+        attribute directly, which is the only way to reach a wait the guard now
+        makes unreachable.
+        """
+        _install_broker(monkeypatch, _SilentClient)
+        transport = _transport(tmp_path, connect_timeout=1.0)
+        transport._connect_timeout = None  # type: ignore[assignment]
+
+        returned: list[object] = []
+        worker = threading.Thread(target=lambda: returned.append(transport.connect()), daemon=True)
+        worker.start()
+        worker.join(timeout=0.5)
+
+        assert worker.is_alive(), "Event.wait(None) is expected to block indefinitely"
+        assert returned == []
+        assert transport._lock.acquire(blocking=False) is False, "connect() holds the lock while it waits"
+
+        # Release the blocked worker so the test leaves no thread parked forever.
+        transport._connected.set()
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+
+    @pytest.mark.parametrize(("value", "expected"), [(0, False), (-1, False), (math.nan, False)])
+    def test_an_expired_budget_returns_at_once_rather_than_erring(self, value: Any, expected: bool) -> None:
+        """Premise: these are silent on ``Event.wait``, which is why they misdiagnose."""
+        assert threading.Event().wait(value) is expected
+
+    def test_infinity_is_not_an_unbounded_wait_here_either(self) -> None:
+        """Premise: ``inf`` is refused by the primitive, matching the sibling transports."""
+        with pytest.raises(OverflowError):
+            threading.Event().wait(math.inf)
+
+
+class TestTheRefusalPrecedesTheOptionalDependency:
+    """One report for one mistake, with or without the ``[mesh-iot]`` extra."""
+
+    def test_the_value_is_refused_with_awsiotsdk_absent(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, "awsiot", None)
+        with pytest.raises(ValueError, match="connect_timeout"):
+            _transport(tmp_path, connect_timeout=0)
+
+    def test_a_usable_value_still_defers_to_the_missing_extra(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The guard must not shadow the install hint for an accepted budget."""
+        monkeypatch.setitem(sys.modules, "awsiot", None)
+        transport = _transport(tmp_path, connect_timeout=5.0)
+        assert transport.connect() is False
+
+
+class TestTheThreeSurfacesShareOneDomain:
+    """A budget one surface refuses cannot be accepted by another spelling the same knob."""
+
+    @pytest.mark.parametrize("value", [*UNUSABLE_TIMEOUTS, *USABLE_TIMEOUTS])
+    def test_every_surface_agrees_with_the_shared_verdict(self, tmp_path: Any, value: Any) -> None:
+        shared = positive_finite_number_error(value, "connect_timeout", "Ctx") is not None
+        builders: dict[str, Callable[[], object]] = {
+            "IotMqttTransport": lambda: _transport(tmp_path, connect_timeout=value),
+            "RemotePolicy": lambda: RemotePolicy(connect_timeout=value),
+            "LerobotAsyncPolicy": lambda: LerobotAsyncPolicy(
+                policy_type="act", pretrained_name_or_path="org/model", connect_timeout=value
+            ),
+        }
+        for name, build in builders.items():
+            assert _refuses_the_timeout(build) is shared, f"{name} disagrees for {value!r}"
+
+
+class TestEverySurfaceTakingAConnectTimeoutRoutesThroughTheDomain:
+    """Structural: a fourth surface cannot ship this knob without the shared rule.
+
+    Scoped by the parameter name rather than a module list, so it is the
+    definition of the surface set rather than a copy of it.
+    """
+
+    @staticmethod
+    def _surfaces(source_root: pathlib.Path) -> dict[str, bool]:
+        """Map ``file::Class.func`` to whether its body calls the shared domain."""
+        found: dict[str, bool] = {}
+        for path in sorted(source_root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # pragma: no cover - the package parses
+                continue
+
+            def walk(node: ast.AST, cls: str | None = None) -> None:
+                for child in ast.iter_child_nodes(node):
+                    if isinstance(child, ast.ClassDef):
+                        walk(child, child.name)
+                        continue
+                    if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                        continue
+                    args = [a.arg for a in child.args.args + child.args.kwonlyargs]
+                    if "connect_timeout" in args:
+                        calls = {
+                            call.func.id
+                            for call in ast.walk(child)
+                            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                        }
+                        label = f"{path.relative_to(source_root)}::{cls + '.' if cls else ''}{child.name}"
+                        found[label] = "positive_finite_number_error" in calls
+                    walk(child, cls)
+
+            walk(tree)
+        return found
+
+    #: Every shipped surface taking the parameter, as of this change.
+    EXPECTED = {
+        "inference/client.py::RemotePolicy.__init__",
+        "mesh/transport/iot_transport.py::IotMqttTransport.__init__",
+        "policies/lerobot_async/policy.py::LerobotAsyncPolicy.__init__",
+    }
+
+    @staticmethod
+    def _source_root() -> pathlib.Path:
+        """Derive the package root from a symbol, never from a path literal."""
+        return pathlib.Path(inspect.getfile(IotMqttTransport)).parents[2]
+
+    def test_the_scan_finds_exactly_the_known_surfaces(self) -> None:
+        """Non-vacuity: a scan resolving elsewhere reports a clean sweep over nothing."""
+        assert set(self._surfaces(self._source_root())) == self.EXPECTED
+
+    def test_no_surface_takes_the_parameter_without_the_shared_domain(self) -> None:
+        adrift = sorted(name for name, guarded in self._surfaces(self._source_root()).items() if not guarded)
+        assert adrift == [], f"connect_timeout is accepted without the shared domain by: {adrift}"
+
+    def test_the_scan_detects_a_surface_that_skips_the_domain(self, tmp_path: Any) -> None:
+        """Meta: an empty result must mean clean sources, not a scanner matching nothing."""
+        planted = tmp_path / "pkg"
+        planted.mkdir()
+        (planted / "leaky.py").write_text(
+            "class Rogue:\n    def __init__(self, connect_timeout: float = 1.0) -> None:\n"
+            "        self._t = connect_timeout\n",
+            encoding="utf-8",
+        )
+        found = self._surfaces(planted)
+        assert found == {"leaky.py::Rogue.__init__": False}
+
+
+def test_the_module_under_test_is_the_one_the_scan_root_points_at() -> None:
+    """Guard the symbol-derived root: it must be the shipped package directory."""
+    root = TestEverySurfaceTakingAConnectTimeoutRoutesThroughTheDomain._source_root()
+    assert root.name == "strands_robots"
+    assert (root / "mesh" / "transport" / "iot_transport.py").exists()


### PR DESCRIPTION
## Problem

`IotMqttTransport(connect_timeout=...)` stored whatever it was handed and spent it on
`threading.Event.wait` inside `connect()`. It is the **third** surface in the library carrying
that exact parameter name, and it was the only one without a domain. The other two are the
remote-inference clients settled by #1984 — `RemotePolicy` over WebSocket and
`LerobotAsyncPolicy` over gRPC — which both refuse a value that names no wait budget.

The gap is a scoping artifact rather than an oversight: that work settled "the knobs left behind
on the same two constructors", and the survey was scoped to remote-inference clients. A mesh
transport spelling the same knob the same way sat outside it. `coerce_zmq_timeout_ms`'s docstring
records the same shape from the other direction — "it is spelled differently from the WebSocket
and gRPC pair's `connect_timeout` / `request_timeout` (#1984), which is why it was missed".

What makes an unusable value worse than a late crash is that `connect()`'s failure report cannot
be told apart from a broker that is genuinely unreachable. Its own docstring promises `False` "if
… the broker is unreachable within `connect_timeout` seconds", and that is exactly what a caller
gets for a budget the transport never spent.

## Measured

Against a fake MQTT5 client whose CONNACK arrives 50 ms after `start()` — reachable, healthy,
connecting normally (a real CONNACK is a network round trip, never instant):

| `connect_timeout` | `connect()` on `main` | what the caller is told | MQTT5 client left | this change |
|---|---|---|---|---|
| `15.0` (default) | connected | CONNACK in 50 ms | running | connected |
| `0.5` | connected | CONNACK in 50 ms | running | connected |
| `0` | **returns `False`** | "timed out after 0.0s" (waited 0.4 ms) | stopped | refused at construction |
| `-1` | **returns `False`** | "timed out after 0.0s" (waited 0.0 ms) | stopped | refused at construction |
| `nan` | **returns `False`** | "timed out after nan s" (waited 0.2 ms) | stopped | refused at construction |
| `inf` | **raises `OverflowError`** | out of a method documented to return `bool` | **started, never stopped** | refused at construction |
| `'15'` | **raises `TypeError`** | out of a method documented to return `bool` | **started, never stopped** | refused at construction |
| `True` | connected | silent 1-second budget | running | refused at construction |
| `None` | connected here | — | running | refused at construction |

Against a broker that never reports CONNACK — the case the budget exists for:

| `connect_timeout` | `main` waited | outcome | instance lock | this change |
|---|---|---|---|---|
| `0.5` | 500.8 ms | `False` | released | unchanged on both trees |
| `1.2` | 1200.5 ms | `False` | released | unchanged on both trees |
| `0` | 0.4 ms | `False` | released | refused at construction |
| `nan` | 0.2 ms | `False` | released | refused at construction |
| `True` | 1000.4 ms | `False` | released | refused at construction |
| `None` | **never returns** | never returns | **held forever** | refused at construction |

Three distinct failures, one missing check:

- `0`, `-1` and `nan` make `Event.wait` return `False` in under half a millisecond, so a broker
  that is connecting normally is reported as having timed out and its client is torn down. The
  operator is pointed at the endpoint, the certs and the broker — the three things that are not wrong.
- `inf` and `'15'` raise from the wait itself. That call sits **after** the `try` that contains
  client construction, so the exception leaves `connect()` with the MQTT5 client started and no
  `stop()` on any path — the caller received an exception, not `False`, so nothing runs the
  teardown the timeout branch does.
- `None` is not a spelling for an unbounded wait. `Event.wait(None)` blocks forever, and
  `connect()` holds `self._lock` for its whole body, so `close()` and every subscription call
  block behind it with no deadline.

## Change

The constructor applies `positive_finite_number_error` — the same function, the same message
shape and the same reasoning the two clients already record. No new helper: this is the domain,
unchanged, applied to the surface that was missing it.

```
IotMqttTransport: connect_timeout must be > 0, got 0.
```

The guard sits in the constructor rather than beside the wait for two reasons. It refuses the
value while the caller still holds it, before any client exists; and it precedes the `awsiot`
import inside `connect()`, so the same mistake reports identically with and without the
`[mesh-iot]` extra installed — the property `LerobotAsyncPolicy`'s own comment names for the
gRPC client. Both are pinned.

A structural test scoped **by the parameter name** rather than by a module list keeps a fourth
surface from shipping the knob without the rule; it is the definition of the surface set rather
than a copy of it, and it currently resolves to exactly the three constructors. The class
docstring gains the `Args`/`Raises` block it had none of — no docs page documents this
constructor, so that docstring is its documentation.

## Artifact

The change is a constructor validation on a mesh transport: no policy, simulation, rendering,
recording or asset behaviour changes, so the artifact is the measured verdict table rather than a
rollout. Both halves come from one script run in a checkout of `main` and on this branch, each
recording which tree it imported; the compose step re-derives every cell from those two JSON
dumps and asserts each claim before saving.

![IotMqttTransport connect_timeout verdict tables](https://raw.githubusercontent.com/cagataycali/robots/artifacts/iot-connect-timeout-domain/iot_connect_timeout_domain.png)

Capture and compose scripts: [`artifacts/iot-connect-timeout-domain`](https://github.com/cagataycali/robots/tree/artifacts/iot-connect-timeout-domain).

## Verification

- **Pre-fix proof** (source at `upstream/main`, new tests kept): **32 failed / 22 passed**. The
  structural test names the adrift surface —
  `connect_timeout is accepted without the shared domain by: ['mesh/transport/iot_transport.py::IotMqttTransport.__init__']`.
  The 22 that pass are the over-reach controls: the `Event.wait` premises, the usable-value
  storage and default-in-domain tests, the connecting/silent-broker controls, and the scanner's
  non-vacuity and planted-defect metas.
- **Post-fix**: 54 passed in 2.9 s (`tests/mesh/test_iot_connect_timeout_domain.py`).
- **Full suite**: `MUJOCO_GL=egl python -m pytest tests` → **23571 passed / 257 skipped / 0 failed**
  in 531 s. Zero existing-test churn — 23517 on pristine `main` plus the 54 new.
- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean (1114 files).
- `mypy strands_robots tests tests_integ`: 0 errors outside `examples/`. The 14 in
  `examples/isaac_gs` are environmental — byte-identical to the same command on a pristine
  `upstream/main` worktree of this working copy.
- Merge-base overlap check: no overlap; the base gained 4 unrelated paths in that span.
