### PR TITLE
ci: refuse a lockfile that does not resolve the manifest

### DIFF
--- a/.github/workflows/lockfile-parity.yml
+++ b/.github/workflows/lockfile-parity.yml
@@ -1,0 +1,141 @@
+# .github/workflows/lockfile-parity.yml
+#
+# Refuses a tree whose `uv.lock` no longer resolves `pyproject.toml`.
+#
+# `uv.lock` is a checked-in artifact, so it *looks* authoritative, and there was
+# no signal distinguishing "the lock is current" from "the lock is fourteen days
+# stale". Nothing ran `uv lock --check`, `uv sync --locked` or `uv sync --frozen`,
+# so the lock was never compared against the manifest at all. On `main` at
+# `9d3ad2f` it no longer resolved it, and CI stayed green throughout because
+# nothing looked. See issue #2038.
+#
+# What the drift cost is not hypothetical, and it is not confined to whoever runs
+# a locked install. `uv.lock` is a **dependency-graph manifest** -
+# `dependencyGraphManifests` lists it with `parseable: true` - so GitHub's
+# security scanning reads it, which is also how #631 resolved 51 Dependabot
+# alerts "via uv lock upgrade". A stale lock is therefore a stale security
+# surface. Measured against the repository's own SBOM while the lock was stale:
+#
+#   lerobot   -> 0.6.0     the version pyproject.toml FORBIDS (floor >=0.6.1)
+#   roslibpy  -> ABSENT    so no roslibpy advisory could ever be reported,
+#                          though [rosbridge] and [all] require it and
+#                          use_rosbridge imports it
+#
+# #1930 existed only to buy that lerobot floor ("floor lerobot at >=0.6.1 so
+# bucket streaming is resolver-guaranteed"), and
+# tests/test_lerobot_floor_guarantees_bucket_streaming.py pins it - on the
+# manifest side. The artifact that pins the build said 0.6.0, and no test looked
+# at that side, which is the gap this file closes.
+#
+# WHY THE MERGE COMMIT AND NOT THE HEAD SHA
+#
+# This job deliberately takes `actions/checkout`'s default ref for a
+# `pull_request` event - `refs/pull/<n>/merge` - rather than naming
+# `github.event.pull_request.head.sha`. The question here is "does the lock
+# resolve the manifest", which is a property of the *tree that would land*, so
+# the merge commit is the tree that has to answer it.
+#
+# Naming the head sha instead would accuse branches that changed nothing. Every
+# branch forked before the relock that ships with this workflow carries the stale
+# lock, so it would fail on the head sha while being entirely innocent; on the
+# merge commit it inherits the relocked lock from the base and passes. Measured
+# against the three pull requests open when this landed - #1722, #1035 and #1087,
+# none of which touch `pyproject.toml` or `uv.lock` - all three pass on the merge
+# tree. Pinned by
+# tests/test_lockfile_parity_gate.py::test_the_gate_reads_the_merge_tree.
+#
+# This is the opposite choice from `changelog-fragment.yml`, and the reason is
+# that the two ask different questions: that gate asks what a branch *added*,
+# which only exists as a diff between base and head, so it must name both. A
+# parity check reads two files and needs exactly one tree.
+#
+# It also needs no `--head`-style argument and no repository script, which is why
+# it is immune to the #1791 failure mode that shaped the changelog gate: `uv lock
+# --check` ships with uv, so a branch that forked before this workflow existed
+# cannot fail it for lack of a file.
+#
+# NO UV VERSION PIN, AND THAT IS MEASURED RATHER THAN ASSUMED
+#
+# The obvious worry is that `uv lock --check` is a verdict about uv's resolver, so
+# a CI uv newer than the one that wrote the lock could demand an update over
+# format or marker churn alone - a gate that fails for no defect. It does not, at
+# least across the range that matters here. uv 0.11.32 (current the day the lock
+# was last written, 2026-07-25) and uv 0.12.3 (latest) write a **byte-identical**
+# lock from this manifest, and each accepts the other's output:
+#
+#   0.11.32 writes -> 0.12.3 `--check`  ->  pass
+#   0.12.3  writes -> 0.11.32 `--check` ->  pass
+#   diff between the two written locks  ->  0 lines
+#
+# So the marker churn in the relock is attributable to the manifest edits, not to
+# a uv upgrade, and pinning uv here would add a maintenance obligation that buys
+# nothing. If a future uv does change the lock format, the fix is a deliberate
+# relock, which this gate is what asks for.
+#
+# ADVISORY, AND SELF-CLEARING
+#
+# Whether a failure here blocks a merge is a branch-protection decision, not a
+# property of this file: the `default` ruleset lists exactly one required check
+# (`call-test-lint / Test and Lint`), so until this job is added to that set it
+# surfaces the drift and leaves the call to the reviewer. The remedy is
+# `uv lock`, committed - so doing the thing the check asks for makes it pass, and
+# no bypass switch is needed.
+#
+# One caveat on that self-clearing claim, for a gate that does go red on a
+# contributor's branch: absorbing a relocked `main` is a push, and per AGENTS.md
+# > PR Workflow a push onto a contributor's branch by a maintainer consumes that
+# maintainer's approval (`require_last_push_approval`). Ask the contributor to
+# merge `main`; do not push it for them.
+#
+# The offline half of this contract - that the locked version satisfies every
+# declared floor, and that every declared dependency is present at all - lives in
+# tests/test_lockfile_parity_gate.py, so the two rows measured above are pinned
+# by the required check and not only by this advisory job.
+#
+
+name: Lockfile Parity Check
+
+# No `types` override: the default is exactly the set that can change the tree,
+# which is the only thing this job reads. Pinned repository-wide by
+# tests/test_pull_request_trigger_types.py.
+on:
+  pull_request:
+    branches: [main, dev]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lockfile:
+    name: Refuse a lockfile that does not resolve the manifest
+    runs-on: ubuntu-latest
+
+    steps:
+      # Default ref: the pull request's merge commit. See "WHY THE MERGE COMMIT
+      # AND NOT THE HEAD SHA" above - this is load-bearing, not an omission.
+      - name: Checkout the merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # Installed with pip rather than a setup action, so this gate adds no new
+      # third-party action to pin and keep fresh. Unpinned for the reason
+      # measured above, and matching how `test-lint.yml` installs hatch.
+      - name: Install uv
+        run: pip install --no-cache-dir uv
+
+      # Resolution only - this neither builds an environment nor downloads a
+      # wheel, and it reports in well under a minute. `--check` exits non-zero
+      # when the lock would have to change to match the manifest, and prints the
+      # `uv lock` hint that is the whole remedy.
+      - name: Refuse a lockfile that does not resolve the manifest
+        run: uv lock --check

