### PR TITLE
fix(mesh): refuse a non-finite env value for the knobs that size a safety bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,9 +1113,10 @@ touches ROS 2.
 | `STRANDS_MESH_CAMERA_HZ` | Camera publish rate; opt-in because frames are large. Unset, non-positive, or unusable leaves camera publishing off | `0` (off) |
 | `STRANDS_MESH_MAX_PEERS` | Peer registry cap; evicts oldest on overflow | `1024` |
 | `STRANDS_MESH_RESUME_MAX_FAILS` | Failed resume attempts before cooldown engages | `5` |
-| `STRANDS_MESH_RESUME_BACKOFF_S` | Cooldown (seconds) after exceeding resume fail threshold | `30` |
+| `STRANDS_MESH_RESUME_BACKOFF_S` | Cooldown (seconds) after exceeding resume fail threshold. A value no cooldown instant can be built from -- unparsable, negative, or non-finite like `inf`/`nan` -- falls back to the default, so the throttle both engages and expires (shared with `STRANDS_MESH_RESUME_FRESHNESS_S` / `_FORWARD_SKEW_S`) | `30` |
 | `STRANDS_MESH_INPUT_AUDIT_EVERY` | Emit `input_stream_applied` audit event every N frames (0 = off) | `100` |
 | `STRANDS_ESTOP_DEDUP_TTL_S` | E-stop fan-out Lambda dedup window (seconds) | `30` |
+| `STRANDS_MESH_DEDUP_TTL` | Window (seconds) the Zenoh<->IoT bridge remembers a delivered `(sender_id, turn_id, command)` triple for cross-transport deduplication. Unparsable, non-positive or non-finite falls back to the default, so a legitimately recurring heartbeat is forgotten again | `120` |
 | `STRANDS_MESH_BRIDGE_TOPICS` | Comma-separated topic suffixes the Zenoh<->IoT bridge forwards (exact match). Unset = the safe default set (`presence,health,safety/event,safety/estop,safety/resume,cmd,response,broadcast`). High-volume topics (`state,pose,imu,odom,lidar`) and LAN-only topics (`camera,input,hand`) are deliberately NOT bridged | default set |
 | `STRANDS_MESH_BRIDGE_TOPICS_PREFIX` | Comma-separated topic suffixes the bridge matches as a path **prefix** (so `response` matches `response/<turn-id>`). Extend this (not `STRANDS_MESH_BRIDGE_TOPICS`) when adding an RPC-shape topic with a per-turn tail | `response` |
 | `STRANDS_GR00T_IMAGE` | Container image the `gr00t_inference` tool runs (must pass the image allowlist; agent cannot choose it) | `gr00t:latest` |

--- a/changelog.d/2037-mesh-env-float-finiteness.md
+++ b/changelog.d/2037-mesh-env-float-finiteness.md
@@ -1,0 +1,28 @@
+### Fixed: a non-finite mesh env knob no longer disables the safety bound it sizes
+
+Both float-valued env resolvers in the mesh package read their value with
+`float()`, which accepts `nan`, `inf`, `Infinity` and `1e999` (that last one
+overflowing to `inf`), and neither range test beside them implies finiteness:
+`_parse_positive_float_env` compares `value < minimum`, which is `False` for
+`nan`, and the bridge deduplicator's `_resolve_dedup_ttl` compares `v > 0`,
+which is `True` for `inf`.
+
+Every knob the first resolver serves is one side of a comparison on the safety
+path, so a `nan` did not widen the bound but removed it. Measured:
+`STRANDS_MESH_RESUME_FRESHNESS_S=nan` made the presence stale/future test
+(`age > window or age < -skew`) `False` for every envelope, so a year-old
+presence was accepted; the replay-cache TTL purge kept all 5 of 5 stale
+entries; and `STRANDS_MESH_RESUME_BACKOFF_S=nan` armed the resume brute-force
+cooldown - the throttle over the E-stop override code - to
+`monotonic() + nan`, which no later `now < locked_until` test can satisfy, so
+it never engaged. `inf` failed open on the first two and closed on the third:
+the cooldown never expired, so a resume could never be granted again. Nothing
+was logged in any of these cases.
+
+Both resolvers now fall back to their documented default for a non-finite
+value, which is the rule the package's three other env-float resolvers already
+applied - `mesh.security._env_pos_float` both documents it and names
+`mesh.core._parse_positive_float_env` as its analogue. A structural test
+asserts every env-float resolver in the package tests finiteness, so a sixth
+cannot ship without it. The `0` floor is unchanged and pinned: the two
+resolvers legitimately disagree there, and what a zero means differs per knob.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import os
 import re
 import socket
