### PR TITLE
ci: compare the whole recorded requirement set, not two properties of it

### DIFF
--- a/changelog.d/2041-lockfile-requires-dist-parity.md
+++ b/changelog.d/2041-lockfile-requires-dist-parity.md
@@ -1,0 +1,32 @@
+### Added: the required check now reports every way `uv.lock` can stop transcribing `pyproject.toml`
+
+#2039 added the `uv lock --check` gate, which is authoritative but **advisory** --
+the `default` ruleset lists exactly one required check. Its offline half ran
+inside the required check but asserted two *properties* of the lock rather than
+comparing it: every declared distribution present somewhere, and no locked version
+below its declared floor. Against `main`'s stale lock that reported 2 of the 5
+rows that had actually drifted.
+
+The three misses were drift in the recorded set's shape rather than in a property
+of a pin. `mink` and `qpsolvers` were both locked -- reachable via
+`[cosmos3-sim]` -- so a presence check passed while `[sim-mujoco]` was recorded
+as `['imageio', 'imageio-ffmpeg', 'mujoco', 'robot-descriptions']`: a locked sim
+install with no IK stack behind `move_to`. `[rosbridge]` was recorded empty. And
+`huggingface-hub` is pinned at `1.20.1`, which satisfies its `>=1.5` floor, so
+only the recorded specifier was stale at `>=1.0` -- invisible to any assertion
+about a correct pin.
+
+`scripts/check_lockfile_parity.py` compares the whole declared set against uv's
+own transcription of it in the lock's `[package.metadata] requires-dist`, in both
+directions, offline -- no resolver, no network, no `uv` binary -- so it runs in
+the required check. It reproduces the current lock exactly (111 declared rows
+against 111 recorded, zero differences) and reports 24 findings against the stale
+one, covering all five rows plus four the audit had not enumerated. Findings are
+grouped by `(extra, name, extras)`, so a changed version range is one
+`specifier-drift` finding naming both sides rather than two opaque rows with
+different remedies.
+
+The script exits 0/1 and can be run before pushing; `tests/test_lockfile_parity_requires_dist.py`
+pins the live pair, the five repaired rows individually, the two encodings the
+comparison depends on, and planted manifest/lock pairs for every finding class so
+an empty finding list means agreement rather than blindness.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,6 +35,8 @@ CI runs `hatch run test -x --strict-markers`.
 
 **JSON registries** - new robots and policies are JSON edits + tests. No hardcoded lookups in `.py` files.
 