--- a/changelog.d/2038-lockfile-parity-gate.md
+++ b/changelog.d/2038-lockfile-parity-gate.md
@@ -1,0 +1,22 @@
+### Added: a lockfile that does not resolve the manifest is refused
+
+Nothing compared `uv.lock` against `pyproject.toml` -- no workflow ran `uv lock
+--check`, `uv sync --locked` or `uv sync --frozen` -- so the lock drifted for
+fourteen days while CI stayed green. The lock was last written 2026-07-25 and the
+manifest was edited three times after that with no relock, leaving `uv lock
+--check` failing on `main`.
+
+Because `uv.lock` is one of the manifests GitHub's dependency graph parses, the
+drift was also a stale security surface rather than only a stale install: the
+graph reported `lerobot 0.6.0`, the version `pyproject.toml` forbids (floor
+`>=0.6.1`, bought by #1930 for exactly this guarantee), and carried no `roslibpy`
+entry at all, so no advisory against it could be reported even though
+`[rosbridge]` and `[all]` require it.
+
+`.github/workflows/lockfile-parity.yml` now runs `uv lock --check` on the merge
+commit, and `uv.lock` is relocked so the gate starts green: 14 packages added
+(`roslibpy` and its transitive tree), 1 removed, and 2 upgraded -- `lerobot`
+`0.6.0` -> `0.6.1` and `draccus` `0.10.0` -> `0.11.6`. The offline half of the
+contract is pinned by `tests/test_lockfile_parity_gate.py`, so a locked version
+below a declared floor, or a declared dependency missing from the lock, is
+reported by the required check rather than only by the advisory gate.

--- a/tests/test_lockfile_parity_gate.py
+++ b/tests/test_lockfile_parity_gate.py
@@ -1,0 +1,295 @@
+"""Contract pins for the lockfile-parity gate and for the lock it guards.
+
+``uv.lock`` is checked in, so it reads as authoritative, and nothing compared it
+against ``pyproject.toml``: no workflow ran ``uv lock --check``, ``uv sync
+--locked`` or ``uv sync --frozen``.  The lock was last written 2026-07-25
+(``4a42ad4``, #1606) and the manifest was edited three times after that
+(``c038f9f``, ``5221459``, ``04dcd31``) with no relock, so ``uv lock --check``
+failed on ``main`` at ``9d3ad2f`` while CI stayed green throughout.  See #2038.
+
+The consequence is not confined to whoever runs a locked install, which is what
+makes the staleness worth a gate rather than a note.  ``uv.lock`` is a
+**dependency-graph manifest** -- ``dependencyGraphManifests`` lists it with
+``parseable: true`` -- so it is one of the inputs GitHub's security scanning
+reads, which is also how #631 cleared 51 Dependabot alerts "via uv lock
+upgrade".  Read off the repository's own SBOM while the lock was stale::
+
+    lerobot   0.6.0     the version pyproject.toml forbids (floor >=0.6.1)
+    roslibpy  ABSENT    no roslibpy advisory could be reported at all
+
+Both rows are pinned below, and the first one is why this module exists at all
+rather than leaving the whole contract to the workflow.  #1930 existed *only* to
+buy that lerobot floor, and
+``tests/test_lerobot_floor_guarantees_bucket_streaming.py`` pins it -- on the
+manifest side.  The artifact that pins the build said ``0.6.0``, one test
+asserted the floor and passed, and no test read the other side.  A guarantee
+pinned on one side of two files is not pinned.
+
+Two halves, deliberately split by what they can afford to do:
+
+* ``uv lock --check``, in ``.github/workflows/lockfile-parity.yml``, is the
+  complete test.  It re-resolves against the index, so it needs the network and
+  belongs in a workflow.
+* The tests here are **offline and structural**.  They cover the two drift
+  classes actually measured above -- a locked version below a declared floor, and
+  a declared dependency missing from the lock entirely -- so the required check
+  reports them without a network round trip, and they name the drift in the
+  manifest's own terms rather than as "the lockfile needs to be updated".
+
+Neither subsumes the other: ``--check`` catches drift these cannot see (a
+transitive pin, a marker change), and these fail in the required check, which
+``--check`` cannot do while the gate is advisory.
+
+**The floor pin refuses a distribution only when every locked version is below
+the floor, not when any is.**  That is measured, not cautious.  ``uv`` forks the
+resolution (``[tool.uv] conflicts``), so one distribution can legitimately appear
+at several versions, and ``robosuite`` is locked at both ``1.4.0`` and ``1.4.1``
+against a ``>=1.4.1`` floor from ``[vera-sim]``.  It reads that way **both before
+and after the relock**, so it is a property of forking rather than drift, and an
+"any version below the floor" rule would fail a correct lock.  The weaker rule
+still names the row that mattered: ``lerobot`` was locked at exactly one version,
+``0.6.0``, below its floor from three separate extras.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_LOCK = _REPO_ROOT / "uv.lock"
+_GATE = _REPO_ROOT / ".github" / "workflows" / "lockfile-parity.yml"
+
+#: This project, which appears in its own manifest as ``strands-robots[<extra>]``
+#: recursive extras. Those resolve to the other extras rather than to a
+#: distribution the lock would carry an entry for.
+_PROJECT_NAME = "strands-robots"
+
+#: ``[[package]]`` entries carry the distribution name and version on the two
+#: lines after the table header, in that order, for every entry uv writes.
+_LOCK_PACKAGE_RE = re.compile(
+    r'^\[\[package\]\]\nname = "(?P<name>[^"]+)"\nversion = "(?P<version>[^"]+)"',
+    re.MULTILINE,
+)
+
+
+def _canonical(name: str) -> str:
+    """Normalise a distribution name per PEP 503, so ``zope.interface`` matches ``zope-interface``."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _locked_versions() -> dict[str, list[str]]:
+    """Map every locked distribution to the versions the lock carries for it.
+
+    A list rather than a scalar because uv forks the resolution, so one
+    distribution can appear at several versions - which is the whole reason the
+    floor pin below is phrased over "every" version.
+    """
+    found: dict[str, list[str]] = defaultdict(list)
+    for match in _LOCK_PACKAGE_RE.finditer(_LOCK.read_text(encoding="utf-8")):
+        found[_canonical(match.group("name"))].append(match.group("version"))
+    return dict(found)
+
+
+def _declared_requirements() -> list[tuple[str, Requirement]]:
+    """Return every direct requirement in the manifest, tagged with where it is declared.
+
+    ``project.dependencies`` and ``project.optional-dependencies`` only: those are
+    what an installer resolves for ``pip install 'strands-robots[rosbridge]'``, which
+    is the population the two measured rows came from. Recursive
+    ``strands-robots[...]`` extras and URL requirements are dropped - neither
+    names a distribution the lock carries an entry for under that name.
+    """
+    project = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]
+
+    rows: list[tuple[str, Requirement]] = []
+    for spec in project.get("dependencies", []):
+        rows.append(("project.dependencies", Requirement(spec)))
+    for extra, specs in project.get("optional-dependencies", {}).items():
+        for spec in specs:
+            rows.append((extra, Requirement(spec)))
+
+    return [(where, req) for where, req in rows if _canonical(req.name) != _PROJECT_NAME and not req.url]
+
+
+def _declared_floor(req: Requirement) -> Version | None:
+    """Return the lowest version the requirement admits, or None if it sets no floor.
+
+    ``max`` over the floor-setting operators: a requirement carrying more than
+    one (``>=0.6.1`` alongside a ``~=`` in a different marker branch) is bounded
+    below by the highest of them.
+    """
+    floors = [Version(spec.version) for spec in req.specifier if spec.operator in (">=", "==", "~=")]
+    return max(floors) if floors else None
+
+
+# --------------------------------------------------------------------------- #
+# Non-vacuity. Every assertion below is a statement about what the two parsers
+# found, so a parser that quietly matches nothing would satisfy all of them.
+# --------------------------------------------------------------------------- #
+
+
+def test_the_manifest_parser_finds_the_declared_requirements() -> None:
+    """The manifest scan must find the requirements the pins below range over."""
+    rows = _declared_requirements()
+    distributions = {_canonical(req.name) for _, req in rows}
+    # 68 requirements over 52 distributions when this was written. Floors, not
+    # equalities: declaring a dependency is routine and must not fail this pin.
+    assert len(rows) >= 60, f"only {len(rows)} direct requirements parsed: {rows}"
+    assert len(distributions) >= 45, f"only {len(distributions)} distributions: {sorted(distributions)}"
+
+
+def test_the_lock_parser_finds_the_locked_packages() -> None:
+    """The lock scan must find the packages the pins below range over."""
+    locked = _locked_versions()
+    # 264 distributions when this was written; 269 packages counting fork
+    # duplicates. A floor, for the same reason as above.
+    assert len(locked) >= 200, f"only {len(locked)} distributions parsed from {_LOCK}"
+    # A distribution known to be required directly, as the cheapest proof the
+    # regex is reading real `[[package]]` tables rather than matching by luck.
+    #
+    # Deliberately not this project's own entry: uv writes the editable root
+    # with a `source = { editable = "." }` line and *no* `version`, so it is
+    # absent from this map by construction. That is also why the pins below drop
+    # self-referential `strands-robots[<extra>]` requirements rather than looking
+    # them up - there is no version there to compare a floor against.
+    assert locked.get("numpy"), sorted(locked)[:20]
+
+
+# --------------------------------------------------------------------------- #
+# The two measured drift classes.
+# --------------------------------------------------------------------------- #
+
+
+def test_every_declared_dependency_is_present_in_the_lock() -> None:
+    """A dependency the manifest requires must appear in the lock.
+
+    ``roslibpy`` did not.  #1110 (2026-07-31) added the whole rosbridge transport
+    and the ``[rosbridge]`` extra that requires it, and ``[all]`` includes that
+    extra, but the lock gained no entry - so a resolution from the lock produced
+    an install where ``use_rosbridge``'s import cannot succeed, and no advisory
+    against ``roslibpy`` could ever be reported for this repository.
+
+    Absence is unambiguous here because a uv lock is *universal*: it carries the
+    packages for every platform and marker branch rather than for the resolving
+    host, so a missing entry is a missing dependency and not a filtered one.
+    """
+    locked = _locked_versions()
+    missing = sorted(
+        {
+            f"{_canonical(req.name)} (declared in [{where}])"
+            for where, req in _declared_requirements()
+            if _canonical(req.name) not in locked
+        }
+    )
+    assert not missing, (
+        "these dependencies are declared in pyproject.toml and absent from "
+        f"uv.lock, so a resolution from the lock omits them entirely: {missing}. "
+        "Run `uv lock` and commit the result."
+    )
+
+
+def test_no_locked_version_falls_below_its_declared_floor() -> None:
+    """A locked version must satisfy the floor the manifest declares for it.
+
+    ``lerobot`` was pinned at ``0.6.0`` against a ``>=0.6.1`` floor declared by
+    three extras, so the lock **violated its own manifest** - and #1930 exists
+    only to buy that floor, which makes the lock's answer the exact opposite of
+    the guarantee that pull request paid for.
+
+    Phrased over *every* locked version rather than any: see this module's
+    docstring for the ``robosuite`` measurement that rules out the stronger form.
+    """
+    locked = _locked_versions()
+    violations: list[str] = []
+    for where, req in _declared_requirements():
+        name = _canonical(req.name)
+        floor = _declared_floor(req)
+        if floor is None or name not in locked:
+            continue
+        versions = sorted(Version(v) for v in locked[name])
+        if all(version < floor for version in versions):
+            violations.append(
+                f"{name} locked at {[str(v) for v in versions]} but [{where}] declares a floor of {floor}"
+            )
+
+    assert not violations, (
+        "the lock pins a version its own manifest forbids, so a resolution from "
+        f"the lock cannot satisfy pyproject.toml: {sorted(set(violations))}. "
+        "Run `uv lock` and commit the result."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The gate that catches everything these two cannot.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def gate_text() -> str:
+    assert _GATE.is_file(), (
+        f"{_GATE.relative_to(_REPO_ROOT)} is missing. The offline pins in this "
+        "module cover two drift classes; the workflow is what compares the lock "
+        "against the manifest in full."
+    )
+    return _GATE.read_text(encoding="utf-8")
+
+
+def test_the_gate_runs_the_parity_check(gate_text: str) -> None:
+    """The workflow must actually run ``uv lock --check``.
+
+    That one command *is* the contract - it re-resolves the manifest and exits
+    non-zero when the lock would have to change - so a gate that installs uv and
+    checks nothing would pass every pin here while enforcing nothing.
+    """
+    assert re.search(r"^\s*run:\s*uv lock --check\s*$", gate_text, re.MULTILINE), (
+        f"{_GATE.name} does not run `uv lock --check`. Neither `uv lock` (which "
+        "rewrites the file and exits 0) nor `uv sync` (which relocks silently) "
+        "reports drift."
+    )
+
+
+def test_the_gate_reads_the_merge_tree(gate_text: str) -> None:
+    """The checkout must not name the head sha.
+
+    This is the one design decision in the workflow that is invisible from its
+    behaviour on a green branch, so it is pinned rather than commented.
+
+    "Does the lock resolve the manifest" is a property of the tree that would
+    land, and for a ``pull_request`` event that tree is ``actions/checkout``'s
+    default ref, the merge commit.  Naming ``head.sha`` instead would accuse
+    every branch that forked before a relock while changing no dependency file -
+    #1722, #1035 and #1087 were all open when this landed, none of them touch
+    ``pyproject.toml`` or ``uv.lock``, and all three pass on the merge tree and
+    would have failed on their own heads.
+
+    It is the opposite choice from ``changelog-fragment.yml``, which must name
+    both base and head because it asks what a branch *added*; an addition only
+    exists as a diff, while a parity check reads two files and needs one tree.
+    """
+    head_sha_ref = re.search(r"^\s*ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha", gate_text, re.MULTILINE)
+    assert head_sha_ref is None, (
+        f"{_GATE.name} checks out the pull request head sha. Take the default "
+        "merge-commit ref instead: on the head sha, a branch that forked before "
+        "a relock fails this gate while having changed no dependency file."
+    )
+
+
+def test_every_action_the_gate_uses_is_sha_pinned(gate_text: str) -> None:
+    """``uses:`` references pin a 40-character commit SHA, per AGENTS.md > Action Pinning.
+
+    A moving tag on a third-party action is the ``tj-actions/changed-files``
+    supply-chain pattern, and this gate runs on ``pull_request``, so it is
+    reachable from a fork.
+    """
+    references = re.findall(r"^\s*uses:\s*(?P<ref>\S+)", gate_text, re.MULTILINE)
+    assert references, f"no `uses:` found in {_GATE.name}"
+    unpinned = [ref for ref in references if not re.search(r"@[0-9a-f]{40}$", ref)]
+    assert not unpinned, f"these action references in {_GATE.name} do not pin a 40-character commit SHA: {unpinned}"

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
+    "(python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim') or (python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')",
     "python_full_version >= '3.15' and sys_platform == 'emscripten' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
+    "(python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim') or (python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
+    "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
     "python_full_version < '3.14' and sys_platform == 'emscripten' and extra != 'extra-14-strands-robots-all' and extra != 'extra-14-strands-robots-benchmark-libero' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-lerobot-async' and extra != 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim'",
     "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
@@ -14,9 +17,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
     "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
     "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
-    "python_full_version >= '3.15' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
     "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
     "(python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
     "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'linux' and extra == 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
@@ -32,9 +38,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
     "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
     "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
-    "python_full_version >= '3.15' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim'",
     "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
     "(python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
     "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'linux' and extra != 'extra-14-strands-robots-lerobot' and extra != 'extra-14-strands-robots-vera-sim')",
@@ -274,6 +283,51 @@ wheels = [
 ]
 
 [[package]]
+name = "autobahn"
+version = "26.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cbor2" },
+    { name = "cffi" },
+    { name = "cryptography" },
+    { name = "hyperlink" },
+    { name = "msgpack", marker = "platform_python_implementation == 'CPython' or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
+    { name = "txaio" },
+    { name = "u-msgpack-python", marker = "platform_python_implementation != 'CPython' or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
+    { name = "ujson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/73/f109f563c27e048e45d135d81af19e6ca391e24905550b06bd1c9d674c57/autobahn-26.7.1.tar.gz", hash = "sha256:c6949a2c6eb95fb1c218837dbda0a59abbbebafb8b11098551c01a7061dfd245", size = 14056542, upload-time = "2026-07-15T19:14:01.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/23/0769ef39e1cfb0bec15bacdd7f407aaedfda14c0ca3f7e818b856f2ed1a1/autobahn-26.7.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:6c9013e9aa9ea8a561c89d7be2709546b51fc7ac8fdf6cd71bc12a634672d9a8", size = 2000605, upload-time = "2026-07-15T19:13:30.391Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ef/26833f38ecf3aef3ff0aa09feb12f5d472f7370104148a6b78e3c7afc286/autobahn-26.7.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd9ebe577dd1030f9a0c41d20dc00eca90d5cf338531abcb510d978825feeea", size = 2082844, upload-time = "2026-07-15T19:13:31.559Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4c/00553ee9d57ee11df47bc9867d120cfe721a73bec0b58fb3a3b91cd7c797/autobahn-26.7.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de491baa4cf52fb6d7f542e445c72d94ce52dc7aabb47b0b4d5191e452dd2c74", size = 2254852, upload-time = "2026-07-15T19:13:32.8Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ca/7884f6ffb8410882df98cb939dea24225dd79e4f091ceb59f4b826e54f2f/autobahn-26.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9723561c820ed032fe5a8f1530cb6d5f91dc595eea6009f3b2de7044a3df892a", size = 3174235, upload-time = "2026-07-15T19:13:34.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e7/c6704e8f6bef3aa552a851a34908a06d91317d35ca55ec04b5db14385c33/autobahn-26.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e81c86cf41adca8a56ca5621ecd9ba40037f6d90d338c334bd529c8ac94bd7b6", size = 3403687, upload-time = "2026-07-15T19:13:35.633Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ae/d0993f37f7ddce595dff8ddbe3cdbe5351a1454e4d9d30bbcb0a6e08e8e3/autobahn-26.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:b2ec0cfb913cc20f10feb3d63cd3eb2e08c9f28f9c1ba4e7776454cd5b345145", size = 2179395, upload-time = "2026-07-15T19:13:37.088Z" },
+    { url = "https://files.pythonhosted.org/packages/36/92/2f6e57d9f9e6b86b9db362f58aaa6cfeadc2f3a6901ec95aab27ef232b5c/autobahn-26.7.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:2ce48214b28f73338fabe0c7fd13d222cfab9e1dd2ef11660293522f64e76727", size = 1987052, upload-time = "2026-07-15T19:13:38.543Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6d/f170134468e276fa9ea57eb1ae41f9cc0dcd0228e9d501f370fa50c0ee31/autobahn-26.7.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5f285dce9b3dff3eb2ef6c818ac8ede24d96bd1edac340855170fc9825c38a9", size = 2082813, upload-time = "2026-07-15T19:13:39.686Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ce/b735fa933e9ba4fa8c3f9aa9ae68b4e2d4aadb0a92b38ade30e37a7d4795/autobahn-26.7.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66ab6e034e54f8c473df1a6b8031a3db46c16deebaf0c9b66db3e9137d2fab5e", size = 2254818, upload-time = "2026-07-15T19:13:40.951Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3e/57855f4f52aa0ee64c6d8210637d0d9847de4c1082e03ddd2ffafd853d2d/autobahn-26.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:20b3eab7d483e93278f9d7345592eb6b465883a6e88c2823aad13c3f943452db", size = 682494, upload-time = "2026-07-15T19:13:42.193Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/3c/3944f17dd2a06aee7d0d9f1c37b5a94518434d13ba2c38e738d33ca10daf/autobahn-26.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cd840524ff190aee695a58e8acd8740ee66b4a0e6a58ccb41416ed2cbe48d43f", size = 3403666, upload-time = "2026-07-15T19:13:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/40/187f83f4048705160bdac91235183e9d0f3bbe002be4da552cce640c239b/autobahn-26.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d158b85f075975dd4d47e937c943588f7cbf8e46f3271544b55f5c6f6500071", size = 2174266, upload-time = "2026-07-15T19:13:45.161Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3e/200471878093a502f8e8078c1ca19fd82acc68ae9ac363e395170da6dbe2/autobahn-26.7.1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f3d1be925e3fb33fff5280c1bd02027047519812c400d3efa5477d3968686c94", size = 1987070, upload-time = "2026-07-15T19:13:47.112Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d1/704f881fd2c52b056dc0f14e6d0d640b1f3ff43f3b84cf85d3631e3243f4/autobahn-26.7.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44f8094b0c0fa29a4963ce12130b7932469f89afa0242ff858d2b26541a81005", size = 2082939, upload-time = "2026-07-15T19:13:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/27/84e76aec7abbcb502d4cd34ef5c859eaa19a3b707cda68ab7ce68478dd92/autobahn-26.7.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0fcf9c3ff6b9b2bc85d6e1814a94d1d941d62f7df36d350b523d77df85d66ea", size = 2254983, upload-time = "2026-07-15T19:13:49.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/81/a810732a10342c5d6b90d19f83fa2bc9b6126e7c0cda7c4df867e311aa2e/autobahn-26.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4f82e5a113f6c1ff14cec99aa411f7da8fceec3dcd4647d7ebdfc0278811e14d", size = 3174295, upload-time = "2026-07-15T19:13:51.227Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c6/4886fdaecfeda013e085288a9d83bad6f1ded9995b8088ca933d9ec37201/autobahn-26.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:919309cbe41b28b0a3028e7c6fed52aca9fd21639619f372d3270c44341b6bdc", size = 3403713, upload-time = "2026-07-15T19:13:52.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/08/0106af17fcbe65a85040a8d98015bdcf2ef68144e12df500a72b91a5873e/autobahn-26.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:354298aa0ab79861578f45f5bf543e4757c32070ff801282beda80c6c4f2a41e", size = 2206827, upload-time = "2026-07-15T19:13:54.499Z" },
+]
+
+[[package]]
+name = "automat"
+version = "25.4.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/0f/d40bbe294bbf004d436a8bcbcfaadca8b5140d39ad0ad3d73d1a8ba15f14/automat-25.4.16.tar.gz", hash = "sha256:0017591a5477066e90d26b0e696ddc143baafd87b588cfac8100bc6be9634de0", size = 129977, upload-time = "2025-04-16T20:12:16.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/ff/1175b0b7371e46244032d43a56862d0af455823b5280a50c63d99cc50f18/automat-25.4.16-py3-none-any.whl", hash = "sha256:04e9bce696a8d5671ee698005af6e5a9fa15354140a87f4870744604dcdd3ba1", size = 42842, upload-time = "2025-04-16T20:12:14.447Z" },
+]
+
+[[package]]
 name = "av"
 version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -391,6 +445,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/cb/09939728be094d155b5d4ac262e39877875f5f7e36eea66beb359f647bd0/cbor2-5.9.0.tar.gz", hash = "sha256:85c7a46279ac8f226e1059275221e6b3d0e370d2bb6bd0500f9780781615bcea", size = 111231, upload-time = "2026-03-22T15:56:50.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/39/72d8a5a4b06565561ec28f4fcb41aff7bb77f51705c01f00b8254a2aca4f/cbor2-5.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f223dffb1bcdd2764665f04c1152943d9daa4bc124a576cd8dee1cad4264313", size = 71223, upload-time = "2026-03-22T15:56:13.68Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fd/7ddf3d3153b54c69c3be77172b8d9aa3a9d74f62a7fbde614d53eaeed9a4/cbor2-5.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae6c706ac1d85a0b3cb3395308fd0c4d55e3202b4760773675957e93cdff45fc", size = 287865, upload-time = "2026-03-22T15:56:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9d/7ede2cc42f9bb4260492e7d29d2aab781eacbbcfb09d983de1e695077199/cbor2-5.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4cd43d8fc374b31643b2830910f28177a606a7bc84975a62675dd3f2e320fc7b", size = 288246, upload-time = "2026-03-22T15:56:16.113Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9d/588ebc7c5bc5843f609b05fe07be8575c7dec987735b0bbc908ac9c1264a/cbor2-5.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4aa07b392cc3d76fb31c08a46a226b58c320d1c172ff3073e864409ced7bc50f", size = 280214, upload-time = "2026-03-22T15:56:17.519Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a1/6fc8f4b15c6a27e7fbb7966c30c2b4b18c274a3221fa2f5e6235502d34bc/cbor2-5.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:971d425b3a23b75953d8853d5f9911bdeefa09d759ee3b5e6b07b5ff3cbd9073", size = 282162, upload-time = "2026-03-22T15:56:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/20/9a22cfe08be16ddfeef2542cf4eeed1b29f3f57ddbba0b42f7e0bb8331fd/cbor2-5.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:34a6cb15e6ab6a8eae94ad2041731cd3ef786af43a8df99f847969af5b902ee7", size = 70049, upload-time = "2026-03-22T15:56:20.502Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/695f92d09006614034e25a9f5b10620f3b219f79c1bec3c37b7c6f27a7a9/cbor2-5.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:7d1ddc4541e7367ac58c2470cc0df847f7137167fe4f5729e2d3cc0b993d7da4", size = 65382, upload-time = "2026-03-22T15:56:21.526Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c5/4901e21a8afe9448fd947b11e8f383903207cd6dd0800e5f5a386838de5b/cbor2-5.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fbb06f34aa645b4deca66643bba3d400d20c15312d1fe88d429be60c1ab50f27", size = 71284, upload-time = "2026-03-22T15:56:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/10/df643a381aebc3f05486de4813662bc58accb640fc3275cb276a75e89694/cbor2-5.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac684fe195c39821fca70d18afbf748f728aefbfbf88456018d299e559b8cae0", size = 287682, upload-time = "2026-03-22T15:56:24.024Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0c/8aa6b766059ae4a0ca1ec3ff96fe3823a69a7be880dba2e249f7fbe2700b/cbor2-5.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a54fbb32cb828c214f7f333a707e4aec61182e7efdc06ea5d9596d3ecee624a", size = 288009, upload-time = "2026-03-22T15:56:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/6236bc25c183a9cf7e8062e5dddf9eae9b0b14ebf14a58a69fe5a1e872c6/cbor2-5.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4753a6d1bc71054d9179557bc65740860f185095ccb401d46637fff028a5b3ec", size = 280437, upload-time = "2026-03-22T15:56:26.479Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0a/84328d23c3c68874ac6497edb9b1900579a1028efa54734df3f1762bbc15/cbor2-5.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:380e534482b843e43442b87d8777a7bf9bed20cb7526f89b780c3400f617304b", size = 282247, upload-time = "2026-03-22T15:56:28.644Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f6/89b4627e09d028c8e5fcaf7cb55f225c33ce6e037ec1844e65d02bcfa945/cbor2-5.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:dcf0f695873e5c94bd072d6af8698e72b8fb7f7a18f37e0bced1041b7111a6cf", size = 70089, upload-time = "2026-03-22T15:56:29.801Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7c/efadcd5f0102db692490e4e206988a2f98d39a09912090db497a2b800885/cbor2-5.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:f7c9751a9611601ab326d8f5837f01379195bbf06175fb4effeb552140e7c9e8", size = 65466, upload-time = "2026-03-22T15:56:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7d/9ccc36d10ef96e6038e48046ebe1ce35a1e7814da0e1e204d09e6ef09b8d/cbor2-5.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23606d31ba1368bd1b6602e3020ee88fe9523ca80e8630faf6b2fc904fd84560", size = 71500, upload-time = "2026-03-22T15:56:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e1/a6cca2cc72e13f00030c6a649f57ae703eb2c620806ab70c40db8eab33fa/cbor2-5.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0322296b9d52f55880e300ba8ba09ecf644303b99b51138bbb1c0fb644fa7c3e", size = 286953, upload-time = "2026-03-22T15:56:33.292Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3c/24cd5ef488a957d90e016f200a3aad820e4c2f85edd61c9fe4523007a1ee/cbor2-5.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:422817286c1d0ce947fb2f7eca9212b39bddd7231e8b452e2d2cc52f15332dba", size = 285454, upload-time = "2026-03-22T15:56:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/35/dca96818494c0ba47cdd73e8d809b27fa91f8fa0ce32a068a09237687454/cbor2-5.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9a4907e0c3035bb8836116854ed8e56d8aef23909d601fa59706320897ec2551", size = 279441, upload-time = "2026-03-22T15:56:35.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/44/d3362378b16e53cf7e535a3f5aed8476e2109068154e24e31981ef5bde9e/cbor2-5.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fb7afe77f8d269e42d7c4b515c6fd14f1ccc0625379fb6829b269f493d16eddd", size = 279673, upload-time = "2026-03-22T15:56:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d1/3533a697e5842fff7c2f64912eb251f8dcab3a8b5d88e228d6eebc3b5021/cbor2-5.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:86baf870d4c0bfc6f79de3801f3860a84ab76d9c8b0abb7f081f2c14c38d79d3", size = 71940, upload-time = "2026-03-22T15:56:38.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e2/c6ba75f3fb25dfa15ab6999cc8709c821987e9ed8e375d7f58539261bcb9/cbor2-5.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:7221483fad0c63afa4244624d552abf89d7dfdbc5f5edfc56fc1ff2b4b818975", size = 67639, upload-time = "2026-03-22T15:56:39.39Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/b83492b096fbef26e9cb62c1a4bf2d3cef579ea7b33138c6c37c4ae66f67/cbor2-5.9.0-py3-none-any.whl", hash = "sha256:27695cbd70c90b8de5c4a284642c2836449b14e2c2e07e3ffe0744cb7669a01b", size = 24627, upload-time = "2026-03-22T15:56:48.847Z" },
 ]
 
 [[package]]