@@ -67,6 +68,39 @@ def _parse_positive_float_env(name: str, default: str, *, minimum: float = 0.0) 
     Catches the case where an operator sets ``STRANDS_MESH_RESUME_FRESHNESS_S=abc``
     or a negative value. The module would otherwise fail to import with an opaque
     ``ValueError`` (found by running the module under bad env locally).
+
+    A non-finite value falls back too, and that test cannot be folded into the
+    range check below: ``float`` accepts ``"nan"``, ``"inf"`` and ``"1e999"``
+    (which overflows to ``inf``), and ``nan < minimum`` is ``False``, so a
+    ``nan`` passed a bare range test and was returned as the resolved knob.
+
+    Every knob resolved here is one side of a comparison on a safety path, and
+    a ``nan`` does not widen those comparisons but removes them. It makes the
+    presence stale/future test (``age > window or age < -skew``) ``False`` for
+    **every** envelope, so a year-old presence is accepted. It reaches
+    :func:`_evict_replay_cache` as ``ttl_s``, where ``cutoff = now - nan``
+    leaves every stale replay entry in the cache. And it reaches the resume
+    brute-force cooldown as ``locked_until = monotonic() + nan``, which no
+    later ``now < locked_until`` test can satisfy, so the throttle protecting
+    the E-stop override code never engages. ``inf`` fails open on the first two
+    and closed on the third: that cooldown never expires, so a resume can never
+    be granted again.
+
+    This is the rule :func:`~strands_robots.mesh.security._env_pos_float`
+    already documents and applies for the teleop input bound, and which
+    :func:`~strands_robots.mesh._zenoh_config._float_env` and
+    :func:`~strands_robots.mesh.session.hz_from_env` also apply. Those three
+    resolvers and this one answer the same question about the same kind of
+    operator input, so what counts as usable must not differ between them.
+
+    The floor is deliberately left alone: ``0`` is still accepted (``minimum``
+    defaults to ``0.0``) because what a zero means differs per knob - a zero
+    backoff is arguably "no cooldown" while a zero freshness window drops every
+    envelope - and that is a per-knob decision rather than this domain's.
+
+    The companion :func:`_parse_positive_int_env` needs no such test: ``int``
+    refuses ``"nan"``, ``"inf"`` and ``"1e999"`` outright, so every non-finite
+    spelling already reaches its ``ValueError`` fallback.
     """
     raw = os.getenv(name, default)
     try:
@@ -76,6 +110,14 @@ def _parse_positive_float_env(name: str, default: str, *, minimum: float = 0.0) 
             "Invalid %s=%r (not a float); falling back to default %r.",
             name,
             raw,
+            default,
+        )
+        return float(default)
+    if not math.isfinite(value):
+        logger.warning(
+            "Invalid %s=%r (must be finite); falling back to default %r.",
+            name,
+            value,
             default,
         )
         return float(default)

--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -44,6 +44,7 @@ import hashlib
 import heapq
 import json
 import logging
+import math
 import os
 import threading
 import time
@@ -269,13 +270,28 @@ def _resolve_dedup_ttl() -> float:
 
     NOTE: read once at ``BridgeTransport`` construction; mid-process
     env-var changes require a bridge restart to take effect.
+
+    A non-finite value falls back like any other unusable one, and the
+    finiteness test is not implied by the positivity test beside it.
+    ``float("inf")`` - and ``float("1e999")``, which overflows to it - is
+    greater than zero, so it was returned as the resolved TTL, and the
+    deduplicator's ``cutoff = now - inf`` then leaves every entry in its cache.
+    Under the ``_MAX_DEDUP_ENTRIES`` cap that turns the window into "for the
+    life of the process", so a heartbeat that legitimately recurs with the same
+    canonical triple is deduplicated away on its second delivery instead of
+    after the TTL. ``nan`` already fell back here because ``nan > 0`` is
+    ``False``, which is what made the hole one-sided and easy to miss.
+
+    The other env-float resolvers in this package all test finiteness; see
+    :func:`~strands_robots.mesh.core._parse_positive_float_env` for the same
+    rule and the reasoning behind it.
     """
     raw = os.getenv("STRANDS_MESH_DEDUP_TTL")
     if raw is None:
         return _DEFAULT_DEDUP_TTL_S
     try:
         v = float(raw)
-        return v if v > 0 else _DEFAULT_DEDUP_TTL_S
+        return v if math.isfinite(v) and v > 0 else _DEFAULT_DEDUP_TTL_S
     except ValueError:
         logger.warning("[bridge] STRANDS_MESH_DEDUP_TTL=%r invalid -- using default", raw)
         return _DEFAULT_DEDUP_TTL_S

