### PR TITLE
fix(training): refuse an on-policy loss weight that cannot be honored

### DIFF
--- a/changelog.d/2045-loss-weight-domain.md
+++ b/changelog.d/2045-loss-weight-domain.md
@@ -1,0 +1,41 @@
+### Fixed: the on-policy loss weights are refused when they cannot be honored
+
+`RLTrainSpec.value_loss_coef` and `RLTrainSpec.entropy_coef` are the two scalars
+that weight the terms of the objective PPO's update descends, and they are read
+in exactly one place - the single expression that composes it:
+
+```python
+loss = surrogate_loss + spec.value_loss_coef * value_loss - spec.entropy_coef * entropy
+```
+
+Nothing judged either of them, and the multiplication cannot: it is defined for
+values no caller can have meant, and every one of them reached the backward pass.
+Measured on a seeded 60-step run whose honored checkpoint parameter sum is
+`140.6023186540351162`:
+
+- `entropy_coef=True` reported `success` and wrote a checkpoint whose parameter
+  sum is `140.6158002523716277` - an entropy bonus at full weight where the field
+  ships defaulting to `0.0`, requested by a value that reads as a flag. `bool` is
+  an `int` subclass, so it lands as a coefficient of one.
+- `nan`, `inf`, `-inf`, `"1.0"`, `None` and `[1.0]` raised **out of** `train()` -
+  documented to return a terminal `TrainResult` and to fail closed on `validate()`
+  first. A `nan` weight makes the loss `nan`, the optimizer writes `nan` into every
+  parameter, and the *next* rollout samples the action distribution from them:
+  `ValueError: Expected parameter loc ... of distribution Normal ... to satisfy the
+  constraint Real()`, a torch message naming neither the field nor the value, after
+  the env, the networks and a full rollout have been built.
+
+Both are now reported by the read-only preflight, through a new
+`loss_weight_problems` gate on the shared `finite_number_error` domain. The gate
+bounds the *domain* rather than the floor: zero and negative stay accepted for
+both fields, because both have a real reading - `entropy_coef=0.0` is the shipped
+default, a negative entropy weight is a determinism penalty, and
+`value_loss_coef=0` stops training the critic. Only the on-policy backend composes
+this objective, so FastSAC and the mock trainer report nothing about either field.
+
+`clip_param` and `init_noise_std` remain out of scope, and now for measured
+reasons rather than by omission: `clip_param` is a clip *bound* whose `inf` is
+coherently honored as "do not clip" (`clamp(ratio, -inf, inf)` returns `ratio`
+unchanged), so it needs the endpoint decision the sibling `max_grad_norm` gate
+records; and every non-finite `init_noise_std` is already refused by `torch`,
+which rejects a `Normal` of non-positive or non-finite scale.

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -103,6 +103,14 @@ stepping. It is scoped like :func:`gae_lambda_problems` - only the on-policy
 backend clips, so FastSAC must not report on a field it never reads - and it is
 the one coefficient of that group whose zero reading *is* settled, by
 ``torch.nn.utils.clip_grad_norm_`` itself: see that gate for the measurement.