@@ -589,6 +673,15 @@ wheels = [
 ]
 
 [[package]]
+name = "constantly"
+version = "23.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6f/cb2a94494ff74aa9528a36c5b1422756330a75a8367bf20bd63171fc324d/constantly-23.10.4.tar.gz", hash = "sha256:aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd", size = 13300, upload-time = "2023-10-28T23:18:24.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/40/c199d095151addf69efdb4b9ca3a4f20f70e20508d6222bffb9b76f58573/constantly-23.10.4-py3-none-any.whl", hash = "sha256:3fd9b4d1c3dc1ec9757f3c52aef7e53ad9323dbe39f51dfd4c43853b68dfa3f9", size = 13547, upload-time = "2023-10-28T23:18:23.038Z" },
+]
+
+[[package]]
 name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -778,7 +871,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32' or extra == 'extra-14-strands-robots-vera-sim'" },
+    { name = "cuda-pathfinder", marker = "sys_platform == 'linux' or (sys_platform != 'emscripten' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -1001,18 +1094,17 @@ wheels = [
 
 [[package]]
 name = "draccus"
-version = "0.10.0"
+version = "0.11.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mergedeep" },
     { name = "pyyaml" },
-    { name = "pyyaml-include" },
     { name = "toml" },
     { name = "typing-inspect" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/e2/f5012fda17ee5d1eaf3481b6ca3e11dffa5348e5e08ab745538fdc8041bb/draccus-0.10.0.tar.gz", hash = "sha256:8dd08304219becdcd66cd16058ba98e9c3e6b7bfe48ccb9579dae39f8d37ae19", size = 62243, upload-time = "2025-02-05T07:27:48.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/b0/cc399719e0cf6fea451f155798e19ea8c5e9c838b701d1565f29ea626c18/draccus-0.11.6.tar.gz", hash = "sha256:d134f576a1f4febd93c6b200df7f92e5febffe9efdc0a5f381bf50c2e0568a39", size = 67940, upload-time = "2026-06-12T13:21:19.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/9a/a83083b230d352ee5d205757b74006dbe084448ca45e3bc5ca99215b1e55/draccus-0.10.0-py3-none-any.whl", hash = "sha256:90243418ae0e9271c390a59cafb6acfd37001193696ed36fcc8525f791a83282", size = 71783, upload-time = "2025-02-05T07:27:46.1Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f1/d56bef4563d1cfaf55dd58de298a456587b9fe0a85dabb55768d44ace8f7/draccus-0.11.6-py3-none-any.whl", hash = "sha256:1cf3f37c64766e0f17d757099b388e762f1d22c772cc2376b4e366b515fb5737", size = 85449, upload-time = "2026-06-12T13:21:18.83Z" },
 ]
 
 [[package]]