--- a/tests/mesh/test_env_float_knobs_reject_non_finite.py
+++ b/tests/mesh/test_env_float_knobs_reject_non_finite.py
@@ -1,0 +1,323 @@
+"""Non-finite env values must not become resolved mesh knobs.
+
+Both float-valued env resolvers in the mesh package read their value with
+``float()``, which accepts ``"nan"``, ``"inf"``, ``"Infinity"`` and
+``"1e999"`` (that last one overflowing to ``inf``). Neither tested
+finiteness, and neither range test implies it:
+``_parse_positive_float_env`` compares ``value < minimum``, which is
+``False`` for ``nan``, and ``_resolve_dedup_ttl`` compares ``v > 0``,
+which is ``True`` for ``inf``.
+
+What made that reachable rather than theoretical is where the resolved
+values go. Every knob ``_parse_positive_float_env`` serves is one side of
+a comparison on the safety path, so a ``nan`` does not widen the bound but
+removes it: the presence stale/future test is ``False`` for every envelope,
+the replay-cache TTL purge keeps every stale entry, and the resume
+brute-force cooldown - the throttle over the E-stop override code - is
+armed to an instant no ``now < locked_until`` test can satisfy. ``inf``
+fails open on the first two and closed on the third.
+
+The rule is not new to the package. Three of its five env-float resolvers
+already applied it, and :func:`strands_robots.mesh.security._env_pos_float`
+both documents it ("Non-numeric / non-positive / NaN / inf values fall back
+to the default") and names ``mesh.core._parse_positive_float_env`` as its
+analogue. So this pins the two that did not, the parity between them, and -
+structurally - that a sixth resolver cannot ship without the test.
+
+Deliberately out of scope: the ``0`` floor. ``_parse_positive_float_env``
+admits it (its ``minimum`` defaults to ``0.0``) while ``_env_pos_float``
+refuses it, and what a zero means differs per knob - a zero resume backoff
+is arguably "no cooldown", a zero freshness window drops every envelope.
+That is a per-knob decision, and :class:`TestTheZeroFloorIsUnchanged` pins
+it so this change is not read as having settled it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+import time
+
+import pytest
+
+from strands_robots.mesh import core as core_mod
+from strands_robots.mesh import security as security_mod
+from strands_robots.mesh.transport import bridge_transport as bridge_mod
+
+#: Spellings ``float()`` accepts and no comparison-based bound can honor.
+NON_FINITE = ["nan", "NaN", "  nan  ", "inf", "Inf", "Infinity", "-inf", "1e999", "-1e999"]
+
+#: Env vars whose resolver is :func:`_parse_positive_float_env`, with the
+#: documented default each falls back to.
+FLOAT_KNOBS = [
+    ("STRANDS_MESH_RESUME_FRESHNESS_S", core_mod._resume_freshness_window_s, 60.0),
+    ("STRANDS_MESH_RESUME_FORWARD_SKEW_S", core_mod._resume_forward_skew_s, 5.0),
+    ("STRANDS_MESH_RESUME_BACKOFF_S", core_mod._resume_backoff_s, 30.0),
+]
+
+
+class TestEveryResumeKnobFallsBackForANonFiniteValue:
+    """A non-finite env value resolves to the documented default."""
+
+    @pytest.mark.parametrize(("env_var", "resolver", "default"), FLOAT_KNOBS, ids=lambda v: str(v))
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_resolver_returns_the_documented_default(self, monkeypatch, env_var, resolver, default, raw):
+        monkeypatch.setenv(env_var, raw)
+        resolved = resolver()
+        assert math.isfinite(resolved), f"{env_var}={raw!r} resolved to {resolved!r}"
+        assert resolved == default
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_the_fallback_is_reported(self, monkeypatch, caplog, raw):
+        """This resolver warns on every rejection; a non-finite value is no
+        exception. Silently substituting the default would make the one
+        rejection an operator cannot see the one that disables a safety bound.
+        """
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", raw)
+        with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+            core_mod._resume_freshness_window_s()
+        assert any("STRANDS_MESH_RESUME_FRESHNESS_S" in r.message for r in caplog.records)
+
+
+class TestThePresenceFreshnessBoundSurvives:
+    """The stale/future presence test keeps refusing what it refused."""
+
+    @staticmethod
+    def _dropped(age_s: float) -> bool:
+        """Replicate the production comparison at ``Mesh._on_presence``."""
+        window = core_mod._resume_freshness_window_s()
+        skew = core_mod._resume_forward_skew_s()
+        return age_s > window or age_s < -skew
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    @pytest.mark.parametrize(("label", "age_s"), [("a year old", 31_536_000.0), ("an hour in the future", -3600.0)])
+    def test_an_out_of_window_envelope_is_still_dropped(self, monkeypatch, raw, label, age_s):
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", raw)
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FORWARD_SKEW_S", raw)
+        assert self._dropped(age_s), f"{label} presence accepted under {raw!r}"
+
+    def test_an_in_window_envelope_is_still_accepted(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", "nan")
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FORWARD_SKEW_S", "nan")
+        assert not self._dropped(2.0)
+
+
+class TestTheResumeBruteForceCooldownEngagesAndExpires:
+    """``locked_until = monotonic() + backoff`` must be a real instant."""
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_the_cooldown_both_engages_and_expires(self, monkeypatch, raw):
+        monkeypatch.setenv("STRANDS_MESH_RESUME_BACKOFF_S", raw)
+        backoff = core_mod._resume_backoff_s()
+        locked_until = time.monotonic() + backoff
+        # Engages: a nan backoff made this comparison False, so the throttle
+        # over the E-stop override code never took effect.
+        assert time.monotonic() < locked_until, f"cooldown never engaged under {raw!r}"
+        # Expires: an inf backoff made it True forever, so a resume could
+        # never be granted again.
+        assert locked_until < time.monotonic() + 86_400.0, f"cooldown never expires under {raw!r}"
+
+
+class TestTheReplayCacheTtlPurgeStillEvicts:
+    """``cutoff = now_mono - ttl_s`` must be a real instant."""
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_stale_entries_are_evicted(self, monkeypatch, raw):
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", raw)
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FORWARD_SKEW_S", raw)
+        ttl = core_mod._resume_freshness_window_s() + core_mod._resume_forward_skew_s()
+        cache: dict[str, float] = {f"k{i}": 1_000.0 + i for i in range(5)}
+        core_mod._evict_replay_cache(cache, max_size=4096, ttl_s=ttl, now_mono=1_000_000.0)
+        assert cache == {}, f"stale replay entries survived under ttl_s={ttl!r}"
+
+    def test_a_fresh_entry_is_kept(self, monkeypatch):
+        monkeypatch.delenv("STRANDS_MESH_RESUME_FRESHNESS_S", raising=False)
+        monkeypatch.delenv("STRANDS_MESH_RESUME_FORWARD_SKEW_S", raising=False)
+        ttl = core_mod._resume_freshness_window_s() + core_mod._resume_forward_skew_s()
+        cache = {"recent": 999_999.0}
+        core_mod._evict_replay_cache(cache, max_size=4096, ttl_s=ttl, now_mono=1_000_000.0)
+        assert cache == {"recent": 999_999.0}
+
+
+class TestTheDedupTtlFallsBackForANonFiniteValue:
+    """``_resolve_dedup_ttl`` was holed on one side only."""
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_the_resolved_ttl_is_finite(self, monkeypatch, raw):
+        monkeypatch.setenv("STRANDS_MESH_DEDUP_TTL", raw)
+        resolved = bridge_mod._resolve_dedup_ttl()
+        assert math.isfinite(resolved), f"STRANDS_MESH_DEDUP_TTL={raw!r} resolved to {resolved!r}"
+        assert resolved == bridge_mod._DEFAULT_DEDUP_TTL_S
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_the_deduplicator_still_forgets(self, monkeypatch, raw):
+        """An infinite TTL made the cache never forget, so a heartbeat that
+        legitimately recurs with the same canonical triple would be dropped
+        as a duplicate for the life of the process.
+        """
+        monkeypatch.setenv("STRANDS_MESH_DEDUP_TTL", raw)
+        dedup = bridge_mod._CommandDeduplicator()
+        assert math.isfinite(dedup.ttl)
+        cache: dict[str, float] = {"seen": 1_000.0}
+        cutoff = 1_000_000.0 - dedup.ttl
+        assert cache["seen"] < cutoff, f"a 999_000s-old entry is not past the cutoff under {raw!r}"
+
+    def test_a_usable_ttl_is_still_honored(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_DEDUP_TTL", "45.5")
+        assert bridge_mod._resolve_dedup_ttl() == 45.5
+
+
+class TestBothResolversAgreeOnNonFinite:
+    """The finiteness axis is the one these resolvers must not diverge on."""
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_no_resolver_in_the_package_returns_a_non_finite_value(self, monkeypatch, raw):
+        monkeypatch.setenv("PARITY_PROBE", raw)
+        monkeypatch.setenv("STRANDS_MESH_DEDUP_TTL", raw)
+        resolved = [
+            core_mod._parse_positive_float_env("PARITY_PROBE", "60"),
+            security_mod._env_pos_float("PARITY_PROBE", 60.0),
+            bridge_mod._resolve_dedup_ttl(),
+        ]
+        assert all(math.isfinite(v) for v in resolved), resolved
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_both_documented_analogues_return_the_same_default(self, monkeypatch, raw):
+        monkeypatch.setenv("PARITY_PROBE", raw)
+        assert core_mod._parse_positive_float_env("PARITY_PROBE", "60") == security_mod._env_pos_float(
+            "PARITY_PROBE", 60.0
+        )
+
+
+class TestTheIntResolverNeedsNoSuchTest:
+    """The control: ``int()`` refuses every non-finite spelling itself."""
+
+    @pytest.mark.parametrize("raw", NON_FINITE)
+    def test_the_int_resolver_already_falls_back(self, monkeypatch, raw):
+        monkeypatch.setenv("INT_PROBE", raw)
+        assert core_mod._parse_positive_int_env("INT_PROBE", "4096") == 4096
+
+    def test_the_int_resolver_carries_no_finiteness_test(self):
+        """Adding one there would be dead code, so its absence is the
+        contract rather than an oversight.
+        """
+        assert "isfinite" not in inspect.getsource(core_mod._parse_positive_int_env)
+
+
+class TestTheZeroFloorIsUnchanged:
+    """Pins the axis this change deliberately does not decide."""
+
+    def test_the_float_resolver_still_admits_zero(self, monkeypatch):
+        monkeypatch.setenv("ZERO_PROBE", "0")
+        assert core_mod._parse_positive_float_env("ZERO_PROBE", "60") == 0.0
+
+    def test_the_teleop_resolver_still_refuses_zero(self, monkeypatch):
+        monkeypatch.setenv("ZERO_PROBE", "0")
+        assert security_mod._env_pos_float("ZERO_PROBE", 60.0) == 60.0
+
+    def test_a_negative_value_still_reports_the_range_reason(self, monkeypatch, caplog):
+        """The finiteness test runs first, so a plain negative must still
+        reach the range branch and name the floor rather than finiteness.
+        """
+        monkeypatch.setenv("ZERO_PROBE", "-10")
+        with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+            assert core_mod._parse_positive_float_env("ZERO_PROBE", "60") == 60.0
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("must be >=" in m for m in messages), messages
+
+
+# --- structural guard: no sixth resolver may ship without the test --------
+
+#: Every env-float resolver in the mesh package, as ``module::function``.
+EXPECTED_ENV_FLOAT_RESOLVERS = frozenset(
+    {
+        "_zenoh_config.py::_float_env",
+        "core.py::_parse_positive_float_env",
+        "security.py::_env_pos_float",
+        "session.py::hz_from_env",
+        "transport/bridge_transport.py::_resolve_dedup_ttl",
+    }
+)
+
+
+def _mesh_root() -> pathlib.Path:
+    """Derive the scanned package from an imported symbol, not a path literal."""
+    return pathlib.Path(inspect.getfile(core_mod)).parent
+
+
+def _reads_the_environment(fn: ast.AST) -> bool:
+    """True when *fn* really reads ``os.environ`` / ``os.getenv``.
+
+    Structural rather than textual: the safety handlers mention ``os.getenv``
+    in a comment explaining why they cache their knobs, and a text scan reads
+    that as an env-float site.
+    """
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            value = node.func.value
+            if node.func.attr == "getenv" and isinstance(value, ast.Name) and value.id == "os":
+                return True
+            if node.func.attr == "get" and isinstance(value, ast.Attribute) and value.attr == "environ":
+                return True
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Attribute) and node.value.attr == "environ":
+            return True
+    return False
+
+
+def _calls(fn: ast.AST, name: str) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == name:
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == name:
+                return True
+    return False
+
+
+def _scan(root: pathlib.Path) -> dict[str, bool]:
+    """Map ``module::function`` to whether it tests finiteness."""
+    found: dict[str, bool] = {}
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if _calls(node, "float") and _reads_the_environment(node):
+                found[f"{path.relative_to(root)}::{node.name}"] = _calls(node, "isfinite")
+    return found
+
+
+class TestEveryEnvFloatResolverTestsFiniteness:
+    """A structural guard, because the divergence is what let this happen."""
+
+    def test_the_scan_finds_exactly_the_known_resolvers(self):
+        """Non-vacuity: a scan rooted elsewhere, or a detector that stopped
+        matching, would report a clean sweep over nothing.
+        """
+        assert set(_scan(_mesh_root())) == set(EXPECTED_ENV_FLOAT_RESOLVERS)
+
+    def test_no_resolver_omits_the_finiteness_test(self):
+        adrift = sorted(name for name, guarded in _scan(_mesh_root()).items() if not guarded)
+        assert adrift == [], f"env-float resolvers with no finiteness test: {adrift}"
+
+    def test_the_scan_detects_a_planted_omission(self, tmp_path):
+        planted = tmp_path / "planted.py"
+        planted.write_text(
+            'import os\n\n\ndef _resolve(name: str) -> float:\n    return float(os.getenv(name, "1"))\n',
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {"planted.py::_resolve": False}
+
+    def test_the_scan_ignores_a_comment_mentioning_getenv(self, tmp_path):
+        """The detector must not re-acquire the text scan's false positive."""
+        planted = tmp_path / "commented.py"
+        planted.write_text(
+            "def _f(raw: str) -> float:\n"
+            "    # Reading them per-use parsed os.getenv on every reference.\n"
+            "    return float(raw)\n",
+            encoding="utf-8",
+        )
+        assert _scan(tmp_path) == {}