+
+:func:`loss_weight_problems` is the thirteenth, on the same *optimization* axis
+and the last of that group whose endpoints are not the question: ``value_loss_coef``
+and ``entropy_coef``, the two scalars that weight the terms of the composed
+on-policy objective. It is scoped like :func:`gradient_clip_problems` - only the
+on-policy backend composes that objective - and it bounds the *domain* rather than
+the floor: zero and negative are real configurations for both fields, while a
+non-finite or non-numeric weight is a value no reading makes usable.
 """
 
 from __future__ import annotations
@@ -564,15 +572,17 @@ def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
     that same scoping reason - see :func:`gae_lambda_problems`,
     ``num_learning_epochs`` likewise in :func:`optimization_epochs_problems`,
     and ``max_grad_norm`` in :func:`gradient_clip_problems`.
-    The remaining PPO coefficients (``clip_param``, ``entropy_coef``,
-    ``value_loss_coef``, ``init_noise_std``) are out of scope in all four: they
-    weight loss terms and initialize the action distribution rather than
-    discounting the return, and for each of them zero has a candidate reading as
-    a *disabled mode* that this repository has not settled - ``entropy_coef`` is
-    shipped defaulting to ``0.0``, so zero is already a supported configuration,
-    and ``init_noise_std=0`` is refused by ``torch`` itself, which rejects a
-    ``Normal`` of zero scale. Those are contract questions rather than defects,
-    so they are left to a gate that settles them.
+    The two *loss weights* named there - ``entropy_coef`` and ``value_loss_coef`` -
+    now have their own gate too, in :func:`loss_weight_problems`, on the domain
+    rather than on the endpoint this docstring called undecided: their zero
+    readings are still unsettled and still accepted, but a non-finite weight has
+    no reading at all. ``clip_param`` and ``init_noise_std`` remain out of scope
+    in all five, and for measured reasons rather than by omission: ``clip_param``
+    is a clip *bound* whose ``inf`` is coherently honored as "do not clip"
+    (``clamp(ratio, -inf, inf)`` returns ``ratio`` unchanged), so it needs the
+    endpoint decision :func:`gradient_clip_problems` records for the sibling
+    bound; and every non-finite ``init_noise_std`` is refused by ``torch``, which
+    rejects a ``Normal`` of non-positive or non-finite scale.
 
     Args:
         spec: The spec to check.
@@ -903,3 +913,86 @@ def gradient_clip_problems(spec: TrainSpec, *, context: str) -> list[str]:
     """
     error = _gradient_clip_error(getattr(spec, "max_grad_norm", 1.0), "max_grad_norm", context)
     return [error] if error is not None else []