@@ -1432,10 +1524,13 @@ name = "gymnasium"
 version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version < '3.14' and sys_platform == 'emscripten'",
 ]
@@ -1461,9 +1556,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux')",
     "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
     "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'linux')",
     "(python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'linux')",
     "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'linux')",
@@ -1648,6 +1746,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hyperlink"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1693,6 +1803,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "incremental"
+version = "24.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/3c/82e84109e02c492f382c711c58a3dd91badda6d746def81a1465f74dc9f5/incremental-24.11.0.tar.gz", hash = "sha256:87d3480dbb083c1d736222511a8cf380012a8176c2456d01ef483242abbbcf8c", size = 24000, upload-time = "2025-11-28T02:30:17.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/55/0f4df2a44053867ea9cbea73fc588b03c55605cd695cee0a3d86f0029cb2/incremental-24.11.0-py3-none-any.whl", hash = "sha256:a34450716b1c4341fe6676a0598e88a39e04189f4dce5dc96f656e040baa10b3", size = 21109, upload-time = "2025-11-28T02:30:16.442Z" },
 ]
 
 [[package]]
@@ -1914,7 +2036,7 @@ wheels = [
 
 [[package]]
 name = "lerobot"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cmake" },
@@ -1934,9 +2056,9 @@ dependencies = [
     { name = "torchvision" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/18/b2999bbb52399d404ddcf05645536d3902bd65575ba0ad6bb7bef990a723/lerobot-0.6.0.tar.gz", hash = "sha256:6cad660816fdb72570ea7345ecb23bf0f74d36324e2d7c816a260d31a0c29186", size = 1367952, upload-time = "2026-07-06T10:42:05.281Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/98/797e5685dd1dc6b932fa6b3c477b0ec37e4e952e36124152df81be02cce5/lerobot-0.6.1.tar.gz", hash = "sha256:2111d67d72d9f6c2379e3b8d3ea41b58855066314d88f9c0893579b7707f04b5", size = 1348864, upload-time = "2026-08-03T14:19:56.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/20/9a96311c19e9d256e65584ca83c49c5782d0f204836e84ceeb420d4d493e/lerobot-0.6.0-py3-none-any.whl", hash = "sha256:b38a564fbc441d98380576863bf68635dde5fc2c42ddc2a39d0486640dc9e9a8", size = 1743768, upload-time = "2026-07-06T10:42:03.165Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c0/8b17580cfae9d970edc1b9138a2231fb5416eb2e8e03e3c79f4355f978c2/lerobot-0.6.1-py3-none-any.whl", hash = "sha256:1894516040c65f80a45bd9741f8174aae90ed5d93da0627ab4f1a85fd8d75e90", size = 1728105, upload-time = "2026-08-03T14:19:54.439Z" },
 ]
 
 [package.optional-dependencies]
@@ -1959,6 +2081,11 @@ feetech = [
     { name = "deepdiff" },
     { name = "feetech-servo-sdk" },
     { name = "pyserial" },
+]
+molmoact2 = [
+    { name = "peft" },
+    { name = "scipy" },
+    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -2770,7 +2897,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32' or extra == 'extra-14-strands-robots-vera-sim'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or (sys_platform != 'emscripten' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -2783,7 +2910,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32' or extra == 'extra-14-strands-robots-vera-sim'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or (sys_platform != 'emscripten' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2815,9 +2942,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32' or extra == 'extra-14-strands-robots-vera-sim'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32' or extra == 'extra-14-strands-robots-vera-sim'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32' or extra == 'extra-14-strands-robots-vera-sim'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or (sys_platform != 'emscripten' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or (sys_platform != 'emscripten' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or (sys_platform != 'emscripten' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2830,7 +2957,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32' or extra == 'extra-14-strands-robots-vera-sim'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or (sys_platform != 'emscripten' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3782,6 +3909,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-14-strands-robots-all' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-benchmark-libero' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-lerobot-async' and extra == 'extra-14-strands-robots-vera-sim') or (extra == 'extra-14-strands-robots-molmoact2' and extra == 'extra-14-strands-robots-vera-sim')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ad/2cf6d3fa2fae5c79e1ed9960c0d42badd0f94d81dd12b50604cdc839e648/pyopenssl-26.4.0-py3-none-any.whl", hash = "sha256:f0eb0cb2d581d3ad2b9c489468485e7f2ab6727d08401bcf9d824c3caddf3c1c", size = 56026, upload-time = "2026-08-01T19:50:48.94Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3973,18 +4113,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "pyyaml-include"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/be/2d07ad85e3d593d69640876a8686eae2c533db8cb7bf298d25c421b4d2d5/pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471", size = 20592, upload-time = "2024-03-25T14:56:43.748Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/ca/6a2cc3a73170d10b5af1f1613baa2ed1f8f46f62dd0bfab2bffd2c2fe260/pyyaml_include-1.4.1-py3-none-any.whl", hash = "sha256:323c7f3a19c82fbc4d73abbaab7ef4f793e146a13383866831631b26ccc7fb00", size = 19079, upload-time = "2024-03-25T14:56:41.274Z" },
 ]
 
 [[package]]
@@ -4245,9 +4373,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux')",
     "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
     "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'linux')",
     "(python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'linux')",
     "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'linux')",
@@ -4276,10 +4407,13 @@ name = "robosuite"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version < '3.14' and sys_platform == 'emscripten'",
 ]
@@ -4309,6 +4443,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/77/793187ba6c773e0ec0e7b0ccff1192e836994b62c275ea5c71df8c977813/robot_descriptions-1.23.0.tar.gz", hash = "sha256:c3f2f807fd2311534bdb0948172f001f1c0848d35dfdf9e4b6eee5e8e0040c85", size = 335361, upload-time = "2026-03-09T17:03:36.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/1b/78fff37a42652c190c3094e17d576df627712e9e31fb0c6b04f71d1c5ee5/robot_descriptions-1.23.0-py3-none-any.whl", hash = "sha256:053c1ce2eceb48ec883f22fe6d0a2851681015b3aafc31cc4dba9aef419aadbc", size = 127721, upload-time = "2026-03-09T17:03:34.021Z" },
+]
+
+[[package]]
+name = "roslibpy"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "autobahn" },
+    { name = "twisted", extra = ["tls"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/db/85586f7d6757bdb1f7e2cd058aa85be5351ea94cb2f4a91cb7600223dc00/roslibpy-1.8.1.tar.gz", hash = "sha256:7e3c42a2c6a5f35d9deda9979ff11e8ffec3388f40329e22b56ad2122228cb55", size = 139569, upload-time = "2025-01-19T11:04:36.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/ef/1a6860b51ae9eb1c8bbf2b4a3c379fa6d54654c5ffe3ef61083699407181/roslibpy-1.8.1-py2.py3-none-any.whl", hash = "sha256:6415d82aac0a36d787b35b4fed7020c9507e2a0ab5b0ba7eac2c1982cc6d418c", size = 39134, upload-time = "2025-01-19T11:04:34.553Z" },
 ]
 
 [[package]]
@@ -4605,6 +4752,19 @@ wheels = [
 ]
 
 [[package]]
+name = "service-identity"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/87/ad52e2c582c0f0e7f0a1b86950494c38d67422dc0f5ed9044a5fb9569a49/service_identity-26.1.0.tar.gz", hash = "sha256:6358c52882c96e66ac4a55eb3a72c7dd4a70763f8cc6fa4e70abde2656f4bf3b", size = 42898, upload-time = "2026-05-30T12:04:55.184Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/eb/2433e1af4ff903499144de4846569fb3300b816179ae99a03c2f011b666a/service_identity-26.1.0-py3-none-any.whl", hash = "sha256:68c32dadbb69135fb951077677e07cd7f6031020f3a8c8f47a28cda8a0742118", size = 11370, upload-time = "2026-05-30T12:04:53.911Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4769,20 +4929,21 @@ all = [
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
     { name = "json5" },
-    { name = "lerobot", extra = ["async", "dataset", "feetech"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-benchmark-libero' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra != 'extra-14-strands-robots-vera-sim'" },
+    { name = "lerobot", extra = ["async", "dataset", "feetech", "molmoact2"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-benchmark-libero' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra != 'extra-14-strands-robots-vera-sim'" },
+    { name = "mink" },
     { name = "msgpack" },
     { name = "mujoco" },
     { name = "omegaconf" },
     { name = "onnxruntime" },
-    { name = "peft" },
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
     { name = "pyzmq" },
+    { name = "qpsolvers", extra = ["daqp"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-benchmark-libero' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra != 'extra-14-strands-robots-vera-sim'" },
     { name = "robot-descriptions" },
+    { name = "roslibpy" },
     { name = "scipy" },
     { name = "strands-agents", extra = ["ollama"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-benchmark-libero' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra != 'extra-14-strands-robots-vera-sim'" },
     { name = "torch" },
-    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" } },
     { name = "vector-quantize-pytorch" },
     { name = "websockets" },
 ]
@@ -4841,10 +5002,7 @@ mesh-iot = [
     { name = "json5" },
 ]
 molmoact2 = [
-    { name = "lerobot", extra = ["dataset", "feetech"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-benchmark-libero' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra != 'extra-14-strands-robots-vera-sim'" },
-    { name = "peft" },
-    { name = "scipy" },
-    { name = "transformers", version = "5.5.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "lerobot", extra = ["dataset", "feetech", "molmoact2"], marker = "extra == 'extra-14-strands-robots-all' or extra == 'extra-14-strands-robots-benchmark-libero' or extra == 'extra-14-strands-robots-lerobot' or extra == 'extra-14-strands-robots-lerobot-async' or extra == 'extra-14-strands-robots-molmoact2' or extra != 'extra-14-strands-robots-vera-sim'" },
 ]
 motionbricks = [
     { name = "adam-atan2-pytorch" },
@@ -4865,6 +5023,9 @@ ollama = [
 ros2 = [
     { name = "cyclonedds" },
 ]
+rosbridge = [
+    { name = "roslibpy" },
+]
 sim = [
     { name = "robot-descriptions" },
 ]
@@ -4882,15 +5043,19 @@ sim-isaac = [
 sim-mujoco = [
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
+    { name = "mink" },
     { name = "mujoco" },
+    { name = "qpsolvers", extra = ["daqp"] },
     { name = "robot-descriptions" },
 ]
 sim-newton = [
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
+    { name = "mink" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
     { name = "newton" },
+    { name = "qpsolvers", extra = ["daqp"] },
     { name = "robot-descriptions" },
     { name = "trimesh" },
     { name = "warp-lang" },
@@ -4931,8 +5096,8 @@ requires-dist = [
     { name = "gsplat", marker = "extra == 'sim-gs'", specifier = ">=1.4.0,<2.0.0" },
     { name = "gym-pusht", marker = "extra == 'vera-sim'", specifier = "==0.1.5" },
     { name = "gymnasium", marker = "extra == 'vera-sim'", specifier = "==0.29.1" },
-    { name = "huggingface-hub", marker = "extra == 'all'", specifier = ">=1.0,<2.0.0" },
-    { name = "huggingface-hub", marker = "extra == 'wbc'", specifier = ">=1.0,<2.0.0" },
+    { name = "huggingface-hub", marker = "extra == 'all'", specifier = ">=1.5,<2.0.0" },
+    { name = "huggingface-hub", marker = "extra == 'wbc'", specifier = ">=1.5,<2.0.0" },
     { name = "hydra-core", marker = "extra == 'all'", specifier = ">=1.3.0,<2.0.0" },
     { name = "hydra-core", marker = "extra == 'motionbricks'", specifier = ">=1.3.0,<2.0.0" },
     { name = "imageio", marker = "extra == 'all'", specifier = ">=2.28.0,<3.0.0" },
@@ -4947,14 +5112,19 @@ requires-dist = [
     { name = "json5", marker = "extra == 'all'", specifier = ">=0.9.0,<1.0.0" },
     { name = "json5", marker = "extra == 'mesh'", specifier = ">=0.9.0,<1.0.0" },
     { name = "json5", marker = "extra == 'mesh-iot'", specifier = ">=0.9.0,<1.0.0" },
-    { name = "lerobot", extras = ["async"], marker = "extra == 'all'", specifier = ">=0.6.0,<0.7.0" },
-    { name = "lerobot", extras = ["async"], marker = "extra == 'lerobot-async'", specifier = ">=0.6.0,<0.7.0" },
-    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'all'", specifier = ">=0.6.0,<0.7.0" },
-    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'lerobot'", specifier = ">=0.6.0,<0.7.0" },
-    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'lerobot-async'", specifier = ">=0.6.0,<0.7.0" },
-    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'molmoact2'", specifier = ">=0.6.0,<0.7.0" },
+    { name = "lerobot", extras = ["async"], marker = "extra == 'all'", specifier = ">=0.6.1,<0.7.0" },
+    { name = "lerobot", extras = ["async"], marker = "extra == 'lerobot-async'", specifier = ">=0.6.1,<0.7.0" },
+    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'all'", specifier = ">=0.6.1,<0.7.0" },
+    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'lerobot'", specifier = ">=0.6.1,<0.7.0" },
+    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'lerobot-async'", specifier = ">=0.6.1,<0.7.0" },
+    { name = "lerobot", extras = ["dataset", "feetech"], marker = "extra == 'molmoact2'", specifier = ">=0.6.1,<0.7.0" },
+    { name = "lerobot", extras = ["molmoact2"], marker = "extra == 'all'", specifier = ">=0.6.1,<0.7.0" },
+    { name = "lerobot", extras = ["molmoact2"], marker = "extra == 'molmoact2'", specifier = ">=0.6.1,<0.7.0" },
     { name = "libero", marker = "extra == 'benchmark-libero'", specifier = ">=0.1.0,<1.0.0" },
+    { name = "mink", marker = "extra == 'all'", specifier = ">=0.0.4" },
     { name = "mink", marker = "extra == 'cosmos3-sim'", specifier = ">=0.0.4" },
+    { name = "mink", marker = "extra == 'sim-mujoco'", specifier = ">=0.0.4" },
+    { name = "mink", marker = "extra == 'sim-newton'", specifier = ">=0.0.4" },
     { name = "msgpack", marker = "extra == 'all'", specifier = ">=1.0.0,<2.0.0" },
     { name = "msgpack", marker = "extra == 'cosmos3-service'", specifier = ">=1.0.0,<2.0.0" },
     { name = "msgpack", marker = "extra == 'groot-service'", specifier = ">=1.0.0,<2.0.0" },
@@ -4973,8 +5143,6 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'all'", specifier = ">=1.17.0,<2.0.0" },
     { name = "onnxruntime", marker = "extra == 'wbc'", specifier = ">=1.17.0,<2.0.0" },
     { name = "opencv-python-headless", specifier = ">=4.5.0,<5.0.0" },
-    { name = "peft", marker = "extra == 'all'", specifier = ">=0.18.0,<1.0.0" },
-    { name = "peft", marker = "extra == 'molmoact2'", specifier = ">=0.18.0,<1.0.0" },
     { name = "pillow", specifier = ">=8.0.0,<13.0.0" },
     { name = "plyfile", marker = "extra == 'sim-gs'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.0,<10.0.0" },
@@ -4987,6 +5155,9 @@ requires-dist = [
     { name = "pyzmq", marker = "extra == 'all'", specifier = ">=27.0.0,<28.0.0" },
     { name = "pyzmq", marker = "extra == 'groot-service'", specifier = ">=27.0.0,<28.0.0" },
     { name = "pyzmq", marker = "extra == 'moveit2'", specifier = ">=27.0.0,<28.0.0" },
+    { name = "qpsolvers", extras = ["daqp"], marker = "extra == 'all'", specifier = ">=4.0.0" },
+    { name = "qpsolvers", extras = ["daqp"], marker = "extra == 'sim-mujoco'", specifier = ">=4.0.0" },
+    { name = "qpsolvers", extras = ["daqp"], marker = "extra == 'sim-newton'", specifier = ">=4.0.0" },
     { name = "qpsolvers", extras = ["quadprog"], marker = "extra == 'cosmos3-sim'", specifier = ">=4.0.0" },
     { name = "robosuite", marker = "extra == 'vera-sim'", specifier = "==1.4.1" },
     { name = "robot-descriptions", marker = "extra == 'all'", specifier = ">=1.11.0,<2.0.0" },
@@ -4994,10 +5165,10 @@ requires-dist = [
     { name = "robot-descriptions", marker = "extra == 'sim-isaac'", specifier = ">=1.11.0,<2.0.0" },
     { name = "robot-descriptions", marker = "extra == 'sim-mujoco'", specifier = ">=1.11.0,<2.0.0" },
     { name = "robot-descriptions", marker = "extra == 'sim-newton'", specifier = ">=1.11.0,<2.0.0" },
+    { name = "roslibpy", marker = "extra == 'all'", specifier = ">=1.7.0,<2.0.0" },
+    { name = "roslibpy", marker = "extra == 'rosbridge'", specifier = ">=1.7.0,<2.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12,<0.16.0" },
     { name = "scipy", marker = "extra == 'all'", specifier = ">=1.10.0" },
-    { name = "scipy", marker = "extra == 'all'", specifier = ">=1.14.0,<2.0.0" },
-    { name = "scipy", marker = "extra == 'molmoact2'", specifier = ">=1.14.0,<2.0.0" },
     { name = "scipy", marker = "extra == 'motionbricks'", specifier = ">=1.10.0" },
     { name = "strands-agents", specifier = ">=1.0.0,<2.0.0" },
     { name = "strands-agents", extras = ["ollama"], marker = "extra == 'all'", specifier = ">=1.0.0,<2.0.0" },
@@ -5006,9 +5177,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'cosmos3-diffusers'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'motionbricks'", specifier = ">=2.0.0" },
     { name = "torch", marker = "extra == 'sim-gs'", specifier = ">=2.2.0,<3.0.0" },
-    { name = "transformers", marker = "extra == 'all'", specifier = ">=5.4.0,<5.6.0" },
     { name = "transformers", marker = "extra == 'cosmos3-diffusers'", specifier = ">=4.40" },
-    { name = "transformers", marker = "extra == 'molmoact2'", specifier = ">=5.4.0,<5.6.0" },
     { name = "trimesh", marker = "extra == 'sim-newton'", specifier = ">=4.0.0,<5.0.0" },
     { name = "usd-core", marker = "extra == 'sim-isaac'", specifier = ">=25.5,<27.0.0" },
     { name = "vector-quantize-pytorch", marker = "extra == 'all'", specifier = ">=1.14.0" },
@@ -5018,7 +5187,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'cosmos3-service'", specifier = ">=12.0" },
     { name = "websockets", marker = "extra == 'inference'", specifier = ">=12.0" },
 ]
-provides-extras = ["all", "benchmark-libero", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "curobo", "dev", "device-connect", "groot-service", "inference", "lerobot", "lerobot-async", "mesh", "mesh-iot", "molmoact2", "motionbricks", "moveit2", "ollama", "ros2", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "vera-sim", "wbc"]
+provides-extras = ["all", "benchmark-libero", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "curobo", "dev", "device-connect", "groot-service", "inference", "lerobot", "lerobot-async", "mesh", "mesh-iot", "molmoact2", "motionbricks", "moveit2", "ollama", "ros2", "rosbridge", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "vera-sim", "wbc"]
 
 [[package]]
 name = "sympy"
@@ -5197,9 +5366,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux')",
     "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/ff/2b27797e039673156710e5a0febe87cafc203722acafa3d34db283b40cf9/torchcodec-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b35fa4061c5757f8d714187c040a90a11669de6470a644bb04e3cd335ff1c110", size = 4073213, upload-time = "2026-01-22T15:41:45.485Z" },
@@ -5316,9 +5488,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux')",
     "python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'",
     "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'linux')",
     "(python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'linux')",
     "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'linux')",
@@ -5350,10 +5525,13 @@ name = "transformers"
 version = "5.12.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.15' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version >= '3.15' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten'",
+    "python_full_version == '3.14.*' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version == '3.14.*' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version < '3.14' and sys_platform == 'emscripten'",
 ]
@@ -5400,6 +5578,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "twisted"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "automat" },
+    { name = "constantly" },
+    { name = "hyperlink" },
+    { name = "incremental" },
+    { name = "typing-extensions" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
+]
+
+[package.optional-dependencies]
+tls = [
+    { name = "idna" },
+    { name = "pyopenssl" },
+    { name = "service-identity" },
+]
+
+[[package]]
+name = "txaio"
+version = "26.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/de/52729cab9d2c8de679ad015e87f11f69e092d6fb3084eb9a39735df09ce7/txaio-26.6.1.tar.gz", hash = "sha256:3ee900b2331c93457530fddbccc1a320c4e2d7ac8f9073d01c3fbe87762ccb35", size = 134555, upload-time = "2026-06-18T14:38:59.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/68/075bf851e11c9ef65bd6a0426791f0d9a0c7dae0e7f6e0b16ca67334b456/txaio-26.6.1-py3-none-any.whl", hash = "sha256:91a84a7825485a367c0b070c7399824c0e1a1e8c071cbdf3882dd3146dab587b", size = 31399, upload-time = "2026-06-18T14:38:57.774Z" },
 ]
 
 [[package]]
@@ -5458,6 +5670,81 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "u-msgpack-python"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/9d/a40411a475e7d4838994b7f6bcc6bfca9acc5b119ce3a7503608c4428b49/u-msgpack-python-2.8.0.tar.gz", hash = "sha256:b801a83d6ed75e6df41e44518b4f2a9c221dc2da4bcd5380e3a0feda520bc61a", size = 18167, upload-time = "2023-05-18T09:28:12.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/5e/512aeb40fd819f4660d00f96f5c7371ee36fc8c6b605128c5ee59e0b28c6/u_msgpack_python-2.8.0-py2.py3-none-any.whl", hash = "sha256:1d853d33e78b72c4228a2025b4db28cda81214076e5b0422ed0ae1b1b2bb586a", size = 10590, upload-time = "2023-05-18T09:28:10.323Z" },
+]
+
+[[package]]
+name = "ujson"
+version = "5.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/7a/c8bb37c8f6f3623d60c33d15d18cd6d6655d0f9c3eb31a9969f76361b199/ujson-5.13.0.tar.gz", hash = "sha256:d62e3d7625384c08082abad81a077af587fdef2761bb14c3822f4234b8d07d75", size = 7166784, upload-time = "2026-06-14T22:36:50.209Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/ae/b66deca15da1f7faf6952d8eddf55978482bcbfd294ed2afe2c526ea325f/ujson-5.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bf81570ac056cb058f9117b52ca5dd800bfe9381d0076d0bb30a08a54591d654", size = 56743, upload-time = "2026-06-14T22:35:28.863Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/b03bcc9eaf4621ac9008dec90918d8fb4839d611666cb99eb255696c67fe/ujson-5.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7edf16359c52ed53406e216565d83e6b98c23c3cb9a0a01673f2493f8fb15edf", size = 54390, upload-time = "2026-06-14T22:35:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/77/79/f98c6c1a4ed9d92d39d5d2d133f2b6fce5da11ea50c341117aedde8011c4/ujson-5.13.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:24539618fb3243cfdf27dab9a850acab80798a01501e9586b61fb9ecd016a891", size = 60047, upload-time = "2026-06-14T22:35:30.857Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1d/f68e14cf476d149945211142f4c20782c1f232c489e8edcc4f4b58ce4997/ujson-5.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fdde6341d213b29f413b5fa9fad1392d5408074c75f0900ed949e97e546fa5df", size = 53437, upload-time = "2026-06-14T22:35:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1a/5718237cf4141e5be46ff371387e90b01f27774cb6f0f79ff4803a2430ca/ujson-5.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:229faf041ef249ee3fd57bac1cedb123d2718ab63f6ccd50eca95ea902eb0dca", size = 55057, upload-time = "2026-06-14T22:35:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6f/7f55c1e9e0be87beebaed553fa186ad5f6d5d639cbaa9d49f78f2f91c3a9/ujson-5.13.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d02f31c2f59cc6a1c2c3633b377701fc2d8e876cc01950735d7a01132ccc233", size = 58186, upload-time = "2026-06-14T22:35:34.055Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c4/9a34ade542426f56a0bc042f774073d1c247ae7575363c27587788cb2b2f/ujson-5.13.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea7204e9fa7538bfbb1396e1ee8c2bbcd3818b3633ef5bb14d4fdea52994d14d", size = 57935, upload-time = "2026-06-14T22:35:35.05Z" },
+    { url = "https://files.pythonhosted.org/packages/36/06/407633f0709e168107f56368bd5a0fa8fe07acd7f1d3000710bc0bb07470/ujson-5.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c5a2478a3a1fa4421f7e035b87194eea0cf44c7971a3f32ad1b42a0dfd63c03", size = 1037685, upload-time = "2026-06-14T22:35:36.022Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/df/eb5bd92dc1b23254fea5b2022007baff5491a7478bfcf7e9260d3a10f1ac/ujson-5.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b535e0970c96957e999cfe5ec89361f0e8d0bb987fb5d5144f6f495cb3ed9e19", size = 1197141, upload-time = "2026-06-14T22:35:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1c/65f2ce1a0411ec9a87339db01f0d5d554a49c4248ec68ab52a1b7e14e9c4/ujson-5.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d0ad1207694988498fca7e0bb28eba7564fa33261d2f9fdf66a3aaab376b803", size = 1090225, upload-time = "2026-06-14T22:35:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/73/53/310aabff0704f9c7ef0d3f431ce8b8e3147c3cca25334a205615c511f65e/ujson-5.13.0-cp312-cp312-win32.whl", hash = "sha256:d6bc9fa43a49e403c68c7eb164eef0feee9dd29474a7c6e0d3b6267025371990", size = 40075, upload-time = "2026-06-14T22:35:40.44Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/23/d3536d8945d1bb00248d998c8dcbe678a884681ad181072daecfafe4eea6/ujson-5.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:6692d49ff970aaa5008f4a6fe06974bc91fd957bf13173f765e46d8ba44906ea", size = 41097, upload-time = "2026-06-14T22:35:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/4b147c06ee5bb14bec6e26786358c8510c4d75e28b88146a6ac7620f1f71/ujson-5.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:5737ffe0740a788b0e6255f0ffb281db49305fd6e6a587be44c73d9e92b554c4", size = 38875, upload-time = "2026-06-14T22:35:42.357Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f1/fe8a467d8ff5821e076b96f398d3acfe3cd568d900e6ccb41b215592b152/ujson-5.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:46998fc8d11aec34a20e2010905e7059732a3d192d9a3c3fe4f9ffd146c87ec8", size = 56746, upload-time = "2026-06-14T22:35:43.398Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/c7ab82d6471dfa7e4fd68ae6ff2c6a50d077c05d6ecdea0cec8af635b2c4/ujson-5.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee03ce288ba25b05cf0de87203165642277a25caa4f00a437e13152e5214e310", size = 54388, upload-time = "2026-06-14T22:35:44.586Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e6/4e9e998d991ff88bbc93b21daa63bba2baa61c6f952dbcec937cf7304ebe/ujson-5.13.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:cdf33b588a81b05d0b585c66f83050c49cb670623424d10e4d1ad37ba2f7eed9", size = 60051, upload-time = "2026-06-14T22:35:45.567Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/11/876dff43f05417a01c6119f0fa10e01f1226631c5927ef08f56876b2bb67/ujson-5.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4cabd73c114ce93c21d7db2e2d8e16217fd8a5b2b3ec754629eebef5c262d47f", size = 53438, upload-time = "2026-06-14T22:35:46.623Z" },
+    { url = "https://files.pythonhosted.org/packages/09/02/f9dbf6c3e46d700eb1d9ed637567221a06eeb1ec289633be992ef54d7a34/ujson-5.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ffc61fc756a64f4d169a78cc638d769e3c324f45fc51997626abf4e5e5dd6460", size = 55060, upload-time = "2026-06-14T22:35:47.647Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3d/7e49a70265a1e5ed1b5e8edd5f54d57ae41e2134faeae9b16f6f5a0eae20/ujson-5.13.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c00323c13a35822c9a67a26c0b2a0787510bf1ef490922b58009b362d1a3e21", size = 58189, upload-time = "2026-06-14T22:35:48.617Z" },
+    { url = "https://files.pythonhosted.org/packages/66/34/b64278f67e19052f09810576c7e50b3da8d4f5218b226046324d4d5c24b4/ujson-5.13.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:496e662a6b46d5f936d77fb68259cece19213bb2301ddd520dbd75ac7c90c5f4", size = 57941, upload-time = "2026-06-14T22:35:49.674Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8c/51513357a5c75bf3e5bae46accfdb3e6e6f5caeb72ca8b253ec45ba853fb/ujson-5.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fd41b86444df14f8b4b7afaaa9f27bacfbf8c18380872317aeab6cd125dcede", size = 1037688, upload-time = "2026-06-14T22:35:50.699Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5a/dc6afe071d6b977390d2dc41e15800a2716f317988dd03187cffe7b4d624/ujson-5.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bf3c2c4ea55d4187903fcdc689a9bf5b0fc72d8c0eaff39db18c1f337c8832c1", size = 1197141, upload-time = "2026-06-14T22:35:52.052Z" },
+    { url = "https://files.pythonhosted.org/packages/50/23/b473d101412c68527cb502a8728f96ab307aa7bfa75d6ea2037e2c7f74e8/ujson-5.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6eca7751d61045a9b1e7f9a8c97ac24b164f085b60bef1c4668654bb2338011", size = 1090235, upload-time = "2026-06-14T22:35:53.589Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0a/8e583cce90f9f91ca1bedb3e628b6f5642aed91feb29b197431268d4c4be/ujson-5.13.0-cp313-cp313-win32.whl", hash = "sha256:b63d3820f978bc8e98cc3f1fe26a33b0d2ea237733a23fe5e9cb5d51f466bd97", size = 40069, upload-time = "2026-06-14T22:35:55.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b5/1fe203bc294e98fdd65606883692ad8dc0aaac73838b89c99c3513404424/ujson-5.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:17a59d5cf23ef98f7c9314524976b4b288374d83200add01d953024fb06404f9", size = 41098, upload-time = "2026-06-14T22:35:55.966Z" },
+    { url = "https://files.pythonhosted.org/packages/50/5e/aceadce24fdb7cbc67f02286b1d4e91a575aaef5afb876c9908d6e6e5769/ujson-5.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:b49516fbe803ff30d6caa9ccc3799ec7f968992747ce3099eae4758928577b53", size = 38877, upload-time = "2026-06-14T22:35:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/b5139d696f5328f3cab70b9ec046f15e3f49497a4de6280974640602f539/ujson-5.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:cc9dfd41fed397ab03bb9d9fe1cbd83301211c772a17536033ce7d68877ac82b", size = 56897, upload-time = "2026-06-14T22:35:57.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/477183aeddfdf0f88ae039ffee0ed866cfb993da0c0c9aa915807554aef8/ujson-5.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca7ef2fa6c408a7c0f558e4d33d93b32ddc35ed6d3cfc505747931a64b7465d5", size = 54451, upload-time = "2026-06-14T22:35:58.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/63/55e5f23e156b4c8bca095d828b4cd3180c0b42aa3501ef88836d79606fea/ujson-5.13.0-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:a554b2e5bee85030369514cef8b0b913cebe1a4c2c0c13541966d50bcba22b1a", size = 60053, upload-time = "2026-06-14T22:35:59.969Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b6/08c6cf5548bd6f4bb557c9fa7e8edf87324bb04c17249d1966028d61dde0/ujson-5.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ea939ff629ab03ae970d03eca6d1febd8ed55ba38ca44aec64ce997537cd3fa0", size = 53481, upload-time = "2026-06-14T22:36:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b3/0ac9a03551467784067f505df1bb875c639ba32f1da79ce467ab15911ada/ujson-5.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b98bf2faa5e37ecfe752226ea08290031e375a0c43d425a0b955fb3e702a2a71", size = 55058, upload-time = "2026-06-14T22:36:02.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/be/ec91029aec067174473d022fa0f6c3c1431a173f888d7599739f05c668eb/ujson-5.13.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a4b92344b16e414aeb609e57f62c466500e53c94f1698f5b149dc0b7223ec3e", size = 58225, upload-time = "2026-06-14T22:36:03.321Z" },
+    { url = "https://files.pythonhosted.org/packages/29/33/a948f329252ece3f9c93d177243de6e677927ebc6ac44256742dbbef3c39/ujson-5.13.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df805aad707507a1fa165fb716218ca3a89f142125dc4b23c9fcc08fa402d97", size = 57930, upload-time = "2026-06-14T22:36:04.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/0c/c33655218b8e0a8adbf066de0b999cae5c324061f3eaa4dda17423145d9e/ujson-5.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7576bdbef327c3528f011002a2d74486f6fe4e33289bdb7a042b7f1a6e9d8285", size = 1037728, upload-time = "2026-06-14T22:36:05.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/bd/d286947525ea7ce3f2d8dc55c15b9ffbe425bc455c96af7b8f8a402599a9/ujson-5.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6eee5d7cce3f32a468905f9ff61807a60287a90258d849460f6fa826e810870d", size = 1197146, upload-time = "2026-06-14T22:36:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3c/9eb916377050b0785f048a34588c1c390ddd41ae00b78db68ee1ad022356/ujson-5.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:144e9d8a454cfa727e0f755e1863738ed68068583bda5463052cb446835bd56c", size = 1090223, upload-time = "2026-06-14T22:36:08.329Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5f/242fd97a2628b842d4bfaa9b18e1f68187f934d67503291ebbaab1254637/ujson-5.13.0-cp314-cp314-win32.whl", hash = "sha256:576f35c35b918d67d41b933878062ec0a5c9f4d1e9e14e04aeef35384963feae", size = 41223, upload-time = "2026-06-14T22:36:09.644Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f3/7f2bd9ca0c507142d0c22347b3d6f8803be1d8851c31707e57f5923fdbea/ujson-5.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:d5e206e9f849ead27e51ef8da44e52b38da7c6dbd929a7340ab44533edcda8d7", size = 42265, upload-time = "2026-06-14T22:36:11.043Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/29/3e9a8fba321c031315f6d263510969a5d01f41fc471b5be107e413c1b2f8/ujson-5.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:dc470179775468f9a007d3a6a2734624248c94bf47c6645e808c7e50a5070d1a", size = 40205, upload-time = "2026-06-14T22:36:12.286Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e9/1c543837c6a3c6672361882a0fa269bd02daf9cc4c0ca88a9dccd9df98d9/ujson-5.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:69b4e36bb7d5f413ba8c00c8006b2ec627cc5ace97301462f6aadb66ec9d2979", size = 57402, upload-time = "2026-06-14T22:36:13.238Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/39862f0f7174ff07cfd1e2d0c9065ded34aeebdb7db8daf2f0e5bf89b46f/ujson-5.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8b644d50f66de5490c1823c7176618cead5e8e8a88cba9f40a6308ca52e79267", size = 54973, upload-time = "2026-06-14T22:36:14.432Z" },
+    { url = "https://files.pythonhosted.org/packages/02/66/f53d3b32c3f177f846ca6b624e832f29000d8a213a2d8768e254bd470ced/ujson-5.13.0-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:15107aaa4f559d55201165ec32abb35c283a861be1fa67229578cb7d93fcd93a", size = 60683, upload-time = "2026-06-14T22:36:15.806Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d4/dddc4646d2633c85c938c2ded7d5a9711cdad5be1e13b31b7dad76f61c83/ujson-5.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6e343c5f0c058523f1edbf6ae4eceb4e0d934205a53bbdd8d9a945c83324662a", size = 54167, upload-time = "2026-06-14T22:36:16.952Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c0/d8608c3f4d3f05e6441364b63fde1d279700135c1a6577a773662c07fbcc/ujson-5.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02200035bc80e830f076ffc1b329a94c295aee6d9de8c9043647cb9a7bd4f76f", size = 55568, upload-time = "2026-06-14T22:36:17.975Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8e/dd12b735aaba0806c3d70c18184d50e1f9712e0757c7c0a4f376450cfe28/ujson-5.13.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7f19b81b73ff28f5c5022ee794f94122bfcda07a76423078e349465d71223a1", size = 59086, upload-time = "2026-06-14T22:36:19.071Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/ad41e8752d5ec3a590a5e7b426a54e36b7aab911d9b5a4f7384dc62507ab/ujson-5.13.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:82e1393e6dbe3c95fdfc95c6c528890e191351a1f024ef51126cf1f22543af52", size = 58667, upload-time = "2026-06-14T22:36:20.171Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8e/b44a6afb77b94118655c029081b7932d64bb4c5b1c8ba2b7f5808b5d0bc2/ujson-5.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38afcf994b28ed85ea2420e2a8d79a37d0a77348b3daf53850c16edda66f942d", size = 1038553, upload-time = "2026-06-14T22:36:21.245Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/93/fab1d786174c8780eb3e386c73f1925a435e97fbf77c957fea4fca83994d/ujson-5.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:1bdf2518971586f2b413156c49d9dd8b56cc990a8647081e1bd00af60564d469", size = 1197938, upload-time = "2026-06-14T22:36:22.585Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bc/2f073bb708f9d128f5d1cb39063a5f6421b1ce94c61be8661c55a189f407/ujson-5.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:751ad01042472f1c7c02f5c597c7aee79834e82a6cc384ca302173bbc8e8deb8", size = 1090938, upload-time = "2026-06-14T22:36:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/cdaa50bba29d7dc9eb19212755b09bb96f56596e75957c3717c6b85454de/ujson-5.13.0-cp314-cp314t-win32.whl", hash = "sha256:74f3dd61aeb01b7b2a6754e400224e819279041b3867935a55ccf57fb86a43b2", size = 41802, upload-time = "2026-06-14T22:36:25.418Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/66/a6e669e90083febdf6c0600d3807f6017fd4d3962d5bd6ddc605c73a06e5/ujson-5.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5c31317d5e4504dae8f98795358b6082fc0ef96e7394806db0a76a4a8717f446", size = 42790, upload-time = "2026-06-14T22:36:26.614Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5f/fcc6c6a9d711fd8b020ca8ff65148212f0a712c809d173cd949e58de68c6/ujson-5.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aefd3c9c95f9b62348956396ff7b31818476f8f54dc4a4e64cbd4f0491db6fca", size = 40708, upload-time = "2026-06-14T22:36:27.721Z" },
+    { url = "https://files.pythonhosted.org/packages/30/70/dbdd277d64bd3a149532567ceb082fe26f4ead58c39e0a97566ccbdf14a3/ujson-5.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3e074a1f7778d58aa3b3056bab7b6251aabb3f381808018ca2b7fb8dbdeef7ab", size = 58393, upload-time = "2026-06-14T22:36:28.702Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/592c70af94a67cafacd9c840ae2980f27d511dde2732a4c0dfac8f176ae8/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bb53ef95d35875262b8d0aa28506ca612ddd07058bee2a90f609938e69dc801", size = 54447, upload-time = "2026-06-14T22:36:29.802Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9d/2bb91e1e25a8584cb3b63544b9bd26f621173535c77ac6cae13bad8e7904/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fb296a0aa480ab88d895ddaa90372604c08ccc72323f02590612c775426ab413", size = 56066, upload-time = "2026-06-14T22:36:30.806Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ec/8e3802fc4a4e31e817b972bbb0e704a484d8c75ec349b3feb45fa9fb54c4/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2862f81af44b3a7e74c5d80caa118d736be1991ce6f1d5c723716fa403060cc6", size = 54938, upload-time = "2026-06-14T22:36:32.051Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/48/d0e3e511039b86fd1ecfe2bf761c800552d273ef8f19e71de93bf38a909e/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c16e07581172f08585b409246f4535dab13ee85af0e3d3cfa8684b653ca44fa8", size = 56115, upload-time = "2026-06-14T22:36:33.349Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b5/689613037fe691d18eae075cd141089f3a3156146be14512df92d8a9ae8f/ujson-5.13.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:9bd0f2dd05937c3b089af316884de18c6f6182ddb8ffce597d2e7c7a9ba9f447", size = 41802, upload-time = "2026-06-14T22:36:34.523Z" },
 ]
 
 [[package]]
@@ -5911,4 +6198,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]
+
+[[package]]
+name = "zope-interface"
+version = "8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/cc/b84123a948f3162a34623e188922827cd845244fdd043ed20f8d02228caa/zope_interface-8.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9", size = 212165, upload-time = "2026-05-26T06:49:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/cbceec44f1b27208a76c1a688c131302685852406a23df5aab68324109cc/zope_interface-8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c", size = 212341, upload-time = "2026-05-26T06:49:28.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c3/005032195ff3b210c139b7c560ed5c534e844b0907d8e44d2b3d8919305e/zope_interface-8.5-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e", size = 265296, upload-time = "2026-05-26T06:49:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/66/1036543d6a66bc04c19df3cf650f3ad938a002ab0a443c24e23e8de5e8b9/zope_interface-8.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560", size = 270689, upload-time = "2026-05-26T06:49:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4c/8b56259558cace4414e753ca6740396a1f59d4a95ddb55b4658600408670/zope_interface-8.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5", size = 270280, upload-time = "2026-05-26T06:49:33.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/649908c83aa8fdb7faf2ddca4d3cf6fb8f2157121267dc56e8f72681e26c/zope_interface-8.5-cp312-cp312-win_amd64.whl", hash = "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e", size = 215019, upload-time = "2026-05-26T06:49:35.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/97/da13037b4c563e4df32eedbc819f8c00b754af494f68211e3dffd48d52da/zope_interface-8.5-cp312-cp312-win_arm64.whl", hash = "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b", size = 213569, upload-time = "2026-05-26T06:49:37.317Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8c/4c15755d701f2ec0e80d64a18e1ebaf5be2c584c0ec153fd516f5d13eada/zope_interface-8.5-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:28e80457c134d1fa57a7d758004dece348654e1b1467ac22dcdc20fc1d127c52", size = 212512, upload-time = "2026-05-26T06:49:38.996Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/4360c54c465db042cc8fbeeec92abac28b4cedbf6ba63c1f092fd08a190f/zope_interface-8.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09495ce9d559c06b70f2d4855b3e4f48a822a9ddc8be1d30c5b4e5be14ae1ace", size = 212541, upload-time = "2026-05-26T06:49:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a5/692a2b8d70f78e848793231d5fae5fecbf8d0cccd73430fdc34802a6d3c1/zope_interface-8.5-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:7849ad8fa90763cc1087f4dda78ca3a233e950b3e08fac7079297c9cafbbd7bb", size = 265191, upload-time = "2026-05-26T06:49:43.449Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8d/454a9cfc7a050c394ab4f11b3371f7897828b7415e096afff724637e65e0/zope_interface-8.5-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5578c9421ca409a1f39f153d6f7803e4cde01da592ec75a9ac5e1b777d18d33b", size = 270626, upload-time = "2026-05-26T06:49:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/db8409cfa3575b8e9b4800babd7d49f8228433cd1f0c56814bd0ada49c33/zope_interface-8.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e1bd7d96b4ca5fa311f54c9eac16dce4886b428c1531dbe06067763ccdf123b4", size = 270444, upload-time = "2026-05-26T06:49:47.025Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/df/a386940e41469ef615e100a216d8b386521e9e598817147f87932ca203c4/zope_interface-8.5-cp313-cp313-win_amd64.whl", hash = "sha256:0c8123d2a4dfde2a613c7cb772605477724782c20bc2e0ad1d9435376a6a44a3", size = 215021, upload-time = "2026-05-26T06:49:48.478Z" },
+    { url = "https://files.pythonhosted.org/packages/89/75/477eb5669b6b2a7a843decd1a075e9b1971a8720017654143a7183abd3d9/zope_interface-8.5-cp313-cp313-win_arm64.whl", hash = "sha256:6d02be14f3173c6c7288bc2fdf530090c01c3cf8764ad46c68024686f364278e", size = 213610, upload-time = "2026-05-26T06:49:50.01Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/19/5032e954827fdf02db2d2f49737ac4378bb9cfc2cd95a8f2e2a5ae2ec01a/zope_interface-8.5-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:ffaecf013251a89d0de6feb49a46eba48ad8cbbf8a40aeb6045e459e7bec6784", size = 212597, upload-time = "2026-05-26T06:49:51.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/53/3ef644012cf8a6a234a2d6134aab5a5c65ac5467c86296865501d4fbc406/zope_interface-8.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:126fa9d1c52295ae076d4cf968634f0a1826afa408a20808b57ff72877b8f69f", size = 212626, upload-time = "2026-05-26T06:49:53.236Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/bc8b4f465d388039255003e230c284a175cedf1203c692f23cb7bff64efe/zope_interface-8.5-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:3090e3a663d20194756a59a272e0c8508b889341e31d5894223331fe6b4f9b21", size = 266827, upload-time = "2026-05-26T06:49:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/37d05b935ede53d79690fecc8d201440084418e590bcfc05f384451c7593/zope_interface-8.5-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9342fb74e2afefdb081bf1df727d209ea56995c6e13f5a0540e6d7aff4beafb8", size = 270139, upload-time = "2026-05-26T06:49:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/fd0c54579e2ce8dc6cf1a757903f3374bc6fbda929a46af9e0f53cb0e5f0/zope_interface-8.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c54725d818f1b57a7efb8b16528326e1f3c257b602b32393fd255c45af8799d", size = 270338, upload-time = "2026-05-26T06:49:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1d/c420dcd777bb761067ea92879ac766694a5ca78608185f1aecea64cbfc11/zope_interface-8.5-cp314-cp314-win_amd64.whl", hash = "sha256:29d74febbae1afeb6834c4ccbf42e242a673c860060f09e53142825270456140", size = 215789, upload-time = "2026-05-26T06:50:00.405Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/50b5eb8f94e527edceac14f9955e58917424ea79bb572ddc18548561cbc2/zope_interface-8.5-cp314-cp314-win_arm64.whl", hash = "sha256:633c8c49396f38df030340797c533e9fe460d1b5d1e42d88e55e938e525f548c", size = 213757, upload-time = "2026-05-26T06:50:01.973Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6f/5d5f32c4dfcdb16ce2ec5363da686840f13c13e1a1214cb70b49e1cd6d9f/zope_interface-8.5-cp314-cp314t-macosx_10_9_x86_64.whl", hash = "sha256:133999820fdbae513c36c03d6f29ef87317aaa3edef39112222b155083664714", size = 213591, upload-time = "2026-05-26T06:50:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/55/de0c3459ff717fce3342f9a29464c281fdeb0d36c3171ee88d119d5f0650/zope_interface-8.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8bd75c96966e573232f0599deaff717564828031c7f05563ccc1ac35c5ee0304", size = 213733, upload-time = "2026-05-26T06:50:05.101Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/d97430abd5ae9677e8b9295b58720c0064a5b557dbb6b8bf5928484cf0d8/zope_interface-8.5-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:14b0e9799351d4c34fe99afd67f0cdd76e55ba15c66a98699d5fc22ea8241e08", size = 294905, upload-time = "2026-05-26T06:50:07.384Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ec/a0f8f3dad6e74992f4654bdd94802be0929eabca7b871cac3b6fbb5e961b/zope_interface-8.5-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0cd6a732ac84b94eb1ef9222a117347a27efd294ee16810ffdf7ecd307677ed5", size = 300885, upload-time = "2026-05-26T06:50:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/6881b48803a0ee8d23eb5efa30fce3ed218a2bd9de5758ce489d224fee81/zope_interface-8.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:798b7c87d0e59a7d5d086d642208d0d8700ff0d55c4029134b3c479c3bfb110f", size = 304672, upload-time = "2026-05-26T06:50:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0e/b4c01320859ff1d585438bc231fd60bd258d096359bccf6654fecdf0cffb/zope_interface-8.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0fc3a9d45f114d27eaa1e53beeb144533689edca8a9f66505b1e8e8b3f075e42", size = 217241, upload-time = "2026-05-26T06:50:12.171Z" },
 ]


### PR DESCRIPTION
## The gap

No workflow ran `uv lock --check`, `uv sync --locked` or `uv sync --frozen`, so `uv.lock` was never compared against `pyproject.toml`. On `main` at `9d3ad2f` it no longer resolved it:

```
$ uv lock --check
Resolved 269 packages in 4.07s
error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
```

The lock was last written **2026-07-25** (`4a42ad4`, #1606). The manifest was edited three times after that (`c038f9f` 07-31, `5221459` 08-04, `04dcd31` 08-05) and none of those commits relocked. Fourteen days of manifest edits were absent from the lock, and CI stayed green throughout because nothing looked.

The same omission recurred three times in two weeks, which is what a missing gate looks like rather than three lapses — the same shape as #2017, #1905 and #1961.

## What the drift actually cost — not a hypothetical locked install

The issue framed the consequence as "consequence of a locked install", and nothing in this repository performs one: CI installs with `pip install -e ".[all,dev]"`, and no workflow, Dockerfile or devcontainer reads the lock. On that framing the lock is decorative and the honest question is whether to **delete** it rather than gate it.

It is not decorative, and one field settles it. `uv.lock` is a **dependency-graph manifest**, so GitHub's security scanning reads it — which is also how #631 cleared 51 Dependabot alerts "via uv lock upgrade":

```
dependencyGraphManifests -> uv.lock   parseable: true
```

So a stale lock is a stale **security surface**, and that is measurable rather than argued. Read off this repository's own SBOM (270 packages) while the lock was stale:

| declared in `pyproject.toml` | what the dependency graph reported | consequence |
|---|---|---|
| `lerobot[...]>=0.6.1,<0.7.0` (three extras) | **`lerobot 0.6.0`** | the graph scans a version the manifest **forbids** |
| `rosbridge = ["roslibpy>=1.7.0,<2.0.0"]`, and `[all]` includes it | **`roslibpy` absent entirely** | no `roslibpy` advisory could ever be reported, though `use_rosbridge` imports it |

The `lerobot` row is the sharpest, because #1930 existed *only* to buy that floor — its title is "floor lerobot at >=0.6.1 so bucket streaming is resolver-guaranteed". `tests/test_lerobot_floor_guarantees_bucket_streaming.py` pins it, passes, and reads the **manifest**. The artifact that pins the build said `0.6.0`, and no test read that side. A guarantee pinned on one side of two files is not pinned — which is why this change adds tests and not only a workflow.

The `roslibpy` row dates to #1110 (2026-07-31), which added the whole rosbridge transport and its extra but not the lock entry.

## The change

**1. The gate.** `.github/workflows/lockfile-parity.yml` runs `uv lock --check`. Advisory, like every sibling gate: the `default` ruleset lists exactly one required check, so this surfaces the drift and leaves the call to the reviewer. Self-clearing — the remedy is `uv lock`, committed.

**2. The relock**, so the gate starts from green. The 478-line diff is mechanical and fully attributable — it is 14 packages, not a mass upgrade:

| | count | what |
|---|---|---|
| added | 14 | `roslibpy` and its transitive tree (`twisted`, `autobahn`, `service-identity`, `pyopenssl`, …) |
| removed | 1 | `pyyaml-include` |
| upgraded | 2 | `lerobot` `0.6.0` → **`0.6.1`** (the floor #1930 bought), `draccus` `0.10.0` → `0.11.6` |

**3. The offline half.** `tests/test_lockfile_parity_gate.py` pins the two drift classes measured above — a locked version below a declared floor, and a declared dependency absent from the lock — so both are reported by the **required** check rather than only by the advisory gate. Neither half subsumes the other: `--check` catches drift the tests cannot see (a transitive pin, a marker change), and the tests fail in the required check, which `--check` cannot do while the gate is advisory.

## Why the merge commit and not the head sha

The job takes `actions/checkout`'s default ref for a `pull_request` event rather than naming `github.event.pull_request.head.sha`. "Does the lock resolve the manifest" is a property of the **tree that would land**.

Naming the head sha would accuse branches that changed nothing: every branch forked before this relock carries the stale lock. Measured against the three pull requests open when this landed — #1722, #1035, #1087, **none of which touch `pyproject.toml` or `uv.lock`**:

| | on its own head sha | on the merge tree |
|---|---|---|
| #1722 (clean merge onto relocked `main`) | would fail | **passes** |
| #1087 (conflicts on `use_ros.py`, unrelated) | would fail | **passes** |

This is the opposite choice from `changelog-fragment.yml`, and the reason is that the two ask different questions: that gate asks what a branch *added*, which only exists as a diff between base and head, so it must name both. A parity check reads two files and needs exactly one tree. It also needs no repository script, so it is immune to the #1791 failure mode that shaped the changelog gate — `uv lock --check` ships with uv, so a branch forked before this workflow cannot fail it for a missing file.

Pinned by `test_the_gate_reads_the_merge_tree`, because it is the one decision in the workflow that is invisible from its behaviour on a green branch.

## No uv version pin — measured, and it corrects the issue

The obvious worry is that `uv lock --check` is a verdict about uv's resolver, so a CI uv newer than the one that wrote the lock could demand an update over format or marker churn alone: a gate that fails with no defect. The issue anticipated this from the other side, predicting the diff would "carry resolver-marker churn from the newer uv".

It does not. uv **0.11.32** (current the day the lock was last written) and uv **0.12.3** (latest) write a byte-identical lock from this manifest, and each accepts the other's output:

| | verdict |
|---|---|
| `0.11.32` writes → `0.12.3 --check` | pass |
| `0.12.3` writes → `0.11.32 --check` | pass |
| `diff` between the two written locks | **0 lines** |

So the marker churn in this diff is attributable to the **manifest edits**, not to a uv upgrade, and pinning uv here would add a maintenance obligation that buys nothing. If a future uv does change the lock format, the fix is a deliberate relock — which is what this gate asks for.

## Deliberately out of scope

- **Resolution parity is the ceiling, not installability.** The issue asks whether the gate should also assert `uv sync --locked --extra rosbridge`. It should not: resolution parity catches every row measured above in ~4s with no wheel downloaded, while a locked sync of `[all]` costs minutes and pulls torch. The semantic half that a sync would add — does the locked set satisfy the declared floors — is covered offline by the tests here instead.
- **`robosuite` straddles its floor and is left alone.** It is locked at both `1.4.0` and `1.4.1` against a `>=1.4.1` floor from `[vera-sim]`, because `[tool.uv] conflicts` forks the resolution. It reads that way **both before and after** the relock, so it is a property of forking rather than drift. This is why the floor pin refuses a distribution only when *every* locked version is below the floor — an "any version" rule would fail a correct lock. The weaker rule still names the row that mattered: `lerobot` was locked at exactly one version.
- **Adding lower bounds for security headroom.** Four of the newly locked packages clear a HIGH advisory with no margin (`cbor2 5.9.0` is the literal first-patched version; `twisted 26.4.0`, `ujson 5.13.0`, `pyopenssl 26.4.0` sit just past theirs). Constraining them so the floor is enforced by the resolver rather than by luck is a real concern and a separate one — it changes what the manifest declares, not whether the lock matches it.

## Verification

Base `ad8696b`, head `942d163`. No `strands_robots/` file changes, so the runtime blast radius is zero.

- **Pre-fix proof** — `uv.lock` reverted to `main`'s, the 7 new tests kept: **2 failed / 5 passed**. The two failures name the drift in the manifest's own terms rather than as "the lockfile needs to be updated":
  ```
  lerobot locked at ['0.6.0'] but [lerobot] declares a floor of 0.6.1
  roslibpy (declared in [rosbridge])  -- absent from uv.lock
  ```
  The 5 that pass are the controls: two non-vacuity guards on the parsers, and the three workflow-shape pins (properties of the new workflow, not of the lock). With the relock restored: **7 passed**, and `uv lock --check` resolves 269 packages clean.
- **No regression, read as a delta.** The 16 neighbouring modules (every workflow scanner, the changelog gates, `test_dependency_audit`, the lerobot floor and dependency-doc suites) run with the same command in the same environment against a pristine `origin/main` worktree and against this branch:

  | tree | result |
  |---|---|
  | `origin/main` | 18 failed, 358 passed, 4 skipped |
  | this branch | 18 failed, **365** passed, 4 skipped |

  Identical failure sets — `comm` over the two sorted `FAILED` lists reports **nothing failing only on the branch** — and every one is a `ModuleNotFoundError` for a heavy optional dep absent from this scratch venv, present identically on `main`. The whole effect is **+7 passes**, exactly the 7 tests added.
- **Dependency review** — the 14 newly locked packages were checked against the GitHub Advisory Database and cross-checked against OSV at their resolved versions: **no HIGH or CRITICAL advisory affects any resolved version**, so `dependency-review-action`'s `fail-on-severity: high` has nothing to fire on. The bumped and removed packages carry no advisories at any version.
- **Lint** — `ruff check` clean, `ruff format --check` clean, `mypy` reports no issues on the new module.
- **Changelog** — recorded as a fragment (`changelog.d/2038-lockfile-parity-gate.md`); `scripts/assemble_changelog.py --check` reports `changelog fragments OK (231 pending)`.

Closes #2038