--- a/tests/mesh/test_env_float_knobs_reject_non_finite.py
+++ b/tests/mesh/test_env_float_knobs_reject_non_finite.py
@@ -30,6 +30,14 @@ refuses it, and what a zero means differs per knob - a zero resume backoff
 is arguably "no cooldown", a zero freshness window drops every envelope.
 That is a per-knob decision, and :class:`TestTheZeroFloorIsUnchanged` pins
 it so this change is not read as having settled it.
+
+One more property is pinned here, about this module rather than the mesh: its
+own node ids. ``FLOAT_KNOBS`` parametrizes over resolver *function objects*,
+and any id generator that stringifies its argument renders one as
+``<function _resume_backoff_s at 0x...>`` - an address that belongs to the
+process. pytest's default already resolves a function to its ``__name__``, so
+:class:`TestTheNodeIdsAreReproducible` pins that the ids stay address-free and
+keep naming the resolver.
 """
 
 from __future__ import annotations
@@ -38,6 +46,8 @@ import ast
 import inspect
 import math
 import pathlib
+import subprocess
+import sys
 import time
 
 import pytest
@@ -58,10 +68,14 @@ FLOAT_KNOBS = [
 ]
 
 
+#: The test whose parametrization carries the resolver function objects.
+TARGET_TEST = "test_resolver_returns_the_documented_default"
+
+
 class TestEveryResumeKnobFallsBackForANonFiniteValue:
     """A non-finite env value resolves to the documented default."""
 
-    @pytest.mark.parametrize(("env_var", "resolver", "default"), FLOAT_KNOBS, ids=lambda v: str(v))
+    @pytest.mark.parametrize(("env_var", "resolver", "default"), FLOAT_KNOBS)
     @pytest.mark.parametrize("raw", NON_FINITE)
     def test_resolver_returns_the_documented_default(self, monkeypatch, env_var, resolver, default, raw):
         monkeypatch.setenv(env_var, raw)
@@ -321,3 +335,71 @@ class TestEveryEnvFloatResolverTestsFiniteness:
             encoding="utf-8",
         )
         assert _scan(tmp_path) == {}
+
+
+@pytest.fixture(scope="module")
+def collected_node_ids() -> list[str]:
+    """This module's node ids, as a child process reports them.
+
+    ``-q -q`` nets out the ``-v`` in the project's ``addopts`` so the output is
+    the flat ``path::Class::test[id]`` form - the node id a caller pastes back
+    to re-run one case, which is the thing whose reproducibility is under test.
+    The two assertions are the non-vacuity guard: a collection that errored, or
+    an output read that matched nothing, must not let the checks below pass by
+    default.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(pathlib.Path(__file__).resolve()),
+            "--collect-only",
+            "-q",
+            "-q",
+            "--no-cov",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert proc.returncode == 0, f"collection failed:\n{proc.stdout}\n{proc.stderr}"
+    ids = [line.strip() for line in proc.stdout.splitlines() if "::" in line]
+    parametrized = [i for i in ids if TARGET_TEST in i]
+    expected = len(NON_FINITE) * len(FLOAT_KNOBS)
+    assert len(parametrized) == expected, f"read {len(parametrized)} ids for {TARGET_TEST}, expected {expected}"
+    return ids
+
+
+class TestTheNodeIdsAreReproducible:
+    """This module's own node ids must survive a change of process.
+
+    ``FLOAT_KNOBS`` carries resolver function objects, so ``ids=str``, the
+    package's usual ``ids=repr``, or a lambda wrapping either all render one as
+    ``<function _resume_backoff_s at 0x...>``. Measured over two collections of
+    identical code, 27 of this module's 128 ids differed, so none of the 27
+    could be pasted back to re-run one case and ``--last-failed`` could not
+    match them across runs. Letting pytest's default apply resolves each
+    function to its ``__name__`` instead; these tests pin that the ids stay
+    address-free *and* keep naming the resolver, because an id generator that
+    merely dropped the parameter would satisfy the first without the second.
+    """
+
+    def test_no_node_id_embeds_an_object_address(self, collected_node_ids):
+        offenders = sorted(node_id for node_id in collected_node_ids if " at 0x" in node_id)
+        assert offenders == [], (
+            f"{len(offenders)} node id(s) embed a process-local address, so they change every "
+            f"run and cannot be re-run; first: {offenders[0] if offenders else ''}"
+        )
+
+    def test_the_resolver_is_still_named_in_the_node_id(self, collected_node_ids):
+        """Address-free is not enough. Without the resolver's name a failure
+        reports an env var and a default with no clue which of the three
+        functions produced it.
+        """
+        parametrized = [node_id for node_id in collected_node_ids if TARGET_TEST in node_id]
+        for _env_var, resolver, _default in FLOAT_KNOBS:
+            assert any(resolver.__name__ in node_id for node_id in parametrized), (
+                f"{resolver.__name__} is named in no node id"
+            )