+
+
+def loss_weight_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return loss-weight problems for an on-policy RL :class:`TrainSpec`.
+
+    ``value_loss_coef`` and ``entropy_coef`` are the two scalars that weight the
+    terms of the objective the on-policy update descends. They are read in
+    exactly one place - the single expression that composes it::
+
+        loss = surrogate_loss + spec.value_loss_coef * value_loss - spec.entropy_coef * entropy
+
+    Nothing judged either of them, and the multiplication cannot: it is defined
+    for values no caller can have meant, and every one of them reaches the
+    backward pass. Measured on this backend, over a seeded 60-step run whose
+    checkpoint parameter sum is ``140.6023186540351162`` when both weights are
+    honored:
+
+    =========================  =========================================
+    Weight                     Outcome
+    =========================  =========================================
+    defaults (``1.0`` / ``0.0``)  trains; sum ``140.6023186540``
+    ``True``                   **trains with a different coefficient**
+    ``nan``                    raises mid-update, from inside ``torch``
+    ``inf`` / ``-inf``         raises mid-update, from inside ``torch``
+    ``"1.0"``                  raises mid-update, from inside ``torch``
+    ``None`` / ``[1.0]``       raises mid-update, from inside ``torch``
+    =========================  =========================================
+
+    Both rows are what make this a gate rather than a lint:
+
+    * **A boolean is a silently different coefficient.** ``bool`` is an ``int``
+      subclass, so ``entropy_coef=True`` is an entropy bonus at full weight where
+      the field ships defaulting to ``0.0`` - exploration is turned on by a value
+      that reads as a flag. The run reports ``success`` and writes a checkpoint
+      whose parameter sum is ``140.6158002523716277`` against the honored run's
+      ``140.6023186540351162``, so it demonstrably trained differently rather
+      than harmlessly.
+    * **Everything non-finite or non-numeric raises out of ``train()``**, which
+      is documented to return a terminal ``TrainResult`` and to fail closed on
+      :meth:`~strands_robots.training.base.Trainer.validate` first. A ``nan``
+      weight makes the loss ``nan``, the optimizer writes ``nan`` into every
+      parameter, and the *next* rollout samples the action distribution from
+      them: ``ValueError: Expected parameter loc ... of distribution Normal ...
+      to satisfy the constraint Real()`` - a torch message that names neither the
+      field nor the value, raised after the env, the networks and a full rollout
+      have been built. A string raises ``TypeError: only integer tensors of a
+      single element can be converted to an index`` from the same depth. That is
+      exactly the "deep stack trace" a read-only preflight exists to replace.
+
+    **The floor is deliberately not decided here.** Zero and negative are inside
+    the domain for both fields, because both have a real reading:
+    ``entropy_coef=0.0`` is the shipped default, a negative entropy weight is a
+    penalty that drives the policy deterministic, and ``value_loss_coef=0`` stops
+    training the critic. So the domain is a *finite real* - the one property no
+    reading of either field can want without - checked through
+    :func:`~strands_robots.utils.finite_number_error`, which also refuses the
+    ``bool`` a bare comparison against zero would accept. This is the narrower
+    counterpart of :func:`gradient_clip_problems`, whose endpoint *is* settled by
+    ``clip_grad_norm_`` and which therefore tests positivity.
+
+    Only the on-policy backend composes this objective - ``grep`` finds
+    ``spec.value_loss_coef`` and ``spec.entropy_coef`` in ``rl/ppo.py`` and
+    nowhere else - so this is scoped like :func:`gae_lambda_problems` rather than
+    :func:`learning_rate_problems`: a backend that does not compose it MUST NOT
+    call this, because per :class:`TrainSpec` a backend ignores the fields it does
+    not support and reporting on one would be a false rejection.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        One problem per weight that cannot be honored; empty when both can.
+    """
+    defaults = {"value_loss_coef": 1.0, "entropy_coef": 0.0}
+    problems = []
+    for param, default in defaults.items():
+        error = finite_number_error(getattr(spec, param, default), param, context)
+        if error is not None:
+            problems.append(error)
+    return problems

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -582,6 +582,46 @@ class Trainer(ABC):
 
         return gradient_clip_problems(spec, context=self.provider_name)
 
+    def _loss_weight_problems(self, spec: TrainSpec) -> list[str]:
+        """Loss-weight preflight for a backend that composes a weighted objective.
+
+        Returns a problem per weight when :attr:`RLTrainSpec.value_loss_coef` or
+        :attr:`RLTrainSpec.entropy_coef` is not a finite real number. Both are
+        multiplied into the loss the update descends, and the multiplication
+        judges nothing: a ``nan`` weight makes the loss ``nan``, the optimizer
+        writes ``nan`` into every parameter, and the next rollout raises from
+        inside ``torch`` naming neither field nor value - after the env, the
+        networks and a full rollout have been built.
+
+        The floor is deliberately *not* tested. Zero and negative are inside the
+        domain for both: ``entropy_coef`` ships defaulting to ``0.0``, a negative
+        entropy weight is a determinism penalty, and ``value_loss_coef=0`` stops
+        training the critic. That is what distinguishes this from
+        :meth:`_gradient_clip_problems`, whose endpoint is settled by
+        ``clip_grad_norm_`` and which therefore tests positivity. A ``bool`` is
+        refused here, because it reads as a flag and lands as a coefficient of
+        one - turning the entropy bonus on at full weight where the field's
+        default is off.
+
+        Only a backend that composes this objective may call this: like
+        :meth:`_gradient_clip_problems`, and unlike
+        :meth:`_learning_rate_problems`, a backend that does not read the fields
+        MUST NOT report on them, because per :class:`TrainSpec` a backend ignores
+        the fields it does not support.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the module import graph one-way.
+
+        Args:
+            spec: The spec to preflight.
+
+        Returns:
+            One problem per weight that cannot be honored; empty when both can.
+        """
+        from strands_robots.training._validate import loss_weight_problems
+
+        return loss_weight_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/base_algo.py
+++ b/strands_robots/training/rl/base_algo.py
@@ -67,8 +67,13 @@ class RLTrainSpec(TrainSpec):
         clip_param: PPO clip range (also clips the value loss).
         num_learning_epochs: Optimization epochs over each rollout batch.
         num_mini_batches: Minibatches the rollout batch is split into per epoch.
-        entropy_coef: Entropy-bonus weight (exploration).
-        value_loss_coef: Value-loss weight.
+        entropy_coef: Entropy-bonus weight (exploration). Any finite real;
+            ``0.0`` (the default) disables the bonus and a negative value
+            penalizes entropy. Non-finite and non-numeric values are
+            refused by the preflight rather than reaching the loss.
+        value_loss_coef: Value-loss weight. Any finite real; ``0`` stops
+            training the critic. Non-finite and non-numeric values are
+            refused by the preflight rather than reaching the loss.
         max_grad_norm: Gradient-norm clip.
         hidden_dims: MLP hidden layer sizes for actor and critic.
         init_noise_std: Initial action-distribution standard deviation.

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -163,6 +163,11 @@ class PpoTrainer(BaseRLAlgo):
         # scales them all to zero and a negative bound negates them, so neither
         # takes the step the caller asked for while the run still succeeds.
         problems.extend(self._gradient_clip_problems(spec))
+        # value_loss_coef and entropy_coef weight the two terms of the objective
+        # the update descends; the multiplication judges neither, so a non-finite
+        # weight poisons every parameter and surfaces as a torch error naming
+        # neither field, and a bool lands as a silently different coefficient.
+        problems.extend(self._loss_weight_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/tests/training/test_loss_weight_domain.py
+++ b/tests/training/test_loss_weight_domain.py
@@ -1,0 +1,316 @@
+"""The on-policy loss weights are refused when they cannot be honored.
+
+``value_loss_coef`` and ``entropy_coef`` are the two scalars that weight the
+terms of the objective PPO's update descends, read in exactly one place - the
+single expression that composes it::
+
+    loss = surrogate_loss + spec.value_loss_coef * value_loss - spec.entropy_coef * entropy
+
+Nothing judged either of them and the multiplication cannot, so every value a
+caller cannot have meant reached the backward pass. Measured on a seeded 60-step
+run whose honored checkpoint parameter sum is ``140.6023186540351162``:
+
+* ``entropy_coef=True`` reports ``success`` and writes a checkpoint whose sum is
+  ``140.6158002523716277`` - an entropy bonus at full weight where the field
+  ships defaulting to ``0.0``, requested by a value that reads as a flag.
+* ``nan`` / ``inf`` / ``"1.0"`` raise out of ``train()`` - documented to return a
+  terminal ``TrainResult`` - from inside ``torch``, naming neither the field nor
+  the value, after the env, the networks and a full rollout have been built.
+
+The floor is deliberately **not** part of the domain: zero and negative are real
+configurations for both fields, so this gate tests finiteness and numeric-ness
+only. That is what distinguishes it from the sibling ``max_grad_norm`` gate,
+whose endpoint ``clip_grad_norm_`` itself settles.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import loss_weight_problems
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.utils import finite_number_error
+
+# The backend that composes the weighted objective.
+ON_POLICY = "ppo"
+
+# Backends that read neither weight. Per ``TrainSpec`` a backend ignores the
+# fields it does not support, so reporting on one would be a false rejection.
+NON_COMPOSING_BACKENDS = ("fast_sac", "mock")
+
+# The two weights, with the default each ships.
+WEIGHTS: tuple[tuple[str, float], ...] = (("value_loss_coef", 1.0), ("entropy_coef", 0.0))
+
+# A non-finite weight makes the loss non-finite, so the optimizer writes it into
+# every parameter and the next rollout raises from inside torch.
+NON_FINITE: list[Any] = [math.nan, math.inf, -math.inf, np.float64(np.nan), np.float64(np.inf)]
+
+# A bool reads as a flag and lands as a coefficient of one.
+BOOLEANS: list[Any] = [True, False, np.bool_(True)]
+
+# Not a number at all: these raise from inside torch, naming nothing.
+NON_NUMERIC: list[Any] = ["1.0", None, [1.0], {}]
+
+# Finite in decimal but outside a 64-bit float, so the conversion itself fails.
+BEYOND_FLOAT_RANGE: list[Any] = [10**400]
+
+UNUSABLE: list[Any] = [*NON_FINITE, *BOOLEANS, *NON_NUMERIC, *BEYOND_FLOAT_RANGE]
+
+# Any finite real. The floor is not this gate's question: zero disables the term
+# and a negative weight reverses its sign, and both are configurations rather
+# than mistakes.
+USABLE: list[Any] = [1.0, 0.0, -0.5, 0.5, 2, 1e-8, np.float64(1.0), np.float32(0.5), np.int64(2)]
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """An otherwise-valid RL spec, so only the field under test is exercised."""
+    return RLTrainSpec(output_dir="/tmp/loss_weight_domain", env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+
+
+def _weight_problems(provider: str, spec: RLTrainSpec, param: str) -> list[str]:
+    """Problems the real ``validate`` entry point reports about *param*.
+
+    Filtered on the shared domains' ``"{context}: {param} "`` message shape
+    rather than on a bare substring, so an unrelated problem can neither mask a
+    missing refusal nor be mistaken for one.
+    """
+    prefix = f"{provider}: {param} "
+    return [p for p in create_trainer(provider).validate(spec) if p.startswith(prefix)]
+
+
+class TestTheOnPolicyBackendRefusesAnUnusableLossWeight:
+    """PPO refuses every weight the composed objective cannot honor."""
+
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: RLTrainSpec, param: str, default: float, value: Any) -> None:
+        setattr(spec, param, value)
+        assert _weight_problems(ON_POLICY, spec, param), f"ppo accepted {param}={value!r}"
+
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    @pytest.mark.parametrize("value", [*NON_FINITE, *BOOLEANS, *NON_NUMERIC])
+    def test_the_problem_names_the_field_the_domain_and_the_value(
+        self, spec: RLTrainSpec, param: str, default: float, value: Any
+    ) -> None:
+        setattr(spec, param, value)
+        (problem,) = _weight_problems(ON_POLICY, spec, param)
+        assert param in problem
+        assert "must be a finite number" in problem
+        assert repr(value) in problem, problem
+
+    def test_each_weight_is_reported_independently(self, spec: RLTrainSpec) -> None:
+        """Two unusable weights produce two problems, not one."""
+        spec.value_loss_coef = math.nan
+        spec.entropy_coef = math.inf
+        problems = create_trainer(ON_POLICY).validate(spec)
+        assert len([p for p in problems if p.startswith("ppo: value_loss_coef ")]) == 1
+        assert len([p for p in problems if p.startswith("ppo: entropy_coef ")]) == 1
+
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    def test_the_refusal_is_read_only_and_train_fails_closed(
+        self, tmp_path: pathlib.Path, param: str, default: float
+    ) -> None:
+        """``train`` reports the problem rather than raising from inside torch."""
+        spec = RLTrainSpec(output_dir=str(tmp_path / "run"), env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+        setattr(spec, param, math.nan)
+        result = create_trainer(ON_POLICY).train(spec)
+        assert result.status == "error"
+        assert param in result.message
+        assert not list(tmp_path.rglob("*.pt")), "a refused spec must not write a checkpoint"
+
+
+class TestTheUsableDomainIsUntouched:
+    """Every finite real weight is still accepted, including the endpoints."""
+
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    @pytest.mark.parametrize("value", USABLE)
+    def test_it_reports_no_problem(self, spec: RLTrainSpec, param: str, default: float, value: Any) -> None:
+        setattr(spec, param, value)
+        assert _weight_problems(ON_POLICY, spec, param) == []
+
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    def test_the_shipped_default_is_accepted(self, spec: RLTrainSpec, param: str, default: float) -> None:
+        assert getattr(spec, param) == default
+        assert _weight_problems(ON_POLICY, spec, param) == []
+
+
+class TestTheFloorIsDeliberatelyNotDecided:
+    """Zero and negative are configurations, so this gate must not refuse them.
+
+    Recorded as its own contract because it is the difference between this gate
+    and the sibling ``max_grad_norm`` one: there the endpoint is settled by
+    ``clip_grad_norm_``, here both readings are live - ``entropy_coef=0.0`` is the
+    shipped default, ``value_loss_coef=0`` stops training the critic, and a
+    negative entropy weight penalizes entropy rather than rewarding it.
+    """
+
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    @pytest.mark.parametrize("value", [0.0, 0, -0.5, -1.0, -1e-8])
+    def test_zero_and_negative_stay_inside_the_domain(
+        self, spec: RLTrainSpec, param: str, default: float, value: Any
+    ) -> None:
+        setattr(spec, param, value)
+        assert _weight_problems(ON_POLICY, spec, param) == []
+
+
+class TestTheGateIsExactlyTheSharedRule:
+    """The gate adds nothing to the shared finite-number domain.
+
+    Looped over both the usable and the unusable sets, so a local difference
+    would have to show up as a disagreement rather than as absent coverage.
+    """
+
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    @pytest.mark.parametrize("value", [*USABLE, *UNUSABLE])
+    def test_it_agrees_with_the_shared_domain_everywhere(
+        self, spec: RLTrainSpec, param: str, default: float, value: Any
+    ) -> None:
+        setattr(spec, param, value)
+        gate_refuses = bool(loss_weight_problems(spec, context="ppo"))
+        shared_refuses = finite_number_error(value, param, "ppo") is not None
+        assert gate_refuses is shared_refuses, f"{param}={value!r}"
+
+    def test_the_message_is_the_shared_one_verbatim(self, spec: RLTrainSpec) -> None:
+        spec.value_loss_coef = math.nan
+        (problem,) = [p for p in loss_weight_problems(spec, context="ppo") if "value_loss_coef" in p]
+        assert problem == finite_number_error(math.nan, "value_loss_coef", "ppo")
+
+
+class TestTheBackendsThatDoNotComposeItStaySilent:
+    """A backend that reads neither weight must not report on either."""
+
+    @pytest.mark.parametrize("provider", NON_COMPOSING_BACKENDS)
+    @pytest.mark.parametrize("param,default", WEIGHTS)
+    def test_no_problem_is_reported(self, provider: str, param: str, default: float, tmp_path: pathlib.Path) -> None:
+        spec = RLTrainSpec(output_dir=str(tmp_path), env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+        setattr(spec, param, math.nan)
+        assert _weight_problems(provider, spec, param) == []
+
+    @pytest.mark.parametrize("provider", NON_COMPOSING_BACKENDS)
+    def test_the_silence_is_scoping_rather_than_an_empty_preflight(self, provider: str, tmp_path: pathlib.Path) -> None:
+        """Non-vacuity: the same spec is still refused on a field they do read."""
+        spec = RLTrainSpec(output_dir=str(tmp_path), env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+        spec.learning_rate = math.nan
+        assert _weight_problems(provider, spec, "learning_rate")
+
+
+def _ppo_update_source() -> str:
+    """The body of the on-policy update, so the premises below are the real one."""
+    from strands_robots.training.rl.ppo import PpoTrainer
+
+    return inspect.getsource(PpoTrainer.update)
+
+
+class TestTheConsumerHonorsTheDomain:
+    """The premises the domain rests on, measured against torch itself."""
+
+    def test_both_weights_are_read_in_one_expression(self) -> None:
+        source = _ppo_update_source()
+        assert "spec.value_loss_coef * value_loss - spec.entropy_coef * entropy" in source
+
+    def test_a_non_finite_weight_makes_the_loss_non_finite(self) -> None:
+        torch = pytest.importorskip("torch")
+        value_loss, entropy = torch.tensor(2.0), torch.tensor(0.5)
+        for weight in (math.nan, math.inf):
+            loss = torch.tensor(1.0) + weight * value_loss - 0.0 * entropy
+            assert not bool(torch.isfinite(loss)), weight
+
+    def test_a_non_finite_loss_writes_non_finite_parameters(self) -> None:
+        """Why the raise lands one rollout later, naming neither field nor value."""
+        torch = pytest.importorskip("torch")
+        model = torch.nn.Linear(3, 2)
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-2)
+        (model(torch.ones(1, 3)).sum() * math.nan).backward()
+        optimizer.step()
+        assert bool(torch.isnan(model.weight).any())
+
+    def test_a_bool_lands_as_a_coefficient_of_one(self) -> None:
+        torch = pytest.importorskip("torch")
+        entropy = torch.tensor(0.5)
+        assert float(True * entropy) == float(1.0 * entropy)
+
+    @pytest.mark.parametrize("value", [0.0, -0.5, 1.0, 2.0])
+    def test_every_accepted_weight_composes_a_finite_loss(self, value: float) -> None:
+        torch = pytest.importorskip("torch")
+        loss = torch.tensor(1.0) + value * torch.tensor(2.0) - value * torch.tensor(0.5)
+        assert bool(torch.isfinite(loss))
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(loss_weight_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_a_weight(source: str) -> bool:
+    """Does *source* read either ``spec.value_loss_coef`` or ``spec.entropy_coef``?"""
+    return any(
+        isinstance(node, ast.Attribute)
+        and node.attr in {"value_loss_coef", "entropy_coef"}
+        and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_loss_weight_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheLossWeightDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* either weight must route it through the shared gate, so a
+    second backend that starts composing a weighted objective with these fields
+    fails this test until it does.
+    """
+
+    def test_every_module_that_reads_one_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name for p in _training_modules() if _reads_a_weight(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules read a loss weight without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_a_weight(p.read_text())}
+        assert readers == {"ppo.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading a weight without the gate is really reported."""
+        planted = "def validate(self, spec):\n    return [] if spec.entropy_coef else []\n"
+        assert _reads_a_weight(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        """A hand-rolled comparison agrees with the shared rule until it drifts."""
+        offenders = [
+            p.name
+            for p in _training_modules()
+            if any(
+                f"{field} {op}" in p.read_text()
+                for field in ("value_loss_coef", "entropy_coef")
+                for op in ("<= 0", "< 0", "> 0", ">= 0")
+            )
+        ]
+        assert offenders == [], f"modules compare a loss weight themselves: {offenders}"


### PR DESCRIPTION
## The defect

`RLTrainSpec.value_loss_coef` and `RLTrainSpec.entropy_coef` are the two scalars that weight the terms of the objective the on-policy update descends. They are read in exactly one place — the single expression that composes it (`rl/ppo.py:448`):

```python
loss = surrogate_loss + spec.value_loss_coef * value_loss - spec.entropy_coef * entropy
```

Nothing judged either of them, and the multiplication cannot: it is defined for values no caller can have meant, and every one of them reached the backward pass.

Measured on a seeded 60-step run whose honored checkpoint parameter sum is `140.6023186540351162`:

| spec | run outcome | checkpoint | parameter sum |
|---|---|---|---|
| defaults (`1.0` / `0.0`) | `success` | 1 written | `140.6023186540351162` |
| `entropy_coef=True` | **`success`** | 1 written | **`140.6158002523716277`** |
| `value_loss_coef=nan` | raised `ValueError` | 0 | — |
| `entropy_coef=nan` | raised `ValueError` | 0 | — |
| `value_loss_coef=inf` | raised `ValueError` | 0 | — |
| `value_loss_coef="1.0"` | raised `TypeError` | 0 | — |

Two failure modes, and both are what make this a gate rather than a lint:

- **A boolean is a silently different coefficient.** `bool` is an `int` subclass, so `entropy_coef=True` is an entropy bonus at full weight where the field ships defaulting to `0.0` — exploration turned on by a value that reads as a flag. The run reports `success` and writes a checkpoint whose parameter sum differs from the honored run's, so it demonstrably trained differently rather than harmlessly.
- **Everything non-finite or non-numeric raises out of `train()`**, which is documented to return a terminal `TrainResult` and to fail closed on `validate()` first. A `nan` weight makes the loss `nan`, the optimizer writes `nan` into every parameter, and the *next* rollout samples the action distribution from them:

  ```
  ValueError: Expected parameter loc (Tensor of shape (5, 6)) of distribution
  Normal(...) to satisfy the constraint Real()
  ```

  A torch message that names neither the field nor the value, raised after the env, the networks and a full rollout have been built. A string raises `TypeError: only integer tensors of a single element can be converted to an index` from the same depth. That is exactly the "deep stack trace" a read-only preflight exists to replace.

### Why this was not covered

`discount_factor_problems`' docstring listed all four remaining PPO coefficients as out of scope because "for each of them zero has a candidate reading as a *disabled mode* that this repository has not settled". That is true of zero — and it is a reason to leave the **floor** undecided, not the **domain**. No reading of `nan`, `inf`, a string or a boolean exists for either field, so those were unguarded by a scope note that only ever argued about the endpoint. That docstring is corrected here.

## The change

A new `loss_weight_problems` gate on the shared `finite_number_error` domain, called from the on-policy preflight only. It bounds the domain rather than the floor: **zero and negative stay accepted for both fields**, because both have a real reading — `entropy_coef=0.0` is the shipped default, a negative entropy weight is a determinism penalty, and `value_loss_coef=0` stops training the critic. `finite_number_error` also refuses the `bool` that a bare comparison against zero would accept.

This is the narrower counterpart of `gradient_clip_problems`, whose endpoint *is* settled (by `clip_grad_norm_` treating `inf` as "do not clip") and which therefore tests positivity.

Scoped like `gae_lambda_problems` rather than `learning_rate_problems`: `grep` finds `spec.value_loss_coef` and `spec.entropy_coef` in `rl/ppo.py` and nowhere else, so FastSAC and the mock trainer report nothing about either field — per `TrainSpec` a backend ignores the fields it does not support, and reporting on one would be a false rejection. A structural test derives the required-caller set from *which modules read the fields* rather than listing it, so a second backend that starts composing a weighted objective with them fails until it routes through the gate.

### Deliberately out of scope, with measurements rather than by omission

- **`clip_param`** is a clip *bound*, not a weight, and its `inf` is coherently honored as "do not clip": `clamp(ratio, -inf, inf)` returns `ratio` unchanged, and `(value - old_values).clamp(-inf, inf)` likewise. So it needs the same endpoint decision `gradient_clip_problems` records for the sibling bound, and settling it here would be a guess.
- **`init_noise_std`** is a distribution scale, and every non-finite value is already refused by `torch`, which rejects a `Normal` of non-positive or non-finite scale.

## Verification

Measured verdicts and the bit-identical control run:

![loss weight domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/loss-weight-domain/loss_weight_domain.png)

Divergences from the documented channel: **14 of 20 cells on `main` → 0 of 20** (10 probe values × 2 fields; the three finite-real rows are shaded, since accepting them is correct).

**No regression, measured rather than asserted.** The honored run is bit-identical on both trees — same seed, same env, same 60 steps, 34715 parameters, `absmax 60.0000000000000000`, `sum 140.6023186540351162` on `main` and on this branch. Nothing in the accepted domain moved. No policy, simulation, rendering, recording or asset behaviour changes; the whole diff is a read-only preflight and the domain it applies, so the artifact is a measured verdict table rather than a rollout. The capture and compose scripts are published alongside it, so every cell is reproducible.

| gate | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | clean |
| `ruff format --check strands_robots tests tests_integ` | 1120 files already formatted |
| `mypy strands_robots tests tests_integ` | 0 errors outside `examples/isaac_gs`; the 14 there are byte-identical to a pristine `upstream/main` worktree of the same working copy, i.e. environmental |
| `MUJOCO_GL=egl pytest tests` | **23965 passed, 257 skipped, 0 failed** in 542.69s |
| `scripts/assemble_changelog.py --check` | OK (234 pending) |
| `scripts/check_merge_base_overlap.py` | no overlap; base unchanged at `5f442b3f` |

**Pre-fix proof.** With the two call sites reverted to `upstream/main` and the gate plus the new tests kept: **54 failed, 92 passed**. The structural test's failure names the adrift module directly (`modules read a loss weight without the shared gate: ['ppo.py']`). The 92 that pass pre-fix are the ones that should: the shared-rule parity tests call the gate directly, the consumer premises measure `torch` rather than the library, the non-composing backends were already silent, and every finite-real value was already accepted.

Zero existing tests changed.