+**A dependency change and its relock are one commit** - editing `pyproject.toml` without running `uv lock` leaves the lock describing a manifest that no longer exists. `uv.lock` is one of the manifests GitHub's dependency graph parses, so a stale lock is a stale *security surface*, not just a stale install. Check it before pushing with `python scripts/check_lockfile_parity.py` (offline, no resolver) or `uv lock --check`.
+
 **Tool errors return, don't raise:**
 ```python
 {"status": "error", "content": [{"text": "human-readable error"}]}

--- a/scripts/check_lockfile_parity.py
+++ b/scripts/check_lockfile_parity.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Refuse a ``uv.lock`` whose transcription of the manifest no longer matches it.
+
+Why this exists
+---------------
+#2039 added ``.github/workflows/lockfile-parity.yml``, which runs ``uv lock
+--check``. That is the authoritative comparison and it catches everything below.
+It is also **advisory**: the ``default`` ruleset lists exactly one required check
+(``call-test-lint / Test and Lint``), so a drifted lock reaches a reviewer as a
+red advisory context beside a green required one.
+
+The offline half #2039 shipped -- ``tests/test_lockfile_parity_gate.py`` -- runs
+*inside* the required check, and it asserts two properties of the lock rather
+than comparing it: every declared distribution is present somewhere, and no
+locked version falls below its declared floor. Against ``main``'s stale lock at
+``ad8696b`` that reports **2 of the 5 rows that had actually drifted**::
+
+    lerobot pinned 0.6.0 vs declared >=0.6.1        reported  (floor violation)
+    roslibpy absent from the lock                   reported  (distribution absent)
+    mink/qpsolvers unrecorded under [sim-mujoco]    MISSED
+    mink/qpsolvers unrecorded under [sim-newton]    MISSED
+    huggingface-hub recorded >=1.0 vs declared >=1.5 MISSED
+
+The three misses share one cause: a presence-and-floor check samples two
+properties of the recorded set, and the drift was in the set's *shape*. ``mink``
+and ``qpsolvers`` are both locked -- reachable via ``[cosmos3-sim]`` -- so a
+presence check passes while ``[sim-mujoco]`` is recorded as
+``['imageio', 'imageio-ffmpeg', 'mujoco', 'robot-descriptions']``: a locked sim
+install with no IK stack behind ``move_to``. ``[rosbridge]`` was recorded
+**empty**. And ``huggingface-hub`` is pinned at ``1.20.1``, which satisfies the
+``>=1.5`` floor, so only the recorded *specifier* was stale -- nothing about the
+pin is wrong, and no property of the pin can see it.
+
+What this compares instead
+--------------------------
+The whole recorded set, against the whole declared set. ``uv.lock`` already
+carries uv's own transcription of the manifest in the root package's
+``[package.metadata] requires-dist``, so the declared set can be reconstructed
+from ``pyproject.toml`` and compared as a set -- offline, no resolver, no
+network, no ``uv`` binary, in the required check.
+
+The reconstruction reproduces the relocked file **exactly**: 111 declared rows
+against 111 recorded, zero differences in either direction. Against the stale
+lock the two sets differ by 32 rows, reported as **24 findings** -- 10
+declared-but-not-recorded, 5 recorded-but-not-declared, 9 specifier-drift --
+which cover all five rows above and four the issue had not enumerated
+(``peft`` and ``transformers`` recorded under extras that no longer declare them,
+``scipy``, and ``lerobot[molmoact2]`` unrecorded entirely).
+
+It is 24 rather than 32 because a changed version range appears in *both*
+directions of the symmetric difference -- once as declared-but-not-recorded and
+once as recorded-but-not-declared -- and reported raw that reads as two
+independent problems with two different remedies. Rows are therefore grouped by
+``(extra, name, extras)`` before classification, so a changed range is one
+finding naming both sides.
+
+Two encodings have to be mirrored rather than approximated, and getting either
+wrong produces a guard that false-fails on a correct lock:
+
+- **Self-references are expanded.** 20 of the 88 requirement lines in the
+  manifest are ``strands-robots[<other-extra>]``; uv resolves those away and
+  records the transitive closure, which is why the recorded set is 111 and not
+  68. Comparing the literal declared lines reports **43** spurious "recorded but
+  not declared" rows -- so the expansion is not a refinement, it is the
+  difference between a working check and one that fails every branch.
+- **One key can carry several specifiers, so neither side may be flattened into
+  a dictionary.** This is not defensive: uv's own lock at ``ad8696b`` recorded
+  ``scipy`` **twice** under ``[all]``, at ``>=1.10.0`` and at ``>=1.14.0,<2.0.0``.
+  Keying a dictionary by ``(extra, name, extras)`` drops one of those silently,
+  and the dropped row then reads as drift against the other side -- a finding on
+  a file that is correct. ``(extra, name, extras)`` therefore maps to a *set* of
+  specifiers on both sides. Today's manifest and relocked file happen to carry a
+  unique specifier per key, so nothing in the live pair exercises this; it is
+  pinned on a planted pair instead.
+
+One fact worth recording because it makes the comparison exact rather than
+approximate: every marker in the lock's ``requires-dist`` is ``extra == '...'``
+and nothing else (107 of 111 rows; the other 4 are unconditional), and no
+requirement in ``pyproject.toml`` carries an environment marker at all. A
+residual-marker comparison is therefore inert today. It is still written as a
+**finding** rather than a silent drop, so that if either side ever grows a real
+marker this reports it instead of quietly comparing fewer rows.
+
+What it deliberately does not do
+--------------------------------
+- **It does not re-check that locked versions satisfy declared floors.**
+  ``tests/test_lockfile_parity_gate.py`` does that, and duplicating it here would
+  create two rulebooks for one rule that can drift apart -- including the
+  non-obvious "every locked version, not any" phrasing that ``robosuite``
+  (locked at ``1.4.0`` *and* ``1.4.1`` against a ``>=1.4.1`` floor, before and
+  after the relock) forces on it. This script compares the two transcriptions of
+  the *manifest*; that module compares the lock against the *resolution*.
+- **It does not re-resolve.** Whether the recorded set is *achievable* is
+  ``uv lock --check``'s question, and it needs the index to answer it. A stale
+  transcription is detectable without one, which is the only reason this can run
+  in the required check.
+- **It does not read ``[tool.uv]``.** Sources, overrides and conflicts change
+  what uv resolves, not what the manifest declares, so they cannot make the two
+  transcriptions disagree.
+
+Usage
+-----
+``--repo-root``  directory holding ``pyproject.toml`` and ``uv.lock`` (default:
+                 the repository this script lives in).
+``--pyproject``  / ``--lock``  override either path individually, which is what
+                 makes the planted-pair tests possible.
+
+Exit status is ``1`` when there is at least one finding, else ``0``. The remedy
+is always the same and is self-clearing: run ``uv lock`` and commit the result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tomllib
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+
+#: This project. It appears in its own manifest as ``strands-robots[<extra>]``
+#: recursive extras, which uv expands away rather than recording.
+PROJECT_NAME = "strands-robots"
+
+#: The only marker shape either side uses. Matched exactly rather than parsed
+#: with ``packaging.markers`` so that anything else becomes a finding instead of
+#: evaluating to something plausible under an assumed environment.
+_EXTRA_MARKER = re.compile(r"extra == '([^']+)'")
+
+MISSING_FROM_LOCK = "declared-but-not-recorded"
+ABSENT_FROM_MANIFEST = "recorded-but-not-declared"
+SPECIFIER_DRIFT = "specifier-drift"
+UNREADABLE_MARKER = "unreadable-marker"
+
+
+def canonical_name(name: str) -> str:
+    """Normalise a distribution name per PEP 503, so ``zope.interface`` matches ``zope-interface``."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _normalise_specifier(specifier: str) -> str:
+    """Render a specifier set in a stable, comparable form.
+
+    ``SpecifierSet`` sorts and deduplicates, so ``>=1.0,<2`` and ``<2,>=1.0``
+    compare equal. Without this the check would report ordering as drift, which
+    is the same class of false finding as the two encodings in the module
+    docstring.
+    """
+    return str(SpecifierSet(specifier))
+
+
+@dataclass(frozen=True, order=True)
+class Row:
+    """One requirement, as declared under one extra (or unconditionally).
+
+    ``extra`` of ``None`` is a ``project.dependencies`` entry, which uv records
+    with no marker.
+    """
+
+    extra: str | None
+    name: str
+    extras: tuple[str, ...]
+    specifier: str
+
+    @property
+    def key(self) -> tuple[str | None, str, tuple[str, ...]]:
+        """What identifies this requirement independently of its version range."""
+        return (self.extra, self.name, self.extras)
+
+    def render(self) -> str:
+        extras = f"[{','.join(self.extras)}]" if self.extras else ""
+        where = f"[{self.extra}]" if self.extra else "project.dependencies"
+        return f"{self.name}{extras}{self.specifier or ' (any version)'} under {where}"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One disagreement between the manifest and the lock's transcription of it."""
+
+    kind: str
+    key: tuple[str | None, str, tuple[str, ...]]
+    declared: tuple[str, ...] = ()
+    recorded: tuple[str, ...] = ()
+    detail: str = ""
+
+    def render(self) -> str:
+        extra, name, extras = self.key
+        extras_text = f"[{','.join(extras)}]" if extras else ""
+        where = f"[{extra}]" if extra else "project.dependencies"
+        subject = f"{name}{extras_text} under {where}"
+        if self.kind == MISSING_FROM_LOCK:
+            return f"{subject}  -- declared {self._join(self.declared)}, not recorded in uv.lock at all"
+        if self.kind == ABSENT_FROM_MANIFEST:
+            return f"{subject}  -- recorded {self._join(self.recorded)} in uv.lock, not declared in pyproject.toml"
+        if self.kind == SPECIFIER_DRIFT:
+            return f"{subject}  -- declared {self._join(self.declared)}, recorded {self._join(self.recorded)}"
+        return f"{subject}  -- {self.detail}"
+
+    @staticmethod
+    def _join(specifiers: Sequence[str]) -> str:
+        rendered = [s or "(any version)" for s in specifiers]
+        return " / ".join(rendered) if rendered else "(nothing)"
+
+
+def declared_rows(pyproject: dict[str, object]) -> set[Row]:
+    """Reconstruct every requirement the manifest declares, with self-references expanded.
+
+    ``strands-robots[sim-mujoco]`` declared under ``[all]`` contributes
+    ``[sim-mujoco]``'s requirements to ``[all]``, transitively, which is what uv
+    records. Real extra names are used in this example rather than placeholders
+    because ``tests/test_dependency_audit.py`` refuses any ``strands-robots[...]``
+    mention naming an extra that does not exist -- pip exits 0 on an unknown
+    extra and installs nothing, so a placeholder here would read as a broken
+    install hint. The recursion carries the set
+    of extras already entered so a cycle terminates rather than recursing until
+    the interpreter stops it; the manifest has no cycle today and this makes that
+    a property of the reader rather than of the input.
+    """
+    project = pyproject.get("project")
+    if not isinstance(project, dict):
+        raise ValueError("pyproject.toml has no [project] table.")
+    optional_raw = project.get("optional-dependencies") or {}
+    optional: dict[str, list[str]] = {
+        str(extra): [str(spec) for spec in specs] for extra, specs in optional_raw.items()
+    }
+
+    def expand(extra: str, entered: frozenset[str]) -> list[Requirement]:
+        collected: list[Requirement] = []
+        for spec in optional.get(extra, []):
+            requirement = Requirement(spec)
+            if canonical_name(requirement.name) == PROJECT_NAME:
+                for inner in sorted(requirement.extras):
+                    if inner not in entered:
+                        collected.extend(expand(inner, entered | {inner}))
+            else:
+                collected.append(requirement)
+        return collected
+
+    rows: set[Row] = set()
+    for spec in project.get("dependencies") or []:
+        requirement = Requirement(str(spec))
+        rows.add(
+            Row(
+                None,
+                canonical_name(requirement.name),
+                tuple(sorted(requirement.extras)),
+                _normalise_specifier(str(requirement.specifier)),
+            )
+        )
+    for extra in optional:
+        for requirement in expand(extra, frozenset({extra})):
+            rows.add(
+                Row(
+                    extra,
+                    canonical_name(requirement.name),
+                    tuple(sorted(requirement.extras)),
+                    _normalise_specifier(str(requirement.specifier)),
+                )
+            )
+    return rows
+
+
+def recorded_rows(lock: dict[str, object]) -> tuple[set[Row], list[Finding]]:
+    """Read the root package's ``requires-dist``, and report any marker that is not ``extra == '...'``.
+
+    An unreadable marker is returned as a finding rather than dropped, so a
+    manifest that grows an environment marker makes this check say so instead of
+    silently comparing fewer rows than it claims to.
+    """
+    packages = lock.get("package")
+    if not isinstance(packages, list):
+        raise ValueError("uv.lock has no [[package]] array.")
+    roots = [
+        package
+        for package in packages
+        if isinstance(package, dict) and canonical_name(str(package.get("name", ""))) == PROJECT_NAME
+    ]
+    if len(roots) != 1:
+        raise ValueError(f"expected exactly one {PROJECT_NAME} package in uv.lock, found {len(roots)}.")
+    metadata = roots[0].get("metadata")
+    if not isinstance(metadata, dict) or "requires-dist" not in metadata:
+        raise ValueError("uv.lock's root package carries no [package.metadata] requires-dist.")
+
+    rows: set[Row] = set()
+    findings: list[Finding] = []
+    for entry in metadata["requires-dist"]:
+        if not isinstance(entry, dict) or "name" not in entry:
+            raise ValueError(f"unreadable requires-dist entry: {entry!r}")
+        name = canonical_name(str(entry["name"]))
+        marker = entry.get("marker")
+        extra: str | None = None
+        if marker is not None:
+            matched = _EXTRA_MARKER.fullmatch(str(marker).strip())
+            if matched is None:
+                findings.append(
+                    Finding(
+                        UNREADABLE_MARKER,
+                        (None, name, ()),
+                        detail=(
+                            f"uv.lock records it under the marker {str(marker)!r}, which is not a plain "
+                            "extra marker. This checker compares extras only, so the row is reported "
+                            "rather than compared."
+                        ),
+                    )
+                )
+                continue
+            extra = matched.group(1)
+        rows.add(
+            Row(
+                extra,
+                name,
+                tuple(sorted(str(value) for value in entry.get("extras", ()))),
+                _normalise_specifier(str(entry.get("specifier", ""))),
+            )
+        )
+    return rows, findings
+
+
+def compare(declared: set[Row], recorded: set[Row]) -> list[Finding]:
+    """Classify every disagreement between the two sets.
+
+    The two sets' symmetric difference is the complete answer, but reported raw
+    it names a changed version range twice -- once as declared-but-not-recorded
+    and once as recorded-but-not-declared -- which reads as two independent
+    problems. So rows are grouped by ``key`` first, and a key present on both
+    sides with differing specifiers becomes one ``specifier-drift`` finding
+    naming both sides. A key present on one side only keeps its own class,
+    because those want different remedies: a missing row means the lock never
+    saw the requirement, an extra row means the manifest dropped it.
+    """
+    declared_by_key: dict[tuple[str | None, str, tuple[str, ...]], set[str]] = defaultdict(set)
+    recorded_by_key: dict[tuple[str | None, str, tuple[str, ...]], set[str]] = defaultdict(set)
+    for row in declared:
+        declared_by_key[row.key].add(row.specifier)
+    for row in recorded:
+        recorded_by_key[row.key].add(row.specifier)
+
+    findings: list[Finding] = []
+    for key in sorted(set(declared_by_key) | set(recorded_by_key), key=lambda k: (k[1], k[0] or "", k[2])):
+        declared_specifiers = declared_by_key.get(key, set())
+        recorded_specifiers = recorded_by_key.get(key, set())
+        if declared_specifiers == recorded_specifiers:
+            continue
+        if not recorded_specifiers:
+            kind = MISSING_FROM_LOCK
+        elif not declared_specifiers:
+            kind = ABSENT_FROM_MANIFEST
+        else:
+            kind = SPECIFIER_DRIFT
+        findings.append(
+            Finding(
+                kind,
+                key,
+                declared=tuple(sorted(declared_specifiers)),
+                recorded=tuple(sorted(recorded_specifiers)),
+            )
+        )
+    return findings
+
+
+def check(pyproject_path: Path, lock_path: Path) -> list[Finding]:
+    """Return every finding for one manifest/lock pair."""
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    lock = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    recorded, marker_findings = recorded_rows(lock)
+    return marker_findings + compare(declared_rows(pyproject), recorded)
+
+
+def render(findings: Sequence[Finding], pyproject_path: Path, lock_path: Path, declared: int, recorded: int) -> str:
+    """Render the job-summary report for one run."""
+    lines = [
+        "## Lockfile requires-dist parity",
+        "",
+        "| field | value |",
+        "|---|---|",
+        f"| manifest | `{pyproject_path}` |",
+        f"| lock | `{lock_path}` |",
+        f"| declared requirements (self-references expanded) | {declared} |",
+        f"| recorded in `[package.metadata] requires-dist` | {recorded} |",
+        f"| findings | **{len(findings)}** |",
+        "",
+    ]
+    if not findings:
+        lines += [
+            "`uv.lock`'s transcription of `pyproject.toml` matches it exactly, in both directions.",
+        ]
+        return "\n".join(lines)
+
+    by_kind: dict[str, list[Finding]] = defaultdict(list)
+    for finding in findings:
+        by_kind[finding.kind].append(finding)
+    for kind in (MISSING_FROM_LOCK, ABSENT_FROM_MANIFEST, SPECIFIER_DRIFT, UNREADABLE_MARKER):
+        group = by_kind.get(kind)
+        if not group:
+            continue
+        lines += [f"### {kind} ({len(group)})", ""]
+        lines += [f"- {finding.render()}" for finding in group]
+        lines += [""]
+    lines += [
+        "### What clears this",
+        "",
+        "Run `uv lock` and commit the result. A dependency change and its relock belong in the",
+        "same commit: the lock is a dependency-graph manifest, so GitHub's security scanning",
+        "reads it, and a stale one is a stale security surface rather than only an inconvenience",
+        "to whoever runs a locked install.",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    default_root = Path(__file__).resolve().parents[1]
+    parser.add_argument("--repo-root", default=str(default_root))
+    parser.add_argument("--pyproject", default="")
+    parser.add_argument("--lock", default="")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root)
+    pyproject_path = Path(args.pyproject) if args.pyproject else repo_root / "pyproject.toml"
+    lock_path = Path(args.lock) if args.lock else repo_root / "uv.lock"
+
+    for path in (pyproject_path, lock_path):
+        if not path.is_file():
+            print(f"check_lockfile_parity: no such file: {path}", file=sys.stderr)
+            return 2
+
+    try:
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+        lock = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+        recorded, marker_findings = recorded_rows(lock)
+        declared = declared_rows(pyproject)
+        findings = marker_findings + compare(declared, recorded)
+    except (ValueError, tomllib.TOMLDecodeError) as exc:
+        print(f"check_lockfile_parity: {exc}", file=sys.stderr)
+        return 2
+
+    report = render(findings, pyproject_path, lock_path, len(declared), len(recorded))
+    print(report)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+    if findings:
+        print(
+            f"::error title=uv.lock no longer transcribes pyproject.toml::"
+            f"{len(findings)} finding(s) comparing the declared requirement set against "
+            f"[package.metadata] requires-dist. Run `uv lock` and commit the result."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lockfile_parity_requires_dist.py
+++ b/tests/test_lockfile_parity_requires_dist.py
@@ -1,0 +1,514 @@
+"""Contract pins for the whole-set ``requires-dist`` parity check.
+
+#2039 gated the lock with ``uv lock --check`` (advisory) and pinned two
+properties of it offline in ``tests/test_lockfile_parity_gate.py`` (required):
+every declared distribution present somewhere, and no locked version below its
+declared floor. Against ``main``'s stale lock at ``ad8696b`` that pair reports 2
+of the 5 rows that had actually drifted. The three it misses are the ones where
+the drift is in the *shape* of the recorded set rather than in a property of a
+pin:
+
+* ``mink`` and ``qpsolvers`` were both locked -- reachable via ``[cosmos3-sim]``
+  -- so a presence check passes while ``[sim-mujoco]`` is recorded as
+  ``['imageio', 'imageio-ffmpeg', 'mujoco', 'robot-descriptions']``, a locked sim
+  install with no IK stack behind ``move_to``. ``[rosbridge]`` was recorded
+  **empty**.
+* ``huggingface-hub`` is pinned at ``1.20.1``, which satisfies its ``>=1.5``
+  floor, so only the recorded *specifier* was stale (``>=1.0``). No property of a
+  correct pin can see that.
+
+``scripts/check_lockfile_parity.py`` compares the whole set instead, in both
+directions, against uv's own transcription of the manifest in the root package's
+``[package.metadata] requires-dist``. See #2041.
+
+What this module pins, and why each part is here
+------------------------------------------------
+The load-bearing assertion is one line -- the live pair agrees -- and on its own
+it is indistinguishable from a checker that finds nothing because it reads
+nothing. So it is surrounded by:
+
+* **Non-vacuity guards.** Both sides must reconstruct a non-trivial number of
+  rows. An empty-versus-empty comparison agrees perfectly.
+* **The five repaired rows, individually.** Asserted present in *both*
+  transcriptions, so this module fails if any of them regresses -- which is what
+  makes it a regression pin for #2038 rather than a restatement of the checker.
+* **The two encodings, as premises.** Self-reference expansion and
+  several-specifiers-per-key are both load-bearing: getting either wrong produces
+  a checker that fails a correct lock, which is worse than one that misses drift
+  because it blocks every branch. Each is asserted to be *necessary* (the
+  unexpanded comparison is shown to manufacture findings) rather than merely
+  described.
+* **Planted manifest/lock pairs.** Every finding class is provoked on a synthetic
+  pair, so an empty finding list on the live pair means agreement rather than
+  blindness. These carry the drift classes rather than a vendored copy of the
+  5914-line stale lock: the classes are what must keep being caught, and a
+  vendored artifact would pin one historical file forever.
+
+The stale lock is not committed here. It is reachable as ``git show
+ad8696b:uv.lock`` for anyone reproducing the 24 findings quoted in the script's
+docstring.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+from packaging.requirements import Requirement
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "scripts" / "check_lockfile_parity.py"
+_PYPROJECT = _ROOT / "pyproject.toml"
+_LOCK = _ROOT / "uv.lock"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_lockfile_parity", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# The script is annotated and mypy-clean on its own
+# (mypy scripts/check_lockfile_parity.py); it is reached through importlib here
+# because scripts/ is not an importable package.
+mod = _load()
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict[str, Any]:
+    return tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def lock() -> dict[str, Any]:
+    return tomllib.loads(_LOCK.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def declared(manifest: dict[str, Any]) -> set[Any]:
+    return mod.declared_rows(manifest)
+
+
+@pytest.fixture(scope="module")
+def recorded(lock: dict[str, Any]) -> set[Any]:
+    rows, marker_findings = mod.recorded_rows(lock)
+    assert marker_findings == [], f"uv.lock carries a marker this checker cannot compare: {marker_findings}"
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# The live pair. One assertion, plus the guards that stop it passing vacuously.
+# ---------------------------------------------------------------------------
+
+
+def test_the_live_pair_agrees_in_both_directions(declared: set[Any], recorded: set[Any]) -> None:
+    """``uv.lock``'s transcription of ``pyproject.toml`` matches it exactly.
+
+    The remedy for a failure here is always ``uv lock``, committed. A dependency
+    change and its relock belong in the same commit.
+    """
+    findings = mod.compare(declared, recorded)
+    assert findings == [], "uv.lock no longer transcribes pyproject.toml:\n" + "\n".join(
+        f"  {finding.kind}: {finding.render()}" for finding in findings
+    )
+
+
+def test_neither_side_reconstructs_an_empty_set(declared: set[Any], recorded: set[Any]) -> None:
+    """A parser that returns nothing agrees with anything.
+
+    The floor is deliberately far below the current 111 on each side, so this
+    guards against a reader that breaks rather than against ordinary dependency
+    churn -- a threshold near the real count would fail on the next extra added.
+    """
+    assert len(declared) > 80
+    assert len(recorded) > 80
+
+
+def test_the_two_transcriptions_are_the_same_size(declared: set[Any], recorded: set[Any]) -> None:
+    """Equal sets have equal size; asserted separately so a size mismatch is legible on its own."""
+    assert len(declared) == len(recorded)
+
+
+def test_the_checker_agrees_with_itself_through_its_file_entry_point() -> None:
+    """``check()`` reads the same pair from paths, which is the entry point the script uses."""
+    assert mod.check(_PYPROJECT, _LOCK) == []
+
+
+# ---------------------------------------------------------------------------
+# The five rows #2038 repaired, asserted present in both transcriptions.
+# ---------------------------------------------------------------------------
+
+#: ``(extra, distribution, extras)`` for each row, with the floor that must be
+#: recorded where the drift was in the specifier rather than in presence.
+REPAIRED_ROWS = [
+    pytest.param("rosbridge", "roslibpy", (), None, id="roslibpy-recorded-under-rosbridge"),
+    pytest.param("sim-mujoco", "mink", (), None, id="mink-recorded-under-sim-mujoco"),
+    pytest.param("sim-mujoco", "qpsolvers", ("daqp",), None, id="qpsolvers-recorded-under-sim-mujoco"),
+    pytest.param("sim-newton", "mink", (), None, id="mink-recorded-under-sim-newton"),
+    pytest.param("sim-newton", "qpsolvers", ("daqp",), None, id="qpsolvers-recorded-under-sim-newton"),
+    pytest.param("lerobot", "lerobot", ("dataset", "feetech"), "0.6.1", id="lerobot-floor-recorded-as-0.6.1"),
+    pytest.param("wbc", "huggingface-hub", (), "1.5", id="huggingface-hub-floor-recorded-as-1.5"),
+]
+
+
+@pytest.mark.parametrize(("extra", "name", "extras", "floor"), REPAIRED_ROWS)
+def test_a_repaired_row_is_present_in_both_transcriptions(
+    extra: str,
+    name: str,
+    extras: tuple[str, ...],
+    floor: str | None,
+    declared: set[Any],
+    recorded: set[Any],
+) -> None:
+    """Each row that had drifted is now declared *and* recorded, with the floor it was given.
+
+    ``roslibpy`` and the two IK packages were absent from the recorded set
+    entirely; ``lerobot`` and ``huggingface-hub`` were recorded at a floor below
+    the declared one. Both failure modes are asserted the same way here, because
+    both are answered by the row being in both sets.
+    """
+    key = (extra, name, extras)
+    declared_here = {row.specifier for row in declared if row.key == key}
+    recorded_here = {row.specifier for row in recorded if row.key == key}
+    assert declared_here, f"pyproject.toml no longer declares {name}{list(extras)} under [{extra}]"
+    assert recorded_here, f"uv.lock no longer records {name}{list(extras)} under [{extra}] -- relock"
+    assert declared_here == recorded_here
+    if floor is not None:
+        assert all(floor in specifier for specifier in recorded_here), (
+            f"uv.lock records {name} under [{extra}] as {recorded_here}, which does not carry the {floor} floor"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The two encodings, as premises. Each is asserted to be necessary.
+# ---------------------------------------------------------------------------
+
+
+def test_the_manifest_uses_self_references(manifest: dict[str, Any]) -> None:
+    """The premise behind expansion: the manifest declares itself with extras.
+
+    If this ever stops being true the expansion becomes dead code, and the next
+    reader should delete it rather than maintain it.
+    """
+    lines = [
+        spec
+        for specs in (manifest["project"].get("optional-dependencies") or {}).values()
+        for spec in specs
+        if mod.canonical_name(Requirement(spec).name) == mod.PROJECT_NAME
+    ]
+    assert lines, "no strands-robots[...] self-reference in pyproject.toml"
+
+
+def test_expansion_is_load_bearing_not_cosmetic(manifest: dict[str, Any], recorded: set[Any]) -> None:
+    """Comparing the literal declared lines manufactures findings on a correct lock.
+
+    uv records the transitive closure of each self-reference, so the unexpanded
+    declared set is strictly smaller than the recorded one. A checker written
+    without the expansion does not merely miss drift -- it reports a correct lock
+    as drifted, and would fail every branch.
+    """
+    project = manifest["project"]
+    unexpanded: set[Any] = set()
+    for spec in project.get("dependencies") or []:
+        requirement = Requirement(str(spec))
+        unexpanded.add(
+            mod.Row(
+                None,
+                mod.canonical_name(requirement.name),
+                tuple(sorted(requirement.extras)),
+                str(requirement.specifier),
+            )
+        )
+    for extra, specs in (project.get("optional-dependencies") or {}).items():
+        for spec in specs:
+            requirement = Requirement(str(spec))
+            if mod.canonical_name(requirement.name) == mod.PROJECT_NAME:
+                continue
+            unexpanded.add(
+                mod.Row(
+                    extra,
+                    mod.canonical_name(requirement.name),
+                    tuple(sorted(requirement.extras)),
+                    str(requirement.specifier),
+                )
+            )
+    assert len(unexpanded) < len(recorded)
+    assert mod.compare(unexpanded, recorded), "the unexpanded comparison agreed, so expansion cannot be load-bearing"
+
+
+def test_the_live_pair_carries_one_specifier_per_key(declared: set[Any], recorded: set[Any]) -> None:
+    """Recorded for honesty: nothing in today's files exercises the set-valued grouping.
+
+    uv's own lock at ``ad8696b`` recorded ``scipy`` twice under ``[all]``, at
+    ``>=1.10.0`` and ``>=1.14.0,<2.0.0``, so the grouping is required by observed
+    input rather than by this pair. That case is pinned behaviourally on a planted
+    pair below. If this assertion ever fails, the grouping has become live and
+    this test should be deleted rather than repaired.
+    """
+    for side in (declared, recorded):
+        counts: dict[Any, int] = {}
+        for row in side:
+            counts[row.key] = counts.get(row.key, 0) + 1
+        assert not {key: count for key, count in counts.items() if count > 1}
+
+
+def test_a_key_recorded_at_two_specifiers_is_compared_as_a_set(tmp_path: Path) -> None:
+    """The ``scipy`` case, as observed in ``ad8696b``'s lock.
+
+    One key legitimately carries two specifiers on both sides. A checker that
+    flattened either side into a dictionary keyed by ``(extra, name, extras)``
+    would keep one specifier and report the other as drift -- a finding on a
+    correct file, which blocks every branch until someone reads the checker.
+    """
+    pyproject, lock = _plant(
+        tmp_path,
+        "dependencies = []\n\n[project.optional-dependencies]\n"
+        'sim-mujoco = ["scipy>=1.10.0"]\n'
+        'wbc = ["scipy>=1.14.0,<2.0.0"]\n'
+        'all = ["strands-robots[sim-mujoco]", "strands-robots[wbc]"]\n',
+        '    { name = "scipy", marker = "extra == \'sim-mujoco\'", specifier = ">=1.10.0" },\n'
+        '    { name = "scipy", marker = "extra == \'wbc\'", specifier = ">=1.14.0,<2.0.0" },\n'
+        '    { name = "scipy", marker = "extra == \'all\'", specifier = ">=1.10.0" },\n'
+        '    { name = "scipy", marker = "extra == \'all\'", specifier = ">=1.14.0,<2.0.0" },',
+    )
+    assert mod.check(pyproject, lock) == []
+
+
+def test_dropping_one_of_two_specifiers_for_a_key_is_reported(tmp_path: Path) -> None:
+    """The counterpart: the lock records only one of the two, which is real drift.
+
+    Without this, the test above could pass on a checker that compares only
+    whether the key is present.
+    """
+    pyproject, lock = _plant(
+        tmp_path,
+        "dependencies = []\n\n[project.optional-dependencies]\n"
+        'sim-mujoco = ["scipy>=1.10.0"]\n'
+        'wbc = ["scipy>=1.14.0,<2.0.0"]\n'
+        'all = ["strands-robots[sim-mujoco]", "strands-robots[wbc]"]\n',
+        '    { name = "scipy", marker = "extra == \'sim-mujoco\'", specifier = ">=1.10.0" },\n'
+        '    { name = "scipy", marker = "extra == \'wbc\'", specifier = ">=1.14.0,<2.0.0" },\n'
+        '    { name = "scipy", marker = "extra == \'all\'", specifier = ">=1.10.0" },',
+    )
+    findings = mod.check(pyproject, lock)
+    assert [finding.kind for finding in findings] == [mod.SPECIFIER_DRIFT]
+    assert findings[0].key == ("all", "scipy", ())
+    # Rendered through ``SpecifierSet``, which sorts within a specifier, and the
+    # tuple itself is sorted -- so the expectation is written normalised too.
+    assert findings[0].declared == ("<2.0.0,>=1.14.0", ">=1.10.0")
+    assert findings[0].recorded == (">=1.10.0",)
+
+
+def test_every_recorded_marker_is_a_plain_extra_marker(lock: dict[str, Any]) -> None:
+    """The comparison is exact only while markers say nothing but ``extra == '...'``."""
+    root = next(p for p in lock["package"] if mod.canonical_name(p["name"]) == mod.PROJECT_NAME)
+    markers = [entry["marker"] for entry in root["metadata"]["requires-dist"] if entry.get("marker")]
+    assert markers, "no marker at all in requires-dist, which would make the extra comparison vacuous"
+    assert all(mod._EXTRA_MARKER.fullmatch(marker.strip()) for marker in markers)
+
+
+def test_no_declared_requirement_carries_an_environment_marker(manifest: dict[str, Any]) -> None:
+    """The other half of the same premise, read off the manifest.
+
+    Inert today. Pinned so that adding a marked requirement fails here -- naming
+    the assumption -- rather than silently comparing fewer rows.
+    """
+    project = manifest["project"]
+    specs = list(project.get("dependencies") or [])
+    for extra_specs in (project.get("optional-dependencies") or {}).values():
+        specs.extend(extra_specs)
+    marked = [spec for spec in specs if Requirement(str(spec)).marker is not None]
+    assert marked == []
+
+
+# ---------------------------------------------------------------------------
+# Planted pairs. Every finding class provoked on a synthetic manifest and lock,
+# so an empty finding list on the live pair means agreement, not blindness.
+# ---------------------------------------------------------------------------
+
+
+def _plant(tmp_path: Path, manifest_body: str, requires_dist: str) -> tuple[Path, Path]:
+    """Write a minimal manifest/lock pair and return the two paths.
+
+    Planted manifests that use a ``strands-robots[...]`` self-reference name a
+    **real declared extra** (``sim-mujoco``, ``wbc``) rather than a placeholder.
+    That is not cosmetic: ``tests/test_dependency_audit.py`` sweeps the tree for
+    ``strands-robots[<extra>]`` and refuses any that names an extra which does not
+    exist, because pip exits 0 on an unknown extra and installs none of its
+    dependencies -- so the mistake surfaces later and misattributed. A placeholder
+    here fails that sweep. The dependencies inside these fixtures stay synthetic;
+    only the extra names are real.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(f'[project]\nname = "strands-robots"\nversion = "0.0.0"\n{manifest_body}', encoding="utf-8")
+    lock = tmp_path / "uv.lock"
+    lock.write_text(
+        "version = 1\nrevision = 3\n\n"
+        '[[package]]\nname = "strands-robots"\nsource = { virtual = "." }\n\n'
+        f"[package.metadata]\nrequires-dist = [\n{requires_dist}\n]\n",
+        encoding="utf-8",
+    )
+    return pyproject, lock
+
+
+_AGREEING_MANIFEST = 'dependencies = ["foo>=1.0,<2.0"]\n\n[project.optional-dependencies]\nx = ["bar[extra1]>=2.0"]\n'
+_AGREEING_LOCK = (
+    '    { name = "foo", specifier = ">=1.0,<2.0" },\n'
+    '    { name = "bar", extras = ["extra1"], marker = "extra == \'x\'", specifier = ">=2.0" },'
+)
+
+
+def test_a_matching_planted_pair_reports_nothing(tmp_path: Path) -> None:
+    """The control. Without it, every finding test below could pass on a checker that always fires."""
+    pyproject, lock = _plant(tmp_path, _AGREEING_MANIFEST, _AGREEING_LOCK)
+    assert mod.check(pyproject, lock) == []
+
+
+def test_a_declared_distribution_absent_from_the_lock_is_reported(tmp_path: Path) -> None:
+    """The ``roslibpy`` class: declared under an extra, recorded nowhere."""
+    pyproject, lock = _plant(
+        tmp_path,
+        _AGREEING_MANIFEST,
+        '    { name = "foo", specifier = ">=1.0,<2.0" },',
+    )
+    findings = mod.check(pyproject, lock)
+    assert [finding.kind for finding in findings] == [mod.MISSING_FROM_LOCK]
+    assert findings[0].key == ("x", "bar", ("extra1",))
+
+
+def test_a_recorded_distribution_the_manifest_does_not_declare_is_reported(tmp_path: Path) -> None:
+    """The ``peft`` class: an extra stopped declaring it and the lock still records it."""
+    pyproject, lock = _plant(
+        tmp_path,
+        'dependencies = ["foo>=1.0,<2.0"]\n',
+        _AGREEING_LOCK,
+    )
+    findings = mod.check(pyproject, lock)
+    assert [finding.kind for finding in findings] == [mod.ABSENT_FROM_MANIFEST]
+    assert findings[0].key == ("x", "bar", ("extra1",))
+
+
+def test_a_lowered_floor_is_one_finding_naming_both_sides(tmp_path: Path) -> None:
+    """The ``lerobot`` / ``huggingface-hub`` class.
+
+    Reported once, as drift, rather than twice as an absence and an addition:
+    the remedy is a relock, and two rows would read as two problems.
+    """
+    pyproject, lock = _plant(
+        tmp_path,
+        _AGREEING_MANIFEST,
+        '    { name = "foo", specifier = ">=1.0,<2.0" },\n'
+        '    { name = "bar", extras = ["extra1"], marker = "extra == \'x\'", specifier = ">=1.0" },',
+    )
+    findings = mod.check(pyproject, lock)
+    assert [finding.kind for finding in findings] == [mod.SPECIFIER_DRIFT]
+    assert findings[0].declared == (">=2.0",)
+    assert findings[0].recorded == (">=1.0",)
+
+
+def test_the_extras_of_a_requirement_are_part_of_its_identity(tmp_path: Path) -> None:
+    """``qpsolvers[daqp]`` recorded as bare ``qpsolvers`` is drift, not a match."""
+    pyproject, lock = _plant(
+        tmp_path,
+        _AGREEING_MANIFEST,
+        '    { name = "foo", specifier = ">=1.0,<2.0" },\n'
+        '    { name = "bar", marker = "extra == \'x\'", specifier = ">=2.0" },',
+    )
+    findings = mod.check(pyproject, lock)
+    kinds = sorted(finding.kind for finding in findings)
+    assert kinds == sorted([mod.ABSENT_FROM_MANIFEST, mod.MISSING_FROM_LOCK])
+
+
+def test_a_marker_that_is_not_an_extra_marker_is_reported_rather_than_dropped(tmp_path: Path) -> None:
+    """An environment marker must not silently shrink the compared set."""
+    pyproject, lock = _plant(
+        tmp_path,
+        _AGREEING_MANIFEST,
+        '    { name = "foo", specifier = ">=1.0,<2.0" },\n'
+        '    { name = "bar", extras = ["extra1"], marker = "extra == \'x\'", specifier = ">=2.0" },\n'
+        '    { name = "baz", marker = "python_full_version < \'3.13\'", specifier = ">=1.0" },',
+    )
+    findings = mod.check(pyproject, lock)
+    assert mod.UNREADABLE_MARKER in [finding.kind for finding in findings]
+
+
+def test_specifier_ordering_is_not_drift(tmp_path: Path) -> None:
+    """``>=1.0,<2.0`` and ``<2.0,>=1.0`` are the same constraint.
+
+    Without normalisation this reports the whole manifest as drifted the first
+    time uv writes a specifier in a different order from the manifest.
+    """
+    pyproject, lock = _plant(
+        tmp_path,
+        'dependencies = ["foo>=1.0,<2.0"]\n',
+        '    { name = "foo", specifier = "<2.0,>=1.0" },',
+    )
+    assert mod.check(pyproject, lock) == []
+
+
+def test_a_self_reference_cycle_terminates(tmp_path: Path) -> None:
+    """Two extras referencing each other must not recurse until the interpreter stops it.
+
+    The manifest has no cycle today, so this is a property of the reader rather
+    than of the input -- which is exactly why it needs a planted pair.
+    """
+    pyproject, lock = _plant(
+        tmp_path,
+        "dependencies = []\n\n[project.optional-dependencies]\n"
+        'sim-mujoco = ["strands-robots[wbc]", "foo>=1.0"]\n'
+        'wbc = ["strands-robots[sim-mujoco]", "bar>=2.0"]\n',
+        '    { name = "foo", marker = "extra == \'sim-mujoco\'", specifier = ">=1.0" },\n'
+        '    { name = "bar", marker = "extra == \'sim-mujoco\'", specifier = ">=2.0" },\n'
+        '    { name = "foo", marker = "extra == \'wbc\'", specifier = ">=1.0" },\n'
+        '    { name = "bar", marker = "extra == \'wbc\'", specifier = ">=2.0" },',
+    )
+    assert mod.check(pyproject, lock) == []
+
+
+def test_a_name_is_compared_canonically(tmp_path: Path) -> None:
+    """``zope.interface`` and ``zope-interface`` are one distribution (PEP 503)."""
+    pyproject, lock = _plant(
+        tmp_path,
+        'dependencies = ["Zope.Interface>=5.0"]\n',
+        '    { name = "zope-interface", specifier = ">=5.0" },',
+    )
+    assert mod.check(pyproject, lock) == []
+
+
+# ---------------------------------------------------------------------------
+# The script's exit contract, which is what makes it usable before a push.
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_zero_on_the_live_pair(capsys: pytest.CaptureFixture[str]) -> None:
+    assert mod.main(["--repo-root", str(_ROOT)]) == 0
+    assert "findings | **0**" in capsys.readouterr().out
+
+
+def test_main_exits_one_and_annotates_on_a_finding(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    pyproject, lock = _plant(tmp_path, _AGREEING_MANIFEST, '    { name = "foo", specifier = ">=1.0,<2.0" },')
+    assert mod.main(["--pyproject", str(pyproject), "--lock", str(lock)]) == 1
+    out = capsys.readouterr().out
+    assert "::error title=uv.lock no longer transcribes pyproject.toml::" in out
+    assert "uv lock" in out
+
+
+def test_main_exits_two_when_a_file_is_missing(tmp_path: Path) -> None:
+    """Distinct from a finding: an unreadable input is not evidence of drift."""
+    assert mod.main(["--repo-root", str(tmp_path)]) == 2
+
+
+def test_main_exits_two_on_a_lock_with_no_root_metadata(tmp_path: Path) -> None:
+    """A lock uv did not write, or one from a future format, is refused rather than read as clean."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "strands-robots"\nversion = "0.0.0"\ndependencies = []\n', encoding="utf-8")
+    lock = tmp_path / "uv.lock"
+    lock.write_text('version = 1\n\n[[package]]\nname = "strands-robots"\n', encoding="utf-8")
+    assert mod.main(["--pyproject", str(pyproject), "--lock", str(lock)]) == 2


### PR DESCRIPTION
## The gap

#2039 landed the `uv lock --check` gate. That gate is the authoritative comparison and it catches everything below. It is also **advisory** — the `default` ruleset lists exactly one required check (`call-test-lint / Test and Lint`) — so a drifted lock reaches a reviewer as a red advisory context beside a green required one.

The offline half #2039 shipped, `tests/test_lockfile_parity_gate.py`, *does* run inside the required check. But it asserts two **properties** of the lock rather than comparing it: every declared distribution present somewhere, and no locked version below its declared floor. Measured against `main`'s stale lock at `ad8696b`, that reports **2 of the 5 rows that had actually drifted**:

| drifted row | reported by #2039's tests | why not |
|---|---|---|
| `lerobot` pinned `0.6.0` vs declared `>=0.6.1` | yes | floor violation |
| `roslibpy` absent from the lock | yes | distribution absent |
| `mink`/`qpsolvers` unrecorded under `[sim-mujoco]` | **no** | both *are* locked (reachable via `[cosmos3-sim]`), just not recorded under this extra, so the presence check passes |
| `mink`/`qpsolvers` unrecorded under `[sim-newton]` | **no** | same |
| `huggingface-hub` recorded `>=1.0` vs declared `>=1.5` | **no** | the pin `1.20.1` satisfies the floor, so only the recorded *specifier* is stale |

The three misses share one cause: a presence-and-floor check samples two properties of the recorded set, and the drift was in the set's **shape**. Concretely, on the pre-fix tree `[rosbridge]` is recorded **empty** and `[sim-mujoco]` is recorded as `['imageio', 'imageio-ffmpeg', 'mujoco', 'robot-descriptions']` — a locked sim install with no IK stack behind `move_to`. Nothing about either pin is wrong, which is exactly why no property of a pin can see it.

That baseline is measured rather than argued. Both modules, same stale lock, same environment:

| module | result on `ad8696b`'s lock |
|---|---|
| `test_lockfile_parity_gate.py` (#2039) | **2 failed**, 5 passed |
| `test_lockfile_parity_requires_dist.py` (this PR) | **12 failed**, 19 passed |

The 12 name all five rows individually, in the manifest's own terms — `uv.lock no longer records qpsolvers['daqp'] under [sim-mujoco] -- relock`.

## The change

Compare the whole recorded set instead of sampling properties of it. `uv.lock` already carries uv's own transcription of the manifest in the root package's `[package.metadata] requires-dist`, so the declared set can be reconstructed from `pyproject.toml` and compared as a set — **offline: no resolver, no network, no `uv` binary**, which is the only reason this can run in the required check.

`scripts/check_lockfile_parity.py` (exit 0/1, matching the `check_*.py` convention so it can be run before pushing) plus `tests/test_lockfile_parity_requires_dist.py`.

Verified in both directions:

| tree | declared rows | recorded rows | findings |
|---|---|---|---|
| this branch (`main` relocked) | 111 | 111 | **0** |
| `ad8696b` lock, same manifest | 111 | 107 | **24** |

The 24 cover all five rows above **and four the issue had not enumerated**: `peft` and `transformers` recorded under extras that no longer declare them, `scipy`, and `lerobot[molmoact2]` unrecorded entirely.

### Why 24 and not 32

The two sets differ by 32 rows, because a changed version range appears in *both* directions of the symmetric difference — once as declared-but-not-recorded and once as recorded-but-not-declared. Reported raw that reads as two independent problems with two different remedies. Rows are grouped by `(extra, name, extras)` first, so a changed range becomes one `specifier-drift` finding naming both sides, while a key present on only one side keeps its own class — those genuinely do want different remedies.

## The two encodings that had to be mirrored, not approximated

Getting either wrong produces a guard that **false-fails on a correct lock**, which is worse than one that misses drift: it blocks every branch until someone reads the checker.

- **Self-references are expanded.** 20 of the 88 requirement lines in the manifest are `strands-robots[<other-extra>]`; uv resolves those away and records the transitive closure, which is why the recorded set is 111 and not 68. Comparing the literal declared lines reports **43** spurious "recorded but not declared" rows. Pinned as a premise that asserts the expansion is *necessary*, not merely present.
- **One key can carry several specifiers, so neither side may be flattened into a dictionary.** This is not defensive: uv's own lock at `ad8696b` recorded `scipy` **twice** under `[all]`, at `>=1.10.0` and `>=1.14.0,<2.0.0`. A dictionary keyed by `(extra, name, extras)` drops one silently, and the dropped row then reads as drift against a file that is correct. Today's manifest and relocked file happen to carry a unique specifier per key, so nothing in the live pair exercises this — that is asserted explicitly, and the case is pinned behaviourally on a planted pair instead.

One fact worth recording because it makes the comparison exact rather than approximate: every marker in the lock's `requires-dist` is `extra == '...'` and nothing else (107 of 111 rows; the other 4 unconditional), and no requirement in `pyproject.toml` carries an environment marker at all. A residual-marker comparison is therefore inert today. It is still written as a **finding** rather than a silent drop, so if either side grows a real marker this reports it instead of quietly comparing fewer rows than it claims to.

## Deliberately out of scope

- **It does not re-check that locked versions satisfy declared floors.** `tests/test_lockfile_parity_gate.py` does that. Duplicating it would create two rulebooks for one rule that can drift apart — including the non-obvious "every locked version, not any" phrasing that `robosuite` (locked at `1.4.0` *and* `1.4.1` against a `>=1.4.1` floor, before and after the relock) forces on it. This script compares the two transcriptions of the **manifest**; that module compares the lock against the **resolution**.
- **It does not re-resolve.** Whether the recorded set is *achievable* is `uv lock --check`'s question and needs the index. A stale transcription is detectable without one.
- **It does not read `[tool.uv]`.** Sources, overrides and conflicts change what uv resolves, not what the manifest declares, so they cannot make the two transcriptions disagree.
- **The stale lock is not vendored.** The planted pairs carry the drift *classes*, which is what must keep being caught; a vendored 5914-line artifact would pin one historical file forever. It stays reachable as `git show ad8696b:uv.lock` for anyone reproducing the 24.

## No workflow change, and that is deliberate

The required check already runs `pytest`, which is the whole point of #2041 — so the test module alone moves these rows into the required check. Adding a step to `lockfile-parity.yml` would be redundant, and it would make the PR touch `.github/workflows/**`, which is what forces `mergeStateStatus` to read `BLOCKED` under an installation token regardless of the actual gate state. This PR touches no workflow, so that field reads truthfully here.

## Verification

Base `69159f2`, head `04d0208`. No `strands_robots/` file changes, no `uv.lock` change, no `pyproject.toml` change, so the runtime blast radius is zero.

- **Pre-fix proof** — `uv.lock` swapped for `ad8696b`'s, the new module kept: **12 failed / 19 passed**, naming all five rows. The 19 that pass are the controls: the planted pairs (properties of the checker, not of the live lock) and the non-vacuity guards. With the real lock restored: **31 passed**.
- **A regression the delta caught.** The first run of the neighbouring suites read **34 failed** against `main`'s 33. `comm` over the two sorted `FAILED` lists named exactly one test failing only on the branch: `test_dependency_audit.py::test_written_install_hints_name_only_declared_extras`. That guard sweeps the tree for `strands-robots[<extra>]` and refuses any naming an extra that does not exist, because pip exits 0 on an unknown extra and installs none of its dependencies. My planted fixtures used synthetic extras `[a]`/`[b]`. Fixed by conforming — the fixtures now name real declared extras (`sim-mujoco`, `wbc`) with synthetic dependencies inside — rather than by exempting the sweep, and the reason is recorded at the fixture helper so it is not "simplified" back.
- **No regression, read as a delta.** The 20 neighbouring modules (every `check_*` gate suite, `test_dependency_audit`, the lerobot floor and dependency-doc suites, `test_lockfile_parity_gate`) run with the same command in the same environment against a pristine `origin/main` worktree and against this branch:

  | tree | result |
  |---|---|
  | `origin/main` | 33 failed, 483 passed, 62 skipped |
  | this branch | 33 failed, **514** passed, 62 skipped |

  Identical failure sets — `comm` over the two sorted `FAILED` lists reports **nothing failing only on the branch, and nothing only on main** — and every one is a `ModuleNotFoundError` for a heavy optional dep absent from this scratch venv, present identically on `main`. The whole effect is **+31 passes**, exactly the 31 tests added.
- **Lint** — `ruff check` clean, `ruff format --check` clean, `mypy scripts/check_lockfile_parity.py` reports no issues.
- **Changelog** — recorded as a fragment (`changelog.d/2041-lockfile-requires-dist-parity.md`); `scripts/assemble_changelog.py --check` reports `changelog fragments OK (232 pending)`.
- **Docs** — `docs/contributing.md` gains the rule under **Rules** that a dependency change and its `uv lock` belong in the same commit, which was not written down anywhere. #2041 asked for this line.

Closes #2041