### PR DESCRIPTION
## The defect

Both float-valued env resolvers in the mesh package read their value with `float()`, which accepts `nan`, `inf`, `Infinity` and `1e999` (that last one overflowing to `inf`). Neither tested finiteness, and neither range test beside them implies it:

- `mesh/core.py::_parse_positive_float_env` compares `value < minimum`, and `nan < minimum` is `False`, so a `nan` passed and was returned as the resolved knob.
- `mesh/transport/bridge_transport.py::_resolve_dedup_ttl` compares `v > 0`, and `inf > 0` is `True`. (`nan` already fell back here for the same reason it passed above, which is what made this hole one-sided and easy to miss.)

What makes this reachable rather than theoretical is where those values go. Every knob the first resolver serves is one side of a comparison on the safety path, so a `nan` does not widen the bound — it removes it. Measured on the real code, nothing logged in any case:

| `STRANDS_MESH_RESUME_*` | main, `nan` | main, `inf` | this change |
|---|---|---|---|
| presence a year old is dropped | **no** | **no** | yes |
| stale replay entries evicted (of 5) | **0 of 5** | **0 of 5** | 5 of 5 |
| resume brute-force cooldown engages | **no** | yes | yes |
| resume brute-force cooldown expires | **no** | **no** | yes |

The cooldown row is the sharpest: `locked_until = monotonic() + nan` is an instant no later `now < locked_until` test can satisfy, so the throttle over the E-stop override code never engaged. `inf` fails the other way — `locked_until = inf` never expires, so a resume could never be granted again. One knob, two opposite failures.

On the bridge side, `cutoff = now - inf` leaves every entry in the deduplicator's cache, which under the `_MAX_DEDUP_ENTRIES` cap turns the window into "for the life of the process": a heartbeat that legitimately recurs with the same canonical triple is dropped as a duplicate on its second delivery instead of after the TTL.

## Why this is a divergence rather than a new rule

The package has five env-float resolvers and three of them already applied exactly this test. One of the three is `mesh/security.py::_env_pos_float`, whose docstring both states the rule — *"Non-numeric / non-positive / NaN / inf values fall back to the default"* — and **names the resolver that did not apply it**:

> Local to `mesh.security`; the analogous helper `mesh.core._parse_positive_float_env` is not importable here without an import cycle.

So the same operator input was usable on one resolver and unusable on its documented analogue. `_zenoh_config._float_env` and `session.hz_from_env` apply it too.

## The change

- Both resolvers fall back to their documented default for a non-finite value. `_parse_positive_float_env` warns, matching the shape of its two existing rejection branches — the one rejection an operator cannot see should not be the one that disables a safety bound. The finiteness test runs *before* the range test so every non-finite spelling gets one consistent reason; a plain negative still reports the floor.
- A structural test asserts every env-float resolver in the package tests finiteness, so a sixth cannot ship without it. Its detector is structural rather than textual, because the safety handlers mention `os.getenv` in a comment explaining why they cache their knobs and a text scan reads that as an env-float site.
- README: the `STRANDS_MESH_RESUME_BACKOFF_S` row now states the fallback, matching how the neighbouring `STRANDS_MESH_INPUT_MAX_HZ` and `_POSE_HZ` rows already describe theirs; `STRANDS_MESH_DEDUP_TTL` was undocumented and gains a row.

## Deliberately out of scope: the `0` floor

`_parse_positive_float_env` admits `0` (its `minimum` defaults to `0.0`) while `_env_pos_float` refuses it. That divergence is left alone because what a zero *means* differs per knob — a zero resume backoff is arguably "no cooldown", a zero freshness window drops every envelope — so it is a per-knob decision rather than this domain's. `TestTheZeroFloorIsUnchanged` pins both sides so this change is not read as having settled it.

`_parse_positive_int_env` needed no change and gets a control test saying why: `int` refuses `"nan"`, `"inf"` and `"1e999"` outright, so every non-finite spelling already reaches its `ValueError` fallback. Adding a finiteness test there would be dead code.

## Measured

![resolver verdicts and their consequence on the safety path](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-env-float-finiteness/env_finiteness.png)

Non-finite values returned as a resolved knob: **5 of 24 cells on main, 0 after**. The bottom band is the no-regression half — a usable value is still honored on both resolvers (`45.5` round-trips), a fresh presence is still accepted, the `0` floor is untouched on both sides, and the int resolver is unchanged. Every number in the figure is re-derived from two JSON dumps produced by one script run unchanged in a `git worktree` at `upstream/main` and on the branch; the generator asserts the two runs imported from different trees before drawing. [capture.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-env-float-finiteness/capture.py) / [compose.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-env-float-finiteness/compose.py).

No policy, simulation, rendering, recording or asset behaviour changes, so the artifact is a measured verdict table rather than a rollout.

## Round 2 — the parametrization stringified a function object

A static-analysis note flagged `ids=lambda v: str(v)` on the resume-knob parametrization as an unnecessary lambda. Measuring the alternatives found the lambda was wrapping the wrong callable rather than merely wrapping one: `FLOAT_KNOBS` carries resolver **function objects**, so `str()` rendered one as `<function _resume_backoff_s at 0x...>`, and that address belongs to the process.

| id generator | stable across two collections of identical code | ids carrying an address |
|---|---|---|
| `ids=lambda v: str(v)` (before) | **no — 27 of 128 ids differ** | 27 |
| `ids=str` (the note's direct reading) | **no — 27 differ** | 27 |
| `ids=repr` (this suite's usual, 120 uses) | no | 27 |
| **no `ids=` (this round)** | **yes** | 0 |

So the obvious fix clears the note and leaves the defect: none of those 27 ids could be pasted back to re-run one case, and `--last-failed` could not match them across runs. pytest's default already resolves a function to its `__name__` — deterministic *and* more readable — so the argument was overriding the default with something strictly worse, and it is removed rather than rewritten.

Two tests pin the contract, which was previously unpinned: no node id embeds an object address, and the resolver is still named in the id. The second is the over-reach control — an id generator that merely dropped the parameter is also address-free, but then a failure names an env var and a default with no clue which of the three resolvers ran. It passes pre-fix, because `str(func)` does contain the `__name__`. A module-scoped fixture collects this module in a child process with `-q -q`, which nets out the `-v` in the project's `addopts` so the output is the flat node-id form — the id a caller actually pastes back — and asserts the read is complete so neither check can pass vacuously.

Measured over the whole suite: **27 of the collected node ids carried an object address before, all 27 in this module, and 0 do after** (23963 → 23965 ids). The only other `0x` in a node id is a deliberate literal. The 120 existing `ids=repr` uses are all on primitive values, where `repr` is correct and address-free.

Round-2 pre-fix proof (re-insert only the `ids=` argument, keep the new tests): **1 failed / 1 passed**, the failure listing all 27 addressed ids. No production line moves in this round; the diff is one test file, +83/−1.

## Verification

Base `9d3ad2f`, head `dd5242b6` (rebased onto the base after #2036 merged; the overlap check reports no overlap and `behind_by: 0`, so the tree verified below is the tree that merges).

- **Pre-fix proof** — source reverted to `upstream/main`, the 130 new tests kept: **79 failed / 51 passed**. The structural guard's failure names both adrift resolvers by module and function. The 51 that pass pre-fix are the controls: the int resolver, the `0` floor, the usable-value cases, the scan's non-vacuity, its two planted-defect metas, and round 2's two node-id tests (which pin a property of this test module, not of the resolvers). Re-run at the new base after rebasing: identical 79 failed.
- **Full suite** — `MUJOCO_GL=egl pytest tests`: **23708 passed, 257 skipped, 0 failed** (522s). 130 new tests, **zero existing-test churn**.
- **Lint** — `ruff check` clean, `ruff format --check` 1116 files already formatted, `mypy strands_robots tests tests_integ` reports 0 errors outside `examples/isaac_gs`; the 14 there are byte-identical to a pristine `upstream/main` worktree of the same working copy, so they are environmental.
- `tests/mesh/test_env_float_knobs_reject_non_finite.py` alone: 130 passed in 3.3s — no zenoh, no GL, no network. (Round 2 adds one child-process collection of this module, which is the 2.5s.)

